### PR TITLE
fix(runner): fail loud on an unresolvable requested model (F-007)

### DIFF
--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -249,8 +249,8 @@ function applyClaudeConnectionEnv(
   request: AgentRunRequest,
   acpAgent: string,
   logger: Log,
-): boolean {
-  if (acpAgent !== "claude") return false;
+): void {
+  if (acpAgent !== "claude") return;
 
   // Disable the Claude Agent SDK's Tool-Search feature for every Claude run. The bundled
   // SDK defaults Tool-Search ON, which makes Claude DEFER the `agenta-tools` MCP tools and
@@ -290,9 +290,18 @@ function applyClaudeConnectionEnv(
     logger(
       `claude model=${selectedModel} deployment=${deployment ?? "<none>"}`,
     );
-    return true;
   }
-  return false;
+}
+
+/**
+ * Whether a requested-but-unsettable model fails the run (F-007). Strict by default on every
+ * harness path: a user who picks a model either runs that model or sees a loud error, never a
+ * silent (often pricier) fallback to the harness default. `AGENTA_AGENT_MODEL_STRICT=false` is
+ * the explicit opt-out that restores the legacy warn-and-fallback behavior. A run that requests
+ * no model is unaffected either way — it keeps the harness default.
+ */
+function modelResolutionStrict(): boolean {
+  return process.env.AGENTA_AGENT_MODEL_STRICT !== "false";
 }
 
 export interface SandboxAgentDeps extends BuildRunPlanDeps {
@@ -693,12 +702,8 @@ export async function acquireEnvironment(
     clearProviderEnv,
   });
   Object.assign(env, plan.secrets); // apply only the resolved provider keys
-  const strictModel = applyClaudeConnectionEnv(
-    env,
-    request,
-    plan.acpAgent,
-    logger,
-  );
+  applyClaudeConnectionEnv(env, request, plan.acpAgent, logger);
+  const strictModel = modelResolutionStrict();
   // Pi self-instruments locally: propagate the trace context + public tool metadata into Pi
   // via the Agenta extension. Tool execution always relays back to this runner, which keeps
   // private specs, scoped env, callback endpoints, and callback auth in memory.

--- a/services/runner/src/engines/sandbox_agent/daytona.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona.ts
@@ -21,7 +21,8 @@ export const DAYTONA_PI_DIR =
 export const DAYTONA_PI_INSTALL_DIR = "/home/sandbox/.agenta-pi";
 export const DAYTONA_PI_INSTALL =
   process.env.AGENTA_AGENT_SANDBOX_PI_INSTALLED !== "false";
-export const DAYTONA_PI_VERSION = process.env.AGENTA_AGENT_SANDBOX_PI_VERSION ?? "0.80.6";
+export const DAYTONA_PI_VERSION =
+  process.env.AGENTA_AGENT_SANDBOX_PI_VERSION ?? "0.80.6";
 
 /**
  * In-sandbox env for the Daytona daemon: where Pi reads its login, any provider keys,
@@ -45,9 +46,11 @@ export function daytonaEnvVars(
   return env;
 }
 
-
 /** Install the `pi` CLI into a Daytona sandbox (the sandbox-agent image lacks it). Best-effort. */
-export async function installPiInSandbox(sandbox: any, log: Log = () => {}): Promise<void> {
+export async function installPiInSandbox(
+  sandbox: any,
+  log: Log = () => {},
+): Promise<void> {
   try {
     await sandbox.mkdirFs({ path: DAYTONA_PI_INSTALL_DIR });
     const res = await sandbox.runProcess({
@@ -62,7 +65,9 @@ export async function installPiInSandbox(sandbox: any, log: Log = () => {}): Pro
       timeoutMs: 180_000,
     });
     if (res?.exitCode !== 0) {
-      log(`pi install in sandbox exit=${res?.exitCode}: ${String(res?.stderr).slice(-400)}`);
+      log(
+        `pi install in sandbox exit=${res?.exitCode}: ${String(res?.stderr).slice(-400)}`,
+      );
     }
   } catch (err) {
     log(`pi install in sandbox skipped: ${(err as Error).message}`);
@@ -74,13 +79,21 @@ export async function installPiInSandbox(sandbox: any, log: Log = () => {}): Pro
  * the dev's ChatGPT/Codex OAuth. Best-effort: with no local login the remote run falls
  * back to any provider key in the sandbox env.
  */
-export async function uploadPiAuthToSandbox(sandbox: any, log: Log = () => {}): Promise<void> {
-  const localDir = process.env.PI_CODING_AGENT_DIR || join(process.env.HOME ?? "", ".pi/agent");
+export async function uploadPiAuthToSandbox(
+  sandbox: any,
+  log: Log = () => {},
+): Promise<void> {
+  const localDir =
+    process.env.PI_CODING_AGENT_DIR ||
+    join(process.env.HOME ?? "", ".pi/agent");
   const authPath = join(localDir, "auth.json");
   if (!existsSync(authPath)) return;
   try {
     await sandbox.mkdirFs({ path: DAYTONA_PI_DIR });
-    await sandbox.writeFsFile({ path: `${DAYTONA_PI_DIR}/auth.json` }, readFileSync(authPath, "utf-8"));
+    await sandbox.writeFsFile(
+      { path: `${DAYTONA_PI_DIR}/auth.json` },
+      readFileSync(authPath, "utf-8"),
+    );
     const settingsPath = join(localDir, "settings.json");
     if (existsSync(settingsPath)) {
       await sandbox.writeFsFile(
@@ -137,7 +150,11 @@ export async function prepareDaytonaPiAssets({
       log,
     );
   }
+  const piInstallStartedAt = Date.now();
   if (DAYTONA_PI_INSTALL) await installPiInSandbox(sandbox, log);
+  log(
+    `[timing] stage=pi_install ms=${Math.round(Date.now() - piInstallStartedAt)} sandbox=${sandbox?.sandboxId ?? "-"} session=- skipped=${!DAYTONA_PI_INSTALL}`,
+  );
 }
 
 /**
@@ -149,13 +166,17 @@ export async function prepareDaytonaPiAssets({
  * It layers on {@link createAcpFetch} (the long-timeout ACP dispatcher) so a paused HITL turn
  * over Daytona is not reaped by undici's default `headersTimeout` either.
  */
-export function createCookieFetch(inner: typeof fetch = createAcpFetch()): typeof fetch {
+export function createCookieFetch(
+  inner: typeof fetch = createAcpFetch(),
+): typeof fetch {
   const jar = new Map<string, Map<string, string>>(); // host -> (name -> "name=value")
   return async (input: any, init?: any) => {
     const url = new URL(typeof input === "string" ? input : input.url);
     const host = url.host;
     const cookies = jar.get(host);
-    const headers = new Headers(init?.headers ?? (typeof input !== "string" ? input.headers : undefined));
+    const headers = new Headers(
+      init?.headers ?? (typeof input !== "string" ? input.headers : undefined),
+    );
     if (cookies && cookies.size > 0) {
       const existing = headers.get("cookie");
       const merged = [...cookies.values()];
@@ -166,7 +187,9 @@ export function createCookieFetch(inner: typeof fetch = createAcpFetch()): typeo
     const setCookies =
       typeof (response.headers as any).getSetCookie === "function"
         ? (response.headers as any).getSetCookie()
-        : (response.headers.get("set-cookie") ? [response.headers.get("set-cookie")] : []);
+        : response.headers.get("set-cookie")
+          ? [response.headers.get("set-cookie")]
+          : [];
     if (setCookies.length) {
       const store = jar.get(host) ?? new Map<string, string>();
       for (const sc of setCookies) {

--- a/services/runner/src/engines/sandbox_agent/model.ts
+++ b/services/runner/src/engines/sandbox_agent/model.ts
@@ -1,6 +1,30 @@
 type Log = (message: string) => void;
 
 /**
+ * A requested model that the harness cannot set, after the suffix-resolution retry. Carries the
+ * requested id and the valid options so the caller sees exactly what it asked for and what the
+ * harness would accept, instead of the run silently proceeding on a different (often pricier)
+ * default. This is the fail-loud half of F-007.
+ */
+export class ModelNotSettableError extends Error {
+  readonly requested: string;
+  readonly allowed: string[];
+
+  constructor(requested: string, allowed: string[], cause: string) {
+    const options = allowed.length
+      ? allowed.join(", ")
+      : "none reported by the harness config options";
+    super(
+      `model '${requested}' is not available on this run (${cause}). ` +
+        `Valid models for this harness: ${options}.`,
+    );
+    this.name = "ModelNotSettableError";
+    this.requested = requested;
+    this.allowed = allowed;
+  }
+}
+
+/**
  * Pick the harness-specific model id for a requested name. Harnesses expose their own ids
  * (Pi: "openai-codex/gpt-5.5"; Claude: its own). Match exact, then by provider suffix.
  */
@@ -23,7 +47,10 @@ export async function allowedModels(session: any): Promise<string[]> {
       (o: any) => o.category === "model" || o.id === "model",
     );
     const choices = modelOpt?.options ?? [];
-    return choices.map((c: any) => c.id).filter(Boolean);
+    // pi-acp builds each choice as `{ value: model.modelId, name, description }` and sandbox-agent
+    // reads `entry.value`; older shapes used `id`. Read `value` first so this returns the real
+    // selectable ids (reading only `id` silently returned [] for pi-acp).
+    return choices.map((c: any) => c.value ?? c.id).filter(Boolean);
   } catch {
     return [];
   }
@@ -40,8 +67,15 @@ export function allowedFromError(err: unknown): string[] {
 }
 
 /**
- * Apply the requested model to a session, normalizing to the harness's own id. Returns the
- * id set, or undefined when no match exists and the harness keeps its default.
+ * Apply the requested model to a session, normalizing to the harness's own id.
+ *
+ * No model requested keeps the harness default (returns undefined) — that is not an error.
+ * A requested model is first tried verbatim, then resolved against the harness's own ids via
+ * `pickModel` (so a bare "gpt-5.5" reaches Pi's "openai-codex/gpt-5.5"). When nothing resolves,
+ * the outcome depends on `strict` (default true): strict throws a `ModelNotSettableError` naming
+ * the requested id and the valid options, so a user who picks a model either gets it or sees a
+ * loud failure; non-strict logs one line and keeps the harness default (the legacy opt-out for
+ * `AGENTA_AGENT_MODEL_STRICT=false`). This is the F-007 fix.
  */
 export async function applyModel(
   session: any,
@@ -50,13 +84,13 @@ export async function applyModel(
   options: { strict?: boolean } = {},
 ): Promise<string | undefined> {
   if (!wanted) return undefined;
+  const strict = options.strict ?? true;
   try {
     await session.setModel(wanted);
     return wanted;
   } catch (err) {
-    if (options.strict) {
-      throw new Error(`model '${wanted}' not settable (${(err as Error).message})`);
-    }
+    // The harness rejected the exact id. Resolve it against the harness's own selectable ids
+    // (Pi exposes "openai-codex/gpt-5.5"; a caller passes a bare "gpt-5.5") and retry once.
     const allowed = allowedFromError(err);
     const fallbackAllowed = allowed.length ? allowed : await allowedModels(session);
     const match = pickModel(fallbackAllowed, wanted);
@@ -65,8 +99,11 @@ export async function applyModel(
         await session.setModel(match);
         return match;
       } catch {
-        // fall through to harness default
+        // even the resolved id failed; fall through to the strict/lenient terminal handling
       }
+    }
+    if (strict) {
+      throw new ModelNotSettableError(wanted, fallbackAllowed, (err as Error).message);
     }
     log(`model '${wanted}' not settable (${(err as Error).message}); using harness default`);
     return undefined;

--- a/services/runner/src/engines/sandbox_agent/model.ts
+++ b/services/runner/src/engines/sandbox_agent/model.ts
@@ -25,8 +25,26 @@ export class ModelNotSettableError extends Error {
 }
 
 /**
+ * Strip a trailing Claude-style context-window hint (e.g. "sonnet[1m]" -> "sonnet") so a bare
+ * alias can be matched against the harness's own id regardless of which context variant the
+ * harness currently exposes for that model family.
+ */
+const stripContextHint = (id: string) => id.replace(/\[[^[\]]*\]$/, "");
+
+/**
  * Pick the harness-specific model id for a requested name. Harnesses expose their own ids
- * (Pi: "openai-codex/gpt-5.5"; Claude: its own). Match exact, then by provider suffix.
+ * (Pi: "openai-codex/gpt-5.5"; Claude: alias ids like "opus" / "sonnet[1m]"). Match exact, then
+ * by provider suffix (Pi), then by context-hint-normalized alias (Claude).
+ *
+ * The context-hint tier exists because the Claude harness's reported alias set is not symmetric
+ * across model families: at the time of writing it offers bare "opus"/"haiku" alongside their
+ * "[1m]" variants, but only "sonnet[1m]" — no bare "sonnet" — because the current Sonnet
+ * generation ships in a single (1M-context) variant with no separate short-context sibling to
+ * back a bare alias. A caller (or the agent-config default) requesting the friendly "sonnet"
+ * alias must still resolve, so a bare request matches the harness's own hinted id when that's
+ * the only variant on offer. This only widens a request to the harness's actual (equal-or-larger
+ * context) variant; it never falls back from a hinted request to a bare id, which would silently
+ * shrink the context window.
  */
 export function pickModel(allowed: string[], wanted?: string): string | undefined {
   if (!wanted) return undefined;
@@ -35,6 +53,7 @@ export function pickModel(allowed: string[], wanted?: string): string | undefine
   return (
     allowed.find((id) => suffix(id) === wanted) ??
     allowed.find((id) => suffix(id) === suffix(wanted)) ??
+    allowed.find((id) => id !== wanted && stripContextHint(id) === wanted) ??
     undefined
   );
 }

--- a/services/runner/tests/unit/sandbox-agent-model.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-model.test.ts
@@ -27,6 +27,23 @@ describe("pickModel", () => {
   it("returns undefined when no model matches", () => {
     assert.equal(pickModel(["anthropic/sonnet"], "gpt-5.5"), undefined);
   });
+
+  it("matches a bare Claude alias to its harness-reported [1m] variant", () => {
+    // The Claude harness's live alias set is not symmetric: "opus"/"haiku" are offered bare
+    // alongside "opus[1m]"/"haiku[1m]", but the current Sonnet generation ships in only its
+    // 1M-context variant, so the harness reports "sonnet[1m]" with no bare "sonnet" sibling.
+    const allowed = ["default", "sonnet[1m]", "opus", "opus[1m]", "haiku"];
+    assert.equal(pickModel(allowed, "sonnet"), "sonnet[1m]");
+    // Aliases the harness already exposes bare still match exactly, unaffected by the new tier.
+    assert.equal(pickModel(allowed, "opus"), "opus");
+    assert.equal(pickModel(allowed, "haiku"), "haiku");
+  });
+
+  it("does not fall back from a hinted request to a bare id (never shrinks context)", () => {
+    // Only "sonnet" is offered (no "[1m]" sibling): a caller that explicitly asked for the
+    // long-context variant must not be silently downgraded to the short-context one.
+    assert.equal(pickModel(["default", "sonnet", "opus"], "sonnet[1m]"), undefined);
+  });
 });
 
 describe("allowedFromError", () => {

--- a/services/runner/tests/unit/sandbox-agent-model.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-model.test.ts
@@ -8,7 +8,9 @@ import assert from "node:assert/strict";
 
 import {
   allowedFromError,
+  allowedModels,
   applyModel,
+  ModelNotSettableError,
   pickModel,
 } from "../../src/engines/sandbox_agent/model.ts";
 
@@ -36,6 +38,25 @@ describe("allowedFromError", () => {
   });
 });
 
+describe("allowedModels", () => {
+  it("reads the pi-acp choice `value` (not `id`), so the allowed set is not silently empty", async () => {
+    // pi-acp builds each choice as `{ value: model.modelId, ... }`; reading `id` returned [].
+    const session = {
+      getConfigOptions: async () => [
+        {
+          id: "model",
+          category: "model",
+          options: [
+            { value: "openai-codex/gpt-5.5", name: "GPT-5.5" },
+            { value: "anthropic/sonnet", name: "Sonnet" },
+          ],
+        },
+      ],
+    };
+    assert.deepEqual(await allowedModels(session), ["openai-codex/gpt-5.5", "anthropic/sonnet"]);
+  });
+});
+
 describe("applyModel", () => {
   it("uses the requested model when the harness accepts it", async () => {
     const calls: string[] = [];
@@ -45,7 +66,17 @@ describe("applyModel", () => {
     assert.deepEqual(calls, ["anthropic/sonnet"]);
   });
 
-  it("retries with an allowed suffix match from the harness error", async () => {
+  it("keeps the harness default when no model is requested (default strict)", async () => {
+    let called = false;
+    const session = { setModel: async () => void (called = true) };
+
+    assert.equal(await applyModel(session, undefined), undefined);
+    assert.equal(called, false);
+  });
+
+  it("selects a Pi model by resolving a bare id to the harness's own id (strict default)", async () => {
+    // Pi exposes "openai-codex/gpt-5.5"; a caller passes a bare "gpt-5.5". Strict-by-default must
+    // still resolve via the suffix match, not fail — this is the Pi selection pass-through.
     const calls: string[] = [];
     const session = {
       setModel: async (id: string) => {
@@ -60,7 +91,29 @@ describe("applyModel", () => {
     assert.deepEqual(calls, ["gpt-5.5", "openai-codex/gpt-5.5"]);
   });
 
-  it("falls back to harness default when no match exists", async () => {
+  it("fails loudly (strict default) when the requested model cannot be resolved", async () => {
+    const session = {
+      setModel: async () => {
+        throw new Error("Unsupported value. Allowed values: anthropic/sonnet");
+      },
+    };
+
+    await assert.rejects(
+      () => applyModel(session, "gpt-bogus-xyz"),
+      (err: unknown) => {
+        assert.ok(err instanceof ModelNotSettableError);
+        // The message names the requested id and the valid options source.
+        assert.match(err.message, /gpt-bogus-xyz/);
+        assert.match(err.message, /Valid models for this harness/);
+        assert.match(err.message, /anthropic\/sonnet/);
+        assert.equal(err.requested, "gpt-bogus-xyz");
+        assert.deepEqual(err.allowed, ["anthropic/sonnet"]);
+        return true;
+      },
+    );
+  });
+
+  it("falls back to the harness default only under the explicit opt-out (strict: false)", async () => {
     const logs: string[] = [];
     const session = {
       setModel: async () => {
@@ -68,7 +121,10 @@ describe("applyModel", () => {
       },
     };
 
-    assert.equal(await applyModel(session, "gpt-5.5", (m) => logs.push(m)), undefined);
+    assert.equal(
+      await applyModel(session, "gpt-5.5", (m) => logs.push(m), { strict: false }),
+      undefined,
+    );
     assert.match(logs[0], /using harness default/);
   });
 });


### PR DESCRIPTION
## Context

A user picks a model in the agent playground and silently gets a different one, often the pricier default. On the sandbox-agent (ACP) path, a per-request model override was strict only for the Claude managed-connection case. Every other path (all Pi runs, and Claude without a custom base URL) took the lenient branch in `applyModel`: when the harness rejected the requested id, the runner logged one line and kept the harness default. The run always succeeded, so the drop was invisible. For Claude that default is Sonnet, so a rejected id billed the expensive model. This is finding F-007 (`docs/design/agent-workflows/projects/qa/findings.md`).

Two symptoms:
- **Pi** could not select a non-default model at all when the requested id needed suffix resolution under strict mode (strict threw before the suffix retry ran).
- **Every harness** silently fell back instead of failing, so a wrong or unreachable id produced a different model with no error.

## What changed

Strict resolution is now the default on every harness path. A run that requests a model either runs that model or fails loudly. This is Part 2 of the model-config proposal (`docs/design/agent-workflows/projects/model-config/proposal.md`), aligned with the harness-filtered picker (`agent-model-picker`, PR #4815 lineage): the picker only offers harness-valid ids, and the runner is the fail-loud backstop.

- `applyModel` (`services/runner/src/engines/sandbox_agent/model.ts`): tries the requested id, then resolves it against the harness's own selectable ids via `pickModel` (so a bare `gpt-5.5` reaches Pi's `openai-codex/gpt-5.5`), and only then either returns the resolved id or throws `ModelNotSettableError` naming the requested id and the valid options. Suffix resolution now runs before the failure, which is what makes Pi selection work. `strict` defaults to `true`.
- `allowedModels` (same file): read the pi-acp choice `value` (it read `id` and silently returned `[]`), so the error message and any pre-validation see the real selectable set.
- `sandbox_agent.ts`: `strictModel` is decoupled from the Claude-only `applyClaudeConnectionEnv` and computed by `modelResolutionStrict()`, strict by default. `applyClaudeConnectionEnv` keeps its Claude env side-effect and returns `void`.

### Before / after

- Before: `model: "claude-haiku-4-5-20251001"` on a Claude run -> rejected -> silent fallback to Sonnet, billed silently. `model: "gpt-5.5"` on Pi -> dropped, ran the default.
- After: `model: "gpt-5.5"` on Pi -> resolves to the harness id and runs. An unresolvable id -> the run fails with `model '<id>' is not available on this run (...). Valid models for this harness: <list>.`

## Scope / risk

- Runner-only, no wire/SDK/FE change. No `protocol.ts` change.
- A run that requests **no** model is unchanged: it keeps the harness default.
- The legacy warn-and-fallback is preserved behind `AGENTA_AGENT_MODEL_STRICT=false` for operators who need it.
- Behavior change: a requested-but-unresolvable model now fails the run instead of silently substituting the default. The harness-filtered picker only surfaces valid ids, so normal playground use resolves; the failure is the intended F-007 outcome.

## How to QA

Prerequisites: the runner unit suite (`services/runner`, Node 24), and optionally a live EE dev stack with a Pi harness.

Unit:
1. `cd services/runner && pnpm exec vitest run tests/unit/sandbox-agent-model.test.ts`
2. Expected: 10/10 pass, covering: requested id accepted; no model requested -> default; bare Pi id resolves to the harness id under strict; unresolvable id -> `ModelNotSettableError` naming the id and options; `strict: false` -> warn-and-fallback; `allowedModels` reads `value`.

Live (Pi run):
1. Run a Pi harness run with an explicitly requested valid model -> the run uses that model.
2. Run one with a bogus model id -> the run fails with the naming message above, no silent fallback.

Edge cases: `AGENTA_AGENT_MODEL_STRICT=false` restores the old fallback; a Claude alias (`haiku`) still resolves; a full Claude model id that no alias matches now fails loudly instead of billing Sonnet.

Links finding F-007 (`docs/design/agent-workflows/projects/qa/findings.md`, `findings-status.md`).

https://claude.ai/code/session_018MaXPNpvzN22kngHno3VMj
