### PR TITLE
fix(runner): pin Daytona Pi ACP adapter parity

### DIFF
--- a/docs/design/agent-workflows/projects/qa/runs/E3__builtin_bash_pi.json
+++ b/docs/design/agent-workflows/projects/qa/runs/E3__builtin_bash_pi.json
@@ -4,9 +4,9 @@
   "capability": "builtin bash",
   "env_label": "E3",
   "sandbox": "daytona",
-  "harness": "pi",
-  "model": "gpt-4o-mini",
-  "ts": "2026-06-20T11:02:49.133906+00:00",
+  "harness": "pi_core",
+  "model": "openai/gpt-4o-mini",
+  "ts": "2026-07-11T15:28:06.701900+00:00",
   "request": {
     "data": {
       "inputs": {
@@ -19,24 +19,38 @@
       },
       "parameters": {
         "agent": {
-          "harness": "pi",
-          "sandbox": "daytona",
-          "model": "gpt-4o-mini",
-          "agents_md": "Use the bash tool when asked to run a command. Report only its stdout.",
+          "harness": {
+            "kind": "pi_core"
+          },
+          "sandbox": {
+            "kind": "daytona"
+          },
+          "llm": {
+            "model": "openai/gpt-4o-mini"
+          },
+          "instructions": {
+            "agents_md": "Use the bash tool when asked to run a command. Report only its stdout."
+          },
           "tools": [
             {
               "type": "builtin",
               "name": "bash"
             }
-          ]
+          ],
+          "runner": {
+            "permissions": {
+              "default": "allow"
+            }
+          }
         }
       }
     }
   },
   "http_status": 200,
   "response": {
-    "span_id": "5fc4483660ed338c",
-    "trace_id": "b6026a64a4a94ea48359943198dedcc6",
+    "session_id": "b1476563e296494ea79012af0ec35567",
+    "span_id": "3880627166641182",
+    "trace_id": "def0db6ab9f613f6f1bf78c01ed6ae0c",
     "version": "2025.07.14",
     "status": {
       "code": 200,
@@ -44,8 +58,28 @@
     },
     "data": {
       "outputs": {
-        "role": "assistant",
-        "content": "QA-BASH-x86_64"
+        "messages": [
+          {
+            "role": "tool",
+            "content": "",
+            "tool_call_id": "call_tSojUJhhVjgM1mFww8hzFA2R|fc_014a2915d446a818016a5261139f108192ac11a9132c80e5f5",
+            "tool_name": "bash",
+            "input": {
+              "command": "echo \"QA-BASH-$(uname -m)\""
+            }
+          },
+          {
+            "role": "tool",
+            "content": "QA-BASH-x86_64\n",
+            "tool_call_id": "call_tSojUJhhVjgM1mFww8hzFA2R|fc_014a2915d446a818016a5261139f108192ac11a9132c80e5f5",
+            "is_error": false
+          },
+          {
+            "role": "assistant",
+            "content": "QA-BASH-x86_64"
+          }
+        ],
+        "stop_reason": "end_turn"
       }
     }
   },

--- a/services/runner/sandbox-images/daytona/README.md
+++ b/services/runner/sandbox-images/daytona/README.md
@@ -20,15 +20,26 @@ AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
 ## What is baked
 
 The recipe bases on `rivetdev/sandbox-agent:*-full`. That base image already installs the
-Claude, Codex, and OpenCode native binaries and ACP adapters. It also includes the Pi ACP
-adapter, but not the standalone `pi` CLI that the adapter launches.
+Claude, Codex, and OpenCode native binaries and ACP adapters. It also includes a Pi ACP
+adapter, but its version can differ from the runner's adapter and it does not include the
+standalone `pi` CLI that the adapter launches.
 
 The snapshot recipe therefore:
 
 - installs `@earendil-works/pi-coding-agent@0.80.6`;
 - fails the build unless `pi --version` succeeds;
+- reinstalls the private Pi ACP adapter at `pi-acp@0.0.29` through
+  `sandbox-agent install-agent`, rather than installing a global package that the daemon
+  would not resolve;
+- fails the build unless the private launcher exists and its installed package reports
+  version `0.0.29`;
 - verifies that the Claude, Codex, and OpenCode binaries are still present; and
 - installs the FUSE and geesefs dependencies used for durable remote working directories.
