### PR TITLE
fix(api): Return analytics buckets chronologically

### DIFF
--- a/api/oss/src/apis/fastapi/tracing/models.py
+++ b/api/oss/src/apis/fastapi/tracing/models.py
@@ -352,7 +352,7 @@ class OldAnalyticsResponse(BaseModel):
         default=[],
         description=(
             "Time-bucketed aggregates with fixed fields (`total`, `errors`) "
-            "holding `count`, `duration`, `costs`, and `tokens`."
+            "holding `count`, `duration`, `costs`, and `tokens`, ordered oldest to newest."
         ),
     )
 
@@ -368,7 +368,7 @@ class AnalyticsResponse(BaseModel):
         default=[],
         description=(
             "Time-bucketed aggregates. Each bucket's `metrics` dict is "
-            "keyed by the dotted `path` of the corresponding `MetricSpec`."
+            "keyed by the dotted `path` of the corresponding `MetricSpec`, ordered oldest to newest."
         ),
     )
     #

--- a/api/oss/src/dbs/postgres/tracing/dao.py
+++ b/api/oss/src/dbs/postgres/tracing/dao.py
@@ -37,6 +37,7 @@ from oss.src.dbs.postgres.tracing.mappings import (
     map_span_dto_to_span_dbe,
     map_span_dbe_to_span_dto,
     map_buckets,
+    sort_buckets_by_timestamp,
 )
 from oss.src.dbs.postgres.tracing.utils import (
     TIMEOUT_STMT,
@@ -523,7 +524,7 @@ class TracingDAO(TracingDAOInterface):
         # log.trace([b.model_dump(mode="json", exclude_none=True) for b in buckets])
         # ---------
 
-        return buckets
+        return sort_buckets_by_timestamp(buckets)
 
     @suppress_exceptions(default=[])
     async def legacy_analytics(
@@ -715,7 +716,7 @@ class TracingDAO(TracingDAOInterface):
                 # )
                 # ---------
 
-            return buckets
+            return sort_buckets_by_timestamp(buckets)
 
         except DBAPIError as e:
             log.error(f"{type(e).__name__}: {e}")

--- a/api/oss/src/dbs/postgres/tracing/mappings.py
+++ b/api/oss/src/dbs/postgres/tracing/mappings.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, TypeVar
 from uuid import UUID
 from datetime import datetime, timezone
 
@@ -17,11 +17,20 @@ from oss.src.core.tracing.dtos import (
     #
     Bucket,
     Analytics,
+    MetricsBucket,
 )
 from oss.src.core.tracing.utils.attributes import marshall, unmarshall
 
 
 log = get_module_logger(__name__)
+
+
+AnalyticsBucket = TypeVar("AnalyticsBucket", Bucket, MetricsBucket)
+
+
+def sort_buckets_by_timestamp(buckets: List[AnalyticsBucket]) -> List[AnalyticsBucket]:
+    """Return analytics buckets in chronological order."""
+    return sorted(buckets, key=lambda bucket: bucket.timestamp)
 
 
 def map_span_dbe_to_link_dto(

--- a/api/oss/tests/pytest/unit/tracing/test_analytics_bucket_order.py
+++ b/api/oss/tests/pytest/unit/tracing/test_analytics_bucket_order.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from oss.src.core.tracing.dtos import Analytics, Bucket, MetricsBucket
+from oss.src.dbs.postgres.tracing.mappings import sort_buckets_by_timestamp
+
+
+UTC = timezone.utc
+EARLIER = datetime(2026, 6, 19, 11, 22, 13, tzinfo=UTC)
+LATER = datetime(2026, 7, 9, 11, 22, 13, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "buckets",
+    [
+        [
+            MetricsBucket(timestamp=LATER, interval=720, metrics={}),
+            MetricsBucket(timestamp=EARLIER, interval=720, metrics={}),
+        ],
+        [
+            Bucket(
+                timestamp=LATER,
+                interval=720,
+                total=Analytics(),
+                errors=Analytics(),
+            ),
+            Bucket(
+                timestamp=EARLIER,
+                interval=720,
+                total=Analytics(),
+                errors=Analytics(),
+            ),
+        ],
+    ],
+)
+def test_sort_buckets_by_timestamp_returns_oldest_first(buckets):
+    sorted_buckets = sort_buckets_by_timestamp(buckets)
+
+    assert [bucket.timestamp for bucket in sorted_buckets] == [EARLIER, LATER]


### PR DESCRIPTION
## Context

The usage charts on the home page and agent home page occasionally move from July to June and back again. The analytics API documented chronological buckets, but the spec-based query preserved unordered database aggregation rows; the legacy endpoint relied on incidental ordering.

## Changes

Both analytics DAO paths now sort their response buckets oldest to newest at the return boundary. This keeps the existing response shape intact while making the chronological-order contract explicit for both the current spec-based API and the deprecated legacy API.

## Tests

- Added unit coverage for ordering both `MetricsBucket` and legacy `Bucket` responses.
- `uv run pytest oss/tests/pytest/unit/tracing -q` (81 passed).
- Ruff format and lint checks pass.

## What to QA

- Open either home page, expand Usage, and select a range containing multiple months. Each chart should progress chronologically from oldest to newest.

Refs #4949