### PR TITLE
[fix] Preserve invoke auth without trace context

### DIFF
--- a/sdks/python/agenta/sdk/agents/tracing.py
+++ b/sdks/python/agenta/sdk/agents/tracing.py
@@ -53,7 +53,8 @@ def trace_context() -> Optional[TraceContext]:
         headers = inject({})
 
         traceparent = headers.get("traceparent")
-        if not traceparent:
+        authorization = headers.get("Authorization")
+        if not traceparent and not authorization:
             return None
 
         endpoint = None
@@ -68,7 +69,7 @@ def trace_context() -> Optional[TraceContext]:
             traceparent=traceparent,
             baggage=headers.get("baggage"),
             endpoint=endpoint,
-            authorization=headers.get("Authorization"),
+            authorization=authorization,
             capture_content=_CAPTURE_CONTENT,
         )
     except Exception:  # pylint: disable=broad-except

--- a/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
@@ -13,6 +13,26 @@ from agenta.sdk.agents import RunContextTrace, RunContextWorkflow
 from agenta.sdk.agents import tracing
 
 
+def test_trace_context_keeps_authorization_without_traceparent(monkeypatch):
+    monkeypatch.setattr(
+        tracing,
+        "inject",
+        lambda _headers: {"Authorization": "ApiKey invoke-credential"},
+    )
+
+    context = tracing.trace_context()
+
+    assert context is not None
+    assert context.traceparent is None
+    assert context.authorization == "ApiKey invoke-credential"
+
+
+def test_trace_context_none_without_traceparent_or_authorization(monkeypatch):
+    monkeypatch.setattr(tracing, "inject", lambda _headers: {})
+
+    assert tracing.trace_context() is None
+
+
 def test_run_context_keeps_trace_when_workflow_capture_fails(monkeypatch):
     # A failure reading the workflow references must not drop an otherwise-valid trace: a
     # trace-only run still ships `runContext.trace`.


### PR DESCRIPTION
## Context

An agent invocation could carry its Agenta authorization through the tracing context even when no active trace span produced a `traceparent`. `trace_context()` returned `None` whenever `traceparent` was absent, so it silently discarded the authorization and the downstream runner request could become unauthenticated.

## Changes

`trace_context()` now keeps the context when either `traceparent` or `Authorization` is present. It still returns `None` when both are absent.

## Tests / notes

- Added coverage for an authorization-only context and an empty context.
- Focused tracing tests: 6 passed.
- Wire-contract tests: 35 passed.
- Combined focused SDK verification: 68 passed.
- Ruff formatting and lint passed.

## How to review

Read the early-return condition in `tracing.py`, then the two regression cases in `test_tracing.py`.
