### PR TITLE
docs(agent-workflows): plan model thinking effort

### DIFF
--- a/docs/design/agent-workflows/projects/agent-thinking-effort/README.md
+++ b/docs/design/agent-workflows/projects/agent-thinking-effort/README.md
@@ -1,0 +1,54 @@
+# Agent thinking effort
+
+Status: proposed for review
+
+This project adds an author-facing model effort control to agent templates and carries it through the Python SDK, `/run` wire contract, runner, Pi, Claude, and playground UI.
+
+The proposed template shape is:
+
+```json
+{
+  "agent": {
+    "llm": {
+      "model": "sonnet",
+      "reasoning": {
+        "effort": "high"
+      }
+    }
+  }
+}
+```
+
+The central recommendation is to treat effort as model configuration, not as harness configuration or an adapter-specific setting. Both Pi and the upgraded Claude ACP adapter expose effort through ACP's `thought_level` category, so the runner can use one semantic field and one runtime operation while still validating each model's supported values.
+
+## Proposed decisions
+
+1. Use `parameters.agent.llm.reasoning.effort` as the stored author contract.
+2. Accept `default`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max` as the schema-level union.
+3. Omit the wire field for `default`; the runner treats omission as a deterministic reset.
+4. Reject unsupported explicit values before prompting. List allowed values when the adapter exposes an exact set; otherwise report the requested and adapter-reported values. Never silently clamp or downgrade an author's choice.
+5. Read legacy `llm.extras.reasoning_effort` when the new field is absent, normalize legacy `none` to `off`, and prefer the new field when both exist.
+6. Apply model first, then effort, and read the value back before prompting.
+7. Place the UI control directly below Model in the existing Model accordion.
+
+## Review questions
+
+- Should the public union include `max` now, even though Pi ACP 0.0.29 does not advertise it yet? This plan says yes, with strict runtime capability validation.
+- Should Pi's deterministic `default` map to its built-in `medium`? This plan says yes to prevent a previous session's persisted setting from leaking.
+- Should the UI initially show the full union with runtime validation, or wait for a runner capability endpoint that can filter per model? This plan recommends the full union plus always-present model-support guidance for explicit values in v1.
+- Is the proposed legacy fallback window sufficient, or should we also write a migration job for stored revisions? This plan recommends read compatibility only.
+
+## Documents
+
+- [Context](context.md)
+- [Research](research.md)
+- [Technical design](design.md)
+- [Implementation plan](plan.md)
+- [QA plan](qa.md)
+- [Status](status.md)
+
+## Related delivery
+
+- Claude ACP adapter upgrade: [PR #5213](https://github.com/Agenta-AI/agenta/pull/5213)
+- Upstream Claude effort support landed in [claude-agent-acp PR #464](https://github.com/agentclientprotocol/claude-agent-acp/pull/464).
+

--- a/docs/design/agent-workflows/projects/agent-thinking-effort/context.md
+++ b/docs/design/agent-workflows/projects/agent-thinking-effort/context.md
@@ -1,0 +1,52 @@
+# Context
+
+## Problem
+
+Authors can choose a model in an agent template, but they cannot reliably choose how much that model should reason. The current schema allows arbitrary `llm.extras`, and examples mention `reasoning_effort`, but that value stops before the runner. The harness adapters pass only a model string and the `/run` request has no effort field.
+
+That creates three confusing states:
+
+- a template can store `llm.extras.reasoning_effort` without changing execution;
+- Pi and Claude Code each have native effort controls outside Agenta, but those settings are global or project-scoped rather than revision-scoped;
+- the old Claude ACP adapter did not expose effort even though the current adapter does.
+
+## What users can do without Agenta support
+
+Pi does not need an extension for this. It reads `defaultThinkingLevel` from `~/.pi/agent/settings.json` or `.pi/settings.json`, and its session API can set the thinking level directly. The limitation is ownership: those files configure a user or project, not one immutable Agenta agent revision.
+
+Claude Code supports `/effort`, the `--effort` flag, `CLAUDE_CODE_EFFORT_LEVEL`, `effortLevel` in settings, and skill or subagent frontmatter. Its documented precedence puts the environment variable above configured session settings. These are useful local overrides, but placing Agenta's revision-level intent in `~/.claude/settings.json` would make agents interfere with one another and would not work consistently across sidecars and remote sandboxes.
+
+References:
+
+- [Claude Code model configuration](https://code.claude.com/docs/en/model-config)
+- [Claude Code settings scopes](https://code.claude.com/docs/en/settings)
+- [Pi settings](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/settings.md)
+
+## Goals
+
+- Let template authors persist an effort choice with the model configuration.
+- Give UI authors a clear Model default option and named effort levels.
+- Preserve one semantic contract across Pi and Claude.
+- Validate against the active model after model selection.
+- Reset effort deterministically when a template removes an override.
+- Preserve warm-session and durable-session behavior when effort changes.
+- Keep legacy stored revisions readable.
+
+## Non-goals
+
+- Define a universal token budget for each effort name.
+- Promise every effort value on every model.
+- Add a Pi extension solely for effort.
+- Configure user-level Pi or Claude files from the Agenta UI.
+- Upgrade the Claude adapter baked into the Daytona image as part of the template feature.
+- Add a live per-model capability endpoint in the first implementation unless static UI validation proves too confusing.
+
+## Success criteria
+
+An author can save an effort in the template, see it in the UI, run the revision through Pi or Claude, and get either:
+
+- an adapter-reported value that exactly matches the explicit request, with separate provider-precedence QA before calling it provider-effective; or
+- a clear pre-prompt error that names the unsupported value and lists exact values when the adapter exposes them, or reports the requested and clamped values when it does not.
+
+Removing the override must restore deterministic defaults instead of inheriting the prior run.s effort. This intentionally changes behavior for old producers whose requests omit effort: after the runner feature ships, omission becomes an active reset instead of doing nothing.
+

--- a/docs/design/agent-workflows/projects/agent-thinking-effort/design.md
+++ b/docs/design/agent-workflows/projects/agent-thinking-effort/design.md
@@ -1,0 +1,199 @@
+# Technical design
+
+## Author contract
+
+Add an optional reasoning object to the agent's LLM configuration:
+
+```json
+{
+  "agent": {
+    "llm": {
+      "model": "openai-codex/gpt-5.5",
+      "reasoning": {
+        "effort": "high"
+      }
+    }
+  }
+}
+```
+
+Schema:
+
+```text
+ReasoningEffort = default | off | minimal | low | medium | high | xhigh | max
+LlmReasoning = { effort?: ReasoningEffort }
+```
+
+Omission and `default` have the same author meaning: use Agenta's deterministic model default. The UI stores omission for Model default so existing revisions and default golden payloads remain unchanged.
+
+The union is intentionally broader than any single model. Support is resolved from the selected session after applying the model.
+
+## Legacy compatibility
+
+Resolution order:
+
+1. `agent.llm.reasoning.effort`
+2. `agent.llm.extras.reasoning_effort`
+3. `default`
+
+Normalize legacy `none` to `off`. Emit a deprecation warning when the legacy path is used. Preserve the original extras object when reading or editing a revision. Do not mutate historical revisions or write a migration on read.
+
+The new field always wins if both are present. A malformed new field fails schema validation even when a valid legacy field exists.
+
+## Wire contract
+
+Add an optional grouped field to `/run`:
+
+```json
+{
+  "reasoning": {
+    "effort": "high"
+  }
+}
+```
+
+The Python serializer omits `reasoning` for default. The Python wire model and TypeScript protocol describe the same literal union. They do not currently provide end-to-end runtime strictness: the Python `_WireModel` allows extra fields, TypeScript types disappear at runtime, and the runner does not validate incoming JSON against a runtime schema.
+
+The runtime DTO parser must validate the first-class literal independently of the catalog schema so direct invocation cannot bypass validation. Runtime rejection of unrelated unknown wire keys is outside this feature's scope unless the implementation deliberately adds a request validator.
+
+Capability negotiation:
+
+- HTTP sidecars expose `features.reasoningEffort: 1` from `GET /health`.
+- Subprocess runners expose the same `runnerInfo` payload through a new `--info` command without reading a run request or starting a harness.
+- The Python backend caches a successful probe per backend instance.
+- An explicit effort fails closed before `/run` when the capability is missing, unknown, timed out, or unreachable.
+- Omission/default may continue through an old runner during rollout and retains that runner's legacy no-reset behavior.
+- This outer capability proves only that the runner knows the contract. It does not prove that a Daytona image's baked adapter supports a value; that remains runtime pre-prompt discovery.
+
+Propagation:
+
+| Source | Destination | Transformation |
+| --- | --- | --- |
+| Template `llm.reasoning.effort` | `AgentTemplate.reasoning_effort` | Parse literal; apply legacy fallback. |
+| `AgentTemplate` | `HarnessAgentTemplate` | Preserve semantic value for Pi and Claude. |
+| Harness adapter | `/run.reasoning.effort` | Omit default, send explicit values. |
+| Runner request | ACP session | Apply model, then call `setThoughtLevel`. |
+| ACP config options | validation/readback | Require category support and exact adapter-reported value. |
+
+Do not send arbitrary `llm.extras` to the runner. Only the normalized semantic field crosses the trust boundary.
+
+## Runner algorithm
+
+For every cold or native-resume acquisition:
+
+1. Create or resume the ACP session.
+2. Apply the requested model.
+3. Fetch config options after model selection.
+4. Resolve the effort option with category `thought_level`.
+5. Apply the normalized requested value or deterministic default.
+6. Fetch config options again and verify the adapter-reported `currentValue`.
+7. Prompt only after validation succeeds.
+
+Explicit values:
+
+- If no thought-level category exists, return an unsupported-effort error before prompting.
+- If the value is not advertised, return the requested value, model, and adapter-advertised values.
+- If the adapter accepts but clamps to a different value, fail rather than silently changing author intent.
+- Pi ACP 0.0.29 cannot list model-specific allowed values. A Pi clamp error therefore reports requested and adapter-reported values and explains that the adapter exposed no exact per-model list.
+
+Default:
+
+- Pi: request `medium`, its built-in default, to prevent global setting leakage. For default intent only, accept a model clamp and record the adapter-reported value.
+- Claude: set `default` when the adapter advertises it.
+- A model with no thought-level category: no-op for default only.
+
+The error shape should be stable enough for UI display when exact allowed values are available, for example:
+
+```text
+Effort 'xhigh' is not supported by model 'sonnet'. Allowed values: default, low, medium, high, max.
+```
+
+## Session continuity
+
+Add normalized reasoning configuration to `configFingerprint()` so a hot session is not reused under a different effort.
+
+A matching hot pooled environment bypasses acquisition and does not reapply model or effort. This is safe only when the fingerprint includes reasoning and therefore proves the requested effort is unchanged. A changed effort must miss or evict the hot entry, then follow the cold/native-resume algorithm above.
+
+Native session resume remains valid. Reapply model and effort on every acquire because:
+
+- model selection changes the adapter's advertised effort values;
+- stored sessions can outlive template edits;
+- default must reset an earlier explicit value.
+
+Reapplying configuration must not discard conversation history. A configuration error must occur before the next prompt and must not append a failed user turn.
+
+## Pi implementation
+
+Use the existing ACP method through `sandbox-agent`:
+
+```ts
+await session.setThoughtLevel(normalizedEffort)
+```
+
+No extension is necessary. The Pi extension remains responsible for Agenta tools, not model reasoning settings.
+
+Pi-specific work:
+
+- map default to `medium`;
+- validate against adapter config options and the selected model's readback;
+- detect clamping by reading `currentValue`; adapter 0.0.29 cannot provide an exact per-model allowed list;
+- decide whether to upgrade Pi ACP before enabling `max` successfully;
+- test two sequential sessions to prove a prior high value cannot leak into default.
+
+## Claude implementation
+
+PR #5213 provides the required local adapter version. The runner uses the same `setThoughtLevel()` call. Adapter 0.58.1 translates the ACP category to Claude SDK `effortLevel`.
+
+Claude-specific work:
+
+- always apply model before reading effort choices;
+- use adapter `default` to clear a prior override;
+- treat CLI settings and environment variables as operator precedence outside the template contract;
+- define operator precedence for `CLAUDE_CODE_EFFORT_LEVEL` and settings before claiming provider-effective effort;
+- test whether a higher-precedence operator source overrides the session flag even when ACP readback matches;
+- upgrade the Daytona image separately before enabling the feature there.
+
+## UI design
+
+Add an Effort row directly below Model in the existing Model accordion.
+
+Options:
+
+| Stored value | Label |
+| --- | --- |
+| omitted or `default` from API callers | Model default |
+| `off` | Off |
+| `minimal` | Minimal |
+| `low` | Low |
+| `medium` | Medium |
+| `high` | High |
+| `xhigh` | Extra high |
+| `max` | Maximum |
+
+V1 behavior:
+
+- Show the schema-level union.
+- Explain that availability depends on the selected model.
+- Preserve a saved value when the model or harness changes.
+- Show always-present guidance for every explicit value that support depends on the selected model. V1 cannot selectively identify an unsupported saved value.
+- Let runtime errors report the adapter's available evidence until a live per-model capability endpoint exists.
+
+Add pure helpers in `SchemaControls/connectionUtils.ts`:
+
+- `reasoningEffortFromConfig()` reads the first-class field and legacy fallback;
+- `composeReasoningEffort()` updates only `reasoning.effort`;
+- choosing Model default deletes `effort` and deletes `reasoning` only when the object is otherwise empty;
+- unknown `reasoning` keys, `extras`, connection data, and model data remain unchanged.
+
+## Observability
+
+Record these non-secret attributes on the run or chat span:
+
+- requested effort;
+- adapter-reported effort;
+- whether the adapter advertised the category.
+
+The Python/service layer may separately record whether normalization used the first-class, legacy, or default source. The runner cannot know that provenance because the proposed wire intentionally carries only normalized effort.
+
+Do not call `currentValue` provider-effective until precedence tests prove it. Do not record full config options or settings files. Log reset and mismatch errors with model and harness, but never credentials or environment contents.
+

--- a/docs/design/agent-workflows/projects/agent-thinking-effort/plan.md
+++ b/docs/design/agent-workflows/projects/agent-thinking-effort/plan.md
@@ -1,0 +1,149 @@
+# Implementation plan
+
+## Delivery shape
+
+Use a linear GitButler stack for implementation, with each PR based on the branch directly below it. Keep the already-open dependency PR separate because it can merge independently.
+
+### Dependency: Claude adapter
+
+PR: [#5213](https://github.com/Agenta-AI/agenta/pull/5213)
+
+Scope:
+
+- upgrade local Claude ACP adapter to 0.58.1;
+- maintain frozen pnpm resolution;
+- prove live ACP effort option and a normal Claude run.
+
+This does not upgrade Daytona.
+
+### Phase 1: contract and Python propagation
+
+Primary files:
+
+- `sdks/python/agenta/sdk/utils/types.py`
+- `sdks/python/agenta/sdk/agents/dtos.py`
+- `sdks/python/agenta/sdk/agents/adapters/harnesses.py`
+- `sdks/python/agenta/sdk/agents/utils/wire.py`
+- `sdks/python/agenta/sdk/agents/wire_models.py`
+- `sdks/python/agenta/sdk/agents/adapters/sandbox_agent.py`
+- `sdks/python/agenta/sdk/agents/utils/ts_runner.py`
+- Python schema, DTO, adapter, and golden wire tests
+
+Work:
+
+1. Add `LlmReasoning` and the effort literal union to the strict author schema.
+2. Parse and runtime-validate first-class effort with legacy extras fallback and `none` to `off` normalization, including direct invoke paths that bypass catalog schema validation.
+3. Add normalized reasoning effort to agent and harness DTOs.
+4. Add optional `/run.reasoning.effort` to both Python wire definitions.
+5. Omit the wire field for default.
+6. Preserve existing default golden files and add explicit-effort fixtures.
+7. Probe HTTP runners through `GET /health` and subprocess runners through a new `--info` command before emitting explicit reasoning. Cache success per backend instance.
+8. Fail closed before `/run` when explicit effort is requested and the capability is missing, unknown, or unreachable; omission/default may use an old runner with legacy no-reset behavior during rollout.
+
+Exit criteria:
+
+- author schema accepts every supported literal and rejects typos;
+- legacy values still execute through the normalized path;
+- Pi and Claude adapters emit the same wire field;
+- default requests remain byte-compatible;
+- HTTP and subprocess capability negotiation have success, missing, timeout, and fail-closed explicit-effort tests.
+
+### Phase 2: runner application and session semantics
+
+Primary files:
+
+- `services/runner/src/protocol.ts`
+- `services/runner/src/version.ts`
+- `services/runner/src/server.ts`
+- `services/runner/src/cli.ts`
+- new `services/runner/src/engines/sandbox_agent/reasoning.ts`
+- `services/runner/src/engines/sandbox_agent.ts`
+- `services/runner/src/engines/sandbox_agent/session-pool.ts`
+- `services/runner/src/tracing/otel.ts` or the selected chat-span tracing seam
+- runner unit and wire contract tests
+
+Work:
+
+1. Mirror the optional reasoning request shape.
+2. Implement category discovery, strict explicit-value validation, apply, and adapter readback.
+3. Apply effort immediately after model on create and resume.
+4. Implement deterministic Pi and Claude default resets.
+5. Add reasoning to the session configuration fingerprint.
+6. Add concise error messages and requested/adapter-reported trace attributes with focused tracing tests.
+7. Advertise `features.reasoningEffort: 1` in HTTP health and the subprocess `--info` response only when validation and application are present.
+
+Exit criteria:
+
+- model is always applied before effort;
+- explicit unsupported or clamped values fail before prompt, with exact allowed values only when the adapter exposes them;
+- default resets a prior explicit value;
+- resumed sessions retain history and reapply configuration;
+- changing only effort invalidates hot reuse;
+- HTTP health and subprocess info return the same capability shape.
+
+### Phase 3: UI control
+
+Primary files:
+
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx`
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts`
+- package unit tests near the existing model/harness tests
+
+Work:
+
+1. Add the Effort selector below Model.
+2. Implement parse and compose helpers that preserve unknown fields.
+3. Represent Model default as omission.
+4. Preserve explicit saved values across model/harness switches and show always-present model-support guidance.
+5. Add concise help text about model-dependent availability.
+
+Exit criteria:
+
+- all values round-trip;
+- selecting default removes only the effort override;
+- unrelated model, connection, extras, and future reasoning keys survive edits;
+- keyboard and screen-reader labeling match the existing model control.
+
+### Phase 4: image parity and end-to-end QA
+
+Work:
+
+1. Upgrade or rebuild the Daytona sandbox image with compatible Claude and Pi adapters.
+2. Run the matrix in `qa.md` locally and on Daytona.
+3. Add replay tests for stable live regressions.
+4. Update agent configuration and harness documentation.
+
+Exit criteria:
+
+- local and Daytona report the same adapter state and provider behavior for shared models;
+- no regression in permission gates, tools, cancellation, or continuity;
+- operator override precedence is documented.
+
+## Suggested PR stack
+
+1. `feat/agent-effort-contract`, base `big-agents`
+2. `feat/agent-effort-runner`, base `feat/agent-effort-contract`
+3. `feat/agent-effort-ui`, base `feat/agent-effort-runner`
+4. `test/agent-effort-qa`, base `feat/agent-effort-ui`
+
+Set each GitHub PR base to the branch below it even if independent file sets could be reviewed separately. This keeps the GitButler graph linear and each PR diff focused.
+
+## Rollout
+
+1. Merge adapter dependency PR.
+2. Add `reasoningEffort: 1` to runner health/capability metadata when the runner can validate and apply the field.
+3. Deploy the runner first. The service emits explicit `/run.reasoning` only after its configured runner reports that capability.
+4. Release the UI only after the service-to-runner capability gate is active.
+5. Do not use outer runner health to claim Daytona adapter support. After session creation, perform the same pre-prompt category/readback validation and keep Daytona parity unclaimed until the image matrix passes.
+6. Monitor unsupported-value errors and legacy fallback usage.
+7. Remove legacy read support only after stored-revision telemetry shows no remaining use.
+
+Default omission is not behavior-neutral even though its payload is byte-compatible. Once the new runner is deployed, old producers that omit reasoning cause an explicit Pi/Claude reset. Include that change in release notes and verify existing self-managed agents do not rely on inherited global effort.
+
+## Rollback
+
+- UI rollback: hide the control; stored fields remain forward-compatible.
+- Runner rollback: first disable the service capability gate so producers stop emitting explicit reasoning, then roll back the runner. An old runner otherwise ignores the unknown field silently.
+- Adapter rollback: pin the previous package only if a critical protocol regression appears; effort stays disabled for Claude until restored.
+- Daytona rollback: keep the feature disabled for that provider while local remains available.
+

--- a/docs/design/agent-workflows/projects/agent-thinking-effort/qa.md
+++ b/docs/design/agent-workflows/projects/agent-thinking-effort/qa.md
@@ -1,0 +1,118 @@
+# QA plan
+
+## Contract tests
+
+### Python
+
+- Accept every effort literal.
+- Reject unknown strings and non-string values.
+- Treat omission as default.
+- Prefer first-class effort over legacy extras.
+- Normalize legacy `none` to `off`.
+- Preserve arbitrary extras.
+- Propagate through Pi and Claude harness adapters.
+- Emit explicit effort on the wire and omit default.
+- Keep default golden requests unchanged.
+
+### TypeScript wire
+
+- Describe the same literal union as Python at compile time.
+- Pin the request key set in `wire-contract.test.ts`.
+- Add runtime DTO tests in the Python/service path because TypeScript types do not validate incoming JSON.
+- Do not claim unrelated unknown-key rejection unless this feature adds a runtime request validator.
+
+### Capability negotiation
+
+- HTTP health and subprocess `--info` expose the same `features.reasoningEffort` version.
+- Explicit effort proceeds only when capability version 1 is present.
+- Missing, malformed, timed-out, and unreachable probes fail closed before `/run` for explicit effort.
+- Probe results are cached per backend instance without crossing runner URLs or commands.
+- Omission/default may use an old runner during staged rollout and keeps legacy no-reset behavior there.
+- Outer capability never counts as Daytona adapter evidence; the session must still pass runtime category and readback checks.
+
+## Runner unit tests
+
+- Call order is create/resume, model, effort, prompt.
+- A supported explicit value is applied and read back.
+- Missing thought-level category fails for explicit effort.
+- Unsupported value lists the advertised values.
+- A clamped adapter-reported value fails for explicit intent.
+- Default requests Pi medium on a reasoning model; a default-only clamp is accepted and recorded.
+- Default maps to Claude default when advertised.
+- Default is a no-op only when no category exists.
+- A reasoning change changes the session fingerprint.
+- A resumed session reapplies effort without losing history.
+- Removing high resets the next turn to default.
+- No effort operation occurs before model selection.
+- Claude operator precedence is tested separately from ACP readback before the trace calls any value provider-effective.
+
+## UI unit tests
+
+- Read and write every option.
+- Model default deletes only `reasoning.effort`.
+- Empty reasoning objects are removed.
+- Non-empty future reasoning keys are preserved.
+- Extras, model, provider, and connection are preserved.
+- Legacy values display correctly without rewriting until the user edits.
+- Model/harness switches preserve a saved selection.
+- Always-present model-support guidance is accessible and does not block saving.
+
+## Live matrix
+
+Run locally first through the subscription sidecar, then repeat on Daytona only after its image is upgraded.
+
+| Harness | Model case | Effort | Expected |
+| --- | --- | --- | --- |
+| Pi | reasoning model | high | Config readback high; prompt succeeds. |
+| Pi | reasoning model supporting medium | default after high | Readback medium; no high leakage. |
+| Pi | model that clamps default medium | default | Clamp accepted as model default and adapter-reported value recorded. |
+| Pi | non-reasoning model | high | Clear pre-prompt unsupported error. |
+| Pi | model without max | max | Clear allowed-value error, no clamp. |
+| Claude | Sonnet or Opus | low | Readback low; prompt succeeds. |
+| Claude | model-specific unsupported level | explicit | Clear allowed-value error. |
+| Claude | default after high | default | Adapter readback reports default; provider behavior is verified separately. |
+| Both | warm second turn | same effort | History preserved and effort remains effective. |
+| Both | warm second turn | changed effort | New config applied before next prompt. |
+
+## Regression capabilities
+
+For both harnesses where supported:
+
+- text and thought event streaming;
+- HTTP MCP tool call;
+- allow, deny, and ask permission flows;
+- parked approval resume;
+- cancellation;
+- session resume/load;
+- usage aggregation;
+- process-tree cleanup.
+
+Claude needs an additional background Agent/subagent permission test because upstream issue #851 reports a possible permission-channel deadlock.
+
+## Adapter dependency evidence already collected
+
+- Frozen install from current `big-agents`: passed.
+- Runner typecheck: passed.
+- Focused ACP/model/provider tests: 44 passed.
+- Rebuilt local runner and Claude subscription sidecar: adapter 0.58.1 in both.
+- Live sidecar and app health: passed.
+- Claude Sonnet config: effort category found; low applied and read back.
+- Claude Sonnet normal run: returned `EFFORT-ADAPTER-OK`.
+
+The dependency PR's full suite reached 826 of 829 tests. The remaining permission microtask timing assertion and two Pi replay failures reproduce outside the focused dependency path and should be tracked separately if they remain on CI.
+
+## Acceptance evidence
+
+Capture for each live cell:
+
+- image and package versions;
+- harness and model;
+- requested and adapter-reported effort, plus separate provider-precedence evidence where available;
+- session id and whether it was cold, warm, or resumed;
+- exact prompt assertion;
+- relevant runner logs;
+- tool/permission result when exercised;
+- cleanup confirmation.
+
+Promote stable passing captures into agent replay tests where the ACP response can be safely redacted and replayed.
+

--- a/docs/design/agent-workflows/projects/agent-thinking-effort/research.md
+++ b/docs/design/agent-workflows/projects/agent-thinking-effort/research.md
@@ -1,0 +1,72 @@
+# Research
+
+Research date: 2026-07-11
+
+## Current Agenta path
+
+| Layer | Current location | Finding |
+| --- | --- | --- |
+| Author schema | `sdks/python/agenta/sdk/utils/types.py`, `_LlmSchema` | Supports model, provider, connection, and arbitrary extras; no first-class reasoning block. |
+| Template parsing | `sdks/python/agenta/sdk/agents/dtos.py`, `AgentTemplate.from_params()` | `llm.extras.reasoning_effort` reaches `ModelRef.extras`. |
+| Harness adapters | `sdks/python/agenta/sdk/agents/adapters/harnesses.py` | Pi and Claude pass the model but drop `ModelRef.extras`. |
+| Python wire | `sdks/python/agenta/sdk/agents/utils/wire.py` | `/run` serialization has no reasoning or effort field. |
+| Wire mirrors | `sdks/python/agenta/sdk/agents/wire_models.py`, `services/runner/src/protocol.ts` | Both descriptive models/types need the same optional field; neither provides complete live runtime validation today. |
+| Session setup | `services/runner/src/engines/sandbox_agent.ts` | Creates or resumes a session, then calls `applyModel()` before prompting. |
+| Session reuse | `services/runner/src/engines/sandbox_agent/session-pool.ts` | The configuration fingerprint omits reasoning, so an effort change would currently reuse the wrong hot session. |
+| UI | `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx` | Model and harness controls already share one accordion; no effort control exists. |
+| UI object helpers | `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts` | Existing composition preserves unknown keys and is the right home for pure reasoning helpers. |
+
+The existing DTO unit test in `sdks/python/oss/tests/pytest/unit/agents/test_dtos_agent_template.py` proves that legacy extras parse. It does not prove execution because the value is lost downstream.
+
+## ACP and harness findings
+
+### Claude
+
+The runner used deprecated `@zed-industries/claude-agent-acp` 0.23.1. PR #5213 upgrades local runner sessions to `@agentclientprotocol/claude-agent-acp` 0.58.1.
+
+The new adapter:
+
+- exposes config option id `effort`;
+- categorizes it as `thought_level`;
+- recomputes allowed values from the selected model;
+- applies it through the Claude Agent SDK's `effortLevel` flag settings.
+
+Live verification on the rebuilt local sidecar returned `default`, `low`, `medium`, `high`, `xhigh`, and `max` for Sonnet, accepted `low`, and read back `currentValue: low`.
+
+Claude Code also supports effort without ACP through `/effort`, `--effort`, `CLAUDE_CODE_EFFORT_LEVEL`, settings, and frontmatter. Those mechanisms should remain operator controls. They should not become the template storage contract.
+
+### Pi
+
+Pi core already supports session thinking levels and persists a selected level to `defaultThinkingLevel`. The installed Pi ACP 0.0.29 exposes ACP `thought_level` values `off`, `minimal`, `low`, `medium`, `high`, and `xhigh` as one adapter-wide list. It does not expose the selected model's exact support table. Model-specific incompatibility becomes visible only when Pi clamps and readback differs.
+
+No Pi extension is required. `sandbox-agent` 0.4.2 already provides `Session.setThoughtLevel()` and `Session.getConfigOptions()` for both adapters.
+
+Pi core has newer `max` support, but Pi ACP 0.0.29 does not advertise it. The contract can retain `max` as a cross-provider union if the runtime rejects it until the adapter supports it.
+
+### Default leakage
+
+Pi's session setter persists the chosen thinking level into its settings manager. If one agent explicitly runs at high and the next agent omits effort, doing nothing can inherit high. The runner therefore needs an explicit reset policy for omission/default.
+
+Claude also persists some CLI effort choices. The adapter's `default` option is the correct reset at the session layer when available.
+
+## Upstream status and risks
+
+- Current stable Claude adapter at research time: [0.58.1](https://github.com/agentclientprotocol/claude-agent-acp/releases/tag/v0.58.1).
+- Effort support: [PR #464](https://github.com/agentclientprotocol/claude-agent-acp/pull/464), released after 0.23.1.
+- Open permission/subagent risk: [issue #851](https://github.com/agentclientprotocol/claude-agent-acp/issues/851).
+- The runner's local `sandbox-agent` client uses an older ACP SDK than the new adapter. The live handshake and effort readback passed, but permissions, cancellation, resume, and subagent behavior still need the broader matrix.
+- Daytona uses the adapter baked into its sandbox image. Updating the runner package changes local sessions only.
+
+## Interface classification
+
+Effort is model behavior configuration:
+
+- owner: template author;
+- lifecycle: stored with a revision and stable across its runs;
+- sensitivity: non-secret;
+- wire role: execution configuration;
+- runtime mechanism: ACP thought-level category;
+- observability: requested and adapter-reported values should be logged or traced without credentials; provider-effective claims require separate precedence evidence.
+
+It is not policy, routing, credentials, metadata, or harness implementation detail. This is why it belongs under `llm.reasoning`, not `harness.extras`, `runner`, or Claude settings.
+

--- a/docs/design/agent-workflows/projects/agent-thinking-effort/status.md
+++ b/docs/design/agent-workflows/projects/agent-thinking-effort/status.md
@@ -1,0 +1,51 @@
+# Status
+
+Last updated: 2026-07-11
+
+## Current state
+
+Planning is complete and ready for morning review. No effort feature implementation has started.
+
+The local Claude adapter prerequisite is implemented and open for review in [PR #5213](https://github.com/Agenta-AI/agenta/pull/5213).
+
+## Completed
+
+- Read Codex onboarding and repo-specific runner, QA, hosting, interface, and GitButler guidance.
+- Audited current schema, DTO, adapter, wire, runner, session pool, and UI paths.
+- Checked current Claude and Pi configuration mechanisms outside Agenta.
+- Confirmed Pi does not need an extension for effort.
+- Confirmed `sandbox-agent` already exposes the common ACP thought-level API.
+- Upgraded and live-tested the local Claude adapter prerequisite.
+- Defined the author contract, legacy behavior, runtime order, default policy, UI behavior, implementation phases, rollout, and QA matrix.
+
+## Proposed decisions awaiting review
+
+| Decision | Proposal |
+| --- | --- |
+| Stored path | `parameters.agent.llm.reasoning.effort` |
+| Public values | `default`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
+| Default storage | Omit the field |
+| Pi default reset | `medium` |
+| Claude default reset | Adapter `default` |
+| Unsupported explicit value | Fail before prompt; list exact values only when the adapter exposes them |
+| Legacy extras | Read fallback; `none` to `off`; new field wins |
+| UI capability behavior | Show union in v1; preserve; always show model-support guidance |
+| Pi extension | Not required |
+| Runner negotiation | HTTP health plus subprocess `--info`; explicit effort fails closed without version 1 |
+| Daytona | Runtime pre-prompt adapter discovery plus separate image upgrade and QA |
+
+## Known risks
+
+- Pi ACP 0.0.29 does not advertise `max` even though newer Pi core supports it.
+- Pi ACP 0.0.29 advertises one adapter-wide level list, not exact per-model support.
+- Pi persists selected thinking level globally, so omission cannot mean do nothing.
+- Claude operator settings or environment variables can outrank session configuration even when ACP readback still matches the session request.
+- ACP `currentValue` proves adapter state, not necessarily provider-effective effort until precedence is tested.
+- The new Claude adapter and runner use different ACP SDK generations; the basic live path passed, but the full interaction matrix is still required.
+- Daytona remains on its image-baked adapter until separately upgraded; outer runner health cannot attest to that adapter.
+- Upstream Claude adapter issue #851 may affect background subagents with permission requests.
+
+## Next action after approval
+
+Start Phase 1 as `feat/agent-effort-contract`, then stack runner, UI, and QA PRs in the order defined in `plan.md`.
+


### PR DESCRIPTION
## Context

Agent templates can store `llm.extras.reasoning_effort`, but the value is dropped before `/run` and does not affect Pi or Claude execution. Both harnesses now have an ACP thought-level mechanism, while their standalone settings remain user or project scoped rather than revision scoped.

This design defines one author-facing effort contract and the changes needed across template schema, Python DTOs, wire transport, runner sessions, UI, adapter images, rollout, and QA.

## Changes

- Propose `parameters.agent.llm.reasoning.effort` with `default`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
- Define legacy fallback from `llm.extras.reasoning_effort`, including `none` to `off` normalization.
- Specify model-first ACP application, explicit-value clamp detection, deterministic defaults, hot-session fingerprinting, and native-resume behavior.
- Define Pi and Claude behavior separately where adapter capabilities differ.
- Place the UI control below Model and preserve unknown config fields.
- Add concrete HTTP health and subprocess `--info` capability negotiation so explicit effort fails closed against old runners.
- Treat Daytona adapter support as runtime pre-prompt discovery plus a separate image upgrade, not as an outer runner-health claim.
- Break implementation into contract, runner, UI, and parity/QA phases with a full test matrix and rollback order.

## Testing

- Reviewed current schema, DTO, harness adapter, wire, runner, session-pool, tracing, transport, and UI code paths.
- Checked current Claude Code and Pi configuration documentation.
- Cross-checked the plan against Claude ACP 0.58.1 live effort readback and the adapter upgrade in PR #5213.
- Ran two independent read-only design audits and resolved their blocking findings.
- Verified the remote branch is based on current `big-agents` and contains exactly the seven planning files.

## Notes

This is a draft for design review. The key choices to confirm are the public value union, Pi's deterministic default of `medium`, strict handling of explicit clamps, the v1 UI's broad option list, and read-only compatibility for legacy extras.

No effort feature code is implemented in this PR.
