### PR TITLE
fix(agent): fail loud on pre-migration flat agent-template selectors (F-016)

### DIFF
--- a/sdks/python/agenta/sdk/agents/__init__.py
+++ b/sdks/python/agenta/sdk/agents/__init__.py
@@ -55,6 +55,7 @@ from .connections import (
 from .dtos import (
     AgentaAgentTemplate,
     AgentTemplate,
+    AgentTemplateShapeError,
     Event,
     AgentResult,
     ClaudeAgentTemplate,
@@ -265,6 +266,7 @@ __all__ = [
     "UnsupportedHarnessError",
     "ToolResolutionError",
     "InvalidPermissionDefaultError",
+    "AgentTemplateShapeError",
     # Adapters
     "SandboxAgentBackend",
     "LocalBackend",

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -22,6 +22,8 @@ from pydantic import (
     model_validator,
 )
 
+from agenta.sdk.engines.running.errors import ERRORS_BASE_URL, ErrorStatus
+
 from .connections import ModelRef, ResolvedConnection
 from .mcp import (
     MCPServerConfig,
@@ -117,6 +119,23 @@ class InvalidPermissionDefaultError(ValueError):
             f"invalid runner.permissions.default {value!r}; expected one of "
             f"{sorted(PERMISSION_MODES)}"
         )
+
+
+class AgentTemplateShapeError(ErrorStatus):
+    """A run request used a pre-migration flat agent-template key, or an unknown key in an
+    execution-selector object (``harness`` / ``sandbox`` / ``runner``).
+
+    Maps to HTTP 400 so a stale caller fails loud (naming the bad key and the expected shape)
+    instead of silently falling back to defaults. Silent fallback is what let a pre-migration
+    "E3 daytona" request run in the LOCAL sandbox and go green (finding F-016): the flat
+    ``harness`` / ``sandbox`` strings and flat ``model`` / ``agents_md`` were simply ignored.
+    """
+
+    code: int = 400
+    type: str = f"{ERRORS_BASE_URL}#v0:agent:invalid-template-shape"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(code=self.code, type=self.type, message=message)
 
 
 # ---------------------------------------------------------------------------
@@ -632,6 +651,9 @@ class AgentTemplate(BaseModel):
         harness's ``permissions`` / ``extras`` collapse onto the flat ``harness_permissions`` /
         ``harness_extras`` here.
         """
+        # Fail loud on a pre-migration flat template or unknown selector keys BEFORE parsing, so a
+        # stale caller gets a named 400 instead of silently running defaults (finding F-016).
+        _validate_agent_template_shape(params)
         base = defaults or cls()
         instructions, model, tools = _parse_agent_fields(params, base)
         harness, sandbox, permission_default = _parse_run_selection(params, base)
@@ -1067,6 +1089,80 @@ def _section(params: Dict[str, Any], key: str) -> Dict[str, Any]:
     """One execution section (``harness`` / ``runner`` / ``sandbox``) of the template, or ``{}``."""
     value = _template(params).get(key)
     return value if isinstance(value, dict) else {}
+
+
+def _has_agent_template(params: Dict[str, Any]) -> bool:
+    """True when the request carries an agent template (wrapped at ``agent``, or a bare template
+    with definition fields), as opposed to the ``prompt`` chat fallback.
+
+    Mirrors the ``has_template`` branch in :func:`_parse_agent_fields` so shape validation and
+    field parsing agree on which requests own an agent template."""
+    return isinstance(params.get("agent"), dict) or any(
+        key in params for key in ("instructions", "llm", "tools", "mcps", "skills")
+    )
+
+
+# The pre-migration flat definition keys and where they moved in the nested template. A caller
+# still sending these silently lost its instructions/model before this guard (finding F-016).
+_LEGACY_FLAT_TEMPLATE_KEYS: Dict[str, str] = {
+    "model": 'llm.model (e.g. "llm": {"model": "gpt-5.5"})',
+    "agents_md": 'instructions.agents_md (e.g. "instructions": {"agents_md": "..."})',
+}
+
+# The execution selectors and the exact keys each accepts. This set is the compat boundary: it is
+# CLOSED (unknown key -> loud error) precisely because it is a small, coordinated, schema-driven
+# enum surface (see ``build_agent_v0_default`` and the FE ``useModelHarness`` sections). The
+# element itself and the portable definition fields (instructions/llm/tools/mcps/skills) stay OPEN
+# for forward-compat; only these three objects are locked down.
+_SELECTOR_ALLOWED_KEYS: Dict[str, frozenset] = {
+    "harness": frozenset({"kind", "permissions", "extras"}),
+    "sandbox": frozenset({"kind", "permissions"}),
+    "runner": frozenset({"kind", "permissions"}),
+}
+
+
+def _validate_agent_template_shape(params: Dict[str, Any]) -> None:
+    """Reject a pre-migration flat agent template, and unknown keys in the execution selectors.
+
+    Fails loud (HTTP 400, naming the bad key and the expected shape) instead of the old silent
+    fallback to defaults that made finding F-016's false-green E3 possible. Scope is deliberately
+    narrow: ONLY the agent-template element and its three selector objects are checked. The prompt
+    chat fallback and the open definition fields are left untouched, so forward-compat additions to
+    the portable template are never rejected here."""
+    if not _has_agent_template(params):
+        return
+    element = _template(params)
+    if not isinstance(element, dict):
+        return
+
+    for legacy_key, moved_to in _LEGACY_FLAT_TEMPLATE_KEYS.items():
+        if legacy_key in element:
+            raise AgentTemplateShapeError(
+                f"agent template carries the pre-migration flat key {legacy_key!r}; "
+                f"put it under {moved_to}"
+            )
+
+    for section, allowed in _SELECTOR_ALLOWED_KEYS.items():
+        value = element.get(section)
+        if value is None:
+            continue
+        if not isinstance(value, dict):
+            if section in ("harness", "sandbox"):
+                raise AgentTemplateShapeError(
+                    f"agent template carries the pre-migration flat {section!r} "
+                    f"({type(value).__name__} {value!r}); use nested {section}.kind "
+                    f'(e.g. "{section}": {{"kind": "..."}})'
+                )
+            raise AgentTemplateShapeError(
+                f"agent template {section!r} must be an object with keys "
+                f"{sorted(allowed)} (got {type(value).__name__} {value!r})"
+            )
+        unknown = sorted(set(value) - allowed)
+        if unknown:
+            raise AgentTemplateShapeError(
+                f"agent template {section!r} has unknown key(s) {unknown}; "
+                f"allowed: {sorted(allowed)}"
+            )
 
 
 def _parse_mcp_servers_raw(

--- a/services/oss/tests/pytest/unit/agent/test_template_shape_validation.py
+++ b/services/oss/tests/pytest/unit/agent/test_template_shape_validation.py
@@ -1,0 +1,182 @@
+"""``AgentTemplate.from_params`` fails loud on a pre-migration flat template or an unknown
+execution-selector key, instead of silently falling back to defaults.
+
+This is finding F-016's residual: the QA driver once sent the flat pre-migration shape
+(``harness`` / ``sandbox`` / ``model`` / ``agents_md`` as flat keys); ``from_params`` ignored the
+unknown keys and returned defaults (``pi_core`` / ``local`` / ``gpt-5.5`` / no instructions), so an
+"E3 daytona" run executed in the LOCAL sandbox and went green. The guard closes that hole: the
+stale caller now gets a named HTTP 400. The compat boundary is deliberately narrow — only the
+agent-template element and its three selector objects are checked; the portable definition fields
+and the ``prompt`` chat fallback stay open.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agenta.sdk.agents import AgentTemplate, AgentTemplateShapeError
+from agenta.sdk.models.workflows import WorkflowServiceRequest
+
+from oss.src.agent import app
+
+
+# ---------------------------------------------------------------------------
+# The valid nested shape is unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_nested_shape_parses_every_selector():
+    template = AgentTemplate.from_params(
+        {
+            "agent": {
+                "harness": {"kind": "claude"},
+                "sandbox": {"kind": "daytona"},
+                "runner": {"kind": "sidecar", "permissions": {"default": "allow"}},
+                "llm": {"model": "gpt-5.5"},
+                "instructions": {"agents_md": "be nice"},
+            }
+        }
+    )
+
+    # The selectors are read from the nested sections, NOT silently defaulted.
+    assert template.harness == "claude"
+    assert template.sandbox == "daytona"
+    assert template.model == "gpt-5.5"
+    assert template.instructions == "be nice"
+    assert template.permission_default == "allow"
+
+
+def test_selector_permissions_and_extras_are_allowed():
+    # harness carries permissions + extras; sandbox carries a Layer-2 permissions boundary.
+    template = AgentTemplate.from_params(
+        {
+            "agent": {
+                "harness": {"kind": "claude", "permissions": {}, "extras": {"x": 1}},
+                "sandbox": {
+                    "kind": "daytona",
+                    "permissions": {"network": {"mode": "on"}},
+                },
+            }
+        }
+    )
+    assert template.harness == "claude"
+    assert template.harness_extras == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# Pre-migration flat selector keys fail loud, naming the key and the new shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("selector", ["harness", "sandbox"])
+def test_flat_string_selector_is_rejected(selector):
+    with pytest.raises(AgentTemplateShapeError) as excinfo:
+        AgentTemplate.from_params({"agent": {selector: "daytona"}})
+
+    message = excinfo.value.message
+    assert selector in message
+    assert f"{selector}.kind" in message
+    assert excinfo.value.code == 400
+
+
+def test_flat_model_key_is_rejected():
+    with pytest.raises(AgentTemplateShapeError) as excinfo:
+        AgentTemplate.from_params(
+            {"agent": {"harness": {"kind": "pi_core"}, "model": "gpt-5.5"}}
+        )
+
+    message = excinfo.value.message
+    assert "model" in message
+    assert "llm.model" in message
+
+
+def test_flat_agents_md_key_is_rejected():
+    with pytest.raises(AgentTemplateShapeError) as excinfo:
+        AgentTemplate.from_params(
+            {"agent": {"harness": {"kind": "pi_core"}, "agents_md": "hi"}}
+        )
+
+    message = excinfo.value.message
+    assert "agents_md" in message
+    assert "instructions.agents_md" in message
+
+
+def test_full_pre_migration_template_is_rejected_not_silently_defaulted():
+    # The exact F-016 payload: flat harness/sandbox/model/agents_md. It must NOT parse to
+    # pi_core/local/gpt-5.5 — it must raise.
+    with pytest.raises(AgentTemplateShapeError):
+        AgentTemplate.from_params(
+            {
+                "agent": {
+                    "harness": "pi_core",
+                    "sandbox": "daytona",
+                    "model": "gpt-5.5",
+                    "agents_md": "you are an agent",
+                }
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unknown keys inside a selector object fail loud (the selectors are closed).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("selector", ["harness", "sandbox", "runner"])
+def test_unknown_selector_key_is_rejected(selector):
+    with pytest.raises(AgentTemplateShapeError) as excinfo:
+        AgentTemplate.from_params(
+            {"agent": {selector: {"kind": "pi_core", "garbage_key": 1}}}
+        )
+
+    message = excinfo.value.message
+    assert selector in message
+    assert "garbage_key" in message
+
+
+# ---------------------------------------------------------------------------
+# The compat boundary: forward-compat definition fields and the prompt fallback
+# stay open. Only the selectors are closed.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_definition_level_key_is_left_open_for_forward_compat():
+    # A future portable-definition field on the element must NOT be rejected: the boundary is
+    # scoped to the execution selectors, not the whole template.
+    template = AgentTemplate.from_params(
+        {
+            "agent": {
+                "harness": {"kind": "pi_core"},
+                "future_definition_field": {"anything": True},
+            }
+        }
+    )
+    assert template.harness == "pi_core"
+
+
+def test_prompt_chat_fallback_is_not_validated():
+    # The prompt-template path owns no agent element; the guard must skip it entirely.
+    template = AgentTemplate.from_params(
+        {
+            "prompt": {
+                "llm_config": {"model": "gpt-4o"},
+                "messages": [{"role": "system", "content": "be nice"}],
+            }
+        }
+    )
+    assert template.model == "gpt-4o"
+    assert template.instructions == "be nice"
+
+
+# ---------------------------------------------------------------------------
+# The error surfaces through the service handler (loud, not swallowed).
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_raises_on_flat_template():
+    with pytest.raises(AgentTemplateShapeError):
+        await app._agent(
+            request=WorkflowServiceRequest(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters={"agent": {"harness": "claude", "sandbox": "daytona"}},
+        )


### PR DESCRIPTION
## The symptom

A run request in the pre-migration flat agent-template shape passed silently while running defaults. Sending

```json
{"agent": {"harness": "pi_core", "sandbox": "daytona", "model": "gpt-5.5", "agents_md": "..."}}
```

parsed without error, and every execution selector fell back to defaults (`pi_core` / `local` / `gpt-5.5` / no instructions). An "E3 daytona" request therefore executed in the LOCAL sandbox and went green, and any user config still in the old shape degraded silently. This is the service-side residual of finding **F-016** (the QA driver half was already fixed).

## Before / after

Before: `AgentTemplate.from_params` read `harness.kind` / `sandbox.kind` / `llm.model` / `instructions.agents_md` from nested sections and ignored anything else. A flat `harness` string made `_section` return `{}` (silent default); flat `model` / `agents_md` were never read.

After: `from_params` validates the agent-template element before parsing and raises `AgentTemplateShapeError` (HTTP 400) naming the bad key and the expected shape.

```
HTTP 400  agent template carries the pre-migration flat key 'model'; put it under llm.model (e.g. "llm": {"model": "gpt-5.5"})
HTTP 400  agent template carries the pre-migration flat 'harness' (str 'claude'); use nested harness.kind (e.g. "harness": {"kind": "..."})
HTTP 400  agent template 'harness' has unknown key(s) ['garbage']; allowed: ['extras', 'kind', 'permissions']
```

A valid nested request is unchanged.

## The compat boundary (why this scope)

The check is deliberately narrow. Only the three **execution selectors** (`harness` / `sandbox` / `runner`) are closed to unknown keys, because they are a small, coordinated, schema-driven enum surface (`build_agent_v0_default`, the FE `useModelHarness` sections). The agent-template element itself and the portable definition fields (`instructions` / `llm` / `tools` / `mcps` / `skills`) stay open (additionalProperties) for forward-compat, and the `prompt` chat fallback is not validated at all. An inline comment marks the boundary at the selector allow-list.

Two legacy definition keys (`model`, `agents_md`) are also rejected with a message pointing to their nested home, since those are the exact pre-migration names F-016 names.

## Tests

New `services/oss/tests/pytest/unit/agent/test_template_shape_validation.py`: valid nested shape unchanged; flat `harness`/`sandbox` string, flat `model`, flat `agents_md`, and unknown selector keys each fail loud; forward-compat definition field and the prompt fallback stay open; the error surfaces through the service handler. All pass. (7 pre-existing reds in `test_invoke_handler.py` are unrelated connection/session model drift, untouched here.)

## Live verification (dev stack :8280)

Real `/services/agent/v0/invoke` calls: flat `model`, flat `harness` string, and an unknown selector key each returned HTTP 400 with the exact messages above; a valid nested request passed shape validation and proceeded to execution.

Finding: docs/design/agent-workflows/projects/qa/findings.md (F-016), findings-status.md (F-016 residual).

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj
