### PR TITLE
fix(sdk): map together_ai to the env var Pi actually reads (F-012)

### DIFF
--- a/sdks/python/agenta/sdk/agents/capabilities.py
+++ b/sdks/python/agenta/sdk/agents/capabilities.py
@@ -114,7 +114,11 @@ PROVIDER_ENV_VARS: Dict[str, str] = {
     "mistralai": "MISTRAL_API_KEY",
     "minimax": "MINIMAX_API_KEY",
     "groq": "GROQ_API_KEY",
-    "together_ai": "TOGETHERAI_API_KEY",
+    # The vault kind is ``together_ai`` (underscore), but the Pi harness reads ``TOGETHER_API_KEY``
+    # (see ``@earendil-works/pi-ai`` ``env-api-keys.js``). This differs from litellm's
+    # ``TOGETHERAI_API_KEY`` (the classic app-runner path); this table feeds the Pi harness, so it
+    # must use Pi's name or the key never reaches the harness.
+    "together_ai": "TOGETHER_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
 }
 

--- a/services/oss/tests/pytest/unit/agent/test_secrets_mapping.py
+++ b/services/oss/tests/pytest/unit/agent/test_secrets_mapping.py
@@ -15,7 +15,7 @@ def test_standard_providers_map_to_expected_env_vars():
     assert _PROVIDER_ENV_VARS["anthropic"] == "ANTHROPIC_API_KEY"
     assert _PROVIDER_ENV_VARS["gemini"] == "GEMINI_API_KEY"
     assert _PROVIDER_ENV_VARS["groq"] == "GROQ_API_KEY"
-    assert _PROVIDER_ENV_VARS["together_ai"] == "TOGETHERAI_API_KEY"
+    assert _PROVIDER_ENV_VARS["together_ai"] == "TOGETHER_API_KEY"
     assert _PROVIDER_ENV_VARS["openrouter"] == "OPENROUTER_API_KEY"
 
 


### PR DESCRIPTION
## Context

A Together AI agent run silently had no Together credential. The vault held the key, but the
harness fell back to login/OAuth as if none was set, so the run used the wrong (or no) model
auth without any error.

Root cause: the canonical agent env-var table set the wrong env var name. The Pi harness reads
`TOGETHER_API_KEY` (per `@earendil-works/pi-ai` `env-api-keys.js`), but the table injected the
key as `TOGETHERAI_API_KEY`, a name Pi never reads. The key was delivered under a name nobody
looks for, so it never reached the harness. This is finding F-012.

Note `TOGETHERAI_API_KEY` is litellm's name and is correct on the separate classic app-runner
path (`engines/running/runners/daytona.py`); that path is unchanged. This table feeds the Pi
agent harness, so it must use Pi's name.

## Before / after

```
# sdks/python/agenta/sdk/agents/capabilities.py  (PROVIDER_ENV_VARS)
- "together_ai": "TOGETHERAI_API_KEY",   # Pi never reads this -> key dropped
+ "together_ai": "TOGETHER_API_KEY",     # the name Pi actually reads
```

The table is the single source of truth: `platform/connections.py`, `platform/secrets.py`, and
`connections/resolver.py` all import it (the parity test enforces this), and the services agent
path re-exports it, so this one edit fixes every consumer.

## Verified provider table

I checked every provider in `PROVIDER_ENV_VARS` against what Pi actually reads
(`@earendil-works/pi-ai@0.80.6` `getApiKeyEnvVars`), not just Together:

| vault kind | env var we set | env var Pi reads | verdict |
|---|---|---|---|
| openai | OPENAI_API_KEY | OPENAI_API_KEY | ok |
| anthropic | ANTHROPIC_API_KEY | ANTHROPIC_API_KEY (+ ANTHROPIC_OAUTH_TOKEN) | ok |
| gemini | GEMINI_API_KEY | GEMINI_API_KEY (Pi provider `google`) | ok |
| mistral | MISTRAL_API_KEY | MISTRAL_API_KEY | ok |
| mistralai | MISTRAL_API_KEY | MISTRAL_API_KEY (alias) | ok |
| minimax | MINIMAX_API_KEY | MINIMAX_API_KEY | ok |
| groq | GROQ_API_KEY | GROQ_API_KEY | ok |
| together_ai | TOGETHERAI_API_KEY | **TOGETHER_API_KEY** | **fixed here** |
| openrouter | OPENROUTER_API_KEY | OPENROUTER_API_KEY | ok |

Only `together_ai` was wrong; all others already match Pi.

## Scope / risk

- Two files: the canonical table plus the services-side unit test that asserted the old value.
- The litellm app-runner map (`daytona.py`) and the belt-and-suspenders clear/allow lists in
  `daemon.ts` and `platform/connections.py` (which list both names) are intentionally untouched.
- No wire, schema, or interface change. Low risk: a dict value flip plus its guard test.

## How to QA

Prerequisites: the SDK/services test envs (`uv sync --locked`).

1. From `sdks/python`: `uv run --no-sync python -m pytest oss/tests/pytest/unit/agents/test_provider_env_vars_parity.py -q` -> 2 passed.
2. From `services`: `uv run --no-sync python -m pytest oss/tests/pytest/unit/agent/test_secrets_mapping.py -q` -> 2 passed.
3. Live (optional, needs a Together `provider_key` in the project vault and the dev stack on :8280):
   start a Pi run configured for a `together_ai` model and confirm the run env carries
   `TOGETHER_API_KEY` (not `TOGETHERAI_API_KEY`) and the run authenticates with the vault key
   instead of falling back to login.

Edge case: `together_ai` also appears in the daemon clear-set and allowed-extras under BOTH
names; those stay, so a `custom_provider` that injects either name still works.

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj
