### PR TITLE
[feat] Agent composer + template chip polish

### DIFF
--- a/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
@@ -29,7 +29,10 @@ const TemplateChip = ({
         // box-border so an explicit width (set by TemplateChipDock) measures border-box, matching
         // the ghost's offsetWidth exactly. Border matches the selected composer's accent so the
         // chip + composer read as one connected shape (the composer forces --ag-colorPrimary too).
-        className={`box-border inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-colorPrimary)] bg-[var(--ag-strip-selected-bg)] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
+        // Background is the selected tint composited over the composer's own base so it stays OPAQUE
+        // (the raw --ag-strip-selected-bg is 6%-alpha in dark) — an opaque bottom is what lets the
+        // chip's overlap actually hide the composer's top border instead of showing it through.
+        className={`box-border inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-colorPrimary)] bg-[var(--ag-colorBgContainer)] bg-[image:linear-gradient(var(--ag-strip-selected-bg),var(--ag-strip-selected-bg))] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
     >
         <span
             className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] text-[9px] font-semibold text-white"

--- a/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
@@ -17,13 +17,18 @@ const TemplateChip = ({
     template,
     onClear,
     className,
+    style,
 }: {
     template: AgentTemplate
     onClear: () => void
     className?: string
+    style?: React.CSSProperties
 }) => (
     <div
-        className={`inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-strip-input-border)] bg-[var(--ag-strip-selected-bg)] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
+        style={style}
+        // box-border so an explicit width (set by TemplateChipDock) measures border-box, matching
+        // the ghost's offsetWidth exactly.
+        className={`box-border inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-strip-input-border)] bg-[var(--ag-strip-selected-bg)] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
     >
         <span
             className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] text-[9px] font-semibold text-white"

--- a/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
@@ -26,12 +26,8 @@ const TemplateChip = ({
 }) => (
     <div
         style={style}
-        // box-border so an explicit width (set by TemplateChipDock) measures border-box, matching
-        // the ghost's offsetWidth exactly. Border matches the selected composer's accent so the
-        // chip + composer read as one connected shape (the composer forces --ag-colorPrimary too).
-        // Background is the selected tint composited over the composer's own base so it stays OPAQUE
-        // (the raw --ag-strip-selected-bg is 6%-alpha in dark) — an opaque bottom is what lets the
-        // chip's overlap actually hide the composer's top border instead of showing it through.
+        // box-border matches the ghost's offsetWidth; the tint is composited over the composer base
+        // so the bg stays opaque (--ag-strip-selected-bg is 6%-alpha in dark) and the overlap hides its border.
         className={`box-border inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-colorPrimary)] bg-[var(--ag-colorBgContainer)] bg-[image:linear-gradient(var(--ag-strip-selected-bg),var(--ag-strip-selected-bg))] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
     >
         <span

--- a/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
@@ -27,8 +27,9 @@ const TemplateChip = ({
     <div
         style={style}
         // box-border so an explicit width (set by TemplateChipDock) measures border-box, matching
-        // the ghost's offsetWidth exactly.
-        className={`box-border inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-strip-input-border)] bg-[var(--ag-strip-selected-bg)] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
+        // the ghost's offsetWidth exactly. Border matches the selected composer's accent so the
+        // chip + composer read as one connected shape (the composer forces --ag-colorPrimary too).
+        className={`box-border inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-colorPrimary)] bg-[var(--ag-strip-selected-bg)] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
     >
         <span
             className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] text-[9px] font-semibold text-white"

--- a/web/oss/src/components/TemplateStrip/components/TemplateChipDock.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChipDock.tsx
@@ -1,0 +1,75 @@
+import {useLayoutEffect, useRef, useState} from "react"
+
+import clsx from "clsx"
+
+import {type AgentTemplate} from "@/oss/components/pages/agent-home/assets/templates"
+
+import TemplateChip from "./TemplateChip"
+
+interface TemplateChipDockProps {
+    template: AgentTemplate
+    /** Whether a template is currently selected — drives the fade/rise in and out. */
+    visible: boolean
+    onClear: () => void
+}
+
+const noop = () => {}
+
+/**
+ * Docks the provenance chip above the composer and animates it. Two transitions run together:
+ * fade + rise on select/clear, and a WIDTH morph when switching templates.
+ *
+ * The chip is `w-fit`, so auto width can't be transitioned directly. We render an off-flow ghost
+ * at natural (max-content) width, measure it, and drive an explicit width on the VISIBLE chip —
+ * the chip itself animates + clips its own content, so the border/background move with the width
+ * in both directions (measuring a transparent wrapper only revealed content on grow, not shrink).
+ */
+const TemplateChipDock = ({template, visible, onClear}: TemplateChipDockProps) => {
+    const ghostRef = useRef<HTMLDivElement>(null)
+    const [width, setWidth] = useState<number>()
+
+    // Mirror the ghost's natural width onto the visible chip. A ResizeObserver catches both the
+    // template swap and late size changes (e.g. badge images decoding).
+    useLayoutEffect(() => {
+        const el = ghostRef.current
+        if (!el) return
+        const measure = () => setWidth(el.offsetWidth)
+        measure()
+        const observer = new ResizeObserver(measure)
+        observer.observe(el)
+        return () => observer.disconnect()
+    }, [])
+
+    return (
+        <div className="relative">
+            {/* Off-flow, unpainted copy at natural width — the measurement source only. */}
+            <div
+                ref={ghostRef}
+                aria-hidden
+                inert
+                className="pointer-events-none invisible absolute left-0 top-0 w-max"
+            >
+                <TemplateChip template={template} onClear={noop} />
+            </div>
+            <div
+                className={clsx(
+                    "origin-bottom-left transition-[opacity,transform] duration-200 ease-out",
+                    visible
+                        ? "translate-y-0 opacity-100"
+                        : "pointer-events-none translate-y-1 opacity-0",
+                )}
+                inert={!visible}
+            >
+                <TemplateChip
+                    template={template}
+                    onClear={onClear}
+                    style={{width}}
+                    // Children keep their natural size and clip (not squish) while the width eases.
+                    className="overflow-hidden transition-[width] duration-200 ease-out [&>*]:shrink-0"
+                />
+            </div>
+        </div>
+    )
+}
+
+export default TemplateChipDock

--- a/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
+++ b/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
@@ -1,5 +1,7 @@
 import {useCallback, useMemo, useRef, useState, type ReactNode} from "react"
 
+import clsx from "clsx"
+
 import {
     AGENT_TEMPLATES,
     templateBuilderMessage,
@@ -54,6 +56,10 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
     // an edited one. Null when nothing is seeded (cleared, or never picked).
     const seededTextRef = useRef<string | null>(null)
 
+    // The last template shown in the chip, retained after a clear so the chip fades OUT with its
+    // real content instead of flipping to the sizing placeholder mid-transition.
+    const lastTemplateRef = useRef<AgentTemplate | null>(null)
+
     // Drop provenance without touching composer text — used when the text is already empty
     // (typed/deleted away) so we don't re-set already-empty content.
     const clearProvenance = useCallback(() => {
@@ -65,6 +71,7 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
         const seeded = templateBuilderMessage(template)
         apiRef.current.setText(seeded)
         seededTextRef.current = seeded.trim()
+        lastTemplateRef.current = template
         setSelectedTemplate(template)
     }, [])
 
@@ -97,23 +104,27 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
         [selectedTemplate],
     )
 
-    // Always render a chip (never null) so its box reserves the same height whether or not a
-    // template is selected — picking/clearing never shifts the composer below it. When nothing
-    // is selected, render the first registry template purely for sizing and hide it with
-    // `invisible` (keeps layout, no paint) rather than guessing a pixel height.
-    const chipNode = useMemo(
-        () => (
+    // Always mounted (never null) so the chip can transition rather than pop: it fades + rises in
+    // on pick and fades out on clear. During the out-transition `selectedTemplate` is already null,
+    // so we show the retained last template (falling back to the registry's first only for the very
+    // first, never-picked render). `inert` drops the hidden chip's ✕ from tab order + the a11y tree.
+    const chipNode = useMemo(() => {
+        const visible = Boolean(selectedTemplate)
+        const shown = selectedTemplate ?? lastTemplateRef.current ?? AGENT_TEMPLATES[0]
+        return (
             <div
-                className={selectedTemplate ? undefined : "invisible"}
-                // `inert` (not just `invisible`) also drops the placeholder's ✕ button from
-                // tab order and the a11y tree — it's not really there.
-                inert={!selectedTemplate}
+                className={clsx(
+                    "origin-bottom-left transition-[opacity,transform] duration-200 ease-out",
+                    visible
+                        ? "translate-y-0 opacity-100"
+                        : "pointer-events-none translate-y-1 opacity-0",
+                )}
+                inert={!visible}
             >
-                <TemplateChip template={selectedTemplate ?? AGENT_TEMPLATES[0]} onClear={clear} />
+                <TemplateChip template={shown} onClear={clear} />
             </div>
-        ),
-        [selectedTemplate, clear],
-    )
+        )
+    }, [selectedTemplate, clear])
 
     return {
         selectedTemplate,

--- a/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
+++ b/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
@@ -1,14 +1,12 @@
 import {useCallback, useMemo, useRef, useState, type ReactNode} from "react"
 
-import clsx from "clsx"
-
 import {
     AGENT_TEMPLATES,
     templateBuilderMessage,
     type AgentTemplate,
 } from "@/oss/components/pages/agent-home/assets/templates"
 
-import TemplateChip from "../components/TemplateChip"
+import TemplateChipDock from "../components/TemplateChipDock"
 
 interface ComposerApi {
     setText: (text: string) => void
@@ -104,25 +102,18 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
         [selectedTemplate],
     )
 
-    // Always mounted (never null) so the chip can transition rather than pop: it fades + rises in
-    // on pick and fades out on clear. During the out-transition `selectedTemplate` is already null,
-    // so we show the retained last template (falling back to the registry's first only for the very
-    // first, never-picked render). `inert` drops the hidden chip's ✕ from tab order + the a11y tree.
+    // Always mounted (never null) so the chip can transition rather than pop. During the
+    // out-transition `selectedTemplate` is already null, so we show the retained last template
+    // (falling back to the registry's first only for the very first, never-picked render).
+    // TemplateChipDock owns the fade/rise + width-morph; passing `visible` drives them.
     const chipNode = useMemo(() => {
-        const visible = Boolean(selectedTemplate)
         const shown = selectedTemplate ?? lastTemplateRef.current ?? AGENT_TEMPLATES[0]
         return (
-            <div
-                className={clsx(
-                    "origin-bottom-left transition-[opacity,transform] duration-200 ease-out",
-                    visible
-                        ? "translate-y-0 opacity-100"
-                        : "pointer-events-none translate-y-1 opacity-0",
-                )}
-                inert={!visible}
-            >
-                <TemplateChip template={shown} onClear={clear} />
-            </div>
+            <TemplateChipDock
+                template={shown}
+                visible={Boolean(selectedTemplate)}
+                onClear={clear}
+            />
         )
     }, [selectedTemplate, clear])
 

--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -113,9 +113,13 @@ const StripHome: React.FC = () => {
                     {/* Chip docks flush above the composer (no gap; the chip has no bottom border).
                         It's absolutely positioned INTO the 44px hero gap (bottom-full), so the
                         subtitle→composer distance is exactly mt-11 with or without a chip — the
-                        invisible reserved slot no longer inflates the gap. */}
+                        invisible reserved slot no longer inflates the gap. The 1.5px nudge overlaps
+                        the composer's top border so the chip opens into it instead of sitting on a
+                        seam line. */}
                     <div className="relative mt-11 flex flex-col items-stretch">
-                        <div className="absolute bottom-full left-0">{provenance.chipNode}</div>
+                        <div className="absolute bottom-full left-0 translate-y-[1.5px]">
+                            {provenance.chipNode}
+                        </div>
                         <StripComposer
                             composerRef={composerRef}
                             onCreate={handleCreate}

--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -113,11 +113,12 @@ const StripHome: React.FC = () => {
                     {/* Chip docks flush above the composer (no gap; the chip has no bottom border).
                         It's absolutely positioned INTO the 44px hero gap (bottom-full), so the
                         subtitle→composer distance is exactly mt-11 with or without a chip — the
-                        invisible reserved slot no longer inflates the gap. The 1.5px nudge overlaps
+                        invisible reserved slot no longer inflates the gap. The 2px nudge overlaps
                         the composer's top border so the chip opens into it instead of sitting on a
-                        seam line. */}
+                        seam line; z-10 keeps the chip painting ABOVE the (relative) composer, whose
+                        border would otherwise draw over the overlap. */}
                     <div className="relative mt-11 flex flex-col items-stretch">
-                        <div className="absolute bottom-full left-0 translate-y-[1.5px]">
+                        <div className="absolute bottom-full left-0 z-10 translate-y-[2px]">
                             {provenance.chipNode}
                         </div>
                         <StripComposer

--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -110,13 +110,9 @@ const StripHome: React.FC = () => {
                         </Typography.Text>
                     </div>
 
-                    {/* Chip docks flush above the composer (no gap; the chip has no bottom border).
-                        It's absolutely positioned INTO the 44px hero gap (bottom-full), so the
-                        subtitle→composer distance is exactly mt-11 with or without a chip — the
-                        invisible reserved slot no longer inflates the gap. The 2px nudge overlaps
-                        the composer's top border so the chip opens into it instead of sitting on a
-                        seam line; z-10 keeps the chip painting ABOVE the (relative) composer, whose
-                        border would otherwise draw over the overlap. */}
+                    {/* Chip docks into the hero gap (bottom-full), so mt-11 holds with or without it.
+                        The 2px nudge + z-10 overlap and paint above the composer's top border so the
+                        chip reads as one shape, not a seam. */}
                     <div className="relative mt-11 flex flex-col items-stretch">
                         <div className="absolute bottom-full left-0 z-10 translate-y-[2px]">
                             {provenance.chipNode}

--- a/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
@@ -23,6 +23,7 @@ import {CharacterCountPlugin} from "./plugins/CharacterCountPlugin"
 import {CodeFencePlugin} from "./plugins/CodeFencePlugin"
 import {EditableSyncPlugin} from "./plugins/EditableSyncPlugin"
 import {EditorRefBridge} from "./plugins/EditorRefBridge"
+import {FocusStatePlugin} from "./plugins/FocusStatePlugin"
 import {LinkPastePlugin} from "./plugins/LinkPastePlugin"
 import {SendButton} from "./plugins/SendButton"
 import {SubmitPlugin} from "./plugins/SubmitPlugin"
@@ -43,8 +44,6 @@ export interface RichChatInputProps {
     /** Disables editing entirely. For streaming chats prefer leaving editable + routing to a queue. */
     disabled?: boolean
     autoFocus?: boolean
-    /** Soft character limit — shown as `count/max` and turns red when exceeded. */
-    maxLength?: number
     className?: string
     /** Leading slot in the footer (e.g. an attach-files button). */
     prefix?: ReactNode
@@ -109,7 +108,6 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
             placeholder = "Type a message…",
             disabled = false,
             autoFocus = false,
-            maxLength,
             className,
             prefix,
             header,
@@ -131,7 +129,7 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
         ref,
     ) {
         const editorRef = useRef<LexicalEditor | null>(null)
-        const [count, setCount] = useState(0)
+        const [focused, setFocused] = useState(false)
         const [modKey, setModKey] = useState("⌘")
 
         useEffect(() => {
@@ -176,7 +174,6 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
             [],
         )
 
-        const overLimit = typeof maxLength === "number" && count > maxLength
         const comfortable = size === "comfortable"
 
         return (
@@ -237,7 +234,17 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                     >
                         {prefix}
                         {hideShortcutHints ? null : (
-                            <div className="flex flex-wrap items-center gap-2.5">
+                            // The format hints are a focus-only aid: kept mounted (so their space
+                            // never reflows the row) and faded in when the editor takes focus.
+                            <div
+                                className={clsx(
+                                    "flex flex-wrap items-center gap-2.5 transition-[opacity,transform] duration-200 ease-out",
+                                    focused
+                                        ? "translate-y-0 opacity-100"
+                                        : "pointer-events-none translate-y-0.5 opacity-0",
+                                )}
+                                aria-hidden={!focused}
+                            >
                                 <ShortcutHint keys={`${modKey} B`} label="Bold" />
                                 <ShortcutHint keys={`${modKey} I`} label="Italic" />
                                 <ShortcutHint keys="↵" label="Send" />
@@ -245,22 +252,6 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                             </div>
                         )}
                         <div className="ml-auto flex items-center gap-2">
-                            {/* Only show a counter when there's a limit to track against, or when the
-                                user has actually typed — a lone "0" beside the button is just clutter. */}
-                            {(typeof maxLength === "number" || count > 0) && (
-                                <span
-                                    className={clsx(
-                                        "shrink-0 text-xs tabular-nums",
-                                        overLimit
-                                            ? "text-[var(--ag-colorError)]"
-                                            : "text-[var(--ag-colorTextTertiary)]",
-                                    )}
-                                >
-                                    {typeof maxLength === "number"
-                                        ? `${count}/${maxLength}`
-                                        : count}
-                                </span>
-                            )}
                             {hideSendButton ? null : (
                                 <SendButton
                                     onSubmit={onSubmit}
@@ -292,7 +283,8 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                     {/* Enter on a lone ``` fence opener → code block (runs before SubmitPlugin). */}
                     <CodeFencePlugin />
                     {submitOnEnter ? <SubmitPlugin onSubmit={onSubmit} /> : null}
