### PR TITLE
docs(design): plan Daytona builtin-gate delivery fix (F-018)

### DIFF
--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/README.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/README.md
@@ -1,0 +1,39 @@
+# Daytona gate delivery (F-018)
+
+Plan to fix the Daytona builtin-gate hang. On a Daytona sandbox, every Pi builtin tool
+call (bash, read, and the rest) stalls until the 300s run-limits guard kills the turn.
+The gate the Pi extension raises inside the sandbox never round-trips to the runner over
+the remote transport, so the tool waits for an answer that never comes.
+
+This workspace is design only. It does not change code. It exists so a fixer can pick up
+F-018 cold, understand the mechanism, weigh the fix directions, and implement the
+recommended one.
+
+## Read in this order
+
+1. [context.md](context.md): what breaks, who it affects, goals and non-goals.
+2. [research.md](research.md): the exact code path and transport mechanics, grounded in
+   file and line references. Read this before proposing any change.
+3. [options.md](options.md): the three fix directions with honest trade-offs, and the
+   recommendation.
+4. [plan.md](plan.md): the phased implementation of the recommendation, including the
+   two new interface shapes reviewed by semantic role.
+5. [design-review.md](design-review.md): the independent critical review of the first
+   draft and how each finding was folded in.
+6. [status.md](status.md): current state, decisions, and open questions. This is the
+   source of truth for progress.
+
+## The finding
+
+The authoritative write-up is F-018 in
+[../qa/findings.md](../qa/findings.md). This workspace expands it into a plan.
+
+## Related work
+
+- [../approval-boundary/](../approval-boundary/): introduced builtin gating and the
+  approval model this fix must preserve.
+- [../qa/findings.md](../qa/findings.md): F-017 (the remote-mount fix that made chat work
+  on Daytona), F-020 (session resume recreates sandboxes), and F-018 itself.
+- The sandbox-agent fork plan (PR #5172) is the natural home for any change to the
+  vendored `sandbox-agent` transport, which option A in [options.md](options.md) would
+  need.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/README.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/README.md
@@ -1,39 +1,39 @@
 # Daytona gate delivery (F-018)
 
-Plan to fix the Daytona builtin-gate hang. On a Daytona sandbox, every Pi builtin tool
-call (bash, read, and the rest) stalls until the 300s run-limits guard kills the turn.
-The gate the Pi extension raises inside the sandbox never round-trips to the runner over
-the remote transport, so the tool waits for an answer that never comes.
+Plan to fix the Daytona Pi builtin-gate hang. The first draft blamed the Daytona preview
+proxy and proposed a second file-based permission channel. Review and follow-up research
+found a smaller, concrete cause: local runs use `pi-acp` 0.0.29, while the Daytona snapshot
+inherits 0.0.23. Version 0.0.23 predates the bridge from Pi extension dialogs to ACP
+`session/request_permission`, so the permission request is never created.
 
-This workspace is design only. It does not change code. It exists so a fixer can pick up
-F-018 cold, understand the mechanism, weigh the fix directions, and implement the
-recommended one.
+The revised plan makes adapter parity the correctness fix. It keeps the existing ACP
+permission plane for both local and Daytona, treats the file-gate design as a contingency
+only, and separates live approval continuation from cold replay.
+
+This workspace is design only. It does not change runner code or rebuild the snapshot.
 
 ## Read in this order
 
-1. [context.md](context.md): what breaks, who it affects, goals and non-goals.
-2. [research.md](research.md): the exact code path and transport mechanics, grounded in
-   file and line references. Read this before proposing any change.
-3. [options.md](options.md): the three fix directions with honest trade-offs, and the
-   recommendation.
-4. [plan.md](plan.md): the phased implementation of the recommendation, including the
-   two new interface shapes reviewed by semantic role.
-5. [design-review.md](design-review.md): the independent critical review of the first
-   draft and how each finding was folded in.
-6. [status.md](status.md): current state, decisions, and open questions. This is the
-   source of truth for progress.
+1. [context.md](context.md): the failure, impact, goals, and corrected mechanism.
+2. [research.md](research.md): the adapter version proof, the real preview-proxy and ACP
+   paths, lifecycle behavior, and harness scope.
+3. [options.md](options.md): the revised choices and recommendation.
+4. [plan.md](plan.md): the snapshot fix, verification, and fallback decision gate.
+5. [design-review.md](design-review.md): the review findings and how the revision answers
+   them.
+6. [status.md](status.md): current state, decisions, remaining validation, and next steps.
 
 ## The finding
 
-The authoritative write-up is F-018 in
-[../qa/findings.md](../qa/findings.md). This workspace expands it into a plan.
+F-018 in [../qa/findings.md](../qa/findings.md) records the live failure. This workspace
+corrects its initial transport diagnosis and turns it into an implementation plan.
 
 ## Related work
 
-- [../approval-boundary/](../approval-boundary/): introduced builtin gating and the
-  approval model this fix must preserve.
-- [../qa/findings.md](../qa/findings.md): F-017 (the remote-mount fix that made chat work
-  on Daytona), F-020 (session resume recreates sandboxes), and F-018 itself.
-- The sandbox-agent fork plan (PR #5172) is the natural home for any change to the
-  vendored `sandbox-agent` transport, which option A in [options.md](options.md) would
-  need.
+- [../approval-boundary/](../approval-boundary/): the builtin gate and durable approval
+  model this fix preserves.
+- [../warm-daytona-sessions/](../warm-daytona-sessions/): hot, warm, cold, and dead sandbox
+  lifecycle behavior.
+- [../qa/findings.md](../qa/findings.md): F-017, F-018, and F-020.
+- [../../../sandbox-agent-fork/](../../../sandbox-agent-fork/): longer-term ownership of
+  sandbox-agent packaging and dependency parity.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
@@ -2,65 +2,63 @@
 
 ## What breaks
 
-A tool-using agent on a Daytona sandbox hangs on its first tool call. Chat-only turns
-work. Any turn that calls a Pi builtin (bash, read, edit, write, grep, find, ls) stalls
-until the 300s run-limits guard kills it. The user sees no approval prompt and no result,
-just a long wait and then a failed turn.
+A Pi agent on Daytona hangs on its first builtin tool call. Chat-only turns work. A call
+to bash, read, edit, write, grep, find, or ls waits until the 300-second run limit kills
+the turn. The user sees no approval prompt and no tool result.
 
-The QA matrix caught this as F-018 during the E3 (Daytona) runs. It reproduces in the
-playground UI, not only the driver. Sessions `fd02cd78` and `7ec8186b` both hung on
-Daytona with no approval prompt shown.
+The QA matrix recorded the failure as F-018. It reproduced in the playground in sessions
+`fd02cd78` and `7ec8186b` and in the captured E3 bash run `f61a67f8...`.
 
 ## Why it matters
 
-Chat on Daytona works after the F-017 remote-mount fix (PR #5197). Tool use does not. That
-leaves Daytona usable for pure conversation and broken for the agents people actually
-build.
+Daytona can run conversation-only agents but not tool-using Pi agents. It also breaks the
+build-kit default agent because that agent begins by reading its skill. When the model
+obeys the instruction, the first turn stalls.
 
-It also breaks the build-kit default agent on Daytona. That agent's instructions tell the
-model to read its skill file first. The model opens the turn with a `read`, which is a
-builtin, so the first turn dies whenever the model follows its own instructions.
+## Corrected mechanism
 
-## The mechanism in one paragraph
+The Pi extension calls `ctx.ui.confirm` for each granted builtin. Pi emits an
+`extension_ui_request`. Local runs start the repo-pinned `pi-acp` 0.0.29 adapter, which
+converts that event into ACP `session/request_permission`. The Daytona snapshot inherits
+`pi-acp` 0.0.23 from `rivetdev/sandbox-agent:0.5.0-rc.2-full`. That older adapter ignores
+the extension UI event because the bridge did not land until `pi-acp` 0.0.28.
 
-Builtin gating is on. For every builtin call, the Pi extension inside the sandbox raises
-`ctx.ui.confirm`, even when the policy would allow the call. The allow, ask, or deny
-decision is made on the runner, after the gate surfaces there. The `pi-acp` bridge turns
-that confirm into an ACP `session/request_permission` reverse request. On a Daytona
-sandbox that reverse request never reaches the runner, so the confirm never resolves. The
-confirm is deliberately built with no reaper, so the tool waits forever. The 300s guard is
-the only thing that ends it. The full path, with file and line references, is in
-[research.md](research.md).
+The request therefore disappears before the HTTP transport. Ordinary `session/update`
+events still work because version 0.0.23 supports them. This explains the exact symptom:
+the runner sees the tool call but never logs `[HITL] pi-gate`.
+
+The Daytona preview proxy is not the source of the failure. It never receives a permission
+request to forward.
 
 ## Goals
 
-- A builtin call on Daytona that the policy allows runs without stalling.
-- A builtin call on Daytona that the policy denies is blocked with a clear result.
-- A builtin call on Daytona that needs a human decision (ask) surfaces a real approval
-  prompt in the UI and resumes correctly when the human answers.
-- Any gate that cannot be answered fails closed with a clear error, and never stalls to
-  the 300s guard.
-- Local behavior is unchanged. Daytona and local stay interchangeable for the `pi`
-  harness, which is the whole promise of the sandbox axis.
+- Pin the Daytona Pi adapter to the same version the local runner uses.
+- Prove allow, deny, and ask behavior on a fresh Daytona sandbox.
+- Keep one ACP permission plane for local and Daytona.
+- Preserve live approval continuation through `respondPermission`.
+- Preserve cold approval through durable decisions and call reissue.
+- Detect future snapshot adapter drift during the snapshot build.
+- Bound and explain any remaining delivery failure instead of waiting 300 seconds.
 
 ## Non-goals
 
-- Fixing the Daytona proxy itself, or rewriting the vendored `sandbox-agent` transport.
-  Option A in [options.md](options.md) would need that, and the plan rejects it as the
-  primary path.
-- Changing the approval model, the permission plan schema, or the `pi-gate-envelope`
-  contract for the local path.
-- Sandboxing where code tools execute (F-010) or session-resume sandbox reuse (F-020).
-  Those are separate findings.
+- A new file-based permission protocol unless the adapter parity fix fails its focused
+  transport test.
+- Moving allow or deny policy into the sandbox before latency measurements justify it.
+- Adding Pi MCP delivery or enabling Claude gateway tools on Daytona. Those are separate
+  forward-delivery capabilities.
+- Changing the public agent configuration or approval policy schema.
+- Replacing the Daytona preview proxy.
 
-## Constraints the fix must respect
+## Constraints
 
-- The sandbox is not trusted to state its own permissions. The current
-  `pi-gate-envelope` design carries tool identity only, never policy, for exactly this
-  reason. Any option that moves a decision into the sandbox must argue why it is safe for
-  the specific tool class it covers.
-- Builtin execution already happens inside the sandbox with no runner mediation. The gate
-  is the only control point for a builtin. This shapes which trust arguments hold.
-- Custom (callback and gateway) tool execution relays back to the runner, which re-checks
-  the decision at the relay guard. That second enforcement point exists for custom tools
-  and does not exist for builtins.
+- The snapshot recipe inherits private ACP adapter installations from its base image.
+  Installing only the standalone Pi CLI does not update `pi-acp`.
+- `sandbox-agent` prefers its private adapter launcher under
+  `/home/sandbox/.local/share/sandbox-agent/agent_processes/`. A global npm install alone
+  is not a reliable fix.
+- A live permission continuation exists only while the sandbox, adapter process, ACP
+  connection, permission id, and prompt promise remain alive.
+- Stopping or recreating a sandbox destroys that continuation. The cold path must use a
+  durable human decision and a reissued call. A file relay cannot keep a dead process
+  alive.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
@@ -1,0 +1,66 @@
+# Context
+
+## What breaks
+
+A tool-using agent on a Daytona sandbox hangs on its first tool call. Chat-only turns
+work. Any turn that calls a Pi builtin (bash, read, edit, write, grep, find, ls) stalls
+until the 300s run-limits guard kills it. The user sees no approval prompt and no result,
+just a long wait and then a failed turn.
+
+The QA matrix caught this as F-018 during the E3 (Daytona) runs. It reproduces in the
+playground UI, not only the driver. Sessions `fd02cd78` and `7ec8186b` both hung on
+Daytona with no approval prompt shown.
+
+## Why it matters
+
+Chat on Daytona works after the F-017 remote-mount fix (PR #5197). Tool use does not. That
+leaves Daytona usable for pure conversation and broken for the agents people actually
+build.
+
+It also breaks the build-kit default agent on Daytona. That agent's instructions tell the
+model to read its skill file first. The model opens the turn with a `read`, which is a
+builtin, so the first turn dies whenever the model follows its own instructions.
+
+## The mechanism in one paragraph
+
+Builtin gating is on. For every builtin call, the Pi extension inside the sandbox raises
+`ctx.ui.confirm`, even when the policy would allow the call. The allow, ask, or deny
+decision is made on the runner, after the gate surfaces there. The `pi-acp` bridge turns
+that confirm into an ACP `session/request_permission` reverse request. On a Daytona
+sandbox that reverse request never reaches the runner, so the confirm never resolves. The
+confirm is deliberately built with no reaper, so the tool waits forever. The 300s guard is
+the only thing that ends it. The full path, with file and line references, is in
+[research.md](research.md).
+
+## Goals
+
+- A builtin call on Daytona that the policy allows runs without stalling.
+- A builtin call on Daytona that the policy denies is blocked with a clear result.
+- A builtin call on Daytona that needs a human decision (ask) surfaces a real approval
+  prompt in the UI and resumes correctly when the human answers.
+- Any gate that cannot be answered fails closed with a clear error, and never stalls to
+  the 300s guard.
+- Local behavior is unchanged. Daytona and local stay interchangeable for the `pi`
+  harness, which is the whole promise of the sandbox axis.
+
+## Non-goals
+
+- Fixing the Daytona proxy itself, or rewriting the vendored `sandbox-agent` transport.
+  Option A in [options.md](options.md) would need that, and the plan rejects it as the
+  primary path.
+- Changing the approval model, the permission plan schema, or the `pi-gate-envelope`
+  contract for the local path.
+- Sandboxing where code tools execute (F-010) or session-resume sandbox reuse (F-020).
+  Those are separate findings.
+
+## Constraints the fix must respect
+
+- The sandbox is not trusted to state its own permissions. The current
+  `pi-gate-envelope` design carries tool identity only, never policy, for exactly this
+  reason. Any option that moves a decision into the sandbox must argue why it is safe for
+  the specific tool class it covers.
+- Builtin execution already happens inside the sandbox with no runner mediation. The gate
+  is the only control point for a builtin. This shapes which trust arguments hold.
+- Custom (callback and gateway) tool execution relays back to the runner, which re-checks
+  the decision at the relay guard. That second enforcement point exists for custom tools
+  and does not exist for builtins.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
@@ -55,7 +55,7 @@ request to forward.
 - The snapshot recipe inherits private ACP adapter installations from its base image.
   Installing only the standalone Pi CLI does not update `pi-acp`.
 - `sandbox-agent` prefers its private adapter launcher under
-  `/home/sandbox/.local/share/sandbox-agent/agent_processes/`. A global npm install alone
+  `/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/`. A global npm install alone
   is not a reliable fix.
 - A live permission continuation exists only while the sandbox, adapter process, ACP
   connection, permission id, and prompt promise remain alive.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/design-review.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/design-review.md
@@ -1,88 +1,55 @@
 # Design review
 
-An independent staff-level review (Codex, xhigh reasoning, read-only on the repo) ran
-against the first draft of this plan on 2026-07-11. Verdict: right direction, do not
-approve as drafted. The findings below are folded into [options.md](options.md) and
-[plan.md](plan.md). This file records what changed and why, so a reader can see the
-plan's weak points and how they were closed.
+The owner review identified one central flaw in the first draft: it treated an unexplained
+transport difference as a reason to skip root-cause work and build a second permission
+channel. The revised design resolves that uncertainty first.
 
-## Findings folded into the plan
+## Findings and resolutions
 
-### 1. The approval state machine was hand-waved
+### 1. “Daytona preview proxy” was undefined
 
-The draft said an ask gate over the file relay "slots into the existing pause and resume
-model." It does not. The relay loop stops as soon as the turn pauses
-(`services/runner/src/engines/sandbox_agent.ts` around line 1713), the parked-approval
-model only understands an ACP permission id answerable via `respondPermission`, and a
-unit test asserts Pi file-relay gates are non-parkable
-(`services/runner/tests/unit/session-keepalive-approval.test.ts` around line 428). The
-plan now defines two explicit state machines (cold replay and live parking with a
-file-transport parked-gate variant), plus idempotency, duplicate-answer, cancellation,
-and late-result rules. See plan.md Phase 3.
+The revised [research.md](research.md) defines it as signed, authenticated ingress to
+sandbox port 3000. It explains target resolution, the Go reverse proxy, the auth cookie,
+and the difference between the preview proxy and outbound secret substitution.
 
-### 2. Custom tools do not need a second gate channel
+### 2. The draft blamed the proxy without evidence
 
-The draft routed Daytona custom-tool gates over a new gate-request file pair. Review
-pointed out the custom tool already reaches the runner as an execution request, where the
-relay guard re-runs policy (`sandbox_agent.ts` around line 1594). Making that existing
-request the authorization seam (allow: execute; deny: return a denied result; pending:
-emit the interaction and pause without executing) removes the fragile
-gate-file/decision-file/execute-file/grant-ledger sequence entirely. The plan now does
-that. The file gate exists only for residual builtins, which never reach the relay.
+The revised research rules that out. The Daytona snapshot inherits `pi-acp` 0.0.23, which
+does not translate Pi extension UI events into ACP permission requests. Local uses 0.0.29,
+which does. The proxy never receives the missing request.
 
-### 3. `ask | defer` was the wrong disposition vocabulary
+### 3. Uncertainty was used to justify a decision
 
-`defer` is not a policy decision. The extension only needs `allow | deny | runner`, where
-both ask and argument-dependent rules compile to `runner`. The compiler belongs in
-`permission-plan.ts` next to `effectivePermission` and the rule matcher, not
-re-implemented in `run-plan.ts`. Adopted.
+The revised plan turns uncertainty into an ordered test. It checks the deployed private
+adapter version first, rebuilds with a pin, and instruments transport only if a corrected
+adapter still fails. Option B now has an explicit evidence gate.
 
-### 4. A single gate timeout cannot tell delivery failure from a deliberating human
+### 4. Warm and cold behavior were mixed with transport
 
-The draft gave every gate one bounded timeout. With one promise the extension cannot
-distinguish "the request never reached the runner" (fail closed, the F-018 case) from
-"the runner paused and the human is thinking" (must never be reaped; run-limits
-deliberately freezes deadlines on pause). The plan now uses two lifetimes: a short
-delivery deadline that ends at a runner acknowledgment file and fails closed, and a human
-approval lifetime after acknowledgment governed by the existing pause and TTL model. On
-the ACP confirm path no acknowledgment exists, so the plan no longer claims an all-path
-timeout there. Late decisions after a delivery timeout get tombstone handling.
+The revised research and plan separate them. A live sandbox can retain and answer the ACP
+permission id. A stopped or dead sandbox cannot retain a pending RPC on any channel. The
+cold path uses durable decisions and a reissued call.
 
-### 5. The decision file is forgeable where it matters most
+### 5. The file relay would recreate a permission plane
 
-The relay dir is sandbox-writable and the extension trusts relay response JSON
-(`services/runner/src/tools/dispatch.ts` around line 89). That is fine for custom-tool
-results because execution is runner-side behind the relay guard. For a builtin, an
-`allow` decision file IS the authorization, and an unsigned file is not demonstrably
-runner-authored. The plan now authenticates decision files with a per-run secret
-delivered via a read-once file (the existing OTLP bearer pattern in `pi-assets.ts`), and
-documents the narrowed threat model either way: builtin policy protects against the
-model, not against an arbitrary hostile process inside the sandbox.
+Agreed. The revised recommendation removes it. The existing ACP path is the one permission
+plane after adapter parity is restored. A file gate is only a contingency after a focused
+transport failure is proved.
 
-### 6. Phase 1 was not shippable alone
+### 6. Option C's dependency was misstated
 
-Under the default `allow_reads` policy, disposition injection alone makes reads work
-while bash, edit, and write still hang (`runner`-routed with no working channel), and
-custom-tool confirms stay broken. The phases are re-cut as one release unit: reproduction
-and the policy compiler, the file transport with acknowledgment, relay-seam custom-tool
-authorization, both resume state machines, the adversarial test set, and live Daytona
-verification.
+Option C does not depend on Option B. Static allow and deny can skip a round-trip, while
+residual decisions use whichever runner channel works. With Option A, that channel is ACP.
+The revision defers C until latency data justifies the extra policy surface.
 
-### 7. Interface sharpening
+### 7. MCP scope was conflated
 
-- Version the injected disposition map (`{"v":1,"builtins":{...}}`) and validate
-  strictly: missing, malformed, unknown name, or grant/disposition mismatch routes to the
-  runner or fails closed, never silently allows.
-- Add an explicit `AGENTA_AGENT_GATE_TRANSPORT=acp|file` capability instead of letting
-  the extension infer Daytona from a directory or provider name.
-- Extract a shared identity validator from `pi-gate-envelope.ts` and define separate
-  versioned ACP and file wrappers; do not reuse the ACP parser wholesale. The file
-  protocol needs a collision-resistant request id, distinct suffixes, and a response
-  status field.
+The revised research distinguishes Pi extension tools, the Pi execution relay, internal
+gateway MCP, user HTTP MCP, and disabled stdio MCP. It also states that F-018 proves a Pi
+adapter failure, not a Claude failure.
 
-## Review points not adopted, and why
+## Review outcome
 
-None were rejected outright. One point is scoped rather than adopted in full: the review
-suggests replay tests are supplemental because they cannot prove the Daytona SSE proxy
-delivers reverse requests. Agreed, and the plan keeps them anyway as regression pins for
-the runner-side logic, with live Daytona verification as the proof for the transport.
+The first recommendation, Option C plus a narrowed Option B, is withdrawn. The current
+recommendation is Option A through adapter parity, followed by focused live verification.
+No new interface is proposed.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/design-review.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/design-review.md
@@ -1,0 +1,88 @@
+# Design review
+
+An independent staff-level review (Codex, xhigh reasoning, read-only on the repo) ran
+against the first draft of this plan on 2026-07-11. Verdict: right direction, do not
+approve as drafted. The findings below are folded into [options.md](options.md) and
+[plan.md](plan.md). This file records what changed and why, so a reader can see the
+plan's weak points and how they were closed.
+
+## Findings folded into the plan
+
+### 1. The approval state machine was hand-waved
+
+The draft said an ask gate over the file relay "slots into the existing pause and resume
+model." It does not. The relay loop stops as soon as the turn pauses
+(`services/runner/src/engines/sandbox_agent.ts` around line 1713), the parked-approval
+model only understands an ACP permission id answerable via `respondPermission`, and a
+unit test asserts Pi file-relay gates are non-parkable
+(`services/runner/tests/unit/session-keepalive-approval.test.ts` around line 428). The
+plan now defines two explicit state machines (cold replay and live parking with a
+file-transport parked-gate variant), plus idempotency, duplicate-answer, cancellation,
+and late-result rules. See plan.md Phase 3.
+
+### 2. Custom tools do not need a second gate channel
+
+The draft routed Daytona custom-tool gates over a new gate-request file pair. Review
+pointed out the custom tool already reaches the runner as an execution request, where the
+relay guard re-runs policy (`sandbox_agent.ts` around line 1594). Making that existing
+request the authorization seam (allow: execute; deny: return a denied result; pending:
+emit the interaction and pause without executing) removes the fragile
+gate-file/decision-file/execute-file/grant-ledger sequence entirely. The plan now does
+that. The file gate exists only for residual builtins, which never reach the relay.
+
+### 3. `ask | defer` was the wrong disposition vocabulary
+
+`defer` is not a policy decision. The extension only needs `allow | deny | runner`, where
+both ask and argument-dependent rules compile to `runner`. The compiler belongs in
+`permission-plan.ts` next to `effectivePermission` and the rule matcher, not
+re-implemented in `run-plan.ts`. Adopted.
+
+### 4. A single gate timeout cannot tell delivery failure from a deliberating human
+
+The draft gave every gate one bounded timeout. With one promise the extension cannot
+distinguish "the request never reached the runner" (fail closed, the F-018 case) from
+"the runner paused and the human is thinking" (must never be reaped; run-limits
+deliberately freezes deadlines on pause). The plan now uses two lifetimes: a short
+delivery deadline that ends at a runner acknowledgment file and fails closed, and a human
+approval lifetime after acknowledgment governed by the existing pause and TTL model. On
+the ACP confirm path no acknowledgment exists, so the plan no longer claims an all-path
+timeout there. Late decisions after a delivery timeout get tombstone handling.
+
+### 5. The decision file is forgeable where it matters most
+
+The relay dir is sandbox-writable and the extension trusts relay response JSON
+(`services/runner/src/tools/dispatch.ts` around line 89). That is fine for custom-tool
+results because execution is runner-side behind the relay guard. For a builtin, an
+`allow` decision file IS the authorization, and an unsigned file is not demonstrably
+runner-authored. The plan now authenticates decision files with a per-run secret
+delivered via a read-once file (the existing OTLP bearer pattern in `pi-assets.ts`), and
+documents the narrowed threat model either way: builtin policy protects against the
+model, not against an arbitrary hostile process inside the sandbox.
+
+### 6. Phase 1 was not shippable alone
+
+Under the default `allow_reads` policy, disposition injection alone makes reads work
+while bash, edit, and write still hang (`runner`-routed with no working channel), and
+custom-tool confirms stay broken. The phases are re-cut as one release unit: reproduction
+and the policy compiler, the file transport with acknowledgment, relay-seam custom-tool
+authorization, both resume state machines, the adversarial test set, and live Daytona
+verification.
+
+### 7. Interface sharpening
+
+- Version the injected disposition map (`{"v":1,"builtins":{...}}`) and validate
+  strictly: missing, malformed, unknown name, or grant/disposition mismatch routes to the
+  runner or fails closed, never silently allows.
+- Add an explicit `AGENTA_AGENT_GATE_TRANSPORT=acp|file` capability instead of letting
+  the extension infer Daytona from a directory or provider name.
+- Extract a shared identity validator from `pi-gate-envelope.ts` and define separate
+  versioned ACP and file wrappers; do not reuse the ACP parser wholesale. The file
+  protocol needs a collision-resistant request id, distinct suffixes, and a response
+  status field.
+
+## Review points not adopted, and why
+
+None were rejected outright. One point is scoped rather than adopted in full: the review
+suggests replay tests are supplemental because they cannot prove the Daytona SSE proxy
+delivers reverse requests. Agreed, and the plan keeps them anyway as regression pins for
+the runner-side logic, with live Daytona verification as the proof for the transport.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/options.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/options.md
@@ -1,114 +1,70 @@
 # Fix directions
 
-Three directions can fix F-018. They are not exclusive. The recommendation combines two of
-them and adds a delivery-acknowledged timeout on the file channel. Each option below
-states what it changes, what it buys, and what it costs.
+The options are not equal after the root-cause investigation. Option A is now a small,
+evidence-backed correctness fix. Option B is a contingency. Option C is an independent
+latency optimization.
 
-The finding names all three. This document evaluates them against the mechanism in
-[research.md](research.md) rather than picking one by default.
+## Option A: restore adapter parity and keep ACP as the permission plane
 
-## Option A: make the reverse permission RPC work over the remote transport
+Rebuild the Daytona snapshot with `pi-acp` 0.0.29, matching the local runner. Install it
+through `sandbox-agent install-agent pi --reinstall --agent-process-version 0.0.29` so the
+private adapter launcher is updated, then verify allow, deny, and ask on a fresh sandbox.
 
-Diagnose why the Daytona proxy passes `session/update` notifications but drops the
-`session/request_permission` server request on the same SSE stream, then fix it so the
-reverse request reaches the runner.
+- What it buys. The existing Pi dialog becomes `session/request_permission` on Daytona,
+  exactly as it does locally. The runner keeps one decision path, one live parking path,
+  and one cold replay path. No new wire shape or trust boundary is required.
+- What it costs. One snapshot recipe change, one dependency assertion, a forced snapshot
+  rebuild, draining sandboxes created from the old snapshot, and focused live QA. This is
+  hours of work, not a transport project.
+- What remains uncertain. The currently deployed snapshot should be queried once to
+  confirm its private adapter version. The recipe and base-image manifest already prove
+  what a snapshot built from the checked-in recipe contains.
 
-- What it buys. One permission plane for local and Daytona. Allow, ask, and deny all work
-  the same way on both. Ask surfaces a real UI prompt with no extra plumbing, because it
-  reuses the existing pause and resume path. It is the cleanest end state on paper.
-- What it costs. The root cause is not pinned by static analysis. It lives in the Daytona
-  preview proxy's handling of a server-initiated request that expects a correlated client
-  response. Confirming it needs live proxy-level inspection. Fixing it probably needs a
-  change in the vendored `sandbox-agent` transport (a self-initiated reverse channel, a
-  long-poll, or a websocket) or a change to how the proxy is used. That work belongs with
-  the sandbox-agent fork plan (PR #5172), not a QA fix. It is the highest cost and the
-  highest uncertainty of the three, and it may not be fixable on the proxy side at all.
+Verdict: adopt as the primary fix.
 
-Verdict: keep as the ideal long-term shape, reject as the primary path now. The plan does
-not depend on it.
+## Option B: add a file-based permission channel
 
-## Option B: deliver gate decisions over the file relay Daytona already polls
+Have the Pi extension write permission requests into the existing Daytona relay directory,
+then have the runner poll, decide, and write authenticated responses.
 
-Stop raising the gate as a reverse RPC on Daytona. Have the extension write a
-gate-request file to the relay directory and poll for a decision file. The runner's relay
-loop, which already polls the sandbox filesystem on Daytona, picks up the request, runs it
-through the same responder policy, and writes the decision back. For an ask gate the
-runner emits the same `interaction_request` event it emits today, surfaces the UI prompt,
-and writes the decision file when the human answers.
+- What it buys. A permission route that does not use ACP reverse requests.
+- What it costs. A second permission protocol, new integrity credentials, new delivery
+  acknowledgments, new cleanup and timeout rules, and separate live and cold behavior.
+  It duplicates a path that already works when the correct adapter is installed.
+- When it is justified. Only if a fresh sandbox with the pinned adapter emits
+  `session/request_permission` at the adapter boundary but a focused signed-preview test
+  proves that the envelope cannot traverse the managed proxy reliably.
 
-- What it buys. It sidesteps the broken reverse request entirely and reuses a channel
-  already proven to work on Daytona (the custom-tool relay, see
-  [research.md](research.md)). It keeps the decision on the runner, so it preserves the
-  trust boundary the `pi-gate-envelope` design set. It is the only option that can surface
-  a real ask prompt on Daytona without fixing the transport.
-- What it costs. It builds a second permission channel next to the ACP one, so there are
-  two paths to keep in sync. The extension must branch local versus Daytona. The runner
-  must start the relay loop for a builtins-only run and pass the relay dir to the
-  extension for builtin gating (both noted in [research.md](research.md)). Ask, pause, and
-  resume across turns must be re-expressed on the file channel, which is the subtle part.
+Verdict: reject for now. Keep it as a documented contingency, not planned work.
 
-Verdict: adopt, narrowed to residual builtins (the `runner` disposition). Custom tools do
-not ride this channel; the design review showed their existing execution relay request is
-the cleaner authorization seam (see the recommendation below).
+## Option C: precompute static builtin decisions
 
-## Option C: resolve auto-allowed builtins in the sandbox with no round-trip
+Compile statically known allow and deny decisions on the runner and inject those decisions
+beside the builtin grant list. The extension skips ACP for those calls. Ask and
+argument-dependent rules still use ACP.
 
-Have the runner precompute each granted builtin's decision and inject it into the sandbox
-alongside the grant list. The extension then resolves an allow with no confirm and blocks
-a deny with no confirm. It raises a gate only when the injected decision is ask, or when
-the decision depends on the call arguments and so cannot be precomputed.
+- What it buys. Fewer remote round-trips for common allow and deny calls.
+- What it costs. Policy-derived state moves into the sandbox, validation logic grows, and
+  local and remote behavior change even though Option A already restores correctness.
+- Dependency. Option C does not depend on Option B. It needs a working runner channel for
+  residual decisions. With Option A, that channel is ACP.
 
-- What it buys. It removes the hang for the entire allow-mode case, which is exactly what
-  the QA matrix exercises and exactly what breaks the build-kit default agent. Read and
-  bash in allow mode both stop round-tripping. It is the smallest change, the lowest risk,
-  and it needs no new channel. A deny also resolves in the sandbox, which is strictly
-  safer than waiting.
-- What it costs. It moves the allow and deny decision for builtins into the sandbox. The
-  `pi-gate-envelope` design deliberately kept policy on the runner because the sandbox is
-  not trusted to state its own permissions. This is a real trust-surface change and the
-  plan must justify it. The justification is specific to builtins: a builtin already
-  executes inside the sandbox with no runner mediation, so the gate is its only control
-  point, and that gate already keys off a grant list the runner injects. Injecting the
-  decision lets the extension enforce deny and ask against the model, which is the actual
-  threat for a builtin (a prompt-injected model calling a tool the policy forbids). It
-  does not weaken defense against a compromised sandbox, because a compromised sandbox can
-  already run any builtin regardless of the gate. The argument holds for builtins. It does
-  not hold for custom tools, which is why this option is scoped to builtins only and
-  custom-tool decisions stay on the runner. Option C alone also cannot answer an ask gate,
-  so it needs Option B for the ask case.
+Verdict: defer until measurements show that the ACP round-trip materially affects tool
+latency. It is not part of the F-018 correctness fix.
 
-Verdict: adopt as the primary fix for allow and deny builtins.
+## Recommendation
 
-## Recommendation (revised after design review)
+Implement Option A and verify it before designing another channel.
 
-Combine C and a narrowed B, with an acknowledged two-lifetime timeout.
-
-1. Option C is the primary fix. The runner compiles each granted builtin's policy into a
-   disposition of `allow`, `deny`, or `runner` (`runner` covers both ask and any
-   argument-dependent rule) and injects the versioned map into the sandbox. Allow and
-   deny resolve with no round-trip. This alone makes the failing QA scenario pass,
-   because those runs use allow mode.
-2. Option B is narrowed to residual builtins only. A `runner`-disposition builtin on
-   Daytona raises its gate as a request file over the relay, with a runner
-   acknowledgment, an authenticated decision file, and explicit cold and live resume
-   paths. Custom tools do NOT get a second gate channel: their execution request already
-   reaches the runner's relay guard, so that existing request becomes the authorization
-   seam (allow executes, deny returns a denied result, pending pauses without
-   executing).
-3. The gate timeout is a two-lifetime model, not one timer: a short delivery deadline
-   that ends at the runner's acknowledgment and fails closed (the F-018 case), and a
-   human approval lifetime after acknowledgment owned by the existing pause model. One
-   timer cannot tell an undeliverable gate from a human deliberating, and reaping a
-   parked approval would break the HITL model that run-limits deliberately protects.
-4. Option A stays documented as the ideal long-term shape and is deferred to the
-   sandbox-agent fork plan. If A ever lands, C stays as a latency optimization and B can
-   retire.
-
-Everything ships as one release unit. Under the default `allow_reads` policy, C alone
-would fix reads while bash, edit, and write still hang, which is not a shippable state.
-
-An independent design review ([design-review.md](design-review.md)) confirmed this
-direction and reshaped the details above; the disposition vocabulary, the relay-seam
-custom-tool authorization, the two-lifetime timeout, the decision-file integrity, and
-the resume state machines all come from that review. The interface shapes are specified
-in [plan.md](plan.md), reviewed by semantic role.
+1. Pin `pi-acp` 0.0.29 in the Daytona snapshot recipe and assert the installed private
+   adapter version.
+2. Rebuild the snapshot and drain old sandboxes.
+3. Verify Pi builtin allow, deny, and ask over the signed preview path.
+4. Verify both approval lifecycles:
+   - live: answer the held ACP permission id and continue the original call;
+   - cold: store the human decision, restart or recreate, and answer the reissued gate.
+5. Test Claude ask on Daytona separately. F-018 proves the Pi adapter failure, not a
+   Claude failure.
+6. Consider Option C only after measuring round-trip latency.
+7. Reopen Option B only if adapter-boundary instrumentation proves that a real permission
+   envelope is emitted and then lost in transport.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/options.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/options.md
@@ -1,0 +1,114 @@
+# Fix directions
+
+Three directions can fix F-018. They are not exclusive. The recommendation combines two of
+them and adds a delivery-acknowledged timeout on the file channel. Each option below
+states what it changes, what it buys, and what it costs.
+
+The finding names all three. This document evaluates them against the mechanism in
+[research.md](research.md) rather than picking one by default.
+
+## Option A: make the reverse permission RPC work over the remote transport
+
+Diagnose why the Daytona proxy passes `session/update` notifications but drops the
+`session/request_permission` server request on the same SSE stream, then fix it so the
+reverse request reaches the runner.
+
+- What it buys. One permission plane for local and Daytona. Allow, ask, and deny all work
+  the same way on both. Ask surfaces a real UI prompt with no extra plumbing, because it
+  reuses the existing pause and resume path. It is the cleanest end state on paper.
+- What it costs. The root cause is not pinned by static analysis. It lives in the Daytona
+  preview proxy's handling of a server-initiated request that expects a correlated client
+  response. Confirming it needs live proxy-level inspection. Fixing it probably needs a
+  change in the vendored `sandbox-agent` transport (a self-initiated reverse channel, a
+  long-poll, or a websocket) or a change to how the proxy is used. That work belongs with
+  the sandbox-agent fork plan (PR #5172), not a QA fix. It is the highest cost and the
+  highest uncertainty of the three, and it may not be fixable on the proxy side at all.
+
+Verdict: keep as the ideal long-term shape, reject as the primary path now. The plan does
+not depend on it.
+
+## Option B: deliver gate decisions over the file relay Daytona already polls
+
+Stop raising the gate as a reverse RPC on Daytona. Have the extension write a
+gate-request file to the relay directory and poll for a decision file. The runner's relay
+loop, which already polls the sandbox filesystem on Daytona, picks up the request, runs it
+through the same responder policy, and writes the decision back. For an ask gate the
+runner emits the same `interaction_request` event it emits today, surfaces the UI prompt,
+and writes the decision file when the human answers.
+
+- What it buys. It sidesteps the broken reverse request entirely and reuses a channel
+  already proven to work on Daytona (the custom-tool relay, see
+  [research.md](research.md)). It keeps the decision on the runner, so it preserves the
+  trust boundary the `pi-gate-envelope` design set. It is the only option that can surface
+  a real ask prompt on Daytona without fixing the transport.
+- What it costs. It builds a second permission channel next to the ACP one, so there are
+  two paths to keep in sync. The extension must branch local versus Daytona. The runner
+  must start the relay loop for a builtins-only run and pass the relay dir to the
+  extension for builtin gating (both noted in [research.md](research.md)). Ask, pause, and
+  resume across turns must be re-expressed on the file channel, which is the subtle part.
+
+Verdict: adopt, narrowed to residual builtins (the `runner` disposition). Custom tools do
+not ride this channel; the design review showed their existing execution relay request is
+the cleaner authorization seam (see the recommendation below).
+
+## Option C: resolve auto-allowed builtins in the sandbox with no round-trip
+
+Have the runner precompute each granted builtin's decision and inject it into the sandbox
+alongside the grant list. The extension then resolves an allow with no confirm and blocks
+a deny with no confirm. It raises a gate only when the injected decision is ask, or when
+the decision depends on the call arguments and so cannot be precomputed.
+
+- What it buys. It removes the hang for the entire allow-mode case, which is exactly what
+  the QA matrix exercises and exactly what breaks the build-kit default agent. Read and
+  bash in allow mode both stop round-tripping. It is the smallest change, the lowest risk,
+  and it needs no new channel. A deny also resolves in the sandbox, which is strictly
+  safer than waiting.
+- What it costs. It moves the allow and deny decision for builtins into the sandbox. The
+  `pi-gate-envelope` design deliberately kept policy on the runner because the sandbox is
+  not trusted to state its own permissions. This is a real trust-surface change and the
+  plan must justify it. The justification is specific to builtins: a builtin already
+  executes inside the sandbox with no runner mediation, so the gate is its only control
+  point, and that gate already keys off a grant list the runner injects. Injecting the
+  decision lets the extension enforce deny and ask against the model, which is the actual
+  threat for a builtin (a prompt-injected model calling a tool the policy forbids). It
+  does not weaken defense against a compromised sandbox, because a compromised sandbox can
+  already run any builtin regardless of the gate. The argument holds for builtins. It does
+  not hold for custom tools, which is why this option is scoped to builtins only and
+  custom-tool decisions stay on the runner. Option C alone also cannot answer an ask gate,
+  so it needs Option B for the ask case.
+
+Verdict: adopt as the primary fix for allow and deny builtins.
+
+## Recommendation (revised after design review)
+
+Combine C and a narrowed B, with an acknowledged two-lifetime timeout.
+
+1. Option C is the primary fix. The runner compiles each granted builtin's policy into a
+   disposition of `allow`, `deny`, or `runner` (`runner` covers both ask and any
+   argument-dependent rule) and injects the versioned map into the sandbox. Allow and
+   deny resolve with no round-trip. This alone makes the failing QA scenario pass,
+   because those runs use allow mode.
+2. Option B is narrowed to residual builtins only. A `runner`-disposition builtin on
+   Daytona raises its gate as a request file over the relay, with a runner
+   acknowledgment, an authenticated decision file, and explicit cold and live resume
+   paths. Custom tools do NOT get a second gate channel: their execution request already
+   reaches the runner's relay guard, so that existing request becomes the authorization
+   seam (allow executes, deny returns a denied result, pending pauses without
+   executing).
+3. The gate timeout is a two-lifetime model, not one timer: a short delivery deadline
+   that ends at the runner's acknowledgment and fails closed (the F-018 case), and a
+   human approval lifetime after acknowledgment owned by the existing pause model. One
+   timer cannot tell an undeliverable gate from a human deliberating, and reaping a
+   parked approval would break the HITL model that run-limits deliberately protects.
+4. Option A stays documented as the ideal long-term shape and is deferred to the
+   sandbox-agent fork plan. If A ever lands, C stays as a latency optimization and B can
+   retire.
+
+Everything ships as one release unit. Under the default `allow_reads` policy, C alone
+would fix reads while bash, edit, and write still hang, which is not a shippable state.
+
+An independent design review ([design-review.md](design-review.md)) confirmed this
+direction and reshaped the details above; the disposition vocabulary, the relay-seam
+custom-tool authorization, the two-lifetime timeout, the decision-file integrity, and
+the resume state machines all come from that review. The interface shapes are specified
+in [plan.md](plan.md), reviewed by semantic role.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
@@ -1,0 +1,220 @@
+# Plan
+
+This implements the recommendation in [options.md](options.md), revised per
+[design-review.md](design-review.md): Option C (a compiled builtin disposition injected
+into the sandbox) plus a narrow Option B (a file gate for residual builtin calls only),
+custom-tool authorization at the existing execution relay, an acknowledged two-lifetime
+timeout, and integrity protection on the decision file.
+
+One release unit. The phases below order the work, but they land together: under the
+default `allow_reads` policy, disposition injection alone would fix reads while bash,
+edit, and write still hang, and custom-tool confirms would stay broken. Do not ship a
+partial cut.
+
+## Phase 0: reproduce and pin
+
+- Reproduce F-018 on Daytona in the playground. Record the session ids and the
+  `[run-limits]` line that kills the turn. Confirm no `[HITL] pi-gate` line appears for
+  the Daytona session while an identical local run logs one.
+- Capture a `/run` pair for a builtin call on Daytona under `../qa/runs/`, per the
+  `agent-replay-test` skill. Replay pins the runner-side logic only; it cannot prove the
+  Daytona proxy delivers reverse requests, so live verification (Phase 5) stays the proof
+  for the transport.
+- Keep Daytona spend minimal; reuse an existing failing capture if one is recorded.
+
+## Phase 1: the compiled builtin disposition (Option C)
+
+### Runner side
+
+- Add a disposition compiler to `permission-plan.ts`, next to `effectivePermission` and
+  the rule matcher, so rule semantics stay in one place. For each granted builtin it
+  resolves the policy with no call arguments and emits one of:
+  - `allow`: the policy statically allows this builtin.
+  - `deny`: the policy statically denies it.
+  - `runner`: the runner must decide at call time. Both `ask` and any
+    argument-dependent rule (a prefix rule like `Bash(git:*)`) compile to `runner`.
+- `run-plan.ts` calls the compiler and passes the result to the env injection. It does
+  not re-implement rule matching.
+- `pi-assets.ts` `buildPiExtensionEnv` injects the map when builtin gating is active.
+  Shape (versioned, strict):
+
+  ```json
+  {"v": 1, "builtins": {"read": "allow", "bash": "runner", "write": "deny"}}
+  ```
+
+- Also inject the gate transport capability explicitly:
+  `AGENTA_AGENT_GATE_TRANSPORT=acp|file` (`acp` for local, `file` for Daytona). The
+  extension must never infer the transport from a directory path or provider name.
+
+### Extension side
+
+- `registerBuiltinGating` reads the map and validates it strictly. A missing or
+  malformed map, an unknown disposition value, an unknown builtin name, or a
+  grant/disposition mismatch routes the call to the runner gate or fails closed. It
+  never silently allows.
+- On a `tool_call` for a builtin: `allow` runs with no gate; `deny` blocks with the
+  policy reason and no gate; `runner` raises the gate on the configured transport.
+- Local keeps `acp` transport and so keeps today's confirm behavior for `runner`
+  builtins; `allow` and `deny` stop round-tripping on local too, which is a latency win
+  on one shared code path.
+
+## Phase 2: the file gate for residual builtins (Option B, narrowed)
+
+Only a `runner`-disposition builtin on the `file` transport uses this. Custom tools do
+not (Phase 3). Every call on this channel pays remote filesystem polling latency, which
+is another reason the disposition map handles the common case.
+
+### Protocol
+
+Files in the relay dir, alongside the existing execution relay but with distinct
+suffixes so the two protocols never collide:
+
+- Gate request (extension writes): a collision-resistant request id in the name; body
+  reuses the gate identity (version, kind discriminator, gate kind, tool name, the
+  model's tool-call id, arguments). Extract a shared identity validator from
+  `pi-gate-envelope.ts` and define separate versioned ACP and file wrappers around it;
+  do not reuse the ACP parser (it is coupled to the ACP request shape and its validator
+  is private). The envelope stays identity-only; the runner recovers policy from its own
+  resolved specs.
+- Acknowledgment (runner writes): a `received` marker as soon as the responder has the
+  gate. This is what makes the two-lifetime timeout implementable (Phase 4).
+- Decision (runner writes): `allow` or `deny` plus a status field, authenticated (below).
+
+### Runner side
+
+- Start the relay loop whenever builtin gating is active on the file transport, not only
+  when custom tools exist (`plan.useToolRelay`). Pass the relay dir for builtin gating in
+  `buildPiExtensionEnv`.
+- The relay loop recognizes a gate-request file, acknowledges it, and runs the identity
+  through the same responder policy `handlePiGate` uses. Allow or deny writes the
+  decision immediately. A pending (human) decision follows Phase 3.
+
+### Decision-file integrity
+
+The relay dir is sandbox-writable, and for a builtin the decision file IS the
+authorization (unlike a custom-tool result, whose execution the runner-side relay guard
+already protects). An unsigned `allow` file is not demonstrably runner-authored. So:
+
+- The runner mints a per-run gate secret and delivers it to the extension via a
+  read-once 0600 file, the same pattern as the OTLP bearer (`pi-assets.ts`,
+  `writeOtlpAuthFile`). Decision files carry an HMAC over the request id and verdict.
+  The extension verifies before honoring an allow; a bad or missing tag fails closed.
+- Independent of the tag, document the narrowed threat model: builtin gating protects
+  against a prompt-injected model, not against an arbitrary hostile process that
+  controls the sandbox (which can already run anything a builtin could). And once a run
+  allows unrestricted bash, builtin permissions are not a meaningful confinement
+  boundary for later in-sandbox effects.
+
+## Phase 3: approval state across the pause, and custom tools at the relay seam
+
+### Custom tools: authorize at the execution relay
+
+Drop the separate gate round-trip for custom tools on the file transport. The execution
+request the extension already writes becomes the authorization seam. The relay guard
+already re-runs `decide()` there:
+
+- Allow: execute.
+- Deny: return a denied tool result.
+- Pending: emit the existing `interaction_request`, pause, and do not execute. No
+  execution grant ledger is needed on this path, because decision and execution are the
+  same request, handled atomically. (The ACP confirm path keeps `onPiGateAllowed` and
+  the grant ledger as today.)
+
+### The two resume paths, defined explicitly
+
+The draft plan assumed the existing pause and resume model absorbs a file gate. It does
+not: the relay loop stops when the turn pauses, and parked approvals are ACP-only (a
+live park holds an ACP permission id answered via `respondPermission`; a unit test
+asserts file-relay gates are non-parkable). Define both paths:
+
+- Cold path (default; keep-alive off, and F-020 means Daytona recreates sandboxes
+  anyway): on pause, the turn ends and the sandbox is destroyed with the pending gate
+  file inside it. Nothing is written back later. On the next turn, the stored decision
+  from the human's answer is in place, the model reissues the call (session continuity
+  restores the transcript), and the reissued gate resolves instantly from the stored
+  decision. This mirrors how the ACP path already resumes cold.
+- Live path (keep-alive on): extend the parked-gate union with a file-transport variant
+  that records the request id and relay dir instead of an ACP permission id. Resume
+  writes the authenticated decision file (and restarts the relay loop for the session)
+  instead of calling `respondPermission`. Server-side validation and resume dispatch
+  learn the new variant. Until this variant exists, a file gate must take the cold path
+  even under keep-alive; shipping file gates that silently break parking would be a
+  regression.
+- Cross-cutting rules for both: request ids are idempotent (a reissued call gets a new
+  id), duplicate decisions are ignored after the first, a cancelled turn tombstones its
+  pending gate so a late decision cannot resurrect it, and a late decision after a
+  delivery timeout must not create a stale approval card.
+
+## Phase 4: the two-lifetime timeout
+
+One timeout around the whole gate cannot distinguish an undeliverable gate (the F-018
+failure, must fail closed fast) from a human deliberating (must never be reaped;
+`run-limits.ts` deliberately freezes all deadlines on pause). Split it:
+
+- Delivery deadline: from writing the gate request until the runner's acknowledgment
+  file appears. Short (seconds, env-overridable), fails closed with a clear result text
+  such as "The approval request could not be delivered and was denied." The model loop
+  continues; the turn never stalls to the 300s guard.
+- Human approval lifetime: starts at acknowledgment. Owned by the existing pause
+  teardown and stored-decision model, not by an extension timer.
+
+On the ACP confirm path there is no acknowledgment signal, so no equivalent split exists
+there today. Do not claim an all-path timeout: local ACP gates keep their current
+semantics (they work), and the honest statement is that the file transport is the one
+with delivery-failure detection. If Option A ever lands, the ACP path can gain an
+acknowledgment then.
+
+## Phase 5: tests, live verification, docs
+
+- Unit tests: the disposition compiler (every default mode, read-only hint, name rule,
+  prefix rule mapping to `allow`/`deny`/`runner`); strict map validation (missing,
+  malformed, unknown, mismatch); the file-gate protocol (ack, decision, HMAC verify,
+  forged and unsigned decisions fail closed, duplicate decisions, tombstones, late
+  results, cancellation); the relay-seam custom-tool authorization (allow, deny,
+  pending); and the parked-gate file variant.
+- Replay regression from the Phase 0 capture, as a runner-side pin.
+- Live Daytona verification per `agent-workflows-qa`, minimum runs: builtin allow (read
+  and bash), builtin deny, builtin ask approved, builtin ask rejected, a prefix rule,
+  and a custom tool (allow and ask). Confirm the build-kit default agent's opening read
+  works.
+- Update F-018 in `../qa/findings.md` to resolved with the PR. Sync every doc that
+  describes the builtin gate transport, per `keep-docs-in-sync`. Note the keep-alive
+  interaction in the session-keepalive project docs if the parked-gate union changes.
+
+## Interface shapes, reviewed by semantic role
+
+Two shapes cross the runner-to-sandbox boundary. Fields are classified by what they are,
+per the `design-interfaces` skill.
+
+### `AGENTA_AGENT_BUILTIN_DECISIONS` (runner to sandbox, per session)
+
+`{"v":1,"builtins":{"read":"allow","bash":"runner",...}}`
+
+- `v` is protocol context (strict version check; mismatch routes to the runner gate).
+- The builtin name key is data (identity), reusing the canonical names in
+  `permission-plan.ts`.
+- The disposition value is compiled policy. The runner owns the compilation; the
+  extension only enforces. `runner` is deliberately not a policy verdict but a routing
+  value: "this decision is not compilable, raise the gate."
+
+Separate from `AGENTA_AGENT_BUILTIN_GRANTS` because grants are tool exposure
+(membership) and dispositions are enforcement (policy per member): different roles,
+different change cadence, and a run legitimately grants a builtin whose disposition is
+`runner`.
+
+`AGENTA_AGENT_GATE_TRANSPORT` is routing/protocol context (`acp` or `file`), injected
+explicitly rather than inferred, so the transport decision has exactly one owner (the
+runner) and one source of truth.
+
+### The file-gate protocol (sandbox to runner and back)
+
+- Request: protocol context (`v`, kind discriminator), routing (gate kind), identity
+  data (tool name, tool-call id, args), and a collision-resistant request id (protocol
+  context, correlation). No policy, no credential.
+- Acknowledgment: protocol context only (delivery state for the timeout split).
+- Decision: the verdict (policy, runner-owned), a status field (protocol context), and
+  an HMAC tag (integrity, keyed by a per-run secret delivered via a read-once file; the
+  secret itself never rides env or the relay dir).
+
+The identity part shares one validator with the ACP envelope (extracted from
+`pi-gate-envelope.ts`); the ACP and file wrappers version independently.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
@@ -1,220 +1,134 @@
 # Plan
 
-This implements the recommendation in [options.md](options.md), revised per
-[design-review.md](design-review.md): Option C (a compiled builtin disposition injected
-into the sandbox) plus a narrow Option B (a file gate for residual builtin calls only),
-custom-tool authorization at the existing execution relay, an acknowledged two-lifetime
-timeout, and integrity protection on the decision file.
+This plan implements Option A from [options.md](options.md): update the Daytona snapshot's
+private Pi ACP adapter, keep the existing ACP permission plane, and verify live and cold
+approval behavior. It does not add a file-gate protocol or an injected policy map.
 
-One release unit. The phases below order the work, but they land together: under the
-default `allow_reads` policy, disposition injection alone would fix reads while bash,
-edit, and write still hang, and custom-tool confirms would stay broken. Do not ship a
-partial cut.
+## Phase 0: confirm the deployed version
 
-## Phase 0: reproduce and pin
+- Create one short-lived Daytona sandbox from the currently selected
+  `agenta-sandbox-pi` snapshot.
+- Query the private Pi adapter that sandbox-agent resolves, not only a global npm package.
+  Record the launcher path and version. Expect 0.0.23.
+- Record the snapshot id or build identity so the evidence is tied to an artifact.
+- Delete the sandbox and confirm the live sandbox count returns to its starting value.
 
-- Reproduce F-018 on Daytona in the playground. Record the session ids and the
-  `[run-limits]` line that kills the turn. Confirm no `[HITL] pi-gate` line appears for
-  the Daytona session while an identical local run logs one.
-- Capture a `/run` pair for a builtin call on Daytona under `../qa/runs/`, per the
-  `agent-replay-test` skill. Replay pins the runner-side logic only; it cannot prove the
-  Daytona proxy delivers reverse requests, so live verification (Phase 5) stays the proof
-  for the transport.
-- Keep Daytona spend minimal; reuse an existing failing capture if one is recorded.
+If the deployed private adapter is already 0.0.28 or newer, stop. Instrument Pi's raw
+`extension_ui_request` and adapter stdout before changing the snapshot recipe. The source
+proof explains the checked-in recipe, but the live artifact wins if it differs.
 
-## Phase 1: the compiled builtin disposition (Option C)
+## Phase 1: pin adapter parity in the snapshot recipe
 
-### Runner side
+Change `services/runner/sandbox-images/daytona/build_snapshot.py`:
 
-- Add a disposition compiler to `permission-plan.ts`, next to `effectivePermission` and
-  the rule matcher, so rule semantics stay in one place. For each granted builtin it
-  resolves the policy with no call arguments and emits one of:
-  - `allow`: the policy statically allows this builtin.
-  - `deny`: the policy statically denies it.
-  - `runner`: the runner must decide at call time. Both `ask` and any
-    argument-dependent rule (a prefix rule like `Bash(git:*)`) compile to `runner`.
-- `run-plan.ts` calls the compiler and passes the result to the env injection. It does
-  not re-implement rule matching.
-- `pi-assets.ts` `buildPiExtensionEnv` injects the map when builtin gating is active.
-  Shape (versioned, strict):
+- Add `PI_ACP_VERSION = "0.0.29"` beside the existing Pi CLI version.
+- After the image switches to `USER sandbox`, run:
 
-  ```json
-  {"v": 1, "builtins": {"read": "allow", "bash": "runner", "write": "deny"}}
+  ```dockerfile
+  RUN sandbox-agent install-agent pi --reinstall --agent-process-version 0.0.29
   ```
 
-- Also inject the gate transport capability explicitly:
-  `AGENTA_AGENT_GATE_TRANSPORT=acp|file` (`acp` for local, `file` for Daytona). The
-  extension must never infer the transport from a directory path or provider name.
+- Add a build-time assertion against the private adapter installation under
+  `/home/sandbox/.local/share/sandbox-agent/agent_processes/`. The assertion must prove the
+  resolved adapter is exactly 0.0.29.
+- Keep the standalone Pi CLI pin at 0.80.6. The CLI and ACP adapter are different
+  dependencies with different responsibilities.
+- Update `services/runner/sandbox-images/daytona/README.md` to list both pins and explain
+  why the recipe must not trust the base image's adapter manifest.
 
-### Extension side
+Do not use only `npm install -g pi-acp`. sandbox-agent prefers its private launcher, so a
+global package can leave the stale adapter active.
 
-- `registerBuiltinGating` reads the map and validates it strictly. A missing or
-  malformed map, an unknown disposition value, an unknown builtin name, or a
-  grant/disposition mismatch routes the call to the runner gate or fails closed. It
-  never silently allows.
-- On a `tool_call` for a builtin: `allow` runs with no gate; `deny` blocks with the
-  policy reason and no gate; `runner` raises the gate on the configured transport.
-- Local keeps `acp` transport and so keeps today's confirm behavior for `runner`
-  builtins; `allow` and `deny` stop round-tripping on local too, which is a latency win
-  on one shared code path.
+## Phase 2: rebuild and rotate the snapshot
 
-## Phase 2: the file gate for residual builtins (Option B, narrowed)
+- Force-rebuild `agenta-sandbox-pi` in the intended Daytona target.
+- Verify the snapshot build prints and asserts adapter 0.0.29.
+- Update the runner deployment only if the snapshot name changes. Reusing the name still
+  requires draining sandboxes created from the prior snapshot because their filesystems
+  retain the old adapter.
+- Confirm the next sandbox is created from the rebuilt artifact and resolves adapter
+  0.0.29 before starting an LLM run.
 
-Only a `runner`-disposition builtin on the `file` transport uses this. Custom tools do
-not (Phase 3). Every call on this channel pays remote filesystem polling latency, which
-is another reason the disposition map handles the common case.
+## Phase 3: verify permission correctness
 
-### Protocol
+Run the smallest matrix that proves the gate and its policy outcomes:
 
-Files in the relay dir, alongside the existing execution relay but with distinct
-suffixes so the two protocols never collide:
+1. Pi core, allow mode, read.
+2. Pi core, allow mode, bash.
+3. Pi core, deny mode, one builtin.
+4. Pi core, ask mode, approve once.
+5. Pi core, ask mode, reject once.
+6. Pi Agenta, opening skill read, which covers the build-kit regression.
+7. Pure chat control.
 
-- Gate request (extension writes): a collision-resistant request id in the name; body
-  reuses the gate identity (version, kind discriminator, gate kind, tool name, the
-  model's tool-call id, arguments). Extract a shared identity validator from
-  `pi-gate-envelope.ts` and define separate versioned ACP and file wrappers around it;
-  do not reuse the ACP parser (it is coupled to the ACP request shape and its validator
-  is private). The envelope stays identity-only; the runner recovers policy from its own
-  resolved specs.
-- Acknowledgment (runner writes): a `received` marker as soon as the responder has the
-  gate. This is what makes the two-lifetime timeout implementable (Phase 4).
-- Decision (runner writes): `allow` or `deny` plus a status field, authenticated (below).
+For each tool run, require both:
 
-### Runner side
+- runner evidence that `[HITL] pi-gate` received the request; and
+- user-visible evidence that the tool executed or was denied as expected.
 
-- Start the relay loop whenever builtin gating is active on the file transport, not only
-  when custom tools exist (`plan.useToolRelay`). Pass the relay dir for builtin gating in
-  `buildPiExtensionEnv`.
-- The relay loop recognizes a gate-request file, acknowledges it, and runs the identity
-  through the same responder policy `handlePiGate` uses. Allow or deny writes the
-  decision immediately. A pending (human) decision follows Phase 3.
+Capture request and response pairs under `projects/qa/runs/` and update F-018 after the
+live checks pass. Use a cheap model and assert the Daytona sandbox count before and after
+every run.
 
-### Decision-file integrity
+## Phase 4: verify both approval lifecycles
 
-The relay dir is sandbox-writable, and for a builtin the decision file IS the
-authorization (unlike a custom-tool result, whose execution the runner-side relay guard
-already protects). An unsigned `allow` file is not demonstrably runner-authored. So:
+### Live
 
-- The runner mints a per-run gate secret and delivers it to the extension via a
-  read-once 0600 file, the same pattern as the OTLP bearer (`pi-assets.ts`,
-  `writeOtlpAuthFile`). Decision files carry an HMAC over the request id and verdict.
-  The extension verifies before honoring an allow; a bad or missing tag fails closed.
-- Independent of the tag, document the narrowed threat model: builtin gating protects
-  against a prompt-injected model, not against an arbitrary hostile process that
-  controls the sandbox (which can already run anything a builtin could). And once a run
-  allows unrestricted bash, builtin permissions are not a meaningful confinement
-  boundary for later in-sandbox effects.
+- Keep the Daytona sandbox and ACP prompt alive through an ask gate.
+- Approve once and reject once.
+- Verify the runner answers the held permission id through `respondPermission`.
+- Verify the original call continues with its original arguments and no model reissue.
 
-## Phase 3: approval state across the pause, and custom tools at the relay seam
+### Cold
 
-### Custom tools: authorize at the execution relay
+- Create an ask gate, then let the live continuation disappear through the supported
+  cold-transition test path.
+- Persist the human decision.
+- Resume with a restarted or recreated session.
+- Verify the model reissues the pending call and the new ACP gate consumes the stored
+  decision.
 
-Drop the separate gate round-trip for custom tools on the file transport. The execution
-request the extension already writes becomes the authorization seam. The relay guard
-already re-runs `decide()` there:
+Do not expect a stopped sandbox to retain a permission id or prompt promise. A successful
+cold test proves durable approval and replay, not live transport continuity.
 
-- Allow: execute.
-- Deny: return a denied tool result.
-- Pending: emit the existing `interaction_request`, pause, and do not execute. No
-  execution grant ledger is needed on this path, because decision and execution are the
-  same request, handled atomically. (The ACP confirm path keeps `onPiGateAllowed` and
-  the grant ledger as today.)
+## Phase 5: test the scope boundary
 
-### The two resume paths, defined explicitly
+- Run one Claude ask-mode tool on Daytona. Record it as a separate control because F-018
+  is a Pi adapter defect.
+- Confirm Pi user MCP remains rejected, user stdio MCP remains disabled, and no design
+  text claims otherwise.
+- Do not expand this fix to Claude gateway-tool delivery on Daytona. That is a separate
+  loopback reachability problem.
 
-The draft plan assumed the existing pause and resume model absorbs a file gate. It does
-not: the relay loop stops when the turn pauses, and parked approvals are ACP-only (a
-live park holds an ACP permission id answered via `respondPermission`; a unit test
-asserts file-relay gates are non-parkable). Define both paths:
+## Phase 6: fallback decision gate
 
-- Cold path (default; keep-alive off, and F-020 means Daytona recreates sandboxes
-  anyway): on pause, the turn ends and the sandbox is destroyed with the pending gate
-  file inside it. Nothing is written back later. On the next turn, the stored decision
-  from the human's answer is in place, the model reissues the call (session continuity
-  restores the transcript), and the reissued gate resolves instantly from the stored
-  decision. This mirrors how the ACP path already resumes cold.
-- Live path (keep-alive on): extend the parked-gate union with a file-transport variant
-  that records the request id and relay dir instead of an ACP permission id. Resume
-  writes the authenticated decision file (and restarts the relay loop for the session)
-  instead of calling `respondPermission`. Server-side validation and resume dispatch
-  learn the new variant. Until this variant exists, a file gate must take the cold path
-  even under keep-alive; shipping file gates that silently break parking would be a
-  regression.
-- Cross-cutting rules for both: request ids are idempotent (a reissued call gets a new
-  id), duplicate decisions are ignored after the first, a cancelled turn tombstones its
-  pending gate so a late decision cannot resurrect it, and a late decision after a
-  delivery timeout must not create a stale approval card.
+Option B remains closed unless all of these are true after the snapshot rebuild:
 
-## Phase 4: the two-lifetime timeout
+1. The sandbox resolves `pi-acp` 0.0.29.
+2. Raw adapter instrumentation shows it emits `session/request_permission`.
+3. The sandbox-agent SSE server records the envelope.
+4. The outer runner does not receive it over the signed preview URL.
+5. A minimal mock SSE probe reproduces the loss independently of Pi and the LLM.
 
-One timeout around the whole gate cannot distinguish an undeliverable gate (the F-018
-failure, must fail closed fast) from a human deliberating (must never be reaped;
-`run-limits.ts` deliberately freezes all deadlines on pause). Split it:
+If those conditions hold, first ask Daytona whether the managed signed-preview path
+supports one long-lived SSE GET plus concurrent POSTs. Evaluate a standard preview token
+or a direct/private ingress before designing a filesystem permission protocol.
 
-- Delivery deadline: from writing the gate request until the runner's acknowledgment
-  file appears. Short (seconds, env-overridable), fails closed with a clear result text
-  such as "The approval request could not be delivered and was denied." The model loop
-  continues; the turn never stalls to the 300s guard.
-- Human approval lifetime: starts at acknowledgment. Owned by the existing pause
-  teardown and stored-decision model, not by an extension timer.
+## Phase 7: optional latency work
 
-On the ACP confirm path there is no acknowledgment signal, so no equivalent split exists
-there today. Do not claim an all-path timeout: local ACP gates keep their current
-semantics (they work), and the honest statement is that the file transport is the one
-with delivery-failure detection. If Option A ever lands, the ACP path can gain an
-acknowledgment then.
+Measure the added latency of the repaired ACP round-trip for allow and deny builtins. Only
+if it materially affects user-visible tool latency should a new design consider Option C.
+That proposal must independently review the runner-to-sandbox policy interface and threat
+model. It is not part of the F-018 fix.
 
-## Phase 5: tests, live verification, docs
+## Tests and acceptance criteria
 
-- Unit tests: the disposition compiler (every default mode, read-only hint, name rule,
-  prefix rule mapping to `allow`/`deny`/`runner`); strict map validation (missing,
-  malformed, unknown, mismatch); the file-gate protocol (ack, decision, HMAC verify,
-  forged and unsigned decisions fail closed, duplicate decisions, tombstones, late
-  results, cancellation); the relay-seam custom-tool authorization (allow, deny,
-  pending); and the parked-gate file variant.
-- Replay regression from the Phase 0 capture, as a runner-side pin.
-- Live Daytona verification per `agent-workflows-qa`, minimum runs: builtin allow (read
-  and bash), builtin deny, builtin ask approved, builtin ask rejected, a prefix rule,
-  and a custom tool (allow and ask). Confirm the build-kit default agent's opening read
-  works.
-- Update F-018 in `../qa/findings.md` to resolved with the PR. Sync every doc that
-  describes the builtin gate transport, per `keep-docs-in-sync`. Note the keep-alive
-  interaction in the session-keepalive project docs if the parked-gate union changes.
-
-## Interface shapes, reviewed by semantic role
-
-Two shapes cross the runner-to-sandbox boundary. Fields are classified by what they are,
-per the `design-interfaces` skill.
-
-### `AGENTA_AGENT_BUILTIN_DECISIONS` (runner to sandbox, per session)
-
-`{"v":1,"builtins":{"read":"allow","bash":"runner",...}}`
-
-- `v` is protocol context (strict version check; mismatch routes to the runner gate).
-- The builtin name key is data (identity), reusing the canonical names in
-  `permission-plan.ts`.
-- The disposition value is compiled policy. The runner owns the compilation; the
-  extension only enforces. `runner` is deliberately not a policy verdict but a routing
-  value: "this decision is not compilable, raise the gate."
-
-Separate from `AGENTA_AGENT_BUILTIN_GRANTS` because grants are tool exposure
-(membership) and dispositions are enforcement (policy per member): different roles,
-different change cadence, and a run legitimately grants a builtin whose disposition is
-`runner`.
-
-`AGENTA_AGENT_GATE_TRANSPORT` is routing/protocol context (`acp` or `file`), injected
-explicitly rather than inferred, so the transport decision has exactly one owner (the
-runner) and one source of truth.
-
-### The file-gate protocol (sandbox to runner and back)
-
-- Request: protocol context (`v`, kind discriminator), routing (gate kind), identity
-  data (tool name, tool-call id, args), and a collision-resistant request id (protocol
-  context, correlation). No policy, no credential.
-- Acknowledgment: protocol context only (delivery state for the timeout split).
-- Decision: the verdict (policy, runner-owned), a status field (protocol context), and
-  an HMAC tag (integrity, keyed by a per-run secret delivered via a read-once file; the
-  secret itself never rides env or the relay dir).
-
-The identity part shares one validator with the ACP envelope (extracted from
-`pi-gate-envelope.ts`); the ACP and file wrappers version independently.
+- Snapshot build fails when the private Pi adapter is not exactly the pinned version.
+- Local and fresh Daytona sandboxes resolve the same `pi-acp` version.
+- Allow, deny, and ask work for Pi builtins on Daytona.
+- Live approval continues the original call.
+- Cold approval answers a reissued call with a durable decision.
+- The build-kit default agent completes its opening read on Daytona.
+- Pure chat remains green.
+- No test sandbox leaks.
+- No new wire field, public config field, file-gate protocol, or policy-injection map lands.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
@@ -4,6 +4,18 @@ This plan implements Option A from [options.md](options.md): update the Daytona 
 private Pi ACP adapter, keep the existing ACP permission plane, and verify live and cold
 approval behavior. It does not add a file-gate protocol or an injected policy map.
 
+## Implementation checkpoint
+
+The snapshot recipe now pins the private Pi ACP adapter to 0.0.29 and asserts the
+actual private launcher and package under
+`/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/`. The named
+`agenta-sandbox-pi` snapshot was force-rebuilt successfully on 2026-07-11.
+
+Focused Daytona verification passed allow-mode Bash and deny-mode Bash. Ask mode produced
+a real `interaction_request` immediately, which proves the repaired adapter emitted
+`session/request_permission` through the existing ACP HTTP/SSE path. The supported UI
+approve/reject continuation and Claude control remain follow-up checks.
+
 ## Phase 0: confirm the deployed version
 
 - Create one short-lived Daytona sandbox from the currently selected
@@ -29,7 +41,7 @@ Change `services/runner/sandbox-images/daytona/build_snapshot.py`:
   ```
 
 - Add a build-time assertion against the private adapter installation under
-  `/home/sandbox/.local/share/sandbox-agent/agent_processes/`. The assertion must prove the
+  `/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/`. The assertion must prove the
   resolved adapter is exactly 0.0.29.
 - Keep the standalone Pi CLI pin at 0.80.6. The CLI and ACP adapter are different
   dependencies with different responsibilities.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/pr-body.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/pr-body.md
@@ -1,0 +1,59 @@
+## Context
+
+On a Daytona sandbox, every Pi builtin tool call hangs. Bash, read, all of them, even in
+allow mode. The turn stalls until the 300s run-limits guard kills it, with no approval
+prompt ever shown. Chat-only turns work. This is F-018 in the QA findings, and it breaks
+the build-kit default agent on Daytona: its "read the skill first" instruction makes the
+model open with a read, so the first turn dies whenever the model obeys.
+
+Root cause: with builtin gating on, the Pi extension raises `ctx.ui.confirm` inside the
+sandbox for every builtin call and blocks on the ACP `session/request_permission`
+reverse-RPC. One-way `session/update` notifications cross the Daytona proxy fine, but the
+reverse permission request never reaches the runner (no `[HITL] pi-gate` log line ever
+appears for a Daytona session; identical local runs log and round-trip it). The confirm
+is deliberately reaper-less, so the tool waits forever.
+
+## What this PR adds
+
+A design-only planning workspace at
+`docs/design/agent-workflows/projects/daytona-gate-delivery/`. No code changes.
+
+The plan evaluates three fix directions and recommends a combination:
+
+- Before: every builtin call round-trips a permission gate to the runner, and on Daytona
+  that round-trip never completes.
+- After (per the plan): the runner compiles each granted builtin's policy into a
+  disposition (`allow`, `deny`, or `runner`) and injects the versioned map into the
+  sandbox. Allow and deny resolve with no round-trip, which alone fixes the failing
+  allow-mode scenario. Only a `runner`-disposition builtin (ask, or an arg-dependent
+  prefix rule) raises a gate, and on Daytona that gate rides the file-relay channel the
+  runner already polls, with a delivery acknowledgment, an HMAC-authenticated decision
+  file, and defined cold and live resume paths so an ask still surfaces a real UI prompt.
+  Custom tools get no second gate channel; their existing execution relay request becomes
+  the authorization seam. A short delivery deadline fails an undeliverable gate closed
+  instead of stalling to the 300s guard.
+
+Fixing the reverse-RPC over the remote transport (the ideal long-term shape) is
+evaluated and deferred to the sandbox-agent fork plan, with the reasoning documented.
+
+## The workspace
+
+- `context.md`: the symptom, the mechanism, goals, non-goals, constraints.
+- `research.md`: the gate path and transport mechanics with file and line references,
+  including why the reverse request dies on Daytona and the facts that constrain the
+  approval state machine.
+- `options.md`: the three directions with trade-offs, and the recommendation.
+- `plan.md`: phased implementation as one release unit, with the two new interface
+  shapes (the disposition map and the file-gate protocol) reviewed by semantic role.
+- `design-review.md`: an independent critical review of the first draft and how each
+  finding was folded in (the approval state machine, the relay-seam custom-tool
+  authorization, the two-lifetime timeout, decision-file integrity, release-unit
+  phasing).
+- `status.md`: decisions and the open questions that need an owner call.
+
+## Notes
+
+- Open questions for review are listed in `status.md`: the delivery-deadline default,
+  whether the live keep-alive parking variant lands in the first cut, and whether local
+  should also use the disposition fast path.
+- No live Daytona runs were made for this plan.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/pr-body.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/pr-body.md
@@ -1,59 +1,43 @@
 ## Context
 
-On a Daytona sandbox, every Pi builtin tool call hangs. Bash, read, all of them, even in
-allow mode. The turn stalls until the 300s run-limits guard kills it, with no approval
-prompt ever shown. Chat-only turns work. This is F-018 in the QA findings, and it breaks
-the build-kit default agent on Daytona: its "read the skill first" instruction makes the
-model open with a read, so the first turn dies whenever the model obeys.
+Pi builtin calls hang on Daytona because the snapshot and local runner use different
+`pi-acp` adapters. Local runs use 0.0.29. The Daytona snapshot inherits 0.0.23, which
+predates the bridge from Pi extension dialogs to ACP permission requests. The runner sees
+the tool update but never receives a permission request, so the dialog waits until the
+300-second run limit ends the turn.
 
-Root cause: with builtin gating on, the Pi extension raises `ctx.ui.confirm` inside the
-sandbox for every builtin call and blocks on the ACP `session/request_permission`
-reverse-RPC. One-way `session/update` notifications cross the Daytona proxy fine, but the
-reverse permission request never reaches the runner (no `[HITL] pi-gate` log line ever
-appears for a Daytona session; identical local runs log and round-trip it). The confirm
-is deliberately reaper-less, so the tool waits forever.
+## What this revision changes
 
-## What this PR adds
+This remains a design-only PR. The revised workspace now identifies adapter version skew
+as the root cause and recommends a small snapshot fix:
 
-A design-only planning workspace at
-`docs/design/agent-workflows/projects/daytona-gate-delivery/`. No code changes.
+- pin the Daytona snapshot's private `pi-acp` adapter to 0.0.29;
+- assert that version during the snapshot build;
+- rebuild and rotate the snapshot;
+- verify allow, deny, ask-live, and ask-cold behavior on fresh sandboxes.
 
-The plan evaluates three fix directions and recommends a combination:
+The revision withdraws the proposed file-based permission channel. ACP remains the one
+permission plane. Option C, precomputing static allow and deny decisions, is now an
+independent latency idea rather than part of the correctness fix.
 
-- Before: every builtin call round-trips a permission gate to the runner, and on Daytona
-  that round-trip never completes.
-- After (per the plan): the runner compiles each granted builtin's policy into a
-  disposition (`allow`, `deny`, or `runner`) and injects the versioned map into the
-  sandbox. Allow and deny resolve with no round-trip, which alone fixes the failing
-  allow-mode scenario. Only a `runner`-disposition builtin (ask, or an arg-dependent
-  prefix rule) raises a gate, and on Daytona that gate rides the file-relay channel the
-  runner already polls, with a delivery acknowledgment, an HMAC-authenticated decision
-  file, and defined cold and live resume paths so an ask still surfaces a real UI prompt.
-  Custom tools get no second gate channel; their existing execution relay request becomes
-  the authorization seam. A short delivery deadline fails an undeliverable gate closed
-  instead of stalling to the 300s guard.
+## Before and after
 
-Fixing the reverse-RPC over the remote transport (the ideal long-term shape) is
-evaluated and deferred to the sandbox-agent fork plan, with the reasoning documented.
+Before: the draft assumed Daytona's preview proxy dropped
+`session/request_permission`, deferred root-cause work, and recommended a second file
+permission protocol.
 
-## The workspace
+After: source and version evidence shows the old Daytona adapter never creates the request.
+The plan restores adapter parity first and opens a transport fallback only if a corrected
+adapter emits a request that is then proven lost.
 
-- `context.md`: the symptom, the mechanism, goals, non-goals, constraints.
-- `research.md`: the gate path and transport mechanics with file and line references,
-  including why the reverse request dies on Daytona and the facts that constrain the
-  approval state machine.
-- `options.md`: the three directions with trade-offs, and the recommendation.
-- `plan.md`: phased implementation as one release unit, with the two new interface
-  shapes (the disposition map and the file-gate protocol) reviewed by semantic role.
-- `design-review.md`: an independent critical review of the first draft and how each
-  finding was folded in (the approval state machine, the relay-seam custom-tool
-  authorization, the two-lifetime timeout, decision-file integrity, release-unit
-  phasing).
-- `status.md`: decisions and the open questions that need an owner call.
+## How to review
 
-## Notes
+1. Start with `research.md` for the version proof and the preview-proxy explanation.
+2. Read `options.md` for the revised A, B, and C relationship.
+3. Read `plan.md` for the snapshot pin, live tests, cold-state test, and fallback gate.
+4. Check `status.md` for the remaining live validation.
 
-- Open questions for review are listed in `status.md`: the delivery-deadline default,
-  whether the live keep-alive parking variant lands in the first cut, and whether local
-  should also use the disposition fast path.
-- No live Daytona runs were made for this plan.
+## Scope
+
+No implementation code, public interface, wire shape, or configuration changes are in
+this PR.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/research.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/research.md
@@ -1,0 +1,194 @@
+# Research
+
+This is grounded in the working tree with PR #5197 (feat/sessions-continuity) applied.
+File and line references are to that state.
+
+## The gate path, end to end
+
+### 1. The extension raises a gate for every builtin call
+
+`services/runner/src/extensions/agenta.ts` registers builtin gating when
+`AGENTA_AGENT_BUILTIN_GATING` is set. `registerBuiltinGating` (lines 210-239) does two
+things:
+
+- On `before_agent_start`, it narrows the model's active builtin set to the granted ones
+  (`replaceActiveBuiltinTools`). A builtin the run did not grant is not offered to the
+  model at all.
+- On every `tool_call` event for a granted builtin, it calls `piDialogAllows` and blocks
+  the call unless the answer is allow (lines 224-238).
+
+`piDialogAllows` (lines 102-126) calls `ctx.ui.confirm(PI_GATE_DIALOG_TITLE, message)`,
+where `message` is the JSON gate envelope. It passes no `opts`, so Pi arms no reaper and
+the dialog waits indefinitely. The comment at lines 94-100 states this on purpose: an
+unavailable UI plane blocks, and a cancellation resolves to a fail-closed block.
+
+The key fact: this confirm fires for every builtin call, including calls the policy would
+allow. The extension does not know the policy. The runner decides allow, ask, or deny
+after the gate surfaces on the runner side. So even a pure allow needs a full round-trip
+to the runner and back.
+
+### 2. The confirm becomes an ACP reverse request
+
+`services/runner/src/engines/sandbox_agent/pi-gate-envelope.ts` documents the tunnel. The
+`pi-acp` bridge forwards the confirm as an ACP `session/request_permission` with a
+synthetic `pi-ui-<uuid>` tool-call id. The real identity (tool name, the model's tool-call
+id, the arguments) rides inside the `message` field as the envelope JSON (lines 1-20). The
+envelope carries identity only, never policy (lines 16-19). The runner recovers policy
+from its own resolved specs.
+
+### 3. The runner classifies and answers the reverse request
+
+`services/runner/src/engines/sandbox_agent/acp-interactions.ts` wires
+`session.onPermissionRequest` (line 104). `handleRequest` detects a Pi gate by the dialog
+title, parses the envelope, builds a `GateDescriptor` from the envelope identity plus the
+run's resolved specs (`buildPiGateDescriptor`, lines 421-450), runs it through the
+responder policy, and either answers the reverse request or pauses the turn for a human
+(lines 274-326). It logs `[HITL] pi-gate ...` for every Pi gate it handles (lines
+297-309).
+
+On a Daytona session this log line never appears. `session.onPermissionRequest` never
+fires. The reverse request does not arrive. On an identical local run it fires and
+round-trips. That is the whole defect.
+
+### 4. The policy decision
+
+`services/runner/src/permission-plan.ts` computes the decision. For a builtin there is no
+`specPermission` or `serverPermission`, so `effectivePermission` (lines 125-136) falls to
+a matching rule (`matchingRulePermission`) or the default (`defaultPermission`, lines
+248-256):
+
+- Default `allow`: every builtin resolves to allow.
+- Default `allow_reads`: read-only builtins (read, grep, find, ls) resolve to allow; write
+  builtins (bash, edit, write) resolve to ask.
+- Default `ask` or `deny`: as named.
+- A rule can override per builtin. A prefix rule like `Bash(git:*)` makes the decision
+  depend on the call arguments (`ruleMatches`, lines 214-224).
+
+`decide` (lines 138-151) returns allow, deny, or pendingApproval. A pendingApproval that
+no stored decision answers pauses the turn and surfaces an approval prompt.
+
+The QA runs use allow mode, where every builtin resolves to allow. Both read and bash
+still hang, because the gate fires before the allow decision is reached.
+
+## Why the reverse request dies on Daytona and not local
+
+Both local and Daytona drive the harness through the same `sandbox-agent` package over
+HTTP. The local provider spawns the `sandbox-agent` binary as an HTTP server
+(`node_modules/sandbox-agent/dist/providers/local.js`, `spawnSandboxAgent` runs
+`server --host --port --token`). The runner connects to it with `AcpHttpClient`. On
+Daytona the same server binary runs inside the sandbox, and the runner connects to it
+through the Daytona preview proxy, with a cookie jar for the proxy auth
+(`createCookieFetch` in `services/runner/src/engines/sandbox_agent/daytona.ts`, lines
+143-181).
+
+`AcpHttpClient` (in `acp-http-client@0.4.2`, bundled under `node_modules/.pnpm`) uses two
+HTTP channels to one endpoint:
+
+- Client to server: a `POST` per JSON-RPC message. A `200` response body is read inline as
+  a direct response (`postMessage`, dist/index.js lines 245-268).
+- Server to client: a single persistent `GET` SSE stream, started after the first POST
+  (`ensureSseLoop` / `runSseLoop`, lines 271-320). Both server-initiated notifications
+  (`session/update`) and server-initiated requests (`session/request_permission`) arrive
+  on this one stream. The client answers a server request by POSTing the response envelope
+  back.
+
+The reverse-request handler is wired all the way through:
+`client.requestPermission -> live.handlePermissionRequest -> onPermissionRequest ->
+enqueuePermissionRequest` (chunk-TVCDKGSM.js lines 763-768, 888-914, 2025). Local proves
+this path works over HTTP.
+
+So the only variable between local and Daytona is the preview proxy. On Daytona the SSE
+stream does deliver `session/update` (the finding confirms the `tool_call` ingests fine),
+which means the stream is alive. Yet the `session/request_permission` envelope on that
+same stream never reaches the runner. Static analysis cannot pin the exact proxy behavior
+that drops or stalls the server-initiated request while passing notifications. Confirming
+and fixing it would need live proxy-level inspection and probably a change in the vendored
+`sandbox-agent` transport or the proxy itself.
+
+This uncertainty is the strongest argument against fixing the transport as the primary
+path, and for options that do not depend on the reverse request at all. See
+[options.md](options.md).
+
+### A related transport fragility already documented
+
+F-017 in [../qa/findings.md](../qa/findings.md) records a Daytona proxy idle-stream
+timeout around 60s that killed quiet streams before PR #5197 detached the mount process.
+That history reinforces the read that server-initiated traffic over the proxy is fragile,
+and that a HITL pause (a human-timescale wait with no traffic) is exactly the shape the
+proxy handles worst.
+
+## Substrate the fix can reuse
+
+### The file relay already works on Daytona
+
+`services/runner/src/tools/relay.ts` runs a runner-side loop that polls the sandbox
+filesystem for request files, executes each, and writes a result file back (lines 16,
+317-378). It supports both a local filesystem host and a Daytona sandbox filesystem host
+(`host.list(relayDir)`, `host.read`, `sandbox.readFsFile`). This is how custom tool calls
+already cross the Daytona boundary. The MCP loopback channel is deliberately skipped on
+Daytona and swapped for this relay (`services/runner/src/engines/sandbox_agent/mcp.ts`
+lines 164-264). This is the proven precedent an ask-mode surface can follow.
+
+Two caveats for reuse:
+
+- The relay loop starts only when `plan.useToolRelay` is set, which today tracks having
+  custom tools (`services/runner/src/engines/sandbox_agent.ts` line 1631). A builtins-only
+  run does not start it. Delivering builtin gates over the relay would need the loop
+  running whenever builtin gating is active on Daytona.
+- Builtin gating passes no relay dir to the extension today. `buildPiExtensionEnv` sets
+  `AGENTA_AGENT_BUILTIN_GATING` and `AGENTA_AGENT_BUILTIN_GRANTS` but notes the gate rides
+  the confirm dialog, not the file relay
+  (`services/runner/src/engines/sandbox_agent/pi-assets.ts` lines 74-79). An option that
+  uses the relay for builtins would set the relay dir there too.
+
+### The relay guard already re-decides runner-side
+
+For Pi custom tools the relay guard re-runs `decide()` on the runner before executing a
+relayed call (`services/runner/src/engines/sandbox_agent.ts` lines 1594-1630). A forged
+execute record cannot run an ask or deny tool. This is the same runner-side enforcement an
+ask-mode file-relay gate would use. It shows the pattern is already in the codebase.
+
+### The runner already computes builtin grants up front
+
+`run-plan.ts` computes `builtinGrants` and `builtinGatingActive`
+(`normalizePiBuiltinGrants`, `computeBuiltinGatingActive`, lines 289-293) and injects them
+into the sandbox env. Adding a per-builtin decision alongside the grant list is a small
+extension of an injection that already exists.
+
+## Facts that constrain the approval state machine
+
+Surfaced during the design review ([design-review.md](design-review.md)); verify at the
+referenced sites.
+
+- The relay loop stops as soon as the turn pauses (`runTurn` stops the relay,
+  `services/runner/src/engines/sandbox_agent.ts` around line 1713), and the loop marks a
+  request seen before processing (`services/runner/src/tools/relay.ts` around lines
+  336-350). A pending gate file inside a paused turn is not answered later by the same
+  loop.
+- Live approval parking is ACP-only: a parked gate holds an ACP permission id answered
+  via `respondPermission` (`sandbox_agent.ts` around line 427, `server.ts` around line
+  590), and a unit test asserts Pi file-relay gates are non-parkable
+  (`services/runner/tests/unit/session-keepalive-approval.test.ts` around line 428). A
+  file-transport gate cannot park without extending that union.
+- Keep-alive is off by default (`session-pool.ts` around line 53), and F-020 records that
+  Daytona sandboxes are deleted at turn end regardless. So the default resume path for a
+  Daytona ask gate is cold: the sandbox that raised the gate is gone by the time the
+  human answers, and the stored decision must answer the reissued call on the next turn.
+- The extension trusts relay response JSON as-is (`services/runner/src/tools/dispatch.ts`
+  around line 89). That is safe for custom-tool results because execution happens
+  runner-side behind the relay guard. It is not safe for a builtin decision file, where
+  the file itself would be the authorization: the relay dir is sandbox-writable, so an
+  unsigned `allow` is not demonstrably runner-authored.
+- `run-limits.ts` freezes every deadline on a HITL pause (`notePaused`) on purpose. Any
+  gate timeout must not reap a legitimately parked approval, which forces the
+  delivery-versus-human split rather than one timer.
+
+## What the runner can and cannot precompute
+
+The runner can precompute a builtin's decision when it does not depend on the call
+arguments: the default mode applied to the builtin's read-only hint, or a plain
+name-match rule. The runner cannot precompute a single decision when a prefix rule like
+`Bash(git:*)` makes the answer depend on the arguments, and it cannot precompute an ask
+that a human must answer per call. Those cases must still reach the runner at call time
+(they compile to the `runner` disposition). This split is what shapes the recommended
+layering in [options.md](options.md).

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/research.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/research.md
@@ -1,194 +1,198 @@
 # Research
 
-This is grounded in the working tree with PR #5197 (feat/sessions-continuity) applied.
-File and line references are to that state.
+This document separates confirmed facts, ruled-out hypotheses, and remaining live
+validation. File references describe the current working tree unless a versioned upstream
+link is provided.
 
-## The gate path, end to end
+## Root cause
 
-### 1. The extension raises a gate for every builtin call
+Daytona and local runs use different `pi-acp` adapter versions.
 
-`services/runner/src/extensions/agenta.ts` registers builtin gating when
-`AGENTA_AGENT_BUILTIN_GATING` is set. `registerBuiltinGating` (lines 210-239) does two
-things:
+### Local uses `pi-acp` 0.0.29
 
-- On `before_agent_start`, it narrows the model's active builtin set to the granted ones
-  (`replaceActiveBuiltinTools`). A builtin the run did not grant is not offered to the
-  model at all.
-- On every `tool_call` event for a granted builtin, it calls `piDialogAllows` and blocks
-  the call unless the answer is allow (lines 224-238).
+`services/runner/package.json` pins `pi-acp` 0.0.29. The local daemon prepends the
+runner's `node_modules/.bin` directory to `PATH` in
+`services/runner/src/engines/sandbox_agent/daemon.ts`, so the local sandbox-agent process
+starts that adapter.
 
-`piDialogAllows` (lines 102-126) calls `ctx.ui.confirm(PI_GATE_DIALOG_TITLE, message)`,
-where `message` is the JSON gate envelope. It passes no `opts`, so Pi arms no reaper and
-the dialog waits indefinitely. The comment at lines 94-100 states this on purpose: an
-unavailable UI plane blocks, and a cancellation resolves to a fail-closed block.
+The installed 0.0.29 adapter handles Pi's `extension_ui_request`. For a confirm dialog it
+calls ACP `requestPermission`, waits for the answer, and sends an
+`extension_ui_response` back to Pi. See the installed adapter near
+`node_modules/.pnpm/pi-acp@0.0.29/node_modules/pi-acp/dist/index.js:1050-1143`.
 
-The key fact: this confirm fires for every builtin call, including calls the policy would
-allow. The extension does not know the policy. The runner decides allow, ask, or deny
-after the gate surfaces on the runner side. So even a pure allow needs a full round-trip
-to the runner and back.
+### Daytona inherits `pi-acp` 0.0.23
 
-### 2. The confirm becomes an ACP reverse request
+`services/runner/sandbox-images/daytona/build_snapshot.py` builds
+`agenta-sandbox-pi` from `rivetdev/sandbox-agent:0.5.0-rc.2-full`. The recipe installs
+`@earendil-works/pi-coding-agent` 0.80.6, but it does not update the base image's private
+Pi ACP adapter.
 
-`services/runner/src/engines/sandbox_agent/pi-gate-envelope.ts` documents the tunnel. The
-`pi-acp` bridge forwards the confirm as an ACP `session/request_permission` with a
-synthetic `pi-ui-<uuid>` tool-call id. The real identity (tool name, the model's tool-call
-id, the arguments) rides inside the `message` field as the envelope JSON (lines 1-20). The
-envelope carries identity only, never policy (lines 16-19). The runner recovers policy
-from its own resolved specs.
+The official sandbox-agent 0.5.0-rc.2 adapter manifest pins `pi-acp` 0.0.23:
+[adapters.json](https://github.com/rivet-dev/sandbox-agent/blob/cb42971b565cbe20c28f0d14a4d72b614c79eac7/scripts/audit-acp-deps/adapters.json#L21-L25).
 
-### 3. The runner classifies and answers the reverse request
+Version 0.0.23 has no `extension_ui_request` branch. It ignores the event in its default
+case: [pi-acp 0.0.23 session.ts](https://github.com/svkozak/pi-acp/blob/9c9bc93dc02228add0cbc0c7297eca2d964aacd0/src/acp/session.ts#L618-L620).
+The bridge landed later in commit
+[`1412ea6110`](https://github.com/svkozak/pi-acp/commit/1412ea611006a86f71c76600f3f0a7d1f3daffcb)
+and shipped in 0.0.28.
 
-`services/runner/src/engines/sandbox_agent/acp-interactions.ts` wires
-`session.onPermissionRequest` (line 104). `handleRequest` detects a Pi gate by the dialog
-title, parses the envelope, builds a `GateDescriptor` from the envelope identity plus the
-run's resolved specs (`buildPiGateDescriptor`, lines 421-450), runs it through the
-responder policy, and either answers the reverse request or pauses the turn for a human
-(lines 274-326). It logs `[HITL] pi-gate ...` for every Pi gate it handles (lines
-297-309).
+### Why this matches F-018
 
-On a Daytona session this log line never appears. `session.onPermissionRequest` never
-fires. The reverse request does not arrive. On an identical local run it fires and
-round-trips. That is the whole defect.
+The Pi extension calls `ctx.ui.confirm` in `services/runner/src/extensions/agenta.ts`.
+Pi emits an extension UI event. On local, adapter 0.0.29 converts it into
+`session/request_permission`. On Daytona, adapter 0.0.23 ignores it, so the confirm never
+gets an answer.
 
-### 4. The policy decision
+Normal Pi events still become `session/update`, which is why the runner sees the tool call.
+The runner never logs `[HITL] pi-gate` because no permission request exists. The request is
+lost before HTTP, SSE, or the Daytona proxy.
 
-`services/runner/src/permission-plan.ts` computes the decision. For a builtin there is no
-`specPermission` or `serverPermission`, so `effectivePermission` (lines 125-136) falls to
-a matching rule (`matchingRulePermission`) or the default (`defaultPermission`, lines
-248-256):
+This is the root cause with high confidence. One live version query against the deployed
+snapshot remains useful confirmation, not an open architecture question.
 
-- Default `allow`: every builtin resolves to allow.
-- Default `allow_reads`: read-only builtins (read, grep, find, ls) resolve to allow; write
-  builtins (bash, edit, write) resolve to ask.
-- Default `ask` or `deny`: as named.
-- A rule can override per builtin. A prefix rule like `Bash(git:*)` makes the decision
-  depend on the call arguments (`ruleMatches`, lines 214-224).
+## What the Daytona preview proxy is
 
-`decide` (lines 138-151) returns allow, deny, or pendingApproval. A pendingApproval that
-no stored decision answers pauses the turn and surfaces an approval prompt.
+The preview proxy is authenticated public ingress to one TCP port inside a Daytona
+sandbox. It is not an ACP-specific service and it is not the outbound proxy Daytona uses
+for protected secrets.
 
-The QA runs use allow mode, where every builtin resolves to allow. Both read and bash
-still hang, because the gate fires before the allow decision is reached.
+The sandbox-agent Daytona provider does the following:
 
-## Why the reverse request dies on Daytona and not local
+1. Starts `sandbox-agent server` on sandbox port 3000.
+2. Requests a signed preview URL for port 3000 with a four-hour TTL.
+3. Connects the outer SDK to that HTTPS URL.
 
-Both local and Daytona drive the harness through the same `sandbox-agent` package over
-HTTP. The local provider spawns the `sandbox-agent` binary as an HTTP server
-(`node_modules/sandbox-agent/dist/providers/local.js`, `spawnSandboxAgent` runs
-`server --host --port --token`). The runner connects to it with `AcpHttpClient`. On
-Daytona the same server binary runs inside the sandbox, and the runner connects to it
-through the Daytona preview proxy, with a cookie jar for the proxy auth
-(`createCookieFetch` in `services/runner/src/engines/sandbox_agent/daytona.ts`, lines
-143-181).
+The signed URL has the form `https://{port}-{signed-token}.{proxy-domain}`. Daytona
+documents the authentication and expiry model in its
+[preview documentation](https://www.daytona.io/docs/en/preview/).
 
-`AcpHttpClient` (in `acp-http-client@0.4.2`, bundled under `node_modules/.pnpm`) uses two
-HTTP channels to one endpoint:
+The last public Daytona proxy source before the repository maintenance change shows the
+request path. The proxy authenticates the signed hostname token, resolves the regional
+runner that owns the sandbox, and forwards the request to the selected sandbox port. The
+final forwarding layer is Go's `httputil.ReverseProxy` with a 100 millisecond flush
+interval for streams. It handles HTTP methods and bodies without parsing ACP or JSON-RPC.
 
-- Client to server: a `POST` per JSON-RPC message. A `200` response body is read inline as
-  a direct response (`postMessage`, dist/index.js lines 245-268).
-- Server to client: a single persistent `GET` SSE stream, started after the first POST
-  (`ensureSseLoop` / `runSseLoop`, lines 271-320). Both server-initiated notifications
-  (`session/update`) and server-initiated requests (`session/request_permission`) arrive
-  on this one stream. The client answers a server request by POSTing the response envelope
-  back.
+The repo's `createCookieFetch` wrapper in
+`services/runner/src/engines/sandbox_agent/daytona.ts` persists the
+`daytona-sandbox-auth-*` cookie because Node fetch has no cookie jar. The wrapper also uses
+the long-timeout ACP dispatcher. It does not translate protocol messages.
 
-The reverse-request handler is wired all the way through:
-`client.requestPermission -> live.handlePermissionRequest -> onPermissionRequest ->
-enqueuePermissionRequest` (chunk-TVCDKGSM.js lines 763-768, 888-914, 2025). Local proves
-this path works over HTTP.
+### Account tier is not the cause
 
-So the only variable between local and Daytona is the preview proxy. On Daytona the SSE
-stream does deliver `session/update` (the finding confirms the `tool_call` ingests fine),
-which means the stream is alive. Yet the `session/request_permission` envelope on that
-same stream never reaches the runner. Static analysis cannot pin the exact proxy behavior
-that drops or stalls the server-initiated request while passing notifications. Confirming
-and fixing it would need live proxy-level inspection and probably a change in the vendored
-`sandbox-agent` transport or the proxy itself.
+The documented Tier 3 preview difference is removal of the browser warning page. The
+warning middleware bypasses non-browser clients, including the runner's Node and Undici
+requests. A tier, token, expiry, or request-rate problem would fail or redirect an HTTP
+request. It would not selectively remove one JSON-RPC method from an SSE byte stream while
+letting another method through.
 
-This uncertainty is the strongest argument against fixing the transport as the primary
-path, and for options that do not depend on the reverse request at all. See
-[options.md](options.md).
+The source contains no filter for `session/request_permission`. More importantly, the
+adapter version proof shows that the failing Daytona process never emits that method.
 
-### A related transport fragility already documented
+## The ACP HTTP path
 
-F-017 in [../qa/findings.md](../qa/findings.md) records a Daytona proxy idle-stream
-timeout around 60s that killed quiet streams before PR #5197 detached the mount process.
-That history reinforces the read that server-initiated traffic over the proxy is fragile,
-and that a HITL pause (a human-timescale wait with no traffic) is exactly the shape the
-proxy handles worst.
+The outer runner-to-sandbox-agent connection uses concurrent HTTP channels to one URL:
 
-## Substrate the fix can reuse
+- Client-to-daemon JSON-RPC uses one POST per envelope.
+- Daemon-to-client traffic uses one persistent GET with
+  `Accept: text/event-stream`.
+- Notifications and server-initiated requests share that SSE stream.
+- The answer to a server-initiated request is another POST.
 
-### The file relay already works on Daytona
+The installed `acp-http-client` implements POST near `dist/index.js:230-268`, starts the
+SSE GET near `269-330`, and sends every parsed SSE message through the same inbound path
+near `333-393`. The sandbox-agent client installs `requestPermission` beside
+`sessionUpdate`, so both message types use the same transport.
 
-`services/runner/src/tools/relay.ts` runs a runner-side loop that polls the sandbox
-filesystem for request files, executes each, and writes a result file back (lines 16,
-317-378). It supports both a local filesystem host and a Daytona sandbox filesystem host
-(`host.list(relayDir)`, `host.read`, `sandbox.readFsFile`). This is how custom tool calls
-already cross the Daytona boundary. The MCP loopback channel is deliberately skipped on
-Daytona and swapped for this relay (`services/runner/src/engines/sandbox_agent/mcp.ts`
-lines 164-264). This is the proven precedent an ask-mode surface can follow.
+This is HTTP plus SSE. It is not WebSocket, long polling, callback delivery, or filesystem
+polling.
 
-Two caveats for reuse:
+Upstream sandbox-agent already fixed an earlier client deadlock that prevented permission
+answers while a long-running prompt POST remained open. The installed 0.4.2 client contains
+that fix and upstream pins it with a test named
+`answers session/request_permission while session/prompt is still in flight` in
+[the 0.4.2 smoke suite](https://github.com/rivet-dev/sandbox-agent/blob/v0.4.2/sdks/acp-http-client/tests/smoke.test.ts).
 
-- The relay loop starts only when `plan.useToolRelay` is set, which today tracks having
-  custom tools (`services/runner/src/engines/sandbox_agent.ts` line 1631). A builtins-only
-  run does not start it. Delivering builtin gates over the relay would need the loop
-  running whenever builtin gating is active on Daytona.
-- Builtin gating passes no relay dir to the extension today. `buildPiExtensionEnv` sets
-  `AGENTA_AGENT_BUILTIN_GATING` and `AGENTA_AGENT_BUILTIN_GRANTS` but notes the gate rides
-  the confirm dialog, not the file relay
-  (`services/runner/src/engines/sandbox_agent/pi-assets.ts` lines 74-79). An option that
-  uses the relay for builtins would set the relay dir there too.
+## Permission delivery, end to end after parity
 
-### The relay guard already re-decides runner-side
+With adapter 0.0.29 in the snapshot, the live path is:
 
-For Pi custom tools the relay guard re-runs `decide()` on the runner before executing a
-relayed call (`services/runner/src/engines/sandbox_agent.ts` lines 1594-1630). A forged
-execute record cannot run an ask or deny tool. This is the same runner-side enforcement an
-ask-mode file-relay gate would use. It shows the pattern is already in the codebase.
+1. The Pi extension raises `ctx.ui.confirm` for the builtin call.
+2. Pi emits `extension_ui_request` to `pi-acp`.
+3. `pi-acp` emits ACP `session/request_permission`.
+4. sandbox-agent broadcasts the request on the same SSE stream as updates.
+5. The outer SDK maps the agent session id to the Agenta session and invokes its permission
+   listener.
+6. `acp-interactions.ts` evaluates the runner-owned permission plan.
+7. The runner POSTs the selected ACP permission response.
+8. `pi-acp` sends the extension UI answer to Pi and the original tool call continues or is
+   blocked.
 
-### The runner already computes builtin grants up front
+The existing runner path already supports allow, deny, and pending human approval. Option A
+does not add a new interface.
 
-`run-plan.ts` computes `builtinGrants` and `builtinGatingActive`
-(`normalizePiBuiltinGrants`, `computeBuiltinGatingActive`, lines 289-293) and injects them
-into the sandbox env. Adding a per-builtin decision alongside the grant list is a small
-extension of an injection that already exists.
+## Live and cold approval are lifecycle states, not transports
 
-## Facts that constrain the approval state machine
+### Live continuation
 
-Surfaced during the design review ([design-review.md](design-review.md)); verify at the
-referenced sites.
+When the sandbox and prompt remain alive, the runner can retain the ACP permission id and
+the original prompt promise. A human answer calls `respondPermission` on the same session.
+The original call continues with its byte-exact arguments. The relevant state is in
+`services/runner/src/engines/sandbox_agent.ts` around the parked-approval type and the
+resume path near lines 1653-1689.
 
-- The relay loop stops as soon as the turn pauses (`runTurn` stops the relay,
-  `services/runner/src/engines/sandbox_agent.ts` around line 1713), and the loop marks a
-  request seen before processing (`services/runner/src/tools/relay.ts` around lines
-  336-350). A pending gate file inside a paused turn is not answered later by the same
-  loop.
-- Live approval parking is ACP-only: a parked gate holds an ACP permission id answered
-  via `respondPermission` (`sandbox_agent.ts` around line 427, `server.ts` around line
-  590), and a unit test asserts Pi file-relay gates are non-parkable
-  (`services/runner/tests/unit/session-keepalive-approval.test.ts` around line 428). A
-  file-transport gate cannot park without extending that union.
-- Keep-alive is off by default (`session-pool.ts` around line 53), and F-020 records that
-  Daytona sandboxes are deleted at turn end regardless. So the default resume path for a
-  Daytona ask gate is cold: the sandbox that raised the gate is gone by the time the
-  human answers, and the stored decision must answer the reissued call on the next turn.
-- The extension trusts relay response JSON as-is (`services/runner/src/tools/dispatch.ts`
-  around line 89). That is safe for custom-tool results because execution happens
-  runner-side behind the relay guard. It is not safe for a builtin decision file, where
-  the file itself would be the authorization: the relay dir is sandbox-writable, so an
-  unsigned `allow` is not demonstrably runner-authored.
-- `run-limits.ts` freezes every deadline on a HITL pause (`notePaused`) on purpose. Any
-  gate timeout must not reap a legitimately parked approval, which forces the
-  delivery-versus-human split rather than one timer.
+### Cold replay
 
-## What the runner can and cannot precompute
+If the sandbox stops, archives, is deleted, or loses its live connection while approval is
+pending, the adapter process and its pending RPC die. No transport can answer that dead
+request. A file channel does not change this.
 
-The runner can precompute a builtin's decision when it does not depend on the call
-arguments: the default mode applied to the builtin's read-only hint, or a plain
-name-match rule. The runner cannot precompute a single decision when a prefix rule like
-`Bash(git:*)` makes the answer depend on the arguments, and it cannot precompute an ask
-that a human must answer per call. Those cases must still reach the runner at call time
-(they compile to the `runner` disposition). This split is what shapes the recommended
-layering in [options.md](options.md).
+The cold path stores the human decision durably. On the next run, the runner restarts or
+recreates the session, the model reissues the pending call, and the responder consumes the
+stored decision. The call is authorized through a new ACP request on the new live
+connection.
+
+Option B is therefore not required for cold approval. Durable decisions and replay are.
+
+## Pi, Claude, MCP, and custom tools
+
+The first draft grouped different delivery mechanisms under “MCP.” The current behavior is:
+
+| Case | Daytona behavior |
+| --- | --- |
+| Pi builtins | Pi extension dialog through `pi-acp` to ACP permission. F-018 is the stale-adapter failure on this path. |
+| Pi Agenta custom and gateway tools | Pi extension plus filesystem execution relay. This is not user MCP. |
+| Pi user-declared MCP | Rejected before the run. Pi receives no ACP MCP server list. |
+| Claude native tools | Native ACP permission requests. F-018 does not prove this path fails. |
+| Claude Agenta gateway tools | Unsupported on Daytona because the internal runner-loopback MCP endpoint is not reachable from sandbox loopback. |
+| Claude user HTTP MCP | Delivered when the harness advertises MCP; the sandbox connects to the remote URL. |
+| User stdio MCP | Disabled for every harness. |
+
+Evidence lives in `services/runner/src/engines/sandbox_agent/mcp.ts` and
+`run-plan.ts`. In particular, `buildSessionMcpServers` returns no ACP MCP servers for Pi,
+skips the internal loopback server on Daytona, retains user HTTP servers for capable
+non-Pi harnesses, and rejects stdio.
+
+Option A fixes the Pi reverse permission path. It does not add new forward-delivery
+capabilities for MCP or custom tools.
+
+## Focused validation
+
+The implementation pass should run these checks in order:
+
+1. Query the current Daytona snapshot's private Pi adapter version. Expect 0.0.23.
+2. Rebuild a temporary snapshot with private adapter 0.0.29 and verify the version before
+   creating a run.
+3. Run allow-mode read and bash. Expect `[HITL] pi-gate`, immediate runner allow, and a
+   completed tool call.
+4. Run deny mode. Expect a denied result and no execution.
+5. Run ask mode while the sandbox remains live. Approve and reject once; expect the
+   original prompt to continue through `respondPermission`.
+6. Exercise cold approval by letting the live continuation go away, then answer and resume.
+   Expect a reissued gate to consume the stored decision.
+7. Run a Claude ask-mode control on Daytona. Record its result separately from F-018.
+8. List Daytona sandboxes before and after the run and delete every test sandbox.
+
+Only if step 3 still fails after the adapter emits a permission request should the team
+instrument raw adapter stdout and the proxy SSE stream. That experiment would establish
+whether a real envelope disappears after generation. Until then, a file permission channel
+has no evidence-based trigger.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
@@ -1,82 +1,72 @@
 # Status
 
-Source of truth for this project's progress. Update it as work moves.
-
 ## Current state
 
-Design complete and independently reviewed. No code changed. The first draft went through
-a critical external review (Codex, xhigh); its findings are recorded in
-[design-review.md](design-review.md) and folded into [options.md](options.md) and
-[plan.md](plan.md). Ready for the owner's review.
+Design revised after owner review. No implementation code changed. Research identified the
+root cause as Pi ACP adapter version skew, not Daytona preview-proxy behavior.
+
+The checked-in snapshot recipe inherits `pi-acp` 0.0.23 from
+`rivetdev/sandbox-agent:0.5.0-rc.2-full`; local runs use the repo-pinned 0.0.29. Version
+0.0.23 predates the extension UI permission bridge. The proposed fix is now a snapshot
+dependency pin and rebuild.
 
 ## Decisions
 
-- Primary fix is Option C: the runner compiles each granted builtin's policy into a
-  disposition (`allow`, `deny`, or `runner`) in `permission-plan.ts` and injects the
-  versioned map into the sandbox, so allow and deny resolve with no round-trip. This
-  fixes the allow-mode scenario the QA matrix exercises and the build-kit default agent's
-  opening read.
-- Residual (`runner`-disposition) builtin gates on Daytona ride a file-gate protocol over
-  the relay dir: request file, runner acknowledgment, authenticated decision file.
-- Custom tools get no second gate channel. Their existing execution relay request is the
-  authorization seam: the relay guard decides and executes atomically (allow executes,
-  deny returns a denied result, pending pauses without executing).
-- The timeout is a two-lifetime model: a short delivery deadline ending at the runner's
-  acknowledgment (fails closed, covers the F-018 undeliverable case) and a human approval
-  lifetime after acknowledgment owned by the existing pause model. No single timer, and
-  no claim of an all-path timeout on the ACP confirm path, which has no acknowledgment.
-- Decision files are HMAC-authenticated with a per-run secret delivered via a read-once
-  file (the OTLP bearer pattern), because the relay dir is sandbox-writable and for a
-  builtin the decision file is the authorization.
-- Resume is defined as two explicit state machines: the cold path (default; stored
-  decision answers the reissued call next turn) and the live keep-alive path (a
-  file-transport variant of the parked-gate union). Until the live variant exists, file
-  gates take the cold path even under keep-alive.
-- Everything ships as one release unit. Under default `allow_reads`, Option C alone would
-  fix reads while bash, edit, and write still hang.
-- Option A (fix the reverse RPC over the remote transport) is deferred to the
-  sandbox-agent fork plan (PR #5172). It is the ideal long-term shape but the highest
-  cost and uncertainty, and the plan does not depend on it.
+- Option A is the primary correctness fix.
+- Option A means adapter parity, not a Daytona proxy rewrite.
+- ACP remains the only permission plane for Pi builtins on local and Daytona.
+- Option B is not planned. It opens only if a fresh, corrected adapter emits a permission
+  request that a focused transport probe proves is lost after emission.
+- Option C does not depend on Option B. It is deferred as a separate latency optimization.
+- Live and cold approval are separate lifecycle paths:
+  - live answers the held ACP permission id and continues the original call;
+  - cold stores the human decision, recreates or reloads, and answers the reissued call.
+- A file relay cannot preserve a pending RPC after the process holding it has stopped.
+- F-018's evidence applies to Pi. Claude ask on Daytona needs its own control run.
+- Pi custom and gateway tools use the extension execution relay, not user MCP.
 
-## Rationale for the trust trade-off in Option C
+## Evidence
 
-Injecting the compiled builtin disposition into the sandbox holds narrowly, per the
-review. Protected: a prompt-injected model calling a builtin outside its policy (the
-model cannot mutate the parent Pi process env through tool arguments, and the enforcement
-hook is the same one that obeys the ACP answer today). Not protected: an arbitrary
-hostile process with control of the sandbox, which can already do anything a builtin
-could regardless of the gate. Caveat to document: once unrestricted bash is allowed,
-builtin permissions are not a meaningful confinement boundary for later in-sandbox
-effects. The runner remains the policy compiler; the extension receives only a minimal
-disposition, never the rule set. Custom-tool decisions stay on the runner.
+- `services/runner/package.json` pins local `pi-acp` 0.0.29.
+- `services/runner/src/engines/sandbox_agent/daemon.ts` puts the local runner dependency on
+  the daemon `PATH`.
+- `services/runner/sandbox-images/daytona/build_snapshot.py` inherits ACP adapters from
+  `rivetdev/sandbox-agent:0.5.0-rc.2-full` and installs only the standalone Pi CLI.
+- The upstream 0.5.0-rc.2 adapter manifest pins `pi-acp` 0.0.23.
+- The upstream 0.0.23 adapter has no `extension_ui_request` handler.
+- The bridge landed in pi-acp commit `1412ea6110` and shipped in 0.0.28.
+- The installed 0.0.29 adapter converts confirm dialogs to ACP permission requests.
+- The last public Daytona proxy source uses a generic Go reverse proxy and contains no
+  ACP method filter.
 
-## Open questions
+## Remaining validation
 
-- Delivery-deadline default: it must cover a relay poll round-trip on Daytona with
-  headroom (the poll has idle backoff), but stay far under the 300s guard. A value near
-  10 to 20 seconds is a guess to validate live.
-- Should the live (keep-alive) file-transport parking variant land in the same release
-  unit, or is cold-path-only acceptable for the first cut given keep-alive is off by
-  default and F-020 means Daytona recreates sandboxes anyway? Default proposal: cold-path
-  only first, with the parked-gate union extension as an immediate follow-up, and file
-  gates forced cold under keep-alive until then.
-- Whether local should also read the disposition map for allow and deny (skipping the
-  confirm). The plan says yes for one shared code path and lower latency; needs the
-  owner's confirm because it changes local approval traffic.
+- Query the private adapter version in the currently deployed snapshot.
+- Rebuild a temporary or replacement snapshot with 0.0.29.
+- Run the allow, deny, ask-live, and ask-cold checks in [plan.md](plan.md).
+- Run one Claude Daytona ask control.
+- Measure the repaired ACP round-trip before considering Option C.
 
-## Not in scope
+The live Daytona checks require confirmation that cloud credits are available. Every run
+must count sandboxes before and after and delete its test sandbox.
 
-- The Daytona proxy behavior itself (Option A).
-- Where code tools execute (F-010).
-- Session-resume sandbox reuse (F-020).
+## Blockers
+
+None for the design. Implementation and live verification require a Daytona snapshot
+rebuild window and available credits.
+
+## Next steps
+
+1. Review this revised design.
+2. If approved, implement the snapshot recipe pin and build assertion.
+3. Rebuild and rotate `agenta-sandbox-pi`.
+4. Run focused live verification.
+5. Close or reopen the transport contingency from evidence.
 
 ## Provenance
 
 - Finding: F-018 in [../qa/findings.md](../qa/findings.md).
-- Working tree at planning time: PR #5197 (feat/sessions-continuity) applied.
-- Key code read: `services/runner/src/extensions/agenta.ts`,
-  `services/runner/src/engines/sandbox_agent/{acp-interactions,pi-gate-envelope,mcp,pi-assets,run-limits,daytona,acp-fetch}.ts`,
-  `services/runner/src/permission-plan.ts`, `services/runner/src/tools/relay.ts`, and the
-  vendored `acp-http-client@0.4.2` and `sandbox-agent@0.4.2` transport.
-- External review: Codex CLI, `model_reasoning_effort=xhigh`, read-only, 2026-07-11; see
-  [design-review.md](design-review.md).
+- Owner review: nine inline threads on PR #5218.
+- Research pass: three independent tracks for Daytona proxy source, sandbox-agent and ACP
+  transport, and permission lifecycle and harness scope.
+- No live Daytona sandbox was started during this review pass.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
@@ -1,0 +1,82 @@
+# Status
+
+Source of truth for this project's progress. Update it as work moves.
+
+## Current state
+
+Design complete and independently reviewed. No code changed. The first draft went through
+a critical external review (Codex, xhigh); its findings are recorded in
+[design-review.md](design-review.md) and folded into [options.md](options.md) and
+[plan.md](plan.md). Ready for the owner's review.
+
+## Decisions
+
+- Primary fix is Option C: the runner compiles each granted builtin's policy into a
+  disposition (`allow`, `deny`, or `runner`) in `permission-plan.ts` and injects the
+  versioned map into the sandbox, so allow and deny resolve with no round-trip. This
+  fixes the allow-mode scenario the QA matrix exercises and the build-kit default agent's
+  opening read.
+- Residual (`runner`-disposition) builtin gates on Daytona ride a file-gate protocol over
+  the relay dir: request file, runner acknowledgment, authenticated decision file.
+- Custom tools get no second gate channel. Their existing execution relay request is the
+  authorization seam: the relay guard decides and executes atomically (allow executes,
+  deny returns a denied result, pending pauses without executing).
+- The timeout is a two-lifetime model: a short delivery deadline ending at the runner's
+  acknowledgment (fails closed, covers the F-018 undeliverable case) and a human approval
+  lifetime after acknowledgment owned by the existing pause model. No single timer, and
+  no claim of an all-path timeout on the ACP confirm path, which has no acknowledgment.
+- Decision files are HMAC-authenticated with a per-run secret delivered via a read-once
+  file (the OTLP bearer pattern), because the relay dir is sandbox-writable and for a
+  builtin the decision file is the authorization.
+- Resume is defined as two explicit state machines: the cold path (default; stored
+  decision answers the reissued call next turn) and the live keep-alive path (a
+  file-transport variant of the parked-gate union). Until the live variant exists, file
+  gates take the cold path even under keep-alive.
+- Everything ships as one release unit. Under default `allow_reads`, Option C alone would
+  fix reads while bash, edit, and write still hang.
+- Option A (fix the reverse RPC over the remote transport) is deferred to the
+  sandbox-agent fork plan (PR #5172). It is the ideal long-term shape but the highest
+  cost and uncertainty, and the plan does not depend on it.
+
+## Rationale for the trust trade-off in Option C
+
+Injecting the compiled builtin disposition into the sandbox holds narrowly, per the
+review. Protected: a prompt-injected model calling a builtin outside its policy (the
+model cannot mutate the parent Pi process env through tool arguments, and the enforcement
+hook is the same one that obeys the ACP answer today). Not protected: an arbitrary
+hostile process with control of the sandbox, which can already do anything a builtin
+could regardless of the gate. Caveat to document: once unrestricted bash is allowed,
+builtin permissions are not a meaningful confinement boundary for later in-sandbox
+effects. The runner remains the policy compiler; the extension receives only a minimal
+disposition, never the rule set. Custom-tool decisions stay on the runner.
+
+## Open questions
+
+- Delivery-deadline default: it must cover a relay poll round-trip on Daytona with
+  headroom (the poll has idle backoff), but stay far under the 300s guard. A value near
+  10 to 20 seconds is a guess to validate live.
+- Should the live (keep-alive) file-transport parking variant land in the same release
+  unit, or is cold-path-only acceptable for the first cut given keep-alive is off by
+  default and F-020 means Daytona recreates sandboxes anyway? Default proposal: cold-path
+  only first, with the parked-gate union extension as an immediate follow-up, and file
+  gates forced cold under keep-alive until then.
+- Whether local should also read the disposition map for allow and deny (skipping the
+  confirm). The plan says yes for one shared code path and lower latency; needs the
+  owner's confirm because it changes local approval traffic.
+
+## Not in scope
+
+- The Daytona proxy behavior itself (Option A).
+- Where code tools execute (F-010).
+- Session-resume sandbox reuse (F-020).
+
+## Provenance
+
+- Finding: F-018 in [../qa/findings.md](../qa/findings.md).
+- Working tree at planning time: PR #5197 (feat/sessions-continuity) applied.
+- Key code read: `services/runner/src/extensions/agenta.ts`,
+  `services/runner/src/engines/sandbox_agent/{acp-interactions,pi-gate-envelope,mcp,pi-assets,run-limits,daytona,acp-fetch}.ts`,
+  `services/runner/src/permission-plan.ts`, `services/runner/src/tools/relay.ts`, and the
+  vendored `acp-http-client@0.4.2` and `sandbox-agent@0.4.2` transport.
+- External review: Codex CLI, `model_reasoning_effort=xhigh`, read-only, 2026-07-11; see
+  [design-review.md](design-review.md).

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
@@ -2,71 +2,67 @@
 
 ## Current state
 
-Design revised after owner review. No implementation code changed. Research identified the
-root cause as Pi ACP adapter version skew, not Daytona preview-proxy behavior.
+Implementation is ready for review on the stacked fix branch. The Daytona snapshot recipe
+now replaces the base image's private Pi ACP adapter with version 0.0.29, verifies the
+private launcher and package version during the build, and keeps the standalone Pi CLI at
+0.80.6.
 
-The checked-in snapshot recipe inherits `pi-acp` 0.0.23 from
-`rivetdev/sandbox-agent:0.5.0-rc.2-full`; local runs use the repo-pinned 0.0.29. Version
-0.0.23 predates the extension UI permission bridge. The proposed fix is now a snapshot
-dependency pin and rebuild.
+The named `agenta-sandbox-pi` snapshot was force-rebuilt on 2026-07-11. Daytona reported
+the snapshot as active after 96.4 seconds.
+
+## Live verification
+
+- Snapshot build: passed. The installer reported private `pi-acp` 0.0.29 at
+  `/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/pi-acp`.
+- Build assertion: passed with `pi-acp-version=0.0.29`.
+- Pi core, allow mode, Bash: passed on Daytona. The command returned
+  `QA-BASH-x86_64`.
+- Pi core, deny mode, Bash: passed on Daytona. The runner returned
+  `Denied by the permission policy.` and the command did not execute.
+- Pi core, ask mode: the runner returned a real `interaction_request` instead of
+  hanging. This proves the adapter now emits the ACP permission request.
+- Sandbox hygiene: zero live sandboxes before the matrix and zero after it.
+- Live Agenta deployments: the EE health endpoint on port 8280 and the OSS health endpoint
+  on port 8290 both returned `{"status":"ok"}`.
+
+The supported playground approve and reject clicks, the cold approval replay, the
+`pi_agenta` opening skill read, and the Claude Daytona control remain to be completed.
+Two hand-built raw API resume payloads re-prompted rather than consuming the approval.
+That result is not enough to call a product regression because the payloads did not come
+from the supported UI client.
 
 ## Decisions
 
-- Option A is the primary correctness fix.
-- Option A means adapter parity, not a Daytona proxy rewrite.
+- Option A is implemented as adapter parity. No file permission protocol or policy map was
+  added.
 - ACP remains the only permission plane for Pi builtins on local and Daytona.
-- Option B is not planned. It opens only if a fresh, corrected adapter emits a permission
-  request that a focused transport probe proves is lost after emission.
-- Option C does not depend on Option B. It is deferred as a separate latency optimization.
-- Live and cold approval are separate lifecycle paths:
-  - live answers the held ACP permission id and continues the original call;
-  - cold stores the human decision, recreates or reloads, and answers the reissued call.
-- A file relay cannot preserve a pending RPC after the process holding it has stopped.
-- F-018's evidence applies to Pi. Claude ask on Daytona needs its own control run.
-- Pi custom and gateway tools use the extension execution relay, not user MCP.
+- The build checks the private sandbox-agent installation, not a global npm package.
+- The correct v0.5.0-rc.2 private install root contains `/bin/agent_processes/`. The
+  earlier design text omitted `/bin`; this implementation corrects it.
+- Existing sandboxes created before the snapshot rebuild retain their old filesystem and
+  must be drained before rollout verification.
 
-## Evidence
+## Verification commands
 
-- `services/runner/package.json` pins local `pi-acp` 0.0.29.
-- `services/runner/src/engines/sandbox_agent/daemon.ts` puts the local runner dependency on
-  the daemon `PATH`.
-- `services/runner/sandbox-images/daytona/build_snapshot.py` inherits ACP adapters from
-  `rivetdev/sandbox-agent:0.5.0-rc.2-full` and installs only the standalone Pi CLI.
-- The upstream 0.5.0-rc.2 adapter manifest pins `pi-acp` 0.0.23.
-- The upstream 0.0.23 adapter has no `extension_ui_request` handler.
-- The bridge landed in pi-acp commit `1412ea6110` and shipped in 0.0.28.
-- The installed 0.0.29 adapter converts confirm dialogs to ACP permission requests.
-- The last public Daytona proxy source uses a generic Go reverse proxy and contains no
-  ACP method filter.
+- `python3 -m py_compile services/runner/sandbox-images/daytona/build_snapshot.py`
+- `ruff format --check services/runner/sandbox-images/daytona/build_snapshot.py`
+- `ruff check services/runner/sandbox-images/daytona/build_snapshot.py`
+- `git diff --check`
+- `uv run services/runner/sandbox-images/daytona/build_snapshot.py --force`
+- `uv run docs/design/agent-workflows/projects/qa/scripts/run_matrix.py --env-label E3 --sandbox daytona --only builtin_bash_pi --timeout 300`
 
-## Remaining validation
+## Remaining work
 
-- Query the private adapter version in the currently deployed snapshot.
-- Rebuild a temporary or replacement snapshot with 0.0.29.
-- Run the allow, deny, ask-live, and ask-cold checks in [plan.md](plan.md).
-- Run one Claude Daytona ask control.
-- Measure the repaired ACP round-trip before considering Option C.
-
-The live Daytona checks require confirmation that cloud credits are available. Every run
-must count sandboxes before and after and delete its test sandbox.
-
-## Blockers
-
-None for the design. Implementation and live verification require a Daytona snapshot
-rebuild window and available credits.
-
-## Next steps
-
-1. Review this revised design.
-2. If approved, implement the snapshot recipe pin and build assertion.
-3. Rebuild and rotate `agenta-sandbox-pi`.
-4. Run focused live verification.
-5. Close or reopen the transport contingency from evidence.
+1. Review and merge the stacked implementation PR.
+2. Exercise approve and reject from the playground UI.
+3. Confirm cold approval replay through the supported UI message history.
+4. Run the `pi_agenta` opening read and one Claude ask-mode control.
+5. Update F-018 to resolved after those lifecycle checks pass.
 
 ## Provenance
 
-- Finding: F-018 in [../qa/findings.md](../qa/findings.md).
-- Owner review: nine inline threads on PR #5218.
-- Research pass: three independent tracks for Daytona proxy source, sandbox-agent and ACP
-  transport, and permission lifecycle and harness scope.
-- No live Daytona sandbox was started during this review pass.
+- Design PR: #5218.
+- Root cause: the Daytona snapshot inherited `pi-acp` 0.0.23, which predates the Pi
+  extension UI permission bridge.
+- Implementation review: one narrow implementer and one independent reviewer.
+- Live verification date: 2026-07-11.

--- a/docs/design/agent-workflows/projects/qa/runs/E3__builtin_bash_pi.json
+++ b/docs/design/agent-workflows/projects/qa/runs/E3__builtin_bash_pi.json
@@ -4,9 +4,9 @@
   "capability": "builtin bash",
   "env_label": "E3",
   "sandbox": "daytona",
-  "harness": "pi",
-  "model": "gpt-4o-mini",
-  "ts": "2026-06-20T11:02:49.133906+00:00",
+  "harness": "pi_core",
+  "model": "openai/gpt-4o-mini",
+  "ts": "2026-07-11T15:28:06.701900+00:00",
   "request": {
     "data": {
       "inputs": {
@@ -19,24 +19,38 @@
       },
       "parameters": {
         "agent": {
-          "harness": "pi",
-          "sandbox": "daytona",
-          "model": "gpt-4o-mini",
-          "agents_md": "Use the bash tool when asked to run a command. Report only its stdout.",
+          "harness": {
+            "kind": "pi_core"
+          },
+          "sandbox": {
+            "kind": "daytona"
+          },
+          "llm": {
+            "model": "openai/gpt-4o-mini"
+          },
+          "instructions": {
+            "agents_md": "Use the bash tool when asked to run a command. Report only its stdout."
+          },
           "tools": [
             {
               "type": "builtin",
               "name": "bash"
             }
-          ]
+          ],
+          "runner": {
+            "permissions": {
+              "default": "allow"
+            }
+          }
         }
       }
     }
   },
   "http_status": 200,
   "response": {
-    "span_id": "5fc4483660ed338c",
-    "trace_id": "b6026a64a4a94ea48359943198dedcc6",
+    "session_id": "b1476563e296494ea79012af0ec35567",
+    "span_id": "3880627166641182",
+    "trace_id": "def0db6ab9f613f6f1bf78c01ed6ae0c",
     "version": "2025.07.14",
     "status": {
       "code": 200,
@@ -44,8 +58,28 @@
     },
     "data": {
       "outputs": {
-        "role": "assistant",
-        "content": "QA-BASH-x86_64"
+        "messages": [
+          {
+            "role": "tool",
+            "content": "",
+            "tool_call_id": "call_tSojUJhhVjgM1mFww8hzFA2R|fc_014a2915d446a818016a5261139f108192ac11a9132c80e5f5",
+            "tool_name": "bash",
+            "input": {
+              "command": "echo \"QA-BASH-$(uname -m)\""
+            }
+          },
+          {
+            "role": "tool",
+            "content": "QA-BASH-x86_64\n",
+            "tool_call_id": "call_tSojUJhhVjgM1mFww8hzFA2R|fc_014a2915d446a818016a5261139f108192ac11a9132c80e5f5",
+            "is_error": false
+          },
+          {
+            "role": "assistant",
+            "content": "QA-BASH-x86_64"
+          }
+        ],
+        "stop_reason": "end_turn"
       }
     }
   },

--- a/services/runner/sandbox-images/daytona/README.md
+++ b/services/runner/sandbox-images/daytona/README.md
@@ -20,15 +20,26 @@ AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
 ## What is baked
 
 The recipe bases on `rivetdev/sandbox-agent:*-full`. That base image already installs the
-Claude, Codex, and OpenCode native binaries and ACP adapters. It also includes the Pi ACP
-adapter, but not the standalone `pi` CLI that the adapter launches.
+Claude, Codex, and OpenCode native binaries and ACP adapters. It also includes a Pi ACP
+adapter, but its version can differ from the runner's adapter and it does not include the
+standalone `pi` CLI that the adapter launches.
 
 The snapshot recipe therefore:
 
 - installs `@earendil-works/pi-coding-agent@0.80.6`;
 - fails the build unless `pi --version` succeeds;
+- reinstalls the private Pi ACP adapter at `pi-acp@0.0.29` through
+  `sandbox-agent install-agent`, rather than installing a global package that the daemon
+  would not resolve;
+- fails the build unless the private launcher exists and its installed package reports
+  version `0.0.29`;
 - verifies that the Claude, Codex, and OpenCode binaries are still present; and
 - installs the FUSE and geesefs dependencies used for durable remote working directories.
+
+The Pi CLI and Pi ACP adapter are separate dependencies. Keep both pins explicit. The CLI
+runs the agent; the adapter translates Pi events and dialogs onto ACP. In particular, the
+adapter version must not be inherited implicitly from the base image because older versions
+do not forward Pi extension dialogs as ACP permission requests.
 
 ## Pi installation controls
 

--- a/services/runner/sandbox-images/daytona/build_snapshot.py
+++ b/services/runner/sandbox-images/daytona/build_snapshot.py
@@ -5,10 +5,10 @@
 """Build a Daytona snapshot for the Agenta sandbox-agent runner.
 
 The full sandbox-agent base image already bakes the Claude, Codex, and OpenCode
-native binaries and ACP adapters. It also includes the Pi ACP adapter, but not the
-standalone `pi` CLI that adapter launches. This recipe adds the pinned Pi CLI and
-verifies the other baked harnesses so Daytona runs do not pay their installation cost
-for every fresh sandbox. Set the runner service to use it:
+native binaries and ACP adapters. This recipe replaces its Pi ACP adapter with the
+pinned version, adds the pinned standalone `pi` CLI that adapter launches, and verifies
+the other baked harnesses so Daytona runs do not pay their installation cost for every
+fresh sandbox. Set the runner service to use it:
 
     DAYTONA_SNAPSHOT=agenta-sandbox-pi
     AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
@@ -41,7 +41,11 @@ from daytona.common.errors import DaytonaNotFoundError
 
 SNAPSHOT_NAME = "agenta-sandbox-pi"
 SANDBOX_AGENT_IMAGE = "rivetdev/sandbox-agent:0.5.0-rc.2-full"
-PI_PACKAGE = "@earendil-works/pi-coding-agent@0.80.6"
+PI_VERSION = "0.80.6"
+PI_PACKAGE = f"@earendil-works/pi-coding-agent@{PI_VERSION}"
+PI_ACP_VERSION = "0.0.29"
+PI_ACP_INSTALL_DIR = "/home/sandbox/.local/share/sandbox-agent/bin/agent_processes"
+PI_ACP_PACKAGE_JSON = f"{PI_ACP_INSTALL_DIR}/pi/node_modules/pi-acp/package.json"
 # Durable session cwd: geesefs (FUSE-over-S3) mounts the store prefix INSIDE the sandbox for
 # remote runs. fuse provides fusermount + /etc/fuse.conf; geesefs is the static mount binary.
 # amd64 is correct here regardless of the builder's local arch: the snapshot is built and run
@@ -101,6 +105,15 @@ def main() -> None:
             f"RUN curl -fsSL -o /usr/local/bin/geesefs {GEESEFS_URL} "
             "&& chmod +x /usr/local/bin/geesefs",
             "USER sandbox",
+            # Replace the base image's private Pi adapter. sandbox-agent resolves this launcher
+            # before PATH, so a global pi-acp install would leave the stale adapter active.
+            f"RUN sandbox-agent install-agent pi --reinstall "
+            f"--agent-process-version {PI_ACP_VERSION}",
+            # Assert the private launcher and its installed npm package, not a global package.
+            f"RUN test -x {PI_ACP_INSTALL_DIR}/pi-acp "
+            f'&& test "$(node -p "require(\'{PI_ACP_PACKAGE_JSON}\').version")" '
+            f'= "{PI_ACP_VERSION}" '
+            f"&& echo pi-acp-version={PI_ACP_VERSION}",
         ]
     )
 


### PR DESCRIPTION
## Context

Pi builtin calls hang on Daytona because the snapshot and local runner use different
`pi-acp` adapters. Local runs use 0.0.29. The Daytona snapshot inherits 0.0.23, which
predates the bridge from Pi extension dialogs to ACP permission requests. The runner sees
the tool update but never receives a permission request, so the dialog waits until the
300-second run limit ends the turn.

## What this revision changes

This remains a design-only PR. The revised workspace now identifies adapter version skew
as the root cause and recommends a small snapshot fix:

- pin the Daytona snapshot's private `pi-acp` adapter to 0.0.29;
- assert that version during the snapshot build;
- rebuild and rotate the snapshot;
- verify allow, deny, ask-live, and ask-cold behavior on fresh sandboxes.

The revision withdraws the proposed file-based permission channel. ACP remains the one
permission plane. Option C, precomputing static allow and deny decisions, is now an
independent latency idea rather than part of the correctness fix.

## Before and after

Before: the draft assumed Daytona's preview proxy dropped
`session/request_permission`, deferred root-cause work, and recommended a second file
permission protocol.

After: source and version evidence shows the old Daytona adapter never creates the request.
The plan restores adapter parity first and opens a transport fallback only if a corrected
adapter emits a request that is then proven lost.

## How to review

1. Start with `research.md` for the version proof and the preview-proxy explanation.
2. Read `options.md` for the revised A, B, and C relationship.
3. Read `plan.md` for the snapshot pin, live tests, cold-state test, and fallback gate.
4. Check `status.md` for the remaining live validation.

## Scope

No implementation code, public interface, wire shape, or configuration changes are in
this PR.
