### PR TITLE
fix(sdk): add proper commit messages for agent revisions

### DIFF
--- a/sdks/python/agenta/sdk/managers/shared.py
+++ b/sdks/python/agenta/sdk/managers/shared.py
@@ -1079,33 +1079,41 @@ class SharedManager:
     @classmethod
     @handle_exceptions()
     def commit(
-        cls,
-        *,
-        parameters: dict,
-        variant_slug: str,
-        #
-        app_id: Optional[str] = None,
-        app_slug: Optional[str] = None,
-    ):
-        variant = cls._resolve_variant(
-            app_id=app_id,
-            app_slug=app_slug,
-            variant_slug=variant_slug,
-        )
+    cls,
+    *,
+    parameters: dict,
+    variant_slug: str,
+    #
+    app_id: Optional[str] = None,
+    app_slug: Optional[str] = None,
+    message: Optional[str] = None,  # <-- ADD THIS LINE
+):
+            variant = cls._resolve_variant(
+        app_id=app_id,
+        app_slug=app_slug,
+        variant_slug=variant_slug,
+    )
+
+    # Generate a proper commit message if none provided  # <-- ADD THESE LINES
+    if not message:
+        message = f"feat(agent): update {variant_slug}"
+        if app_slug:
+            message += f" in {app_slug}"
 
         response = authed_api()(
             method="POST",
             endpoint="/applications/revisions/commit",
-            json={
-                "application_revision": {
-                    "application_id": variant.get("application_id")
-                    or variant.get("artifact_id"),
-                    "application_variant_id": variant.get("application_variant_id")
-                    or variant.get("id"),
-                    "slug": uuid4().hex[:12],
-                    "data": {"parameters": parameters},
-                }
-            },
+                    json={
+            "application_revision": {
+                "application_id": variant.get("application_id")
+                or variant.get("artifact_id"),
+                "application_variant_id": variant.get("application_variant_id")
+                or variant.get("id"),
+                "slug": uuid4().hex[:12],
+                "data": {"parameters": parameters},
+                "message": message,  # <-- ADD THIS LINE
+            }
+        },
         )
         _raise_for_status(response)
 

--- a/sdks/python/agenta/sdk/managers/shared.py
+++ b/sdks/python/agenta/sdk/managers/shared.py
@@ -1079,41 +1079,41 @@ class SharedManager:
     @classmethod
     @handle_exceptions()
     def commit(
-    cls,
-    *,
-    parameters: dict,
-    variant_slug: str,
-    #
-    app_id: Optional[str] = None,
-    app_slug: Optional[str] = None,
-    message: Optional[str] = None,  # <-- ADD THIS LINE
-):
-            variant = cls._resolve_variant(
-        app_id=app_id,
-        app_slug=app_slug,
-        variant_slug=variant_slug,
-    )
+        cls,
+        *,
+        parameters: dict,
+        variant_slug: str,
+        #
+        app_id: Optional[str] = None,
+        app_slug: Optional[str] = None,
+        message: Optional[str] = None,
+    ):
+        variant = cls._resolve_variant(
+            app_id=app_id,
+            app_slug=app_slug,
+            variant_slug=variant_slug,
+        )
 
-    # Generate a proper commit message if none provided  # <-- ADD THESE LINES
-    if not message:
-        message = f"feat(agent): update {variant_slug}"
-        if app_slug:
-            message += f" in {app_slug}"
+        # Generate a proper commit message if none provided
+        if not message:
+            message = f"feat(agent): update {variant_slug}"
+            if app_slug:
+                message += f" in {app_slug}"
 
         response = authed_api()(
             method="POST",
             endpoint="/applications/revisions/commit",
-                    json={
-            "application_revision": {
-                "application_id": variant.get("application_id")
-                or variant.get("artifact_id"),
-                "application_variant_id": variant.get("application_variant_id")
-                or variant.get("id"),
-                "slug": uuid4().hex[:12],
-                "data": {"parameters": parameters},
-                "message": message,  # <-- ADD THIS LINE
-            }
-        },
+            json={
+                "application_revision": {
+                    "application_id": variant.get("application_id")
+                    or variant.get("artifact_id"),
+                    "application_variant_id": variant.get("application_variant_id")
+                    or variant.get("id"),
+                    "slug": uuid4().hex[:12],
+                    "data": {"parameters": parameters},
+                    "message": message,
+                }
+            },
         )
         _raise_for_status(response)
 
@@ -1139,12 +1139,19 @@ class SharedManager:
         #
         app_id: Optional[str] = None,
         app_slug: Optional[str] = None,
+        message: Optional[str] = None,
     ):
         variant = await cls._aresolve_variant(
             app_id=app_id,
             app_slug=app_slug,
             variant_slug=variant_slug,
         )
+
+        # Generate a proper commit message if none provided
+        if not message:
+            message = f"feat(agent): update {variant_slug}"
+            if app_slug:
+                message += f" in {app_slug}"
 
         response = await authed_async_api()(
             method="POST",
@@ -1157,6 +1164,7 @@ class SharedManager:
                     or variant.get("id"),
                     "slug": uuid4().hex[:12],
                     "data": {"parameters": parameters},
+                    "message": message,
                 }
             },
         )


### PR DESCRIPTION
## Summary
Agent-generated revision commits were using generic or missing commit messages. This PR adds proper Conventional Commit-style messages to both `commit()` and `acommit()` methods in `SharedManager`.

## What changed
- Added `message: Optional[str] = None` parameter to `commit()` and `acommit()`
- Added automatic message generation when no message is provided: `feat(agent): update {variant_slug}`
- Included `message` field in the API payload sent to `/applications/revisions/commit`

## Fixes
Fixes #5187

## Demo

Before this change, agent revision commits had no message field:
```python
json={
    "application_revision": {
        "application_id": ...,
        "application_variant_id": ...,
        "slug": ...,
        "data": {"parameters": parameters},
        # No message field
    }
}


json={
    "application_revision": {
        "application_id": ...,
        "application_variant_id": ...,
        "slug": ...,
        "data": {"parameters": parameters},
        "message": "feat(agent): update my-variant in my-app",
    }
}