### PR TITLE
[5173] docs(design): plan — surface gateway tool-resolution failures and stop one dead tool bricking the agent

### DIFF
--- a/docs/design/agent-workflows/projects/gateway-tool-resolution/README.md
+++ b/docs/design/agent-workflows/projects/gateway-tool-resolution/README.md
@@ -1,0 +1,28 @@
+# Gateway tool resolution: surface failures, stop one dead tool bricking the agent
+
+Planning workspace for issues [#5173](https://github.com/Agenta-AI/agenta/issues/5173)
+and [#5174](https://github.com/Agenta-AI/agenta/issues/5174), and QA finding F-019.
+
+One stale Composio action takes down a whole agent, and the error the user sees names
+only an HTTP status. This workspace plans two independently shippable fixes: surface the
+resolver's real error detail end to end, and stop a single unresolvable tool from failing
+the entire turn.
+
+## Files
+
+- `context.md` — why this work exists, the incident, goals and non-goals.
+- `research.md` — the verified failure chain through the code, file by file, with the
+  exact swallow point and the run lifecycle.
+- `design.md` — the three decisions (surface the detail, the failure policy, the
+  relationship to #5174) with options and honest trade-offs.
+- `plan.md` — phased execution: the contained fix first, then the resilience change, then
+  the deferred config-health surface.
+- `status.md` — current state, open questions, decisions log. Source of truth for progress.
+
+## Recommended direction (one line)
+
+Ship the surfacing fix now (read the resolve response body in the SDK, name the failing
+tool in the run error), then make resolution resilient by dropping only genuinely-absent
+actions with a loud warning while keeping connection and auth failures fatal.
+</content>
+</invoke>

--- a/docs/design/agent-workflows/projects/gateway-tool-resolution/context.md
+++ b/docs/design/agent-workflows/projects/gateway-tool-resolution/context.md
@@ -1,0 +1,73 @@
+# Context
+
+## The incident
+
+Last night's QA run (E2 local, `pi_core`, Composio gateway tools) hit a committed agent
+config that referenced the Composio action `github/COMMIT_MULTIPLE_FILES`. That action no
+longer exists in the Composio catalog. The other four GitHub actions on the same config
+resolved fine, and the connection was healthy.
+
+Every turn on that config failed in about six seconds. The only thing the user saw was:
+
+```
+Gateway tool resolution failed (HTTP 404)
+```
+
+No mention of which tool broke, no mention that a specific tool was even the cause. The
+run died before the model ran, so nothing happened.
+
+The failing trace is `ac4459f96920599d49a710f2c92ed764`. `POST /api/tools/resolve` returned
+`404 {"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"}`. The response
+body named the dead action precisely. The user never saw that sentence.
+
+This is QA finding F-019, and it reproduces the two problems that issues #5173 and #5174
+describe from a separate self-hosted incident (a Slack agent whose
+`DOWNLOAD_SLACK_FILE` tool 404s at resolve time).
+
+## The two problems
+
+**1. The failure is opaque.** The backend produces a precise error and puts it in the HTTP
+response body. The SDK reads only the status code and throws the body away. The run error,
+and therefore the UI, shows a bare `HTTP 404`. A user cannot tell which tool is at fault or
+why. Diagnosing the incident required backend access: reading the saved config out of
+Postgres and probing each action slug against Composio by hand.
+
+**2. Resolution is all-or-nothing.** The agent's whole tool set resolves together. One
+unresolvable tool fails the entire resolution, so the agent cannot run at all, even though
+its other tools are valid. One stale action disables the whole agent.
+
+## Why it matters
+
+Composio catalog drift is routine. An action that was valid when an agent was built can
+disappear later. Today that bricks the committed agent with an unactionable error, and the
+only recovery is backend surgery. Both problems compound: the run fails completely, and the
+one message that would let a user fix it is hidden.
+
+## The relationship to #5174
+
+Issue #5174 is the root cause of how a dead action reaches a committed config in the first
+place: Agenta's discover path and its resolve path ask Composio about tools under different
+implicit toolkit-version scopes, so discovery can surface a tool that resolve and execute
+cannot find. That is a real and separate fix (validate-on-discover, version pinning).
+
+This workspace handles the symptom, which is needed regardless of #5174. Even with discover
+and resolve perfectly aligned, a committed agent still rots when Composio removes an action
+during the agent's lifetime. Symptom-handling is not optional. See `design.md` decision D3.
+
+## Goals
+
+- The run error names the failing tool and the real reason, end to end, from the API
+  response body through the SDK exception to the run error the UI shows.
+- One unresolvable tool does not, by itself, take down an agent that has other working
+  tools, where the failure is a genuinely-absent action.
+- The fixes land at the right layer. Error surfacing and run-time policy live in the SDK
+  and the resolve contract, not in core-API special cases for specific tools.
+
+## Non-goals
+
+- Fixing the discover-versus-resolve version drift itself. That stays with #5174.
+- A general retry or circuit-breaker for provider outages. This is about a tool that is
+  permanently gone, not a flaky provider.
+- Building the full config-level tool-health UI. This workspace scopes it and defers it
+  (design.md D2, option C).
+</content>

--- a/docs/design/agent-workflows/projects/gateway-tool-resolution/design.md
+++ b/docs/design/agent-workflows/projects/gateway-tool-resolution/design.md
@@ -1,0 +1,171 @@
+# Design
+
+Three decisions. D1 surfaces the resolver's error detail end to end. D2 chooses what a run
+does when one tool of several fails to resolve. D3 settles whether the discover-resolve
+drift from #5174 belongs here.
+
+## D1: Surface the resolver's error detail end to end
+
+### The problem, restated
+
+The backend already produces the useful sentence and puts it in the HTTP response body
+(`{"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"}`). The SDK reads
+only the status code and discards the body (research.md step 3). So this is not a missing
+message. It is a message that gets thrown away one hop before the user.
+
+### The fix
+
+In `gateway.py`, when the resolve response is a non-2xx, read the body, pull `detail` out of
+the FastAPI error envelope, and carry it on the exception. The run error then reads, for
+example:
+
+```
+Gateway tool resolution failed: Action not found: composio/github/COMMIT_MULTIPLE_FILES (HTTP 404)
+```
+
+instead of the bare `HTTP 404`.
+
+### Interface shape (design-interfaces review)
+
+The new information is a **diagnostic metadata** field: a human-facing reason string that
+travels from the server to the SDK exception to the run error. It is not routing, not
+policy, not credentials, not config. Classify and name it accordingly.
+
+- Add a `detail: Optional[str]` field to `ToolResolutionError` (sdks tools/errors.py),
+  alongside the existing `status`, `ref_count`, `reference`. The name mirrors the HTTP body
+  field and the backend exception messages, so the vocabulary stays consistent across the
+  boundary.
+- Fold `detail` into the exception's message string so any caller that only prints the
+  exception still shows it. Keep the structured field too, for callers that format richly.
+- Guard the read. If the body is not JSON, or has no `detail`, fall back to a bounded slice
+  of `response.text`. Cap the length so a stray HTML error page cannot flood the run error.
+
+### Trade-offs and risks
+
+- This leaks whatever the resolve endpoint chose to put in `detail`. Today that is catalog
+  and connection messages, which are safe. The guard should keep it to `detail` plus a
+  bounded text fallback, not the whole body, so a future endpoint change cannot turn this
+  into an accidental data channel.
+- With today's fail-on-first-bad-ref backend, the 404 body names exactly one action even
+  when two are dead. That is fine for D1 on its own. Naming every failing tool at once
+  needs the structured per-reference errors from D2.
+
+### Layer check
+
+This is squarely an SDK fix (read the body you already receive). It respects the repo rule
+that agent-facing failures get handled at the SDK layer, not with a core-API special case.
+The backend already does the right thing.
+
+## D2: What a run does when one tool of several fails to resolve
+
+This is the policy question. Three options, most contained first.
+
+### Option A: Fail the turn, but with a clear, named error
+
+Keep resolution all-or-nothing. Apply only D1, so the failure now names the tool and the
+reason. Simplest possible change. One dead tool still stops the agent, but the user learns
+exactly which tool to remove and why, from the run error alone, with no backend access.
+
+- Pro: tiny, safe, no contract change. Fully addresses problem 1 (opacity).
+- Pro: no silent capability loss. The run either works with all its tools or fails loudly.
+- Con: does not address problem 2. A stale action still bricks a committed agent until a
+  human edits the config. For an agent running unattended, that is an outage until someone
+  notices.
+
+### Option B: Resolve the survivors, drop the dead tool, warn loudly
+
+Resolve the tools that resolve, drop the ones that do not, run the turn with the survivors,
+and surface a prominent, non-fatal warning that names each dropped tool and why. The agent
+keeps working with its good tools.
+
+This needs a contract change. `POST /tools/resolve` stops failing the batch on the first bad
+reference. It returns the resolved specs plus a per-reference list of failures (reference,
+status, reason). The backend `resolve_tools` collects outcomes instead of raising on the
+first. The SDK builds specs for the survivors and threads the failures into the run as a
+visible warning, not an exception.
+
+Not every failure should be dropped. Classify by kind:
+
+- **Genuinely-absent action** (404 action-not-found): safe to drop. The tool does not exist;
+  there is nothing to fix in the connection. Drop it and warn.
+- **Connection or auth failure** (connection missing, inactive, invalid): do not drop. This
+  is an actionable state the user must fix, and silently continuing hides a problem the user
+  can and should resolve. Keep these fatal, with D1's clear message.
+- **Provider or network error** (5xx, timeout): keep fatal. This is transient, not a dead
+  tool. Dropping a tool because the provider blipped would hide the outage and silently
+  change the agent's capability for that turn.
+
+The visible warning matters. A dropped tool is a silent capability change: the model may
+need the tool and now cannot call it, producing a subtly wrong answer with no hard error. So
+the warning has to be loud and it has to reach the model, not just the human. Per the repo
+rule, telling the model "the tool X was unavailable this turn" belongs in the run context or
+a system note the SDK injects, not in a core-API behavior change. The backend contract change
+is a general partial-resolution contract, not a special case for a named tool, so it is a
+legitimate contract, not an agent-guidance special case.
+
+- Pro: directly fixes problem 2. A committed agent survives one rotted tool.
+- Pro: the drop is scoped to the one failure kind where dropping is unambiguously correct.
+- Con: silent capability loss is a real hazard. The warning design carries the weight, and a
+  warning is easier to ignore than an error. Getting it in front of both the model and the
+  user is the hard part, not the resolution change.
+- Con: a contract change on `/tools/resolve` (response gains a per-reference failure list)
+  plus SDK and run-context work. Larger than A.
+
+### Option C: Surface tool health where the agent is configured
+
+Resolve the config's tools at commit or edit time and flag dead tools in the UI, so the user
+sees a broken tool before any run. Runs then either fail fast (A) or drop-and-warn (B), but
+the user already knew which tool was dead.
+
+- Pro: best user experience. The problem shows up where the user can fix it, not mid-run.
+- Pro: overlaps naturally with #5174's validate-on-discover, so the two can share one
+  "is this action resolvable" check.
+- Con: largest surface. It needs a validation endpoint (or reuse of resolve) plus frontend
+  work on the agent config screen. It is a project of its own.
+
+### Recommendation
+
+Layer A, then B, and defer C.
+
+- Ship **A** first as the contained, safe fix. It fully closes the opacity problem and needs
+  no contract change. It is valuable on its own and unblocks nothing.
+- Follow with **B**, scoped so only a genuinely-absent action is dropped, with connection,
+  auth, and provider failures staying fatal, and with a loud warning that reaches both the
+  model and the user. This closes the all-or-nothing problem for the one case where dropping
+  is clearly right, without pretending a broken connection is fine.
+- **Defer C** to a follow-up. It is the best UX but it is a frontend and validation-surface
+  project, and it depends on the same resolvability check #5174 introduces. Scope it here,
+  build it there.
+
+## D3: Does the #5174 discover-resolve drift belong in this plan?
+
+No. Keep it separate. Cross-link the two.
+
+### Why separate
+
+- #5174 is a **root-cause** fix: discover and resolve ask Composio under different implicit
+  version scopes, so discovery surfaces actions that resolve cannot find. Its remedy is
+  validate-on-discover, explicit version pinning, and version as part of tool identity. That
+  is a large, self-contained surface with its own contract and data-model changes.
+- #5173 and F-019 are **symptom-handling**: surface the failure and stop it bricking the
+  agent. That is this workspace.
+- The maintainer framed them this way in the issue comments: #5174 is the root cause, #5173
+  is the symptom side.
+
+### Why symptom-handling is needed even after #5174 lands
+
+Validate-on-discover stops a fresh build from picking a dead action. It does not stop a
+**committed** agent from rotting. Composio can remove an action months after an agent was
+built. When it does, the committed config still points at the now-dead action, and the run
+fails at resolve time exactly as F-019 shows. So the surfacing (D1) and the resilience (D2)
+are necessary regardless of #5174. This plan is not blocked on #5174 and does not block it.
+
+### Where the two plans touch
+
+One shared primitive: a single "can this action resolve" check. #5174 needs it to filter
+discovery output. D2 option B needs it to classify a failure as a genuinely-absent action.
+And D2 option C, when built, needs it to flag dead tools in the UI. If #5174 lands first, D2
+should reuse its check rather than add a second one. If this plan lands first, keep the
+classification in the resolve path where #5174 can call it. Either order works. Note it as a
+coordination point, do not couple the two plans.
+</content>

--- a/docs/design/agent-workflows/projects/gateway-tool-resolution/plan.md
+++ b/docs/design/agent-workflows/projects/gateway-tool-resolution/plan.md
@@ -1,0 +1,92 @@
+# Execution plan
+
+Three phases, matching design.md D2. Each phase is independently shippable and valuable.
+Phase 1 is the fast, safe fix. Phase 2 is the resilience change. Phase 3 is the deferred UX.
+
+## Phase 1: Surface the resolver detail (D1, D2 option A)
+
+Goal: the run error names the failing tool and the real reason. No contract change.
+
+1. Add `detail: Optional[str]` to `ToolResolutionError` in
+   `sdks/python/agenta/sdk/agents/tools/errors.py`, next to `status` and `reference`.
+2. In `sdks/python/agenta/sdk/agents/platform/gateway.py`, in the `status_code >= 400`
+   branch (lines 111-118), read the response body. Pull `detail` from the JSON error
+   envelope. Fall back to a bounded slice of `response.text` when the body is not JSON or
+   has no `detail`. Cap the length. Put the reason into both the exception message and the
+   new `detail` field.
+3. Keep the existing `status` and `ref_count` on the exception.
+4. Confirm the enriched message reaches the run error unchanged. Resolution happens at
+   `handler.py:275`, before the harness, so the exception string is the run error already.
+   No downstream re-enrichment is needed.
+
+Tests:
+
+- Unit test in the SDK: a stubbed resolve response of
+  `404 {"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"}` produces a
+  `GatewayToolResolutionError` whose message and `detail` contain the sentence.
+- Unit test: a non-JSON 500 body still yields a bounded, non-empty detail and does not raise
+  a secondary error.
+- Replay or live check: reproduce F-019's config and confirm the run error now names the
+  tool. Use the agent-workflows QA harness, not an ad-hoc script.
+
+Docs: none beyond the interface inventory if the exception field is documented there.
+
+## Phase 2: Partial resolution with a loud warning (D2 option B)
+
+Goal: a genuinely-absent action drops out with a visible warning; the agent runs with its
+surviving tools. Connection, auth, and provider failures stay fatal.
+
+1. Backend contract. Change `POST /tools/resolve` so `resolve_tools` in
+   `api/oss/src/core/tools/service.py` collects per-reference outcomes instead of raising on
+   the first bad reference. The response gains a per-reference failure list: reference,
+   status, reason, and a failure kind (absent-action versus connection versus provider).
+   Apply the `design-interfaces` review to the new response fields before coding them.
+2. Classify failures. Only `ActionNotFoundError` becomes a droppable "absent-action"
+   outcome. `ConnectionNotFoundError`, `ConnectionInactiveError`, `ConnectionInvalidError`,
+   and `ToolSlugInvalidError` stay fatal. Provider and network errors stay fatal.
+3. SDK. In `gateway.py`, build specs for the resolved references and read the failure list.
+   For absent-action failures, drop the tool and collect a warning. For any fatal failure,
+   raise `GatewayToolResolutionError` with the D1 detail. A batch with only absent-action
+   failures resolves successfully with a warning; a batch with any fatal failure still
+   fails.
+4. Surface the warning to both audiences. The user sees a non-fatal run warning that names
+   each dropped tool and why. The model sees a system note or run-context entry saying the
+   tool was unavailable this turn, so it does not silently assume the tool exists. Inject
+   this at the SDK or op-schema layer per the repo rule, not as a core-API behavior change.
+5. Decide the warning transport. Options: a run annotation, a trace event, a system message
+   the SDK prepends. Pick one and record it in status.md before building.
+
+Open question to resolve before coding: is any tool "required"? If an agent's whole point is
+one tool and that tool is the dead one, dropping it and running anyway may be worse than
+failing. Consider a per-tool "required" flag, or a rule that an empty surviving tool set
+fails rather than runs. Record the call in status.md.
+
+Tests:
+
+- Backend: a mixed batch (one absent action, several good tools) returns the good specs plus
+  one absent-action failure, and does not raise.
+- Backend: a connection failure in the batch still fails the whole resolve.
+- SDK: absent-action-only batch resolves with a warning; any fatal failure raises.
+- End to end: F-019's config runs with its four good GitHub tools and a visible warning about
+  the dead one.
+
+## Phase 3 (deferred): Config-level tool health (D2 option C)
+
+Out of scope for this workspace. Scoped here so the follow-up has a starting point.
+
+- Resolve a config's tools at commit or edit time and flag dead tools in the agent config UI.
+- Reuse the "can this action resolve" check rather than duplicate it. If #5174 lands first,
+  reuse its validate-on-discover primitive.
+- Frontend work on the agent config screen: a per-tool health badge and a clear message.
+
+## Coordination with #5174
+
+- Do not couple. This plan ships without #5174 and #5174 ships without this plan.
+- One shared primitive: a single "can this action resolve" check. Whichever plan lands first
+  owns it; the other reuses it. See design.md D3.
+
+## Sequencing
+
+Phase 1 first and alone. It is small, safe, and closes the opacity problem. Phase 2 after,
+once the warning transport is chosen. Phase 3 is a separate future project.
+</content>

--- a/docs/design/agent-workflows/projects/gateway-tool-resolution/research.md
+++ b/docs/design/agent-workflows/projects/gateway-tool-resolution/research.md
@@ -1,0 +1,130 @@
+# Research: the verified failure chain
+
+Every step below is confirmed in the code at workspace base `b94346f1fc` plus PR #5197.
+File and line references are current as of 2026-07-10.
+
+## The path a resolve takes
+
+An agent run resolves its tools once, up front, before the model runs. The chain:
+
+`handler.py` (run entry) -> SDK `resolver.py` -> SDK `gateway.py` (HTTP) ->
+`POST /api/tools/resolve` -> backend `router.py` -> backend `service.py` -> Composio catalog.
+
+### 1. The backend produces a precise error
+
+`api/oss/src/core/tools/service.py`, `ToolsService._resolve_composio_tool` (lines 432-481).
+For each Composio tool it validates the connection, then calls `get_action`. When the
+catalog has no such action:
+
+```python
+action = await self.get_action(
+    provider_key=provider_key,
+    integration_key=ref.integration,
+    action_key=ref.action,
+)
+if not action:
+    raise ActionNotFoundError(
+        provider_key=provider_key,
+        integration_key=ref.integration,
+        action_key=ref.action,
+    )
+```
+
+`ActionNotFoundError` (exceptions.py:43-58) carries the message
+`"Action not found: composio/github/COMMIT_MULTIPLE_FILES"`.
+
+`resolve_tools` (service.py:400-430) loops over the references and calls
+`_resolve_composio_tool` per tool. It raises on the first failure and returns nothing
+partial. This is the backend half of the all-or-nothing behavior.
+
+### 2. The router puts the detail in the HTTP body
+
+`api/oss/src/apis/fastapi/tools/router.py`, `resolve_tools` handler (lines 1026-1066):
+
+```python
+except ActionNotFoundError as e:
+    raise HTTPException(status_code=404, detail=e.message) from e
+```
+
+So the wire response is `404 {"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"}`.
+The useful sentence is present at the HTTP boundary. The router also maps connection errors
+(`ConnectionNotFoundError` -> 404, `ConnectionInactiveError` / `ConnectionInvalidError` ->
+400, `ToolSlugInvalidError` -> 400), each with a real message in `detail`.
+
+### 3. The SDK throws the body away (the swallow point)
+
+`sdks/python/agenta/sdk/agents/platform/gateway.py`,
+`AgentaGatewayToolResolver.resolve` (lines 111-118):
+
+```python
+if response.status_code >= 400:
+    error = GatewayToolResolutionError(
+        f"Gateway tool resolution failed (HTTP {response.status_code})",
+        status=response.status_code,
+        ref_count=len(tools),
+    )
+    log.warning("agent: %s", error)
+    raise error
+```
+
+The code never reads `response.json()` or `response.text`. The `{"detail": ...}` body is
+discarded. The only surviving information is the status code. This single branch is the
+root of problem 1. Everything downstream inherits the bare string.
+
+Note the SDK sends the whole tool set in one batched `POST /tools/resolve` (gateway.py:80-99)
+and raises on any non-2xx. This is the SDK half of the all-or-nothing behavior.
+
+`GatewayToolResolutionError` (sdks tools/errors.py:51) extends `ToolResolutionError`, which
+already carries optional `status`, `ref_count`, `spec_count`, `provider`, and `reference`
+fields. There is no field for a server-provided detail string today.
+
+### 4. The exception fails the whole turn before the model runs
+
+`sdks/python/agenta/sdk/agents/handler.py`, `_agent` (line 275):
+
+```python
+resolved_tools = await comp.resolve_tools(agent_template.tools)
+```
+
+This runs before `make_harness`, before `agent_event_stream` / `agent_batch`, before any
+model call. A `GatewayToolResolutionError` here propagates straight out of the workflow
+handler and becomes the run error. That is why the run dies in about six seconds: it is the
+resolve round-trip and nothing else. No harness starts, so there is no partial transcript.
+
+### 5. The UI shows the run error string
+
+The run error surfaced to the caller and the UI is the exception's string:
+`Gateway tool resolution failed (HTTP 404)`. There is no separate place downstream that
+re-enriches it, so the fix for problem 1 has to keep the detail attached from step 3 onward.
+
+## Where all-or-nothing lives, precisely
+
+Two layers both enforce it, so a resilience fix has to touch both:
+
+- Backend `service.py` `resolve_tools` raises on the first bad reference and returns no
+  partial result. To resolve survivors, it would need to collect per-reference outcomes
+  instead of raising on the first.
+- SDK `gateway.py` `resolve` sends one batch and raises on any non-2xx. To keep survivors,
+  it would need the endpoint to return a partial result plus per-reference errors, then
+  build specs for the ones that resolved and carry a warning for the ones that did not.
+
+## The discover side (issue #5174), for context
+
+`service.py` `discover_capabilities` (lines 487-525) and `_discovery_connection_state`
+(lines 564-627) drive the discover path. The docstring at `_discovery_connection_state`
+claims `ready` "mirrors what resolve_connection_by_slug accepts at invoke time ... so a
+ready here means the tool will actually resolve." That covers the connection, but not the
+action's existence in the resolvable catalog. The action-level drift #5174 describes
+(search surfaces an action that `get_action` cannot find) is not closed by this check.
+That is why #5174 proposes a validate-on-discover backstop: filter discovered actions
+through the same `get_action` resolve uses. This workspace does not implement that. See
+design.md D3 for why it stays separate and where the two plans touch.
+
+## What a fix must preserve
+
+- The per-request credential handling in `PlatformConnection` (connection.py) stays as is.
+  The detail we surface is a catalog or connection message, never a secret, so surfacing it
+  is safe. Any new field must not become a channel for provider keys or auth headers.
+- The resolve happens once per turn, up front. A resilience change must not move resolution
+  into the model loop or change when secrets are resolved.
+</content>

--- a/docs/design/agent-workflows/projects/gateway-tool-resolution/status.md
+++ b/docs/design/agent-workflows/projects/gateway-tool-resolution/status.md
@@ -1,0 +1,52 @@
+# Status
+
+## Current state
+
+Design only. No code written. This workspace plans the fix for QA finding F-019 and issues
+#5173 and #5174 (symptom side).
+
+- `context.md`, `research.md`, `design.md`, `plan.md` complete.
+- The failure chain is verified in code (research.md), including the exact swallow point
+  (`gateway.py` lines 111-118) and the run lifecycle fail point (`handler.py:275`).
+
+## Recommended direction
+
+Ship Phase 1 (surface the detail, name the tool, keep fail-fast) now. It is contained, needs
+no contract change, and fully closes the opacity problem. Follow with Phase 2 (drop only a
+genuinely-absent action, keep connection and auth failures fatal, warn loudly to both the
+model and the user). Defer Phase 3 (config-level health UI) to a follow-up. Keep #5174
+separate; the two plans share one resolvability check.
+
+## Key findings
+
+- The backend already emits the useful error and puts it in the HTTP body. The SDK discards
+  it. So problem 1 is a one-hop drop, not a missing message. Phase 1 is genuinely small.
+- All-or-nothing lives in two layers (backend `resolve_tools` raises on first bad ref; SDK
+  sends one batch and raises on any non-2xx). Phase 2 must touch both.
+- Symptom-handling is needed even if #5174 lands, because a committed agent rots when Composio
+  removes an action after the agent was built.
+
+## Open questions (need a decision before Phase 2 coding)
+
+1. Warning transport for a dropped tool: run annotation, trace event, or an SDK-injected
+   system message. Pick one.
+2. Are any tools "required"? Should an agent whose only useful tool is the dead one fail
+   rather than run tool-less? Consider a per-tool required flag or an empty-surviving-set
+   rule.
+3. Ownership of the shared "can this action resolve" check across this plan and #5174.
+
+## Decisions log
+
+- 2026-07-10: Keep #5173/F-019 (this plan) separate from #5174 (root cause). Symptom-handling
+  is independently necessary. (design.md D3)
+- 2026-07-10: Phase the fix. A (surface) first, B (partial resolution) second, C (config
+  health) deferred. (design.md D2)
+- 2026-07-10: In Phase 2, drop only genuinely-absent actions. Connection, auth, and provider
+  failures stay fatal. (design.md D2 option B)
+
+## Next steps
+
+- Review this workspace, resolve the three open questions.
+- Implement Phase 1 as its own change (SDK-only, small).
+- Then scope Phase 2 with the warning transport decided.
+</content>


### PR DESCRIPTION
## Context

A committed agent config referenced the Composio action `github/COMMIT_MULTIPLE_FILES`, which Composio removed from its catalog. Every turn on that config failed in about six seconds with only:

```
Gateway tool resolution failed (HTTP 404)
```

The message named no tool and no reason. Diagnosing it required backend access: reading the saved config out of Postgres and probing each action slug against Composio by hand. This is QA finding F-019, and it reproduces the two problems in issues #5173 and #5174.

Two things are wrong. The failure is opaque, and resolution is all-or-nothing so one dead tool takes down an agent whose other tools are fine.

The root cause of the opacity is a one-hop drop. The backend already produces the useful sentence and puts it in the HTTP body (`{"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"}`). The SDK reads only the status code and discards the body.

## What this adds

This is a design-only plan-feature workspace. No code changes. It plans two independently shippable fixes and settles where each one lives.

- **Surface the detail end to end.** Read the resolve response body in the SDK (`gateway.py`), pull `detail` out, and carry it on the exception so the run error reads `Action not found: composio/github/COMMIT_MULTIPLE_FILES (HTTP 404)` instead of a bare `HTTP 404`.
- **Stop one dead tool bricking the agent.** Resolve the survivors and drop only a genuinely-absent action, with a loud warning to both the model and the user. Keep connection, auth, and provider failures fatal, because those are actionable states, not dead tools.
- **Keep #5174 separate.** #5174 is the root cause (discover and resolve use different Composio version scopes). This plan is the symptom side, needed even after #5174 lands, because a committed agent still rots when Composio removes an action months later.

Before and after, from the user's point of view:

```
before:  Gateway tool resolution failed (HTTP 404)          # run dies, no tool named
after:   Gateway tool resolution failed: Action not found:  # run names the tool, or
         composio/github/COMMIT_MULTIPLE_FILES (HTTP 404)    # drops it and runs on with a warning
```

## Workspace

`docs/design/agent-workflows/projects/gateway-tool-resolution/`: `context.md`, `research.md` (the verified failure chain, including the exact swallow point and run lifecycle), `design.md` (the three decisions with trade-offs), `plan.md` (three phases), `status.md`.

## Notes

- Design only, so nothing to run. The failure chain in `research.md` is verified against the code at the current base.
- Draft. Three open questions in `status.md` need a decision before Phase 2 coding: the warning transport, whether any tool is "required", and who owns the shared resolvability check across this plan and #5174.

Closes the design step for #5173. Related: #5174.

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj
