### PR TITLE
docs(design): agent mounts, one derived durable folder per agent

### DIFF
--- a/docs/design/agent-workflows/projects/agent-mounts/README.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/README.md
@@ -1,0 +1,23 @@
+# Agent mounts
+
+One durable folder per agent, derived from the workflow artifact id. No schema change, no
+configuration, no wire change. Decided 2026-07-11 (Mahmoud + JP); this workspace is the
+design and execution plan.
+
+## Files
+
+- `context.md`: why the work exists, the decision and its alternatives, goals, non-goals.
+  Read this first.
+- `research.md`: the code facts the design stands on, with file:line pointers (slug
+  mechanism, table shape, wire fields, runner plumbing, the frontend discovery gap).
+- `plan.md`: design decisions D1-D4, the four slices, tests, and the open questions to
+  settle in PR review.
+- `status.md`: current state; kept up to date as slices land.
+
+## Related
+
+- `docs/design/agent-workflows/projects/runner-selfhosting-explainer/mounts-design-notes.md`:
+  the conversation notes this project came from (mount taxonomy, future project mounts).
+- `docs/design/agent-workflows/projects/harness-session-resume/`: JP's #5197, which built
+  the transcript-mounts pattern the runner slice copies.
+- `docs/design/mount-file-viewer/`: the frontend file browser the web slice reuses.

--- a/docs/design/agent-workflows/projects/agent-mounts/context.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/context.md
@@ -1,0 +1,95 @@
+# Context: agent mounts
+
+## Why this work exists
+
+Agent workflows already have durable storage at the session level. Every session gets a
+mount: a row in the mounts table that names an S3 prefix, signed with short-lived
+prefix-scoped credentials and mounted as the session's working directory via geesefs
+(FUSE over S3: the prefix appears as a normal local folder). JP's session-continuity PR
+(#5197) extended the same mechanism to per-session harness transcript directories.
+
+Nothing equivalent exists at the agent level. Two consequences:
+
+1. **An agent has no folder of its own.** Skills it accumulates, scratch memory, artifacts
+   it should keep across conversations: there is no place for them. Each session starts
+   from its own prefix and dies with it.
+2. **A request without a session id gets a throwaway temp folder.** The runner only signs
+   session mounts, so a sessionless run falls back to an ephemeral temp directory and its
+   files evaporate. Once an agent mount exists, a sessionless run still has an agent, so
+   it has a mount to use (provided that run type carries the workflow identity on the
+   wire; verifying this per run type is part of the plan).
+
+This project adds the agent mount: one durable folder per agent, derived from the workflow
+artifact id, requiring no configuration and no schema change.
+
+## The decision (made 2026-07-11, Mahmoud + JP)
+
+Build agent mounts the way session mounts are built: **identity by reserved slug, not by
+schema.**
+
+The mounts table enforces one generic constraint, `unique(project_id, slug)`. Session
+mounts are unique per session because their slug is minted deterministically from the
+session id (`__ag__<uuid5(session_id)>__<name>`) and upserted. The agent mount uses the
+identical trick with the workflow **artifact id** in place of the session id, and leaves
+the `session_id` column NULL. The runner upserts it at mount time, exactly as it already
+does for session mounts. Anyone who needs the mount (runner, frontend inspector)
+re-derives the slug from the artifact id; nobody configures anything.
+
+The mount point inside the sandbox follows a hardcoded derivation rule (a per-run sibling
+of the working directory; see the plan's D3). Nothing about it is user-configurable.
+Anything configurable would need a home in the agent template config, and we are
+deliberately not adding one.
+
+### Why the artifact id and not the revision id
+
+The artifact is the agent's stable identity; revisions are config versions. A mount derived
+from the revision id would orphan the agent's files on every config change.
+
+### Alternatives considered
+
+| Option | What it adds | Why not now |
+|---|---|---|
+| Schema-level uniqueness (new `artifact_id` column + unique index) | Reverse lookup (mount to owner), indexed per-agent listing, FK integrity and cascade delete | None of these serve the feature: the runner and the frontend always start FROM the agent (forward lookup), which the derived slug already gives. Costs a migration and commits the schema before the model has settled. Can be added later by backfilling from re-derived slugs. |
+| Informational `artifact_id` column, slug still enforces uniqueness (what sessions do with `session_id`) | Same lookups as above, no uniqueness machinery | Discussed and dropped 2026-07-11: the limitations it fixes are not a problem for the planned use. Revisit if per-agent storage reporting or cleanup jobs materialize. |
+| Mount declared in the agent template config | Re-pointable and shareable mounts | No use case: an agent's mount never needs to be visible to another agent. Config is for access to SHARED mounts (project mounts), a future kind, not for the agent's own identity. |
+
+### Accepted limitations
+
+All queries that start from the mount side are given up, deliberately:
+
+- No reverse lookup from a mount row to its owning agent (the uuid5 slug is one-way).
+- No indexed "all agent mounts with owners" listing or per-agent storage aggregation
+  (slug prefix scans at best).
+- No FK integrity: deleting an agent orphans its mount row and S3 prefix; cleanup is a
+  future job.
+
+The frontend files view is NOT limited: showing an agent's files starts from the artifact
+id the UI already holds, derives the mount, and lists files the same way the session
+inspector does today.
+
+## Goals
+
+1. Every agent has exactly one derived mount per key (key `"default"` to start), created
+   lazily by upsert on first use.
+2. The runner mounts it into the sandbox at a predictable derived path on every run of
+   that agent, local and Daytona, alongside the session cwd mount.
+3. The frontend can show the agent's files by artifact id, reusing the session inspector's
+   mount file browser.
+4. Zero configuration, zero schema change, zero new uniqueness machinery.
+
+## Non-goals
+
+- Project mounts and shared-mount access control in the agent template (future kind; this
+  design must not block it).
+- Making mount signing failures loud instead of silently falling back to ephemeral
+  (tracked in the runner-selfhosting-explainer workspace notes; separate change).
+- Cleanup/GC of orphaned mounts after agent deletion.
+- Configurable mount points.
+
+## Source conversations
+
+- Mahmoud + agent session 2026-07-10/11: the mount taxonomy notes in
+  `docs/design/agent-workflows/projects/runner-selfhosting-explainer/mounts-design-notes.md`.
+- JP voice note 2026-07-11: the chosen mechanism (reserved slug with artifact id, no
+  session_id, runner upserts at mount time, hardcoded mount point, inspector reads via the
+  non-session mounts path), and the open questions it settles.

--- a/docs/design/agent-workflows/projects/agent-mounts/open-issues.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/open-issues.md
@@ -1,0 +1,74 @@
+# Open issues and deferred work: agent mounts
+
+Captured during implementation (2026-07-12). None blocks the PR; each has a clean repro or
+a clear next step.
+
+## Live QA: done
+
+The Daytona cell ran on 2026-07-12 and passed every check. An agent workflow ran twice on
+Daytona (eu.preview key, EU target). Confirmed inside the live sandbox: `${cwd}-agent` is a real
+mount, the README is present, the `agent-files` symlink resolves, and a marker file written in
+run 1 read back in run 2 (persistence, README not rewritten). The `AGENTA_AGENT_MOUNT_DIR` fix
+was verified two ways: the var is set in the live sandbox's environment, and Daytona's own stored
+sandbox record echoes it, which proves it rode `daytonaEnvVars(piExtEnv, secrets)` into the
+sandbox at create time. Nothing about the Daytona path is left unverified.
+
+## Environment bug found during Daytona QA (not agent-mounts)
+
+The EE dev runner boots Daytona sandboxes from the wrong snapshot. Its compose service reads the
+plain `DAYTONA_SNAPSHOT` (set to `daytona-small` by another integration), not the intended
+`SANDBOX_AGENT_DAYTONA_SNAPSHOT` (`agenta-sandbox-pi`). `daytona-small` has no sandbox-agent
+daemon, so any Daytona run on `agenta-ee-dev-wp-b2-rendering-runner-1` hangs forever on
+daemon-health polling. This blocks all Daytona runs on that container, not just agent mounts. The
+QA worked around it with a disposable sibling runner using the correct snapshot. Fixing it needs
+the compose var mapping corrected and a container recreate.
+
+## Correctness and robustness
+
+2. **`unmountStorage` returns an inconclusive `false` after a lazy unmount in the dev runner
+   container.** `defaultCheckMountpoint`'s `mountpoint -q` did not exit cleanly 0/1 right after
+   a `fusermount -uz`, so `unmountStorage` reported "not safe to delete" even though the unmount
+   had happened (remount + readback proved it). The failure direction is safe (a false negative
+   just skips the mountpoint-dir cleanup). This is pre-existing behavior shared with the durable
+   cwd teardown, not new to agent mounts, but the return value is not a reliable "safe to delete"
+   signal in this environment. Worth hardening `defaultCheckMountpoint` (and auditing every caller
+   that deletes a dir on a `true` return) separately.
+
+3. **geesefs does not persist symlinks.** Resolved for this feature by making `linkAgentFiles`
+   self-healing (recreate a degraded/wrong-target link each run). If geesefs ever gains durable
+   symlink support on the pinned version, the self-heal can relax to a plain create-if-absent.
+
+## Cleanup and reuse
+
+4. **Shared sign core in the runner.** `signSessionMountCredentials` (mount.ts) and
+   `signAgentMountCredentials` (agent-mount.ts) are near-duplicates (fetch, non-2xx handling,
+   credential-field guard, snake_case → `MountCredentials` mapping). Extract a shared
+   `signMountCredentialsAt(url, label, deps)` and make both thin wrappers. Deferred here to keep
+   blast radius off the durable-cwd sign path; do it when next touching `mount.ts`.
+
+5. **Sign endpoints double-fetch the mount row.** Both the session and agent sign paths fetch the
+   mount again inside `sign_mount_credentials` after the upsert already returned it. Fix both
+   together at the service layer.
+
+6. **Shared test fakes.** The runner tests re-implement a fake `Response`; the api mounts tests
+   re-implement an in-memory DAO fake. Hoist each into one shared helper.
+
+7. **Fern client regen for `fetchAgentMount`.** The web fetcher calls the endpoint through raw
+   axios with `_ignoreError: true`, pending a Fern client regeneration that exposes the agent
+   mount endpoints. Migrate off raw axios once the generated client has them.
+
+8. **Scope-keyed atom for `artifactId`.** The inspector threads `artifactId` through the store as
+   plain state. If a third pass-through consumer appears, switch to a scope-keyed atom rather than
+   widening the prop chain again.
+
+## Environment (not feature bugs)
+
+9. **Dev API container hot-reload watcher died silently.** During QA the dev API stopped emitting
+   `WatchFiles` events (schema changes did not hot-reload); `fs.inotify.max_user_instances=128`
+   is the suspect. A container restart fixed it. Recurrence watch only.
+
+10. **codex `workspace-write` sandbox failure.** For the duration of this run, codex
+    `--sandbox workspace-write` failed every `apply_patch` with
+    `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted` (a host policy issue, not
+    namespace exhaustion). Worked around with `--sandbox danger-full-access`. Host-level, not this
+    feature; noted so the next session recognizes it.

--- a/docs/design/agent-workflows/projects/agent-mounts/open-issues.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/open-issues.md
@@ -38,6 +38,12 @@ the compose var mapping corrected and a container recreate.
    self-healing (recreate a degraded/wrong-target link each run). If geesefs ever gains durable
    symlink support on the pinned version, the self-heal can relax to a plain create-if-absent.
 
+3a. **Timeout on the sign fetch.** `signAgentMountCredentials` now bounds its POST with
+   `AbortSignal.timeout(10_000)` so a hung `/sign` endpoint fails open instead of stalling
+   environment acquisition (CodeRabbit catch on #5247). The sibling `signSessionMountCredentials`
+   in `mount.ts` (durable-cwd path, out of this PR's scope) still issues an unbounded POST and
+   deserves the same guard.
+
 ## Cleanup and reuse
 
 4. **Shared sign core in the runner.** `signSessionMountCredentials` (mount.ts) and

--- a/docs/design/agent-workflows/projects/agent-mounts/plan.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/plan.md
@@ -9,7 +9,8 @@ the workflow artifact id, no schema change, no configuration, no wire change.
 1. The API can mint, upsert, and sign an **agent mount**: a mount row with `session_id`
    NULL whose slug derives from the workflow artifact id.
 2. The runner mounts it into every run of that agent, next to the session cwd, local and
-   Daytona, and tells the harness where it is.
+   Daytona, and makes it discoverable from inside the workspace without any agent.md
+   change (env var + `agent-files` symlink + seeded README; D3).
 3. The frontend can look the mount up by artifact id and browse its files with the
    existing mount file browser.
 
@@ -93,10 +94,38 @@ lands.
   Rejected: a fixed absolute path (collides across concurrent local runs of the same
   agent) and a directory inside the cwd (a FUSE mount nested inside the durable cwd's FUSE
   mount).
-- **Harness discovery:** one env var on the daemon env, `AGENTA_AGENT_MOUNT_DIR=<path>`,
-  set only when the mount is live. Follow-up (not this project): a line in the rendered
-  instructions file so the model knows the folder exists; the env-var-naming cleanup in
-  the runner-selfhosting-explainer notes applies to this name too.
+- **Harness discovery (decided 2026-07-11, Mahmoud):** the env var alone is plumbing, not
+  discovery — neither Pi nor Claude inspects `env` or lists the cwd's parent unprompted,
+  and the mount would sit unused until an instructions change ships. The constraint is to
+  make the folder obvious **without touching the author's agent.md**: for `pi_core` and
+  `claude` the rendered instructions file is the author's text verbatim
+  (research.md, "The rendered instructions file"), so a platform-injected line would
+  change the no-wrapping policy for those harnesses. The filesystem itself carries the
+  signal instead, with three mechanisms:
+  1. `AGENTA_AGENT_MOUNT_DIR=<path>` on the daemon env, set only when the mount is live
+     (machine-readable pointer; the env-var-naming cleanup in the
+     runner-selfhosting-explainer notes applies to this name too).
+  2. A **symlink inside the cwd**: `<cwd>/agent-files -> <cwd>-agent`, created after both
+     mounts are up. Listing the working directory is the one discovery action every
+     harness performs, and the link shows up there. This does not reintroduce the
+     rejected dir-inside-cwd option: that rejection was about nesting a FUSE mount inside
+     a FUSE mount; a symlink is a pointer, not a mount. Caveat: the session cwd is itself
+     geesefs, so creating the link needs geesefs symlink support on the pinned version —
+     a slice-2 verification task. Failure to create it is logged and non-fatal (env var
+     and README still stand); the ephemeral sessionless cwd is a plain local dir where
+     symlinks trivially work.
+  3. A **seeded `README.md` in the agent mount**, written by the runner after mount only
+     when absent: files here persist across all sessions and runs of this agent; the
+     working directory persists only for the current session (or not at all, sessionless).
+     Write-if-absent keeps it idempotent and never clobbers an agent's own edit. It also
+     gives the D4 frontend panel real content the first time anyone opens it.
+     Alternative rejected: seeding from the API at upsert time — it would need S3 write
+     access on the sign path for a purely presentational file; the runner already holds
+     the mounted path.
+  The agent's discovery story, with zero instructions text: list the cwd → see
+  `agent-files/` → open it → the README states the persistence rule. Follow-up (not this
+  project): a line in the rendered instructions file, now nice-to-have rather than
+  load-bearing.
 - **Keepalive interplay (#5197):** the mount lives and dies with the run environment;
   `destroy({keepWarm})` keeps it, final destroy unmounts it. Same rule the durable cwd
   follows; implementation must add the agent mountpoint to the same unmount bookkeeping.
@@ -126,7 +155,7 @@ moves to the agent page instead.
 | # | Lane | Content | Tests |
 |---|---|---|---|
 | 1 | api | `mint_agent_slug` (with UUID canonicalization), `get_or_create_agent_mount`, `fetch_mount_by_slug`, the two endpoints; verify runContext + `RUN_SESSIONS` coverage per run type (playground, trigger, evaluation, API) | pytest: slug format + parse-back, non-UUID rejected 422, upsert idempotence (same row id twice), query returns row/empty and never creates, reserved-slug guard still rejects forged `__ag__agent__` slugs, permission checks |
-| 2 | runner | sign call with artifact id from runContext, `<cwd>-agent` mount local+remote, `AGENTA_AGENT_MOUNT_DIR`, teardown, keepalive + warm-resume idempotency | vitest: plan wiring (artifact id present/absent), path derivation, env var set only when mounted, unmount on final destroy, no re-mount on warm resume; wire-contract goldens untouched (asserts no protocol change) |
+| 2 | runner | sign call with artifact id from runContext, `<cwd>-agent` mount local+remote, `AGENTA_AGENT_MOUNT_DIR`, `agent-files` symlink in cwd (verify geesefs symlink support first), seeded README (write-if-absent), teardown, keepalive + warm-resume idempotency | vitest: plan wiring (artifact id present/absent), path derivation, env var set only when mounted, symlink created best-effort and skipped when present, README seeded only when absent, unmount on final destroy, no re-mount on warm resume; wire-contract goldens untouched (asserts no protocol change) |
 | 3 | web | Agent files panel per D4 (includes exporting `MountFilesPanel`) | vitest for the lookup hook; manual e2e in QA |
 | 4 | docs | keep-docs-in-sync sweep: `documentation/` mounts page, runner-selfhosting-explainer, env reference | docs build |
 
@@ -137,6 +166,9 @@ mount. The live QA below needs both deployed together.
 Live QA (after slice 2): local and Daytona; agent writes a file into
 `$AGENTA_AGENT_MOUNT_DIR` in session A, session B of the same agent reads it back; a
 sessionless run writes and a later session reads; a different agent does not see it.
+Discovery QA, run without any instructions hint: ask the agent to list its working
+directory and explain what it has — it must find `agent-files/`, read the README, and
+state the persistence rule unaided.
 
 ## Open questions (comment on the PR)
 
@@ -146,8 +178,9 @@ sessionless run writes and a later session reads; a different agent does not see
 2. **Endpoint placement:** `/mounts/agents/*` as specified, or hang the sign off the
    sessions router's sibling for symmetry? Current shape keeps the sessions router
    session-only.
-3. **Mount point:** `<cwd>-agent` and the `AGENTA_AGENT_MOUNT_DIR` name. Better ideas
-   welcome; both are one-line constants.
+3. **Mount point and visible name:** `<cwd>-agent`, the `AGENTA_AGENT_MOUNT_DIR` name,
+   and — now user-visible to the model — the `agent-files` symlink name and the seeded
+   README wording. Better ideas welcome; all are one-line constants.
 4. **Query semantics:** confirmed no-create-on-read?
 5. **Scope check:** slice 3 in this project, or hand the panel to the mount-file-viewer
    work (draft PR #5204, the session file browser this panel builds on)?

--- a/docs/design/agent-workflows/projects/agent-mounts/plan.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/plan.md
@@ -1,0 +1,156 @@
+# Plan: agent mounts
+
+Prerequisite reading: `context.md` (the decision and its why), `research.md` (code facts).
+One-line summary: one durable folder per agent, identity minted into the reserved slug from
+the workflow artifact id, no schema change, no configuration, no wire change.
+
+## What gets built
+
+1. The API can mint, upsert, and sign an **agent mount**: a mount row with `session_id`
+   NULL whose slug derives from the workflow artifact id.
+2. The runner mounts it into every run of that agent, next to the session cwd, local and
+   Daytona, and tells the harness where it is.
+3. The frontend can look the mount up by artifact id and browse its files with the
+   existing mount file browser.
+
+No database migration. No `/run` protocol change (`runContext.workflow.artifact.id` is
+already on the wire). No agent template change.
+
+## Design decisions
+
+### D1. Slug shape: readable keyword form (recommended)
+
+Session slugs hash the id: `__ag__<uuid5(ns, session_id)>__<name>`. For agent mounts:
+
+| Option | Shape | Trade-off |
+|---|---|---|
+| (a) Hash, like sessions | `__ag__<uuid5(ns, "agent:" + artifact_id)>__<key>` | Symmetric with sessions. One-way: given a mount row you can never tell which agent owns it. |
+| (b) Readable keyword (recommended) | `__ag__agent__<artifact_id>__<key>` | Reverse lookup and "all agent mounts" scans become string operations. Trivially collision-proof against session slugs (the `agent` keyword). Slightly asymmetric with session slugs. |
+
+Recommendation: **(b)**. JP's voice note already suggested a keyword, and readability buys
+back two of the three accepted limitations (reverse lookup, listing) for free. The
+`reject_reserved_slug` guard already stops users from forging either form.
+
+The readable form has one hard requirement the hash form does not: every minted slug
+passes the `URL_SAFE_SLUG` validator (research.md, "The slug validator"), and a raw
+non-UUID string would fail it as a 500 inside the service. So **`artifact_id` must parse
+as a UUID and is canonicalized to its lowercase form before minting**, on the sign path
+and the query path alike; the two derivations must be byte-identical or the frontend
+query silently misses an existing mount. A value that does not parse as a UUID is
+rejected with a 422.
+
+The key (the `name` slot) starts as the literal `"default"`. One agent, one key, one mount;
+more keys are possible later without any change to this design.
+
+### D2. API surface: mirror the session-mounts shape
+
+Two new endpoints on the mounts domain, both thin wrappers over existing service parts:
+
+```
+POST /mounts/agents/sign?artifact_id=<uuid>&name=default     permission: RUN_SESSIONS
+POST /mounts/agents/query   {"artifact_id": "<uuid>"}        permission: VIEW_SESSIONS
+```
+
+- `sign` mints the slug, upserts (`get_or_create_agent_mount`, the exact analogue of
+  `get_or_create_session_mount`), and signs prefix-scoped credentials. Same
+  upsert-then-sign semantics as `POST /sessions/mounts/sign`, which the runner already
+  uses; the runner treats both as best-effort.
+- `query` mints the slug and fetches by `(project_id, slug)`; returns the mount row or an
+  empty list. **It does not create.** A read path that upserts would materialize mount rows
+  for every agent anyone ever looks at; the frontend shows "no files yet" instead. Needs
+  one new DAO helper, `fetch_mount_by_slug` (the unique index already exists).
+- `artifact_id` must parse as a UUID (422 otherwise; see D1), but there is no existence
+  check beyond that, matching the session endpoints (session ids are not validated
+  either; they may be external). Project scoping comes from auth: the mount lands in the
+  caller's project regardless of what id they name. A well-formed UUID that names no real
+  agent yields an unused empty mount in their own project; accepted.
+- Permissions reuse the `*_SESSIONS` family the whole mounts domain uses. The name reads
+  oddly for agent storage; renaming the permission family is out of scope.
+
+Interface-role check (design-interfaces): `artifact_id` is routing/identity (names which
+agent's storage), `name` is identity-within-owner (which of the agent's mounts), neither is
+data or config; both belong in the request as shown, nothing belongs in the agent config.
+
+Alternative rejected: a generalized `POST /mounts/sign?scope=agent|session&id=...`. Cleaner
+on paper, but it would deprecate the session endpoint the runner and #5197 just shipped
+against, for zero functional gain. Revisit if a third scope (project mounts) actually
+lands.
+
+### D3. Runner behavior
+
+- **When:** after the session cwd sign, on every run whose `runContext.workflow.artifact.id`
+  is present (drafts included; `is_draft` does not matter). Sessionless runs qualify: the
+  cwd stays ephemeral, the agent mount still attaches, the first time such runs keep
+  anything. Caveat: artifact-id presence is verified for playground runs only; whether
+  trigger, evaluation, and direct API runs populate `runContext` (and carry `RUN_SESSIONS`
+  on their credential) is a slice-1 verification task, and the sessionless benefit only
+  covers run types that pass it. Missing artifact id, missing store, or a failed sign:
+  log and continue without it, exactly like the #5197 transcript mounts.
+- **Where:** per-run mountpoint `<cwd>-agent` (sibling of the working directory, both
+  local and Daytona). The prefix is shared across runs of the agent; the mountpoint is
+  per-run, so concurrent runs of one agent each hold their own geesefs mount of the same
+  prefix and teardown stays per-run (the cwd unmount path already exists to copy).
+  Rejected: a fixed absolute path (collides across concurrent local runs of the same
+  agent) and a directory inside the cwd (a FUSE mount nested inside the durable cwd's FUSE
+  mount).
+- **Harness discovery:** one env var on the daemon env, `AGENTA_AGENT_MOUNT_DIR=<path>`,
+  set only when the mount is live. Follow-up (not this project): a line in the rendered
+  instructions file so the model knows the folder exists; the env-var-naming cleanup in
+  the runner-selfhosting-explainer notes applies to this name too.
+- **Keepalive interplay (#5197):** the mount lives and dies with the run environment;
+  `destroy({keepWarm})` keeps it, final destroy unmounts it. Same rule the durable cwd
+  follows; implementation must add the agent mountpoint to the same unmount bookkeeping.
+  Re-mount idempotency on a warm resumed sandbox needs explicit handling: local
+  `mountStorage` already skips a live mountpoint, but `mountStorageRemote` has no such
+  guard (research.md, "Re-mount guard asymmetry"), so the remote path must skip the mount
+  when the environment already holds it, whatever treatment the durable cwd gets on
+  resume.
+- **Concurrency property, documented not solved:** two live sessions of one agent share
+  the prefix; geesefs gives last-writer-wins per file, no locking. Acceptable for the
+  intended content (skills, notes, artifacts).
+
+### D4. Frontend
+
+Minimal slice: the SessionInspector's Mounts tab gains an "Agent files" panel. It calls
+`POST /mounts/agents/query` with the artifact id from the inspector's context and, when a
+mount comes back, renders `MountFilesPanel` with that mount id. `MountFilesPanel` is
+today a module-private const inside `MountsTab.tsx`, so the slice exports or extracts it;
+beyond that one move, no new file-browsing code (the panel, `deriveRows`, and the
+`fetchMountFiles*` API functions are already mount-id-generic; research.md §frontend).
+Empty result renders "no files yet". Where exactly the artifact id is available in the
+inspector's props is an implementation-time detail; if it is absent there, the panel
+moves to the agent page instead.
+
+## Slices (in dependency order: 2 and 3 both need 1)
+
+| # | Lane | Content | Tests |
+|---|---|---|---|
+| 1 | api | `mint_agent_slug` (with UUID canonicalization), `get_or_create_agent_mount`, `fetch_mount_by_slug`, the two endpoints; verify runContext + `RUN_SESSIONS` coverage per run type (playground, trigger, evaluation, API) | pytest: slug format + parse-back, non-UUID rejected 422, upsert idempotence (same row id twice), query returns row/empty and never creates, reserved-slug guard still rejects forged `__ag__agent__` slugs, permission checks |
+| 2 | runner | sign call with artifact id from runContext, `<cwd>-agent` mount local+remote, `AGENTA_AGENT_MOUNT_DIR`, teardown, keepalive + warm-resume idempotency | vitest: plan wiring (artifact id present/absent), path derivation, env var set only when mounted, unmount on final destroy, no re-mount on warm resume; wire-contract goldens untouched (asserts no protocol change) |
+| 3 | web | Agent files panel per D4 (includes exporting `MountFilesPanel`) | vitest for the lookup hook; manual e2e in QA |
+| 4 | docs | keep-docs-in-sync sweep: `documentation/` mounts page, runner-selfhosting-explainer, env reference | docs build |
+
+Slice 2 is safe to deploy even where slice 1 is not live yet: a 404 from
+`/mounts/agents/sign` is a failed best-effort sign, and the run proceeds without the
+mount. The live QA below needs both deployed together.
+
+Live QA (after slice 2): local and Daytona; agent writes a file into
+`$AGENTA_AGENT_MOUNT_DIR` in session A, session B of the same agent reads it back; a
+sessionless run writes and a later session reads; a different agent does not see it.
+
+## Open questions (comment on the PR)
+
+1. **D1 slug shape:** readable `__ag__agent__<artifact_id>__default` vs session-style
+   hash. Recommendation is readable; JP should confirm nothing depends on slugs being
+   opaque.
+2. **Endpoint placement:** `/mounts/agents/*` as specified, or hang the sign off the
+   sessions router's sibling for symmetry? Current shape keeps the sessions router
+   session-only.
+3. **Mount point:** `<cwd>-agent` and the `AGENTA_AGENT_MOUNT_DIR` name. Better ideas
+   welcome; both are one-line constants.
+4. **Query semantics:** confirmed no-create-on-read?
+5. **Scope check:** slice 3 in this project, or hand the panel to the mount-file-viewer
+   work (draft PR #5204, the session file browser this panel builds on)?
+6. **Run-type coverage:** if the slice-1 verification finds that triggers/evaluations/API
+   runs do not populate `runContext.workflow.artifact.id`, do we fix their population in
+   this project or scope them out?

--- a/docs/design/agent-workflows/projects/agent-mounts/plan.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/plan.md
@@ -48,8 +48,8 @@ more keys are possible later without any change to this design.
 Two new endpoints on the mounts domain, both thin wrappers over existing service parts:
 
 ```
-POST /mounts/agents/sign?artifact_id=<uuid>&name=default     permission: RUN_SESSIONS
-POST /mounts/agents/query   {"artifact_id": "<uuid>"}        permission: VIEW_SESSIONS
+POST /mounts/agents/sign?artifact_id=<uuid>&name=default              permission: RUN_SESSIONS
+POST /mounts/agents/query   {"artifact_id": "<uuid>", "name": "default"}  permission: VIEW_SESSIONS
 ```
 
 - `sign` mints the slug, upserts (`get_or_create_agent_mount`, the exact analogue of
@@ -59,7 +59,11 @@ POST /mounts/agents/query   {"artifact_id": "<uuid>"}        permission: VIEW_SE
 - `query` mints the slug and fetches by `(project_id, slug)`; returns the mount row or an
   empty list. **It does not create.** A read path that upserts would materialize mount rows
   for every agent anyone ever looks at; the frontend shows "no files yet" instead. Needs
-  one new DAO helper, `fetch_mount_by_slug` (the unique index already exists).
+  one new DAO helper, `fetch_mount_by_slug` (the unique index already exists). Review
+  round 2026-07-11 added two read-path rules: the query body carries an optional `name`
+  (default `"default"`) so sign and query stay capability-symmetric (a mount signed under
+  another key must be reachable), and an archived mount reads as absent (matching the
+  sibling `POST /mounts/query` default; the next sign resurrects it).
 - `artifact_id` must parse as a UUID (422 otherwise; see D1), but there is no existence
   check beyond that, matching the session endpoints (session ids are not validated
   either; they may be external). Project scoping comes from auth: the mount lands in the
@@ -109,11 +113,15 @@ lands.
      mounts are up. Listing the working directory is the one discovery action every
      harness performs, and the link shows up there. This does not reintroduce the
      rejected dir-inside-cwd option: that rejection was about nesting a FUSE mount inside
-     a FUSE mount; a symlink is a pointer, not a mount. Caveat: the session cwd is itself
-     geesefs, so creating the link needs geesefs symlink support on the pinned version —
-     a slice-2 verification task. Failure to create it is logged and non-fatal (env var
-     and README still stand); the ephemeral sessionless cwd is a plain local dir where
-     symlinks trivially work.
+     a FUSE mount; a symlink is a pointer, not a mount. Verified (slice-2 live QA,
+     2026-07-12): geesefs accepts symlink creation while the mount is live, but does not
+     persist a symlink across unmount and remount. The link degrades to a 0-byte regular
+     file, and silently, since the `symlink` call itself never errors. So `linkAgentFiles`
+     is self-healing: each run it keeps a correct-target symlink and replaces a degraded or
+     wrong-target node, so the agent gets a working link for that run's session. The env var
+     and README are the durable discovery mechanisms; the symlink is a per-run convenience
+     rebuilt at mount. The ephemeral sessionless cwd is a plain local dir where symlinks
+     persist normally.
   3. A **seeded `README.md` in the agent mount**, written by the runner after mount only
      when absent: files here persist across all sessions and runs of this agent; the
      working directory persists only for the current session (or not at all, sessionless).
@@ -143,7 +151,10 @@ lands.
 Minimal slice: the SessionInspector's Mounts tab gains an "Agent files" panel. It calls
 `POST /mounts/agents/query` with the artifact id from the inspector's context and, when a
 mount comes back, renders `MountFilesPanel` with that mount id. `MountFilesPanel` is
-today a module-private const inside `MountsTab.tsx`, so the slice exports or extracts it;
+today a module-private const inside `MountsTab.tsx` (drift note 2026-07-11: the file
+moved to `web/oss/src/components/SessionInspector/tabs/MountsTab.tsx` on the applied
+`feat/mount-file-viewer` lane, #5204; the implementation lane stacks on it), so the
+slice exports or extracts it;
 beyond that one move, no new file-browsing code (the panel, `deriveRows`, and the
 `fetchMountFiles*` API functions are already mount-id-generic; research.md §frontend).
 Empty result renders "no files yet". Where exactly the artifact id is available in the
@@ -155,7 +166,7 @@ moves to the agent page instead.
 | # | Lane | Content | Tests |
 |---|---|---|---|
 | 1 | api | `mint_agent_slug` (with UUID canonicalization), `get_or_create_agent_mount`, `fetch_mount_by_slug`, the two endpoints; verify runContext + `RUN_SESSIONS` coverage per run type (playground, trigger, evaluation, API) | pytest: slug format + parse-back, non-UUID rejected 422, upsert idempotence (same row id twice), query returns row/empty and never creates, reserved-slug guard still rejects forged `__ag__agent__` slugs, permission checks |
-| 2 | runner | sign call with artifact id from runContext, `<cwd>-agent` mount local+remote, `AGENTA_AGENT_MOUNT_DIR`, `agent-files` symlink in cwd (verify geesefs symlink support first), seeded README (write-if-absent), teardown, keepalive + warm-resume idempotency | vitest: plan wiring (artifact id present/absent), path derivation, env var set only when mounted, symlink created best-effort and skipped when present, README seeded only when absent, unmount on final destroy, no re-mount on warm resume; wire-contract goldens untouched (asserts no protocol change) |
+| 2 | runner | sign call with artifact id from runContext, `<cwd>-agent` mount local+remote, `AGENTA_AGENT_MOUNT_DIR`, self-healing `agent-files` symlink in cwd (geesefs drops symlinks across remount, so it is rebuilt each run), seeded README (write-if-absent), teardown, keepalive + warm-resume idempotency | vitest: plan wiring (artifact id present/absent), path derivation, env var set only when mounted, symlink kept when correct and replaced when degraded or wrong-target, README seeded only when absent, unmount on final destroy, no re-mount on warm resume; wire-contract goldens untouched (asserts no protocol change) |
 | 3 | web | Agent files panel per D4 (includes exporting `MountFilesPanel`) | vitest for the lookup hook; manual e2e in QA |
 | 4 | docs | keep-docs-in-sync sweep: `documentation/` mounts page, runner-selfhosting-explainer, env reference | docs build |
 

--- a/docs/design/agent-workflows/projects/agent-mounts/research.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/research.md
@@ -123,10 +123,41 @@ pre-rendered `harnessFiles`, and prior-turn session files. Sibling directories (
 scratch, transcript mounts) and the daemon env are effectively invisible — neither Pi nor
 Claude lists the parent directory or dumps `env` unprompted.
 
-Unverified, slice-2 verification task: whether the pinned geesefs version supports
-creating symlinks (the session cwd is a geesefs mount, and the planned `agent-files`
-symlink lives inside it). The sessionless ephemeral cwd is a plain local directory where
-symlinks work unconditionally.
+Verified (slice-2 live QA, 2026-07-12): the pinned geesefs version accepts symlink
+creation inside a live mount, but does not persist the symlink across unmount and remount.
+The link degrades to a 0-byte regular file, and silently, because the `symlink` call itself
+succeeds. `linkAgentFiles` is therefore self-healing: each run it keeps a correct-target
+symlink and replaces a degraded or wrong-target node, so the agent gets a working link for
+that run's session. The env var and README carry the durable discovery signal. The
+sessionless ephemeral cwd is a plain local directory where symlinks persist unconditionally.
+
+## Run-type coverage (slice-1 verification, done 2026-07-11)
+
+The runner's mount-sign callback authenticates as the invoke caller: the SDK re-emits the
+caller's credential as the OTLP `authorization` header (`sdks/python/agenta/sdk/agents/tracing.py:71`),
+the runner reads it back (`services/runner/src/engines/sandbox_agent.ts:172-178`) and signs
+with it. The credential is a Secret JWT carrying only user/project
+(`api/oss/src/middlewares/auth.py:916-945`); RUN_SESSIONS resolves from that user's RBAC
+role at callback time — EDITOR and above (`api/oss/src/core/access/permissions/types.py:218`).
+
+Per run type:
+
+- **Playground**: artifact id verified present; RUN_SESSIONS iff the user is editor+.
+- **Trigger**: references forwarded from the subscription entity; a dispatch with no
+  workflow/application ref aborts with 400 before invoke
+  (`api/oss/src/tasks/asyncio/triggers/dispatcher.py:224-266`), so runs that reach the
+  runner carry the artifact id. Acting user = `subscription.created_by_id`; a
+  viewer-created trigger fails the sign with 403 → best-effort, run proceeds mountless.
+- **Evaluation**: refs come from the evaluation step (`runtime/adapters.py:504-607`);
+  present when the step targets a workflow/application/evaluator artifact (the normal
+  case). Acting user = the evaluation run's user.
+- **Direct API**: whatever the caller/interaction supplies as references
+  (`sessions/router.py:854-869`); the session endpoints are RUN_SESSIONS-gated anyway.
+- **Local standalone SDK**: no runner path today (`adapters/local.py:34-53` is
+  NotImplemented); out of scope.
+
+Consequence for open question 6: nothing to fix in reference population; degradation is
+graceful (missing id or 403 = no agent mount, run unaffected).
 
 ## Concurrency fact to carry into the design
 

--- a/docs/design/agent-workflows/projects/agent-mounts/research.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/research.md
@@ -1,0 +1,114 @@
+# Research: what exists, with pointers
+
+Facts gathered from the working tree (2026-07-11, with #5197 session-continuity applied).
+Only the facts that drive design decisions; the general mount model is summarized in
+`context.md`.
+
+## The slug mechanism agent mounts will reuse
+
+- Reserved prefix: `_RESERVED_SLUG_PREFIX = "__ag__"`
+  (`api/oss/src/core/mounts/service.py:34`). `reject_reserved_slug` (service.py:76) blocks
+  callers of `POST /mounts/` from authoring slugs in this namespace; only the service mints
+  them.
+- Session slug minting (`mint_session_slug`, service.py:66):
+  `f"__ag__{uuid5(_MOUNTS_NAMESPACE, session_id)}__{slugify_mount_name(name)}"` where
+  `_MOUNTS_NAMESPACE = uuid5(uuid5(NAMESPACE_DNS, "agenta"), "mounts")` (service.py:39).
+- Upsert (`get_or_create_session_mount`, service.py:161 → `upsert_mount`,
+  `api/oss/src/dbs/postgres/mounts/dao.py:60`): `INSERT ... ON CONFLICT
+  uq_mounts_project_id_slug DO UPDATE` touching only audit fields and clearing archive.
+  Re-binding keeps the original row id, and therefore the durable prefix.
+- Storage key (`_storage_key`, service.py:114): `[namespace/]mounts/<project_id>/<mount_id>/
+  <path>`. The prefix uses the mount row's UUID, not the slug, so slugs can change without
+  moving bytes. Signed credentials scope to that prefix; the TTL constant
+  `_CREDENTIALS_TTL_SECONDS = 3600` (service.py:46) is applied in
+  `sign_mount_credentials` (service.py:304).
+
+## The slug validator (load-bearing for the readable-slug decision)
+
+`MountCreate` inherits `Slug` (`api/oss/src/core/mounts/dtos.py:36`), whose
+`check_url_safety` enforces `URL_SAFE_SLUG = r"^[a-zA-Z0-9_\-][a-zA-Z0-9_.\-]*$"`
+(`sdks/python/agenta/sdk/models/shared.py:74,110-118`). Every minted slug passes through
+it. Session slugs are safe by construction (uuid5 output is URL-safe; the name is
+slugified). A readable agent slug that splices in a RAW artifact id is only safe if the id
+is first canonicalized to a UUID: a non-UUID string with a space or slash would fail the
+validator inside the service as an uncaught pydantic `ValidationError` (the
+`handle_mount_exceptions` decorator does not catch it), surfacing as a 500. The design
+therefore requires parsing `artifact_id` as a UUID and lowercasing it before minting, on
+both the sign and the query paths, so the two derivations are byte-identical.
+
+## The table
+
+`MountDBE` (`api/oss/src/dbs/postgres/mounts/dbes.py`): PK `(project_id, id)`; the sole
+uniqueness is `uq_mounts_project_id_slug` on `(project_id, slug)`; `session_id` is a bare
+nullable String column, not an FK (dbas.py:29), with a partial index where
+`session_id IS NOT NULL`. **There is no artifact/agent/workflow column anywhere** (DBE,
+DTO, mappings all checked). This confirms the chosen mechanism needs no schema change.
+
+## The agent identity is already on the wire
+
+- `AgentRunRequest.runContext.workflow.artifact.id` exists today
+  (`services/runner/src/protocol.ts:390,504`; `RunContext` shape at lines 156-208).
+  `runContext` carries `run`, `project.id` (added by commit `661cbc076f`, "stamp the
+  project scope into runContext"), `workflow.{artifact,variant,revision,is_draft}`,
+  `trace`.
+- The Python side assembles it from ambient tracing context:
+  `sdks/python/agenta/sdk/agents/tracing.py:136-167` maps reference families
+  (`workflow`/`application`/`evaluator` → `artifact`, etc.). Draft runs have an artifact
+  and `is_draft: true`; committed runs also carry `revision`.
+- Consequence: **no wire or golden-fixture change is needed.** The runner consumes a field
+  it already receives.
+- **Verified for playground runs only.** Whether trigger-driven, evaluation, and direct
+  API runs hydrate the tracing references (and therefore `workflow.artifact.id`) is
+  unverified, and so is whether their run credentials carry `RUN_SESSIONS`. Both must be
+  checked per run type during implementation; the plan carries this as a verification
+  task.
+
+## The runner plumbing to copy
+
+- `signSessionMountCredentials(sessionId, deps, name="cwd")`
+  (`services/runner/src/engines/sandbox_agent/mount.ts:63-126`) POSTs
+  `/sessions/mounts/sign?session_id=...&name=...`. A different `name` yields an additional
+  mount with its own prefix. Returns null on any failure; callers treat mounts as
+  best-effort.
+- geesefs mounting works at arbitrary paths: `mountStorage(path, creds)` local
+  (mount.ts:288), `mountStorageRemote(sandbox, path, creds)` remote (mount.ts:516). The
+  #5197 transcript mounts (`mountHarnessSessionDirs`, mount.ts:587) prove the
+  sign-with-name → mount-at-path pattern for non-cwd dirs; they are remote-only, additive,
+  and best-effort (one failed dir is logged and skipped).
+- Re-mount guard asymmetry: local `mountStorage` checks whether the path is already
+  mounted before mounting (`checkMounted`, mount.ts:302); remote `mountStorageRemote` has
+  no such guard. On a warm resumed sandbox (#5197), a second turn re-signs and would
+  re-run geesefs over a live mountpoint unless the implementation skips it.
+- cwd path constants (`sandbox_agent.ts:645-654`): local `/tmp/agenta/<prefix>`, Daytona
+  `/home/sandbox/agenta/<prefix>`; sign happens before plan build (sandbox_agent.ts:626).
+
+## The sign endpoint and permissions
+
+- Session sign: `POST /sessions/mounts/sign?session_id&name` (default `"cwd"`), permission
+  `RUN_SESSIONS` (`api/oss/src/apis/fastapi/sessions/router.py:919-927,1014-1051`); it
+  upserts then signs.
+- Generic per-mount routes exist (`/mounts/{id}`, `/mounts/{id}/sign`,
+  `/mounts/{id}/files*`), permissions VIEW/EDIT/RUN_SESSIONS
+  (`api/oss/src/apis/fastapi/mounts/router.py:115-232`).
+
+## The one real gap: discovery of a non-session mount
+
+`POST /mounts/query` filters ONLY on `session_id` and `include_archived` (`MountQuery`,
+`api/oss/src/core/mounts/dtos.py:50-52`; DAO `query_mounts`, dao.py:206). There is **no
+query-by-slug and no query-by-artifact**. The frontend can browse any mount's files given a
+`mount.id` (`GET /mounts/{mount_id}/files`, plus `?read=` and `/files/download`; see
+`web/oss/src/components/SessionInspector/api.ts:45-81`), but its only discovery path is
+`querySessionMounts(session_id)`. An agent mount therefore needs one new lookup (by
+artifact id) for the frontend. The reusable mount-id-generic units are `MountFilesPanel`
+(currently a module-private const in `MountsTab.tsx:187`; reuse means exporting or
+extracting it), `deriveRows`/`formatSize` in `mountBrowser.ts`, and the
+`fetchMountFiles*` functions in `api.ts:49-81`. `MountsTab` itself is session-scoped (it
+takes a `sessionId` and queries session mounts), so it is the integration point, not the
+reusable unit.
+
+## Concurrency fact to carry into the design
+
+Multiple live geesefs mounts of one prefix are possible (different mountpoints, same S3
+prefix). Writes are last-writer-wins per file with no locking. Two concurrent sessions of
+the same agent will share the agent mount; acceptable for the intended content (skills,
+notes, artifacts), documented as a known property.

--- a/docs/design/agent-workflows/projects/agent-mounts/research.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/research.md
@@ -106,6 +106,28 @@ extracting it), `deriveRows`/`formatSize` in `mountBrowser.ts`, and the
 takes a `sessionId` and queries session mounts), so it is the integration point, not the
 reusable unit.
 
+## The rendered instructions file (load-bearing for the discovery decision)
+
+What the harness reads as its instructions file (`AGENTS.md`, or `CLAUDE.md` for the
+claude harness; `prepareWorkspace`, `services/runner/src/engines/sandbox_agent/workspace.ts:53-54`)
+is the author's `agent.instructions` **verbatim** for `pi_core` and `claude`
+(`sdks/python/agenta/sdk/agents/adapters/harnesses.py:68,102`). Only `pi_agenta` composes
+a platform preamble in front of it (`compose_instructions`, harnesses.py:131 →
+`agenta_builtins.py:762`). Consequence: a platform-injected "you have an agent folder"
+line in the instructions would change the no-wrapping policy for two of the three
+harnesses; discovery that must not touch agent.md has to ride the filesystem or the env.
+
+What the agent sees in its workspace today: the cwd containing the instructions file,
+skill packages (`.claude/skills/<name>` for claude; Pi loads skills via its agent dir),
+pre-rendered `harnessFiles`, and prior-turn session files. Sibling directories (relay
+scratch, transcript mounts) and the daemon env are effectively invisible — neither Pi nor
+Claude lists the parent directory or dumps `env` unprompted.
+
+Unverified, slice-2 verification task: whether the pinned geesefs version supports
+creating symlinks (the session cwd is a geesefs mount, and the planned `agent-files`
+symlink lives inside it). The sessionless ephemeral cwd is a plain local directory where
+symlinks work unconditionally.
+
 ## Concurrency fact to carry into the design
 
 Multiple live geesefs mounts of one prefix are possible (different mountpoints, same S3

--- a/docs/design/agent-workflows/projects/agent-mounts/status.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/status.md
@@ -1,5 +1,10 @@
 # Status: agent mounts
 
+- **2026-07-11 (later)**: Review round with Mahmoud on discovery: the env var alone is
+  not discoverable, and agent.md must not change. D3 gains the `agent-files` symlink in
+  the cwd and the seeded README in the agent mount (write-if-absent); research.md gains
+  the verbatim-instructions fact that rules out a platform instructions line, and the
+  geesefs-symlink verification task. Implementation started (slices 1-3 in flight).
 - **2026-07-11**: Workspace created from the Mahmoud+JP conversation (JP's voice note
   settled the mechanism: reserved slug from the artifact id, no session_id, runner upserts
   at mount time, derived mount point). Docs went through one internal review round before
@@ -9,14 +14,16 @@
 
 ## Current state
 
-Design review. The six open questions at the end of `plan.md` need answers (slug shape,
-endpoint placement, mount point constant, query semantics, frontend slice ownership,
-run-type coverage); JP and Mahmoud comment on the PR.
+Design review + implementation in flight (Mahmoud approved starting 2026-07-11 evening).
+The six open questions at the end of `plan.md` still need JP's answers (slug shape,
+endpoint placement, mount point + visible names, query semantics, frontend slice
+ownership, run-type coverage); implementation follows the recommendations and adjusts if
+an answer lands differently.
 
 ## Next
 
-1. Resolve the open questions on the PR.
-2. Implement slice 1 (API) per `plan.md`.
+1. Land the implementation PR(s) for slices 1-3 per `plan.md`.
+2. Resolve the open questions on the design PR.
 
 ## Blockers
 

--- a/docs/design/agent-workflows/projects/agent-mounts/status.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/status.md
@@ -1,5 +1,22 @@
 # Status: agent mounts
 
+- **2026-07-12**: Slices 1-3 implemented, reviewed, and landed to the working tree. API
+  endpoints (sign + query) live-QA'd green against the EE dev stack (422 on non-UUID,
+  empty on unknown, roundtrip, idempotency, name-scoping, archived-absent); 36 unit +
+  4 acceptance tests. Runner: `agent-mount.ts` module + the `sandbox_agent.ts` runtime
+  wiring; a review pass caught one blocking bug (on Daytona the `AGENTA_AGENT_MOUNT_DIR`
+  env var never reached the daemon, whose env is fixed at sandbox-create from `piExtEnv`,
+  not the mutated local `env`) which was fixed by injecting the deterministic mount path
+  into `piExtEnv` before provider creation. Live QA settled the open geesefs-symlink
+  question: geesefs creates a symlink but does not persist it across remount (it degrades
+  to a 0-byte file), so `linkAgentFiles` is now self-healing per run; the env var and
+  README are the durable discovery mechanisms. 17 runner unit tests; full runner suite
+  regression-clean. Web: agent-files panel + artifact-id plumbing, unit-tested and
+  reviewed. Daytona verified live: an agent ran twice on Daytona (eu.preview key), and the
+  mount, README, symlink, cross-run persistence, and the `AGENTA_AGENT_MOUNT_DIR` reaching
+  the Daytona daemon all passed. Remaining notes live in `open-issues.md` (including an
+  unrelated EE-dev-runner snapshot-mapping bug found during that QA). PR: #5247, stacked on
+  `feat/mount-file-viewer`.
 - **2026-07-11 (later)**: Review round with Mahmoud on discovery: the env var alone is
   not discoverable, and agent.md must not change. D3 gains the `agent-files` symlink in
   the cwd and the seeded README in the agent mount (write-if-absent); research.md gains
@@ -14,16 +31,18 @@
 
 ## Current state
 
-Design review + implementation in flight (Mahmoud approved starting 2026-07-11 evening).
+Slices 1-3 implemented, reviewed, QA'd, and on a stacked PR (base `feat/mount-file-viewer`).
 The six open questions at the end of `plan.md` still need JP's answers (slug shape,
 endpoint placement, mount point + visible names, query semantics, frontend slice
-ownership, run-type coverage); implementation follows the recommendations and adjusts if
-an answer lands differently.
+ownership, run-type coverage); the implementation follows the recommendations and can
+adjust if an answer lands differently. Two naming choices (`agent-files` link name, README
+wording) are worth a second look from JP.
 
 ## Next
 
-1. Land the implementation PR(s) for slices 1-3 per `plan.md`.
-2. Resolve the open questions on the design PR.
+1. Review + merge the implementation PR (stacked on #5204).
+2. Resolve the open questions on the design PR #5215.
+3. Work the `open-issues.md` list (notably the full-agent-run + Daytona live QA cell).
 
 ## Blockers
 

--- a/docs/design/agent-workflows/projects/agent-mounts/status.md
+++ b/docs/design/agent-workflows/projects/agent-mounts/status.md
@@ -1,0 +1,24 @@
+# Status: agent mounts
+
+- **2026-07-11**: Workspace created from the Mahmoud+JP conversation (JP's voice note
+  settled the mechanism: reserved slug from the artifact id, no session_id, runner upserts
+  at mount time, derived mount point). Docs went through one internal review round before
+  the PR: reconciled the mount-point wording, added the UUID-canonicalization requirement
+  the slug validator forces, and scoped the sessionless claim to verified run types.
+  Nothing implemented yet.
+
+## Current state
+
+Design review. The six open questions at the end of `plan.md` need answers (slug shape,
+endpoint placement, mount point constant, query semantics, frontend slice ownership,
+run-type coverage); JP and Mahmoud comment on the PR.
+
+## Next
+
+1. Resolve the open questions on the PR.
+2. Implement slice 1 (API) per `plan.md`.
+
+## Blockers
+
+None. The design depends on #5197's transcript-mount pattern, which is applied to the
+working tree; if #5197 changes shape before merge, revisit the runner slice only.


### PR DESCRIPTION
Today an agent has no storage of its own: every run's files live in the session's mount (or an ephemeral temp dir for sessionless runs) and are invisible to the agent's other conversations. After this project, every agent has one durable folder, mounted into all of its runs next to the session cwd, browsable from the frontend.

This PR is the design workspace, no code. It captures the mechanism JP settled in his voice note (2026-07-11) plus the review that sharpened it:

- **Identity by reserved slug, not schema.** Same trick session mounts already use: the slug is minted deterministically (`__ag__agent__<artifact_id>__default`), upserted on the existing `unique(project_id, slug)` constraint, `session_id` stays NULL. No migration, no new column, no uniqueness machinery.
- **No wire change.** The runner already receives `runContext.workflow.artifact.id`; it signs the agent mount best-effort and mounts it at `<cwd>-agent`, local and Daytona, exposing the path via one env var.
- **Two thin endpoints** mirror the session shape: `POST /mounts/agents/sign` (runner) and `POST /mounts/agents/query` (frontend lookup; read never creates). The frontend reuses the existing mount file browser.
- **Deliberate limitations** (no reverse lookup machinery, no FK/cascade, shared-prefix last-writer-wins) are documented in context.md with the graduation path if they ever start to matter.

How to review: `plan.md` is the document to comment on; it ends with six open questions (slug shape, endpoint placement, mount point constant, query semantics, frontend slice ownership, run-type coverage). `context.md` holds the why and the rejected alternatives; `research.md` the code facts with file:line pointers.

Depends on nothing; builds on the transcript-mounts pattern from #5197 (applied to the tree, unmerged), so the runner slice tracks that PR's final shape.

https://claude.ai/code/session_01QHXdTFZjipBCPX3PkeWbh6
