### PR TITLE
docs(agent-workflows): Plan MCP configuration redesign

### DIFF
--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/README.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/README.md
@@ -1,0 +1,48 @@
+# MCP configuration redesign
+
+Status: planning complete, implementation not started  
+Date: 2026-07-13
+
+This project turns the MCP status-quo audit into an implementation sequence. It narrows the
+public product to remote MCP servers, removes controls that cannot work, separates saved author
+intent from runtime delivery, and makes the Claude failure observable before expanding to Pi or
+authenticated servers.
+
+## Decisions
+
+- The internal `agenta-tools` MCP is never shown or edited in the user MCP UI.
+- The user MCP section is shown only when the deployment publishes the user-MCP capability.
+- User-authored stdio is removed from the public schema and UI. The trusted internal Daytona
+  stdio shim remains a private runner implementation detail.
+- The saved interface is role-based: identity, connection, credentials, and policy.
+- The first supported connection is remote HTTPS. Protocol negotiation belongs to the MCP client
+  or future gateway, not the agent template.
+- Credentials remain part of the extensible contract, but the first acceptance slice uses
+  `credentials.type = "none"`.
+- Secret values are never stored in agent revisions. Static credentials are references, and OAuth
+  will reference a platform connection.
+- Tool policy uses an explicit mode. An empty string or empty array never means "all tools."
+- The currently reported enabled-deployment Claude failure is unresolved until reproduced on the
+  exact deployment and traced across every boundary.
+
+## Deliverables
+
+- [Context](context.md)
+- [Research](research.md)
+- [Interface design](interface.md)
+- [Implementation plan](plan.md)
+- [Migration](migration.md)
+- [QA plan](qa.md)
+- [Status and decisions](status.md)
+
+The source audit that precedes this plan is in
+[MCP status quo and interface recommendation](../mcp-delivery-architecture/status-quo-report.md).
+
+## Intended outcome
+
+A user can add an unauthenticated remote MCP server to a capability-enabled Claude deployment,
+test the connection, see the discovered tools or a concrete error, save an unambiguous config,
+and run it. Unsupported combinations are absent from the editor or rejected clearly. The saved
+shape remains valid when execution later moves behind the Agenta MCP gateway and becomes
+available to Pi.
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/README.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/README.md
@@ -1,17 +1,16 @@
 # MCP configuration redesign
 
-Status: planning complete, implementation not started  
+Status: slices 0-2 implemented, validation in progress
 Date: 2026-07-13
 
 This project turns the MCP status-quo audit into an implementation sequence. It narrows the
 public product to remote MCP servers, removes controls that cannot work, separates saved author
-intent from runtime delivery, and makes the Claude failure observable before expanding to Pi or
-authenticated servers.
+intent from runtime delivery, and gives the UI one runtime capability source.
 
 ## Decisions
 
 - The internal `agenta-tools` MCP is never shown or edited in the user MCP UI.
-- The user MCP section is shown only when the deployment publishes the user-MCP capability.
+- The user MCP section is shown only when the selected harness publishes `mcp.user_servers`.
 - User-authored stdio is removed from the public schema and UI. The trusted internal Daytona
   stdio shim remains a private runner implementation detail.
 - The saved interface is role-based: identity, connection, credentials, and policy.
@@ -22,6 +21,9 @@ authenticated servers.
 - Secret values are never stored in agent revisions. Static credentials are references, and OAuth
   will reference a platform connection.
 - Tool policy uses an explicit mode. An empty string or empty array never means "all tools."
+- There is no backward compatibility, feature flag, or MCP-specific frontend environment
+  variable.
+- Claude keeps the existing direct ACP HTTP path. Pi is the immediate slice 2.2 follow-up.
 - The currently reported enabled-deployment Claude failure is unresolved until reproduced on the
   exact deployment and traced across every boundary.
 
@@ -40,9 +42,6 @@ The source audit that precedes this plan is in
 
 ## Intended outcome
 
-A user can add an unauthenticated remote MCP server to a capability-enabled Claude deployment,
-test the connection, see the discovered tools or a concrete error, save an unambiguous config,
-and run it. Unsupported combinations are absent from the editor or rejected clearly. The saved
-shape remains valid when execution later moves behind the Agenta MCP gateway and becomes
-available to Pi.
-
+A user can add an external HTTP MCP server to Claude with an unambiguous config. Unsupported
+controls are absent, Pi stays hidden until slice 2.2 works, and future discovery, status, OAuth,
+and gateway work can extend the role-based object without moving existing fields.

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/context.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/context.md
@@ -1,0 +1,71 @@
+# Context
+
+## Problem
+
+The MCP editor currently exposes a protocol-shaped object rather than a working product. It asks
+for `stdio` commands even though the runner rejects them, labels HTTP headers as environment
+variables, asks users to type tool names before discovery, and offers no connection status. A
+saved remote HTTP server can therefore appear to do nothing.
+
+The public object also mixes four semantic roles:
+
+- endpoint configuration;
+- process configuration inherited from stdio;
+- credential references;
+- authorization policy.
+
+That coupling makes the public agent template expensive to evolve. The planned MCP gateway,
+OAuth connections, Pi support, and direct-to-gateway migration should not require moving fields
+again.
+
+## Scope
+
+This project covers:
+
+- the public MCP authoring contract in the Python SDK and agent template schema;
+- normalization into a private resolved runner contract;
+- MCP controls in the agent-template UI;
+- deployment and harness capability gating;
+- the no-secret remote HTTP path for Claude local and Daytona;
+- connection discovery, visible status, and tool-selection enforcement;
+- a migration plan for pre-production saved drafts;
+- the future seam for gateway execution and connection-backed credentials.
+
+## Out of scope for the first delivery
+
+- accepting user-authored commands or packages;
+- hosting arbitrary MCP stdio processes;
+- OAuth implementation;
+- production enablement;
+- Pi execution through the gateway;
+- making Daytona Secrets the permanent MCP credential architecture;
+- exposing the internal `agenta-tools` MCP as user configuration.
+
+## Product language
+
+Use these names consistently:
+
+- **Agenta tools**: the trusted internal tool channel named `agenta-tools` at runtime. It is not a
+  user MCP server.
+- **MCP server**: an external server selected by a template author.
+- **Remote MCP URL**: the external HTTPS endpoint. Do not make users choose a transport when only
+  remote HTTP is supported.
+- **Credentials**: an authentication strategy and references to platform-held values. A credential
+  is not a raw token field.
+- **Tools**: functions discovered from the MCP server through `tools/list`.
+
+## Success criteria
+
+1. No public UI or authoring type offers stdio, command, arguments, or process environment.
+2. The internal Daytona stdio shim continues to work independently.
+3. A deployment that does not enable user MCP does not show an editable MCP section.
+4. A capability-enabled Claude run can prove whether the saved server reached the service,
+   runner, ACP session, and Claude MCP client.
+5. The UI displays `not_tested`, `connecting`, `connected`, or `error`, with discovered tool count
+   and actionable error text.
+6. Tool selection is discovered and enforced, not an inert list of user-typed strings.
+7. Saved configs contain credential references only. Runtime contracts clearly identify any
+   secret-bearing boundary.
+8. Moving execution behind the gateway requires an adapter change, not another authoring-schema
+   redesign.
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/interface.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/interface.md
@@ -2,170 +2,132 @@
 
 ## Interface layers
 
-Do not use one type for author intent, resolved secrets, runner delivery, and MCP protocol state.
-
 | Layer | Owner | Lifetime | May contain secret values |
 | --- | --- | --- | --- |
 | `MCPServerConfig` | Template author | Saved revision | No |
-| `ResolvedMCPServer` | Service resolver | One run | Temporarily, until gateway migration |
-| Runner MCP entry | Runner adapter | One session | Temporarily, direct Claude only |
-| MCP connection status | MCP client or gateway | Ephemeral | No |
+| `ResolvedMCPServer` | Service resolver | One run | Yes, in redacted headers |
+| Runner MCP entry | Runner adapter | One session | Yes, direct Claude only |
+| MCP connection status | Future MCP client or gateway | Ephemeral | No |
 
-## Canonical author contract
+## Saved author contract
 
 ```json
 {
-  "version": 2,
   "name": "memory",
   "connection": {
-    "type": "remote_http",
+    "type": "http",
     "url": "https://memory.example.com/mcp",
     "headers": {},
-    "credentials": {
-      "type": "none"
-    }
+    "credentials": {"type": "none"}
   },
   "policy": {
-    "tools": {
-      "mode": "all"
-    },
+    "tools": {"mode": "all"},
     "permission": "ask"
   }
 }
 ```
 
-`version` is the Agenta author-config version. It is not the negotiated MCP protocol version.
+There is no config version and no compatibility decoder. This is a breaking pre-production reset.
+There is also no public transport selector: the only accepted connection type is external HTTP.
 
-### Identity
+### Semantic roles
 
-`name` is the stable server name within one agent revision. It must be unique and must not equal
-the reserved runtime name `agenta-tools`.
+| Field | Role | Owner |
+| --- | --- | --- |
+| `name` | Stable identity within one agent revision | Author |
+| `connection.type` and `url` | External routing | Author |
+| `connection.headers` | Non-secret public HTTP metadata | Author |
+| `connection.credentials` | Credential strategy and secret references | Author plus platform |
+| `policy.tools` | Tool exposure policy | Author |
+| `policy.permission` | Whole-server authorization policy | Author |
 
-### Connection
-
-`connection` owns how Agenta reaches the external server.
-
-```text
-type: "remote_http"
-url: absolute HTTPS MCP endpoint
-headers: non-secret static headers only
-credentials: discriminated authentication strategy
-```
-
-There is no public `transport` selector in version 2. `remote_http` is a semantic connection type
-and leaves room for future managed-server references without accepting arbitrary commands.
+`name` must not be `agenta-tools`. That name is reserved for the private runtime channel.
 
 ### Credentials
 
-Credentials are extensible through a discriminator in the same location:
+Unauthenticated:
 
 ```json
 {"type": "none"}
 ```
 
+Static header secret references:
+
 ```json
 {
   "type": "header_secret_refs",
-  "headers": {
-    "Authorization": "memory_token"
-  }
+  "headers": {"Authorization": "memory_token"}
 }
 ```
 
-```json
-{
-  "type": "oauth_connection",
-  "connection_ref": "memory-production"
-}
-```
+The values are project secret names, never credential values. Future OAuth can add another
+discriminator in this same location without moving unrelated fields.
 
-The secret-ref mapping contains platform secret names, never values. A future connection resource
-may replace or resolve those refs without moving `credentials`.
-
-### Policy
-
-Policy is separate from connectivity:
+### Tool policy
 
 ```json
 {"tools": {"mode": "all"}, "permission": "ask"}
 ```
 
-or:
+`include` requires a non-empty `names` list. `all` rejects names. The initial UI uses `all`
+because discovery and enforceable selection belong to slice 3.
 
-```json
-{
-  "tools": {
-    "mode": "include",
-    "names": ["search", "remember"]
-  },
-  "permission": "ask"
-}
-```
-
-`names` is valid only for `include` and is populated from discovery. The gateway or direct-client
-adapter must enforce it for both `tools/list` and `tools/call`. Prompt rendering is not enforcement.
-
-## Capability contract
-
-Add an optional MCP capability to harness metadata:
+## Runtime capability contract
 
 ```json
 {
   "mcp": {
     "user_servers": {
-      "enabled": true,
-      "connection_types": ["remote_http"],
-      "credentials": ["none"],
-      "discovery": true
+      "connection_types": ["http"],
+      "credentials": ["none", "header_secret_refs"]
     }
   }
 }
 ```
 
-The service publishes the effective deployment plus harness capability. Older or missing metadata
-means disabled. Pi publishes disabled until the gateway projection exists. Internal
-`agenta-tools` support is not part of this public capability.
+Presence means the selected harness supports external user MCP authoring and delivery. Absence
+means unsupported. There is no separate `enabled` boolean and no frontend environment variable.
 
-## Status contract
+The UI reads this from the existing inspect-fed harness catalog:
 
-Connection testing returns an ephemeral result, not a mutation of the saved author object:
+- Claude publishes `mcp.user_servers`.
+- Pi omits it until slice 2.2 works.
+- missing or loading metadata fails closed;
+- internal `agenta-tools` capability is not represented here.
+
+This is the same path in local Docker and Agenta Cloud, so `agenta_cloud` needs no MCP-specific
+frontend or compose setting.
+
+## Resolved runner contract
+
+The service resolves secret references per run and sends:
 
 ```json
 {
-  "state": "connected",
-  "server": {"name": "Memory", "version": "1.2.0"},
-  "protocol_version": "negotiated-value",
-  "tools": [
-    {"name": "remember", "description": "Store a memory", "input_schema": {}}
-  ],
-  "error": null
+  "name": "memory",
+  "connection": {
+    "type": "http",
+    "url": "https://memory.example.com/mcp",
+    "headers": {"Authorization": "resolved value"}
+  },
+  "policy": {
+    "tools": {"mode": "all"},
+    "permission": "ask"
+  }
 }
 ```
 
-Allowed states are `not_tested`, `connecting`, `connected`, and `error`. The test endpoint returns
-normalized error codes and safe messages. It never returns credential values or raw authorization
-headers.
+Resolved headers are secret-bearing. They must not be persisted, returned by inspect, included in
+repr output, or logged. Claude's adapter maps this object to the existing ACP HTTP MCP entry.
 
-## Resolved contract
+## Removed fields
 
-Version 2 author config normalizes into a private resolved form. For the interim direct-Claude
-adapter it may contain resolved header values, but that type must be named and documented as
-secret-bearing. It must never be serialized into logs, persisted, returned by inspect, or copied
-back into the author config.
-
-The gateway adapter later consumes the same author intent and resolves credentials inside the
-gateway. No public field changes when that switch happens.
-
-## Removed public fields
-
-| Field | Disposition | Reason |
-| --- | --- | --- |
-| `transport` | Replaced by `connection.type` | The UI supports one public connection type |
-| `command` | Removed | Arbitrary runner-host execution is unsupported |
-| `args` | Removed | Belongs to removed user stdio |
-| `env` | Removed | Mixed process env and HTTP headers |
-| flat `url` | Moved to `connection.url` | Endpoint ownership |
-| flat `secrets` | Moved to `connection.credentials` | Credential ownership |
-| flat `tools` | Moved to explicit policy | Empty-list ambiguity and dead enforcement |
-| flat `permission` | Moved to policy | Authorization ownership |
-
+| Field | Disposition |
+| --- | --- |
+| `transport` | Removed |
+| `command`, `args` | Removed with public stdio |
+| `env` | Removed; it mixed process environment with HTTP headers |
+| flat `url` | Moved to `connection.url` |
+| flat `secrets` | Moved to `connection.credentials` |
+| flat `tools` | Replaced by explicit `policy.tools` |
+| flat `permission` | Moved to `policy.permission` |

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/interface.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/interface.md
@@ -1,0 +1,171 @@
+# Interface design
+
+## Interface layers
+
+Do not use one type for author intent, resolved secrets, runner delivery, and MCP protocol state.
+
+| Layer | Owner | Lifetime | May contain secret values |
+| --- | --- | --- | --- |
+| `MCPServerConfig` | Template author | Saved revision | No |
+| `ResolvedMCPServer` | Service resolver | One run | Temporarily, until gateway migration |
+| Runner MCP entry | Runner adapter | One session | Temporarily, direct Claude only |
+| MCP connection status | MCP client or gateway | Ephemeral | No |
+
+## Canonical author contract
+
+```json
+{
+  "version": 2,
+  "name": "memory",
+  "connection": {
+    "type": "remote_http",
+    "url": "https://memory.example.com/mcp",
+    "headers": {},
+    "credentials": {
+      "type": "none"
+    }
+  },
+  "policy": {
+    "tools": {
+      "mode": "all"
+    },
+    "permission": "ask"
+  }
+}
+```
+
+`version` is the Agenta author-config version. It is not the negotiated MCP protocol version.
+
+### Identity
+
+`name` is the stable server name within one agent revision. It must be unique and must not equal
+the reserved runtime name `agenta-tools`.
+
+### Connection
+
+`connection` owns how Agenta reaches the external server.
+
+```text
+type: "remote_http"
+url: absolute HTTPS MCP endpoint
+headers: non-secret static headers only
+credentials: discriminated authentication strategy
+```
+
+There is no public `transport` selector in version 2. `remote_http` is a semantic connection type
+and leaves room for future managed-server references without accepting arbitrary commands.
+
+### Credentials
+
+Credentials are extensible through a discriminator in the same location:
+
+```json
+{"type": "none"}
+```
+
+```json
+{
+  "type": "header_secret_refs",
+  "headers": {
+    "Authorization": "memory_token"
+  }
+}
+```
+
+```json
+{
+  "type": "oauth_connection",
+  "connection_ref": "memory-production"
+}
+```
+
+The secret-ref mapping contains platform secret names, never values. A future connection resource
+may replace or resolve those refs without moving `credentials`.
+
+### Policy
+
+Policy is separate from connectivity:
+
+```json
+{"tools": {"mode": "all"}, "permission": "ask"}
+```
+
+or:
+
+```json
+{
+  "tools": {
+    "mode": "include",
+    "names": ["search", "remember"]
+  },
+  "permission": "ask"
+}
+```
+
+`names` is valid only for `include` and is populated from discovery. The gateway or direct-client
+adapter must enforce it for both `tools/list` and `tools/call`. Prompt rendering is not enforcement.
+
+## Capability contract
+
+Add an optional MCP capability to harness metadata:
+
+```json
+{
+  "mcp": {
+    "user_servers": {
+      "enabled": true,
+      "connection_types": ["remote_http"],
+      "credentials": ["none"],
+      "discovery": true
+    }
+  }
+}
+```
+
+The service publishes the effective deployment plus harness capability. Older or missing metadata
+means disabled. Pi publishes disabled until the gateway projection exists. Internal
+`agenta-tools` support is not part of this public capability.
+
+## Status contract
+
+Connection testing returns an ephemeral result, not a mutation of the saved author object:
+
+```json
+{
+  "state": "connected",
+  "server": {"name": "Memory", "version": "1.2.0"},
+  "protocol_version": "negotiated-value",
+  "tools": [
+    {"name": "remember", "description": "Store a memory", "input_schema": {}}
+  ],
+  "error": null
+}
+```
+
+Allowed states are `not_tested`, `connecting`, `connected`, and `error`. The test endpoint returns
+normalized error codes and safe messages. It never returns credential values or raw authorization
+headers.
+
+## Resolved contract
+
+Version 2 author config normalizes into a private resolved form. For the interim direct-Claude
+adapter it may contain resolved header values, but that type must be named and documented as
+secret-bearing. It must never be serialized into logs, persisted, returned by inspect, or copied
+back into the author config.
+
+The gateway adapter later consumes the same author intent and resolves credentials inside the
+gateway. No public field changes when that switch happens.
+
+## Removed public fields
+
+| Field | Disposition | Reason |
+| --- | --- | --- |
+| `transport` | Replaced by `connection.type` | The UI supports one public connection type |
+| `command` | Removed | Arbitrary runner-host execution is unsupported |
+| `args` | Removed | Belongs to removed user stdio |
+| `env` | Removed | Mixed process env and HTTP headers |
+| flat `url` | Moved to `connection.url` | Endpoint ownership |
+| flat `secrets` | Moved to `connection.credentials` | Credential ownership |
+| flat `tools` | Moved to explicit policy | Empty-list ambiguity and dead enforcement |
+| flat `permission` | Moved to policy | Authorization ownership |
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/migration.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/migration.md
@@ -1,0 +1,43 @@
+# Pre-production migration
+
+## Policy
+
+Use the pre-production window to remove the bad public shape now. Do not carry indefinite dual
+write or preserve stdio as a first-class author option.
+
+The migration has one compatibility boundary so existing development revisions fail clearly or
+upgrade deterministically. New saves and all public documentation use version 2 only.
+
+## Version 1 mapping
+
+| Version 1 | Version 2 |
+| --- | --- |
+| `name` | `name` |
+| `transport: "http"` | `connection.type: "remote_http"` |
+| `url` | `connection.url` |
+| HTTP `env` | `connection.headers` |
+| `secrets` | `connection.credentials.type: "header_secret_refs"` and `headers` |
+| `tools: []` | `policy.tools.mode: "all"` |
+| non-empty `tools` | `policy.tools.mode: "include"` and `names` |
+| `permission` | `policy.permission` |
+
+Version 1 stdio has no version 2 mapping. It receives a clear unsupported validation error.
+
+## Migration mechanism
+
+1. Inventory saved revisions containing `agent.mcps` in pre-production databases.
+2. If the inventory is disposable, reset those drafts and remove version 1 parsing immediately.
+3. If the inventory must be retained, run an explicit data migration for version 1 HTTP entries.
+4. Reject version 1 stdio entries and report their revision identifiers for manual cleanup.
+5. Keep a read-only v1 decoder for one release only if external API callers already depend on it.
+6. Remove the decoder after telemetry shows no v1 calls.
+
+Do not normalize and rewrite a saved revision during invocation. Runs should be deterministic and
+must not mutate author state.
+
+## Rollback
+
+The feature capability remains off by default. A rollback disables editing and execution without
+rewriting saved version 2 configs. Because the author contract is independent of direct versus
+gateway delivery, a runtime rollback does not require a schema rollback.
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/migration.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/migration.md
@@ -1,43 +1,19 @@
-# Pre-production migration
+# Pre-production breaking reset
 
-## Policy
+There is no backward compatibility work.
 
-Use the pre-production window to remove the bad public shape now. Do not carry indefinite dual
-write or preserve stdio as a first-class author option.
+- Do not decode the old flat object.
+- Do not migrate it during invocation.
+- Do not dual write.
+- Do not add a feature flag.
+- Do not preserve public stdio as an unsupported variant.
 
-The migration has one compatibility boundary so existing development revisions fail clearly or
-upgrade deterministically. New saves and all public documentation use version 2 only.
+Existing development revisions containing the old MCP object are invalid after this change. Users
+must remove and recreate those entries in the new editor. A malformed entry fails validation
+before the runner starts, so development does not degrade into a confusing agent-wide runtime
+failure.
 
-## Version 1 mapping
+The private trusted Daytona stdio shim is a different internal type and remains unchanged.
 
-| Version 1 | Version 2 |
-| --- | --- |
-| `name` | `name` |
-| `transport: "http"` | `connection.type: "remote_http"` |
-| `url` | `connection.url` |
-| HTTP `env` | `connection.headers` |
-| `secrets` | `connection.credentials.type: "header_secret_refs"` and `headers` |
-| `tools: []` | `policy.tools.mode: "all"` |
-| non-empty `tools` | `policy.tools.mode: "include"` and `names` |
-| `permission` | `policy.permission` |
-
-Version 1 stdio has no version 2 mapping. It receives a clear unsupported validation error.
-
-## Migration mechanism
-
-1. Inventory saved revisions containing `agent.mcps` in pre-production databases.
-2. If the inventory is disposable, reset those drafts and remove version 1 parsing immediately.
-3. If the inventory must be retained, run an explicit data migration for version 1 HTTP entries.
-4. Reject version 1 stdio entries and report their revision identifiers for manual cleanup.
-5. Keep a read-only v1 decoder for one release only if external API callers already depend on it.
-6. Remove the decoder after telemetry shows no v1 calls.
-
-Do not normalize and rewrite a saved revision during invocation. Runs should be deterministic and
-must not mutate author state.
-
-## Rollback
-
-The feature capability remains off by default. A rollback disables editing and execution without
-rewriting saved version 2 configs. Because the author contract is independent of direct versus
-gateway delivery, a runtime rollback does not require a schema rollback.
-
+Rollback means reverting the code while still in pre-production. It does not justify permanent
+schema or runtime compatibility branches.

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/plan.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/plan.md
@@ -1,0 +1,127 @@
+# Implementation plan
+
+## Dependency order
+
+```text
+Live trace ───────────────────────────────┐
+                                         v
+Author contract -> capability gate -> no-secret Claude acceptance -> discovery and policy
+       |                                      |                              |
+       v                                      v                              v
+pre-prod migration                      local + Daytona                 gateway seam -> Pi
+                                                                              |
+                                                                              v
+                                                                         credentials
+```
+
+## Slice 0: Reproduce the enabled Claude failure
+
+This is the first gate because the static code path already claims to work.
+
+1. Identify the exact live deployment, service container, revision, harness, and sandbox provider
+   used in the reported run.
+2. Confirm the effective service flag inside that process, not only deployment configuration.
+3. Save a no-secret HTTPS MCP server with a distinctive name.
+4. Capture the invoked revision's `agent.mcps`.
+5. Capture the service-resolved `/run.mcpServers` without logging headers.
+6. Capture runner `sessionInit.mcpServers` and confirm the external entry is distinct from
+   `agenta-tools`.
+7. Query or instrument Claude's MCP status after initialization.
+8. Classify the first missing boundary and write a regression test before fixing it.
+
+Exit: one root cause with reproducible evidence, or a proven successful connection with the UI
+diagnostic gap isolated.
+
+## Slice 1: Clean the public contract
+
+This slice fixes the interface without expanding runtime capability.
+
+1. Add version 2 author models for remote HTTP connection, credentials, and policy.
+2. Add a single v1-to-v2 normalization boundary.
+3. Remove stdio, command, arguments, and environment from the version 2 public model.
+4. Keep the private internal `McpServerStdio` runner type unchanged.
+5. Split author and resolved types. Mark secret-bearing resolved fields non-repr and non-loggable.
+6. Make tool policy explicit as `all` or `include`.
+7. Reserve `agenta-tools` in author validation.
+8. Update built-in authoring descriptions and generated schema fixtures.
+
+Exit: new saves emit only version 2; all schema and normalization tests pass; unsupported stdio is
+not representable in version 2.
+
+## Slice 2: Clean and gate the UI
+
+This slice also avoids claiming new functionality.
+
+1. Publish the effective `mcp.user_servers` capability through inspect/catalog metadata.
+2. Fail closed when the capability is absent, false, or still loading.
+3. Never count or render the internal `agenta-tools` server.
+4. Replace the transport form with server name, remote MCP URL, credentials type, tool policy,
+   and permission.
+5. For the initial deployment capability, allow only credentials `None`.
+6. Remove Environment, command, arguments, and manual tool-name tags.
+7. If a legacy entry exists during the migration window, show a read-only unsupported notice or
+   migrate it. Do not silently reinterpret stdio.
+8. Add UI unit tests for capability gating, version 2 editing, and hidden legacy controls.
+
+Exit: the UI accurately represents current deployment support and cannot create a config that the
+runner rejects merely because it is stdio.
+
+## Slice 3: Make no-secret Claude remote MCP observable and reliable
+
+1. Fix the boundary found in Slice 0.
+2. Add structured, redacted correlation from saved server name through service, runner, and ACP.
+3. Surface Claude MCP connection state after session initialization.
+4. Return a specific run error if a required MCP server fails to connect, or explicitly model
+   optional servers later. Do not silently continue as if the server worked.
+5. Add local and Daytona acceptance tests against a deterministic no-auth MCP fixture.
+
+Exit: Claude local and Claude Daytona both reach the fixture, list at least one tool, call it, and
+show a concrete error for an invalid endpoint.
+
+## Slice 4: Connect, discover, and enforce tool policy
+
+1. Add a service-owned test-connection endpoint using the same MCP client behavior as execution.
+2. Return safe status, server identity, negotiated protocol version, and discovered tool schemas.
+3. Populate the tool selector from discovery, not user-entered tags.
+4. Enforce `all` or `include` in the execution adapter for `tools/list` and `tools/call`.
+5. Handle tool-list changes by showing missing selections and requiring an explicit save decision.
+
+Exit: the UI can prove connectivity before a chat run, and excluded tools cannot be called.
+
+## Slice 5: Gateway seam and Pi projection
+
+1. Define an internal gateway registration from the unchanged version 2 author config.
+2. Let the gateway own upstream initialization, discovery, filtering, calls, and errors.
+3. Project gateway MCP tools onto the existing common Agenta tool plane.
+4. Feed that plane to Claude and Pi using their existing harness-specific delivery mechanisms.
+5. Run the full harness and backend matrix.
+
+Exit: moving a server from direct Claude delivery to gateway delivery does not change its saved
+config, and Pi can execute the same allowed tools.
+
+## Slice 6: Credentials
+
+1. Enable static header secret references only after the no-secret path is accepted.
+2. Keep values in the gateway for the long-run path.
+3. For an explicitly interim direct Daytona path, evaluate the opaque placeholder work against the
+   version 2 credential model and host restriction requirements.
+4. Do not claim equivalent safety for local direct Claude while plaintext enters the process.
+5. Add `oauth_connection` only with a platform connection resource that owns token refresh,
+   scopes, revocation, and callback state.
+
+Exit: no saved config or inspect response contains a raw credential, and the supported runtime
+boundary is documented per backend.
+
+## Reviewable PR sequence
+
+1. `docs(mcp): lock public config and capability contracts`
+2. `refactor(sdk): add MCP v2 author model and pre-production migration`
+3. `fix(frontend): gate and simplify the MCP editor`
+4. `fix(agent): trace and repair Claude remote MCP delivery`
+5. `feat(mcp): add connection discovery and tool policy enforcement`
+6. `feat(mcp): route external MCP through the gateway`
+7. `feat(mcp): add connection-backed credentials`
+
+Each PR should preserve the full build while keeping future-only gateway behavior behind the
+capability contract.
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/plan.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/plan.md
@@ -1,127 +1,80 @@
 # Implementation plan
 
-## Dependency order
+## Scope now
 
-```text
-Live trace ───────────────────────────────┐
-                                         v
-Author contract -> capability gate -> no-secret Claude acceptance -> discovery and policy
-       |                                      |                              |
-       v                                      v                              v
-pre-prod migration                      local + Daytona                 gateway seam -> Pi
-                                                                              |
-                                                                              v
-                                                                         credentials
-```
+Slices 0 through 2 are one breaking pre-production cleanup. There is no feature flag, legacy
+decoder, dual write, or saved-config migration.
 
-## Slice 0: Reproduce the enabled Claude failure
+## Slice 0: Pin the real delivery path
 
-This is the first gate because the static code path already claims to work.
+1. Keep external user MCP separate from the private `agenta-tools` channel.
+2. Prove the service resolves saved `agent.mcps` into `/run.mcpServers`.
+3. Prove the runner converts the resolved HTTP server into Claude ACP `sessionInit.mcpServers`.
+4. Preserve URL validation, SSRF protection, redaction, and reserved-name checks.
+5. Cover local and Daytona session layering with unit tests.
 
-1. Identify the exact live deployment, service container, revision, harness, and sandbox provider
-   used in the reported run.
-2. Confirm the effective service flag inside that process, not only deployment configuration.
-3. Save a no-secret HTTPS MCP server with a distinctive name.
-4. Capture the invoked revision's `agent.mcps`.
-5. Capture the service-resolved `/run.mcpServers` without logging headers.
-6. Capture runner `sessionInit.mcpServers` and confirm the external entry is distinct from
-   `agenta-tools`.
-7. Query or instrument Claude's MCP status after initialization.
-8. Classify the first missing boundary and write a regression test before fixing it.
+Exit: the static delivery path is pinned by tests. A live endpoint failure can be located without
+confusing it with config gating or internal tools.
 
-Exit: one root cause with reproducible evidence, or a proven successful connection with the UI
-diagnostic gap isolated.
+## Slice 1: Replace the public contract
 
-## Slice 1: Clean the public contract
+1. Replace the flat transport object with `name`, `connection`, and `policy`.
+2. Support only external HTTP connections. Remove public stdio, command, arguments, environment,
+   and ambiguous flat tool lists.
+3. Keep `credentials` as a discriminated object under `connection`.
+4. Split saved author intent from the secret-bearing resolved run object.
+5. Reserve `agenta-tools` in author validation.
+6. Reject every old object as invalid. Development drafts must be recreated.
 
-This slice fixes the interface without expanding runtime capability.
+Exit: the old public shape is not representable or accepted.
 
-1. Add version 2 author models for remote HTTP connection, credentials, and policy.
-2. Add a single v1-to-v2 normalization boundary.
-3. Remove stdio, command, arguments, and environment from the version 2 public model.
-4. Keep the private internal `McpServerStdio` runner type unchanged.
-5. Split author and resolved types. Mark secret-bearing resolved fields non-repr and non-loggable.
-6. Make tool policy explicit as `all` or `include`.
-7. Reserve `agenta-tools` in author validation.
-8. Update built-in authoring descriptions and generated schema fixtures.
+## Slice 2: Make the UI truthful
 
-Exit: new saves emit only version 2; all schema and normalization tests pass; unsupported stdio is
-not representable in version 2.
+1. Publish `mcp.user_servers` in the runtime harness catalog only for harnesses that work.
+2. Show the MCP editor only when the selected harness publishes that capability.
+3. Do not add a browser environment variable or deployment feature flag.
+4. Show server name, HTTP URL, public headers, and the credential strategy.
+5. Remove transport, command, arguments, environment, and manual exposed-tool controls.
+6. Never show or count the internal `agenta-tools` channel.
+7. Test fail-closed capability behavior and request serialization.
 
-## Slice 2: Clean and gate the UI
+Cloud uses the same service capability document as local development. `agenta_cloud` does not
+need a separate MCP environment variable.
 
-This slice also avoids claiming new functionality.
+Exit: Claude shows the editor; Pi and missing capability metadata do not. The UI cannot author a
+public stdio process or the old flat object.
 
-1. Publish the effective `mcp.user_servers` capability through inspect/catalog metadata.
-2. Fail closed when the capability is absent, false, or still loading.
-3. Never count or render the internal `agenta-tools` server.
-4. Replace the transport form with server name, remote MCP URL, credentials type, tool policy,
-   and permission.
-5. For the initial deployment capability, allow only credentials `None`.
-6. Remove Environment, command, arguments, and manual tool-name tags.
-7. If a legacy entry exists during the migration window, show a read-only unsupported notice or
-   migrate it. Do not silently reinterpret stdio.
-8. Add UI unit tests for capability gating, version 2 editing, and hidden legacy controls.
+## Slice 2.1: Claude acceptance
 
-Exit: the UI accurately represents current deployment support and cannot create a config that the
-runner rejects merely because it is stdio.
+Claude already accepts external HTTP MCP entries through ACP session initialization. This slice
+does not change ACP. After slices 0 through 2 land:
 
-## Slice 3: Make no-secret Claude remote MCP observable and reliable
+1. Run a no-secret HTTPS MCP fixture on Claude local.
+2. Run the same fixture on Claude Daytona.
+3. Verify the server is delivered, lists a tool, and the tool can be called.
+4. Record the first failed boundary if the reported live deployment still fails.
 
-1. Fix the boundary found in Slice 0.
-2. Add structured, redacted correlation from saved server name through service, runner, and ACP.
-3. Surface Claude MCP connection state after session initialization.
-4. Return a specific run error if a required MCP server fails to connect, or explicitly model
-   optional servers later. Do not silently continue as if the server worked.
-5. Add local and Daytona acceptance tests against a deterministic no-auth MCP fixture.
+Exit: the no-secret Claude path works in both environments or has one evidenced runtime defect.
 
-Exit: Claude local and Claude Daytona both reach the fixture, list at least one tool, call it, and
-show a concrete error for an invalid endpoint.
+## Slice 2.2: Pi support
 
-## Slice 4: Connect, discover, and enforce tool policy
+Pi is the next implementation slice, not a distant gateway phase. Pi is not currently an MCP
+client in this runtime, so a separate plan must choose the smallest bridge from external MCP tools
+onto Pi's existing tool plane. That decision must compare a runner MCP client with the future MCP
+gateway and avoid changing the saved author object.
 
-1. Add a service-owned test-connection endpoint using the same MCP client behavior as execution.
-2. Return safe status, server identity, negotiated protocol version, and discovered tool schemas.
-3. Populate the tool selector from discovery, not user-entered tags.
-4. Enforce `all` or `include` in the execution adapter for `tools/list` and `tools/call`.
-5. Handle tool-list changes by showing missing selections and requiring an explicit save decision.
+Exit: a dedicated design PR specifies and tests Pi local and Daytona delivery.
 
-Exit: the UI can prove connectivity before a chat run, and excluded tools cannot be called.
+## Slice 3: Product features
 
-## Slice 5: Gateway seam and Pi projection
+Create a separate plan-feature draft PR for connection testing, discovery, status, tool selection,
+policy enforcement, credentials, OAuth, and the long-run gateway boundary. Do not mix those
+features into the contract/UI cleanup.
 
-1. Define an internal gateway registration from the unchanged version 2 author config.
-2. Let the gateway own upstream initialization, discovery, filtering, calls, and errors.
-3. Project gateway MCP tools onto the existing common Agenta tool plane.
-4. Feed that plane to Claude and Pi using their existing harness-specific delivery mechanisms.
-5. Run the full harness and backend matrix.
+## PR sequence
 
-Exit: moving a server from direct Claude delivery to gateway delivery does not change its saved
-config, and Pi can execute the same allowed tools.
-
-## Slice 6: Credentials
-
-1. Enable static header secret references only after the no-secret path is accepted.
-2. Keep values in the gateway for the long-run path.
-3. For an explicitly interim direct Daytona path, evaluate the opaque placeholder work against the
-   version 2 credential model and host restriction requirements.
-4. Do not claim equivalent safety for local direct Claude while plaintext enters the process.
-5. Add `oauth_connection` only with a platform connection resource that owns token refresh,
-   scopes, revocation, and callback state.
-
-Exit: no saved config or inspect response contains a raw credential, and the supported runtime
-boundary is documented per backend.
-
-## Reviewable PR sequence
-
-1. `docs(mcp): lock public config and capability contracts`
-2. `refactor(sdk): add MCP v2 author model and pre-production migration`
-3. `fix(frontend): gate and simplify the MCP editor`
-4. `fix(agent): trace and repair Claude remote MCP delivery`
-5. `feat(mcp): add connection discovery and tool policy enforcement`
-6. `feat(mcp): route external MCP through the gateway`
-7. `feat(mcp): add connection-backed credentials`
-
-Each PR should preserve the full build while keeping future-only gateway behavior behind the
-capability contract.
-
+1. Update the accepted design with the breaking-reset and capability-source decisions.
+2. Implement slices 0 through 2 in one reviewable PR.
+3. Verify Claude in slice 2.1.
+4. Open the slice 2.2 Pi design PR.
+5. Open the separate slice 3 feature-plan draft PR.

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/qa.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/qa.md
@@ -1,0 +1,75 @@
+# QA plan
+
+## Capability and UI
+
+- Disabled deployment: MCP section absent.
+- Enabled deployment plus unsupported harness: MCP section absent.
+- Enabled Claude capability: MCP section visible.
+- Missing or old capability metadata: section absent.
+- Internal `agenta-tools`: never rendered, counted, saved, or editable.
+- New server form: no transport, command, arguments, or environment controls.
+- Credentials defaults to `None` in the initial slice.
+- Tool policy defaults explicitly to all tools.
+
+## Contract
+
+- Version 2 remote HTTP config round-trips without defaults changing meaning.
+- Unknown fields fail validation.
+- `agenta-tools` name fails validation.
+- Non-HTTPS and private or metadata URLs fail before credentials are attached.
+- `include` requires at least one discovered tool name.
+- `all` rejects a `names` field.
+- Version 1 HTTP maps deterministically to version 2.
+- Version 1 stdio fails with a specific unsupported error.
+- Resolved secret-bearing objects never appear in repr, logs, inspect, or persistence snapshots.
+
+## Live no-secret matrix
+
+| Harness | Local | Daytona |
+| --- | --- | --- |
+| Claude | connect, list, call, bad-URL error | connect, list, call, bad-URL error |
+| Pi before gateway | clear unsupported response | clear unsupported response |
+| Pi after gateway | connect, list, call, filtered-tool denial | connect, list, call, filtered-tool denial |
+
+Use a deterministic HTTPS fixture with one read-only tool and one tool that returns its input. The
+fixture must record initialization, `tools/list`, and `tools/call` without recording authorization
+headers.
+
+## Enabled-live failure evidence
+
+For the user's exact deployment, retain a redacted evidence bundle containing:
+
+- deployment identity and effective capability;
+- saved agent revision and external MCP name;
+- service run correlation identifier;
+- whether `/run.mcpServers` contained the external server;
+- whether ACP session initialization contained it;
+- Claude MCP status and safe error text;
+- whether `tools/list` reached the fixture.
+
+This becomes a replayable regression test at the first failed seam.
+
+## Tool policy
+
+- Discovery shows actual server tool names and schemas.
+- `all` exposes every discovered tool.
+- `include` exposes and calls only selected tools.
+- A direct call to an excluded tool fails at the execution boundary.
+- Removed or renamed upstream tools are visible as stale selections.
+- Empty arrays and empty strings never widen access.
+
+## Credentials, later slice
+
+- Secret refs are stored, values are not.
+- Missing refs fail closed with the server and ref name, never the value.
+- Redaction covers service, runner, ACP, and sandbox logs.
+- Daytona placeholders are restricted to the exact upstream HTTPS host.
+- Local direct-Claude credentials are not marked production-safe while plaintext is delivered.
+- Gateway runs keep upstream values outside every harness sandbox.
+
+## Release gate
+
+Do not enable this in production until the Claude local and Daytona no-secret cells pass, status is
+visible in the UI, excluded tools are enforced, and the failure path is covered by an integration
+or replay test.
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/qa.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/qa.md
@@ -2,9 +2,8 @@
 
 ## Capability and UI
 
-- Disabled deployment: MCP section absent.
-- Enabled deployment plus unsupported harness: MCP section absent.
-- Enabled Claude capability: MCP section visible.
+- Pi or another unsupported harness: MCP section absent.
+- Claude capability: MCP section visible.
 - Missing or old capability metadata: section absent.
 - Internal `agenta-tools`: never rendered, counted, saved, or editable.
 - New server form: no transport, command, arguments, or environment controls.
@@ -13,14 +12,13 @@
 
 ## Contract
 
-- Version 2 remote HTTP config round-trips without defaults changing meaning.
+- External HTTP config round-trips without defaults changing meaning.
 - Unknown fields fail validation.
 - `agenta-tools` name fails validation.
 - Non-HTTPS and private or metadata URLs fail before credentials are attached.
 - `include` requires at least one discovered tool name.
 - `all` rejects a `names` field.
-- Version 1 HTTP maps deterministically to version 2.
-- Version 1 stdio fails with a specific unsupported error.
+- Every old flat HTTP or stdio object fails validation.
 - Resolved secret-bearing objects never appear in repr, logs, inspect, or persistence snapshots.
 
 ## Live no-secret matrix
@@ -28,8 +26,8 @@
 | Harness | Local | Daytona |
 | --- | --- | --- |
 | Claude | connect, list, call, bad-URL error | connect, list, call, bad-URL error |
-| Pi before gateway | clear unsupported response | clear unsupported response |
-| Pi after gateway | connect, list, call, filtered-tool denial | connect, list, call, filtered-tool denial |
+| Pi before slice 2.2 | clear unsupported response | clear unsupported response |
+| Pi after slice 2.2 | connect, list, call | connect, list, call |
 
 Use a deterministic HTTPS fixture with one read-only tool and one tool that returns its input. The
 fixture must record initialization, `tools/list`, and `tools/call` without recording authorization
@@ -69,7 +67,6 @@ This becomes a replayable regression test at the first failed seam.
 
 ## Release gate
 
-Do not enable this in production until the Claude local and Daytona no-secret cells pass, status is
-visible in the UI, excluded tools are enforced, and the failure path is covered by an integration
-or replay test.
-
+Do not release this to production until the Claude local and Daytona no-secret cells pass and the
+failure path is covered by an integration or replay test. Status and tool selection are separate
+slice 3 features.

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/research.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/research.md
@@ -2,18 +2,15 @@
 
 ## Current wiring
 
-The author config is `MCPServerConfig` in
-`sdks/python/agenta/sdk/agents/mcp/models.py`. It currently contains `transport`, `command`,
-`args`, `env`, `url`, `secrets`, `tools`, and `permission` in one flat object. The UI mirrors that
-shape and seeds new entries as stdio.
+Before this implementation, `MCPServerConfig` mixed `transport`, `command`, `args`, `env`, `url`,
+`secrets`, `tools`, and `permission` in one flat object. The UI mirrored it and seeded stdio.
 
-The service resolver is guarded by `AGENTA_AGENT_MCPS_ENABLED`. It resolves vault names before
-creating the `/run` request. The runner then:
+The service resolves project secret names before creating the `/run` request. There is no MCP
+feature flag. The runner then:
 
 - rejects any user MCP on Pi;
-- rejects user stdio for every harness;
 - accepts remote HTTP only for non-Pi harnesses after URL and SSRF validation;
-- converts the resolved `env` map into HTTP headers;
+- converts resolved credential references into HTTP headers;
 - passes the HTTP entry into Claude ACP session initialization.
 
 The installed Claude adapter maps server name, URL, and headers. It does not enforce the public
@@ -38,19 +35,11 @@ product capability.
 
 The frontend already consumes per-harness capabilities from the workflow harness catalog. That
 catalog currently describes providers, deployments, connection modes, model naming, and models.
-It does not describe user MCP support, and the service deployment flag is not published to the
-editor.
+The implementation adds optional `mcp.user_servers` to that same catalog.
 
-The UI must not read a build-time browser environment variable for this. The capability is a
-runtime conjunction:
-
-```text
-deployment enables user MCP
-AND selected harness supports the authoring and execution path
-```
-
-Publish that effective capability in inspect/catalog metadata, with a default of unsupported for
-older backends. The control should fail closed while metadata is missing.
+The UI must not read a build-time browser environment variable for this. It reads the selected
+harness's runtime catalog entry and fails closed while metadata is missing. Claude publishes the
+capability; Pi omits it until slice 2.2.
 
 ## Internal MCP visibility
 
@@ -60,17 +49,15 @@ Internal transport failures belong in run diagnostics, not in the external MCP e
 
 ## The reported enabled-Claude failure
 
-Prior inspection found other active development services with the flag disabled. The user has
-now identified a live deployment where MCP was enabled and still did not reach Claude. These are
-not contradictory until the exact deployment and run are matched.
+The user identified a live deployment where MCP was expected to reach Claude but did not. The
+exact deployment and run still need to be matched.
 
 The failure can occur at five distinct seams:
 
 1. the editor did not save `agent.mcps` into the invoked revision;
-2. the selected deployment process did not receive the enablement flag;
-3. the service did not emit `mcpServers` in `/run`;
-4. the runner did not place the server in `sessionInit.mcpServers`;
-5. Claude attempted asynchronous connection and failed, while status was discarded.
+2. the service did not emit `mcpServers` in `/run`;
+3. the runner did not place the server in `sessionInit.mcpServers`;
+4. Claude attempted asynchronous connection and failed, while status was discarded.
 
 The first live work item is evidence capture across these seams. The model saying it has no tools
 is not diagnostic evidence.
@@ -97,4 +84,3 @@ upstream credentials and projects filtered tools onto the common Agenta tool pla
 | Pi user MCP | 0/5 | 1/5, clean gateway seam only |
 | Credential safety | 1/5 | 2/5, safe author contract and explicit runtime debt |
 | Gateway readiness | 1/5 | 3/5, stable adapter boundary |
-

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/research.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/research.md
@@ -1,0 +1,100 @@
+# Research
+
+## Current wiring
+
+The author config is `MCPServerConfig` in
+`sdks/python/agenta/sdk/agents/mcp/models.py`. It currently contains `transport`, `command`,
+`args`, `env`, `url`, `secrets`, `tools`, and `permission` in one flat object. The UI mirrors that
+shape and seeds new entries as stdio.
+
+The service resolver is guarded by `AGENTA_AGENT_MCPS_ENABLED`. It resolves vault names before
+creating the `/run` request. The runner then:
+
+- rejects any user MCP on Pi;
+- rejects user stdio for every harness;
+- accepts remote HTTP only for non-Pi harnesses after URL and SSRF validation;
+- converts the resolved `env` map into HTTP headers;
+- passes the HTTP entry into Claude ACP session initialization.
+
+The installed Claude adapter maps server name, URL, and headers. It does not enforce the public
+`tools` list. The SDK has MCP status and reconnect surfaces, but Agenta does not publish them.
+
+## Stdio conclusion
+
+There is no supported public stdio cell.
+
+| Use | Status | Contract |
+| --- | --- | --- |
+| User stdio on Claude local | Rejected before session start | Public legacy shape |
+| User stdio on Claude Daytona | Rejected before session start | Public legacy shape |
+| User stdio on Pi local or Daytona | Rejected because all user MCP is rejected | Public legacy shape |
+| Internal Claude Daytona shim | Active trusted delivery mechanism | Private runner `McpServerStdio` |
+
+The private shim does not consume `MCPServerConfig`. Public stdio can therefore be removed without
+removing the internal shim. The shared word "stdio" describes a protocol transport, not a shared
+product capability.
+
+## UI capability source
+
+The frontend already consumes per-harness capabilities from the workflow harness catalog. That
+catalog currently describes providers, deployments, connection modes, model naming, and models.
+It does not describe user MCP support, and the service deployment flag is not published to the
+editor.
+
+The UI must not read a build-time browser environment variable for this. The capability is a
+runtime conjunction:
+
+```text
+deployment enables user MCP
+AND selected harness supports the authoring and execution path
+```
+
+Publish that effective capability in inspect/catalog metadata, with a default of unsupported for
+older backends. The control should fail closed while metadata is missing.
+
+## Internal MCP visibility
+
+`agenta-tools` is synthesized by the runner and is absent from the saved template. It must remain
+absent from authoring, saved diffs, counts, status rows, and discovered external-server tools.
+Internal transport failures belong in run diagnostics, not in the external MCP editor.
+
+## The reported enabled-Claude failure
+
+Prior inspection found other active development services with the flag disabled. The user has
+now identified a live deployment where MCP was enabled and still did not reach Claude. These are
+not contradictory until the exact deployment and run are matched.
+
+The failure can occur at five distinct seams:
+
+1. the editor did not save `agent.mcps` into the invoked revision;
+2. the selected deployment process did not receive the enablement flag;
+3. the service did not emit `mcpServers` in `/run`;
+4. the runner did not place the server in `sessionInit.mcpServers`;
+5. Claude attempted asynchronous connection and failed, while status was discarded.
+
+The first live work item is evidence capture across these seams. The model saying it has no tools
+is not diagnostic evidence.
+
+## Secret boundary
+
+Today the saved template contains secret names, but resolution converts them to plaintext before
+the `/run` boundary. For HTTP, the runner treats the values as headers. Plaintext therefore exists
+in service memory, the wire request, runner memory, ACP configuration, and the Claude process.
+
+Daytona opaque egress placeholders can improve the interim direct-Claude path, but they do not
+provide one architecture for local and Daytona. The long-run boundary is the MCP gateway: it owns
+upstream credentials and projects filtered tools onto the common Agenta tool plane.
+
+## Stage score
+
+| Layer | Current | Exit target for this project |
+| --- | ---: | ---: |
+| Public author config | 2/5 | 4/5 |
+| Editor | 1/5 | 4/5 |
+| Claude remote HTTP, no secrets | 2/5 | 4/5 |
+| Claude diagnostics | 0/5 | 4/5 |
+| Tool policy enforcement | 0/5 | 4/5 |
+| Pi user MCP | 0/5 | 1/5, clean gateway seam only |
+| Credential safety | 1/5 | 2/5, safe author contract and explicit runtime debt |
+| Gateway readiness | 1/5 | 3/5, stable adapter boundary |
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/status.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/status.md
@@ -1,0 +1,38 @@
+# Status
+
+Last updated: 2026-07-13
+
+## Current stage
+
+Planning complete. No runtime or UI implementation has started in this project.
+
+## Locked decisions
+
+- Public MCP is remote HTTPS only.
+- User-authored stdio is removed.
+- Internal trusted stdio remains private to the runner.
+- Internal `agenta-tools` is never shown in the external MCP editor.
+- The editor is gated by an effective deployment and harness capability.
+- Version 2 uses `connection`, `credentials`, and `policy` roles.
+- The initial acceptance path has no credentials.
+- Credential references stay in the contract for later slices.
+- The gateway is the long-run execution and secret boundary.
+- Pi support follows gateway projection, not a second direct MCP client path.
+
+## Open implementation questions
+
+1. Which exact live deployment and run exhibited enabled MCP without Claude delivery?
+2. Should pre-production MCP drafts be reset, or does any external caller require one-release v1
+   decoding?
+3. Where should ephemeral discovery results live: short-lived server cache or always-fresh test
+   responses? They must not become part of the saved author contract.
+4. Should an MCP connection failure abort every run in the first slice? The recommendation is yes,
+   because optional silent degradation recreates the current failure mode.
+5. Which public connection resource will own OAuth references? This does not block no-secret work.
+
+## Next action
+
+Run Slice 0 against the user's exact capability-enabled deployment, then begin the contract-only
+Slice 1 while the live root cause is being fixed. The two tasks can proceed independently after
+the interface in `interface.md` is accepted.
+

--- a/docs/design/agent-workflows/projects/mcp-configuration-redesign/status.md
+++ b/docs/design/agent-workflows/projects/mcp-configuration-redesign/status.md
@@ -4,7 +4,7 @@ Last updated: 2026-07-13
 
 ## Current stage
 
-Planning complete. No runtime or UI implementation has started in this project.
+Slices 0 through 2 are implemented in the working tree and under validation.
 
 ## Locked decisions
 
@@ -12,27 +12,24 @@ Planning complete. No runtime or UI implementation has started in this project.
 - User-authored stdio is removed.
 - Internal trusted stdio remains private to the runner.
 - Internal `agenta-tools` is never shown in the external MCP editor.
-- The editor is gated by an effective deployment and harness capability.
-- Version 2 uses `connection`, `credentials`, and `policy` roles.
+- The editor is gated by the selected harness's runtime catalog capability.
+- The breaking contract uses `connection`, `credentials`, and `policy` roles.
 - The initial acceptance path has no credentials.
 - Credential references stay in the contract for later slices.
-- The gateway is the long-run execution and secret boundary.
-- Pi support follows gateway projection, not a second direct MCP client path.
+- There is no compatibility decoder, feature flag, or frontend MCP environment variable.
+- Claude continues using ACP HTTP MCP delivery.
+- Pi is the immediate slice 2.2 follow-up; its bridge versus gateway decision is not made here.
 
 ## Open implementation questions
 
 1. Which exact live deployment and run exhibited enabled MCP without Claude delivery?
-2. Should pre-production MCP drafts be reset, or does any external caller require one-release v1
-   decoding?
-3. Where should ephemeral discovery results live: short-lived server cache or always-fresh test
+2. Where should ephemeral discovery results live: short-lived server cache or always-fresh test
    responses? They must not become part of the saved author contract.
-4. Should an MCP connection failure abort every run in the first slice? The recommendation is yes,
+3. Should an MCP connection failure abort every run in the first slice? The recommendation is yes,
    because optional silent degradation recreates the current failure mode.
-5. Which public connection resource will own OAuth references? This does not block no-secret work.
+4. Which public connection resource will own OAuth references? This does not block no-secret work.
 
 ## Next action
 
-Run Slice 0 against the user's exact capability-enabled deployment, then begin the contract-only
-Slice 1 while the live root cause is being fixed. The two tasks can proceed independently after
-the interface in `interface.md` is accepted.
-
+Finish automated checks, publish the slices 0-2 implementation PR, then run Claude acceptance and
+open the separate Pi 2.2 and product-feature slice 3 planning PRs.

--- a/docs/design/agent-workflows/projects/mcp-delivery-architecture/status-quo-report.md
+++ b/docs/design/agent-workflows/projects/mcp-delivery-architecture/status-quo-report.md
@@ -251,7 +251,7 @@ Adopt role-based nesting before broad availability:
 {
   "name": "memory",
   "connection": {
-    "type": "remote_http",
+    "type": "http",
     "url": "https://memory.example.com/mcp",
     "headers": {},
     "credentials": {"type": "none"}
@@ -268,7 +268,7 @@ A future static secret header does not move fields:
 ```json
 {
   "connection": {
-    "type": "remote_http",
+    "type": "http",
     "url": "https://memory.example.com/mcp",
     "headers": {},
     "credentials": {
@@ -284,7 +284,7 @@ Future OAuth changes only the credential discriminator:
 ```json
 {
   "connection": {
-    "type": "remote_http",
+    "type": "http",
     "url": "https://memory.example.com/mcp",
     "credentials": {
       "type": "oauth_connection",
@@ -307,58 +307,38 @@ Contract rules:
 - Empty arrays carry no overloaded meaning. Use `mode: "all"` or `mode: "include"`.
 - Keep the author model separate from the internal resolved credential and placeholder contract.
 
-## Backwards-compatible migration
+## Pre-production reset
 
-Do not mutate old saved templates during invocation. Add one normalization boundary:
-
-1. Continue accepting the legacy flat shape as version 1.
-2. Convert it into the canonical nested model before resolution.
-3. Emit only the nested model for newly saved MCP entries.
-4. Preserve old entries byte-for-byte until the user edits or explicitly migrates them.
-5. Reject legacy stdio clearly. Do not reinterpret it.
-6. Treat legacy HTTP `env` as headers only in compatibility decoding.
-7. Map legacy `tools: []` to `policy.tools.mode = "all"`; non-empty lists become `include`.
-8. Keep resolved values and Daytona placeholders out of the author model.
-
-This lets execution move from direct Claude MCP to the platform gateway without changing saved
-agent templates.
+Reject the old flat object. Do not add a decoder, migration-on-read, dual write, or feature flag.
+Development users recreate old MCP entries in the new editor. Keep resolved values and Daytona
+placeholders out of the author model.
 
 ## Recommended UI and delivery order
 
-### Slice 1: no-secret HTTP MCP
+### Slices 0-2: contract, delivery pin, and truthful UI
 
-Show server name, remote MCP URL, authentication set to `None`, a Connect button, connection
-status and error, discovered tools, all-or-selected tool access, and allow/ask/deny permission.
-Hide stdio, environment, raw secret mapping, and manual tool-name tags.
+Replace the public contract, pin Claude HTTP delivery with tests, and gate the editor from the
+selected harness's runtime catalog. Show server name, URL, public headers, and credential
+strategy. Hide stdio, environment, command, arguments, and manual tool names.
 
-The Connect action should perform the same initialization and `tools/list` call as production.
-Show negotiated server identity, protocol version, capabilities, and tool count. Saving an
-untested server may remain possible, but the row must say "Not tested".
+### Slice 2.2: Pi parity
 
-### Slice 2: gateway and Pi parity
+Plan the smallest bridge from external MCP tools onto Pi's existing tool plane. Compare a runner
+MCP client with the future gateway; do not assume the gateway decision in this cleanup.
 
-Move discovery and calls behind the platform gateway. Convert discovered MCP tools into the same
-public specs Pi already receives. Apply selection and permission at the gateway executor. The
-same server then works on Claude and Pi, local and Daytona.
+### Slice 3: product features
 
-### Slice 3: authentication
-
-Add platform connection selection and OAuth. Keep static secret-header references as a bounded
-advanced option only if demand exists. Do not add raw tokens to agent templates.
+Plan connection testing, discovery, status, tool selection and enforcement, static credentials,
+OAuth, and the long-run gateway boundary in a separate draft PR.
 
 ### Work sequence
 
-1. Make deployment capability visible to the frontend. Do not render an editable MCP section
-   when the service has MCP disabled.
+1. Publish `mcp.user_servers` for Claude in the runtime harness catalog.
 2. Remove stdio from the UI and stop seeding entries with `transport: "stdio"`.
-3. Add the nested author model and legacy normalization tests. Keep the runner wire unchanged.
-4. Add service-side connect and discovery for unauthenticated HTTPS MCP.
-5. Surface connection state and discovered tools. Enforce selected tools.
-6. Enable MCP in development and run live Claude local and Claude Daytona acceptance tests.
-7. Build gateway execution and Pi projection. Run the full four-cell matrix.
-8. Add connection-backed OAuth and settle the PR #5242 recut for remaining direct-sandbox use.
-
-Do not flip the production feature flag until steps 1 through 6 are complete.
+3. Add the nested author model and reject the old shape.
+4. Run live Claude local and Daytona acceptance tests.
+5. Plan and build Pi slice 2.2.
+6. Plan the slice 3 product features separately.
 
 ## Verification performed
 
@@ -374,7 +354,7 @@ Do not flip the production feature flag until steps 1 through 6 are complete.
 
 - Ship remote HTTP only in the public UI.
 - Start without secrets.
-- Treat stdio as unsupported legacy input, not a product option.
+- Remove public stdio rather than preserving it as a variant.
 - Remove or implement `tools`; do not keep dead configuration.
 - Add connect, discover, and visible status before enablement.
 - Normalize the public contract into connection, credentials, and policy roles.

--- a/docs/design/agent-workflows/projects/mcp-delivery-architecture/status-quo-report.md
+++ b/docs/design/agent-workflows/projects/mcp-delivery-architecture/status-quo-report.md
@@ -1,0 +1,382 @@
+# MCP status quo and interface recommendation
+
+Date: 2026-07-13
+
+This report covers user-configured MCP servers on Claude and Pi, on local and Daytona
+sandboxes. It also separates that feature from Agenta's internal tool MCP, reviews the public
+configuration and UI, assesses secret safety, and recommends a contract that can survive the
+planned MCP gateway.
+
+## Executive verdict
+
+The current product is not ready to present MCP as a generally working feature.
+
+- User-configured remote HTTP MCP is wired only for Claude. It is disabled by default in every
+  deployment, including both live EE development deployments inspected for this report.
+- Pi rejects every user-configured MCP server on both local and Daytona. Pi does not implement an
+  MCP client. Agenta has not yet bridged remote MCP tools onto Pi's native tool plane.
+- User-configured stdio is rejected for every harness and backend. The UI should not offer it.
+- The `tools` or "Exposed tools" value is dead configuration. It reaches the runner wire, but no
+  runtime reads it and the Claude ACP adapter does not pass it into Claude's SDK.
+- The UI never initializes a server, calls `tools/list`, displays discovered tools, or displays
+  connection state. Claude's SDK connects remote MCP asynchronously by default, while Agenta
+  discards the status surface. A failed server therefore looks like no change.
+- The current `env` field has two meanings. For stdio it means process environment. For HTTP it
+  is converted into request headers. The UI labels it "Environment" in both cases.
+- Static header secrets currently resolve from Agenta's vault, cross the `/run` wire as plaintext,
+  and enter the Claude process as header values. PR #5242 can replace those values with opaque
+  Daytona placeholders for HTTP egress, but the PR is a draft, has a dirty merge state, and is
+  being recut. It is not a production-ready dependency for MCP.
+- Agenta's internal `agenta-tools` MCP is separate. Pi uses its native extension and file relay.
+  Local Claude uses a runner-loopback HTTP MCP. Claude on Daytona is intended to use an
+  in-sandbox stdio shim and the file relay, but recent live logs show shim-delivery failures.
+
+The first product slice should be deliberately smaller: unauthenticated remote Streamable HTTP
+MCP, Claude only, with an explicit deployment capability, a connect-and-discover action, visible
+status, and no stdio, environment, secrets, or manual tool-name input in the form.
+
+## Direct answers to the reported behavior
+
+### HTTP MCP on Claude with a local sandbox shows nothing
+
+The live deployments have `AGENTA_AGENT_MCPS_ENABLED=false`. The service therefore refuses a
+declared MCP before it reaches the runner. Current source raises `MCPDisabledError` instead of
+silently stripping the server (`services/oss/src/agent/tools/resolver.py:23-46`). If the
+playground still completes a run, the saved MCP array did not reach the invocation, or the
+deployed path predates the fail-loud change.
+
+After enablement, the source path is real:
+
+1. The template reads `agent.mcps` into strict `MCPServerConfig` objects.
+2. The service resolves named vault secrets.
+3. The runner validates the URL and creates an ACP HTTP MCP entry.
+4. The installed Claude ACP adapter converts the entry into Claude SDK `mcpServers` config.
+5. Claude connects directly to the remote URL. ACP carries configuration. It does not proxy MCP
+   traffic.
+
+This path has unit and wire-contract coverage, but this audit found no live user-HTTP-MCP
+acceptance evidence. It is implemented but not product-verified.
+
+### What "Environment" and "Secrets" mean today
+
+`Environment` is authored as `KEY=value` lines. `Secrets` is authored as
+`HEADER_OR_ENV_NAME=vault_secret_name` lines.
+
+- For stdio, `env` would be non-secret environment variables for the child process.
+- For HTTP, every `env` entry becomes an HTTP request header.
+- `secrets` maps the left-hand name to a project-vault secret name. The resolver reads the value
+  and merges it into the same `env` map. For HTTP, that merged value becomes a header.
+
+For a no-secret public MCP server, both fields should be empty. Today that is the only usage this
+report recommends enabling.
+
+### What "Exposed tools" means
+
+An MCP tool is a function the server advertises through `tools/list`, with a name, description,
+and JSON Schema input. The intended field is an allowlist. Empty is intended to mean all tools.
+
+The implementation does not enforce that intent. `tools` is parsed, resolved, and serialized,
+but the runner conversion in `services/runner/src/engines/sandbox_agent/mcp.ts:218-244` ignores
+it. The installed Claude ACP adapter also maps only type, name, URL, and headers
+(`services/runner/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:
+2782-2804`).
+
+The UI should not ask users to type tool names before it has connected and called `tools/list`.
+After discovery, it can show a selectable list. The gateway must enforce the selection when it
+serves `tools/list` and `tools/call`; prompt filtering alone is not a security boundary.
+
+### Why Claude says it has no tools
+
+There are three independent explanations in the current system:
+
+1. The live deployment disables user MCP, so the server never reaches Claude.
+2. Claude's SDK connects remote MCP asynchronously by default. Agenta does not surface
+   `mcpServerStatus`, connection errors, or reconnect controls, so a bad URL looks inert.
+3. A separate recent Claude plus Daytona failure prevents Agenta's internal gateway tools from
+   being advertised because the in-sandbox shim could not be delivered.
+
+The UI needs a pre-run status of `not tested`, `connecting`, `connected`, or `error`, plus the
+server-reported tool count and error text. The chat model should not be the diagnostic surface.
+
+### Why stdio exists and whether to keep it
+
+Stdio is a standard MCP transport. The MCP client launches the server as a local subprocess and
+exchanges JSON-RPC over stdin and stdout. This fits desktop tools and coding agents on a user's
+machine.
+
+It is not a viable Agenta public feature today. In Agenta's hosted architecture, accepting `npx`
+or another command would launch arbitrary code on the runner host. The runner rejects it before
+execution (`services/runner/src/engines/sandbox_agent/run-plan.ts:347-353`).
+
+Recommendation:
+
+- Remove stdio from the UI now and stop defaulting the public schema to stdio.
+- Keep a legacy parser long enough to return a clear unsupported error for saved templates.
+- Do not promise hosted stdio. A future managed MCP workload should be a managed server
+  reference, not a command inside the agent template.
+- The internal Daytona shim may use stdio as an implementation detail. It is trusted Agenta code,
+  not a user MCP server and not part of the public contract.
+
+## Two MCP channels that must remain separate
+
+| Channel | Purpose | Who creates it | Where credentials execute |
+| --- | --- | --- | --- |
+| Internal `agenta-tools` | Deliver Agenta gateway, callback, and client tools to MCP-only harnesses | Runner | Runner or Agenta API |
+| User MCP server | Connect an agent to an external MCP endpoint | Template author | Today Claude sends headers directly; the future gateway should hold credentials |
+
+A fix for one channel does not fix the other.
+
+## Current capability matrix
+
+Score scale: 0 is absent or rejected; 1 is shape or design only; 2 is wired with component tests;
+3 is integrated with end-to-end coverage; 4 is live verified; 5 is production-ready with
+diagnostics, security controls, and supported operations.
+
+### User-configured servers, no secrets
+
+| Harness | Backend | Remote HTTP | Stdio | Score |
+| --- | --- | --- | --- | --- |
+| Claude | local | Code path exists, but deployment flag is off and status is hidden | Rejected | 2/5 |
+| Claude | Daytona | Intended direct sandbox-to-remote connection; flag off and no live acceptance evidence | Rejected | 2/5 |
+| Pi | local | Rejected before session start | Rejected | 0/5 |
+| Pi | Daytona | Rejected before session start | Rejected | 0/5 |
+
+### Agenta internal tools
+
+| Harness | Backend | Delivery | Score |
+| --- | --- | --- | --- |
+| Pi | local | Pi extension plus runner tool plane | 4/5 |
+| Pi | Daytona | Pi extension plus file relay | 4/5 |
+| Claude | local | Runner-loopback authenticated HTTP MCP | 3/5 |
+| Claude | Daytona | Trusted in-sandbox stdio shim plus file relay | 2/5 today; recent live failures |
+
+### Product layers
+
+| Layer | Score | Reason |
+| --- | --- | --- |
+| Public config model | 2/5 | Strict and round-tripped, but flat role mixing, unsupported default, and dead `tools` |
+| UI | 1/5 | Offers unsupported stdio, mislabels headers, takes manual tool names, and has no status or tests |
+| Claude remote HTTP adapter | 2/5 | Static wire and tests exist; default off, failures hidden, no live acceptance evidence |
+| Pi remote HTTP adapter | 0/5 | Explicitly rejected |
+| Secret handling on current branch | 1/5 | Vault references at rest, but values cross the run wire and enter Claude |
+| Daytona opaque secret work in PR #5242 | 2/5 | Functional prototype and tests, but draft is dirty and recut pending |
+| MCP gateway | 1/5 | Direction and adjacent `/tools/call` plane exist; user MCP proxy is not implemented |
+| Overall user MCP product | 1.5/5 | A hidden Claude-only path, not a supported product loop |
+
+## Protocol status outside Agenta
+
+As of 2026-07-13, the current released MCP specification is `2025-11-25`. It standardizes stdio
+and Streamable HTTP. Streamable HTTP replaced the older HTTP plus SSE transport. Current clients
+and servers negotiate a protocol version and capabilities during initialization.
+
+The `2026-07-28` revision is a release candidate and contains breaking changes. It moves the core
+toward stateless HTTP, removes the old session handshake for the new revision, introduces routing
+headers, and formalizes extensions and deprecation. Agenta should not encode a protocol revision
+or session behavior in the public agent template. The MCP client or gateway should negotiate
+versions internally.
+
+Primary references:
+
+- [Current specification](https://modelcontextprotocol.io/specification/2025-11-25/basic)
+- [Streamable HTTP and stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports)
+- [Authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [2026-07-28 release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [Server tools and `tools/list`](https://modelcontextprotocol.io/docs/learn/server-concepts)
+
+Product consequence: the UI should say "Remote MCP URL", not ask most users to select a
+transport. The gateway owns protocol negotiation and backwards compatibility. Legacy SSE support,
+if needed, belongs in gateway compatibility rather than a permanent template field.
+
+## Secret boundary
+
+### Current branch
+
+The saved template contains vault secret names, not values. At run time, the resolver fetches the
+values and merges them into `env` (`sdks/python/agenta/sdk/agents/mcp/resolver.py:28-66`). The
+runner turns the map into HTTP headers. Plaintext is present in service memory, the `/run`
+payload, runner memory, ACP session configuration, and the Claude process.
+
+The SSRF guard requires HTTPS and blocks loopback, private, link-local, and metadata targets. It
+does not make the secret opaque to code running in the same sandbox as Claude.
+
+### PR #5242
+
+PR #5242 separates public headers, process environment, and typed credential bindings. On
+Daytona, it creates host-restricted Daytona Secrets and replaces each HTTP MCP header value with
+an opaque placeholder before Claude receives the MCP entry. Daytona substitutes the value only
+on outbound HTTPS requests to the exact allowed host.
+
+That improves Daytona, but it is not the final architecture:
+
+- The sandbox can still exercise the capability against the allowed host. Hiding bytes does not
+  remove authority.
+- The mechanism covers HTTP header credentials, not arbitrary credential formats or stdio.
+- Local Claude still receives plaintext header values.
+- PR #5242 is an open draft with `mergeStateStatus=DIRTY`. Its description says the current
+  database-backed implementation should not merge unchanged and proposes a two-PR recut.
+
+### Long-run recommendation
+
+Keep credential values in the platform gateway for local and Daytona. The gateway connects to
+the upstream MCP server, runs `tools/list`, exposes filtered public tool specs to the harness,
+and executes `tools/call` with platform-held credentials. This gives Claude and Pi the same tool
+plane and removes upstream secrets from every sandbox.
+
+Daytona Secrets remain useful where direct sandbox egress still needs a credential, including an
+interim direct-Claude HTTP path. They are not a substitute for the gateway.
+
+OAuth belongs to a platform connection resource, not raw strings in the agent template. The
+template should reference that connection. Token acquisition, refresh, revocation, scopes, and
+callback state can then evolve without changing every agent revision.
+
+## Recommended public interface
+
+The current flat shape mixes connection configuration, process environment, credentials, and
+tool policy:
+
+```json
+{
+  "name": "memory",
+  "transport": "http",
+  "url": "https://memory.example.com/mcp",
+  "env": {},
+  "secrets": {},
+  "tools": []
+}
+```
+
+Adopt role-based nesting before broad availability:
+
+```json
+{
+  "name": "memory",
+  "connection": {
+    "type": "remote_http",
+    "url": "https://memory.example.com/mcp",
+    "headers": {},
+    "credentials": {"type": "none"}
+  },
+  "policy": {
+    "tools": {"mode": "all"},
+    "permission": "ask"
+  }
+}
+```
+
+A future static secret header does not move fields:
+
+```json
+{
+  "connection": {
+    "type": "remote_http",
+    "url": "https://memory.example.com/mcp",
+    "headers": {},
+    "credentials": {
+      "type": "header_secret_refs",
+      "headers": {"Authorization": "memory_token"}
+    }
+  }
+}
+```
+
+Future OAuth changes only the credential discriminator:
+
+```json
+{
+  "connection": {
+    "type": "remote_http",
+    "url": "https://memory.example.com/mcp",
+    "credentials": {
+      "type": "oauth_connection",
+      "connection_ref": "memory-production"
+    }
+  }
+}
+```
+
+Tool selection is explicit: `{"policy":{"tools":{"mode":"include","names":["search",
+"remember"]}}}`.
+
+Contract rules:
+
+- `connection` owns endpoint, public headers, and credentials.
+- `policy` owns tool selection and permission.
+- No protocol-version field. The gateway or client negotiates it.
+- No stdio command in the public hosted-agent shape.
+- No raw credential value in a saved agent revision.
+- Empty arrays carry no overloaded meaning. Use `mode: "all"` or `mode: "include"`.
+- Keep the author model separate from the internal resolved credential and placeholder contract.
+
+## Backwards-compatible migration
+
+Do not mutate old saved templates during invocation. Add one normalization boundary:
+
+1. Continue accepting the legacy flat shape as version 1.
+2. Convert it into the canonical nested model before resolution.
+3. Emit only the nested model for newly saved MCP entries.
+4. Preserve old entries byte-for-byte until the user edits or explicitly migrates them.
+5. Reject legacy stdio clearly. Do not reinterpret it.
+6. Treat legacy HTTP `env` as headers only in compatibility decoding.
+7. Map legacy `tools: []` to `policy.tools.mode = "all"`; non-empty lists become `include`.
+8. Keep resolved values and Daytona placeholders out of the author model.
+
+This lets execution move from direct Claude MCP to the platform gateway without changing saved
+agent templates.
+
+## Recommended UI and delivery order
+
+### Slice 1: no-secret HTTP MCP
+
+Show server name, remote MCP URL, authentication set to `None`, a Connect button, connection
+status and error, discovered tools, all-or-selected tool access, and allow/ask/deny permission.
+Hide stdio, environment, raw secret mapping, and manual tool-name tags.
+
+The Connect action should perform the same initialization and `tools/list` call as production.
+Show negotiated server identity, protocol version, capabilities, and tool count. Saving an
+untested server may remain possible, but the row must say "Not tested".
+
+### Slice 2: gateway and Pi parity
+
+Move discovery and calls behind the platform gateway. Convert discovered MCP tools into the same
+public specs Pi already receives. Apply selection and permission at the gateway executor. The
+same server then works on Claude and Pi, local and Daytona.
+
+### Slice 3: authentication
+
+Add platform connection selection and OAuth. Keep static secret-header references as a bounded
+advanced option only if demand exists. Do not add raw tokens to agent templates.
+
+### Work sequence
+
+1. Make deployment capability visible to the frontend. Do not render an editable MCP section
+   when the service has MCP disabled.
+2. Remove stdio from the UI and stop seeding entries with `transport: "stdio"`.
+3. Add the nested author model and legacy normalization tests. Keep the runner wire unchanged.
+4. Add service-side connect and discovery for unauthenticated HTTPS MCP.
+5. Surface connection state and discovered tools. Enforce selected tools.
+6. Enable MCP in development and run live Claude local and Claude Daytona acceptance tests.
+7. Build gateway execution and Pi projection. Run the full four-cell matrix.
+8. Add connection-backed OAuth and settle the PR #5242 recut for remaining direct-sandbox use.
+
+Do not flip the production feature flag until steps 1 through 6 are complete.
+
+## Verification performed
+
+- Runner MCP, run-plan, and layering tests: 76 passed.
+- Python MCP resolver and wire tests selected by `-k mcp`: 10 passed.
+- Service MCP gate tests: 5 passed.
+- No MCP form tests exist under `web/packages/agenta-entity-ui`.
+- Both live EE services inspected had `AGENTA_AGENT_MCPS_ENABLED=false`.
+- Recent live logs contained Claude plus Daytona internal-shim delivery failures.
+- PR #5242 was inspected live: open draft, dirty merge state, with a recut pending.
+
+## Decision summary
+
+- Ship remote HTTP only in the public UI.
+- Start without secrets.
+- Treat stdio as unsupported legacy input, not a product option.
+- Remove or implement `tools`; do not keep dead configuration.
+- Add connect, discover, and visible status before enablement.
+- Normalize the public contract into connection, credentials, and policy roles.
+- Make the gateway the long-run credential and execution boundary for Claude and Pi.
+- Use Daytona Secrets only where direct sandbox egress still requires a credential.


### PR DESCRIPTION
## Context

The MCP editor currently exposes controls that do not match the working runtime. It offers user stdio even though every harness rejects it, labels HTTP headers as environment variables, accepts a tool allowlist that is not enforced, and gives no connection status when Claude cannot reach a server.

This design defines the public contract before MCP moves into production. It also separates external user MCP servers from the trusted internal `agenta-tools` delivery channel.

## Changes

The plan narrows the initial product to remote HTTPS MCP on Claude with no credentials. It removes user stdio from the public interface while retaining the private Daytona stdio shim used for internal Agenta tools.

Before, one flat object mixed transport, process environment, URL, secret references, tool selection, and permission:

```json
{"name":"memory","transport":"http","url":"https://example.com/mcp","env":{},"secrets":{},"tools":[]}
```

The proposed version 2 contract separates connection, credentials, and policy:

```json
{
  "version": 2,
  "name": "memory",
  "connection": {
    "type": "remote_http",
    "url": "https://example.com/mcp",
    "headers": {},
    "credentials": {"type": "none"}
  },
  "policy": {
    "tools": {"mode": "all"},
    "permission": "ask"
  }
}
```

The workspace includes the current capability matrix, stage scores, migration policy, QA matrix, and an implementation sequence. Slice 0 traces the reported capability-enabled Claude failure across the saved revision, service request, runner session, and Claude MCP status before any production enablement.

## Tests and notes

This is a documentation-only design PR. The underlying status audit previously passed the selected runner, SDK, and service MCP tests. No runtime behavior changes in this PR.

## How to review

1. Start with `mcp-delivery-architecture/status-quo-report.md` for what is wired today.
2. Read `mcp-configuration-redesign/interface.md` for the proposed public and resolved contracts.
3. Review `migration.md` for the pre-production compatibility decision.
4. Review `plan.md` and `qa.md` for sequencing and release gates.

The main decisions are whether the version 2 nesting is the public shape we want to keep, whether pre-production version 1 drafts can be reset instead of decoded for one release, and whether a failed required MCP connection should abort the run.
