### PR TITLE
docs(design): plan warm and resumable Daytona sessions (F-020)

### DIFF
--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
@@ -1,39 +1,54 @@
-# Warm and resumable Daytona sessions (F-020)
+# Warm and resumable Daytona sessions
 
-Design workspace for making follow-up turns on a Daytona agent skip full sandbox creation.
-Every Daytona turn today pays about 20 seconds of cold provision plus mount plus harness
-startup. This workspace plans two tiers that reuse a session's sandbox between turns, with
-honest cost trade-offs and a recommendation.
+## What this project is about
 
-This is a takeover of work that builds on PR #5197 (durable session continuity). A follow-up
-commit at HEAD (`60990d396e`, untested) already prototypes most of Tier 1. Read `context.md`
-first; the "what changed under our feet" section is load-bearing.
+When you chat with an agent that runs on Daytona, every message waits about twenty seconds before
+the agent starts to answer. That wait is a fresh cloud machine being built from scratch, once per
+turn, even though the previous turn already built one. This workspace plans how to reuse that
+machine between turns so the second message, and every message after it, starts fast. It is a
+design plan only. No code ships in this pull request.
 
-## Files
+A few words you will meet throughout, defined once:
 
-- `context.md` — why this exists, the symptom, why it happens, the untested lifecycle commit,
-  goals and non-goals.
-- `research.md` — the actual current code at HEAD (teardown, reconnect, provider flags, the
-  sandbox-agent patch), how the local keep-alive pool works, the three-tier fallback model, and
-  Daytona lifecycle and billing semantics.
-- `plan.md` — the two tiers, phased, with the recommendation. Tier 1 (cheap resume, park to
-  stopped) ships first behind a default-off flag. Tier 2 (true warm pool, park to running) is
-  an opt-in follow-up.
-- `open-questions.md` — the decisions a reviewer and a billing owner still have to make.
-- `status.md` — current state, decisions, the design-review round, blockers.
+- **Sandbox:** the isolated cloud machine an agent runs in. On Daytona it is a billed resource.
+- **Daytona:** the cloud provider that hosts these sandboxes.
+- **Runner:** the Agenta service that drives one agent turn. It builds the sandbox, runs the turn
+  inside it, and tears it down.
+- **Harness:** the agent program that runs inside the sandbox (Claude Code or Pi).
+- **Park a sandbox:** stop it but keep its disk, so the next turn can restart the same one instead
+  of rebuilding it. This is the whole idea behind the project.
 
-## Recommendation in one line
+## Read the files in this order
 
-Land Tier 1 (mostly prototyped, storage-only parked cost) behind a default-off flag, close the
-P0 lifecycle gaps the review round found, enable it after one credit-controlled live test, keep
-durable continuity as the floor, and defer Tier 2 (running compute; TTL and a running cap are
-the billing knobs) until F-018 lands and a billing owner sets those knobs.
+1. **context.md.** What a user sees today, what recent work already tried, why it still fails, and
+   the finding that shaped the whole plan: the code to keep a sandbox warm was already written, but
+   the piece of it that talks to Daytona is missing two functions it needs.
+2. **research.md.** The current code, function by function, with the exact reasons warm reuse does
+   not work yet. Read this for the evidence behind context.md. It also covers the local warm-reuse
+   pool and how Daytona bills a stopped sandbox.
+3. **plan.md.** The proposal. Two levels of reuse, the work each needs, the gaps to close first, and
+   a recommendation. Start here if you only want the decision.
+4. **open-questions.md.** The decisions that still need a human: a reviewer for the correctness ones,
+   a billing owner for the cost ones.
+5. **status.md.** Where the project stands, what was decided and why, and what the design review
+   changed.
+
+## The recommendation, in one paragraph
+
+Ship the cheaper level first. Park-to-stopped stops the sandbox at the end of a turn and restarts
+the same one on the next turn; its parked cost is disk storage only. Put it behind a flag that is
+off by default, close the handful of correctness gaps the design review found, and turn it on after
+one careful live test. Keep today's always-correct fallback (rebuild the sandbox and replay the
+transcript) underneath it. Defer the more expensive level, park-to-running, which keeps the sandbox
+running between turns, until a billing owner sets its cost limits.
 
 ## Related workspaces
 
-- `docs/design/agent-workflows/projects/session-keepalive/` — the local in-memory keep-alive
-  pool. Its deferred "slice 3 (Daytona)" is this project's Tier 2.
-- `docs/design/agent-workflows/projects/harness-session-resume/` — durable continuity via ACP
-  `session/load`. The fallback rung under both tiers.
-- `docs/design/agent-workflows/projects/qa/findings.md` — F-020 (this problem), F-018 (the
-  Daytona tool-call hang that gates the benefit), F-017 (the mount fix PR #5197 shipped).
+- `docs/design/agent-workflows/projects/session-keepalive/`: the local, in-memory pool that already
+  gives non-Daytona sessions warm reuse. Its deferred Daytona slice is this project's park-to-running
+  level.
+- `docs/design/agent-workflows/projects/harness-session-resume/`: how a restarted sandbox reloads the
+  past conversation. This is the fallback both levels rely on.
+- `docs/design/agent-workflows/projects/qa/findings.md`: the QA findings referenced here. F-020 (this
+  slow-turn problem), F-018 (a separate Daytona bug that hangs tool calls), and F-017 (a mount bug
+  already fixed).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
@@ -28,8 +28,9 @@ A few words you will meet throughout, defined once:
    not work yet, plus the measured Daytona lifecycle numbers and prices (2026-07-11) that reshaped
    the plan. Read this for the evidence behind context.md.
 3. **plan.md.** The proposal: one progressive sequence of slices from the correctness base through
-   park-to-stopped and a provider-aware pool refactor up to park-to-running. Start here if you
-   only want the decision.
+   park-to-stopped and a provider-aware pool refactor up to park-to-running. Its section "The
+   three resume paths, compared" prices fresh create, stop-then-restart, and kept-running from
+   the measured stages; start there if you only want the decision.
 4. **open-questions.md.** What still needs a human: three correctness decisions for a reviewer and
    two proposed defaults to confirm. The former cost questions are answered by the measurement.
 5. **status.md.** Where the project stands, what was decided and why, the measurement summary, and

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
@@ -2,11 +2,12 @@
 
 ## What this project is about
 
-When you chat with an agent that runs on Daytona, every message waits about twenty seconds before
-the agent starts to answer. That wait is a fresh cloud machine being built from scratch, once per
-turn, even though the previous turn already built one. This workspace plans how to reuse that
-machine between turns so the second message, and every message after it, starts fast. It is a
-design plan only. No code ships in this pull request.
+When you chat with an agent that runs on Daytona, every message waits about fifteen seconds before
+the agent starts to answer. That wait is the whole per-turn setup being redone from scratch, once
+per message: build a cloud machine, install and start the agent inside it, mount its files, reload
+the conversation, even though the previous turn already did all of that. This workspace plans how
+to reuse the running setup between turns so the second message, and every message after it, starts
+fast. It is a design plan only. No code ships in this pull request.
 
 A few words you will meet throughout, defined once:
 
@@ -43,11 +44,12 @@ end instead of deleting it; parked cost is disk storage only, about $0.0009/hour
 that makes the existing local keepalive pool provider-aware, then park-to-running (keep the
 sandbox running for a short window after each turn, default 60 seconds with a hard cap of 4
 concurrently running sandboxes enforced before creation, about $0.0028 per parked minute), and
-finally credit-controlled live verification before any flag flips on. The measurement behind this
-order: creating a Daytona sandbox takes under 2 seconds, so the roughly 20-second turn is our own
-per-turn setup, and only a sandbox that stays running skips it. The archive state is dropped
-entirely (restoring from archive is slower than creating fresh). Today's always-correct fallback
-(rebuild and replay the transcript) stays underneath everything.
+finally credit-controlled live verification before any flag flips on. The measurements behind
+this order: creating a Daytona sandbox takes about 1 second of a measured ~15-second turn; the
+rest is our own per-turn setup, stage by stage in research.md, and only a sandbox that stays
+running skips it (a resumed turn is roughly 2 to 3 seconds, estimated). The archive state is
+dropped entirely (restoring from archive is slower than creating fresh). Today's always-correct
+fallback (rebuild and replay the transcript) stays underneath everything.
 
 ## Related workspaces
 

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
@@ -39,14 +39,13 @@ A few words you will meet throughout, defined once:
 ## The recommendation, in one paragraph
 
 Build the whole ladder in slices, each shippable on its own. First the correctness base (the two
-missing Daytona provider functions plus the leak and race fixes two design-review rounds found,
-gated behind a default-off flag from the start), then park-to-stopped (stop the sandbox at turn
-end instead of deleting it; parked cost is disk storage only, about $0.0009/hour), then a refactor
-that makes the existing local keepalive pool provider-aware, then park-to-running (keep the
-sandbox running for a short window after each turn, default 60 seconds with a hard cap of 4
-concurrently running sandboxes enforced before creation, about $0.0028 per parked minute), and
-finally credit-controlled live verification before any flag flips on. The measurements behind
-this order: creating a Daytona sandbox takes about 1 second of a measured ~15-second turn; the
+missing Daytona provider functions plus the leak and race fixes), then park-to-stopped (stop the
+sandbox at turn end instead of deleting it; parked cost is disk storage only, about $0.0009/hour),
+then a refactor that makes the existing local keepalive pool provider-aware, then park-to-running
+(keep the sandbox running for two minutes after each turn, with a hard cap of 20 warm sandboxes,
+about $0.0028 per parked minute), and finally credit-controlled live verification before the
+defaults change. The finished feature has no feature flags; the off switch is configuration
+(setting the live window to zero). The measurements behind this order: creating a Daytona sandbox takes about 1 second of a measured ~15-second turn; the
 rest is our own per-turn setup, stage by stage in research.md, and only a sandbox that stays
 running skips it (a resumed turn is roughly 2 to 3 seconds, estimated). The archive state is
 dropped entirely (restoring from archive is slower than creating fresh). Today's always-correct

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
@@ -1,0 +1,39 @@
+# Warm and resumable Daytona sessions (F-020)
+
+Design workspace for making follow-up turns on a Daytona agent skip full sandbox creation.
+Every Daytona turn today pays about 20 seconds of cold provision plus mount plus harness
+startup. This workspace plans two tiers that reuse a session's sandbox between turns, with
+honest cost trade-offs and a recommendation.
+
+This is a takeover of work that builds on PR #5197 (durable session continuity). A follow-up
+commit at HEAD (`60990d396e`, untested) already prototypes most of Tier 1. Read `context.md`
+first; the "what changed under our feet" section is load-bearing.
+
+## Files
+
+- `context.md` — why this exists, the symptom, why it happens, the untested lifecycle commit,
+  goals and non-goals.
+- `research.md` — the actual current code at HEAD (teardown, reconnect, provider flags, the
+  sandbox-agent patch), how the local keep-alive pool works, the three-tier fallback model, and
+  Daytona lifecycle and billing semantics.
+- `plan.md` — the two tiers, phased, with the recommendation. Tier 1 (cheap resume, park to
+  stopped) ships first behind a default-off flag. Tier 2 (true warm pool, park to running) is
+  an opt-in follow-up.
+- `open-questions.md` — the decisions a reviewer and a billing owner still have to make.
+- `status.md` — current state, decisions, the design-review round, blockers.
+
+## Recommendation in one line
+
+Land Tier 1 (mostly prototyped, storage-only parked cost) behind a default-off flag, close the
+P0 lifecycle gaps the review round found, enable it after one credit-controlled live test, keep
+durable continuity as the floor, and defer Tier 2 (running compute; TTL and a running cap are
+the billing knobs) until F-018 lands and a billing owner sets those knobs.
+
+## Related workspaces
+
+- `docs/design/agent-workflows/projects/session-keepalive/` — the local in-memory keep-alive
+  pool. Its deferred "slice 3 (Daytona)" is this project's Tier 2.
+- `docs/design/agent-workflows/projects/harness-session-resume/` — durable continuity via ACP
+  `session/load`. The fallback rung under both tiers.
+- `docs/design/agent-workflows/projects/qa/findings.md` — F-020 (this problem), F-018 (the
+  Daytona tool-call hang that gates the benefit), F-017 (the mount fix PR #5197 shipped).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/README.md
@@ -21,34 +21,43 @@ A few words you will meet throughout, defined once:
 ## Read the files in this order
 
 1. **context.md.** What a user sees today, what recent work already tried, why it still fails, and
-   the finding that shaped the whole plan: the code to keep a sandbox warm was already written, but
-   the piece of it that talks to Daytona is missing two functions it needs.
+   the finding that shaped the first draft: the code to keep a sandbox warm was already written,
+   but the piece of it that talks to Daytona is missing two functions it needs.
 2. **research.md.** The current code, function by function, with the exact reasons warm reuse does
-   not work yet. Read this for the evidence behind context.md. It also covers the local warm-reuse
-   pool and how Daytona bills a stopped sandbox.
-3. **plan.md.** The proposal. Two levels of reuse, the work each needs, the gaps to close first, and
-   a recommendation. Start here if you only want the decision.
-4. **open-questions.md.** The decisions that still need a human: a reviewer for the correctness ones,
-   a billing owner for the cost ones.
-5. **status.md.** Where the project stands, what was decided and why, and what the design review
-   changed.
+   not work yet, plus the measured Daytona lifecycle numbers and prices (2026-07-11) that reshaped
+   the plan. Read this for the evidence behind context.md.
+3. **plan.md.** The proposal: one progressive sequence of slices from the correctness base through
+   park-to-stopped and a provider-aware pool refactor up to park-to-running. Start here if you
+   only want the decision.
+4. **open-questions.md.** What still needs a human: three correctness decisions for a reviewer and
+   two proposed defaults to confirm. The former cost questions are answered by the measurement.
+5. **status.md.** Where the project stands, what was decided and why, the measurement summary, and
+   what the two design-review rounds changed.
 
 ## The recommendation, in one paragraph
 
-Ship the cheaper level first. Park-to-stopped stops the sandbox at the end of a turn and restarts
-the same one on the next turn; its parked cost is disk storage only. Put it behind a flag that is
-off by default, close the handful of correctness gaps the design review found, and turn it on after
-one careful live test. Keep today's always-correct fallback (rebuild the sandbox and replay the
-transcript) underneath it. Defer the more expensive level, park-to-running, which keeps the sandbox
-running between turns, until a billing owner sets its cost limits.
+Build the whole ladder in slices, each shippable on its own. First the correctness base (the two
+missing Daytona provider functions plus the leak and race fixes two design-review rounds found,
+gated behind a default-off flag from the start), then park-to-stopped (stop the sandbox at turn
+end instead of deleting it; parked cost is disk storage only, about $0.0009/hour), then a refactor
+that makes the existing local keepalive pool provider-aware, then park-to-running (keep the
+sandbox running for a short window after each turn, default 60 seconds with a hard cap of 4
+concurrently running sandboxes enforced before creation, about $0.0028 per parked minute), and
+finally credit-controlled live verification before any flag flips on. The measurement behind this
+order: creating a Daytona sandbox takes under 2 seconds, so the roughly 20-second turn is our own
+per-turn setup, and only a sandbox that stays running skips it. The archive state is dropped
+entirely (restoring from archive is slower than creating fresh). Today's always-correct fallback
+(rebuild and replay the transcript) stays underneath everything.
 
 ## Related workspaces
 
 - `docs/design/agent-workflows/projects/session-keepalive/`: the local, in-memory pool that already
-  gives non-Daytona sessions warm reuse. Its deferred Daytona slice is this project's park-to-running
-  level.
+  gives non-Daytona sessions warm reuse. This project refactors that pool to be provider-aware;
+  its once-deferred Daytona slice is this project's park-to-running level.
 - `docs/design/agent-workflows/projects/harness-session-resume/`: how a restarted sandbox reloads the
   past conversation. This is the fallback both levels rely on.
+- `docs/design/agent-workflows/projects/daytona-gate-delivery/`: the F-018 fix (approval gates on
+  Daytona), in implementation. This plan follows its pending-approval resume model.
 - `docs/design/agent-workflows/projects/qa/findings.md`: the QA findings referenced here. F-020 (this
   slow-turn problem), F-018 (a separate Daytona bug that hangs tool calls), and F-017 (a mount bug
   already fixed).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
@@ -1,0 +1,83 @@
+# Context: warm and resumable Daytona sessions (F-020)
+
+## The symptom
+
+Every conversational turn on a Daytona agent pays full sandbox creation. QA measured this at
+about 20 seconds or more per turn on a live E3 run. A user sends a second message in the same
+chat and waits through a cold provision, a mount, and a harness startup that the previous turn
+already paid for. This is the whole problem: Daytona has no warm reuse between turns.
+
+## Why it happens
+
+Three independent mechanisms combine to force a cold create on every turn.
+
+1. The runner tore the sandbox down at turn end. Before the lifecycle work described below,
+   `provider.ts` created the Daytona sandbox with `ephemeral: true`, and an ephemeral sandbox
+   auto-deletes when it stops. So the sandbox was gone by the time the next turn arrived.
+
+2. PR #5197 added a `sandbox-reconnect` module that stores the sandbox id and restarts a
+   stopped or archived sandbox on the next turn instead of provisioning fresh. But because the
+   sandbox was deleted at turn end, the stored id never resolved. Reconnect was a dead rung:
+   the runner logged "reconnect failed ... not found, creating fresh" on every follow-up turn.
+
+3. The in-memory keep-alive pool that gives local sessions warm reuse is gated local-only on
+   purpose (`resolvesToLocalProvider` in `session-pool.ts`, `isLocalSandbox` in `server.ts`).
+   The gate is deliberate. Local keep-alive spends host RAM only; a warm Daytona sandbox spends
+   billed compute, and a leaked one costs money. The `session-keepalive` workspace deferred the
+   remote extension to "slice 3" for exactly this reason.
+
+The 15-minute `SANDBOX_AGENT_DAYTONA_AUTOSTOP_MINUTES` that existed at the time was a leak
+backstop, not a reuse mechanism. It stopped an abandoned sandbox so it stopped billing; it did
+nothing to make the next turn fast.
+
+This is finding F-020 in `docs/design/agent-workflows/projects/qa/findings.md`. It is triaged
+`minor` and `defer`: correctness is fine (durable continuity restores the transcript and the
+resumed turn answers correctly in about 20 seconds), but every turn pays create latency.
+
+## What changed under our feet: the untested lifecycle commit
+
+F-020 and the brief that started this project describe the PR #5197 state. The working tree has
+since moved past it. Commit `60990d396e` ("[fix] Resolve hot/warm/cold/dead/new lifecycle
+(untested)") already implements most of Tier 1 below, and it is unverified. Any plan here has to
+start from the real current state, not from F-020's premise. See `research.md` for the exact
+code. In short, at HEAD:
+
+- `provider.ts` now creates with `ephemeral: false` and a five-state lifecycle: `autoStop = 5`
+  min, `autoArchive = 15` min, `autoDelete = 30` min. Daytona's own reapers park then reap.
+- `sandbox_agent.ts` teardown takes a `keepWarm` option. On a resumable Daytona turn it calls
+  `pauseSandbox()` (stop, keep the disk) instead of `destroySandbox()` (delete).
+- Both run paths (`runSandboxAgent` and the keep-alive `runCold`) pass `keepWarm` when the turn
+  succeeded, was not aborted, the client did not disconnect, and the turn did not pause.
+- Reconnect is wired: `readStoredSandboxId` at acquire restarts the stored sandbox; a failure
+  falls through to a fresh create; `writeSandboxId` records the live id forward.
+- A `pnpm patch` on `sandbox-agent@0.4.2` adds native ACP `loadSession` so a reconnected
+  sandbox resumes the harness session in place, with transcript replay as the fallback.
+
+So Tier 1 is prototyped end to end but untested and unproven live. This project is a takeover:
+verify it, close its gaps, decide the orphan-cleanup story, and decide whether and when to add
+the true warm pool (Tier 2).
+
+## Goals
+
+- Make a second Daytona turn in the same conversation avoid a full cold create.
+- Keep the parked cost honest and bounded. Storage-only for the default tier; a clear billing
+  knob for any tier that parks live compute.
+- Never leak a running sandbox. The orphan-cleanup story has to be at least as safe as the
+  `ephemeral: true` behavior it replaces.
+- Keep durable continuity (PR #5197) as the always-correct fallback rung.
+
+## Non-goals
+
+- Fixing the Daytona tool-call hang (F-018). Warmth helps chat first; tool turns fail on
+  Daytona until F-018 lands, and a failed turn does not park.
+- Multi-replica pool routing. The runner is single-replica; a pool miss degrades to cold.
+- Changing the wire contract, the SDK, or the frontend. This is a runner-only change.
+- Running live Daytona sandboxes during this design pass (credits). Verification is by code
+  read and unit or contract tests; live QA is called out as a follow-up, not done here.
+
+## Who cares
+
+Anyone running a multi-turn chat agent on Daytona through the deployed app. Today they wait 20
+seconds per turn. The build-kit default agent is hit hardest because its "read the skill first"
+instruction makes the model open with a tool call, though that path is currently blocked by
+F-018 rather than by cold-create latency.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
@@ -1,83 +1,111 @@
-# Context: warm and resumable Daytona sessions (F-020)
+# Context: warm and resumable Daytona sessions
 
-## The symptom
+## What a user sees today
 
-Every conversational turn on a Daytona agent pays full sandbox creation. QA measured this at
-about 20 seconds or more per turn on a live E3 run. A user sends a second message in the same
-chat and waits through a cold provision, a mount, and a harness startup that the previous turn
-already paid for. This is the whole problem: Daytona has no warm reuse between turns.
+When you chat with an agent that runs on Daytona, every message waits about twenty seconds
+before the agent starts to answer. QA measured this on a live run (the E3 scenario, a scripted
+chat used to test the agent runtime). The wait is the same on every turn. Your second message
+in a conversation waits just as long as your first, because the runner builds a brand-new
+sandbox for it, mounts its files, and starts the harness from scratch. Nothing from the
+previous turn is reused.
 
-## Why it happens
+A few terms, since they recur below:
 
-Three independent mechanisms combine to force a cold create on every turn.
+- **Sandbox**: the isolated cloud machine an agent runs in. On Daytona it is a billed resource.
+- **Runner**: the Agenta service that drives one agent turn. It creates the sandbox, runs the
+  turn inside it, and tears it down.
+- **Harness**: the agent program inside the sandbox (Claude Code or Pi).
+- **Park a sandbox**: stop it but keep its disk, so the next turn can restart the same one
+  instead of rebuilding it.
 
-1. The runner tore the sandbox down at turn end. Before the lifecycle work described below,
-   `provider.ts` created the Daytona sandbox with `ephemeral: true`, and an ephemeral sandbox
-   auto-deletes when it stops. So the sandbox was gone by the time the next turn arrived.
+The slow turn is the whole problem. This is QA finding F-020.
 
-2. PR #5197 added a `sandbox-reconnect` module that stores the sandbox id and restarts a
-   stopped or archived sandbox on the next turn instead of provisioning fresh. But because the
-   sandbox was deleted at turn end, the stored id never resolved. Reconnect was a dead rung:
-   the runner logged "reconnect failed ... not found, creating fresh" on every follow-up turn.
+The answer itself is still correct. A separate feature, durable session continuity (PR #5197),
+saves the conversation to storage and replays it into the fresh sandbox, so the agent remembers
+what was said. The only cost is speed. Correctness is fine; every turn just pays the full build
+time.
 
-3. The in-memory keep-alive pool that gives local sessions warm reuse is gated local-only on
-   purpose (`resolvesToLocalProvider` in `session-pool.ts`, `isLocalSandbox` in `server.ts`).
-   The gate is deliberate. Local keep-alive spends host RAM only; a warm Daytona sandbox spends
-   billed compute, and a leaked one costs money. The `session-keepalive` workspace deferred the
-   remote extension to "slice 3" for exactly this reason.
+## What recent work already tried
 
-The 15-minute `SANDBOX_AGENT_DAYTONA_AUTOSTOP_MINUTES` that existed at the time was a leak
-backstop, not a reuse mechanism. It stopped an abandoned sandbox so it stopped billing; it did
-nothing to make the next turn fast.
+The working tree has moved past the state F-020 described. A recent, still-untested commit
+(`60990d396e`, "Resolve hot/warm/cold/dead/new lifecycle") already wired up most of the
+warm-reuse machinery. Any plan has to start from this real current state, not from F-020's
+older premise. Here is what that commit put in place:
 
-This is finding F-020 in `docs/design/agent-workflows/projects/qa/findings.md`. It is triaged
-`minor` and `defer`: correctness is fine (durable continuity restores the transcript and the
-resumed turn answers correctly in about 20 seconds), but every turn pays create latency.
+- **Keep the sandbox instead of deleting it.** `provider.ts` now creates the sandbox with
+  `ephemeral: false`, which means a stopped sandbox is parked, not auto-deleted. It also sets
+  three idle timers: stop after 5 minutes, move to cheaper cold storage after 15, delete after
+  30. Daytona runs these timers itself.
+- **Park at a clean turn end.** The teardown path (`sandbox_agent.ts`) takes a `keepWarm`
+  option. On a Daytona turn that finished cleanly, it calls `pauseSandbox()` (stop, keep the
+  disk) instead of `destroySandbox()` (delete). Both run paths request `keepWarm` only when the
+  turn succeeded, was not aborted, and the user did not disconnect.
+- **Reconnect on the next turn.** The runner stores the sandbox id, and on the next turn it
+  reads that id back and restarts the same sandbox instead of provisioning a fresh one.
+- **Reload the conversation in place.** A patch on the vendored `sandbox-agent` package adds a
+  native "reload this session" call, so a restarted sandbox resumes the harness where it left
+  off, with transcript replay as the fallback.
 
-## What changed under our feet: the untested lifecycle commit
+So on paper, a follow-up turn should restart the parked sandbox and pick up the conversation.
+In practice it does not, for the reason below.
 
-F-020 and the brief that started this project describe the PR #5197 state. The working tree has
-since moved past it. Commit `60990d396e` ("[fix] Resolve hot/warm/cold/dead/new lifecycle
-(untested)") already implements most of Tier 1 below, and it is unverified. Any plan here has to
-start from the real current state, not from F-020's premise. See `research.md` for the exact
-code. In short, at HEAD:
+## Why it still fails
 
-- `provider.ts` now creates with `ephemeral: false` and a five-state lifecycle: `autoStop = 5`
-  min, `autoArchive = 15` min, `autoDelete = 30` min. Daytona's own reapers park then reap.
-- `sandbox_agent.ts` teardown takes a `keepWarm` option. On a resumable Daytona turn it calls
-  `pauseSandbox()` (stop, keep the disk) instead of `destroySandbox()` (delete).
-- Both run paths (`runSandboxAgent` and the keep-alive `runCold`) pass `keepWarm` when the turn
-  succeeded, was not aborted, the client did not disconnect, and the turn did not pause.
-- Reconnect is wired: `readStoredSandboxId` at acquire restarts the stored sandbox; a failure
-  falls through to a fresh create; `writeSandboxId` records the live id forward.
-- A `pnpm patch` on `sandbox-agent@0.4.2` adds native ACP `loadSession` so a reconnected
-  sandbox resumes the harness session in place, with transcript replay as the fallback.
+The runner asks for the right behavior, but the piece that carries it out is missing.
 
-So Tier 1 is prototyped end to end but untested and unproven live. This project is a takeover:
-verify it, close its gaps, decide the orphan-cleanup story, and decide whether and when to add
-the true warm pool (Tier 2).
+The code that talks to Daytona is called the *provider*. The runner's park and reconnect calls
+depend on two provider functions: one to pause (stop) a sandbox, and one to reconnect to a
+stopped one. The Daytona provider implements neither. As a result:
+
+- `pauseSandbox()` finds no pause function and falls through to a plain delete. The sandbox is
+  gone at turn end, `keepWarm` or not.
+- The reconnect call finds a deleted sandbox id and cannot revive it, so the runner builds a
+  fresh sandbox anyway.
+
+The net effect is a full rebuild on every turn, exactly what F-020 reported. `research.md`
+walks the code that proves each step.
+
+## The key finding
+
+The warm-reuse machinery is mostly written already and sitting untested in the working tree.
+What blocks it is small and specific: two missing functions in the Daytona provider, plus a few
+correctness gaps around them that a design review surfaced. This project is a takeover. Verify
+the existing code, add the two functions, close the gaps, decide how the runner cleans up
+abandoned sandboxes, and decide how far to push reuse.
+
+Two older facts are worth carrying forward, because a later decision depends on them:
+
+- The Daytona sandbox used to be created `ephemeral: true`, which auto-deleted it the moment it
+  stopped. That was a safety backstop: a crashed runner could not leave a sandbox billing for
+  long. Switching to `ephemeral: false` removes that reflex, so the plan has to answer what now
+  cleans up an abandoned sandbox.
+- The local (non-Daytona) sessions already get warm reuse from an in-memory pool, but that pool
+  is deliberately kept off Daytona. A leaked local session costs only host memory; a leaked
+  Daytona sandbox costs real money. `research.md` covers the pool in full.
 
 ## Goals
 
-- Make a second Daytona turn in the same conversation avoid a full cold create.
-- Keep the parked cost honest and bounded. Storage-only for the default tier; a clear billing
-  knob for any tier that parks live compute.
-- Never leak a running sandbox. The orphan-cleanup story has to be at least as safe as the
+- Make a second Daytona turn in the same conversation skip the full rebuild.
+- Keep the parked cost honest and bounded. Storage only for the default level; a clear cost
+  limit for any level that keeps a sandbox running.
+- Never leak a running sandbox. Cleanup of abandoned sandboxes has to be at least as safe as the
   `ephemeral: true` behavior it replaces.
-- Keep durable continuity (PR #5197) as the always-correct fallback rung.
+- Keep durable continuity (PR #5197) as the always-correct fallback.
 
 ## Non-goals
 
-- Fixing the Daytona tool-call hang (F-018). Warmth helps chat first; tool turns fail on
-  Daytona until F-018 lands, and a failed turn does not park.
-- Multi-replica pool routing. The runner is single-replica; a pool miss degrades to cold.
+- Fixing the Daytona tool-call hang (F-018, a separate bug). Warm reuse helps chat first. Tool
+  turns fail on Daytona until F-018 lands, and a failed turn does not park.
+- Routing across multiple runner replicas. The runner is single-replica; a miss just falls back
+  to a cold build.
 - Changing the wire contract, the SDK, or the frontend. This is a runner-only change.
-- Running live Daytona sandboxes during this design pass (credits). Verification is by code
-  read and unit or contract tests; live QA is called out as a follow-up, not done here.
+- Running live Daytona sandboxes during this design pass, which would spend credits.
+  Verification here is by code read and unit or contract tests. Live testing is called out as a
+  later step, not done here.
 
-## Who cares
+## Who is affected
 
-Anyone running a multi-turn chat agent on Daytona through the deployed app. Today they wait 20
-seconds per turn. The build-kit default agent is hit hardest because its "read the skill first"
-instruction makes the model open with a tool call, though that path is currently blocked by
-F-018 rather than by cold-create latency.
+Anyone running a multi-turn chat agent on Daytona through the deployed app. Today they wait
+about twenty seconds per turn. The build-kit default agent feels it most, because its "read the
+skill first" instruction makes the model open with a tool call. That path is currently blocked
+by F-018 rather than by build latency, so it will not benefit until F-018 lands.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
@@ -2,7 +2,7 @@
 
 ## What a user sees today
 
-When you chat with an agent that runs on Daytona, every message waits about twenty seconds
+When you chat with an agent that runs on Daytona, every message waits fifteen to twenty seconds
 before the agent starts to answer. QA measured this on a live run (the E3 scenario, a scripted
 chat used to test the agent runtime). The wait is the same on every turn. Your second message
 in a conversation waits just as long as your first, because the runner builds a brand-new
@@ -20,12 +20,14 @@ A few terms, since they recur below:
 
 The slow turn is the whole problem. This is QA finding F-020.
 
-One measured fact sharpens where the twenty seconds goes (research.md, 2026-07-11): creating the
-Daytona sandbox itself takes under 2 seconds. The rest of the wait is our own per-turn setup
-inside and around it: starting the daemon, uploading assets, mounting files, starting the
-harness, and reloading the conversation. That setup only disappears entirely when the sandbox,
-with its processes, stays running between turns. This is why the plan builds up to keeping
-sandboxes running for a short window, not just to stopping and restarting them.
+Measurement sharpened where the wait goes (research.md, 2026-07-11; the cold turn measured about
+15 seconds on that day's runs). Creating the Daytona sandbox itself takes about 1 second. The
+rest is our own per-turn setup inside and around it: installing the Pi CLI (redundantly; the
+skip is already live on the dev sidecar), starting the harness, mounting files, uploading
+assets, and reloading the conversation. Research.md has the stage-by-stage table. That setup
+only disappears entirely when the sandbox, with its processes, stays running between turns. This
+is why the plan builds up to keeping sandboxes running for a short window, not just to stopping
+and restarting them.
 
 The answer itself is still correct. A separate feature, durable session continuity (PR #5197),
 saves the conversation to storage and replays it into the fresh sandbox, so the agent remembers
@@ -120,6 +122,6 @@ Two older facts are worth carrying forward, because a later decision depends on 
 ## Who is affected
 
 Anyone running a multi-turn chat agent on Daytona through the deployed app. Today they wait
-about twenty seconds per turn. The build-kit default agent feels it most, because its "read the
+fifteen to twenty seconds per turn. The build-kit default agent feels it most, because its "read the
 skill first" instruction makes the model open with a tool call. That path is currently blocked
 by F-018 rather than by build latency, so it will not benefit until F-018 lands.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/context.md
@@ -20,6 +20,13 @@ A few terms, since they recur below:
 
 The slow turn is the whole problem. This is QA finding F-020.
 
+One measured fact sharpens where the twenty seconds goes (research.md, 2026-07-11): creating the
+Daytona sandbox itself takes under 2 seconds. The rest of the wait is our own per-turn setup
+inside and around it: starting the daemon, uploading assets, mounting files, starting the
+harness, and reloading the conversation. That setup only disappears entirely when the sandbox,
+with its processes, stays running between turns. This is why the plan builds up to keeping
+sandboxes running for a short window, not just to stopping and restarting them.
+
 The answer itself is still correct. A separate feature, durable session continuity (PR #5197),
 saves the conversation to storage and replays it into the fresh sandbox, so the agent remembers
 what was said. The only cost is speed. Correctness is fine; every turn just pays the full build
@@ -85,23 +92,30 @@ Two older facts are worth carrying forward, because a later decision depends on 
 
 ## Goals
 
-- Make a second Daytona turn in the same conversation skip the full rebuild.
-- Keep the parked cost honest and bounded. Storage only for the default level; a clear cost
-  limit for any level that keeps a sandbox running.
+- Make a second Daytona turn in the same conversation near-instant while the conversation is
+  active (the sandbox stays running for a short window), and cheap to resume after the window
+  closes (restart the stopped sandbox instead of rebuilding).
+- Keep the parked cost honest and bounded, as configuration with measured, conservative defaults:
+  storage only for a stopped sandbox, a short window and a hard cap on concurrently running
+  parked sandboxes.
 - Never leak a running sandbox. Cleanup of abandoned sandboxes has to be at least as safe as the
   `ephemeral: true` behavior it replaces.
+- Reuse the existing local keepalive pool logic (`session-pool.ts`), refactored to be
+  provider-aware, instead of building a second pooling mechanism.
 - Keep durable continuity (PR #5197) as the always-correct fallback.
 
 ## Non-goals
 
-- Fixing the Daytona tool-call hang (F-018, a separate bug). Warm reuse helps chat first. Tool
-  turns fail on Daytona until F-018 lands, and a failed turn does not park.
+- Fixing the Daytona tool-call hang (F-018, a separate bug with its own implementation workspace,
+  `daytona-gate-delivery`). Warm reuse helps chat first. Tool turns fail on Daytona until F-018
+  lands, and a failed turn does not park.
 - Routing across multiple runner replicas. The runner is single-replica; a miss just falls back
   to a cold build.
 - Changing the wire contract, the SDK, or the frontend. This is a runner-only change.
-- Running live Daytona sandboxes during this design pass, which would spend credits.
-  Verification here is by code read and unit or contract tests. Live testing is called out as a
-  later step, not done here.
+- Running the full app path against live Daytona during this design pass. One credit-controlled
+  lifecycle measurement was run directly against the Daytona API on 2026-07-11 (two sandboxes,
+  created and deleted, numbers in research.md); end-to-end verification through the app is the
+  plan's final slice, not done here.
 
 ## Who is affected
 

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
@@ -1,57 +1,68 @@
 # Open questions
 
-These are the decisions a human still has to make. The 2026-07-11 lifecycle measurement
-(research.md) answered the cost questions that used to sit here: the abandonment budget is cents
-per crash, the park-to-running knobs became configuration with stated defaults, and the archive
-state is dropped outright. What remains open is about correctness, plus two proposed defaults
-that need a reviewer's confirmation rather than an owner's decision.
+The decisions a human still has to make, each with the context and trade-offs needed to make it
+from this file alone. Answered questions move to the bottom with their answers.
 
-## Still open (correctness, reviewer)
+## Still open
 
-1. **How to guard the sandbox pointer write** (Slice 1). `writeSandboxId` is a fire-and-forget,
-   last-writer-wins PUT, and the Daytona path skips the runner's ownership check. The plan calls
-   for awaited, conditional (compare-and-set) writes. Where does the guard live: a new generation
-   column on `session_states`, the existing turn counter, or the Redis owner claim PR #5197 added
-   for local sessions? Related: PR #5197's own risk list flags the same missing concurrency guard
-   on its durable-continuity write, so one guard mechanism should probably cover both writes.
+1. **Which counter guards the sandbox-pointer write** (Slice 1). Background, in brief (plan.md
+   must-fix item 3 has the full story): the runner records which sandbox belongs to a
+   conversation in a database row. Two turns racing on one conversation can leave the row
+   pointing at the wrong sandbox, which orphans one instance (it runs until the idle timers reap
+   it, cents per incident) and sends the next turn through one doomed reconnect. The fix is to
+   wait for the write and make it conditional, so an older turn cannot overwrite a newer one.
+   The open choice is what the condition compares against:
+   - The turn counter already on the `session_states` row. No schema change; the counter is
+     maintained by the continuity code, so this couples the pointer guard to that code's
+     correctness.
+   - A new generation column on `session_states`. Cleanest semantics, needs a schema migration.
+   - The Redis session-owner claim PR #5197 added. No schema change and already per-session,
+     but Redis contents can be flushed, and a flushed key silently drops the guard.
+   Related: PR #5197's own durable-continuity write has the same unguarded pattern, so one
+   mechanism should probably cover both writes.
 
-2. **Shutdown policy** (Slice 2). The plan splits shutdown (SIGTERM) by state: delete when a turn
-   is in flight (the transcript may be partial), stop when idle. Confirm that split, and that
-   explicit `/kill` keeps its hard-delete meaning.
+2. **What happens to sandboxes when the runner shuts down** (Slice 2). Background: the runner
+   process stops on every deploy, restart, or scale-down (a SIGTERM). At that moment some
+   conversations have a turn mid-flight and others have an idle parked sandbox. The choice, per
+   sandbox:
+   - Turn mid-flight: delete, or stop? Delete is safe: the transcript may be missing the last
+     exchange, and restarting later from a half-written state risks a wrong resume. Stop would
+     save the next turn about a second but carries that risk.
+   - Idle: stop, or delete? Stop means a rolling deploy keeps the parked disks, and the next
+     turn restarts one instead of rebuilding. Delete is simpler and forces the next turn cold.
+   The plan proposes delete for mid-flight, stop for idle, and `/kill` keeps its hard-delete
+   meaning. The cost difference is about a second per affected conversation either way; the
+   proposal favors correctness for mid-flight and warmth for idle. Confirm or override.
 
-3. **Saturation behavior of the capacity gate** (Slice 4). When every running permit belongs to an
-   active or approval-waiting turn, the plan says queue briefly or reject with a clear error.
-   Which, and with what bound? A short queue is friendlier; a fast reject is simpler and easier to
-   observe. This only bites when concurrent Daytona conversations exceed `MAX_RUNNING`.
-
-4. **Does the session reload behave identically on a reattached same-instance sandbox?** With the
+3. **Does the session reload behave identically on a reattached same-instance sandbox?** With the
    harness transcript mounts enabled, the transcript comes from the durable mounted files either
    way, so it should. Confirm live in Slice 5, including the mount-hygiene case (an old file mount
    with expired credentials surviving a stop and start; see plan.md must-fix item 4).
 
-## Proposed defaults awaiting confirmation
+## Answered (kept for the record)
 
-5. **The stop timer at 15 minutes** (Slice 2). Daytona's idle clock resets on external API calls,
-   not on processes running inside the sandbox, so a short stop timer can stop a sandbox under a
-   live long tool call or an unanswered approval gate (the run-limits guard allows 300 seconds).
-   The measured cost of the longer timer is about 4 cents per crash orphan versus about 1.4 cents
-   at 5 minutes. The plan proposes 15; confirm.
-
-6. **The park-to-running defaults** (Slice 4). Idle window 60 seconds, cap of 4 concurrently
-   running sandboxes; measured worst case about $0.67/hour with all four parked. These are
-   env-configurable (`AGENTA_RUNNER_DAYTONA_SESSION_*`), so confirming them blocks nothing; they
-   can be tuned after the Slice 5 measurement.
-
-## Resolved by measurement or direction (kept for the record)
-
+- **Warm-cap overflow behavior**: when every warm slot is taken, a finishing turn parks its
+  sandbox to stopped instead of keeping it running. Active turns are never blocked by the warm
+  cap; there is no queue and no rejection. (Mahmoud, PR review.)
+- **The live-window default and the off switch**: two minutes
+  (`AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS=120000`), and setting it to 0 disables keeping
+  sandboxes running. No separate enabled flag, and no feature flags in the finished feature; the
+  controls are env vars. (Mahmoud, PR review.)
+- **The warm cap default**: 20 (`AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM`), sized so roughly 20
+  parallel conversations can all stay warm; worst case about $3.33/hour while fully loaded,
+  bounded in time by the two-minute window. A separate variable from the local pool's
+  `AGENTA_RUNNER_SESSION_POOL_MAX`, because that one budgets host memory and this one budgets
+  billed compute. (Mahmoud, PR review.)
+- **The stop timer**: 15 minutes, env-overridable via `DAYTONA_AUTOSTOP`. The timer resets on
+  every turn, so an active conversation never hits it; it only fires after 15 minutes of
+  silence. (Mahmoud, PR review.)
+- **Auto-archive**: removed entirely, not configured around. The create call drops the
+  `autoArchiveInterval` field and the `DAYTONA_AUTOARCHIVE` override. Restoring from archive
+  (33 to 66 seconds measured) is slower than a fresh create (1.2 to 1.7 seconds). The ladder is
+  stop, then delete. (Mahmoud, PR review; measurement.)
 - **Abandonment compute budget**: measured at about 1.4 to 4 cents per crashed-runner incident
   depending on the stop timer, plus a fraction of a cent of storage until the delete timer. No
-  separate sweeper is needed; the timers are the sweeper. (Was: a billing-owner gate.)
-- **Should park-to-running ship at all**: yes, by direction (2026-07-11) and by measurement.
-  Sandbox creation is about 1 second of a ~15-second turn, so park-to-stopped cannot fix it; only a
-  sandbox that stays running skips the per-turn pipeline. Park-to-running is now Slice 4 of the
-  main line, not a deferred level.
-- **Archive**: dropped. Restoring from archive (33 to 66 seconds measured) is slower than a fresh
-  create (1.2 to 1.7 seconds), and the freed disk costs under a tenth of a cent per hour. The
-  demotion ladder is stop, then delete, with `DAYTONA_AUTOARCHIVE` strictly greater than
-  `DAYTONA_AUTODELETE`.
+  separate sweeper is needed; the timers are the sweeper.
+- **Should park-to-running ship at all**: yes. Sandbox creation is about 1 second of a
+  ~15-second turn, so park-to-stopped cannot fix latency; only a sandbox that stays running
+  skips the per-turn pipeline. Park-to-running is Slice 4 of the main line.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
@@ -1,0 +1,40 @@
+# Open questions
+
+For the reviewer and the billing owner. Each needs a decision before the matching phase ships.
+
+1. Orphan compute budget (Phase 2, billing owner). With `ephemeral: false` and real
+   stop-not-delete, a SIGKILL'd runner leaves a running Daytona sandbox billing compute until
+   `autoStop` (5 idle minutes), then storage until `autoDelete` (30). Is that acceptable as the
+   price of warm reuse? The API-side `orphan_sweep.py` does not help (verified: it cleans DB
+   rows and Redis locks only, never contacts Daytona). If the budget is unacceptable, the
+   options are a lower `DAYTONA_AUTOSTOP` or a new provider-side sweeper.
+
+2. AutoStop value versus long silent turns (Phase 2). Daytona's inactivity clock resets on
+   external API interactions, not on in-sandbox processes, so a 5-minute autoStop can stop a
+   sandbox under a live long tool call or an unanswered approval gate (the run-limits guard
+   allows 300s). The old default was 15. What value balances the crash-orphan budget against
+   mid-turn stops?
+
+3. Fencing design for the sandbox pointer (Phase 1, reviewer). `writeSandboxId` is a
+   fire-and-forget last-writer-wins PUT, and the remote path skips the runner ownership check.
+   The plan calls for awaited, compare-and-set writes. Where does the fence live: a generation
+   column on `session_states`, the existing turn counter, or the Redis owner claim PR #5197
+   added for local sessions?
+
+4. Graceful-shutdown policy (Phase 2). The plan splits SIGTERM by state: delete when a turn is
+   in flight (partial transcript), stop when idle. Confirm that split, and that `/kill` keeps
+   hard-delete semantics.
+
+5. Daytona TTL and running cap (Phase 4, billing owner). What idle TTL and
+   `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` make Tier 2 affordable? These are the direct
+   cost knobs. Until set, Tier 2 stays off.
+
+6. Should Tier 2 ship at all, given Tier 1 plus durable `session/load`? Tier 1 replaces the
+   cold create with a stopped-start plus daemon plus mounts plus load; the actual saving is
+   unmeasured ("create minus start"). Measure Tier 1's real second-turn latency on E3 (Phase 3)
+   before committing to Tier 2.
+
+7. Does `session/load` behave identically on a reattached same-instance sandbox? With harness
+   mounts enabled the transcript comes from the durable mounted prefixes either way, so it
+   should. Confirm live in Phase 3, including the mount-hygiene case (an old geesefs mount with
+   expired credentials surviving a stop/start; see plan.md P0 item 4).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
@@ -48,7 +48,7 @@ that need a reviewer's confirmation rather than an owner's decision.
   depending on the stop timer, plus a fraction of a cent of storage until the delete timer. No
   separate sweeper is needed; the timers are the sweeper. (Was: a billing-owner gate.)
 - **Should park-to-running ship at all**: yes, by direction (2026-07-11) and by measurement.
-  Sandbox creation is under 2 seconds, so park-to-stopped cannot fix the 20-second turn; only a
+  Sandbox creation is about 1 second of a ~15-second turn, so park-to-stopped cannot fix it; only a
   sandbox that stays running skips the per-turn pipeline. Park-to-running is now Slice 4 of the
   main line, not a deferred level.
 - **Archive**: dropped. Restoring from archive (33 to 66 seconds measured) is slower than a fresh

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
@@ -1,40 +1,42 @@
 # Open questions
 
-For the reviewer and the billing owner. Each needs a decision before the matching phase ships.
+These are the decisions a human still has to make. A reviewer owns the correctness ones; a billing
+owner owns the cost ones. Each names the phase it gates. The three that gate shipping at all are
+the abandonment budget, the pointer write guard, and the park-to-running cost limits.
 
-1. Orphan compute budget (Phase 2, billing owner). With `ephemeral: false` and real
-   stop-not-delete, a SIGKILL'd runner leaves a running Daytona sandbox billing compute until
-   `autoStop` (5 idle minutes), then storage until `autoDelete` (30). Is that acceptable as the
-   price of warm reuse? The API-side `orphan_sweep.py` does not help (verified: it cleans DB
-   rows and Redis locks only, never contacts Daytona). If the budget is unacceptable, the
-   options are a lower `DAYTONA_AUTOSTOP` or a new provider-side sweeper.
+1. **Abandonment compute budget** (Phase 2, billing owner). With `ephemeral: false` and a real
+   stop-not-delete park, a hard-killed runner leaves a running Daytona sandbox billing compute
+   until the 5-minute stop timer fires, then billing storage until the 30-minute delete timer.
+   Is that acceptable as the price of warm reuse? The API-side `orphan_sweep.py` does not help:
+   it cleans only database rows and Redis locks and never contacts Daytona. If the budget is too
+   large, the options are a lower `DAYTONA_AUTOSTOP` or a new provider-side sweeper.
 
-2. AutoStop value versus long silent turns (Phase 2). Daytona's inactivity clock resets on
-   external API interactions, not on in-sandbox processes, so a 5-minute autoStop can stop a
-   sandbox under a live long tool call or an unanswered approval gate (the run-limits guard
-   allows 300s). The old default was 15. What value balances the crash-orphan budget against
-   mid-turn stops?
+2. **Stop-timer value versus long silent turns** (Phase 2, billing owner). Daytona's idle clock
+   resets on external API calls, not on processes running inside the sandbox. So a 5-minute stop
+   timer can stop a sandbox under a live long tool call or an unanswered approval gate (the
+   run-limits guard allows 300 seconds). The old default was 15 minutes. What value balances the
+   crash-orphan budget against stopping a sandbox mid-turn?
 
-3. Fencing design for the sandbox pointer (Phase 1, reviewer). `writeSandboxId` is a
-   fire-and-forget last-writer-wins PUT, and the remote path skips the runner ownership check.
-   The plan calls for awaited, compare-and-set writes. Where does the fence live: a generation
-   column on `session_states`, the existing turn counter, or the Redis owner claim PR #5197
-   added for local sessions?
+3. **How to guard the sandbox pointer write** (Phase 1, reviewer). `writeSandboxId` is a
+   fire-and-forget, last-writer-wins PUT, and the Daytona path skips the runner's ownership check.
+   The plan calls for awaited, conditional (compare-and-set) writes. Where does the guard live: a
+   new generation column on `session_states`, the existing turn counter, or the Redis owner claim
+   PR #5197 added for local sessions?
 
-4. Graceful-shutdown policy (Phase 2). The plan splits SIGTERM by state: delete when a turn is
-   in flight (partial transcript), stop when idle. Confirm that split, and that `/kill` keeps
-   hard-delete semantics.
+4. **Shutdown policy** (Phase 2, reviewer). The plan splits shutdown (SIGTERM) by state: delete when
+   a turn is in flight (the transcript may be partial), stop when idle. Confirm that split, and that
+   explicit `/kill` keeps its hard-delete meaning.
 
-5. Daytona TTL and running cap (Phase 4, billing owner). What idle TTL and
-   `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` make Tier 2 affordable? These are the direct
-   cost knobs. Until set, Tier 2 stays off.
+5. **Park-to-running cost limits** (Phase 4, billing owner). What idle time-to-live and what value
+   for `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` make park-to-running affordable? These are the
+   direct cost knobs. Until they are set, park-to-running stays off.
 
-6. Should Tier 2 ship at all, given Tier 1 plus durable `session/load`? Tier 1 replaces the
-   cold create with a stopped-start plus daemon plus mounts plus load; the actual saving is
-   unmeasured ("create minus start"). Measure Tier 1's real second-turn latency on E3 (Phase 3)
-   before committing to Tier 2.
+6. **Should park-to-running ship at all**, given park-to-stopped plus durable reload? Park-to-stopped
+   replaces the cold build with a stopped-start plus daemon plus mounts plus reload; the actual
+   saving is unmeasured (a full build minus the build). Measure park-to-stopped's real second-turn
+   latency on E3 (Phase 3) before committing to park-to-running.
 
-7. Does `session/load` behave identically on a reattached same-instance sandbox? With harness
-   mounts enabled the transcript comes from the durable mounted prefixes either way, so it
-   should. Confirm live in Phase 3, including the mount-hygiene case (an old geesefs mount with
-   expired credentials surviving a stop/start; see plan.md P0 item 4).
+7. **Does the session reload behave identically on a reattached same-instance sandbox?** With the
+   harness transcript mounts enabled, the transcript comes from the durable mounted files either
+   way, so it should. Confirm live in Phase 3, including the mount-hygiene case (an old file mount
+   with expired credentials surviving a stop and start; see plan.md must-fix item 4).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/open-questions.md
@@ -1,42 +1,57 @@
 # Open questions
 
-These are the decisions a human still has to make. A reviewer owns the correctness ones; a billing
-owner owns the cost ones. Each names the phase it gates. The three that gate shipping at all are
-the abandonment budget, the pointer write guard, and the park-to-running cost limits.
+These are the decisions a human still has to make. The 2026-07-11 lifecycle measurement
+(research.md) answered the cost questions that used to sit here: the abandonment budget is cents
+per crash, the park-to-running knobs became configuration with stated defaults, and the archive
+state is dropped outright. What remains open is about correctness, plus two proposed defaults
+that need a reviewer's confirmation rather than an owner's decision.
 
-1. **Abandonment compute budget** (Phase 2, billing owner). With `ephemeral: false` and a real
-   stop-not-delete park, a hard-killed runner leaves a running Daytona sandbox billing compute
-   until the 5-minute stop timer fires, then billing storage until the 30-minute delete timer.
-   Is that acceptable as the price of warm reuse? The API-side `orphan_sweep.py` does not help:
-   it cleans only database rows and Redis locks and never contacts Daytona. If the budget is too
-   large, the options are a lower `DAYTONA_AUTOSTOP` or a new provider-side sweeper.
+## Still open (correctness, reviewer)
 
-2. **Stop-timer value versus long silent turns** (Phase 2, billing owner). Daytona's idle clock
-   resets on external API calls, not on processes running inside the sandbox. So a 5-minute stop
-   timer can stop a sandbox under a live long tool call or an unanswered approval gate (the
-   run-limits guard allows 300 seconds). The old default was 15 minutes. What value balances the
-   crash-orphan budget against stopping a sandbox mid-turn?
+1. **How to guard the sandbox pointer write** (Slice 1). `writeSandboxId` is a fire-and-forget,
+   last-writer-wins PUT, and the Daytona path skips the runner's ownership check. The plan calls
+   for awaited, conditional (compare-and-set) writes. Where does the guard live: a new generation
+   column on `session_states`, the existing turn counter, or the Redis owner claim PR #5197 added
+   for local sessions? Related: PR #5197's own risk list flags the same missing concurrency guard
+   on its durable-continuity write, so one guard mechanism should probably cover both writes.
 
-3. **How to guard the sandbox pointer write** (Phase 1, reviewer). `writeSandboxId` is a
-   fire-and-forget, last-writer-wins PUT, and the Daytona path skips the runner's ownership check.
-   The plan calls for awaited, conditional (compare-and-set) writes. Where does the guard live: a
-   new generation column on `session_states`, the existing turn counter, or the Redis owner claim
-   PR #5197 added for local sessions?
-
-4. **Shutdown policy** (Phase 2, reviewer). The plan splits shutdown (SIGTERM) by state: delete when
-   a turn is in flight (the transcript may be partial), stop when idle. Confirm that split, and that
+2. **Shutdown policy** (Slice 2). The plan splits shutdown (SIGTERM) by state: delete when a turn
+   is in flight (the transcript may be partial), stop when idle. Confirm that split, and that
    explicit `/kill` keeps its hard-delete meaning.
 
-5. **Park-to-running cost limits** (Phase 4, billing owner). What idle time-to-live and what value
-   for `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` make park-to-running affordable? These are the
-   direct cost knobs. Until they are set, park-to-running stays off.
+3. **Saturation behavior of the capacity gate** (Slice 4). When every running permit belongs to an
+   active or approval-waiting turn, the plan says queue briefly or reject with a clear error.
+   Which, and with what bound? A short queue is friendlier; a fast reject is simpler and easier to
+   observe. This only bites when concurrent Daytona conversations exceed `MAX_RUNNING`.
 
-6. **Should park-to-running ship at all**, given park-to-stopped plus durable reload? Park-to-stopped
-   replaces the cold build with a stopped-start plus daemon plus mounts plus reload; the actual
-   saving is unmeasured (a full build minus the build). Measure park-to-stopped's real second-turn
-   latency on E3 (Phase 3) before committing to park-to-running.
-
-7. **Does the session reload behave identically on a reattached same-instance sandbox?** With the
+4. **Does the session reload behave identically on a reattached same-instance sandbox?** With the
    harness transcript mounts enabled, the transcript comes from the durable mounted files either
-   way, so it should. Confirm live in Phase 3, including the mount-hygiene case (an old file mount
+   way, so it should. Confirm live in Slice 5, including the mount-hygiene case (an old file mount
    with expired credentials surviving a stop and start; see plan.md must-fix item 4).
+
+## Proposed defaults awaiting confirmation
+
+5. **The stop timer at 15 minutes** (Slice 2). Daytona's idle clock resets on external API calls,
+   not on processes running inside the sandbox, so a short stop timer can stop a sandbox under a
+   live long tool call or an unanswered approval gate (the run-limits guard allows 300 seconds).
+   The measured cost of the longer timer is about 4 cents per crash orphan versus about 1.4 cents
+   at 5 minutes. The plan proposes 15; confirm.
+
+6. **The park-to-running defaults** (Slice 4). Idle window 60 seconds, cap of 4 concurrently
+   running sandboxes; measured worst case about $0.67/hour with all four parked. These are
+   env-configurable (`AGENTA_RUNNER_DAYTONA_SESSION_*`), so confirming them blocks nothing; they
+   can be tuned after the Slice 5 measurement.
+
+## Resolved by measurement or direction (kept for the record)
+
+- **Abandonment compute budget**: measured at about 1.4 to 4 cents per crashed-runner incident
+  depending on the stop timer, plus a fraction of a cent of storage until the delete timer. No
+  separate sweeper is needed; the timers are the sweeper. (Was: a billing-owner gate.)
+- **Should park-to-running ship at all**: yes, by direction (2026-07-11) and by measurement.
+  Sandbox creation is under 2 seconds, so park-to-stopped cannot fix the 20-second turn; only a
+  sandbox that stays running skips the per-turn pipeline. Park-to-running is now Slice 4 of the
+  main line, not a deferred level.
+- **Archive**: dropped. Restoring from archive (33 to 66 seconds measured) is slower than a fresh
+  create (1.2 to 1.7 seconds), and the freed disk costs under a tenth of a cent per hour. The
+  demotion ladder is stop, then delete, with `DAYTONA_AUTOARCHIVE` strictly greater than
+  `DAYTONA_AUTODELETE`.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
@@ -1,242 +1,256 @@
 # Plan: warm and resumable Daytona sessions
 
-Read `research.md` first. The single most important fact: the runner-side warm plumbing already
-exists (keepWarm park, stored-id reconnect, native `session/load`, `ephemeral: false` plus idle
-timers), but the vendored Daytona provider (`sandbox-agent@0.4.2`, `dist/providers/daytona.js`)
-implements only `create`, `destroy`, `getUrl`, and `ensureServer`. It has no `pause` and no
-`reconnect`. So today:
+Read `research.md` first. The one fact this plan turns on: the runner-side warm plumbing already
+exists (park at turn end, reconnect by stored id, native session reload, `ephemeral: false` with
+idle timers), but the code that talks to Daytona (the "provider" in `sandbox-agent@0.4.2`)
+implements only `create`, `destroy`, `getUrl`, and `ensureServer`. It has no pause and no
+reconnect. So today:
 
-- On a successful turn, `pauseSandbox()` finds no `provider.pause` and falls back to
-  `provider.destroy()`, which calls `sandbox.delete()`. The sandbox is deleted at turn end,
-  keepWarm or not. (Verified in the vendored `chunk-TVCDKGSM.js`: `pauseSandbox` calls
-  `provider.destroy(rawSandboxId)` when `provider.pause` is absent.)
-- The `ephemeral: false` plus autoStop/autoArchive/autoDelete timers never get to act, because
-  the sandbox is already gone.
-- Next turn, `readStoredSandboxId` resolves a deleted id; `start({sandboxId})` calls the missing
-  `provider.reconnect`, then `ensureServer`, which cannot start a dead instance, so it throws and
-  the runner creates fresh.
+- On a successful turn, `pauseSandbox()` finds no pause function and falls back to a delete. The
+  sandbox is deleted at turn end, whether the runner asked to keep it warm or not.
+- The `ephemeral: false` idle timers never get to act, because the sandbox is already gone.
+- On the next turn, the runner looks up the stored id, tries to reconnect, hits the missing
+  reconnect function, and builds a fresh sandbox.
 
-F-020's conclusion therefore still holds at HEAD, for a deeper reason than F-020 stated. The
-correctness path (durable `session/load` over the mounted transcript) makes resume answer
-correctly in about 20 seconds, but no instance is ever reused. This plan makes reuse real.
+F-020's conclusion still holds at HEAD, for a deeper reason than F-020 gave. Durable continuity
+makes the resumed turn answer correctly in about twenty seconds, but no sandbox is ever reused.
+This plan makes reuse real.
 
-The Daytona SDK already exposes what the provider is missing. `sandbox.stop()`,
-`sandbox.start()` (which also resumes an archived sandbox), `sandbox.delete()`, and a `state`
-field are all present in `@daytonaio/sdk` 0.187.0. But the design review (see status.md)
-established that two optional hooks alone are not enough: two failure-cleanup seams in the
-vendored lifecycle must be fixed with them, and reuse needs a compatibility check and write
-fencing. Those are the P0 items below.
+The Daytona SDK already exposes what the provider is missing: `sandbox.stop()`, `sandbox.start()`
+(which also resumes an archived sandbox), `sandbox.delete()`, and a `state` field are all present
+in `@daytonaio/sdk` 0.187.0. But adding the two functions is not enough on its own. Two spots in
+the vendored teardown code clean up incorrectly and must be fixed alongside them, and safe reuse
+needs a compatibility check and a guard against racing writes. Those are the must-fix items under
+park-to-stopped below.
 
-## Tier 1: cheap resume (park to stopped)
+## The two levels of reuse
+
+The plan proposes two levels, in order of cost:
+
+- **Park-to-stopped** (cheaper, ships first). At a clean turn end, stop the sandbox instead of
+  deleting it; on the next turn, start the same one and reload the harness session. The parked
+  sandbox costs disk storage only. Most of this is already prototyped in the working tree.
+- **Park-to-running** (more expensive, deferred). Keep the sandbox running with its live session
+  between turns, for a short window, so the next turn is near-instant. The parked sandbox costs
+  live compute, so it needs cost limits and a billing owner to set them.
+
+Each maps onto one level of the fallback ladder in `research.md`: park-to-stopped builds the
+stopped-restart level, park-to-running builds the live-warm level. They compose. The cold-rebuild
+floor stays underneath both.
+
+## Park-to-stopped: cheap resume
 
 Goal: at a clean turn end, stop the Daytona sandbox instead of deleting it; on the next turn,
-start the same instance and `session/load` the harness. Parked cost is storage only. Resume cost
-is "create minus start": the restart path still pays sandbox start, daemon startup, asset
-preparation, cwd and transcript mounts, harness startup, and `session/load`. The win is real but
-unmeasured; Phase 3 measures it before any latency number is claimed.
+start the same instance and reload the harness session. The parked cost is disk storage only. The
+resume cost is "a full build minus the build": the restart path still pays sandbox start, daemon
+startup, asset preparation, file mounts, harness startup, and the session reload. The win is real
+but unmeasured. Phase 3 measures it before any latency number is claimed.
 
-### What is already done (HEAD, untested)
+### What is already built (at HEAD, untested)
 
-- `provider.ts`: `ephemeral: false`, autoStop 5, autoArchive 15, autoDelete 30. The three
-  `DAYTONA_AUTOSTOP` / `DAYTONA_AUTOARCHIVE` / `DAYTONA_AUTODELETE` envs are forwarded by every
-  compose file and by the Helm runner deployment (verified; PR #5197's "compose gap" risk note
-  is stale).
-- `sandbox_agent.ts`: `destroy({ keepWarm })` park branch; `shouldPark` gating; both run paths
-  pass keepWarm on a clean resumable Daytona turn.
-- `sandbox-reconnect.ts`: store and read-back of the Daytona instance id in
-  `session_states.sandbox_id`; the reconnect ladder in acquire.
-- `patches/sandbox-agent@0.4.2.patch`: native ACP `session/load` and local process-group kill.
+- `provider.ts`: `ephemeral: false`, with idle timers at 5 minutes (stop), 15 (archive), 30
+  (delete). Every compose file and the Helm runner deployment forward the three
+  `DAYTONA_AUTOSTOP` / `DAYTONA_AUTOARCHIVE` / `DAYTONA_AUTODELETE` overrides (verified; PR
+  #5197's "compose gap" risk note is stale).
+- `sandbox_agent.ts`: the `destroy({ keepWarm })` park branch, the `shouldPark` gate, and both run
+  paths passing `keepWarm` on a clean, resumable Daytona turn.
+- `sandbox-reconnect.ts`: storing and reading back the Daytona instance id in
+  `session_states.sandbox_id`, and the reconnect ladder at the start of a run.
+- `patches/sandbox-agent@0.4.2.patch`: the native session reload and the local process-group kill.
 
-### P0: correctness gaps to close before Tier 1 can be enabled
+### Must-fix before it can be turned on
 
-These came out of the design-review round. Each is a real leak or race, not polish.
+Each of these is a real leak or race, not polish. They block enabling the feature.
 
-1. Provider `pause` and `reconnect` hooks, plus the two broken failure-cleanup seams.
-   - `pause(id)`: fetch the handle (`client.get(id)`), call `sandbox.stop()`.
-   - `reconnect(id)`: fetch the handle; drive a small state machine, not a two-state check. The
-     Daytona state enum includes `starting`, `stopping`, `restoring`, `archiving`, `destroying`,
-     and error states alongside started/stopped/archived. Wait out transitional states with a
-     bound, `start()` a stopped or archived instance (archived resumes via plain `start()`, just
-     slower), reattach a running one, and fail cleanly on error states.
-   - Seam A (failed pause loses its delete fallback): the vendored `pauseSandbox()` clears
-     `sandboxProvider` and the raw id in its `finally`, even when `provider.pause()` throws. The
-     runner's follow-up `destroySandbox()` then has no provider attached and silently does
-     nothing, leaving the sandbox running. Fix in the dist patch (or a replacement seam): a
-     failed pause must keep the handle so the delete fallback actually deletes.
-   - Seam B (reconnect failure leaks a double sandbox): `SandboxAgent.start({sandboxId})` runs
-     `reconnect`, `ensureServer`, `getUrl`, and client construction, but only cleans up sandboxes
-     it created itself. If `sandbox.start()` succeeds and a later step throws, the old sandbox is
-     left running and the runner's ladder creates a second one. The reconnect path needs an
-     ownership-aware cleanup: if it transitioned the sandbox to running and attachment failed,
-     stop it before falling back to a fresh create.
-   - Home: the hooks themselves fit a runner-side wrapper over the vendored `daytona(...)`
-     provider (survives package bumps). The two seams live inside the vendored `SandboxAgent`
-     lifecycle, so they need the dist patch that PR #5197 already established. Accept the split:
-     hooks in the wrapper, seam fixes in the patch.
+1. **The two provider functions, plus the two teardown cleanup gaps.**
+   - `pause(id)`: fetch the sandbox handle (`client.get(id)`), call `sandbox.stop()`.
+   - `reconnect(id)`: fetch the handle, then drive a small state machine, not a two-state check.
+     Daytona's state field includes transitional values (`starting`, `stopping`, `restoring`,
+     `archiving`, `destroying`) and error states alongside started, stopped, and archived. Wait
+     out the transitional states with a time bound, `start()` a stopped or archived instance
+     (archived resumes via plain `start()`, just slower), reattach a running one, and fail cleanly
+     on error states.
+   - Cleanup gap A (a failed pause loses its delete fallback): the vendored `pauseSandbox()` clears
+     the provider handle and the raw id in its `finally` block, even when `pause()` throws. The
+     runner's follow-up `destroySandbox()` then has no provider attached and silently does nothing,
+     leaving the sandbox running. Fix in the package patch: a failed pause must keep the handle so
+     the delete fallback actually deletes.
+   - Cleanup gap B (a failed reconnect leaks a second sandbox): `SandboxAgent.start({sandboxId})`
+     runs reconnect, `ensureServer`, `getUrl`, and client construction, but cleans up only
+     sandboxes it created itself. If `sandbox.start()` succeeds and a later step throws, the old
+     sandbox is left running and the runner builds a second one. The reconnect path needs
+     ownership-aware cleanup: if it started the sandbox and then failed to attach, it must stop the
+     sandbox before falling back to a fresh build.
+   - Where the code lives: the two functions fit a runner-side wrapper over the vendored Daytona
+     provider, which survives package bumps. The two cleanup gaps are inside the vendored
+     `SandboxAgent` teardown, so they need the package patch that PR #5197 already established.
+     Accept the split: functions in the wrapper, cleanup fixes in the patch.
 
-2. Compatibility fingerprint before reuse. A Daytona sandbox bakes create-time state: env vars,
-   resolved secrets, snapshot/image, target, and the network policy. Reconnect applies none of
-   the new request's create configuration, so reuse keyed only on `session_id` can resurrect
-   stale credentials or a weaker network policy. Store a fingerprint over the sandbox-baked
-   configuration next to the sandbox id; on mismatch, delete the old sandbox and create fresh.
-   This mirrors the keep-alive pool's `configFingerprint` and credential epoch, applied at the
-   reconnect rung.
+2. **A compatibility check before reuse.** A Daytona sandbox bakes in its create-time settings:
+   env vars, resolved secrets, the snapshot or image, the target, and the network policy.
+   Reconnect applies none of the new request's settings, so reusing a sandbox keyed only on the
+   conversation id can resurrect stale credentials or a weaker network policy. Store a fingerprint
+   of the baked-in settings next to the sandbox id. On a mismatch, delete the old sandbox and build
+   fresh. This mirrors the local pool's config fingerprint and credential epoch, applied at the
+   reconnect step.
 
-3. Fencing on the sandbox pointer. `writeSandboxId` is a fire-and-forget last-writer-wins PUT,
-   and the remote path is excluded from the runner ownership check. Two turns racing on one
-   `session_id` (or a forced steer that starts the replacement before the old turn stops) can
-   cross-write the pointer, orphaning one instance and double-using another. Await the write,
-   and make read-modify-write conditional (compare-and-set on a generation or turn index; the
+3. **A write guard on the sandbox pointer.** `writeSandboxId` is a fire-and-forget,
+   last-writer-wins PUT, and the Daytona path skips the runner's ownership check. Two turns racing
+   on one conversation (or a forced re-steer that starts a replacement before the old turn stops)
+   can cross-write the pointer, orphaning one instance and double-using another. Await the write,
+   and make it conditional (a compare-and-set on a generation number or the turn index; the
    `session_states` row already carries a turn counter). A stale turn must not overwrite or stop
-   the current turn's sandbox. Clearing a stale id after a failed reconnect must be conditional
-   for the same reason.
+   the current turn's sandbox. Clearing a stale id after a failed reconnect must be conditional for
+   the same reason.
 
-4. Mount hygiene on reattach. Reconnecting an already-running sandbox can find an old geesefs
-   mount with expired credentials; `mountStorageRemote()` accepts any live mount and does not
-   verify it uses the new credentials. Require a clean remount or verify the mount generation
-   before `session/load`.
+4. **Mount hygiene on reattach.** Reconnecting to an already-running sandbox can find an old file
+   mount with expired credentials. `mountStorageRemote()` accepts any live mount and does not check
+   that it uses the new credentials. Require a clean remount, or verify the mount generation, before
+   the session reload.
 
-### The rest of the Tier 1 work
+### The rest of the park-to-stopped work
 
-5. Teardown by reason, not one generic destroy. The cases want different dispositions:
-   - `/kill`, failed turn, aborted turn, config/policy mismatch: delete.
-   - Clean resumable turn end: stop (this is the Tier 1 park).
-   - SIGTERM with a turn in flight: delete (the transcript may be partial).
-   - SIGTERM idle: stop, so a rolling restart keeps warmth.
-   Today `/kill` and shutdown share the same drain mechanics; reinterpreting all teardown as
-   stop would break explicit kill semantics, so the reason has to travel into the teardown.
+5. **Teardown by reason, not one generic destroy.** Different endings want different dispositions:
+   - Explicit `/kill`, a failed turn, an aborted turn, or a compatibility mismatch: delete.
+   - A clean resumable turn end: stop (this is the park).
+   - Shutdown (SIGTERM) with a turn in flight: delete, since the transcript may be partial.
+   - Shutdown while idle: stop, so a rolling restart keeps the sandbox warm.
+   Today `/kill` and shutdown share the same drain mechanics, so reinterpreting all teardown as a
+   stop would break explicit kill semantics. The reason has to travel into the teardown.
 
-6. The reaper cascade is the sweeper, and the orphan budget is a decision. Once a sandbox
-   survives turn end, Daytona's own timers reap abandonment: autoStop (5 min) stops a warm
-   sandbox, autoArchive (15) colds it, autoDelete (30) deletes it. No runner cron is needed.
-   Two open points for a billing owner:
-   - Crash orphans. `ephemeral: true` auto-deleted on stop, so a crashed runner leaked little.
-     Now a SIGKILL'd runner leaves a running sandbox billing compute for up to 5 idle minutes,
-     then storage until autoDelete. Note the API-side `orphan_sweep.py` does NOT help here: it
-     only cleans Postgres rows and Redis locks and never contacts Daytona. If the 5-minute
+6. **The idle timers are the sweeper; the abandonment budget is a decision.** Once a sandbox
+   survives turn end, Daytona's own timers reap abandonment: stop after 5 idle minutes, archive
+   after 15, delete after 30. No runner cron job is needed. Two points need a billing owner:
+   - Crash orphans. `ephemeral: true` auto-deleted a sandbox on stop, so a crashed runner leaked
+     little. Now a hard-killed runner leaves a running sandbox billing compute for up to 5 idle
+     minutes, then storage until the delete timer. The API-side `orphan_sweep.py` does not help:
+     it cleans only Postgres rows and Redis locks and never contacts Daytona. If the 5-minute
      compute budget is unacceptable, the options are a lower `DAYTONA_AUTOSTOP` or a new
-     provider-side sweeper; do not lean on the existing sweep task.
-   - Auto-stop can fire mid-turn. Daytona's inactivity clock resets on external API
-     interactions, not on processes running inside the sandbox. A long silent tool call or an
-     unanswered approval gate can outlast a 5-minute autoStop and the sandbox stops under a live
-     turn. The old default was 15. Compare the autoStop value against the runner's maximum
-     silent interval (the 300s run-limits guard is one bound) before keeping 5.
+     provider-side sweeper. Do not lean on the existing sweep task.
+   - The stop timer can fire mid-turn. Daytona's idle clock resets on external API calls, not on
+     processes running inside the sandbox. A long, silent tool call or an unanswered approval gate
+     can outlast a 5-minute stop timer, and the sandbox stops under a live turn. The old default
+     was 15 minutes. Compare the stop timer against the runner's longest silent interval (the
+     300-second run-limits guard is one bound) before keeping 5.
 
-7. Stale stored-id hygiene. When autoDelete reaps a sandbox, `session_states.sandbox_id` goes
-   stale. The ladder degrades gracefully (failed get, fresh create), but the doomed reconnect
-   repeats every turn. Clear the stored id on a failed reconnect, conditionally (see item 3).
+7. **Clean up a stale stored id.** When the delete timer reaps a sandbox, `session_states.sandbox_id`
+   goes stale. The reconnect ladder degrades gracefully (failed lookup, fresh build), but the
+   doomed reconnect repeats every turn. Clear the stored id after a failed reconnect, conditionally
+   (see must-fix item 3).
 
-8. Tests, no live Daytona. The lifecycle commit is labelled "(untested)". Unit-test the wrapper
-   hooks against a fake Daytona client (stop on pause; start on reconnect only from
-   stopped/archived; transitional-state waits; error-state refusal), the two seam fixes (failed
-   pause still deletes; failed reconnect stops the half-started instance), the teardown-reason
-   matrix (park on clean resumable turns, delete on failed/aborted/kill), and the fenced
-   pointer write. Live E3 verification is Phase 3, gated on credits.
+8. **Tests, no live Daytona.** The lifecycle commit is labelled "(untested)". Unit-test the wrapper
+   functions against a fake Daytona client (stop on pause; start on reconnect only from stopped or
+   archived; waits through transitional states; refusal on error states), the two cleanup fixes (a
+   failed pause still deletes; a failed reconnect stops the half-started instance), the
+   teardown-by-reason matrix (park on clean resumable turns, delete on failed, aborted, or killed
+   turns), and the guarded pointer write. Live testing on E3 is Phase 3, gated on credits.
 
-### Tier 1 cost and fidelity
+### Cost and fidelity
 
-- Parked cost: storage only (stopped disk), bounded by the archive-then-delete cascade.
-- Resume cost: unmeasured; budget it as "create minus start" plus daemon, mounts, harness
-  startup, and `session/load`. An archived restore is slower than a stopped start. Phase 3
-  produces the number.
-- Fidelity: full. `session/load` restores the harness's own session state from the durable
-  transcript mounts (the per-harness geesefs prefixes), whether the instance was reused or not.
-  The one caveat, from the `harness-session-resume` experiments: a tool call left dangling at a
-  gate is not answered byte-exact after a reload; that is the durable-decision path's job,
-  unchanged here.
+- Parked cost: disk storage only (a stopped disk), bounded by the archive-then-delete timers.
+- Resume cost: unmeasured. Budget it as a full build minus the build, plus daemon startup, mounts,
+  harness startup, and the session reload. An archived restore is slower than a stopped start.
+  Phase 3 produces the real number.
+- Fidelity: full. The session reload restores the harness's own state from the durable transcript
+  mounts, whether or not the instance was reused. The one caveat, from the `harness-session-resume`
+  experiments: a tool call left dangling at an approval gate is not answered byte-exact after a
+  reload. That is the durable-decision path's job and is unchanged here.
 
-## Tier 2: true warm pool (park to running)
+## Park-to-running: true warm pool
 
-Goal: keep the sandbox running with its live ACP session between turns for a short window, so a
-second turn is near-instant (no start, no remount, no load). This is the `session-keepalive`
-workspace's deferred "slice 3", now concrete.
+Goal: keep the sandbox running with its live session between turns for a short window, so a second
+turn is near-instant (no start, no remount, no reload). This is the `session-keepalive` workspace's
+deferred Daytona slice, now made concrete.
 
 ### The work
 
-1. Lift the local-only gate for a Daytona-warm mode. Today `runWithKeepalive` sends any
-   non-local request straight to `runCold` (`server.ts` `isLocalSandbox`). Add a Daytona-warm
+1. **Open a Daytona-warm path through the local-only gate.** Today the keep-alive path sends any
+   non-local request straight to a cold build (`isLocalSandbox` in `server.ts`). Add a Daytona-warm
    path behind its own flag, off by default.
 
-2. A separate pool instance, not shared entries. Reuse the `SessionPool` class (it is already
-   engine-agnostic: opaque `environment`, one idempotent `destroy`), but instantiate a second
-   pool for Daytona entries with its own cap and TTLs. Do not mix local and remote entries in
-   one map, and do not reinterpret the local `poolMax`: locally it is a RAM budget (about 330 MB
-   per hot Claude tree); for Daytona it bounds concurrently running billed sandboxes. Those are
-   different resources with different eviction accounting.
+2. **A separate pool instance, not shared entries.** Reuse the pool class (it is already
+   engine-agnostic: an opaque environment and one idempotent `destroy`), but create a second pool
+   for Daytona entries with its own cap and timers. Do not mix local and remote entries in one map,
+   and do not reinterpret the local size cap: locally it is a memory budget (about 330 MB per hot
+   Claude tree); for Daytona it bounds the count of concurrently running billed sandboxes. Those
+   are different resources with different accounting.
 
-3. Daytona-scoped config, named by provider (lifecycle and billing semantics differ per
-   provider, so "remote" is too vague):
+3. **Daytona-scoped config, named by provider** (lifecycle and billing differ per provider, so
+   "remote" is too vague):
    - `AGENTA_RUNNER_DAYTONA_SESSION_KEEPALIVE_ENABLED` (default off).
    - `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS` (short, for example 30000 to 60000).
-   - `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` (a running-sandbox cap; call it that, not a
+   - `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` (a cap on running sandboxes; call it that, not a
      spend cap, since sandboxes are not billed identically).
-   These are operator cost/resource policy. They live in the runner config module next to the
-   existing keepalive config, read once, never via ad-hoc `process.env`.
+   These are operator cost and resource policy. They live in the runner config module next to the
+   existing keep-alive config, read once, never via ad-hoc environment lookups.
 
-4. Eviction wired to the lifecycle, with awaited teardown. On TTL expiry or LRU eviction, a
-   Daytona entry stops the sandbox (drop to Tier 1 warm) rather than deletes it, so the session
-   can still reconnect after the live window closes. And unlike the local pool's fire-and-forget
-   LRU destroy (fine for a soft RAM cache), the Daytona pool must await the stop before
-   admitting a replacement, or the cap does not actually bound running sandboxes: the old one
-   still bills while the new one starts, and a failed stop exceeds the cap indefinitely. A
-   failed stop escalates to delete.
+4. **Eviction wired to the lifecycle, with an awaited teardown.** When the timer expires or the pool
+   evicts an entry, a Daytona entry stops the sandbox (dropping it to the park-to-stopped state)
+   rather than deleting it, so the session can still reconnect after the live window closes. And
+   unlike the local pool's fire-and-forget eviction (fine for a soft memory cache), the Daytona pool
+   must wait for the stop to finish before admitting a replacement. Otherwise the cap does not
+   actually bound running sandboxes: the old one still bills while the new one starts, and a failed
+   stop exceeds the cap indefinitely. A failed stop escalates to a delete.
 
-5. Runner restart and the parked live session. The in-memory pool does not survive a restart.
-   On graceful SIGTERM, drain idle Daytona entries to stop (not delete), so the next turn falls
-   to Tier 1 reconnect and then durable `session/load`; delete entries whose turn was in flight.
-   On SIGKILL, the sandboxes leak until autoStop, the same orphan budget as Tier 1. So Tier 2
-   never has a floor below Tier 1: worst case it degrades to Tier 1, which degrades to cold.
+5. **Runner restart and the parked live session.** The in-memory pool does not survive a restart.
+   On a graceful shutdown, drain idle Daytona entries to stopped (not deleted), so the next turn
+   falls to park-to-stopped reconnect and then durable reload; delete entries whose turn was in
+   flight. On a hard kill, the sandboxes leak until the stop timer, the same abandonment budget as
+   park-to-stopped. So park-to-running never sits below park-to-stopped: its worst case degrades to
+   park-to-stopped, which degrades to cold.
 
-6. Credential epoch and mount expiry are more load-bearing remotely. A parked Daytona session
-   holds signed mount credentials with a real expiry. The existing credential-epoch check
-   already evicts to cold on expiry; keep the Daytona TTL comfortably under the mount-credential
-   lifetime so a live checkout never runs against an expired mount.
+6. **Credentials and mounts matter more here.** A parked running Daytona session holds signed mount
+   credentials with a real expiry. The existing credential-epoch check already evicts to cold on
+   expiry. Keep the Daytona time-to-live comfortably under the mount-credential lifetime, so a live
+   turn never runs against an expired mount.
 
-### Tier 2 cost and fidelity
+### Cost and fidelity
 
-- Parked cost: full running compute for the TTL window, bounded by the running cap. This is the
+- Parked cost: full running compute for the window, bounded by the running-sandbox cap. This is the
   honest downside and the reason it is opt-in.
 - Resume cost: near zero. The sandbox is up, the mount is live, the session is open.
-- Fidelity: highest. It is the only rung that can hold an open approval gate for byte-exact
-  resume (the `session-keepalive` slice-2 result), though gate parking is a separate, Pi-gated
-  concern (F-018) and not required for chat.
+- Fidelity: highest. It is the only level that can hold an open approval gate for byte-exact
+  resume, though holding a gate open is a separate concern (F-018) and is not needed for chat.
 
 ## Recommendation
 
-Land Tier 1 behind a default-off rollout flag, not default-on. The plumbing is mostly built and
-the parked cost is storage only, but the review round surfaced real P0 gaps (the broken
-pause-delete fallback, the double-sandbox reconnect leak, unfenced pointer writes, no
-compatibility check on reuse). Close those, then enable after one credit-controlled live
-lifecycle test on E3 that measures the actual resume latency and confirms single-instance reuse
-with zero leak. Keep durable `session/load` as the always-correct floor.
+Ship park-to-stopped behind a flag that is off by default, not on by default. The plumbing is
+mostly built and the parked cost is storage only, but the review found real must-fix gaps: the
+broken pause-delete fallback, the double-sandbox reconnect leak, the unguarded pointer writes, and
+the missing compatibility check on reuse. Close those, then turn it on after one credit-controlled
+live test on E3 that measures the real resume latency and confirms one instance is reused with zero
+leak. Keep durable reload as the always-correct floor.
 
-Defer Tier 2. The blockers, in order of strength: its eviction cannot enforce a running-sandbox
-cap without awaited, reason-aware teardown (a billing-safety property, stronger than any latency
-argument); a billing owner has to set the TTL and running cap; and F-018 means tool-using turns
-cannot benefit or be validated yet. Wire Tier 2 eviction to stop-not-delete so it composes with
-Tier 1 rather than replacing it.
+Defer park-to-running. The reasons, strongest first: its eviction cannot enforce a running-sandbox
+cap without an awaited, reason-aware teardown (a billing-safety property, stronger than any latency
+argument); a billing owner has to set the time-to-live and the cap; and F-018 means tool-using
+turns cannot benefit or be validated yet. Wire park-to-running eviction to stop-not-delete, so it
+composes with park-to-stopped rather than replacing it.
 
 ## Phasing
 
-- Phase 1 (Tier 1 activation, flag off): provider wrapper hooks + the two dist-patch seam fixes;
-  reconnect state machine; teardown-by-reason; fenced and awaited pointer writes; compatibility
-  fingerprint; unit tests for all of it. No live Daytona.
-- Phase 2 (Tier 1 hardening): orphan-budget and autoStop-value decision with a billing owner;
-  SIGTERM stop-vs-delete split; conditional stale-id cleanup; mount-generation check.
-- Phase 3 (Tier 1 live verification, then enable): one credit-controlled E3 pass. Measure resume
-  latency against the cold baseline, confirm one instance serves consecutive turns, confirm zero
-  live sandboxes after abandonment (autoStop through autoDelete observed once). Chat first;
-  tool turns wait on F-018.
-- Phase 4 (Tier 2, opt-in): separate Daytona pool instance, Daytona-scoped config, awaited
-  evict-to-stop, graceful drain-to-stop. Ships only after the billing owner sets the knobs.
+- **Phase 1 (build park-to-stopped, flag off).** The provider wrapper functions plus the two
+  package-patch cleanup fixes; the reconnect state machine; teardown by reason; guarded and awaited
+  pointer writes; the compatibility fingerprint; unit tests for all of it. No live Daytona.
+- **Phase 2 (harden park-to-stopped).** The abandonment-budget and stop-timer-value decision with a
+  billing owner; the shutdown stop-versus-delete split; conditional stale-id cleanup; the
+  mount-generation check.
+- **Phase 3 (verify park-to-stopped live, then turn it on).** One credit-controlled E3 pass. Measure
+  resume latency against the cold baseline, confirm one instance serves consecutive turns, and
+  confirm zero live sandboxes after abandonment (watch the stop, archive, and delete timers fire
+  once). Chat first; tool turns wait on F-018.
+- **Phase 4 (park-to-running, opt-in).** The separate Daytona pool instance, the Daytona-scoped
+  config, awaited evict-to-stop, and graceful drain-to-stop. Ships only after a billing owner sets
+  the limits.
 
-## Interaction summary
+## How this fits with other work
 
-- F-018 (Daytona tool-call hang): a tool turn fails, and a failed turn does not park, so warmth
-  benefits chat first and cannot be validated on tool turns until F-018 lands.
-- PR #5197 (durable continuity): transcript `session/load` (native) and text replay (fallback)
-  stay the correct floor under both tiers. This project reuses its stored-id and continuity
-  machinery; it does not replace it.
-- Billing: Tier 1 parks to stopped (storage only); Tier 2 parks to running (compute, TTL and the
-  running cap are the knobs); the archive-then-delete cascade bounds abandoned storage; deleted
-  is free. Stopped sandboxes free CPU and RAM but keep billing disk, per Daytona's billing docs.
+- **F-018 (Daytona tool-call hang):** a tool turn fails, and a failed turn does not park, so warm
+  reuse helps chat first and cannot be validated on tool turns until F-018 lands.
+- **PR #5197 (durable continuity):** native session reload and text replay stay the correct floor
+  under both levels. This project reuses PR #5197's stored-id and continuity machinery; it does not
+  replace it.
+- **Billing:** park-to-stopped parks to stopped (storage only); park-to-running parks to running
+  (compute, with the time-to-live and the running cap as the knobs); the archive-then-delete timers
+  bound abandoned storage; deleted is free. A stopped sandbox frees CPU and RAM but still bills for
+  its disk.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
@@ -13,18 +13,18 @@ native session reload, `ephemeral: false` with idle timers), but the code that t
 - On the next turn, the runner looks up the stored id, tries to reconnect, hits the missing
   reconnect function, and builds a fresh sandbox.
 
-Second, the measured lifecycle numbers (research.md, 2026-07-11) say the sandbox itself is not
-the 20-second problem. A cold create to a usable exec is 1.2 to 1.7 seconds; a start from
-stopped is 0.7 to 0.8 seconds. The roughly 20 seconds QA measured per turn is therefore almost
-entirely our own per-turn pipeline (daemon startup, asset upload, geesefs mounts, harness
-startup, session reload); the exact split is not instrumented yet and Slice 5 measures it.
-Stopping and restarting the sandbox keeps its disk but kills every process, so a restarted
-sandbox still pays most of that pipeline (today's code even re-uploads the Pi assets and
-rematerializes workspace files on the Daytona path, so the warm disk saves less than it could).
-Only a sandbox that stays running, with its daemon, mounts, and harness session alive, skips the
-pipeline. That is why this plan builds all the way to park-to-running instead of stopping at
-park-to-stopped, and why it drops the archive state entirely (restoring from archive is slower
-than creating fresh; see research.md).
+Second, the measurements (research.md, 2026-07-11) say the sandbox itself is not the slow-turn
+problem. A cold create to a usable exec is 1.2 to 1.7 seconds; a start from stopped is 0.7 to
+0.8 seconds. The measured cold Daytona turn is about 15 seconds of client wall time, of which
+about 12.3 seconds is our own per-turn pipeline; the full stage split is in research.md ("Where
+the time goes"). About 7.2 seconds of that pipeline (a redundant Pi install, whose skip is
+already live on the dev sidecar, and the pi-acp version probes, removal planned in PR #5221) is
+removable by config and patch fixes independent of this plan. Stopping and restarting the
+sandbox keeps its disk but kills every process, so a restarted sandbox still pays the harness
+respawn and the mounts. Only a sandbox that stays running, with its daemon, mounts, and harness
+session alive, skips the pipeline. That is why this plan builds all the way to park-to-running
+instead of stopping at park-to-stopped, and why it drops the archive state entirely (restoring
+from archive is slower than creating fresh; see research.md).
 
 The Daytona SDK already exposes what the provider is missing: `sandbox.stop()`, `sandbox.start()`
 (which also resumes an archived sandbox), `sandbox.delete()`, and a `state` field are all present
@@ -59,13 +59,13 @@ turning the live pool off must never disable stopped reuse on the cold path.
 Goal: at a clean turn end, stop the Daytona sandbox instead of deleting it; on the next turn,
 start the same instance and reload the harness session. The parked cost is disk storage only.
 
-The measured numbers bound its latency win at the provider level: the create it skips costs 1.2
-to 1.7 seconds and the restart it pays costs 0.7 to 0.8 seconds, so the sandbox-level saving is
-about one second. What the prepared disk saves beyond that is unknown today, and smaller than it
-looks: the current Daytona path re-uploads Pi assets and rematerializes workspace files on every
-start, so most of the pipeline repeats even on a reused disk. Park-to-stopped's real value is
-that it is the state a park-to-running eviction lands in, and that its correctness work is the
-base every higher level stands on. The pipeline split is measured, not guessed, in Slice 5.
+The measured stage split (research.md, "Where the time goes") bounds its latency win honestly:
+the create it skips costs about 1 second, and a restarted sandbox still pays the ~5.15-second
+harness respawn, ~0.7 seconds of mounts, and (until the skip is everywhere) the Pi install,
+because the current Daytona path re-uploads assets and rematerializes workspace files on every
+start. So park-to-stopped saves about 1 second out of a roughly 10-second pipeline once the
+install skip is live. Its real value is that it is the state a park-to-running eviction lands
+in, and that its correctness work is the base every higher level stands on.
 
 ### What is already built (at HEAD, untested)
 
@@ -192,9 +192,9 @@ Each of these is a real leak or race, not polish. They block enabling the featur
 ### Cost and fidelity
 
 - Parked cost: about $0.0009/hour (the reserved 8 GiB disk), bounded by the delete timer.
-- Resume cost: 0.7 to 0.8 seconds to restart the sandbox, plus daemon startup, remount, harness
-  startup, and the session reload. The pipeline share, and how much the prepared disk actually
-  saves, is measured in the verification slice.
+- Resume cost: 0.7 to 0.8 seconds to restart the sandbox, plus the measured ~5.15-second harness
+  respawn, ~0.7 seconds of mounts, and the session reload (research.md, "Where the time goes").
+  Net saving versus cold: about the 1-second create.
 - Fidelity: full for completed turns. The session reload restores the harness's own state from the
   durable transcript mounts. A stop kills process memory, so a turn parked mid-approval cannot be
   resumed byte-exact from stopped; it takes the cold approval path (see the approval section under
@@ -240,7 +240,8 @@ does not care which provider produced it.
 Goal: keep the Daytona sandbox running with its live session between turns for a short window, so
 a second turn is near-instant (no start, no remount, no daemon or harness startup, no reload).
 This is the only level that removes the pipeline rather than shaving the sandbox-create second
-off it.
+off it: a resumed turn is the model time plus small overheads, roughly 2 to 3 seconds against
+today's ~15-second cold turn (estimated from the measured stage split; confirmed in Slice 5).
 
 ### The work
 
@@ -344,10 +345,12 @@ park-to-running behind its own flag with capacity admission and the conservative
 then live verification, and only then flip the flags on. Park-to-stopped can graduate from
 verification independently of park-to-running.
 
-The measurement is what moved park-to-running from "deferred" into the main line: sandbox
-creation costs under 2 seconds, so park-to-stopped alone cannot fix the 20-second turn; the
-pipeline can only be skipped by a sandbox that stays running; and the compute cost that justified
-deferral is small and bounded (about a third of a cent per parked turn at the default window).
+The measurements are what moved park-to-running from "deferred" into the main line: sandbox
+creation costs about 1 second of a ~15-second turn, so park-to-stopped alone cannot fix it; the
+~12-second pipeline can only be skipped by a sandbox that stays running (about 7 seconds of it
+falls to config and patch fixes outside this plan, leaving a ~5-second floor that only
+park-to-running removes); and the compute cost that justified deferral is small and bounded
+(about a third of a cent per parked turn at the default window).
 The billing questions that previously gated it are now configuration defaults backed by measured
 prices. What remains genuinely open is listed in `open-questions.md` and is about correctness
 (the pointer-write guard, the shutdown split), not cost.
@@ -380,11 +383,12 @@ Each slice lands independently, with tests, and does not regress the one below i
   Pending approvals take the cold path until the gate plan's file-transport parked-gate variant
   lands (see the approval section).
 - **Slice 5 (live verification, then flip the flags).** Credit-controlled E3 passes, in two
-  independent gates. Park-to-stopped: instrument the turn (provider create or start, daemon
-  ready, assets, cwd and harness mounts, workspace preparation, session create or load, prompt
-  accepted, first model event), measure cold versus stopped-restart, confirm one instance serves
-  consecutive turns, confirm the stop and delete timers fire once with no archive state observed,
-  and confirm zero live sandboxes afterwards. Park-to-running additionally needs a concurrency
+  independent gates, compared against the 2026-07-11 stage-split baseline in research.md. First
+  add the duration log lines that baseline had to hand-instrument (the Pi install, sandbox
+  created, `prepareWorkspace`, `probeCapabilities`, `createSession`). Park-to-stopped: measure
+  cold versus stopped-restart, confirm one instance serves consecutive turns, confirm the stop
+  and delete timers fire once with no archive state observed, and confirm zero live sandboxes
+  afterwards. Park-to-running additionally needs a concurrency
   test: more than `MAX_RUNNING` distinct sessions at once, the cap holding (admission queues or
   rejects, never over-creates), a TTL expiry confirmed as a stop, a SIGTERM drain, and one forced
   stop failure escalating to delete. Chat first; tool and approval turns wait on F-018. Then flip

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
@@ -1,0 +1,242 @@
+# Plan: warm and resumable Daytona sessions
+
+Read `research.md` first. The single most important fact: the runner-side warm plumbing already
+exists (keepWarm park, stored-id reconnect, native `session/load`, `ephemeral: false` plus idle
+timers), but the vendored Daytona provider (`sandbox-agent@0.4.2`, `dist/providers/daytona.js`)
+implements only `create`, `destroy`, `getUrl`, and `ensureServer`. It has no `pause` and no
+`reconnect`. So today:
+
+- On a successful turn, `pauseSandbox()` finds no `provider.pause` and falls back to
+  `provider.destroy()`, which calls `sandbox.delete()`. The sandbox is deleted at turn end,
+  keepWarm or not. (Verified in the vendored `chunk-TVCDKGSM.js`: `pauseSandbox` calls
+  `provider.destroy(rawSandboxId)` when `provider.pause` is absent.)
+- The `ephemeral: false` plus autoStop/autoArchive/autoDelete timers never get to act, because
+  the sandbox is already gone.
+- Next turn, `readStoredSandboxId` resolves a deleted id; `start({sandboxId})` calls the missing
+  `provider.reconnect`, then `ensureServer`, which cannot start a dead instance, so it throws and
+  the runner creates fresh.
+
+F-020's conclusion therefore still holds at HEAD, for a deeper reason than F-020 stated. The
+correctness path (durable `session/load` over the mounted transcript) makes resume answer
+correctly in about 20 seconds, but no instance is ever reused. This plan makes reuse real.
+
+The Daytona SDK already exposes what the provider is missing. `sandbox.stop()`,
+`sandbox.start()` (which also resumes an archived sandbox), `sandbox.delete()`, and a `state`
+field are all present in `@daytonaio/sdk` 0.187.0. But the design review (see status.md)
+established that two optional hooks alone are not enough: two failure-cleanup seams in the
+vendored lifecycle must be fixed with them, and reuse needs a compatibility check and write
+fencing. Those are the P0 items below.
+
+## Tier 1: cheap resume (park to stopped)
+
+Goal: at a clean turn end, stop the Daytona sandbox instead of deleting it; on the next turn,
+start the same instance and `session/load` the harness. Parked cost is storage only. Resume cost
+is "create minus start": the restart path still pays sandbox start, daemon startup, asset
+preparation, cwd and transcript mounts, harness startup, and `session/load`. The win is real but
+unmeasured; Phase 3 measures it before any latency number is claimed.
+
+### What is already done (HEAD, untested)
+
+- `provider.ts`: `ephemeral: false`, autoStop 5, autoArchive 15, autoDelete 30. The three
+  `DAYTONA_AUTOSTOP` / `DAYTONA_AUTOARCHIVE` / `DAYTONA_AUTODELETE` envs are forwarded by every
+  compose file and by the Helm runner deployment (verified; PR #5197's "compose gap" risk note
+  is stale).
+- `sandbox_agent.ts`: `destroy({ keepWarm })` park branch; `shouldPark` gating; both run paths
+  pass keepWarm on a clean resumable Daytona turn.
+- `sandbox-reconnect.ts`: store and read-back of the Daytona instance id in
+  `session_states.sandbox_id`; the reconnect ladder in acquire.
+- `patches/sandbox-agent@0.4.2.patch`: native ACP `session/load` and local process-group kill.
+
+### P0: correctness gaps to close before Tier 1 can be enabled
+
+These came out of the design-review round. Each is a real leak or race, not polish.
+
+1. Provider `pause` and `reconnect` hooks, plus the two broken failure-cleanup seams.
+   - `pause(id)`: fetch the handle (`client.get(id)`), call `sandbox.stop()`.
+   - `reconnect(id)`: fetch the handle; drive a small state machine, not a two-state check. The
+     Daytona state enum includes `starting`, `stopping`, `restoring`, `archiving`, `destroying`,
+     and error states alongside started/stopped/archived. Wait out transitional states with a
+     bound, `start()` a stopped or archived instance (archived resumes via plain `start()`, just
+     slower), reattach a running one, and fail cleanly on error states.
+   - Seam A (failed pause loses its delete fallback): the vendored `pauseSandbox()` clears
+     `sandboxProvider` and the raw id in its `finally`, even when `provider.pause()` throws. The
+     runner's follow-up `destroySandbox()` then has no provider attached and silently does
+     nothing, leaving the sandbox running. Fix in the dist patch (or a replacement seam): a
+     failed pause must keep the handle so the delete fallback actually deletes.
+   - Seam B (reconnect failure leaks a double sandbox): `SandboxAgent.start({sandboxId})` runs
+     `reconnect`, `ensureServer`, `getUrl`, and client construction, but only cleans up sandboxes
+     it created itself. If `sandbox.start()` succeeds and a later step throws, the old sandbox is
+     left running and the runner's ladder creates a second one. The reconnect path needs an
+     ownership-aware cleanup: if it transitioned the sandbox to running and attachment failed,
+     stop it before falling back to a fresh create.
+   - Home: the hooks themselves fit a runner-side wrapper over the vendored `daytona(...)`
+     provider (survives package bumps). The two seams live inside the vendored `SandboxAgent`
+     lifecycle, so they need the dist patch that PR #5197 already established. Accept the split:
+     hooks in the wrapper, seam fixes in the patch.
+
+2. Compatibility fingerprint before reuse. A Daytona sandbox bakes create-time state: env vars,
+   resolved secrets, snapshot/image, target, and the network policy. Reconnect applies none of
+   the new request's create configuration, so reuse keyed only on `session_id` can resurrect
+   stale credentials or a weaker network policy. Store a fingerprint over the sandbox-baked
+   configuration next to the sandbox id; on mismatch, delete the old sandbox and create fresh.
+   This mirrors the keep-alive pool's `configFingerprint` and credential epoch, applied at the
+   reconnect rung.
+
+3. Fencing on the sandbox pointer. `writeSandboxId` is a fire-and-forget last-writer-wins PUT,
+   and the remote path is excluded from the runner ownership check. Two turns racing on one
+   `session_id` (or a forced steer that starts the replacement before the old turn stops) can
+   cross-write the pointer, orphaning one instance and double-using another. Await the write,
+   and make read-modify-write conditional (compare-and-set on a generation or turn index; the
+   `session_states` row already carries a turn counter). A stale turn must not overwrite or stop
+   the current turn's sandbox. Clearing a stale id after a failed reconnect must be conditional
+   for the same reason.
+
+4. Mount hygiene on reattach. Reconnecting an already-running sandbox can find an old geesefs
+   mount with expired credentials; `mountStorageRemote()` accepts any live mount and does not
+   verify it uses the new credentials. Require a clean remount or verify the mount generation
+   before `session/load`.
+
+### The rest of the Tier 1 work
+
+5. Teardown by reason, not one generic destroy. The cases want different dispositions:
+   - `/kill`, failed turn, aborted turn, config/policy mismatch: delete.
+   - Clean resumable turn end: stop (this is the Tier 1 park).
+   - SIGTERM with a turn in flight: delete (the transcript may be partial).
+   - SIGTERM idle: stop, so a rolling restart keeps warmth.
+   Today `/kill` and shutdown share the same drain mechanics; reinterpreting all teardown as
+   stop would break explicit kill semantics, so the reason has to travel into the teardown.
+
+6. The reaper cascade is the sweeper, and the orphan budget is a decision. Once a sandbox
+   survives turn end, Daytona's own timers reap abandonment: autoStop (5 min) stops a warm
+   sandbox, autoArchive (15) colds it, autoDelete (30) deletes it. No runner cron is needed.
+   Two open points for a billing owner:
+   - Crash orphans. `ephemeral: true` auto-deleted on stop, so a crashed runner leaked little.
+     Now a SIGKILL'd runner leaves a running sandbox billing compute for up to 5 idle minutes,
+     then storage until autoDelete. Note the API-side `orphan_sweep.py` does NOT help here: it
+     only cleans Postgres rows and Redis locks and never contacts Daytona. If the 5-minute
+     compute budget is unacceptable, the options are a lower `DAYTONA_AUTOSTOP` or a new
+     provider-side sweeper; do not lean on the existing sweep task.
+   - Auto-stop can fire mid-turn. Daytona's inactivity clock resets on external API
+     interactions, not on processes running inside the sandbox. A long silent tool call or an
+     unanswered approval gate can outlast a 5-minute autoStop and the sandbox stops under a live
+     turn. The old default was 15. Compare the autoStop value against the runner's maximum
+     silent interval (the 300s run-limits guard is one bound) before keeping 5.
+
+7. Stale stored-id hygiene. When autoDelete reaps a sandbox, `session_states.sandbox_id` goes
+   stale. The ladder degrades gracefully (failed get, fresh create), but the doomed reconnect
+   repeats every turn. Clear the stored id on a failed reconnect, conditionally (see item 3).
+
+8. Tests, no live Daytona. The lifecycle commit is labelled "(untested)". Unit-test the wrapper
+   hooks against a fake Daytona client (stop on pause; start on reconnect only from
+   stopped/archived; transitional-state waits; error-state refusal), the two seam fixes (failed
+   pause still deletes; failed reconnect stops the half-started instance), the teardown-reason
+   matrix (park on clean resumable turns, delete on failed/aborted/kill), and the fenced
+   pointer write. Live E3 verification is Phase 3, gated on credits.
+
+### Tier 1 cost and fidelity
+
+- Parked cost: storage only (stopped disk), bounded by the archive-then-delete cascade.
+- Resume cost: unmeasured; budget it as "create minus start" plus daemon, mounts, harness
+  startup, and `session/load`. An archived restore is slower than a stopped start. Phase 3
+  produces the number.
+- Fidelity: full. `session/load` restores the harness's own session state from the durable
+  transcript mounts (the per-harness geesefs prefixes), whether the instance was reused or not.
+  The one caveat, from the `harness-session-resume` experiments: a tool call left dangling at a
+  gate is not answered byte-exact after a reload; that is the durable-decision path's job,
+  unchanged here.
+
+## Tier 2: true warm pool (park to running)
+
+Goal: keep the sandbox running with its live ACP session between turns for a short window, so a
+second turn is near-instant (no start, no remount, no load). This is the `session-keepalive`
+workspace's deferred "slice 3", now concrete.
+
+### The work
+
+1. Lift the local-only gate for a Daytona-warm mode. Today `runWithKeepalive` sends any
+   non-local request straight to `runCold` (`server.ts` `isLocalSandbox`). Add a Daytona-warm
+   path behind its own flag, off by default.
+
+2. A separate pool instance, not shared entries. Reuse the `SessionPool` class (it is already
+   engine-agnostic: opaque `environment`, one idempotent `destroy`), but instantiate a second
+   pool for Daytona entries with its own cap and TTLs. Do not mix local and remote entries in
+   one map, and do not reinterpret the local `poolMax`: locally it is a RAM budget (about 330 MB
+   per hot Claude tree); for Daytona it bounds concurrently running billed sandboxes. Those are
+   different resources with different eviction accounting.
+
+3. Daytona-scoped config, named by provider (lifecycle and billing semantics differ per
+   provider, so "remote" is too vague):
+   - `AGENTA_RUNNER_DAYTONA_SESSION_KEEPALIVE_ENABLED` (default off).
+   - `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS` (short, for example 30000 to 60000).
+   - `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` (a running-sandbox cap; call it that, not a
+     spend cap, since sandboxes are not billed identically).
+   These are operator cost/resource policy. They live in the runner config module next to the
+   existing keepalive config, read once, never via ad-hoc `process.env`.
+
+4. Eviction wired to the lifecycle, with awaited teardown. On TTL expiry or LRU eviction, a
+   Daytona entry stops the sandbox (drop to Tier 1 warm) rather than deletes it, so the session
+   can still reconnect after the live window closes. And unlike the local pool's fire-and-forget
+   LRU destroy (fine for a soft RAM cache), the Daytona pool must await the stop before
+   admitting a replacement, or the cap does not actually bound running sandboxes: the old one
+   still bills while the new one starts, and a failed stop exceeds the cap indefinitely. A
+   failed stop escalates to delete.
+
+5. Runner restart and the parked live session. The in-memory pool does not survive a restart.
+   On graceful SIGTERM, drain idle Daytona entries to stop (not delete), so the next turn falls
+   to Tier 1 reconnect and then durable `session/load`; delete entries whose turn was in flight.
+   On SIGKILL, the sandboxes leak until autoStop, the same orphan budget as Tier 1. So Tier 2
+   never has a floor below Tier 1: worst case it degrades to Tier 1, which degrades to cold.
+
+6. Credential epoch and mount expiry are more load-bearing remotely. A parked Daytona session
+   holds signed mount credentials with a real expiry. The existing credential-epoch check
+   already evicts to cold on expiry; keep the Daytona TTL comfortably under the mount-credential
+   lifetime so a live checkout never runs against an expired mount.
+
+### Tier 2 cost and fidelity
+
+- Parked cost: full running compute for the TTL window, bounded by the running cap. This is the
+  honest downside and the reason it is opt-in.
+- Resume cost: near zero. The sandbox is up, the mount is live, the session is open.
+- Fidelity: highest. It is the only rung that can hold an open approval gate for byte-exact
+  resume (the `session-keepalive` slice-2 result), though gate parking is a separate, Pi-gated
+  concern (F-018) and not required for chat.
+
+## Recommendation
+
+Land Tier 1 behind a default-off rollout flag, not default-on. The plumbing is mostly built and
+the parked cost is storage only, but the review round surfaced real P0 gaps (the broken
+pause-delete fallback, the double-sandbox reconnect leak, unfenced pointer writes, no
+compatibility check on reuse). Close those, then enable after one credit-controlled live
+lifecycle test on E3 that measures the actual resume latency and confirms single-instance reuse
+with zero leak. Keep durable `session/load` as the always-correct floor.
+
+Defer Tier 2. The blockers, in order of strength: its eviction cannot enforce a running-sandbox
+cap without awaited, reason-aware teardown (a billing-safety property, stronger than any latency
+argument); a billing owner has to set the TTL and running cap; and F-018 means tool-using turns
+cannot benefit or be validated yet. Wire Tier 2 eviction to stop-not-delete so it composes with
+Tier 1 rather than replacing it.
+
+## Phasing
+
+- Phase 1 (Tier 1 activation, flag off): provider wrapper hooks + the two dist-patch seam fixes;
+  reconnect state machine; teardown-by-reason; fenced and awaited pointer writes; compatibility
+  fingerprint; unit tests for all of it. No live Daytona.
+- Phase 2 (Tier 1 hardening): orphan-budget and autoStop-value decision with a billing owner;
+  SIGTERM stop-vs-delete split; conditional stale-id cleanup; mount-generation check.
+- Phase 3 (Tier 1 live verification, then enable): one credit-controlled E3 pass. Measure resume
+  latency against the cold baseline, confirm one instance serves consecutive turns, confirm zero
+  live sandboxes after abandonment (autoStop through autoDelete observed once). Chat first;
+  tool turns wait on F-018.
+- Phase 4 (Tier 2, opt-in): separate Daytona pool instance, Daytona-scoped config, awaited
+  evict-to-stop, graceful drain-to-stop. Ships only after the billing owner sets the knobs.
+
+## Interaction summary
+
+- F-018 (Daytona tool-call hang): a tool turn fails, and a failed turn does not park, so warmth
+  benefits chat first and cannot be validated on tool turns until F-018 lands.
+- PR #5197 (durable continuity): transcript `session/load` (native) and text replay (fallback)
+  stay the correct floor under both tiers. This project reuses its stored-id and continuity
+  machinery; it does not replace it.
+- Billing: Tier 1 parks to stopped (storage only); Tier 2 parks to running (compute, TTL and the
+  running cap are the knobs); the archive-then-delete cascade bounds abandoned storage; deleted
+  is free. Stopped sandboxes free CPU and RAM but keep billing disk, per Daytona's billing docs.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
@@ -1,10 +1,11 @@
 # Plan: warm and resumable Daytona sessions
 
-Read `research.md` first. The one fact this plan turns on: the runner-side warm plumbing already
-exists (park at turn end, reconnect by stored id, native session reload, `ephemeral: false` with
-idle timers), but the code that talks to Daytona (the "provider" in `sandbox-agent@0.4.2`)
-implements only `create`, `destroy`, `getUrl`, and `ensureServer`. It has no pause and no
-reconnect. So today:
+Read `research.md` first. Two facts shape this plan.
+
+First, the runner-side warm plumbing already exists (park at turn end, reconnect by stored id,
+native session reload, `ephemeral: false` with idle timers), but the code that talks to Daytona
+(the "provider" in `sandbox-agent@0.4.2`) implements only `create`, `destroy`, `getUrl`, and
+`ensureServer`. It has no pause and no reconnect. So today:
 
 - On a successful turn, `pauseSandbox()` finds no pause function and falls back to a delete. The
   sandbox is deleted at turn end, whether the runner asked to keep it warm or not.
@@ -12,9 +13,18 @@ reconnect. So today:
 - On the next turn, the runner looks up the stored id, tries to reconnect, hits the missing
   reconnect function, and builds a fresh sandbox.
 
-F-020's conclusion still holds at HEAD, for a deeper reason than F-020 gave. Durable continuity
-makes the resumed turn answer correctly in about twenty seconds, but no sandbox is ever reused.
-This plan makes reuse real.
+Second, the measured lifecycle numbers (research.md, 2026-07-11) say the sandbox itself is not
+the 20-second problem. A cold create to a usable exec is 1.2 to 1.7 seconds; a start from
+stopped is 0.7 to 0.8 seconds. The roughly 20 seconds QA measured per turn is therefore almost
+entirely our own per-turn pipeline (daemon startup, asset upload, geesefs mounts, harness
+startup, session reload); the exact split is not instrumented yet and Slice 5 measures it.
+Stopping and restarting the sandbox keeps its disk but kills every process, so a restarted
+sandbox still pays most of that pipeline (today's code even re-uploads the Pi assets and
+rematerializes workspace files on the Daytona path, so the warm disk saves less than it could).
+Only a sandbox that stays running, with its daemon, mounts, and harness session alive, skips the
+pipeline. That is why this plan builds all the way to park-to-running instead of stopping at
+park-to-stopped, and why it drops the archive state entirely (restoring from archive is slower
+than creating fresh; see research.md).
 
 The Daytona SDK already exposes what the provider is missing: `sandbox.stop()`, `sandbox.start()`
 (which also resumes an archived sandbox), `sandbox.delete()`, and a `state` field are all present
@@ -25,26 +35,37 @@ park-to-stopped below.
 
 ## The two levels of reuse
 
-The plan proposes two levels, in order of cost:
+The plan builds two levels, in one progressive sequence:
 
-- **Park-to-stopped** (cheaper, ships first). At a clean turn end, stop the sandbox instead of
+- **Park-to-stopped** (the floor above cold). At a clean turn end, stop the sandbox instead of
   deleting it; on the next turn, start the same one and reload the harness session. The parked
-  sandbox costs disk storage only. Most of this is already prototyped in the working tree.
-- **Park-to-running** (more expensive, deferred). Keep the sandbox running with its live session
-  between turns, for a short window, so the next turn is near-instant. The parked sandbox costs
-  live compute, so it needs cost limits and a billing owner to set them.
+  sandbox costs disk storage only (about $0.0009/hour measured against our sandbox shape). Most
+  of this is already prototyped in the working tree, and its correctness work is a prerequisite
+  for everything above it.
+- **Park-to-running** (the target). Keep the sandbox running with its live session between turns
+  for a short window, so the next turn is near-instant. The parked sandbox costs live compute
+  (about $0.0028/minute for our 2 vCPU / 4 GiB shape), so it gets a short time-to-live and a hard
+  cap on concurrently running sandboxes, as configuration with conservative defaults.
 
 Each maps onto one level of the fallback ladder in `research.md`: park-to-stopped builds the
-stopped-restart level, park-to-running builds the live-warm level. They compose. The cold-rebuild
-floor stays underneath both.
+stopped-restart level, park-to-running builds the live-warm level. They compose rather than
+compete: a park-to-running entry that outlives its window is evicted by stopping it, which drops
+it to the park-to-stopped state, which degrades to the cold rebuild floor. The always-correct
+cold rebuild plus transcript replay stays underneath both. Two flags stay independent on purpose:
+turning the live pool off must never disable stopped reuse on the cold path.
 
-## Park-to-stopped: cheap resume
+## Park-to-stopped: the correctness base
 
 Goal: at a clean turn end, stop the Daytona sandbox instead of deleting it; on the next turn,
-start the same instance and reload the harness session. The parked cost is disk storage only. The
-resume cost is "a full build minus the build": the restart path still pays sandbox start, daemon
-startup, asset preparation, file mounts, harness startup, and the session reload. The win is real
-but unmeasured. Phase 3 measures it before any latency number is claimed.
+start the same instance and reload the harness session. The parked cost is disk storage only.
+
+The measured numbers bound its latency win at the provider level: the create it skips costs 1.2
+to 1.7 seconds and the restart it pays costs 0.7 to 0.8 seconds, so the sandbox-level saving is
+about one second. What the prepared disk saves beyond that is unknown today, and smaller than it
+looks: the current Daytona path re-uploads Pi assets and rematerializes workspace files on every
+start, so most of the pipeline repeats even on a reused disk. Park-to-stopped's real value is
+that it is the state a park-to-running eviction lands in, and that its correctness work is the
+base every higher level stands on. The pipeline split is measured, not guessed, in Slice 5.
 
 ### What is already built (at HEAD, untested)
 
@@ -58,12 +79,19 @@ but unmeasured. Phase 3 measures it before any latency number is claimed.
   `session_states.sandbox_id`, and the reconnect ladder at the start of a run.
 - `patches/sandbox-agent@0.4.2.patch`: the native session reload and the local process-group kill.
 
+One consequence of "already built" matters for sequencing: both run paths already request
+`keepWarm` on clean Daytona turns. The moment a real `pause` lands, parking activates. So the
+feature flag is part of Slice 1, not a later addition, and it gates all three moving parts
+together: the stored-id read and reconnect, the pointer write, and the stop at turn end.
+
 ### Must-fix before it can be turned on
 
 Each of these is a real leak or race, not polish. They block enabling the feature.
 
 1. **The two provider functions, plus the two teardown cleanup gaps.**
-   - `pause(id)`: fetch the sandbox handle (`client.get(id)`), call `sandbox.stop()`.
+   - `pause(id)`: fetch the sandbox handle (`client.get(id)`), inspect its state, and call
+     `sandbox.stop()` only from a running state. Already stopped counts as success. The SDK's
+     `stop()` calls the stop endpoint unconditionally, so idempotence is the wrapper's job.
    - `reconnect(id)`: fetch the handle, then drive a small state machine, not a two-state check.
      Daytona's state field includes transitional values (`starting`, `stopping`, `restoring`,
      `archiving`, `destroying`) and error states alongside started, stopped, and archived. Wait
@@ -90,9 +118,12 @@ Each of these is a real leak or race, not polish. They block enabling the featur
    env vars, resolved secrets, the snapshot or image, the target, and the network policy.
    Reconnect applies none of the new request's settings, so reusing a sandbox keyed only on the
    conversation id can resurrect stale credentials or a weaker network policy. Store a fingerprint
-   of the baked-in settings next to the sandbox id. On a mismatch, delete the old sandbox and build
-   fresh. This mirrors the local pool's config fingerprint and credential epoch, applied at the
-   reconnect step.
+   of the baked-in settings next to the sandbox id, derived from the resolved create specification
+   in `provider.ts` (snapshot or image, target, env names, network policy) plus a credential
+   generation. The live pool's `configFingerprint()` is not sufficient here: it hashes request
+   fields and omits resolved operator settings such as `DAYTONA_SNAPSHOT`, `DAYTONA_IMAGE`, and
+   `DAYTONA_TARGET`, which also invalidate a stopped sandbox. On a mismatch, delete the old
+   sandbox and build fresh.
 
 3. **A write guard on the sandbox pointer.** `writeSandboxId` is a fire-and-forget,
    last-writer-wins PUT, and the Daytona path skips the runner's ownership check. Two turns racing
@@ -111,27 +142,39 @@ Each of these is a real leak or race, not polish. They block enabling the featur
 ### The rest of the park-to-stopped work
 
 5. **Teardown by reason, not one generic destroy.** Different endings want different dispositions:
-   - Explicit `/kill`, a failed turn, an aborted turn, or a compatibility mismatch: delete.
+   - Explicit `/kill`, a failed turn, an aborted turn, or a compatibility or credential mismatch:
+     delete.
    - A clean resumable turn end: stop (this is the park).
    - Shutdown (SIGTERM) with a turn in flight: delete, since the transcript may be partial.
    - Shutdown while idle: stop, so a rolling restart keeps the sandbox warm.
+   - A failed stop: delete. A failed stop and failed delete: treat the instance as still running
+     for capacity accounting until a later reconciliation confirms otherwise.
    Today `/kill` and shutdown share the same drain mechanics, so reinterpreting all teardown as a
-   stop would break explicit kill semantics. The reason has to travel into the teardown.
+   stop would break explicit kill semantics. The reason has to travel into the teardown as a typed
+   value; this same reason-to-disposition mapping is what the pool eviction reuses in the
+   park-to-running slice.
 
-6. **The idle timers are the sweeper; the abandonment budget is a decision.** Once a sandbox
-   survives turn end, Daytona's own timers reap abandonment: stop after 5 idle minutes, archive
-   after 15, delete after 30. No runner cron job is needed. Two points need a billing owner:
-   - Crash orphans. `ephemeral: true` auto-deleted a sandbox on stop, so a crashed runner leaked
-     little. Now a hard-killed runner leaves a running sandbox billing compute for up to 5 idle
-     minutes, then storage until the delete timer. The API-side `orphan_sweep.py` does not help:
-     it cleans only Postgres rows and Redis locks and never contacts Daytona. If the 5-minute
-     compute budget is unacceptable, the options are a lower `DAYTONA_AUTOSTOP` or a new
-     provider-side sweeper. Do not lean on the existing sweep task.
-   - The stop timer can fire mid-turn. Daytona's idle clock resets on external API calls, not on
-     processes running inside the sandbox. A long, silent tool call or an unanswered approval gate
-     can outlast a 5-minute stop timer, and the sandbox stops under a live turn. The old default
-     was 15 minutes. Compare the stop timer against the runner's longest silent interval (the
-     300-second run-limits guard is one bound) before keeping 5.
+6. **The idle timers are the sweeper, with measured defaults.** Once a sandbox survives turn end,
+   Daytona's own timers reap abandonment. Two settings change from the current working-tree values:
+   - Configure the archive step out by setting `DAYTONA_AUTOARCHIVE` strictly greater than
+     `DAYTONA_AUTODELETE` (equal values would race; Daytona's own "archive interval 0 means
+     maximum" convention is unusable here because our `positiveMinutes()` parser treats 0 as
+     unset). Daytona documents auto-delete as firing after a sandbox has been continuously
+     stopped, with no archive step required, but the archive-disabled path is worth one explicit
+     live check in Slice 5: stop a sandbox with delete set shorter than archive and confirm it
+     goes stopped to destroyed without passing through archived. Why drop archive at all:
+     measured restore from archive takes 33 to 66 seconds, slower than the 1.2 to 1.7 second
+     fresh create, and the disk it frees costs under a tenth of a cent per hour. The ladder is
+     stop, then delete.
+   - Set the stop timer to 15 minutes, not 5. Daytona's idle clock resets on external API calls,
+     not on processes running inside the sandbox, so a stop timer shorter than the longest silent
+     stretch of a live turn (the run-limits guard alone allows 300 seconds) can stop a sandbox
+     mid-turn. At measured prices the difference is small money: a crash orphan bills about 4
+     cents with a 15-minute stop timer versus about 1.4 cents with a 5-minute one. Paying 3 cents
+     per crash to never stop a live turn is the right trade.
+   The API-side `orphan_sweep.py` does not participate: it cleans only Postgres rows and Redis
+   locks and never contacts Daytona. No new sweeper is needed; the timers are the sweeper, and at
+   these prices the abandonment budget no longer needs a billing-owner sign-off, only review.
 
 7. **Clean up a stale stored id.** When the delete timer reaps a sandbox, `session_states.sandbox_id`
    goes stale. The reconnect ladder degrades gracefully (failed lookup, fresh build), but the
@@ -139,118 +182,224 @@ Each of these is a real leak or race, not polish. They block enabling the featur
    (see must-fix item 3).
 
 8. **Tests, no live Daytona.** The lifecycle commit is labelled "(untested)". Unit-test the wrapper
-   functions against a fake Daytona client (stop on pause; start on reconnect only from stopped or
-   archived; waits through transitional states; refusal on error states), the two cleanup fixes (a
-   failed pause still deletes; a failed reconnect stops the half-started instance), the
-   teardown-by-reason matrix (park on clean resumable turns, delete on failed, aborted, or killed
-   turns), and the guarded pointer write. Live testing on E3 is Phase 3, gated on credits.
+   functions against a fake Daytona client (idempotent stop by state; start on reconnect only from
+   stopped or archived; waits through transitional states; refusal on error states), the two
+   cleanup fixes (a failed pause still deletes; a failed reconnect stops the half-started
+   instance), the teardown-by-reason matrix (park on clean resumable turns, delete on failed,
+   aborted, or killed turns), and the guarded pointer write. Live testing on E3 is the
+   verification slice, gated on credits.
 
 ### Cost and fidelity
 
-- Parked cost: disk storage only (a stopped disk), bounded by the archive-then-delete timers.
-- Resume cost: unmeasured. Budget it as a full build minus the build, plus daemon startup, mounts,
-  harness startup, and the session reload. An archived restore is slower than a stopped start.
-  Phase 3 produces the real number.
-- Fidelity: full. The session reload restores the harness's own state from the durable transcript
-  mounts, whether or not the instance was reused. The one caveat, from the `harness-session-resume`
-  experiments: a tool call left dangling at an approval gate is not answered byte-exact after a
-  reload. That is the durable-decision path's job and is unchanged here.
+- Parked cost: about $0.0009/hour (the reserved 8 GiB disk), bounded by the delete timer.
+- Resume cost: 0.7 to 0.8 seconds to restart the sandbox, plus daemon startup, remount, harness
+  startup, and the session reload. The pipeline share, and how much the prepared disk actually
+  saves, is measured in the verification slice.
+- Fidelity: full for completed turns. The session reload restores the harness's own state from the
+  durable transcript mounts. A stop kills process memory, so a turn parked mid-approval cannot be
+  resumed byte-exact from stopped; it takes the cold approval path (see the approval section under
+  park-to-running).
 
-## Park-to-running: true warm pool
+## The provider-aware keepalive refactor
 
-Goal: keep the sandbox running with its live session between turns for a short window, so a second
-turn is near-instant (no start, no remount, no reload). This is the `session-keepalive` workspace's
-deferred Daytona slice, now made concrete.
+Local (non-Daytona) sessions already get live warm reuse from the in-memory pool in
+`session-pool.ts`. The pool class itself is engine-agnostic (an opaque environment, fingerprints,
+a credential epoch, one idempotent `destroy()` closure), so it is the right machinery to reuse.
+What keeps it local today is one policy gate: `runWithKeepalive` in `server.ts` sends any request
+that does not resolve to the `local` provider straight to the cold path
+(`resolvesToLocalProvider`, `isLocalSandbox`).
+
+The refactor separates two things that must not be one record:
+
+- **Operator configuration**, per provider name (`local`, `daytona`): enabled, idle time-to-live,
+  approval time-to-live, pool cap. Env-var backed, read once. The local values reproduce today's
+  behavior (the `AGENTA_RUNNER_SESSION_*` env vars keep working); the Daytona ones ship disabled.
+- **Lifecycle mechanisms**, owned by the engine, not by config: the typed teardown-reason mapping
+  from item 5 (the pool passes a reason such as idle-expiry, capacity-eviction, failed-turn, or
+  shutdown to an engine-owned lifecycle function, which picks stop or delete), awaited versus
+  fire-and-forget teardown, and (for Daytona) the capacity admission described in the
+  park-to-running section. The pool's `destroy: () => Promise<void>` closure becomes
+  `teardown(reason)`; `destroyAll` passes its reason too, so shutdown can split idle-stop from
+  in-flight-delete.
+
+Shape: one `SessionPool` instance per enabled provider, all of the same class. Entries never mix
+across pools, because the caps measure different resources: the local cap is a host-memory budget
+(about 330 MB per hot Claude tree), the Daytona cap bounds concurrently running billed sandboxes.
+Do not overload one `poolMax` to mean both. The dispatch in `runWithKeepalive` looks up the
+provider's config and routes to that provider's pool, or cold when absent or disabled; unknown
+providers keep failing closed to cold. Local semantics are preserved deliberately rather than
+promised byte-identical: the one visible change is the teardown signature, and local eviction
+stays fire-and-forget.
+
+Two boundaries stay put: `resolveKeepaliveMount()` is already provider-neutral and serves the
+Daytona path unchanged, and the continuation path operates on an opaque live environment, so it
+does not care which provider produced it.
+
+## Park-to-running: the live warm window
+
+Goal: keep the Daytona sandbox running with its live session between turns for a short window, so
+a second turn is near-instant (no start, no remount, no daemon or harness startup, no reload).
+This is the only level that removes the pipeline rather than shaving the sandbox-create second
+off it.
 
 ### The work
 
-1. **Open a Daytona-warm path through the local-only gate.** Today the keep-alive path sends any
-   non-local request straight to a cold build (`isLocalSandbox` in `server.ts`). Add a Daytona-warm
-   path behind its own flag, off by default.
+1. **Capacity admission before anything starts a Daytona sandbox.** The pool alone cannot enforce
+   a running cap: a fresh miss acquires its environment before the pool ever sees the session, so
+   concurrent misses could create arbitrarily many sandboxes while the pool holds four. The cap
+   therefore lives in a small admission gate (a permit counter) taken before create and before a
+   reconnect's `start()`, and released only when Daytona confirms the instance stopped or deleted.
+   It counts everything that can be running: reserved, creating, starting, busy in a turn, parked
+   live, and stopping. When the gate is full: evict an idle parked entry and await its confirmed
+   stop, then admit; if every permit belongs to an active or approval-waiting turn, queue briefly
+   or reject the run with a clear error. Daytona never gets the local pool's "run unparked
+   best-effort" behavior; that rule is what makes the local cap soft, and a soft cap on billed
+   compute is not a cap.
 
-2. **A separate pool instance, not shared entries.** Reuse the pool class (it is already
-   engine-agnostic: an opaque environment and one idempotent `destroy`), but create a second pool
-   for Daytona entries with its own cap and timers. Do not mix local and remote entries in one map,
-   and do not reinterpret the local size cap: locally it is a memory budget (about 330 MB per hot
-   Claude tree); for Daytona it bounds the count of concurrently running billed sandboxes. Those
-   are different resources with different accounting.
+2. **Enable the Daytona pool** from the refactor above, behind its own flag, off by default until
+   the verification slice passes.
 
-3. **Daytona-scoped config, named by provider** (lifecycle and billing differ per provider, so
-   "remote" is too vague):
-   - `AGENTA_RUNNER_DAYTONA_SESSION_KEEPALIVE_ENABLED` (default off).
-   - `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS` (short, for example 30000 to 60000).
-   - `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` (a cap on running sandboxes; call it that, not a
-     spend cap, since sandboxes are not billed identically).
-   These are operator cost and resource policy. They live in the runner config module next to the
-   existing keep-alive config, read once, never via ad-hoc environment lookups.
+3. **Daytona-scoped configuration, with conservative defaults** (lifecycle and billing differ per
+   provider, so the names say `DAYTONA`, not "remote"):
+   - `AGENTA_RUNNER_DAYTONA_SESSION_KEEPALIVE_ENABLED` (default off; flipped on after
+     verification). Independent of the park-to-stopped flag: disabling the live pool must not
+     disable stopped reuse.
+   - `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS` (default 60000; at $0.0028 per parked minute this
+     is about a third of a cent per parked turn).
+   - `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` (default 4; worst-case burn with all four parked
+     is about $0.67/hour). This is the admission gate's permit count.
+   These live in the runner config module next to the existing keepalive config, read once, never
+   via ad-hoc environment lookups. They are operator policy with stated defaults, not open
+   decisions: the defaults above are conservative enough to ship, and an operator can tighten or
+   widen them without a code change.
 
-4. **Eviction wired to the lifecycle, with an awaited teardown.** When the timer expires or the pool
-   evicts an entry, a Daytona entry stops the sandbox (dropping it to the park-to-stopped state)
-   rather than deleting it, so the session can still reconnect after the live window closes. And
-   unlike the local pool's fire-and-forget eviction (fine for a soft memory cache), the Daytona pool
-   must wait for the stop to finish before admitting a replacement. Otherwise the cap does not
-   actually bound running sandboxes: the old one still bills while the new one starts, and a failed
-   stop exceeds the cap indefinitely. A failed stop escalates to a delete.
+4. **Eviction wired to the lifecycle, awaited.** When the window expires or the admission gate
+   forces an eviction, a Daytona entry is stopped, not deleted, so it drops to the
+   park-to-stopped state and the session can still reconnect after the live window closes. The
+   eviction goes through the typed teardown reason from the refactor, is awaited before a
+   replacement is admitted, and releases the capacity permit only on a confirmed stop. A failed
+   stop escalates to a delete; a failed stop plus failed delete keeps the permit consumed until a
+   reconciliation pass confirms the instance is gone.
 
-5. **Runner restart and the parked live session.** The in-memory pool does not survive a restart.
+5. **Daytona's own timers versus the pool window.** With a 15-minute stop timer and a 60-second
+   window, overlap is unlikely but not impossible: Daytona's idle clock may be old when the pool
+   parks the entry (a long silent tool stretch resets nothing, since only external API calls
+   count). On entering the live parked state, refresh the sandbox's activity once through the API
+   so the full window is guaranteed, then let the pool's own timer do the stopping. No recurring
+   heartbeats: a periodic keepalive ping would keep a leaked sandbox alive forever and defeat the
+   auto-stop backstop.
+
+6. **Runner restart and the parked live session.** The in-memory pool does not survive a restart.
    On a graceful shutdown, drain idle Daytona entries to stopped (not deleted), so the next turn
    falls to park-to-stopped reconnect and then durable reload; delete entries whose turn was in
    flight. On a hard kill, the sandboxes leak until the stop timer, the same abandonment budget as
-   park-to-stopped. So park-to-running never sits below park-to-stopped: its worst case degrades to
-   park-to-stopped, which degrades to cold.
+   park-to-stopped (about 4 cents per crash at a 15-minute stop timer). So park-to-running never
+   sits below park-to-stopped: its worst case degrades to park-to-stopped, which degrades to cold.
 
-6. **Credentials and mounts matter more here.** A parked running Daytona session holds signed mount
-   credentials with a real expiry. The existing credential-epoch check already evicts to cold on
-   expiry. Keep the Daytona time-to-live comfortably under the mount-credential lifetime, so a live
-   turn never runs against an expired mount.
+7. **Credentials and mounts.** A parked running Daytona session holds signed mount credentials
+   with a real expiry. The existing credential-epoch check already evicts to cold on expiry. Keep
+   the Daytona time-to-live comfortably under the mount-credential lifetime, so a live turn never
+   runs against an expired mount.
+
+### Pending approvals, aligned with the F-018 gate plan
+
+The `daytona-gate-delivery` workspace (the F-018 fix, in implementation) defines how an approval
+gate raised inside a Daytona sandbox reaches the runner: a file-based gate for residual builtin
+calls, custom-tool authorization at the execution relay, and a two-lifetime timeout. Its resume
+model is the contract this plan follows, not a thing this plan redefines:
+
+- **Cold path (its default, and ours below park-to-running):** when a turn pauses on a pending
+  approval, the turn ends and the sandbox is torn down with the pending gate inside it. The
+  human's decision is stored; on the next turn the transcript is restored, the model reissues the
+  tool call, and the reissued gate resolves instantly from the stored decision. A stopped sandbox
+  cannot do better, because stopping kills the waiting process. So under park-to-stopped, a
+  pending approval always takes this path.
+- **Live path (park-to-running only):** holding a gate open byte-exact requires the sandbox to
+  stay running and the gate plan's parked-gate machinery to support the file transport (its
+  "file-transport parked-gate variant": resume writes the authenticated decision file instead of
+  answering an ACP permission id). Until that variant exists, a Daytona file gate must take the
+  cold path even when the sandbox is parked running. Whether a paused turn may park live is an
+  explicit capability check on the gate's transport, never inferred from
+  `result.stopReason === "paused"` or the mere presence of a pending gate.
+- The two timeout models compose: a live-pool window expiring under a parked gate changes the
+  execution path from live to cold; it does not expire the human's stored decision.
+
+One consequence worth stating: park-to-running's chat benefit does not wait for F-018 (a pure
+chat turn raises no gate), but its approval benefit does. Sequence the slices accordingly and do
+not couple the flag flip to the gate work.
 
 ### Cost and fidelity
 
-- Parked cost: full running compute for the window, bounded by the running-sandbox cap. This is the
-  honest downside and the reason it is opt-in.
+- Parked cost: $0.0028 per parked minute per sandbox, bounded by the time-to-live and the running
+  cap (defaults: 60 seconds, 4 sandboxes, worst case about $0.67/hour).
 - Resume cost: near zero. The sandbox is up, the mount is live, the session is open.
 - Fidelity: highest. It is the only level that can hold an open approval gate for byte-exact
-  resume, though holding a gate open is a separate concern (F-018) and is not needed for chat.
+  resume, once the gate plan's file-transport parked-gate variant exists.
 
 ## Recommendation
 
-Ship park-to-stopped behind a flag that is off by default, not on by default. The plumbing is
-mostly built and the parked cost is storage only, but the review found real must-fix gaps: the
-broken pause-delete fallback, the double-sandbox reconnect leak, the unguarded pointer writes, and
-the missing compatibility check on reuse. Close those, then turn it on after one credit-controlled
-live test on E3 that measures the real resume latency and confirms one instance is reused with zero
-leak. Keep durable reload as the always-correct floor.
+Build the whole ladder, in slices, each shippable on its own: the correctness base with its flag,
+then park-to-stopped enabled behind that flag, then the provider-aware pool refactor, then
+park-to-running behind its own flag with capacity admission and the conservative defaults above,
+then live verification, and only then flip the flags on. Park-to-stopped can graduate from
+verification independently of park-to-running.
 
-Defer park-to-running. The reasons, strongest first: its eviction cannot enforce a running-sandbox
-cap without an awaited, reason-aware teardown (a billing-safety property, stronger than any latency
-argument); a billing owner has to set the time-to-live and the cap; and F-018 means tool-using
-turns cannot benefit or be validated yet. Wire park-to-running eviction to stop-not-delete, so it
-composes with park-to-stopped rather than replacing it.
+The measurement is what moved park-to-running from "deferred" into the main line: sandbox
+creation costs under 2 seconds, so park-to-stopped alone cannot fix the 20-second turn; the
+pipeline can only be skipped by a sandbox that stays running; and the compute cost that justified
+deferral is small and bounded (about a third of a cent per parked turn at the default window).
+The billing questions that previously gated it are now configuration defaults backed by measured
+prices. What remains genuinely open is listed in `open-questions.md` and is about correctness
+(the pointer-write guard, the shutdown split), not cost.
 
-## Phasing
+Drop the archive state from the design entirely: restoring from archive is slower than creating
+fresh, so it can never be the right move for us.
 
-- **Phase 1 (build park-to-stopped, flag off).** The provider wrapper functions plus the two
-  package-patch cleanup fixes; the reconnect state machine; teardown by reason; guarded and awaited
-  pointer writes; the compatibility fingerprint; unit tests for all of it. No live Daytona.
-- **Phase 2 (harden park-to-stopped).** The abandonment-budget and stop-timer-value decision with a
-  billing owner; the shutdown stop-versus-delete split; conditional stale-id cleanup; the
-  mount-generation check.
-- **Phase 3 (verify park-to-stopped live, then turn it on).** One credit-controlled E3 pass. Measure
-  resume latency against the cold baseline, confirm one instance serves consecutive turns, and
-  confirm zero live sandboxes after abandonment (watch the stop, archive, and delete timers fire
-  once). Chat first; tool turns wait on F-018.
-- **Phase 4 (park-to-running, opt-in).** The separate Daytona pool instance, the Daytona-scoped
-  config, awaited evict-to-stop, and graceful drain-to-stop. Ships only after a billing owner sets
-  the limits.
+## Slices
+
+Each slice lands independently, with tests, and does not regress the one below it.
+
+- **Slice 1 (correctness base, everything disabled).** The provider wrapper functions plus the
+  two package-patch cleanup fixes; the reconnect state machine; teardown by typed reason; guarded
+  and awaited pointer writes; the compatibility fingerprint derived from the resolved create
+  specification; and the park-to-stopped feature flag, default off, gating reconnect, pointer
+  writes, and stop-at-turn-end together. The flag belongs here, not later: the run paths already
+  request `keepWarm`, so landing a real `pause` without the flag would activate parking
+  immediately. Unit tests for all of it. No live Daytona.
+- **Slice 2 (park-to-stopped, enabled behind its flag).** Wire the park path end to end; timer
+  defaults per item 6 (stop at 15 minutes, archive configured out with strict inequality, delete
+  at 30); conditional stale-id cleanup; the mount-generation check.
+- **Slice 3 (provider-aware pool refactor).** Per-provider operator config, the engine-owned
+  lifecycle adapter with typed teardown reasons, one pool instance per provider, dispatch by
+  resolved provider, local semantics preserved, Daytona pool present but disabled. This slice
+  depends on Slice 1's teardown-reason contract; it does not depend on Slice 2.
+- **Slice 4 (park-to-running, flag off).** The capacity admission gate (permits before create and
+  reconnect-start, awaited evict-to-stop, release on confirmed stop or delete, queue-or-reject
+  when saturated, never run-unparked); the one-time activity refresh at live park; drain-to-stop
+  on graceful shutdown, delete-in-flight on shutdown; credential-epoch bound on the window.
+  Pending approvals take the cold path until the gate plan's file-transport parked-gate variant
+  lands (see the approval section).
+- **Slice 5 (live verification, then flip the flags).** Credit-controlled E3 passes, in two
+  independent gates. Park-to-stopped: instrument the turn (provider create or start, daemon
+  ready, assets, cwd and harness mounts, workspace preparation, session create or load, prompt
+  accepted, first model event), measure cold versus stopped-restart, confirm one instance serves
+  consecutive turns, confirm the stop and delete timers fire once with no archive state observed,
+  and confirm zero live sandboxes afterwards. Park-to-running additionally needs a concurrency
+  test: more than `MAX_RUNNING` distinct sessions at once, the cap holding (admission queues or
+  rejects, never over-creates), a TTL expiry confirmed as a stop, a SIGTERM drain, and one forced
+  stop failure escalating to delete. Chat first; tool and approval turns wait on F-018. Then flip
+  each flag as its gate passes.
 
 ## How this fits with other work
 
-- **F-018 (Daytona tool-call hang):** a tool turn fails, and a failed turn does not park, so warm
-  reuse helps chat first and cannot be validated on tool turns until F-018 lands.
+- **F-018 / `daytona-gate-delivery` (in implementation):** a tool turn on Daytona currently fails,
+  and a failed turn does not park, so warm reuse benefits chat until that fix lands. The approval
+  section above binds this plan to its gate and resume model; the two plans must not define the
+  pending-approval-at-park behavior differently.
 - **PR #5197 (durable continuity):** native session reload and text replay stay the correct floor
-  under both levels. This project reuses PR #5197's stored-id and continuity machinery; it does not
-  replace it.
-- **Billing:** park-to-stopped parks to stopped (storage only); park-to-running parks to running
-  (compute, with the time-to-live and the running cap as the knobs); the archive-then-delete timers
-  bound abandoned storage; deleted is free. A stopped sandbox frees CPU and RAM but still bills for
-  its disk.
+  under both levels. This project reuses PR #5197's stored-id and continuity machinery; it does
+  not replace it.
+- **Billing, with measured prices:** park-to-stopped parks to stopped (about $0.0009/hour);
+  park-to-running parks to running (about $0.17/hour per sandbox, bounded by the window and the
+  cap); abandoned sandboxes cost cents per incident under the timers; deleted is free. The archive
+  state is configured out.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
@@ -15,7 +15,9 @@ native session reload, `ephemeral: false` with idle timers), but the code that t
 
 Second, the measurements (research.md, 2026-07-11) say the sandbox itself is not the slow-turn
 problem. A cold create to a usable exec is 1.2 to 1.7 seconds; a start from stopped is 0.7 to
-0.8 seconds. The measured cold Daytona turn is about 15 seconds of client wall time, of which
+0.8 seconds (both provider operations alone, not what a user waits; "The three resume paths,
+compared" below prices the user-visible totals). The measured cold Daytona turn is about 15
+seconds of client wall time, of which
 about 12.3 seconds is our own per-turn pipeline; the full stage split is in research.md ("Where
 the time goes"). About 7.2 seconds of that pipeline (a redundant Pi install, whose skip is
 already live on the dev sidecar, and the pi-acp version probes, removal planned in PR #5221) is
@@ -53,6 +55,40 @@ compete: a park-to-running entry that outlives its window is evicted by stopping
 it to the park-to-stopped state, which degrades to the cold rebuild floor. The always-correct
 cold rebuild plus transcript replay stays underneath both. Two flags stay independent on purpose:
 turning the live pool off must never disable stopped reuse on the cold path.
+
+## The three resume paths, compared
+
+A second turn in a conversation starts from one of three states. This section prices each from
+the measured stage table (research.md, "Where the time goes") so the decision can be made from
+this document alone. One labelling rule: the fresh-create total is measured end to end; the
+other two totals are constructed from the stage measurements and are verified end to end in
+Slice 5.
+
+**Path 1: fresh create (today's behavior).** The old sandbox is gone. Every stage is paid:
+sandbox create (~1.05 s), the Pi install (~5.2 s where the skip is not live), extension upload,
+mounts (~0.7 s), harness spawn (~5.15 s), session reload, then the model. User-visible total:
+about 15 seconds measured at HEAD; about 10 with the install skip that is now live on the dev
+runner; about 8 once the pi-acp probe removal (PR #5221) lands.
+
+**Path 2: stop, then restart (park-to-stopped).** Stopping destroys every process in the
+sandbox: the harness, the geesefs mount processes, the daemon. Only the disk survives. So the
+restart pays, stage by stage: start-from-stopped (~0.7 to 0.8 s) in place of create (~1.05 s);
+the mounts again (~0.7 s, new processes); the harness respawn again (~5.15 s today, ~3.15 s
+after the probe fix); the session reload again. The install is not paid, but only because the
+binary survives on disk, and the live skip makes that saving moot on the fresh path too.
+User-visible total, constructed: nearly the same as a fresh create, roughly 1 second cheaper.
+Said plainly: the 0.7-second number is the provider operation, not what a user waits;
+park-to-stopped buys durability of the disk, not latency.
+
+**Path 3: kept running (park-to-running).** Everything survives: the processes, the mounts, the
+daemon, the open harness session. The turn pays the keepalive checkout overheads plus the model
+time. User-visible total: roughly 2 to 3 seconds, estimated.
+
+The decision this comparison forces: if the goal is latency, park-to-stopped is not the
+mechanism; park-to-running is. Park-to-stopped is still worth shipping first, but for exactly
+two reasons: it is the safety and lifecycle base park-to-running builds on (the reconnect
+machinery, the pointer guard, the compatibility fingerprint, and the state a live eviction lands
+in), and it saves its small create second. The slices below are ordered by that logic.
 
 ## Park-to-stopped: the correctness base
 

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/plan.md
@@ -13,15 +13,15 @@ native session reload, `ephemeral: false` with idle timers), but the code that t
 - On the next turn, the runner looks up the stored id, tries to reconnect, hits the missing
   reconnect function, and builds a fresh sandbox.
 
-Second, the measurements (research.md, 2026-07-11) say the sandbox itself is not the slow-turn
+Second, the measurements (research.md) say the sandbox itself is not the slow-turn
 problem. A cold create to a usable exec is 1.2 to 1.7 seconds; a start from stopped is 0.7 to
 0.8 seconds (both provider operations alone, not what a user waits; "The three resume paths,
 compared" below prices the user-visible totals). The measured cold Daytona turn is about 15
 seconds of client wall time, of which
 about 12.3 seconds is our own per-turn pipeline; the full stage split is in research.md ("Where
-the time goes"). About 7.2 seconds of that pipeline (a redundant Pi install, whose skip is
-already live on the dev sidecar, and the pi-acp version probes, removal planned in PR #5221) is
-removable by config and patch fixes independent of this plan. Stopping and restarting the
+the time goes"). About 7.2 seconds of that pipeline (a redundant Pi install that a config
+switch removes, and the pi-acp version probes that PR #5221 removes) goes away independently of
+this plan. Stopping and restarting the
 sandbox keeps its disk but kills every process, so a restarted sandbox still pays the harness
 respawn and the mounts. Only a sandbox that stays running, with its daemon, mounts, and harness
 session alive, skips the pipeline. That is why this plan builds all the way to park-to-running
@@ -53,8 +53,8 @@ Each maps onto one level of the fallback ladder in `research.md`: park-to-stoppe
 stopped-restart level, park-to-running builds the live-warm level. They compose rather than
 compete: a park-to-running entry that outlives its window is evicted by stopping it, which drops
 it to the park-to-stopped state, which degrades to the cold rebuild floor. The always-correct
-cold rebuild plus transcript replay stays underneath both. Two flags stay independent on purpose:
-turning the live pool off must never disable stopped reuse on the cold path.
+cold rebuild plus transcript replay stays underneath both. The two controls stay independent on
+purpose: setting the live window to zero must never disable stopped reuse on the cold path.
 
 ## The three resume paths, compared
 
@@ -67,15 +67,15 @@ Slice 5.
 **Path 1: fresh create (today's behavior).** The old sandbox is gone. Every stage is paid:
 sandbox create (~1.05 s), the Pi install (~5.2 s where the skip is not live), extension upload,
 mounts (~0.7 s), harness spawn (~5.15 s), session reload, then the model. User-visible total:
-about 15 seconds measured at HEAD; about 10 with the install skip that is now live on the dev
-runner; about 8 once the pi-acp probe removal (PR #5221) lands.
+about 15 seconds measured; about 10 with the Pi install skipped; about 8 once the pi-acp probe
+removal (PR #5221) lands.
 
 **Path 2: stop, then restart (park-to-stopped).** Stopping destroys every process in the
 sandbox: the harness, the geesefs mount processes, the daemon. Only the disk survives. So the
 restart pays, stage by stage: start-from-stopped (~0.7 to 0.8 s) in place of create (~1.05 s);
 the mounts again (~0.7 s, new processes); the harness respawn again (~5.15 s today, ~3.15 s
 after the probe fix); the session reload again. The install is not paid, but only because the
-binary survives on disk, and the live skip makes that saving moot on the fresh path too.
+binary survives on disk, and the install skip makes that saving moot on the fresh path too.
 User-visible total, constructed: nearly the same as a fresh create, roughly 1 second cheaper.
 Said plainly: the 0.7-second number is the provider operation, not what a user waits;
 park-to-stopped buys durability of the disk, not latency.
@@ -97,10 +97,10 @@ start the same instance and reload the harness session. The parked cost is disk 
 
 The measured stage split (research.md, "Where the time goes") bounds its latency win honestly:
 the create it skips costs about 1 second, and a restarted sandbox still pays the ~5.15-second
-harness respawn, ~0.7 seconds of mounts, and (until the skip is everywhere) the Pi install,
+harness respawn, ~0.7 seconds of mounts, and (where the install is not skipped) the Pi install,
 because the current Daytona path re-uploads assets and rematerializes workspace files on every
-start. So park-to-stopped saves about 1 second out of a roughly 10-second pipeline once the
-install skip is live. Its real value is that it is the state a park-to-running eviction lands
+start. So park-to-stopped saves about 1 second out of a roughly 10-second pipeline with the
+install skipped. Its real value is that it is the state a park-to-running eviction lands
 in, and that its correctness work is the base every higher level stands on.
 
 ### What is already built (at HEAD, untested)
@@ -116,8 +116,9 @@ in, and that its correctness work is the base every higher level stands on.
 - `patches/sandbox-agent@0.4.2.patch`: the native session reload and the local process-group kill.
 
 One consequence of "already built" matters for sequencing: both run paths already request
-`keepWarm` on clean Daytona turns. The moment a real `pause` lands, parking activates. So the
-feature flag is part of Slice 1, not a later addition, and it gates all three moving parts
+`keepWarm` on clean Daytona turns. The moment a real `pause` lands, parking activates. So Slice 1
+keeps the park path inert (the default teardown stays delete) until the correctness work and its
+tests are in place, and Slice 2 switches the default. The switch covers all three moving parts
 together: the stored-id read and reconnect, the pointer write, and the stop at turn end.
 
 ### Must-fix before it can be turned on
@@ -161,14 +162,29 @@ Each of these is a real leak or race, not polish. They block enabling the featur
    `DAYTONA_TARGET`, which also invalidate a stopped sandbox. On a mismatch, delete the old
    sandbox and build fresh.
 
-3. **A write guard on the sandbox pointer.** `writeSandboxId` is a fire-and-forget,
-   last-writer-wins PUT, and the Daytona path skips the runner's ownership check. Two turns racing
-   on one conversation (or a forced re-steer that starts a replacement before the old turn stops)
-   can cross-write the pointer, orphaning one instance and double-using another. Await the write,
-   and make it conditional (a compare-and-set on a generation number or the turn index; the
-   `session_states` row already carries a turn counter). A stale turn must not overwrite or stop
-   the current turn's sandbox. Clearing a stale id after a failed reconnect must be conditional for
-   the same reason.
+3. **A write guard on the sandbox pointer.** The runner remembers which sandbox belongs to a
+   conversation by writing the sandbox id to a database row (`session_states.sandbox_id`,
+   written by `writeSandboxId`) at the start of each turn. Today that write has two weaknesses:
+   the runner does not wait for it to finish, so a failure is silent, and whichever write lands
+   last wins, with no check that it is the newest.
+
+   When this bites: two turns run against the same conversation at nearly the same time. That
+   happens when a user sends a second message before the first turn finishes, or cancels and
+   immediately re-sends, so the platform starts a replacement sandbox while the old turn is
+   still shutting down. Both turns write their own sandbox id; if the older write lands last,
+   the row points at a sandbox that is being torn down. Without reuse this was harmless: the
+   row was never read back against a live sandbox. With reuse it costs two things: the next
+   turn tries to restart the wrong instance (one doomed reconnect, then a cold build), and the
+   newer sandbox is orphaned, running until the idle timers reap it (cents per incident, but
+   the conversation also loses its warm sandbox).
+
+   The fix is small: wait for the write, and make it conditional so an older turn cannot
+   overwrite a newer one (a compare-and-set on the turn counter the `session_states` row
+   already carries). This is plumbing inside one function plus one conditional check on the
+   sessions API; it is not a re-architecture, and it is unrelated to the F-018 transport work.
+   The only open choice is which existing counter to compare against; `open-questions.md`
+   item 1 lays out the candidates. Clearing a stale id after a failed reconnect must be
+   conditional for the same reason.
 
 4. **Mount hygiene on reattach.** Reconnecting to an already-running sandbox can find an old file
    mount with expired credentials. `mountStorageRemote()` accepts any live mount and does not check
@@ -192,25 +208,27 @@ Each of these is a real leak or race, not polish. They block enabling the featur
 
 6. **The idle timers are the sweeper, with measured defaults.** Once a sandbox survives turn end,
    Daytona's own timers reap abandonment. Two settings change from the current working-tree values:
-   - Configure the archive step out by setting `DAYTONA_AUTOARCHIVE` strictly greater than
-     `DAYTONA_AUTODELETE` (equal values would race; Daytona's own "archive interval 0 means
-     maximum" convention is unusable here because our `positiveMinutes()` parser treats 0 as
-     unset). Daytona documents auto-delete as firing after a sandbox has been continuously
-     stopped, with no archive step required, but the archive-disabled path is worth one explicit
-     live check in Slice 5: stop a sandbox with delete set shorter than archive and confirm it
-     goes stopped to destroyed without passing through archived. Why drop archive at all:
-     measured restore from archive takes 33 to 66 seconds, slower than the 1.2 to 1.7 second
-     fresh create, and the disk it frees costs under a tenth of a cent per hour. The ladder is
-     stop, then delete.
-   - Set the stop timer to 15 minutes, not 5. Daytona's idle clock resets on external API calls,
-     not on processes running inside the sandbox, so a stop timer shorter than the longest silent
-     stretch of a live turn (the run-limits guard alone allows 300 seconds) can stop a sandbox
-     mid-turn. At measured prices the difference is small money: a crash orphan bills about 4
-     cents with a 15-minute stop timer versus about 1.4 cents with a 5-minute one. Paying 3 cents
-     per crash to never stop a live turn is the right trade.
+   - Remove the auto-archive logic entirely: drop the `autoArchiveInterval` field from the
+     create call and the `DAYTONA_AUTOARCHIVE` override with it. Archive can never be the right
+     state for us: restoring from it takes 33 to 66 seconds, slower than the 1.2 to 1.7 second
+     fresh create, and the disk it frees costs under a tenth of a cent per hour. With the field
+     unset, Daytona's own archive default (7 days) sits far past our 30-minute delete, so the
+     ladder is simply stop, then delete. Daytona documents auto-delete as firing after a sandbox
+     has been continuously stopped, with no archive step required; Slice 5 confirms this once
+     live (stop a sandbox and watch it go stopped to destroyed without passing through
+     archived).
+   - Set the stop timer to 15 minutes, not 5, via the existing `DAYTONA_AUTOSTOP` env override.
+     The timer counts idle time since the last API interaction with the sandbox and resets on
+     every turn (each turn drives exec and file calls), so an active conversation never hits it;
+     it only fires after 15 minutes of silence. What it does not reset on is work running purely
+     inside the sandbox, so a stop timer shorter than the longest silent stretch of a live turn
+     (the run-limits guard alone allows 300 seconds) could stop a sandbox mid-turn; 15 minutes
+     clears that comfortably. At measured prices the difference is small money: a crash orphan
+     bills about 4 cents at 15 minutes versus about 1.4 cents at 5. Paying 3 cents per crash to
+     never stop a live turn is the right trade. All three timer values stay env-overridable.
    The API-side `orphan_sweep.py` does not participate: it cleans only Postgres rows and Redis
    locks and never contacts Daytona. No new sweeper is needed; the timers are the sweeper, and at
-   these prices the abandonment budget no longer needs a billing-owner sign-off, only review.
+   these prices the abandonment budget needs review, not a billing-owner sign-off.
 
 7. **Clean up a stale stored id.** When the delete timer reaps a sandbox, `session_states.sandbox_id`
    goes stale. The reconnect ladder degrades gracefully (failed lookup, fresh build), but the
@@ -276,49 +294,51 @@ does not care which provider produced it.
 Goal: keep the Daytona sandbox running with its live session between turns for a short window, so
 a second turn is near-instant (no start, no remount, no daemon or harness startup, no reload).
 This is the only level that removes the pipeline rather than shaving the sandbox-create second
-off it: a resumed turn is the model time plus small overheads, roughly 2 to 3 seconds against
-today's ~15-second cold turn (estimated from the measured stage split; confirmed in Slice 5).
+off it. A resumed turn still pays the request's own path even though the sandbox is up: the hop
+through the services layer (measured 100 to 220 ms locally), the pool checkout with its
+validation (config and history fingerprints, credential expiry), and forwarding the prompt over
+the open session. That plus the model's own generation time puts the resumed turn at roughly 2
+to 3 seconds against today's ~15-second cold turn (estimated; Slice 5 confirms).
 
 ### The work
 
-1. **Capacity admission before anything starts a Daytona sandbox.** The pool alone cannot enforce
-   a running cap: a fresh miss acquires its environment before the pool ever sees the session, so
-   concurrent misses could create arbitrarily many sandboxes while the pool holds four. The cap
-   therefore lives in a small admission gate (a permit counter) taken before create and before a
-   reconnect's `start()`, and released only when Daytona confirms the instance stopped or deleted.
-   It counts everything that can be running: reserved, creating, starting, busy in a turn, parked
-   live, and stopping. When the gate is full: evict an idle parked entry and await its confirmed
-   stop, then admit; if every permit belongs to an active or approval-waiting turn, queue briefly
-   or reject the run with a clear error. Daytona never gets the local pool's "run unparked
-   best-effort" behavior; that rule is what makes the local cap soft, and a soft cap on billed
-   compute is not a cap.
+1. **A hard cap on warm sandboxes, enforced where they are kept, not where turns run.** An
+   active turn always gets a sandbox; the platform's own concurrency limits govern that, and a
+   turn a user is waiting on is never blocked by warmth accounting. What the cap bounds is idle
+   spend: how many sandboxes may stay running between turns. At turn end, the session asks for a
+   warm slot; if none is free (and no idle entry can be evicted to stopped first, awaited), the
+   sandbox is stopped instead of kept running. The conversation degrades to the stop-then-restart
+   path for its next turn, nothing fails, and idle compute stays bounded. The slot accounting
+   must count everything warm or on its way there (parked live, being reattached, being stopped),
+   and a reconnect's `start()` takes a slot before starting, so concurrent resumes cannot
+   overshoot. Daytona never gets the local pool's "run unparked best-effort" rule; that rule is
+   what makes the local cap soft, and a soft cap on billed compute is not a cap.
 
-2. **Enable the Daytona pool** from the refactor above, behind its own flag, off by default until
-   the verification slice passes.
+2. **Daytona-scoped configuration, with the time-to-live as the on/off switch** (lifecycle and
+   billing differ per provider, so the names say `DAYTONA`, not "remote"):
+   - `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS`: how long a sandbox stays running after its
+     turn. Default 120000 (two minutes, about half a cent per parked turn at $0.0028 per
+     minute). 0 disables keeping sandboxes running entirely; there is no separate enabled flag.
+     Independent of park-to-stopped: setting it to 0 must not disable stopped reuse.
+   - `AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM`: the warm-slot cap from item 1. Default 20
+     (worst case with all 20 idle at once: about $3.33/hour, and the time-to-live bounds how
+     long that worst case can last). This is deliberately its own variable, not the local
+     pool's `AGENTA_RUNNER_SESSION_POOL_MAX`: that one budgets host memory (about 330 MB per
+     hot Claude tree), this one budgets billed compute, and an operator will want to tune them
+     apart.
+   These live in the runner config module next to the existing keepalive config, read once,
+   never via ad-hoc environment lookups. Both are plain env vars from day one, so they can be
+   tuned per deployment without a code change.
 
-3. **Daytona-scoped configuration, with conservative defaults** (lifecycle and billing differ per
-   provider, so the names say `DAYTONA`, not "remote"):
-   - `AGENTA_RUNNER_DAYTONA_SESSION_KEEPALIVE_ENABLED` (default off; flipped on after
-     verification). Independent of the park-to-stopped flag: disabling the live pool must not
-     disable stopped reuse.
-   - `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS` (default 60000; at $0.0028 per parked minute this
-     is about a third of a cent per parked turn).
-   - `AGENTA_RUNNER_DAYTONA_SESSION_MAX_RUNNING` (default 4; worst-case burn with all four parked
-     is about $0.67/hour). This is the admission gate's permit count.
-   These live in the runner config module next to the existing keepalive config, read once, never
-   via ad-hoc environment lookups. They are operator policy with stated defaults, not open
-   decisions: the defaults above are conservative enough to ship, and an operator can tighten or
-   widen them without a code change.
-
-4. **Eviction wired to the lifecycle, awaited.** When the window expires or the admission gate
+3. **Eviction wired to the lifecycle, awaited.** When the window expires or a full warm cap
    forces an eviction, a Daytona entry is stopped, not deleted, so it drops to the
    park-to-stopped state and the session can still reconnect after the live window closes. The
    eviction goes through the typed teardown reason from the refactor, is awaited before a
-   replacement is admitted, and releases the capacity permit only on a confirmed stop. A failed
-   stop escalates to a delete; a failed stop plus failed delete keeps the permit consumed until a
+   replacement takes the slot, and frees the warm slot only on a confirmed stop. A failed stop
+   escalates to a delete; a failed stop plus failed delete keeps the slot consumed until a
    reconciliation pass confirms the instance is gone.
 
-5. **Daytona's own timers versus the pool window.** With a 15-minute stop timer and a 60-second
+4. **Daytona's own timers versus the pool window.** With a 15-minute stop timer and a two-minute
    window, overlap is unlikely but not impossible: Daytona's idle clock may be old when the pool
    parks the entry (a long silent tool stretch resets nothing, since only external API calls
    count). On entering the live parked state, refresh the sandbox's activity once through the API
@@ -326,17 +346,27 @@ today's ~15-second cold turn (estimated from the measured stage split; confirmed
    heartbeats: a periodic keepalive ping would keep a leaked sandbox alive forever and defeat the
    auto-stop backstop.
 
-6. **Runner restart and the parked live session.** The in-memory pool does not survive a restart.
+5. **Runner restart and the parked live session.** The in-memory pool does not survive a restart.
    On a graceful shutdown, drain idle Daytona entries to stopped (not deleted), so the next turn
    falls to park-to-stopped reconnect and then durable reload; delete entries whose turn was in
    flight. On a hard kill, the sandboxes leak until the stop timer, the same abandonment budget as
    park-to-stopped (about 4 cents per crash at a 15-minute stop timer). So park-to-running never
    sits below park-to-stopped: its worst case degrades to park-to-stopped, which degrades to cold.
 
-7. **Credentials and mounts.** A parked running Daytona session holds signed mount credentials
+6. **Credentials and mounts.** A parked running Daytona session holds signed mount credentials
    with a real expiry. The existing credential-epoch check already evicts to cold on expiry. Keep
    the Daytona time-to-live comfortably under the mount-credential lifetime, so a live turn never
    runs against an expired mount.
+
+7. **Leak safety is a review focus, not one mechanism.** The catastrophic failure here is a bug
+   that keeps many sandboxes running unnoticed. Four defenses stack: the warm cap (item 1)
+   bounds how many sandboxes the pool will ever hold running; every sandbox carries its stop
+   and delete timers from creation, so a sandbox the runner forgets stops billing compute
+   within 15 idle minutes and deletes within 30, no matter what the bug is; recurring
+   keepalive pings are prohibited, so a forgotten sandbox cannot be kept alive by accident;
+   and the verification slice ends with a zero-live-sandboxes check after abandonment. Code
+   review of the pool and teardown paths must treat "can this path leave a sandbox out of the
+   accounting" as its first question.
 
 ### Pending approvals, aligned with the F-018 gate plan
 
@@ -363,23 +393,25 @@ model is the contract this plan follows, not a thing this plan redefines:
 
 One consequence worth stating: park-to-running's chat benefit does not wait for F-018 (a pure
 chat turn raises no gate), but its approval benefit does. Sequence the slices accordingly and do
-not couple the flag flip to the gate work.
+not couple this plan's defaults to the gate work.
 
 ### Cost and fidelity
 
-- Parked cost: $0.0028 per parked minute per sandbox, bounded by the time-to-live and the running
-  cap (defaults: 60 seconds, 4 sandboxes, worst case about $0.67/hour).
+- Parked cost: $0.0028 per parked minute per sandbox, bounded by the time-to-live and the warm
+  cap (defaults: two minutes, 20 sandboxes, worst case about $3.33/hour while fully loaded).
 - Resume cost: near zero. The sandbox is up, the mount is live, the session is open.
 - Fidelity: highest. It is the only level that can hold an open approval gate for byte-exact
   resume, once the gate plan's file-transport parked-gate variant exists.
 
 ## Recommendation
 
-Build the whole ladder, in slices, each shippable on its own: the correctness base with its flag,
-then park-to-stopped enabled behind that flag, then the provider-aware pool refactor, then
-park-to-running behind its own flag with capacity admission and the conservative defaults above,
-then live verification, and only then flip the flags on. Park-to-stopped can graduate from
-verification independently of park-to-running.
+Build the whole ladder, in slices, each shippable on its own: the correctness base first, then
+park-to-stopped, then the provider-aware pool refactor, then park-to-running with the warm cap
+and the defaults above, then live verification. The finished feature ships on by default with no
+feature flags; the off switches are configuration (the live window's time-to-live, 0 to disable)
+and the timers, all env vars. Until the live verification passes, the defaults stay at today's
+behavior; the final slice changes the defaults. Park-to-stopped can graduate from verification
+independently of park-to-running.
 
 The measurements are what moved park-to-running from "deferred" into the main line: sandbox
 creation costs about 1 second of a ~15-second turn, so park-to-stopped alone cannot fix it; the
@@ -401,34 +433,37 @@ Each slice lands independently, with tests, and does not regress the one below i
 - **Slice 1 (correctness base, everything disabled).** The provider wrapper functions plus the
   two package-patch cleanup fixes; the reconnect state machine; teardown by typed reason; guarded
   and awaited pointer writes; the compatibility fingerprint derived from the resolved create
-  specification; and the park-to-stopped feature flag, default off, gating reconnect, pointer
-  writes, and stop-at-turn-end together. The flag belongs here, not later: the run paths already
-  request `keepWarm`, so landing a real `pause` without the flag would activate parking
-  immediately. Unit tests for all of it. No live Daytona.
-- **Slice 2 (park-to-stopped, enabled behind its flag).** Wire the park path end to end; timer
+  specification. The park path stays inert in this slice (the default teardown remains delete),
+  because the run paths already request `keepWarm` and landing a real `pause` would otherwise
+  activate parking before its correctness work is verified. Unit tests for all of it. No live
+  Daytona.
+- **Slice 2 (park-to-stopped).** Wire the park path end to end and make stop the default
+  teardown for clean resumable turns; timer
   defaults per item 6 (stop at 15 minutes, archive configured out with strict inequality, delete
   at 30); conditional stale-id cleanup; the mount-generation check.
 - **Slice 3 (provider-aware pool refactor).** Per-provider operator config, the engine-owned
   lifecycle adapter with typed teardown reasons, one pool instance per provider, dispatch by
   resolved provider, local semantics preserved, Daytona pool present but disabled. This slice
   depends on Slice 1's teardown-reason contract; it does not depend on Slice 2.
-- **Slice 4 (park-to-running, flag off).** The capacity admission gate (permits before create and
-  reconnect-start, awaited evict-to-stop, release on confirmed stop or delete, queue-or-reject
-  when saturated, never run-unparked); the one-time activity refresh at live park; drain-to-stop
-  on graceful shutdown, delete-in-flight on shutdown; credential-epoch bound on the window.
-  Pending approvals take the cold path until the gate plan's file-transport parked-gate variant
-  lands (see the approval section).
-- **Slice 5 (live verification, then flip the flags).** Credit-controlled E3 passes, in two
-  independent gates, compared against the 2026-07-11 stage-split baseline in research.md. First
+- **Slice 4 (park-to-running).** The warm-slot cap (slots counted for parked, reattaching, and
+  stopping entries; a reconnect's start takes a slot first; awaited evict-to-stop; a finished
+  turn that finds no free slot parks to stopped instead); the one-time activity refresh at live
+  park; drain-to-stop on graceful shutdown, delete-in-flight on shutdown; credential-epoch bound
+  on the window. Ships with the live window at zero until Slice 5 passes. Pending approvals take
+  the cold path until the gate plan's file-transport parked-gate variant lands (see the approval
+  section).
+- **Slice 5 (live verification, then the defaults change).** Credit-controlled E3 passes, in two
+  independent gates, compared against the stage-split baseline in research.md. First
   add the duration log lines that baseline had to hand-instrument (the Pi install, sandbox
   created, `prepareWorkspace`, `probeCapabilities`, `createSession`). Park-to-stopped: measure
   cold versus stopped-restart, confirm one instance serves consecutive turns, confirm the stop
   and delete timers fire once with no archive state observed, and confirm zero live sandboxes
   afterwards. Park-to-running additionally needs a concurrency
-  test: more than `MAX_RUNNING` distinct sessions at once, the cap holding (admission queues or
-  rejects, never over-creates), a TTL expiry confirmed as a stop, a SIGTERM drain, and one forced
-  stop failure escalating to delete. Chat first; tool and approval turns wait on F-018. Then flip
-  each flag as its gate passes.
+  test: more than `MAX_WARM` distinct sessions at once, the cap holding (overflow parks to
+  stopped, never over-holds), a window expiry confirmed as a stop, a SIGTERM drain, and one
+  forced stop failure escalating to delete. Chat first; tool and approval turns wait on F-018.
+  Then change each default (stop-not-delete teardown; the two-minute live window) as its gate
+  passes.
 
 ## How this fits with other work
 

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
@@ -1,9 +1,10 @@
 # Research: the current code, the fallback ladder, Daytona billing
 
 This file is the evidence behind `context.md`. Read `context.md` first for the story; read this
-when you want to see the code that proves it. It covers four things, in order: what happens in
+when you want to see the code that proves it. It covers five things, in order: what happens in
 the runner during one turn, the gap that defeats warm reuse, the local warm-reuse pool and why
-it is kept off Daytona, and how Daytona bills a stopped sandbox.
+it is kept off Daytona, how Daytona bills a stopped sandbox, and where the time actually goes in
+a measured turn.
 
 All line references are against the working tree at the time of writing (HEAD carries PR #5197
 plus commit `60990d396e`). Treat them as pointers, not exact addresses.
@@ -156,7 +157,7 @@ slowest:
    mount plus reload. Zero idle compute cost while parked. This is what the **park-to-stopped**
    proposal builds.
 3. **Cold rebuild.** Neither survived. The runner builds a fresh sandbox and replays the
-   transcript. Always available, always correct, about twenty seconds. This is today's floor and
+   transcript. Always available, always correct, about fifteen seconds measured. This is today's floor and
    stays the floor.
 
 The levels compose; they do not replace each other. Park-to-stopped gives memory across a
@@ -249,15 +250,14 @@ Three conclusions follow:
    unusable because our `positiveMinutes()` parser treats 0 as unset). Daytona documents
    auto-delete as firing after continuous stopped time with no archive step required; the
    archive-disabled path still gets one explicit live check in the verification slice.
-2. **Sandbox creation is not the 20-second problem.** A cold create to a usable exec is under 2
-   seconds at the Daytona API, so almost all of the roughly 20 seconds QA measured per turn sits
-   in our own per-turn pipeline: daemon startup inside the sandbox, asset upload, the geesefs
-   mounts, harness startup, and the session reload. This is arithmetic, not instrumentation; the
-   split across those steps is unmeasured, and the verification slice instruments it. Two
-   corollaries: park-to-stopped skips only the create at the provider level (and today's Daytona
-   path re-uploads Pi assets and rematerializes workspace files on every start, so the prepared
-   disk saves less than it could); park-to-running is the only level that skips the whole
-   pipeline.
+2. **Sandbox creation is not the slow-turn problem.** A cold create to a usable exec is under 2
+   seconds at the Daytona API, so almost all of the turn sits in our own per-turn pipeline:
+   daemon startup inside the sandbox, asset upload, the geesefs mounts, harness startup, and the
+   session reload. The full stage-by-stage split was measured on real E3 runs the same day; see
+   "Where the time goes" below. Two corollaries: park-to-stopped skips only the create at the
+   provider level (and today's Daytona path re-uploads Pi assets and rematerializes workspace
+   files on every start, so the prepared disk saves less than it could); park-to-running is the
+   only level that skips the whole pipeline.
 3. **Parked-running compute is cheap in absolute terms.** $0.0028 per parked minute. A 60-second
    keep-warm window after each turn costs at most about a third of a cent; a cap of 4 concurrently
    running parked sandboxes has a worst-case burn of about $0.67/hour.
@@ -277,6 +277,64 @@ measured prices this abandonment budget is now a number, not a question: about 1
 crash at a 5-minute stop timer, about 4 cents at the 15-minute value the plan proposes, plus a
 fraction of a cent of storage until the delete timer. That is acceptable without a separate
 sweeper; the timers are the sweeper.
+
+## Where the time goes in a real turn (measured 2026-07-11)
+
+The lifecycle numbers above isolate the sandbox; this section measures the whole turn. Three
+real E3 chat runs (Daytona, Pi harness) plus micro-measurements inside the runner container.
+The cold Daytona turn took about 15 seconds of client wall time (16.6, 14.9, and 15.5 seconds
+across the three runs; F-020's earlier QA runs saw about 20). The stage split:
+
+| Stage of a cold Daytona Pi turn | Measured |
+|---|---|
+| Request receipt to run plan | ~55 ms |
+| Sandbox create to usable | ~1,050 ms |
+| npm install of the Pi CLI into the sandbox | ~5,200 ms |
+| Extension upload (1.4 MB) | ~90 ms |
+| Durable geesefs mounts (cwd + pi-sessions) | ~700 ms |
+| Harness spawn to ready (`createSession`) | ~5,150 ms |
+| Model generation (not pipeline) | ~2,300 ms |
+| Teardown / park after the reply | ~800 ms |
+
+Three findings inside that table:
+
+- **The npm install is redundant.** The snapshot bakes `pi` 0.80.6 at `/usr/local/bin/pi`, so
+  the ~5.2-second install re-installs what is already there. It is silent in the logs (it logs
+  only on failure), which is why it hid this long. Skipping it via
+  `AGENTA_AGENT_SANDBOX_PI_INSTALLED=false` is already live on the dev sidecar as of 2026-07-11;
+  the E3 smoke turn dropped to 12.2 seconds.
+- **About 2,000 ms of the harness spawn is pi-acp version and update probes** running inside the
+  EU sandbox: two `pi --version` calls at ~750 ms each and one `npm view` at ~305 ms. Their
+  removal is planned in PR #5221. The remaining ~3,150 ms is estimated (not separately logged):
+  Pi process start, the ACP handshake, and workspace and probe round-trips.
+- **Net Daytona-specific pipeline: ~12.3 seconds.** About 7.2 seconds of it (install skip plus
+  probe removal) is removable by those two config and patch fixes alone, independent of this
+  plan's lifecycle work. What the lifecycle work then competes with is the ~5-second remainder.
+
+For contrast, measured the same day:
+
+- **Cold local Pi turn: ~4 to 6.5 seconds.** Services hop 100 to 220 ms, plan and assets 210 to
+  320 ms, local geesefs mount 540 to 590 ms, harness spawn 2,000 to 2,500 ms (of which ~1,600 ms
+  is the same pi-acp probes), model 600 to 3,000 ms. A warm keepalive hit skips everything but
+  the model.
+- **Cold local Claude turn: 6.4 seconds** (one measured run, haiku). Request to spawn 347 ms
+  (Pi's is 325 ms), spawn to first token 3.09 s (the current logs cannot split adapter from
+  model), generation 2.94 s. No Claude analogue of the pi probe waste was found. Claude on
+  Daytona is currently blocked before harness start (auth), so no Daytona Claude timing exists
+  yet.
+
+What this means for the two park levels, stated once here and reflected in `plan.md`:
+
+- **Park-to-stopped saves only the ~1-second provider create at today's HEAD**, because a
+  restarted sandbox still pays the install, the mounts, and the harness spawn. With the install
+  skip live, it saves about 1 second out of about 10. The real remaining cost a stopped restart
+  pays is the ~5.15-second harness respawn plus ~0.7 seconds of mounts.
+- **Park-to-running removes the whole pipeline.** A resumed turn is the model time plus small
+  overheads, roughly 2 to 3 seconds (estimated, to be confirmed in the verification slice).
+
+The measurement also surfaced the log lines the runner is missing to make this split repeatable
+without hand instrumentation: a duration line for the Pi install, a sandbox-created line, and
+duration lines for `prepareWorkspace`, `probeCapabilities`, and `createSession`.
 
 ## PR #5197 (durable session continuity)
 

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
@@ -171,8 +171,9 @@ Local (non-Daytona) sessions already get warm reuse from an in-memory pool (`ses
 It is a per-process map from a pool key to a live session, with a size cap and idle reaping. The
 facts that bear on extending it to Daytona:
 
-- The pool key is `<projectId>:<sessionId>`. Without a project scope there is no parking, which is
-  the safe default.
+- The pool key is `<projectId>:<sessionId>`. The project id comes from the service-stamped run
+  context, with the signed mount's owning project as the fallback. Without a project scope from
+  either source there is no parking, which is the safe default.
 - Two idle timers: a plain idle time-to-live (`AGENTA_RUNNER_SESSION_TTL_MS`, default 60s) and an
   approval-wait time-to-live (`AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS`, default 300s). A size cap
   (`AGENTA_RUNNER_SESSION_POOL_MAX`, default 8). An on/off flag
@@ -259,9 +260,9 @@ Three conclusions follow:
    provider level (and today's Daytona path re-uploads Pi assets and rematerializes workspace
    files on every start, so the prepared disk saves less than it could); park-to-running is the
    only level that skips the whole pipeline.
-3. **Parked-running compute is cheap in absolute terms.** $0.0028 per parked minute. A 60-second
-   keep-warm window after each turn costs at most about a third of a cent; a cap of 4 concurrently
-   running parked sandboxes has a worst-case burn of about $0.67/hour.
+3. **Parked-running compute is cheap in absolute terms.** $0.0028 per parked minute. A two-minute
+   keep-warm window after each turn costs at most about half a cent; a cap of 20 concurrently
+   warm sandboxes has a worst-case burn of about $3.33/hour while fully loaded.
 
 Park-to-stopped parks to Stopped: storage cost only, and the delete timer bounds even that.
 Park-to-running parks to Running for a short window: the parked cost is live compute, so its

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
@@ -1,0 +1,247 @@
+# Research: the current code, the fallback model, Daytona billing
+
+All line numbers are against the working tree at the time of writing (HEAD carries PR #5197
+plus commit `60990d396e`). Treat them as pointers, not exact addresses.
+
+## The turn lifecycle at HEAD
+
+### Provider create flags (`provider.ts`)
+
+`buildDaytonaCreate` returns, among the network and env fields:
+
+```ts
+autoStopInterval: daytonaAutoStopMinutes(),      // DEFAULT 5
+autoArchiveInterval: daytonaAutoArchiveMinutes(), // DEFAULT 15
+autoDeleteInterval: daytonaAutoDeleteMinutes(),   // DEFAULT 30
+ephemeral: false,
+```
+
+The comment states the intent: "stop preserves the disk (warm), archive moves it to cold
+storage, delete reaps it (dead). `ephemeral: false` so a stop parks rather than deletes; the
+three intervals ... are the platform-run reapers. A leaked sandbox self-reaps via autoDelete
+instead of ephemeral." So the "TTL sweeper for stopped sandboxes" that Tier 1 needs is already
+delegated to Daytona's own idle intervals. Overrides are `DAYTONA_AUTOSTOP`,
+`DAYTONA_AUTOARCHIVE`, `DAYTONA_AUTODELETE` (whole minutes, floor 1).
+
+This is the exact opposite of the F-020 premise. F-020 was written against `ephemeral: true` and
+a single 15-minute autostop.
+
+### Turn-end teardown (`sandbox_agent.ts`, the `destroy` closure)
+
+`environment.destroy` takes `opts?: { keepWarm?: boolean }`. The relevant branch:
+
+```ts
+// keepWarm pauses a remote sandbox (parked, resumable) instead of deleting it; falls back to destroy.
+const parked =
+  opts?.keepWarm && plan.isDaytona && environment.sandbox?.pauseSandbox
+    ? await environment.sandbox.pauseSandbox().then(() => true).catch(() => false)
+    : false;
+if (!parked) await environment.sandbox?.destroySandbox().catch(() => {});
+```
+
+Order matters: the graceful `session/cancel` (`destroySession`) runs BEFORE this, then the park
+or delete, then `dispose()`, then the durable-cwd unmount. So a parked sandbox has its harness
+session cancelled and its host mount torn down; resume re-mounts and re-opens the session.
+
+### Who requests keepWarm
+
+`shouldPark` gates it:
+
+```ts
+if (signal?.aborted) return false;   // aborted run: destroy, do not park
+if (clientGone?.()) return false;    // client disconnected mid-turn: destroy, do not park
+if (!result.ok) return false;        // failed turn: teardown as today
+if (result.stopReason === "paused") return false; // a plain pause never parks
+return true;
+```
+
+Both run paths pass `keepWarm: env.resumable && result !== undefined && shouldPark(...)`, where
+`env.resumable = Boolean(plan.isDaytona && sessionForMount)`. The two paths are
+`runSandboxAgent` (the plain path) and the keep-alive `runCold` in `server.ts`. Net effect at
+HEAD: a successful, non-aborted, non-paused Daytona chat turn that has a session id parks the
+sandbox to stopped and records its id. A failed turn (which today includes every tool-using
+Daytona turn, per F-018) does not park, so F-018 failures do not leak a warm sandbox.
+
+### Reconnect (`sandbox-reconnect.ts` + acquire path)
+
+At acquire, for a Daytona run with a session and a run credential:
+
+```ts
+const storedSandboxId = plan.isDaytona && sessionForMount && runCred
+  ? await readStoredSandboxId(sessionForMount, { authorization: runCred, log })
+  : undefined;
+if (storedSandboxId) {
+  try {
+    environment.sandbox = await startSandboxAgent({ ...startOptions, sandboxId: storedSandboxId });
+    log(`reconnected sandbox=${storedSandboxId} ...`);
+  } catch (err) {
+    log(`reconnect failed sandbox=${storedSandboxId}, creating fresh: ...`);
+  }
+}
+if (!environment.sandbox) environment.sandbox = await startSandboxAgent(startOptions);
+if (sessionForMount && runCred) {
+  const liveSandboxId = environment.sandbox?.sandboxId ?? plan.sandboxId;
+  void writeSandboxId(sessionForMount, liveSandboxId, { authorization: runCred, log });
+}
+```
+
+The stored id lives in the sessions plane: `GET`/`PUT /sessions/states/?session_id=...` with a
+`sandbox_id` field. Read failure, write failure, and reconnect failure are all best-effort and
+degrade to a fresh create. This is the "dead rung" F-020 named, now reachable because the park
+path keeps the sandbox alive for the stored id to resolve against.
+
+Two caveats the review round surfaced. The `writeSandboxId` PUT is fire-and-forget (`void`) and
+last-writer-wins, with no compare-and-set; a delayed older write can replace a newer sandbox id
+when two turns race on one session. And the vendored `SandboxAgent.start({sandboxId})` cleans up
+only sandboxes it created itself, so a reconnect that starts the old instance and then fails a
+later step (daemon, URL, client) leaves it running while the ladder creates a second one.
+
+### The vendored provider gap (the load-bearing finding)
+
+The vendored Daytona provider (`node_modules/sandbox-agent/dist/providers/daytona.js`)
+implements only `create`, `destroy`, `getUrl`, and `ensureServer`. The `SandboxProvider`
+interface declares `pause?` and `reconnect?` as optional, and the e2b and sprites providers
+implement them, but daytona does not. Verified consequences in `dist/chunk-TVCDKGSM.js`:
+
+- `pauseSandbox()` with no `provider.pause` calls `provider.destroy(rawSandboxId)`. So the
+  runner's keepWarm park deletes the sandbox anyway.
+- `pauseSandbox()` clears `sandboxProvider` and the raw id in its `finally`, even when
+  `provider.pause()` throws. The runner's fallback `destroySandbox()` then has no provider and
+  silently no-ops, so a failed pause leaks a running sandbox.
+- `start({sandboxId})` calls `provider.reconnect` then `ensureServer`; with `reconnect` missing
+  (and `ensureServer` unable to start a stopped instance) reconnect always throws and falls to a
+  fresh create.
+
+So at HEAD, despite the keepWarm plumbing, every Daytona turn still deletes and recreates.
+F-020's observed behavior stands; only its mechanism description is out of date.
+
+### The sandbox-agent patch (`patches/sandbox-agent@0.4.2.patch`)
+
+Commit `60990d396e` patches the vendored `sandbox-agent` package to add native session resume:
+
+- `LiveAcpConnection.loadRemoteSession(...)` and a `loadSessionSupported` capability flag read
+  from `initResult.agentCapabilities.loadSession`.
+- `SandboxAgent`'s resume path now tries `loadRemoteSession` (ACP `session/load` with
+  `_meta.claudeCode.options.resume`) when the agent advertises `loadSession` and a prior
+  `agentSessionId` exists, and only falls back to `collectReplayEvents` + `createRemoteSession`
+  (transcript replay) when load is unsupported or throws.
+- The `local` provider spawns the daemon `detached: true` and kills by process group
+  (`killGroup`), so a runner exit reaps the whole local tree instead of orphaning children.
+
+This is the `harness-session-resume` "Half B: pnpm patch" bridge, landed. It matters here
+because a reconnected (Tier 1) or pool-parked (Tier 2) sandbox now resumes the harness session
+in place rather than replaying text, which is the high-fidelity rung.
+
+## The three-tier fallback model (from the sibling workspaces)
+
+The `session-keepalive` and `harness-session-resume` workspaces define a fallback ladder keyed
+on the conversation `session_id`. This project extends its bottom two rungs to Daytona.
+
+1. Live pool hit inside the TTL: keep-alive. Fastest, highest fidelity (the live process tree,
+   native memory, byte-exact approval resume). Costs idle RAM locally, idle compute remotely.
+   This is Tier 2 here.
+2. Pool miss but the sandbox and harness session survive: session resume. The sandbox restarts
+   from stopped and the harness runs `session/load`. Full fidelity, paid per turn as a restart
+   plus mount plus load. Zero idle live cost when parked to stopped. This is Tier 1 here.
+3. Both miss: cold replay. Always available, always correct, about 20 seconds. The floor.
+
+The tiers compose. They do not replace each other. Tier 1 is memory across a stopped-sandbox
+gap; Tier 2 is memory within a short live window. Durable continuity (PR #5197) is the machinery
+that makes rungs 2 and 3 correct.
+
+## The local keep-alive pool (`session-pool.ts`), and why it is local-only
+
+The pool is a per-process `Map<poolKey, LiveSession>` with an LRU cap and TTL reaping. Key facts
+that bear on extending it to Daytona:
+
+- Pool key is `<projectId>:<sessionId>`. No project scope means no park (safety default).
+- Two TTLs: idle `AGENTA_RUNNER_SESSION_TTL_MS` (default 60s), approval
+  `AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS` (default 300s). Cap `AGENTA_RUNNER_SESSION_POOL_MAX`
+  (default 8). Flag `AGENTA_RUNNER_SESSION_KEEPALIVE` (default off).
+- A `LiveSession` holds the live environment, a config fingerprint, a history fingerprint, a
+  credential epoch, a state (`busy`/`idle`/`awaiting_approval`/`destroyed`), and one idempotent
+  `destroy()` closure the engine supplies. The pool never imports the engine.
+- Eviction routes every teardown through that one `destroy()`. LRU evicts only idle sessions;
+  it never evicts a busy or approval-parked one; if nothing is evictable, the new session runs
+  unparked (best-effort).
+- The gate: `resolvesToLocalProvider(requestSandbox)` and `isLocalSandbox` in `server.ts`. The
+  module comment is explicit that `poolMax` is a LOCAL parameter, "how many ~300 MB hot Claude
+  trees fit on this runner host," never a global one.
+
+The local-only rationale, measured on the Hetzner dev box: a parked Claude tree is about 330 MB
+RSS (about 224 MB Pss) at near-zero idle CPU, so the cap is a RAM-budget knob. Remote is
+different in kind. A parked Daytona sandbox is not host RAM; it is billed compute (Tier 2) or
+billed storage (Tier 1). So the cap for a remote pool is a dollar cap, not a RAM cap, and it
+needs its own reaper reasoning. This is why `session-keepalive` deferred Daytona to slice 3.
+
+The credential epoch and the two fingerprints (config and history) carry over unchanged. A
+parked session that outlives its mount credential or whose resolved secrets rotate evicts to
+cold. On Daytona the mount-credential expiry is the tighter bound, so the epoch check is more
+load-bearing there than locally.
+
+## Daytona lifecycle and billing semantics
+
+The five states the provider comment names, with billing as the provider comments and Daytona's
+public docs describe them. Per the Daytona limits and billing pages, a stopped sandbox frees CPU
+and RAM but keeps billing disk; billing tracks CPU, RAM, and disk usage. An archived sandbox
+moves its filesystem to object storage and resumes via a plain `start()` (no separate restore
+API), just slower, and archiving requires the sandbox to be stopped first. One more semantic
+that matters: Daytona's inactivity clock for autoStop resets on external API interactions, not
+on processes running inside the sandbox, so a long silent in-sandbox operation can be
+auto-stopped mid-turn.
+
+| State | How reached | Disk | Billing | Resume cost |
+|---|---|---|---|---|
+| Running (hot) | create, or start a stopped one | live | full compute | none, already up |
+| Stopped (warm) | `pauseSandbox()` / autoStop after 5 min idle | retained | storage only, no compute | fast start (about 1s) + remount + session load |
+| Archived (cold) | autoArchive after 15 min idle | moved to cold storage | cheaper cold storage | slower restore + remount + load |
+| Deleted (dead) | autoDelete after 30 min idle, or `destroySandbox()` | gone | none | full cold create + mount + replay |
+
+Tier 1 parks to Stopped: storage cost only, and the autoArchive then autoDelete cascade bounds
+even that. Tier 2 parks to Running for a short TTL: the parked cost is live compute, so the TTL
+is a direct billing knob, and the pool cap bounds the concurrent spend.
+
+The orphan question. `ephemeral: true` used to auto-delete a sandbox the moment it stopped,
+which is why it existed as a leak backstop: a crashed runner could not leave a sandbox billing
+for long. `ephemeral: false` removes that reflex. The new backstop is the autoStop (5 min) to
+autoArchive (15 min) to autoDelete (30 min) cascade plus the local-tree process-group kill from
+the patch. So a SIGKILL'd runner now leaves a running Daytona sandbox billing compute until
+autoStop stops it (up to 5 idle minutes of compute), then storage until autoDelete. That is a
+larger orphan budget than `ephemeral: true` gave. Whether 5 minutes of orphaned compute is
+acceptable is a decision for `plan.md` and a billing owner.
+
+## PR #5197 (durable session continuity)
+
+PR #5197 ("Resume agent sessions across the sandbox lifecycle", `feat/sessions-continuity`,
+open, base `big-agents`) is the durable-continuity base this project builds on. What it ships:
+
+- `session-continuity.ts`: an in-memory store mapping `(sessionId, harness)` to
+  `{agentSessionId, turnIndex}`, with a staleness guard (a harness may `session/load` only if it
+  authored the most recent completed turn) that makes Pi/Claude switching safe.
+- `session-continuity-durable.ts`: mirrors that store into `session_states.data` (GET then PUT,
+  fire and forget) so a runner restart does not lose continuity. Its own risk list flags that
+  this write path has no concurrency guard and can drop a harness entry under concurrent
+  writers; the failure mode is a silent cold replay.
+- `sandbox-reconnect.ts`: `session_states.sandbox_id` changes meaning from a display label
+  ("local") to the actual Daytona instance id.
+- Per-harness transcript mounts: `~/.claude/projects` and Pi's sessions dir get the same durable
+  geesefs treatment as the session cwd (credentials deliberately excluded), so even a dead
+  sandbox can `session/load` natively. `AGENTA_SESSION_HARNESS_MOUNTS=false` disables this.
+- The detached-geesefs mount rewrite (fixes F-017's 60-second stream death), heartbeat ownership
+  via an atomic Redis claim, and the `sandbox-agent@0.4.2` dist patch described above.
+- An API-side `orphan_sweep.py` task. Important scope fact, verified in the review round: it
+  only cleans Postgres rows and Redis locks. It never contacts the runner or Daytona and cannot
+  stop or delete a sandbox. It is not a provider-side leak sweeper.
+
+Its own risk list also names: a failed turn parking its sandbox warm (HEAD's `shouldPark` now
+gates this), the 5-minute autoStop versus long HITL waits, legacy `sandbox_id` label values
+causing one doomed reconnect, and deploy order (API before runner).
+
+## Interaction with F-018 (Daytona tool-call hang)
+
+F-018: every sandbox-executed tool call on Daytona hangs because the Pi builtin gate's reverse
+permission RPC never reaches the runner; the turn is bounded at 300s by the run-limits guard and
+then fails. Consequence for this project: a tool-using Daytona turn fails, and a failed turn does
+not park (`shouldPark` returns false on `!result.ok`). So warmth benefits chat first. It also
+means Tier 1 and Tier 2 cannot be fully validated on tool turns until F-018 lands. The build-kit
+default agent, whose first turn is a tool call, gets no benefit until then.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
@@ -152,10 +152,11 @@ slowest:
    Fastest, highest fidelity: the live process tree, native memory, byte-exact approval resume.
    The cost is idle RAM locally, idle billed compute remotely. This is what the **park-to-running**
    proposal builds.
-2. **Stopped-restart.** The sandbox was stopped but its disk survived. The runner restarts it and
-   the harness runs its native session reload. Full fidelity, paid per turn as a restart plus
-   mount plus reload. Zero idle compute cost while parked. This is what the **park-to-stopped**
-   proposal builds.
+2. **Stopped-restart.** The sandbox was stopped but its disk survived. Stopping killed every
+   process, so the runner restarts the sandbox, remounts, respawns the harness, and reloads the
+   session. Full fidelity, but the user-visible cost is nearly a full cold turn (roughly 1 second
+   cheaper; plan.md's "The three resume paths, compared" prices it stage by stage). Zero idle
+   compute cost while parked. This is what the **park-to-stopped** proposal builds.
 3. **Cold rebuild.** Neither survived. The runner builds a fresh sandbox and replays the
    transcript. Always available, always correct, about fifteen seconds measured. This is today's floor and
    stays the floor.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
@@ -196,37 +196,87 @@ The credential epoch and the two fingerprints carry over unchanged. A parked ses
 outlives its mount credential, or whose resolved secrets rotate, is evicted to cold. On Daytona
 the mount-credential expiry is the tighter bound, so that check matters more there than locally.
 
-## Daytona lifecycle and billing
+## Daytona lifecycle and billing: measured numbers (2026-07-11)
 
-A Daytona sandbox moves through four states. The billing is as the provider comments and
-Daytona's public docs describe. A stopped sandbox frees CPU and RAM but still bills for its disk.
-An archived sandbox moves its files to object storage and resumes via a plain `start()` (there is
-no separate restore call), just more slowly, and it must be stopped before it can be archived.
-One more rule matters: Daytona's idle clock for the stop timer resets on external API calls, not
-on processes running inside the sandbox. So a long, silent, in-sandbox operation can be
-auto-stopped mid-turn.
+A Daytona sandbox moves through four states: running, stopped, archived, deleted. A stopped
+sandbox keeps its disk but loses all process memory; Daytona's docs are explicit that stopping a
+container sandbox kills its processes and clears memory, and there is no CRIU-style memory freeze
+for the container class (only Daytona's separate VM sandbox class has pause/resume with memory,
+and we do not use it). An archived sandbox has its filesystem moved to object storage and resumes
+via a plain `start()`, just more slowly; it must be stopped before it can be archived. One more
+rule matters: Daytona's idle clock for the stop timer resets on external API calls, not on
+processes running inside the sandbox. So a long, silent, in-sandbox operation can be auto-stopped
+mid-turn.
 
-| State | How reached | Disk | Billing | Resume cost |
-|---|---|---|---|---|
-| Running | create, or start a stopped one | live | full compute | none, already up |
-| Stopped | `pauseSandbox()`, or the 5-minute idle stop | retained | storage only, no compute | fast start (about 1s) + remount + session reload |
-| Archived | the 15-minute idle archive | moved to cold storage | cheaper cold storage | slower restore + remount + reload |
-| Deleted | the 30-minute idle delete, or `destroySandbox()` | gone | none | full rebuild + mount + replay |
+On 2026-07-11 we measured the lifecycle directly against the Daytona API (SDK 0.187.0, snapshot
+`agenta-sandbox-pi`, target `eu`, two repetitions; every sandbox created was deleted, with zero
+sandboxes in the organization before and after). "Usable" means a trivial `echo` exec succeeds
+through the Daytona API; the measurement deliberately does not start our daemon, upload assets,
+mount storage, or load a harness, so it isolates the sandbox lifecycle from our pipeline. The
+sandbox provisions 2 vCPU, 4 GiB RAM, 8 GiB disk.
 
-Park-to-stopped parks to Stopped: storage cost only, and the archive-then-delete timers bound
-even that. Park-to-running parks to Running for a short window: the parked cost is live compute,
-so its time-to-live is a direct cost knob and its pool cap bounds the concurrent spend.
+| Transition | Rep 1 | Rep 2 |
+|---|---|---|
+| Cold create to usable | 1.7 s | 1.2 s |
+| Stop (running to stopped) | 2.0 s | 1.8 s |
+| Start from stopped to usable | 0.8 s | 0.7 s |
+| Archive (stopped to archived) | 82.3 s | 50.3 s |
+| Start from archived to usable | 33.2 s | 65.7 s |
+| Delete | 0.1 s | 0.2 s |
+
+Prices, from Daytona's public pricing page (Linux sandboxes, checked 2026-07-11): $0.0504 per
+vCPU-hour, $0.0162 per GiB of RAM per hour, $0.000108 per GiB of disk per hour (first 5 GiB
+free). Daytona's billing docs confirm a stopped sandbox bills for its reserved disk only, and an
+archived sandbox bills for no active resources (object storage; the per-GiB price is not
+published). For our 2 vCPU / 4 GiB / 8 GiB sandbox that gives:
+
+| State | Billing | Cost for our sandbox | Resume to usable (sandbox only) |
+|---|---|---|---|
+| Running | compute + RAM + disk | about $0.17/hour, or $0.0028/minute | zero, already up |
+| Stopped | reserved disk only | about $0.0009/hour (about 2 cents/day) | 0.7 to 0.8 s |
+| Archived | object storage | below stopped; exact price unpublished | 33 to 66 s |
+| Deleted | nothing | zero | 1.2 to 1.7 s (fresh create) |
+
+Three conclusions follow:
+
+1. **Archive is worthless for us.** Restoring from archive (33 to 66 s) is slower than deleting
+   and creating fresh from the snapshot (1.2 to 1.7 s), and the disk it frees costs under a tenth
+   of a cent per hour. Our sandboxes keep almost nothing on their own disk (24 KiB written above
+   the snapshot layers in the measurement; the durable data lives in the mounted cloud storage),
+   so archive's one advantage, freeing disk quota, buys us nothing. The demotion ladder should be
+   stop then delete, with the archive step configured out: `DAYTONA_AUTOARCHIVE` strictly greater
+   than `DAYTONA_AUTODELETE` (equal values would race, and "archive interval 0 means maximum" is
+   unusable because our `positiveMinutes()` parser treats 0 as unset). Daytona documents
+   auto-delete as firing after continuous stopped time with no archive step required; the
+   archive-disabled path still gets one explicit live check in the verification slice.
+2. **Sandbox creation is not the 20-second problem.** A cold create to a usable exec is under 2
+   seconds at the Daytona API, so almost all of the roughly 20 seconds QA measured per turn sits
+   in our own per-turn pipeline: daemon startup inside the sandbox, asset upload, the geesefs
+   mounts, harness startup, and the session reload. This is arithmetic, not instrumentation; the
+   split across those steps is unmeasured, and the verification slice instruments it. Two
+   corollaries: park-to-stopped skips only the create at the provider level (and today's Daytona
+   path re-uploads Pi assets and rematerializes workspace files on every start, so the prepared
+   disk saves less than it could); park-to-running is the only level that skips the whole
+   pipeline.
+3. **Parked-running compute is cheap in absolute terms.** $0.0028 per parked minute. A 60-second
+   keep-warm window after each turn costs at most about a third of a cent; a cap of 4 concurrently
+   running parked sandboxes has a worst-case burn of about $0.67/hour.
+
+Park-to-stopped parks to Stopped: storage cost only, and the delete timer bounds even that.
+Park-to-running parks to Running for a short window: the parked cost is live compute, so its
+time-to-live is a direct cost knob and its running cap bounds the concurrent spend.
 
 ### Cleaning up abandoned sandboxes
 
 `ephemeral: true` used to auto-delete a sandbox the moment it stopped. That is why it existed: a
 crashed runner could not leave a sandbox billing for long. `ephemeral: false` removes that reflex.
-The new backstop is the stop-then-archive-then-delete timer cascade (5, 15, 30 minutes), plus the
-process-group kill for local trees from the patch above. So a hard-killed runner now leaves a
-running Daytona sandbox billing compute until the stop timer fires (up to 5 idle minutes of
-compute), then billing storage until the delete timer fires. That is a larger abandonment budget
-than `ephemeral: true` gave. Whether 5 minutes of orphaned compute is acceptable is a decision
-for `plan.md` and a billing owner.
+The new backstop is the stop-then-delete timer cascade, plus the process-group kill for local
+trees from the patch above. So a hard-killed runner now leaves a running Daytona sandbox billing
+compute until the stop timer fires, then billing storage until the delete timer fires. With the
+measured prices this abandonment budget is now a number, not a question: about 1.4 cents per
+crash at a 5-minute stop timer, about 4 cents at the 15-minute value the plan proposes, plus a
+fraction of a cent of storage until the delete timer. That is acceptable without a separate
+sweeper; the timers are the sweeper.
 
 ## PR #5197 (durable session continuity)
 
@@ -263,3 +313,7 @@ The consequence for this project: a tool-using Daytona turn fails, and a failed 
 (`shouldPark` returns false on a failed result). So warm reuse helps chat first. It also means
 neither reuse level can be fully validated on tool turns until F-018 lands. The build-kit default
 agent, whose first turn is a tool call, gets no benefit until then.
+
+F-018 has its own implementation workspace, `../daytona-gate-delivery/`. Its gate and resume
+model (a file-based gate, a stored decision the model's reissued call resolves against, and a
+two-lifetime timeout) is the contract this plan's pending-approval section in `plan.md` follows.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/research.md
@@ -1,11 +1,16 @@
-# Research: the current code, the fallback model, Daytona billing
+# Research: the current code, the fallback ladder, Daytona billing
 
-All line numbers are against the working tree at the time of writing (HEAD carries PR #5197
+This file is the evidence behind `context.md`. Read `context.md` first for the story; read this
+when you want to see the code that proves it. It covers four things, in order: what happens in
+the runner during one turn, the gap that defeats warm reuse, the local warm-reuse pool and why
+it is kept off Daytona, and how Daytona bills a stopped sandbox.
+
+All line references are against the working tree at the time of writing (HEAD carries PR #5197
 plus commit `60990d396e`). Treat them as pointers, not exact addresses.
 
-## The turn lifecycle at HEAD
+## What happens during one turn
 
-### Provider create flags (`provider.ts`)
+### Create: the sandbox flags (`provider.ts`)
 
 `buildDaytonaCreate` returns, among the network and env fields:
 
@@ -16,19 +21,20 @@ autoDeleteInterval: daytonaAutoDeleteMinutes(),   // DEFAULT 30
 ephemeral: false,
 ```
 
-The comment states the intent: "stop preserves the disk (warm), archive moves it to cold
-storage, delete reaps it (dead). `ephemeral: false` so a stop parks rather than deletes; the
-three intervals ... are the platform-run reapers. A leaked sandbox self-reaps via autoDelete
-instead of ephemeral." So the "TTL sweeper for stopped sandboxes" that Tier 1 needs is already
-delegated to Daytona's own idle intervals. Overrides are `DAYTONA_AUTOSTOP`,
-`DAYTONA_AUTOARCHIVE`, `DAYTONA_AUTODELETE` (whole minutes, floor 1).
+The code comment states the intent: stop preserves the disk (the sandbox is parked), archive
+moves that disk to cheaper cold storage, delete reaps it. `ephemeral: false` is what makes a
+stop park the sandbox rather than delete it. The three intervals are timers Daytona runs itself.
+A sandbox that is left idle stops after 5 minutes, archives after 15, and deletes after 30, so
+an abandoned sandbox reaps itself through `autoDelete` instead of through `ephemeral`. Operators
+can override the three with `DAYTONA_AUTOSTOP`, `DAYTONA_AUTOARCHIVE`, and `DAYTONA_AUTODELETE`
+(whole minutes, floor 1).
 
-This is the exact opposite of the F-020 premise. F-020 was written against `ephemeral: true` and
-a single 15-minute autostop.
+This is the opposite of the F-020 premise. F-020 was written against `ephemeral: true` and a
+single 15-minute stop timer.
 
-### Turn-end teardown (`sandbox_agent.ts`, the `destroy` closure)
+### Teardown: park or delete (`sandbox_agent.ts`, the `destroy` closure)
 
-`environment.destroy` takes `opts?: { keepWarm?: boolean }`. The relevant branch:
+`environment.destroy` takes `opts?: { keepWarm?: boolean }`. The branch that matters:
 
 ```ts
 // keepWarm pauses a remote sandbox (parked, resumable) instead of deleting it; falls back to destroy.
@@ -39,13 +45,11 @@ const parked =
 if (!parked) await environment.sandbox?.destroySandbox().catch(() => {});
 ```
 
-Order matters: the graceful `session/cancel` (`destroySession`) runs BEFORE this, then the park
-or delete, then `dispose()`, then the durable-cwd unmount. So a parked sandbox has its harness
-session cancelled and its host mount torn down; resume re-mounts and re-opens the session.
+Order matters. The graceful session cancel (`destroySession`) runs before this, then the park or
+delete, then `dispose()`, then the durable-storage unmount. So a parked sandbox has its harness
+session cancelled and its host mount torn down. Resume re-mounts and re-opens the session.
 
-### Who requests keepWarm
-
-`shouldPark` gates it:
+### When the runner asks to park (`shouldPark`)
 
 ```ts
 if (signal?.aborted) return false;   // aborted run: destroy, do not park
@@ -56,15 +60,16 @@ return true;
 ```
 
 Both run paths pass `keepWarm: env.resumable && result !== undefined && shouldPark(...)`, where
-`env.resumable = Boolean(plan.isDaytona && sessionForMount)`. The two paths are
-`runSandboxAgent` (the plain path) and the keep-alive `runCold` in `server.ts`. Net effect at
-HEAD: a successful, non-aborted, non-paused Daytona chat turn that has a session id parks the
-sandbox to stopped and records its id. A failed turn (which today includes every tool-using
-Daytona turn, per F-018) does not park, so F-018 failures do not leak a warm sandbox.
+`env.resumable = Boolean(plan.isDaytona && sessionForMount)`. The two paths are `runSandboxAgent`
+(the plain path) and the keep-alive `runCold` in `server.ts`. In plain terms: a Daytona chat
+turn that succeeds, is not aborted, is not a plain pause, and has a conversation id parks the
+sandbox to stopped and records its id. A failed turn does not park. This matters because every
+tool-using Daytona turn currently fails (see F-018 below), so those failures do not leave a warm
+sandbox behind.
 
-### Reconnect (`sandbox-reconnect.ts` + acquire path)
+### Reconnect: restart the stored sandbox (`sandbox-reconnect.ts` plus the acquire path)
 
-At acquire, for a Daytona run with a session and a run credential:
+At the start of a Daytona run that has a conversation id and a run credential:
 
 ```ts
 const storedSandboxId = plan.isDaytona && sessionForMount && runCred
@@ -86,162 +91,175 @@ if (sessionForMount && runCred) {
 ```
 
 The stored id lives in the sessions plane: `GET`/`PUT /sessions/states/?session_id=...` with a
-`sandbox_id` field. Read failure, write failure, and reconnect failure are all best-effort and
-degrade to a fresh create. This is the "dead rung" F-020 named, now reachable because the park
-path keeps the sandbox alive for the stored id to resolve against.
+`sandbox_id` field. A failed read, a failed write, and a failed reconnect are all best-effort and
+fall back to a fresh build. F-020 called this reconnect path a dead end because the sandbox was
+always deleted before the next turn. With the park path keeping the sandbox alive, the stored id
+now has something to resolve against, in principle.
 
-Two caveats the review round surfaced. The `writeSandboxId` PUT is fire-and-forget (`void`) and
-last-writer-wins, with no compare-and-set; a delayed older write can replace a newer sandbox id
-when two turns race on one session. And the vendored `SandboxAgent.start({sandboxId})` cleans up
-only sandboxes it created itself, so a reconnect that starts the old instance and then fails a
-later step (daemon, URL, client) leaves it running while the ladder creates a second one.
+Two problems with this code are worth flagging up front, because the plan addresses them:
 
-### The vendored provider gap (the load-bearing finding)
+- The `writeSandboxId` PUT is fire-and-forget (`void`) and last-writer-wins. It has no
+  compare-and-set. If two turns race on one conversation, a delayed older write can replace a
+  newer sandbox id.
+- The vendored `SandboxAgent.start({sandboxId})` cleans up only sandboxes it created itself. So a
+  reconnect that starts the old instance and then fails a later step (daemon, URL, or client
+  setup) leaves it running while the runner builds a second one.
 
-The vendored Daytona provider (`node_modules/sandbox-agent/dist/providers/daytona.js`)
-implements only `create`, `destroy`, `getUrl`, and `ensureServer`. The `SandboxProvider`
-interface declares `pause?` and `reconnect?` as optional, and the e2b and sprites providers
-implement them, but daytona does not. Verified consequences in `dist/chunk-TVCDKGSM.js`:
+### The gap that defeats it all: the Daytona provider has no pause or reconnect
+
+The vendored Daytona provider (`node_modules/sandbox-agent/dist/providers/daytona.js`) implements
+only `create`, `destroy`, `getUrl`, and `ensureServer`. The provider interface declares `pause?`
+and `reconnect?` as optional. The e2b and sprites providers implement them; the Daytona provider
+does not. The consequences, verified in the vendored `dist/chunk-TVCDKGSM.js`:
 
 - `pauseSandbox()` with no `provider.pause` calls `provider.destroy(rawSandboxId)`. So the
-  runner's keepWarm park deletes the sandbox anyway.
-- `pauseSandbox()` clears `sandboxProvider` and the raw id in its `finally`, even when
-  `provider.pause()` throws. The runner's fallback `destroySandbox()` then has no provider and
-  silently no-ops, so a failed pause leaks a running sandbox.
-- `start({sandboxId})` calls `provider.reconnect` then `ensureServer`; with `reconnect` missing
-  (and `ensureServer` unable to start a stopped instance) reconnect always throws and falls to a
-  fresh create.
+  runner's `keepWarm` park deletes the sandbox anyway.
+- `pauseSandbox()` clears the provider handle and the raw id in its `finally` block, even when
+  `provider.pause()` throws. The runner's fallback `destroySandbox()` then has no provider to work
+  with and silently does nothing. A failed pause therefore leaks a running sandbox.
+- `start({sandboxId})` calls `provider.reconnect` and then `ensureServer`. With `reconnect`
+  missing (and `ensureServer` unable to start a stopped instance), reconnect always throws and
+  falls to a fresh build.
 
-So at HEAD, despite the keepWarm plumbing, every Daytona turn still deletes and recreates.
-F-020's observed behavior stands; only its mechanism description is out of date.
+So at HEAD, despite all the `keepWarm` plumbing, every Daytona turn still deletes and rebuilds.
+F-020's observed behavior stands; only its explanation is out of date. This is the finding the
+whole plan turns on.
 
-### The sandbox-agent patch (`patches/sandbox-agent@0.4.2.patch`)
+### The session-reload patch (`patches/sandbox-agent@0.4.2.patch`)
 
-Commit `60990d396e` patches the vendored `sandbox-agent` package to add native session resume:
+Commit `60990d396e` patches the vendored `sandbox-agent` package to add native session reload:
 
-- `LiveAcpConnection.loadRemoteSession(...)` and a `loadSessionSupported` capability flag read
-  from `initResult.agentCapabilities.loadSession`.
-- `SandboxAgent`'s resume path now tries `loadRemoteSession` (ACP `session/load` with
-  `_meta.claudeCode.options.resume`) when the agent advertises `loadSession` and a prior
-  `agentSessionId` exists, and only falls back to `collectReplayEvents` + `createRemoteSession`
-  (transcript replay) when load is unsupported or throws.
-- The `local` provider spawns the daemon `detached: true` and kills by process group
-  (`killGroup`), so a runner exit reaps the whole local tree instead of orphaning children.
+- A `loadRemoteSession(...)` call and a capability flag read from
+  `initResult.agentCapabilities.loadSession`.
+- The resume path now tries `loadRemoteSession` (the harness's native "reload this session" call)
+  when the agent advertises `loadSession` and a prior session id exists. It falls back to
+  transcript replay only when reload is unsupported or throws.
+- The local provider now spawns its daemon detached and kills it by process group, so a runner
+  exit reaps the whole local process tree instead of orphaning children.
 
-This is the `harness-session-resume` "Half B: pnpm patch" bridge, landed. It matters here
-because a reconnected (Tier 1) or pool-parked (Tier 2) sandbox now resumes the harness session
-in place rather than replaying text, which is the high-fidelity rung.
+This is the durable-continuity bridge (`harness-session-resume`), already landed. It matters here
+because a restarted sandbox now reloads the harness session in place rather than replaying text,
+which is the highest-fidelity way to resume.
 
-## The three-tier fallback model (from the sibling workspaces)
+## The fallback ladder: three levels of reuse
 
-The `session-keepalive` and `harness-session-resume` workspaces define a fallback ladder keyed
-on the conversation `session_id`. This project extends its bottom two rungs to Daytona.
+The `session-keepalive` and `harness-session-resume` workspaces define a fallback ladder keyed on
+the conversation id. This project builds out the bottom two levels for Daytona. From fastest to
+slowest:
 
-1. Live pool hit inside the TTL: keep-alive. Fastest, highest fidelity (the live process tree,
-   native memory, byte-exact approval resume). Costs idle RAM locally, idle compute remotely.
-   This is Tier 2 here.
-2. Pool miss but the sandbox and harness session survive: session resume. The sandbox restarts
-   from stopped and the harness runs `session/load`. Full fidelity, paid per turn as a restart
-   plus mount plus load. Zero idle live cost when parked to stopped. This is Tier 1 here.
-3. Both miss: cold replay. Always available, always correct, about 20 seconds. The floor.
+1. **Live-warm.** The sandbox is still running from the last turn, inside a short time window.
+   Fastest, highest fidelity: the live process tree, native memory, byte-exact approval resume.
+   The cost is idle RAM locally, idle billed compute remotely. This is what the **park-to-running**
+   proposal builds.
+2. **Stopped-restart.** The sandbox was stopped but its disk survived. The runner restarts it and
+   the harness runs its native session reload. Full fidelity, paid per turn as a restart plus
+   mount plus reload. Zero idle compute cost while parked. This is what the **park-to-stopped**
+   proposal builds.
+3. **Cold rebuild.** Neither survived. The runner builds a fresh sandbox and replays the
+   transcript. Always available, always correct, about twenty seconds. This is today's floor and
+   stays the floor.
 
-The tiers compose. They do not replace each other. Tier 1 is memory across a stopped-sandbox
-gap; Tier 2 is memory within a short live window. Durable continuity (PR #5197) is the machinery
-that makes rungs 2 and 3 correct.
+The levels compose; they do not replace each other. Park-to-stopped gives memory across a
+stopped-sandbox gap. Park-to-running gives memory within a short live window. Durable continuity
+(PR #5197) is the machinery that keeps levels 2 and 3 correct.
 
-## The local keep-alive pool (`session-pool.ts`), and why it is local-only
+## The local keep-alive pool, and why it is kept off Daytona
 
-The pool is a per-process `Map<poolKey, LiveSession>` with an LRU cap and TTL reaping. Key facts
-that bear on extending it to Daytona:
+Local (non-Daytona) sessions already get warm reuse from an in-memory pool (`session-pool.ts`).
+It is a per-process map from a pool key to a live session, with a size cap and idle reaping. The
+facts that bear on extending it to Daytona:
 
-- Pool key is `<projectId>:<sessionId>`. No project scope means no park (safety default).
-- Two TTLs: idle `AGENTA_RUNNER_SESSION_TTL_MS` (default 60s), approval
-  `AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS` (default 300s). Cap `AGENTA_RUNNER_SESSION_POOL_MAX`
-  (default 8). Flag `AGENTA_RUNNER_SESSION_KEEPALIVE` (default off).
-- A `LiveSession` holds the live environment, a config fingerprint, a history fingerprint, a
-  credential epoch, a state (`busy`/`idle`/`awaiting_approval`/`destroyed`), and one idempotent
-  `destroy()` closure the engine supplies. The pool never imports the engine.
-- Eviction routes every teardown through that one `destroy()`. LRU evicts only idle sessions;
-  it never evicts a busy or approval-parked one; if nothing is evictable, the new session runs
+- The pool key is `<projectId>:<sessionId>`. Without a project scope there is no parking, which is
+  the safe default.
+- Two idle timers: a plain idle time-to-live (`AGENTA_RUNNER_SESSION_TTL_MS`, default 60s) and an
+  approval-wait time-to-live (`AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS`, default 300s). A size cap
+  (`AGENTA_RUNNER_SESSION_POOL_MAX`, default 8). An on/off flag
+  (`AGENTA_RUNNER_SESSION_KEEPALIVE`, default off).
+- Each pooled session holds the live environment, a config fingerprint, a history fingerprint, a
+  credential epoch, a state (busy, idle, awaiting approval, or destroyed), and one idempotent
+  `destroy()` closure supplied by the engine. The pool never imports the engine.
+- Eviction routes every teardown through that one `destroy()`. The size cap evicts only idle
+  sessions, never a busy or approval-parked one. If nothing can be evicted, the new session runs
   unparked (best-effort).
-- The gate: `resolvesToLocalProvider(requestSandbox)` and `isLocalSandbox` in `server.ts`. The
-  module comment is explicit that `poolMax` is a LOCAL parameter, "how many ~300 MB hot Claude
-  trees fit on this runner host," never a global one.
+- The gate that keeps this local: `resolvesToLocalProvider(requestSandbox)` and `isLocalSandbox`
+  in `server.ts`. The module comment is explicit that the size cap is a local measure, "how many
+  ~300 MB hot Claude trees fit on this runner host," never a global one.
 
-The local-only rationale, measured on the Hetzner dev box: a parked Claude tree is about 330 MB
-RSS (about 224 MB Pss) at near-zero idle CPU, so the cap is a RAM-budget knob. Remote is
-different in kind. A parked Daytona sandbox is not host RAM; it is billed compute (Tier 2) or
-billed storage (Tier 1). So the cap for a remote pool is a dollar cap, not a RAM cap, and it
-needs its own reaper reasoning. This is why `session-keepalive` deferred Daytona to slice 3.
+The reason it is local-only is cost, measured on the Hetzner dev box. A parked Claude tree is
+about 330 MB of memory at near-zero idle CPU, so the cap is a memory-budget knob. Remote is
+different in kind. A parked Daytona sandbox is not host memory; it is either billed compute (if
+kept running) or billed storage (if stopped). So a remote pool's cap is a dollar cap, not a
+memory cap, and it needs its own reaping logic. This is exactly why `session-keepalive` deferred
+Daytona to a later slice, which is this project's park-to-running level.
 
-The credential epoch and the two fingerprints (config and history) carry over unchanged. A
-parked session that outlives its mount credential or whose resolved secrets rotate evicts to
-cold. On Daytona the mount-credential expiry is the tighter bound, so the epoch check is more
-load-bearing there than locally.
+The credential epoch and the two fingerprints carry over unchanged. A parked session that
+outlives its mount credential, or whose resolved secrets rotate, is evicted to cold. On Daytona
+the mount-credential expiry is the tighter bound, so that check matters more there than locally.
 
-## Daytona lifecycle and billing semantics
+## Daytona lifecycle and billing
 
-The five states the provider comment names, with billing as the provider comments and Daytona's
-public docs describe them. Per the Daytona limits and billing pages, a stopped sandbox frees CPU
-and RAM but keeps billing disk; billing tracks CPU, RAM, and disk usage. An archived sandbox
-moves its filesystem to object storage and resumes via a plain `start()` (no separate restore
-API), just slower, and archiving requires the sandbox to be stopped first. One more semantic
-that matters: Daytona's inactivity clock for autoStop resets on external API interactions, not
-on processes running inside the sandbox, so a long silent in-sandbox operation can be
+A Daytona sandbox moves through four states. The billing is as the provider comments and
+Daytona's public docs describe. A stopped sandbox frees CPU and RAM but still bills for its disk.
+An archived sandbox moves its files to object storage and resumes via a plain `start()` (there is
+no separate restore call), just more slowly, and it must be stopped before it can be archived.
+One more rule matters: Daytona's idle clock for the stop timer resets on external API calls, not
+on processes running inside the sandbox. So a long, silent, in-sandbox operation can be
 auto-stopped mid-turn.
 
 | State | How reached | Disk | Billing | Resume cost |
 |---|---|---|---|---|
-| Running (hot) | create, or start a stopped one | live | full compute | none, already up |
-| Stopped (warm) | `pauseSandbox()` / autoStop after 5 min idle | retained | storage only, no compute | fast start (about 1s) + remount + session load |
-| Archived (cold) | autoArchive after 15 min idle | moved to cold storage | cheaper cold storage | slower restore + remount + load |
-| Deleted (dead) | autoDelete after 30 min idle, or `destroySandbox()` | gone | none | full cold create + mount + replay |
+| Running | create, or start a stopped one | live | full compute | none, already up |
+| Stopped | `pauseSandbox()`, or the 5-minute idle stop | retained | storage only, no compute | fast start (about 1s) + remount + session reload |
+| Archived | the 15-minute idle archive | moved to cold storage | cheaper cold storage | slower restore + remount + reload |
+| Deleted | the 30-minute idle delete, or `destroySandbox()` | gone | none | full rebuild + mount + replay |
 
-Tier 1 parks to Stopped: storage cost only, and the autoArchive then autoDelete cascade bounds
-even that. Tier 2 parks to Running for a short TTL: the parked cost is live compute, so the TTL
-is a direct billing knob, and the pool cap bounds the concurrent spend.
+Park-to-stopped parks to Stopped: storage cost only, and the archive-then-delete timers bound
+even that. Park-to-running parks to Running for a short window: the parked cost is live compute,
+so its time-to-live is a direct cost knob and its pool cap bounds the concurrent spend.
 
-The orphan question. `ephemeral: true` used to auto-delete a sandbox the moment it stopped,
-which is why it existed as a leak backstop: a crashed runner could not leave a sandbox billing
-for long. `ephemeral: false` removes that reflex. The new backstop is the autoStop (5 min) to
-autoArchive (15 min) to autoDelete (30 min) cascade plus the local-tree process-group kill from
-the patch. So a SIGKILL'd runner now leaves a running Daytona sandbox billing compute until
-autoStop stops it (up to 5 idle minutes of compute), then storage until autoDelete. That is a
-larger orphan budget than `ephemeral: true` gave. Whether 5 minutes of orphaned compute is
-acceptable is a decision for `plan.md` and a billing owner.
+### Cleaning up abandoned sandboxes
+
+`ephemeral: true` used to auto-delete a sandbox the moment it stopped. That is why it existed: a
+crashed runner could not leave a sandbox billing for long. `ephemeral: false` removes that reflex.
+The new backstop is the stop-then-archive-then-delete timer cascade (5, 15, 30 minutes), plus the
+process-group kill for local trees from the patch above. So a hard-killed runner now leaves a
+running Daytona sandbox billing compute until the stop timer fires (up to 5 idle minutes of
+compute), then billing storage until the delete timer fires. That is a larger abandonment budget
+than `ephemeral: true` gave. Whether 5 minutes of orphaned compute is acceptable is a decision
+for `plan.md` and a billing owner.
 
 ## PR #5197 (durable session continuity)
 
-PR #5197 ("Resume agent sessions across the sandbox lifecycle", `feat/sessions-continuity`,
+PR #5197 ("Resume agent sessions across the sandbox lifecycle", branch `feat/sessions-continuity`,
 open, base `big-agents`) is the durable-continuity base this project builds on. What it ships:
 
 - `session-continuity.ts`: an in-memory store mapping `(sessionId, harness)` to
-  `{agentSessionId, turnIndex}`, with a staleness guard (a harness may `session/load` only if it
-  authored the most recent completed turn) that makes Pi/Claude switching safe.
-- `session-continuity-durable.ts`: mirrors that store into `session_states.data` (GET then PUT,
-  fire and forget) so a runner restart does not lose continuity. Its own risk list flags that
-  this write path has no concurrency guard and can drop a harness entry under concurrent
-  writers; the failure mode is a silent cold replay.
-- `sandbox-reconnect.ts`: `session_states.sandbox_id` changes meaning from a display label
-  ("local") to the actual Daytona instance id.
-- Per-harness transcript mounts: `~/.claude/projects` and Pi's sessions dir get the same durable
-  geesefs treatment as the session cwd (credentials deliberately excluded), so even a dead
-  sandbox can `session/load` natively. `AGENTA_SESSION_HARNESS_MOUNTS=false` disables this.
-- The detached-geesefs mount rewrite (fixes F-017's 60-second stream death), heartbeat ownership
-  via an atomic Redis claim, and the `sandbox-agent@0.4.2` dist patch described above.
-- An API-side `orphan_sweep.py` task. Important scope fact, verified in the review round: it
-  only cleans Postgres rows and Redis locks. It never contacts the runner or Daytona and cannot
-  stop or delete a sandbox. It is not a provider-side leak sweeper.
+  `{agentSessionId, turnIndex}`, with a guard that lets a harness reload a session only if it
+  authored the most recent completed turn. That guard makes switching between Pi and Claude safe.
+- `session-continuity-durable.ts`: mirrors that store into `session_states.data` (a GET then a
+  fire-and-forget PUT) so a runner restart does not lose continuity. Its own risk list flags that
+  this write path has no concurrency guard and can drop a harness entry under concurrent writers;
+  the failure mode is a silent cold replay.
+- `sandbox-reconnect.ts`: changes `session_states.sandbox_id` from a display label (like "local")
+  to the actual Daytona instance id.
+- Per-harness transcript mounts: the harness transcript directories get the same durable
+  cloud-storage treatment as the working directory (credentials deliberately excluded), so even a
+  dead sandbox can reload its session natively. `AGENTA_SESSION_HARNESS_MOUNTS=false` disables it.
+- The detached mount rewrite that fixed F-017 (a 60-second stream death), heartbeat ownership via
+  an atomic Redis claim, and the `sandbox-agent@0.4.2` patch described above.
+- An API-side `orphan_sweep.py` task. One scope fact matters here: it only cleans Postgres rows
+  and Redis locks. It never contacts the runner or Daytona and cannot stop or delete a sandbox. It
+  is not a provider-side leak sweeper.
 
-Its own risk list also names: a failed turn parking its sandbox warm (HEAD's `shouldPark` now
-gates this), the 5-minute autoStop versus long HITL waits, legacy `sandbox_id` label values
-causing one doomed reconnect, and deploy order (API before runner).
+Its own risk list also names: a failed turn parking its sandbox warm (the `shouldPark` gate now
+prevents this), the 5-minute stop timer versus long human-in-the-loop waits, legacy `sandbox_id`
+label values causing one doomed reconnect, and deploy order (API before runner).
 
-## Interaction with F-018 (Daytona tool-call hang)
+## Interaction with F-018 (the Daytona tool-call hang)
 
-F-018: every sandbox-executed tool call on Daytona hangs because the Pi builtin gate's reverse
-permission RPC never reaches the runner; the turn is bounded at 300s by the run-limits guard and
-then fails. Consequence for this project: a tool-using Daytona turn fails, and a failed turn does
-not park (`shouldPark` returns false on `!result.ok`). So warmth benefits chat first. It also
-means Tier 1 and Tier 2 cannot be fully validated on tool turns until F-018 lands. The build-kit
-default agent, whose first turn is a tool call, gets no benefit until then.
+F-018: every tool call that runs inside a Daytona sandbox hangs, because the permission check the
+tool needs never reaches the runner. The turn is capped at 300 seconds by a guard and then fails.
+The consequence for this project: a tool-using Daytona turn fails, and a failed turn does not park
+(`shouldPark` returns false on a failed result). So warm reuse helps chat first. It also means
+neither reuse level can be fully validated on tool turns until F-018 lands. The build-kit default
+agent, whose first turn is a tool call, gets no benefit until then.

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
@@ -30,32 +30,40 @@ the organization before and after). Its numbers are in research.md and reshaped 
 - **Park-to-running is in the main line, not deferred** (Mahmoud, 2026-07-11). The plan is one
   progressive sequence of slices ending with park-to-running. Rationale: the measurement shows
   only a running sandbox removes the per-turn pipeline, and the compute cost that justified
-  deferral is small and bounded ($0.0028 per parked minute; worst case about $0.67/hour at the
-  default cap of 4).
+  deferral is small and bounded ($0.0028 per parked minute, capped).
 - **Reuse the local keepalive pool logic, refactored provider-aware** (Mahmoud, 2026-07-11).
   Per-provider operator config plus an engine-owned lifecycle adapter; one `SessionPool` instance
   per provider; local semantics preserved. No second pooling mechanism.
-- **Billing knobs are configuration with conservative defaults, not deferral reasons**
-  (Mahmoud, 2026-07-11). `AGENTA_RUNNER_DAYTONA_SESSION_*`: keepalive off until verification,
-  idle window 60 seconds, cap 4.
-- **The Daytona running cap is enforced by admission before creation, not by the pool**
-  (review round 2, 2026-07-11). Permits are taken before create and before a reconnect's start,
-  released only on a confirmed stop or delete; eviction is awaited; Daytona never gets the local
-  "run unparked best-effort" behavior.
+- **No feature flags in the finished feature; the time-to-live is the off switch** (Mahmoud, PR
+  review 2026-07-11). `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS` default 120000 (two minutes,
+  raised from the proposed 60 seconds); 0 disables keeping sandboxes running. No
+  `KEEPALIVE_ENABLED` variable. Defaults stay at today's behavior until the Slice 5 verification
+  passes; the final slice changes the defaults.
+- **The cap bounds warm (idle running) sandboxes, never active turns** (Mahmoud, PR review
+  2026-07-11; supersedes review round 2's admission-before-creation shape). Active turns always
+  run; at turn end a session with no free warm slot parks to stopped instead of staying live.
+  `AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM` default 20 (raised from 4; sized so ~20 parallel
+  conversations stay warm; worst case about $3.33/hour while fully loaded). Slots are counted
+  for parked, reattaching, and stopping entries; a reconnect's start takes a slot first;
+  eviction is awaited; a slot frees only on a confirmed stop or delete; Daytona never gets the
+  local "run unparked best-effort" behavior. Kept separate from the local pool's
+  `SESSION_POOL_MAX` (host memory vs billed compute).
 - **Teardown reasons are typed and travel from the pool into an engine-owned lifecycle function**
   (review round 2). Kill, failed, aborted turns, and mismatches delete; clean resumable turns and
   idle expiries stop; shutdown deletes an in-flight turn and stops an idle one; a failed stop
   escalates to delete; a failed stop plus failed delete keeps the capacity permit consumed until
   reconciliation.
-- **The park-to-stopped feature flag lands in Slice 1, not Slice 2** (review round 2). The run
-  paths already request `keepWarm`, so a real `pause` without the flag would activate parking
-  immediately.
-- **Archive is configured out of the demotion ladder** (measurement, 2026-07-11). The ladder is
-  stop, then delete, with `DAYTONA_AUTOARCHIVE` strictly greater than `DAYTONA_AUTODELETE`
-  (equality would race; interval 0 is unusable because `positiveMinutes()` treats it as unset).
-- **Stop timer proposed at 15 minutes, not 5** (measurement, 2026-07-11). About 4 cents per crash
+- **Slice 1 keeps the park path inert; Slice 2 switches the default teardown to stop** (review
+  round 2, reworked after the no-flags decision). The run paths already request `keepWarm`, so a
+  real `pause` must not land with parking active before its correctness work is verified.
+- **The auto-archive logic is removed entirely** (Mahmoud, PR review 2026-07-11; hardened from
+  "configured out"). The create call drops `autoArchiveInterval` and the `DAYTONA_AUTOARCHIVE`
+  override; Daytona's own 7-day archive default sits far past the 30-minute delete. The ladder
+  is stop, then delete.
+- **Stop timer 15 minutes, confirmed** (Mahmoud, PR review 2026-07-11). About 4 cents per crash
   orphan buys never stopping a sandbox under a live silent turn (the run-limits guard alone
-  allows 300 seconds). Awaiting confirmation (open-questions.md).
+  allows 300 seconds). Env-overridable via `DAYTONA_AUTOSTOP`. The timer resets on every turn,
+  so an active conversation never hits it.
 - **Pending approvals follow the `daytona-gate-delivery` (F-018) resume model.** Below
   park-to-running, a pending approval always takes the cold path (teardown, stored decision,
   reissue on the next turn), because a stopped sandbox kills the waiting process. Holding a gate

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
@@ -2,9 +2,11 @@
 
 The source of truth for this workspace's progress. Keep it current.
 
-## State: design draft, review round done, awaiting human review
+## State: design revised after measurement, direction, and a second review round; awaiting human review
 
-Design only. No code changed. No live Daytona sandbox was run (that would spend credits).
+Design only. No production code changed. One credit-controlled lifecycle measurement was run
+directly against the Daytona API on 2026-07-11 (two sandboxes, both deleted; zero sandboxes in
+the organization before and after). Its numbers are in research.md and reshaped the plan.
 
 ## What this workspace concluded
 
@@ -12,68 +14,135 @@ Design only. No code changed. No live Daytona sandbox was run (that would spend 
   runner-side warm plumbing exists (park at turn end, reconnect by stored id, native session
   reload, `ephemeral: false` with idle timers), but the vendored Daytona provider
   (`sandbox-agent@0.4.2`) has no pause and no reconnect. So `pauseSandbox()` falls back to delete,
-  reconnect cannot revive a stopped instance, and every turn still rebuilds. This is the key
-  finding.
-- The core fix is the two provider functions the runner already calls (the Daytona SDK exposes
-  `sandbox.stop()`, `sandbox.start()`, and a `state` field), plus two teardown cleanup fixes in the
-  vendored code, a compatibility check before reuse, and a guard on the pointer writes (the
-  must-fix list in `plan.md`).
-- Two levels of reuse, honest trade-offs, one recommendation. Park-to-stopped (stop the sandbox at
-  turn end, storage-only parked cost) lands behind a default-off flag and is turned on after one
-  credit-controlled live test. Park-to-running (keep the sandbox running, compute cost, with a
-  time-to-live and a running cap as the knobs) is opt-in and deferred. Durable reload stays the
-  floor.
+  reconnect cannot revive a stopped instance, and every turn still rebuilds.
+- The measurement added the second key finding: the sandbox is not the 20-second problem. Cold
+  create to usable is 1.2 to 1.7 seconds, start from stopped is 0.7 to 0.8 seconds. Almost all of
+  the 20 seconds is our per-turn pipeline (daemon, assets, mounts, harness, reload); the split is
+  instrumented in Slice 5. Archive is a dead state for us: restore (33 to 66 seconds) is slower
+  than a fresh create, and the disk it frees costs under a tenth of a cent per hour.
+- The core correctness fix is unchanged: the two provider functions the runner already calls,
+  plus two teardown cleanup fixes in the vendored code, a compatibility check before reuse, and a
+  guard on the pointer writes (the must-fix list in `plan.md`).
 
 ## Decisions
 
-- Park-to-stopped ships behind a default-off flag first, not default-on; it is turned on after the
-  Phase 3 live test. This changed from "on by default" as a result of the review round.
-- The two functions live in a runner-side provider wrapper; the two teardown cleanup fixes live in
-  the existing `sandbox-agent@0.4.2` package patch (they sit inside the vendored code).
-- Park-to-running uses a separate Daytona-scoped pool instance with an awaited evict-to-stop; it
-  never reinterprets the local size cap. The env names are Daytona-scoped
-  (`AGENTA_RUNNER_DAYTONA_SESSION_*`), and the cap is named `MAX_RUNNING`, not a "spend cap".
-- Teardown carries a reason: kill, failed, and aborted turns delete; clean resumable turns stop;
-  shutdown deletes an in-flight turn and stops an idle one.
+- **Park-to-running is in the main line, not deferred** (Mahmoud, 2026-07-11). The plan is one
+  progressive sequence of slices ending with park-to-running. Rationale: the measurement shows
+  only a running sandbox removes the 20-second pipeline, and the compute cost that justified
+  deferral is small and bounded ($0.0028 per parked minute; worst case about $0.67/hour at the
+  default cap of 4).
+- **Reuse the local keepalive pool logic, refactored provider-aware** (Mahmoud, 2026-07-11).
+  Per-provider operator config plus an engine-owned lifecycle adapter; one `SessionPool` instance
+  per provider; local semantics preserved. No second pooling mechanism.
+- **Billing knobs are configuration with conservative defaults, not deferral reasons**
+  (Mahmoud, 2026-07-11). `AGENTA_RUNNER_DAYTONA_SESSION_*`: keepalive off until verification,
+  idle window 60 seconds, cap 4.
+- **The Daytona running cap is enforced by admission before creation, not by the pool**
+  (review round 2, 2026-07-11). Permits are taken before create and before a reconnect's start,
+  released only on a confirmed stop or delete; eviction is awaited; Daytona never gets the local
+  "run unparked best-effort" behavior.
+- **Teardown reasons are typed and travel from the pool into an engine-owned lifecycle function**
+  (review round 2). Kill, failed, aborted turns, and mismatches delete; clean resumable turns and
+  idle expiries stop; shutdown deletes an in-flight turn and stops an idle one; a failed stop
+  escalates to delete; a failed stop plus failed delete keeps the capacity permit consumed until
+  reconciliation.
+- **The park-to-stopped feature flag lands in Slice 1, not Slice 2** (review round 2). The run
+  paths already request `keepWarm`, so a real `pause` without the flag would activate parking
+  immediately.
+- **Archive is configured out of the demotion ladder** (measurement, 2026-07-11). The ladder is
+  stop, then delete, with `DAYTONA_AUTOARCHIVE` strictly greater than `DAYTONA_AUTODELETE`
+  (equality would race; interval 0 is unusable because `positiveMinutes()` treats it as unset).
+- **Stop timer proposed at 15 minutes, not 5** (measurement, 2026-07-11). About 4 cents per crash
+  orphan buys never stopping a sandbox under a live silent turn (the run-limits guard alone
+  allows 300 seconds). Awaiting confirmation (open-questions.md).
+- **Pending approvals follow the `daytona-gate-delivery` (F-018) resume model.** Below
+  park-to-running, a pending approval always takes the cold path (teardown, stored decision,
+  reissue on the next turn), because a stopped sandbox kills the waiting process. Holding a gate
+  open byte-exact requires park-to-running plus that plan's file-transport parked-gate variant;
+  parkability is an explicit transport capability check, never inferred from a paused stop
+  reason.
+- The two provider functions live in a runner-side provider wrapper (with state-inspecting,
+  idempotent stop); the two teardown cleanup fixes live in the existing `sandbox-agent@0.4.2`
+  package patch (they sit inside the vendored code).
 
-## Design-review round
+## The measurement (2026-07-11)
 
-An `ask-codex` review (xhigh reasoning, gpt-5.6) ran as an adversarial design review on `plan.md`,
-`research.md`, and `context.md`. Codex checked the claims against the runner source, the vendored
-package, and the Daytona SDK. Verdict: the two-level split is sound, but "park-to-stopped on by
-default" was not sound yet. Its must-fix findings are folded into `plan.md`:
+Run directly against the Daytona API (SDK 0.187.0, snapshot `agenta-sandbox-pi`, target `eu`),
+two repetitions, full numbers and prices in research.md. Headlines: create 1.2 to 1.7 s, stop
+about 2 s, start from stopped 0.7 to 0.8 s, archive 50 to 82 s, restore from archive 33 to 66 s.
+Prices from Daytona's pricing page: $0.0504/vCPU-hour, $0.0162/GiB-hour RAM, $0.000108/GiB-hour
+disk. Our shape (2 vCPU, 4 GiB, 8 GiB disk): running about $0.17/hour, stopped about
+$0.0009/hour. Hygiene: sandbox count zero before, zero after; both created sandboxes deleted.
+Scope limit: the measurement isolates the sandbox lifecycle (a trivial exec as "usable"); it does
+not measure our daemon, mounts, harness, or reload, which is why Slice 5 instruments the full
+turn.
 
-- the broken failed-pause delete fallback (the vendored `finally` clears the provider handle),
-- the double-sandbox leak when reconnect fails after `start()`,
-- the unguarded last-writer-wins `writeSandboxId` races,
-- no compatibility check on reuse (stale secrets or a weaker network policy),
-- mount hygiene on reattach,
-- teardown by reason,
-- the `orphan_sweep.py` scope correction (database only, never touches Daytona),
-- Daytona's external-interaction-only idle clock,
-- the unmeasured latency claim (now a Phase 3 measurement),
-- and Daytona-scoped park-to-running config naming with a separate pool instance.
+## Design-review round 2 (2026-07-11, after the reshape)
 
-Two of Codex's factual corrections were re-checked in the repo before folding: the compose files do
-forward the `DAYTONA_AUTO*` timers (PR #5197's risk note is stale), and archived sandboxes resume
-via a plain `start()`.
+A second `ask-codex` review (xhigh reasoning, gpt-5.6) ran on the five-slice design, checking it
+against `server.ts`, `session-pool.ts`, `sandbox_agent.ts`, the vendored package, the Daytona SDK,
+and the `daytona-gate-delivery` plan. Verdict: the five-slice direction and ordering are right;
+request changes on two design properties that were false as drafted. All of its findings were
+accepted and folded into `plan.md`:
+
+- The pool cannot enforce the running cap (fresh misses create sandboxes before the pool sees
+  them; approval checkout removes entries from the map; LRU eviction is fire-and-forget). Fixed
+  with the capacity admission gate in Slice 4.
+- One provider-level "eviction disposition" cannot implement the teardown matrix (a mismatch must
+  delete while an idle expiry stops). Fixed with typed teardown reasons through an engine-owned
+  lifecycle function.
+- Slice 1 without a flag would activate parking immediately (`keepWarm` is already requested at
+  HEAD). Fixed by moving the flag into Slice 1.
+- Operator config and lifecycle mechanisms must not be one "policy" record. Fixed in the refactor
+  section.
+- The live pool's `configFingerprint()` is not sufficient as the stopped-reconnect compatibility
+  fingerprint (it omits resolved operator settings like `DAYTONA_SNAPSHOT`); derive it from the
+  resolved create specification. Folded into must-fix item 2.
+- Archive-out needs strict inequality, and Daytona's own timer semantics (auto-delete fires from
+  continuously stopped, no archive required) get one explicit live check. Folded into item 6.
+- Refresh Daytona activity once when entering the live parked state; make stop idempotent by
+  state inspection; no recurring heartbeats. Folded into the park-to-running section.
+- Do not claim the pipeline split is instrumentally proven, and do not call the one-second
+  provider delta an end-to-end ceiling (today's Daytona path re-uploads assets on every start).
+  Folded into plan.md, research.md, and the Slice 5 instrumentation list.
+- Slice 5 verification split: park-to-stopped graduates independently; park-to-running needs a
+  concurrent over-cap test, a TTL stop confirmation, a SIGTERM drain, and a forced stop failure.
+
+Nothing from round 2 was rejected. One of its observations was procedural rather than design: it
+noted the PR did not yet contain the reshaped files, which is expected; the reshape sits in the
+working tree pending the coordinated commit.
+
+## Design-review round 1 (before the reshape)
+
+The first `ask-codex` review ran on the two-tier draft. Its must-fix findings are folded into
+`plan.md` and still stand: the broken failed-pause delete fallback, the double-sandbox reconnect
+leak, the unguarded `writeSandboxId` races, the missing compatibility check, mount hygiene on
+reattach, teardown by reason, the `orphan_sweep.py` scope correction, Daytona's
+external-interaction-only idle clock, and the unmeasured-latency correction (since replaced by
+the 2026-07-11 measurement). Its "defer park-to-running" recommendation was superseded on
+2026-07-11 by the measurement and Mahmoud's direction; its safety conditions (awaited eviction, a
+real running cap, reason-aware teardown) are kept as requirements inside Slice 4 rather than as
+reasons to defer.
 
 ## Open questions
 
-See `open-questions.md`. The three that gate shipping: the abandonment compute budget and the
-stop-timer value (billing owner), the pointer write guard (reviewer), and the park-to-running
-time-to-live and running cap (billing owner).
+See `open-questions.md`. Still open: the pointer-write guard mechanism, the shutdown split, and
+the capacity-gate saturation behavior (reviewer), plus two proposed defaults to confirm (the
+15-minute stop timer, the park-to-running window and cap). The former billing-owner gates are
+resolved by the measurement.
 
 ## Blockers
 
-- F-018 (the Daytona tool-call hang) gates validation and benefit on tool-using turns. Chat can be
-  verified first.
-- Live E3 verification (Phase 3) needs Daytona credits; deferred out of this design pass.
+- F-018 (the Daytona tool-call hang, in implementation at `daytona-gate-delivery/`) gates
+  validation and benefit on tool-using and approval turns. Chat can be verified first.
+- Live end-to-end verification (Slice 5) needs Daytona credits; deferred out of this design pass.
 
 ## Provenance
 
 - Project: warm-daytona-sessions. Built on PR #5197 (`feat/sessions-continuity`, open, base
   `big-agents`) and commit `60990d396e` ("Resolve hot/warm/cold/dead/new lifecycle (untested)").
 - Authoritative source: F-020 in `docs/design/agent-workflows/projects/qa/findings.md`.
-- Sibling workspaces: `session-keepalive/` (park-to-running is its deferred Daytona slice),
-  `harness-session-resume/` (durable continuity fallback).
+- Lifecycle measurement: 2026-07-11, direct Daytona API; numbers transcribed into research.md.
+- Sibling workspaces: `session-keepalive/` (the local pool this plan refactors provider-aware),
+  `harness-session-resume/` (durable continuity fallback), `daytona-gate-delivery/` (F-018, the
+  approval-gate contract this plan follows).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
@@ -1,64 +1,72 @@
 # Status
 
-Source of truth for this workspace's progress. Keep it current.
+The source of truth for this workspace's progress. Keep it current.
 
 ## State: design draft, review round done, awaiting human review
 
-Design only. No code changed. No live Daytona sandbox was run (credits).
+Design only. No code changed. No live Daytona sandbox was run (that would spend credits).
 
 ## What this workspace concluded
 
-- F-020's observed behavior still holds at HEAD, for a deeper reason than F-020 stated. The
-  runner-side warm plumbing exists (keepWarm park, stored-id reconnect, native `session/load`,
-  `ephemeral: false` plus idle timers), but the vendored Daytona provider (`sandbox-agent@0.4.2`)
-  has no `pause` and no `reconnect`. So `pauseSandbox()` falls back to delete, reconnect cannot
-  revive a stopped instance, and every turn still recreates. This is the load-bearing finding.
-- The core fix is two provider hooks the runner already calls (the Daytona SDK exposes
-  `sandbox.stop()` / `sandbox.start()` / `state`), plus two failure-cleanup seam fixes in the
-  vendored lifecycle, a compatibility fingerprint, and fenced pointer writes (P0 list in
-  `plan.md`).
-- Two tiers, honest trade-offs, one recommendation. Tier 1 (park to stopped, storage-only
-  parked cost) lands behind a default-off flag and is enabled after one credit-controlled live
-  test. Tier 2 (park to running, compute cost, TTL and running cap are the knobs) is opt-in and
-  deferred. Durable replay stays the floor.
+- F-020's slow-turn behavior still holds at HEAD, for a deeper reason than F-020 gave. The
+  runner-side warm plumbing exists (park at turn end, reconnect by stored id, native session
+  reload, `ephemeral: false` with idle timers), but the vendored Daytona provider
+  (`sandbox-agent@0.4.2`) has no pause and no reconnect. So `pauseSandbox()` falls back to delete,
+  reconnect cannot revive a stopped instance, and every turn still rebuilds. This is the key
+  finding.
+- The core fix is the two provider functions the runner already calls (the Daytona SDK exposes
+  `sandbox.stop()`, `sandbox.start()`, and a `state` field), plus two teardown cleanup fixes in the
+  vendored code, a compatibility check before reuse, and a guard on the pointer writes (the
+  must-fix list in `plan.md`).
+- Two levels of reuse, honest trade-offs, one recommendation. Park-to-stopped (stop the sandbox at
+  turn end, storage-only parked cost) lands behind a default-off flag and is turned on after one
+  credit-controlled live test. Park-to-running (keep the sandbox running, compute cost, with a
+  time-to-live and a running cap as the knobs) is opt-in and deferred. Durable reload stays the
+  floor.
 
 ## Decisions
 
-- Tier 1 behind a default-off rollout flag first, not default-on; enable after the Phase 3 live
-  lifecycle test. Changed from "default" by the review round.
-- Hooks in a runner-side provider wrapper; the two failure-cleanup seam fixes in the existing
-  `sandbox-agent@0.4.2` dist patch (they live inside the vendored `SandboxAgent`).
-- Tier 2 uses a separate Daytona-scoped pool instance with awaited evict-to-stop; never
-  reinterpret the local `poolMax`. Env names are Daytona-scoped
-  (`AGENTA_RUNNER_DAYTONA_SESSION_*`), and the cap is `MAX_RUNNING`, not a "spend cap".
-- Teardown carries a reason: kill/failed/aborted delete; clean resumable turns stop; SIGTERM
-  deletes in-flight and stops idle.
+- Park-to-stopped ships behind a default-off flag first, not default-on; it is turned on after the
+  Phase 3 live test. This changed from "on by default" as a result of the review round.
+- The two functions live in a runner-side provider wrapper; the two teardown cleanup fixes live in
+  the existing `sandbox-agent@0.4.2` package patch (they sit inside the vendored code).
+- Park-to-running uses a separate Daytona-scoped pool instance with an awaited evict-to-stop; it
+  never reinterprets the local size cap. The env names are Daytona-scoped
+  (`AGENTA_RUNNER_DAYTONA_SESSION_*`), and the cap is named `MAX_RUNNING`, not a "spend cap".
+- Teardown carries a reason: kill, failed, and aborted turns delete; clean resumable turns stop;
+  shutdown deletes an in-flight turn and stops an idle one.
 
 ## Design-review round
 
-Ran the `ask-codex` skill (xhigh, gpt-5.6) on `plan.md`, `research.md`, and `context.md` as an
-adversarial design review; Codex verified claims against the runner source, the vendored dist,
-and the Daytona SDK. Verdict: two-tier split sound, "Tier 1 default-on" not sound yet. Its P0
-findings are folded into `plan.md`: the broken failed-pause delete fallback (the vendored
-`finally` clears the provider handle), the double-sandbox leak when reconnect fails after
-`start()`, unfenced last-writer-wins `writeSandboxId` races, no compatibility check on reuse
-(stale secrets or network policy), mount hygiene on reattach, teardown-by-reason, the
-`orphan_sweep.py` scope correction (DB-only, never touches Daytona), Daytona's
-external-interaction-only inactivity clock, the unmeasured latency claim (now a Phase 3
-measurement), and Daytona-scoped Tier 2 config naming with a separate pool instance. Two of its
-factual corrections were re-verified in-repo before folding: compose does forward the
-`DAYTONA_AUTO*` timers (PR #5197's risk note is stale), and archived sandboxes resume via plain
-`start()`.
+An `ask-codex` review (xhigh reasoning, gpt-5.6) ran as an adversarial design review on `plan.md`,
+`research.md`, and `context.md`. Codex checked the claims against the runner source, the vendored
+package, and the Daytona SDK. Verdict: the two-level split is sound, but "park-to-stopped on by
+default" was not sound yet. Its must-fix findings are folded into `plan.md`:
+
+- the broken failed-pause delete fallback (the vendored `finally` clears the provider handle),
+- the double-sandbox leak when reconnect fails after `start()`,
+- the unguarded last-writer-wins `writeSandboxId` races,
+- no compatibility check on reuse (stale secrets or a weaker network policy),
+- mount hygiene on reattach,
+- teardown by reason,
+- the `orphan_sweep.py` scope correction (database only, never touches Daytona),
+- Daytona's external-interaction-only idle clock,
+- the unmeasured latency claim (now a Phase 3 measurement),
+- and Daytona-scoped park-to-running config naming with a separate pool instance.
+
+Two of Codex's factual corrections were re-checked in the repo before folding: the compose files do
+forward the `DAYTONA_AUTO*` timers (PR #5197's risk note is stale), and archived sandboxes resume
+via a plain `start()`.
 
 ## Open questions
 
-See `open-questions.md`. The three that gate shipping: the orphan compute budget and autoStop
-value (billing owner), the pointer-fencing design (reviewer), and the Tier 2 TTL and running
-cap (billing owner).
+See `open-questions.md`. The three that gate shipping: the abandonment compute budget and the
+stop-timer value (billing owner), the pointer write guard (reviewer), and the park-to-running
+time-to-live and running cap (billing owner).
 
 ## Blockers
 
-- F-018 (Daytona tool-call hang) gates validation and benefit on tool-using turns. Chat can be
+- F-018 (the Daytona tool-call hang) gates validation and benefit on tool-using turns. Chat can be
   verified first.
 - Live E3 verification (Phase 3) needs Daytona credits; deferred out of this design pass.
 
@@ -67,5 +75,5 @@ cap (billing owner).
 - Project: warm-daytona-sessions. Built on PR #5197 (`feat/sessions-continuity`, open, base
   `big-agents`) and commit `60990d396e` ("Resolve hot/warm/cold/dead/new lifecycle (untested)").
 - Authoritative source: F-020 in `docs/design/agent-workflows/projects/qa/findings.md`.
-- Sibling workspaces: `session-keepalive/` (Tier 2 is its deferred slice 3),
+- Sibling workspaces: `session-keepalive/` (park-to-running is its deferred Daytona slice),
   `harness-session-resume/` (durable continuity fallback).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
@@ -1,0 +1,71 @@
+# Status
+
+Source of truth for this workspace's progress. Keep it current.
+
+## State: design draft, review round done, awaiting human review
+
+Design only. No code changed. No live Daytona sandbox was run (credits).
+
+## What this workspace concluded
+
+- F-020's observed behavior still holds at HEAD, for a deeper reason than F-020 stated. The
+  runner-side warm plumbing exists (keepWarm park, stored-id reconnect, native `session/load`,
+  `ephemeral: false` plus idle timers), but the vendored Daytona provider (`sandbox-agent@0.4.2`)
+  has no `pause` and no `reconnect`. So `pauseSandbox()` falls back to delete, reconnect cannot
+  revive a stopped instance, and every turn still recreates. This is the load-bearing finding.
+- The core fix is two provider hooks the runner already calls (the Daytona SDK exposes
+  `sandbox.stop()` / `sandbox.start()` / `state`), plus two failure-cleanup seam fixes in the
+  vendored lifecycle, a compatibility fingerprint, and fenced pointer writes (P0 list in
+  `plan.md`).
+- Two tiers, honest trade-offs, one recommendation. Tier 1 (park to stopped, storage-only
+  parked cost) lands behind a default-off flag and is enabled after one credit-controlled live
+  test. Tier 2 (park to running, compute cost, TTL and running cap are the knobs) is opt-in and
+  deferred. Durable replay stays the floor.
+
+## Decisions
+
+- Tier 1 behind a default-off rollout flag first, not default-on; enable after the Phase 3 live
+  lifecycle test. Changed from "default" by the review round.
+- Hooks in a runner-side provider wrapper; the two failure-cleanup seam fixes in the existing
+  `sandbox-agent@0.4.2` dist patch (they live inside the vendored `SandboxAgent`).
+- Tier 2 uses a separate Daytona-scoped pool instance with awaited evict-to-stop; never
+  reinterpret the local `poolMax`. Env names are Daytona-scoped
+  (`AGENTA_RUNNER_DAYTONA_SESSION_*`), and the cap is `MAX_RUNNING`, not a "spend cap".
+- Teardown carries a reason: kill/failed/aborted delete; clean resumable turns stop; SIGTERM
+  deletes in-flight and stops idle.
+
+## Design-review round
+
+Ran the `ask-codex` skill (xhigh, gpt-5.6) on `plan.md`, `research.md`, and `context.md` as an
+adversarial design review; Codex verified claims against the runner source, the vendored dist,
+and the Daytona SDK. Verdict: two-tier split sound, "Tier 1 default-on" not sound yet. Its P0
+findings are folded into `plan.md`: the broken failed-pause delete fallback (the vendored
+`finally` clears the provider handle), the double-sandbox leak when reconnect fails after
+`start()`, unfenced last-writer-wins `writeSandboxId` races, no compatibility check on reuse
+(stale secrets or network policy), mount hygiene on reattach, teardown-by-reason, the
+`orphan_sweep.py` scope correction (DB-only, never touches Daytona), Daytona's
+external-interaction-only inactivity clock, the unmeasured latency claim (now a Phase 3
+measurement), and Daytona-scoped Tier 2 config naming with a separate pool instance. Two of its
+factual corrections were re-verified in-repo before folding: compose does forward the
+`DAYTONA_AUTO*` timers (PR #5197's risk note is stale), and archived sandboxes resume via plain
+`start()`.
+
+## Open questions
+
+See `open-questions.md`. The three that gate shipping: the orphan compute budget and autoStop
+value (billing owner), the pointer-fencing design (reviewer), and the Tier 2 TTL and running
+cap (billing owner).
+
+## Blockers
+
+- F-018 (Daytona tool-call hang) gates validation and benefit on tool-using turns. Chat can be
+  verified first.
+- Live E3 verification (Phase 3) needs Daytona credits; deferred out of this design pass.
+
+## Provenance
+
+- Project: warm-daytona-sessions. Built on PR #5197 (`feat/sessions-continuity`, open, base
+  `big-agents`) and commit `60990d396e` ("Resolve hot/warm/cold/dead/new lifecycle (untested)").
+- Authoritative source: F-020 in `docs/design/agent-workflows/projects/qa/findings.md`.
+- Sibling workspaces: `session-keepalive/` (Tier 2 is its deferred slice 3),
+  `harness-session-resume/` (durable continuity fallback).

--- a/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
+++ b/docs/design/agent-workflows/projects/warm-daytona-sessions/status.md
@@ -15,11 +15,12 @@ the organization before and after). Its numbers are in research.md and reshaped 
   reload, `ephemeral: false` with idle timers), but the vendored Daytona provider
   (`sandbox-agent@0.4.2`) has no pause and no reconnect. So `pauseSandbox()` falls back to delete,
   reconnect cannot revive a stopped instance, and every turn still rebuilds.
-- The measurement added the second key finding: the sandbox is not the 20-second problem. Cold
+- The measurements added the second key finding: the sandbox is not the slow-turn problem. Cold
   create to usable is 1.2 to 1.7 seconds, start from stopped is 0.7 to 0.8 seconds. Almost all of
-  the 20 seconds is our per-turn pipeline (daemon, assets, mounts, harness, reload); the split is
-  instrumented in Slice 5. Archive is a dead state for us: restore (33 to 66 seconds) is slower
-  than a fresh create, and the disk it frees costs under a tenth of a cent per hour.
+  the measured ~15-second turn is our per-turn pipeline (~12.3 s; stage split in research.md,
+  dominated by a redundant Pi install and the harness spawn). Archive is a dead state for us:
+  restore (33 to 66 seconds) is slower than a fresh create, and the disk it frees costs under a
+  tenth of a cent per hour.
 - The core correctness fix is unchanged: the two provider functions the runner already calls,
   plus two teardown cleanup fixes in the vendored code, a compatibility check before reuse, and a
   guard on the pointer writes (the must-fix list in `plan.md`).
@@ -28,7 +29,7 @@ the organization before and after). Its numbers are in research.md and reshaped 
 
 - **Park-to-running is in the main line, not deferred** (Mahmoud, 2026-07-11). The plan is one
   progressive sequence of slices ending with park-to-running. Rationale: the measurement shows
-  only a running sandbox removes the 20-second pipeline, and the compute cost that justified
+  only a running sandbox removes the per-turn pipeline, and the compute cost that justified
   deferral is small and bounded ($0.0028 per parked minute; worst case about $0.67/hour at the
   default cap of 4).
 - **Reuse the local keepalive pool logic, refactored provider-aware** (Mahmoud, 2026-07-11).
@@ -73,9 +74,15 @@ about 2 s, start from stopped 0.7 to 0.8 s, archive 50 to 82 s, restore from arc
 Prices from Daytona's pricing page: $0.0504/vCPU-hour, $0.0162/GiB-hour RAM, $0.000108/GiB-hour
 disk. Our shape (2 vCPU, 4 GiB, 8 GiB disk): running about $0.17/hour, stopped about
 $0.0009/hour. Hygiene: sandbox count zero before, zero after; both created sandboxes deleted.
-Scope limit: the measurement isolates the sandbox lifecycle (a trivial exec as "usable"); it does
-not measure our daemon, mounts, harness, or reload, which is why Slice 5 instruments the full
-turn.
+
+A second measurement the same day filled the gap the first one left: the full turn. Three real E3
+chat runs plus micro-measurements inside the runner container produced the stage-by-stage split
+now in research.md ("Where the time goes"): ~15-second cold Daytona turn, ~12.3 seconds of it our
+pipeline, dominated by a redundant ~5.2-second Pi install (skip already live on the dev sidecar,
+E3 smoke down to 12.2 s) and a ~5.15-second harness spawn (of which ~2 seconds are pi-acp version
+probes, removal planned in PR #5221). Consequences recorded in plan.md: park-to-stopped saves
+about 1 second; park-to-running gets the turn to an estimated 2 to 3 seconds; Slice 5 first adds
+the missing duration log lines, then re-measures against this baseline.
 
 ## Design-review round 2 (2026-07-11, after the reshape)
 


### PR DESCRIPTION
## What a user sees today

When you chat with an agent that runs on Daytona, every message waits about twenty seconds before the agent starts to answer. The answer itself is correct, because durable continuity replays the conversation into a fresh sandbox, but every turn pays the full setup time. This is QA finding F-020.

## What we measured (new in this revision)

A credit-controlled measurement against the Daytona API (2026-07-11, two repetitions, all sandboxes deleted afterwards) changed the plan's shape:

- Creating a sandbox takes 1.2 to 1.7 seconds, and starting a stopped one takes under a second. So the twenty-second turn is not sandbox creation; it is our own per-turn pipeline (daemon startup, asset upload, mounts, harness startup, session reload). Only a sandbox that stays running skips that pipeline.
- Restoring an archived sandbox (33 to 66 seconds) is slower than creating a fresh one, and the disk archive frees costs under a tenth of a cent per hour. Archive is dropped from the design.
- A parked running sandbox costs about $0.0028 per minute. A 60-second keep-warm window costs about a third of a cent per turn.

Full numbers and prices are in `research.md`.

## What this PR proposes

One progressive sequence of five slices, each shippable on its own, ending with warm running sandboxes:

1. **Correctness base, everything behind a default-off flag.** The two Daytona provider functions the runner already calls (pause, reconnect), two teardown leak fixes in the vendored package, guarded sandbox-pointer writes, and a compatibility fingerprint.
2. **Park-to-stopped.** Stop the sandbox at a clean turn end instead of deleting it; restart the same one next turn. Parked cost is disk storage only (about $0.0009/hour).
3. **Provider-aware pool refactor.** The existing local keepalive pool (`session-pool.ts`) gets per-provider configuration and typed teardown reasons instead of the local-only gate. Local behavior is preserved; no second pooling mechanism.
4. **Park-to-running.** Keep the sandbox running for a short window after each turn (default 60 seconds, hard cap of 4 concurrently running sandboxes, enforced by an admission gate before creation, not by the pool).
5. **Live verification, then flip the flags.** Park-to-stopped and park-to-running graduate independently.

Pending approvals follow the F-018 gate plan's resume model (`daytona-gate-delivery/`): below park-to-running a pending approval always takes the cold path, because a stopped sandbox kills the waiting process.

## What the design reviews changed

Two adversarial review rounds ran. Round 1 found the teardown leaks and races now in the must-fix list. Round 2 reviewed the five-slice reshape and found two design properties that were false as drafted, both fixed: the pool alone cannot enforce the running cap (fresh misses create sandboxes before the pool sees them; the cap now lives in an admission gate taken before creation), and a single eviction disposition cannot implement the teardown matrix (teardown reasons are now typed). `status.md` records both rounds in full.

## Decisions that still need you

- Where the compare-and-set guard on the stored sandbox id lives (`open-questions.md` item 1).
- The shutdown split: delete an in-flight turn, stop an idle one (item 2).
- Queue briefly or reject when the running cap is saturated (item 3).
- Two proposed defaults to confirm: the 15-minute stop timer, and the 60-second window with cap 4 (items 5 and 6).

## How to read it

Start with `README.md` (reading order), then `context.md` for the story. The inline comments on this PR mark the exact decision points.

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj