### PR TITLE
feat(frontend): add Motion transitions for template chip + sessions

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/sessionMotion.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/sessionMotion.ts
@@ -1,0 +1,28 @@
+import type {Transition, Variants} from "motion/react"
+
+/**
+ * Shared session-item motion. The bar (SessionTagBar) and the rail (SessionRail) render the same
+ * sessions two ways — compact tags vs list rows — and both import these so a session's two
+ * representations enter and leave with IDENTICAL physics: the "connected" feel across the views.
+ *
+ * Each item collapses its OWN size (tags their width, rows their height) in step with its fade, so
+ * neighbours close the gap as one continuous motion rather than a pop-then-reflow two-step. No
+ * overshoot (bounce 0) so the size settles cleanly into — and out of — the flow.
+ */
+export const SESSION_SPRING: Transition = {type: "spring", visualDuration: 0.28, bounce: 0}
+
+/** Vertical row (rail): grows/collapses its height AND its bottom gap (2px = gap-0.5) together, so
+ * the spacing shrinks to nothing with the row — no leftover margin to snap when it unmounts. */
+export const ROW_VARIANTS: Variants = {
+    initial: {height: 0, opacity: 0, marginBottom: 0},
+    animate: {height: "auto", opacity: 1, marginBottom: 2},
+    exit: {height: 0, opacity: 0, marginBottom: 0},
+}
+
+/** Horizontal tag (bar): grows/collapses its width AND its right gap (6px = gap-1.5) together, so
+ * the spacing shrinks to nothing with the tag — no leftover margin to snap when it unmounts. */
+export const TAG_VARIANTS: Variants = {
+    initial: {width: 0, opacity: 0, marginRight: 0},
+    animate: {width: "auto", opacity: 1, marginRight: 6},
+    exit: {width: 0, opacity: 0, marginRight: 0},
+}

--- a/web/oss/src/components/AgentChatSlice/assets/sessionMotion.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/sessionMotion.ts
@@ -1,26 +1,16 @@
 import type {Transition, Variants} from "motion/react"
 
-/**
- * Shared session-item motion. The bar (SessionTagBar) and the rail (SessionRail) render the same
- * sessions two ways — compact tags vs list rows — and both import these so a session's two
- * representations enter and leave with IDENTICAL physics: the "connected" feel across the views.
- *
- * Each item collapses its OWN size (tags their width, rows their height) in step with its fade, so
- * neighbours close the gap as one continuous motion rather than a pop-then-reflow two-step. No
- * overshoot (bounce 0) so the size settles cleanly into — and out of — the flow.
- */
+/** Shared session-item motion so the bar (tags) and rail (rows) move with identical physics. */
 export const SESSION_SPRING: Transition = {type: "spring", visualDuration: 0.28, bounce: 0}
 
-/** Vertical row (rail): grows/collapses its height AND its bottom gap (2px = gap-0.5) together, so
- * the spacing shrinks to nothing with the row — no leftover margin to snap when it unmounts. */
+/** Rail row: collapses height + its bottom-gap margin (2px = gap-0.5) together so nothing snaps on unmount. */
 export const ROW_VARIANTS: Variants = {
     initial: {height: 0, opacity: 0, marginBottom: 0},
     animate: {height: "auto", opacity: 1, marginBottom: 2},
     exit: {height: 0, opacity: 0, marginBottom: 0},
 }
 
-/** Horizontal tag (bar): grows/collapses its width AND its right gap (6px = gap-1.5) together, so
- * the spacing shrinks to nothing with the tag — no leftover margin to snap when it unmounts. */
+/** Bar tag: collapses width + its right-gap margin (6px = gap-1.5) together so nothing snaps on unmount. */
 export const TAG_VARIANTS: Variants = {
     initial: {width: 0, opacity: 0, marginRight: 0},
     animate: {width: "auto", opacity: 1, marginRight: 6},

--- a/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
@@ -1,13 +1,15 @@
-import {useCallback, useEffect, useRef, useState} from "react"
+import {useState} from "react"
 
 import {MagnifyingGlass, Plus, Trash} from "@phosphor-icons/react"
 import {Button, Empty, Input, Tooltip} from "antd"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
+import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 // Direct file import — the barrel would statically pull the inspector drawer into this chunk.
 import SessionInspectorButton from "@/oss/components/SessionInspector/SessionInspectorButton"
 
+import {ROW_VARIANTS, SESSION_SPRING} from "../assets/sessionMotion"
 import {useChatScopeKey} from "../state/scope"
 import {
     type AgentChatSession,
@@ -31,104 +33,87 @@ interface SessionRailRowProps {
     label: string
     active: boolean
     open: boolean
-    /** True when this row is newly added since the rail mounted (animate its entrance). */
-    enter: boolean
-    /** True while this row is being removed (collapse + fade before it unmounts). */
-    leaving: boolean
     onSelect: () => void
     onDelete: () => void
     onRename: (title: string) => void
 }
 
-/** One history row: status dot + label (double-click to rename) + created-at stamp, with an
- * inspect action on the active row and a hover-revealed delete. Wrapped in a grid-rows collapse so
- * it eases in on add and out on remove (siblings reflow smoothly). */
+/** One history row: status dot + label (double-click to rename) + created-at stamp, with an inspect
+ * action on the active row and a hover-revealed delete. The outer `motion.div` collapses its own
+ * height AND its bottom-gap margin in step with its fade, so adding/removing a row closes the gap
+ * as one continuous motion — nothing snaps on unmount. */
 const SessionRailRow = ({
     session,
     label,
     active,
     open,
-    enter,
-    leaving,
     onSelect,
     onDelete,
     onRename,
-}: SessionRailRowProps) => {
-    // Start collapsed only for genuinely-new rows; reveal a frame later so the transition plays.
-    const [shown, setShown] = useState(!enter)
-    useEffect(() => {
-        const raf = requestAnimationFrame(() => setShown(true))
-        return () => cancelAnimationFrame(raf)
-    }, [])
-    useEffect(() => {
-        if (leaving) setShown(false)
-    }, [leaving])
-
-    const expanded = shown && !leaving
-    return (
+}: SessionRailRowProps) => (
+    <motion.div
+        variants={ROW_VARIANTS}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        transition={SESSION_SPRING}
+        className="overflow-hidden"
+    >
         <div
-            className="grid motion-safe:transition-[grid-template-rows,opacity] motion-safe:duration-200 motion-safe:ease-out"
-            style={{gridTemplateRows: expanded ? "1fr" : "0fr", opacity: expanded ? 1 : 0}}
-            aria-hidden={leaving}
+            role="tab"
+            aria-selected={active}
+            tabIndex={0}
+            onClick={onSelect}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    onSelect()
+                }
+            }}
+            className={clsx(
+                "group flex cursor-pointer items-center gap-2 rounded-md border border-solid px-2 py-1.5 transition-colors",
+                active ? "ag-surface-selected" : "ag-row-hover border-transparent",
+            )}
         >
