### PR TITLE
fix(runner): pin Daytona Pi ACP adapter parity

### DIFF
--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/context.md
@@ -55,7 +55,7 @@ request to forward.
 - The snapshot recipe inherits private ACP adapter installations from its base image.
   Installing only the standalone Pi CLI does not update `pi-acp`.
 - `sandbox-agent` prefers its private adapter launcher under
-  `/home/sandbox/.local/share/sandbox-agent/agent_processes/`. A global npm install alone
+  `/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/`. A global npm install alone
   is not a reliable fix.
 - A live permission continuation exists only while the sandbox, adapter process, ACP
   connection, permission id, and prompt promise remain alive.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/plan.md
@@ -4,6 +4,18 @@ This plan implements Option A from [options.md](options.md): update the Daytona 
 private Pi ACP adapter, keep the existing ACP permission plane, and verify live and cold
 approval behavior. It does not add a file-gate protocol or an injected policy map.
 
+## Implementation checkpoint
+
+The snapshot recipe now pins the private Pi ACP adapter to 0.0.29 and asserts the
+actual private launcher and package under
+`/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/`. The named
+`agenta-sandbox-pi` snapshot was force-rebuilt successfully on 2026-07-11.
+
+Focused Daytona verification passed allow-mode Bash and deny-mode Bash. Ask mode produced
+a real `interaction_request` immediately, which proves the repaired adapter emitted
+`session/request_permission` through the existing ACP HTTP/SSE path. The supported UI
+approve/reject continuation and Claude control remain follow-up checks.
+
 ## Phase 0: confirm the deployed version
 
 - Create one short-lived Daytona sandbox from the currently selected
