### PR TITLE
docs(agent-workflows): Plan Daytona secret delivery

### DIFF
--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/README.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/README.md
@@ -1,35 +1,37 @@
 # Daytona secret delivery for agent sandboxes
 
-This workspace evaluates replacing plaintext API keys in Daytona sandbox environment variables
-with Daytona Secrets. It is a focused extension of the broader
-[`secret-isolation`](../secret-isolation/README.md) project.
+This workspace designs a consumer-scoped credential contract and Daytona Secret delivery for
+agent sandboxes. It extends the broader [`secret-isolation`](../secret-isolation/README.md)
+project without copying the Agenta vault into Daytona.
 
 ## Recommendation
 
-Adopt Daytona Secrets for credentials that a Daytona-hosted agent sends unchanged in outbound
-HTTP(S) requests. Create a unique, short-lived Daytona organization Secret for each sandbox and
-credential binding, attach it when the sandbox is created, retain it while the sandbox can resume,
-and delete it after the sandbox is deleted.
+Use one resolved contract for local and Daytona runs. Each model or HTTP MCP consumer owns its
+route and credential bindings. The local provider materializes plaintext as it does today. The
+Daytona provider creates a unique organization Secret for each sandbox binding and gives the agent
+only a host-scoped placeholder.
 
-Do not put Agenta API credentials into Daytona Secrets. Keep callback authorization, telemetry
-authorization, the Daytona API key, and other Agenta control-plane credentials on the runner side.
-Do not copy every Agenta vault secret into Daytona. Resolve only credentials explicitly requested
-by the selected model connection, MCP server, or tool.
+Support opaque HTTP credentials whose destination is known before sandbox creation. This includes
+standard model API keys, Azure OpenAI keys, custom-provider API keys, HTTP MCP authorization, and
+potentially Bedrock bearer tokens. It does not include AWS SigV4 keys, Vertex service-account
+configuration, private keys, or other values that code must use locally.
 
-This mechanism does not support credentials that code must transform or use outside HTTP(S), such
-as AWS SigV4 keys, service-account JSON, private keys, database protocol passwords, or secrets used
-for local cryptography. Those need an out-of-sandbox gateway or narrowly scoped temporary
-credentials.
+Unsupported credentials may keep the current plaintext behavior only through an explicit
+non-isolated mode. Failure of isolated delivery never falls back silently. A gateway remains the
+general solution when plaintext must stay outside both local and Daytona sandboxes.
 
 ## Files
 
 - [`context.md`](context.md): problem, goals, threat model, and scope.
-- [`research.md`](research.md): current code, Daytona behavior, feasibility, and upgrade risk.
-- [`design.md`](design.md): recommended architecture, interfaces, lifecycle, and alternatives.
-- [`plan.md`](plan.md): implementation phases and migration sequence.
-- [`qa.md`](qa.md): security, compatibility, failure, and live verification matrix.
-- [`status.md`](status.md): decisions, blockers, and next action.
+- [`research.md`](research.md): current code, external behavior, credential feasibility, and
+  dependency risk.
+- [`design.md`](design.md): resolved contract, provider materialization, lease lifecycle, and
+  alternatives.
+- [`plan.md`](plan.md): implementation phases and rollout sequence.
+- [`qa.md`](qa.md): security, contract, provider, lifecycle, and live verification matrix.
+- [`open-questions.md`](open-questions.md): decisions required before implementation starts.
+- [`status.md`](status.md): current recommendation, constraints, and next action.
 
 ## Current state
 
-Planning only. No runtime code or dependency has changed.
+Planning only. No runtime dependency or production behavior changes in this PR.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/README.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/README.md
@@ -1,0 +1,35 @@
+# Daytona secret delivery for agent sandboxes
+
+This workspace evaluates replacing plaintext API keys in Daytona sandbox environment variables
+with Daytona Secrets. It is a focused extension of the broader
+[`secret-isolation`](../secret-isolation/README.md) project.
+
+## Recommendation
+
+Adopt Daytona Secrets for credentials that a Daytona-hosted agent sends unchanged in outbound
+HTTP(S) requests. Create a unique, short-lived Daytona organization Secret for each sandbox and
+credential binding, attach it when the sandbox is created, retain it while the sandbox can resume,
+and delete it after the sandbox is deleted.
+
+Do not put Agenta API credentials into Daytona Secrets. Keep callback authorization, telemetry
+authorization, the Daytona API key, and other Agenta control-plane credentials on the runner side.
+Do not copy every Agenta vault secret into Daytona. Resolve only credentials explicitly requested
+by the selected model connection, MCP server, or tool.
+
+This mechanism does not support credentials that code must transform or use outside HTTP(S), such
+as AWS SigV4 keys, service-account JSON, private keys, database protocol passwords, or secrets used
+for local cryptography. Those need an out-of-sandbox gateway or narrowly scoped temporary
+credentials.
+
+## Files
+
+- [`context.md`](context.md): problem, goals, threat model, and scope.
+- [`research.md`](research.md): current code, Daytona behavior, feasibility, and upgrade risk.
+- [`design.md`](design.md): recommended architecture, interfaces, lifecycle, and alternatives.
+- [`plan.md`](plan.md): implementation phases and migration sequence.
+- [`qa.md`](qa.md): security, compatibility, failure, and live verification matrix.
+- [`status.md`](status.md): decisions, blockers, and next action.
+
+## Current state
+
+Planning only. No runtime code or dependency has changed.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/context.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/context.md
@@ -2,69 +2,67 @@
 
 ## Why this work exists
 
-Agenta currently resolves one model connection and sends its credential values to the runner. On
-the Daytona path, the runner puts those values into the sandbox creation request as plaintext
-`envVars`. The harness and agent shell can therefore read them.
+Agenta resolves credentials for the selected model and HTTP MCP servers. The current runner wire
+then flattens model values into `AgentRunRequest.secrets` and resolved MCP values into each
+server's `env` map. On Daytona, model values enter sandbox `envVars` as plaintext. HTTP MCP values
+enter ACP session configuration as plaintext headers. Agent code can therefore read both.
 
-Daytona added a Secrets feature in SDK 0.192.0. A Daytona Secret is organization-scoped and
-encrypted at rest. A sandbox receives an opaque placeholder in its environment. Daytona's outbound
-HTTP(S) proxy replaces that placeholder with the real value only when the destination matches the
-Secret's host allowlist. The plaintext is not placed in the sandbox.
+Daytona Secrets are organization-scoped encrypted credentials. A sandbox receives an opaque
+placeholder. Daytona's outbound HTTP(S) proxy replaces that placeholder only when the destination
+host matches the Secret allowlist. Secret reads return metadata, not plaintext.
 
-This feature is the egress-substitution option discussed but deferred in the broader
-[`secret-isolation`](../secret-isolation/api-design.md) project. It removes the need for Agenta to
-operate a separate model proxy for supported credentials on Daytona. It does not solve secret
-isolation on the local sandbox provider.
+The feature can remove plaintext from the Daytona agent boundary for opaque HTTP credentials. It
+cannot hide a value that code must parse, sign with, or use over another protocol. It also cannot
+provide the same property on the local provider without a separate proxy.
 
 ## Threat model
 
-The adversary is code running in the sandbox, including an agent following a malicious or
-prompt-injected instruction. It can read environment variables and files, inspect same-user
-processes, and make arbitrary network requests allowed by sandbox policy.
+The adversary is the agent and any code it runs inside a Daytona sandbox. It can read environment
+variables and files, inspect same-user processes, change its own requests, and make any network
+request permitted by sandbox policy.
 
-The desired property is narrow:
+The desired property is:
 
-> Sandbox code can use an approved credential against approved HTTP(S) hosts, but it cannot read
-> the plaintext credential or send it to another host.
+> Sandbox code can exercise an approved credential against one approved HTTP(S) host, but it
+> cannot read the plaintext credential or send it to another host.
 
-This does not prevent the agent from using the granted capability. An agent with an OpenAI key
-placeholder can still make OpenAI requests. Model restrictions, budgets, approvals, and tool
-allowlists remain separate policy controls.
+Daytona's control plane and Agenta's resolver are trusted with plaintext. The runner handles it
+transiently to create the Daytona Secret. The agent, harness process, shell, files, logs, traces,
+and durable session state must not receive it.
 
-We trust Daytona's control plane and egress proxy with the plaintext. This is not a zero-trust
-design with respect to Daytona. It is a boundary change from "Daytona and sandbox code hold the
-key" to "Daytona holds the key and sandbox code holds a constrained placeholder."
+The capability itself remains usable. An agent with an OpenAI placeholder can make OpenAI calls.
+Budgets, model restrictions, approvals, and tool policy remain separate controls.
 
 ## Goals
 
-1. Remove plaintext direct HTTP API keys from Daytona sandbox environment variables.
-2. Keep Agenta control-plane credentials outside Daytona Secrets and outside the sandbox.
-3. Create one isolated credential lease per sandbox, with deterministic cleanup and crash
-   reconciliation.
-4. Support standard model API keys, custom-provider API keys, and explicitly declared text custom
-   secrets when their allowed HTTP hosts are known.
-5. Fail closed for secret shapes that Daytona cannot safely substitute.
-6. Preserve least privilege. Never copy the whole Agenta vault into Daytona.
-7. Pin and verify the Daytona SDK upgrade before enabling secret delivery.
+1. Replace plaintext Daytona delivery for supported model and HTTP MCP credentials.
+2. Use one consumer-owned resolved contract for local and Daytona materialization.
+3. Derive the destination from the consumer's effective model endpoint or MCP URL.
+4. Create one isolated lease per sandbox binding and reconcile cleanup after crashes.
+5. Keep Agenta, Daytona, telemetry, session, and tool-relay control-plane credentials outside the
+   sandbox.
+6. Keep unsupported credentials explicit. Never claim isolation or downgrade silently.
+7. Pin and verify the Daytona SDK and control-plane behavior before rollout.
 
 ## Non-goals
 
-- Protecting local sandbox runs. They still need the separate proxy or gateway design.
-- Hiding the ability to call an approved provider from the agent.
-- Sending Agenta API keys, tool-callback authorization, OTLP authorization, or `DAYTONA_API_KEY`
-  into Daytona Secrets.
-- Making AWS access keys, service-account JSON, private keys, or signing credentials work through
-  placeholder substitution.
-- Adding a generic "all project secrets" field to the agent configuration.
-- Replacing Agenta's vault as the source of truth.
+- Giving the local provider secret isolation without a gateway or local egress proxy.
+- Hiding approved provider capability from the agent.
+- Copying all project or organization secrets into Daytona.
+- Migrating the legacy Python evaluator. It is outside the agent-runner scope.
+- Making SigV4, service-account JSON, private-key, or native-protocol credentials compatible with
+  proxy substitution.
+- Solving billing limits, provider authorization, model policy, or sandbox network policy through
+  the credential contract.
 
 ## Success criteria
 
-- `env`, `/proc`, files, logs, and process arguments inside a Daytona sandbox contain placeholders,
-  not plaintext, for supported credentials.
-- The credential works against its allowlisted provider host and remains a placeholder everywhere
-  else.
-- Sandbox deletion eventually deletes every Daytona Secret created for that sandbox, including
-  after runner crashes and failed sandbox creation.
-- A credential with no non-empty host allowlist is rejected.
-- Unsupported secret types fail with a clear error and never fall back silently to plaintext.
+- Supported Daytona runs contain placeholders, not plaintext, in environment, ACP configuration,
+  `/proc`, files, logs, arguments, traces, and persisted state.
+- The allowlisted exact host receives plaintext. Every other host receives a placeholder or no
+  request.
+- Local and Daytona consume the same resolved contract and differ only in materialization.
+- Missing values, resolution failures, empty hosts, wildcards, and unsupported isolated modes fail
+  before sandbox creation.
+- Sandbox deletion and crash reconciliation converge to zero orphan Secrets.
+- The product and logs distinguish `isolated` from `non_isolated` credential delivery.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/context.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/context.md
@@ -1,0 +1,70 @@
+# Context
+
+## Why this work exists
+
+Agenta currently resolves one model connection and sends its credential values to the runner. On
+the Daytona path, the runner puts those values into the sandbox creation request as plaintext
+`envVars`. The harness and agent shell can therefore read them.
+
+Daytona added a Secrets feature in SDK 0.192.0. A Daytona Secret is organization-scoped and
+encrypted at rest. A sandbox receives an opaque placeholder in its environment. Daytona's outbound
+HTTP(S) proxy replaces that placeholder with the real value only when the destination matches the
+Secret's host allowlist. The plaintext is not placed in the sandbox.
+
+This feature is the egress-substitution option discussed but deferred in the broader
+[`secret-isolation`](../secret-isolation/api-design.md) project. It removes the need for Agenta to
+operate a separate model proxy for supported credentials on Daytona. It does not solve secret
+isolation on the local sandbox provider.
+
+## Threat model
+
+The adversary is code running in the sandbox, including an agent following a malicious or
+prompt-injected instruction. It can read environment variables and files, inspect same-user
+processes, and make arbitrary network requests allowed by sandbox policy.
+
+The desired property is narrow:
+
+> Sandbox code can use an approved credential against approved HTTP(S) hosts, but it cannot read
+> the plaintext credential or send it to another host.
+
+This does not prevent the agent from using the granted capability. An agent with an OpenAI key
+placeholder can still make OpenAI requests. Model restrictions, budgets, approvals, and tool
+allowlists remain separate policy controls.
+
+We trust Daytona's control plane and egress proxy with the plaintext. This is not a zero-trust
+design with respect to Daytona. It is a boundary change from "Daytona and sandbox code hold the
+key" to "Daytona holds the key and sandbox code holds a constrained placeholder."
+
+## Goals
+
+1. Remove plaintext direct HTTP API keys from Daytona sandbox environment variables.
+2. Keep Agenta control-plane credentials outside Daytona Secrets and outside the sandbox.
+3. Create one isolated credential lease per sandbox, with deterministic cleanup and crash
+   reconciliation.
+4. Support standard model API keys, custom-provider API keys, and explicitly declared text custom
+   secrets when their allowed HTTP hosts are known.
+5. Fail closed for secret shapes that Daytona cannot safely substitute.
+6. Preserve least privilege. Never copy the whole Agenta vault into Daytona.
+7. Pin and verify the Daytona SDK upgrade before enabling secret delivery.
+
+## Non-goals
+
+- Protecting local sandbox runs. They still need the separate proxy or gateway design.
+- Hiding the ability to call an approved provider from the agent.
+- Sending Agenta API keys, tool-callback authorization, OTLP authorization, or `DAYTONA_API_KEY`
+  into Daytona Secrets.
+- Making AWS access keys, service-account JSON, private keys, or signing credentials work through
+  placeholder substitution.
+- Adding a generic "all project secrets" field to the agent configuration.
+- Replacing Agenta's vault as the source of truth.
+
+## Success criteria
+
+- `env`, `/proc`, files, logs, and process arguments inside a Daytona sandbox contain placeholders,
+  not plaintext, for supported credentials.
+- The credential works against its allowlisted provider host and remains a placeholder everywhere
+  else.
+- Sandbox deletion eventually deletes every Daytona Secret created for that sandbox, including
+  after runner crashes and failed sandbox creation.
+- A credential with no non-empty host allowlist is rejected.
+- Unsupported secret types fail with a clear error and never fall back silently to plaintext.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/design.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/design.md
@@ -2,62 +2,106 @@
 
 ## Decision summary
 
-Use per-sandbox Daytona Secret leases for proxy-substitutable HTTP credentials. Keep Agenta as the
-source of truth. Daytona stores a temporary encrypted copy for the lifetime of one sandbox.
+Use one consumer-owned resolved credential contract for local and Daytona runs. The contract keeps
+the credential value, its protocol binding, and its destination together. The sandbox provider
+then materializes that contract:
 
-Do not create a permanent one-to-one mirror of Agenta vault entries in the Daytona organization.
-Do not pass plaintext fallback values when secret delivery fails.
+- local passes the plaintext to the local harness process or HTTP MCP header;
+- Daytona creates a per-sandbox organization Secret and gives the sandbox only a placeholder;
+- unsupported local-use credentials remain an explicit non-isolated mode or move behind a
+  gateway. They never silently downgrade from isolated delivery to plaintext.
+
+Agenta remains the source of truth. Daytona stores an encrypted temporary copy only while its
+sandbox can run or resume. Do not mirror the Agenta vault into Daytona and do not put Agenta
+control-plane credentials in Daytona Secrets.
+
+## Security boundary
+
+The protected subject is the agent and any code it runs inside a Daytona sandbox. It can inspect
+its environment, files, process table, and network responses, but it receives only a Daytona
+placeholder for isolated credentials. Daytona and the Agenta resolver still handle plaintext.
+Daytona documents that Secret values are encrypted at rest, write-only after creation, and absent
+from Secret reads and audit-log payloads.
+
+This design does not give local sandboxes the same confidentiality property. The shared contract
+works on local, but local materialization is plaintext until an Agenta gateway or equivalent local
+egress proxy exists.
 
 ## Credential classification
 
-Before building a sandbox, classify every resolved environment entry by semantic role:
-
-| Class | Examples | Delivery |
+| Class | Examples | Daytona delivery |
 |---|---|---|
-| Non-secret configuration | region, project, base URL, feature flags | plain `envVars` |
-| HTTP substitution credential | provider API key, bearer token, custom text API key | Daytona `secrets` mapping |
-| Local-use confidential material | AWS signing keys, service-account JSON, private keys | reject for isolated mode; route through a gateway or use scoped temporary credentials |
-| Agenta control-plane credential | callback auth, Agenta API key, OTLP auth, Daytona API key | runner-side only |
+| Non-secret configuration | region, project, base URL, feature flags | Plain `envVars` |
+| Opaque HTTP credential | provider API key, bearer token, HTTP MCP header | Daytona Secret placeholder |
+| Local-use confidential material | AWS SigV4 keys, service-account JSON, private keys | Explicit non-isolated mode or gateway |
+| Agenta control-plane credential | callback auth, Agenta API key, OTLP auth, Daytona API key | Runner-side only |
 
-An unclassified value fails closed. Environment-variable naming alone is not a durable interface,
-so the long-term resolver output should describe the credential's use rather than rely on a growing
-denylist.
+An opaque HTTP credential is a value that the client copies unchanged into an HTTP request. Code
+inside the sandbox must not parse it, sign with it, derive another value from it, or use it over a
+non-HTTP protocol.
 
-## Interface design
+The concrete cloud cases are:
 
-### User-facing configuration
+- Azure OpenAI API keys qualify because the client sends the unchanged key in an HTTP header and
+  the configured endpoint supplies the exact host.
+- `AWS_BEARER_TOKEN_BEDROCK` qualifies in principle. AWS documents it as an unchanged bearer token
+  for Bedrock Runtime requests. The exact regional runtime host must be known.
+- AWS access-key, secret-key, and session-token credentials do not qualify because the SDK uses
+  them locally to calculate SigV4 signatures.
+- Vertex service-account or Application Default Credentials do not qualify because the client
+  reads credential configuration and mints OAuth tokens locally. A Vertex API-key mode may qualify
+  separately if Agenta supports that connection shape and the live spike verifies its request
+  path.
 
-Keep credentials under the consumer that uses them:
+An unclassified credential fails before sandbox creation. An operator may explicitly allow a
+reviewed non-isolated credential mode during migration, but the run and UI must not describe that
+mode as protected by Daytona Secrets.
 
-- model credentials stay under the selected model connection;
-- MCP credentials stay under `mcp_servers[].secrets`;
-- tool credentials stay under that tool declaration;
-- a future general runtime credential, if a real use case requires one, belongs under
-  `runtime.credentials`, not in a top-level vault dump.
+## Consumer-owned internal contract
 
-Every custom credential use must declare one or more HTTPS destination hosts. Secret storage and
-destination policy are different roles: the Agenta vault owns the value, while the consumer
-declaration owns where that use may send it.
+There is no backward-compatibility requirement for the pre-release agent contract. Replace the
+ambiguous top-level `secrets: Record<string, string>` field rather than preserving it alongside a
+new shape.
 
-Do not expose Daytona Secret names or IDs in the agent configuration or public run API. They are a
-provider-specific delivery mechanism.
-
-### Resolved internal contract
-
-The current `secrets: Record<string, string>` wire field combines credential values with their
-environment binding and carries no destination policy. Preserve it only as a compatibility input.
-Add a typed resolved credential binding owned by the consumer, conceptually:
+Each consumer owns its connection, routing, and credentials. A conceptual resolved model shape is:
 
 ```json
 {
-  "modelCredential": {
-    "environment": "OPENAI_API_KEY",
-    "value": "<redacted plaintext on the internal wire>",
-    "usage": "http_substitution",
-    "destinations": {
-      "httpsHosts": ["api.openai.com"]
-    }
+  "modelConnection": {
+    "provider": "openai",
+    "deployment": "direct",
+    "endpoint": {
+      "baseUrl": "https://api.openai.com/v1"
+    },
+    "credentials": [
+      {
+        "binding": { "kind": "environment", "name": "OPENAI_API_KEY" },
+        "value": "<plaintext on the trusted internal wire>",
+        "usage": "opaque_http"
+      }
+    ]
   }
+}
+```
+
+An HTTP MCP server uses the same roles without duplicating its destination:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "support",
+      "transport": "http",
+      "url": "https://mcp.example.com/mcp",
+      "credentials": [
+        {
+          "binding": { "kind": "header", "name": "Authorization" },
+          "value": "<plaintext on the trusted internal wire>",
+          "usage": "opaque_http"
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -65,144 +109,173 @@ Field roles:
 
 | Field | Role | Owner and lifecycle |
 |---|---|---|
-| `environment` | protocol binding | harness adapter, per connection |
-| `value` | credential | Agenta vault, per resolved run; never logged or persisted by the runner |
-| `usage` | credential-use contract | resolver, stable for the credential kind |
-| `destinations.httpsHosts` | egress policy | consumer or connection definition, per use |
+| consumer `endpoint` or `url` | routing | resolved connection or MCP declaration, per run configuration |
+| `credentials[].binding` | protocol binding | consumer adapter, stable for that connection |
+| `credentials[].value` | credential | Agenta vault, resolved per run and never logged or persisted by the runner |
+| `credentials[].usage` | credential-use contract | resolver, stable for that credential kind |
 
-The concrete wire shape should be finalized with the provider-model-auth owner. The important
-constraint is that value, use, and destination travel together. A sibling `secretHosts` map would
-allow them to drift and is rejected.
+Destination hosts are derived from the resolved consumer route, not transported in a sibling
+secret-host map:
 
-For the first implementation slice, standard direct providers may use a reviewed static host
-registry and custom providers may derive one exact hostname from their validated `endpoint.baseUrl`.
-This avoids blocking on a full wire migration. It must reject unknown providers, empty hosts,
-Bedrock, Vertex service-account credentials, and arbitrary custom environment values.
+- model credentials use the effective `modelConnection.endpoint.baseUrl` after provider and
+  deployment resolution;
+- HTTP MCP credentials use `mcpServers[].url` after URL and SSRF validation;
+- a consumer that has no effective HTTPS endpoint cannot request isolated delivery.
+
+The resolver should emit the effective endpoint for standard providers too. A runner-only static
+host registry would duplicate routing knowledge and can drift from the client that sends the
+request. Exact hostnames are the only supported first-version policy. Wildcards remain rejected.
+
+## Provider materialization
+
+The runner validates and classifies the resolved contract once, then delegates materialization.
+
+### Local
+
+Local materialization puts model credential values in the harness subprocess environment and HTTP
+MCP credential values in ACP header entries. This matches current behavior. It is functionally
+compatible with the contract but does not claim secret isolation.
+
+### Daytona
+
+Daytona materialization:
+
+1. Parses each consumer endpoint and derives one exact, lowercase hostname.
+2. Creates one organization Secret per isolated credential binding with that non-empty host list.
+3. For environment bindings, passes `{environmentName: daytonaSecretName}` in the sandbox create
+   `secrets` map instead of copying the value into `envVars`.
+4. For HTTP MCP header bindings, passes the Daytona placeholder as the header value in the ACP
+   session configuration. Phase 0 must prove that Daytona substitutes a placeholder that reaches
+   the proxy this way, even when the placeholder did not originate from an environment read.
+5. Rejects any empty host, non-HTTPS route, wildcard, IP literal, localhost, metadata address, or
+   credential whose use is not `opaque_http`.
+
+This is a runner change. It does not require an upstream sandbox-agent implementation. The
+existing runner-side `daytonaWithLifecycle` wrapper already adds native pause, reconnect, and
+delete operations around the vendored provider. Secret provisioning and cleanup should extend
+that wrapper or a sibling runner-owned adapter. The existing package patch remains limited to
+vendored sandbox-agent cleanup behavior.
 
 ## Daytona lease model
 
-A `DaytonaSecretLease` is internal runner state:
+A `DaytonaSecretLease` is runner-owned lifecycle state:
 
 ```text
 lease id               random 128-bit identifier
-sandbox name or id      one Daytona sandbox
-bindings[]               env name, Daytona Secret id/name, exact hosts
-created at               reconciliation age
-state                    provisioning | attached | parked | deleting
+sandbox id             one Daytona sandbox
+bindings[]              consumer binding, Daytona Secret id/name, exact hosts
+created at              reconciliation age
+state                   provisioning | attached | stopped | deleting
 ```
 
-It never stores credential plaintext. Secret names use only an Agenta prefix, the random lease ID,
-and an opaque binding suffix. They do not contain project IDs, provider names, user names, or raw
+It never stores plaintext. Secret names use only an Agenta prefix, the random lease ID, and an
+opaque binding suffix. They do not contain project IDs, provider names, user names, vault slugs, or
 environment names.
 
 ### Provisioning
 
-1. Resolve only the selected consumers' credentials from the Agenta vault.
-2. Partition configuration, supported credentials, and unsupported material.
-3. Generate a lease ID and create one Daytona organization Secret per binding with an exact host
-   allowlist.
-4. Create the sandbox with:
-   - non-secret values in `envVars`;
-   - `{environmentName: daytonaSecretName}` in `secrets`;
-   - an opaque sandbox name or label that carries the lease ID for reconciliation.
-5. Start the sandbox-agent daemon only after Secret attachment is part of sandbox creation.
-6. Persist sandbox and lease metadata without plaintext.
+1. Resolve only credentials requested by selected model and MCP consumers.
+2. Validate consumer routes, classify values, and reject invalid combinations.
+3. Generate a lease ID and create each Daytona Secret with an exact non-empty host list.
+4. Create the sandbox with non-secret configuration in `envVars` and isolated model credentials
+   in `secrets`.
+5. Give HTTP MCP consumers only placeholders in their header bindings.
+6. Start the daemon only after the Secret set is complete.
+7. Persist sandbox and lease metadata without plaintext.
 
-The Secret must exist before sandbox creation. Attaching it afterward risks an already-running
-daemon retaining the wrong environment.
+Missing names, empty values, vault-resolution failures, partial Secret creation, and empty host
+derivation all abort before sandbox creation. Partial Secret creation triggers compensation.
 
-### Rotation and model changes
+### Credential changes
 
-If the underlying value changes but the environment binding and hosts stay the same, update the
-Daytona Secret. Its placeholder remains stable. Wait for documented propagation before starting a
-new provider request, with a bounded retry for authentication failures.
+The first version does not rotate a live lease in place. The existing session compatibility path
+already treats a credential-epoch change as a mismatch. Delete the old sandbox and lease, then
+create a new pair. This avoids Daytona's documented propagation window and avoids assuming that a
+long-lived daemon has refreshed bindings.
 
-If the environment binding, credential class, or allowed host changes, provision a fresh sandbox
-or restart the daemon after replacing the attached set. Do not assume an already-running process
-sees newly attached variables. Credential identity must participate in the reusable environment or
-session-pool key.
+If a later optimization updates a Secret in place, the update must reassert the previously
+validated exact host set and verify the returned metadata. Daytona documents PATCH semantics in
+which omitted fields remain unchanged, but reassertion makes Agenta converge a Secret that an
+administrator may have widened outside the runner.
 
-### Pause, resume, and delete
+### Stop, resume, and delete
 
-- Pause or archive: retain the lease because the sandbox may resume.
-- Resume: reconcile the stored sandbox ID and lease bindings, rotate values if needed, then start
-  the daemon.
-- Confirmed sandbox delete: delete every Secret in the lease, then mark the lease complete.
-- Secret cleanup failure: report and retry asynchronously. Do not report a successful security
-  cleanup until the Secret deletions are confirmed or queued durably.
+- Stop: retain the lease because the sandbox may resume.
+- Resume: reconcile the stored sandbox ID, lease bindings, and credential epoch before starting.
+- Credential mismatch: delete the old sandbox and its lease, then provision fresh.
+- Confirmed sandbox delete: delete every Secret in the lease, then mark cleanup complete.
+- Secret cleanup failure: queue a durable retry and report cleanup as pending.
 
-The Daytona provider adapter must implement real `pause`, not the current delete fallback.
+Archive is not part of the Agenta lifecycle. The current warm-Daytona create specification omits
+`autoArchiveInterval`; the lifecycle ladder is running, stopped, then deleted. A Daytona sandbox
+may still appear archived through provider defaults or manual administration, so reconciliation
+must treat an existing archived sandbox as live until it is deleted.
 
 ### Reconciliation
 
 Run a periodic janitor with a dedicated lock:
 
-1. List all Agenta-owned Secret names with full cursor pagination.
-2. List Agenta-owned Daytona sandboxes across running, stopped, archived, and deleting states.
-3. Keep Secrets whose lease belongs to a live sandbox or an in-flight provisioning record.
+1. List Agenta-owned Secret names with the current SDK's full list semantics.
+2. List Agenta-owned sandboxes in every provider state.
+3. Keep Secrets referenced by a live sandbox or in-flight provisioning record.
 4. Delete Secrets whose sandbox is absent and whose grace period has elapsed.
-5. Emit counts and opaque lease IDs only. Never log values or user-facing secret names.
+5. Emit counts and opaque lease IDs only.
 
-The janitor must not infer ownership from age alone. A long-lived archived sandbox is valid.
+Age alone never proves that a Secret is orphaned. The durable lease record and sandbox existence
+are the authority.
 
-## Provider adapter strategy
+## Control-plane isolation
 
-The current `sandbox-agent/daytona` adapter is about 60 lines, creates its own Daytona client, and
-does not expose Secret lifecycle hooks or native pause. The safest implementation is an
-Agenta-owned Daytona provider adapter that still implements sandbox-agent's provider interface but
-uses an injected, exact-version Daytona client.
+Secret management needs Daytona `manage:secrets`, which can manage every Secret in the
+organization. A dedicated API key limits credential reuse but does not narrow that permission to
+Agenta-created Secrets. The recommended production boundary is a dedicated Daytona organization
+for Agenta-managed sandboxes plus a dedicated runner credential. If deployment cannot provide
+that boundary, enabling this feature requires explicit acceptance of organization-wide Secret
+management blast radius.
 
-This adapter owns create, get URL, ensure server, pause, destroy, and lease compensation. It avoids
-forking the sandbox-agent runtime while removing the deprecated package-name constraint from this
-security-sensitive boundary.
-
-An upstream contribution can later add client injection and lifecycle hooks to sandbox-agent. The
-Agenta implementation should not wait on that contribution.
-
-## Agenta credentials
-
-The TypeScript agent runner does not need an Agenta API key inside the sandbox for normal tool
-callbacks. Keep all of the following out of Daytona Secrets:
+Keep these values out of Daytona Secrets and the sandbox:
 
 - `DAYTONA_API_KEY`;
-- Agenta request or callback authorization;
+- Agenta request, callback, and session authorization;
 - OTLP authorization;
-- internal MCP or tool relay credentials;
+- internal tool-relay credentials;
 - durable-store master credentials.
 
-The legacy Python evaluator currently injects Agenta credentials directly. Treat its migration or
-retirement as a separate decision. Do not normalize that behavior into the new lease model.
+## Unsupported credential options
 
-## Alternatives
+For credentials that code must use locally, the choices are:
+
+1. Keep the current plaintext delivery as an explicit non-isolated mode. This preserves provider
+   support but the agent can read the credential. Short-lived, scoped credentials and process
+   isolation reduce impact but do not provide the target property.
+2. Use a provider-specific opaque token when available, such as a Bedrock bearer token or a
+   supported Vertex API key. This may qualify for Daytona substitution after a live proof.
+3. Use a token broker or workload federation to mint short-lived credentials. The sandbox can
+   still read the resulting token, so this limits lifetime rather than preventing disclosure.
+4. Move the provider call behind an Agenta gateway. This is the general solution that keeps
+   signing keys and service-account material outside the sandbox.
+
+The first implementation may improve supported credentials without disabling existing cloud
+connections. It must expose and test the difference between isolated and non-isolated delivery,
+and it must never fall back silently after isolated delivery fails.
+
+## Rejected alternatives
 
 ### Permanent organization mirror
 
-Mirror every Agenta vault secret into Daytona once and reuse it across sandboxes.
-
-Rejected. It creates a second durable source of truth, broad cross-sandbox reuse, difficult tenant
-deletion semantics, and larger blast radius.
+Rejected. It creates a second durable source of truth, broad cross-sandbox reuse, and difficult
+tenant deletion semantics.
 
 ### One Secret per project or provider
 
-Reuse one Daytona Secret across a project's sandboxes.
-
-Rejected for the first version. It makes sandbox cleanup unable to revoke one sandbox and increases
-cross-session coupling. Per-sandbox copies cost more API operations but provide clear ownership.
+Rejected for the first version. Per-sandbox copies give each sandbox a clear revocation and cleanup
+boundary.
 
 ### Delete immediately after attachment
 
 Rejected. Daytona's proxy needs the organization Secret while requests are in flight.
 
-### Continue plaintext `envVars`
-
-Rejected for supported credentials. It leaves the key readable by the agent.
-
-### Use only an Agenta model proxy
-
-Still valid and required for local sandboxes or unsupported credentials. For direct HTTP keys on
-Daytona, native substitution is smaller and avoids operating another inference hop.
-
 ### Send every custom secret to the agent
 
-Rejected. Secret access must remain explicit and consumer-scoped. A project vault is not an agent
-environment template.
+Rejected. A vault is not an environment template. Every credential must belong to a selected
+consumer with a known route.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/design.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/design.md
@@ -1,0 +1,208 @@
+# Design
+
+## Decision summary
+
+Use per-sandbox Daytona Secret leases for proxy-substitutable HTTP credentials. Keep Agenta as the
+source of truth. Daytona stores a temporary encrypted copy for the lifetime of one sandbox.
+
+Do not create a permanent one-to-one mirror of Agenta vault entries in the Daytona organization.
+Do not pass plaintext fallback values when secret delivery fails.
+
+## Credential classification
+
+Before building a sandbox, classify every resolved environment entry by semantic role:
+
+| Class | Examples | Delivery |
+|---|---|---|
+| Non-secret configuration | region, project, base URL, feature flags | plain `envVars` |
+| HTTP substitution credential | provider API key, bearer token, custom text API key | Daytona `secrets` mapping |
+| Local-use confidential material | AWS signing keys, service-account JSON, private keys | reject for isolated mode; route through a gateway or use scoped temporary credentials |
+| Agenta control-plane credential | callback auth, Agenta API key, OTLP auth, Daytona API key | runner-side only |
+
+An unclassified value fails closed. Environment-variable naming alone is not a durable interface,
+so the long-term resolver output should describe the credential's use rather than rely on a growing
+denylist.
+
+## Interface design
+
+### User-facing configuration
+
+Keep credentials under the consumer that uses them:
+
+- model credentials stay under the selected model connection;
+- MCP credentials stay under `mcp_servers[].secrets`;
+- tool credentials stay under that tool declaration;
+- a future general runtime credential, if a real use case requires one, belongs under
+  `runtime.credentials`, not in a top-level vault dump.
+
+Every custom credential use must declare one or more HTTPS destination hosts. Secret storage and
+destination policy are different roles: the Agenta vault owns the value, while the consumer
+declaration owns where that use may send it.
+
+Do not expose Daytona Secret names or IDs in the agent configuration or public run API. They are a
+provider-specific delivery mechanism.
+
+### Resolved internal contract
+
+The current `secrets: Record<string, string>` wire field combines credential values with their
+environment binding and carries no destination policy. Preserve it only as a compatibility input.
+Add a typed resolved credential binding owned by the consumer, conceptually:
+
+```json
+{
+  "modelCredential": {
+    "environment": "OPENAI_API_KEY",
+    "value": "<redacted plaintext on the internal wire>",
+    "usage": "http_substitution",
+    "destinations": {
+      "httpsHosts": ["api.openai.com"]
+    }
+  }
+}
+```
+
+Field roles:
+
+| Field | Role | Owner and lifecycle |
+|---|---|---|
+| `environment` | protocol binding | harness adapter, per connection |
+| `value` | credential | Agenta vault, per resolved run; never logged or persisted by the runner |
+| `usage` | credential-use contract | resolver, stable for the credential kind |
+| `destinations.httpsHosts` | egress policy | consumer or connection definition, per use |
+
+The concrete wire shape should be finalized with the provider-model-auth owner. The important
+constraint is that value, use, and destination travel together. A sibling `secretHosts` map would
+allow them to drift and is rejected.
+
+For the first implementation slice, standard direct providers may use a reviewed static host
+registry and custom providers may derive one exact hostname from their validated `endpoint.baseUrl`.
+This avoids blocking on a full wire migration. It must reject unknown providers, empty hosts,
+Bedrock, Vertex service-account credentials, and arbitrary custom environment values.
+
+## Daytona lease model
+
+A `DaytonaSecretLease` is internal runner state:
+
+```text
+lease id               random 128-bit identifier
+sandbox name or id      one Daytona sandbox
+bindings[]               env name, Daytona Secret id/name, exact hosts
+created at               reconciliation age
+state                    provisioning | attached | parked | deleting
+```
+
+It never stores credential plaintext. Secret names use only an Agenta prefix, the random lease ID,
+and an opaque binding suffix. They do not contain project IDs, provider names, user names, or raw
+environment names.
+
+### Provisioning
+
+1. Resolve only the selected consumers' credentials from the Agenta vault.
+2. Partition configuration, supported credentials, and unsupported material.
+3. Generate a lease ID and create one Daytona organization Secret per binding with an exact host
+   allowlist.
+4. Create the sandbox with:
+   - non-secret values in `envVars`;
+   - `{environmentName: daytonaSecretName}` in `secrets`;
+   - an opaque sandbox name or label that carries the lease ID for reconciliation.
+5. Start the sandbox-agent daemon only after Secret attachment is part of sandbox creation.
+6. Persist sandbox and lease metadata without plaintext.
+
+The Secret must exist before sandbox creation. Attaching it afterward risks an already-running
+daemon retaining the wrong environment.
+
+### Rotation and model changes
+
+If the underlying value changes but the environment binding and hosts stay the same, update the
+Daytona Secret. Its placeholder remains stable. Wait for documented propagation before starting a
+new provider request, with a bounded retry for authentication failures.
+
+If the environment binding, credential class, or allowed host changes, provision a fresh sandbox
+or restart the daemon after replacing the attached set. Do not assume an already-running process
+sees newly attached variables. Credential identity must participate in the reusable environment or
+session-pool key.
+
+### Pause, resume, and delete
+
+- Pause or archive: retain the lease because the sandbox may resume.
+- Resume: reconcile the stored sandbox ID and lease bindings, rotate values if needed, then start
+  the daemon.
+- Confirmed sandbox delete: delete every Secret in the lease, then mark the lease complete.
+- Secret cleanup failure: report and retry asynchronously. Do not report a successful security
+  cleanup until the Secret deletions are confirmed or queued durably.
+
+The Daytona provider adapter must implement real `pause`, not the current delete fallback.
+
+### Reconciliation
+
+Run a periodic janitor with a dedicated lock:
+
+1. List all Agenta-owned Secret names with full cursor pagination.
+2. List Agenta-owned Daytona sandboxes across running, stopped, archived, and deleting states.
+3. Keep Secrets whose lease belongs to a live sandbox or an in-flight provisioning record.
+4. Delete Secrets whose sandbox is absent and whose grace period has elapsed.
+5. Emit counts and opaque lease IDs only. Never log values or user-facing secret names.
+
+The janitor must not infer ownership from age alone. A long-lived archived sandbox is valid.
+
+## Provider adapter strategy
+
+The current `sandbox-agent/daytona` adapter is about 60 lines, creates its own Daytona client, and
+does not expose Secret lifecycle hooks or native pause. The safest implementation is an
+Agenta-owned Daytona provider adapter that still implements sandbox-agent's provider interface but
+uses an injected, exact-version Daytona client.
+
+This adapter owns create, get URL, ensure server, pause, destroy, and lease compensation. It avoids
+forking the sandbox-agent runtime while removing the deprecated package-name constraint from this
+security-sensitive boundary.
+
+An upstream contribution can later add client injection and lifecycle hooks to sandbox-agent. The
+Agenta implementation should not wait on that contribution.
+
+## Agenta credentials
+
+The TypeScript agent runner does not need an Agenta API key inside the sandbox for normal tool
+callbacks. Keep all of the following out of Daytona Secrets:
+
+- `DAYTONA_API_KEY`;
+- Agenta request or callback authorization;
+- OTLP authorization;
+- internal MCP or tool relay credentials;
+- durable-store master credentials.
+
+The legacy Python evaluator currently injects Agenta credentials directly. Treat its migration or
+retirement as a separate decision. Do not normalize that behavior into the new lease model.
+
+## Alternatives
+
+### Permanent organization mirror
+
+Mirror every Agenta vault secret into Daytona once and reuse it across sandboxes.
+
+Rejected. It creates a second durable source of truth, broad cross-sandbox reuse, difficult tenant
+deletion semantics, and larger blast radius.
+
+### One Secret per project or provider
+
+Reuse one Daytona Secret across a project's sandboxes.
+
+Rejected for the first version. It makes sandbox cleanup unable to revoke one sandbox and increases
+cross-session coupling. Per-sandbox copies cost more API operations but provide clear ownership.
+
+### Delete immediately after attachment
+
+Rejected. Daytona's proxy needs the organization Secret while requests are in flight.
+
+### Continue plaintext `envVars`
+
+Rejected for supported credentials. It leaves the key readable by the agent.
+
+### Use only an Agenta model proxy
+
+Still valid and required for local sandboxes or unsupported credentials. For direct HTTP keys on
+Daytona, native substitution is smaller and avoids operating another inference hop.
+
+### Send every custom secret to the agent
+
+Rejected. Secret access must remain explicit and consumer-scoped. A project vault is not an agent
+environment template.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/open-questions.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/open-questions.md
@@ -1,0 +1,79 @@
+# Open questions before implementation
+
+These decisions block implementation. The recommendation under each question is the current design
+preference, not an approved decision.
+
+## 1. What production Daytona boundary can we require?
+
+Daytona grants `manage:secrets` across an organization, not only Agenta-created Secrets.
+
+- **Option A:** require a dedicated Daytona organization and dedicated runner credential.
+- **Option B:** use a shared organization and explicitly accept organization-wide management blast
+  radius.
+
+**Recommendation:** Option A. A separate API key alone does not narrow the permission.
+
+## 2. What happens to SigV4 and Vertex service-account connections?
+
+Daytona substitution cannot protect values used for local signing or token minting.
+
+- **Option A:** keep the current plaintext behavior as an explicit `non_isolated` mode.
+- **Option B:** disable those connections on Daytona until a gateway exists.
+- **Option C:** require provider-specific opaque credentials where available.
+
+**Recommendation:** allow A during migration, prefer C when available, and make B available to
+operators that require strict isolation. Never downgrade from `isolated` to `non_isolated`
+automatically.
+
+## 3. Where is the effective model endpoint resolved?
+
+Custom and Azure connections already carry a base URL. Standard providers and regional Bedrock
+routes also need an exact effective endpoint so the host policy matches the client request.
+
+- **Option A:** the Python connection resolver emits the effective endpoint for every deployment.
+- **Option B:** the runner maintains a provider-host registry.
+
+**Recommendation:** Option A. Routing knowledge and its credential should travel under the same
+consumer. A second registry can drift.
+
+## 4. Does Daytona substitute placeholders passed directly in HTTP MCP headers?
+
+The runner can obtain the Secret placeholder and put it in ACP session configuration, but Daytona's
+documentation demonstrates environment injection rather than this exact path.
+
+**Recommendation:** make this a Phase 0 live gate. If direct placeholder substitution fails, either
+teach the in-sandbox MCP adapter to read a Secret-backed environment binding or keep HTTP MCP
+credentials on a runner-side gateway.
+
+## 5. Where does durable lease metadata live?
+
+Cleanup needs a durable mapping from sandbox ID to Secret IDs, host policy, and lifecycle state.
+Session state is already durable, but the janitor also needs organization-wide enumeration and
+partial-provisioning recovery.
+
+**Recommendation:** define a small runner-owned lease record in the control plane rather than
+encoding user metadata into Daytona Secret names or descriptions.
+
+## 6. Is explicit non-isolated delivery visible in the public configuration or only operator policy?
+
+Users may need to know that a selected cloud credential remains readable inside Daytona. Exposing
+mechanism-specific Daytona settings in the agent contract would be the wrong abstraction.
+
+**Recommendation:** expose a portable credential-delivery requirement such as `isolated_required`
+or `best_available`, then report the resolved mode in run metadata. Keep Daytona details internal.
+
+## 7. Do we support Vertex API keys in the first scope?
+
+Google now documents API-key authentication for some Vertex Gemini paths, while Agenta's current
+Vertex connection uses Application Default Credentials through `GOOGLE_APPLICATION_CREDENTIALS`.
+
+**Recommendation:** keep Vertex API keys out of the first scope unless the provider-model contract
+adds and tests that distinct credential shape. Do not infer it from service-account configuration.
+
+## 8. What exact Daytona SDK and self-hosted control-plane versions are supported?
+
+Secrets first shipped in SDK 0.192.0. The current package is 0.196.0, while the runner still uses
+`@daytonaio/sdk` 0.187.0. Self-hosted control-plane compatibility is not yet proven.
+
+**Recommendation:** select one exact `@daytona/sdk` version after the live spike and add startup
+capability validation for the minimum control-plane version.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/plan.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/plan.md
@@ -1,0 +1,110 @@
+# Plan
+
+This is a design-only plan. Implementation starts only after review and approval.
+
+## Phase 0: prove Daytona's security behavior
+
+Use a non-production Daytona organization and disposable credentials.
+
+1. Pin a small spike to `@daytona/sdk` 0.196.0 or the reviewed exact version selected at
+   implementation time.
+2. Create a Secret with a random value and one controlled HTTPS echo host.
+3. Create a sandbox with the Secret attached at creation.
+4. Prove the sandbox sees only a `dtn_secret_*` placeholder in environment, files, `/proc`, process
+   arguments, stdout, and stderr.
+5. Prove the allowlisted host receives plaintext and a non-allowlisted host receives only the
+   placeholder.
+6. Test redirects, subdomains, explicit ports, alternate URL forms, DNS changes, proxy errors, and
+   logs.
+7. Test value and host rotation, detach, Secret deletion while attached, pause, archive, resume,
+   sandbox deletion, and auto-delete.
+8. Measure Secret create/update/delete latency, rate limits, and organization quotas with realistic
+   per-sandbox counts.
+
+Exit gate: do not implement if plaintext appears inside the sandbox, host restrictions can be
+bypassed, lifecycle semantics cannot be reconciled, or quotas make per-sandbox leases impractical.
+
+## Phase 1: isolate and pin the Daytona dependency
+
+1. Add the current exact `@daytona/sdk` package. Remove the caret for this security-sensitive
+   dependency.
+2. Implement an Agenta-owned sandbox-agent Daytona provider adapter with dependency injection.
+3. Preserve current create, signed preview, server start, destroy, and reconnect behavior.
+4. Add native `pause()` support so keep-warm no longer falls back to deletion.
+5. Run runner unit tests and live Daytona smoke tests before any Secret behavior is enabled.
+6. Keep a kill switch that restores the existing plaintext path only in non-production during the
+   migration. Production isolated mode must fail closed rather than downgrade silently.
+
+Exit gate: existing Daytona chat, tools, previews, lifecycle timers, mounts, pause/resume, and
+cleanup work with no Secret attachment.
+
+## Phase 2: model API keys behind per-sandbox leases
+
+1. Add credential classification for reviewed direct HTTP providers and Azure/custom endpoint API
+   keys.
+2. Derive a non-empty exact host allowlist from the canonical provider registry or validated custom
+   endpoint.
+3. Split non-secret configuration from credential values before sandbox creation.
+4. Add `DaytonaSecretLease` provisioning and compensation.
+5. Pass Secret names through Daytona's `secrets` field and stop copying those values into
+   `envVars`.
+6. Persist only lease metadata needed for resume and cleanup.
+7. Rotate the Daytona Secret on same-binding credential changes.
+8. Reject unsupported Bedrock, Vertex service-account, signing, and unknown credential shapes with
+   an actionable error.
+
+Exit gate: direct provider and custom endpoint runs succeed, plaintext checks stay clean, and every
+normal and failed run leaves no orphan after reconciliation.
+
+## Phase 3: crash-safe lifecycle and janitor
+
+1. Couple Secret cleanup to confirmed sandbox deletion, not turn completion.
+2. Retain leases across real pause, stop, archive, and resume.
+3. Add a cursor-paginated janitor for Agenta-owned leases.
+4. Cover partial Secret creation, failed sandbox creation, failed state persistence, runner crash,
+   sandbox auto-delete, deletion retry, and concurrent cleanup.
+5. Alert on orphan count, oldest orphan age, reconciliation failures, and Secret API errors without
+   logging names or values.
+
+Exit gate: fault-injection tests and a runner-kill live test converge to zero orphan Secrets.
+
+## Phase 4: explicitly declared custom text secrets
+
+1. Repair or replace the missing `POST /secrets/resolve` backend path while preserving project
+   authorization and requested-name filtering.
+2. Define consumer-scoped destination policy. Do not add a whole-vault export.
+3. Support text custom secrets only when the consumer sends the value unchanged over HTTP(S).
+4. Reuse the same per-sandbox lease and exact-host rules.
+5. Keep MCP and gateway tool secrets server-side when the existing callback plane can do so. Use
+   Daytona substitution only when the client truly runs inside Daytona.
+6. Reject JSON, signing, file, private-key, and native-protocol uses unless a separate secure
+   delivery design exists.
+
+Exit gate: an explicitly requested text secret works against its declared host, is unavailable
+elsewhere, and undeclared project secrets never reach Daytona.
+
+## Phase 5: remove compatibility paths and document support
+
+1. Remove the production plaintext fallback for supported Daytona credentials.
+2. Document the minimum Daytona control-plane version and required API-key permissions.
+3. Document supported and unsupported credential classes.
+4. Decide separately whether to migrate or retire the legacy Python Daytona evaluator.
+5. Update the broader secret-isolation design: Daytona native substitution is the preferred remote
+   path; the Agenta model proxy remains the cross-provider and local-sandbox solution.
+
+## Rollout
+
+Roll out by environment, then by a small percentage of Daytona sessions. Track sandbox creation
+latency, authentication failures, proxy substitution errors, cleanup failures, and orphan count.
+
+Do not use a per-run best-effort fallback to plaintext. If Daytona Secret APIs fail, fail the run
+before sandbox creation or use an explicitly configured environment-level rollback during the
+early migration window.
+
+## Dependencies and coordination
+
+- Coordinate the resolved credential contract with `provider-model-auth` and
+  `custom-providers-in-pi`.
+- Coordinate provider lifecycle changes with `session-keepalive` and `sandbox-agent-fork`.
+- Keep MCP secret delivery aligned with `secret-isolation` and the backend gateway direction.
+- Use the repository BUT-LOCK before any GitButler write during implementation.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/plan.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/plan.md
@@ -1,110 +1,106 @@
 # Plan
 
-This is a design-only plan. Implementation starts only after review and approval.
+Implementation starts after the decisions in `open-questions.md` are resolved.
 
-## Phase 0: prove Daytona's security behavior
+## Phase 0: prove Daytona behavior
 
 Use a non-production Daytona organization and disposable credentials.
 
-1. Pin a small spike to `@daytona/sdk` 0.196.0 or the reviewed exact version selected at
-   implementation time.
-2. Create a Secret with a random value and one controlled HTTPS echo host.
-3. Create a sandbox with the Secret attached at creation.
-4. Prove the sandbox sees only a `dtn_secret_*` placeholder in environment, files, `/proc`, process
-   arguments, stdout, and stderr.
-5. Prove the allowlisted host receives plaintext and a non-allowlisted host receives only the
-   placeholder.
-6. Test redirects, subdomains, explicit ports, alternate URL forms, DNS changes, proxy errors, and
-   logs.
-7. Test value and host rotation, detach, Secret deletion while attached, pause, archive, resume,
-   sandbox deletion, and auto-delete.
-8. Measure Secret create/update/delete latency, rate limits, and organization quotas with realistic
-   per-sandbox counts.
+1. Pin the spike to one exact `@daytona/sdk` version at or above 0.192.0.
+2. Prove environment-backed Secret substitution with one random marker and one exact HTTPS host.
+3. Prove direct placeholder substitution when the placeholder is placed in an HTTP MCP header
+   through ACP session configuration.
+4. Confirm plaintext is absent from environment, `/proc`, files, process arguments, stdout,
+   stderr, ACP payload logs, and traces.
+5. Test the exact host, a different host, a subdomain, redirects, explicit ports, DNS changes, and
+   proxy failures. Reject every wildcard in the first version.
+6. Test Secret create, read, update, delete, sandbox stop, resume, manual archive, delete, and
+   auto-delete. Confirm Secret reads and audit records never return plaintext.
+7. Verify PATCH semantics. Reassert and read back the exact host set on rotation even though
+   Daytona documents omitted fields as unchanged.
+8. Measure latency, list behavior, rate limits, and organization quotas at realistic lease counts.
 
-Exit gate: do not implement if plaintext appears inside the sandbox, host restrictions can be
-bypassed, lifecycle semantics cannot be reconciled, or quotas make per-sandbox leases impractical.
+Exit gate: stop if plaintext appears inside the sandbox, direct MCP-header substitution fails
+without a safe alternative, host restrictions can be bypassed, or lifecycle and quotas make
+per-sandbox leases impractical.
 
-## Phase 1: isolate and pin the Daytona dependency
+## Phase 1: replace the resolved credential contract
 
-1. Add the current exact `@daytona/sdk` package. Remove the caret for this security-sensitive
-   dependency.
-2. Implement an Agenta-owned sandbox-agent Daytona provider adapter with dependency injection.
-3. Preserve current create, signed preview, server start, destroy, and reconnect behavior.
-4. Add native `pause()` support so keep-warm no longer falls back to deletion.
-5. Run runner unit tests and live Daytona smoke tests before any Secret behavior is enabled.
-6. Keep a kill switch that restores the existing plaintext path only in non-production during the
-   migration. Production isolated mode must fail closed rather than downgrade silently.
+1. Replace top-level model `secrets` with consumer-owned `modelConnection.credentials`.
+2. Make the resolver emit the effective HTTPS model endpoint for direct, custom, Azure, and
+   candidate Bedrock bearer-token deployments.
+3. Replace HTTP MCP's merged `env` secret values with typed header credential bindings. Keep
+   non-secret environment configuration separate.
+4. Classify each binding as `opaque_http` or `local_use` and validate combinations.
+5. Materialize the same contract to plaintext environment or headers for local runs.
+6. Add contract tests across Python serialization, TypeScript parsing, Pi, and Claude.
+7. Require missing names, empty values, and vault-resolution errors to fail before runner dispatch.
 
-Exit gate: existing Daytona chat, tools, previews, lifecycle timers, mounts, pause/resume, and
-cleanup work with no Secret attachment.
+Exit gate: local behavior works from the new contract with no compatibility copy of the old field,
+and model and MCP routes remain attached to their credentials.
 
-## Phase 2: model API keys behind per-sandbox leases
+## Phase 2: isolate and pin the Daytona dependency
 
-1. Add credential classification for reviewed direct HTTP providers and Azure/custom endpoint API
-   keys.
-2. Derive a non-empty exact host allowlist from the canonical provider registry or validated custom
-   endpoint.
-3. Split non-secret configuration from credential values before sandbox creation.
-4. Add `DaytonaSecretLease` provisioning and compensation.
-5. Pass Secret names through Daytona's `secrets` field and stop copying those values into
-   `envVars`.
-6. Persist only lease metadata needed for resume and cleanup.
-7. Rotate the Daytona Secret on same-binding credential changes.
-8. Reject unsupported Bedrock, Vertex service-account, signing, and unknown credential shapes with
-   an actionable error.
+1. Replace `@daytonaio/sdk` with one exact `@daytona/sdk` version.
+2. Extend the runner-owned Daytona lifecycle wrapper with Secret create, attach, delete, and
+   compensation hooks. Do not patch upstream for these hooks.
+3. Keep native pause, reconnect, and delete in the runner wrapper. Keep the vendored
+   `sandbox-agent@0.4.2` patch limited to cleanup behavior that belongs inside that package.
+4. Preserve current snapshot, target, network policy, signed preview, daemon start, mount,
+   stop/resume, and auto-delete behavior. Do not restore auto-archive configuration.
+5. Add startup capability validation for unsupported self-hosted Daytona control planes.
+6. Run the full runner unit suite, typecheck, and live Daytona smoke before Secret delivery is
+   enabled.
 
-Exit gate: direct provider and custom endpoint runs succeed, plaintext checks stay clean, and every
-normal and failed run leaves no orphan after reconciliation.
+Exit gate: existing Daytona behavior works on the pinned SDK and lifecycle ownership is explicit.
 
-## Phase 3: crash-safe lifecycle and janitor
+## Phase 3: model and HTTP MCP credentials
 
-1. Couple Secret cleanup to confirmed sandbox deletion, not turn completion.
-2. Retain leases across real pause, stop, archive, and resume.
-3. Add a cursor-paginated janitor for Agenta-owned leases.
-4. Cover partial Secret creation, failed sandbox creation, failed state persistence, runner crash,
-   sandbox auto-delete, deletion retry, and concurrent cleanup.
-5. Alert on orphan count, oldest orphan age, reconciliation failures, and Secret API errors without
-   logging names or values.
+1. Add the per-sandbox Secret lease provisioner.
+2. Derive one exact hostname from each validated effective consumer URL.
+3. Put environment bindings in Daytona's sandbox create `secrets` map.
+4. Put HTTP MCP placeholders in header bindings using the Phase 0 proven path.
+5. Support direct provider keys, Azure keys, custom-provider keys, and HTTP MCP authorization.
+6. Add Bedrock bearer tokens only if the regional endpoint and live substitution tests pass.
+7. Keep SigV4 and Vertex service-account credentials in the approved explicit non-isolated mode or
+   reject them when the run requires strict isolation.
+8. Never fall back to plaintext after Secret provisioning, attachment, or substitution fails.
 
-Exit gate: fault-injection tests and a runner-kill live test converge to zero orphan Secrets.
+Exit gate: supported consumers work, unsupported modes are explicit, and plaintext checks remain
+clean.
 
-## Phase 4: explicitly declared custom text secrets
+## Phase 4: crash-safe leases and cleanup
 
-1. Repair or replace the missing `POST /secrets/resolve` backend path while preserving project
-   authorization and requested-name filtering.
-2. Define consumer-scoped destination policy. Do not add a whole-vault export.
-3. Support text custom secrets only when the consumer sends the value unchanged over HTTP(S).
-4. Reuse the same per-sandbox lease and exact-host rules.
-5. Keep MCP and gateway tool secrets server-side when the existing callback plane can do so. Use
-   Daytona substitution only when the client truly runs inside Daytona.
-6. Reject JSON, signing, file, private-key, and native-protocol uses unless a separate secure
-   delivery design exists.
+1. Store only lease ID, sandbox ID, Secret IDs and names, exact hosts, binding metadata, timestamps,
+   and state. Never store plaintext or vault slugs.
+2. Compensate partial Secret creation and sandbox creation failure.
+3. Retain leases across stop and resume.
+4. On credential-epoch mismatch, delete the old sandbox and lease and provision fresh.
+5. Delete Secrets only after sandbox deletion is confirmed or absence is confirmed.
+6. Add durable cleanup retries and an organization-wide janitor.
+7. Cover runner crash, failed persistence, Daytona auto-delete, manual archive, concurrent cleanup,
+   and paginated listing.
 
-Exit gate: an explicitly requested text secret works against its declared host, is unavailable
-elsewhere, and undeclared project secrets never reach Daytona.
+Exit gate: fault injection and a runner-kill live test converge to zero orphan Secrets.
 
-## Phase 5: remove compatibility paths and document support
+## Phase 5: rollout and hardening
 
-1. Remove the production plaintext fallback for supported Daytona credentials.
-2. Document the minimum Daytona control-plane version and required API-key permissions.
-3. Document supported and unsupported credential classes.
-4. Decide separately whether to migrate or retire the legacy Python Daytona evaluator.
-5. Update the broader secret-isolation design: Daytona native substitution is the preferred remote
-   path; the Agenta model proxy remains the cross-provider and local-sandbox solution.
+1. Require the approved organization and API-key isolation boundary.
+2. Roll out by environment, then by a small percentage of Daytona sessions.
+3. Report resolved credential delivery as `isolated` or `non_isolated` without exposing values,
+   Secret names, or placeholders.
+4. Add operator policy for `isolated_required` versus an approved non-isolated migration mode.
+5. Document supported provider credential shapes and the minimum Daytona version.
+6. Keep local and unsupported-cloud gateway work as separate follow-up projects.
 
-## Rollout
-
-Roll out by environment, then by a small percentage of Daytona sessions. Track sandbox creation
-latency, authentication failures, proxy substitution errors, cleanup failures, and orphan count.
-
-Do not use a per-run best-effort fallback to plaintext. If Daytona Secret APIs fail, fail the run
-before sandbox creation or use an explicitly configured environment-level rollback during the
-early migration window.
+Metrics cover Secret API latency and failures, authentication failures, active leases, orphan age,
+cleanup retries, and fail-closed counts. An environment-level rollback may disable Secret delivery
+during rollout, but no individual run may downgrade silently.
 
 ## Dependencies and coordination
 
-- Coordinate the resolved credential contract with `provider-model-auth` and
-  `custom-providers-in-pi`.
-- Coordinate provider lifecycle changes with `session-keepalive` and `sandbox-agent-fork`.
-- Keep MCP secret delivery aligned with `secret-isolation` and the backend gateway direction.
-- Use the repository BUT-LOCK before any GitButler write during implementation.
+- Resolve every item in `open-questions.md`.
+- Coordinate the model connection shape with `provider-model-auth` and custom providers.
+- Coordinate HTTP MCP credential bindings with the current MCP resolver and SSRF guard.
+- Build on the current warm-Daytona runner wrapper and credential-epoch compatibility behavior.
+- Coordinate durable lease storage with the sessions control-plane owner.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/qa.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/qa.md
@@ -1,101 +1,112 @@
 # QA plan
 
-## Security assertions
+## Contract parity
 
-For every supported credential, assert the real random marker is absent from:
+For the same resolved model or HTTP MCP consumer, assert that local and Daytona accept the same
+consumer-owned contract.
 
-- `env` and language runtime environment APIs;
-- `/proc/self/environ` and readable peer-process environments;
-- process arguments and process listings;
-- uploaded files, harness settings, shell history, and durable mounts;
-- sandbox-agent, harness, runner, and Daytona-visible application logs;
-- traces, errors, request echoes, and persisted session state.
+- Local materializes plaintext only into the selected harness subprocess or MCP header.
+- Daytona materializes a placeholder and never copies an isolated value to `envVars` or ACP
+  plaintext.
+- Model destination derives from the effective endpoint.
+- HTTP MCP destination derives from the validated server URL.
+- Non-secret configuration never becomes a Daytona Secret.
+- Missing values, empty values, resolution errors, unknown usage, and missing routes fail before
+  sandbox creation.
 
-Assert the placeholder is present where the harness expects the credential. The test must search
-for the random plaintext marker, not only known variable names.
+## Plaintext absence
 
-## Network substitution matrix
+Use a unique random marker for every credential and search for it in:
+
+- environment APIs and `/proc` process environments;
+- process arguments and listings;
+- ACP session configuration and debug output;
+- uploaded files, settings, shell history, and durable mounts;
+- sandbox-agent, harness, runner, and application logs;
+- traces, errors, responses, and persisted session or lease state.
+
+The placeholder may appear only where the consumer needs it. Logs must not contain placeholders,
+vault slugs, Daytona Secret names, or full create payloads.
+
+## Network substitution
 
 | Case | Expected result |
 |---|---|
-| Exact allowlisted HTTPS host | Remote host receives plaintext; sandbox sees placeholder. |
-| Different host | Remote host receives placeholder or request is rejected; never plaintext. |
-| Subdomain without wildcard | No plaintext. |
-| Explicit allowed wildcard | Works only for the documented base and subdomains. |
-| Redirect to disallowed host | No plaintext at redirect destination. |
-| Redirect from disallowed to allowed host | Confirm documented behavior; no earlier disclosure. |
-| Non-HTTPS URL | Rejected by Agenta policy. |
-| IP literal, localhost, metadata IP | Rejected before Secret creation. |
-| Alternate port | Verify host matching and ensure policy cannot be widened accidentally. |
-| DNS change or rebinding attempt | No plaintext outside the approved TLS host boundary. |
+| Exact allowlisted HTTPS host | Host receives plaintext; sandbox sees placeholder. |
+| Different host | Placeholder or rejected request; never plaintext. |
+| Subdomain | No plaintext. |
+| Any wildcard declaration | Rejected before Secret creation. |
+| Redirect to another host | Redirect target never receives plaintext. |
+| Non-HTTPS URL | Rejected before Secret creation. |
+| IP literal, localhost, or metadata address | Rejected before Secret creation. |
+| Alternate port | Live result documented; policy never broadens beyond the host. |
+| DNS change or rebinding | No plaintext outside the approved TLS host boundary. |
 
-## Provider matrix
+Run the matrix for an environment-backed model key and a placeholder passed directly in an HTTP
+MCP header.
 
-- OpenAI direct.
-- Anthropic direct.
-- One additional header-key provider such as Mistral or Groq.
-- Azure OpenAI with exact custom endpoint host.
-- Custom OpenAI-compatible endpoint.
-- Bedrock access-key flow, expected fail-closed.
-- Vertex service-account flow, expected fail-closed.
-- Self-managed OAuth, explicitly unchanged and not claimed secure by this feature.
+## Provider and credential matrix
 
-## Custom-secret matrix
+| Credential | Expected mode |
+|---|---|
+| OpenAI and Anthropic direct API keys | Isolated |
+| One additional direct header-key provider | Isolated |
+| Azure OpenAI API key with configured endpoint | Isolated |
+| Custom OpenAI-compatible key with configured endpoint | Isolated |
+| HTTP MCP authorization header | Isolated if the Phase 0 header path passes |
+| Bedrock bearer token | Candidate isolated mode; live regional-host proof required |
+| AWS SigV4 access-key triple | Explicit non-isolated mode or rejected by strict policy |
+| Vertex service-account or ADC configuration | Explicit non-isolated mode or rejected by strict policy |
+| Vertex API key | Out of first scope unless the connection contract adds it explicitly |
+| Private key, signing seed, JSON parsed locally | Non-isolated unsupported; never proxy-claimed |
+| Self-managed subscription OAuth | Unchanged and outside this feature's isolation claim |
 
-- Text bearer token with explicit HTTPS host, supported.
-- Text value used in a request body unchanged, verify substitution.
-- Flat JSON parsed locally, expected fail-closed.
-- Private key or signing secret, expected fail-closed.
-- Secret requested by no consumer, never resolved or copied.
-- Missing custom secret, run fails before sandbox creation.
-- Hostless or wildcard-all declaration, rejected.
+## Custom-secret resolution
 
-## Lifecycle matrix
+- A selected HTTP MCP secret resolves only its requested name.
+- Missing name, empty resolved value, authorization failure, and resolver transport failure abort
+  before runner dispatch and sandbox creation.
+- A project secret requested by no selected consumer is never resolved.
+- The old MCP `env` merge cannot erase the distinction between non-secret headers and credential
+  headers.
+- A generic agent-wide secret list is rejected.
 
-- Successful create, run, destroy, and Secret delete.
+## Lifecycle and cleanup
+
+- Complete Secret creation, sandbox creation, run, delete, and Secret cleanup.
 - Partial multi-Secret creation failure with compensation.
-- Sandbox create failure after Secret creation.
-- Daemon start failure after sandbox creation.
-- Pause and resume with the same placeholders.
-- Stop, archive, and resume.
-- Value rotation during a parked session.
-- Host change requiring restart or fresh sandbox.
-- Runner termination before sandbox ID persistence.
-- Runner termination after sandbox persistence but before Secret metadata persistence.
-- Daytona sandbox auto-delete without runner teardown.
-- Secret deletion transient failure and retry.
-- Two cleanup workers racing on the same lease.
-- Janitor pagination beyond 200 Secrets.
+- Sandbox creation or daemon start failure after Secret creation.
+- Stop and resume with the same lease.
+- Manual archive is treated as existing, not orphaned.
+- Credential-epoch mismatch deletes the old sandbox and lease and creates fresh.
+- Runner termination before and after each persistence boundary.
+- Daytona auto-delete without runner teardown.
+- Secret deletion retry and two cleanup workers racing.
+- Listing beyond one SDK page or response limit.
+- An administrator-widened host list is restored to the exact approved set before any later
+  in-place rotation path proceeds.
 
-## Dependency upgrade checks
+## Dependency and regression checks
 
-- `pnpm test` for the runner unit suite.
-- runner TypeScript typecheck.
-- exact lockfile version, no caret drift.
-- no duplicate old/new Daytona SDK clients in the production bundle.
-- existing sandbox create, preview URL, process execution, file upload, mount, destroy, and reconnect
-  tests.
-- live Pi and Claude smoke runs on Daytona where currently supported.
-- verify self-hosted Daytona below the minimum version fails at startup capability validation, not
-  halfway through a run.
+- Runner `pnpm test` and TypeScript typecheck.
+- Python SDK agent contract tests.
+- Exact `@daytona/sdk` lockfile version and no production `@daytonaio/sdk` duplicate.
+- Existing create, preview, process, upload, mount, pause, reconnect, delete, timer, and network
+  policy tests.
+- Live Pi and Claude Daytona smoke runs where supported.
+- Unsupported self-hosted control plane fails startup capability validation.
 
-## Observability and redaction
+## Control-plane isolation
 
-Log only counts, provider class, sandbox ID where already permitted, and opaque lease ID. Never log
-Secret values, Daytona placeholders, Agenta secret slugs, Daytona Secret names, or full create
-payloads.
-
-Metrics:
-
-- Secret create/update/delete latency and failures;
-- sandbox create latency added by lease provisioning;
-- active leases and orphan leases;
-- oldest orphan age;
-- reconciliation deletions and failures;
-- provider authentication failures after rotation;
-- fail-closed counts by unsupported credential class.
+- Production uses the approved dedicated organization boundary or records explicit blast-radius
+  acceptance.
+- The runner credential has only required Daytona permissions.
+- Secret reads and audit events never return plaintext.
+- `DAYTONA_API_KEY`, Agenta/session authorization, OTLP authorization, and internal relay
+  credentials never enter a Daytona Secret or sandbox payload.
 
 ## Acceptance bar
 
-The feature is not ready based on unit tests alone. It requires live disposable-credential tests
-against the supported Daytona control plane and a deliberate runner-kill cleanup test.
+Unit tests are not sufficient. Release requires the Phase 0 adversarial live matrix, disposable
+provider and MCP credentials, a deliberate runner-kill cleanup test, and zero Daytona sandboxes and
+Agenta-owned Secrets left after the test.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/qa.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/qa.md
@@ -1,0 +1,101 @@
+# QA plan
+
+## Security assertions
+
+For every supported credential, assert the real random marker is absent from:
+
+- `env` and language runtime environment APIs;
+- `/proc/self/environ` and readable peer-process environments;
+- process arguments and process listings;
+- uploaded files, harness settings, shell history, and durable mounts;
+- sandbox-agent, harness, runner, and Daytona-visible application logs;
+- traces, errors, request echoes, and persisted session state.
+
+Assert the placeholder is present where the harness expects the credential. The test must search
+for the random plaintext marker, not only known variable names.
+
+## Network substitution matrix
+
+| Case | Expected result |
+|---|---|
+| Exact allowlisted HTTPS host | Remote host receives plaintext; sandbox sees placeholder. |
+| Different host | Remote host receives placeholder or request is rejected; never plaintext. |
+| Subdomain without wildcard | No plaintext. |
+| Explicit allowed wildcard | Works only for the documented base and subdomains. |
+| Redirect to disallowed host | No plaintext at redirect destination. |
+| Redirect from disallowed to allowed host | Confirm documented behavior; no earlier disclosure. |
+| Non-HTTPS URL | Rejected by Agenta policy. |
+| IP literal, localhost, metadata IP | Rejected before Secret creation. |
+| Alternate port | Verify host matching and ensure policy cannot be widened accidentally. |
+| DNS change or rebinding attempt | No plaintext outside the approved TLS host boundary. |
+
+## Provider matrix
+
+- OpenAI direct.
+- Anthropic direct.
+- One additional header-key provider such as Mistral or Groq.
+- Azure OpenAI with exact custom endpoint host.
+- Custom OpenAI-compatible endpoint.
+- Bedrock access-key flow, expected fail-closed.
+- Vertex service-account flow, expected fail-closed.
+- Self-managed OAuth, explicitly unchanged and not claimed secure by this feature.
+
+## Custom-secret matrix
+
+- Text bearer token with explicit HTTPS host, supported.
+- Text value used in a request body unchanged, verify substitution.
+- Flat JSON parsed locally, expected fail-closed.
+- Private key or signing secret, expected fail-closed.
+- Secret requested by no consumer, never resolved or copied.
+- Missing custom secret, run fails before sandbox creation.
+- Hostless or wildcard-all declaration, rejected.
+
+## Lifecycle matrix
+
+- Successful create, run, destroy, and Secret delete.
+- Partial multi-Secret creation failure with compensation.
+- Sandbox create failure after Secret creation.
+- Daemon start failure after sandbox creation.
+- Pause and resume with the same placeholders.
+- Stop, archive, and resume.
+- Value rotation during a parked session.
+- Host change requiring restart or fresh sandbox.
+- Runner termination before sandbox ID persistence.
+- Runner termination after sandbox persistence but before Secret metadata persistence.
+- Daytona sandbox auto-delete without runner teardown.
+- Secret deletion transient failure and retry.
+- Two cleanup workers racing on the same lease.
+- Janitor pagination beyond 200 Secrets.
+
+## Dependency upgrade checks
+
+- `pnpm test` for the runner unit suite.
+- runner TypeScript typecheck.
+- exact lockfile version, no caret drift.
+- no duplicate old/new Daytona SDK clients in the production bundle.
+- existing sandbox create, preview URL, process execution, file upload, mount, destroy, and reconnect
+  tests.
+- live Pi and Claude smoke runs on Daytona where currently supported.
+- verify self-hosted Daytona below the minimum version fails at startup capability validation, not
+  halfway through a run.
+
+## Observability and redaction
+
+Log only counts, provider class, sandbox ID where already permitted, and opaque lease ID. Never log
+Secret values, Daytona placeholders, Agenta secret slugs, Daytona Secret names, or full create
+payloads.
+
+Metrics:
+
+- Secret create/update/delete latency and failures;
+- sandbox create latency added by lease provisioning;
+- active leases and orphan leases;
+- oldest orphan age;
+- reconciliation deletions and failures;
+- provider authentication failures after rotation;
+- fail-closed counts by unsupported credential class.
+
+## Acceptance bar
+
+The feature is not ready based on unit tests alone. It requires live disposable-credential tests
+against the supported Daytona control plane and a deliberate runner-kill cleanup test.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/research.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/research.md
@@ -1,0 +1,200 @@
+# Research
+
+Research date: 2026-07-10. External behavior was checked against Daytona's current documentation,
+SDK package, npm metadata, and public source history. No live Daytona resources were created.
+
+## 1. Current Agenta behavior
+
+### TypeScript agent runner
+
+The live agent runner receives provider credentials as `AgentRunRequest.secrets`, currently
+documented as `{OPENAI_API_KEY: value, ...}`
+(`services/runner/src/protocol.ts:390-402`). The Python service fills this map from the selected
+`ResolvedConnection.env` (`sdks/python/agenta/sdk/agents/handler.py:278-307`). The connection
+resolver is already least-privilege for model credentials: it selects one connection rather than
+copying the whole provider vault.
+
+For Daytona, `daytonaEnvVars` spreads the resolved values directly into the sandbox environment
+(`services/runner/src/engines/sandbox_agent/daytona.ts:31-45`). `buildDaytonaCreate` passes that map
+as `envVars` (`services/runner/src/engines/sandbox_agent/provider.ts:78-101`). Sandbox processes can
+read the plaintext.
+
+The runner deliberately blanks its own `DAYTONA_API_KEY` and other sandbox infrastructure
+credentials before starting the daemon (`services/runner/src/engines/sandbox_agent/daemon.ts`).
+Tool callback authorization and most private tool configuration remain on the runner. The new
+design must preserve those boundaries.
+
+### Legacy Python Daytona evaluator
+
+The older Python Daytona evaluator also sends `AGENTA_API_KEY`, `AGENTA_CREDENTIALS`, and provider
+keys through `env_vars`
+(`sdks/python/agenta/sdk/engines/running/runners/daytona.py:275-301`). That path is separate from the
+TypeScript agent runner. It should not be migrated implicitly. If it remains supported, it needs a
+separate follow-up because this design explicitly keeps Agenta credentials out of Daytona Secrets.
+
+### Agenta vault and custom secrets
+
+Agenta stores vault payloads through PostgreSQL `pgp_sym_encrypt` and decrypts them only under the
+configured data-encryption context
+(`api/oss/src/dbs/postgres/secrets/custom_fields.py:12-63`). `custom_secret` supports text or flat
+JSON payloads (`api/oss/src/core/secrets/enums.py:4-14`,
+`api/oss/src/core/secrets/dtos.py:71-78`).
+
+The SDK contains a named-secret client that calls `POST /secrets/resolve`, but the current API
+vault router does not register that batch endpoint
+(`sdks/python/agenta/sdk/agents/platform/secrets.py:30-78`,
+`api/oss/src/apis/fastapi/vault/router.py:25-72`). Custom-secret delivery therefore has a backend
+prerequisite or must use an existing authorized read-by-slug path. This mismatch should be fixed
+without broadening which secrets a run may resolve.
+
+Current authored secret references are consumer-scoped:
+
+- a selected model connection resolves one provider credential;
+- MCP `secrets` maps a header or environment name to a vault secret name;
+- code-tool `secrets` names only the values that tool requested.
+
+There is no general agent-wide custom-secret list. That is a useful least-privilege property.
+
+## 2. What Daytona Secrets guarantee
+
+Daytona documents Secrets as organization-scoped, encrypted credentials. The API accepts the
+plaintext only on create or update and never returns it. The sandbox environment contains an
+opaque `dtn_secret_*` placeholder. Daytona substitutes the real value in outbound HTTP(S) traffic
+only for allowed hosts. Requests to other hosts keep the placeholder unchanged.
+
+Primary sources:
+
+- [Daytona Secrets guide](https://www.daytona.io/docs/en/secrets/)
+- [Daytona TypeScript SDK](https://www.daytona.io/docs/en/typescript-sdk/)
+- [SDK feature commit](https://github.com/daytona/clients/commit/6e763de2c7e6655d58c1371ad8ea4c48d88842d8)
+
+Important semantics:
+
+- `daytona.secret.create({name, value, hosts})` creates an organization Secret.
+- Sandbox creation accepts `secrets: {ENV_VAR: secretName}`.
+- Omitting `hosts` makes a Secret unrestricted. Agenta must never omit it.
+- Rotating a Secret preserves its placeholder and reaches attached sandboxes within about 15
+  seconds.
+- `sandbox.updateSecrets(...)` replaces the attached set, but new environment variables appear
+  only in newly spawned processes. A sandbox created with no secrets must restart before newly
+  attached secrets work.
+- Secret management needs `manage:secrets`. Sandbox creation or attachment uses
+  `write:sandboxes`. Operations appear in Daytona audit logs with masked values.
+- Daytona documents no per-Secret TTL, sandbox ownership link, automatic cascade delete, or
+  public quota for this feature. Agenta must own cleanup and verify limits in a live spike.
+
+## 3. Feasibility by credential type
+
+| Credential | Feasible with Daytona Secrets? | Reason |
+|---|---:|---|
+| OpenAI, Anthropic, Mistral, Groq, Gemini and similar API keys | Yes | Client sends the unchanged value in an HTTP header or request. |
+| Azure OpenAI API key | Yes, with a derived exact host | The selected custom endpoint supplies the destination host. |
+| Custom-provider text API key | Usually | Works when the client sends it unchanged over HTTP(S) and the endpoint host is known. |
+| Text `custom_secret` used as bearer token or API key | Yes, with an explicit consumer and hosts | The value is opaque and does not need local transformation. |
+| MCP HTTP authorization | Technically yes | The adapter must receive the placeholder, not the plaintext. Backend gateway delivery may still be safer and works across sandbox providers. |
+| AWS access key, secret key, and session token | No | AWS clients need the plaintext to compute SigV4 signatures locally. Replacing a placeholder after signing invalidates the signature. |
+| `GOOGLE_APPLICATION_CREDENTIALS` JSON or file path | No | Code must parse and use the credential locally. A placeholder is not valid JSON or a file. |
+| JSON custom secret | Not generally | Code that parses the environment value sees the placeholder. It works only if the entire JSON string is forwarded unchanged in HTTP(S). |
+| Private key, signing seed, encryption key | No | The sandbox needs plaintext for local cryptographic operations. |
+| Database password over a native database protocol | No | Daytona documents substitution for HTTP(S), not arbitrary TCP protocols. |
+| Agenta callback or API credential | Do not attach | Agenta calls should execute on the runner or backend, outside the sandbox. |
+| Scoped mount STS credentials | No | The in-sandbox mount client performs AWS signing. Keep them short-lived and prefix-scoped, or move the mount outside the sandbox. |
+
+The existing custom-provider resolver can emit both opaque keys and locally used cloud
+credentials (`sdks/python/agenta/sdk/agents/platform/connections.py:116-157`). The runner cannot
+treat every entry in `ResolvedConnection.env` alike. It must partition non-secret configuration,
+proxy-substitutable credentials, and unsupported confidential material.
+
+## 4. The organization-scope constraint
+
+Daytona does not offer a sandbox-local secret object. Every Secret is organization-scoped. The
+closest safe match to the requested behavior is an ephemeral organization Secret with a random
+name, created for one sandbox and deleted with that sandbox.
+
+The plaintext must remain stored by Daytona while the sandbox uses it. Deleting the Secret right
+after sandbox creation would remove the value the egress proxy needs. Therefore we cannot both use
+Daytona Secrets and avoid organization-scoped storage entirely.
+
+We can minimize exposure:
+
+- create one unique Secret per sandbox binding;
+- use an opaque random lease identifier and never include project, provider, or environment names
+  in the Daytona Secret name;
+- attach an exact, non-empty host allowlist;
+- keep only Secret IDs, names, hosts, and lifecycle metadata in Agenta state, never a second copy
+  of the plaintext;
+- delete after sandbox destruction;
+- reconcile orphans after crashes.
+
+The Daytona API key gains `manage:secrets`, which can create, rotate, and delete every Secret in
+its organization. This is broader and more destructive than sandbox-only permissions. A dedicated
+runner API key and a dedicated Daytona organization or environment reduce the blast radius.
+
+## 5. Lifecycle and reconnect risks
+
+The runner creates resumable Daytona sessions and stores a sandbox ID in session state
+(`services/runner/src/engines/sandbox_agent/sandbox-reconnect.ts:25-77`). A credential lease must
+live as long as that sandbox, including stopped or archived periods.
+
+The current `sandbox-agent` Daytona provider has no `pause` method. Its generic `pauseSandbox()`
+falls back to deleting the sandbox but reports successful completion to the caller. The runner then
+treats it as parked (`services/runner/node_modules/sandbox-agent/dist/providers/daytona.js:16-57`,
+`services/runner/node_modules/sandbox-agent/dist/chunk-TVCDKGSM.js:1226-1243`,
+`services/runner/src/engines/sandbox_agent.ts:808-817`). A secret implementation layered on this
+behavior could retain credentials for a sandbox that was already deleted. The current SDK adds a
+native `Sandbox.pause()` method, but the wrapper does not expose it.
+
+This is a prerequisite for reliable leases: the provider adapter must distinguish pause from
+delete and call lease cleanup only after confirmed deletion.
+
+Failure cases require saga-style compensation:
+
+1. Secret creation partly succeeds, then another Secret fails. Delete the ones already created.
+2. Secrets succeed, then sandbox creation fails. Delete all lease Secrets.
+3. Sandbox succeeds, then state persistence fails. Keep the live lease in memory and register it
+   for reconciliation; do not delete a credential out from under a live run.
+4. Runner crashes. A janitor compares Agenta-owned Daytona Secret leases with live sandboxes and
+   deletes only expired, unreferenced leases.
+5. Sandbox auto-delete runs without runner teardown. The janitor removes the orphan Secrets.
+
+## 6. SDK upgrade risk
+
+The runner pins `@daytonaio/sdk` 0.187.0 through its lockfile and uses `sandbox-agent` 0.4.2
+(`services/runner/package.json:22-35`). The old package name is deprecated in favor of
+`@daytona/sdk`.
+
+Daytona Secrets landed on 2026-06-26 and first shipped in 0.192.0. The current release checked on
+2026-07-10 is 0.196.0. The Secret list API then made a documented breaking pagination change on
+2026-07-06. This is a fast-moving API, so use an exact version rather than the current caret range.
+
+The public type diff from 0.187.0 to 0.196.0 is mostly additive for Agenta's current calls:
+
+- sandbox create adds `secrets` and `domainAllowList`;
+- `Daytona` adds `secret`;
+- `Sandbox` adds `pause`, `updateSecrets`, and `updateEnv`;
+- existing `create`, `get`, process execution, signed preview, and delete APIs remain.
+
+Risks remain:
+
+- generated API clients and OpenTelemetry dependencies change across nine releases;
+- the package namespace migration conflicts with `sandbox-agent`, which imports the deprecated
+  package name as a peer dependency;
+- self-hosted or pinned Daytona control planes older than the feature will reject Secret APIs;
+- the list API changed once already and reconciliation depends on correct pagination;
+- no current Agenta live test covers Secret creation, proxy substitution, rotation, or cleanup.
+
+Upgrade risk is medium, not high. The methods Agenta already uses remain compatible, but the new
+security guarantee depends on recently released control-plane and proxy behavior that needs live
+verification.
+
+## 7. Security limits that remain
+
+- The runner and Daytona control plane see plaintext during Secret creation or rotation.
+- The Python service-to-runner wire still contains plaintext model credentials. This project moves
+  the boundary at the sandbox, not at the sidecar transport.
+- The agent can spend or otherwise use the credential against allowed hosts.
+- An allowed host that reflects credentials could reveal them. Host allowlists must name trusted,
+  purpose-specific API hosts, not broad wildcards.
+- Redirect handling, ports, DNS rebinding, proxy logs, quota behavior, and orphan cleanup are not
+  documented deeply enough to accept without a live security spike.
+- Self-managed OAuth files uploaded into the sandbox remain readable and are outside this design.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/research.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/research.md
@@ -1,200 +1,238 @@
 # Research
 
-Research date: 2026-07-10. External behavior was checked against Daytona's current documentation,
-SDK package, npm metadata, and public source history. No live Daytona resources were created.
+Research date: 2026-07-11. Findings combine the current shared worktree, the PR base, Daytona's
+current documentation and npm packages, and provider authentication documentation. No Daytona
+resource was created for this research.
 
-## 1. Current Agenta behavior
+## 1. Current Agenta credential paths
 
-### TypeScript agent runner
+### Model connections
 
-The live agent runner receives provider credentials as `AgentRunRequest.secrets`, currently
-documented as `{OPENAI_API_KEY: value, ...}`
-(`services/runner/src/protocol.ts:390-402`). The Python service fills this map from the selected
-`ResolvedConnection.env` (`sdks/python/agenta/sdk/agents/handler.py:278-307`). The connection
-resolver is already least-privilege for model credentials: it selects one connection rather than
-copying the whole provider vault.
+The Python connection resolver selects one model connection and returns `ResolvedConnection.env`.
+The agent handler copies that map into `SessionConfig.secrets`, and the TypeScript runner receives
+it as `AgentRunRequest.secrets`.
 
-For Daytona, `daytonaEnvVars` spreads the resolved values directly into the sandbox environment
-(`services/runner/src/engines/sandbox_agent/daytona.ts:31-45`). `buildDaytonaCreate` passes that map
-as `envVars` (`services/runner/src/engines/sandbox_agent/provider.ts:78-101`). Sandbox processes can
-read the plaintext.
+Relevant code:
 
-The runner deliberately blanks its own `DAYTONA_API_KEY` and other sandbox infrastructure
-credentials before starting the daemon (`services/runner/src/engines/sandbox_agent/daemon.ts`).
-Tool callback authorization and most private tool configuration remain on the runner. The new
-design must preserve those boundaries.
+- `sdks/python/agenta/sdk/agents/platform/connections.py`
+- `sdks/python/agenta/sdk/agents/handler.py`
+- `services/runner/src/protocol.ts`
 
-### Legacy Python Daytona evaluator
+The resolver already separates non-secret endpoint configuration from the credential map. Custom
+and Azure connections can carry `endpoint.baseUrl`, API version, and region. Standard direct
+providers do not always carry an explicit effective base URL, which leaves the runner without an
+authoritative exact host.
 
-The older Python Daytona evaluator also sends `AGENTA_API_KEY`, `AGENTA_CREDENTIALS`, and provider
-keys through `env_vars`
-(`sdks/python/agenta/sdk/engines/running/runners/daytona.py:275-301`). That path is separate from the
-TypeScript agent runner. It should not be migrated implicitly. If it remains supported, it needs a
-separate follow-up because this design explicitly keeps Agenta credentials out of Daytona Secrets.
+The current runner applies resolved provider values to the selected daemon environment. Daytona's
+`buildDaytonaCreate` then calls `daytonaEnvVars`, which spreads those values into sandbox
+`envVars`. They are plaintext inside the sandbox.
 
-### Agenta vault and custom secrets
+Before building the daemon environment, the runner sets known sandbox-infrastructure variables,
+including `DAYTONA_API_KEY`, to the empty string. "Empty" means an explicit `KEY=""` override. An
+absent entry would inherit the runner process value through the underlying spawn. This prevents the
+runner's Daytona credential from leaking into either local or remote harness processes.
 
-Agenta stores vault payloads through PostgreSQL `pgp_sym_encrypt` and decrypts them only under the
-configured data-encryption context
-(`api/oss/src/dbs/postgres/secrets/custom_fields.py:12-63`). `custom_secret` supports text or flat
-JSON payloads (`api/oss/src/core/secrets/enums.py:4-14`,
-`api/oss/src/core/secrets/dtos.py:71-78`).
+### HTTP MCP credentials
 
-The SDK contains a named-secret client that calls `POST /secrets/resolve`, but the current API
-vault router does not register that batch endpoint
-(`sdks/python/agenta/sdk/agents/platform/secrets.py:30-78`,
-`api/oss/src/apis/fastapi/vault/router.py:25-72`). Custom-secret delivery therefore has a backend
-prerequisite or must use an existing authorized read-by-slug path. This mismatch should be fixed
-without broadening which secrets a run may resolve.
+The authored MCP shape already ties a secret reference to a consumer:
 
-Current authored secret references are consumer-scoped:
+```text
+mcp server -> url + secrets {header name: vault secret name}
+```
 
-- a selected model connection resolves one provider credential;
-- MCP `secrets` maps a header or environment name to a vault secret name;
-- code-tool `secrets` names only the values that tool requested.
+The current resolver fetches all requested values, then merges them into `ResolvedMCPServer.env`.
+The runner interprets every HTTP MCP `env` entry as an ACP request header. This has two problems for
+Daytona isolation:
 
-There is no general agent-wide custom-secret list. That is a useful least-privilege property.
+1. secret and non-secret values lose their classification after the merge;
+2. plaintext travels in ACP session configuration to the in-sandbox harness.
 
-## 2. What Daytona Secrets guarantee
+The MCP URL is already the right host source. `validateUserMcpUrl` requires HTTPS, resolves DNS,
+and blocks loopback, private, link-local, metadata, and disallowed IP targets before attaching
+credentials. A revised resolved MCP contract can keep credential headers separate and derive the
+exact host from the validated URL without adding another public host field.
 
-Daytona documents Secrets as organization-scoped, encrypted credentials. The API accepts the
-plaintext only on create or update and never returns it. The sandbox environment contains an
-opaque `dtn_secret_*` placeholder. Daytona substitutes the real value in outbound HTTP(S) traffic
-only for allowed hosts. Requests to other hosts keep the placeholder unchanged.
+Relevant code:
+
+- `sdks/python/agenta/sdk/agents/mcp/resolver.py`
+- `sdks/python/agenta/sdk/agents/mcp/models.py`
+- `services/runner/src/engines/sandbox_agent/mcp.ts`
+
+The missing-secret policy already defaults to error. The full path must preserve that behavior for
+missing names, empty resolved values, authorization failures, and resolver request failures before
+sandbox creation.
+
+### Other secrets
+
+Custom tools execute through runner-side callbacks and file relays. Their private callback
+configuration does not need to enter Daytona. There is no valid reason to expose an agent-wide
+project vault. The first custom-secret use that belongs in this project is an HTTP MCP credential
+or another explicit in-sandbox HTTP consumer with its own route.
+
+The legacy Python evaluator is outside this project's scope.
+
+## 2. Daytona Secret semantics
+
+Daytona documents Secrets as organization-scoped credentials that are encrypted at rest. The
+plaintext is accepted on create or update and is never returned by Secret reads. A sandbox sees an
+opaque `dtn_secret_*` placeholder. The outbound proxy substitutes plaintext only when an HTTP(S)
+request carrying that placeholder targets an allowed host.
 
 Primary sources:
 
 - [Daytona Secrets guide](https://www.daytona.io/docs/en/secrets/)
-- [Daytona TypeScript SDK](https://www.daytona.io/docs/en/typescript-sdk/)
-- [SDK feature commit](https://github.com/daytona/clients/commit/6e763de2c7e6655d58c1371ad8ea4c48d88842d8)
+- [Daytona TypeScript Secret API](https://www.daytona.io/docs/en/typescript-sdk/secret/)
+- [Daytona SDK feature commit](https://github.com/daytona/clients/commit/6e763de2c7e6655d58c1371ad8ea4c48d88842d8)
 
-Important semantics:
+Important details:
 
-- `daytona.secret.create({name, value, hosts})` creates an organization Secret.
-- Sandbox creation accepts `secrets: {ENV_VAR: secretName}`.
-- Omitting `hosts` makes a Secret unrestricted. Agenta must never omit it.
-- Rotating a Secret preserves its placeholder and reaches attached sandboxes within about 15
-  seconds.
-- `sandbox.updateSecrets(...)` replaces the attached set, but new environment variables appear
-  only in newly spawned processes. A sandbox created with no secrets must restart before newly
-  attached secrets work.
-- Secret management needs `manage:secrets`. Sandbox creation or attachment uses
-  `write:sandboxes`. Operations appear in Daytona audit logs with masked values.
-- Daytona documents no per-Secret TTL, sandbox ownership link, automatic cascade delete, or
-  public quota for this feature. Agenta must own cleanup and verify limits in a live spike.
+- Secret names are unique within an organization.
+- Sandbox creation accepts `secrets: {ENVIRONMENT_NAME: secretName}`.
+- Omitting `hosts` creates an unrestricted Secret. Agenta must never omit the field on create.
+- Daytona supports exact hosts and `*.` wildcards. Agenta can apply a stricter policy and reject all
+  wildcards in the first version.
+- Host entries contain only hostnames, without protocol, path, port, or query.
+- Updating a value keeps the placeholder stable and propagates within about 15 seconds.
+- Update uses PATCH semantics. Omitted fields remain unchanged. Omitting `hosts` on update does not
+  itself remove the allowlist.
+- A later Agenta rotation path should still resend and verify the approved exact host list. This
+  repairs a Secret that an organization administrator may have widened outside the runner.
+- Secret management requires `manage:secrets`; sandbox attachment requires sandbox permissions.
+- Create, update, and delete operations appear in audit logs with masked values.
+- Daytona documents no Secret TTL, per-sandbox Secret ownership, cascade delete, or public quota.
 
-## 3. Feasibility by credential type
+Daytona's examples inject the placeholder through an environment mapping. The documentation says
+the proxy inspects outbound requests that carry a placeholder, but it does not demonstrate a
+placeholder placed directly into ACP HTTP MCP headers. That exact path is a live-spike gate.
 
-| Credential | Feasible with Daytona Secrets? | Reason |
+## 3. Where exact hosts come from
+
+The destination belongs to the consumer, not the vault entry.
+
+| Consumer | Current route source | Required change |
+|---|---|---|
+| Custom model provider | `ResolvedConnection.endpoint.baseUrl` | Parse and use its exact hostname. |
+| Azure OpenAI | Configured endpoint base URL | Parse and use its exact hostname. |
+| HTTP MCP | `ResolvedMCPServer.url` | Use after the existing SSRF validation. |
+| Standard direct provider | Often implicit in the client | Resolver emits the effective endpoint. |
+| Bedrock bearer token | Region plus AWS partition and runtime endpoint | Resolver emits the effective regional endpoint. |
+
+A runner-only provider-host registry is possible but weaker. It duplicates routing knowledge and
+can diverge from custom SDK behavior, regional endpoints, sovereign partitions, or a user-selected
+base URL. The resolved connection should carry the actual endpoint used by the harness.
+
+Redirects remain a live security question. An exact original host is not sufficient if Daytona
+substitutes the credential again after a cross-host redirect. Phase 0 must test this.
+
+## 4. Feasibility by credential shape
+
+| Credential | Daytona isolation | Evidence and constraint |
 |---|---:|---|
-| OpenAI, Anthropic, Mistral, Groq, Gemini and similar API keys | Yes | Client sends the unchanged value in an HTTP header or request. |
-| Azure OpenAI API key | Yes, with a derived exact host | The selected custom endpoint supplies the destination host. |
-| Custom-provider text API key | Usually | Works when the client sends it unchanged over HTTP(S) and the endpoint host is known. |
-| Text `custom_secret` used as bearer token or API key | Yes, with an explicit consumer and hosts | The value is opaque and does not need local transformation. |
-| MCP HTTP authorization | Technically yes | The adapter must receive the placeholder, not the plaintext. Backend gateway delivery may still be safer and works across sandbox providers. |
-| AWS access key, secret key, and session token | No | AWS clients need the plaintext to compute SigV4 signatures locally. Replacing a placeholder after signing invalidates the signature. |
-| `GOOGLE_APPLICATION_CREDENTIALS` JSON or file path | No | Code must parse and use the credential locally. A placeholder is not valid JSON or a file. |
-| JSON custom secret | Not generally | Code that parses the environment value sees the placeholder. It works only if the entire JSON string is forwarded unchanged in HTTP(S). |
-| Private key, signing seed, encryption key | No | The sandbox needs plaintext for local cryptographic operations. |
-| Database password over a native database protocol | No | Daytona documents substitution for HTTP(S), not arbitrary TCP protocols. |
-| Agenta callback or API credential | Do not attach | Agenta calls should execute on the runner or backend, outside the sandbox. |
-| Scoped mount STS credentials | No | The in-sandbox mount client performs AWS signing. Keep them short-lived and prefix-scoped, or move the mount outside the sandbox. |
+| OpenAI, Anthropic, Mistral, Groq, Gemini API keys | Yes | The unchanged key enters an HTTP header and the provider host is known. |
+| Azure OpenAI API key | Yes | Microsoft documents the unchanged key in the `api-key` header; the configured endpoint supplies the host. |
+| Custom-provider API key | Usually | Requires an HTTPS endpoint and an unchanged header or body value. |
+| HTTP MCP authorization | Candidate | URL supplies the host; direct ACP-header placeholder substitution needs a live proof. |
+| Bedrock API key in `AWS_BEARER_TOKEN_BEDROCK` | Candidate | AWS documents `Authorization: Bearer` for regional Bedrock Runtime HTTP requests. |
+| AWS access key, secret key, and session token | No | The SDK needs plaintext locally to calculate SigV4. |
+| Vertex service-account or ADC configuration | No | `GOOGLE_APPLICATION_CREDENTIALS` points to credential JSON used to mint OAuth tokens locally. |
+| Vertex API key | Candidate later | Google documents API-key authentication for some Vertex Gemini paths, but Agenta's current Vertex connection is ADC-shaped. |
+| JSON parsed by sandbox code | No | Code sees a placeholder, not parseable JSON. |
+| Private key, signing seed, encryption key | No | Local cryptographic use requires plaintext. |
+| Native database password | No | Daytona documents HTTP(S) substitution, not arbitrary database protocols. |
 
-The existing custom-provider resolver can emit both opaque keys and locally used cloud
-credentials (`sdks/python/agenta/sdk/agents/platform/connections.py:116-157`). The runner cannot
-treat every entry in `ResolvedConnection.env` alike. It must partition non-secret configuration,
-proxy-substitutable credentials, and unsupported confidential material.
+Provider sources:
 
-## 4. The organization-scope constraint
+- [AWS Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html)
+- [Google Application Default Credentials](https://docs.cloud.google.com/docs/authentication/application-default-credentials)
+- [Vertex AI quickstart authentication choices](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/quickstart)
+- [Azure OpenAI REST authentication](https://learn.microsoft.com/en-us/azure/foundry/openai/reference)
 
-Daytona does not offer a sandbox-local secret object. Every Secret is organization-scoped. The
-closest safe match to the requested behavior is an ephemeral organization Secret with a random
-name, created for one sandbox and deleted with that sandbox.
+The current Agenta resolver supports both Bedrock bearer tokens and SigV4 environment fields. They
+must not share one classification. The bearer token can be proxy-substituted if its endpoint is
+known and the harness sends it unchanged. The access-key triple cannot.
 
-The plaintext must remain stored by Daytona while the sandbox uses it. Deleting the Secret right
-after sandbox creation would remove the value the egress proxy needs. Therefore we cannot both use
-Daytona Secrets and avoid organization-scoped storage entirely.
+A proxy is the only general way to keep local-use signing or service-account material completely
+outside the sandbox. Provider-specific bearer or API-key modes can avoid the proxy. Short-lived
+credentials, workload federation, restricted IAM, and process hardening reduce exposure but do not
+stop the agent from reading a token or key that its own process must use.
 
-We can minimize exposure:
+## 5. Current lifecycle implementation
 
-- create one unique Secret per sandbox binding;
-- use an opaque random lease identifier and never include project, provider, or environment names
-  in the Daytona Secret name;
-- attach an exact, non-empty host allowlist;
-- keep only Secret IDs, names, hosts, and lifecycle metadata in Agenta state, never a second copy
-  of the plaintext;
-- delete after sandbox destruction;
-- reconcile orphans after crashes.
+The active warm-Daytona worktree has moved beyond the earlier design assumptions:
 
-The Daytona API key gains `manage:secrets`, which can create, rotate, and delete every Secret in
-its organization. This is broader and more destructive than sandbox-only permissions. A dedicated
-runner API key and a dedicated Daytona organization or environment reduce the blast radius.
+- `services/runner/src/engines/sandbox_agent/daytona-provider.ts` wraps the vendored provider and
+  implements state-aware `pause`, `reconnect`, and `deleteSandbox` with the Daytona client.
+- `services/runner/src/engines/sandbox_agent/provider.ts` sets `ephemeral: false`, a 15-minute
+  auto-stop, and a 30-minute auto-delete. It no longer sets `autoArchiveInterval`.
+- `services/runner/src/engines/sandbox_agent/teardown.ts` distinguishes stop from delete.
+- the `sandbox-agent@0.4.2` patch fixes vendored session and process cleanup behavior. Secret
+  lifecycle does not belong in that patch.
 
-## 5. Lifecycle and reconnect risks
+These are concurrent implementation-lane changes, not part of this design PR. Secret delivery
+should extend the runner-owned provider boundary after that work lands. It should not wait for or
+require an upstream sandbox-agent change.
 
-The runner creates resumable Daytona sessions and stores a sandbox ID in session state
-(`services/runner/src/engines/sandbox_agent/sandbox-reconnect.ts:25-77`). A credential lease must
-live as long as that sandbox, including stopped or archived periods.
+The lifecycle ladder is running, stopped, then deleted. Reconciliation must still recognize a
+manually or provider-archived sandbox as existing, but Agenta does not intentionally archive one.
 
-The current `sandbox-agent` Daytona provider has no `pause` method. Its generic `pauseSandbox()`
-falls back to deleting the sandbox but reports successful completion to the caller. The runner then
-treats it as parked (`services/runner/node_modules/sandbox-agent/dist/providers/daytona.js:16-57`,
-`services/runner/node_modules/sandbox-agent/dist/chunk-TVCDKGSM.js:1226-1243`,
-`services/runner/src/engines/sandbox_agent.ts:808-817`). A secret implementation layered on this
-behavior could retain credentials for a sandbox that was already deleted. The current SDK adds a
-native `Sandbox.pause()` method, but the wrapper does not expose it.
+The current keepalive path also tracks a credential epoch. A changed epoch makes a reusable
+session incompatible. The simplest safe first version deletes the old sandbox and lease and
+provisions fresh instead of updating a live Secret and waiting for propagation.
 
-This is a prerequisite for reliable leases: the provider adapter must distinguish pause from
-delete and call lease cleanup only after confirmed deletion.
+## 6. Lease and organization risks
 
-Failure cases require saga-style compensation:
+Daytona has no sandbox-local Secret object. The closest boundary is one random organization Secret
+per sandbox credential binding, retained as long as the sandbox can resume and deleted afterward.
 
-1. Secret creation partly succeeds, then another Secret fails. Delete the ones already created.
-2. Secrets succeed, then sandbox creation fails. Delete all lease Secrets.
-3. Sandbox succeeds, then state persistence fails. Keep the live lease in memory and register it
-   for reconciliation; do not delete a credential out from under a live run.
-4. Runner crashes. A janitor compares Agenta-owned Daytona Secret leases with live sandboxes and
-   deletes only expired, unreferenced leases.
-5. Sandbox auto-delete runs without runner teardown. The janitor removes the orphan Secrets.
+The lease record needs sandbox ID, Secret IDs and opaque names, exact hosts, binding metadata,
+state, and timestamps. It must not store plaintext or user-facing vault names. A durable record is
+required for crash reconciliation; process memory alone is insufficient.
 
-## 6. SDK upgrade risk
+`manage:secrets` can manage every Secret in the organization. A dedicated API key prevents sharing
+the runner credential with other services but does not narrow its object scope. A dedicated
+Daytona organization for Agenta sandboxes is the strongest available documented boundary. A shared
+organization requires explicit acceptance of the broader blast radius.
 
-The runner pins `@daytonaio/sdk` 0.187.0 through its lockfile and uses `sandbox-agent` 0.4.2
-(`services/runner/package.json:22-35`). The old package name is deprecated in favor of
-`@daytona/sdk`.
+Failure compensation must cover:
 
-Daytona Secrets landed on 2026-06-26 and first shipped in 0.192.0. The current release checked on
-2026-07-10 is 0.196.0. The Secret list API then made a documented breaking pagination change on
-2026-07-06. This is a fast-moving API, so use an exact version rather than the current caret range.
+1. partial Secret creation;
+2. sandbox creation failure after Secret creation;
+3. sandbox success followed by lease persistence failure;
+4. runner crash at each boundary;
+5. sandbox auto-delete without runner teardown;
+6. Secret deletion failure and concurrent janitor retries.
 
-The public type diff from 0.187.0 to 0.196.0 is mostly additive for Agenta's current calls:
+## 7. SDK upgrade state and risk
 
-- sandbox create adds `secrets` and `domainAllowList`;
-- `Daytona` adds `secret`;
-- `Sandbox` adds `pause`, `updateSecrets`, and `updateEnv`;
-- existing `create`, `get`, process execution, signed preview, and delete APIs remain.
+The runner currently declares `@daytonaio/sdk` with `^0.187.0`; its lockfile resolves 0.187.0. It
+also uses `sandbox-agent` 0.4.2. The active worktree has not upgraded the Daytona package.
 
-Risks remain:
+On 2026-07-11, npm reports:
 
-- generated API clients and OpenTelemetry dependencies change across nine releases;
-- the package namespace migration conflicts with `sandbox-agent`, which imports the deprecated
-  package name as a peer dependency;
-- self-hosted or pinned Daytona control planes older than the feature will reject Secret APIs;
-- the list API changed once already and reconciliation depends on correct pagination;
-- no current Agenta live test covers Secret creation, proxy substitution, rotation, or cleanup.
+- `@daytona/sdk` current version: 0.196.0;
+- `@daytonaio/sdk` current version: 0.196.0 and deprecated in favor of `@daytona/sdk`;
+- the deprecation message states that the package move keeps the same API;
+- Daytona Secrets first shipped in 0.192.0.
 
-Upgrade risk is medium, not high. The methods Agenta already uses remain compatible, but the new
-security guarantee depends on recently released control-plane and proxy behavior that needs live
-verification.
+The upgrade remains medium risk. Secret APIs, native pause, and attachment are additive for the
+calls Agenta uses, but nine releases change generated clients and transitive dependencies. The
+package also changed Secret list behavior during this fast release sequence. Pin one exact version,
+remove the old package, test for duplicate clients, and verify the actual self-hosted control plane.
 
-## 7. Security limits that remain
+The upgrade must preserve snapshot/image selection, target routing, network policy fields, signed
+preview, process execution, file operations, mounts, state transitions, and deletion. Unit tests
+cannot replace a live Daytona smoke.
 
-- The runner and Daytona control plane see plaintext during Secret creation or rotation.
-- The Python service-to-runner wire still contains plaintext model credentials. This project moves
-  the boundary at the sandbox, not at the sidecar transport.
-- The agent can spend or otherwise use the credential against allowed hosts.
-- An allowed host that reflects credentials could reveal them. Host allowlists must name trusted,
-  purpose-specific API hosts, not broad wildcards.
-- Redirect handling, ports, DNS rebinding, proxy logs, quota behavior, and orphan cleanup are not
-  documented deeply enough to accept without a live security spike.
-- Self-managed OAuth files uploaded into the sandbox remain readable and are outside this design.
+## 8. Security limits
+
+Daytona Secrets prevent the sandbox from reading supported plaintext, but they do not make Agenta
+or Daytona unable to access it:
+
+- Agenta's authorized vault layer decrypts the value.
+- The runner handles it transiently in the create request.
+- Daytona stores an encrypted copy and performs egress substitution.
+- Daytona's API does not return the plaintext after creation.
+
+If the requirement includes hiding plaintext from Agenta operators or the runner process, this
+architecture is insufficient. It would require client-side encryption to a trusted execution
+boundary or a provider authorization flow that never gives Agenta the credential.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/status.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/status.md
@@ -2,55 +2,37 @@
 
 ## Phase
 
-Research and plan complete. Design-only. The planning workspace is committed on
-`docs/daytona-secret-delivery` for a draft PR. No implementation, dependency update, or Daytona
-resource was created.
+Design-only. The recommended architecture is defined, but implementation is blocked on the
+questions in `open-questions.md` and the Phase 0 Daytona security spike.
 
 ## Recommendation
 
-Proceed with a live security spike, then implement per-sandbox ephemeral Daytona organization
-Secrets for direct HTTP credentials on Daytona.
+Use one consumer-owned resolved credential contract for local and Daytona. On Daytona, materialize
+opaque HTTP credentials as per-sandbox organization Secrets with exact host policies. On local,
+materialize the same contract with current plaintext behavior and make the weaker boundary clear.
 
-The requested "not an organization Secret" property is not available in Daytona's model. Secrets
-are organization-scoped by definition and must remain there while the sandbox uses them. The safe
-approximation is a unique random Secret per sandbox binding, exact host allowlists, no descriptive
-metadata, and deterministic cleanup.
+Support direct model keys, Azure and custom-provider keys, and HTTP MCP authorization when the
+consumer supplies an effective HTTPS route. Treat Bedrock bearer tokens as a live-spike candidate.
+Do not group them with SigV4 credentials. Keep SigV4 and Vertex service-account flows as an
+explicit non-isolated mode or route them through a gateway.
 
-## Decisions captured
+## Current technical constraints
 
-- Agenta vault remains the source of truth.
-- Do not mirror the whole vault into Daytona.
-- Do not put Agenta control-plane credentials into Daytona Secrets.
-- Use Daytona substitution only for unchanged HTTP(S) credentials.
-- Reject unsupported credential shapes instead of falling back to plaintext.
-- Keep destination policy attached to the credential use, not in a separate loose map.
-- Pin an exact Daytona SDK version.
-- Own the small Daytona provider adapter in Agenta so create, pause, destroy, and Secret cleanup
-  share one lifecycle.
-- Retain leases across resume and delete them only after confirmed sandbox deletion.
+- The runner still sends model credentials as plaintext Daytona `envVars`.
+- The MCP resolver merges secret values into `env`, and the runner turns HTTP MCP `env` entries
+  into plaintext headers. The new contract must keep credential headers distinct.
+- The active warm-Daytona worktree has a runner-owned lifecycle wrapper with native pause,
+  reconnect, and delete, and it removes Agenta auto-archive configuration. Secret lifecycle should
+  build on that boundary rather than add an upstream patch.
+- The runner still uses `@daytonaio/sdk` 0.187.0. Daytona Secrets require at least 0.192.0; the
+  current package observed on 2026-07-11 is `@daytona/sdk` 0.196.0.
+- Daytona Secrets remain organization-scoped and require organization-wide `manage:secrets`.
+- Agenta's named-secret SDK client and current backend resolution surface still need alignment for
+  fail-closed custom-secret resolution.
 
-## Important blockers and risks
+## Implementation gate
 
-1. Daytona Secrets is recent and needs a live adversarial spike before adoption.
-2. Daytona publishes no documented Secret quota or automatic TTL/cascade behavior.
-3. The runner's Daytona API key needs broad `manage:secrets` permission.
-4. The current sandbox-agent Daytona provider does not implement native pause.
-5. The current Agenta named-secret SDK client calls a batch endpoint absent from the vault router.
-6. Bedrock, Vertex service-account, signing, JSON, and native-protocol credentials cannot use
-   placeholder substitution.
-7. Local sandboxes remain unsolved by this feature.
-
-## Decision needed before implementation
-
-Approve or reject the recommended first scope:
-
-> Phase 0 security spike plus standard direct model API keys and exact-host custom-provider API
-> keys on Daytona. Custom text secrets follow only after the explicit consumer and host-policy
-> contract is reviewed.
-
-This scope proves the security boundary without introducing a generic agent secret surface.
-
-## Next action
-
-Review this workspace. If approved, open a design PR based on `big-agents` with the Phase 0 spike
-and Phase 1 dependency/provider work as the first implementation milestone.
+Before implementation starts, decide the production organization boundary, unsupported-cloud
+policy, endpoint ownership, durable lease store, public isolation requirement, Vertex API-key
+scope, and exact Daytona version. Then run Phase 0. No production code should assume direct HTTP
+MCP placeholder substitution until the live test proves it.

--- a/docs/design/agent-workflows/projects/daytona-secret-delivery/status.md
+++ b/docs/design/agent-workflows/projects/daytona-secret-delivery/status.md
@@ -1,0 +1,56 @@
+# Status
+
+## Phase
+
+Research and plan complete. Design-only. The planning workspace is committed on
+`docs/daytona-secret-delivery` for a draft PR. No implementation, dependency update, or Daytona
+resource was created.
+
+## Recommendation
+
+Proceed with a live security spike, then implement per-sandbox ephemeral Daytona organization
+Secrets for direct HTTP credentials on Daytona.
+
+The requested "not an organization Secret" property is not available in Daytona's model. Secrets
+are organization-scoped by definition and must remain there while the sandbox uses them. The safe
+approximation is a unique random Secret per sandbox binding, exact host allowlists, no descriptive
+metadata, and deterministic cleanup.
+
+## Decisions captured
+
+- Agenta vault remains the source of truth.
+- Do not mirror the whole vault into Daytona.
+- Do not put Agenta control-plane credentials into Daytona Secrets.
+- Use Daytona substitution only for unchanged HTTP(S) credentials.
+- Reject unsupported credential shapes instead of falling back to plaintext.
+- Keep destination policy attached to the credential use, not in a separate loose map.
+- Pin an exact Daytona SDK version.
+- Own the small Daytona provider adapter in Agenta so create, pause, destroy, and Secret cleanup
+  share one lifecycle.
+- Retain leases across resume and delete them only after confirmed sandbox deletion.
+
+## Important blockers and risks
+
+1. Daytona Secrets is recent and needs a live adversarial spike before adoption.
+2. Daytona publishes no documented Secret quota or automatic TTL/cascade behavior.
+3. The runner's Daytona API key needs broad `manage:secrets` permission.
+4. The current sandbox-agent Daytona provider does not implement native pause.
+5. The current Agenta named-secret SDK client calls a batch endpoint absent from the vault router.
+6. Bedrock, Vertex service-account, signing, JSON, and native-protocol credentials cannot use
+   placeholder substitution.
+7. Local sandboxes remain unsolved by this feature.
+
+## Decision needed before implementation
+
+Approve or reject the recommended first scope:
+
+> Phase 0 security spike plus standard direct model API keys and exact-host custom-provider API
+> keys on Daytona. Custom text secrets follow only after the explicit consumer and host-policy
+> contract is reviewed.
+
+This scope proves the security boundary without introducing a generic agent secret surface.
+
+## Next action
+
+Review this workspace. If approved, open a design PR based on `big-agents` with the Phase 0 spike
+and Phase 1 dependency/provider work as the first implementation milestone.


### PR DESCRIPTION
## Context

The runner currently resolves model-provider API keys and passes them to Daytona sandboxes as plaintext environment variables. That makes the values readable from the agent process and shell. Daytona Secrets can reduce direct exposure through proxy-side substitution, but their organization scope, resource lifecycle, host matching, and credential-format limits require explicit controls.

This PR is design-only. It does not update the Daytona SDK, create Daytona resources, or change runtime behavior.

## Proposed direction

- Create ephemeral per-sandbox Daytona organization Secret leases only for the exact credentials required by that run.
- Use exact, non-empty HTTP(S) host allowlists and opaque credential substitution.
- Never sync the whole Agenta vault or expose Agenta control-plane credentials.
- Fail closed for unsupported signing, structured JSON, native-protocol, or ambiguous custom-secret cases.
- Require a live security spike, pinned SDK behavior, crash cleanup, and a janitor before rollout.

## How to review

1. Start with `README.md` and `context.md` for scope and threat model.
2. Check `research.md` for Daytona feasibility, SDK upgrade risk, and open evidence gaps.
3. Review `design.md` for the delivery contract and lease lifecycle.
4. Review `plan.md` and `qa.md` for implementation slices and exit gates.

## Validation

- Confirmed the branch diff contains exactly the seven planning files under `docs/design/agent-workflows/projects/daytona-secret-delivery/`.
- `git diff --check` passes.
- No runtime tests were run because this PR changes documentation only.

## Decision requested

Please confirm whether the first implementation scope should include the Phase 0 security spike plus standard direct model-provider keys and exact-host custom-provider keys. Custom text secrets remain out of scope until each consumer and destination-host policy is explicit.