### PR TITLE
fix(frontend): open rendered links in playground chat in new tabs [5175]

### DIFF
--- a/web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx
+++ b/web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx
@@ -52,7 +52,20 @@ const MATCHERS = [
     createLinkMatcherWithRegExp(EMAIL_REGEX, (text) => {
         return `mailto:${text}`
     }),
-]
+].map((matcher) => {
+    return (text: string) => {
+        const result = matcher(text)
+        return result
+            ? {
+                  ...result,
+                  attributes: {
+                      rel: "noopener noreferrer",
+                      target: "_blank",
+                  },
+              }
+            : null
+    }
+})
 
 const MARKDOWN_VIEW_TOGGLE_UPDATE_TAG = "agenta:markdown-view-toggle"
 
@@ -542,7 +555,7 @@ const MarkdownPlugin = ({
             <HorizontalRulePlugin />
             <TablePlugin />
             <TableCellResizerPlugin />
-            <LexicalLinkPlugin />
+            <LexicalLinkPlugin hasLinkAttributes={true} />
         </>
     )
 }


### PR DESCRIPTION
Context
Clicking on links in the playground chat navigated the browser away from the application, causing users to lose their active chat history and configurations.

Changes
Passed hasLinkAttributes={true} to LexicalLinkPlugin to open markdown links ([text](url)) in a new tab.
Wrapped AutoLinkPlugin matchers to append target="_blank" and rel="noopener noreferrer" attributes to raw, auto-detected URLs.
What to QA
Click raw URLs or markdown links rendered in the playground chat thread. They must open in a new browser tab.