### PR TITLE
[5283] fix(agent): Preserve Pi history after cold resume

### DIFF
--- a/docs/design/agent-workflows/projects/session-workspace-materialization/README.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/README.md
@@ -1,0 +1,16 @@
+# Pi session resources and continuity
+
+This workspace plans a launch-safe fix for two failures caused by Pi's temporary per-run agent
+directory: skill paths become invalid after cold resume, and native transcripts can be deleted
+while Agenta still treats their session IDs as resumable. The immediate gate verifies native loads
+and falls back to the canonical transcript replay. The filesystem follow-up uses append-only skill
+snapshots and durable private transcript storage without deleting workspace files.
+
+## Files
+
+- `context.md` - Problem, goals, non-goals, and terminology.
+- `research.md` - Current Agenta behavior and Pi 0.80.6 discovery rules.
+- `design.md` - Proposed cwd ownership and materialization contract.
+- `plan.md` - Phased implementation sequence.
+- `qa.md` - Unit, integration, lifecycle, and security verification.
+- `status.md` - Current decisions, open questions, and next steps.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/context.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/context.md
@@ -1,0 +1,64 @@
+# Context
+
+## Problem
+
+Local Pi creates a random per-run `PI_CODING_AGENT_DIR` whenever a run has configured skills or a
+custom system prompt. Pi stores both injected configuration and native transcripts under this
+directory. Teardown deletes it after the turn.
+
+This produces two independent failures. Skill paths remembered by the model become invalid after a
+cold resume. More seriously, Agenta can retain a native session ID after deleting its transcript.
+`pi-acp` can then create a blank replacement transcript at the stale path, report a successful
+load, and cause the runner to send only the newest message instead of the canonical cold replay.
+
+Claude already receives configured skills in the session cwd under `.claude/skills`. That path
+shares the session workspace lifecycle. Its current copier merges files and does not remove stale
+content. Changing that behavior as part of an urgent Pi fix adds unnecessary launch risk.
+
+The design separates four lifecycles:
+
+1. user and agent data that should persist with the session;
+2. agent configuration rendered as harness-readable files;
+3. private native transcripts that should persist with the conversation;
+4. ephemeral runner transport files.
+
+## Goals
+
+1. Make uncertain native loads fall back to the canonical replay before launch.
+2. Never treat an inferred or requested native session ID as proof that history loaded.
+3. Put configured Pi skills in immutable snapshots at
+   `<cwd>/agents/skills/<skill-set-digest>/<name>`.
+4. Give Pi transcripts a private durable lifetime aligned with the Agenta conversation.
+5. Keep credentials, executable extensions, per-run settings, and relay files ephemeral.
+6. Avoid deletion-based reconciliation and leave Claude unchanged in the urgent work.
+7. State when the runner refreshes startup resources and when it recreates a harness.
+8. Preserve progressive disclosure: skill metadata is eager, while full skill content remains
+   on-demand.
+
+## Non-goals
+
+- Making every Pi project resource trusted.
+- Loading arbitrary `.pi/extensions`, `.pi/settings.json`, prompts, or themes from a mutable
+  workspace.
+- Changing the public agent configuration or `/run` wire shape.
+- Moving model credentials or OAuth files into the session mount.
+- Reloading instructions or skills inside an already-running harness without recreating it.
+- Making native-load correctness depend on warm reuse.
+- Garbage-collecting old skill snapshots during environment acquisition.
+- Changing Claude skill materialization in the urgent implementation.
+
+## Terms
+
+- **Session cwd:** The workspace passed to the harness as its working directory. It is durable when
+  a session mount is available and ephemeral for an ad hoc run.
+- **Agent directory:** Pi's private configuration directory selected by `PI_CODING_AGENT_DIR`.
+- **Canonical replay:** The complete Agenta transcript prepared in `plan.turnText` for a cold
+  harness session.
+- **Verified native load:** A load whose transcript exists, is readable, and identifies the
+  requested native session. Transport success alone is not verification.
+- **Literal `./agents/skills`:** The non-hidden `<cwd>/agents/skills` directory. Pi does not
+  discover it by convention; the runner supplies one exact snapshot as an explicit skill path.
+- **Project `.agents/skills`:** Pi's hidden conventional project directory. It is trust-gated and
+  is not used for runner-injected skills.
+- **Immutable skill snapshot:** A content-addressed directory that is written once and never
+  reconciled in place.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/context.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/context.md
@@ -60,5 +60,11 @@ The design separates four lifecycles:
   discover it by convention; the runner supplies one exact snapshot as an explicit skill path.
 - **Project `.agents/skills`:** Pi's hidden conventional project directory. It is trust-gated and
   is not used for runner-injected skills.
+- **Trust-gated:** Loaded only after the user trusts the project in Pi's consent flow. Pi stores
+  the decision in `<agent-dir>/trust.json` keyed by the cwd. Trust authorizes the project's own
+  in-cwd configuration: `.pi/settings.json`, executable `.pi/extensions`, `.pi/skills`,
+  `.agents/skills`, prompts, themes, and `SYSTEM.md`. RPC runs cannot prompt, so the default `ask`
+  policy leaves projects untrusted and loads none of these.
 - **Immutable skill snapshot:** A content-addressed directory that is written once and never
-  reconciled in place.
+  reconciled in place. Immutability is a convention the runner upholds, not something the
+  filesystem enforces.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/design.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/design.md
@@ -1,0 +1,134 @@
+# Design
+
+## Decision
+
+Fix correctness before storage. The runner may send only the newest message when native history was
+verified, not merely when an ACP request returned successfully. Any missing, corrupt, mismatched, or
+uncertain native session falls back to a new harness session with the canonical Agenta replay.
+
+After that gate is safe, separate resources by lifecycle:
+
+| Resource | Role | Lifecycle | Destination |
+| --- | --- | --- | --- |
+| `AGENTS.md` | declarative instructions | configuration | session cwd |
+| Pi skills | declarative capability packages | immutable configuration snapshot | `<cwd>/agents/skills/<digest>` |
+| Claude skills | current Claude project configuration | existing behavior | `<cwd>/.claude/skills` |
+| Pi native transcripts | private harness state | Agenta conversation | dedicated private session storage |
+| system prompt files and private settings | harness configuration | environment | temporary Pi agent directory |
+| credentials and custom models | secrets/private configuration | credential epoch | temporary Pi agent directory |
+| Agenta Pi extension | executable runtime infrastructure | runner build/environment | temporary Pi agent directory |
+| relay and tool files | transport scratch | turn/environment | ephemeral runner paths |
+
+The urgent implementation changes only native-load verification and replay selection. It does not
+move skills, add a reconciler, or alter Claude.
+
+## Gate 1: verified native load
+
+The current `loaded: boolean` has ambiguous meaning. Transport success and native-history success
+are different facts. The internal continuation result must carry an explicit history outcome:
+
+```text
+verified
+  transcript exists and is readable
+  requested native ID equals transcript header ID
+  adapter reports the same actual native ID
+
+unavailable
+  mapping or transcript is missing
+
+invalid
+  transcript is corrupt or its header ID differs
+
+unverified
+  the adapter cannot prove which history it loaded
+```
+
+Only `verified` permits last-message-only prompting. Every other outcome must:
+
+1. invalidate the stale continuity record;
+2. create a clean native session;
+3. send `plan.turnText`, the canonical cold replay;
+4. record the new native ID only after the replayed turn completes successfully.
+
+The sandbox-agent wrapper must not substitute `requestedSessionId` for a missing response ID and
+then present it as loaded identity. A requested identifier is routing input, not evidence.
+
+The immediate gate should validate at the closest layer that owns the native transcript mapping.
+For Pi, that is `pi-acp`. The runner still applies the conservative rule so an adapter regression
+cannot silently drop history.
+
+## Existing mapping migration
+
+Old `session-map.json` entries may already point to deleted or replaced files. The first
+post-change continuation must treat them as unverified, invalidate the pointer, and replay the
+canonical transcript. Migration must not fail the user turn merely because native state is stale.
+
+## Durable native transcript state
+
+The private transcript directory must live as long as the Agenta conversation. Do not make the
+whole `PI_CODING_AGENT_DIR` durable because it also contains credentials, settings, extensions,
+and system prompt files with different lifecycles.
+
+The existing harness-session mount model already identifies only Pi's `sessions` child. Extend
+that model to local execution, or link the temporary agent directory's `sessions` child to a
+stable private per-conversation directory. Choose the mechanism after fault-injection tests prove
+teardown, runner restart, and mount failure behavior.
+
+Durability improves efficiency, but it does not relax the verified-load gate. A durable file can
+still be missing, corrupt, or mismatched.
+
+Two processes must never append to the same native transcript concurrently. Reuse the existing
+session ownership and serialization boundary and fail closed if exclusive ownership cannot be
+proven.
+
+## Append-only Pi skill snapshots
+
+Use the literal non-hidden path:
+
+```text
+<cwd>/
+|-- AGENTS.md
+`-- agents/
+    `-- skills/
+        `-- <skill-set-digest>/
+            |-- .agenta-skill-set.json
+            `-- <configured-skill>/
+                `-- SKILL.md
+```
+
+The digest covers normalized skill names and complete package contents. A cold resume with the same
+configuration gets the same path. A changed or removed skill produces a new path.
+
+The runner writes the completion record last and supplies only a complete current snapshot as an
+explicit Pi skill source. It never trusts the whole project. It never deletes or replaces an old
+snapshot during acquisition. Old paths remain readable for references already present in a resumed
+transcript, but Pi does not advertise them as current skills.
+
+This intentionally trades bounded storage growth for launch safety. Session retention can remove
+the whole workspace when the session is deleted. Fine-grained garbage collection requires a
+separate post-launch design.
+
+## Refresh timing
+
+```text
+same warm environment and same fingerprint
+  -> reuse the loaded harness and resource paths
+
+cold start, cold resume, or changed fingerprint
+  -> mount/create cwd and private transcript storage
+  -> materialize or validate the current skill snapshot
+  -> attempt verified native load
+  -> verified: send newest message only
+  -> anything else: create clean native session and send canonical replay
+```
+
+## Failure behavior
+
+- Native history uncertainty falls back to canonical replay, not a failed user turn.
+- A missing or malformed skill snapshot fails before Pi starts. It never falls back to temporary
+  skill paths.
+- An existing snapshot with a mismatched completion record is left untouched and rejected.
+- Environment acquisition performs no recursive workspace deletion.
+- Transcript storage never includes credentials, provider settings, or executable extensions.
+- Logs include IDs, path hashes, existence, header identity, load outcome, and replay choice. They
+  never include transcript or skill content.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/design.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/design.md
@@ -53,9 +53,24 @@ Only `verified` permits last-message-only prompting. Every other outcome must:
 The sandbox-agent wrapper must not substitute `requestedSessionId` for a missing response ID and
 then present it as loaded identity. A requested identifier is routing input, not evidence.
 
-The immediate gate should validate at the closest layer that owns the native transcript mapping.
-For Pi, that is `pi-acp`. The runner still applies the conservative rule so an adapter regression
-cannot silently drop history.
+Verification evidence belongs in the layer that owns the native transcript mapping. For Pi, that
+is `pi-acp`. But `pi-acp` is an external prebuilt dependency pinned at 0.0.29, and its load
+response carries no identity evidence at all. The launch gate therefore must not depend on
+changing it. At launch, the runner applies the conservative rule alone: every cold Pi load is
+`unverified`, and every cold continuation replays the canonical transcript. That is the intended
+launch behavior, not a regression. It trades repeated replay tokens for guaranteed history.
+
+Verified loads return as evidence lands, from two acceptable sources in order of preference:
+
+1. `pi-acp` validates existence and header identity and returns the actual loaded ID, through an
+   upstream fix, a version bump, or a patch file like the existing sandbox-agent patch.
+2. The runner checks the mapped transcript itself. On local runs this is a pure file read of
+   information the runner already has: it shares the filesystem and `HOME` with Pi, knows the
+   agent directory it created, holds the expected native ID in its continuity store, and already
+   parses transcript headers in `pi-error.ts`. On Daytona the same check reuses the existing
+   in-sandbox exec and file channel but is new code on the read-back direction.
+
+Either source may upgrade an outcome to `verified`. Nothing relaxes the conservative rule.
 
 ## Existing mapping migration
 
@@ -69,17 +84,25 @@ The private transcript directory must live as long as the Agenta conversation. D
 whole `PI_CODING_AGENT_DIR` durable because it also contains credentials, settings, extensions,
 and system prompt files with different lifecycles.
 
-The existing harness-session mount model already identifies only Pi's `sessions` child. Extend
-that model to local execution, or link the temporary agent directory's `sessions` child to a
-stable private per-conversation directory. Choose the mechanism after fault-injection tests prove
-teardown, runner restart, and mount failure behavior.
+Pi has a supported seam for this: a session directory override, resolved from `--session-dir`,
+`PI_CODING_AGENT_SESSION_DIR`, or the `sessionDir` key in the agent directory's `settings.json`.
+The leading option is to write `sessionDir` into the per-run agent directory's `settings.json`,
+pointing at stable private per-conversation storage. The settings form is required rather than the
+env var because `pi-acp` resolves its scan directory from the same settings key and ignores the
+env var. The settings form keeps Pi's writes, `pi-acp`'s session listing, and its validating
+map-miss fallback on one directory. The alternatives remain extending the harness-session mount
+model to local execution, or linking the temporary agent directory's `sessions` child to stable
+storage. Confirm the choice with fault-injection tests that prove teardown, runner restart, and
+storage-failure behavior.
 
 Durability improves efficiency, but it does not relax the verified-load gate. A durable file can
 still be missing, corrupt, or mismatched.
 
 Two processes must never append to the same native transcript concurrently. Reuse the existing
 session ownership and serialization boundary and fail closed if exclusive ownership cannot be
-proven.
+proven. This is deliberately different from history uncertainty. Uncertain history degrades to a
+clean session with canonical replay because reading stale history risks nothing. Uncertain write
+ownership refuses the turn because two writers can corrupt the transcript for every later turn.
 
 ## Append-only Pi skill snapshots
 
@@ -103,6 +126,12 @@ The runner writes the completion record last and supplies only a complete curren
 explicit Pi skill source. It never trusts the whole project. It never deletes or replaces an old
 snapshot during acquisition. Old paths remain readable for references already present in a resumed
 transcript, but Pi does not advertise them as current skills.
+
+Snapshots are immutable by convention, not enforcement. The cwd is agent-writable, so a run can
+edit its own snapshot files, and the completion record lists expected files without hashing their
+contents. This is the accepted threat model: the workspace already belongs to the same user and
+agent, so an in-place edit crosses no trust boundary. Acquisition-time content verification is out
+of scope.
 
 This intentionally trades bounded storage growth for launch safety. Session retention can remove
 the whole workspace when the session is deleted. Fine-grained garbage collection requires a

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/plan.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/plan.md
@@ -3,15 +3,13 @@
 ## Phase 0: launch gate for conversation correctness
 
 1. Turn the supplied `session-7e9ad207` run into a production-shaped regression case.
-2. Stop the sandbox-agent wrapper from substituting the requested ID when the adapter omits actual
-   loaded identity.
-3. Replace inferred `loaded=true` with an explicit verified-history outcome. With pinned
+2. Replace inferred `loaded=true` with an explicit verified-history outcome. With pinned
    `pi-acp@0.0.29` no load can produce evidence, so every cold Pi continuation replays. That is
    the intended launch behavior.
-4. On missing, corrupt, mismatched, or unverified history, invalidate continuity, create a clean
+3. On missing, corrupt, mismatched, or unverified history, invalidate continuity, create a clean
    native session, and send `plan.turnText`.
-5. Record the new native ID only after the replayed turn succeeds.
-6. Add structured logs and counters without transcript content.
+4. Record the new native ID only after the replayed turn succeeds.
+5. Add structured logs and counters without transcript content.
 
 Exit criterion: after deleting or replacing the mapped Pi transcript, turn 1 still receives turn 0
 through canonical replay. Only a verified native load sends the newest message alone.
@@ -22,14 +20,17 @@ exists yet.
 
 ## Phase 0b: restore verified loads
 
-1. Preferred: fix `pi-acp` so `session/load` rejects a missing transcript before spawning Pi with
+1. Stop the sandbox-agent wrapper from substituting the requested ID when the adapter omits actual
+   loaded identity. This cleanup is required before any Pi load can become verified, but it is not
+   required for the Phase 0 gate because Phase 0 bypasses cold Pi loading entirely.
+2. Preferred: fix `pi-acp` so `session/load` rejects a missing transcript before spawning Pi with
    `--session`, requires the transcript header ID to equal the requested mapping ID, and returns
    the actual loaded ID. Deliver through an upstream fix, a version bump, or a patch file like the
    existing sandbox-agent patch. Name the mechanism in the implementation PR.
-2. Acceptable interim: the runner performs the existence and header-identity check itself on local
+3. Acceptable interim: the runner performs the existence and header-identity check itself on local
    runs. It already holds the agent directory, the expected native ID, and a transcript header
    parser in `pi-error.ts`, so this adds no new access path.
-3. Either source upgrades the history outcome to `verified` and re-enables newest-message-only
+4. Either source upgrades the history outcome to `verified` and re-enables newest-message-only
    prompting. The conservative fallback from Phase 0 stays in place regardless.
 
 ## Phase 1: durable local Pi transcripts

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/plan.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/plan.md
@@ -1,0 +1,81 @@
+# Plan
+
+## Phase 0: launch gate for conversation correctness
+
+1. Turn the supplied `session-7e9ad207` run into a production-shaped regression case.
+2. Make `pi-acp` reject a missing transcript before spawning Pi with `--session`.
+3. Parse the transcript header and require its native ID to equal the requested mapping ID.
+4. Stop the sandbox-agent wrapper from substituting the requested ID when the adapter omits actual
+   loaded identity.
+5. Replace inferred `loaded=true` with an explicit verified-history outcome.
+6. On missing, corrupt, mismatched, or unverified history, invalidate continuity, create a clean
+   native session, and send `plan.turnText`.
+7. Record the new native ID only after the replayed turn succeeds.
+8. Add structured logs and counters without transcript content.
+
+Exit criterion: after deleting or replacing the mapped Pi transcript, turn 1 still receives turn 0
+through canonical replay. Only a verified native load sends the newest message alone.
+
+This phase is the release gate. It contains no workspace reconciliation, skill move, transcript
+mount, or Claude behavior change.
+
+## Phase 1: durable local Pi transcripts
+
+1. Reuse the existing harness-session mount abstraction for local Pi, or link the temporary Pi
+   agent directory's `sessions` child to stable private session storage.
+2. Persist only native transcripts. Keep auth, settings, custom models, extensions, and system
+   prompt files ephemeral.
+3. Align transcript retention and cleanup with the Agenta conversation lifecycle.
+4. Enforce single-writer ownership for each native session.
+5. Migrate stale existing mappings through replay rather than failing the turn.
+6. Test runner restart, teardown, remount, and unavailable-storage behavior.
+
+Exit criterion: a valid local Pi native transcript survives full environment teardown and runner
+restart, while a lost transcript still recovers through Phase 0.
+
+## Phase 2: prove the explicit Pi skill seam
+
+1. Use pinned Pi 0.80.6 and `pi-acp@0.0.29`.
+2. Create an untrusted cwd with a marker under `agents/skills/<digest>`.
+3. Add only that absolute snapshot path to the isolated agent directory's global `skills` list.
+4. Add different markers under trust-gated `.agents/skills` and `.pi/extensions`.
+5. Confirm only the explicit snapshot loads, the extension does not execute, and no trust decision
+   is persisted.
+6. If the seam fails, stop. Review a narrow `pi-acp` `--skill` passthrough separately.
+
+Exit criterion: Pi loads one literal cwd snapshot without trusting project resources.
+
+## Phase 3: append-only Pi skill snapshots
+
+1. Compute a deterministic digest from normalized Pi skill names and complete contents.
+2. Materialize `agents/skills/<digest>/<name>` after the cwd mount and before harness startup.
+3. Write and validate a completion record after all expected files succeed.
+4. Reuse a complete matching snapshot without rewriting it.
+5. Fail without mutation on collisions or mismatched completion records.
+6. Configure Pi with only the current snapshot.
+7. Stop copying configured skills into the temporary local and Daytona Pi agent directories.
+8. Keep old snapshots. Do not add acquisition-time garbage collection.
+9. Leave Claude's `.claude/skills` implementation unchanged.
+
+Exit criterion: cold resumes retain stable skill paths, removed skills are not advertised by new
+runs, and old transcript references remain readable.
+
+## Phase 4: verification and rollout
+
+1. Run focused runner tests for load identity, replay selection, local teardown, Daytona, partial
+   writes, collisions, and concurrency.
+2. Run the canonical services test entrypoint.
+3. Run the local and Daytona Pi cells from the agent-workflows QA matrix.
+4. Replay both supplied incidents: stale skill paths and lost turn 0.
+5. Confirm the implementation diff contains no Claude runtime changes and no recursive cwd delete.
+6. Roll out the verified-load gate before the storage and skill phases.
+
+## Delivery shape
+
+Use separate reviewable implementation PRs linked to one issue:
+
+1. verified native-load fallback;
+2. durable local Pi transcript state;
+3. append-only cwd skill snapshots.
+
+Do not combine the launch gate with reconciliation or the filesystem migrations.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/plan.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/plan.md
@@ -3,32 +3,51 @@
 ## Phase 0: launch gate for conversation correctness
 
 1. Turn the supplied `session-7e9ad207` run into a production-shaped regression case.
-2. Make `pi-acp` reject a missing transcript before spawning Pi with `--session`.
-3. Parse the transcript header and require its native ID to equal the requested mapping ID.
-4. Stop the sandbox-agent wrapper from substituting the requested ID when the adapter omits actual
+2. Stop the sandbox-agent wrapper from substituting the requested ID when the adapter omits actual
    loaded identity.
-5. Replace inferred `loaded=true` with an explicit verified-history outcome.
-6. On missing, corrupt, mismatched, or unverified history, invalidate continuity, create a clean
+3. Replace inferred `loaded=true` with an explicit verified-history outcome. With pinned
+   `pi-acp@0.0.29` no load can produce evidence, so every cold Pi continuation replays. That is
+   the intended launch behavior.
+4. On missing, corrupt, mismatched, or unverified history, invalidate continuity, create a clean
    native session, and send `plan.turnText`.
-7. Record the new native ID only after the replayed turn succeeds.
-8. Add structured logs and counters without transcript content.
+5. Record the new native ID only after the replayed turn succeeds.
+6. Add structured logs and counters without transcript content.
 
 Exit criterion: after deleting or replacing the mapped Pi transcript, turn 1 still receives turn 0
 through canonical replay. Only a verified native load sends the newest message alone.
 
 This phase is the release gate. It contains no workspace reconciliation, skill move, transcript
-mount, or Claude behavior change.
+mount, `pi-acp` change, or Claude behavior change. The gate must ship even if no verified path
+exists yet.
+
+## Phase 0b: restore verified loads
+
+1. Preferred: fix `pi-acp` so `session/load` rejects a missing transcript before spawning Pi with
+   `--session`, requires the transcript header ID to equal the requested mapping ID, and returns
+   the actual loaded ID. Deliver through an upstream fix, a version bump, or a patch file like the
+   existing sandbox-agent patch. Name the mechanism in the implementation PR.
+2. Acceptable interim: the runner performs the existence and header-identity check itself on local
+   runs. It already holds the agent directory, the expected native ID, and a transcript header
+   parser in `pi-error.ts`, so this adds no new access path.
+3. Either source upgrades the history outcome to `verified` and re-enables newest-message-only
+   prompting. The conservative fallback from Phase 0 stays in place regardless.
 
 ## Phase 1: durable local Pi transcripts
 
-1. Reuse the existing harness-session mount abstraction for local Pi, or link the temporary Pi
-   agent directory's `sessions` child to stable private session storage.
-2. Persist only native transcripts. Keep auth, settings, custom models, extensions, and system
+1. Point Pi's session directory at stable private per-conversation storage by writing the
+   `sessionDir` key into the per-run agent directory's `settings.json`. Use the settings form,
+   not the env var: `pi-acp` resolves its scan directory from the same settings key and ignores
+   `PI_CODING_AGENT_SESSION_DIR`. Keep the harness-session mount extension and the
+   `sessions`-child link as fallbacks if the probe fails.
+2. Probe the override end to end with pinned versions: Pi writes new transcripts to the durable
+   directory, `pi-acp`'s session listing and map-miss fallback scan the same directory, and a
+   deleted `session-map.json` entry recovers through the header-matching scan.
+3. Persist only native transcripts. Keep auth, settings, custom models, extensions, and system
    prompt files ephemeral.
-3. Align transcript retention and cleanup with the Agenta conversation lifecycle.
-4. Enforce single-writer ownership for each native session.
-5. Migrate stale existing mappings through replay rather than failing the turn.
-6. Test runner restart, teardown, remount, and unavailable-storage behavior.
+4. Align transcript retention and cleanup with the Agenta conversation lifecycle.
+5. Enforce single-writer ownership for each native session.
+6. Migrate stale existing mappings through replay rather than failing the turn.
+7. Test runner restart, teardown, remount, and unavailable-storage behavior.
 
 Exit criterion: a valid local Pi native transcript survives full environment teardown and runner
 restart, while a lost transcript still recovers through Phase 0.
@@ -74,8 +93,10 @@ runs, and old transcript references remain readable.
 
 Use separate reviewable implementation PRs linked to one issue:
 
-1. verified native-load fallback;
-2. durable local Pi transcript state;
-3. append-only cwd skill snapshots.
+1. conservative fallback gate (Phase 0);
+2. verified-load evidence (Phase 0b, may follow the gate);
+3. durable local Pi transcript state;
+4. append-only cwd skill snapshots.
 
-Do not combine the launch gate with reconciliation or the filesystem migrations.
+Do not combine the launch gate with reconciliation, the `pi-acp` change, or the filesystem
+migrations.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/qa.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/qa.md
@@ -1,0 +1,100 @@
+# QA plan
+
+## Verified-load unit tests
+
+- A missing mapped transcript returns an unavailable history outcome.
+- An unreadable or malformed transcript returns an invalid outcome.
+- A transcript header ID mismatch is rejected.
+- A missing adapter response ID is never replaced and presented as verified evidence.
+- Only a verified load enables last-message-only prompting.
+- Every uncertain outcome invalidates continuity and sends `plan.turnText`.
+- A replayed turn records its new native ID only after successful completion.
+- Existing stale mappings recover through replay instead of failing the user turn.
+
+## Conversation-loss regression
+
+Automate the supplied production-shaped reproduction:
+
+1. configure local `pi_core` with one skill;
+2. send `Remember marker ALPHA-7` in turn 0;
+3. fully tear down the local environment;
+4. continue the same Agenta session with `What marker did I give you?`;
+5. confirm Pi answers `ALPHA-7`;
+6. confirm the outcome was either verified native load or canonical replay.
+
+Repeat with a custom system prompt and no skills. Repeat across a runner process restart.
+
+Fault-injection variants:
+
+- delete the mapped transcript between turns;
+- replace it with a transcript whose header has another ID;
+- truncate or corrupt its first line;
+- retain a stale `session-map.json` entry from the pre-fix runner;
+- make transcript storage unavailable during resume.
+
+Every variant must preserve conversation history through canonical replay.
+
+## Durable transcript tests
+
+- Local Pi persists only the `sessions` child, not auth, settings, models, extensions, or system
+  prompt files.
+- Full environment teardown does not remove the private transcript.
+- Runner restart can verify and load the same transcript.
+- Expired conversation cleanup removes transcript state according to retention policy.
+- Two concurrent continuations cannot append to the same native transcript.
+- Failure to mount or link durable storage falls back to canonical replay.
+
+## Pi skill-path probe
+
+Use pinned Pi 0.80.6 and `pi-acp@0.0.29`:
+
+1. place a marker skill under `<cwd>/agents/skills/<digest>`;
+2. place a different skill under `<cwd>/.agents/skills`;
+3. place a marker extension under `<cwd>/.pi/extensions`;
+4. leave project trust unset;
+5. explicitly configure only the literal snapshot path;
+6. confirm only the explicit skill is advertised and readable;
+7. confirm the project skill and extension remain inactive;
+8. confirm no trust decision is persisted.
+
+## Append-only snapshot tests
+
+- The same normalized skill set produces the same digest and path.
+- Any skill name, content, addition, or removal change produces a new digest.
+- A complete existing snapshot is reused without writes.
+- The completion record is written after all expected files.
+- A partial or mismatched snapshot is never supplied to Pi.
+- Acquisition does not delete an old snapshot or unrelated cwd file.
+- A removed skill remains readable at its old path but is not advertised to the new run.
+- Local and Daytona follow the same snapshot semantics.
+- Existing Claude tests and behavior remain unchanged.
+
+## Lifecycle matrix
+
+| Case | Expected result |
+| --- | --- |
+| warm local Pi continuation | verified live history sends newest message only |
+| cold local Pi with valid transcript | verified native load sends newest message only |
+| cold local Pi with missing transcript | clean session receives canonical replay |
+| local Pi with skill | transcript survives teardown; skill path survives cold resume |
+| local Pi with custom system prompt only | transcript survives teardown |
+| runner restart | native load verifies or canonical replay recovers |
+| configuration change | new environment uses new snapshot and verified continuity |
+| Daytona Pi | existing durable transcript behavior remains correct |
+| Claude | continuation and skill behavior remain unchanged |
+| no durable mount | canonical replay preserves correctness |
+
+## Security and observability
+
+- Project trust remains unset.
+- No credential or executable extension enters cwd skill snapshots or transcript storage.
+- Transcript logs contain no prompts, tool inputs, tool outputs, or model responses.
+- Logs distinguish requested ID, actual header ID, verified load, rejected load, and replay fallback.
+- Metrics count missing, corrupt, mismatched, and unverified native sessions.
+- Acquisition contains no recursive deletion or broad replacement of cwd content.
+
+## Verification commands
+
+Use focused Vitest files during implementation, then the canonical services test entrypoint. Run
+the agent-workflows QA skill after the focused tests pass and preserve the real failing run as a
+replayable regression fixture.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/qa.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/qa.md
@@ -11,6 +11,17 @@
 - A replayed turn records its new native ID only after successful completion.
 - Existing stale mappings recover through replay instead of failing the user turn.
 
+## Pinned upstream behavior
+
+Pin the upstream behaviors the gate defends against, so a Pi or `pi-acp` upgrade that changes
+them fails a test instead of silently shifting the safety argument:
+
+- Pi `--session <path>` on a missing file creates a blank session at that path without error.
+- Pi `--session <id>` on an unknown ID exits with an error.
+- The `pi-acp@0.0.29` load response omits a session ID.
+- `pi-acp` trusts a `session-map.json` hit without an existence or header check, while its
+  map-miss scan matches transcript header IDs.
+
 ## Conversation-loss regression
 
 Automate the supplied production-shaped reproduction:
@@ -36,8 +47,13 @@ Every variant must preserve conversation history through canonical replay.
 
 ## Durable transcript tests
 
-- Local Pi persists only the `sessions` child, not auth, settings, models, extensions, or system
+- Local Pi persists only the native transcripts, not auth, settings, models, extensions, or system
   prompt files.
+- The `sessionDir` override is written into the run agent directory's `settings.json`, and Pi and
+  `pi-acp` resolve the same directory: new transcripts land in durable storage, and `pi-acp`'s
+  session listing and map-miss fallback scan that directory.
+- A deleted `session-map.json` entry with a valid durable transcript recovers through the
+  header-matching scan.
 - Full environment teardown does not remove the private transcript.
 - Runner restart can verify and load the same transcript.
 - Expired conversation cleanup removes transcript state according to retention policy.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/research.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/research.md
@@ -49,14 +49,61 @@ Pi 0.80.6 uses the cwd for project resources, `AGENTS.md`, tool path resolution,
 naming. It uses the agent directory for credentials, private settings, global resources, custom
 models, and native sessions.
 
-Project `.pi/skills` and `.agents/skills` are trust-gated. RPC mode cannot display a trust prompt,
-and the default `ask` policy leaves them unloaded. Trusting the whole cwd would also authorize
-project settings and executable extensions.
+Trust gating is Pi's project consent mechanism. The first time Pi runs in a cwd, it asks whether
+to trust that project, and it stores the decision in `<agent-dir>/trust.json` keyed by the
+canonical cwd path. Trust authorizes loading the project's own configuration from inside the cwd:
+`.pi/settings.json`, executable `.pi/extensions`, `.pi/skills`, `.agents/skills`, prompts, themes,
+and `SYSTEM.md`. Global settings in the agent directory load regardless of trust. RPC mode cannot
+display a trust prompt, and the default `ask` policy resolves to untrusted, so none of these
+project resources load. One nuance: an installed extension can answer the trust request
+programmatically before the UI check. The runner installs the Agenta extension into every Pi run,
+so that extension must never answer trust requests.
 
 The literal `./agents/skills` path has no leading dot. Pi does not discover it automatically, but
 Pi accepts arbitrary skill directories through global `settings.json` or repeatable `--skill`
-arguments. An explicit path can therefore load one runner-created snapshot without widening
-project trust.
+arguments. Explicit paths bypass trust regardless of where they point. An explicit path can
+therefore load one runner-created snapshot without widening project trust.
+
+## Pi session storage and load behavior
+
+Pi resolves its session directory with the precedence `--session-dir`, then the
+`PI_CODING_AGENT_SESSION_DIR` env var, then the `sessionDir` key in the agent directory's
+`settings.json`, then the default `<agent-dir>/sessions/--<encoded-cwd>--/`. RPC mode honors the
+override. With an override set, transcripts for all cwds land flat in that directory without the
+encoded-cwd subdirectory.
+
+`--session <id>` and `--session <path>` behave differently on stale references. The id form scans
+known sessions, matches transcript headers, and exits with an error when nothing matches. The path
+form performs no existence check: a missing file silently becomes a new blank session at that
+path. `pi-acp` spawns Pi with the path form. This is the exact mechanism that created the blank
+replacement transcript in the incident.
+
+`pi-acp@0.0.29` validates asymmetrically. When `session-map.json` has an entry, it trusts the
+stored path blindly: no existence check and no header comparison. When the map misses, it scans
+the sessions directory and matches each transcript's header ID, which does validate identity. The
+load response never carries a session ID in either case, so the adapter offers no positive
+evidence that history loaded.
+
+`pi-acp` computes its scan directory as `<agent-dir>/sessions`, or the `sessionDir` value it reads
+from the agent directory's `settings.json`. It does not read `PI_CODING_AGENT_SESSION_DIR`. An
+env-only override therefore splits the two programs. Pi writes transcripts to the override
+directory, and the main loop keeps working because `pi-acp` learns each new transcript's absolute
+path from Pi over RPC and stores it in the map. But `pi-acp`'s two scan paths, session listing and
+the map-miss fallback, still point at the old directory. Writing `sessionDir` into the run agent
+directory's `settings.json` aligns both programs on the same directory, which also aims the
+validating map-miss fallback at the durable transcripts. `session-map.json` itself lives under
+`~/.pi/pi-acp/` and no override affects it.
+
+## What the runner can already verify
+
+On local runs the runner, sandbox-agent, `pi-acp`, and Pi share one host, one filesystem, and one
+`HOME`. The runner created the agent directory, knows it as `environment.runAgentDir`, and holds
+the expected native session ID in its continuity store both before `session/load` and after the
+turn. It already reads Pi transcripts and parses their first-line headers for error handling in
+`pi-error.ts`. Local existence and header-identity verification is therefore a pure file read of
+information the runner already has, with no new access path. On Daytona the same check would reuse
+the existing in-sandbox exec and file APIs, but the transcript read-back direction is new code
+there.
 
 ## Current Claude behavior
 

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/research.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/research.md
@@ -1,0 +1,95 @@
+# Research
+
+## Current Agenta behavior
+
+`buildRunPlan` chooses the cwd before the harness starts. A durable mount path is used when mount
+credentials exist. Otherwise local runs use `mkdtemp` and Daytona uses a random sandbox path.
+
+`acquireEnvironment` mounts the durable cwd before calling `prepareWorkspace`. This ordering makes
+`AGENTS.md`, harness files, and Claude skills visible before `createSession` starts the harness.
+
+`prepareLocalPiAssets` creates `/tmp/agenta-pi-agentdir-*` when a local Pi run has skills or a
+Pi-specific system prompt. It copies private configuration, installs the Agenta extension and
+skills, writes `SYSTEM.md` or `APPEND_SYSTEM.md`, and sets `PI_CODING_AGENT_DIR`. Pi also writes
+its native `sessions` directory below that agent directory. Teardown removes the whole directory.
+
+Daytona uses a fixed Pi agent directory and can mount harness transcript directories separately.
+The existing `harnessSessionMounts` model already excludes credentials and selects only
+`$PI_CODING_AGENT_DIR/sessions` for Pi, but `mountHarnessSessionDirs` is remote-only. Local runs
+therefore lose native transcripts when their per-run Pi directory is removed.
+
+The keep-alive configuration fingerprint includes instructions, system prompts, skills, and harness
+files. A change evicts a warm environment and performs a cold acquire. Warm reuse can hide the
+lifetime bug, but correctness must not depend on it.
+
+## Confirmed conversation-loss incident
+
+`debug/session-7e9ad207-bug-report.md` records a four-turn local EE conversation through
+`pi_core` and `pi-acp@0.0.29`. The outer Agenta transcript and turn indexes remained complete.
+The native Pi history lost turn 0 after teardown.
+
+The runner prepared a complete cold replay with zero evictions on each continuation, but
+`session/load` reported `loaded=true`. The runner therefore sent only the newest user message.
+The mapped transcript filename contained the requested old native session ID, while the transcript
+header contained a new ID created at the start of turn 1. This proves that a blank replacement
+session was accepted behind the stale continuation pointer.
+
+The failure chain crosses three layers:
+
+1. Agenta deletes the temporary Pi directory that contains the native transcript.
+2. `pi-acp` reuses the stale mapped path without validating file existence and header identity.
+3. The sandbox-agent wrapper substitutes the requested ID when the load response omits one, and the
+   runner treats that inferred ID as proof that history loaded.
+
+A correct cold replay was already available. False load success suppressed it.
+
+## Pi resource discovery and trust
+
+Pi 0.80.6 uses the cwd for project resources, `AGENTS.md`, tool path resolution, and session
+naming. It uses the agent directory for credentials, private settings, global resources, custom
+models, and native sessions.
+
+Project `.pi/skills` and `.agents/skills` are trust-gated. RPC mode cannot display a trust prompt,
+and the default `ask` policy leaves them unloaded. Trusting the whole cwd would also authorize
+project settings and executable extensions.
+
+The literal `./agents/skills` path has no leading dot. Pi does not discover it automatically, but
+Pi accepts arbitrary skill directories through global `settings.json` or repeatable `--skill`
+arguments. An explicit path can therefore load one runner-created snapshot without widening
+project trust.
+
+## Current Claude behavior
+
+Claude skill materialization copies present files into `.claude/skills/<name>`. Local `cpSync`
+merges into an existing directory. Daytona recursively uploads current files. Neither path removes
+a skill that disappeared from configuration or a bundled file removed from a later version.
+Daytona copy failures are logged and skipped.
+
+A shared reconciliation change would add deletion, collision, partial-write, and concurrency
+semantics to Claude immediately before launch. The urgent Pi fix does not need that change.
+
+## Context and token use
+
+Filesystem placement does not itself save model context.
+
+| Resource | Model loading behavior | Filesystem consequence |
+| --- | --- | --- |
+| system prompt | eager | Same prompt tokens through SDK input or file |
+| `AGENTS.md` | eager project context | Same context tokens through injection or cwd discovery |
+| skill name and description | eager | Advertised so the model can choose a skill |
+| full `SKILL.md` and bundled files | on demand | Stable paths preserve progressive disclosure across resumes |
+| credentials and extensions | runtime state | Placement affects security, not prompt size |
+| native transcript | harness state | Placement determines whether native continuation is possible |
+
+## Design implications
+
+Moving skills alone cannot fix conversation loss because a custom system prompt still creates a
+throwaway Pi agent directory. Durable transcripts also cannot be the only defense because missing,
+corrupt, migrated, or mismatched native state must degrade to canonical replay.
+
+The required order is:
+
+1. make native-load success explicit and verifiable;
+2. persist only native transcript state with the Agenta conversation;
+3. move skills to append-only cwd snapshots without reconciliation;
+4. leave credentials, system prompt files, settings, and executable extensions ephemeral.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/status.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/status.md
@@ -1,0 +1,57 @@
+# Status
+
+## Current state
+
+Research and revised launch design complete. No implementation has started. The plan now covers
+native transcript loss as well as stale skill paths.
+
+## Progress log
+
+- 2026-07-13: Traced the stale Pi skill path to the random per-run agent directory.
+- 2026-07-13: Verified the history that introduced Pi agent-dir skills and later added Claude
+  workspace-local skills.
+- 2026-07-13: Verified Pi 0.80.6 cwd discovery and project-trust behavior from the pinned upstream
+  source.
+- 2026-07-13: Confirmed a local Pi resume can report `loaded=true` after replacing a deleted
+  transcript with a blank native session.
+- 2026-07-13: Rejected launch-time deletion reconciliation after reviewing Claude's existing
+  merge-only copier and the failure modes of mutable workspace ownership.
+- 2026-07-13: Split delivery into an immediate verified-load gate, append-only skill snapshots, and
+  durable private transcript storage.
+
+## Decisions
+
+- Land the verified-load replay fallback before storage or skill-layout changes.
+- Use the literal non-hidden `./agents/skills`, not trust-gated `.agents/skills` or
+  `.pi/skills`, for configured Pi skill snapshots.
+- Keep `AGENTS.md` in the cwd.
+- Keep Pi system prompts, credentials, settings, custom models, and executable extensions in the
+  ephemeral private Pi agent directory.
+- Persist only the native transcript directory in private session-scoped storage.
+- Do not auto-trust the session cwd.
+- Load only the complete current skill snapshot through an explicit Pi skill source.
+- Refresh startup resources on environment acquisition, not on every warm turn.
+- Do not reconcile, replace, or garbage-collect old snapshots during environment acquisition.
+- Do not change Claude skill materialization in the urgent implementation.
+
+## Blockers
+
+The explicit Pi skill-path seam and local transcript persistence seam require focused probes before
+their follow-up implementations. They do not block the verified-load correctness gate.
+
+## Open questions
+
+1. Does Pi 0.80.6 load an absolute skill path from isolated global settings while the project stays
+   untrusted? The probe must pass before moving skills.
+2. Should local Pi use a direct session mount, or should the throwaway agent directory link its
+   `sessions` child to stable private storage? Choose after fault-injection tests compare teardown
+   and mount-failure behavior.
+3. Does a newer `pi-acp` validate transcript existence and identity? Keep the Agenta verification
+   guard even if upstream now does.
+
+## Next steps
+
+1. File the confirmed conversation-loss issue and publish this design-only PR.
+2. Implement the verified-load fallback as the launch gate.
+3. Add durable local Pi transcript storage.
+4. Move Pi skills to append-only cwd snapshots after the explicit-path probe passes.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/status.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/status.md
@@ -2,8 +2,9 @@
 
 ## Current state
 
-Research and revised launch design complete. No implementation has started. The plan now covers
-native transcript loss as well as stale skill paths.
+Phase 0 is implemented and locally verified. Cold Pi continuations now bypass identity-free native
+loads, invalidate the stale continuity pointer, create a clean native session, and receive canonical
+replay. Later transcript-storage and skill-snapshot phases remain planned.
 
 ## Progress log
 
@@ -27,6 +28,19 @@ native transcript loss as well as stale skill paths.
   settings key for its scans and ignores the env var.
 - 2026-07-13: Accepted immutable-by-convention skill snapshots as the threat model and documented
   the write-ownership fail-closed rule as distinct from history-uncertainty fallback.
+- 2026-07-13: Implemented Phase 0 in the runner. Cold Pi continuations no longer call native
+  `session/load` while the pinned adapter cannot prove loaded identity. Claude native resume is
+  unchanged.
+- 2026-07-13: Added a production-shaped runner regression that seeds a stale Pi pointer, proves
+  `resumeSession` is not called, verifies full replay contains the earlier marker, and confirms the
+  new native ID replaces the stale pointer only after success. Added a companion Claude guard.
+- 2026-07-13: Focused replay and continuity tests pass, runner typecheck passes, and the complete
+  runner suite reports 1,045 passing tests. Two older transcript captures fail on an unrelated
+  concurrent harness-ID contract change; both new Phase 0 tests pass.
+- 2026-07-13: Live local QA passes with `pi_core` and the self-managed Codex subscription. After a
+  60-second environment TTL eviction, the second turn answered `BETA-9`; after a full sidecar
+  restart, the second turn answered `ALPHA-7`. Both logs show a cold keepalive miss, canonical
+  replay, `outcome=unverified replay=canonical`, and a fresh native session create.
 
 ## Decisions
 
@@ -53,7 +67,7 @@ native transcript loss as well as stale skill paths.
 ## Blockers
 
 The explicit Pi skill-path seam and local transcript persistence seam require focused probes before
-their follow-up implementations. They do not block the verified-load correctness gate.
+their follow-up implementations. They do not block the completed Phase 0 correctness gate.
 
 ## Open questions
 
@@ -69,7 +83,7 @@ their follow-up implementations. They do not block the verified-load correctness
 ## Next steps
 
 1. Issue #5283 and design PR #5284 are filed; the review updates are on the PR.
-2. Implement the Phase 0 conservative fallback as the launch gate.
+2. Review and merge the implemented Phase 0 conservative fallback.
 3. Restore verified loads (Phase 0b), preferably in `pi-acp`.
 4. Add durable local Pi transcript storage through the `sessionDir` settings override.
 5. Move Pi skills to append-only cwd snapshots after the explicit-path probe passes.

--- a/docs/design/agent-workflows/projects/session-workspace-materialization/status.md
+++ b/docs/design/agent-workflows/projects/session-workspace-materialization/status.md
@@ -18,6 +18,15 @@ native transcript loss as well as stale skill paths.
   merge-only copier and the failure modes of mutable workspace ownership.
 - 2026-07-13: Split delivery into an immediate verified-load gate, append-only skill snapshots, and
   durable private transcript storage.
+- 2026-07-13: Review pass on PR #5284. Confirmed every research claim against the runner source
+  and the pinned Pi 0.80.6 and `pi-acp@0.0.29` code. Adopted the launch stance that every cold Pi
+  load is unverified until real evidence exists, and split the `pi-acp` change out of the gate
+  into Phase 0b.
+- 2026-07-13: Traced Pi's session-directory override end to end. Selected the `settings.json`
+  `sessionDir` form as the leading durable-transcript mechanism because `pi-acp` reads the same
+  settings key for its scans and ignores the env var.
+- 2026-07-13: Accepted immutable-by-convention skill snapshots as the threat model and documented
+  the write-ownership fail-closed rule as distinct from history-uncertainty fallback.
 
 ## Decisions
 
@@ -33,6 +42,13 @@ native transcript loss as well as stale skill paths.
 - Refresh startup resources on environment acquisition, not on every warm turn.
 - Do not reconcile, replace, or garbage-collect old snapshots during environment acquisition.
 - Do not change Claude skill materialization in the urgent implementation.
+- Ship the launch gate without any `pi-acp` change: every cold Pi load starts unverified and
+  replays. Verified loads return through Phase 0b, preferably in `pi-acp`, with a local runner
+  header check as an acceptable interim source.
+- Use the `settings.json` `sessionDir` key in the per-run agent directory, not the env var, as
+  the leading mechanism for durable local transcripts.
+- Accept immutable-by-convention snapshots: the cwd is agent-writable and the completion record
+  does not hash contents.
 
 ## Blockers
 
@@ -43,15 +59,17 @@ their follow-up implementations. They do not block the verified-load correctness
 
 1. Does Pi 0.80.6 load an absolute skill path from isolated global settings while the project stays
    untrusted? The probe must pass before moving skills.
-2. Should local Pi use a direct session mount, or should the throwaway agent directory link its
-   `sessions` child to stable private storage? Choose after fault-injection tests compare teardown
-   and mount-failure behavior.
+2. Does the `sessionDir` settings override hold up under fault injection? Code reading confirms Pi
+   honors it in RPC mode and `pi-acp` reads the same settings key for its scans, but teardown,
+   runner restart, map-miss recovery, and storage-failure behavior still need the Phase 1 probe.
+   The mount extension and the `sessions`-child link remain fallbacks.
 3. Does a newer `pi-acp` validate transcript existence and identity? Keep the Agenta verification
    guard even if upstream now does.
 
 ## Next steps
 
-1. File the confirmed conversation-loss issue and publish this design-only PR.
-2. Implement the verified-load fallback as the launch gate.
-3. Add durable local Pi transcript storage.
-4. Move Pi skills to append-only cwd snapshots after the explicit-path probe passes.
+1. Issue #5283 and design PR #5284 are filed; the review updates are on the PR.
+2. Implement the Phase 0 conservative fallback as the launch gate.
+3. Restore verified loads (Phase 0b), preferably in `pi-acp`.
+4. Add durable local Pi transcript storage through the `sessionDir` settings override.
+5. Move Pi skills to append-only cwd snapshots after the explicit-path probe passes.

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -1468,13 +1468,11 @@ export async function acquireEnvironment(
       ...(claudeSystemPromptMeta ? { _meta: claudeSystemPromptMeta } : {}),
     };
 
-    // If this harness authored the conversation's most recent turn (staleness-guarded) and we
-    // still remember its native `agentSessionId`, seed the fresh persist driver with a synthetic
-    // record and resume-by-id so the patched `resumeSession` reaches `session/load` instead of
-    // `session/new`. Any failure inside `resumeSession` already degrades to a plain new session
-    // internally (the patch's own `catch {}` around `loadRemoteSession`), so this call is safe to
-    // attempt unconditionally whenever we have an eligible id — worst case it is exactly today's
-    // cold `createSession`.
+    // If this harness authored the most recent turn and we still remember its native session id,
+    // non-Pi harnesses may resume by id. Pi is deliberately excluded: the pinned adapter does not
+    // return loaded-session identity, and the compatibility patch substitutes the requested id
+    // when that response field is absent. Until the adapter supplies verifiable identity, every
+    // cold Pi continuation starts a clean session and receives canonical replay.
     const continuitySessionKey = request.sessionId?.trim();
     const continuityStore =
       deps.sessionContinuityStore ?? sessionContinuityStore;
@@ -1524,7 +1522,17 @@ export async function acquireEnvironment(
       );
     }
     let loadedFromContinuity = false;
-    if (priorAgentSessionId && localSessionId) {
+    if (plan.isPi && priorAgentSessionId && continuitySessionKey) {
+      continuityStore.invalidate(continuitySessionKey, plan.harness);
+      logger(
+        "[continuity] native load skipped session=" +
+          continuitySessionKey +
+          " harness=" +
+          plan.harness +
+          " outcome=unverified replay=canonical",
+      );
+    }
+    if (!plan.isPi && priorAgentSessionId && localSessionId) {
       await persist.updateSession({
         id: localSessionId,
         agent: plan.acpAgent,

--- a/services/runner/tests/unit/sandbox-agent-qa-transcript-replay.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-qa-transcript-replay.test.ts
@@ -27,6 +27,8 @@ import {
   type SandboxAgentDeps,
 } from "../../src/engines/sandbox_agent.ts";
 import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import { SessionContinuityStore } from "../../src/engines/sandbox_agent/session-continuity.ts";
+import type { AgentRunRequest } from "../../src/protocol.ts";
 import {
   agentRunRequestFromTranscript,
   loadTranscript,
@@ -41,14 +43,18 @@ import {
  * unchanged, not exercise every orchestration branch (that is the existing suite's job).
  */
 function fakeReplayHarness() {
+  const continuityStore = new SessionContinuityStore();
   const calls = {
     createSessionOptions: undefined as any,
     promptBlocks: undefined as any,
     workspacePlan: undefined as any,
+    resumeSessionIds: [] as string[],
+    logs: [] as string[],
   };
 
   const session = {
     id: "session-replay",
+    agentSessionId: "native-new",
     onEvent() {},
     onPermissionRequest() {},
     async prompt(blocks: any) {
@@ -58,6 +64,10 @@ function fakeReplayHarness() {
   };
 
   const sandbox = {
+    async resumeSession(id: string) {
+      calls.resumeSessionIds.push(id);
+      return { ...session, agentSessionId: "native-stale" };
+    },
     async createSession(opts: any) {
       calls.createSessionOptions = opts;
       return session;
@@ -93,14 +103,19 @@ function fakeReplayHarness() {
   };
 
   const deps: SandboxAgentDeps = {
-    log: () => {},
+    log: (message) => {
+      calls.logs.push(message);
+    },
+    sessionContinuityStore: continuityStore,
+    hydrateHarnessSessionFromDurable: async () => {},
+    syncHarnessSessionDurable: async () => {},
     createLocalCwd: () => "/tmp/agenta-replay-cwd",
     createDaytonaCwd: () => "/home/sandbox/agenta-replay-cwd",
     resolveSkillDirs: () => ({ skills: [], cleanup: () => {} }),
     buildDaemonEnv: () => ({}),
     resolveDaemonBinary: () => "/bin/sandbox-agent",
     buildSandboxProvider: () => ({ provider: true }) as any,
-    createPersist: () => ({}) as any,
+    createPersist: () => ({ updateSession: async () => {} }) as any,
     startSandboxAgent: (async () => sandbox) as any,
     prepareWorkspace: (async ({ plan }: any) => {
       calls.workspacePlan = plan;
@@ -131,7 +146,7 @@ function fakeReplayHarness() {
     }),
   };
 
-  return { calls, deps };
+  return { calls, deps, continuityStore };
 }
 
 describe("runSandboxAgent replays real captured QA transcripts", () => {
@@ -197,4 +212,66 @@ describe("runSandboxAgent replays real captured QA transcripts", () => {
       }
     },
   );
+});
+
+describe("cold Pi native-history fallback", () => {
+  it("bypasses an eligible stale native pointer and sends canonical replay to a clean session", async () => {
+    const { calls, deps, continuityStore } = fakeReplayHarness();
+    continuityStore.record("session-loss", "pi_core", "native-stale", 0);
+    const request: AgentRunRequest = {
+      harness: "pi_core",
+      sandbox: "local",
+      sessionId: "session-loss",
+      messages: [
+        { role: "user", content: "Remember marker ALPHA-7" },
+        { role: "assistant", content: "I will remember ALPHA-7" },
+        { role: "user", content: "What marker did I give you?" },
+      ],
+    };
+
+    const result = await runSandboxAgent(request, undefined, undefined, deps);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(
+      calls.resumeSessionIds,
+      [],
+      "cold Pi must not call an identity-free native load",
+    );
+    assert.equal(calls.createSessionOptions.agent, "pi");
+    assert.match(calls.promptBlocks[0].text, /Conversation so far:/);
+    assert.match(calls.promptBlocks[0].text, /Remember marker ALPHA-7/);
+    assert.match(calls.promptBlocks[0].text, /What marker did I give you\?/);
+    assert.ok(
+      calls.logs.some((line) =>
+        line.includes("outcome=unverified replay=canonical"),
+      ),
+      "the continuity decision must be observable without transcript content",
+    );
+    assert.deepEqual(continuityStore.get("session-loss", "pi_core"), {
+      agentSessionId: "native-new",
+      turnIndex: 1,
+    });
+  });
+
+  it("keeps non-Pi native resume behavior unchanged", async () => {
+    const { calls, deps, continuityStore } = fakeReplayHarness();
+    continuityStore.record("session-claude", "claude", "native-stale", 0);
+    const request: AgentRunRequest = {
+      harness: "claude",
+      sandbox: "local",
+      sessionId: "session-claude",
+      messages: [
+        { role: "user", content: "earlier" },
+        { role: "assistant", content: "answer" },
+        { role: "user", content: "latest" },
+      ],
+    };
+
+    const result = await runSandboxAgent(request, undefined, undefined, deps);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.resumeSessionIds, ["session-claude:claude"]);
+    assert.equal(calls.createSessionOptions, undefined);
+    assert.deepEqual(calls.promptBlocks, [{ type: "text", text: "latest" }]);
+  });
 });


### PR DESCRIPTION
## Problem

A cold local Pi continuation could report a successful native resume after its transcript had disappeared. The runner then sent only the newest user message, so Pi silently lost the earlier conversation. The same investigation found that Pi skill paths currently point into a throwaway per-run agent directory.

The immediate correctness bug is caused by identity-free loading: pinned `pi-acp@0.0.29` does not return the loaded native session ID, while the compatibility wrapper substitutes the requested ID. That makes an unverified load look successful.

Refs #5283.

## What changes

- Cold Pi continuations no longer call native `session/load` while loaded identity cannot be verified.
- A stale Pi continuity pointer is invalidated, a clean native session is created, and canonical Agenta history is replayed.
- The new native ID is recorded only after the replayed turn succeeds.
- Warm live Pi continuation is unchanged, and Claude native resume remains newest-message-only.
- Structured logs record `outcome=unverified replay=canonical` without transcript content.
- A production-shaped regression seeds a stale Pi pointer and proves the earlier marker reaches the clean session; a companion test protects Claude behavior.
- The design workspace records the later, separate work for verified loads, durable transcripts, and append-only cwd skill snapshots.

## Before and after

Before: cold Pi load appeared successful, the runner sent only the latest message, and missing native history became user-visible conversation loss.

After: every cold Pi load is conservative until identity evidence exists. Pi receives the full canonical transcript, so correctness does not depend on the temporary native transcript surviving.

## Verification

- `pnpm exec vitest run tests/unit/sandbox-agent-qa-transcript-replay.test.ts -t "cold Pi native-history fallback"`: 2 passed.
- `pnpm exec vitest run tests/unit/continuation.test.ts`: 7 passed.
- `pnpm run typecheck`: passed.
- Complete shared-workspace runner run: 1,045 passed; two older green-capture tests fail on an unrelated concurrently applied harness-ID contract change. Both new tests pass, and that contract change is not in this PR.
- Pre-commit hooks passed for the implementation and documentation commits.

## Local QA

Tested against the live local deployment on port 8280 with `pi_core`, local sandboxing, and the self-managed Codex subscription:

1. After the 60-second keepalive TTL fully evicted the environment, turn 1 returned `BETA-9` from turn 0.
2. After a full sidecar restart and ownership-lease expiry, turn 1 returned `ALPHA-7` from turn 0.
3. Both runs logged a cold keepalive miss, canonical replay, `outcome=unverified replay=canonical`, a fresh native session create, and successful continuity sync.

## What to review

1. Confirm cold Pi bypasses the unverified resume branch and always sends `plan.turnText`.
2. Confirm the stale pointer is invalidated before the clean session and replaced only after success.
3. Confirm Claude resume behavior is unchanged.
4. Treat Phase 0b identity verification, durable transcript storage, and skill snapshot migration as follow-up PRs rather than requirements for this launch gate.