### PR TITLE
[5283] fix(agent): Persist Pi transcripts in session workspaces

### DIFF
--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -53,8 +53,9 @@
       "esbuild"
     ],
     "patchedDependencies": {
-      "sandbox-agent@0.4.2": "patches/sandbox-agent@0.4.2.patch",
-      "acp-http-client@0.4.2": "patches/acp-http-client@0.4.2.patch"
+      "acp-http-client@0.4.2": "patches/acp-http-client@0.4.2.patch",
+      "pi-acp@0.0.29": "patches/pi-acp@0.0.29.patch",
+      "sandbox-agent@0.4.2": "patches/sandbox-agent@0.4.2.patch"
     }
   }
 }

--- a/services/runner/patches/pi-acp@0.0.29.patch
+++ b/services/runner/patches/pi-acp@0.0.29.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.js b/dist/index.js
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1206,5 +1206,9 @@ function readSessionDirFromSettings(agentDir) {
+ }
+ function getPiSessionsDir() {
++  const envSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
++  if (typeof envSessionDir === "string" && envSessionDir.trim()) {
++    return resolve2(envSessionDir);
++  }
+   const agentDir = getPiAgentDir();
+   return readSessionDirFromSettings(agentDir) ?? join3(agentDir, "sessions");
+ }

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   acp-http-client@0.4.2:
     hash: a673c410af2021d9bb5f05c899522b66e6bcbe67134a92f506f0aef23fcf090d
     path: patches/acp-http-client@0.4.2.patch
+  pi-acp@0.0.29:
+    hash: 02294f0adb0cd9d3f3650f8fd86f3d2a9eef567b6eef0b6eb495415685dbb0a3
+    path: patches/pi-acp@0.0.29.patch
   sandbox-agent@0.4.2:
     hash: ade0985e7ab79fab885a4cd818c0790d5cf319730931bd0a049775c7fbdeb7a4
     path: patches/sandbox-agent@0.4.2.patch
@@ -54,7 +57,7 @@ importers:
         version: 0.4.2(patch_hash=a673c410af2021d9bb5f05c899522b66e6bcbe67134a92f506f0aef23fcf090d)(zod@4.4.3)
       pi-acp:
         specifier: 0.0.29
-        version: 0.0.29
+        version: 0.0.29(patch_hash=02294f0adb0cd9d3f3650f8fd86f3d2a9eef567b6eef0b6eb495415685dbb0a3)
       sandbox-agent:
         specifier: 0.4.2
         version: 0.4.2(patch_hash=ade0985e7ab79fab885a4cd818c0790d5cf319730931bd0a049775c7fbdeb7a4)(@daytonaio/sdk@0.187.0(ws@8.21.0))(zod@4.4.3)
@@ -4578,7 +4581,7 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pi-acp@0.0.29:
+  pi-acp@0.0.29(patch_hash=02294f0adb0cd9d3f3650f8fd86f3d2a9eef567b6eef0b6eb495415685dbb0a3):
     dependencies:
       '@agentclientprotocol/sdk': 0.26.0(zod@3.25.76)
       zod: 3.25.76

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -768,6 +768,10 @@ export async function acquireEnvironment(
         skills: plan.skillDirs.map((s) => s.name),
       })
     : {};
+  // Daytona's provider is built from `piExtEnv` rather than the local daemon env. Keep the
+  // transcript location in both environment slices so Pi and pi-acp see the same durable path
+  // regardless of provider.
+  if (piSessionDir) piExtEnv.PI_CODING_AGENT_SESSION_DIR = piSessionDir;
   Object.assign(env, piExtEnv); // local daemon inherits it; daytona gets it via envVars
   logger(
     `tools=${plan.toolSpecs.length} executableTools=${plan.executableToolSpecs.length} ` +

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -88,6 +88,7 @@ import { applyModel } from "./sandbox_agent/model.ts";
 import { findSwallowedPiError } from "./sandbox_agent/pi-error.ts";
 import {
   buildPiExtensionEnv,
+  configurePiSessionWorkspace,
   prepareLocalPiAssets,
   uploadSystemPromptToSandbox,
   writeSystemPromptLocal,
@@ -740,6 +741,7 @@ export async function acquireEnvironment(
   });
   Object.assign(env, plan.secrets); // apply only the resolved provider keys
   applyClaudeConnectionEnv(env, request, plan.acpAgent, logger);
+  const piSessionDir = configurePiSessionWorkspace(plan, env);
   const strictModel = modelResolutionStrict();
   // Pi self-instruments locally: propagate the trace context + public tool metadata into Pi
   // via the Agenta extension. Tool execution always relays back to this runner, which keeps
@@ -1399,6 +1401,17 @@ export async function acquireEnvironment(
       }
     } finally {
       timingLog("prepare_workspace", prepareWorkspaceStartedAt);
+    }
+
+    // Pi native transcripts belong to the conversation workspace, not the temporary agent
+    // directory that holds credentials, settings, extensions, skills, and system prompts.
+    // The cwd mount is already active here on local and Daytona before Pi starts.
+    if (piSessionDir) {
+      if (plan.isDaytona) {
+        await environment.sandbox.mkdirFs({ path: piSessionDir });
+      } else {
+        mkdirSync(piSessionDir, { recursive: true });
+      }
     }
 
     // Sandbox-start invariant: `startSandboxAgent` must hand back a usable handle.

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -20,6 +20,27 @@ import type { RunPlan } from "./run-plan.ts";
 
 type Log = (message: string) => void;
 
