### PR TITLE
fix(sdk): surface gateway tool-resolution detail so one stale action names itself (F-019)

### DIFF
--- a/sdks/python/agenta/sdk/agents/platform/gateway.py
+++ b/sdks/python/agenta/sdk/agents/platform/gateway.py
@@ -31,9 +31,64 @@ from .connection import PlatformConnection
 
 log = get_module_logger(__name__)
 
+# Cap the reason string so a stray HTML error page (or any oversized body) cannot flood
+# the run error. The useful backend detail is a single short sentence; this is only a
+# fallback bound for the non-JSON case.
+_MAX_DETAIL_LENGTH = 500
+
+# The backend raises ActionNotFoundError with this exact prefix when a committed config
+# points at a Composio action that has left the catalog (the F-019 case). Detecting it
+# lets us append an actionable remedy the bare "not found" message does not spell out.
+_STALE_ACTION_PREFIX = "Action not found:"
+
 
 def _normalize_reference(reference: str) -> str:
     return reference.replace("__", ".")
+
+
+def _extract_resolution_detail(response: httpx.Response) -> Optional[str]:
+    """Pull the human-facing reason out of a non-2xx ``/tools/resolve`` response.
+
+    The backend puts the useful sentence in the FastAPI error envelope
+    (``{"detail": "Action not found: ..."}``). Prefer that. Fall back to a bounded slice
+    of the raw body so a non-JSON error page still yields something, without letting a
+    large page through. Returns ``None`` when there is nothing usable to surface.
+    """
+    detail: Optional[str] = None
+
+    try:
+        payload = response.json()
+    except (ValueError, TypeError):
+        payload = None
+
+    if isinstance(payload, dict):
+        raw = payload.get("detail")
+        if isinstance(raw, str) and raw.strip():
+            detail = raw.strip()
+
+    if detail is None:
+        text = (response.text or "").strip()
+        if text:
+            detail = text
+
+    if detail is None:
+        return None
+
+    if len(detail) > _MAX_DETAIL_LENGTH:
+        detail = detail[:_MAX_DETAIL_LENGTH].rstrip() + " ... (truncated)"
+    return detail
+
+
+def _format_resolution_failure(status_code: int, detail: Optional[str]) -> str:
+    """Build the run-error message from the status code and the extracted detail."""
+    if not detail:
+        return f"Gateway tool resolution failed (HTTP {status_code})"
+    message = f"Gateway tool resolution failed: {detail} (HTTP {status_code})"
+    if detail.startswith(_STALE_ACTION_PREFIX):
+        message += (
+            ". Remove or re-resolve this tool; the action is no longer in the catalog."
+        )
+    return message
 
 
 def _to_gateway_reference(tool_config: GatewayToolConfig) -> Dict[str, Any]:
@@ -109,10 +164,16 @@ class AgentaGatewayToolResolver:
             ) from exc
 
         if response.status_code >= 400:
+            # Read the body the backend already sent. It names the failing tool/action
+            # and the real reason (F-019: the SDK used to drop it and surface only the
+            # bare status code). Carry the reason on the exception, in both the message
+            # and the structured ``detail`` field.
+            detail = _extract_resolution_detail(response)
             error = GatewayToolResolutionError(
-                f"Gateway tool resolution failed (HTTP {response.status_code})",
+                _format_resolution_failure(response.status_code, detail),
                 status=response.status_code,
                 ref_count=len(tools),
+                detail=detail,
             )
             log.warning("agent: %s", error)
             raise error

--- a/sdks/python/agenta/sdk/agents/tools/errors.py
+++ b/sdks/python/agenta/sdk/agents/tools/errors.py
@@ -39,6 +39,7 @@ class ToolResolutionError(ToolError):
         spec_count: Optional[int] = None,
         provider: Optional[str] = None,
         reference: Optional[str] = None,
+        detail: Optional[str] = None,
     ) -> None:
         super().__init__(message)
         self.status = status
@@ -46,6 +47,10 @@ class ToolResolutionError(ToolError):
         self.spec_count = spec_count
         self.provider = provider
         self.reference = reference
+        # Human-facing reason string from the resolver response body (the FastAPI
+        # ``detail`` field). Diagnostic metadata: it travels server -> exception -> run
+        # error so the user learns which tool broke without backend access. Never a secret.
+        self.detail = detail
 
 
 class GatewayToolResolutionError(ToolResolutionError):

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_gateway_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_gateway_http.py
@@ -151,3 +151,70 @@ async def test_http_status_failure_is_typed(fake_http, connection):
     with pytest.raises(GatewayToolResolutionError) as caught:
         await _resolver(connection).resolve([_gateway()])
     assert caught.value.status == 400
+
+
+async def test_stale_action_404_surfaces_backend_detail(fake_http, connection):
+    """F-019: the resolver body naming the dead action reaches the run error."""
+    fake_http(
+        gateway,
+        status=404,
+        payload={"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"},
+    )
+    with pytest.raises(GatewayToolResolutionError) as caught:
+        await _resolver(connection).resolve([_gateway(action="COMMIT_MULTIPLE_FILES")])
+    error = caught.value
+    assert error.status == 404
+    # The structured field carries the raw backend reason verbatim.
+    assert error.detail == "Action not found: composio/github/COMMIT_MULTIPLE_FILES"
+    message = str(error)
+    # The message names the tool, the reason, and the actionable remedy.
+    assert "composio/github/COMMIT_MULTIPLE_FILES" in message
+    assert "(HTTP 404)" in message
+    assert "no longer in the catalog" in message
+
+
+async def test_non_json_error_body_falls_back_to_bounded_text(fake_http, connection):
+    """A non-JSON 500 body still yields a non-empty detail without a secondary error."""
+    fake_http(
+        gateway,
+        status=500,
+        payload={},  # no "detail" key -> fall through to text
+        text="Internal Server Error: upstream boom",
+    )
+    with pytest.raises(GatewayToolResolutionError) as caught:
+        await _resolver(connection).resolve([_gateway()])
+    error = caught.value
+    assert error.status == 500
+    assert error.detail == "Internal Server Error: upstream boom"
+    assert "upstream boom" in str(error)
+    # No stale-action remedy for a non-action failure.
+    assert "no longer in the catalog" not in str(error)
+
+
+def test_extract_detail_prefers_json_detail_field():
+    response = httpx.Response(
+        status_code=404,
+        json={"detail": "Action not found: composio/github/GONE"},
+    )
+    assert (
+        gateway._extract_resolution_detail(response)
+        == "Action not found: composio/github/GONE"
+    )
+
+
+def test_extract_detail_falls_back_to_text_for_non_json_body():
+    response = httpx.Response(status_code=502, text="<html>Bad Gateway</html>")
+    assert gateway._extract_resolution_detail(response) == "<html>Bad Gateway</html>"
+
+
+def test_extract_detail_truncates_a_long_body():
+    response = httpx.Response(status_code=500, text="x" * 5000)
+    detail = gateway._extract_resolution_detail(response)
+    assert detail is not None
+    assert detail.endswith(" ... (truncated)")
+    assert len(detail) <= gateway._MAX_DETAIL_LENGTH + len(" ... (truncated)")
+
+
+def test_extract_detail_returns_none_for_empty_body():
+    response = httpx.Response(status_code=500, text="")
+    assert gateway._extract_resolution_detail(response) is None


### PR DESCRIPTION
## Context

A committed agent whose config references a Composio action that has since left the catalog fails **every turn**, in about six seconds, with only:

```
Gateway tool resolution failed (HTTP 404)
```

The message names no tool and no reason. Diagnosing it required backend access: reading the saved config out of Postgres and probing each action slug against Composio by hand. One stale action bricks the whole agent, and the user cannot tell which tool broke or why. This is QA finding **F-019** and the opacity half of issue **#5173**.

The root cause is a one-hop drop. The backend already produces the useful sentence and puts it in the HTTP body (`{"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"}`). The SDK read only the status code and discarded the body.

## What this changes

Phase 1 (Option A) of the [gateway-tool-resolution design](../blob/big-agents/docs/design/agent-workflows/projects/gateway-tool-resolution/design.md). A contained, safe SDK fix; no contract change.

In `sdks/python/agenta/sdk/agents/platform/gateway.py`, when the resolve response is non-2xx:

- Read the body and pull the FastAPI `detail` field. Fall back to a bounded slice of the raw text when the body is not JSON or has no `detail`, capped at 500 chars so a stray HTML error page cannot flood the run error.
- Carry the reason on `GatewayToolResolutionError`, in both the message and a new structured `detail` field (added to `ToolResolutionError`).
- When the reason is a stale action (`Action not found:`), append an actionable remedy.

Before and after, from the user's point of view:

```
before:  Gateway tool resolution failed (HTTP 404)

after:   Gateway tool resolution failed: Action not found:
         composio/github/COMMIT_MULTIPLE_FILES (HTTP 404). Remove or
         re-resolve this tool; the action is no longer in the catalog.
```

The resolve happens once, up front, before the harness starts (`handler.py`), so the exception string is the run error already. No downstream re-enrichment is needed.

## Scope / risk

- **SDK only.** The backend already puts the reason in the body; this reads what it already sends. No API, wire, runner, or frontend change.
- **Not touched:** the all-or-nothing behavior (one dead tool still fails the turn). That is Phase 2 / Option B in the design (partial resolution with a loud warning) and is deliberately out of this PR. Connection, auth, and provider failures also surface their detail now, which is strictly more information than before.
- **Data-leak guard:** only the `detail` field plus a bounded text fallback are surfaced, never the whole body, so a future endpoint change cannot turn this into an accidental data channel. Today `detail` carries catalog and connection messages, which are safe. Never a secret.
- The `detail` field is a new optional field on an existing exception; additive, no caller breaks.

## How to QA

Prerequisites: the SDK checked out on this branch.

Unit tests (the exact F-019 payload plus the truncation and fallback edges):

```
cd sdks/python
uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/platform/test_gateway_http.py -q
```

Expected: 13 passed. Key cases:
- `test_stale_action_404_surfaces_backend_detail`: a `404 {"detail": "Action not found: composio/github/COMMIT_MULTIPLE_FILES"}` produces an error whose message names the action, the HTTP status, and the remedy, and whose `.detail` carries the raw backend reason.
- `test_non_json_error_body_falls_back_to_bounded_text`: a non-JSON 500 body still yields a non-empty `.detail`.
- `test_extract_detail_truncates_a_long_body`: a 5000-char body is capped.

Live check (against a running stack): call the real resolver against `/tools/resolve` with a bogus Composio reference and confirm the raised `GatewayToolResolutionError` message now contains the backend `detail` and `(HTTP 404)`, and `.detail` / `.status` are populated. Verified on the dev stack: a bogus reference surfaced `Gateway tool resolution failed: Connection not found: composio/github/does-not-exist (HTTP 404)` with `status=404` and `detail` set (before this change: bare `HTTP 404`).

Edge cases covered: JSON body with `detail`, JSON body without `detail`, non-JSON body, empty body, oversized body, and a non-action failure (no stale-action remedy appended).

Finding F-019. Closes the opacity half of #5173. Related: #5174 (root-cause discover/resolve drift, kept separate per the design's D3). Design PR: #5212.

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj