### PR TITLE
docs(design): plan event-driven tool relay (remove relay polling latency)

### DIFF
--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/README.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/README.md
@@ -2,8 +2,23 @@
 
 Remove the polling latency from the sandbox-to-runner tool relay. Today every gateway tool
 call waits on two poll loops (0.3 s to 1.5 s per hop). This project replaces the waiting
-with filesystem-event wakeups while keeping polling as the correctness fallback. The relay
-files, the security model, and the wire contract do not change.
+with filesystem-event wakeups while keeping polling as the correctness fallback. The final
+relay files, the security model, and the wire contract do not change; publication becomes
+atomic (a temp name plus a rename) so an event can never expose a partial file.
+
+## Who writes the relay
+
+The fast path covers every writer, current and future, because the watch is on the relay
+directory, not on any writer:
+
+- **Pi's in-sandbox extension** (today): each registered tool executes through
+  `runResolvedTool`, which routes to the shared relay writer.
+- **Local Claude** (today): the runner's loopback MCP handler dispatches `tools/call`
+  through the same `runResolvedTool`, so local Claude writes the same relay files.
+- **The in-sandbox stdio MCP shim** (tomorrow,
+  [PR #5234](../in-sandbox-tool-mcp/README.md)): Claude on Daytona, a third writer of the
+  same files through the same client module. This project's slice 0 extracts that shared
+  client module (`tools/relay-client.ts`); the shim consumes it.
 
 ## Glossary
 
@@ -15,13 +30,15 @@ files, the security model, and the wire contract do not change.
 - **Relay**: the file-based channel for tool calls. The in-sandbox writer creates
   `<id>.req.json` in a relay directory; the runner executes the call with its own
   credentials and writes `<id>.res.json`; the writer reads it and deletes both files.
+  Both sides publish via `<name>.tmp.<nonce>` plus a same-directory rename.
 - **Hop 1**: the in-sandbox writer waiting for `<id>.res.json`.
 - **Hop 2**: the runner discovering `<id>.req.json`. On Daytona this is a remote `ls`
   through the daemon API; locally it is a directory read.
 - **Watch exec**: the proposed hop 2 mechanism on Daytona. One bounded, blocking
-  `runProcess` call runs a small node script in the sandbox that lists the relay directory,
-  then watches it, prints when a request appears, and exits. The runner re-issues it in a
-  loop.
+  `runProcess` call runs a small node script in the sandbox that arms a directory watch,
+  lists the relay directory, and exits when a request appears or its window ends. The
+  runner treats each completion as a wake and re-issues the exec; while the watch is
+  healthy the runner suspends its remote polling apart from a slow safety poll.
 
 ## Files and reading order
 
@@ -39,8 +56,12 @@ files, the security model, and the wire contract do not change.
 - [../mcp-delivery-architecture/gateway-mcp-location.md](../mcp-delivery-architecture/gateway-mcp-location.md):
   the decision that keeps tool delivery on the runner and the file relay. This project is
   the latency follow-up named in that decision.
-- [../claude-daytona-tools/design.md](../claude-daytona-tools/design.md): the in-sandbox
-  MCP shim for Claude. It will become a second writer of the same relay files; the design
-  here must not assume Pi is the only writer.
+- [../in-sandbox-tool-mcp/README.md](../in-sandbox-tool-mcp/README.md): the in-sandbox
+  MCP shim for Claude on Daytona (PR #5234). It becomes the third writer of the same relay
+  files and consumes this project's slice 0 modules.
+- [../mcp-delivery-architecture/orchestration.md](../mcp-delivery-architecture/orchestration.md):
+  the landing order across the three tool-delivery plans.
+- [../claude-daytona-tools/design.md](../claude-daytona-tools/design.md): the earlier
+  shim design that #5234 supersedes; kept for provenance.
 - [../session-keepalive/README.md](../session-keepalive/README.md): warm sessions. The
   relay loop is per-turn, so keep-alive and this project interact only at turn boundaries.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/README.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/README.md
@@ -1,0 +1,46 @@
+# Event-driven tool relay
+
+Remove the polling latency from the sandbox-to-runner tool relay. Today every gateway tool
+call waits on two poll loops (0.3 s to 1.5 s per hop). This project replaces the waiting
+with filesystem-event wakeups while keeping polling as the correctness fallback. The relay
+files, the security model, and the wire contract do not change.
+
+## Glossary
+
+- **Runner**: the Node sidecar (`services/runner/`) that executes agent runs. It holds the
+  run's credentials and executes gateway and platform tools server-side.
+- **Harness**: the coding agent that runs inside the sandbox (Pi or Claude Code).
+- **Sandbox**: the isolated environment the harness runs in. Local (same machine as the
+  runner) or Daytona (a remote cloud VM the runner reaches through a daemon API).
+- **Relay**: the file-based channel for tool calls. The in-sandbox writer creates
+  `<id>.req.json` in a relay directory; the runner executes the call with its own
+  credentials and writes `<id>.res.json`; the writer reads it and deletes both files.
+- **Hop 1**: the in-sandbox writer waiting for `<id>.res.json`.
+- **Hop 2**: the runner discovering `<id>.req.json`. On Daytona this is a remote `ls`
+  through the daemon API; locally it is a directory read.
+- **Watch exec**: the proposed hop 2 mechanism on Daytona. One bounded, blocking
+  `runProcess` call runs a small node script in the sandbox that lists the relay directory,
+  then watches it, prints when a request appears, and exits. The runner re-issues it in a
+  loop.
+
+## Files and reading order
+
+1. [context.md](context.md): why the relay exists, the settled decisions this project
+   builds on, goals and non-goals.
+2. [research.md](research.md): how the relay works today, with verified file and line
+   anchors, plus the daemon API facts the design depends on.
+3. [plan.md](plan.md): the design. Each decision lists its options and why one wins.
+   Slices, test plan, measurement, and rollout with the poll fallback.
+4. [open-questions.md](open-questions.md): what the owner still needs to decide or verify.
+5. [status.md](status.md): progress and provenance.
+
+## Related projects
+
+- [../mcp-delivery-architecture/gateway-mcp-location.md](../mcp-delivery-architecture/gateway-mcp-location.md):
+  the decision that keeps tool delivery on the runner and the file relay. This project is
+  the latency follow-up named in that decision.
+- [../claude-daytona-tools/design.md](../claude-daytona-tools/design.md): the in-sandbox
+  MCP shim for Claude. It will become a second writer of the same relay files; the design
+  here must not assume Pi is the only writer.
+- [../session-keepalive/README.md](../session-keepalive/README.md): warm sessions. The
+  relay loop is per-turn, so keep-alive and this project interact only at turn boundaries.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/context.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/context.md
@@ -37,7 +37,9 @@ milliseconds instead of seconds. Explicitly unchanged:
 
 - The security model. No new network surface, no credentials into the sandbox, the relay
   files stay the data channel.
-- The req/res file contract (names, contents, who deletes what).
+- The req/res file contract (final names, contents, who deletes what). Publication
+  becomes atomic (a temp name plus a same-directory rename, plan.md decision 2), which
+  changes how a file appears, not what it is once it exists.
 - The `/run` wire contract and the SDK.
 
 ## The reliability principle (non-negotiable)

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/context.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/context.md
@@ -1,0 +1,64 @@
+# Context
+
+## What the user experiences today
+
+Every gateway or platform tool call from a sandboxed harness pays a polling tax. The
+in-sandbox writer drops a request file and sleeps in 300 ms steps until the response file
+appears. The runner, on its side, discovers the request file by listing the relay directory
+every 300 ms, backing off to 1.5 s when the turn is quiet. A single tool call therefore adds
+roughly 0.3 s to 1.8 s of pure waiting on top of the tool's real execution time. An agent
+turn that makes ten tool calls can spend over ten seconds doing nothing.
+
+On Daytona the cost is also request volume: the runner's poll is a remote `ls` exec through
+the daemon API, about three requests per second per active turn, for the whole turn.
+
+## Settled decisions this project builds on
+
+These are owner decisions (2026-07-11). They are inputs, not open questions.
+
+1. **The sandbox talks only to the runner.** An API-hosted tool gateway (an MCP endpoint on
+   the Agenta API that sandboxes would dial directly) was considered and rejected. Warm
+   sandboxes are the priority, and the committed model is: the harness runs in the sandbox;
+   tools, credentials, and policy live in the runner. The full analysis is in
+   [../mcp-delivery-architecture/gateway-mcp-location.md](../mcp-delivery-architecture/gateway-mcp-location.md).
+2. **Tool calls ride the file relay.** The in-sandbox writer creates `<id>.req.json` in a
+   relay directory. The runner discovers it, executes the call with runner-held credentials,
+   and writes `<id>.res.json`. The writer reads the response and deletes both files. No
+   network path opens from the sandbox to the runner, and no credential enters the sandbox.
+3. **Claude gets tools through an in-sandbox MCP shim feeding the same relay files**
+   ([../claude-daytona-tools/design.md](../claude-daytona-tools/design.md)). Pi's extension
+   is the first writer; the shim will be the second. Any relay change must keep the
+   req/res file contract unchanged and must not assume Pi is the only writer.
+
+## The feature
+
+Replace the polling latency with event-driven wakeups so a tool call round-trips in
+milliseconds instead of seconds. Explicitly unchanged:
+
+- The security model. No new network surface, no credentials into the sandbox, the relay
+  files stay the data channel.
+- The req/res file contract (names, contents, who deletes what).
+- The `/run` wire contract and the SDK.
+
+## The reliability principle (non-negotiable)
+
+Polling stays as the correctness fallback. The event path is an optimization layered on the
+existing loop: an event only shortens the current sleep. A watcher that dies, hangs, or was
+never available degrades the relay to today's polling behavior. It must never degrade to a
+hang.
+
+## Goals
+
+- Tool-call relay overhead near zero on the local backend (both hops are local
+  filesystem watches).
+- Tool-call relay overhead on Daytona bounded by one daemon round-trip, not by a poll
+  interval.
+- Fewer daemon requests per turn on Daytona, not more.
+- The same fast path works for Pi's extension today and the Claude MCP shim later.
+
+## Non-goals
+
+- No change to how tools are resolved, gated, or executed.
+- No change to approval parking or permission gates.
+- No new transport (no sockets, no tunnels, no SSE channel for tool data).
+- No removal of the poll loop.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/open-questions.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/open-questions.md
@@ -1,27 +1,66 @@
 # Open questions
 
-None of these blocks slice 1. Question 1 should be answered before flipping the Daytona
-flag on by default.
+Updated 2026-07-11 after the Codex, CodeRabbit, and owner review round on PR #5232.
+Questions the reviews answered moved to the bottom.
 
-1. **Daytona held-exec limits.** The design holds one bounded (25 s) `runProcess` request
-   per active turn. In-repo evidence says long-held requests through the preview proxy
-   work (ACP approval pauses hold for minutes to hours), but Daytona's documented limits
-   on concurrent execs per sandbox and per organization, and any proxy idle timeout, are
-   unverified. Who confirms with Daytona, and does the answer move the 25 s window
-   default?
-2. **Default-on timing for the Daytona watch.** Flip `AGENTA_AGENT_TOOLS_RELAY_WATCH` to
-   `true` right after the QA pass, or keep it opt-in until the Claude MCP shim (the
-   second relay writer) lands so both writers are QA'd on the same fast path?
-3. **Backstop cadence follow-up.** Once the watch is trusted, is it worth raising the
-   idle backoff cap (1.5 s today) to cut Daytona fallback polling further, for example to
-   5 s or 30 s? Plan.md defers this deliberately (decision 4); this question is about
-   whether the follow-up is wanted at all, and at what value.
-4. **Permanent timing log.** Keep the `stage=relay_pickup` per-call latency log after QA,
-   or remove it once the numbers are recorded?
-5. **Custom snapshots without node.** The watch exec needs node in the sandbox image. The
-   default snapshot has it (Pi runs on node). Is degrade-to-poll acceptable for custom
-   snapshots without node, or should the script have a shell-only variant
+## Open
+
+1. **Daytona held-exec limits (rollout gate).** The design holds one bounded (25 s,
+   jittered) `runProcess` request per active turn. In-repo evidence says long-held
+   requests through the preview proxy work (ACP approval pauses hold for minutes to
+   hours), but Daytona's published limits document organization request rates, not
+   concurrent execs per sandbox. This is now framed as a rollout gate: the batch-load QA
+   pass (test plan) must confirm it before the `REMOTE_WATCH_ENABLED` default flips.
+   Who confirms with Daytona, and does the answer move the 25 s window default?
+2. **Daytona atomic rename.** Atomic publication (plan.md decision 2) needs a
+   same-directory `rename(2)` on the response write. The daemon SDK exposes `moveFs`
+   (`post_v1_fs_move`), but its atomicity is undocumented. Verify during slice 1; if it
+   is not atomic, `RelayHost` grows a rename capability implemented as a shell `mv`
+   exec. Reader-side JSON retry is the rejected fallback (plan.md decision 2 says why).
+3. **Sibling docs still name the old seam and flags.** Slice 0 ownership is settled:
+   this project extracts `tools/relay-client.ts` and `tools/relay-protocol.ts`, and
+   #5234 consumes them (its workspace is being corrected to match). Two references
+   remain stale until their owners update them, and this workspace cannot edit them:
+   [../mcp-delivery-architecture/orchestration.md](../mcp-delivery-architecture/orchestration.md)
+   assigns the extraction to "#5234 slice 1" (landing order group 1) and lists the old
+   env names `AGENTA_AGENT_TOOLS_RELAY_WATCH`/`_WATCH_WINDOW_MS` in its env-names
+   contract; the renamed per-hop flags are
+   `AGENTA_AGENT_TOOLS_RELAY_RESPONSE_WATCH_ENABLED`,
+   `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_ENABLED`, and
+   `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_WINDOW_MS`.
+4. **Orphaned-request residue across warm-continued turns.** A crashed turn inside one
+   live environment can leave a `.req.json` that the next warm-continued turn's fresh
+   relay loop re-executes (cold builds are covered by the `rm -rf` in
+   `workspace.ts:60-66`; warm continuations skip `prepareWorkspace`). The sibling
+   project flagged this to this project as the owner of relay mechanics
+   (orchestration.md, "Pending changes for PR #5232"). Owner call: pull a fix into this
+   scope (for example, an initial-list handshake that quarantines request files
+   predating the turn) or assign it elsewhere explicitly.
+5. **Permanent timing log.** Keep the `stage=relay_pickup` per-call latency log after
+   QA, or remove it once the numbers are recorded?
+6. **Custom snapshots without node.** The watch exec needs node in the sandbox image.
+   The default snapshot has it (Pi runs on node). Is degrade-to-poll acceptable for
+   custom snapshots without node, or should the script have a shell-only variant
    (`inotifywait` is not guaranteed either, so a portable shell variant may not exist)?
-6. **Sequencing against the MCP shim revival (#4873).** Land this relay work first (the
-   shim then inherits the fast path), or together with the shim revival in one review
-   cycle?
+
+## Answered by the review round
+
+- **Flag naming and granularity.** One flag for both hops was the wrong granularity
+  (different owners, different failure modes). Now per hop:
+  `RESPONSE_WATCH_ENABLED` (hop 1), `REMOTE_WATCH_ENABLED` (hop 2 Daytona), and
+  `REMOTE_WATCH_WINDOW_MS` validated and clamped (plan.md decision 7).
+- **Backoff fate (was question 3).** Decided, not deferred: a healthy remote watch
+  suspends the runner's remote polling entirely, replaced by a 30 s safety poll; the
+  idle backoff survives only in the fallback poll mode; hop 1 and local hop 2 keep
+  today's cadence as a cheap local safety timer (plan.md decisions 4 and 6). The
+  "raise the cap later" follow-up is dead; there is no healthy-mode cap to raise.
+- **Sequencing against the MCP shim (was question 6).** The full shim does not need to
+  land first; the `relay-client.ts` extraction does, and it is now slice 0 of this
+  project, consumed by #5234 (plan.md decision 5).
+- **Default-on timing for the Daytona watch (was question 2).** Answered by the
+  consolidated QA step in orchestration.md: run both relay writers (the Pi extension
+  and the shim) through the watch path in one matrix pass, and flip the default only
+  after it, plus the capacity gates above.
+- **The 25 s window.** A plausible starting value, not a measured one; it gets about
+  20 percent jitter, validation, and clamping (plan.md decision 7), and QA revisits the
+  number.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/open-questions.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/open-questions.md
@@ -1,47 +1,53 @@
 # Open questions
 
-Updated 2026-07-11 after the Codex, CodeRabbit, and owner review round on PR #5232.
-Questions the reviews answered moved to the bottom.
+Updated 2026-07-12 after the implementation pass on lane `feat-event-driven-tool-relay`.
+Answered questions moved to the bottom; original numbering kept (other docs cite it).
 
 ## Open
 
-1. **Daytona held-exec limits (rollout gate).** The design holds one bounded (25 s,
-   jittered) `runProcess` request per active turn. In-repo evidence says long-held
-   requests through the preview proxy work (ACP approval pauses hold for minutes to
-   hours), but Daytona's published limits document organization request rates, not
-   concurrent execs per sandbox. This is now framed as a rollout gate: the batch-load QA
-   pass (test plan) must confirm it before the `REMOTE_WATCH_ENABLED` default flips.
-   Who confirms with Daytona, and does the answer move the 25 s window default?
-2. **Daytona atomic rename.** Atomic publication (plan.md decision 2) needs a
-   same-directory `rename(2)` on the response write. The daemon SDK exposes `moveFs`
-   (`post_v1_fs_move`), but its atomicity is undocumented. Verify during slice 1; if it
-   is not atomic, `RelayHost` grows a rename capability implemented as a shell `mv`
-   exec. Reader-side JSON retry is the rejected fallback (plan.md decision 2 says why).
-3. **Sibling docs still name the old seam and flags.** Slice 0 ownership is settled:
-   this project extracts `tools/relay-client.ts` and `tools/relay-protocol.ts`, and
-   #5234 consumes them (its workspace is being corrected to match). Two references
-   remain stale until their owners update them, and this workspace cannot edit them:
-   [../mcp-delivery-architecture/orchestration.md](../mcp-delivery-architecture/orchestration.md)
-   assigns the extraction to "#5234 slice 1" (landing order group 1) and lists the old
-   env names `AGENTA_AGENT_TOOLS_RELAY_WATCH`/`_WATCH_WINDOW_MS` in its env-names
-   contract; the renamed per-hop flags are
-   `AGENTA_AGENT_TOOLS_RELAY_RESPONSE_WATCH_ENABLED`,
-   `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_ENABLED`, and
-   `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_WINDOW_MS`.
-4. **Orphaned-request residue across warm-continued turns.** A crashed turn inside one
-   live environment can leave a `.req.json` that the next warm-continued turn's fresh
-   relay loop re-executes (cold builds are covered by the `rm -rf` in
-   `workspace.ts:60-66`; warm continuations skip `prepareWorkspace`). The sibling
-   project flagged this to this project as the owner of relay mechanics
-   (orchestration.md, "Pending changes for PR #5232"). Owner call: pull a fix into this
-   scope (for example, an initial-list handshake that quarantines request files
-   predating the turn) or assign it elsewhere explicitly.
-5. **Permanent timing log.** Keep the `stage=relay_pickup` per-call latency log after
-   QA, or remove it once the numbers are recorded?
-6. **Custom snapshots without node.** The watch exec needs node in the sandbox image.
-   The default snapshot has it (Pi runs on node). Is degrade-to-poll acceptable for
-   custom snapshots without node, or should the script have a shell-only variant
-   (`inotifywait` is not guaranteed either, so a portable shell variant may not exist)?
+- **1. Daytona held-exec limits (rollout gate).** The design holds one bounded (25 s,
+  jittered) `runProcess` request per active turn. In-repo evidence says long-held
+  requests through the preview proxy work (ACP approval pauses hold for minutes to
+  hours), but Daytona's published limits document organization request rates, not
+  concurrent execs per sandbox. This is now framed as a rollout gate: the batch-load QA
+  pass (test plan) must confirm it before the `REMOTE_WATCH_ENABLED` default flips.
+  Who confirms with Daytona, and does the answer move the 25 s window default?
+- **3. Sibling docs still name the old seam and flags.** Slice 0 ownership is settled:
+  this project extracts `tools/relay-client.ts` and `tools/relay-protocol.ts`, and
+  #5234 consumes them (its workspace is being corrected to match). Two references
+  remain stale until their owners update them, and this workspace cannot edit them:
+  [../mcp-delivery-architecture/orchestration.md](../mcp-delivery-architecture/orchestration.md)
+  assigns the extraction to "#5234 slice 1" (landing order group 1) and lists the old
+  env names `AGENTA_AGENT_TOOLS_RELAY_WATCH`/`_WATCH_WINDOW_MS` in its env-names
+  contract; the renamed per-hop flags are
+  `AGENTA_AGENT_TOOLS_RELAY_RESPONSE_WATCH_ENABLED`,
+  `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_ENABLED`, and
+  `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_WINDOW_MS`.
+- **5. Permanent timing log.** The log is shipped: one
+  `[relay] stage=relay_pickup id=... pickup_ms=... wake=...` line per executed request
+  (mtime-based, approximate across clocks on Daytona, one extra stat call per executed
+  request). The removal decision is still open: keep it after QA, or remove it once the
+  numbers are recorded?
+- **6. Custom snapshots without node.** The watch exec needs node in the sandbox image.
+  The default snapshot has it (Pi runs on node). Is degrade-to-poll acceptable for
+  custom snapshots without node, or should the script have a shell-only variant
+  (`inotifywait` is not guaranteed either, so a portable shell variant may not exist)?
+
+## Answered during implementation
+
+- **Daytona atomic rename (was question 2).** Resolved early, during slice 1: the
+  daemon v0.4.2 source (`router.rs`) implements `/v1/fs/move` as Rust
+  `std::fs::rename`, which is `rename(2)` and atomic for a same-directory move.
+  `RelayHost.rename` calls `moveFs` (with `overwrite: true` only as a guard against a
+  pathological duplicate response); the shell-`mv` fallback was never needed. Reader-side
+  JSON retry stays rejected (plan.md decision 2 says why).
+- **Orphaned-request residue across warm-continued turns (was question 4).** Ownership
+  accepted; fixed in this project. The first successful list of each turn's relay loop
+  is a snapshot: pre-existing request files are marked seen and best-effort deleted,
+  never executed, so a turn only executes requests created after it started. Combined
+  with delete-on-pickup (the runner removes each request file right after reading it),
+  a request executes at most once per publication; a crashed turn's request surfaces as
+  a writer timeout, never a re-execution.
 
 ## Answered by the review round
 
@@ -61,6 +67,7 @@ Questions the reviews answered moved to the bottom.
   consolidated QA step in orchestration.md: run both relay writers (the Pi extension
   and the shim) through the watch path in one matrix pass, and flip the default only
   after it, plus the capacity gates above.
-- **The 25 s window.** A plausible starting value, not a measured one; it gets about
-  20 percent jitter, validation, and clamping (plan.md decision 7), and QA revisits the
-  number.
+- **The 25 s window.** A plausible starting value, not a measured one; it gets
+  downward-only jitter of up to 20 percent (a deliberate deviation from the reviewed
+  plus-or-minus 20 percent, recorded in status.md), validation, and clamping (plan.md
+  decision 7), and QA revisits the number.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/open-questions.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/open-questions.md
@@ -1,0 +1,27 @@
+# Open questions
+
+None of these blocks slice 1. Question 1 should be answered before flipping the Daytona
+flag on by default.
+
+1. **Daytona held-exec limits.** The design holds one bounded (25 s) `runProcess` request
+   per active turn. In-repo evidence says long-held requests through the preview proxy
+   work (ACP approval pauses hold for minutes to hours), but Daytona's documented limits
+   on concurrent execs per sandbox and per organization, and any proxy idle timeout, are
+   unverified. Who confirms with Daytona, and does the answer move the 25 s window
+   default?
+2. **Default-on timing for the Daytona watch.** Flip `AGENTA_AGENT_TOOLS_RELAY_WATCH` to
+   `true` right after the QA pass, or keep it opt-in until the Claude MCP shim (the
+   second relay writer) lands so both writers are QA'd on the same fast path?
+3. **Backstop cadence follow-up.** Once the watch is trusted, is it worth raising the
+   idle backoff cap (1.5 s today) to cut Daytona fallback polling further, for example to
+   5 s or 30 s? Plan.md defers this deliberately (decision 4); this question is about
+   whether the follow-up is wanted at all, and at what value.
+4. **Permanent timing log.** Keep the `stage=relay_pickup` per-call latency log after QA,
+   or remove it once the numbers are recorded?
+5. **Custom snapshots without node.** The watch exec needs node in the sandbox image. The
+   default snapshot has it (Pi runs on node). Is degrade-to-poll acceptable for custom
+   snapshots without node, or should the script have a shell-only variant
+   (`inotifywait` is not guaranteed either, so a portable shell variant may not exist)?
+6. **Sequencing against the MCP shim revival (#4873).** Land this relay work first (the
+   shim then inherits the fast path), or together with the shim revival in one review
+   cycle?

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/plan.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/plan.md
@@ -1,0 +1,289 @@
+# Plan: event-driven tool relay
+
+## The design in one paragraph
+
+Keep both poll loops exactly as they are and add wake sources that shorten their sleeps.
+An event never carries data and never triggers execution directly; it only means "poll
+now". Inside the sandbox, the writer watches the relay dir with `fs.watch` and wakes the
+moment `<id>.res.json` lands (hop 1). On the local backend the runner does the same for
+`<id>.req.json`. On Daytona, where the runner cannot watch a remote filesystem, the runner
+holds one bounded, blocking exec in the sandbox: a small node script that lists the relay
+dir, watches it, prints when a request appears, and exits; the runner re-issues it each
+window (hop 2). Every wake feeds the existing list-then-read pass with its existing `seen`
+dedup. If any watcher dies, the sleep timer it was racing against fires and the loop polls
+as it does today.
+
+## Decision 1: what an event means
+
+**Options.**
+
+- (a) The event carries the filename; the runner handles that file directly.
+- (b) The event is a wake signal only; the list pass remains the single source of truth.
+
+**Choice: (b).** With (a), every event-path defect becomes a correctness bug: a coalesced
+event (two request files, one notification) drops a call, a renamed or partially written
+file crashes the handler, a duplicate event double-executes. With (b), all of those are
+harmless because the list pass and the `seen` set (relay.ts:332) already handle multiple
+files, partial names, and duplicates. The poll path and the event path converge on one
+code path, so the fallback is exercised on every wake, not only in disaster. The cost is
+one extra directory list per wake, which is cheap on a local filesystem and one daemon
+request on Daytona.
+
+Concretely, the runner loop's `await sleep(delay)` (relay.ts:389) becomes
+`await Promise.race([sleep(delay), watcher.wake()])`. The writer loop in `relayToolCall`
+(dispatch.ts:87-105) gets the same shape. A watcher is an optional object with a `wake()`
+promise and a `close()`; when absent or broken, the race degenerates to the plain sleep.
+This structure is the reliability principle made mechanical: a dead watcher cannot delay
+anything beyond today's poll interval.
+
+## Decision 2: the hop 2 mechanism on Daytona
+
+**Options.**
+
+- (a) Re-issued bounded watch exec. One `sandbox.runProcess` runs a node script:
+  list the dir; if a `*.req.json` is already there, print and exit (this closes the
+  created-before-armed race); otherwise `fs.watch` with a bounded timeout (the watch
+  window, default 25 s); print on the first relevant event or timeout; exit. The runner
+  treats any completion (output, timeout, error) as a wake, runs the list pass, and
+  issues the next watch exec.
+- (b) Persistent watcher process. `createProcess` starts a long-lived watcher; the runner
+  subscribes to its stdout with `followProcessLogs`; each printed filename is a wake.
+- (c) ACP doorbell. Pi's extension emits an `extNotification` ("check the relay dir")
+  right after writing a request file; the runner observes the frame and wakes the loop.
+- (d) No event path on Daytona; just tighten the poll interval.
+
+**Choice: (a).** Reasons, option by option:
+
+- (a) is self-healing by construction. Each window is a fresh request: a wedged script, a
+  dropped connection, or a daemon restart costs at most one window, after which the next
+  issue starts clean; and while a window is broken, the racing backstop poll still runs.
+  There is no orphan to clean up: the script exits on its own timeout even if the runner
+  vanished, so a runner restart or crash leaves nothing behind beyond the tail of the
+  current window. It replaces ~3 execs/second with ~0.04 held requests/second.
+- (b) wins on request count (one process, one stream, no re-issue) but buys three new
+  failure surfaces: stream reconnect (the log follow can drop and must resubscribe
+  without missing prints), orphan lifecycle (the process outlives turns and must be
+  killed on turn end, teardown, and runner restart, exactly the "orphaned watcher"
+  problem the requirements call out), and output handling (log truncation and
+  backpressure). Option (a)'s re-issue cost is one small request per 25 s per active
+  turn; that does not justify (b)'s lifecycle machinery. Revisit if window re-issues
+  ever show up in profiles.
+- (c) is cheap and real: the runner already observes every ACP frame, and the channel
+  exists. But it only covers Pi (the MCP shim is a separate process with no ACP
+  session), only works while the session is streaming, and couples the tool transport to
+  the harness wire, which decision 3 of the delivery architecture deliberately avoids.
+  It also cannot be the only mechanism for the same reason polling stays: a dropped
+  frame must not strand a call. Verdict: feasible, insufficient alone, and redundant
+  once (a) exists. Keep it in the back pocket as an additional wake hint if (a)'s
+  round-trip ever matters; do not build it now.
+- (d) fails the goal. 100 ms polling still adds up per call and triples the daemon
+  request volume that the idle backoff was added to reduce.
+
+**Watch exec details.**
+
+- The script is generated inline by the runner (a `node -e` argument), not uploaded, so
+  there is no asset to version inside the sandbox.
+- It watches for `*.req.json` events but its exit is only a wake; the runner's list pass
+  decides what is actually there.
+- Window default 25 s: short enough that any proxy idle limit is irrelevant and an
+  orphaned script dies quickly, long enough that re-issue traffic is negligible. The
+  60-minute undici timeouts (acp-fetch.ts) sit far above it as the transport backstop.
+- The runner stops issuing new windows when the relay loop stops (`active` flag); the
+  last window expires on its own inside the sandbox.
+- If the exec fails in a way that suggests the fast path cannot work (node missing in a
+  custom snapshot, repeated non-zero exits), the runner logs once and stops issuing
+  windows for the turn; the backstop poll carries the turn at today's cadence.
+
+## Decision 3: where the hop 1 watch lives
+
+**Options.**
+
+- (a) In `relayToolCall` (tools/dispatch.ts), the shared writer.
+- (b) In Pi's extension (extensions/agenta.ts), the only writer today.
+
+**Choice: (a).** `relayToolCall` is the one function every relay writer goes through: Pi's
+extension calls it via `runResolvedTool` today, and the Claude MCP shim is designed to use
+the same dispatch module. Putting the watch there means the second writer gets the fast
+path with zero extra work and the req/res file contract stays the only coupling between
+writers. Option (b) would leave the shim on 300 ms polling and split the relay's timing
+behavior across writers.
+
+The runner-local watch (the local backend's hop 2) lives next to `localRelayHost` so
+`startToolRelay` can race it, keeping `relay.ts` the single home of relay timing.
+
+## Decision 4: what happens to the poll cadence and idle backoff
+
+**Options.**
+
+- (a) Keep every existing constant; the watch only shortens sleeps.
+- (b) Lengthen the backstop poll (for example, cap at 5 s instead of 1.5 s) when a watch
+  is active and healthy.
+
+**Choice: (a) for the initial slices, (b) as a measured follow-up.** The watch already
+removes the latency, so lengthening the backstop buys only fewer fallback requests, and
+doing both changes at once makes a regression ambiguous (was the missed call a watch bug
+or a backoff bug?). Ship the watch with today's constants, measure, then raise the cap in
+a follow-up if the daemon request count still matters. `RELAY_TIMEOUT_MS` and the writer's
+deadline logic are untouched either way; the idle backoff survives as the backstop
+cadence.
+
+## Decision 5: configuration surface
+
+Two new environment variables, both in the existing `AGENTA_AGENT_TOOLS_RELAY_*` family.
+By semantic role (per the interface-design review): both are **config**, operator-owned,
+service-level, read by the runner only. Nothing new crosses the wire, enters the sandbox
+env, or touches the SDK.
+
+| Variable | Role | Default | Meaning |
+| --- | --- | --- | --- |
+| `AGENTA_AGENT_TOOLS_RELAY_WATCH` | config (rollout switch) | `false` initially, flip to `true` after QA | Enables the Daytona watch exec (hop 2). |
+| `AGENTA_AGENT_TOOLS_RELAY_WATCH_WINDOW_MS` | config | `25000` | Bounded lifetime of one watch exec window. |
+
+The hop 1 and local-backend watches (plain `fs.watch` on a local filesystem) ship without
+a flag: they are in-process, their failure mode is "fall back to the poll", and gating
+them would put a flag inside the sandbox env for no operational benefit. The Daytona watch
+exec gets the flag because it changes what the runner asks the daemon to do, which is the
+part an operator may need to switch off against a misbehaving provider.
+
+Existing variables (`AGENTA_AGENT_TOOLS_RELAY_POLLING`, `_POLLING_MAX`,
+`_IDLE_GROW_AFTER`, `_TIMEOUT`) keep their names and meanings.
+
+## Does this make anything worse? (reliability and scalability)
+
+### Races and duplicates
+
+- **File created before the watch is armed.** Three independent covers: the watch exec
+  script lists before watching; the runner runs a list pass on every wake and on every
+  window start; the backstop poll fires regardless. Writer side (hop 1): arm `fs.watch`,
+  then check `existsSync`, then wait; the response cannot fall between the check and the
+  watch because the watch is already armed.
+- **Event coalescing.** Two request files, one event (or one window exit): the wake
+  triggers a full list, which returns both; the `seen` set dedups across wakes. Nothing
+  is lost.
+- **Duplicate detection.** Unchanged: the `seen` set already guards re-listing the same
+  request file; the writer already deletes the pair after reading. Duplicate events cause
+  duplicate lists, not duplicate executions.
+- **Spurious events.** Pi's usage file lives inside the relay dir and its writes will
+  fire watch events. Cost: an extra list pass that finds nothing. Accepted; filtering
+  event names would reintroduce the trust-the-event-payload problem decision 1 rejects.
+
+### Watcher lifecycle
+
+- **Watcher crash or absence.** The `Promise.race` structure means the loop's worst case
+  is exactly today's poll cadence. A watch exec that errors repeatedly is disabled for
+  the turn with one log line.
+- **Orphaned watcher processes.** None by design: each watch exec dies at its own bounded
+  timeout, enforced by the daemon (`timeoutMs` on `runProcess`), even if the runner is
+  gone. Turn end stops new windows; sandbox teardown kills the VM and the script with it.
+- **Runner restart mid-watch.** The in-flight window expires in the sandbox within the
+  window bound. The restarted runner starts a fresh relay loop that lists first, so
+  request files written during the gap are found. Stale request files from a crashed run
+  behave exactly as they do today (a fresh loop would execute them); this project does
+  not change that property.
+
+### Held connections and Daytona limits
+
+- **Concurrency shape.** N concurrent Daytona turns hold N watch requests. But undici's
+  keep-alive (10 min, acp-fetch.ts) means today's 3/s polling already keeps roughly one
+  persistent connection per sandbox host; the held watch rides that same connection.
+  Connection and fd count per run: approximately unchanged. Requests per run: down about
+  two orders of magnitude (from ~180/min to ~2.4/min idle).
+- **Proxy and daemon tolerance.** The ACP prompt request is already held open for
+  human-timescale approval pauses through the same preview proxy and cookie auth; that is
+  the production evidence that held requests survive the path. The 25 s window sits far
+  below both the 60-minute undici timeouts and any plausible proxy idle limit.
+  Daytona-side limits on concurrent execs per sandbox are not documented in the repo;
+  the design needs exactly one concurrent exec per sandbox above today's baseline, which
+  is the smallest possible ask. Verification is open question 1.
+- **Runner memory.** One pending promise and one small script string per active turn.
+  Negligible against the existing per-turn state.
+
+### Interplay with neighbors
+
+- **`RELAY_TIMEOUT_MS`.** Unchanged. The writer's deadline still governs; the watch only
+  makes the success path faster.
+- **Idle backoff.** Survives as the backstop cadence (decision 4). Its reset-on-activity
+  behavior still works because wakes feed the same `sawNew` accounting.
+- **Warm sessions (session-keepalive).** The relay loop is per-turn and stays per-turn. A
+  kept-alive session between turns runs no relay loop and no watch exec, so an idle warm
+  sandbox costs zero relay requests, same as today. If the relay ever becomes
+  per-session, the watch window design carries over unchanged; only the start/stop call
+  sites move.
+- **The second writer (Claude MCP shim).** The file contract is untouched, hop 1 lives in
+  the shared `relayToolCall`, and the hop 2 watch is directory-level, so a second writer's
+  request files wake the runner identically. Nothing in this design is Pi-specific.
+
+### Net verdict
+
+Latency: hop 1 drops to one filesystem event (~0 ms). Hop 2 drops to ~0 ms locally and to
+one daemon round-trip on Daytona (the script prints, the held request completes, the
+runner lists and reads). Per-call relay overhead goes from 0.3-1.8 s to under ~150 ms on
+Daytona and near zero locally. Request volume on Daytona drops sharply. Failure modes are
+bounded by the untouched poll loop. The one genuinely new cost is one held daemon request
+per active turn, which the ACP channel already proves out at far longer durations.
+
+## Slices
+
+1. **Hop 1 and local hop 2 (no flag).** Add the watcher abstraction to `relay.ts`
+   (wake-race helper + local `fs.watch` watcher) and use it in `startToolRelay` and in
+   `relayToolCall`. Unit tests. This alone removes ~0.6 s per call locally and ~0.3 s per
+   call on Daytona (the response wait).
+2. **Daytona watch exec (flag off).** The inline node watch script, the window loop, the
+   disable-on-repeated-failure guard, wired into `sandboxRelayHost` usage in
+   `startToolRelay` behind `AGENTA_AGENT_TOOLS_RELAY_WATCH`. Unit tests with a fake
+   sandbox handle.
+3. **Measurement and QA.** A `[timing] stage=relay_pickup` log (request-file write to
+   handler start) alongside the existing timing lines. Run the Daytona tool cells of the
+   QA matrix with the flag on; record before/after per-call latency in status.md. Flip
+   the default after a clean pass.
+4. **Docs sync.** Env var inventory and the relay description in
+   `docs/design/agent-workflows/documentation/` (tools page), per the keep-docs-in-sync
+   rule.
+
+## Test plan
+
+**Unit (vitest, `services/runner/tests/unit/`).**
+
+- Wake-race helper: event before sleep expiry wakes early; no event falls through at the
+  poll delay; a watcher whose `wake()` rejects degrades to the sleep (the degrade test).
+- Local watcher: file created after arming wakes; file created before arming is found by
+  the accompanying list (simulated arm gap); two files, one wake, both handled; close is
+  idempotent.
+- `startToolRelay` with a fake host and a controllable fake watcher: request handled on
+  wake without waiting a poll interval; watcher death mid-turn does not stall the loop;
+  `seen` dedup across wake and poll pickups of the same file.
+- Watch exec script builder: emits list-first behavior; exits on first event; exits at
+  the window bound; the runner's window loop treats error, timeout, and output uniformly
+  as wakes and disables after repeated failures.
+- `relayToolCall`: response via watch resolves promptly; watch failure falls back to the
+  300 ms poll; deadline behavior unchanged.
+
+**Integration.**
+
+- Local end-to-end: real `startToolRelay` with `localRelayHost` plus a real
+  `relayToolCall` against a temp dir; assert round-trip completes in well under one poll
+  interval.
+- The race, deterministically: with injected hooks, write the request file in the gap
+  between the watcher arming and the first list, and assert pickup; same for the
+  response file on the writer side.
+- The watch script as a process: spawn the actual node script against a temp dir; cover
+  the pre-existing-file path, the event path, and the timeout path.
+
+**Measurement.**
+
+- The `stage=relay_pickup` timing log gives per-call pickup latency in both modes.
+- Before/after comparison on the dev box: a Daytona run with several gateway tool calls,
+  flag off then on; record median and worst per-call relay overhead in status.md. Success
+  is median pickup under 150 ms on Daytona and under 10 ms locally, with zero missed
+  calls across the QA matrix tool cells.
+
+## Rollout
+
+1. Slice 1 ships unflagged (in-process watches, poll fallback intact). Runner tests plus
+   one dev-box smoke run gate it.
+2. Slice 2 ships with `AGENTA_AGENT_TOOLS_RELAY_WATCH=false`. QA on the dev box with the
+   flag on (slice 3). Flip the default to `true` in a follow-up commit once the matrix
+   passes; the flag stays as the operator kill switch.
+3. Any incident playbook is one line: set `AGENTA_AGENT_TOOLS_RELAY_WATCH=false` and the
+   relay is byte-for-byte today's behavior on Daytona; slice 1's in-process watches have
+   no operational surface to switch.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/plan.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/plan.md
@@ -2,16 +2,25 @@
 
 ## The design in one paragraph
 
-Keep both poll loops exactly as they are and add wake sources that shorten their sleeps.
+Make relay-file publication atomic, then add wake sources that shorten the poll sleeps.
 An event never carries data and never triggers execution directly; it only means "poll
-now". Inside the sandbox, the writer watches the relay dir with `fs.watch` and wakes the
-moment `<id>.res.json` lands (hop 1). On the local backend the runner does the same for
-`<id>.req.json`. On Daytona, where the runner cannot watch a remote filesystem, the runner
-holds one bounded, blocking exec in the sandbox: a small node script that lists the relay
-dir, watches it, prints when a request appears, and exits; the runner re-issues it each
-window (hop 2). Every wake feeds the existing list-then-read pass with its existing `seen`
-dedup. If any watcher dies, the sleep timer it was racing against fires and the loop polls
-as it does today.
+now". Both directions publish via a temporary name plus a same-directory rename, so a
+wake can never observe a partial file. Inside the sandbox, the writer watches the relay
+dir with `fs.watch` and wakes the moment `<id>.res.json` lands (hop 1). On the local
+backend the runner does the same for `<id>.req.json`. On Daytona, where the runner cannot
+watch a remote filesystem, the runner holds one bounded, blocking exec in the sandbox: a
+small node script that arms a watch, lists the relay dir, and exits on the first request
+or at its window bound. While that watch is healthy the runner suspends its remote `ls`
+polling and keeps only an ultra-slow safety poll; when the watch cannot run, the turn
+falls back to today's poll loop. Every wake feeds the existing list-then-read pass with
+its existing `seen` dedup.
+
+This mechanism is writer-agnostic because it watches the relay directory, not any writer.
+Today the relay has two writers: Pi's in-sandbox extension, and local Claude through the
+runner's loopback MCP handler (both route through the same dispatch module,
+`tool-mcp-http.ts:210` -> `runResolvedTool` -> `relayToolCall`). Tomorrow the in-sandbox
+stdio MCP shim ([../in-sandbox-tool-mcp/plan.md](../in-sandbox-tool-mcp/plan.md), PR
+#5234) becomes the third. Nothing here assumes Pi.
 
 ## Decision 1: what an event means
 
@@ -21,269 +30,467 @@ as it does today.
 - (b) The event is a wake signal only; the list pass remains the single source of truth.
 
 **Choice: (b).** With (a), every event-path defect becomes a correctness bug: a coalesced
-event (two request files, one notification) drops a call, a renamed or partially written
-file crashes the handler, a duplicate event double-executes. With (b), all of those are
-harmless because the list pass and the `seen` set (relay.ts:332) already handle multiple
-files, partial names, and duplicates. The poll path and the event path converge on one
-code path, so the fallback is exercised on every wake, not only in disaster. The cost is
-one extra directory list per wake, which is cheap on a local filesystem and one daemon
-request on Daytona.
+event (two request files, one notification) drops a call, and a duplicate event
+double-executes. With (b), those are harmless because the list pass and the `seen` set
+(relay.ts:332) handle multiple files and duplicate filenames. The poll path and the event
+path converge on one code path, so the fallback is exercised on every wake, not only in
+disaster. The cost is one extra directory list per wake.
 
-Concretely, the runner loop's `await sleep(delay)` (relay.ts:389) becomes
-`await Promise.race([sleep(delay), watcher.wake()])`. The writer loop in `relayToolCall`
-(dispatch.ts:87-105) gets the same shape. A watcher is an optional object with a `wake()`
-promise and a `close()`; when absent or broken, the race degenerates to the plain sleep.
-This structure is the reliability principle made mechanical: a dead watcher cannot delay
-anything beyond today's poll interval.
+**Correction from review.** An earlier draft claimed the `seen` set also handles
+partially written files. It does not; it only dedups filenames. Under polling, the 300 ms
+delay usually hides the write interval, but an event can arrive mid-write. The runner
+would then mark the request seen (relay.ts:338), read partial JSON (relay.ts:380), write
+an error response, and never retry. The response direction has the same defect: the
+writer parses the moment the file exists (dispatch.ts:87) while the runner writes the
+final path directly (relay.ts:362). Wake-only semantics therefore require atomic
+publication, which is decision 2.
 
-## Decision 2: the hop 2 mechanism on Daytona
+## Decision 2: atomic file publication (protocol amendment)
 
-**Options.**
+Both directions publish via a temporary name plus a same-directory rename:
 
-- (a) Re-issued bounded watch exec. One `sandbox.runProcess` runs a node script:
-  list the dir; if a `*.req.json` is already there, print and exit (this closes the
-  created-before-armed race); otherwise `fs.watch` with a bounded timeout (the watch
-  window, default 25 s); print on the first relevant event or timeout; exit. The runner
-  treats any completion (output, timeout, error) as a wake, runs the list pass, and
-  issues the next watch exec.
-- (b) Persistent watcher process. `createProcess` starts a long-lived watcher; the runner
-  subscribes to its stdout with `followProcessLogs`; each printed filename is a wake.
-- (c) ACP doorbell. Pi's extension emits an `extNotification` ("check the relay dir")
-  right after writing a request file; the runner observes the frame and wakes the loop.
-- (d) No event path on Daytona; just tighten the poll interval.
+```text
+<id>.req.json.tmp.<nonce>  -> rename ->  <id>.req.json
+<id>.res.json.tmp.<nonce>  -> rename ->  <id>.res.json
+```
 
-**Choice: (a).** Reasons, option by option:
+The final file contract (names, contents, who deletes what) does not change. Temporary
+names never match the `.req.json`/`.res.json` suffix filters, so no reader ever sees
+them. A same-directory rename is atomic on POSIX, so the final name either does not exist
+or holds complete bytes.
 
-- (a) is self-healing by construction. Each window is a fresh request: a wedged script, a
-  dropped connection, or a daemon restart costs at most one window, after which the next
-  issue starts clean; and while a window is broken, the racing backstop poll still runs.
-  There is no orphan to clean up: the script exits on its own timeout even if the runner
-  vanished, so a runner restart or crash leaves nothing behind beyond the tail of the
-  current window. It replaces ~3 execs/second with ~0.04 held requests/second.
-- (b) wins on request count (one process, one stream, no re-issue) but buys three new
-  failure surfaces: stream reconnect (the log follow can drop and must resubscribe
-  without missing prints), orphan lifecycle (the process outlives turns and must be
-  killed on turn end, teardown, and runner restart, exactly the "orphaned watcher"
-  problem the requirements call out), and output handling (log truncation and
-  backpressure). Option (a)'s re-issue cost is one small request per 25 s per active
-  turn; that does not justify (b)'s lifecycle machinery. Revisit if window re-issues
-  ever show up in profiles.
-- (c) is cheap and real: the runner already observes every ACP frame, and the channel
-  exists. But it only covers Pi (the MCP shim is a separate process with no ACP
-  session), only works while the session is streaming, and couples the tool transport to
-  the harness wire, which decision 3 of the delivery architecture deliberately avoids.
-  It also cannot be the only mechanism for the same reason polling stays: a dropped
-  frame must not strand a call. Verdict: feasible, insufficient alone, and redundant
-  once (a) exists. Keep it in the back pocket as an additional wake hint if (a)'s
-  round-trip ever matters; do not build it now.
-- (d) fails the goal. 100 ms polling still adds up per call and triples the daemon
-  request volume that the idle backoff was added to reduce.
+Where the rename runs:
 
-**Watch exec details.**
+- The in-sandbox writer (hop 1 request, both backends): `fs.renameSync`, local to the
+  sandbox filesystem.
+- The runner's response write, local backend: `fs.renameSync` in `localRelayHost`.
+- The runner's response write, Daytona: `RelayHost` gains a rename capability. The
+  daemon SDK exposes `moveFs` (`post_v1_fs_move`), but whether it is a
+  `rename(2)`-atomic same-directory move is unverified (open question 2). If it is not,
+  the capability is implemented as a shell `mv` exec instead (an `mv` within one
+  filesystem is `rename(2)`).
+
+**Rejected weaker fallback: reader-side JSON parse retry.** Retrying a failed parse
+interacts badly with the `seen` set and exactly-once execution: a parse failure would
+have to un-see the file and retry under a deadline, and a genuinely corrupt file would
+then loop. Correctness would once again depend on timing. Publication-side atomicity
+removes the class of bug instead of handling it.
+
+## Decision 3: the wake contract
+
+The seam between a wake source and a poll loop is a coalesced, single-flight activity
+source, not a bare promise race. An earlier draft proposed
+`Promise.race([sleep(delay), watcher.wake()])`; review showed that shape leaks listeners
+on timer wins and can launch overlapping Daytona execs. The contract is:
+
+```ts
+interface RelayActivitySource {
+  wait(options: {
+    timeoutMs: number;
+    signal?: AbortSignal;
+  }): Promise<"activity" | "timeout" | "closed">;
+
+  close(): void;
+}
+```
+
+Invariants, each pinned by a unit test:
+
+- At most one underlying Daytona `runProcess` exists per relay, ever (single-flight).
+- Notifications coalesce into one sticky pending wake: any number of events while no
+  waiter is present resolve the next `wait()` immediately with `"activity"`.
+- A timer win leaves no accumulated listener; thousands of consecutive timeouts produce
+  zero listener growth.
+- An event that arrives between a directory scan and the next `wait()` stays observable
+  (an epoch counter or sticky bit that `wait()` consumes).
+- `close()` resolves in-flight waits with `"closed"`, prevents rearming, and aborts the
+  in-flight held exec request, so relay stop (turn end, pause, teardown) cannot leave a
+  request pinned on a stalled proxy or daemon.
+- Errors are consumed and logged once. They degrade the source (the wait resolves like a
+  timeout and the loop polls); they never become unhandled rejections.
+
+Both loops use the same shape: `wait()`, then run the list pass regardless of the
+outcome, then loop unless `"closed"`. Polling stays authoritative; the source only
+shortens the sleep. When no source is available the loop uses a plain sleep, which is
+byte-for-byte today's behavior.
+
+## Decision 4: the hop 2 mechanism on Daytona
+
+**Choice: a re-issued bounded watch exec that replaces the runner's remote polling while
+healthy.** One `sandbox.runProcess` runs a small node script in the sandbox:
+
+1. Arm `fs.watch` on the relay dir.
+2. List the dir; if a `*.req.json` is already present, exit immediately.
+3. Wait for the sticky watch signal, an in-script periodic `readdir` hit, or the internal
+   window timer; then exit.
+
+The arm-then-list order matters. An earlier draft listed first and then watched, claiming
+that closed the created-before-armed race; it does not, because a file can land after the
+list returns and before `fs.watch` arms. Arming first, then listing, then waiting on a
+sticky signal closes it: a file that lands during the list fires the already-armed watch,
+and the sticky bit keeps the event observable.
+
+The runner treats the exec's completion as the wake, runs the list pass, and issues the
+next window. While the watch is healthy:
+
+- The runner does **not** run its 300 ms to 1.5 s remote `ls` poll. This is the request
+  reduction; racing the watch against the full poll loop, as an earlier draft did, would
+  have reduced nothing.
+- The script's own periodic `readdir` (every 2 s, in-sandbox, no network cost) is the
+  in-window correctness fallback against `fs.watch` losing an event.
+- The runner keeps a hard outer bound on each window: the daemon request's `timeoutMs`
+  is the window plus a 5 s grace, and an `AbortSignal` fires at the same bound, so a
+  stalled proxy cannot hold the socket past the window. The grace exists so a normal
+  window expiry (the script's internal timer) is never misclassified as a daemon timeout
+  and counted as a failure.
+
+**Fallback demotion.** If the watch exec cannot start, is rejected, or exits abnormally
+repeatedly (three consecutive failures, retried with jittered exponential backoff, 1 s
+doubling to a 30 s cap, plus or minus 20 percent), the runner stops issuing windows for
+the turn and switches back to the classic poll loop at today's cadence, including the
+idle backoff. One log line records the demotion.
+
+**The safety poll: kept, at 30 s.** While the watch is healthy the runner additionally
+runs one remote `ls` every 30 s. Decision and reasoning:
+
+- The alternative (rely on the in-script `readdir` plus the outer timeout alone) makes
+  the worst case depend on the watch subsystem detecting its own failure. The in-script
+  `readdir` shares fate with the script: a wedged node process, a paused sandbox, or a
+  daemon that accepted the exec but never delivers completion all silence it, and the
+  outer timeout only catches those after window plus grace, followed by the demotion
+  counter, which is itself new code that can be wrong.
+- The safety poll is independent of every one of those layers. It uses the same primitive
+  today's loop uses (a plain remote list) and nothing else, so it preserves the
+  reliability principle as an absolute property: pickup latency is bounded by 30 s no
+  matter what the watch subsystem does, including lying about success.
+- It is nearly free: 2 requests per minute next to the watch's 2.4 re-issues per minute.
+  Keeping it does not change the order of magnitude of the reduction.
+- A request first discovered by the safety poll while a watch window was supposedly
+  healthy counts as a watch miss and feeds the same demotion counter.
+
+**Request volume, honestly.** Today an active Daytona turn costs about 200 remote `ls`
+requests per minute (300 ms cadence), settling to about 40 per minute after idle backoff.
+The healthy watch mode costs about 2.4 watch re-issues plus 2 safety polls per minute,
+about 4.4 requests per minute total: roughly 45x fewer than today's active cadence and
+roughly 9x fewer than today's idle floor. Per actual tool call, the list, read, and write
+daemon calls are unchanged. An earlier draft claimed a ~75x reduction while also keeping
+the full poll loop racing the watch; that combination was wrong, and would have reduced
+request volume not at all.
+
+### Alternatives considered and rejected
+
+None of the following is part of the design. Each was evaluated and rejected.
+
+- **Persistent watcher process** (`createProcess` plus `followProcessLogs`). Wins on
+  request count (one process, one stream, no re-issue) but buys three new failure
+  surfaces: stream reconnect (the log follow can drop and must resubscribe without
+  missing prints), orphan lifecycle (the process outlives turns and must be killed on
+  turn end, teardown, and runner restart, exactly the orphaned-watcher problem the
+  requirements call out), and output handling (log truncation and backpressure). The
+  re-issued exec is self-healing by construction: each window is a fresh request, a
+  wedged script or daemon restart costs at most one window, and an orphan dies at its
+  own internal timer even if the runner vanished. Revisit only if window re-issues ever
+  show up in profiles.
+- **ACP doorbell.** Rejected first because it cannot serve Claude at all: the MCP shim
+  is a separate process with no ACP session, so a doorbell only ever covers Pi. It also
+  only works while a session is streaming, and it couples the tool transport to the
+  harness wire, which the delivery architecture deliberately avoids. It could return
+  later as an extra wake hint on top of the watch, never as the mechanism.
+- **No event path on Daytona; just tighten the poll interval.** Fails the goal: 100 ms
+  polling still adds up per call and triples the daemon request volume that the idle
+  backoff was added to reduce.
+
+### Watch exec details (hardening, from review)
 
 - The script is generated inline by the runner (a `node -e` argument), not uploaded, so
   there is no asset to version inside the sandbox.
-- It watches for `*.req.json` events but its exit is only a wake; the runner's list pass
-  decides what is actually there.
-- Window default 25 s: short enough that any proxy idle limit is irrelevant and an
-  orphaned script dies quickly, long enough that re-issue traffic is negligible. The
-  60-minute undici timeouts (acp-fetch.ts) sit far above it as the transport backstop.
-- The runner stops issuing new windows when the relay loop stops (`active` flag); the
-  last window expires on its own inside the sandbox.
-- If the exec fails in a way that suggests the fast path cannot work (node missing in a
-  custom snapshot, repeated non-zero exits), the runner logs once and stops issuing
-  windows for the turn; the backstop poll carries the turn at today's cadence.
+- The relay directory is passed as an argv value (`process.argv`), never interpolated
+  into the script source or a shell string. A regression test covers a path containing
+  quotes, whitespace, shell metacharacters, and newlines.
+- The script wakes on every directory event. It ignores `eventType` and `filename`
+  entirely (filenames may be absent per the Node docs), so a rename versus create
+  distinction cannot break it; every event is merely a wake.
+- It handles a synchronous `fs.watch` throw and the watcher `error` event: both close
+  cleanly and exit, which the runner treats as a wake plus a failure count.
+- It closes the watcher and clears the timer on every exit path.
+- Its exit (the exec completion) is the wake signal. The runner does not parse stdout,
+  and the script does not `process.exit()` immediately after `console.log` (piped
+  stdout can truncate).
+- The internal window timer expires the script normally; the daemon `timeoutMs` sits at
+  window plus grace, so normal expiry never races the daemon timeout.
+- Node documents `fs.watch` caveats that this design absorbs by construction: it is not
+  fully portable, filenames may be absent, and it is unreliable on virtualized or
+  network filesystems. The relay dir is a plain local directory inside the VM by
+  construction (research.md), and the periodic `readdir` covers residual event loss.
+  One gotcha needs a live check: deleting and recreating the watched directory leaves
+  the watcher attached to the old inode (Node `fs.watch` docs). `workspace.ts:60`
+  recreates the relay dir when preparing a workspace; the QA pass includes a
+  directory-replacement cell.
+- The runner stops issuing windows when the relay loop stops (`active` flag, plus
+  `close()` aborting the held request); the last in-sandbox script expires on its own
+  internal timer.
 
-## Decision 3: where the hop 1 watch lives
+## Decision 5: where the code lives (slice 0)
 
-**Options.**
+The relay client moves to its final modules first, as a no-behavior-change extraction:
 
-- (a) In `relayToolCall` (tools/dispatch.ts), the shared writer.
-- (b) In Pi's extension (extensions/agenta.ts), the only writer today.
+- `tools/relay-protocol.ts`: the suffixes, the temp-name scheme, request/response JSON
+  types, and `sanitizeRelayId`. Bundle-safe by rule: no server-side imports, so the
+  future shim bundle and the runner both consume it.
+- `tools/relay-client.ts`: request publication (write temp, rename), the response wait
+  as one exported function, `waitForRelayResponse(resPath, { timeoutMs, signal })`
+  (final name at implementation time), per-tool timeout, abort, and pair cleanup.
+  `dispatch.ts` re-exports so existing call sites (the Pi extension, local Claude's
+  loopback handler) compile unchanged.
+- `tools/relay.ts`: stays the runner-side consumer and executor. Shared wake helpers do
+  **not** live here: the shim bundle must never import server-heavy code, so the
+  writer-side watch lives inside `relay-client.ts`'s wait function and the runner-side
+  wake lives behind a `RelayHost` capability (`waitForActivity` or similar, returning
+  the decision 3 activity source), implemented by `localRelayHost` with `fs.watch` and
+  by `sandboxRelayHost` with the watch exec. `RelayHost` also gains the rename
+  capability from decision 2.
 
-**Choice: (a).** `relayToolCall` is the one function every relay writer goes through: Pi's
-extension calls it via `runResolvedTool` today, and the Claude MCP shim is designed to use
-the same dispatch module. Putting the watch there means the second writer gets the fast
-path with zero extra work and the req/res file contract stays the only coupling between
-writers. Option (b) would leave the shim on 300 ms polling and split the relay's timing
-behavior across writers.
+The hop 1 watch therefore lives inside `waitForRelayResponse`, not in `dispatch.ts` as an
+earlier draft said. Every relay writer goes through that one function, so the second and
+third writers get the fast path with zero extra work.
 
-The runner-local watch (the local backend's hop 2) lives next to `localRelayHost` so
-`startToolRelay` can race it, keeping `relay.ts` the single home of relay timing.
+**Ownership, settled with the sibling project.** This project owns the extraction as
+slice 0. The in-sandbox-tool-mcp plan originally defined `relay-client.ts` and the
+`waitForRelayResponse` contract as its own slice 1
+([../in-sandbox-tool-mcp/plan.md](../in-sandbox-tool-mcp/plan.md):117) and sequenced
+that slice before this watcher (plan.md:269); that project now consumes the modules this
+slice 0 creates, with the identical contract, and its workspace is being corrected to
+match. The landing-order note in
+[../mcp-delivery-architecture/orchestration.md](../mcp-delivery-architecture/orchestration.md)
+needs the same update (tracked in [open-questions.md](open-questions.md)).
 
-## Decision 4: what happens to the poll cadence and idle backoff
+## Decision 6: poll cadence and idle backoff
 
-**Options.**
+- **Hop 1 and local hop 2:** the existing poll cadence survives as a cheap safety timer
+  racing the watch. A local `existsSync` or `readdirSync` every 300 ms costs nothing
+  worth optimizing, and it keeps the degrade path exercised.
+- **Daytona hop 2, watch healthy:** the remote poll is suspended (decision 4); the 30 s
+  safety poll replaces it. The idle backoff does not run in this mode; there is nothing
+  for it to back off.
+- **Daytona hop 2, fallback mode:** today's loop, byte for byte, including the 300 ms
+  cadence and the idle backoff to 1.5 s.
+- `RELAY_TIMEOUT_MS` and the writer's deadline logic are untouched in every mode.
 
-- (a) Keep every existing constant; the watch only shortens sleeps.
-- (b) Lengthen the backstop poll (for example, cap at 5 s instead of 1.5 s) when a watch
-  is active and healthy.
+## Decision 7: configuration surface
 
-**Choice: (a) for the initial slices, (b) as a measured follow-up.** The watch already
-removes the latency, so lengthening the backstop buys only fewer fallback requests, and
-doing both changes at once makes a regression ambiguous (was the missed call a watch bug
-or a backoff bug?). Ship the watch with today's constants, measure, then raise the cap in
-a follow-up if the daemon request count still matters. `RELAY_TIMEOUT_MS` and the writer's
-deadline logic are untouched either way; the idle backoff survives as the backstop
-cadence.
+Three environment variables, per hop, in the existing `AGENTA_AGENT_TOOLS_RELAY_*`
+family. By semantic role: all three are **config**, operator-owned. An earlier draft had
+one flag for both hops; review rejected that granularity because the in-sandbox response
+watch and the remote Daytona exec have different owners and different failure modes.
 
-## Decision 5: configuration surface
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `AGENTA_AGENT_TOOLS_RELAY_RESPONSE_WATCH_ENABLED` | `true` | Hop 1: the writer's in-sandbox `fs.watch` on the response file. Read by the writer from its env (the existing relay env channel). Off means the writer keeps today's 300 ms poll only. |
+| `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_ENABLED` | `false` initially, flip to `true` after QA | Hop 2 on Daytona: the watch exec plus suspended polling. Off means today's poll loop, byte for byte. |
+| `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_WINDOW_MS` | `25000` | Bounded lifetime of one watch exec window. Validated and clamped, below. |
 
-Two new environment variables, both in the existing `AGENTA_AGENT_TOOLS_RELAY_*` family.
-By semantic role (per the interface-design review): both are **config**, operator-owned,
-service-level, read by the runner only. Nothing new crosses the wire, enters the sandbox
-env, or touches the SDK.
+**Window validation and clamping.** The value is parsed as an integer. A missing or
+unparseable value falls back to the 25000 default with one warning log. A parsed value is
+clamped to the range 5000 to 120000, again with one warning log: below 5 s the re-issue
+cadence becomes the request storm this design removes; above 2 min the bounded-lifetime
+and orphan-cleanup assumptions stop holding. Each issued window applies about 20 percent
+jitter so a fleet of turns does not re-issue in lockstep. The 25 s default is a plausible
+operational starting value, not a measured one; QA revisits it.
 
-| Variable | Role | Default | Meaning |
-| --- | --- | --- | --- |
-| `AGENTA_AGENT_TOOLS_RELAY_WATCH` | config (rollout switch) | `false` initially, flip to `true` after QA | Enables the Daytona watch exec (hop 2). |
-| `AGENTA_AGENT_TOOLS_RELAY_WATCH_WINDOW_MS` | config | `25000` | Bounded lifetime of one watch exec window. |
-
-The hop 1 and local-backend watches (plain `fs.watch` on a local filesystem) ship without
-a flag: they are in-process, their failure mode is "fall back to the poll", and gating
-them would put a flag inside the sandbox env for no operational benefit. The Daytona watch
-exec gets the flag because it changes what the runner asks the daemon to do, which is the
-part an operator may need to switch off against a misbehaving provider.
+The runner-local hop 2 watch (local backend, in-process `fs.watch`) ships without a flag:
+its failure mode is "fall back to the poll" and it has no operational surface an operator
+would need to switch. The remote watch gets the flag because it changes what the runner
+asks the daemon to do.
 
 Existing variables (`AGENTA_AGENT_TOOLS_RELAY_POLLING`, `_POLLING_MAX`,
-`_IDLE_GROW_AFTER`, `_TIMEOUT`) keep their names and meanings.
+`_IDLE_GROW_AFTER`, `_TIMEOUT`) keep their names and meanings; they now describe the
+fallback mode and the local safety timers.
 
 ## Does this make anything worse? (reliability and scalability)
 
-### Races and duplicates
+### Races and partial files
 
-- **File created before the watch is armed.** Three independent covers: the watch exec
-  script lists before watching; the runner runs a list pass on every wake and on every
-  window start; the backstop poll fires regardless. Writer side (hop 1): arm `fs.watch`,
-  then check `existsSync`, then wait; the response cannot fall between the check and the
-  watch because the watch is already armed.
-- **Event coalescing.** Two request files, one event (or one window exit): the wake
-  triggers a full list, which returns both; the `seen` set dedups across wakes. Nothing
-  is lost.
-- **Duplicate detection.** Unchanged: the `seen` set already guards re-listing the same
-  request file; the writer already deletes the pair after reading. Duplicate events cause
-  duplicate lists, not duplicate executions.
-- **Spurious events.** Pi's usage file lives inside the relay dir and its writes will
-  fire watch events. Cost: an extra list pass that finds nothing. Accepted; filtering
-  event names would reintroduce the trust-the-event-payload problem decision 1 rejects.
+- **Partial files.** Removed by construction (decision 2): a final-name file is always
+  complete. Delayed and chunked writes become invisible to readers.
+- **File created before the watch is armed.** Writer side (hop 1): arm `fs.watch`, then
+  check `existsSync`, then wait; the response cannot fall between the check and the
+  watch because the watch is already armed. Sandbox side (hop 2): the script arms before
+  listing (decision 4). Runner side: a list pass runs on every wake and window start,
+  and the safety poll fires regardless.
+- **Event coalescing.** Two request files, one wake: the list pass returns both; the
+  `seen` set dedups across wakes. The activity source's sticky bit means a wake can
+  never be lost between a scan and the next wait.
+- **Duplicate detection.** Unchanged: the `seen` set guards re-listing the same request
+  filename; the writer deletes the pair after reading. Duplicate events cause duplicate
+  lists, not duplicate executions.
+- **Spurious events.** Pi's usage file lives inside the relay dir and its writes fire
+  watch events, as do the `.tmp.<nonce>` names themselves. Cost: an extra list pass that
+  finds nothing new. Accepted; filtering event payloads would reintroduce the
+  trust-the-event problem decision 1 rejects.
 
 ### Watcher lifecycle
 
-- **Watcher crash or absence.** The `Promise.race` structure means the loop's worst case
-  is exactly today's poll cadence. A watch exec that errors repeatedly is disabled for
-  the turn with one log line.
-- **Orphaned watcher processes.** None by design: each watch exec dies at its own bounded
-  timeout, enforced by the daemon (`timeoutMs` on `runProcess`), even if the runner is
-  gone. Turn end stops new windows; sandbox teardown kills the VM and the script with it.
+- **Watcher crash or absence.** The loop's worst case is the racing timer: today's poll
+  cadence on hop 1 and local hop 2, the 30 s safety poll plus fallback demotion on
+  Daytona. A watch exec that fails repeatedly is demoted for the turn with one log line
+  and jittered backoff on the way there.
+- **Orphaned watcher processes.** None by design: each watch exec dies at its own
+  internal timer, and the daemon's `timeoutMs` (window plus grace) backstops that, even
+  if the runner is gone. Turn end stops new windows and aborts the held request; sandbox
+  teardown kills the VM and the script with it.
 - **Runner restart mid-watch.** The in-flight window expires in the sandbox within the
   window bound. The restarted runner starts a fresh relay loop that lists first, so
-  request files written during the gap are found. Stale request files from a crashed run
-  behave exactly as they do today (a fresh loop would execute them); this project does
-  not change that property.
+  request files written during the gap are found. Stale request files from a crashed
+  turn inside a warm-continued environment are a pre-existing property this project does
+  not change; ownership of that residue is an open question raised by the sibling
+  project (see open-questions.md).
 
 ### Held connections and Daytona limits
 
-- **Concurrency shape.** N concurrent Daytona turns hold N watch requests. But undici's
-  keep-alive (10 min, acp-fetch.ts) means today's 3/s polling already keeps roughly one
+- **Concurrency shape.** N concurrent Daytona turns hold N watch requests. Undici's
+  keep-alive (10 min, acp-fetch.ts) means today's ~3/s polling already keeps roughly one
   persistent connection per sandbox host; the held watch rides that same connection.
-  Connection and fd count per run: approximately unchanged. Requests per run: down about
-  two orders of magnitude (from ~180/min to ~2.4/min idle).
+  Connections and file descriptors per run: approximately unchanged. Requests per run:
+  about 4.4 per minute against about 200 per minute active today (decision 4 has the
+  honest arithmetic).
 - **Proxy and daemon tolerance.** The ACP prompt request is already held open for
-  human-timescale approval pauses through the same preview proxy and cookie auth; that is
-  the production evidence that held requests survive the path. The 25 s window sits far
-  below both the 60-minute undici timeouts and any plausible proxy idle limit.
-  Daytona-side limits on concurrent execs per sandbox are not documented in the repo;
-  the design needs exactly one concurrent exec per sandbox above today's baseline, which
-  is the smallest possible ask. Verification is open question 1.
-- **Runner memory.** One pending promise and one small script string per active turn.
-  Negligible against the existing per-turn state.
+  human-timescale approval pauses through the same preview proxy and cookie auth; that
+  is production evidence that held requests survive the path. The 25 s window sits far
+  below the 60-minute undici timeouts and any plausible proxy idle limit. Daytona's
+  documented limits cover organization request rates, not concurrent execs per sandbox;
+  this design needs exactly one concurrent exec above today's baseline per sandbox.
+  **These capacity assumptions are rollout gates, not facts**: the QA pass at expected
+  peak turn concurrency (test plan) must confirm them before the default flips.
+- **Runner memory.** One pending promise, one activity source, and one small script
+  string per active turn. Negligible against existing per-turn state.
 
 ### Interplay with neighbors
 
 - **`RELAY_TIMEOUT_MS`.** Unchanged. The writer's deadline still governs; the watch only
   makes the success path faster.
-- **Idle backoff.** Survives as the backstop cadence (decision 4). Its reset-on-activity
-  behavior still works because wakes feed the same `sawNew` accounting.
-- **Warm sessions (session-keepalive).** The relay loop is per-turn and stays per-turn. A
-  kept-alive session between turns runs no relay loop and no watch exec, so an idle warm
-  sandbox costs zero relay requests, same as today. If the relay ever becomes
-  per-session, the watch window design carries over unchanged; only the start/stop call
-  sites move.
-- **The second writer (Claude MCP shim).** The file contract is untouched, hop 1 lives in
-  the shared `relayToolCall`, and the hop 2 watch is directory-level, so a second writer's
-  request files wake the runner identically. Nothing in this design is Pi-specific.
+- **Idle backoff.** Survives in fallback mode only (decision 6).
+- **Warm sessions (session-keepalive).** The relay loop is per-turn and stays per-turn.
+  An idle warm sandbox runs no relay loop, no watch exec, and no safety poll: zero relay
+  requests, same as today. If the relay ever becomes per-session, the window design
+  carries over; only the start/stop call sites move.
+- **The second and third writers.** The final-file contract is untouched, hop 1 lives in
+  the shared `waitForRelayResponse`, and the hop 2 watch is directory-level, so any
+  writer's request files wake the runner identically.
 
-### Net verdict
+### Latency accounting (what the numbers measure)
 
-Latency: hop 1 drops to one filesystem event (~0 ms). Hop 2 drops to ~0 ms locally and to
-one daemon round-trip on Daytona (the script prints, the held request completes, the
-runner lists and reads). Per-call relay overhead goes from 0.3-1.8 s to under ~150 ms on
-Daytona and near zero locally. Request volume on Daytona drops sharply. Failure modes are
-bounded by the untouched poll loop. The one genuinely new cost is one held daemon request
-per active turn, which the ACP channel already proves out at far longer durations.
+Three different measures, defined so the target is not ambiguous:
+
+- **Wake latency**: request-file rename to the runner observing the watch exec
+  completion. One held-request completion through the preview proxy.
+- **Handler pickup** (the `stage=relay_pickup` metric): request-file publication to
+  handler start. After the wake the runner still lists and then reads the request, so
+  this is wake latency plus two daemon round-trips, not a single round-trip as an
+  earlier draft implied. At a 20 to 50 ms proxy round-trip this lands around 60 to
+  150 ms.
+- **Full relay completion**: pickup plus execution plus the response write (a daemon
+  write and a rename) plus the hop 1 in-sandbox wake (near zero) plus the writer's read
+  and delete.
+
+The target is **median handler pickup under 150 ms on Daytona and under 10 ms locally**,
+measured during QA. It is a rollout gate to verify, not an asserted fact, and it depends
+on proxy round-trip times the repo does not control. Hop 1 alone (the response wait)
+drops from a 0 to 300 ms poll interval to one filesystem event on every backend.
 
 ## Slices
 
-1. **Hop 1 and local hop 2 (no flag).** Add the watcher abstraction to `relay.ts`
-   (wake-race helper + local `fs.watch` watcher) and use it in `startToolRelay` and in
-   `relayToolCall`. Unit tests. This alone removes ~0.6 s per call locally and ~0.3 s per
-   call on Daytona (the response wait).
-2. **Daytona watch exec (flag off).** The inline node watch script, the window loop, the
-   disable-on-repeated-failure guard, wired into `sandboxRelayHost` usage in
-   `startToolRelay` behind `AGENTA_AGENT_TOOLS_RELAY_WATCH`. Unit tests with a fake
-   sandbox handle.
-3. **Measurement and QA.** A `[timing] stage=relay_pickup` log (request-file write to
-   handler start) alongside the existing timing lines. Run the Daytona tool cells of the
-   QA matrix with the flag on; record before/after per-call latency in status.md. Flip
-   the default after a clean pass.
-4. **Docs sync.** Env var inventory and the relay description in
+0. **Relay-client extraction (no behavior change).** Create `tools/relay-protocol.ts`
+   and `tools/relay-client.ts` as specified in decision 5; `dispatch.ts` re-exports;
+   all call sites compile unchanged; golden test pins the request-file bytes. This is
+   the slice the sibling project consumes (decision 5).
+1. **Atomic publication.** Temp-name plus rename in both directions; the `RelayHost`
+   rename capability with the local and Daytona implementations; the Daytona rename
+   atomicity check (open question 2) resolves here. Tests: delayed and chunked
+   publication, rename verification on both hosts.
+2. **Hop 1 and local hop 2 watches.** The activity source (decision 3) with the local
+   `fs.watch` implementations, inside `waitForRelayResponse` and behind
+   `RelayHost.waitForActivity` for `localRelayHost`. `RESPONSE_WATCH_ENABLED` wired.
+   Unit tests including the invariant set. This alone removes about 0.6 s per call
+   locally and about 0.3 s per call on Daytona (the response wait).
+3. **Daytona watch exec (flag off).** The inline hardened script, the window loop with
+   suspend-while-healthy, the safety poll, the demotion guard with jittered backoff,
+   window validation and clamping, wired behind `REMOTE_WATCH_ENABLED`. Unit tests with
+   a fake sandbox handle.
+4. **Measurement and QA.** The `stage=relay_pickup` timing log (request-file publication
+   to handler start). Run the Daytona tool cells of the QA matrix with the flag on;
+   record before and after per-call latency distributions and request counts in
+   status.md. Flip the default after a clean pass.
+5. **Docs sync.** Env var inventory and the relay description in
    `docs/design/agent-workflows/documentation/` (tools page), per the keep-docs-in-sync
    rule.
 
 ## Test plan
 
+Deterministic tests prove ordering and invariants; live QA records latency
+distributions. No strict latency assertions in CI.
+
 **Unit (vitest, `services/runner/tests/unit/`).**
 
-- Wake-race helper: event before sleep expiry wakes early; no event falls through at the
-  poll delay; a watcher whose `wake()` rejects degrades to the sleep (the degrade test).
-- Local watcher: file created after arming wakes; file created before arming is found by
-  the accompanying list (simulated arm gap); two files, one wake, both handled; close is
-  idempotent.
-- `startToolRelay` with a fake host and a controllable fake watcher: request handled on
-  wake without waiting a poll interval; watcher death mid-turn does not stall the loop;
-  `seen` dedup across wake and poll pickups of the same file.
-- Watch exec script builder: emits list-first behavior; exits on first event; exits at
-  the window bound; the runner's window loop treats error, timeout, and output uniformly
-  as wakes and disables after repeated failures.
-- `relayToolCall`: response via watch resolves promptly; watch failure falls back to the
-  300 ms poll; deadline behavior unchanged.
+- Activity source invariants: coalescing under simultaneous notifications and calls; an
+  event at every arm/list/wait boundary stays observable; thousands of timer wins with
+  zero listener growth; at most one concurrent `runProcess` per relay (a counting fake
+  asserts the maximum); `close()` during a held window resolves waiters with `"closed"`
+  and aborts the exec request; a rejecting source degrades to the timer and logs once.
+- Publication: a reader never observes partial JSON under delayed and chunked writes;
+  temp names are invisible to the suffix filters; rename semantics on `localRelayHost`
+  and on a fake sandbox host.
+- Watch exec script builder: arm-before-list ordering (an injected file between arm and
+  list still wakes); exits on first event; exits at the window bound via the internal
+  timer; the in-script `readdir` catches a lost event; argv-passed relay dir with
+  quotes, whitespace, shell metacharacters, and newlines; watcher `error` and
+  synchronous `fs.watch` throw both exit cleanly.
+- Window loop: suspend-while-healthy (no remote `ls` between wakes except the 30 s
+  safety poll); demotion after repeated immediate exec failure, repeated abnormal exit,
+  and repeated daemon-level timeout, each with jittered backoff; normal window expiry is
+  not counted as failure (the grace test); a safety-poll discovery increments the miss
+  counter; fallback mode equals today's loop.
+- Config: window parsing, invalid-value fallback, min and max clamping, jitter bounds.
+- `startToolRelay` with a fake host: request handled on wake without waiting a poll
+  interval; watcher death mid-turn does not stall the loop; `seen` dedup across wake and
+  poll pickups of the same file; `stop()` during a held window ends the turn cleanly.
+- `waitForRelayResponse`: response via watch resolves promptly; watch failure falls back
+  to the 300 ms poll; deadline and abort behavior unchanged; golden request-file bytes
+  across the Pi path and the client module (slice 0).
 
 **Integration.**
 
-- Local end-to-end: real `startToolRelay` with `localRelayHost` plus a real
-  `relayToolCall` against a temp dir; assert round-trip completes in well under one poll
-  interval.
-- The race, deterministically: with injected hooks, write the request file in the gap
-  between the watcher arming and the first list, and assert pickup; same for the
-  response file on the writer side.
+- Local end-to-end: real `startToolRelay` with `localRelayHost` plus a real writer
+  against a temp dir; round trip completes in well under one poll interval.
+- The race, deterministically: with injected hooks, publish the request file in the gap
+  between watch arming and the first list, and assert pickup; same for the response file
+  on the writer side.
 - The watch script as a process: spawn the actual node script against a temp dir; cover
-  the pre-existing-file path, the event path, and the timeout path.
+  the pre-existing-file path, the event path, the `readdir` fallback path, and the
+  timeout path.
+- Failure injection against a fake daemon: daemon restart mid-window, proxy disconnect,
+  sandbox pause, relay-directory deletion and recreation (the inode gotcha), node
+  missing from the image, `ENOSPC` and `EMFILE` from `fs.watch`, immediate exec
+  failure, repeated timeout. Each must land in a wake, a demotion, or a clean fallback;
+  never a hang.
 
-**Measurement.**
+**Live QA and measurement.**
 
-- The `stage=relay_pickup` timing log gives per-call pickup latency in both modes.
-- Before/after comparison on the dev box: a Daytona run with several gateway tool calls,
-  flag off then on; record median and worst per-call relay overhead in status.md. Success
-  is median pickup under 150 ms on Daytona and under 10 ms locally, with zero missed
-  calls across the QA matrix tool cells.
+- Batch load at expected peak turn concurrency; record request count, open sockets, held
+  execs, and p50/p95/p99 handler pickup and fallback latency, before and after, in
+  status.md.
+- The Daytona capacity gates (concurrent held execs per sandbox and per organization,
+  proxy behavior under N held requests) are confirmed here before any default flip.
 
 ## Rollout
 
-1. Slice 1 ships unflagged (in-process watches, poll fallback intact). Runner tests plus
-   one dev-box smoke run gate it.
-2. Slice 2 ships with `AGENTA_AGENT_TOOLS_RELAY_WATCH=false`. QA on the dev box with the
-   flag on (slice 3). Flip the default to `true` in a follow-up commit once the matrix
-   passes; the flag stays as the operator kill switch.
-3. Any incident playbook is one line: set `AGENTA_AGENT_TOOLS_RELAY_WATCH=false` and the
-   relay is byte-for-byte today's behavior on Daytona; slice 1's in-process watches have
-   no operational surface to switch.
+1. Slice 0 and slice 1 ship unflagged (a refactor and a publication change with no
+   observable contract change). Runner tests plus one dev-box smoke run gate them.
+2. Slice 2 ships with `RESPONSE_WATCH_ENABLED=true` (in-process, degrade-to-poll) after
+   the invariant tests pass.
+3. Slice 3 ships with `REMOTE_WATCH_ENABLED=false`. QA on the dev box with the flag on
+   (slice 4), including the capacity gates. Flip the default to `true` in a follow-up
+   commit once the matrix passes; the flag stays as the operator kill switch.
+4. The incident playbook is one line: set
+   `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_ENABLED=false` and the Daytona relay is
+   byte-for-byte today's behavior; set `RESPONSE_WATCH_ENABLED=false` and the writer is
+   too.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/research.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/research.md
@@ -1,0 +1,123 @@
+# Research: how the relay works today
+
+All anchors verified on `gitbutler/workspace` on 2026-07-11. Re-verify before implementing;
+the runner moves fast.
+
+## The two poll loops
+
+### Hop 2: the runner discovers request files
+
+`services/runner/src/tools/relay.ts:322-400` (`startToolRelay`) is the runner-side loop.
+Each iteration calls `host.list(relayDir)`, queues every unseen `*.req.json` (a `seen` set
+at `relay.ts:332` dedups), then sleeps.
+
+The cadence (`relay.ts:53-80`):
+
+- `RELAY_POLL_MS` = 300 ms (`AGENTA_AGENT_TOOLS_RELAY_POLLING`).
+- `RELAY_TIMEOUT_MS` = 60 s (`AGENTA_AGENT_TOOLS_RELAY_TIMEOUT`); enforced by the writer,
+  not this loop.
+- Idle backoff: after `RELAY_POLL_IDLE_GROW_AFTER` = 5 idle polls the delay doubles per
+  idle poll up to `RELAY_POLL_MAX_MS` = 1500 ms (`relayPollDelayMs`, `relay.ts:76-80`).
+  Any new request resets it to 300 ms.
+
+Two host implementations (`relay.ts:182-220`):
+
+- `localRelayHost` (`relay.ts:182`): `readdirSync`/`readFileSync`/`writeFileSync` on the
+  runner's own filesystem.
+- `sandboxRelayHost` (`relay.ts:197-220`): `list` is a remote `ls -1 <dir>` via
+  `sandbox.runProcess` with a 10 s timeout; `read`/`write` are `readFsFile`/`writeFsFile`
+  daemon calls. On Daytona the active-turn poll is therefore ~3 remote execs per second,
+  settling to ~0.7 per second when idle.
+
+The loop is wired per turn at `services/runner/src/engines/sandbox_agent.ts:1761-1773`:
+Daytona gets `sandboxRelayHost(env.sandbox)`, local gets `localRelayHost()`. It stops at
+turn end (`sandbox_agent.ts:1842`), on pause teardown (`:823`), and on run teardown
+(`:1950-1951`). `plan.useToolRelay` is true whenever the run has tool specs
+(`engines/sandbox_agent/run-plan.ts:449`).
+
+### Hop 1: the writer waits for the response file
+
+`services/runner/src/tools/dispatch.ts:62-107` (`relayToolCall`) is the in-sandbox writer.
+It writes `<id>.req.json`, then loops: check `existsSync(resPath)`, sleep `RELAY_POLL_MS`
+(300 ms, `dispatch.ts:104`), until `RELAY_TIMEOUT_MS` (or the tool's own `timeoutMs` plus
+10 s). On success it deletes both files (`dispatch.ts:91-100`).
+
+Both writers reach this one function:
+
+- Pi's in-sandbox extension registers each tool with an `execute` that calls
+  `runResolvedTool(spec, params, { toolCallId, relayDir, signal })`
+  (`services/runner/src/extensions/agenta.ts:341-345`), which routes to `relayToolCall`
+  when `relayDir` is set (`dispatch.ts:133-158`).
+- The future Claude MCP shim is planned to use the same dispatch module
+  (`dispatch.ts:1-21` documents this sharing). A hop 1 change inside `relayToolCall`
+  therefore covers both writers automatically.
+
+## The relay directory is a local filesystem on both ends of hop 1
+
+`run-plan.ts:384-391`: the relay dir is deliberately an ephemeral plain directory, never
+the geesefs-mounted durable cwd. Locally it is `$TMPDIR/agenta/relay/<name>`; on Daytona
+it is `/home/sandbox/agenta/relay/<name>` inside the VM. This matters for the design:
+inotify (Node's `fs.watch`) is unreliable on FUSE and network filesystems, but the relay
+dir avoids those by construction. So:
+
+- Inside the sandbox, the writer can `fs.watch` the relay dir and get instant response
+  wakeups.
+- On the local backend, the runner shares that same filesystem, so it can `fs.watch` for
+  requests too.
+- Only the Daytona hop 2 (runner to remote VM) has no local filesystem to watch.
+
+Two non-relay files share the relay namespace and will cause spurious watch events, both
+harmless because the loop filters by suffix:
+
+- `<relayDir>/.agenta-usage.json`, Pi's usage writeback (`run-plan.ts:442`).
+- `<relayDir>.otlp-auth`, a sibling path outside the dir (`sandbox_agent.ts:714`).
+
+Cleanup: `engines/sandbox_agent/workspace.ts:63-66` removes the relay dir (`rm -rf`) when
+preparing the workspace, and the writer deletes each req/res pair after reading the
+response.
+
+## The Daytona daemon API facts the watch exec depends on
+
+- `sandbox.runProcess` is one blocking HTTP request (`POST /v1/processes/run`) that
+  returns when the command exits. The request body accepts `timeoutMs` and the response
+  reports `timedOut` (sandbox-agent SDK,
+  `node_modules/sandbox-agent/dist/index.d.ts:502-523`). The mount code relies on the
+  same blocking behavior (`engines/sandbox_agent/mount.ts:561`).
+- The daemon is reached through a signed Daytona preview URL. The preview proxy
+  authenticates with a cookie captured by `createCookieFetch`
+  (`engines/sandbox_agent/daytona.ts:169-204`).
+- That fetch layers on `createAcpFetch` (`engines/sandbox_agent/acp-fetch.ts`): an undici
+  dispatcher with 60-minute `headersTimeout`/`bodyTimeout` and 10-minute keep-alive,
+  built precisely so a request held open for human-timescale approval pauses is not
+  reaped. Held requests through the preview proxy are therefore already a proven,
+  production-exercised pattern; the watch exec adds nothing new in kind.
+- Node is present in the sandbox image (Pi runs on it), so a node one-liner watch script
+  needs no install. Custom snapshots without node need the poll fallback.
+- The SDK also offers `createProcess` (start a background process) plus
+  `followProcessLogs` (a streaming log subscription). This is the raw material for the
+  persistent-watcher alternative that plan.md evaluates and does not pick.
+
+## The ACP side channel (for the doorbell alternative)
+
+ACP carries session and prompt traffic from the runner to the sandbox; the runner observes
+every frame, and the wire has a generic `extNotification` method/params channel. Pi's
+extension could emit a "check the relay dir" notification when it writes a request. Two
+limits, both noted in
+[../mcp-delivery-architecture/gateway-mcp-location.md](../mcp-delivery-architecture/gateway-mcp-location.md):
+the notification rides the live ACP session, so it only exists while a Pi session is
+streaming, and the Claude MCP shim is a separate process with no ACP session at all, so a
+doorbell from it would require the daemon to grow a watch or notify feature.
+
+## Latency and request-volume baseline (what we are fixing)
+
+Per tool call today:
+
+- Hop 2 pickup: 0 to 300 ms when the turn is active, up to 1500 ms after idle backoff
+  (the first call of a quiet turn always eats backoff).
+- Hop 1 response wait: 0 to 300 ms.
+- Total added: roughly 0.3 s typical, up to 1.8 s worst case, per call, on top of tool
+  execution. Both hops apply on local and on Daytona.
+
+Per active Daytona turn today: one `ls` exec per poll, ~3/s active, ~0.7/s idle. A
+60-second turn costs roughly 40 to 200 daemon requests just for polling, plus one read and
+one write per actual tool call.

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/research.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/research.md
@@ -42,15 +42,34 @@ It writes `<id>.req.json`, then loops: check `existsSync(resPath)`, sleep `RELAY
 (300 ms, `dispatch.ts:104`), until `RELAY_TIMEOUT_MS` (or the tool's own `timeoutMs` plus
 10 s). On success it deletes both files (`dispatch.ts:91-100`).
 
-Both writers reach this one function:
+All writers reach this one function:
 
 - Pi's in-sandbox extension registers each tool with an `execute` that calls
   `runResolvedTool(spec, params, { toolCallId, relayDir, signal })`
   (`services/runner/src/extensions/agenta.ts:341-345`), which routes to `relayToolCall`
   when `relayDir` is set (`dispatch.ts:133-158`).
-- The future Claude MCP shim is planned to use the same dispatch module
-  (`dispatch.ts:1-21` documents this sharing). A hop 1 change inside `relayToolCall`
-  therefore covers both writers automatically.
+- Local Claude's loopback MCP handler dispatches every non-client `tools/call` to the
+  same `runResolvedTool` with the run's `relayDir` (`tools/tool-mcp-http.ts:210-212`),
+  so local Claude is a relay writer today, not a future one.
+- The future Claude MCP shim on Daytona is planned to use the same dispatch module
+  (`dispatch.ts:1-21` documents this sharing). A hop 1 change inside the shared writer
+  therefore covers all three automatically.
+
+## Partial-file exposure today
+
+Nothing in the current relay publishes atomically; polling delay is what hides the write
+interval:
+
+- The writer creates the final request path directly with `writeFileSync`
+  (`dispatch.ts:73`).
+- The runner adds a discovered filename to `seen` before reading it (`relay.ts:338`) and
+  parses asynchronously (`relay.ts:380`), so a partial read would error once and never
+  retry that request.
+- The runner writes the final response path directly (`relay.ts:362`), and the writer
+  parses the moment `existsSync` is true (`dispatch.ts:87`).
+
+Under 300 ms polling these windows are rarely hit. Any event-driven wake makes them hot,
+which is why the plan amends publication (plan.md decision 2).
 
 ## The relay directory is a local filesystem on both ends of hop 1
 
@@ -91,6 +110,11 @@ response.
   built precisely so a request held open for human-timescale approval pauses is not
   reaped. Held requests through the preview proxy are therefore already a proven,
   production-exercised pattern; the watch exec adds nothing new in kind.
+- The daemon file API includes a move endpoint: `moveFs` / `post_v1_fs_move`
+  (`node_modules/sandbox-agent/dist/index.d.ts:2103`, `:3253`). Whether it performs a
+  `rename(2)`-atomic same-directory move is not documented; the atomic-publication
+  amendment (plan.md decision 2) needs that verified, with a shell `mv` exec as the
+  fallback implementation.
 - Node is present in the sandbox image (Pi runs on it), so a node one-liner watch script
   needs no install. Custom snapshots without node need the poll fallback.
 - The SDK also offers `createProcess` (start a background process) plus

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/status.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/status.md
@@ -2,23 +2,40 @@
 
 ## Current state
 
-Planning workspace complete; awaiting owner review. Design only, no runtime code changed.
+Review round addressed; awaiting owner re-review on PR #5232. Design only, no runtime
+code changed.
 
 ## Timeline
 
 - 2026-07-11: Workspace created (README, context, research, plan, open-questions). All
-  research anchors verified against `gitbutler/workspace` on this date. Draft PR opened
-  for review.
+  research anchors verified against `gitbutler/workspace` on this date. Draft PR #5232
+  opened for review.
+- 2026-07-11 (later): Review round folded in. Codex (xhigh) raised three blocking
+  defects, all adopted: atomic temp-plus-rename publication (plan.md decision 2), the
+  coalesced single-flight activity source replacing the bare promise race (decision 3),
+  and suspend-remote-polling-while-watch-healthy with honest request-volume numbers
+  (decision 4). Codex P1s adopted: the relay-client/relay-protocol extraction as slice
+  0 of this project, watcher hardening, per-hop flags, expanded test plan. CodeRabbit's
+  four inline comments addressed: held-request abort on window end and relay stop,
+  argv-safe script arguments, window validation and clamping, and the three-way latency
+  definition with capacity assumptions as rollout gates. Owner framing points
+  addressed: writer coverage (Pi, local Claude, the shim) stated up front; rejected
+  alternatives moved into an explicit rejected subsection.
 
 ## Decisions recorded
 
 - Owner (2026-07-11): API-hosted tool gateway rejected; sandbox talks only to the runner;
   relay polling latency addressed here as its own feature. Source:
   `../mcp-delivery-architecture/gateway-mcp-location.md` (decision section).
-- This plan (proposed, not yet approved): events are wake signals only (plan.md decision
-  1); Daytona hop 2 uses a re-issued bounded watch exec (decision 2); hop 1 watch lives in
-  the shared `relayToolCall` (decision 3); poll constants unchanged initially (decision
-  4); one new flag plus one window variable (decision 5).
+- Cross-project (2026-07-11): this project owns the `tools/relay-client.ts` and
+  `tools/relay-protocol.ts` extraction as slice 0; #5234 consumes it.
+- This plan (proposed, not yet approved): events are wake signals only (decision 1);
+  publication is atomic via temp name plus rename (decision 2); the wake seam is a
+  coalesced single-flight activity source (decision 3); Daytona hop 2 uses a re-issued
+  bounded watch exec that suspends remote polling while healthy, with a 30 s safety
+  poll kept deliberately (decision 4); the extraction is slice 0 (decision 5); idle
+  backoff survives only in fallback mode (decision 6); three per-hop config variables
+  with a validated, clamped window (decision 7).
 
 ## Verification notes
 
@@ -26,15 +43,18 @@ Planning workspace complete; awaiting owner review. Design only, no runtime code
   from prior docs. Re-verify before implementation; `relay.ts`, `dispatch.ts`, and
   `sandbox_agent.ts` are active files.
 - The `runProcess` blocking semantics and `timeoutMs`/`timedOut` fields were verified
-  against the installed sandbox-agent SDK type definitions.
-- Daytona-side limits on held execs are NOT verified (open question 1).
+  against the installed sandbox-agent SDK type definitions, as was the existence of
+  `moveFs` (`post_v1_fs_move`); its rename atomicity is NOT verified (open question 2).
+- Daytona-side limits on held execs are NOT verified (open question 1, a rollout gate).
 
 ## Blockers
 
-None for review. Open question 1 gates the Daytona default-on step only.
+None for review. Open questions 1 and 2 gate the Daytona work (question 2 gates slice
+1's Daytona side; question 1 gates the default flip only).
 
 ## Next steps
 
-1. Owner review and interview on the draft PR.
-2. Answer open questions 1 and 2.
-3. Implement slice 1 (in-process watches) via the implement-feature flow.
+1. Owner re-review on the draft PR.
+2. Implement slice 0 (the extraction) via the implement-feature flow; #5234 rebases to
+   consume it.
+3. Verify `moveFs` atomicity during slice 1 (open question 2).

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/status.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/status.md
@@ -2,8 +2,92 @@
 
 ## Current state
 
-Review round addressed; awaiting owner re-review on PR #5232. Design only, no runtime
-code changed.
+Implemented on lane `feat-event-driven-tool-relay`. Slices 0 to 2 are committed: the
+relay-client/relay-protocol extraction (d078d1d), atomic publication plus the hop-1
+in-sandbox response watch (2ed4253), and the flagged Daytona hop-2 watch (bc96aa9).
+Slice 3 landed in two commits: the orphan-residue snapshot plus the `relay_pickup`
+timing log (b857f07) and the docs sync (330efd7).
+
+Live QA (2026-07-12, dev box, EE stack on 8280): one real Claude-local turn with a
+workflow-reference tool (Exact Match) through the playground UI. The tool executed
+through the relay and the runner logged
+`[relay] stage=relay_pickup id=... pickup_ms=1.28 wake=activity`: event-driven pickup
+at 1.3 ms against the 0-300 ms polling baseline, well under the 10 ms local target.
+The local cell is green. The Daytona cell is PENDING live QA: the remote watch ships
+default-off, the shared sidecar would need a container recreate to carry the flag, and
+the capacity gates (held execs at peak concurrency) are rollout gates by design;
+unit and integration coverage (fake daemon, real watch-script process runs) stands in
+until the flag-on QA pass.
+
+The moveFs atomicity spike (open question 2) resolved early, during slice 1: daemon
+v0.4.2 implements `/v1/fs/move` as Rust `std::fs::rename`, which is `rename(2)` and
+atomic for a same-directory move. `RelayHost.rename` uses `moveFs` directly; no
+shell-`mv` fallback was needed.
+
+Test coverage: 71 unit and integration tests across four suites, all green.
+`relay-client.test.ts` (16: the writer, the golden byte-pinned request serialization,
+the coalescing dir watch, the hop-1 wait), `relay-watch.test.ts` (31: both activity
+sources, window clamping, jitter, demotion, the outer bound, close semantics),
+`relay-loop.test.ts` (15: the runner loop with wake sources, safety-poll misses,
+delete-on-pickup, the orphan snapshot, the pickup telemetry), and
+`relay-atomic-publish.test.ts` (9: integration-style, writer and runner end to end over
+a real temp dir).
+
+## Post-draft review round (2026-07-12)
+
+A seven-angle high-effort review ran on the draft PR; commit a1ec038 fixed the five
+verified findings (the orphan-snapshot resume race, replaced by an engine-awaited
+pre-loop sweep; nullish exec results counting as watch success; pickup completing
+after the next window armed; mid-wait failures leaving the source windowless; the
+safety poll's independence moved into the loop). The extension build now fails if
+server-side relay symbols leak into the sandbox bundle.
+
+Deferred follow-ups from the same review (cost or structure, not correctness):
+
+- The watch exec wakes on the runner's own response publications (about two extra
+  daemon calls per tool call). Option: pass ignorable names to the script.
+- close() leaves the final in-sandbox watcher to die at its own window timer (up to
+  window + grace). Option: a sentinel-file wake through the same sandbox handle.
+- The Daytona source's waiter/sticky machinery shares shape with the writer's
+  createRelayDirWatch; a shared coalescing primitive would remove the drift risk.
+- The Pi client-tool browser-fulfilled flow on a warm continuation needs one QA pass:
+  crash-redelivery by re-listing is gone, and that flow previously leaned on it.
+- One relay env family now has three env-read disciplines (module-load, creation-time,
+  call-time); unify when the config surface next changes.
+
+## Deviations from the reviewed plan
+
+- **`close()` abandons the in-flight watch exec instead of aborting it.** The
+  sandbox-agent SDK's `runProcess` takes no per-call AbortSignal. The exec is bounded by
+  the script's own window timer plus a runner-side generation-tagged outer bound (at
+  window + grace + margin) the plan did not have; the outer bound replaces the promised
+  AbortSignal mechanism and also feeds demotion when an exec request wedges.
+- **Window jitter is downward-only (0.8x to 1.0x) instead of plus-or-minus 20 percent.**
+  A jittered window then always completes before the 30 s safety wait, which removes a
+  false-miss race where an upward draw read as a watch miss.
+- **Delete-on-pickup was not in the plan; adopted from review.** A request file left on
+  disk for the whole execution insta-completed every watch window and rearmed at network
+  speed (measured ~66 daemon requests per second, versus ~3.3 today). The runner now
+  removes each request file right after reading it. Consequences, on BOTH backends
+  (local and Daytona): a request executes at most once per publication, and
+  crash-redelivery-by-re-listing is deliberately gone. A runner crash after pickup but
+  before the response write loses the request permanently; the writer times out at
+  `AGENTA_AGENT_TOOLS_RELAY_TIMEOUT` (60 s default) and surfaces a tool error.
+  Consistent with the orphan-residue decision.
+- **Request-volume accounting correction.** The plan said the per-tool-call list, read,
+  and write daemon calls were unchanged. Delete-on-pickup adds one daemon delete per
+  executed tool call and the `relay_pickup` telemetry adds one stat, so the honest
+  number is +2 daemon calls per executed tool call. Trivial next to the removed polling
+  (~200/min down to ~4.4/min).
+- **Atomic publication landed in slice 1 for BOTH directions.** The plan had the
+  Daytona-side rename in a later slice, but the hop-1 watch defaults on and would
+  otherwise race a non-atomic Daytona response write.
+- **moveFs atomicity spike resolved early.** See Current state; open question 2 is
+  answered, no `RelayHost` shell-`mv` fallback exists.
+- **Orphan residue (open question 4) accepted and fixed here.** The first successful
+  list of each turn's relay loop is a snapshot: pre-existing request files are marked
+  seen and best-effort deleted, never executed. A turn only executes requests created
+  after it started.
 
 ## Timeline
 
@@ -21,6 +105,11 @@ code changed.
   definition with capacity assumptions as rollout gates. Owner framing points
   addressed: writer coverage (Pi, local Claude, the shim) stated up front; rejected
   alternatives moved into an explicit rejected subsection.
+- 2026-07-12: Implemented on lane `feat-event-driven-tool-relay`. Slice 0 (d078d1d),
+  slice 1 (2ed4253), and slice 2 (bc96aa9) committed; slice 3 pending commit. The
+  moveFs spike resolved (question 2 answered), orphan residue fixed here (question 4
+  answered). Deviations from the plan recorded above. Docs synced (documentation/
+  tools.md, interfaces runner-to-mcp-server.md, the interfaces index). Live QA pending.
 
 ## Decisions recorded
 
@@ -29,32 +118,39 @@ code changed.
   `../mcp-delivery-architecture/gateway-mcp-location.md` (decision section).
 - Cross-project (2026-07-11): this project owns the `tools/relay-client.ts` and
   `tools/relay-protocol.ts` extraction as slice 0; #5234 consumes it.
-- This plan (proposed, not yet approved): events are wake signals only (decision 1);
-  publication is atomic via temp name plus rename (decision 2); the wake seam is a
-  coalesced single-flight activity source (decision 3); Daytona hop 2 uses a re-issued
-  bounded watch exec that suspends remote polling while healthy, with a 30 s safety
-  poll kept deliberately (decision 4); the extraction is slice 0 (decision 5); idle
-  backoff survives only in fallback mode (decision 6); three per-hop config variables
-  with a validated, clamped window (decision 7).
+- This plan (implemented on the lane, with the deviations recorded above): events are
+  wake signals only (decision 1); publication is atomic via temp name plus rename
+  (decision 2); the wake seam is a coalesced single-flight activity source (decision 3);
+  Daytona hop 2 uses a re-issued bounded watch exec that suspends remote polling while
+  healthy, with a 30 s safety poll kept deliberately (decision 4); the extraction is
+  slice 0 (decision 5); idle backoff survives only in fallback mode (decision 6); three
+  per-hop config variables with a validated, clamped window (decision 7).
 
 ## Verification notes
 
-- File:line anchors in research.md were read directly from the working tree, not quoted
-  from prior docs. Re-verify before implementation; `relay.ts`, `dispatch.ts`, and
-  `sandbox_agent.ts` are active files.
 - The `runProcess` blocking semantics and `timeoutMs`/`timedOut` fields were verified
-  against the installed sandbox-agent SDK type definitions, as was the existence of
-  `moveFs` (`post_v1_fs_move`); its rename atomicity is NOT verified (open question 2).
-- Daytona-side limits on held execs are NOT verified (open question 1, a rollout gate).
+  against the installed sandbox-agent SDK type definitions. `runProcess` takes no
+  per-call AbortSignal, which forced the close()-abandons deviation above.
+- `moveFs` rename atomicity is now verified against the daemon v0.4.2 source
+  (`router.rs`: `/v1/fs/move` is `std::fs::rename`). Open question 2 answered.
+- Daytona-side limits on held execs are NOT verified (open question 1, a rollout gate
+  for the `REMOTE_WATCH_ENABLED` default flip).
+- Operator note: `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_WINDOW_MS` clamps to
+  [5000, 120000], but values at or above 30000 (the fixed safety-poll interval) degrade
+  the design: safety waits time out while the window is in flight, safety-poll
+  discoveries become the normal pickup path, and each one counts as a watch miss
+  feeding demotion. Keep the window below 30 s; the 25 s default is deliberate.
 
 ## Blockers
 
-None for review. Open questions 1 and 2 gate the Daytona work (question 2 gates slice
-1's Daytona side; question 1 gates the default flip only).
+None for landing with the Daytona watch flag off (its default). Open question 1 (Daytona
+held-exec limits) gates only the default flip, via the QA capacity pass.
 
 ## Next steps
 
-1. Owner re-review on the draft PR.
-2. Implement slice 0 (the extraction) via the implement-feature flow; #5234 rebases to
-   consume it.
-3. Verify `moveFs` atomicity during slice 1 (open question 2).
+1. Commit slice 3 (orphan snapshot + `relay_pickup` telemetry) on the lane.
+2. Live QA across the matrix (local Pi, local Claude, Daytona with
+   `AGENTA_AGENT_TOOLS_RELAY_REMOTE_WATCH_ENABLED=true`); record `relay_pickup` numbers
+   here.
+3. Decide the timing-log fate after QA (open question 5).
+4. Flip the `REMOTE_WATCH_ENABLED` default after the capacity gate (open question 1).

--- a/docs/design/agent-workflows/projects/event-driven-tool-relay/status.md
+++ b/docs/design/agent-workflows/projects/event-driven-tool-relay/status.md
@@ -1,0 +1,40 @@
+# Status
+
+## Current state
+
+Planning workspace complete; awaiting owner review. Design only, no runtime code changed.
+
+## Timeline
+
+- 2026-07-11: Workspace created (README, context, research, plan, open-questions). All
+  research anchors verified against `gitbutler/workspace` on this date. Draft PR opened
+  for review.
+
+## Decisions recorded
+
+- Owner (2026-07-11): API-hosted tool gateway rejected; sandbox talks only to the runner;
+  relay polling latency addressed here as its own feature. Source:
+  `../mcp-delivery-architecture/gateway-mcp-location.md` (decision section).
+- This plan (proposed, not yet approved): events are wake signals only (plan.md decision
+  1); Daytona hop 2 uses a re-issued bounded watch exec (decision 2); hop 1 watch lives in
+  the shared `relayToolCall` (decision 3); poll constants unchanged initially (decision
+  4); one new flag plus one window variable (decision 5).
+
+## Verification notes
+
+- File:line anchors in research.md were read directly from the working tree, not quoted
+  from prior docs. Re-verify before implementation; `relay.ts`, `dispatch.ts`, and
+  `sandbox_agent.ts` are active files.
+- The `runProcess` blocking semantics and `timeoutMs`/`timedOut` fields were verified
+  against the installed sandbox-agent SDK type definitions.
+- Daytona-side limits on held execs are NOT verified (open question 1).
+
+## Blockers
+
+None for review. Open question 1 gates the Daytona default-on step only.
+
+## Next steps
+
+1. Owner review and interview on the draft PR.
+2. Answer open questions 1 and 2.
+3. Implement slice 1 (in-process watches) via the implement-feature flow.


### PR DESCRIPTION
## Context

Every gateway tool call from a sandboxed harness pays a polling tax today: the in-sandbox writer sleeps in 300 ms steps waiting for the response file, and the runner discovers request files by listing the relay dir every 300 ms (backing off to 1.5 s when idle). That adds roughly 0.3 to 1.8 s of pure waiting per tool call, and on Daytona it also costs ~3 remote `ls` execs per second for the whole turn.

This follows the owner decision (2026-07-11, recorded in `mcp-delivery-architecture/gateway-mcp-location.md`): the API-hosted tool gateway is rejected, the sandbox talks only to the runner, tool calls stay on the file relay, and the relay's polling latency is addressed as its own feature. This PR is that feature's planning workspace.

## What the plan proposes

Design only, no runtime code. New workspace at `docs/design/agent-workflows/projects/event-driven-tool-relay/` (README, context, research with verified file:line anchors, plan, open-questions, status).

The core idea: events are wake signals only; the poll loops stay as the correctness fallback. Each `await sleep(delay)` becomes `Promise.race([sleep(delay), watcher.wake()])`, so a dead watcher degrades to today's behavior, never to a hang.

- Hop 1 (writer waits for `res.json`): `fs.watch` in the shared `relayToolCall`, so Pi's extension and the future Claude MCP shim both get it. Same trick runner-side on the local backend.
- Hop 2 (runner spots `req.json` on Daytona): one bounded (25 s) blocking `runProcess` holding a tiny node script that lists first (closes the created-before-armed race), watches, prints, exits; the runner re-issues it per window. Replaces ~180 daemon requests/min with ~2.4/min.
- Alternatives evaluated and not picked: persistent watcher + log-follow stream (orphan and reconnect lifecycle), ACP `extNotification` doorbell (Pi-only, does not cover the MCP shim), tighter polling.
- Reliability/scale analysis covers races, coalescing, watcher lifecycle, held-connection limits, runner restart, warm sessions, and the second relay writer. Expected result: per-call relay overhead from 0.3-1.8 s down to under ~150 ms on Daytona and near zero locally, with fewer daemon requests and unchanged security model.

## What review is needed

This is a plan to interview, not code. Please read `plan.md` (five decisions, each with options and why) and `open-questions.md` (six questions; Daytona held-exec limits gate the default-on step). Push back on decision 2 (bounded watch exec vs persistent watcher) and decision 5 (flag shape) in particular.

https://claude.ai/code/session_01Fr4A5zjs5rsufRaWgWiUNC