### PR TITLE
fix(frontend): skill editor toggle label + paste a SKILL.md

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/MarkdownEditor.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/MarkdownEditor.tsx
@@ -215,7 +215,7 @@ export function MarkdownEditor({
             disabled={disabled}
             className="shrink-0 cursor-pointer border-0 bg-transparent px-1 text-xs text-[var(--ag-c-97A4B0,#97a4b0)] transition-colors hover:text-[var(--ag-c-586673,#586673)] disabled:cursor-not-allowed disabled:opacity-50"
         >
-            {markdownView ? "Rich text" : "Markdown"}
+            {markdownView ? "Rich text" : "Source"}
         </button>
     ) : null
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
@@ -12,16 +12,16 @@
  * `.zip`, or `.skill` (parsed into the fields) or editing inline. `@ag.embed` reference entries are
  * NOT edited here — the host renders the drawer JSON-only for those so their markers round-trip.
  */
-import {useState} from "react"
+import {useEffect, useRef, useState} from "react"
 
 import {LabeledField} from "@agenta/ui/components/presentational"
 import {cn} from "@agenta/ui/styles"
 import {File as FileIcon, Info, Plus, Trash} from "@phosphor-icons/react"
-import {Input, Switch, Tooltip, Typography} from "antd"
+import {App, Input, Switch, Tooltip, Typography} from "antd"
 
 import {CodeEditor, codeLanguageFromPath} from "./CodeEditor"
 import {MarkdownEditor} from "./MarkdownEditor"
-import {type ParsedSkill, type SkillFileEntry} from "./skillUpload"
+import {mergePastedSkill, type ParsedSkill, type SkillFileEntry} from "./skillUpload"
 import {SkillUploadZone} from "./SkillUploadZone"
 
 export interface SkillFormViewProps {
@@ -125,6 +125,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
         : []
 
     const [selected, setSelected] = useState<Selection>("skill")
+    const {message} = App.useApp()
 
     const set = (key: string, fieldValue: unknown) => {
         const next = {...skill}
@@ -176,6 +177,37 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
         setSelected("skill")
     }
 
+    // Paste a whole SKILL.md anywhere in the drawer (while not typing in a field) to fill the
+    // fields — the remote-friendly path when you can't drop a file. Refs keep the once-registered
+    // listener reading the latest draft.
+    const skillRef = useRef(skill)
+    skillRef.current = skill
+    const onChangeRef = useRef(onChange)
+    onChangeRef.current = onChange
+    useEffect(() => {
+        if (disabled) return
+        const onPaste = (e: ClipboardEvent) => {
+            const el = e.target as HTMLElement | null
+            if (
+                el &&
+                (el.tagName === "INPUT" ||
+                    el.tagName === "TEXTAREA" ||
+                    el.isContentEditable ||
+                    el.closest('[contenteditable="true"]'))
+            )
+                return
+            const text = e.clipboardData?.getData("text/plain") ?? ""
+            // Only claim a paste that opens with a metadata block, so arbitrary pastes fall through.
+            if (!/^\uFEFF?---\r?\n/.test(text)) return
+            e.preventDefault()
+            onChangeRef.current(mergePastedSkill(skillRef.current, text))
+            setSelected("skill")
+            message.success("Filled from the pasted skill")
+        }
+        document.addEventListener("paste", onPaste)
+        return () => document.removeEventListener("paste", onPaste)
+    }, [disabled, message])
+
     // The selected entry: SKILL.md (body) unless a valid file index is active.
     const activeFile = typeof selected === "number" ? files[selected] : undefined
     const showSkill = selected === "skill" || !activeFile
@@ -222,8 +254,11 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                 </div>
 
                 {!disabled ? (
-                    <div className="shrink-0">
+                    <div className="flex shrink-0 flex-col gap-1.5">
                         <SkillUploadZone onParsed={applyParsed} disabled={disabled} />
+                        <Typography.Text type="secondary" className="!text-[11px] leading-snug">
+                            …or paste a SKILL.md anywhere here to fill the fields
+                        </Typography.Text>
                     </div>
                 ) : null}
             </div>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
@@ -177,9 +177,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
         setSelected("skill")
     }
 
-    // Paste a whole SKILL.md anywhere in the drawer (while not typing in a field) to fill the
-    // fields — the remote-friendly path when you can't drop a file. Refs keep the once-registered
-    // listener reading the latest draft.
+    // Drawer-wide SKILL.md paste: refs keep the once-registered listener reading the latest draft.
     const skillRef = useRef(skill)
     skillRef.current = skill
     const onChangeRef = useRef(onChange)

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillUpload.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillUpload.ts
@@ -147,6 +147,21 @@ async function readDataTransfer(dt: DataTransfer): Promise<RawFile[]> {
     return filesToRaw(dt.files)
 }
 
+/**
+ * Merge a pasted SKILL.md into an existing skill draft: frontmatter → name/description,
+ * the remainder → body. Unlike a full upload it never touches `files` (paste is a merge).
+ */
+export function mergePastedSkill(
+    skill: Record<string, unknown>,
+    md: string,
+): Record<string, unknown> {
+    const {name, description, body} = parseSkillMarkdown(md)
+    const next: Record<string, unknown> = {...skill, body}
+    if (name) next.name = name
+    if (description) next.description = description
+    return next
+}
+
 /** Top-level: a selected FileList → a parsed skill. */
 export async function parseSkillFromFileList(list: FileList | File[]): Promise<ParsedSkill> {
     return buildSkillFromFiles(expandArchives(await filesToRaw(list)))

--- a/web/packages/agenta-entity-ui/tests/unit/skillUpload.mergePastedSkill.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/skillUpload.mergePastedSkill.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, it} from "vitest"
+
+import {mergePastedSkill} from "../../src/DrillInView/SchemaControls/skillUpload"
+
+describe("mergePastedSkill", () => {
+    it("lifts frontmatter name/description out and keeps only the body", () => {
+        const md = `---\nname: my-skill\ndescription: When to use it\n---\n# Body\n\nDo the thing.`
+        const next = mergePastedSkill({name: "old", files: [{path: "a.py", content: "x"}]}, md)
+        expect(next.name).toBe("my-skill")
+        expect(next.description).toBe("When to use it")
+        expect(next.body).toBe("# Body\n\nDo the thing.")
+        expect(next.files).toEqual([{path: "a.py", content: "x"}])
+    })
+
+    it("with no frontmatter, sets body and leaves name/description untouched", () => {
+        const next = mergePastedSkill({name: "keep", description: "keep me"}, "# Just a body")
+        expect(next.name).toBe("keep")
+        expect(next.description).toBe("keep me")
+        expect(next.body).toBe("# Just a body")
+    })
+})


### PR DESCRIPTION
## Context
Two skill-editor issues. The body editor's view toggle labeled the raw-source side "Markdown", but everywhere else in the app "Markdown" means the rendered view. Selecting it dropped you into raw text. Separately there was no way to paste a full SKILL.md. On a remote machine you cannot drop a file, so you had to paste the body and then hand-move the name and description out of the frontmatter.

## Changes
The toggle now reads "Source" for the raw view and "Rich text" for the rendered view, so no button labels raw text "Markdown". The render pipeline is unchanged.

Paste is now drawer-wide. With a skill open and no text field focused, pasting a full SKILL.md fills Name, Description, and the body. Frontmatter is parsed with the existing `parseSkillMarkdown`, and a new pure `mergePastedSkill` merges it into the draft without touching bundled files. A paste that is not a SKILL.md is ignored.

## Tests / notes
- Unit test for `mergePastedSkill` (frontmatter lifted; body-only paste preserves name/description/files).
- Typecheck and lint clean.

## What to QA
- Open a skill. The view toggle reads "Source" in rendered mode; click it to see raw markdown, where it reads "Rich text".
- With the drawer open and focus not in a field, paste a full SKILL.md. Name, Description, and body fill, with a "Filled from the pasted skill" note. Existing bundled files stay.
- Regression: click into the Name or body field and paste. It pastes into that field as normal, not intercepted.
