### PR TITLE
[fix] Resolve missing Evaluators "Create new" template popover [AGE-3944]

### DIFF
--- a/web/oss/src/components/Evaluators/assets/evaluatorFiltering.ts
+++ b/web/oss/src/components/Evaluators/assets/evaluatorFiltering.ts
@@ -95,7 +95,7 @@ export const getEvaluatorTagValues = (item: FilterableEvaluator): string[] => {
     }
 
     // Legacy Evaluator type uses `tags`
-    const legacyTags = (item as Evaluator).tags
+    const legacyTags = (item as any).tags
     if (Array.isArray(legacyTags)) {
         legacyTags.filter(Boolean).forEach((tag) => {
             registry.add(String(tag).toLowerCase())
@@ -129,7 +129,7 @@ export const getEvaluatorTagColor = (item: FilterableEvaluator): string | undefi
  * Uses `flags.is_recommended` from the catalog when available.
  * Falls back to the legacy ENABLED_EVALUATORS allowlist + !archived check.
  */
-export const filterEnabledEvaluators = <T extends Record<string, unknown>>(
+export const filterEnabledEvaluators = <T extends FilterableEvaluator>(
     evaluators: T[],
 ): T[] => {
     return evaluators.filter((item) => {

--- a/web/oss/src/components/Evaluators/components/EvaluatorTemplateDropdown.tsx
+++ b/web/oss/src/components/Evaluators/components/EvaluatorTemplateDropdown.tsx
@@ -191,7 +191,7 @@ const EvaluatorTemplateDropdown = ({
             arrow={false}
             styles={{container: {padding: 0}}}
         >
-            <span className={className}>{trigger || defaultTrigger}</span>
+            {trigger || defaultTrigger}
         </Popover>
     )
 }


### PR DESCRIPTION
## Context
On the Evaluators page under the Automatic tab, clicking the "Create new" button did nothing. The button was wrapped in an unnecessary `<span>` element which was intercepting the click events meant for the Ant Design `Popover`. 

## Changes
Removed the `<span>` wrapper around the `Popover` trigger so that `rc-trigger` correctly attaches its click handlers directly to the `<Button>`. Also resolved related TypeScript type constraint errors inside `evaluatorFiltering.ts`.

Before:
```tsx
<Popover styles={{container: {padding: 0}}}>
    <span className={className}>{trigger || defaultTrigger}</span>
</Popover>
```

After:
```tsx
<Popover styles={{container: {padding: 0}}}>
    {trigger || defaultTrigger}
</Popover>
```

## Tests / notes
- Ran `pnpm lint-fix` locally in the `web` directory (no ESLint errors or warnings).
- Resolved existing TypeScript errors associated with `EvaluatorCatalogTemplate` in `evaluatorFiltering.ts`.
- Manually verified the dropdown opens as expected when the `Create new` button is clicked.

## What to QA
- Go to the Evaluators page, navigate to the "Automatic" tab, and click the "Create new" button. The template popover should open properly.
- Regression: Ensure the "Create new" button under the "Human" tab (which opens a drawer instead of a popover) still functions correctly.
