### PR TITLE
[fix] Route known custom providers directly

### DIFF
--- a/sdks/python/agenta/sdk/agents/platform/connections.py
+++ b/sdks/python/agenta/sdk/agents/platform/connections.py
@@ -306,7 +306,7 @@ def _custom_provider_candidate(
     settings = _settings(secret)
     extras = _extras(settings)
     slug = _header_name(secret) or _stripped(data.get("provider_slug"))
-    deployment = _stripped(data.get("kind")) or "custom"
+    provider_kind = _stripped(data.get("kind")) or "custom"
     if not slug:
         return None
 
@@ -327,8 +327,12 @@ def _custom_provider_candidate(
     if not endpoint.to_wire():
         endpoint = None
 
-    data_kind = deployment.lower()
+    data_kind = provider_kind.lower()
     provider = data_kind if data_kind in _PROVIDER_ENV_VARS else None
+    # Vault custom-provider records use data.kind for two different roles: a known
+    # provider family (for example openrouter) or a deployment surface (for example
+    # bedrock). Pi consumes the known provider families through its direct surface.
+    deployment = "direct" if provider is not None else provider_kind
     api_key = _stripped(settings.get("key")) or _stripped(extras.get("api_key"))
 
     return _ConnectionCandidate(
@@ -340,7 +344,9 @@ def _custom_provider_candidate(
         env=env,
         endpoint=endpoint,
         model_slugs=_model_slugs(data),
-        model_keys=_model_keys(data, slug=slug, deployment=deployment),
+        # Stored model keys remain namespaced by the vault provider kind. Runtime
+        # deployment normalization must not change how a committed model selector matches.
+        model_keys=_model_keys(data, slug=slug, deployment=provider_kind),
     )
 
 

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
@@ -216,6 +216,48 @@ async def test_bare_model_matching_a_candidate_infers_the_provider(
     assert resolved.credential_mode == "env"
 
 
+@pytest.mark.parametrize(
+    ("provider", "environment_name"),
+    [
+        ("openai", "OPENAI_API_KEY"),
+        ("anthropic", "ANTHROPIC_API_KEY"),
+        ("openrouter", "OPENROUTER_API_KEY"),
+    ],
+)
+async def test_known_direct_custom_provider_uses_direct_deployment(
+    fake_http, connection, provider, environment_name
+):
+    endpoint = "https://93.184.216.34/v1"
+    model_id = "vendor/model-v1"
+    fake_http(
+        connections,
+        payload=[
+            _custom_provider(
+                "custom-direct",
+                provider,
+                key="provider-key",
+                url=endpoint,
+                models=[model_id],
+            )
+        ],
+    )
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=_model("custom-direct", provider=provider, model=model_id),
+        context=_context(),
+    )
+
+    assert resolved.provider == provider
+    assert resolved.deployment == "direct"
+    assert resolved.model == model_id
+    assert resolved.endpoint.base_url == endpoint
+    if hasattr(resolved, "plaintext_environment"):
+        environment = resolved.plaintext_environment()
+    else:
+        environment = resolved.env
+    assert environment == {environment_name: "provider-key"}
+
+
 async def test_missing_named_connection_fails_loud(fake_http, connection):
     fake_http(connections, payload=[_provider_key("openai-prod", "openai", "sk-prod")])
     with pytest.raises(ConnectionNotFoundError):


### PR DESCRIPTION
## Context

A project could store OpenRouter, OpenAI, or Anthropic as a custom provider, but Pi rejected the connection before starting the run. The resolver copied the vault provider kind into `deployment`, so OpenRouter became `deployment="openrouter"` while Pi accepts the `direct` deployment surface.

## Changes

Known provider families now resolve through `deployment="direct"`. The provider identity, custom HTTPS endpoint, selected model ID, and credential environment stay unchanged. Cloud-specific custom providers such as Bedrock and Vertex keep their existing deployment value.

Before:

```text
provider=openrouter, deployment=openrouter
```

After:

```text
provider=openrouter, deployment=direct
```

Stored model keys still use their original vault provider kind, so the routing normalization does not change model matching.

## Tests / notes

- Added a regression test for custom OpenAI, Anthropic, and OpenRouter connections.
- Confirmed the regression failed for all three providers before the implementation commit.
- Ran the complete connection resolver test file: 27 passed.
- Ran the combined focused SDK verification: 68 passed.
- Ruff formatting and lint passed.
- This PR covers built-in model IDs over known direct providers. Writing Pi `models.json` for genuinely new model IDs remains separate work.

## How to review

1. Read the parameterized regression in `test_connections_http.py` to see the rejected shape.
2. Read `_custom_provider_candidate` to verify provider identity and deployment surface are now separate.
3. Check that model-key construction still uses the original provider kind.

## What to QA

- Select Pi with a custom OpenRouter connection and a model already supported by Pi. The run should pass connection validation instead of reporting that deployment `openrouter` is unsupported.
- Regression: use a Bedrock or Vertex custom connection. Its deployment classification should remain unchanged.