-            <div className="min-h-0 overflow-hidden">
-                <div
-                    role="tab"
-                    aria-selected={active}
-                    tabIndex={leaving ? -1 : 0}
-                    onClick={onSelect}
-                    onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault()
-                            onSelect()
-                        }
-                    }}
+            <SessionStatusDot sessionId={session.id} />
+            <div className="flex min-w-0 flex-1 flex-col">
+                <SessionTabLabel
+                    label={label}
+                    onRename={onRename}
                     className={clsx(
-                        "group flex cursor-pointer items-center gap-2 rounded-md border border-solid px-2 py-1.5 transition-colors",
-                        active ? "ag-surface-selected" : "ag-row-hover border-transparent",
+                        "block min-w-0 truncate text-xs",
+                        active ? "text-colorText" : "text-colorTextSecondary",
                     )}
-                >
-                    <SessionStatusDot sessionId={session.id} />
-                    <div className="flex min-w-0 flex-1 flex-col">
-                        <SessionTabLabel
-                            label={label}
-                            onRename={onRename}
-                            className={clsx(
-                                "block min-w-0 truncate text-xs",
-                                active ? "text-colorText" : "text-colorTextSecondary",
-                            )}
-                        />
-                        {timeAgo(session.createdAt) && (
-                            <span className="text-[11px] text-colorTextTertiary">
-                                {timeAgo(session.createdAt)}
-                            </span>
-                        )}
-                    </div>
-                    <div className="flex shrink-0 items-center gap-0.5">
-                        {open && !active && (
-                            <span className="ag-surface-chip rounded px-1.5 py-px text-[11px] text-colorTextSecondary">
-                                open
-                            </span>
-                        )}
-                        {active && <SessionInspectorButton sessionId={session.id} />}
-                        <Tooltip title="Delete session">
-                            <Button
-                                type="text"
-                                aria-label="Delete session"
-                                icon={<Trash size={12} />}
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    onDelete()
-                                }}
-                                className="!h-5 !w-5 !min-w-0 shrink-0 !p-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-                            />
-                        </Tooltip>
-                    </div>
-                </div>
+                />
+                {timeAgo(session.createdAt) && (
+                    <span className="text-[11px] text-colorTextTertiary">
+                        {timeAgo(session.createdAt)}
+                    </span>
+                )}
+            </div>
+            <div className="flex shrink-0 items-center gap-0.5">
+                {open && !active && (
+                    <span className="ag-surface-chip rounded px-1.5 py-px text-[11px] text-colorTextSecondary">
+                        open
+                    </span>
+                )}
+                {active && <SessionInspectorButton sessionId={session.id} />}
+                <Tooltip title="Delete session">
+                    <Button
+                        type="text"
+                        aria-label="Delete session"
+                        icon={<Trash size={12} />}
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            onDelete()
+                        }}
+                        className="!h-5 !w-5 !min-w-0 shrink-0 !p-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                    />
+                </Tooltip>
             </div>
         </div>
-    )
-}
+    </motion.div>
+)
 
 export interface SessionRailProps {
     /** The resolved active session id (source of truth for the chat), used for row highlight. */
@@ -159,47 +144,6 @@ const SessionRail = ({activeId, addDisabled = false, className}: SessionRailProp
     const q = query.trim().toLowerCase()
     const currentActiveId = activeId ?? resolvedActiveId
 
-    // Ids present at mount aren't "new" (don't animate the initial list in); ids that appear later
-    // are. `seenRef` is seeded on first render and topped up after each render.
-    const seenRef = useRef<Set<string>>(new Set())
-    const initedRef = useRef(false)
-    if (!initedRef.current) {
-        initedRef.current = true
-        history.forEach((s) => seenRef.current.add(s.id))
-    }
-    useEffect(() => {
-        history.forEach((s) => seenRef.current.add(s.id))
-    }, [history])
-
-    // Deleting keeps the row mounted for the exit animation, THEN removes it from history. The
-    // pending timers are tracked so an unmount mid-animation (e.g. revision switch) clears them
-    // instead of firing `deleteSession` against a stale scope afterwards.
-    const [leavingIds, setLeavingIds] = useState<ReadonlySet<string>>(() => new Set())
-    const deleteTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
-    useEffect(
-        () => () => {
-            deleteTimersRef.current.forEach((t) => clearTimeout(t))
-            deleteTimersRef.current.clear()
-        },
-        [],
-    )
-    const handleDelete = useCallback(
-        (id: string) => {
-            setLeavingIds((prev) => new Set(prev).add(id))
-            const timer = setTimeout(() => {
-                deleteTimersRef.current.delete(id)
-                deleteSession(id)
-                setLeavingIds((prev) => {
-                    const next = new Set(prev)
-                    next.delete(id)
-                    return next
-                })
-            }, 220)
-            deleteTimersRef.current.set(id, timer)
-        },
-        [deleteSession],
-    )
-
     const rows = history.map((session) => ({
         session,
         label: session.title || firstUserText(allMessages[session.id]) || "Untitled chat",
@@ -207,77 +151,81 @@ const SessionRail = ({activeId, addDisabled = false, className}: SessionRailProp
     const filtered = q ? rows.filter((r) => r.label.toLowerCase().includes(q)) : rows
 
     return (
-        <div
-            className={clsx(
-                "ag-panel-raised flex h-full min-h-0 flex-col border-0 border-r border-solid border-[var(--ag-surface-divider)]",
-                className,
-            )}
-        >
-            <div className="flex h-[48px] shrink-0 items-center justify-between gap-2 border-0 border-b border-solid border-[var(--ag-surface-divider)] px-3">
-                <span className="text-xs font-medium text-colorTextSecondary">Sessions</span>
-                <Tooltip
-                    title={
-                        addDisabled ? "Available after your agent's first response" : "New session"
-                    }
-                >
-                    {/* Non-disabled span trigger: antd v6 Tooltips don't fire on a disabled Button. */}
-                    <span className="inline-flex">
-                        <Button
-                            type="text"
-                            aria-label="New session"
-                            icon={<Plus size={14} />}
-                            onClick={() => addSession()}
-                            disabled={addDisabled}
-                            className="!h-7 !w-7 !min-w-0 shrink-0 !p-0"
-                        />
-                    </span>
-                </Tooltip>
-            </div>
-
-            <div className="shrink-0 px-2 pt-2">
-                <Input
-                    allowClear
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    placeholder="Search sessions"
-                    prefix={<MagnifyingGlass size={14} className="text-colorTextTertiary" />}
-                    className="!text-xs !border-[var(--ag-surface-inset-border)] !bg-[var(--ag-surface-inset)]"
-                />
-            </div>
-
+        <MotionConfig reducedMotion="user">
             <div
-                role="tablist"
-                aria-label="Sessions"
-                className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-2"
-            >
-                {history.length === 0 ? (
-                    <Empty
-                        image={Empty.PRESENTED_IMAGE_SIMPLE}
-                        description={<span className="text-xs">No sessions yet</span>}
-                        className="!my-6"
-                    />
-                ) : filtered.length === 0 ? (
-                    <div className="px-2 py-6 text-center text-xs text-colorTextTertiary">
-                        No matching sessions
-                    </div>
-                ) : (
-                    filtered.map(({session, label}) => (
-                        <SessionRailRow
-                            key={session.id}
-                            session={session}
-                            label={label}
-                            active={session.id === currentActiveId}
-                            open={openIds.has(session.id)}
-                            enter={!seenRef.current.has(session.id)}
-                            leaving={leavingIds.has(session.id)}
-                            onSelect={() => openSession(session.id)}
-                            onDelete={() => handleDelete(session.id)}
-                            onRename={(title) => renameSession({id: session.id, title})}
-                        />
-                    ))
+                className={clsx(
+                    "ag-panel-raised flex h-full min-h-0 flex-col border-0 border-r border-solid border-[var(--ag-surface-divider)]",
+                    className,
                 )}
+            >
+                <div className="flex h-[48px] shrink-0 items-center justify-between gap-2 border-0 border-b border-solid border-[var(--ag-surface-divider)] px-3">
+                    <span className="text-xs font-medium text-colorTextSecondary">Sessions</span>
+                    <Tooltip
+                        title={
+                            addDisabled
+                                ? "Available after your agent's first response"
+                                : "New session"
+                        }
+                    >
+                        {/* Non-disabled span trigger: antd v6 Tooltips don't fire on a disabled Button. */}
+                        <span className="inline-flex">
+                            <Button
+                                type="text"
+                                aria-label="New session"
+                                icon={<Plus size={14} />}
+                                onClick={() => addSession()}
+                                disabled={addDisabled}
+                                className="!h-7 !w-7 !min-w-0 shrink-0 !p-0"
+                            />
+                        </span>
+                    </Tooltip>
+                </div>
+
+                <div className="shrink-0 px-2 pt-2">
+                    <Input
+                        allowClear
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder="Search sessions"
+                        prefix={<MagnifyingGlass size={14} className="text-colorTextTertiary" />}
+                        className="!text-xs !border-[var(--ag-surface-inset-border)] !bg-[var(--ag-surface-inset)]"
+                    />
+                </div>
+
+                <div
+                    role="tablist"
+                    aria-label="Sessions"
+                    className="flex min-h-0 flex-1 flex-col overflow-y-auto p-2"
+                >
+                    {history.length === 0 ? (
+                        <Empty
+                            image={Empty.PRESENTED_IMAGE_SIMPLE}
+                            description={<span className="text-xs">No sessions yet</span>}
+                            className="!my-6"
+                        />
+                    ) : filtered.length === 0 ? (
+                        <div className="px-2 py-6 text-center text-xs text-colorTextTertiary">
+                            No matching sessions
+                        </div>
+                    ) : (
+                        <AnimatePresence initial={false}>
+                            {filtered.map(({session, label}) => (
+                                <SessionRailRow
+                                    key={session.id}
+                                    session={session}
+                                    label={label}
+                                    active={session.id === currentActiveId}
+                                    open={openIds.has(session.id)}
+                                    onSelect={() => openSession(session.id)}
+                                    onDelete={() => deleteSession(session.id)}
+                                    onRename={(title) => renameSession({id: session.id, title})}
+                                />
+                            ))}
+                        </AnimatePresence>
+                    )}
+                </div>
             </div>
-        </div>
+        </MotionConfig>
     )
 }
 

--- a/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
@@ -38,10 +38,7 @@ interface SessionRailRowProps {
     onRename: (title: string) => void
 }
 
-/** One history row: status dot + label (double-click to rename) + created-at stamp, with an inspect
- * action on the active row and a hover-revealed delete. The outer `motion.div` collapses its own
- * height AND its bottom-gap margin in step with its fade, so adding/removing a row closes the gap
- * as one continuous motion — nothing snaps on unmount. */
+/** History row: status dot, label (double-click to rename), timestamp; collapses its height + gap margin on enter/exit so nothing snaps. */
 const SessionRailRow = ({
     session,
     label,
@@ -197,32 +194,33 @@ const SessionRail = ({activeId, addDisabled = false, className}: SessionRailProp
                     aria-label="Sessions"
                     className="flex min-h-0 flex-1 flex-col overflow-y-auto p-2"
                 >
-                    {history.length === 0 ? (
+                    {history.length === 0 && (
                         <Empty
                             image={Empty.PRESENTED_IMAGE_SIMPLE}
                             description={<span className="text-xs">No sessions yet</span>}
                             className="!my-6"
                         />
-                    ) : filtered.length === 0 ? (
+                    )}
+                    {history.length > 0 && filtered.length === 0 && (
                         <div className="px-2 py-6 text-center text-xs text-colorTextTertiary">
                             No matching sessions
                         </div>
-                    ) : (
-                        <AnimatePresence initial={false}>
-                            {filtered.map(({session, label}) => (
-                                <SessionRailRow
-                                    key={session.id}
-                                    session={session}
-                                    label={label}
-                                    active={session.id === currentActiveId}
-                                    open={openIds.has(session.id)}
-                                    onSelect={() => openSession(session.id)}
-                                    onDelete={() => deleteSession(session.id)}
-                                    onRename={(title) => renameSession({id: session.id, title})}
-                                />
-                            ))}
-                        </AnimatePresence>
                     )}
+                    {/* Always mounted so the last row (delete/filter-to-empty) still plays its exit. */}
+                    <AnimatePresence initial={false}>
+                        {filtered.map(({session, label}) => (
+                            <SessionRailRow
+                                key={session.id}
+                                session={session}
+                                label={label}
+                                active={session.id === currentActiveId}
+                                open={openIds.has(session.id)}
+                                onSelect={() => openSession(session.id)}
+                                onDelete={() => deleteSession(session.id)}
+                                onRename={(title) => renameSession({id: session.id, title})}
+                            />
+                        ))}
+                    </AnimatePresence>
                 </div>
             </div>
         </MotionConfig>

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -4,7 +4,9 @@ import {Plus, X} from "@phosphor-icons/react"
 import {Button, Tooltip} from "antd"
 import clsx from "clsx"
 import {useAtomValue} from "jotai"
+import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
+import {SESSION_SPRING, TAG_VARIANTS} from "../assets/sessionMotion"
 import {
     type AgentChatSession,
     type SessionRunStatus,
@@ -109,46 +111,57 @@ const SessionTag = ({
         mountedRef.current = true
     }, [active])
     return (
-        <div
+        // Wrapper collapses its own width AND its right-gap margin in step with the fade, so a tab
+        // added or closed slides its neighbours as one continuous motion — nothing snaps on unmount.
+        <motion.div
             ref={tabRef}
-            role="tab"
-            aria-selected={active}
-            tabIndex={0}
-            onClick={onSelect}
-            onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    onSelect()
-                }
-            }}
-            className={clsx(
-                "group flex h-7 max-w-[180px] min-w-0 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-solid px-2 text-xs transition-colors",
-                // White pill on the recessed chat canvas (raised); the active tab keeps the primary
-                // text + a 2px accent underline so it's unmistakable against its neighbours.
-                active
-                    ? "border-colorBorder border-b-2 border-b-[var(--ag-surface-accent)] bg-colorBgContainer text-colorText"
-                    : "border-colorBorderSecondary bg-colorBgContainer text-colorTextSecondary hover:border-colorBorder",
-            )}
+            variants={TAG_VARIANTS}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            transition={SESSION_SPRING}
+            className="shrink-0 overflow-hidden"
         >
-            <SessionStatusDot sessionId={session.id} active={active} />
-            <SessionTabLabel
-                label={label}
-                onRename={onRename}
-                className="block min-w-0 flex-1 truncate"
-            />
-            {closable && (
-                <Button
-                    type="text"
-                    aria-label="Close session"
-                    icon={<X size={12} />}
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        onClose()
-                    }}
-                    className="!h-5 !w-5 !min-w-0 shrink-0 !p-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+            <div
+                role="tab"
+                aria-selected={active}
+                tabIndex={0}
+                onClick={onSelect}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        onSelect()
+                    }
+                }}
+                className={clsx(
+                    "group flex h-7 max-w-[180px] min-w-0 cursor-pointer items-center gap-1.5 rounded-md border border-solid px-2 text-xs transition-colors",
+                    // White pill on the recessed chat canvas (raised); the active tab keeps the
+                    // primary text + a 2px accent underline so it's unmistakable against neighbours.
+                    active
+                        ? "border-colorBorder border-b-2 border-b-[var(--ag-surface-accent)] bg-colorBgContainer text-colorText"
+                        : "border-colorBorderSecondary bg-colorBgContainer text-colorTextSecondary hover:border-colorBorder",
+                )}
+            >
+                <SessionStatusDot sessionId={session.id} active={active} />
+                <SessionTabLabel
+                    label={label}
+                    onRename={onRename}
+                    className="block min-w-0 flex-1 truncate"
                 />
-            )}
-        </div>
+                {closable && (
+                    <Button
+                        type="text"
+                        aria-label="Close session"
+                        icon={<X size={12} />}
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            onClose()
+                        }}
+                        className="!h-5 !w-5 !min-w-0 shrink-0 !p-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                    />
+                )}
+            </div>
+        </motion.div>
     )
 }
 
@@ -195,56 +208,60 @@ const SessionTagBar = ({
         sessions.forEach((s) => presentAtMountRef.current.add(s.id))
     }
     return (
-        <div className="flex h-[48px] min-w-0 w-full shrink-0 items-center gap-2 overflow-hidden border-0 border-b border-solid border-[var(--ag-surface-card-border)] px-3">
-            {showSessions ? (
-                <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto overscroll-x-contain motion-safe:scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                    {sessions.map((session, index) => (
-                        <SessionTag
-                            key={session.id}
-                            session={session}
-                            index={index}
-                            active={session.id === activeId}
-                            closable={closable}
-                            presentAtMount={presentAtMountRef.current.has(session.id)}
-                            onSelect={() => onSelect(session.id)}
-                            onClose={() => onClose(session.id)}
-                            onRename={(title) => onRename(session.id, title)}
-                        />
-                    ))}
-                </div>
-            ) : (
-                <div className="min-w-0 flex-1" />
-            )}
-            {/* Fixed session-actions cluster — pinned outside the scroll area so New session (+) sits
+        <MotionConfig reducedMotion="user">
+            <div className="flex h-[48px] min-w-0 w-full shrink-0 items-center gap-2 overflow-hidden border-0 border-b border-solid border-[var(--ag-surface-card-border)] px-3">
+                {showSessions ? (
+                    <div className="flex min-w-0 flex-1 items-center overflow-x-auto overscroll-x-contain motion-safe:scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                        <AnimatePresence initial={false}>
+                            {sessions.map((session, index) => (
+                                <SessionTag
+                                    key={session.id}
+                                    session={session}
+                                    index={index}
+                                    active={session.id === activeId}
+                                    closable={closable}
+                                    presentAtMount={presentAtMountRef.current.has(session.id)}
+                                    onSelect={() => onSelect(session.id)}
+                                    onClose={() => onClose(session.id)}
+                                    onRename={(title) => onRename(session.id, title)}
+                                />
+                            ))}
+                        </AnimatePresence>
+                    </div>
+                ) : (
+                    <div className="min-w-0 flex-1" />
+                )}
+                {/* Fixed session-actions cluster — pinned outside the scroll area so New session (+) sits
                 at the end of the tab strip without scrolling away, grouped with the inspect/history
                 controls. */}
-            {(showSessions || extra) && (
-                <div className="flex shrink-0 items-center gap-1">
-                    {showSessions && (
-                        <Tooltip
-                            title={
-                                addDisabled
-                                    ? "Available after your agent's first response"
-                                    : "New session"
-                            }
-                        >
-                            {/* Non-disabled span trigger: antd v6 Tooltips don't fire on a disabled Button. */}
-                            <span className="inline-flex">
-                                <Button
-                                    type="text"
-                                    aria-label="New session"
-                                    icon={<Plus size={14} />}
-                                    onClick={onAdd}
-                                    disabled={addDisabled}
-                                    className="!h-7 !w-7 !min-w-0 shrink-0 !p-0"
-                                />
-                            </span>
-                        </Tooltip>
-                    )}
-                    {extra}
-                </div>
-            )}
-        </div>
+                {(showSessions || extra) && (
+                    <div className="flex shrink-0 items-center gap-1">
+                        {showSessions && (
+                            <Tooltip
+                                title={
+                                    addDisabled
+                                        ? "Available after your agent's first response"
+                                        : "New session"
+                                }
+                            >
+                                {/* Non-disabled span trigger: antd v6 Tooltips don't fire on a disabled Button. */}
+                                <span className="inline-flex">
+                                    <Button
+                                        type="text"
+                                        aria-label="New session"
+                                        icon={<Plus size={14} />}
+                                        onClick={onAdd}
+                                        disabled={addDisabled}
+                                        className="!h-7 !w-7 !min-w-0 shrink-0 !p-0"
+                                    />
+                                </span>
+                            </Tooltip>
+                        )}
+                        {extra}
+                    </div>
+                )}
+            </div>
+        </MotionConfig>
     )
 }
 

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -111,8 +111,7 @@ const SessionTag = ({
         mountedRef.current = true
     }, [active])
     return (
-        // Wrapper collapses its own width AND its right-gap margin in step with the fade, so a tab
-        // added or closed slides its neighbours as one continuous motion — nothing snaps on unmount.
+        // Wrapper collapses its width + gap margin on enter/exit so neighbours close up with no snap.
         <motion.div
             ref={tabRef}
             variants={TAG_VARIANTS}

--- a/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
@@ -10,24 +10,11 @@ import {STRIP_COPY} from "../assets/constants"
 
 import IntegrationBadges from "./IntegrationBadges"
 
-// Modern spring API: `visualDuration` is when the bulk of the width morph lands; `bounce: 0`
-// keeps the 1.5px border from overshooting its target width. Timed to the content crossfade.
+// bounce 0 keeps the 1.5px border from overshooting its target width during the morph.
 const WIDTH_SPRING = {type: "spring", visualDuration: 0.32, bounce: 0} as const
-// Overlapping crossfade reads smoothest with a plain linear opacity ramp.
 const CONTENT_TRANSITION = {duration: 0.26, ease: "linear"} as const
 
-/**
- * Provenance chip docked above the composer ("From template: <name>"). No bottom border —
- * it sits flush against the composer's top edge (adjacent siblings, no gap).
- *
- * Two Motion transitions run on a template switch:
- *  - the container's `layout` spring morphs the chip's auto width (CSS `transition-[width]` couldn't);
- *  - an inner `AnimatePresence` (keyed on the template) crossfades the WHOLE content group —
- *    initials badge, name, and provider logos — so they swap rather than snap. `popLayout` pulls
- *    the outgoing group out of flow so the container can measure + morph to the incoming width.
- * `LayoutGroup` coordinates the exit + layout animations; the ✕ lives outside the presence so it
- * stays put while the content swaps. Reduced-motion handling lives in the parent MotionConfig.
- */
+/** Provenance chip docked flush on the composer's top edge (no bottom border); morphs its width and crossfades its content on a template switch. */
 const TemplateChip = ({
     template,
     onClear,
@@ -41,10 +28,7 @@ const TemplateChip = ({
         <motion.div
             layout
             transition={{layout: WIDTH_SPRING}}
-            // border-radius via style so Motion scale-corrects it during the width morph (Tailwind
-            // classes aren't corrected). `relative` gives popLayout a non-static positioning parent.
-            // The tint composites over the composer base so the bg stays opaque
-            // (--ag-strip-selected-bg is 6%-alpha in dark) and the overlap hides its border.
+            // Inline radius so Motion scale-corrects it during the morph (Tailwind radius isn't corrected).
             style={{borderRadius: "9px 9px 0 0"}}
             className={`relative box-border inline-flex w-fit items-center gap-2 overflow-hidden whitespace-nowrap border-[1.5px] border-b-0 border-solid border-[var(--ag-colorPrimary)] bg-[var(--ag-colorBgContainer)] bg-[image:linear-gradient(var(--ag-strip-selected-bg),var(--ag-strip-selected-bg))] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
         >

--- a/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChip.tsx
@@ -1,4 +1,5 @@
 import {X} from "lucide-react"
+import {AnimatePresence, LayoutGroup, motion} from "motion/react"
 
 import {
     templateProviderSlugs,
@@ -9,47 +10,77 @@ import {STRIP_COPY} from "../assets/constants"
 
 import IntegrationBadges from "./IntegrationBadges"
 
+// Modern spring API: `visualDuration` is when the bulk of the width morph lands; `bounce: 0`
+// keeps the 1.5px border from overshooting its target width. Timed to the content crossfade.
+const WIDTH_SPRING = {type: "spring", visualDuration: 0.32, bounce: 0} as const
+// Overlapping crossfade reads smoothest with a plain linear opacity ramp.
+const CONTENT_TRANSITION = {duration: 0.26, ease: "linear"} as const
+
 /**
  * Provenance chip docked above the composer ("From template: <name>"). No bottom border —
- * it must sit flush against the composer's top edge (adjacent siblings, no gap).
+ * it sits flush against the composer's top edge (adjacent siblings, no gap).
+ *
+ * Two Motion transitions run on a template switch:
+ *  - the container's `layout` spring morphs the chip's auto width (CSS `transition-[width]` couldn't);
+ *  - an inner `AnimatePresence` (keyed on the template) crossfades the WHOLE content group —
+ *    initials badge, name, and provider logos — so they swap rather than snap. `popLayout` pulls
+ *    the outgoing group out of flow so the container can measure + morph to the incoming width.
+ * `LayoutGroup` coordinates the exit + layout animations; the ✕ lives outside the presence so it
+ * stays put while the content swaps. Reduced-motion handling lives in the parent MotionConfig.
  */
 const TemplateChip = ({
     template,
     onClear,
     className,
-    style,
 }: {
     template: AgentTemplate
     onClear: () => void
     className?: string
-    style?: React.CSSProperties
 }) => (
-    <div
-        style={style}
-        // box-border matches the ghost's offsetWidth; the tint is composited over the composer base
-        // so the bg stays opaque (--ag-strip-selected-bg is 6%-alpha in dark) and the overlap hides its border.
-        className={`box-border inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-t-[9px] border-[1.5px] border-b-0 border-solid border-[var(--ag-colorPrimary)] bg-[var(--ag-colorBgContainer)] bg-[image:linear-gradient(var(--ag-strip-selected-bg),var(--ag-strip-selected-bg))] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
-    >
-        <span
-            className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] text-[9px] font-semibold text-white"
-            style={{background: template.color}}
+    <LayoutGroup>
+        <motion.div
+            layout
+            transition={{layout: WIDTH_SPRING}}
+            // border-radius via style so Motion scale-corrects it during the width morph (Tailwind
+            // classes aren't corrected). `relative` gives popLayout a non-static positioning parent.
+            // The tint composites over the composer base so the bg stays opaque
+            // (--ag-strip-selected-bg is 6%-alpha in dark) and the overlap hides its border.
+            style={{borderRadius: "9px 9px 0 0"}}
+            className={`relative box-border inline-flex w-fit items-center gap-2 overflow-hidden whitespace-nowrap border-[1.5px] border-b-0 border-solid border-[var(--ag-colorPrimary)] bg-[var(--ag-colorBgContainer)] bg-[image:linear-gradient(var(--ag-strip-selected-bg),var(--ag-strip-selected-bg))] px-3 py-1.5 text-[12.5px] text-[var(--ag-colorTextSecondary)] ${className ?? ""}`}
         >
-            {template.initials}
-        </span>
-        <span>
-            {STRIP_COPY.fromTemplate}{" "}
-            <b className="font-semibold text-[var(--ag-colorText)]">{template.name}</b>
-        </span>
-        <IntegrationBadges slugs={templateProviderSlugs(template)} size="chip" />
-        <button
-            type="button"
-            aria-label="Remove template"
-            onClick={onClear}
-            className="cursor-pointer border-0 bg-transparent px-0.5 py-0 text-[var(--ag-colorTextTertiary)] hover:text-[var(--ag-colorTextSecondary)]"
-        >
-            <X size={12} />
-        </button>
-    </div>
+            <AnimatePresence mode="popLayout" initial={false}>
+                <motion.div
+                    key={template.key}
+                    layout="position"
+                    initial={{opacity: 0}}
+                    animate={{opacity: 1}}
+                    exit={{opacity: 0}}
+                    transition={CONTENT_TRANSITION}
+                    className="inline-flex shrink-0 items-center gap-2"
+                >
+                    <span
+                        className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] text-[9px] font-semibold text-white"
+                        style={{background: template.color}}
+                    >
+                        {template.initials}
+                    </span>
+                    <span>
+                        {STRIP_COPY.fromTemplate}{" "}
+                        <b className="font-semibold text-[var(--ag-colorText)]">{template.name}</b>
+                    </span>
+                    <IntegrationBadges slugs={templateProviderSlugs(template)} size="chip" />
+                </motion.div>
+            </AnimatePresence>
+            <button
+                type="button"
+                aria-label="Remove template"
+                onClick={onClear}
+                className="relative z-[1] shrink-0 cursor-pointer border-0 bg-transparent px-0.5 py-0 text-[var(--ag-colorTextTertiary)] hover:text-[var(--ag-colorTextSecondary)]"
+            >
+                <X size={12} />
+            </button>
+        </motion.div>
+    </LayoutGroup>
 )
 
 export default TemplateChip

--- a/web/oss/src/components/TemplateStrip/components/TemplateChipDock.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChipDock.tsx
@@ -14,14 +14,7 @@ interface TemplateChipDockProps {
 // No-bounce spring so the rise settles without overshoot (the chip seams onto the composer edge).
 const ENTRANCE = {type: "spring", visualDuration: 0.3, bounce: 0} as const
 
-/**
- * Docks the provenance chip above the composer. AnimatePresence fades + rises the chip as it
- * mounts/unmounts; the chip's own `layout` morphs its width when the template switches. During
- * the exit the caller keeps passing the last template, so it fades out with its real content.
- *
- * `MotionConfig reducedMotion="user"` respects the OS setting: transform + layout animations
- * (the rise and the width morph) collapse to instant, leaving only the opacity crossfades.
- */
+/** Docks the chip and fades/rises it on mount/unmount (TemplateChip owns the width morph). */
 const TemplateChipDock = ({template, visible, onClear}: TemplateChipDockProps) => (
     <MotionConfig reducedMotion="user">
         <AnimatePresence>

--- a/web/oss/src/components/TemplateStrip/components/TemplateChipDock.tsx
+++ b/web/oss/src/components/TemplateStrip/components/TemplateChipDock.tsx
@@ -1,6 +1,4 @@
-import {useLayoutEffect, useRef, useState} from "react"
-
-import clsx from "clsx"
+import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 import {type AgentTemplate} from "@/oss/components/pages/agent-home/assets/templates"
 
@@ -13,63 +11,34 @@ interface TemplateChipDockProps {
     onClear: () => void
 }
 
-const noop = () => {}
+// No-bounce spring so the rise settles without overshoot (the chip seams onto the composer edge).
+const ENTRANCE = {type: "spring", visualDuration: 0.3, bounce: 0} as const
 
 /**
- * Docks the provenance chip above the composer and animates it. Two transitions run together:
- * fade + rise on select/clear, and a WIDTH morph when switching templates.
+ * Docks the provenance chip above the composer. AnimatePresence fades + rises the chip as it
+ * mounts/unmounts; the chip's own `layout` morphs its width when the template switches. During
+ * the exit the caller keeps passing the last template, so it fades out with its real content.
  *
- * The chip is `w-fit`, so auto width can't be transitioned directly. We render an off-flow ghost
- * at natural (max-content) width, measure it, and drive an explicit width on the VISIBLE chip —
- * the chip itself animates + clips its own content, so the border/background move with the width
- * in both directions (measuring a transparent wrapper only revealed content on grow, not shrink).
+ * `MotionConfig reducedMotion="user"` respects the OS setting: transform + layout animations
+ * (the rise and the width morph) collapse to instant, leaving only the opacity crossfades.
  */
-const TemplateChipDock = ({template, visible, onClear}: TemplateChipDockProps) => {
-    const ghostRef = useRef<HTMLDivElement>(null)
-    const [width, setWidth] = useState<number>()
-
-    // Mirror the ghost's natural width onto the visible chip. A ResizeObserver catches both the
-    // template swap and late size changes (e.g. badge images decoding).
-    useLayoutEffect(() => {
-        const el = ghostRef.current
-        if (!el) return
-        const measure = () => setWidth(el.offsetWidth)
-        measure()
-        const observer = new ResizeObserver(measure)
-        observer.observe(el)
-        return () => observer.disconnect()
-    }, [])
-
-    return (
-        <div className="relative">
-            {/* Off-flow, unpainted copy at natural width — the measurement source only. */}
-            <div
-                ref={ghostRef}
-                aria-hidden
-                inert
-                className="pointer-events-none invisible absolute left-0 top-0 w-max"
-            >
-                <TemplateChip template={template} onClear={noop} />
-            </div>
-            <div
-                className={clsx(
-                    "origin-bottom-left transition-[opacity,transform] duration-200 ease-out",
-                    visible
-                        ? "translate-y-0 opacity-100"
-                        : "pointer-events-none translate-y-1 opacity-0",
-                )}
-                inert={!visible}
-            >
-                <TemplateChip
-                    template={template}
-                    onClear={onClear}
-                    style={{width}}
-                    // Children keep their natural size and clip (not squish) while the width eases.
-                    className="overflow-hidden transition-[width] duration-200 ease-out [&>*]:shrink-0"
-                />
-            </div>
-        </div>
-    )
-}
+const TemplateChipDock = ({template, visible, onClear}: TemplateChipDockProps) => (
+    <MotionConfig reducedMotion="user">
+        <AnimatePresence>
+            {visible && (
+                <motion.div
+                    key="template-chip"
+                    className="origin-bottom-left"
+                    initial={{opacity: 0, y: 4}}
+                    animate={{opacity: 1, y: 0}}
+                    exit={{opacity: 0, y: 4}}
+                    transition={ENTRANCE}
+                >
+                    <TemplateChip template={template} onClear={onClear} />
+                </motion.div>
+            )}
+        </AnimatePresence>
+    </MotionConfig>
+)
 
 export default TemplateChipDock

--- a/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
+++ b/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
@@ -105,10 +105,10 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
         [selectedTemplate],
     )
 
-    // Always mounted (never null) so the chip can transition rather than pop. During the
-    // out-transition `selectedTemplate` is already null, so we show the retained last template
-    // (falling back to the registry's first only for the very first, never-picked render).
-    // TemplateChipDock owns the fade/rise + width-morph; passing `visible` drives them.
+    // During the exit `selectedTemplate` is already null, so we show the retained last template
+    // (falling back to the registry's first only for the very first, never-picked render) — the
+    // chip fades out with its real content. TemplateChipDock owns the AnimatePresence fade/rise
+    // and the width-morph; passing `visible` drives them.
     const chipNode = useMemo(() => {
         const shown = selectedTemplate ?? lastTemplateRef.current ?? AGENT_TEMPLATES[0]
         return (

--- a/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
+++ b/web/oss/src/components/TemplateStrip/hooks/useTemplateProvenance.tsx
@@ -105,10 +105,7 @@ export function useTemplateProvenance({composerApi}: {composerApi: ComposerApi})
         [selectedTemplate],
     )
 
-    // During the exit `selectedTemplate` is already null, so we show the retained last template
-    // (falling back to the registry's first only for the very first, never-picked render) — the
-    // chip fades out with its real content. TemplateChipDock owns the AnimatePresence fade/rise
-    // and the width-morph; passing `visible` drives them.
+    // Keep showing the last template during the exit so the chip fades out with real content, not a placeholder.
     const chipNode = useMemo(() => {
         const shown = selectedTemplate ?? lastTemplateRef.current ?? AGENT_TEMPLATES[0]
         return (


### PR DESCRIPTION
## Context

Two spots in the agent experience changed with no motion, or with hand-rolled animation code. On the home composer, switching templates snapped the provenance chip's width and swapped its content instantly. In the playground, session items had no coordinated enter/exit: the chat-mode rail hand-rolled a grid-collapse plus a rAF reveal plus a 220ms `setTimeout` delete-defer, and the build-mode tag bar just popped.

This is the first batch of moving those onto Motion (the `motion` package was already a dependency but unused until now).

## Changes

Two independent, file-disjoint pieces (one commit each).

**Template chip (`TemplateStrip/`)**
- The chip's width now morphs when you switch templates, via Motion's `layout`. CSS `transition-[width]` can't animate an auto width, which is why the old code measured an off-flow ghost with a ResizeObserver and drove an explicit width. All of that machinery is deleted.
- The content group (initials badge, name, provider logos) crossfades on a switch via `AnimatePresence`, instead of snapping.
- `AnimatePresence` owns the chip's fade/rise on select and clear.

**Agent sessions (`AgentChatSlice/`)**
- New `assets/sessionMotion.ts` holds one shared spring plus the tag/row variants, so a session's tag (bar) and row (rail) enter and leave with identical physics.
- Each item collapses its own size in step with its fade (rows their height, tags their width), and the inter-item spacing is an animated margin that collapses to nothing with the item. Removing a session closes the gap as one continuous motion, with no leftover hop when the node unmounts.
- Deleting a rail row is now immediate; `AnimatePresence` plays the exit. This replaces the `leavingIds` / `deleteTimersRef` / 220ms-timer bookkeeping.

Both surfaces are wrapped in `MotionConfig reducedMotion="user"`, so the transform and layout animations degrade to plain opacity when the OS asks for reduced motion.

## Tests / notes

- `pnpm lint-fix` clean across the workspace.
- The modern spring API (`visualDuration` / `bounce`) and `reducedMotion` are type-checked against the installed `motion@12.38.0`.
- No automated coverage (animation); verified by eye in the playground.
- The two features are separate commits touching disjoint files, if you would rather split them into two PRs.

## What to QA

- Home composer: pick a template, then switch between a short-named and a long-named one. The chip width morphs and the badge/name/logos crossfade. No snap.
- Home composer: clear the chip (the x). It fades and rises out.
- Playground build mode: add a session (+) and close one (hover the x on a tag). Tabs slide in and out and neighbours close up with no jump at the end of the close.
- Playground chat mode: add and delete rows in the Sessions rail, and type in Search. Rows collapse and expand as one motion.
- Turn on OS reduced-motion: all of the above become a plain fade.
- Regression: rename a session (double-click a tag or row); active-tab styling and scroll-into-view still work.