### PR TITLE
docs(agents): GitButler wedge prevention, freeze rule, and recovery lessons

### DIFF
--- a/.agents/skills/codex-onboarding/SKILL.md
+++ b/.agents/skills/codex-onboarding/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: codex-onboarding
+description: Onboarding for Codex (and any non-Claude agent) working on documentation or implementation in this repo. Read this FIRST, before touching code, docs, or git. Distills the working agreements that otherwise live in Claude's session memory - GitButler-only version control, the design-first PR workflow, PR bases and labels, writing style, testing, and coordination with the other agents on the big-agents trunk.
+---
+
+# Codex Onboarding
+
+You are one of several AI agents working in this repo alongside Mahmoud (the user) and
+his co-workers' agents. This skill captures the working agreements that are NOT in the
+code or in AGENTS.md. Read `AGENTS.md` at the repo root as well; it holds the repo map,
+area conventions, and the full GitButler reference. This file holds the rules learned
+from experience and the workflow Mahmoud expects.
+
+## The one-paragraph version
+
+All work happens on GitButler lanes over the `big-agents` integration branch, never on
+raw git branches and never in worktrees. Non-trivial work is design-first: a design-doc
+PR that the user reviews on GitHub, then implementation only after he approves. Every PR
+targets `big-agents`, carries the right label (`needs-review` / `implementing`), and gets
+a comment signed as the AI agent. Verify with the real test suites and a live-stack
+check, not ad-hoc scripts. Write everything in plain, short, active-voice English with no
+em dashes.
+
+## 1. Version control: GitButler only (hard rules)
+
+The workspace is in GitButler mode (branch `gitbutler/workspace`). The full command
+reference is in root `AGENTS.md`. The non-negotiable rules:
+
+- **Use `but` for every branch, commit, and push.** Never `git commit`, `git branch`,
+  `git stash`, or `git checkout` for workspace operations. Parallel lanes ARE GitButler
+  (`but branch new <name>` with no anchor); never describe or attempt anything as
+  "skipping GitButler".
+- **Never create a git worktree.** No exceptions, including "read-only" or "QA-only"
+  worktrees. If a task seems to need one (e.g. testing a PR branch), stop and ask; the
+  answer is applying the branch as a lane.
+- **Never push a stack that contains a branch you don't own.** `but push` force-pushes
+  EVERY series in the stack, including a co-worker's base branch, and will clobber their
+  work. If the stack base is someone else's branch, push only your own series with
+  `git push origin <your-branch> --force-with-lease` (raw git is allowed for pushes,
+  not for commits).
+- **`but push` prints nothing on success.** Always verify:
+  `git rev-parse <branch>` must equal `git ls-remote --heads origin <branch>`.
+- **Never revert or delete working-tree files you did not create.** They may hold the
+  user's own uncommitted edits, which `git checkout` destroys irrecoverably. Diff first;
+  if in doubt, ask.
+- One lane at a time: assign exactly one lane's files, `but commit <lane> --only`,
+  verify with `git show --stat <lane>`, then move to the next lane. Details and failure
+  modes are in root `AGENTS.md`; recovery procedures are in the
+  `gitbutler-workspace-recovery` skill.
+
+## 2. Coordination with other agents
+
+Several agents (Mahmoud's, Arda's, JP's) work this workspace and the `big-agents` trunk
+concurrently.
+
+- **The coordination board** is
+  `docs/design/agent-workflows/scratch/agent-coordination.md`, section
+  "STANDING COORDINATION PROTOCOL" (everything above it is historical log).
+- **Take the BUT-LOCK before any `but` write** (stage/commit/push/branch): set it to
+  `LOCKED <agent> <UTC ISO8601>` on the board, set it back to `FREE` when done. A lock
+  older than 15 minutes is stale; take it with a fresh timestamp. Concurrent `but`
+  writes corrupt the workspace. `but status` (read-only) needs no lock.
+- Board rows older than 2 days are stale. Live `but status` plus open PRs are the real
+  source of truth.
+- When merging into `big-agents`, post a merge-sync comment on PR #4791 (the
+  big-agents to main integration PR): a bold `**Merged: X**` header, plain-language
+  what-changed, and implications (new/removed routes, wire/schema changes, branches
+  that should rebase). The other agents read #4791 to stay in sync.
+
+## 3. The design-first workflow
+
+For any non-trivial feature or fix, do NOT jump to implementation.
+
+1. **Research first.** Investigate thoroughly and write findings into a design
+   workspace under `docs/design/<project>/`: `README.md` (index), `context.md` (why,
+   goals, non-goals), `research.md` (codebase findings, gotchas), `plan.md` (the
+   design and phases), `status.md` (live progress). A lone README is not a design doc.
+2. **Open a draft PR containing the design docs only, never implementation code.**
+   The PR is where the user reviews and steers; he works from GitHub, not from chat.
+3. Add the `needs-review` label and post a specific comment saying exactly what
+   feedback you need (never a generic "check it out").
+4. **Implement only after the user approves** ("implement it", "lgtm", or PR comments
+   plus "fix them" all count as approval). Swap the label to `implementing` while you
+   build, back to `needs-review` when the implementation is ready.
+5. Decisions the user must make (a transport, a default, a name, A-vs-B) go ON a PR as
+   a "🔸 Decision needed" comment with concrete options and your recommendation. A
+   decision left only in chat is a decision he will never see.
+
+Trivial, mechanical, or explicitly-ordered changes can go straight to a lane and PR.
+
+## 4. Pull requests
+
+- **Base every lane PR on `big-agents`, never `main`.** Lanes branch off `big-agents`;
+  a PR based on main shows all of big-agents' unmerged work and is blocked by main's
+  review ruleset. For stacked PRs, base each PR on the branch directly below it.
+- Title format: `[issue-id] <type>(<area>): <Title>` where type is fix/feat/chore/ci/
+  doc/test and area is API, SDK, frontend, docs, and so on.
+- **Description quality bar** (full procedure in the `write-pr-description` skill):
+  lead with the concrete symptom from the user's point of view, then the fix in plain
+  words with a before/after example. Open with 2-4 full sentences of background so a
+  reader with zero session context can follow. Define terms of art on first use.
+  Include a "How to review" section walking the diff in reading order. No padded
+  bullets, no checkbox theater.
+- `gh pr edit` is broken in this repo (classic-Projects GraphQL bug). Edit title/body
+  via REST: `gh api repos/Agenta-AI/agenta/pulls/<n> -X PATCH -f title="..."
+  -F body=@/tmp/body.md`. Add labels via
+  `gh api --method POST repos/Agenta-AI/agenta/issues/<n>/labels -f "labels[]=needs-review"`.
+  Retarget a wrong base the same way (`-f base=big-agents`).
+- **Sign every GitHub comment as the AI agent.** `gh` is authenticated as Mahmoud, so
+  an unsigned comment reads as if he wrote it. Prefix comments with
+  `🤖 _The AI agent says:_`. Sign as "the AI agent", not as a model name.
+- After pushing a revision that addresses review comments, always post a PR comment
+  mapping each review comment to what changed. Never a silent force-push.
+- Label lifecycle: the user applies `lgtm` when he approves; you apply `needs-review`
+  whenever a PR is ready for (or again needs) his review; `implementing` while building
+  an approved design. Keep labels accurate at every transition; he filters GitHub by
+  them.
+- When a PR is ready, trigger the bot review by commenting `@coderabbitai review`
+  (CodeRabbit skips drafts, so mark ready first), then come back later and address its
+  comments.
+- If you reuse a design PR's branch for the implementation, rename the title and
+  rewrite the body so it reads as the implementation, not the old plan.
+
+## 5. Writing style (all user-facing text)
+
+Applies to PR descriptions, comments, commit messages, docs, design docs, issues.
+
+- **Never use em dashes.** Replace with a period, parentheses, or a semicolon. This is
+  an absolute rule.
+- Active voice, short sentences, 11th grade English except unavoidable technical
+  terms. Complete sentences. Sparing bold and bullets; prefer prose.
+- No engineering slang ("soak", "greenfield", "yak-shaving"). Precise technical terms
+  (TTL, JSON-RPC) are fine.
+- In code and interfaces, prefer full words over abbreviations (`operation`, not `op`;
+  `config`, not `cfg`) unless the short form is a universal convention (`id`, `url`,
+  `db`).
+- Design docs additionally require: current-state context before the change, every
+  decision with options and trade-offs and why, worked examples, and no meta text in
+  the body ("updated after review" belongs in PR comments or status.md, never in the
+  doc). See the `write-docs` skill for docs pages and the `write-pr-description`
+  skill for PR bodies.
+
+## 6. Verification and testing
+
+- **Run the real test suites, never ad-hoc scripts.** A throwaway python snippet is
+  not verification. Canonical targets (from the repo root; details in
+  `docs/designs/testing/README.md`):
+  - Python areas: `cd <area> && py-run-tests` where area is `sdks/python`, `api`, or
+    `services` (`py-run-tests` = `uv sync --locked && uv run --no-sync python
+    run-tests.py`).
+  - Web: `cd web && pnpm install`, then from `web/tests/` run `pnpm test:smoke` or
+    `pnpm test:acceptance`.
+- Before committing: `ruff format` + `ruff check --fix` for Python; `pnpm lint-fix` in
+  `web/` for frontend.
+- **Green unit tests do not mean the live stack works.** After merges or between
+  milestones, verify the local deployment actually serves (login loads, playground
+  renders, chat works, model can be changed). The dev loop (load-env + run.sh pairs)
+  is in root `AGENTS.md`.
+- CI hygiene: after merging, sweep CI and fix what broke. The short API/unit/lint/
+  contract checks must be green before merging; the slow web tests may be skipped. A
+  red check is acceptable only if the reason is documented as explicitly deferred.
+
+## 7. Architecture guardrails
+
+- **Fix agent-guidance problems at the SDK layer, never in core platform surfaces.**
+  When a builder agent misuses a platform tool, the fix ladder is: (1) typed input
+  schema on the operation in the SDK op catalog, (2) the operation description,
+  (3) a skill reference file with a complete example call. Changes to the workflows
+  service or harness adapters need a design doc and explicit approval first; harnesses
+  stay neutral.
+- Frontend/backend shape mismatches are fixed on the frontend read path, not by
+  changing the backend.
+- When an env var or flag switch achieves the goal, use it instead of editing frontend
+  code. But never add `NEXT_PUBLIC_AGENT_*` feature flags or debug knobs to the
+  `web/entrypoint.sh` `__env.js` runtime-injection block; those are dev-mode-only.
+- API config goes through `api/oss/src/utils/env.py` and the shared `env` object,
+  never direct `os.getenv` calls.
+- System constants are reserved `__ag__*` static workflows (the static catalog
+  pattern), not bespoke endpoints.
+
+## 8. Sibling skills worth reading
+
+All in `.agents/skills/`:
+
+- `write-pr-description` - PR title and body procedure with a worked example.
+- `write-docs` - style and structure for pages under `docs/` (Diátaxis types).
+- `design-interfaces` - classify interface fields by semantic role before adding any
+  API/wire/config field.
+- `write-issue` - Linear/GitHub issue format.
+- `agenta-package-practices` - frontend package-vs-app placement and `@agenta/*` usage.
+- `write-template-playbooks` - authoring build-an-agent template playbooks.
+- `gitbutler-workspace-recovery` - when a `but` operation scrambles the workspace, or
+  the workspace looks wedged (see the freeze rule below).
+
+## 9. When in doubt
+
+Research and write findings before changing code. Ask before anything destructive or
+irreversible. If a `but` operation errors about hunk locking or conflicts, stop and
+report rather than improvising raw-git surgery; `but oplog list` / `but oplog restore`
+exist but a human should decide. Surface open questions on the PR, one clear question
+at a time.
+
+**If the workspace looks wedged, freeze.** Signs: a failed `but pull` integration,
+`Could not find branch CLI id '' in IdMap`, or a conflict attributed to a lane that
+cannot conflict (e.g. one with no commits). Run no `but` mutation at all, not even `but
+branch new`, until the wedge is diagnosed; a mutation issued while wedged can create
+phantom commits and corrupt refs. Follow the freeze rule and recovery steps in the
+`gitbutler-workspace-recovery` skill.