+/**
+ * Pi native transcripts belong to the Agenta conversation, not the temporary Pi agent dir.
+ * The session cwd is already the durable, session-scoped workspace on both local and Daytona
+ * runs, so keeping transcripts below it gives Pi a stable path without persisting credentials,
+ * settings, extensions, or system prompts.
+ */
+export function piSessionWorkspaceDir(cwd: string): string {
+  return join(cwd, "agents", "sessions", "pi");
+}
+
+/** Point Pi at the durable conversation-scoped transcript directory. */
+export function configurePiSessionWorkspace(
+  plan: Pick<RunPlan, "isPi" | "cwd">,
+  env: Record<string, string>,
+): string | undefined {
+  if (!plan.isPi) return undefined;
+  const sessionDir = piSessionWorkspaceDir(plan.cwd);
+  env.PI_CODING_AGENT_SESSION_DIR = sessionDir;
+  return sessionDir;
+}
+
 // The bundled Agenta Pi extension (tracing + tools). Built by `pnpm run build:extension`
 // and baked into the image; installed into Pi's agent dir so Pi loads it on every run.
 export const EXTENSION_BUNDLE =

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -370,6 +370,11 @@ describe("runSandboxAgent orchestration", () => {
         .PI_CODING_AGENT_SESSION_DIR,
       expected,
     );
+    assert.equal(
+      (calls.providerArgs[3] as Record<string, string>)
+        .PI_CODING_AGENT_SESSION_DIR,
+      expected,
+    );
     assert.equal(existsSync(expected), true);
     rmSync(cwd, { recursive: true, force: true });
   });
@@ -393,6 +398,11 @@ describe("runSandboxAgent orchestration", () => {
     const expected = "/home/sandbox/agenta-fake-cwd/agents/sessions/pi";
     assert.equal(
       (calls.providerArgs[1] as Record<string, string>)
+        .PI_CODING_AGENT_SESSION_DIR,
+      expected,
+    );
+    assert.equal(
+      (calls.providerArgs[3] as Record<string, string>)
         .PI_CODING_AGENT_SESSION_DIR,
       expected,
     );

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -63,6 +63,7 @@ function fakeHarness(options: FakeOptions = {}) {
     daemonAgent: "",
     daemonOptions: undefined as { clearProviderEnv?: boolean } | undefined,
     providerArgs: [] as unknown[],
+    mkdirFsPaths: [] as string[],
     startOptions: undefined as any,
     createSessionOptions: undefined as any,
     promptBlocks: undefined as any,
@@ -147,6 +148,9 @@ function fakeHarness(options: FakeOptions = {}) {
   };
 
   const sandbox = {
+    async mkdirFs({ path }: { path: string }) {
+      calls.mkdirFsPaths.push(path);
+    },
     async createSession(opts: any) {
       calls.createSessionOptions = opts;
       return session;
@@ -343,6 +347,56 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(calls.sandboxDestroyed, 1);
     assert.equal(calls.sandboxDisposed, 1);
     assert.equal(calls.workspaceCleanup, 1);
+  });
+
+  it("points local Pi and pi-acp at the conversation workspace transcript directory", async () => {
+    const cwd = join(
+      tmpdir(),
+      "agenta-pi-session-dir-" + process.pid + "-" + Date.now(),
+    );
+    const { calls, deps } = fakeHarness({ cwd });
+
+    const result = await runSandboxAgent(
+      { harness: "pi_core", messages: [{ role: "user", content: "hello" }] },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    const expected = join(cwd, "agents", "sessions", "pi");
+    assert.equal(
+      (calls.providerArgs[1] as Record<string, string>)
+        .PI_CODING_AGENT_SESSION_DIR,
+      expected,
+    );
+    assert.equal(existsSync(expected), true);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("creates the configured Pi transcript directory inside a Daytona cwd", async () => {
+    const { calls, deps } = fakeHarness();
+    deps.prepareDaytonaPiAssets = (async () => {}) as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+      },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    const expected = "/home/sandbox/agenta-fake-cwd/agents/sessions/pi";
+    assert.equal(
+      (calls.providerArgs[1] as Record<string, string>)
+        .PI_CODING_AGENT_SESSION_DIR,
+      expected,
+    );
+    assert.ok(calls.mkdirFsPaths.includes(expected));
   });
 
   it("advertises durable agent storage only after a confirmed local mount", async () => {

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -20,6 +20,8 @@ import { join } from "node:path";
 import type { AgentRunRequest } from "../../src/protocol.ts";
 import {
   buildPiExtensionEnv,
+  configurePiSessionWorkspace,
+  piSessionWorkspaceDir,
   prepareLocalAgentDir,
   prepareLocalPiAssets,
   uploadDirToSandbox,
@@ -27,6 +29,40 @@ import {
   writeOtlpAuthFile,
   writeSystemPromptLocal,
 } from "../../src/engines/sandbox_agent/pi-assets.ts";
+
+describe("Pi session workspace", () => {
+  it("uses one stable transcript directory inside the conversation cwd", () => {
+    assert.equal(
+      piSessionWorkspaceDir("/work/session-1"),
+      "/work/session-1/agents/sessions/pi",
+    );
+
+    const env: Record<string, string> = {};
+    const sessionDir = configurePiSessionWorkspace(
+      { isPi: true, cwd: "/work/session-1" },
+      env,
+    );
+
+    assert.equal(sessionDir, "/work/session-1/agents/sessions/pi");
+    assert.equal(
+      env.PI_CODING_AGENT_SESSION_DIR,
+      "/work/session-1/agents/sessions/pi",
+    );
+  });
+
+  it("does not add Pi configuration to another harness", () => {
+    const env: Record<string, string> = {};
+
+    assert.equal(
+      configurePiSessionWorkspace(
+        { isPi: false, cwd: "/work/session-1" },
+        env,
+      ),
+      undefined,
+    );
+    assert.equal(env.PI_CODING_AGENT_SESSION_DIR, undefined);
+  });
+});
 
 const dirs: string[] = [];
 


### PR DESCRIPTION
## Context

Pi stored native transcripts below its agent directory. Local runs create a temporary agent directory whenever they carry skills or a system prompt, then delete that directory at teardown. The next cold continuation could therefore point at a transcript path that no longer existed.

This is the lower PR in the launch stack. It fixes transcript persistence only. #5295 stacks the stable skill path on top.

## Changes

Pi now writes native transcripts to `<cwd>/agents/sessions/pi`, inside the existing durable conversation workspace. The runner creates that directory before starting Pi on local and Daytona runs.

Pi already honors `PI_CODING_AGENT_SESSION_DIR`. The pinned `pi-acp@0.0.29` did not consult that variable when rebuilding its session index, so this PR carries a narrow package patch that makes its scan use the same directory.

Before:

```text
<temporary PI_CODING_AGENT_DIR>/sessions/...
```

After:

```text
<durable session cwd>/agents/sessions/pi/...
```

This PR does not change warm or cold decisions, `session/load`, replay selection, continuity IDs, token usage, prompt caching, or Claude behavior. Healthy Pi resumes continue to use native history exactly as before.

## Live local QA

Verified on the EE deployment at port 8280 against the actual service-targeted subscription sidecar and `pi_core` with `openai-codex/gpt-5.4-mini`.

- Turn 1 created one Pi JSONL under `<cwd>/agents/sessions/pi` and stored the private marker `PI-COLD-MEM-9Q7R`.
- The sidecar container was deleted and recreated. The new container had no prior `/tmp` workspace.
- The existing 120-second local-runner ownership lease first rejected the replacement replica as designed. After that lease expired, the same session cold-loaded with `hydrated ... turn=0` and `session/load ... loaded=true`, then recalled the marker.
- After the normal 60-second warm-pool eviction unmounted the cwd, another turn remounted the same workspace, logged `session/load ... loaded=true`, and recalled the marker again.

The ownership retry is existing local-runner affinity behavior, not introduced by this PR. A stable `AGENTA_RUNNER_REPLICA_ID` avoids that delay across normal orchestrated restarts.

## Tests

- `pnpm exec vitest run --project unit tests/unit/sandbox-agent-pi-assets.test.ts tests/unit/sandbox-agent-orchestration.test.ts`: 60 passed.
- `pnpm run typecheck`: passed.
- The full runner suite was also run on the complete stack: 69 files and 1,066 tests passed.

## How to review

1. Start with `pi-assets.ts` for the single session-directory contract.
2. Check `sandbox_agent.ts` for local and Daytona directory creation before Pi starts.
3. Review the `pi-acp` patch. It only adds environment-variable precedence to the existing scan-directory resolver.
4. Finish with the local and Daytona orchestration guards.

Part of #5283. The upper #5295 completes the issue.