-                    <CharacterCountPlugin onCountChange={setCount} onTextChange={onChange} />
+                    <FocusStatePlugin onFocusChange={setFocused} />
+                    {onChange ? <CharacterCountPlugin onTextChange={onChange} /> : null}
                 </div>
             </LexicalExtensionComposer>
         )

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/CharacterCountPlugin.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/CharacterCountPlugin.tsx
@@ -4,13 +4,13 @@ import {useLexicalComposerContext} from "@lexical/react/LexicalComposerContext"
 import {$getRoot} from "lexical"
 
 interface CharacterCountPluginProps {
-    onCountChange: (count: number) => void
+    onCountChange?: (count: number) => void
     /** Optional: reports the editor's current plain text on every commit (e.g. so a consumer can
      * react to the composer becoming empty). */
     onTextChange?: (text: string) => void
 }
 
-/** Reports the editor's plain-text length (and, optionally, content) on every commit. */
+/** Reports the editor's plain-text length and/or content on every commit. */
 export function CharacterCountPlugin({onCountChange, onTextChange}: CharacterCountPluginProps) {
     const [editor] = useLexicalComposerContext()
 
@@ -18,7 +18,7 @@ export function CharacterCountPlugin({onCountChange, onTextChange}: CharacterCou
         return editor.registerUpdateListener(({editorState}) => {
             editorState.read(() => {
                 const root = $getRoot()
-                onCountChange(root.getTextContentSize())
+                onCountChange?.(root.getTextContentSize())
                 onTextChange?.(root.getTextContent())
             })
         })

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/FocusStatePlugin.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/FocusStatePlugin.tsx
@@ -1,0 +1,37 @@
+import {useEffect} from "react"
+
+import {useLexicalComposerContext} from "@lexical/react/LexicalComposerContext"
+import {mergeRegister} from "@lexical/utils"
+import {BLUR_COMMAND, COMMAND_PRIORITY_LOW, FOCUS_COMMAND} from "lexical"
+
+interface FocusStatePluginProps {
+    onFocusChange: (focused: boolean) => void
+}
+
+/** Reports the editor's focus state so the composer can reveal focus-only chrome (shortcut hints). */
+export function FocusStatePlugin({onFocusChange}: FocusStatePluginProps) {
+    const [editor] = useLexicalComposerContext()
+
+    useEffect(() => {
+        return mergeRegister(
+            editor.registerCommand(
+                FOCUS_COMMAND,
+                () => {
+                    onFocusChange(true)
+                    return false
+                },
+                COMMAND_PRIORITY_LOW,
+            ),
+            editor.registerCommand(
+                BLUR_COMMAND,
+                () => {
+                    onFocusChange(false)
+                    return false
+                },
+                COMMAND_PRIORITY_LOW,
+            ),
+        )
+    }, [editor, onFocusChange])
+
+    return null
+}

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/FocusStatePlugin.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/FocusStatePlugin.tsx
@@ -13,6 +13,10 @@ export function FocusStatePlugin({onFocusChange}: FocusStatePluginProps) {
     const [editor] = useLexicalComposerContext()
 
     useEffect(() => {
+        // Seed from current DOM focus so an autoFocus that fired before this registered isn't missed.
+        const root = editor.getRootElement()
+        if (root && root.ownerDocument.activeElement === root) onFocusChange(true)
+
         return mergeRegister(
             editor.registerCommand(
                 FOCUS_COMMAND,


### PR DESCRIPTION
## Context

Polish on the agent composer (the shared `RichChatInput`) and the home `/apps` template chip. Three things read as unfinished: the composer showed a bare character count next to the send button, the Bold/Italic/Send/Newline format hints were always on regardless of focus, and the "From template" chip popped in/out and switched size instantly, with a visible border seam where it met the composer.

## Changes

**Drop the character counter.** No consumer ever passed `maxLength`, so the counter only rendered a lone clutter number beside the send button. Removed the counter, the `maxLength` prop, and the `count`/`overLimit` state. `CharacterCountPlugin`'s count callback is now optional; it still reports text for the `onChange` consumers.

**Reveal format hints on focus.** A new `FocusStatePlugin` (Lexical `FOCUS_COMMAND`/`BLUR_COMMAND`) drives a `focused` flag, and the hint row fades + rises in when the editor takes focus. It stays mounted so its width never reflows the toolbar row.

**Transition the template chip.** The provenance chip above the home composer now:
- fades + rises in on select and out on clear, showing the retained last template through the fade rather than flipping to a sizing placeholder;
- morphs its width when switching templates. The chip is `w-fit`, so auto width can't be CSS-transitioned. A new `TemplateChipDock` measures an off-flow ghost at natural (max-content) width via a `ResizeObserver` and animates an explicit width on the visible chip; children keep their size and clip rather than squish while it eases.

**Connect the chip to the composer (no seam).** The chip is a docked tab, so it should read as one shape with the composer. Three things were needed and each masked the next:
- match the chip border to the composer's selected accent (`--ag-colorPrimary`);
- overlap the composer's top border by 2px and give the chip `z-10` so it paints above the (relative, later-in-source) composer instead of under it;
- composite the chip background over `--ag-colorBgContainer` so it's opaque. The raw `--ag-strip-selected-bg` is 6%-alpha in dark, so the composer border showed straight through the chip until the background was made opaque.

## Tests / notes

- `@agenta/ui` builds clean (`tsc --noEmit`); oss typecheck shows no new errors in any touched file.
- Lint + pre-commit hooks pass.
- Known transient: during the chip's ~200ms fade-in the whole chip is briefly translucent, so the composer border can show through for that window before the chip goes opaque. The static seam is fully fixed; switching the enter/exit to a width-wipe would remove that transient too, as a follow-up if wanted.

## What to QA

- Open the composer (home hero and an agent chat). The character count is gone. The Bold/Italic/Send/Newline hints are hidden until you focus the editor, then fade in; blur fades them out. No layout jump in the toolbar row.
- On `/apps`, pick a template. The chip fades + rises in above the composer and reads as one connected shape with it (continuous accent border, no seam line under the chip). Check dark mode specifically — that's where the seam lived.
- Switch between a short-name and a long-name template a few times. The chip width eases in both directions (grow and shrink), not just grow.
- Clear the chip (✕ or empty the composer). It fades out showing the correct template, and the composer returns to its default border.
