### PR TITLE
docs(design): sandbox network story: tunnels today, NetBird overlay plan

### DIFF
--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/README.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/README.md
@@ -1,0 +1,65 @@
+# NetBird sandbox overlay network
+
+Research and effort assessment for one idea: put the runner and its Daytona sandboxes on a
+shared private WireGuard mesh (an overlay network) using NetBird, so the runner and a sandbox
+can open connections to each other in both directions. That would attack a whole class of
+connectivity problems at once, instead of one workaround per feature, and could carry MCP
+traffic later. Includes a side assessment of Cloudflare Tunnel as a near-term, zero-auth
+replacement for the ngrok store tunnel.
+
+This is research only. No code changed. Owner: Mahmoud.
+
+## The problem it targets
+
+Today the runner reaches a Daytona sandbox one way (the Daytona signed preview URL). The
+sandbox has no direct way back to the runner; it only writes files the runner polls. That
+missing return direction is the root cause behind three separate workarounds:
+
+- **F-017:** a remote sandbox cannot reach the runner-side store, so mounts go through a
+  public ngrok tunnel (`../qa/findings.md`,
+  `services/runner/src/engines/sandbox_agent/mount.ts`).
+- **F-018:** the reverse permission RPC from sandbox to runner never arrives, so gate
+  decisions are being routed through polled files instead (`../daytona-gate-delivery/`).
+- **MCP delivery:** the runner's tool-MCP server binds a loopback the sandbox cannot reach,
+  so it is skipped on Daytona and an in-sandbox shim is planned
+  (`../mcp-delivery-architecture/directions.md`).
+
+A shared overlay would give the sandbox a direct, private route back to the runner, which is
+the one thing all three lack.
+
+## Files (reading order)
+
+- [plan.md](plan.md) — start here: the whole sandbox network story in one place. The four
+  problems as they exist today, the near-term Cloudflare quick-tunnel step, the longer-term
+  NetBird overlay phases, which workarounds retire in which order, local mode and
+  self-hosters, and the sequencing against the work in flight.
+- [research.md](research.md) — the five research questions answered with sources
+  (feasibility inside a Daytona sandbox, architecture, security and tenancy, local mode,
+  effort and alternatives), plus the Cloudflare Tunnel assessment.
+- [recommendation.md](recommendation.md) — the verdict, the one-day confirmation run, phase
+  estimates, and the Cloudflare quick-tunnel call.
+
+## Glossary
+
+- **Overlay network.** A virtual private network on top of the internet. Peers get private
+  addresses and reach each other by them, wherever they run. WireGuard does the encryption.
+- **Peer.** One machine on the overlay (the runner; each sandbox).
+- **TUN device.** A kernel virtual network interface at `/dev/net/tun`. Kernel-mode WireGuard
+  creates one for transparent routing; it needs the `NET_ADMIN` capability.
+- **Userspace mode (netstack).** WireGuard entirely inside one process, own TCP/IP stack, no
+  TUN, no `NET_ADMIN`. Not transparent: it proxies specific ports rather than routing all
+  traffic.
+- **Management plane.** NetBird's control service: registers peers, holds the network map,
+  distributes access policy. Separate from the data path; peer traffic does not flow through
+  it.
+- **Setup key.** A token a headless machine uses to join the overlay with no human login. Can
+  be reusable and ephemeral (auto-removed when the peer goes offline).
+
+## One-line verdict
+
+Feasible and documented: Daytona's docs support NetBird inside sandboxes as a first-class
+flow with setup-key join, and their OpenVPN flow shows TUN devices exist, so kernel mode is
+the design basis. One short confirmation run in our stack (join, both directions, latency,
+egress-policy interaction), then it is a prioritization decision. Near term, adopt
+Cloudflare quick tunnels for the store mount path to remove the ngrok token requirement. See
+[recommendation.md](recommendation.md).

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/README.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/README.md
@@ -1,65 +1,70 @@
-# NetBird sandbox overlay network
+# Sandbox network paths
 
-Research and effort assessment for one idea: put the runner and its Daytona sandboxes on a
-shared private WireGuard mesh (an overlay network) using NetBird, so the runner and a sandbox
-can open connections to each other in both directions. That would attack a whole class of
-connectivity problems at once, instead of one workaround per feature, and could carry MCP
-traffic later. Includes a side assessment of Cloudflare Tunnel as a near-term, zero-auth
-replacement for the ngrok store tunnel.
+This workspace answers a narrower question than its first draft:
 
-This is research only. No code changed. Owner: Mahmoud.
+> Which agent features actually need a Daytona sandbox to open a new network path into
+> Agenta infrastructure, and which transport should serve each one?
 
-## The problem it targets
+## Recommendation
 
-Today the runner reaches a Daytona sandbox one way (the Daytona signed preview URL). The
-sandbox has no direct way back to the runner; it only writes files the runner polls. That
-missing return direction is the root cause behind three separate workarounds:
+Do not build NetBird as a general sandbox-to-runner transport.
 
-- **F-017:** a remote sandbox cannot reach the runner-side store, so mounts go through a
-  public ngrok tunnel (`../qa/findings.md`,
-  `services/runner/src/engines/sandbox_agent/mount.ts`).
-- **F-018:** the reverse permission RPC from sandbox to runner never arrives, so gate
-  decisions are being routed through polled files instead (`../daytona-gate-delivery/`).
-- **MCP delivery:** the runner's tool-MCP server binds a loopback the sandbox cannot reach,
-  so it is skipped on Daytona and an in-sandbox shim is planned
-  (`../mcp-delivery-architecture/directions.md`).
+The original proposal treated every reverse application message as a missing reverse
+network connection. That premise was wrong. The runner already connects to sandbox-agent
+with HTTP POST plus a persistent server-sent events (SSE) GET. Notifications and
+server-initiated ACP requests share that SSE stream. PR #5218 found that Pi permissions
+failed because the old `pi-acp` adapter never emitted `session/request_permission`, not
+because Daytona could not carry it.
 
-A shared overlay would give the sandbox a direct, private route back to the runner, which is
-the one thing all three lack.
+After separating the flows, one current capability needs direct sandbox-initiated access
+to Agenta-side infrastructure:
 
-## Files (reading order)
+- geesefs inside Daytona must reach the configured S3-compatible mount store when that
+  endpoint is private.
 
-- [plan.md](plan.md) — start here: the whole sandbox network story in one place. The four
-  problems as they exist today, the near-term Cloudflare quick-tunnel step, the longer-term
-  NetBird overlay phases, which workarounds retire in which order, local mode and
-  self-hosters, and the sequencing against the work in flight.
-- [research.md](research.md) — the five research questions answered with sources
-  (feasibility inside a Daytona sandbox, architecture, security and tenancy, local mode,
-  effort and alternatives), plus the Cloudflare Tunnel assessment.
-- [recommendation.md](recommendation.md) — the verdict, the one-day confirmation run, phase
-  estimates, and the Cloudflare quick-tunnel call.
+A second possible future capability has the same network direction:
 
-## Glossary
+- Claude on Daytona could call Agenta gateway tools through a separately exposed,
+  authenticated HTTP MCP endpoint. That capability is rejected today and is not part of
+  this project.
 
-- **Overlay network.** A virtual private network on top of the internet. Peers get private
-  addresses and reach each other by them, wherever they run. WireGuard does the encryption.
-- **Peer.** One machine on the overlay (the runner; each sandbox).
-- **TUN device.** A kernel virtual network interface at `/dev/net/tun`. Kernel-mode WireGuard
-  creates one for transparent routing; it needs the `NET_ADMIN` capability.
-- **Userspace mode (netstack).** WireGuard entirely inside one process, own TCP/IP stack, no
-  TUN, no `NET_ADMIN`. Not transparent: it proxies specific ports rather than routing all
-  traffic.
-- **Management plane.** NetBird's control service: registers peers, holds the network map,
-  distributes access policy. Separate from the data path; peer traffic does not flow through
-  it.
-- **Setup key.** A token a headless machine uses to join the overlay with no human login. Can
-  be reusable and ephemeral (auto-removed when the peer goes offline).
+Keep the current ngrok path while we make mount endpoint resolution generic and test any
+Cloudflare Quick Tunnel replacement against the real S3 workload. Retain NetBird only as a
+conditional private-store option if public endpoints or tunnels prove unacceptable.
 
-## One-line verdict
+## Current transport map
 
