### PR TITLE
docs(agent-workflows): propose future Artifacts workspace

### DIFF
--- a/docs/design/agent-workflows/projects/artifacts/README.md
+++ b/docs/design/agent-workflows/projects/artifacts/README.md
@@ -1,0 +1,23 @@
+# Artifacts
+
+> **Future direction.** This workspace records a product direction for later review. It
+> does not authorize implementation, change the current playground, or add a new agent
+> capability.
+
+Artifacts let an agent communicate through a small interactive workspace when a question
+or questionnaire is the wrong shape. An artifact is a normal HTML, CSS, and JavaScript
+application stored in the agent's durable mount. The user can work in it. Its durable
+state is written back to the same mount, so the agent can read it on a later turn.
+
+## Files
+
+- `context.md`: product model, goals, and boundaries.
+- `research.md`: current mount and playground facts this direction builds on.
+- `plan.md`: future phases for the runtime, agent skill, toolkit, templates, and UI.
+- `status.md`: current proposal status and decisions still needed.
+
+## Related work
+
+- `../agent-mounts/`: the planned durable folder per agent.
+- `../../../mount-file-viewer/`: the current session-mount browser and preview.
+

--- a/docs/design/agent-workflows/projects/artifacts/context.md
+++ b/docs/design/agent-workflows/projects/artifacts/context.md
@@ -1,0 +1,68 @@
+# Context: Artifacts
+
+## The model
+
+An artifact is a small, agent-authored web application with one durable directory as its
+only capability. The agent writes normal HTML, CSS, and JavaScript. The user opens the
+artifact in the playground, interacts with it, and the application persists its state to
+the artifact directory. On a later turn, the agent reads that state as ordinary files.
+
+```text
+agent <-> artifact directory <-> sandboxed artifact page <-> user
+```
+
+This is not a replacement for questions, approvals, or questionnaires. Those remain the
+right interface when the agent needs a bounded answer. Artifacts cover work that benefits
+from a shared, editable object: a pipeline, plan, CRM, launch board, visual brief, or
+lightweight dashboard.
+
+## Proposed folder convention
+
+```text
+artifacts/
+  launch-plan/
+    index.html
+    state.json
+```
+
+`index.html` is the presentation and interaction code. `state.json` is the durable shared
+state. Keeping them separate means a user moving a task does not rewrite the application
+itself, and an agent can inspect a small, meaningful file instead of reconstructing state
+from rendered DOM.
+
+The artifact root is also the capability boundary. It can read and write only its own
+files. It cannot reach the Agenta application, other mounts, browser credentials, or the
+general network.
+
+## Goals
+
+- Give agents a way to communicate and collaborate through an interactive object, not
+  only chat text or a questionnaire.
+- Let agents use the familiar web platform instead of a new generative-UI language.
+- Keep the mount as the durable source of truth for collaboration between user and agent.
+- Make artifacts easy to discover, expand, inspect, and work with in the playground.
+- Give agents repeatable instructions, a toolkit, and templates instead of expecting each
+  one to invent a safe artifact from scratch.
+
+## Non-goals
+
+- A general application-hosting platform or arbitrary Internet browser.
+- Direct access from artifact JavaScript to Agenta APIs, session credentials, or tools.
+- Replacing the existing questionnaire or approval interaction types.
+- Automatically waking an agent for every user edit. The initial loop is: edit an
+  artifact, then continue the conversation; the agent reads the changed files.
+- Implementing this direction in the current design PR.
+
+## Product direction
+
+The playground should have an **Artifacts** surface associated with the agent's files.
+It lists artifacts, opens one in a contained work area, and lets the user expand it while
+continuing to talk with the agent. The user can inspect the underlying files, but the
+primary interaction is the artifact itself.
+
+Initial templates should demonstrate useful collaboration patterns:
+
+- CRM: contacts, opportunities, stages, notes, and next actions.
+- Go-to-market workspace: audience, positioning, launch checklist, assets, and owners.
+- Project board: tasks, priorities, status, and blockers.
+

