### PR TITLE
[fix] Drain approval events before done

### DIFF
--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -1835,6 +1835,16 @@ export async function runTurn(
     }
     const stopReason =
       raced === PAUSED || pause.active ? "paused" : (raced as any)?.stopReason;
+    // Pause notification is immediate, but terminalization must wait for managed cancellation
+    // and already-queued ACP updates. Re-sweep after the drain so a sibling announced during
+    // cancellation receives exactly one deterministic terminal result before `done`.
+    if (stopReason === "paused") {
+      await pause.waitForEventDrain();
+      run.settleOpenToolCalls(
+        (id) => pause.isPausedToolCall(id),
+        TOOL_NOT_EXECUTED_PAUSED,
+      );
+    }
     const result = raced === PAUSED ? undefined : raced;
     // A parkable pause this turn: hand the still-pending prompt promise to the parked record so a
     // later resume can await the same continuation. (Set after the race so `promptPromise` exists.

--- a/services/runner/src/engines/sandbox_agent/pause.ts
+++ b/services/runner/src/engines/sandbox_agent/pause.ts
@@ -12,10 +12,13 @@ export class PendingApprovalPauseController {
   private pendingApproval = false;
   private readonly pausedToolCallIds = new Set<string>();
   private resolvePause: (() => void) | undefined;
+  private eventDrain: Promise<void> = Promise.resolve();
 
   readonly signal: Promise<void>;
 
-  constructor(private readonly destroySession: () => Promise<void> | void | undefined) {
+  constructor(
+    private readonly destroySession: () => Promise<void> | void | undefined,
+  ) {
     this.signal = new Promise<void>((resolve) => {
       this.resolvePause = resolve;
     });
@@ -24,8 +27,23 @@ export class PendingApprovalPauseController {
   pause(): void {
     if (this.pendingApproval) return;
     this.pendingApproval = true;
+    let destroyResult: Promise<void> | void | undefined;
+    try {
+      destroyResult = this.destroySession();
+    } catch {
+      destroyResult = undefined;
+    }
+    this.eventDrain = Promise.resolve(destroyResult)
+      .catch(() => {})
+      .then(() => new Promise<void>((resolve) => setImmediate(resolve)));
+    // The turn races this immediate signal; terminalization separately awaits eventDrain so the
+    // permission callback never holds the human pause open while queued ACP updates still settle.
     this.resolvePause?.();
-    void Promise.resolve(this.destroySession()).catch(() => {});
+  }
+
+  /** Wait until managed cancellation and already-queued ACP updates have drained. */
+  waitForEventDrain(): Promise<void> {
+    return this.eventDrain;
   }
 
   /**

--- a/services/runner/tests/unit/pending-approval-pause.test.ts
+++ b/services/runner/tests/unit/pending-approval-pause.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import { PendingApprovalPauseController } from "../../src/engines/sandbox_agent/pause.ts";
+
+describe("PendingApprovalPauseController", () => {
+  it("signals the pause before managed cancellation and queued updates drain", async () => {
+    let finishDestroy: (() => void) | undefined;
+    const queuedUpdates: string[] = [];
+    const destroySession = new Promise<void>((resolve) => {
+      finishDestroy = () => {
+        setImmediate(() => queuedUpdates.push("session update"));
+        resolve();
+      };
+    });
+    const pause = new PendingApprovalPauseController(() => destroySession);
+
+    pause.pause();
+    await pause.signal;
+
+    let drainFinished = false;
+    const drain = pause.waitForEventDrain().then(() => {
+      drainFinished = true;
+    });
+    await Promise.resolve();
+    assert.equal(drainFinished, false);
+
+    finishDestroy?.();
+    await drain;
+
+    assert.equal(drainFinished, true);
+    assert.deepEqual(queuedUpdates, ["session update"]);
+  });
+
+  it("finishes the event drain when managed cancellation rejects", async () => {
+    const pause = new PendingApprovalPauseController(() =>
+      Promise.reject(new Error("session already gone")),
+    );
+
+    pause.pause();
+
+    await assert.doesNotReject(pause.signal);
+    await assert.doesNotReject(pause.waitForEventDrain());
+  });
+
+  it("finishes the event drain when managed cancellation throws", async () => {
+    const pause = new PendingApprovalPauseController(() => {
+      throw new Error("session already gone");
+    });
+
+    pause.pause();
+
+    await assert.doesNotReject(pause.signal);
+    await assert.doesNotReject(pause.waitForEventDrain());
+  });
+});


### PR DESCRIPTION
## Context

When a tool requested human approval, the runner signaled the pause immediately and began cancelling the managed session. It could emit the terminal `done` event before cancellation and already-queued ACP tool updates finished, leaving a late sibling tool call without its deterministic terminal result.

## Changes

The pause controller now tracks a separate event-drain promise. The human-facing pause signal remains immediate, while terminalization waits for managed cancellation plus one event-loop turn. After the drain, the runner re-sweeps paused sibling tool calls before emitting `done`.

Cancellation failures remain best-effort. A rejected or synchronously thrown destroy operation cannot block the pause.

## Tests / notes

- Added focused tests proving the pause signal is immediate, queued updates drain before completion, and destroy failures are absorbed.
- Focused tests: 3 passed.
- Runner typecheck passed.
- Full runner suite during extraction: 1062 of 1065 passed. The three failures were pre-existing shared-lane failures in model-credential and replay tests, outside this PR.

## How to review

1. Read `PendingApprovalPauseController.pause()` and `waitForEventDrain()`.
2. Read the terminalization block in `sandbox_agent.ts` that awaits the drain and re-sweeps siblings.
3. Read `pending-approval-pause.test.ts` for timing and failure behavior.

## What to QA

- Trigger a tool approval while another tool update is queued. The approval prompt should appear immediately, the sibling receives one terminal result, and `done` remains the final event.