@@ -29,7 +41,7 @@ Change `services/runner/sandbox-images/daytona/build_snapshot.py`:
   ```
 
 - Add a build-time assertion against the private adapter installation under
-  `/home/sandbox/.local/share/sandbox-agent/agent_processes/`. The assertion must prove the
+  `/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/`. The assertion must prove the
   resolved adapter is exactly 0.0.29.
 - Keep the standalone Pi CLI pin at 0.80.6. The CLI and ACP adapter are different
   dependencies with different responsibilities.

--- a/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
+++ b/docs/design/agent-workflows/projects/daytona-gate-delivery/status.md
@@ -2,71 +2,67 @@
 
 ## Current state
 
-Design revised after owner review. No implementation code changed. Research identified the
-root cause as Pi ACP adapter version skew, not Daytona preview-proxy behavior.
+Implementation is ready for review on the stacked fix branch. The Daytona snapshot recipe
+now replaces the base image's private Pi ACP adapter with version 0.0.29, verifies the
+private launcher and package version during the build, and keeps the standalone Pi CLI at
+0.80.6.
 
-The checked-in snapshot recipe inherits `pi-acp` 0.0.23 from
-`rivetdev/sandbox-agent:0.5.0-rc.2-full`; local runs use the repo-pinned 0.0.29. Version
-0.0.23 predates the extension UI permission bridge. The proposed fix is now a snapshot
-dependency pin and rebuild.
+The named `agenta-sandbox-pi` snapshot was force-rebuilt on 2026-07-11. Daytona reported
+the snapshot as active after 96.4 seconds.
+
+## Live verification
+
+- Snapshot build: passed. The installer reported private `pi-acp` 0.0.29 at
+  `/home/sandbox/.local/share/sandbox-agent/bin/agent_processes/pi-acp`.
+- Build assertion: passed with `pi-acp-version=0.0.29`.
+- Pi core, allow mode, Bash: passed on Daytona. The command returned
+  `QA-BASH-x86_64`.
+- Pi core, deny mode, Bash: passed on Daytona. The runner returned
+  `Denied by the permission policy.` and the command did not execute.
+- Pi core, ask mode: the runner returned a real `interaction_request` instead of
+  hanging. This proves the adapter now emits the ACP permission request.
+- Sandbox hygiene: zero live sandboxes before the matrix and zero after it.
+- Live Agenta deployments: the EE health endpoint on port 8280 and the OSS health endpoint
+  on port 8290 both returned `{"status":"ok"}`.
+
+The supported playground approve and reject clicks, the cold approval replay, the
+`pi_agenta` opening skill read, and the Claude Daytona control remain to be completed.
+Two hand-built raw API resume payloads re-prompted rather than consuming the approval.
+That result is not enough to call a product regression because the payloads did not come
+from the supported UI client.
 
 ## Decisions
 
-- Option A is the primary correctness fix.
-- Option A means adapter parity, not a Daytona proxy rewrite.
+- Option A is implemented as adapter parity. No file permission protocol or policy map was
+  added.
 - ACP remains the only permission plane for Pi builtins on local and Daytona.
-- Option B is not planned. It opens only if a fresh, corrected adapter emits a permission
-  request that a focused transport probe proves is lost after emission.
-- Option C does not depend on Option B. It is deferred as a separate latency optimization.
-- Live and cold approval are separate lifecycle paths:
-  - live answers the held ACP permission id and continues the original call;
-  - cold stores the human decision, recreates or reloads, and answers the reissued call.
-- A file relay cannot preserve a pending RPC after the process holding it has stopped.
-- F-018's evidence applies to Pi. Claude ask on Daytona needs its own control run.
-- Pi custom and gateway tools use the extension execution relay, not user MCP.
+- The build checks the private sandbox-agent installation, not a global npm package.
+- The correct v0.5.0-rc.2 private install root contains `/bin/agent_processes/`. The
+  earlier design text omitted `/bin`; this implementation corrects it.
+- Existing sandboxes created before the snapshot rebuild retain their old filesystem and
+  must be drained before rollout verification.
 
-## Evidence
+## Verification commands
 
-- `services/runner/package.json` pins local `pi-acp` 0.0.29.
-- `services/runner/src/engines/sandbox_agent/daemon.ts` puts the local runner dependency on
-  the daemon `PATH`.
-- `services/runner/sandbox-images/daytona/build_snapshot.py` inherits ACP adapters from
-  `rivetdev/sandbox-agent:0.5.0-rc.2-full` and installs only the standalone Pi CLI.
-- The upstream 0.5.0-rc.2 adapter manifest pins `pi-acp` 0.0.23.
-- The upstream 0.0.23 adapter has no `extension_ui_request` handler.
-- The bridge landed in pi-acp commit `1412ea6110` and shipped in 0.0.28.
-- The installed 0.0.29 adapter converts confirm dialogs to ACP permission requests.
-- The last public Daytona proxy source uses a generic Go reverse proxy and contains no
-  ACP method filter.
+- `python3 -m py_compile services/runner/sandbox-images/daytona/build_snapshot.py`
+- `ruff format --check services/runner/sandbox-images/daytona/build_snapshot.py`
+- `ruff check services/runner/sandbox-images/daytona/build_snapshot.py`
+- `git diff --check`
+- `uv run services/runner/sandbox-images/daytona/build_snapshot.py --force`
+- `uv run docs/design/agent-workflows/projects/qa/scripts/run_matrix.py --env-label E3 --sandbox daytona --only builtin_bash_pi --timeout 300`
 
-## Remaining validation
+## Remaining work
 
-- Query the private adapter version in the currently deployed snapshot.
-- Rebuild a temporary or replacement snapshot with 0.0.29.
-- Run the allow, deny, ask-live, and ask-cold checks in [plan.md](plan.md).
-- Run one Claude Daytona ask control.
-- Measure the repaired ACP round-trip before considering Option C.
-
-The live Daytona checks require confirmation that cloud credits are available. Every run
-must count sandboxes before and after and delete its test sandbox.
-
-## Blockers
-
-None for the design. Implementation and live verification require a Daytona snapshot
-rebuild window and available credits.
-
-## Next steps
-
-1. Review this revised design.
-2. If approved, implement the snapshot recipe pin and build assertion.
-3. Rebuild and rotate `agenta-sandbox-pi`.
-4. Run focused live verification.
-5. Close or reopen the transport contingency from evidence.
+1. Review and merge the stacked implementation PR.
+2. Exercise approve and reject from the playground UI.
+3. Confirm cold approval replay through the supported UI message history.
+4. Run the `pi_agenta` opening read and one Claude ask-mode control.
+5. Update F-018 to resolved after those lifecycle checks pass.
 
 ## Provenance
 
-- Finding: F-018 in [../qa/findings.md](../qa/findings.md).
-- Owner review: nine inline threads on PR #5218.
-- Research pass: three independent tracks for Daytona proxy source, sandbox-agent and ACP
-  transport, and permission lifecycle and harness scope.
-- No live Daytona sandbox was started during this review pass.
+- Design PR: #5218.
+- Root cause: the Daytona snapshot inherited `pi-acp` 0.0.23, which predates the Pi
+  extension UI permission bridge.
+- Implementation review: one narrow implementer and one independent reviewer.
+- Live verification date: 2026-07-11.

--- a/docs/design/agent-workflows/projects/qa/runs/E3__builtin_bash_pi.json
+++ b/docs/design/agent-workflows/projects/qa/runs/E3__builtin_bash_pi.json
@@ -4,9 +4,9 @@
   "capability": "builtin bash",
   "env_label": "E3",
   "sandbox": "daytona",
-  "harness": "pi",
-  "model": "gpt-4o-mini",
-  "ts": "2026-06-20T11:02:49.133906+00:00",
+  "harness": "pi_core",
+  "model": "openai/gpt-4o-mini",
+  "ts": "2026-07-11T15:28:06.701900+00:00",
   "request": {
     "data": {
       "inputs": {
@@ -19,24 +19,38 @@
       },
       "parameters": {
         "agent": {
-          "harness": "pi",
-          "sandbox": "daytona",
-          "model": "gpt-4o-mini",
-          "agents_md": "Use the bash tool when asked to run a command. Report only its stdout.",
+          "harness": {
+            "kind": "pi_core"
+          },
+          "sandbox": {
+            "kind": "daytona"
+          },
+          "llm": {
+            "model": "openai/gpt-4o-mini"
+          },
+          "instructions": {
+            "agents_md": "Use the bash tool when asked to run a command. Report only its stdout."
+          },
           "tools": [
             {
               "type": "builtin",
               "name": "bash"
             }
-          ]
+          ],
+          "runner": {
+            "permissions": {
+              "default": "allow"
+            }
+          }
         }
       }
     }
   },
   "http_status": 200,
   "response": {
-    "span_id": "5fc4483660ed338c",
-    "trace_id": "b6026a64a4a94ea48359943198dedcc6",
+    "session_id": "b1476563e296494ea79012af0ec35567",
+    "span_id": "3880627166641182",
+    "trace_id": "def0db6ab9f613f6f1bf78c01ed6ae0c",
     "version": "2025.07.14",
     "status": {
       "code": 200,
@@ -44,8 +58,28 @@
     },
     "data": {
       "outputs": {
-        "role": "assistant",
-        "content": "QA-BASH-x86_64"
+        "messages": [
+          {
+            "role": "tool",
+            "content": "",
+            "tool_call_id": "call_tSojUJhhVjgM1mFww8hzFA2R|fc_014a2915d446a818016a5261139f108192ac11a9132c80e5f5",
+            "tool_name": "bash",
+            "input": {
+              "command": "echo \"QA-BASH-$(uname -m)\""
+            }
+          },
+          {
+            "role": "tool",
+            "content": "QA-BASH-x86_64\n",
+            "tool_call_id": "call_tSojUJhhVjgM1mFww8hzFA2R|fc_014a2915d446a818016a5261139f108192ac11a9132c80e5f5",
+            "is_error": false
+          },
+          {
+            "role": "assistant",
+            "content": "QA-BASH-x86_64"
+          }
+        ],
+        "stop_reason": "end_turn"
       }
     }
   },

--- a/services/runner/sandbox-images/daytona/README.md
+++ b/services/runner/sandbox-images/daytona/README.md
@@ -20,15 +20,26 @@ AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
 ## What is baked
 
 The recipe bases on `rivetdev/sandbox-agent:*-full`. That base image already installs the
-Claude, Codex, and OpenCode native binaries and ACP adapters. It also includes the Pi ACP
-adapter, but not the standalone `pi` CLI that the adapter launches.
+Claude, Codex, and OpenCode native binaries and ACP adapters. It also includes a Pi ACP
+adapter, but its version can differ from the runner's adapter and it does not include the
+standalone `pi` CLI that the adapter launches.
 
 The snapshot recipe therefore:
 
 - installs `@earendil-works/pi-coding-agent@0.80.6`;
 - fails the build unless `pi --version` succeeds;
+- reinstalls the private Pi ACP adapter at `pi-acp@0.0.29` through
+  `sandbox-agent install-agent`, rather than installing a global package that the daemon
+  would not resolve;
+- fails the build unless the private launcher exists and its installed package reports
+  version `0.0.29`;
 - verifies that the Claude, Codex, and OpenCode binaries are still present; and
 - installs the FUSE and geesefs dependencies used for durable remote working directories.
+
+The Pi CLI and Pi ACP adapter are separate dependencies. Keep both pins explicit. The CLI
+runs the agent; the adapter translates Pi events and dialogs onto ACP. In particular, the
+adapter version must not be inherited implicitly from the base image because older versions
+do not forward Pi extension dialogs as ACP permission requests.
 
 ## Pi installation controls
 

--- a/services/runner/sandbox-images/daytona/build_snapshot.py
+++ b/services/runner/sandbox-images/daytona/build_snapshot.py
@@ -5,10 +5,10 @@
 """Build a Daytona snapshot for the Agenta sandbox-agent runner.
 
 The full sandbox-agent base image already bakes the Claude, Codex, and OpenCode
-native binaries and ACP adapters. It also includes the Pi ACP adapter, but not the
-standalone `pi` CLI that adapter launches. This recipe adds the pinned Pi CLI and
-verifies the other baked harnesses so Daytona runs do not pay their installation cost
-for every fresh sandbox. Set the runner service to use it:
+native binaries and ACP adapters. This recipe replaces its Pi ACP adapter with the
+pinned version, adds the pinned standalone `pi` CLI that adapter launches, and verifies
+the other baked harnesses so Daytona runs do not pay their installation cost for every
+fresh sandbox. Set the runner service to use it:
 
     DAYTONA_SNAPSHOT=agenta-sandbox-pi
     AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
@@ -41,7 +41,11 @@ from daytona.common.errors import DaytonaNotFoundError
 
 SNAPSHOT_NAME = "agenta-sandbox-pi"
 SANDBOX_AGENT_IMAGE = "rivetdev/sandbox-agent:0.5.0-rc.2-full"
-PI_PACKAGE = "@earendil-works/pi-coding-agent@0.80.6"
+PI_VERSION = "0.80.6"
+PI_PACKAGE = f"@earendil-works/pi-coding-agent@{PI_VERSION}"
+PI_ACP_VERSION = "0.0.29"
+PI_ACP_INSTALL_DIR = "/home/sandbox/.local/share/sandbox-agent/bin/agent_processes"
+PI_ACP_PACKAGE_JSON = f"{PI_ACP_INSTALL_DIR}/pi/node_modules/pi-acp/package.json"
 # Durable session cwd: geesefs (FUSE-over-S3) mounts the store prefix INSIDE the sandbox for
 # remote runs. fuse provides fusermount + /etc/fuse.conf; geesefs is the static mount binary.
 # amd64 is correct here regardless of the builder's local arch: the snapshot is built and run
@@ -101,6 +105,15 @@ def main() -> None:
             f"RUN curl -fsSL -o /usr/local/bin/geesefs {GEESEFS_URL} "
             "&& chmod +x /usr/local/bin/geesefs",
             "USER sandbox",
+            # Replace the base image's private Pi adapter. sandbox-agent resolves this launcher
+            # before PATH, so a global pi-acp install would leave the stale adapter active.
+            f"RUN sandbox-agent install-agent pi --reinstall "
+            f"--agent-process-version {PI_ACP_VERSION}",
+            # Assert the private launcher and its installed npm package, not a global package.
+            f"RUN test -x {PI_ACP_INSTALL_DIR}/pi-acp "
+            f'&& test "$(node -p "require(\'{PI_ACP_PACKAGE_JSON}\').version")" '
+            f'= "{PI_ACP_VERSION}" '
+            f"&& echo pi-acp-version={PI_ACP_VERSION}",
         ]
     )
 


### PR DESCRIPTION
## Context

Pi agents on Daytona stalled on their first builtin tool call until the 300-second run limit ended the turn. Local Pi runs worked because the runner uses `pi-acp` 0.0.29, while the Daytona snapshot inherited 0.0.23 from its base image. That older adapter predates the bridge that turns Pi extension dialogs into ACP permission requests, so the request never reached the existing HTTP and SSE transport.

## Changes

The snapshot recipe now keeps the standalone Pi CLI at 0.80.6 and separately reinstalls sandbox-agent's private `pi-acp` adapter at 0.0.29. A build step checks both the private launcher and the installed package version, so a future base-image change fails the snapshot build instead of silently restoring version skew.

Before:

```text
base image private pi-acp: 0.0.23
snapshot recipe: installs only Pi CLI 0.80.6
```

After:

```text
Pi CLI: 0.80.6
private pi-acp: 0.0.29
build assertion: pi-acp-version=0.0.29
```

The design status records the implementation and live evidence. It also corrects the private install root to include `/bin/agent_processes/`.

## Scope / risk

This PR changes only the Daytona snapshot recipe, its operator documentation, design status, and one QA capture. It does not change the runner protocol, permission policy, API schema, local sandbox path, or public configuration.

The rollout risk is snapshot state. Sandboxes created before the rebuild retain the old adapter and must be drained. The build also depends on the upstream adapter registry continuing to serve the pinned package.

## Tests / notes

- `python3 -m py_compile services/runner/sandbox-images/daytona/build_snapshot.py`
- `ruff format --check services/runner/sandbox-images/daytona/build_snapshot.py`
- `ruff check services/runner/sandbox-images/daytona/build_snapshot.py`
- `git diff --check`
- Force-rebuilt `agenta-sandbox-pi`; Daytona reported `SnapshotState.ACTIVE` after 96.4 seconds.
- Build logs reported the private launcher and `pi-acp-version=0.0.29`.
- E3 Daytona Pi allow-mode Bash passed and returned `QA-BASH-x86_64`.
- E3 Daytona Pi deny-mode Bash passed and returned a policy denial without executing the command.
- E3 Daytona Pi ask mode returned a real `interaction_request` instead of hanging.
- Live Daytona sandbox count was zero before and zero after the matrix.
- EE port 8280 and OSS port 8290 health endpoints both returned `{"status":"ok"}`.

The supported playground approve and reject actions, cold replay through UI history, the `pi_agenta` opening read, and the Claude Daytona control remain follow-up checks. Two hand-built raw API resume payloads re-prompted, but they did not come from the supported UI client, so this PR does not classify that result as a regression.

## How to review

1. Read the two explicit version pins and private-adapter build assertion in `build_snapshot.py`.
2. Check the operator explanation in the snapshot README.
3. Review the corrected design path and implementation checkpoint.
4. Inspect `status.md` and the E3 capture for the live result and remaining checks.

## How to QA

Prerequisite: Daytona credits and the EE dev deployment credentials.

1. Run `uv run services/runner/sandbox-images/daytona/build_snapshot.py --force`. The build must print `pi-acp-version=0.0.29` and finish with an active snapshot.
2. Run `AGENTA_BASE=http://144.76.237.122:8280 AGENTA_QA_MODEL=openai/gpt-4o-mini uv run docs/design/agent-workflows/projects/qa/scripts/run_matrix.py --env-label E3 --sandbox daytona --only builtin_bash_pi --timeout 300`. The reply must contain `QA-BASH-x86_64` or the target architecture.
3. Set the permission default to deny for the same Bash prompt. The tool result must say the policy denied it and the command output must be absent.
4. Set the permission default to ask. The playground must show an approval prompt promptly. Approve and reject once each.
5. List Daytona sandboxes before and after. The live count must not grow.

Regression check: a local Pi builtin run must continue using the runner-pinned adapter without any snapshot dependency.