+
+The Pi CLI and Pi ACP adapter are separate dependencies. Keep both pins explicit. The CLI
+runs the agent; the adapter translates Pi events and dialogs onto ACP. In particular, the
+adapter version must not be inherited implicitly from the base image because older versions
+do not forward Pi extension dialogs as ACP permission requests.
 
 ## Pi installation controls
 

--- a/services/runner/sandbox-images/daytona/build_snapshot.py
+++ b/services/runner/sandbox-images/daytona/build_snapshot.py
@@ -5,10 +5,10 @@
 """Build a Daytona snapshot for the Agenta sandbox-agent runner.
 
 The full sandbox-agent base image already bakes the Claude, Codex, and OpenCode
-native binaries and ACP adapters. It also includes the Pi ACP adapter, but not the
-standalone `pi` CLI that adapter launches. This recipe adds the pinned Pi CLI and
-verifies the other baked harnesses so Daytona runs do not pay their installation cost
-for every fresh sandbox. Set the runner service to use it:
+native binaries and ACP adapters. This recipe replaces its Pi ACP adapter with the
+pinned version, adds the pinned standalone `pi` CLI that adapter launches, and verifies
+the other baked harnesses so Daytona runs do not pay their installation cost for every
+fresh sandbox. Set the runner service to use it:
 
     DAYTONA_SNAPSHOT=agenta-sandbox-pi
     AGENTA_AGENT_SANDBOX_PI_INSTALLED=false
@@ -41,7 +41,11 @@ from daytona.common.errors import DaytonaNotFoundError
 
 SNAPSHOT_NAME = "agenta-sandbox-pi"
 SANDBOX_AGENT_IMAGE = "rivetdev/sandbox-agent:0.5.0-rc.2-full"
-PI_PACKAGE = "@earendil-works/pi-coding-agent@0.80.6"
+PI_VERSION = "0.80.6"
+PI_PACKAGE = f"@earendil-works/pi-coding-agent@{PI_VERSION}"
+PI_ACP_VERSION = "0.0.29"
+PI_ACP_INSTALL_DIR = "/home/sandbox/.local/share/sandbox-agent/bin/agent_processes"
+PI_ACP_PACKAGE_JSON = f"{PI_ACP_INSTALL_DIR}/pi/node_modules/pi-acp/package.json"
 # Durable session cwd: geesefs (FUSE-over-S3) mounts the store prefix INSIDE the sandbox for
 # remote runs. fuse provides fusermount + /etc/fuse.conf; geesefs is the static mount binary.
 # amd64 is correct here regardless of the builder's local arch: the snapshot is built and run
@@ -101,6 +105,15 @@ def main() -> None:
             f"RUN curl -fsSL -o /usr/local/bin/geesefs {GEESEFS_URL} "
             "&& chmod +x /usr/local/bin/geesefs",
             "USER sandbox",
+            # Replace the base image's private Pi adapter. sandbox-agent resolves this launcher
+            # before PATH, so a global pi-acp install would leave the stale adapter active.
+            f"RUN sandbox-agent install-agent pi --reinstall "
+            f"--agent-process-version {PI_ACP_VERSION}",
+            # Assert the private launcher and its installed npm package, not a global package.
+            f"RUN test -x {PI_ACP_INSTALL_DIR}/pi-acp "
+            f'&& test "$(node -p "require(\'{PI_ACP_PACKAGE_JSON}\').version")" '
+            f'= "{PI_ACP_VERSION}" '
+            f"&& echo pi-acp-version={PI_ACP_VERSION}",
         ]
     )
 


### PR DESCRIPTION
Re-land of #5224 onto big-agents. #5224 was approved but squash-merged into its stacked base (docs/daytona-gate-delivery-plan) instead of big-agents. This carries the runner fix files only; the daytona-gate-delivery plan-doc updates from #5224 stay on the plan branch and land through #5218.

Original context (#5224): Pi agents on Daytona stalled on their first builtin tool call until the 300-second run limit ended the turn. The Daytona snapshot inherited pi-acp 0.0.23 from its base image while local runs use 0.0.29; the older adapter predates the bridge that turns Pi extension dialogs into ACP permission requests. Fix pins the adapter version in the snapshot build.

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj