### PR TITLE
[5246] fix(frontend): keep the agent chat draft when committing a revision

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -619,10 +619,11 @@ const AgentConversation = ({
     })
     // Provenance is scoped to ONE agent revision. `AgentConversation` survives an `entityId`
     // change in place (see the self-commit `switchEntity` above and a revision swap) — without
-    // this, a template picked against the old entity would leak its name into the new one.
+    // this, a template picked against the old entity would leak its name into the new one. Drop
+    // only the chip, not the composer text: a commit must not wipe the user's in-progress draft (#5246).
     useEffect(() => {
-        stripProvenance.clear()
-    }, [entityId, stripProvenance.clear])
+        stripProvenance.clearProvenance()
+    }, [entityId, stripProvenance.clearProvenance])
     // S6 gate: fresh agent only (`version` v0/v1 = creation, same seed-vs-history convention used
     // elsewhere); unknown while loading counts as not-fresh so the strip never flashes in.
     const revisionQuery = useAtomValue(workflowMolecule.selectors.query(entityId))

--- a/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
+++ b/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
@@ -33,6 +33,9 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
     selectedTemplateKey: string | null
     pick: (template: AgentTemplate) => void
     clear: () => void
+    /** Drop the chip without touching composer text — for callers (e.g. a revision swap) that must
+     * reset provenance while preserving the user's in-progress draft. */
+    clearProvenance: () => void
     /** Wire to the composer's text-change signal (e.g. `RichChatInput`'s `onChange`) so a fully
      * emptied composer drops the chip too — a template pick must not survive its own erasure. */
     onComposerTextChange: (text: string) => void
@@ -122,6 +125,7 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
         selectedTemplateKey: selectedTemplate?.key ?? null,
         pick,
         clear,
+        clearProvenance,
         onComposerTextChange,
         resolveTemplateName,
         chipNode,


### PR DESCRIPTION
## What

Fixes #5246 — committing a new revision in the agent playground clears the message the user is currently typing.

## Root cause

The composer draft is stored per **session** (`composerDraftBySession[sessionId]`), a key that is stable across commits, and `AgentConversation` stays mounted through a commit — only its `entityId` prop swaps (old revision → new revision). So the draft loss was **not** a remount.

The culprit is a reset effect that runs on every `entityId` change:

```tsx
// AgentConversation.tsx
useEffect(() => {
    stripProvenance.clear()
}, [entityId, stripProvenance.clear])
```

Its intent is only to reset the *template provenance chip* so a template name picked against the old revision doesn't leak into the new one. But `clear()` does more than that — it also runs `setText("")` on the composer, emptying the Lexical editor:

```tsx
// useTemplateProvenance.tsx
const clear = useCallback(() => {
    apiRef.current.setText("")   // ← wipes the in-progress draft
    clearProvenance()            // ← drops the chip
}, [clearProvenance])
```

So: commit → `entityId` swaps → effect fires → `clear()` → the user's draft is nuked. The agent's own `commit_revision` tool takes the same `switchEntity` path, so it blanked the box mid-conversation too.

## Fix

The hook already had the right primitive — `clearProvenance()` (*"Drop provenance without touching composer text"*) — it just wasn't exposed on the public API. Two small edits:

1. Expose `clearProvenance` from `useTemplateProvenance` (return + type).
2. The revision-change effect now calls `stripProvenance.clearProvenance()` instead of `clear()`.

This preserves the effect's real purpose (reset the template chip on revision swap) while leaving the in-progress draft intact. The legitimate `clear()` calls on the post-send / post-commit paths (where the composer *should* empty) are unchanged.

## Testing

- Verified manually in EE: type a draft in the agent chat composer, commit a new version → draft now **survives** (was previously wiped).
- Confirmed a normal send still clears the composer, and template pick/clear still works.