### PR TITLE
[fix] Give the model selection dropdown a stable layout

### DIFF
--- a/web/oss/src/hooks/useLLMProviderConfig.tsx
+++ b/web/oss/src/hooks/useLLMProviderConfig.tsx
@@ -54,7 +54,7 @@ export function useLLMProviderConfig() {
         <>
             <Divider className="!mx-0 !my-0.5" />
             <Button
-                className="flex items-center justify-between mb-0.5 px-2"
+                className="mb-0.5 flex w-full items-center justify-between px-2"
                 onClick={() => setIsConfigProviderOpen(true)}
                 type="text"
                 variant="outlined"

--- a/web/packages/agenta-ui/src/SelectLLMProvider/SelectLLMProviderBase.tsx
+++ b/web/packages/agenta-ui/src/SelectLLMProvider/SelectLLMProviderBase.tsx
@@ -276,7 +276,7 @@ const SelectLLMProviderBase: React.FC<SelectLLMProviderBaseProps> = ({
 
                     {/* When not searching and has model options with showGroup: show provider/model panels */}
                     {!isSearching && hasModelOptions && showGroup && (
-                        <div className="relative min-w-0">
+                        <div className="relative flex min-h-[220px] min-w-0">
                             <div
                                 className="flex min-w-0 flex-col"
                                 style={{width: providerPanelWidth}}
@@ -317,7 +317,9 @@ const SelectLLMProviderBase: React.FC<SelectLLMProviderBaseProps> = ({
                                     })}
                                 </div>
 
-                                {footerContent}
+                                {footerContent && (
+                                    <div className="mt-auto w-full">{footerContent}</div>
+                                )}
                             </div>
 
                             {hoveredGroup && (


### PR DESCRIPTION
## Context

The model selection dropdown collapsed to the height of its contents when only a few providers or models were available. This made the provider and model panels feel cramped, while the “Add custom provider” action appeared directly below the provider list instead of at the bottom.

## Preview
<img width="1758" height="906" alt="image" src="https://github.com/user-attachments/assets/109da4a3-1710-47be-a96e-11bf02d2961b" />