--- a/docs/design/agent-workflows/projects/artifacts/plan.md
+++ b/docs/design/agent-workflows/projects/artifacts/plan.md
@@ -1,0 +1,69 @@
+# Plan: Artifacts
+
+> Future plan. Start only after a separate review approves the product and security
+> decisions in this workspace.
+
+## Phase 1: Define the artifact contract
+
+1. Reserve `artifacts/<name>/` inside the agent mount and use `index.html` as the entry
+   point. Start with a single durable `state.json` convention.
+2. Define ownership and lifecycle: an artifact is agent-created, its directory is its
+   capability boundary, and the mount is the source of truth.
+3. Define stale-write handling using revisions or checksums. Decide whether an artifact
+   may write application files or only its state files in the first release.
+4. Specify the sandbox policy separately from the file contract: scripts are allowed;
+   Agenta APIs, credentials, parent access, and external network are not.
+
+## Phase 2: Build the artifact runtime
+
+1. Serve or render artifact files in an isolated web context with relative assets.
+2. Implement scoped state persistence through local-storage mirroring or relative file
+   reads and writes. Debounce writes and expose saving, saved, error, and conflict state.
+3. Enforce root-relative paths, file-size limits, rate limits, and permission checks.
+4. Add tests for isolation, path escape rejection, state writes, stale writes, and
+   cleanup on close or reload.
+
+## Phase 3: Give agents a skill and toolkit
+
+Create a new **artifacts skill**. It should tell an agent when an artifact is appropriate:
+when the user needs a shared object to manipulate or inspect, not merely a question with
+bounded answers. It should also teach:
+
+- The folder and state conventions.
+- The sandbox limits and persistence API.
+- How to explain the artifact to the user and invite them to work in it.
+- How to read the resulting state on a later turn.
+- When to use a questionnaire or approval instead.
+
+Create an **artifact build toolkit** used by that skill. It should provide a tiny starter
+application, state helpers, validation, a preview command or test harness, and reusable
+templates. The toolkit gives agents reliable primitives without defining a new UI DSL.
+
+Initial templates:
+
+- CRM workspace.
+- Go-to-market planner.
+- Project or launch board.
+- A small editable brief or decision canvas.
+
+## Phase 4: Add the playground work area
+
+1. Add an Artifacts section beside the agent's files. It lists available artifacts with
+   title, state, and last-change information.
+2. Open an artifact in a contained work area. The user can expand it, return to chat, and
+   keep the conversation and artifact visible together.
+3. Provide a file inspector and a clear reset or reload action. Show save errors and
+   conflicts where the user works.
+4. Make the agent aware of changed artifact paths on the next user turn without granting
+   the page any direct agent-control capability.
+
+## Release gates
+
+- Security review approves the sandbox and scoped-write design.
+- A template-driven CRM and go-to-market flow both persist user changes that the agent
+  correctly reads on a later turn.
+- The user can identify agent-created content, recover from a broken artifact, and inspect
+  the underlying state.
+- Existing questionnaire and approval flows remain the recommended choice for bounded
+  structured input.
+

--- a/docs/design/agent-workflows/projects/artifacts/research.md
+++ b/docs/design/agent-workflows/projects/artifacts/research.md
@@ -1,0 +1,58 @@
+# Research: Artifacts
+
+## Current building blocks
+
+- The SessionInspector Mounts tab already lists mount files, reads text, previews images,
+  and offers downloads. HTML is currently treated as text, so it is displayed as source,
+  not executed. See `web/oss/src/components/SessionInspector/tabs/MountsTab.tsx`.
+- The mounts API already supports durable file reads and writes. `GET /mounts/{id}/files`
+  reads or lists files; `PUT /mounts/{id}/files?path=...` writes a file. Writes require
+  `EDIT_SESSIONS`. See `api/oss/src/apis/fastapi/mounts/router.py`.
+- The `agent-mounts` design workspace proposes one durable mount per agent and a frontend
+  entry point for that mount's files. Artifacts should live inside that mount rather than
+  create a competing storage resource.
+
+## Implications
+
+The file store is sufficient for a first artifact state model. The missing pieces are an
+isolated browser runtime, a narrowly scoped persistence bridge, an agent-facing skill and
+toolkit, and a first-class playground surface.
+
+## Runtime boundary
+
+HTML with JavaScript is viable only when it is treated as untrusted application code. A
+safe runtime needs an isolated origin or equivalently strong iframe boundary, restrictive
+content security policy, no Agenta credentials, no parent-page access, and no external
+network by default. It may expose a filesystem capability limited to the artifact root.
+
+The browser must not receive a reusable project API key. The host or artifact-serving
+endpoint validates paths, permissions, sizes, revisions, and write rate before it writes
+to the mount.
+
+## Persistence choices
+
+Do not persist arbitrary DOM mutations as the default. The DOM includes temporary UI
+state and may not represent the application's data.
+
+Prefer one of two conventional browser interfaces:
+
+1. Mirror `localStorage` into `state.json` or a state directory. An app saves normally;
+   the runtime persists it to the mount automatically.
+2. Support relative `fetch` reads and writes within the artifact root. An app can read
+   `./state.json` and `PUT` its updated state back to that path.
+
+Both avoid an artifact-specific UI language. The first makes automatic persistence very
+easy. The second handles multiple state files and assets naturally. They can share the
+same scoped host implementation.
+
+## Risks to design before implementation
+
+- Concurrent agent and user writes need a revision or checksum, so one does not silently
+  overwrite the other.
+- Infinite loops and resource-heavy scripts can still degrade a browser tab even without
+  network access. The host needs a reliable close and reload path.
+- The artifact may contain deceptive content. The playground must clearly label it as
+  agent-created, sandboxed content rather than native Agenta controls.
+- Multi-file assets and relative paths favor a dedicated artifact-serving origin rather
+  than a basic `srcDoc` preview.
+

--- a/docs/design/agent-workflows/projects/artifacts/status.md
+++ b/docs/design/agent-workflows/projects/artifacts/status.md
@@ -1,0 +1,36 @@
+# Status: Artifacts
+
+## Current state
+
+Proposed for the future. No runtime, skill, toolkit, templates, or playground UI has been
+implemented by this workspace.
+
+## Decisions recorded
+
+- Name: **Artifacts**.
+- Storage: artifact files live in the agent's durable mount, under `artifacts/`.
+- Authoring model: normal HTML, CSS, and JavaScript. Do not design a proprietary
+  generative-UI language.
+- Collaboration model: the artifact writes durable files; the agent reads those files on
+  a later turn.
+- Product boundary: artifacts complement questionnaires. They are for shared interactive
+  work, not bounded answers.
+- Enablement: implementation includes a dedicated agent skill and an artifact build
+  toolkit with templates.
+
+## Open questions
+
+- Is `localStorage` mirroring, relative file `fetch`, or both the first persistence API?
+- Does the first release allow writes only to `state.json`, or to any file inside the
+  artifact root with version protection?
+- Which isolated-origin and content-security-policy design meets the required browser
+  security boundary?
+- Where does the Artifacts work area live in the playground when no inspector is open?
+- Should the next agent turn receive only changed paths, or a small system note that an
+  artifact changed?
+
+## Next step
+
+Review this direction with the agent-mount and playground owners. If approved, make a
+separate implementation plan that settles the runtime security model before frontend work.
+


### PR DESCRIPTION
## Context
Agents can currently communicate through chat and bounded questionnaires, but there is no planned shared interactive surface for work such as a CRM, go-to-market board, or editable project object.

## Changes
This design workspace proposes **Artifacts** as a future direction. An artifact is a sandboxed HTML, CSS, and JavaScript application in an agent mount. It persists user changes to its own files, which the agent can read on a later turn.

The proposal records:

- the artifact directory and state-file model;
- the isolated runtime and scoped-write boundary;
- a future artifacts skill and build toolkit;
- starter templates for CRM, go-to-market, project-board, and decision-canvas use cases;
- an expandable playground work area beside the agent files.

No runtime, agent skill, toolkit, templates, or frontend behavior is implemented in this PR.

## Tests / notes
- Verified the final commit contains exactly five files under `docs/design/agent-workflows/projects/artifacts/`.
- Ran `git diff --check` on the new workspace.
- The repository-wide pre-commit hook was not used for the docs-only commit because unrelated API work currently fails ruff unused-import checks.