### PR TITLE
feat(agents): template playbooks adopt real request_input defaults

### DIFF
--- a/.agents/skills/write-template-playbooks/SKILL.md
+++ b/.agents/skills/write-template-playbooks/SKILL.md
@@ -36,13 +36,14 @@ One line: when this playbook applies. The card key plus the shape of the ask, in
 free-text asks that match no card.
 
 ## Required context (ask via one request_input form)
-- <field>: why the agent cannot proceed without it. Put the recommended value in the
-  description ("Recommended: <guess>"), never in a default field. [required]
+- <field>: why the agent cannot proceed without it. When the agent can propose a value, set
+  it as the field's `default` (prefilled, one-click acceptable); no default otherwise. [required]
 Only fields the agent genuinely cannot proceed without. One to four. Secrets never go here.
 
-## Researchable context (ask, but the first enum option is "figure it out")
-- <field>: the agent can discover this. Enum whose FIRST option is "Use your best judgment"
-  or "Figure it out from what's connected." Note the speed trade-off in the description.
+## Researchable context (ask, defaulting to "figure it out")
+- <field>: the agent can discover this. Enum with a "Use your best judgment" or "Figure it
+  out from what's connected" option set as the `default`; the built-in Other… covers custom
+  values. Note the speed trade-off in the description.
 
 ## Explore first (read before proposing)
 - Which read tools to discover_tools and wire.
@@ -82,15 +83,17 @@ and the trigger test, Report to the final step.
 
 These are counterintuitive and every first draft gets them backwards. State them correctly.
 
-1. **`request_input` has NO default field, and there is no prefill.** A schema `default` is
-   silently dropped and the field renders empty; pressing Enter on an empty field submits
-   nothing. So never tell the agent to "press Enter to accept" a value the form does not
-   contain. Put the proposed value in the field description as something the user can type
-   ("Recommended: owner/repo-guess"), or state the explicit behavior when the field is left
-   empty ("Leave empty to use UTC"). For a researchable choice, use an enum whose FIRST option
-   is "Figure it out, use your best judgment" and put the proposed value in the description.
-   Listing it first is the only way to signal the default. When issue #5190 lands (real
-   defaults), playbooks migrate to a real default field.
+1. **`request_input` HAS a real `default` field (#5190, shipped) — use it.** A field's
+   `default` prefills the form so the user can accept every proposal in one click; set one
+   whenever the agent can propose a value. Rules: the default must match the field type
+   (array of strings on a multi-select); an empty default (`""`/`[]`) means "no proposal" and
+   is stripped; **date/date-time fields ignore defaults** — do not set them there. For a
+   researchable choice, include a "Figure it out, use your best judgment" enum option and set
+   it as the `default`. Enum options are SUGGESTIONS: every enum renders a built-in "Other…"
+   free-text escape hatch, so keep lists short and likely, not exhaustive. Multi-pick
+   questions use `{type: "array", items: {type: "string", enum: [...]}}`; options needing a
+   sentence of explanation use `oneOf: [{const, title, description}]`, which renders as
+   selectable choice cards.
 2. **`test_run` exercises uncommitted tools** through its in-memory delta
    (`delta.set.parameters.agent.tools` carries the FULL tools list, lists replace wholesale).
    So exploration does NOT require commit-and-stop-turn. Explore the real repo or workspace

--- a/.agents/skills/write-template-playbooks/references/prompting-checklist.md
+++ b/.agents/skills/write-template-playbooks/references/prompting-checklist.md
@@ -44,15 +44,15 @@ builder-reliability findings, or design reasoning).
 
 - `[E]` Minimize required fields. Completion drops sharply as field count rises. Keep required
   to one to four.
-- `[J]` Separate REQUIRED context (must ask) from RESEARCHABLE context (offer "figure it out"
-  as the first enum option) explicitly in the playbook. Do not leave the ask/research boundary
+- `[J]` Separate REQUIRED context (must ask) from RESEARCHABLE context ("figure it out" as
+  the default enum option) explicitly in the playbook. Do not leave the ask/research boundary
   to the model.
-- `[J]` Put the recommended value in the field DESCRIPTION or title. Prefilled defaults do not
-  exist (`ElicitationFieldSchema` declares `default?: never`); a schema default is silently
-  dropped. See the platform facts in SKILL.md.
-- `[J]` For a researchable value, make "Figure it out, use your best judgment" the FIRST enum
-  option. Listing it first is the only way to signal the recommended path; there is no
-  selected-by-default marker.
+- `[J]` Propose values via the field's `default` — the form prefills and the user can accept
+  everything in one click. The default must match the field type; empty defaults are stripped;
+  date/date-time fields ignore defaults. See the platform facts in SKILL.md.
+- `[J]` For a researchable value, include a "Figure it out, use your best judgment" enum
+  option and set it as the `default`. The built-in Other… escape hatch covers custom values,
+  so keep option lists short and likely.
 - `[J]` Surface the speed trade-off in the description: handing information over is faster than
   "figure it out," because research takes time. Let the user choose to save the round trip.
 - `[J]` Never request secrets via `request_input`; route credentials to `request_connection`.

--- a/.agents/skills/write-template-playbooks/references/prompting-checklist.md
+++ b/.agents/skills/write-template-playbooks/references/prompting-checklist.md
@@ -61,8 +61,9 @@ builder-reliability findings, or design reasoning).
   trigger) so the user can veto. Commit and trigger are approval gates; pre-state what is
   coming.
 
-Field types are `string`, `number`, `integer`, `boolean` only. No arrays, no nested objects,
-no multi-select. Formats: `date`, `date-time`, `email`, `uri`, `multiline`.
+Field types are `string`, `number`, `integer`, `boolean`, and the multi-pick array
+`{type: "array", items: {type: "string", enum: [...]}}`. No nested objects. Formats: `date`,
+`date-time`, `email`, `uri`, `multiline` (date fields ignore defaults).
 
 ## Verification (against our runtime)
 

--- a/.agents/skills/write-template-playbooks/references/worked-example.md
+++ b/.agents/skills/write-template-playbooks/references/worked-example.md
@@ -2,9 +2,9 @@
 
 Copy from this. It is the seed playbook, already corrected against the runtime: `test_run`
 explores uncommitted tools through its delta, the trigger test is the Lightning "Test event"
-button (Play "Run" for schedules), and no field is prefilled because `request_input` has no
-default. Notice how each section is short, names exact tools, and ends the instructions on the
-terminal side effect.
+button (Play "Run" for schedules), and proposals ride each field's `default` so the form is
+one-click acceptable. Notice how each section is short, names exact tools, and ends the
+instructions on the terminal side effect.
 
 The fenced block below is the file that ships as `references/agent-templates/changelog-writer.md`.
 
@@ -80,8 +80,9 @@ authorize).
 - **Required vs researchable is explicit.** The repo and publish target are required (the agent
   cannot proceed without them). The release process is researchable, so its enum leads with
   "Use your best judgment."
-- **No prefilled defaults.** The repo guess lives in the field description, not a default field.
-  The recommended enum choice is listed first.
+- **Proposals ride the `default` field.** The repo guess becomes the field `default` when a
+  prior read surfaces one; the recommended enum choice is set as the `default`, and the
+  built-in Other… covers off-list answers.
 - **The priors table proposes a setup** per release process, so the agent does not interrogate
   the user about the trigger and tools.
 - **The instructions template ends on the publish tool** and names each tool in order. It does

--- a/.agents/skills/write-template-playbooks/references/worked-example.md
+++ b/.agents/skills/write-template-playbooks/references/worked-example.md
@@ -17,17 +17,16 @@ changelog-writer. Also matches free-text asks about release notes, changelogs, o
 shipped" summaries from a repo.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub or GitLab repo to read merged PRs from. No default; the agent
-  cannot proceed without it. Description: "Recommended: <guess>" when a prior read
-  surfaced one.
+- Repository: which GitHub or GitLab repo to read merged PRs from; the agent cannot proceed
+  without it. Set the field default to the guess a prior read surfaced; no default otherwise.
 - Where release notes are published: the docs page, a Notion database, or a Linear
-  document. Offer these as an enum. First option: "Figure it out from what's connected."
+  document. Offer these as an enum with default "Figure it out from what's connected."
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - How the team releases: merge to main, GitHub releases, or release branches. The agent can
-  discover this by reading the repo. Enum first option: "Use your best judgment (I'll read
-  the repo)." Note in the description: handing this over is faster than the agent researching
-  it.
+  discover this by reading the repo. Enum with default "Use your best judgment (I'll read
+  the repo)"; the built-in Other… covers anything else. Note in the description: handing
+  this over is faster than the agent researching it.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub read tools (list merged PRs, get a PR).

--- a/docs/design/agent-workflows/projects/agent-templates/open-questions.md
+++ b/docs/design/agent-workflows/projects/agent-templates/open-questions.md
@@ -36,6 +36,8 @@ is click data. This avoids frontend tab work now and keeps the option open.
 
 **Decided: live with the workaround.** Enum-first "figure it out" plus guidance in descriptions. A real `default` field goes to Arda as a separate issue; playbooks adopt it when it ships.
 
+**Update (2026-07-11): shipped and adopted.** Issue #5190 landed in PR #5177 — real `default`, plus multi-select arrays and oneOf choice cards. The playbooks, the write-template-playbooks skill, and the playbook spec now use real defaults; the enum-first workaround is retired.
+
 **Context.** The elicitation form has no `default` field; a `default` in the schema is silently
 dropped ([research.md](research.md) Section 4, `elicitation.ts:56`). The playbooks want to
 propose values the user can accept or edit. Today they do it with an enum-first "figure it out"

--- a/docs/design/agent-workflows/projects/agent-templates/playbook-spec.md
+++ b/docs/design/agent-workflows/projects/agent-templates/playbook-spec.md
@@ -20,15 +20,16 @@ free-text asks that match no card.
 
 ## Required context (ask via one compact request_input form)
 - <field>: <why the agent cannot proceed without it>. [required]
-  Put the recommended value in the field description, not a default (there is no default
-  field): "press Enter to accept: <proposed value>".
+  When the agent can propose a value, set it as the field's `default` — the form prefills
+  and the user can accept everything in one click. No default when there is no basis for one.
 Only fields the agent genuinely cannot proceed without. Keep to one to four. Secrets never
 go here; they go to request_connection.
 
-## Researchable context (ask, but the first enum option is "figure it out")
-- <field>: the agent can discover this. Offer an enum whose FIRST option is
-  "Use your best judgment" or "Figure it out from what's connected." Note the trade-off in
-  the description: handing it over is faster than the agent researching it.
+## Researchable context (ask, defaulting to "figure it out")
+- <field>: the agent can discover this. Offer an enum including a "Use your best judgment"
+  or "Figure it out from what's connected" option and set it as the `default`; the built-in
+  Other… option covers custom values. Note the trade-off in the description: handing it over
+  is faster than the agent researching it.
 
 ## Explore first (read before proposing)
 - Which read tools to discover_tools and wire.
@@ -77,25 +78,27 @@ needs the user.
   cannot extract what is relevant. Keep it a coherent, moderately detailed unit with a working
   instructions template.
 
-## The request_input reality (no defaults)
+## The request_input dialect (defaults, multi-select, choice cards)
 
-The elicitation form has no `default` field (`ElicitationFieldSchema` declares `default?: never`,
-`web/packages/agenta-shared/src/utils/elicitation.ts:56`; see [research.md](research.md) Section
-4). A `default` in the schema is silently dropped and the field renders empty. So a playbook
-must not tell the agent to prefill. Instead:
+Resolved: [open-questions.md](open-questions.md) #2 shipped as issue #5190 (PR #5177). The
+elicitation form supports real defaults and two richer field shapes
+(`web/packages/agenta-shared/src/utils/elicitation.ts`; design record:
+`docs/design/agent-chat-interaction-kinds/decisions.md`):
 
-- **Put the proposed value in the field description or title.** For example: "press Enter to
-  accept: owner/repo-guess." The user sees the recommendation and can accept or edit it.
-- **Use enum options for researchable context, with "Figure it out" as the FIRST listed
-  option.** The first option reads as the recommended path. There is no way to mark it selected,
-  so listing it first is how a playbook signals the default choice.
-- **Field types are string, number, integer, boolean only.** No arrays, no nested objects, no
-  multi-select. Formats: date, date-time, email, uri, multiline.
+- **`default` prefills the field** (string/number/boolean; array of strings on a multi-select),
+  so a form whose proposals are right is accepted in one click. The default must match the
+  declared type. An empty default (`""`/`[]`) means "no proposal" and is stripped.
+  **Date/date-time fields ignore defaults** — do not set them there.
+- **Researchable context: set the "Figure it out" enum option as the `default`.** Enum options
+  are suggestions, not a hard constraint — every enum renders a built-in "Other…" free-text
+  escape hatch, so keep option lists short and likely.
+- **Multi-pick questions** use `{type: "array", items: {type: "string", enum: [...]}}` — the
+  one admitted array shape; the answer is an array of strings.
+- **Context-ful options** use `oneOf: [{const, title, description}]` (single fields and array
+  items); options with descriptions render as selectable choice cards.
+- **Field leaves are string, number, integer, boolean** (plus the string-array multi-select).
+  No nested objects. Formats: date, date-time, email, uri, multiline.
 - **Secrets are refused.** Credentials go through `request_connection`, never `request_input`.
-
-Whether to add a real `default` field to the elicitation protocol is
-[open-questions.md](open-questions.md) #2. Until it is decided, every playbook uses the
-enum-plus-description workaround.
 
 ## The index.md match table
 

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/engineering.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/engineering.py
@@ -23,15 +23,15 @@ changelog-writer. Also matches free-text asks about release notes, changelogs, o
 shipped" summaries from a repo.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub or GitLab repo to read merged PRs from. No default; the agent
-  cannot proceed without it. Description: "Recommended: <guess>" when a prior read
-  surfaced one.
+- Repository: which GitHub or GitLab repo to read merged PRs from. The agent cannot proceed
+  without it. Set the field default to the guess a prior read surfaced; leave no
+  default otherwise.
 - Where release notes are published: the docs page, a Notion database, or a Linear
-  document. Offer these as an enum. First option: "Figure it out from what's connected."
+  document. Offer these as an enum with default "Figure it out from what's connected."
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - How the team releases: merge to main, GitHub releases, or release branches. The agent can
-  discover this by reading the repo. Enum first option: "Use your best judgment (I'll read
+  discover this by reading the repo. Enum with default "Use your best judgment (I'll read
   the repo)." Note in the description: handing this over is faster than the agent researching
   it.
 
@@ -91,17 +91,17 @@ key pr-reviewer. Also matches free-text asks for automated code review or PR fee
 repo.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub or GitLab repo to review PRs on. No default; the agent cannot
-  proceed without it. Description: "Recommended: <guess>" when a prior read surfaced
-  one.
+- Repository: which GitHub or GitLab repo to review PRs on. The agent cannot proceed
+  without it. Set the field default to the guess a prior read surfaced; leave no
+  default otherwise.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Review posture: comment only (advisory) or request changes when tests are missing
-  (blocking). Enum first option: "Use your best judgment (advisory comments, no blocking)."
+  (blocking). Enum with default "Use your best judgment (advisory comments, no blocking)."
   Note the trade-off: blocking is stricter but can hold up a PR the agent misjudged.
 - What counts as risky: the agent can discover this from the diff (auth, secrets, migrations,
-  deletions). Enum first option: "Figure it out from the diff." Second option: a short list the
-  user types themselves.
+  deletions). Enum with default "Figure it out from the diff"; the built-in Other… option
+  covers a short list the user types themselves.
 
 ## Explore first (read before proposing)
 1. discover_tools for the PR read tools (get PR diff, list changed files, list existing review
@@ -156,14 +156,14 @@ issues." Card key issue-triage. Also matches free-text asks about issue routing 
 labeling.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub or GitLab repo to triage issues on. No default; the agent cannot
-  proceed without it. Description: "Recommended: <guess>" when a prior read surfaced
-  one.
+- Repository: which GitHub or GitLab repo to triage issues on. The agent cannot proceed
+  without it. Set the field default to the guess a prior read surfaced; leave no
+  default otherwise.
 
-## Researchable context (ask, but the first option is "figure it out")
-- Label taxonomy: which area and priority labels to use. Enum first option: "Figure it out
-  from the repo's existing labels." Second option: the user types a short list.
-- Owner assignment: how to pick who gets assigned. Enum first option: "Use your best judgment
+## Researchable context (ask, defaulting to "figure it out")
+- Label taxonomy: which area and priority labels to use. Enum with default "Figure it out
+  from the repo's existing labels"; Other… covers a typed short list.
+- Owner assignment: how to pick who gets assigned. Enum with default "Use your best judgment
   (read CODEOWNERS, or leave unassigned if there is none)." Note: handing over a mapping is
   faster than the agent researching it.
 
@@ -215,12 +215,12 @@ of a failing run." Card key ci-failure-triage. Also matches free-text asks about
 workflow runs or broken builds.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub repo's workflow runs to watch. No default; the agent cannot proceed
-  without it. Description: "Recommended: <guess>" when a prior read surfaced one.
+- Repository: which GitHub repo's workflow runs to watch. The agent cannot proceed without
+  it. Set the field default to the guess a prior read surfaced; leave no default otherwise.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Where to notify: a comment on the PR or commit tagging the author, or also a Slack channel if
-  Slack is connected. Enum first option: "Use your best judgment (comment on the PR or commit;
+  Slack is connected. Enum with default "Use your best judgment (comment on the PR or commit;
   add Slack only if it's already connected)." Slack and Discord are optional extensions here,
   not requirements: GitHub alone is enough to run.
 
@@ -272,15 +272,15 @@ The ask is "answer questions about our repo," "explain how this code works," or 
 code Q&A bot. Card key code-qa. Also matches free-text asks for a repo-grounded assistant.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub or GitLab repo to answer questions about. No default; the agent
-  cannot proceed without it. Description: "Recommended: <guess>" when a prior read
-  surfaced one.
+- Repository: which GitHub or GitLab repo to answer questions about. The agent cannot proceed
+  without it. Set the field default to the guess a prior read surfaced; leave no
+  default otherwise.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Where questions come in: a Slack channel mention or a GitHub issue/PR comment mention. Enum
-  first option: "Figure it out from what's connected." Note: handing this over is faster than
+  with default "Figure it out from what's connected." Note: handing this over is faster than
   the agent researching it.
-- Answer depth: cite exact files and lines, or give a higher-level summary. Enum first option:
+- Answer depth: cite exact files and lines, or give a higher-level summary. Enum with default
   "Use your best judgment (cite file paths and line numbers by default)."
 
 ## Explore first (read before proposing)
@@ -333,16 +333,16 @@ The ask is "summarize open dependency-update PRs," "weekly dependency digest," o
 key dependency-digest. Also matches free-text asks about tracking Dependabot or Renovate PRs.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub or GitLab repo to scan for dependency PRs. No default; the agent
-  cannot proceed without it. Description: "Recommended: <guess>" when a prior read
-  surfaced one.
+- Repository: which GitHub or GitLab repo to scan for dependency PRs. The agent cannot proceed
+  without it. Set the field default to the guess a prior read surfaced; leave no
+  default otherwise.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Where to post the digest: a Slack channel if connected, or a comment on a pinned tracking
-  issue otherwise. Enum first option: "Figure it out from what's connected." Slack is an
+  issue otherwise. Enum with default "Figure it out from what's connected." Slack is an
   optional extension here, not a requirement.
 - Which PRs count as dependency updates: detect by author (dependabot[bot], renovate[bot]) or by
-  label. Enum first option: "Use your best judgment (detect by author, then by label)."
+  label. Enum with default "Use your best judgment (detect by author, then by label)."
 
 ## Explore first (read before proposing)
 1. discover_tools for the PR list tool (filterable by author or label) and the get-PR tool.

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/knowledge.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/knowledge.py
@@ -21,16 +21,16 @@ base" agent for teammates (not customers; see knowledge-chatbot for a customer-f
 
 ## Required context (ask via one request_input form)
 - Channel to answer @mentions in: which Slack channel(s) the agent should listen in and reply
-  in. No default; the agent cannot know this. Description: "Recommended: #<guess>" if one
-  was mentioned.
+  in. The agent cannot know this; set the field default to a channel a prior read surfaced,
+  and leave no default otherwise.
 - What counts as "the docs": the Notion space or top-level pages to search, if the connected
   workspace holds more than docs (product specs, meeting notes, and so on). Description:
   "Leave empty to search the whole connected workspace."
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Additional sources beyond Notion: also search Confluence, Google Drive, or Slack history if
-  connected. Enum first option: "Figure it out from what's connected." Note: naming sources now
-  saves a research pass.
+  connected. Multi-select ({type: "array", items: {type: "string", enum: [...]}}) with default
+  ["Figure it out from what's connected"]. Note: naming sources now saves a research pass.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Notion search and page-read tools (and Confluence/Drive/Slack reads
@@ -90,9 +90,9 @@ teammate-only bot, see docs-qa instead).
   excluding anything internal-only. Description: "Leave empty to search the whole connected
   workspace" if there is no internal/external split.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Tone: match the brand voice found in existing customer-facing pages, or a plain, neutral
-  tone. Enum first option: "Figure it out from the docs I find."
+  tone. Enum with default "Figure it out from the docs I find."
 
 ## Explore first (read before proposing)
 1. discover_tools for the Notion search/fetch tools and the reply tool for the chosen platform
@@ -150,11 +150,12 @@ this one).
   #onboarding or #new-hires channel). No default; the agent cannot know this.
 - Which wiki counts as "the internal wiki": the Notion or Confluence space to search, if the
   workspace holds more than onboarding content. Description: "Leave empty to search the whole
-  connected workspace" as the proposed default.
+  connected workspace."
 
-## Researchable context (ask, but the first option is "figure it out")
-- Which topics to prioritize (benefits, tools setup, team structure). Enum first option:
-  "Figure it out from what the wiki covers."
+## Researchable context (ask, defaulting to "figure it out")
+- Which topics to prioritize (benefits, tools setup, team structure): a multi-pick, so use
+  multi-select ({type: "array", items: {type: "string", enum: [...]}}) with default
+  ["Figure it out from what the wiki covers"].
 
 ## Explore first (read before proposing)
 1. discover_tools for the Notion (or Confluence) search and page-read tools.
@@ -206,14 +207,16 @@ key content-repurposer. Matches free-text asks to repurpose a blog post, doc, or
 entry into social copy (this is a one-shot transform, not a standing Q&A bot).
 
 ## Required context (ask via one request_input form)
-- Source doc: the Notion page or Google Drive doc to repurpose. No default; the agent cannot
-  proceed without it. Description: "Recommended: <guess>" if a prior read surfaced one.
-- Where to post drafts for review: a Slack channel or a Notion draft page. Offer as an enum,
-  first option "Figure it out from what's connected."
+- Source doc: the Notion page or Google Drive doc to repurpose. The agent cannot proceed
+  without it. Set the field default to the doc a prior read surfaced; leave no default
+  otherwise.
+- Where to post drafts for review: a Slack channel or a Notion draft page. Offer as an enum
+  with default "Figure it out from what's connected."
 
-## Researchable context (ask, but the first option is "figure it out")
-- Which platforms to draft for (LinkedIn, X, or both). Enum first option: "Figure it out, draft
-  both."
+## Researchable context (ask, defaulting to "figure it out")
+- Which platforms to draft for (LinkedIn, X, or both): a multi-pick, so use multi-select
+  ({type: "array", items: {type: "string", enum: ["LinkedIn", "X"]}}) with default
+  ["LinkedIn", "X"] (draft both).
 
 ## Explore first (read before proposing)
 1. discover_tools for the source-read tool (Notion or Drive) and the draft-post tool (Slack
@@ -261,10 +264,12 @@ newsletter draft (for a Slack-only digest with no draft doc, see repo-slack-dige
 - Where to draft the newsletter: which Notion page or database to write the weekly draft into.
   No default; the agent cannot know this.
 
-## Researchable context (ask, but the first option is "figure it out")
-- Which sources to pull from: GitHub merged PRs, Linear completed issues, or both. Enum first
-  option: "Figure it out from what's connected."
-- Send day/time: default Monday 09:00 local. Enum first option: "Use Monday 09:00 local."
+## Researchable context (ask, defaulting to "figure it out")
+- Which sources to pull from: GitHub merged PRs, Linear completed issues, or both. A
+  multi-pick, so use multi-select ({type: "array", items: {type: "string", enum: [...]}})
+  with default ["Figure it out from what's connected"].
+- Send day/time: enum with default "Monday 09:00 local"; the built-in Other… option covers a
+  custom time.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub (merged PRs) and/or Linear (completed issues) read tools, and

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/monitoring.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/monitoring.py
@@ -25,14 +25,14 @@ incident-responder. Also matches free-text asks about incident response, alert t
 "who do I page for this."
 
 ## Required context (ask via one request_input form)
-- Sentry project or org to watch: no default; the agent cannot proceed without it.
-  Description: "Recommended: <guess>" when a prior read surfaced one.
+- Sentry project or org to watch: the agent cannot proceed without it. Set the
+  field default to the guess a prior read surfaced; leave no default otherwise.
 - Where to send alerts: the Slack channel to post to, and/or the PagerDuty escalation policy
   to page. No default; the agent cannot know who is on call or where the team looks for
   alerts without being told.
 
-## Researchable context (ask, but the first option is "figure it out")
-- Paging threshold: which severities actually page vs. just get logged. Enum first option:
+## Researchable context (ask, defaulting to "figure it out")
+- Paging threshold: which severities actually page vs. just get logged. Enum with default
   "Use your best judgment (page on fatal/error, log the rest)." Note in the description:
   handing this over is faster than the agent inferring it from issue history.
 
@@ -92,14 +92,14 @@ Card key error-triage. Also matches free-text asks about error noise reduction o
 file a ticket for this error."
 
 ## Required context (ask via one request_input form)
-- Sentry project or org to watch: no default; the agent cannot proceed without it.
-  Description: "Recommended: <guess>" when a prior read surfaced one.
+- Sentry project or org to watch: the agent cannot proceed without it. Set the
+  field default to the guess a prior read surfaced; leave no default otherwise.
 - Where new tickets go: a Linear team or a Jira project. No default; the agent cannot guess
   the filing destination.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - What counts as noise vs. a real error: known third-party or expected exceptions to ignore,
-  and the frequency that promotes an error to "file it." Enum first option: "Use your best
+  and the frequency that promotes an error to "file it." Enum with default "Use your best
   judgment (ignore known-noisy exceptions, file anything crossing a frequency threshold)."
 
 ## Explore first (read before proposing)
@@ -152,14 +152,14 @@ The ask is "post a daily uptime and error-rate summary to Slack" or similar. Car
 uptime-reporter. Also matches free-text asks about a daily status digest or an SLA rollup.
 
 ## Required context (ask via one request_input form)
-- Sentry project or org to summarize: no default; the agent cannot proceed without it.
-  Description: "Recommended: <guess>" when a prior read surfaced one.
+- Sentry project or org to summarize: the agent cannot proceed without it. Set the
+  field default to the guess a prior read surfaced; leave no default otherwise.
 - Slack channel to post the daily summary to: no default; the agent cannot guess where the
   team wants it.
 
-## Researchable context (ask, but the first option is "figure it out")
-- Whether to include an uptime percentage from Datadog or New Relic, if connected. Enum first
-  option: "Use your best judgment (include it if connected, otherwise report error rate
+## Researchable context (ask, defaulting to "figure it out")
+- Whether to include an uptime percentage from Datadog or New Relic, if connected. Enum with
+  default "Use your best judgment (include it if connected, otherwise report error rate
   only)." Note in the description: this is a CHECK integration, so treat it as optional.
 
 ## Explore first (read before proposing)
@@ -215,14 +215,14 @@ key oncall-briefer. Also matches free-text asks about an on-call handoff briefin
 incident standup.
 
 ## Required context (ask via one request_input form)
-- Sentry project or org to watch: no default; the agent cannot proceed without it.
-  Description: "Recommended: <guess>" when a prior read surfaced one.
+- Sentry project or org to watch: the agent cannot proceed without it. Set the
+  field default to the guess a prior read surfaced; leave no default otherwise.
 - Where to post the briefing: a Slack channel or DM, and, if PagerDuty is connected, which
   escalation policy to read on-call from. No default; the agent cannot guess either.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - How far back "open" reaches: all unresolved Sentry issues, or only ones touched in the last
-  24 hours. Enum first option: "Use your best judgment (all unresolved issues, plus any open
+  24 hours. Enum with default "Use your best judgment (all unresolved issues, plus any open
   PagerDuty incidents if connected)."
 
 ## Explore first (read before proposing)

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/ops.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/ops.py
@@ -23,11 +23,11 @@ Slack or Discord channel since yesterday.
 - Source channel: which Slack (or Discord) channel to summarize. No default; the agent
   cannot proceed without it.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Destination channel: post the digest back into the source channel, or to a separate
-  #standup channel. Enum first option: "Same channel as the one being summarized."
-- Post time: local time to send the digest. Enum first option: "09:00 local (default)."
-  Note: handing over an exact time is faster than guessing.
+  #standup channel. Enum with default "Same channel as the one being summarized."
+- Post time: local time to send the digest. Enum with default "09:00 local"; the built-in
+  Other… option covers an exact custom time.
 - Local timezone: needed to convert the daily post time into a UTC cron. Description:
   "e.g. America/New_York. Leave empty to use UTC."
 
@@ -84,16 +84,17 @@ Card key repo-slack-digest. Also matches free-text asks for a periodic repo acti
 sent to a channel.
 
 ## Required context (ask via one request_input form)
-- Repository: which GitHub (or GitLab) repo to read activity from. No default; the agent
-  cannot proceed without it. Description: "Recommended: <guess>"
-  when a prior read surfaced one.
+- Repository: which GitHub (or GitLab) repo to read activity from. The agent cannot proceed
+  without it. Set the field default to the guess a prior read surfaced; leave no default
+  otherwise.
 - Destination channel: which Slack (or Discord) channel to post the digest to. No default.
 
-## Researchable context (ask, but the first option is "figure it out")
-- What to include: new issues, commits, and PRs, or a subset. Enum first option: "Include
-  all three (issues, commits, PRs)."
-- Digest times: local times to post, twice a day. Enum first option: "09:00 and 17:00 local
-  (default)." Note: handing over exact times is faster than guessing.
+## Researchable context (ask, defaulting to "figure it out")
+- What to include: new issues, commits, and PRs, or a subset. A multi-pick, so use
+  multi-select ({type: "array", items: {type: "string", enum: ["issues", "commits", "PRs"]}})
+  with default ["issues", "commits", "PRs"] (all three).
+- Digest times: local times to post, twice a day. Enum with default "09:00 and 17:00 local";
+  the built-in Other… option covers exact custom times.
 
 ## Explore first (read before proposing)
 1. discover_tools for the repo-read tools (list issues, list commits, list pull requests)
@@ -155,12 +156,12 @@ mirroring issues, tickets, or records between two systems.
 - Destination: which tool and identifier to write mirrored records to (for example, a Notion
   database URL, a Confluence space). No default.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Sync cadence: polling on a schedule, or event-driven if the source supports a webhook.
-  Enum first option: "Use your best judgment (hourly schedule is simplest and most
+  Enum with default "Use your best judgment (hourly schedule is simplest and most
   reliable)."
-- Field mapping: which source fields map to which destination properties. Enum first
-  option: "Use your best judgment based on the destination's existing schema."
+- Field mapping: which source fields map to which destination properties. Enum with
+  default "Use your best judgment based on the destination's existing schema."
 
 ## Explore first (read before proposing)
 1. discover_tools for the source-read tool (list issues) and the destination-write tool
@@ -218,11 +219,12 @@ doc or channel.
 - Destination: which Notion page or database (or Slack channel) to publish the report to.
   No default.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Metrics scope: shipping activity only, or shipping plus product metrics from PostHog.
-  Enum first option: "Use your best judgment: include PostHog only if it's connected,
+  Enum with default "Use your best judgment: include PostHog only if it's connected,
   otherwise shipping activity only."
-- Report time: default weekly send time. Enum first option: "Monday 09:00 local (default)."
+- Report time: enum with default "Monday 09:00 local"; the built-in Other… option covers a
+  custom time.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub read tools (list merged PRs, list commits), the Linear read

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/sales.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/sales.py
@@ -23,17 +23,17 @@ The ask is "enrich and qualify new inbound leads" or "add qualified leads to Hub
 Card key lead-qualifier. Also matches free-text asks about scoring or triaging new leads.
 
 ## Required context (ask via one request_input form)
-- CRM destination: which pipeline or list qualified leads get added to. No default; the agent
-  cannot proceed without it. Description: "Recommended: <guess>" when a prior read
-  surfaced one.
+- CRM destination: which pipeline or list qualified leads get added to. The agent cannot
+  proceed without it. Set the field default to the guess a prior read surfaced; leave no
+  default otherwise.
 - Qualification criteria: what makes a lead qualified (company size, industry, budget signal).
   Multiline. No default; this is the user's business judgment.
 
-## Researchable context (ask, but the first option is "figure it out")
-- Lead source: which inbox, form, or CRM webhook produces new leads. Enum first option:
+## Researchable context (ask, defaulting to "figure it out")
+- Lead source: which inbox, form, or CRM webhook produces new leads. Enum with default
   "Figure it out from what's connected." Note: handing this over is faster than researching it.
-- Enrichment depth: a quick domain lookup or deeper company research per lead. Enum first
-  option: "Use your best judgment (quick lookup, deepen only for borderline leads)."
+- Enrichment depth: a quick domain lookup or deeper company research per lead. Enum with
+  default "Use your best judgment (quick lookup, deepen only for borderline leads)."
 
 ## Explore first (read before proposing)
 1. discover_tools for the CRM read/write tools (get contact, create contact) and, if the lead
@@ -86,10 +86,10 @@ threads each day." Card key crm-updater. Also matches free-text asks about stale
 - CRM target and scope: which CRM (HubSpot, Salesforce, or Attio) and which list or pipeline of
   contacts to consider. No default; the agent cannot proceed without it.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - What counts as update-worthy: a new title, company change, or a mentioned next step, versus a
-  fixed field list. Enum first option: "Use your best judgment from what the thread says."
-- Unknown senders: skip them, or flag as a possible new contact for review. Enum first option:
+  fixed field list. Enum with default "Use your best judgment from what the thread says."
+- Unknown senders: skip them, or flag as a possible new contact for review. Enum with default
   "Figure it out (flag likely prospects, skip the rest)."
 
 ## Explore first (read before proposing)
@@ -141,10 +141,10 @@ outreach-drafter. Also matches free-text asks about cold email drafts or sequenc
 - Contact list or segment: which CRM view, list name, or filter to draft outreach for. No
   default; the agent cannot proceed without it.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Angle or value prop: the agent can infer this from each contact's company and role. Enum
-  first option: "Figure it out per contact from their company and role."
-- Draft destination: Gmail drafts, or returned as text. Enum first option: "Figure it out from
+  with default "Figure it out per contact from their company and role."
+- Draft destination: Gmail drafts, or returned as text. Enum with default "Figure it out from
   what's connected (Gmail drafts if connected, else text)."
 
 ## Explore first (read before proposing)
@@ -197,12 +197,12 @@ Card key meeting-followup. Also matches free-text asks about post-call recaps or
 ## Required context (ask via one request_input form)
 - Meeting signal: how the agent should learn a meeting happened. Offer as an enum: a Google
   Calendar event ending, a recap or notes email landing in Gmail, or you mentioning a meeting by
-  name. No default; the trigger depends on it. Description: propose "recap email in Gmail" if no
-  calendar is connected yet.
+  name. The trigger depends on it. Default to "recap email in Gmail" when no calendar is
+  connected yet; otherwise leave no default.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Follow-up depth: a short thank-you-plus-next-steps note, or a fuller recap with agenda items.
-  Enum first option: "Figure it out from the notes (short if sparse, fuller if detailed)."
+  Enum with default "Figure it out from the notes (short if sparse, fuller if detailed)."
 
 ## Explore first (read before proposing)
 1. discover_tools for the Gmail read and create-draft tools, plus Google Calendar and the CRM
@@ -249,14 +249,14 @@ The ask is "post a daily digest of pipeline changes and stale deals to Slack" or
 key pipeline-digest. Also matches free-text asks about a deals summary or pipeline health check.
 
 ## Required context (ask via one request_input form)
-- Slack channel: where the digest posts. No default; the agent cannot proceed without it.
-  Description: "Recommended: <guess>" when a prior read surfaced one.
+- Slack channel: where the digest posts. The agent cannot proceed without it. Set the field
+  default to the guess a prior read surfaced; leave no default otherwise.
 - Pipeline: which CRM pipeline to summarize, if the CRM has more than one. No default when more
   than one pipeline exists.
 
-## Researchable context (ask, but the first option is "figure it out")
-- Stale threshold: how many days without activity marks a deal stale. Enum first option:
-  "Use your best judgment (14 days)." Second option: the user types a number.
+## Researchable context (ask, defaulting to "figure it out")
+- Stale threshold: how many days without activity marks a deal stale. Enum with default
+  "Use your best judgment (14 days)"; the built-in Other… option covers a custom number.
 
 ## Explore first (read before proposing)
 1. discover_tools for the CRM list-deals tool and the Slack post-message tool.

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/support.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/support.py
@@ -21,14 +21,14 @@ key support-triage. Also matches free-text asks about watching a support channel
 ticket urgency, or routing threads to the right person.
 
 ## Required context (ask via one request_input form)
-- Support channel: which Slack (or Discord) channel to watch. Description: "Recommended:
-  <guess>" when a prior read surfaced one.
+- Support channel: which Slack (or Discord) channel to watch. Set the field default to the
+  guess a prior read surfaced; leave no default otherwise.
 - Owners and their areas: who routes get sent to, and what each owns. No default; the agent
   cannot invent your team's routing.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Urgency scale: how many tiers (for example urgent/normal/low) and what counts as urgent.
-  Enum first option: "Use your best judgment (I'll propose a 3-tier scale)." Note in the
+  Enum with default "Use your best judgment (I'll propose a 3-tier scale)." Note in the
   description: handing this over is faster than the agent inferring it from past threads.
 
 ## Explore first (read before proposing)
@@ -87,16 +87,16 @@ support-reply-drafter. Also matches free-text asks about auto-drafting ticket re
 answering tickets from a knowledge base.
 
 ## Required context (ask via one request_input form)
-- Ticket source: which Zendesk (or Intercom) instance to watch for new tickets. Description:
-  "Recommended: <guess>" when a prior read surfaced one.
+- Ticket source: which Zendesk (or Intercom) instance to watch for new tickets. Set the field
+  default to the guess a prior read surfaced; leave no default otherwise.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Knowledge source: where answers come from (Notion, Confluence, Google Drive, or the ticket
-  system's own help center). Enum first option: "Figure it out from what's connected." These
+  system's own help center). Enum with default "Figure it out from what's connected." These
   are optional extensions, not required to run; without one the agent drafts from ticket
   history alone and says so.
-- Draft posture: draft-only for review, or auto-send for high-confidence matches. Enum first
-  option: "Use your best judgment (draft-only until you say otherwise)."
+- Draft posture: draft-only for review, or auto-send for high-confidence matches. Enum with
+  default "Use your best judgment (draft-only until you say otherwise)."
 
 ## Explore first (read before proposing)
 1. discover_tools for the ticket read tools (get ticket, list tickets) and, if connected, the
@@ -156,11 +156,11 @@ Slack or Intercom messages into filed bugs, or being mentioned to file one.
 
 ## Required context (ask via one request_input form)
 - Bug tracker and project: which Linear team, Jira project, or GitHub repo new tickets go to.
-  Description: "Recommended: <guess>" when a prior read surfaced one.
+  Set the field default to the guess a prior read surfaced; leave no default otherwise.
 
-## Researchable context (ask, but the first option is "figure it out")
+## Researchable context (ask, defaulting to "figure it out")
 - Repro-steps extraction: whether to ask the reporter follow-up questions when steps are
-  missing, or file with what is given. Enum first option: "Use your best judgment (ask once
+  missing, or file with what is given. Enum with default "Use your best judgment (ask once
   if repro steps are missing, then file anyway)."
 
 ## Explore first (read before proposing)
@@ -220,13 +220,13 @@ similar. Card key feedback-clusterer. Also matches free-text asks about summariz
 trends or grouping complaints by topic.
 
 ## Required context (ask via one request_input form)
-- Feedback source: which Slack channel (or Intercom inbox) to read feedback from.
-  Description: "Recommended: <guess>" when a prior read surfaced one.
+- Feedback source: which Slack channel (or Intercom inbox) to read feedback from. Set the
+  field default to the guess a prior read surfaced; leave no default otherwise.
 - Where clusters are logged: a Notion database or page. No default; the agent cannot invent
   where you track this.
 
-## Researchable context (ask, but the first option is "figure it out")
-- Clustering granularity: broad themes (3-5) or fine-grained topics. Enum first option: "Use
+## Researchable context (ask, defaulting to "figure it out")
+- Clustering granularity: broad themes (3-5) or fine-grained topics. Enum with default "Use
   your best judgment (I'll propose 3-5 themes from a sample day)." Note in the description:
   handing this over is faster than the agent researching your past feedback volume.
 

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -605,6 +605,11 @@ Do not discover tools or triggers for an ask that does not need them.
    criteria. Do not guess concrete destinations. When you need typed values the user must
    confirm — which actions to enable, non-secret settings such as a subdomain or workspace,
    schedule details — ask with `request_input` (renders an inline form) instead of prose.
+   Propose a `default` for every field you can — the form prefills, and the user accepts
+   everything in one click when your proposals are right. Enum options are suggestions (the
+   form has a built-in "Other…" escape hatch), so keep them short and likely. Use
+   `{type: "array", items: {type: "string", enum: [...]}}` for a multi-pick question, and
+   `oneOf: [{const, title, description}]` when options need a sentence of explanation.
    Never request secrets through it; credentials go through `request_connection`.
 2. Decide from the table. Most agents need only instructions. If the ask needs outside actions,
    call `discover_tools` with one short fragment per capability, such as "list github issues" or


### PR DESCRIPTION
## Context

The stated follow-up of #5190 (shipped in #5177): the elicitation form now supports a real `default` per field, multi-select arrays, and `oneOf` choice cards — but the template playbooks still taught the pre-#5190 workarounds ("Recommended: <guess>" in descriptions, first-enum-option-as-default). Until this lands, builder agents never author the shapes the form can render.

## What changes

- **All 28 playbooks** (engineering/knowledge/monitoring/ops/sales/support): proposed values become field `default`s (one-click accept); researchable enums set "Figure it out" **as** the default and rely on the built-in Other… escape hatch; fields already implying multiplicity use `{type: "array", items: {type: "string", enum: [...]}}`. Bodies stay within the 1–2 KB budget (largest drift +3%).
- **write-template-playbooks skill**: platform fact #1 flipped (defaults exist — use them; must match the field type; empty defaults stripped; date fields ignore them), skeleton, prompting checklist and worked example updated.
- **playbook-spec.md**: the "no defaults" reality section replaced with the shipped dialect; open-questions #2 closed as shipped-and-adopted.
- **build-an-agent skill, loop step 1**: the builder is now told at the decisive prompt position to propose defaults, treat enum options as suggestions, and reach for multi-select/`oneOf` when the question calls for them.

## Tests

- api `test_static_catalog`: 41 pass (skill-body pins intact)
- sdk `test_agenta_builtins_reference_files`: 22 pass (no test pinned the old workaround text)
- ruff format + check clean

## What to QA

Build an agent from any template card: the clarify form should arrive prefilled (accept-in-one-click when the proposals are right), researchable questions should default to "figure it out", and multi-pick questions (e.g. newsletter sources, digest contents) should render as chip pickers.