-Feasible and documented: Daytona's docs support NetBird inside sandboxes as a first-class
-flow with setup-key join, and their OpenVPN flow shows TUN devices exist, so kernel mode is
-the design basis. One short confirmation run in our stack (join, both directions, latency,
-egress-policy interaction), then it is a prioritization decision. Near term, adopt
-Cloudflare quick tunnels for the store mount path to remove the ngrok token requirement. See
-[recommendation.md](recommendation.md).
+| Capability | Current path | Needs NetBird? |
+| --- | --- | --- |
+| Pi builtin permissions | Pi dialog to `pi-acp`, then ACP request over existing POST and SSE | No |
+| Claude native permissions | Native ACP permission request over existing POST and SSE | No |
+| Pi custom and gateway tools | Extension file request; runner polls the sandbox filesystem and executes with runner credentials | No |
+| User HTTP MCP on Claude | Sandbox connects directly to the user's remote HTTPS URL | No |
+| User MCP on Pi | Rejected before the run | No |
+| User stdio MCP | Rejected for every harness | No |
+| Claude Agenta gateway tools on Daytona | Rejected because runner-loopback MCP is not reachable from sandbox loopback | Maybe later, but NetBird alone is insufficient |
+| Durable mount with public S3 endpoint | geesefs connects directly to that endpoint | No |
+| Durable mount with private S3 endpoint | geesefs uses the discovered ngrok endpoint today | This is the only current candidate |
+| Telemetry | Runner reconstructs and exports spans from ACP events | No |
+
+## Documents
+
+- [Context](context.md): why the first framing changed and what remains in scope.
+- [Research](research.md): code paths, authentication, limits, topology, and security.
+- [Plan](plan.md): near-term mount work and the decision gate for any overlay.
+- [Recommendation](recommendation.md): the decision and alternatives in one place.
+- [Status](status.md): current state, answered review threads, and remaining experiments.
+
+## Terms
+
+- **ACP**: Agent Client Protocol. The runner and harness exchange JSON-RPC messages through
+  sandbox-agent.
+- **SSE**: Server-sent events. The daemon-to-runner half of the ACP HTTP transport.
+- **Public endpoint**: reachable from Daytona over the internet. It does not mean
+  anonymously readable.
+- **Private endpoint**: reachable only inside the deployment network, such as Docker DNS or
+  a Kubernetes ClusterIP.
+- **Overlay**: a private network layered over existing networks. NetBird builds one with
+  WireGuard.
+- **Runner-loopback MCP**: Agenta's internal HTTP MCP server bound to the runner's
+  `127.0.0.1`. This is separate from user-configured remote HTTP MCP.

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/context.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/context.md
@@ -1,0 +1,62 @@
+# Context
+
+## Why this work started
+
+Remote Daytona sandboxes do not share the runner's Docker or Kubernetes network. A private
+store address such as `http://seaweedfs:8333` therefore cannot be used by geesefs inside
+the sandbox. The current compose setup exposes the S3 gateway through ngrok and the runner
+discovers its public URL.
+
+The first draft generalized that fact into "the sandbox cannot talk back to the runner" and
+attributed permissions, Pi tools, MCP, and mounts to one missing connection. Review of the
+actual code and PR #5218 disproved that model.
+
+## Corrected model
+
+Network direction and application direction are different.
+
+The runner initiates the HTTP connections to sandbox-agent, but ACP is application
+bidirectional:
+
+1. the runner sends JSON-RPC envelopes with POST;
+2. it keeps one SSE GET open;
+3. the daemon sends notifications and reverse requests on that stream;
+4. the runner answers a reverse request with another POST.
+
+Pi's permission request was absent because `pi-acp` 0.0.23 ignored the extension UI event.
+Adapter parity restores the existing route.
+
+Other capabilities use deliberate, separate transports:
+
+- Pi custom tools stay runner-side so credentials do not enter the sandbox. The extension
+  writes request files and the runner polls them through Daytona APIs.
+- User HTTP MCP is a sandbox-to-user-server connection for capable non-Pi harnesses.
+- Internal gateway-tool MCP is a runner-loopback service. Daytona Claude cannot use it
+  until Agenta designs an authenticated remote endpoint.
+- geesefs must speak S3 directly. ACP is not an S3 or filesystem tunnel.
+
+## Goals
+
+- Document each traffic flow and its actual direction.
+- Keep public reachability separate from storage authentication.
+- Make mount orchestration consume one effective sandbox-reachable store endpoint.
+- Fail clearly when a durable mount is requested but no endpoint becomes reachable.
+- Test Cloudflare Quick Tunnels before recommending them as the self-hosted default.
+- Define the evidence and security baseline required before any NetBird work begins.
+
+## Non-goals
+
+- Replacing ACP for permission delivery.
+- Replacing the Pi file relay.
+- Enabling Pi user MCP or user stdio MCP.
+- Shipping Claude gateway tools on Daytona.
+- Building a NetBird control plane or client in this change.
+- Claiming that production, Agenta Cloud, or any deployment type always has a public store.
+
+## Decision boundary
+
+The deployment topology decides whether a tunnel or overlay is needed:
+
+- A publicly reachable S3-compatible endpoint needs no extra route.
+- A private bundled SeaweedFS endpoint needs a tunnel, overlay, or equivalent route.
+- Authentication remains S3 credential based in either topology.

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/plan.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/plan.md
@@ -1,0 +1,155 @@
+# Plan: the sandbox network story
+
+One place for the whole runner-to-sandbox networking picture: what exists today and why each
+piece exists, the near-term step (swap ngrok for a Cloudflare quick tunnel), the longer-term
+step (a NetBird overlay), and an honest sequencing recommendation relative to the work in
+flight. Research status: nothing here is committed work; this is the plan Mahmoud asked for
+as reading material.
+
+Terms are defined once in the [README glossary](README.md#glossary): overlay network, peer,
+TUN device, userspace mode, management plane, setup key.
+
+## The problems as they exist today
+
+When an agent runs on Daytona, the harness process lives in a sandbox out in Daytona's
+cloud, and the runner stays in our deployment. Traffic between them has exactly one direct
+channel: the runner dials the sandbox through Daytona's signed preview URL. The sandbox has
+no channel back to the runner. Every feature that needs the reverse direction, or needs the
+sandbox to reach a runner-side service, has grown its own workaround:
+
+1. **Mounts ride a public ngrok tunnel.** Durable sessions mount the S3 store as the
+   working directory via geesefs. On Daytona, geesefs runs inside the sandbox and cannot
+   reach `seaweedfs:8333` on our private docker network, so the compose stack tunnels the
+   store port through ngrok and the runner discovers the public URL from ngrok's local API
+   (`discoverTunnelEndpoint` in `services/runner/src/engines/sandbox_agent/mount.ts`, the
+   `with-tunnel` profile). The failure mode is provisioning: ngrok needs an
+   `NGROK_AUTHTOKEN`, and a deployment without one has no tunnel. F-017 documented the
+   result: geesefs mounted against an unreachable endpoint and every file operation hung.
+2. **Tool execution rides a polled file relay.** Custom tools execute on the runner so
+   credentials never enter the sandbox. Because the sandbox cannot call the runner, the Pi
+   extension writes a request file into a relay directory and the runner polls the sandbox
+   filesystem for it (`services/runner/src/tools/relay.ts`). It works, at polling latency,
+   and only for harnesses with an in-sandbox writer (Pi's extension).
+3. **The reverse permission RPC is lost (F-018).** Pi's builtin gate asks the runner for an
+   allow/deny decision through an ACP `session/request_permission` reverse request. Over
+   the Daytona preview proxy that request never arrives, while one-way notifications on the
+   same stream do. Every builtin tool call on Daytona therefore hung until the 300 second
+   guard killed the turn. The fix in flight (`../daytona-gate-delivery/`) does two things:
+   precompute allow/deny on the runner and inject the decisions into the sandbox (its
+   Option C), and carry the residual ask-gates over the same polled file relay (its
+   Option B narrowed).
+4. **MCP delivery is swapped out on Daytona.** Claude only accepts tools over MCP, so the
+   runner synthesizes an MCP server. It binds the runner's `127.0.0.1`, which inside a
+   Daytona sandbox is the sandbox's own loopback, so the channel is skipped there
+   (`services/runner/src/engines/sandbox_agent/mcp.ts`) and an in-sandbox shim is the
+   planned replacement (`../mcp-delivery-architecture/directions.md`).
+
+Four features, four transports, one root cause: the sandbox cannot reach the runner. Each
+workaround also has its own failure mode (the zombie mount, the polling latency, the lost
+RPC, the silent zero-tools run that the fail-loud gate now refuses).
+
+## Near term: replace ngrok with a Cloudflare quick tunnel
+
+This attacks the provisioning failure mode of problem 1 without waiting for anything else.
+
+A Cloudflare quick tunnel (`cloudflared tunnel --url http://seaweedfs:8333`) exposes the
+store on a random `*.trycloudflare.com` HTTPS URL with no account and no token
+([quick tunnels docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/)).
+The tunnel is therefore always up on every dev box and self-hosted deployment, which removes
+exactly the F-017 failure mode. The trade-aways are stated plainly in
+[research.md](research.md): no SLA, testing-only intent, 200 in-flight requests, one edge
+connection, and an approximately 100 MB per-request body limit (**UNVERIFIED** exact number)
+to check against our geesefs multipart part sizes.
+
+The concrete change, one to two days (**UNVERIFIED**):
+
+- `mount.ts`: `discoverTunnelEndpoint` gains a cloudflared branch that queries
+  `http://cloudflared:<metrics-port>/quicktunnel`, which returns `{"hostname":"..."}`
+  (verified in cloudflared source, `metrics/metrics.go`), and falls back to the existing
+  ngrok discovery. Null-on-failure semantics stay as they are.
+- Compose: a `cloudflared` service joins the existing `with-tunnel` profile alongside ngrok
+  (official image, `tunnel --url http://seaweedfs:8333 --metrics 0.0.0.0:20241`, no env
+  vars). ngrok stays available for anyone who already holds a token.
+- No sandbox-side change: geesefs takes whatever endpoint URL discovery returns.
+
+Production (Agenta Cloud) is unaffected: its store is genuinely public and uses no tunnel.
+The security posture does not change relative to ngrok: the store is on a public URL in both
+cases, and the guard is the signed, prefix-scoped, short-lived S3 credentials, never the
+bucket master key. Only the overlay removes the public surface.
+
+## Longer term: the NetBird overlay
+
+The overlay puts the runner and each sandbox on one private WireGuard mesh so each can dial
+the other directly. Feasibility is documented by Daytona itself: NetBird inside a sandbox is
+a first-class flow with a non-interactive setup-key join, and the same page's OpenVPN flow
+verifies a TUN device, so kernel mode (a real network interface, transparent routing) is the
+design basis ([Daytona VPN connections](https://www.daytona.io/docs/en/vpn-connections/#netbird)).
+Full analysis in [research.md](research.md); the verdict and the confirmation run in
+[recommendation.md](recommendation.md).
+
+Phases, with estimates (**all UNVERIFIED**):
+
+1. **Confirmation run, about 1 day.** Bake the NetBird client into a test snapshot, join one
+   sandbox with an ephemeral setup key, verify kernel mode and both directions, measure join
+   time and latency, and test against a restricted Daytona egress policy. This can piggyback
+   on any Daytona test session; it needs no code change in the product.
+2. **MVP behind a flag, about 1 week.** Daytona only, default off. The runner mints a
+   per-run ephemeral setup key and injects it into the sandbox env; the sandbox joins on
+   boot; the geesefs mount targets the store at the runner's overlay address. NetBird cloud
+   as the control plane first; the self-hosted control plane (three services: management,
+   signal, relay) follows for self-hosters.
+3. **ACL hardening, 1 to 2 weeks.** Default-deny policy generated per run: a sandbox reaches
+   only the runner ports its run needs, never another sandbox. Key and peer revocation on
+   teardown. Fail-loud when the overlay does not come up (the F-017 lesson: never a silent
+   fallback that hangs). Observability and self-hosting docs.
+
+### Which workarounds retire, in which order
+
+1. **The store tunnel retires first** (ngrok and the cloudflared swap alike, the compose
+   profile, `discoverTunnelEndpoint`, and the public-store requirement). It is the least
+   entangled: one endpoint URL changes, nothing about run semantics.
+2. **The MCP loopback swap retires second.** The sandbox reaches the runner's synthesized
+   MCP server at its overlay address, so the Daytona skip and the planned in-sandbox shim
+   become unnecessary. This also serves any future MCP-client harness (Codex) for free.
+3. **The file-relay gate channel retires last, maybe never fully.** With a direct channel,
+   the ACP reverse permission request can work (the F-018 project's deferred Option A), and
+   the file-borne ask-gate path (its Option B) can retire. Its Option C, precomputed
+   allow/deny decisions injected into the sandbox, stays regardless: skipping a round-trip
+   for the allow case is worth keeping on any transport. The custom-tool execution relay
+   also stays: executing tools runner-side where the credentials live is a security
+   decision, not a transport workaround, though the transport under it could become an HTTP
+   call over the overlay instead of file polling.
+
+## Local mode and self-hosters
+
+Local sandboxes run inside the runner container and share the docker network with the runner
+and the store. Every feature already works there with no tunnel and no relay detour. The
+overlay is therefore remote-only: it attaches to the Daytona path, where the shared network
+does not exist, and the local path changes not at all. The code already branches on the
+sandbox axis for mounts, MCP delivery, and asset upload; the overlay becomes the Daytona
+answer inside that existing branch, not a new axis.
+
+For self-hosters the cost profile is: local-only self-hosters see nothing new. Daytona
+self-hosters get, near term, a tunnel that no longer needs a token; longer term, either a
+NetBird cloud account or three additional self-hosted services. That last cost is real and
+is the main reason the overlay stays behind a flag until the ACL hardening and the
+self-hosting docs exist.
+
+## Sequencing against the work in flight
+
+- **The F-018 file-gate fix ships regardless.** It is being implemented now and is the
+  near-term answer for tool gating on Daytona. None of it is wasted: Option C is permanent,
+  Option B is the bridge the overlay could retire later.
+- **The warm-sessions work (PR #5214) is unaffected.** Sandbox lifecycle (park, restart,
+  resume) is orthogonal to which network path connects runner and sandbox. If sandboxes park
+  rather than delete, the overlay's ephemeral peer cleanup (10 minutes offline) still fits,
+  since a parked sandbox that resumes simply rejoins with its next run's key.
+- **The Cloudflare swap can go now.** It touches one discovery function and one compose
+  service, both deleted wholesale when the overlay lands.
+- **The overlay confirmation run can go any time** and needs no product change; it
+  piggybacks on any Daytona test session. The MVP and hardening phases are a prioritization
+  decision after that, weighed against the MVP backlog.
+
+Recommended order: Cloudflare swap now, confirmation run at the next natural Daytona test
+session, then decide the overlay MVP with the confirmation data (latency, join time, egress
+interaction) in hand.

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/plan.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/plan.md
@@ -1,155 +1,203 @@
-# Plan: the sandbox network story
+# Plan
 
-One place for the whole runner-to-sandbox networking picture: what exists today and why each
-piece exists, the near-term step (swap ngrok for a Cloudflare quick tunnel), the longer-term
-step (a NetBird overlay), and an honest sequencing recommendation relative to the work in
-flight. Research status: nothing here is committed work; this is the plan Mahmoud asked for
-as reading material.
+## Decision
 
-Terms are defined once in the [README glossary](README.md#glossary): overlay network, peer,
-TUN device, userspace mode, management plane, setup key.
+Do not implement a general NetBird overlay now. First fix the mount endpoint boundary and
+measure a Quick Tunnel against the real geesefs workload. Reopen NetBird only if the
+private-store requirement survives that work and a public endpoint or tunnel is not
+acceptable.
 
-## The problems as they exist today
+## Phase 1: make the mount boundary provider-neutral
 
-When an agent runs on Daytona, the harness process lives in a sandbox out in Daytona's
-cloud, and the runner stays in our deployment. Traffic between them has exactly one direct
-channel: the runner dials the sandbox through Daytona's signed preview URL. The sandbox has
-no channel back to the runner. Every feature that needs the reverse direction, or needs the
-sandbox to reach a runner-side service, has grown its own workaround:
+The mount operation should receive an effective endpoint URL. It should not know how a
+provider allocated that URL.
 
-1. **Mounts ride a public ngrok tunnel.** Durable sessions mount the S3 store as the
-   working directory via geesefs. On Daytona, geesefs runs inside the sandbox and cannot
-   reach `seaweedfs:8333` on our private docker network, so the compose stack tunnels the
-   store port through ngrok and the runner discovers the public URL from ngrok's local API
-   (`discoverTunnelEndpoint` in `services/runner/src/engines/sandbox_agent/mount.ts`, the
-   `with-tunnel` profile). The failure mode is provisioning: ngrok needs an
-   `NGROK_AUTHTOKEN`, and a deployment without one has no tunnel. F-017 documented the
-   result: geesefs mounted against an unreachable endpoint and every file operation hung.
-2. **Tool execution rides a polled file relay.** Custom tools execute on the runner so
-   credentials never enter the sandbox. Because the sandbox cannot call the runner, the Pi
-   extension writes a request file into a relay directory and the runner polls the sandbox
-   filesystem for it (`services/runner/src/tools/relay.ts`). It works, at polling latency,
-   and only for harnesses with an in-sandbox writer (Pi's extension).
-3. **The reverse permission RPC is lost (F-018).** Pi's builtin gate asks the runner for an
-   allow/deny decision through an ACP `session/request_permission` reverse request. Over
-   the Daytona preview proxy that request never arrives, while one-way notifications on the
-   same stream do. Every builtin tool call on Daytona therefore hung until the 300 second
-   guard killed the turn. The fix in flight (`../daytona-gate-delivery/`) does two things:
-   precompute allow/deny on the runner and inject the decisions into the sandbox (its
-   Option C), and carry the residual ask-gates over the same polled file relay (its
-   Option B narrowed).
-4. **MCP delivery is swapped out on Daytona.** Claude only accepts tools over MCP, so the
-   runner synthesizes an MCP server. It binds the runner's `127.0.0.1`, which inside a
-   Daytona sandbox is the sandbox's own loopback, so the channel is skipped there
-   (`services/runner/src/engines/sandbox_agent/mcp.ts`) and an in-sandbox shim is the
-   planned replacement (`../mcp-delivery-architecture/directions.md`).
+Current behavior is close but named around ngrok:
 
-Four features, four transports, one root cause: the sandbox cannot reach the runner. Each
-workaround also has its own failure mode (the zombie mount, the polling latency, the lost
-RPC, the silent zero-tools run that the fail-loud gate now refuses).
+1. the mount-sign response supplies the configured S3 endpoint;
+2. `storeReachableFromSandbox` decides whether Daytona can reach it;
+3. a public endpoint goes directly to geesefs;
+4. for a private endpoint, `discoverTunnelEndpoint` queries ngrok's agent API;
+5. the discovered URL overrides only geesefs's endpoint.
 
-## Near term: replace ngrok with a Cloudflare quick tunnel
+Refactor the orchestration boundary to a function such as
+`resolveSandboxStoreEndpoint`. Its sources, in priority order:
 
-This attacks the provisioning failure mode of problem 1 without waiting for anything else.
+1. the configured store endpoint when it is sandbox-reachable;
+2. an explicit operator-configured public endpoint;
+3. a dynamic endpoint supplied by a tunnel sidecar adapter.
 
-A Cloudflare quick tunnel (`cloudflared tunnel --url http://seaweedfs:8333`) exposes the
-store on a random `*.trycloudflare.com` HTTPS URL with no account and no token
-([quick tunnels docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/)).
-The tunnel is therefore always up on every dev box and self-hosted deployment, which removes
-exactly the F-017 failure mode. The trade-aways are stated plainly in
-[research.md](research.md): no SLA, testing-only intent, 200 in-flight requests, one edge
-connection, and an approximately 100 MB per-request body limit (**UNVERIFIED** exact number)
-to check against our geesefs multipart part sizes.
+The mount function receives the resolved URL and temporary credentials. Provider discovery
+stays outside the geesefs process builder.
 
-The concrete change, one to two days (**UNVERIFIED**):
+Acceptance:
 
-- `mount.ts`: `discoverTunnelEndpoint` gains a cloudflared branch that queries
-  `http://cloudflared:<metrics-port>/quicktunnel`, which returns `{"hostname":"..."}`
-  (verified in cloudflared source, `metrics/metrics.go`), and falls back to the existing
-  ngrok discovery. Null-on-failure semantics stay as they are.
-- Compose: a `cloudflared` service joins the existing `with-tunnel` profile alongside ngrok
-  (official image, `tunnel --url http://seaweedfs:8333 --metrics 0.0.0.0:20241`, no env
-  vars). ngrok stays available for anyone who already holds a token.
-- No sandbox-side change: geesefs takes whatever endpoint URL discovery returns.
+- public S3 skips discovery;
+- private S3 uses the configured public override when present;
+- dynamic provider discovery returns the same endpoint shape;
+- no mount code branches on a tunnel product name.
 
-Production (Agenta Cloud) is unaffected: its store is genuinely public and uses no tunnel.
-The security posture does not change relative to ngrok: the store is on a public URL in both
-cases, and the guard is the signed, prefix-scoped, short-lived S3 credentials, never the
-bucket master key. Only the overlay removes the public surface.
+## Phase 2: make dynamic endpoints ready or fail clearly
 
-## Longer term: the NetBird overlay
+Starting a sidecar does not mean its public hostname is ready. A durable mount request must
+not silently fall back to an ephemeral workspace.
 
-The overlay puts the runner and each sandbox on one private WireGuard mesh so each can dial
-the other directly. Feasibility is documented by Daytona itself: NetBird inside a sandbox is
-a first-class flow with a non-interactive setup-key join, and the same page's OpenVPN flow
-verifies a TUN device, so kernel mode (a real network interface, transparent routing) is the
-design basis ([Daytona VPN connections](https://www.daytona.io/docs/en/vpn-connections/#netbird)).
-Full analysis in [research.md](research.md); the verdict and the confirmation run in
-[recommendation.md](recommendation.md).
+Required behavior:
 
-Phases, with estimates (**all UNVERIFIED**):
+- poll discovery with bounded retry and backoff;
+- distinguish "storage disabled or no durable mount requested" from provisioning failure;
+- when credentials exist and the configured endpoint is private, fail the run if no
+  sandbox-reachable endpoint appears before the deadline;
+- probe the public route before mounting. An authenticated response or an expected S3 403
+  without credentials proves that the route answers;
+- retain the post-mount liveness check and dead-FUSE cleanup;
+- log the provider, elapsed readiness time, and selected endpoint origin without logging
+  credentials.
 
-1. **Confirmation run, about 1 day.** Bake the NetBird client into a test snapshot, join one
-   sandbox with an ephemeral setup key, verify kernel mode and both directions, measure join
-   time and latency, and test against a restricted Daytona egress policy. This can piggyback
-   on any Daytona test session; it needs no code change in the product.
-2. **MVP behind a flag, about 1 week.** Daytona only, default off. The runner mints a
-   per-run ephemeral setup key and injects it into the sandbox env; the sandbox joins on
-   boot; the geesefs mount targets the store at the runner's overlay address. NetBird cloud
-   as the control plane first; the self-hosted control plane (three services: management,
-   signal, relay) follows for self-hosters.
-3. **ACL hardening, 1 to 2 weeks.** Default-deny policy generated per run: a sandbox reaches
-   only the runner ports its run needs, never another sandbox. Key and peer revocation on
-   teardown. Fail-loud when the overlay does not come up (the F-017 lesson: never a silent
-   fallback that hangs). Observability and self-hosting docs.
+This removes the silent part of F-017. A Quick Tunnel can remove the ngrok token dependency,
+but it does not remove startup races or every unreachable-store failure.
 
-### Which workarounds retire, in which order
+## Phase 3: qualify Cloudflare Quick Tunnels
 
-1. **The store tunnel retires first** (ngrok and the cloudflared swap alike, the compose
-   profile, `discoverTunnelEndpoint`, and the public-store requirement). It is the least
-   entangled: one endpoint URL changes, nothing about run semantics.
-2. **The MCP loopback swap retires second.** The sandbox reaches the runner's synthesized
-   MCP server at its overlay address, so the Daytona skip and the planned in-sandbox shim
-   become unnecessary. This also serves any future MCP-client harness (Codex) for free.
-3. **The file-relay gate channel retires last, maybe never fully.** With a direct channel,
-   the ACP reverse permission request can work (the F-018 project's deferred Option A), and
-   the file-borne ask-gate path (its Option B) can retire. Its Option C, precomputed
-   allow/deny decisions injected into the sandbox, stays regardless: skipping a round-trip
-   for the allow case is worth keeping on any transport. The custom-tool execution relay
-   also stays: executing tools runner-side where the credentials live is a security
-   decision, not a transport workaround, though the transport under it could become an HTTP
-   call over the overlay instead of file polling.
+Cloudflare documents Quick Tunnels as testing and development only. They have no SLA, use
+one connection, do not support SSE, and cap a tunnel at 200 concurrent in-flight requests.
+Requests beyond that cap receive 429 responses. See the
+[Quick Tunnel limits](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/).
 
-## Local mode and self-hosters
+The 200 number is concurrency, not requests per minute. One S3 multipart part is one
+in-flight HTTP request for the duration of that upload. Multipart creates separate
+requests. GeeseFS 0.43.0 defaults can issue parallel flushes and uploads, so one developer
+may fit while several busy mounts may not.
 
-Local sandboxes run inside the runner container and share the docker network with the runner
-and the store. Every feature already works there with no tunnel and no relay detour. The
-overlay is therefore remote-only: it attaches to the Daytona path, where the shared network
-does not exist, and the local path changes not at all. The code already branches on the
-sandbox axis for mounts, MCP delivery, and asset upload; the overlay becomes the Daytona
-answer inside that existing branch, not a new axis.
+Before adding a Cloudflare sidecar:
 
-For self-hosters the cost profile is: local-only self-hosters see nothing new. Daytona
-self-hosters get, near term, a tunnel that no longer needs a token; longer term, either a
-NetBird cloud account or three additional self-hosted services. That last cost is real and
-is the main reason the overlay stays behind a flag until the ACL hardening and the
-self-hosting docs exist.
+- mount a small workspace and exercise metadata reads, ranged reads, writes, rename, and
+  delete;
+- upload and read back objects across the geesefs multipart size transitions;
+- test a part larger than 100 MiB instead of assuming the Cloudflare Free proxied-upload
+  limit applies to `trycloudflare.com`;
+- run multiple concurrent mounts and record peak in-flight requests, 429s, latency, and
+  throughput;
+- restart cloudflared during discovery and during active I/O;
+- prove bounded readiness and fail-loud behavior;
+- confirm the S3 and STS endpoints behave correctly through the tunnel.
 
-## Sequencing against the work in flight
+Do not replace ngrok by default until these checks pass.
 
-- **The F-018 file-gate fix ships regardless.** It is being implemented now and is the
-  near-term answer for tool gating on Daytona. None of it is wasted: Option C is permanent,
-  Option B is the bridge the overlay could retire later.
-- **The warm-sessions work (PR #5214) is unaffected.** Sandbox lifecycle (park, restart,
-  resume) is orthogonal to which network path connects runner and sandbox. If sandboxes park
-  rather than delete, the overlay's ephemeral peer cleanup (10 minutes offline) still fits,
-  since a parked sandbox that resumes simply rejoins with its next run's key.
-- **The Cloudflare swap can go now.** It touches one discovery function and one compose
-  service, both deleted wholesale when the overlay lands.
-- **The overlay confirmation run can go any time** and needs no product change; it
-  piggybacks on any Daytona test session. The MVP and hardening phases are a prioritization
-  decision after that, weighed against the MVP backlog.
+For comparison, ngrok currently documents free-plan limits in requests per minute, monthly
+requests, and outbound transfer, not a concurrent-request cap:
+[ngrok limits](https://ngrok.com/docs/pricing-limits). The products constrain different
+dimensions, so the design should not call either one universally better.
 
-Recommended order: Cloudflare swap now, confirmation run at the next natural Daytona test
-session, then decide the overlay MVP with the confirmation data (latency, join time, egress
-interaction) in hand.
+## Phase 4: decide the store connectivity product
+
+Choose from the following using the Phase 3 data:
+
+### A. Direct public S3 endpoint
+
+Best when the operator already has S3, R2, MinIO, or SeaweedFS on a TLS endpoint.
+
+- Fewest moving parts.
+- No tunnel discovery.
+- Publicly routable S3 and STS surface.
+- Data remains protected by short-lived, prefix-scoped S3 credentials.
+
+### B. Stable authenticated tunnel
+
+Best when a self-hoster accepts public ingress but wants a stable hostname and provider
+controls.
+
+- Keeps the store private inside the deployment.
+- Adds a tunnel account, credentials, quotas, and provider dependency.
+- Needs the same readiness and fail-loud contract.
+
+### C. Cloudflare Quick Tunnel for development
+
+Best only if Phase 3 shows the geesefs workload fits.
+
+- No account or token.
+- Random hostname, testing-only service, documented concurrency limit.
+- Not a production or general self-hosting recommendation.
+
+### D. NetBird private overlay
+
+Consider only when the operator requires private connectivity and rejects public ingress.
+
+- Adds a client in every sandbox, a runner-side peer or router, control-plane operations,
+  ACL lifecycle, setup-key lifecycle, and Daytona tier requirements.
+- Does not expose SeaweedFS or loopback MCP by itself.
+
+Record the choice in [recommendation.md](recommendation.md) before implementation.
+
+## Phase 5: NetBird decision gate
+
+Open a NetBird implementation project only if all are true:
+
+1. a concrete private resource must be reached from Daytona;
+2. a direct public endpoint and an authenticated tunnel are unacceptable;
+3. Daytona's required VPN tier is available for the intended users;
+4. measured join time and reconnect behavior fit the run lifecycle;
+5. the topology and default-deny policy below are approved;
+6. the team accepts the self-hosted control-plane or NetBird Cloud dependency.
+
+### Required topology
+
+A peer in the runner container sees only that container's network namespace.
+
+For SeaweedFS, choose one explicit exposure:
+
+- a NetBird peer beside SeaweedFS;
+- a routing peer with IP forwarding into a narrowly scoped network resource; or
+- a runner-side TCP proxy bound only to the runner's overlay address and forwarding to
+  `seaweedfs:8333`.
+
+For internal gateway-tool MCP:
+
+- bind or proxy the server on the runner's overlay address instead of `127.0.0.1`;
+- add a per-run bearer credential;
+- advertise the overlay URL only to the paired Daytona Claude session;
+- keep the feature rejected until the listener, authentication, and policy are ready.
+
+### Security baseline before the first sandbox joins
+
+NetBird creates an all-to-all default policy for a new account. Remove it before enrollment.
+The MVP must include:
+
+- one per-run sandbox group;
+- one-way TCP policy from that group to the paired runner service and exact port;
+- no sandbox-to-sandbox policy;
+- no `ALL` protocol rule;
+- no broad Docker subnet route;
+- policy creation before peer enrollment;
+- explicit deletion of the peer, policies, group, proxies, and setup key at teardown.
+
+NetBird is stateful, so return traffic does not require a reverse allow rule. See
+[NetBird access control](https://docs.netbird.io/manage/access-control).
+
+### Setup-key handling
+
+Never inject a reusable setup key into sandbox environment variables.
+
+- mint a one-off key with usage limit 1, short expiry, ephemeral peer, and only the
+  run-scoped auto-group;
+- write it through the Daytona control plane to a temporary 0600 file outside the
+  workspace;
+- run `netbird up --setup-key-file <path>`;
+- delete the file immediately;
+- verify the peer, then delete or revoke the setup key through the management API;
+- delete the enrolled peer explicitly at teardown because revoking the setup key does not
+  disconnect it.
+
+Any process with full sandbox control may still capture enrollment material while joining.
+The one-off key and immediate revocation limit reuse; they do not make the key invisible.
+See [NetBird setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys)
+and the [CLI reference](https://docs.netbird.io/get-started/cli).
+
+## Acceptance criteria
+
+- The documentation does not claim that permissions need a new reverse network route.
+- The MCP matrix distinguishes user HTTP MCP from internal gateway-tool MCP.
+- A durable private-store request never silently runs without its mount.
+- A Quick Tunnel recommendation is contingent on multipart and concurrency results.
+- Any future NetBird MVP includes service exposure, authentication, default-deny ACLs, and
+  one-off setup-key handling from its first sandbox.

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/recommendation.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/recommendation.md
@@ -1,93 +1,88 @@
 # Recommendation
 
-## Verdict
+## Decision
 
-Feasible and documented. Daytona's own docs treat VPN clients inside sandboxes, NetBird
-included, as a supported first-class flow with SDK examples
-([Daytona VPN connections](https://www.daytona.io/docs/en/vpn-connections/#netbird)). The
-remaining work before committing to a build is a short confirmation run in our own stack, not
-a go/no-go spike on an unknown. After the confirmation, this is a build-decision question
-(priority against the roadmap), not a feasibility question.
+Do not build NetBird as the common sandbox transport, and do not replace ngrok with a
+Cloudflare Quick Tunnel by default yet.
 
-## What the confirmation run must show
+Build the smaller abstraction first: resolve one sandbox-reachable S3 endpoint, wait for it
+to become ready, and fail clearly when a requested durable mount cannot be provisioned.
+Then qualify Quick Tunnels against geesefs before choosing a default.
 
-Daytona documents the flow but does not document the container's capability set, gives no
-ACL guidance, and says nothing about performance or its own egress policy. So confirm in our
-stack, about one day:
+## Why
 
-1. Bake the NetBird client into a test Daytona snapshot next to Pi and geesefs (the
-   documented per-run install works too, but costs seconds per run).
-2. Mint an ephemeral setup key and join one sandbox non-interactively
-   (`sudo netbird up --setup-key ...`, per the Daytona page).
-3. Verify kernel mode: the WireGuard interface exists (`ip addr`, `netbird status`), no
-   userspace fallback needed.
-4. Verify both directions: the runner dials the sandbox daemon at its overlay address, and a
-   sandbox process (geesefs against the store port) dials the runner at its overlay address.
-5. Measure join time and round-trip latency against the current preview-proxy and ngrok
-   paths.
-6. Check the interaction with a restricted Daytona egress policy (`networkAllowList`), since
-   the docs are silent on it.
+### Permissions already have a return path
 
-If kernel mode fails on our tier, NetBird's userspace (netstack) mode is the fallback; it
-runs with no capabilities but proxies specific ports instead of giving a transparent
-interface, and it is slower. Detail in `research.md`, Question 1.
+ACP over sandbox-agent uses POST for runner-to-daemon messages and one SSE GET for
+daemon-to-runner notifications and requests. The runner answers reverse requests with POST.
+PR #5218 found the Pi permission failure before this transport: the stale adapter never
+created the request. NetBird would add infrastructure without fixing that cause.
 
-## What it would replace
+### Most other flows already use the right boundary
 
-- The ngrok tunnel for remote store mounts, the `with-tunnel` compose profile,
-  `discoverTunnelEndpoint`, and the public-store requirement (F-017).
-- Later, the file-relay gate channel that the F-018 fix adds now (Option B), by making the
-  ACP reverse permission RPC work over a direct channel (Option A, which the F-018 project
-  deferred as unfixable over the Daytona proxy).
-- Later, the MCP loopback swap on Daytona and the planned in-sandbox MCP shim.
+- Pi custom tools execute on the runner and use a runner-polled file relay.
+- User HTTP MCP already connects Daytona Claude to the user's remote server.
+- Pi user MCP is rejected and stdio MCP is disabled.
+- Telemetry is exported by the runner from ACP events.
+- Runner filesystem and process operations use Daytona or sandbox-agent APIs.
 
-## What it must not block
+### Private mounts are the concrete exception
 
-The F-018 fix is being implemented now and stays the near-term answer. Nothing here changes
-that. The relationship:
+geesefs runs inside the sandbox and must speak S3. When the configured endpoint is public,
+it connects directly. When the endpoint is private, the current stack supplies an ngrok
+URL. ACP is not an S3 data-plane tunnel, so this case needs a reachable endpoint.
 
-- Option C of that fix (precompute builtin allow/deny on the runner, resolve in-sandbox with
-  no round-trip) is complementary and permanent. Keep it regardless.
-- Option B of that fix (carry the gate over the polled file relay) is the near-term bridge
-  the overlay could later retire. It is not throwaway: it ships the fix ahead of the overlay,
-  and it is a small channel to remove later.
+## Public does not mean anonymous
 
-Build the F-018 fix as planned. Frame NetBird as the possible longer-term transport.
+The tunnel exposes the SeaweedFS S3 and STS network surface. It does not grant object
+access. Agenta's bundled SeaweedFS configuration requires S3 authentication, and the API
+mints short-lived credentials restricted to one mount prefix. geesefs signs its requests
+with those credentials.
 
-## Phases after the confirmation run (estimates UNVERIFIED)
+The tunnel provider token authenticates the tunnel agent, not clients of the public URL.
+The public layer still increases the reachable attack surface and denial-of-service risk.
+Use TLS, keep SeaweedFS current, and retain strict S3 and STS authentication.
 
-- Phase 1, about 1 week: MVP behind a flag, Daytona only, default off. Per-run ephemeral key
-  minting in the runner, injected into the sandbox env; join on boot; route the store mount
-  over the overlay and drop ngrok on that path. NetBird cloud as the control plane first.
-- Phase 2, 1 to 2 weeks: production hardening. Default-deny ACL generated per run, per-run
-  groups, key and peer revocation on teardown, fail-loud when the overlay does not come up,
-  observability, the self-hosted control-plane option, and self-hosting docs.
+## Deployment topology, not environment name
 
-## Cloudflare Tunnel (the near-term mounts fix, separate from the overlay)
+Do not describe this as development versus production.
 
-Adopt TryCloudflare quick tunnels as the default dev and self-host tunnel for the store
-mount path, keeping ngrok as an alternative for anyone who already holds a token. A quick
-tunnel needs no account and no token, which removes exactly the F-017 failure mode (no
-`NGROK_AUTHTOKEN`, tunnel down, zombie mounts). It trades away any SLA and is explicitly not
-for production, which is acceptable because the tunnel path itself is a dev and self-host
-workaround; Agenta Cloud's store is genuinely public and uses no tunnel. Integration is 1 to
-2 days (**UNVERIFIED**): a `cloudflared` compose service under the existing `with-tunnel`
-profile and a second discovery branch in `mount.ts` against cloudflared's `/quicktunnel`
-metrics endpoint (verified in cloudflared source). Everything added is deleted wholesale when
-the overlay lands, and the overlay is far enough out that the interim fix pays for itself.
-Full analysis in `research.md`, last section.
+- External, publicly reachable S3: no tunnel.
+- Bundled private SeaweedFS in Compose, Railway, or Kubernetes: Daytona needs another
+  route.
+- Authentication is S3 based in both cases.
 
-## Local mode
+Agenta durable mounts require an S3-compatible endpoint. SeaweedFS may support other
+protocols, but the current mount implementation does not use them.
 
-Leave local as-is. Local sandboxes share the docker network with the runner and need no
-overlay. Make the overlay a remote-sandbox transport, gated on the Daytona path. See the
-local mode section in `research.md`.
+## Cloudflare versus ngrok
 
-## Alternatives considered
+Cloudflare's 200 limit counts simultaneous requests. It may fit one light development
+mount, but the design has no workload evidence yet. ngrok documents other free limits,
+including requests per minute, monthly requests, and outbound transfer. Neither set of
+limits establishes a general winner.
 
-NetBird over Tailscale (Tailscale is equally feasible per the same Daytona page, but its
-control plane is proprietary SaaS with per-user pricing that fits ephemeral machine peers
-poorly; NetBird self-hosts the whole control plane as one open-source project). Both over
-plain WireGuard (which would make us rebuild the management plane). Any of them over keeping
-per-feature tunnels (whose count grows with each new sandbox-to-runner need). Detail in
-`research.md`, Question 5.
+Quick Tunnels also use random hostnames and are documented for testing. Make them an
+experiment whose rollout depends on S3 multipart, concurrency, restart, readiness, and
+fail-loud checks.
+
+## When NetBird becomes reasonable
+
+Reconsider NetBird when an operator requires a private store route and rejects public
+endpoints and tunnels. A future authenticated Claude gateway-tool endpoint may create a
+second use case, but it needs a separate product decision.
+
+Even then, joining two peers is only the first step. The design must add:
+
+- an explicit SeaweedFS peer, route, or overlay-bound proxy;
+- an overlay-bound and authenticated MCP endpoint if needed;
+- default-deny, port-scoped, paired-peer ACLs before enrollment;
+- one-off setup-key delivery outside environment variables;
+- teardown for peers, policies, groups, listeners, and keys;
+- a plan for Daytona's documented VPN tier requirement.
+
+## Next decision
+
+Run the Quick Tunnel qualification in [plan.md](plan.md). After that evidence exists,
+choose direct public S3, a stable authenticated tunnel, a development-only Quick Tunnel, or
+a private overlay for each supported deployment topology.

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/recommendation.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/recommendation.md
@@ -1,0 +1,93 @@
+# Recommendation
+
+## Verdict
+
+Feasible and documented. Daytona's own docs treat VPN clients inside sandboxes, NetBird
+included, as a supported first-class flow with SDK examples
+([Daytona VPN connections](https://www.daytona.io/docs/en/vpn-connections/#netbird)). The
+remaining work before committing to a build is a short confirmation run in our own stack, not
+a go/no-go spike on an unknown. After the confirmation, this is a build-decision question
+(priority against the roadmap), not a feasibility question.
+
+## What the confirmation run must show
+
+Daytona documents the flow but does not document the container's capability set, gives no
+ACL guidance, and says nothing about performance or its own egress policy. So confirm in our
+stack, about one day:
+
+1. Bake the NetBird client into a test Daytona snapshot next to Pi and geesefs (the
+   documented per-run install works too, but costs seconds per run).
+2. Mint an ephemeral setup key and join one sandbox non-interactively
+   (`sudo netbird up --setup-key ...`, per the Daytona page).
+3. Verify kernel mode: the WireGuard interface exists (`ip addr`, `netbird status`), no
+   userspace fallback needed.
+4. Verify both directions: the runner dials the sandbox daemon at its overlay address, and a
+   sandbox process (geesefs against the store port) dials the runner at its overlay address.
+5. Measure join time and round-trip latency against the current preview-proxy and ngrok
+   paths.
+6. Check the interaction with a restricted Daytona egress policy (`networkAllowList`), since
+   the docs are silent on it.
+
+If kernel mode fails on our tier, NetBird's userspace (netstack) mode is the fallback; it
+runs with no capabilities but proxies specific ports instead of giving a transparent
+interface, and it is slower. Detail in `research.md`, Question 1.
+
+## What it would replace
+
+- The ngrok tunnel for remote store mounts, the `with-tunnel` compose profile,
+  `discoverTunnelEndpoint`, and the public-store requirement (F-017).
+- Later, the file-relay gate channel that the F-018 fix adds now (Option B), by making the
+  ACP reverse permission RPC work over a direct channel (Option A, which the F-018 project
+  deferred as unfixable over the Daytona proxy).
+- Later, the MCP loopback swap on Daytona and the planned in-sandbox MCP shim.
+
+## What it must not block
+
+The F-018 fix is being implemented now and stays the near-term answer. Nothing here changes
+that. The relationship:
+
+- Option C of that fix (precompute builtin allow/deny on the runner, resolve in-sandbox with
+  no round-trip) is complementary and permanent. Keep it regardless.
+- Option B of that fix (carry the gate over the polled file relay) is the near-term bridge
+  the overlay could later retire. It is not throwaway: it ships the fix ahead of the overlay,
+  and it is a small channel to remove later.
+
+Build the F-018 fix as planned. Frame NetBird as the possible longer-term transport.
+
+## Phases after the confirmation run (estimates UNVERIFIED)
+
+- Phase 1, about 1 week: MVP behind a flag, Daytona only, default off. Per-run ephemeral key
+  minting in the runner, injected into the sandbox env; join on boot; route the store mount
+  over the overlay and drop ngrok on that path. NetBird cloud as the control plane first.
+- Phase 2, 1 to 2 weeks: production hardening. Default-deny ACL generated per run, per-run
+  groups, key and peer revocation on teardown, fail-loud when the overlay does not come up,
+  observability, the self-hosted control-plane option, and self-hosting docs.
+
+## Cloudflare Tunnel (the near-term mounts fix, separate from the overlay)
+
+Adopt TryCloudflare quick tunnels as the default dev and self-host tunnel for the store
+mount path, keeping ngrok as an alternative for anyone who already holds a token. A quick
+tunnel needs no account and no token, which removes exactly the F-017 failure mode (no
+`NGROK_AUTHTOKEN`, tunnel down, zombie mounts). It trades away any SLA and is explicitly not
+for production, which is acceptable because the tunnel path itself is a dev and self-host
+workaround; Agenta Cloud's store is genuinely public and uses no tunnel. Integration is 1 to
+2 days (**UNVERIFIED**): a `cloudflared` compose service under the existing `with-tunnel`
+profile and a second discovery branch in `mount.ts` against cloudflared's `/quicktunnel`
+metrics endpoint (verified in cloudflared source). Everything added is deleted wholesale when
+the overlay lands, and the overlay is far enough out that the interim fix pays for itself.
+Full analysis in `research.md`, last section.
+
+## Local mode
+
+Leave local as-is. Local sandboxes share the docker network with the runner and need no
+overlay. Make the overlay a remote-sandbox transport, gated on the Daytona path. See the
+local mode section in `research.md`.
+
+## Alternatives considered
+
+NetBird over Tailscale (Tailscale is equally feasible per the same Daytona page, but its
+control plane is proprietary SaaS with per-user pricing that fits ephemeral machine peers
+poorly; NetBird self-hosts the whole control plane as one open-source project). Both over
+plain WireGuard (which would make us rebuild the management plane). Any of them over keeping
+per-feature tunnels (whose count grows with each new sandbox-to-runner need). Detail in
+`research.md`, Question 5.

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/research.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/research.md
@@ -1,0 +1,398 @@
+# Research
+
+The idea: put the runner and its Daytona sandboxes on one shared private WireGuard mesh
+(overlay) using NetBird, so the runner and a sandbox can open connections to each other in
+both directions. Today there is no direct sandbox-to-runner channel, and each connectivity
+need has its own workaround. This document answers the five research questions with sources,
+plus a sixth section assessing Cloudflare Tunnel as a near-term ngrok replacement.
+
+Sources are cited inline. Every number that has not been measured in our own stack is marked
+**UNVERIFIED**.
+
+## Glossary (each term defined once)
+
+- **Overlay network.** A virtual private network laid on top of the real internet. Machines
+  on it get private addresses (for example `100.x.y.z`) and reach each other by those
+  addresses regardless of where they physically run. WireGuard is the encryption layer here.
+- **Peer.** One machine on the overlay. The runner is a peer; each sandbox is a peer.
+- **TUN device.** A virtual network interface the Linux kernel exposes at `/dev/net/tun`. A
+  normal (kernel-mode) WireGuard client creates one so the whole machine can route traffic
+  into the tunnel transparently. Creating it needs the `NET_ADMIN` capability.
+- **Userspace mode (netstack).** WireGuard running entirely inside one process, with its own
+  TCP/IP stack (gVisor netstack), no kernel TUN device, no `NET_ADMIN`. The tradeoff is that
+  it is not a transparent interface: it proxies specific ports rather than routing all
+  traffic.
+- **Management plane.** The NetBird control service that registers peers, holds the network
+  map, and distributes access policy. It is separate from the data path: traffic between
+  peers does not flow through it.
+- **Setup key.** A token a headless machine presents to the management plane to join the
+  overlay without a human login. Can be reusable and can be ephemeral (auto-removed when the
+  peer goes offline).
+
+## Question 1: Can NetBird run inside a Daytona container sandbox?
+
+Yes. Daytona documents VPN clients inside sandboxes as a first-class, supported flow, and
+NetBird is one of the three documented clients
+([Daytona VPN connections](https://www.daytona.io/docs/en/vpn-connections/#netbird)). That
+page is the primary source for this question.
+
+### What the Daytona VPN page establishes
+
+- **NetBird join is documented, non-interactive, setup-key based.** Install with the official
+  script (`curl -fsSL https://pkgs.netbird.io/install.sh | sudo sh`), then join with
+  `sudo netbird up --setup-key [KEY]`, verify with `netbird status`. The page ships Python and
+  TypeScript SDK examples that create a sandbox, install the client via `process.exec()` /
+  `executeCommand()`, join, and verify. Note that sandboxes have `sudo`.
+- **TUN devices exist in sandboxes.** The page's OpenVPN flow verifies the connection with
+  `ip addr show tun0`. OpenVPN requires a kernel TUN device, so a documented-working OpenVPN
+  flow means a sandbox can create TUN interfaces. That is the capability kernel-mode
+  WireGuard needs.
+- **Both directions are documented.** The page states the sandbox becomes part of your
+  private network, "allowing you to access resources... and enabling other devices on the
+  network to access the sandbox." That is exactly the bidirectional property this design
+  needs: the sandbox reaches the runner, and the runner reaches the sandbox.
+
+### What the page does not state (stay honest)
+
+- It does not name the sandbox container's Linux capability set (`NET_ADMIN` and so on), its
+  device list, or whether sandboxes run privileged. The TUN conclusion is inferred from the
+  OpenVPN flow, not stated as a capability guarantee.
+- It gives no security or ACL guidance: nothing about isolating VPN-joined sandboxes from
+  each other or from the rest of the private network. That burden falls entirely on our
+  NetBird policy design (Question 3).
+- It says nothing about performance, connect time, or interaction with Daytona's own
+  per-sandbox egress policy (`networkBlockAll` / `networkAllowList`, which our provider sets
+  per run in `services/runner/src/engines/sandbox_agent/provider.ts`). Whether a restricted
+  egress policy blocks the WireGuard UDP path is untested.
+
+So the residual unknown is small: one live confirmation that kernel-mode NetBird comes up in
+our own snapshot and passes traffic both ways, not a go/no-go on an undocumented capability.
+
+### Background: what Daytona sandboxes are
+
+Daytona sandboxes are Docker containers by default (a shared host kernel), with optional Kata
+Containers for microVM-grade isolation. Startup is sub-90ms with the container path
+([Northflank comparison](https://northflank.com/blog/daytona-vs-e2b-ai-code-execution-sandboxes)).
+Consistent with the VPN page, sandboxes are capable containers: Daytona also documents
+Docker-in-Docker and running Kubernetes inside a sandbox
+([Daytona snapshots](https://www.daytona.io/docs/en/snapshots/)).
+
+### Kernel mode is the design basis
+
+Kernel-mode WireGuard creates a real TUN interface, so every process in the sandbox reaches
+overlay addresses transparently through normal kernel routing: geesefs dials the store at the
+runner's overlay address, a permission RPC dials the runner, no per-port plumbing. For
+reference, NetBird's standard Docker image asks for the `NET_ADMIN`, `SYS_ADMIN`, and
+`SYS_RESOURCE` capabilities plus `/dev/net/tun`
+([NetBird Docker client](https://netbirdio-netbird-9.mintlify.app/clients/docker)); inside a
+Daytona sandbox the documented flow simply installs and runs the client with sudo, and the
+OpenVPN `tun0` evidence says the TUN prerequisite is met.
+
+### Fallback only: userspace mode (netstack, no TUN)
+
+Kept in case a live run contradicts the docs (for example on a restricted Daytona tier).
+NetBird can run WireGuard entirely in userspace with gVisor netstack, no TUN device and no
+capabilities, enabled with `NB_USE_NETSTACK_MODE=true`
+([NetBird Docker client](https://netbirdio-netbird-9.mintlify.app/clients/docker),
+[netstack explainer](https://ryan-schachte.com/blog/userspace_wireguard_tunnels/)). The costs
+that make it the wrong primary design: it is not a transparent interface (its TCP/IP stack
+lives inside the NetBird process); inbound works by proxying overlay traffic to local
+listeners, but outbound from other sandbox processes needs NetBird's port forwarding and
+`NB_ENABLE_LOCAL_FORWARDING=true` rather than dialing overlay addresses directly
+([issue #4929](https://github.com/netbirdio/netbird/issues/4929)); it is slower than kernel
+WireGuard; and DNS is disabled by default. Workable for our small fixed set of endpoints, but
+strictly worse than the documented kernel path. Do not design against it; keep it as the
+escape hatch.
+
+### Answer
+
+Feasible, documented by Daytona. Design against kernel mode (real TUN interface, transparent
+routing). One short confirmation run replaces a full go/no-go spike: bake the client into our
+snapshot, join with a setup key, verify the interface and both directions, measure latency
+and connect time. Userspace mode is the fallback footnote, not the design basis.
+
+## Question 2: Architecture
+
+### Where the management plane lives
+
+NetBird has four services: management (registration, network map, policy), signal (peer
+discovery and connection setup, stores no data, no traffic through it), relay (a Coturn TURN
+server used only when a direct peer connection cannot be established), and the client on each
+peer. All of management, signal, and relay can be self-hosted or used from NetBird's cloud
+([how NetBird works](https://docs.netbird.io/about-netbird/how-netbird-works)). The peer's
+private key never leaves the machine, and relayed traffic stays WireGuard-encrypted end to
+end.
+
+Two options for us:
+
+- **NetBird cloud.** Agenta Cloud points its runner and sandboxes at NetBird's managed
+  control plane. No new services to run. The cost is a hard dependency on a third-party
+  control plane for the sandbox data path to come up, and it does not help self-hosters who
+  run Daytona.
+- **Self-hosted management, signal, relay.** Three more services in the Agenta stack. This is
+  the only option that lets a self-hoster on Daytona use the overlay without a NetBird
+  account. The cost is three more moving parts in compose and Helm, which cuts against the
+  self-hosting story the runner explainer works to keep simple (see
+  `../runner-selfhosting-explainer/README.md`).
+
+The important scoping fact: the overlay is only needed when the sandbox is remote (Daytona).
+A self-hoster on the default local provider shares a docker network with the runner and needs
+none of this. So the overlay components attach specifically to the Daytona path, which bounds
+who pays the added complexity.
+
+### How a sandbox joins, how the runner joins
+
+- **Runner joins once, long-lived.** The runner container runs a NetBird client (kernel mode;
+  the runner container already carries `SYS_ADMIN` and `/dev/fuse` for geesefs per the
+  explainer, so granting its capabilities is in our own hands). It stays on the overlay for
+  its lifetime, in a fixed group.
+- **Sandbox joins per run, ephemeral.** The NetBird client is baked into the Daytona snapshot
+  (the snapshot already bakes Pi and geesefs; adding one binary is in scope; the Daytona VPN
+  page's install-per-run flow also works but costs seconds per run). On sandbox boot the
+  runner injects a freshly minted, ephemeral, run-scoped setup key as an env var (the same
+  channel that already carries provider keys and Pi config into the sandbox, see
+  `daytona.ts`), and the sandbox runs `netbird up --setup-key` to join. Ephemeral peers
+  auto-remove after 10 minutes of no activity, which matches sandbox teardown
+  ([setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys)).
+  Baking a single long-lived key into the snapshot instead is rejected under Question 3: a
+  shared key means any sandbox can impersonate any other.
+
+### What each workaround becomes over the overlay
+
+| Need | Today | Over the overlay |
+|---|---|---|
+| F-017 mounts (sandbox reaches the store) | geesefs in the sandbox hits the store through a public ngrok tunnel (`with-tunnel` profile, `discoverTunnelEndpoint` in `mount.ts`); requires a publicly reachable store | geesefs reaches the runner-side store over the overlay; ngrok, the `with-tunnel` profile, `discoverTunnelEndpoint`, and the `storeReachableFromSandbox` public-store rule all go away |
+| F-018 reverse permission RPC (sandbox asks runner to approve a tool) | The ACP `session/request_permission` reverse request never arrives over the Daytona preview proxy; being fixed by delivering gate decisions over the polled file relay | A direct sandbox-to-runner channel exists, so the reverse RPC can travel it. This is Option A in `../daytona-gate-delivery/options.md` (make the reverse RPC work), which that project deferred because the transport was unfixable |
+| MCP delivery (our tools to a Claude/Codex sandbox) | The internal tool-MCP server binds the runner's `127.0.0.1`, unreachable from the sandbox, so it is skipped on Daytona and an in-sandbox shim is planned (`mcp.ts`, `../mcp-delivery-architecture/directions.md`) | The sandbox reaches the runner's MCP server (or a future L2 gateway) at the runner's overlay address, so the loopback problem disappears and the in-sandbox shim may not be needed |
+
+The through-line: today the runner-to-sandbox direction has one channel (the Daytona signed
+preview URL) and the sandbox-to-runner direction has none (only the runner-polled file relay,
+per `../mcp-delivery-architecture/directions.md`). The overlay adds the missing direction,
+which is the root cause behind F-017, F-018, and the MCP loopback gap at once.
+
+## Question 3: Security and tenancy
+
+Sandboxes run untrusted agent code. A flat overlay where every peer can reach every other
+peer and the whole runner network is unacceptable: a compromised sandbox could reach other
+sandboxes and any service on the runner's private network. The overlay is only safe with
+strict access control. Daytona's VPN page gives no guidance here; the policy design is
+entirely ours.
+
+### What NetBird gives us
+
+- **Groups and access policies.** NetBird controls reachability between peers with groups and
+  policies. A policy names which groups may connect to which, on which protocols and ports
+  ([manage network access](https://docs.netbird.io/manage/access-control/manage-network-access)).
+  The default posture we want: one `runner` group, one `sandboxes` group, a policy that lets
+  `sandboxes` reach only the specific runner ports it needs (the store port, the permission
+  RPC port), and no policy permitting `sandboxes` to `sandboxes`. Sandbox-to-sandbox is denied
+  by omission.
+- **Per-run isolation with auto-assign groups.** A setup key can auto-assign every peer that
+  uses it to named groups
+  ([setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys)). A
+  per-run key can drop that run's sandbox into a run-scoped group so its policy is exactly the
+  endpoints that run needs, and nothing else.
+- **Ephemeral keys and lifetime.** Ephemeral peers are auto-removed after 10 minutes offline,
+  and keys are minted per run rather than shared. Revocation is deleting the key or the peer
+  on the management plane
+  ([setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys)).
+
+### Blast radius versus today's ngrok tunnel
+
+Today's ngrok tunnel exposes the SeaweedFS store on a public URL behind an auth token (per the
+runner explainer and the `mount.ts` tunnel code). Its blast radius is one port on the public
+internet, guarded by a single shared token, reachable by anyone who learns the URL and token.
+
+A correctly-fenced overlay is better: no public surface at all, per-run scoping, and per-peer
+revocation. A misconfigured flat overlay is worse: the sandbox holds a live peer credential
+and a route into the runner's private network, so a wrong policy exposes far more than one
+store port. So the overlay improves blast radius only if the ACL is right, and ACL
+correctness is the one thing this design cannot get wrong. That argues for the overlay policy
+to be default-deny, generated per run, and tested as a first-class part of the feature rather
+than hand-maintained.
+
+One residual to name: the sandbox now runs a NetBird client that holds a WireGuard key and
+can reach the runner peer. That is strictly more reachability than the sandbox has today
+(today it reaches the runner through nothing; the runner reaches it). The ACL is what keeps
+that reachability down to the intended ports. This is the security tradeoff of the whole
+idea.
+
+## Question 4: Local mode
+
+Local sandboxes run inside the runner container's own host and share the docker network with
+the runner and the store, so the sandbox reaches everything directly and every feature works
+(per the runner explainer, "How a local run executes"). There is no connectivity problem to
+solve locally.
+
+Two options:
+
+- **Leave local as-is; the overlay is remote-only.** The sandbox-to-runner reachability
+  question already has two answers in the code depending on the sandbox axis (local shares
+  the docker network; Daytona goes through the preview proxy and file relay). The overlay
+  becomes the Daytona answer to that same question. It does not add a new divergence axis;
+  the code already branches on `isDaytona` for mounts, MCP delivery, and asset upload.
+- **Run the overlay locally too, for uniformity.** One code path for sandbox-to-runner
+  everywhere. The cost is that every self-hoster, including the common local-only case that
+  needs no isolation, now runs the management, signal, and relay services for no connectivity
+  benefit.
+
+**Recommendation: leave local as-is.** The overlay is a remote-sandbox transport, gated on
+the Daytona path, exactly where the shared docker network does not exist. Forcing it on the
+local path adds three services to every self-hosted install to solve a problem the local path
+does not have. The uniformity argument is weaker than it looks, because the local and Daytona
+paths already differ in mount location, MCP delivery, and asset handling. Adding the overlay
+only to the remote path fits the existing shape rather than fighting it.
+
+## Question 5: Effort, fit, and alternatives
+
+### What it would replace, and what it must not block
+
+- **Replaces the ngrok tunnel** for remote store mounts (F-017): the `with-tunnel` compose
+  profile, the ngrok service, `discoverTunnelEndpoint`, and the public-store requirement.
+  This is the cleanest and least contentious win.
+- **Could later retire the file-relay gate channel** (Option B of the F-018 fix) by making
+  the ACP reverse RPC work over a direct channel (Option A). It does not retire Option C.
+- **Could remove the MCP loopback swap** on Daytona and the need for the in-sandbox MCP shim.
+
+The F-018 fix is being implemented now (`../daytona-gate-delivery/`), and NetBird must not
+block it. The relationship:
+
+- **Option C of the F-018 fix is complementary and permanent.** Option C precomputes each
+  builtin's allow/deny decision on the runner and injects it, so an allowed builtin resolves
+  in the sandbox with no round-trip. That is a correctness-and-latency improvement
+  independent of the transport. It stays valuable even with the overlay, because a direct
+  channel still has round-trip cost you would rather avoid for the allow case.
+- **Option B of the F-018 fix is the near-term bridge that the overlay could later replace.**
+  Option B carries the gate over the polled file relay because the reverse RPC transport is
+  broken. If the overlay lands and makes Option A viable, Option B's second channel can
+  retire. So Option B is not throwaway work: it ships the fix now, ahead of the overlay, and
+  it is a small, contained channel to remove later.
+
+Net: none of the F-018 work is wasted. Build it now as the near-term fix. Frame NetBird as
+the possible longer-term transport that could later retire Option B and keep Option C.
+
+### Effort by phase (all estimates UNVERIFIED)
+
+- **Phase 0, confirmation run: about 1 day.** Not a go/no-go on an unknown; Daytona documents
+  the flow. Bake the NetBird client into a test snapshot, mint an ephemeral setup key, join
+  one sandbox, verify the interface comes up in kernel mode and that the runner and sandbox
+  reach each other in both directions, and measure round-trip latency and join time against
+  the current preview-proxy and ngrok paths. Also test the interaction with a restricted
+  Daytona egress policy.
+- **Phase 1, MVP behind a flag: about 1 week.** Point at a control plane (NetBird cloud for
+  Agenta Cloud first; self-hosted can follow). Mint a per-run ephemeral setup key in the
+  runner, inject it into the sandbox env, join on boot. Route the geesefs store mount over
+  the overlay and drop ngrok on that path. Behind a flag, default off, Daytona only.
+- **Phase 2, production and ACL hardening: 1 to 2 weeks.** Per-run groups and a default-deny
+  policy generated per run, key and peer revocation on teardown, fail-loud behavior when the
+  overlay does not come up (never a silent fallback that hangs, the F-017 lesson),
+  observability, self-hosted control-plane option, and the self-hosting docs.
+
+### Alternatives
+
+- **Tailscale.** Also a first-class documented flow on the same Daytona VPN page (auth-key
+  join, `sudo tailscale up --auth-key=...`), so feasibility is equal. The Tailscale client is
+  open source, but the control plane is proprietary SaaS; the open-source self-hosted control
+  plane is Headscale (BSD-3), a separate project ([Headscale](https://headscale.net/)).
+  Tailscale's pricing is per-user (Standard around $8/user, **UNVERIFIED** current number,
+  [Tailscale pricing analysis](https://wz-it.com/en/blog/tailscale-pricing-2026-headscale-netbird-self-hosted/)),
+  which fits a fleet of ephemeral machine peers poorly. NetBird is a single open-source
+  project that self-hosts the whole control plane, which is a better fit for shipping the
+  control plane inside a self-hosted product.
+- **Plain WireGuard.** No management plane, no signal, no NAT traversal. We would hand-manage
+  keys, peer config, and IP allocation per ephemeral sandbox, and build our own key
+  distribution and revocation. That is most of what NetBird's management plane already does.
+  Not worth it for a fleet of short-lived peers.
+- **Keep per-feature tunnels (the status quo).** ngrok for mounts, the file relay for gates
+  and tools, the in-sandbox shim for MCP. Each is small and already mostly built. The cost is
+  that the count of one-off workarounds grows with each new sandbox-to-runner need, and each
+  has its own failure mode (the zombie mount in F-017, the lost RPC in F-018). The overlay's
+  pitch is to replace that growing set with one transport.
+
+## Cloudflare Tunnel as a near-term ngrok replacement (mounts only)
+
+Separate question from the overlay: the tunnel's only current job is the remote mount path.
+The runner-side stack exposes the store's S3 endpoint (`seaweedfs:8333`) through ngrok so
+geesefs inside a Daytona sandbox can reach it; the runner discovers the public URL through
+ngrok's local API (`http://ngrok:4040/api/tunnels`, `discoverTunnelEndpoint` in `mount.ts`).
+ngrok requires every deployment to provision an `NGROK_AUTHTOKEN`, and that requirement is
+exactly what bit us in F-017: the dev box had no token, the tunnel was down, and mounts
+zombie-hung. Cloudflare Tunnel can run with no account at all, which is the draw.
+
+### Option 1: TryCloudflare quick tunnels (zero auth)
+
+`cloudflared tunnel --url http://seaweedfs:8333` with no account and no token gets a random
+`*.trycloudflare.com` HTTPS URL
+([Cloudflare quick tunnels](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/)).
+What it trades away, plainly:
+
+- **No SLA and stated non-production intent.** Cloudflare says quick tunnels are for testing
+  and development only and guarantees no uptime. The tunnel can be reclaimed at any time.
+- **A new random subdomain on every start.** Harmless for us, because the runner re-discovers
+  the URL at mount time anyway, but it means the URL is never stable across restarts.
+- **Limits.** 200 in-flight requests per quick tunnel (429 beyond that), a single connection
+  to Cloudflare's edge (no redundancy), and the docs note quick tunnels do not support
+  Server-Sent Events (irrelevant for S3)
+  ([quick tunnels docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/),
+  [cloudflared internals](https://deepwiki.com/cloudflare/cloudflared/3.4-quick-tunnels)).
+- **The S3 workload should fit, with one caveat.** geesefs traffic is ordinary HTTPS: ranged
+  GETs, PUTs, multipart uploads, each a bounded request, which is what the tunnel proxies.
+  The caveat is Cloudflare's proxy body-size limit (around 100 MB per request on the free
+  tier, **UNVERIFIED** exact number): a multipart PUT whose part size exceeds it would fail.
+  geesefs part sizes are configurable and small by default (**UNVERIFIED**; confirm our
+  effective part sizes in the confirmation run), so this is a checkable risk, not a blocker.
+
+Verdict on quick tunnels: they fit the dev-box case exactly (the F-017 failure mode was "no
+token, no tunnel"; a quick tunnel needs no token, so the tunnel is simply always up), and
+they are explicitly the wrong thing to document as the production path.
+
+### Option 2: named Cloudflare tunnels (free, needs account + domain)
+
+A named tunnel is free but needs a Cloudflare account, a domain on Cloudflare, and a tunnel
+token ([Cloudflare tunnel setup](https://developers.cloudflare.com/tunnel/setup/)). For a
+self-hoster that is the same shape of burden as ngrok's authtoken (provision a credential),
+plus a domain requirement ngrok does not have. It buys a stable hostname, production intent,
+and multiple edge connections. Named tunnels beat "ngrok with token" mainly on price
+(Cloudflare's is free at this scale; ngrok's free tier has its own limits) and on the 100s of
+megabytes of bandwidth ngrok's free tier caps (**UNVERIFIED** current ngrok free-tier caps).
+They do not remove the provisioning step, which was the actual pain.
+
+### Security
+
+Same public-exposure model as ngrok: the store rides a public URL, and the only guard is the
+store's own auth (the signed, prefix-scoped, short-TTL S3 credentials the API mints; the
+bucket master key never rides the tunnel). A quick tunnel is marginally worse than ngrok in
+one respect: the URL is unauthenticated at the tunnel layer and anyone who learns it can
+reach the store port, exactly like ngrok minus the account-level controls ngrok offers.
+Cloudflare Access can add authentication in front of a named tunnel, but that reintroduces
+per-deployment auth setup, which defeats the zero-auth goal; say so plainly and do not plan
+on it. The real security posture in every tunnel variant remains: the store endpoint is
+public, the credentials scoped and short-lived. Only the overlay removes the public surface.
+
+### Integration effort
+
+Small and contained (**UNVERIFIED**, estimate 1 to 2 days):
+
+- **Discovery.** cloudflared's metrics server exposes `GET /quicktunnel` returning
+  `{"hostname":"..."}` (verified in source: `metrics/metrics.go` lines 86-88 on cloudflared
+  master). `discoverTunnelEndpoint` in `mount.ts` gains a cloudflared branch: query
+  `http://cloudflared:<metrics-port>/quicktunnel` instead of `http://ngrok:4040/api/tunnels`,
+  prepend `https://`. The function already returns null-on-failure with the mount skipped.
+- **Compose.** Swap or add a `cloudflared` service under the same `with-tunnel` profile
+  (`cloudflared tunnel --url http://seaweedfs:8333 --metrics 0.0.0.0:20241`, official image,
+  no env vars needed for quick tunnels). Both services can coexist behind the profile with
+  discovery trying each in turn, which gives a migration path rather than a flag-day swap.
+- **No sandbox-side change.** geesefs already takes whatever endpoint URL discovery returns.
+
+### Where it sits relative to the overlay
+
+The tunnel is the today-fix for mounts; the overlay is the later-fix that deletes the tunnel
+entirely. Cloudflare quick tunnels are worth the small churn on one condition: they remove
+the token-provisioning failure mode from every dev and self-hosted deployment now, for one to
+two days of contained work, and everything added (one compose service, one discovery branch)
+is deleted wholesale when the overlay lands. If the overlay were committed and starting next
+week, skip the churn. Since the overlay is still pre-confirmation and Phase 2 hardening is
+weeks out, the quick-tunnel swap pays for itself in unbroken dev boxes in the meantime.
+Recommend: quick tunnels as the default dev/self-host path behind the existing profile,
+ngrok kept as the alternative for anyone who already has a token, production (Agenta Cloud)
+unaffected because its store is genuinely public.

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/research.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/research.md
@@ -1,398 +1,221 @@
 # Research
 
-The idea: put the runner and its Daytona sandboxes on one shared private WireGuard mesh
-(overlay) using NetBird, so the runner and a sandbox can open connections to each other in
-both directions. Today there is no direct sandbox-to-runner channel, and each connectivity
-need has its own workaround. This document answers the five research questions with sources,
-plus a sixth section assessing Cloudflare Tunnel as a near-term ngrok replacement.
-
-Sources are cited inline. Every number that has not been measured in our own stack is marked
-**UNVERIFIED**.
-
-## Glossary (each term defined once)
-
-- **Overlay network.** A virtual private network laid on top of the real internet. Machines
-  on it get private addresses (for example `100.x.y.z`) and reach each other by those
-  addresses regardless of where they physically run. WireGuard is the encryption layer here.
-- **Peer.** One machine on the overlay. The runner is a peer; each sandbox is a peer.
-- **TUN device.** A virtual network interface the Linux kernel exposes at `/dev/net/tun`. A
-  normal (kernel-mode) WireGuard client creates one so the whole machine can route traffic
-  into the tunnel transparently. Creating it needs the `NET_ADMIN` capability.
-- **Userspace mode (netstack).** WireGuard running entirely inside one process, with its own
-  TCP/IP stack (gVisor netstack), no kernel TUN device, no `NET_ADMIN`. The tradeoff is that
-  it is not a transparent interface: it proxies specific ports rather than routing all
-  traffic.
-- **Management plane.** The NetBird control service that registers peers, holds the network
-  map, and distributes access policy. It is separate from the data path: traffic between
-  peers does not flow through it.
-- **Setup key.** A token a headless machine presents to the management plane to join the
-  overlay without a human login. Can be reusable and can be ephemeral (auto-removed when the
-  peer goes offline).
-
-## Question 1: Can NetBird run inside a Daytona container sandbox?
-
-Yes. Daytona documents VPN clients inside sandboxes as a first-class, supported flow, and
-NetBird is one of the three documented clients
-([Daytona VPN connections](https://www.daytona.io/docs/en/vpn-connections/#netbird)). That
-page is the primary source for this question.
-
-### What the Daytona VPN page establishes
-
-- **NetBird join is documented, non-interactive, setup-key based.** Install with the official
-  script (`curl -fsSL https://pkgs.netbird.io/install.sh | sudo sh`), then join with
-  `sudo netbird up --setup-key [KEY]`, verify with `netbird status`. The page ships Python and
-  TypeScript SDK examples that create a sandbox, install the client via `process.exec()` /
-  `executeCommand()`, join, and verify. Note that sandboxes have `sudo`.
-- **TUN devices exist in sandboxes.** The page's OpenVPN flow verifies the connection with
-  `ip addr show tun0`. OpenVPN requires a kernel TUN device, so a documented-working OpenVPN
-  flow means a sandbox can create TUN interfaces. That is the capability kernel-mode
-  WireGuard needs.
-- **Both directions are documented.** The page states the sandbox becomes part of your
-  private network, "allowing you to access resources... and enabling other devices on the
-  network to access the sandbox." That is exactly the bidirectional property this design
-  needs: the sandbox reaches the runner, and the runner reaches the sandbox.
-
-### What the page does not state (stay honest)
-
-- It does not name the sandbox container's Linux capability set (`NET_ADMIN` and so on), its
-  device list, or whether sandboxes run privileged. The TUN conclusion is inferred from the
-  OpenVPN flow, not stated as a capability guarantee.
-- It gives no security or ACL guidance: nothing about isolating VPN-joined sandboxes from
-  each other or from the rest of the private network. That burden falls entirely on our
-  NetBird policy design (Question 3).
-- It says nothing about performance, connect time, or interaction with Daytona's own
-  per-sandbox egress policy (`networkBlockAll` / `networkAllowList`, which our provider sets
-  per run in `services/runner/src/engines/sandbox_agent/provider.ts`). Whether a restricted
-  egress policy blocks the WireGuard UDP path is untested.
-
-So the residual unknown is small: one live confirmation that kernel-mode NetBird comes up in
-our own snapshot and passes traffic both ways, not a go/no-go on an undocumented capability.
-
-### Background: what Daytona sandboxes are
-
-Daytona sandboxes are Docker containers by default (a shared host kernel), with optional Kata
-Containers for microVM-grade isolation. Startup is sub-90ms with the container path
-([Northflank comparison](https://northflank.com/blog/daytona-vs-e2b-ai-code-execution-sandboxes)).
-Consistent with the VPN page, sandboxes are capable containers: Daytona also documents
-Docker-in-Docker and running Kubernetes inside a sandbox
-([Daytona snapshots](https://www.daytona.io/docs/en/snapshots/)).
-
-### Kernel mode is the design basis
-
-Kernel-mode WireGuard creates a real TUN interface, so every process in the sandbox reaches
-overlay addresses transparently through normal kernel routing: geesefs dials the store at the
-runner's overlay address, a permission RPC dials the runner, no per-port plumbing. For
-reference, NetBird's standard Docker image asks for the `NET_ADMIN`, `SYS_ADMIN`, and
-`SYS_RESOURCE` capabilities plus `/dev/net/tun`
-([NetBird Docker client](https://netbirdio-netbird-9.mintlify.app/clients/docker)); inside a
-Daytona sandbox the documented flow simply installs and runs the client with sudo, and the
-OpenVPN `tun0` evidence says the TUN prerequisite is met.
-
-### Fallback only: userspace mode (netstack, no TUN)
-
-Kept in case a live run contradicts the docs (for example on a restricted Daytona tier).
-NetBird can run WireGuard entirely in userspace with gVisor netstack, no TUN device and no
-capabilities, enabled with `NB_USE_NETSTACK_MODE=true`
-([NetBird Docker client](https://netbirdio-netbird-9.mintlify.app/clients/docker),
-[netstack explainer](https://ryan-schachte.com/blog/userspace_wireguard_tunnels/)). The costs
-that make it the wrong primary design: it is not a transparent interface (its TCP/IP stack
-lives inside the NetBird process); inbound works by proxying overlay traffic to local
-listeners, but outbound from other sandbox processes needs NetBird's port forwarding and
-`NB_ENABLE_LOCAL_FORWARDING=true` rather than dialing overlay addresses directly
-([issue #4929](https://github.com/netbirdio/netbird/issues/4929)); it is slower than kernel
-WireGuard; and DNS is disabled by default. Workable for our small fixed set of endpoints, but
-strictly worse than the documented kernel path. Do not design against it; keep it as the
-escape hatch.
-
-### Answer
-
-Feasible, documented by Daytona. Design against kernel mode (real TUN interface, transparent
-routing). One short confirmation run replaces a full go/no-go spike: bake the client into our
-snapshot, join with a setup key, verify the interface and both directions, measure latency
-and connect time. Userspace mode is the fallback footnote, not the design basis.
-
-## Question 2: Architecture
-
-### Where the management plane lives
-
-NetBird has four services: management (registration, network map, policy), signal (peer
-discovery and connection setup, stores no data, no traffic through it), relay (a Coturn TURN
-server used only when a direct peer connection cannot be established), and the client on each
-peer. All of management, signal, and relay can be self-hosted or used from NetBird's cloud
-([how NetBird works](https://docs.netbird.io/about-netbird/how-netbird-works)). The peer's
-private key never leaves the machine, and relayed traffic stays WireGuard-encrypted end to
-end.
-
-Two options for us:
-
-- **NetBird cloud.** Agenta Cloud points its runner and sandboxes at NetBird's managed
-  control plane. No new services to run. The cost is a hard dependency on a third-party
-  control plane for the sandbox data path to come up, and it does not help self-hosters who
-  run Daytona.
-- **Self-hosted management, signal, relay.** Three more services in the Agenta stack. This is
-  the only option that lets a self-hoster on Daytona use the overlay without a NetBird
-  account. The cost is three more moving parts in compose and Helm, which cuts against the
-  self-hosting story the runner explainer works to keep simple (see
-  `../runner-selfhosting-explainer/README.md`).
-
-The important scoping fact: the overlay is only needed when the sandbox is remote (Daytona).
-A self-hoster on the default local provider shares a docker network with the runner and needs
-none of this. So the overlay components attach specifically to the Daytona path, which bounds
-who pays the added complexity.
-
-### How a sandbox joins, how the runner joins
-
-- **Runner joins once, long-lived.** The runner container runs a NetBird client (kernel mode;
-  the runner container already carries `SYS_ADMIN` and `/dev/fuse` for geesefs per the
-  explainer, so granting its capabilities is in our own hands). It stays on the overlay for
-  its lifetime, in a fixed group.
-- **Sandbox joins per run, ephemeral.** The NetBird client is baked into the Daytona snapshot
-  (the snapshot already bakes Pi and geesefs; adding one binary is in scope; the Daytona VPN
-  page's install-per-run flow also works but costs seconds per run). On sandbox boot the
-  runner injects a freshly minted, ephemeral, run-scoped setup key as an env var (the same
-  channel that already carries provider keys and Pi config into the sandbox, see
-  `daytona.ts`), and the sandbox runs `netbird up --setup-key` to join. Ephemeral peers
-  auto-remove after 10 minutes of no activity, which matches sandbox teardown
-  ([setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys)).
-  Baking a single long-lived key into the snapshot instead is rejected under Question 3: a
-  shared key means any sandbox can impersonate any other.
-
-### What each workaround becomes over the overlay
-
-| Need | Today | Over the overlay |
-|---|---|---|
-| F-017 mounts (sandbox reaches the store) | geesefs in the sandbox hits the store through a public ngrok tunnel (`with-tunnel` profile, `discoverTunnelEndpoint` in `mount.ts`); requires a publicly reachable store | geesefs reaches the runner-side store over the overlay; ngrok, the `with-tunnel` profile, `discoverTunnelEndpoint`, and the `storeReachableFromSandbox` public-store rule all go away |
-| F-018 reverse permission RPC (sandbox asks runner to approve a tool) | The ACP `session/request_permission` reverse request never arrives over the Daytona preview proxy; being fixed by delivering gate decisions over the polled file relay | A direct sandbox-to-runner channel exists, so the reverse RPC can travel it. This is Option A in `../daytona-gate-delivery/options.md` (make the reverse RPC work), which that project deferred because the transport was unfixable |
-| MCP delivery (our tools to a Claude/Codex sandbox) | The internal tool-MCP server binds the runner's `127.0.0.1`, unreachable from the sandbox, so it is skipped on Daytona and an in-sandbox shim is planned (`mcp.ts`, `../mcp-delivery-architecture/directions.md`) | The sandbox reaches the runner's MCP server (or a future L2 gateway) at the runner's overlay address, so the loopback problem disappears and the in-sandbox shim may not be needed |
-
-The through-line: today the runner-to-sandbox direction has one channel (the Daytona signed
-preview URL) and the sandbox-to-runner direction has none (only the runner-polled file relay,
-per `../mcp-delivery-architecture/directions.md`). The overlay adds the missing direction,
-which is the root cause behind F-017, F-018, and the MCP loopback gap at once.
-
-## Question 3: Security and tenancy
-
-Sandboxes run untrusted agent code. A flat overlay where every peer can reach every other
-peer and the whole runner network is unacceptable: a compromised sandbox could reach other
-sandboxes and any service on the runner's private network. The overlay is only safe with
-strict access control. Daytona's VPN page gives no guidance here; the policy design is
-entirely ours.
-
-### What NetBird gives us
-
-- **Groups and access policies.** NetBird controls reachability between peers with groups and
-  policies. A policy names which groups may connect to which, on which protocols and ports
-  ([manage network access](https://docs.netbird.io/manage/access-control/manage-network-access)).
-  The default posture we want: one `runner` group, one `sandboxes` group, a policy that lets
-  `sandboxes` reach only the specific runner ports it needs (the store port, the permission
-  RPC port), and no policy permitting `sandboxes` to `sandboxes`. Sandbox-to-sandbox is denied
-  by omission.
-- **Per-run isolation with auto-assign groups.** A setup key can auto-assign every peer that
-  uses it to named groups
-  ([setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys)). A
-  per-run key can drop that run's sandbox into a run-scoped group so its policy is exactly the
-  endpoints that run needs, and nothing else.
-- **Ephemeral keys and lifetime.** Ephemeral peers are auto-removed after 10 minutes offline,
-  and keys are minted per run rather than shared. Revocation is deleting the key or the peer
-  on the management plane
-  ([setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys)).
-
-### Blast radius versus today's ngrok tunnel
-
-Today's ngrok tunnel exposes the SeaweedFS store on a public URL behind an auth token (per the
-runner explainer and the `mount.ts` tunnel code). Its blast radius is one port on the public
-internet, guarded by a single shared token, reachable by anyone who learns the URL and token.
-
-A correctly-fenced overlay is better: no public surface at all, per-run scoping, and per-peer
-revocation. A misconfigured flat overlay is worse: the sandbox holds a live peer credential
-and a route into the runner's private network, so a wrong policy exposes far more than one
-store port. So the overlay improves blast radius only if the ACL is right, and ACL
-correctness is the one thing this design cannot get wrong. That argues for the overlay policy
-to be default-deny, generated per run, and tested as a first-class part of the feature rather
-than hand-maintained.
-
-One residual to name: the sandbox now runs a NetBird client that holds a WireGuard key and
-can reach the runner peer. That is strictly more reachability than the sandbox has today
-(today it reaches the runner through nothing; the runner reaches it). The ACL is what keeps
-that reachability down to the intended ports. This is the security tradeoff of the whole
-idea.
-
-## Question 4: Local mode
-
-Local sandboxes run inside the runner container's own host and share the docker network with
-the runner and the store, so the sandbox reaches everything directly and every feature works
-(per the runner explainer, "How a local run executes"). There is no connectivity problem to
-solve locally.
-
-Two options:
-
-- **Leave local as-is; the overlay is remote-only.** The sandbox-to-runner reachability
-  question already has two answers in the code depending on the sandbox axis (local shares
-  the docker network; Daytona goes through the preview proxy and file relay). The overlay
-  becomes the Daytona answer to that same question. It does not add a new divergence axis;
-  the code already branches on `isDaytona` for mounts, MCP delivery, and asset upload.
-- **Run the overlay locally too, for uniformity.** One code path for sandbox-to-runner
-  everywhere. The cost is that every self-hoster, including the common local-only case that
-  needs no isolation, now runs the management, signal, and relay services for no connectivity
-  benefit.
-
-**Recommendation: leave local as-is.** The overlay is a remote-sandbox transport, gated on
-the Daytona path, exactly where the shared docker network does not exist. Forcing it on the
-local path adds three services to every self-hosted install to solve a problem the local path
-does not have. The uniformity argument is weaker than it looks, because the local and Daytona
-paths already differ in mount location, MCP delivery, and asset handling. Adding the overlay
-only to the remote path fits the existing shape rather than fighting it.
-
-## Question 5: Effort, fit, and alternatives
-
-### What it would replace, and what it must not block
-
-- **Replaces the ngrok tunnel** for remote store mounts (F-017): the `with-tunnel` compose
-  profile, the ngrok service, `discoverTunnelEndpoint`, and the public-store requirement.
-  This is the cleanest and least contentious win.
-- **Could later retire the file-relay gate channel** (Option B of the F-018 fix) by making
-  the ACP reverse RPC work over a direct channel (Option A). It does not retire Option C.
-- **Could remove the MCP loopback swap** on Daytona and the need for the in-sandbox MCP shim.
-
-The F-018 fix is being implemented now (`../daytona-gate-delivery/`), and NetBird must not
-block it. The relationship:
-
-- **Option C of the F-018 fix is complementary and permanent.** Option C precomputes each
-  builtin's allow/deny decision on the runner and injects it, so an allowed builtin resolves
-  in the sandbox with no round-trip. That is a correctness-and-latency improvement
-  independent of the transport. It stays valuable even with the overlay, because a direct
-  channel still has round-trip cost you would rather avoid for the allow case.
-- **Option B of the F-018 fix is the near-term bridge that the overlay could later replace.**
-  Option B carries the gate over the polled file relay because the reverse RPC transport is
-  broken. If the overlay lands and makes Option A viable, Option B's second channel can
-  retire. So Option B is not throwaway work: it ships the fix now, ahead of the overlay, and
-  it is a small, contained channel to remove later.
-
-Net: none of the F-018 work is wasted. Build it now as the near-term fix. Frame NetBird as
-the possible longer-term transport that could later retire Option B and keep Option C.
-
-### Effort by phase (all estimates UNVERIFIED)
-
-- **Phase 0, confirmation run: about 1 day.** Not a go/no-go on an unknown; Daytona documents
-  the flow. Bake the NetBird client into a test snapshot, mint an ephemeral setup key, join
-  one sandbox, verify the interface comes up in kernel mode and that the runner and sandbox
-  reach each other in both directions, and measure round-trip latency and join time against
-  the current preview-proxy and ngrok paths. Also test the interaction with a restricted
-  Daytona egress policy.
-- **Phase 1, MVP behind a flag: about 1 week.** Point at a control plane (NetBird cloud for
-  Agenta Cloud first; self-hosted can follow). Mint a per-run ephemeral setup key in the
-  runner, inject it into the sandbox env, join on boot. Route the geesefs store mount over
-  the overlay and drop ngrok on that path. Behind a flag, default off, Daytona only.
-- **Phase 2, production and ACL hardening: 1 to 2 weeks.** Per-run groups and a default-deny
-  policy generated per run, key and peer revocation on teardown, fail-loud behavior when the
-  overlay does not come up (never a silent fallback that hangs, the F-017 lesson),
-  observability, self-hosted control-plane option, and the self-hosting docs.
-
-### Alternatives
-
-- **Tailscale.** Also a first-class documented flow on the same Daytona VPN page (auth-key
-  join, `sudo tailscale up --auth-key=...`), so feasibility is equal. The Tailscale client is
-  open source, but the control plane is proprietary SaaS; the open-source self-hosted control
-  plane is Headscale (BSD-3), a separate project ([Headscale](https://headscale.net/)).
-  Tailscale's pricing is per-user (Standard around $8/user, **UNVERIFIED** current number,
-  [Tailscale pricing analysis](https://wz-it.com/en/blog/tailscale-pricing-2026-headscale-netbird-self-hosted/)),
-  which fits a fleet of ephemeral machine peers poorly. NetBird is a single open-source
-  project that self-hosts the whole control plane, which is a better fit for shipping the
-  control plane inside a self-hosted product.
-- **Plain WireGuard.** No management plane, no signal, no NAT traversal. We would hand-manage
-  keys, peer config, and IP allocation per ephemeral sandbox, and build our own key
-  distribution and revocation. That is most of what NetBird's management plane already does.
-  Not worth it for a fleet of short-lived peers.
-- **Keep per-feature tunnels (the status quo).** ngrok for mounts, the file relay for gates
-  and tools, the in-sandbox shim for MCP. Each is small and already mostly built. The cost is
-  that the count of one-off workarounds grows with each new sandbox-to-runner need, and each
-  has its own failure mode (the zombie mount in F-017, the lost RPC in F-018). The overlay's
-  pitch is to replace that growing set with one transport.
-
-## Cloudflare Tunnel as a near-term ngrok replacement (mounts only)
-
-Separate question from the overlay: the tunnel's only current job is the remote mount path.
-The runner-side stack exposes the store's S3 endpoint (`seaweedfs:8333`) through ngrok so
-geesefs inside a Daytona sandbox can reach it; the runner discovers the public URL through
-ngrok's local API (`http://ngrok:4040/api/tunnels`, `discoverTunnelEndpoint` in `mount.ts`).
-ngrok requires every deployment to provision an `NGROK_AUTHTOKEN`, and that requirement is
-exactly what bit us in F-017: the dev box had no token, the tunnel was down, and mounts
-zombie-hung. Cloudflare Tunnel can run with no account at all, which is the draw.
-
-### Option 1: TryCloudflare quick tunnels (zero auth)
-
-`cloudflared tunnel --url http://seaweedfs:8333` with no account and no token gets a random
-`*.trycloudflare.com` HTTPS URL
-([Cloudflare quick tunnels](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/)).
-What it trades away, plainly:
-
-- **No SLA and stated non-production intent.** Cloudflare says quick tunnels are for testing
-  and development only and guarantees no uptime. The tunnel can be reclaimed at any time.
-- **A new random subdomain on every start.** Harmless for us, because the runner re-discovers
-  the URL at mount time anyway, but it means the URL is never stable across restarts.
-- **Limits.** 200 in-flight requests per quick tunnel (429 beyond that), a single connection
-  to Cloudflare's edge (no redundancy), and the docs note quick tunnels do not support
-  Server-Sent Events (irrelevant for S3)
-  ([quick tunnels docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/),
-  [cloudflared internals](https://deepwiki.com/cloudflare/cloudflared/3.4-quick-tunnels)).
-- **The S3 workload should fit, with one caveat.** geesefs traffic is ordinary HTTPS: ranged
-  GETs, PUTs, multipart uploads, each a bounded request, which is what the tunnel proxies.
-  The caveat is Cloudflare's proxy body-size limit (around 100 MB per request on the free
-  tier, **UNVERIFIED** exact number): a multipart PUT whose part size exceeds it would fail.
-  geesefs part sizes are configurable and small by default (**UNVERIFIED**; confirm our
-  effective part sizes in the confirmation run), so this is a checkable risk, not a blocker.
-
-Verdict on quick tunnels: they fit the dev-box case exactly (the F-017 failure mode was "no
-token, no tunnel"; a quick tunnel needs no token, so the tunnel is simply always up), and
-they are explicitly the wrong thing to document as the production path.
-
-### Option 2: named Cloudflare tunnels (free, needs account + domain)
-
-A named tunnel is free but needs a Cloudflare account, a domain on Cloudflare, and a tunnel
-token ([Cloudflare tunnel setup](https://developers.cloudflare.com/tunnel/setup/)). For a
-self-hoster that is the same shape of burden as ngrok's authtoken (provision a credential),
-plus a domain requirement ngrok does not have. It buys a stable hostname, production intent,
-and multiple edge connections. Named tunnels beat "ngrok with token" mainly on price
-(Cloudflare's is free at this scale; ngrok's free tier has its own limits) and on the 100s of
-megabytes of bandwidth ngrok's free tier caps (**UNVERIFIED** current ngrok free-tier caps).
-They do not remove the provisioning step, which was the actual pain.
-
-### Security
-
-Same public-exposure model as ngrok: the store rides a public URL, and the only guard is the
-store's own auth (the signed, prefix-scoped, short-TTL S3 credentials the API mints; the
-bucket master key never rides the tunnel). A quick tunnel is marginally worse than ngrok in
-one respect: the URL is unauthenticated at the tunnel layer and anyone who learns it can
-reach the store port, exactly like ngrok minus the account-level controls ngrok offers.
-Cloudflare Access can add authentication in front of a named tunnel, but that reintroduces
-per-deployment auth setup, which defeats the zero-auth goal; say so plainly and do not plan
-on it. The real security posture in every tunnel variant remains: the store endpoint is
-public, the credentials scoped and short-lived. Only the overlay removes the public surface.
-
-### Integration effort
-
-Small and contained (**UNVERIFIED**, estimate 1 to 2 days):
-
-- **Discovery.** cloudflared's metrics server exposes `GET /quicktunnel` returning
-  `{"hostname":"..."}` (verified in source: `metrics/metrics.go` lines 86-88 on cloudflared
-  master). `discoverTunnelEndpoint` in `mount.ts` gains a cloudflared branch: query
-  `http://cloudflared:<metrics-port>/quicktunnel` instead of `http://ngrok:4040/api/tunnels`,
-  prepend `https://`. The function already returns null-on-failure with the mount skipped.
-- **Compose.** Swap or add a `cloudflared` service under the same `with-tunnel` profile
-  (`cloudflared tunnel --url http://seaweedfs:8333 --metrics 0.0.0.0:20241`, official image,
-  no env vars needed for quick tunnels). Both services can coexist behind the profile with
-  discovery trying each in turn, which gives a migration path rather than a flag-day swap.
-- **No sandbox-side change.** geesefs already takes whatever endpoint URL discovery returns.
-
-### Where it sits relative to the overlay
-
-The tunnel is the today-fix for mounts; the overlay is the later-fix that deletes the tunnel
-entirely. Cloudflare quick tunnels are worth the small churn on one condition: they remove
-the token-provisioning failure mode from every dev and self-hosted deployment now, for one to
-two days of contained work, and everything added (one compose service, one discovery branch)
-is deleted wholesale when the overlay lands. If the overlay were committed and starting next
-week, skip the churn. Since the overlay is still pre-confirmation and Phase 2 hardening is
-weeks out, the quick-tunnel swap pays for itself in unbroken dev boxes in the meantime.
-Recommend: quick tunnels as the default dev/self-host path behind the existing profile,
-ngrok kept as the alternative for anyone who already has a token, production (Agenta Cloud)
-unaffected because its store is genuinely public.
+## 1. ACP traffic is already application bidirectional
+
+The outer runner connects to sandbox-agent through Daytona's signed preview URL. The ACP
+HTTP client uses:
+
+- one POST per runner-to-daemon JSON-RPC envelope;
+- one persistent SSE GET for daemon-to-runner traffic;
+- POST for the runner's response to a server-initiated request.
+
+Notifications such as `session/update` and reverse requests such as
+`session/request_permission` use the same inbound SSE parser. Daytona authentication adds
+a cookie jar and long timeout; it does not translate ACP methods.
+
+PR #5218 found the Pi failure one layer earlier. The snapshot inherited `pi-acp` 0.0.23,
+which had no `extension_ui_request` bridge. Pi 0.0.29 creates the ACP permission request,
+and the rebuilt snapshot delivered an ask-mode `interaction_request`.
+
+Conclusion: runner-initiated TCP does not mean runner-only application messages. NetBird is
+not required for Pi or Claude permission delivery.
+
+## 2. Capability and transport matrix
+
+| Capability | Pi local | Pi Daytona | Claude local | Claude Daytona |
+| --- | --- | --- | --- | --- |
+| Builtin or native permission | ACP | ACP after adapter parity | ACP | ACP |
+| Agenta custom or gateway tools | Extension plus file relay | Extension plus Daytona filesystem relay | Runner-loopback HTTP MCP | Rejected before session |
+| User remote HTTP MCP | Rejected | Rejected | Supported with HTTPS and SSRF checks | Supported when sandbox egress reaches the URL |
+| User stdio MCP | Rejected | Rejected | Rejected | Rejected |
+| Internal runner tool-MCP | Not used | Not used | Bound to `127.0.0.1` | Not exposed to sandbox |
+| Direct sandbox OTLP to Agenta | Not needed | Not used | Not needed | Not used |
+
+The user comment said "Cloudflare" while asking about harnesses. This workspace interprets
+that as Claude. Cloudflare is a tunnel provider, not an agent harness.
+
+### Pi custom and gateway tools
+
+The Pi extension advertises resolved tools and writes execution requests inside the
+sandbox. The runner polls those files through local or Daytona filesystem APIs, evaluates
+permission again, and executes runner-side with runner credentials. No sandbox-to-runner
+TCP listener exists or is needed.
+
+### User HTTP MCP
+
+For capable non-Pi harnesses, the runner converts user HTTP MCP entries and passes the
+remote HTTPS URL to the harness. Daytona Claude dials that user server directly. Named
+secrets travel in request headers. Pi rejects user MCP today. All harnesses reject user
+stdio MCP.
+
+### Internal gateway-tool MCP
+
+For local non-Pi runs, Agenta starts a stateless Streamable HTTP MCP server bound to the
+runner's `127.0.0.1`. This server executes credentialed gateway actions. Daytona loopback
+belongs to the sandbox, so non-Pi remote custom tools are rejected.
+
+NetBird would provide IP reachability only after Agenta rebinds or proxies the service. The
+current no-auth assumption is safe only because the listener is loopback. Remote exposure
+requires per-run authentication and ACLs.
+
+## 3. Mount endpoint flow
+
+Durable mounts use an S3-compatible object store. geesefs runs inside Daytona.
+
+Current flow:
+
+1. the API signs a mount and returns temporary credentials plus the configured S3
+   endpoint;
+2. the runner decides whether the endpoint is reachable from the sandbox;
+3. a public endpoint is passed directly to geesefs;
+4. a private endpoint triggers `discoverTunnelEndpoint`;
+5. that function queries ngrok's internal API and returns its public URL;
+6. the URL overrides geesefs's endpoint only.
+
+The user is correct that geesefs only needs a URL. Provider discovery belongs in endpoint
+resolution, not in the mounting primitive. A random Cloudflare hostname creates the same
+discovery need as ngrok unless the sidecar exports a normalized endpoint.
+
+## 4. Storage authentication
+
+### Bundled SeaweedFS
+
+The API signs a web-identity JWT and exchanges it through SeaweedFS STS for short-lived
+credentials. The inline session policy restricts the credential to the mount's bucket and
+project or mount prefix. geesefs receives the access key, secret, and session token.
+
+### External S3-compatible storage
+
+The API uses the configured backend credentials to request temporary, prefix-scoped
+credentials through the backend's STS-compatible path. geesefs still signs S3 requests.
+
+### Public endpoint implications
+
+A public tunnel exposes the S3 and STS network surface. The ngrok authtoken authenticates
+the tunnel process; it does not put HTTP authentication in front of SeaweedFS.
+
+Agenta does not configure anonymous SeaweedFS object access. Knowing the URL does not grant
+data access without valid S3 credentials. SeaweedFS can be configured for anonymous or
+public reads, but that is not the Agenta default.
+
+Public reachability still matters for TLS, rate limiting, denial of service, vulnerability
+exposure, and endpoint discovery. Storage authentication and network exposure are separate
+controls.
+
+## 5. Deployment topology
+
+The previous claim that production is public and unaffected was unsupported.
+
+- Compose commonly uses private Docker DNS for bundled SeaweedFS.
+- Railway configuration uses a private service domain for SeaweedFS.
+- The Helm chart exposes bundled SeaweedFS as a ClusterIP service.
+- External S3, R2, or another publicly reachable endpoint needs no tunnel.
+
+The relevant axis is public versus private endpoint, not production versus development.
+
+## 6. Tunnel readiness
+
+`discoverTunnelEndpoint` performs one fetch and returns null on a startup race, HTTP
+failure, or missing tunnel. The caller can then continue without the requested durable
+mount.
+
+A Cloudflare process can have the same race before it assigns a hostname. "No token
+required" removes one provisioning dependency but does not mean "always ready."
+
+The endpoint contract needs bounded polling, a route probe, and a provisioning error when a
+private durable store cannot be exposed. The existing post-mount liveness check covers a
+different stage after geesefs starts.
+
+## 7. Cloudflare Quick Tunnel limits
+
+Cloudflare's official Quick Tunnel page documents:
+
+- testing and development use;
+- no SLA;
+- one connection;
+- no SSE support;
+- 200 concurrent in-flight requests, with 429 beyond the cap.
+
+Source: [Cloudflare Quick Tunnels](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/).
+
+The 200 cap is not 200 requests per minute. A long S3 upload part consumes one slot while it
+is active. GeeseFS can issue parallel flushes, multipart uploads, metadata requests, and
+reads. Several mounts share the sidecar's cap.
+
+Cloudflare documents a 100 MB upload limit for Free-plan proxied requests elsewhere, but
+the Quick Tunnel page does not state that `trycloudflare.com` inherits it. GeeseFS later
+multipart tiers can exceed 100 MiB. Test the actual path and cap part sizes if required.
+Do not record 100 MB as a verified Quick Tunnel fact before that test.
+
+## 8. ngrok comparison
+
+ngrok's current free limits are expressed as 4,000 HTTP requests per minute, 20,000
+requests per month, and 1 GB outbound transfer per month. It does not document the same
+200-concurrent-request cap.
+
+Source: [ngrok pricing and limits](https://ngrok.com/docs/pricing-limits).
+
+The products can fail different workloads. A short concurrency burst may fit ngrok while a
+long-lived S3 filesystem exhausts monthly requests or bandwidth. A Quick Tunnel may avoid
+those account quotas but hit its concurrency or testing-service constraints. Measure
+geesefs instead of comparing one headline number.
+
+## 9. NetBird topology
+
+A NetBird peer exposes its own network namespace. A peer in the runner container does not
+automatically expose:
+
+- the sibling SeaweedFS container;
+- a Kubernetes ClusterIP;
+- a service bound to runner loopback.
+
+SeaweedFS needs a separate peer, a routing peer with a scoped network resource, or a proxy
+bound to the runner's NetBird address. NetBird routing peers must already reach the
+resource they route. See
+[how routing peers work](https://docs.netbird.io/manage/networks/how-routing-peers-work).
+
+Internal MCP needs an overlay-bound listener or proxy plus per-run authentication. Opening
+the current unauthenticated credentialed tool server beyond loopback would be unsafe.
+
+## 10. NetBird ACL baseline
+
+A new NetBird account includes a default all-to-all policy. The first untrusted sandbox
+must not enroll under that policy.
+
+The minimum baseline is:
+
+- delete the default policy;
+- create the per-run sandbox group and service policy first;
+- allow one-way TCP only to the paired resource and exact port;
+- do not allow sandbox-to-sandbox traffic;
+- avoid broad Docker-subnet routes;
+- delete the peer and policy objects explicitly on teardown.
+
+NetBird policies are stateful, so return traffic follows an allowed connection without a
+reverse policy. Source: [NetBird access control](https://docs.netbird.io/manage/access-control).
+
+## 11. Setup-key security
+
+A setup key delivered as a sandbox environment variable is visible to processes in that
+sandbox and may leak through diagnostics.
+
+Use a one-off key with usage limit 1, short expiry, ephemeral peer, and a run-scoped
+auto-group. Deliver it through the Daytona control plane as a temporary 0600 file, use
+`netbird up --setup-key-file`, delete the file, verify the peer, and revoke the key.
+Delete the enrolled peer separately because key revocation does not disconnect it.
+
+This limits replay. It cannot hide the key from an arbitrary process that controls the
+sandbox during enrollment.
+
+Sources:
+[setup keys](https://docs.netbird.io/manage/peers/register-machines-using-setup-keys),
+[NetBird CLI](https://docs.netbird.io/get-started/cli).
+
+## 12. Daytona feasibility
+
+Daytona documents NetBird as a VPN connection that requires its applicable higher account
+tier. That makes an overlay a conditional capability, not a universal self-host default.
+A confirmation run would still need to measure TUN availability, join time, reconnect,
+egress policy interaction, and peer cleanup.
+
+Source: [Daytona VPN connections](https://www.daytona.io/docs/en/vpn-connections/).

--- a/docs/design/agent-workflows/projects/netbird-sandbox-network/status.md
+++ b/docs/design/agent-workflows/projects/netbird-sandbox-network/status.md
@@ -1,0 +1,58 @@
+# Status
+
+## Current state
+
+The design has been revised after owner and CodeRabbit review. No implementation code has
+changed.
+
+The broad NetBird recommendation is withdrawn. ACP already carries reverse application
+requests, so permissions do not need a new network route. The only current direct
+sandbox-to-Agenta infrastructure requirement is private S3 connectivity for durable
+mounts.
+
+## Decisions
+
+- Do not build NetBird as a general sandbox transport.
+- Do not replace ngrok with Cloudflare Quick Tunnels by default until geesefs qualification
+  passes.
+- Refactor mount orchestration around one sandbox-reachable store endpoint.
+- Add bounded readiness, route probing, and fail-loud behavior for requested private
+  mounts.
+- Keep storage authentication separate from network reachability.
+- Treat NetBird as a conditional private-store option.
+- If NetBird is reopened, service exposure, per-run authentication, default-deny ACLs, and
+  one-off setup-key handling belong in the first MVP.
+
+## Review threads addressed
+
+- Public SeaweedFS is network-exposed through the tunnel but still S3-authenticated.
+- Quick Tunnel's 200 limit is concurrent in-flight requests; ngrok limits different
+  dimensions.
+- Mounting only needs an effective URL. Provider discovery moves behind endpoint
+  resolution.
+- Store behavior depends on endpoint topology, not production versus development.
+- ACP already supports the permission request and response flow.
+- The MCP matrix now distinguishes Pi relay tools, user HTTP MCP, and runner-loopback MCP.
+- Dynamic tunnel readiness now has retry and fail-loud acceptance criteria.
+- NetBird topology now names the required peer, route, or proxy.
+- Default-deny and port-scoped ACLs moved into the first possible MVP.
+- Setup keys no longer ride sandbox environment variables.
+- Multipart S3 qualification is a rollout gate for Quick Tunnels.
+
+## Remaining work
+
+1. Review this revised decision.
+2. Implement the provider-neutral endpoint resolver and fail-loud readiness as a separate
+   approved change.
+3. Run the Quick Tunnel multipart and concurrency experiment.
+4. Choose the supported store connectivity option from measured results.
+5. Open a new NetBird project only if the decision gate in [plan.md](plan.md) passes.
+
+## Provenance
+
+- PR: #5219.
+- Owner review: comments beginning at #discussion_r3564405773.
+- Requested anchor: #discussion_r3564426767.
+- Research: three parallel tracks covering ACP and transport direction, storage and tunnel
+  behavior, and MCP plus NetBird security.
+- Related corrected root cause: PR #5218.


### PR DESCRIPTION
## Context

This design started from a real remote-sandbox problem: geesefs inside Daytona cannot reach a private S3 endpoint such as `seaweedfs:8333`. The first draft generalized that into a missing sandbox-to-runner connection and proposed NetBird as the common answer for mounts, permissions, tools, and MCP.

The revised design separates those flows. ACP already carries daemon-to-runner requests over SSE, and PR #5218 showed that Pi permissions failed because the old adapter never emitted the request. Private S3 connectivity is the only current direct sandbox-to-Agenta infrastructure need.

## Decision

Do not build NetBird as a general sandbox transport. Keep ngrok while we:

1. make mount orchestration consume one provider-neutral, sandbox-reachable store endpoint;
2. add bounded readiness, route probing, and fail-loud behavior;
3. test Cloudflare Quick Tunnels against geesefs multipart and concurrency behavior;
4. choose direct public S3, a stable tunnel, a development-only Quick Tunnel, or a private overlay from measured results.

NetBird remains a conditional private-store option. If reopened, its first MVP must include an explicit SeaweedFS route or proxy, authenticated remote MCP if needed, default-deny port-scoped ACLs, and one-off setup-key handling outside sandbox environment variables.

## What changed

- Added a current transport matrix for Pi, Claude, permissions, tools, MCP, telemetry, and mounts.
- Explained that public S3 reachability does not mean anonymous object access.
- Reframed deployment behavior by endpoint topology instead of production versus development.
- Moved tunnel discovery behind a provider-neutral endpoint resolver.
- Made readiness, fail-loud provisioning, multipart upload, and concurrency checks rollout gates.
- Compared Cloudflare's 200 concurrent-request cap with ngrok's request and transfer quotas.
- Defined the service exposure, authentication, ACL, and setup-key requirements for any future NetBird work.
- Added `context.md` and `status.md` so the design workspace can be continued without session context.

## How to review

1. Start with the verdict and transport matrix in `README.md`.
2. Read `recommendation.md` for the decision and alternatives.
3. Review the near-term endpoint and tunnel qualification phases in `plan.md`.
4. Use `research.md` for the implementation evidence, authentication model, limits, and NetBird security details.
5. Check `status.md` for the mapping from every review thread to the revised design.

## Feedback requested

Please confirm whether the narrowed decision is right: no general NetBird project now, provider-neutral mount endpoint resolution first, and a Quick Tunnel experiment before choosing the self-hosted connectivity default.