--- a/.agents/skills/gitbutler-workspace-recovery/SKILL.md
+++ b/.agents/skills/gitbutler-workspace-recovery/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: gitbutler-workspace-recovery
+description: Recover, reconcile, and operate safely in a GitButler workspace. Use when Codex is in `gitbutler/workspace`, the user says to use GitButler only, local lanes/stacks diverge from remote PR branches, merged PR changes still appear as unassigned changes, `but pull` reports conflicts, the workspace looks wedged, GitButler hunk locks or empty commits appear, or a multi-agent GitButler workflow needs coordination, cleanup, sync, or PR repair.
+---
+
+# GitButler Workspace Recovery
+
+Use this skill when the repo is in GitButler workspace mode and correctness matters more
+than speed. The main goals are:
+
+- Preserve every intended local change.
+- Avoid clobbering other lanes or PR branches.
+- Keep the local GitButler workspace, remote PR branches, and target branch in sync.
+- Recover safely from hunk locks, stale local branches, duplicate-stack graph issues, and
+  redundant unassigned overlays.
+
+For the full incident-derived runbook, read
+[references/recovery-runbook.md](references/recovery-runbook.md) when doing an actual
+repair or merge/sync operation.
+
+## Freeze Rule (read first)
+
+The moment the workspace looks wedged, stop. Run no `but` mutation of any kind, not even
+`but branch new`, until the wedge is diagnosed.
+
+Wedge signatures:
+
+- `but pull` reports a failed integration, or `completed_with_conflicts` naming a lane that
+  has no way to conflict (e.g. one with zero commits).
+- `Could not find branch CLI id '' in IdMap`.
+- Any conflict message that attributes the conflict to a lane that cannot conflict.
+
+On 2026-07-11 a `but branch new` issued while the workspace was wedged created phantom
+commits, a junk local ref at the wrong SHA, and a 47-parent display corruption in `but
+status`. Retrying or "working around" a wedge with another `but` write compounds the
+damage every time. Diagnose first using
+[references/recovery-runbook.md](references/recovery-runbook.md) section 4. If work must
+ship while the wedge is still unresolved, use the plumbing escape hatch (runbook section
+12) instead of any `but` command.
+
+Also keep applied lanes to about 15 or fewer before pulling; `but pull` against a heavily
+saturated workspace (~30 applied lanes) is what triggers these wedges in the first place.
+See root `AGENTS.md`, "Wedge prevention and freeze rule".
+
+## Non-Negotiables
+
+- Use `but` for local VCS operations in GitButler workspace mode.
+- Do not use raw `git commit`, `git reset`, branch switching, or worktrees unless the user
+  explicitly overrides the GitButler-only rule. The one exception is the plumbing escape
+  hatch (runbook section 12), which exists precisely for when `but` itself is blocked.
+- Serialize GitButler writes. Do not run `but` writes in parallel. GitButler can lock its
+  local DB, and parallel writes make diagnosis worse.
+- Take an oplog snapshot before any risky operation:
+
+```bash
+but oplog snapshot -m "before <operation>"
+```
+
+- Prefer `but pull --check --json` before `but pull --json`.
+- Treat `but discard <id>` as destructive: it can cascade to items beyond the one ID named.
+  Only discard after proving the content is already present in the target/base or is
+  intentionally local-only noise, and never as a batch (runbook section 13).
+- Never run `but clean` while any applied lane has zero commits; it can sweep the lane
+  itself (runbook section 13).
+- Before any `but oplog restore`, back up every agent's uncommitted work first (runbook
+  section 11). A restore rewinds uncommitted content for the whole workspace, not just the
+  operator's own changes.
+- If a coordination file has a lock protocol, honor it. Release locks when done.
+
+## Fast Orientation
+
+Start with these checks:
+
+```bash
+but status --json -f
+but pull --check --json
+```
+
+If GitHub remote state matters, use the GitHub app or `gh api` for PR/branch reads. That
+is remote API work, not local VCS work. Verify:
+
+- target branch head (`big-agents`, `main`, etc.)
+- each PR state/head/base/mergeability
+- compare result for `base...head`
+- whether a PR marked "merged" actually put the expected files in the target branch
+
+## Common Failure Patterns
+
+### Wedged Workspace: Stale-Parent Workspace Commit
+
+If every topology operation (apply, unapply, commit, pull) fails cherry-picking the
+synthetic "GitButler Workspace Commit" (`Failed to merge bases while cherry picking commit
+...`), this is a stale-parent wedge, not a hunk lock or a real file conflict. Stop per the
+Freeze Rule above and follow
+[references/recovery-runbook.md](references/recovery-runbook.md) section 4. Note that a
+`but pull` can report an error while the base has still advanced underneath it; check
+`mergeBase` before assuming the pull did nothing.
+
+### Empty GitButler Commits
+
+If `but commit`, `but amend`, or `but rub` creates an empty commit while the file still
+shows as changed, suspect a hunk lock to a sibling stack. Do not keep retrying.
+
+Actions:
+
+1. Check `but status --json -f` for assigned/unassigned ownership.
+2. Compare the file's base lines against sibling lanes.
+3. If the hunk depends on a sibling stack, land or merge the owning PR first, then reapply
+   the orphan hunk after the base contains the dependency.
+
+### Remote PR Fixed, Local Branch Still Dirty
+
+If you repair or rebuild a PR branch remotely, the local GitButler branch may become stale
+and un-rebasable. Once that PR is merged into the target branch, the stale local branch is
+safe to delete from the workspace only after confirming its content is in the target.
+
+Useful sequence:
+
+```bash
+but pull --check --json
+but oplog snapshot -m "before removing stale merged branch"
+but branch delete <branch>
+but pull --json
+```
+
+If delete fails before pull because of worktree overlays, see the full runbook.
+
+### Merged Remote Changes Still Show as Unassigned
+
+After the target branch advances, GitButler can show many unassigned changes that are
+byte-for-byte identical to the new target branch. This is a redundant overlay, not new
+work. Prove it by comparing local blob hashes to the target branch tree, then discard only
+matching `but status` IDs, one at a time (see the discard caution above and runbook
+section 13). Leave local-only coordination files alone until the end.
+
+### `but pull` Says `completed_with_conflicts`
+
+Read the JSON. If it lists no file conflicts and one stale branch as
+`conflicted_not_rebasable`, the base may still have advanced successfully. Check:
+
+```bash
+but status --json -f
+```
+
+If `mergeBase` equals the remote target head and `behind` is `0`, delete the stale branch
+afterward. If instead the conflict is attributed to a lane that cannot conflict, treat it
+as a stale-parent wedge (section above) rather than a normal conflict.
+
+## Verification Bar
+
+Before declaring success:
+
+- `but status --json -f` shows `upstreamState.behind == 0`.
+- `mergeBase.commitId` equals the remote target branch SHA.
+- `unassignedChanges` is empty or only intentional local files remain.
+- `stacks` is empty, or only intentionally active lanes remain.
+- Every relevant PR is closed/merged or explicitly left open with a reason.
+- Any coordination lock is released.
+
+## Communication
+
+Report concrete state, not vibes:
+
+- PR numbers and merge SHAs.
+- target branch SHA.
+- GitButler `mergeBase`, `behind`, unassigned count, and stack count.
+- Tests run and their result.
+- Restore points (`but oplog snapshot` IDs) for risky operations.

--- a/.agents/skills/gitbutler-workspace-recovery/references/recovery-runbook.md
+++ b/.agents/skills/gitbutler-workspace-recovery/references/recovery-runbook.md
@@ -1,0 +1,417 @@
+# GitButler Recovery Runbook
+
+This runbook captures the lessons from the agent-workflows reconcile on 2026-06-24
+(multiple stacked PRs, hunk locks, stale local GitButler branches, remote PR repair, an
+already-merged UI branch that was not actually present in the target, and a final clean
+sync to `origin/big-agents`), and from the workspace-wedge incident on 2026-07-11 (a
+saturated 30-lane workspace, a stale-parent workspace commit, a botched `but oplog
+restore`, and two PRs shipped via raw plumbing while `but` was blocked).
+
+## Freeze Rule (read first)
+
+The moment the workspace looks wedged, stop. Run no `but` mutation of any kind, not even
+`but branch new`, until the wedge is diagnosed.
+
+Wedge signatures:
+
+- `but pull` reports a failed integration, or `completed_with_conflicts` naming a lane
+  that has no way to conflict (e.g. one with zero commits).
+- `Could not find branch CLI id '' in IdMap`.
+- Any conflict message that attributes the conflict to a lane that cannot conflict.
+
+On 2026-07-11 a `but branch new` issued while the workspace was wedged created phantom
+commits, a junk local ref at the wrong SHA, and a 47-parent display corruption in `but
+status`. Retrying or "working around" a wedge with another `but` write compounds the
+damage every time. Diagnose using section 4 below. If work must ship while the wedge is
+still unresolved, use the plumbing escape hatch in section 12 instead of any `but`
+command.
+
+Keep applied lanes to about 15 or fewer before pulling. `but pull` against a heavily
+saturated workspace (~30 applied lanes) is what triggers open GitButler integration bugs
+(#11364, #14497, #12355) in the first place; unapply idle lanes before pulling. Upgrading
+GitButler does not help; these bugs are open as of 0.21.0.
+
+## 1. Work From Ground Truth
+
+Do not trust one source of truth when GitButler is tangled.
+
+Use three views:
+
+- Local GitButler state: `but status --json -f`
+- Pull feasibility: `but pull --check --json`
+- Remote PR/branch state: GitHub app or `gh api`
+
+For each relevant PR, record:
+
+- PR number, base, head, state, merged flag
+- head SHA and merge commit SHA if merged
+- compare status: ahead/behind/diverged
+- changed file list
+
+For the target branch, record:
+
+- remote head SHA
+- local GitButler `mergeBase`
+- `upstreamState.behind`
+
+## 2. Respect GitButler's Model
+
+GitButler has three different surfaces:
+
+- committed branch/stack changes
+- assigned/unassigned working tree changes
+- the projected workspace graph
+
+Do not assume a file showing as unassigned means "new work." It can be a projection artifact
+after the target branch moved.
+
+Rules:
+
+- One `but` write at a time.
+- Do not run `but status`, `but discard`, `but branch delete`, or `but pull` in parallel
+  with another `but` write.
+- After a DB-lock error, serialize all later GitButler operations.
+- Prefer JSON output and narrow it with `jq`.
+- Never repeat a failed topology operation blindly.
+
+## 3. Hunk Locks and Empty Commits
+
+Symptoms:
+
+- `but commit <lane> -p <id>` creates an empty commit.
+- `but amend <id> <commit>` says it succeeded, but the file remains changed.
+- The same file has base lines from one stack and replacement lines from a sibling stack.
+
+Diagnosis:
+
+- The hunk belongs to a sibling lane according to GitButler's dependency model.
+- The intended target lane cannot accept it until the sibling's commits are in the base.
+
+Resolution:
+
+1. Stop retrying commits.
+2. Preserve state with `but oplog snapshot`.
+3. Merge the sibling/owner PRs into the target branch in dependency order.
+4. Pull/update the target branch.
+5. Re-check whether the hunk is still an unassigned change.
+6. If it remains and is truly not in the target branch, land it as a follow-up from the new
+   base.
+
+This is a hunk-dependency issue, not a wedge. If instead every topology operation fails
+cherry-picking the workspace commit itself, see section 4.
+
+## 4. Wedged Workspace: Stale-Parent Workspace Commit Signature
+
+GitButler tracks the workspace as a synthetic "GitButler Workspace Commit" that merges
+every applied lane. That commit can carry stale parents left over from an old projection.
+When it does, every topology operation (apply, unapply, commit, pull) fails cherry-picking
+it, with an error like:
+
+```text
+Failed to merge bases while cherry picking commit <sha>
+```
+
+This is the signature of a stale-parent wedge, distinct from an ordinary hunk lock
+(section 3) or a genuine file conflict.
+
+A `but pull` can report an error and still have advanced the base underneath it. Do not
+trust the error text alone. Check:
+
+```bash
+but status --json -f | jq '.mergeBase, .upstreamState'
+```
+
+If `mergeBase.commitId` already equals the remote target branch SHA, the pull's
+integration step (not the fetch/merge step) is what failed, and the fix is narrower than
+it looks.
+
+Fix, only after securing uncommitted work (section 11):
+
+1. Snapshot: `but oplog snapshot -m "before workspace-commit rebuild"`.
+2. Confirm every agent's uncommitted changes are backed up (section 11). A workspace-commit
+   rebuild can touch the working tree.
+3. Rebuild the workspace commit so it no longer carries the stale parents. This is a
+   GitButler-internal repair; do not attempt it by hand-editing refs. If the installed
+   GitButler CLI has no direct "rebuild workspace commit" command, unapply every lane,
+   confirm the workspace commit is gone, then re-apply lanes one at a time, verifying `but
+   status` after each.
+4. Re-run `but pull --check --json` and confirm it completes without the cherry-pick error
+   before resuming normal work.
+
+If step 3 does not clear the wedge, stop using `but` and fall back to the plumbing escape
+hatch (section 12) to keep shipping work while a human or GitButler support resolves the
+underlying repo state.
+
+## 5. Repairing a Dirty Remote PR Branch
+
+When a PR branch is stale/diverged but the local workspace contains the intended file
+contents, the safest remote repair is:
+
+1. Compare `base...head` to get the PR's file set.
+2. Create a new tree from the current base branch tree.
+3. For each PR file, use the verified local content, or remote head content if local does
+   not exist.
+4. Create one new commit parented on the current base.
+5. Force-update the PR branch ref to that commit.
+6. Verify every changed remote file matches local content.
+7. Merge the PR with an expected head SHA.
+
+This is remote API work. It avoids local GitButler topology surgery. Use the GitHub app
+where possible; use `gh api` when the connector does not expose tree/ref operations.
+
+Guardrails:
+
+- Snapshot before remote branch rewrites.
+- Only rewrite branches owned by this workspace/effort.
+- Do not force-update a branch if another human/session owns it and its contents are
+  unknown.
+- Verify file contents after the rewrite before merging.
+
+## 6. Handling "Merged" Branches That Did Not Land Expected Files
+
+A PR can be closed/merged while the current target branch still lacks expected files due to
+stacking, wrong base, branch replacement, or later graph movement.
+
+Check representative files directly on the target branch:
+
+```bash
+gh api repos/<owner>/<repo>/contents/<path>?ref=<target>
+```
+
+If missing:
+
+1. Compare target branch against the source branch.
+2. Rebuild a fresh reconciliation branch from the current target.
+3. Add the exact intended file set from the local workspace or source branch.
+4. Open/merge a small restore PR.
+
+In the incident, Arda's UI branch was marked merged, but `big-agents` missed 77 UI/RAG
+files. The fix was a new restore PR built from current `big-agents` with those 77 files,
+then merged last.
+
+## 7. Clearing Redundant Unassigned Overlays
+
+After remote PRs merge and the base moves, GitButler may still show the old local file
+contents as unassigned changes. If those file contents are already in the new target
+branch, discard the overlay.
+
+Safe proof:
+
+1. Fetch the target branch tree through GitHub API.
+2. Compute each local file's Git blob SHA:
+
+```text
+sha1("blob <byte_length>\\0" + bytes)
+```
+
+3. Compare against the target tree blob SHA.
+4. Only discard unassigned IDs where local blob SHA equals target blob SHA.
+5. Leave local-only coordination files or hook wrappers for a final decision.
+
+Discard through GitButler:
+
+```bash
+but discard <cli-id>
+```
+
+Run this serially, one ID at a time. Recompute `but status --json` between discards
+because IDs can change, and because a discard can cascade beyond the single ID named (see
+section 13).
+
+## 8. Final Pull and Stale Branch Cleanup
+
+Preferred flow:
+
+1. `but oplog snapshot -m "before final pull"`
+2. `but pull --check --json`
+3. If no worktree conflicts: `but pull --json`
+4. Inspect the result.
+
+If `but pull` reports `completed_with_conflicts` but:
+
+- `conflicts` contains only a stale branch with no files, and
+- `but status` shows `upstreamState.behind == 0`, and
+- `mergeBase` equals remote target head,
+
+then the base update likely succeeded. Delete the stale local branch:
+
+```bash
+but branch delete <merged-stale-branch>
+```
+
+If delete fails before the pull because of overlays, clear redundant overlays first, then
+retry after the base update.
+
+If instead `but status` shows the cherry-pick failure described in section 4, this is a
+stale-parent wedge, not a normal stale-branch case; follow section 4, not this section.
+
+## 9. GitButler Hook Noise
+
+GitButler may modify `.husky/pre-commit`, `.husky/post-checkout`, and create
+`*-user` hook files while managing the workspace branch. Treat these as local GitButler
+runtime noise unless the task explicitly concerns hooks.
+
+At the end, if they are the only remaining unassigned changes and the user did not ask to
+commit them, discard them with `but discard <id>`.
+
+## 10. Coordination Files and Locks
+
+If a coordination file has a `BUT-LOCK`:
+
+- Set it before risky `but` writes.
+- Refresh it for long operations.
+- Release it when done.
+- If the remote file already says `FREE` and the local edit only contains stale local
+  chatter, discard the local file after release.
+
+Do not leave a stale local lock as the final state.
+
+## 11. Before Any `but oplog restore`: Back Up Uncommitted Work
+
+`but oplog restore` rewinds the entire workspace, including every agent's UNCOMMITTED
+working-tree content, to the snapshot's state. On 2026-07-11 this wiped other agents'
+in-flight files twice, because the restoring agent had not accounted for concurrent work.
+
+Mandatory sequence before any `but oplog restore`:
+
+1. Freeze all agents' tree writes. Confirm on the coordination board (or directly) that no
+   other agent is mid-edit.
+2. List every modified and untracked file: `git status --porcelain`.
+3. Back up each listed file to a tmp directory, preserving relative paths, before running
+   the restore. A flat loop over the `git status --porcelain` list that copies each path
+   into a tmp directory is enough; the point is a copy that exists outside the working tree
+   GitButler is about to rewind.
+4. Run `but oplog restore <snapshot-id>`.
+5. Diff the backup against the restored working tree. Re-apply any content that the
+   restore discarded and that still belongs in the tree.
+
+Skipping steps 1-3 is what caused the data loss. Treat them as non-optional even under
+time pressure.
+
+## 12. Escape Hatch: Publish via Plumbing When `but` Is Blocked
+
+When the workspace is wedged (section 4) or otherwise blocked and work needs to ship,
+build and push a commit with raw `git` plumbing against a temporary index. This never
+touches the real index, never moves local refs, and never invokes `but`, so it cannot make
+the wedge worse.
+
+```bash
+export GIT_INDEX_FILE=$(mktemp)
+git read-tree <remote-tip-or-base-sha>      # seed the temp index from a known-good tree
+# for each changed file:
+blob=$(git hash-object -w <path>)
+git update-index --add --cacheinfo 100644 "$blob" "<path>"
+tree=$(git write-tree)
+commit=$(git commit-tree "$tree" -p <parent-sha> -m "<message>")
+git push --no-verify origin "$commit":refs/heads/<branch>
+unset GIT_INDEX_FILE
+```
+
+Rules:
+
+- Use the remote tip (or the intended base branch) as the `read-tree` source, never the
+  local working directory's HEAD; the point is to build the tree from known-good state
+  plus the specific files you intend to change.
+- Never move a local ref (no `git update-ref`, no `git branch -f`) and never touch the
+  real index. Confirm `GIT_INDEX_FILE` is set to the temp file before any `git
+  update-index` or `git write-tree` call, and `unset` it immediately after.
+- Verify the push landed: `git ls-remote --heads origin <branch>` must equal `<commit>`.
+- This is a publishing escape hatch, not a wedge fix. It gets a PR out; it does not repair
+  the workspace. Still follow section 4 (or ask a human) to clear the underlying wedge.
+
+This recipe shipped two PRs on 2026-07-11 while the workspace was blocked by a
+stale-parent wedge.
+
+## 13. `but clean` and `but discard` Cascade Cautions
+
+`but clean` must never run when any applied lane has zero commits. GitButler can
+attribute an empty lane's placeholder state to "nothing to keep" and sweep the lane
+itself, not just stray files. Before running `but clean`, check `but status --json -f`
+for any stack with `commits | length == 0` and either commit or unapply that lane first.
+
+`but discard` can cascade further than the single ID it names. Discarding one path can
+pull in dozens of dependent items under GitButler's hunk-dependency model, including
+protected or coordination files you did not intend to touch. Before discarding:
+
+1. Run the discard in isolation, one ID at a time, never as a batch.
+2. Check what the discard actually claims to remove (GitButler reports the affected set)
+   before confirming.
+3. Re-run `but status --json -f` immediately after each discard to confirm nothing besides
+   the intended ID changed.
+
+Section 7 (clearing redundant unassigned overlays) already requires serial discards for
+this reason; the same caution applies to any other use of `but discard`.
+
+## 14. Success Checklist
+
+Remote:
+
+- All intended PRs are merged or intentionally left open.
+- Target branch contains the expected representative files.
+- Target branch SHA is recorded.
+
+Local:
+
+- `but status --json -f` has `unassignedChanges | length == 0`.
+- `upstreamState.behind == 0`.
+- `mergeBase.commitId == <remote target SHA>`.
+- `stacks | length == 0`, unless the user intentionally wants active lanes left applied.
+
+Communication:
+
+- Report merged PRs and SHAs.
+- Report final GitButler state.
+- Report tests and known gaps.
+- Report snapshot IDs if risky operations were performed.
+
+## 15. Commands Worth Memorizing
+
+Status summary:
+
+```bash
+but status --json -f
+```
+
+Pull dry-run:
+
+```bash
+but pull --check --json
+```
+
+Snapshot:
+
+```bash
+but oplog snapshot -m "before <operation>"
+```
+
+Restore (back up uncommitted work first — section 11):
+
+```bash
+but oplog restore <snapshot-id>
+```
+
+Undo last operation:
+
+```bash
+but undo
+```
+
+Unapply an idle lane before a pull, to keep applied lanes under the ~15 threshold:
+
+```bash
+but unapply <branch>
+```
+
+Delete stale local branch after it is merged remotely:
+
+```bash
+but branch delete <branch>
+```
+
+Discard a proven-redundant unassigned change (one at a time — section 13):
+
+```bash
+but discard <cli-id>
+```
+
+Plumbing escape hatch when `but` is blocked: section 12.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,21 @@ If so, use the `but` CLI instead of raw `git branch`/`git commit`:
 - To update an already-committed file, `but absorb <path>` amends it into the right
   commit; force-push with `but push <branch> -f`.
 
+### Wedge prevention and freeze rule
+
+`but pull` against a workspace with many applied lanes (~30) can trigger open GitButler
+integration bugs (#11364 "new head names do not match the current heads", #14497
+stale-parent workspace-commit wedge, #12355 mass auto-unapply). Keep applied lanes to
+about 15 or fewer; `but unapply` idle lanes before pulling. Never `but pull` a saturated
+workspace. Upgrading GitButler does not fix this; the bugs are open as of 0.21.0.
+
+The moment the workspace is wedged, freeze: run no `but` mutation of any kind, not even
+`but branch new`. Signs of a wedge: a failed pull integration, `Could not find branch CLI
+id '' in IdMap`, or a conflict message that attributes the conflict to a lane that cannot
+conflict (for example, one with no commits). A `but` mutation issued while wedged can
+create phantom commits, junk local refs at the wrong SHA, and display corruption. Stop and
+follow the `gitbutler-workspace-recovery` skill instead of retrying or improvising.
+
 ### Committing to specific lanes in a stack (the part that bites)
 
 Changes are assigned to the **stack**, not to an individual branch. `but rub <file>
@@ -167,6 +182,10 @@ lanes that touch disjoint files (e.g. `web/**` vs `api/**`) can sit anywhere in 
   workspace (including uncommitted changes) to any prior snapshot — this is how
   you undo a botched unapply/apply and get a collapsed stack's series back. Take
   a `but oplog snapshot -m "..."` before risky operations.
+- **`but oplog restore` wipes every agent's uncommitted work, not just yours.** Before
+  restoring, freeze all agents' tree writes and back up each file from
+  `git status --porcelain` to a tmp dir; restoring without a backup can destroy other
+  agents' in-flight edits, and it has happened twice.
 
 ## Before committing
 


### PR DESCRIPTION
## Summary

On 2026-07-11 a GitButler workspace with ~30 applied lanes hit open GitButler integration
bugs during `but pull`, wedging the workspace (a stale-parent "GitButler Workspace Commit"
that made every topology operation fail cherry-picking it). A `but branch new` issued while
wedged made things worse, creating phantom commits, a junk local ref at the wrong SHA, and a
47-parent display corruption. A subsequent `but oplog restore` used to recover also wiped
other agents' uncommitted work twice, because it wasn't preceded by a backup. Two PRs still
needed to ship during the outage, which happened by building commits with raw `git` plumbing
against a temp index and pushing directly, bypassing `but` entirely. This PR encodes those
lessons into the agent instruction files so Claude, Codex, and Cursor don't repeat them.

## Changes

- **`AGENTS.md`** (repo root): new "Wedge prevention and freeze rule" subsection under
  "Branching and PRs with GitButler" - keep applied lanes to ~15 or fewer before pulling,
  never pull a saturated workspace, and freeze (no `but` mutation of any kind) the moment
  the workspace shows wedge signatures. Added one "Hard-won gotchas" bullet: `but oplog
  restore` wipes every agent's uncommitted work, not just the operator's, so back up
  `git status --porcelain` files before restoring.
- **`.agents/skills/gitbutler-workspace-recovery/SKILL.md`**: new "Freeze Rule (read
  first)" section up front; Non-Negotiables gained cautions on `but discard` cascades, `but
  clean` on zero-commit lanes, and backing up work before `but oplog restore`; Common Failure
  Patterns gained a "Wedged Workspace: Stale-Parent Workspace Commit" entry pointing at the
  runbook.
- **`.agents/skills/gitbutler-workspace-recovery/references/recovery-runbook.md`**: new
  freeze rule at the top; new section 4 documenting the stale-parent workspace-commit
  signature (`Failed to merge bases while cherry picking commit ...`) and the "pull errored
  but the base still advanced" check; new section 11 with the mandatory backup-before-restore
  sequence; new section 12 with the full plumbing escape-hatch recipe (temp `GIT_INDEX_FILE`,
  `hash-object`, `update-index`, `write-tree`, `commit-tree`, `push`); new section 13 on
  `but clean` / `but discard` cascade cautions. Existing sections renumbered to fit.
- **`.agents/skills/codex-onboarding/SKILL.md`**: added a "freeze if wedged" paragraph to
  the "When in doubt" section, pointing at the freeze rule and the
  `gitbutler-workspace-recovery` skill, and updated the sibling-skills pointer.

Note: `.agents/skills/gitbutler-workspace-recovery/` and `.agents/skills/codex-onboarding/`
were previously untracked (matched by the `.agents/skills/*` gitignore rule with no
allowlist entry, unlike `write-template-playbooks`). This PR is the first commit of both
directories, consistent with how `agenta-package-practices`, `write-docs`, and
`write-pr-description` are already tracked despite the same ignore pattern.

## How to review

Read `AGENTS.md`'s new subsection first for the two-sentence version of the rule, then the
`gitbutler-workspace-recovery` `SKILL.md` for the enforcement summary, then the runbook for
the full incident-derived procedures (sections 4, 11, 12, 13 are new).

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj
