### PR TITLE
[fix] Keep Usage totals and charts on one date range

### DIFF
--- a/web/oss/src/components/Filters/Sort.tsx
+++ b/web/oss/src/components/Filters/Sort.tsx
@@ -78,6 +78,7 @@ interface Props {
     type?: "link" | "text" | "default" | "primary" | "dashed"
     disabled?: boolean
     exclude?: SortTypes[]
+    ariaLabel?: string
 }
 
 const SORT_PRESETS: SortPresetMeta[] = [
@@ -93,7 +94,14 @@ const SORT_PRESETS: SortPresetMeta[] = [
     {label: "all time"},
 ]
 
-const Sort: React.FC<Props> = ({onSortApply, defaultSortValue, type, disabled, exclude}) => {
+const Sort: React.FC<Props> = ({
+    onSortApply,
+    defaultSortValue,
+    type,
+    disabled,
+    exclude,
+    ariaLabel,
+}) => {
     const classes = useStyles()
 
     const [sort, setSort] = useState<SortTypes>(defaultSortValue)
@@ -301,6 +309,7 @@ const Sort: React.FC<Props> = ({onSortApply, defaultSortValue, type, disabled, e
                     disabled={disabled}
                     icon={<Calendar size={14} className="mt-0.5" />}
                     onClick={() => setDropdownVisible(true)}
+                    aria-label={ariaLabel}
                     className="flex items-center gap-2"
                 >
                     {sort ? (

--- a/web/oss/src/components/pages/agent-home/components/UsageSummary/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/UsageSummary/index.tsx
@@ -3,9 +3,12 @@ import {useMemo, useState} from "react"
 import {formatNumber} from "@agenta/shared/utils"
 import {CaretDown, CaretUp, ChartLineIcon} from "@phosphor-icons/react"
 import {Button} from "antd"
+import {useAtom} from "jotai"
 import dynamic from "next/dynamic"
 
+import Sort from "@/oss/components/Filters/Sort"
 import {useObservabilityDashboard} from "@/oss/state/observability"
+import {observabilityDashboardTimeRangeAtom} from "@/oss/state/observability/dashboard"
 
 // Reuse the full observability charts for the expanded view (default range = 30 days).
 const AnalyticsDashboard = dynamic(
@@ -19,10 +22,11 @@ const StatItem = ({label, value}: {label: string; value: string}) => (
     </div>
 )
 
-/** Collapsed 30-day usage strip; expands to the full observability charts. */
+/** Usage summary with an optional expanded observability dashboard. */
 const UsageSummary = ({variant = "default"}: {variant?: "default" | "strip"}) => {
     const [expanded, setExpanded] = useState(false)
     const {data} = useObservabilityDashboard()
+    const [timeRange, setTimeRange] = useAtom(observabilityDashboardTimeRangeAtom)
 
     const stats = useMemo(
         () => [
@@ -47,9 +51,13 @@ const UsageSummary = ({variant = "default"}: {variant?: "default" | "strip"}) =>
                         <span className="text-[14.5px] font-semibold text-[var(--ag-colorText)]">
                             Usage
                         </span>
-                        <span className="text-[12.5px] text-[var(--ag-colorTextTertiary)]">
-                            last 30 days
-                        </span>
+                        <Sort
+                            type="text"
+                            onSortApply={setTimeRange}
+                            defaultSortValue={timeRange.label || "1 month"}
+                            exclude={["all time"]}
+                            ariaLabel="Usage date range"
+                        />
                     </div>
                     <div className="ml-4 flex flex-wrap items-center gap-8">
                         {stats.map((stat) => (
@@ -80,7 +88,9 @@ const UsageSummary = ({variant = "default"}: {variant?: "default" | "strip"}) =>
                     </button>
                 </div>
 
-                {expanded ? <AnalyticsDashboard layout="grid-4" /> : null}
+                {expanded ? (
+                    <AnalyticsDashboard layout="grid-4" showTimeRangeSelector={false} />
+                ) : null}
             </section>
         )
     }
@@ -91,9 +101,13 @@ const UsageSummary = ({variant = "default"}: {variant?: "default" | "strip"}) =>
                 <div className="flex items-center gap-2">
                     <ChartLineIcon size={16} className="text-[var(--ag-colorTextSecondary)]" />
                     <span className="text-xs font-medium">Usage</span>
-                    <span className="text-[11px] text-[var(--ag-colorTextTertiary)]">
-                        last 30 days
-                    </span>
+                    <Sort
+                        type="text"
+                        onSortApply={setTimeRange}
+                        defaultSortValue={timeRange.label || "1 month"}
+                        exclude={["all time"]}
+                        ariaLabel="Usage date range"
+                    />
                 </div>
                 <div className="flex flex-wrap items-center gap-x-6 gap-y-1">
                     {stats.map((stat) => (
@@ -110,7 +124,7 @@ const UsageSummary = ({variant = "default"}: {variant?: "default" | "strip"}) =>
                 </Button>
             </div>
 
-            {expanded ? <AnalyticsDashboard layout="grid-4" /> : null}
+            {expanded ? <AnalyticsDashboard layout="grid-4" showTimeRangeSelector={false} /> : null}
         </section>
     )
 }

--- a/web/oss/src/components/pages/observability/dashboard/AnalyticsDashboard.tsx
+++ b/web/oss/src/components/pages/observability/dashboard/AnalyticsDashboard.tsx
@@ -32,9 +32,13 @@ const EmptyChart = ({className}: {className: string}) => (
 
 interface AnalyticsDashboardProps {
     layout?: "grid-2" | "grid-4"
+    showTimeRangeSelector?: boolean
 }
 
-const AnalyticsDashboard = ({layout = "grid-2"}: AnalyticsDashboardProps) => {
+const AnalyticsDashboard = ({
+    layout = "grid-2",
+    showTimeRangeSelector = true,
+}: AnalyticsDashboardProps) => {
     const {data, loading, isFetching} = useObservabilityDashboard()
     const [timeRange, setTimeRange] = useAtom(observabilityDashboardTimeRangeAtom)
 
@@ -58,15 +62,18 @@ const AnalyticsDashboard = ({layout = "grid-2"}: AnalyticsDashboardProps) => {
 
     return (
         <div>
-            <div className="flex justify-end mb-4">
-                <Sort
-                    type="text"
-                    disabled={loading || isFetching}
-                    onSortApply={setTimeRange}
-                    defaultSortValue={timeRange.label || "1 month"}
-                    exclude={["all time"]}
-                />
-            </div>
+            {showTimeRangeSelector ? (
+                <div className="flex justify-end mb-4">
+                    <Sort
+                        type="text"
+                        disabled={loading || isFetching}
+                        onSortApply={setTimeRange}
+                        defaultSortValue={timeRange.label || "1 month"}
+                        exclude={["all time"]}
+                        ariaLabel="Usage date range"
+                    />
+                </div>
+            ) : null}
             <Spin spinning={loading || isFetching}>
                 <div className={gridClassName}>
                     <WidgetCard


### PR DESCRIPTION
## Context

The Usage card always said “last 30 days,” even after a user changed the date range in the expanded dashboard. The selector and the summary appeared in different places, which made the displayed period unclear.

## Changes

The Usage header now contains the date-range selector. The card totals and expanded charts read the same existing range state, so selecting “Last 7 days” updates both views together. The embedded dashboard hides its duplicate selector while the standalone observability dashboard keeps it.

The selector has the accessible name “Usage date range.”

## Tests / notes

- `pnpm lint-fix` passed.
- `pnpm --filter @agenta/oss run types:check` remains red on existing unrelated TypeScript errors. None reference the changed files.

## What to QA

- On the agent home page, choose a different range from the Usage header. The Requests, Latency, Cost, and Tokens totals update to that range.
- Expand Usage. The four charts show the same range and there is only one date selector.
- Repeat on the strip agent-home layout.