### PR TITLE
[5283] fix(agent): Keep Pi skill paths stable on cold resume

### DIFF
--- a/services/runner/patches/pi-acp@0.0.29.patch
+++ b/services/runner/patches/pi-acp@0.0.29.patch
@@ -1,6 +1,17 @@
 diff --git a/dist/index.js b/dist/index.js
 --- a/dist/index.js
 +++ b/dist/index.js
+@@ -133,6 +133,10 @@ class PiRpcClient {
+   static async spawn(params) {
+     const cmd = getPiCommand(params.piCommand);
+     const args = ["--mode", "rpc", "--no-themes"];
++    const skillDir = process.env.PI_CODING_AGENT_SKILL_DIR;
++    if (typeof skillDir === "string" && skillDir.trim()) {
++      args.push("--no-skills", "--skill", skillDir);
++    }
+     if (params.sessionPath) args.push("--session", params.sessionPath);
+     const child = spawn(cmd, args, {
+       cwd: params.cwd,
 @@ -1206,5 +1206,9 @@ function readSessionDirFromSettings(agentDir) {
  }
  function getPiSessionsDir() {

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: a673c410af2021d9bb5f05c899522b66e6bcbe67134a92f506f0aef23fcf090d
     path: patches/acp-http-client@0.4.2.patch
   pi-acp@0.0.29:
-    hash: 02294f0adb0cd9d3f3650f8fd86f3d2a9eef567b6eef0b6eb495415685dbb0a3
+    hash: e30d9db3a9981a7f844a83795d7ceef6d86919eede6e2adf8a9bf0024d5ff49c
     path: patches/pi-acp@0.0.29.patch
   sandbox-agent@0.4.2:
     hash: ade0985e7ab79fab885a4cd818c0790d5cf319730931bd0a049775c7fbdeb7a4
@@ -57,7 +57,7 @@ importers:
         version: 0.4.2(patch_hash=a673c410af2021d9bb5f05c899522b66e6bcbe67134a92f506f0aef23fcf090d)(zod@4.4.3)
       pi-acp:
         specifier: 0.0.29
-        version: 0.0.29(patch_hash=02294f0adb0cd9d3f3650f8fd86f3d2a9eef567b6eef0b6eb495415685dbb0a3)
+        version: 0.0.29(patch_hash=e30d9db3a9981a7f844a83795d7ceef6d86919eede6e2adf8a9bf0024d5ff49c)
       sandbox-agent:
         specifier: 0.4.2
         version: 0.4.2(patch_hash=ade0985e7ab79fab885a4cd818c0790d5cf319730931bd0a049775c7fbdeb7a4)(@daytonaio/sdk@0.187.0(ws@8.21.0))(zod@4.4.3)
@@ -4581,7 +4581,7 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pi-acp@0.0.29(patch_hash=02294f0adb0cd9d3f3650f8fd86f3d2a9eef567b6eef0b6eb495415685dbb0a3):
+  pi-acp@0.0.29(patch_hash=e30d9db3a9981a7f844a83795d7ceef6d86919eede6e2adf8a9bf0024d5ff49c):
     dependencies:
       '@agentclientprotocol/sdk': 0.26.0(zod@3.25.76)
       zod: 3.25.76

--- a/services/runner/src/engines/sandbox_agent.ts
+++ b/services/runner/src/engines/sandbox_agent.ts
@@ -89,7 +89,9 @@ import { findSwallowedPiError } from "./sandbox_agent/pi-error.ts";
 import {
   buildPiExtensionEnv,
   configurePiSessionWorkspace,
+  configurePiSkillSnapshot,
   prepareLocalPiAssets,
+  resolvePiSkillSnapshot,
   uploadSystemPromptToSandbox,
   writeSystemPromptLocal,
   writeOtlpAuthFile,
@@ -729,6 +731,7 @@ export async function acquireEnvironment(
   });
   if (!planResult.ok) return { ok: false, error: planResult.error };
   const plan = planResult.plan;
+  const piSkillSnapshot = resolvePiSkillSnapshot(plan);
   const agentMountDir = agentMountCreds ? agentMountPath(plan.cwd) : undefined;
 
   // Clear-then-apply (Security rule 5): on a managed run (credentialMode "env") the daemon
@@ -742,6 +745,7 @@ export async function acquireEnvironment(
   Object.assign(env, plan.secrets); // apply only the resolved provider keys
   applyClaudeConnectionEnv(env, request, plan.acpAgent, logger);
   const piSessionDir = configurePiSessionWorkspace(plan, env);
+  configurePiSkillSnapshot(piSkillSnapshot, env);
   const strictModel = modelResolutionStrict();
   // Pi self-instruments locally: propagate the trace context + public tool metadata into Pi
   // via the Agenta extension. Tool execution always relays back to this runner, which keeps
@@ -772,6 +776,7 @@ export async function acquireEnvironment(
   // transcript location in both environment slices so Pi and pi-acp see the same durable path
   // regardless of provider.
   if (piSessionDir) piExtEnv.PI_CODING_AGENT_SESSION_DIR = piSessionDir;
+  configurePiSkillSnapshot(piSkillSnapshot, piExtEnv);
   Object.assign(env, piExtEnv); // local daemon inherits it; daytona gets it via envVars
   logger(
     `tools=${plan.toolSpecs.length} executableTools=${plan.executableToolSpecs.length} ` +
@@ -1252,7 +1257,7 @@ export async function acquireEnvironment(
     if (plan.isDaytona) {
       await (deps.prepareDaytonaPiAssets ?? prepareDaytonaPiAssets)({
         sandbox: environment.sandbox,
-        plan,
+        plan: { ...plan, skillDirs: [] },
         log: logger,
       });
       if (!plan.isPi && plan.executableToolSpecs.length > 0) {
@@ -1380,6 +1385,7 @@ export async function acquireEnvironment(
         {
           sandbox: environment.sandbox,
           plan,
+          piSkillSnapshot,
           log: logger,
         },
       );
@@ -1398,6 +1404,7 @@ export async function acquireEnvironment(
         )({
           sandbox: environment.sandbox,
           plan,
+          piSkillSnapshot,
           log: logger,
         });
       } else {

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -1,3 +1,4 @@
+import { createHash, randomUUID } from "node:crypto";
 import {
   copyFileSync,
   cpSync,
@@ -6,6 +7,8 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  renameSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -39,6 +42,205 @@ export function configurePiSessionWorkspace(
   const sessionDir = piSessionWorkspaceDir(plan.cwd);
   env.PI_CODING_AGENT_SESSION_DIR = sessionDir;
   return sessionDir;
+}
+
+export const PI_SKILL_SNAPSHOT_MARKER = ".agenta-skill-set.json";
+
+export interface PiSkillSnapshot {
+  digest: string;
+  dir: string;
+  marker: string;
+  skills: MaterializedSkill[];
+}
+
+interface SkillFile {
+  path: string;
+  mode: number;
+  content: Buffer;
+}
+
+function listSkillFiles(dir: string, relativeDir = ""): SkillFile[] {
+  const files: SkillFile[] = [];
+  for (const entry of readdirSync(join(dir, relativeDir), {
+    withFileTypes: true,
+  }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const relativePath = relativeDir
+      ? `${relativeDir}/${entry.name}`
+      : entry.name;
+    const sourcePath = join(dir, relativePath);
+    const stat = entry.isSymbolicLink() ? statSync(sourcePath) : undefined;
+    if (entry.isDirectory() || stat?.isDirectory()) {
+      files.push(...listSkillFiles(dir, relativePath));
+    } else if (entry.isFile() || stat?.isFile()) {
+      files.push({
+        path: relativePath,
+        mode: statSync(sourcePath).mode & 0o777,
+        content: readFileSync(sourcePath),
+      });
+    }
+  }
+  return files;
+}
+
+function hashPart(
+  hash: ReturnType<typeof createHash>,
+  value: string | Buffer,
+): void {
+  const bytes = typeof value === "string" ? Buffer.from(value, "utf-8") : value;
+  const length = Buffer.alloc(8);
+  length.writeBigUInt64BE(BigInt(bytes.length));
+  hash.update(length);
+  hash.update(bytes);
+}
+
+/** Resolve the immutable project-local snapshot selected for this Pi run. */
+export function resolvePiSkillSnapshot(
+  plan: Pick<RunPlan, "isPi" | "cwd" | "skillDirs">,
+): PiSkillSnapshot | undefined {
+  if (!plan.isPi || plan.skillDirs.length === 0) return undefined;
+
+  const skills = [...plan.skillDirs].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  const hash = createHash("sha256");
+  hashPart(hash, "agenta-pi-skill-set-v1");
+  for (const skill of skills) {
+    hashPart(hash, skill.name);
+    for (const file of listSkillFiles(skill.dir)) {
+      hashPart(hash, file.path);
+      hashPart(hash, file.mode.toString(8));
+      hashPart(hash, file.content);
+    }
+  }
+  const digest = hash.digest("hex");
+  const marker = `${JSON.stringify({
+    version: 1,
+    digest,
+    skills: skills.map((skill) => skill.name),
+  })}\n`;
+  return {
+    digest,
+    dir: join(plan.cwd, "agents", "skills", digest),
+    marker,
+    skills,
+  };
+}
+
+/** Tell Pi to load only the explicitly selected project-local snapshot. */
+export function configurePiSkillSnapshot(
+  snapshot: PiSkillSnapshot | undefined,
+  env: Record<string, string>,
+): void {
+  if (snapshot) env.PI_CODING_AGENT_SKILL_DIR = snapshot.dir;
+}
+
+function validateLocalPiSkillSnapshot(snapshot: PiSkillSnapshot): boolean {
+  if (!existsSync(snapshot.dir)) return false;
+  const markerPath = join(snapshot.dir, PI_SKILL_SNAPSHOT_MARKER);
+  if (
+    !existsSync(markerPath) ||
+    readFileSync(markerPath, "utf-8") !== snapshot.marker
+  ) {
+    throw new Error(
+      `Pi skill snapshot ${snapshot.dir} exists without the expected completion marker`,
+    );
+  }
+  return true;
+}
+
+/** Publish a local snapshot once; existing snapshots are only validated and reused. */
+export function materializeLocalPiSkillSnapshot(
+  snapshot: PiSkillSnapshot,
+): void {
+  if (validateLocalPiSkillSnapshot(snapshot)) return;
+
+  const root = dirname(snapshot.dir);
+  mkdirSync(root, { recursive: true });
+  const staging = mkdtempSync(join(root, `.${snapshot.digest}.tmp-`));
+  try {
+    for (const skill of snapshot.skills) {
+      cpSync(skill.dir, join(staging, skill.name), {
+        recursive: true,
+        dereference: true,
+      });
+    }
+    writeFileSync(
+      join(staging, PI_SKILL_SNAPSHOT_MARKER),
+      snapshot.marker,
+      "utf-8",
+    );
+    try {
+      renameSync(staging, snapshot.dir);
+    } catch (err) {
+      if (!validateLocalPiSkillSnapshot(snapshot)) throw err;
+    }
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+async function readDaytonaSnapshotMarker(
+  sandbox: any,
+  snapshot: PiSkillSnapshot,
+): Promise<string | undefined> {
+  try {
+    const bytes = await sandbox.readFsFile({
+      path: `${snapshot.dir}/${PI_SKILL_SNAPSHOT_MARKER}`,
+    });
+    return Buffer.from(bytes).toString("utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+async function validateDaytonaPiSkillSnapshot(
+  sandbox: any,
+  snapshot: PiSkillSnapshot,
+): Promise<boolean> {
+  const marker = await readDaytonaSnapshotMarker(sandbox, snapshot);
+  if (marker === undefined) return false;
+  if (marker !== snapshot.marker) {
+    throw new Error(
+      `Pi skill snapshot ${snapshot.dir} exists without the expected completion marker`,
+    );
+  }
+  return true;
+}
+
+/** Publish a Daytona snapshot through a unique staging dir and a non-overwriting move. */
+export async function materializeDaytonaPiSkillSnapshot(
+  sandbox: any,
+  snapshot: PiSkillSnapshot,
+): Promise<void> {
+  if (await validateDaytonaPiSkillSnapshot(sandbox, snapshot)) return;
+
+  const root = dirname(snapshot.dir);
+  const staging = `${root}/.${snapshot.digest}.tmp-${randomUUID()}`;
+  await sandbox.mkdirFs({ path: staging });
+  try {
+    for (const skill of snapshot.skills) {
+      await uploadDirToSandbox(sandbox, skill.dir, `${staging}/${skill.name}`);
+    }
+    await sandbox.writeFsFile(
+      { path: `${staging}/${PI_SKILL_SNAPSHOT_MARKER}` },
+      snapshot.marker,
+    );
+    try {
+      await sandbox.moveFs({
+        from: staging,
+        to: snapshot.dir,
+        overwrite: false,
+      });
+    } catch (err) {
+      if (!(await validateDaytonaPiSkillSnapshot(sandbox, snapshot))) throw err;
+    }
+  } finally {
+    if (typeof sandbox.runProcess === "function") {
+      await sandbox
+        .runProcess({ command: "rm", args: ["-rf", "--", staging] })
+        .catch(() => {});
+    }
+  }
 }
 
 // The bundled Agenta Pi extension (tracing + tools). Built by `pnpm run build:extension`
@@ -221,30 +423,12 @@ export async function uploadPiExtensionToSandbox(
   }
 }
 
-/** Install materialized skill dirs into a local Pi agent dir's user-scope `skills/`. */
-export function installSkillsLocal(
-  agentDir: string,
-  skillDirs: MaterializedSkill[],
-  log: Log = () => {},
-): void {
-  for (const skill of skillDirs) {
-    try {
-      const dest = join(agentDir, "skills", skill.name);
-      mkdirSync(dirname(dest), { recursive: true });
-      cpSync(skill.dir, dest, { recursive: true, dereference: true });
-    } catch (err) {
-      log(`skill install skipped for ${skill.name}: ${(err as Error).message}`);
-    }
-  }
-}
-
 /**
  * Seed a throwaway local Pi agent dir from `sourceAgentDir` and install the Agenta extension
- * plus the run's materialized skills into it.
+ * into it.
  */
 export function prepareLocalAgentDir(
   sourceAgentDir: string,
-  skillDirs: MaterializedSkill[],
   log: Log = () => {},
 ): string {
   const dir = mkdtempSync(join(tmpdir(), "agenta-pi-agentdir-"));
@@ -257,7 +441,6 @@ export function prepareLocalAgentDir(
     }
   }
   installPiExtensionLocal(dir, log);
-  installSkillsLocal(dir, skillDirs, log);
   return dir;
 }
 
@@ -289,11 +472,7 @@ export function prepareLocalPiAssets({
   if (!plan.isPi || plan.isDaytona) return undefined;
 
   if (plan.skillDirs.length > 0 || plan.hasSystemPrompt) {
-    const runAgentDir = prepareLocalAgentDir(
-      plan.sourcePiAgentDir,
-      plan.skillDirs,
-      log,
-    );
+    const runAgentDir = prepareLocalAgentDir(plan.sourcePiAgentDir, log);
     if (plan.hasSystemPrompt) {
       writeSystemPromptLocal(
         runAgentDir,

--- a/services/runner/src/engines/sandbox_agent/workspace.ts
+++ b/services/runner/src/engines/sandbox_agent/workspace.ts
@@ -2,7 +2,12 @@ import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import type { RunPlan } from "./run-plan.ts";
-import { uploadDirToSandbox } from "./pi-assets.ts";
+import {
+  materializeDaytonaPiSkillSnapshot,
+  materializeLocalPiSkillSnapshot,
+  type PiSkillSnapshot,
+  uploadDirToSandbox,
+} from "./pi-assets.ts";
 
 type Log = (message: string) => void;
 
@@ -12,6 +17,7 @@ export interface Workspace {
 
 export interface PrepareWorkspaceInput {
   sandbox: any;
+  piSkillSnapshot?: PiSkillSnapshot;
   plan: Pick<
     RunPlan,
     | "isDaytona"
@@ -29,9 +35,9 @@ export interface PrepareWorkspaceInput {
 
 /**
  * Prepare the run cwd, relay directory, the instructions memory file, generic `harnessFiles`,
- * and non-Pi skill packages for local or Daytona runs. `harnessFiles` are written blind: the
+ * and harness skill packages for local or Daytona runs. `harnessFiles` are written blind: the
  * Python harness adapter already rendered them. Skills stay resolved inline packages on the
- * wire; Pi installs them through its agent dir, while Claude loads project-local
+ * wire; Pi loads one immutable `agents/skills/<digest>` snapshot, while Claude loads project-local
  * `.claude/skills/<name>` directories from the cwd.
  *
  * The instructions (`agentsMd`) filename is harness-aware. Claude runs through
@@ -43,6 +49,7 @@ export interface PrepareWorkspaceInput {
 export async function prepareWorkspace({
   sandbox,
   plan,
+  piSkillSnapshot,
   log = () => {},
 }: PrepareWorkspaceInput): Promise<Workspace> {
   const harnessFiles = plan.harnessFiles ?? [];
@@ -86,6 +93,9 @@ export async function prepareWorkspace({
       });
       await sandbox.writeFsFile({ path }, file.content);
     }
+    if (piSkillSnapshot) {
+      await materializeDaytonaPiSkillSnapshot(sandbox, piSkillSnapshot);
+    }
     if (projectSkillRoot) {
       for (const skill of plan.skillDirs) {
         await uploadDirToSandbox(
@@ -120,6 +130,7 @@ export async function prepareWorkspace({
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, file.content, "utf-8");
   }
+  if (piSkillSnapshot) materializeLocalPiSkillSnapshot(piSkillSnapshot);
   if (projectSkillRoot) {
     for (const skill of plan.skillDirs) {
       const dest = join(plan.cwd, projectSkillRoot, skill.name);

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -70,6 +70,7 @@ function fakeHarness(options: FakeOptions = {}) {
     runStart: undefined as any,
     otelOptions: undefined as any,
     workspacePlan: undefined as any,
+    workspacePiSkillSnapshot: undefined as any,
     workspaceCleanup: 0,
     sandboxDestroyed: 0,
     sandboxDisposed: 0,
@@ -239,8 +240,9 @@ function fakeHarness(options: FakeOptions = {}) {
       }
       return sandbox;
     }) as any,
-    prepareWorkspace: (async ({ plan }: any) => {
+    prepareWorkspace: (async ({ plan, piSkillSnapshot }: any) => {
       calls.workspacePlan = plan;
+      calls.workspacePiSkillSnapshot = piSkillSnapshot;
       return {
         cleanup: async () => {
           calls.workspaceCleanup += 1;
@@ -407,6 +409,88 @@ describe("runSandboxAgent orchestration", () => {
       expected,
     );
     assert.ok(calls.mkdirFsPaths.includes(expected));
+  });
+
+  it("passes the same Pi skill snapshot to local Pi and workspace preparation", async () => {
+    const cwd = join(
+      tmpdir(),
+      `agenta-pi-skill-dir-${process.pid}-${Date.now()}`,
+    );
+    const skill = join(
+      tmpdir(),
+      `agenta-pi-skill-source-${process.pid}-${Date.now()}`,
+    );
+    mkdirSync(skill, { recursive: true });
+    writeFileSync(join(skill, "SKILL.md"), "skill", "utf-8");
+    const { calls, deps } = fakeHarness({ cwd });
+    deps.resolveSkillDirs = () => ({
+      skills: [{ name: "release-notes", dir: skill }],
+      cleanup: () => {},
+    });
+
+    const result = await runSandboxAgent(
+      { harness: "pi_core", messages: [{ role: "user", content: "hello" }] },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    const selected = calls.workspacePiSkillSnapshot;
+    assert.ok(selected);
+    assert.match(
+      selected.dir,
+      new RegExp(`${cwd}/agents/skills/[a-f0-9]{64}$`),
+    );
+    assert.equal(
+      (calls.providerArgs[1] as Record<string, string>)
+        .PI_CODING_AGENT_SKILL_DIR,
+      selected.dir,
+    );
+    assert.equal(
+      (calls.providerArgs[3] as Record<string, string>)
+        .PI_CODING_AGENT_SKILL_DIR,
+      selected.dir,
+    );
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(skill, { recursive: true, force: true });
+  });
+
+  it("keeps configured skills out of the Daytona Pi agent directory", async () => {
+    const skill = join(
+      tmpdir(),
+      `agenta-pi-daytona-skill-${process.pid}-${Date.now()}`,
+    );
+    mkdirSync(skill, { recursive: true });
+    writeFileSync(join(skill, "SKILL.md"), "skill", "utf-8");
+    const { calls, deps } = fakeHarness();
+    deps.resolveSkillDirs = () => ({
+      skills: [{ name: "release-notes", dir: skill }],
+      cleanup: () => {},
+    });
+    let agentDirSkillCount = -1;
+    deps.prepareDaytonaPiAssets = (async ({ plan }: any) => {
+      agentDirSkillCount = plan.skillDirs.length;
+    }) as any;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        sandbox: "daytona",
+        messages: [{ role: "user", content: "hello" }],
+      },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(agentDirSkillCount, 0);
+    assert.match(
+      calls.workspacePiSkillSnapshot.dir,
+      /^\/home\/sandbox\/agenta-fake-cwd\/agents\/skills\/[a-f0-9]{64}$/,
+    );
+    rmSync(skill, { recursive: true, force: true });
   });
 
   it("advertises durable agent storage only after a confirmed local mount", async () => {

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -20,12 +20,16 @@ import { join } from "node:path";
 import type { AgentRunRequest } from "../../src/protocol.ts";
 import {
   buildPiExtensionEnv,
+  configurePiSkillSnapshot,
   configurePiSessionWorkspace,
+  materializeDaytonaPiSkillSnapshot,
+  materializeLocalPiSkillSnapshot,
+  PI_SKILL_SNAPSHOT_MARKER,
   piSessionWorkspaceDir,
   prepareLocalAgentDir,
   prepareLocalPiAssets,
+  resolvePiSkillSnapshot,
   uploadDirToSandbox,
-  uploadSkillsToSandbox,
   writeOtlpAuthFile,
   writeSystemPromptLocal,
 } from "../../src/engines/sandbox_agent/pi-assets.ts";
@@ -348,17 +352,12 @@ describe("writeSystemPromptLocal", () => {
 });
 
 describe("prepareLocalAgentDir", () => {
-  it("seeds auth/settings and installs materialized skills into a throwaway dir", () => {
+  it("seeds auth/settings without copying skills into the agent dir", () => {
     const source = tempDir("agenta-pi-source-test-");
     writeFileSync(join(source, "auth.json"), '{"token":"x"}', "utf-8");
     writeFileSync(join(source, "settings.json"), '{"model":"gpt"}', "utf-8");
 
-    const skill = tempDir("agenta-pi-skill-test-");
-    writeFileSync(join(skill, "SKILL.md"), "---\nname: skill\n---\n", "utf-8");
-
-    const runDir = prepareLocalAgentDir(source, [
-      { name: "skill", dir: skill },
-    ]);
+    const runDir = prepareLocalAgentDir(source);
     dirs.push(runDir);
 
     assert.notEqual(runDir, source);
@@ -370,11 +369,7 @@ describe("prepareLocalAgentDir", () => {
       readFileSync(join(runDir, "settings.json"), "utf-8"),
       '{"model":"gpt"}',
     );
-    // The dest dir is named by the skill's `name`, not the (throwaway) source dir basename.
-    assert.equal(
-      readFileSync(join(runDir, "skills", "skill", "SKILL.md"), "utf-8"),
-      "---\nname: skill\n---\n",
-    );
+    assert.equal(existsSync(join(runDir, "skills")), false);
   });
 });
 
@@ -429,6 +424,93 @@ describe("prepareLocalPiAssets (PI_CODING_AGENT_DIR guard)", () => {
   });
 });
 
+describe("Pi skill snapshots", () => {
+  it("publishes content-addressed local snapshots without replacing older versions", () => {
+    const cwd = tempDir("agenta-pi-snapshot-cwd-");
+    const skill = tempDir("agenta-pi-snapshot-skill-");
+    mkdirSync(join(skill, "references"));
+    writeFileSync(join(skill, "SKILL.md"), "first", "utf-8");
+    writeFileSync(join(skill, "references", "guide.md"), "guide", "utf-8");
+
+    const first = resolvePiSkillSnapshot({
+      isPi: true,
+      cwd,
+      skillDirs: [{ name: "release-notes", dir: skill }],
+    });
+    assert.ok(first);
+    assert.match(first.dir, new RegExp(`${cwd}/agents/skills/[a-f0-9]{64}$`));
+    const env: Record<string, string> = {};
+    configurePiSkillSnapshot(first, env);
+    assert.equal(env.PI_CODING_AGENT_SKILL_DIR, first.dir);
+
+    materializeLocalPiSkillSnapshot(first);
+    assert.equal(
+      readFileSync(
+        join(first.dir, "release-notes", "references", "guide.md"),
+        "utf-8",
+      ),
+      "guide",
+    );
+    assert.equal(
+      readFileSync(join(first.dir, PI_SKILL_SNAPSHOT_MARKER), "utf-8"),
+      first.marker,
+    );
+    materializeLocalPiSkillSnapshot(first);
+
+    writeFileSync(join(skill, "SKILL.md"), "second", "utf-8");
+    const second = resolvePiSkillSnapshot({
+      isPi: true,
+      cwd,
+      skillDirs: [{ name: "release-notes", dir: skill }],
+    });
+    assert.ok(second);
+    assert.notEqual(second.dir, first.dir);
+    materializeLocalPiSkillSnapshot(second);
+    assert.equal(existsSync(first.dir), true);
+    assert.equal(
+      readFileSync(join(second.dir, "release-notes", "SKILL.md"), "utf-8"),
+      "second",
+    );
+  });
+
+  it("fails closed when the digest path exists without its completion marker", () => {
+    const cwd = tempDir("agenta-pi-snapshot-invalid-cwd-");
+    const skill = tempDir("agenta-pi-snapshot-invalid-skill-");
+    writeFileSync(join(skill, "SKILL.md"), "skill", "utf-8");
+    const snapshot = resolvePiSkillSnapshot({
+      isPi: true,
+      cwd,
+      skillDirs: [{ name: "release-notes", dir: skill }],
+    });
+    assert.ok(snapshot);
+    mkdirSync(snapshot.dir, { recursive: true });
+    writeFileSync(join(snapshot.dir, "partial.txt"), "keep", "utf-8");
+
+    assert.throws(
+      () => materializeLocalPiSkillSnapshot(snapshot),
+      /expected completion marker/,
+    );
+    assert.equal(
+      readFileSync(join(snapshot.dir, "partial.txt"), "utf-8"),
+      "keep",
+    );
+  });
+
+  it("does not configure snapshots for non-Pi or empty-skill runs", () => {
+    assert.equal(
+      resolvePiSkillSnapshot({ isPi: false, cwd: "/work", skillDirs: [] }),
+      undefined,
+    );
+    assert.equal(
+      resolvePiSkillSnapshot({ isPi: true, cwd: "/work", skillDirs: [] }),
+      undefined,
+    );
+    const env: Record<string, string> = {};
+    configurePiSkillSnapshot(undefined, env);
+    assert.equal(env.PI_CODING_AGENT_SKILL_DIR, undefined);
+  });
+});
+
 describe("sandbox uploads", () => {
   it("recursively uploads files into sandbox fs", async () => {
     const root = tempDir("agenta-pi-upload-test-");
@@ -458,21 +540,58 @@ describe("sandbox uploads", () => {
     ]);
   });
 
-  it("uploads each materialized skill under the Pi skills directory", async () => {
-    const skill = tempDir("agenta-pi-skill-upload-test-");
+  it("publishes and reuses a Daytona snapshot with a non-overwriting move", async () => {
+    const skill = tempDir("agenta-pi-daytona-snapshot-skill-");
     writeFileSync(join(skill, "SKILL.md"), "skill", "utf-8");
-    const written: string[] = [];
+    const snapshot = resolvePiSkillSnapshot({
+      isPi: true,
+      cwd: "/workspace",
+      skillDirs: [{ name: "release-notes", dir: skill }],
+    });
+    assert.ok(snapshot);
+
+    const files = new Map<string, string>();
+    const moves: Array<{ from: string; to: string; overwrite: boolean }> = [];
     const sandbox = {
       mkdirFs: async () => {},
-      writeFsFile: async ({ path }: { path: string }) => written.push(path),
+      writeFsFile: async ({ path }: { path: string }, body: string) => {
+        files.set(path, body);
+      },
+      readFsFile: async ({ path }: { path: string }) => {
+        const body = files.get(path);
+        if (body === undefined) throw new Error("missing");
+        return Buffer.from(body, "utf-8");
+      },
+      moveFs: async ({
+        from,
+        to,
+        overwrite,
+      }: {
+        from: string;
+        to: string;
+        overwrite: boolean;
+      }) => {
+        moves.push({ from, to, overwrite });
+        for (const [path, body] of [...files.entries()]) {
+          if (path === from || path.startsWith(`${from}/`)) {
+            files.set(`${to}${path.slice(from.length)}`, body);
+            files.delete(path);
+          }
+        }
+      },
     };
 
-    await uploadSkillsToSandbox(sandbox, "/agent", [
-      { name: "release-notes", dir: skill },
-    ]);
+    await materializeDaytonaPiSkillSnapshot(sandbox, snapshot);
+    assert.equal(moves.length, 1);
+    assert.equal(moves[0]?.to, snapshot.dir);
+    assert.equal(moves[0]?.overwrite, false);
+    assert.equal(files.get(`${snapshot.dir}/release-notes/SKILL.md`), "skill");
+    assert.equal(
+      files.get(`${snapshot.dir}/${PI_SKILL_SNAPSHOT_MARKER}`),
+      snapshot.marker,
+    );
 
-    assert.equal(existsSync(skill), true);
-    // The sandbox dest dir is named by the skill's `name`.
-    assert.deepEqual(written, ["/agent/skills/release-notes/SKILL.md"]);
+    await materializeDaytonaPiSkillSnapshot(sandbox, snapshot);
+    assert.equal(moves.length, 1);
   });
 });


### PR DESCRIPTION
## Context

Configured Pi skills currently live under a random per-run agent directory. Teardown deletes that directory, so a cold resume can contain references to skill files that no longer exist.

This PR is stacked on #5292. The lower PR persists Pi transcripts. This PR gives configured skills a stable session-workspace path without changing replay, continuation, token, cache, or Claude behavior.

## Changes

Pi now receives one content-addressed skill snapshot at:

```text
<cwd>/agents/skills/<digest>/<skill-name>
```

The runner computes the digest from skill names, file paths, modes, and contents. It publishes through a unique temporary directory, writes a completion marker last, and reuses only a matching complete snapshot. Existing or older snapshots are never reconciled, replaced, or deleted during acquisition.

The `pi-acp` patch passes the exact snapshot to Pi with `--no-skills --skill <path>`. Only the current snapshot is advertised, while old paths remain readable by a cold-resumed transcript. The runner no longer copies configured skills into the temporary local or Daytona Pi agent directory.

This deliberately accepts append-only storage growth until the session workspace is removed. Snapshot immutability is a runner convention because the cwd remains agent-writable.

## Live local QA

Verified on the EE deployment at port 8280 against the actual service-targeted subscription sidecar. The live installed `pi-acp` was checked for `PI_CODING_AGENT_SKILL_DIR` before the run.

- Turn 1 delivered an inline `continuity-probe` skill. Pi called `read` on `<cwd>/agents/skills/4d2431.../continuity-probe/SKILL.md`, then returned `SKILL-COLD-7Q42-OK`.
- The same durable cwd contained one Pi transcript, one `.agenta-skill-set.json` marker, and the skill file under that digest.
- After deleting and recreating the sidecar, the new container had no prior `/tmp`. Once the existing 120-second owner lease expired, the session loaded natively and returned `SKILL-COLD-7Q42-OK PI-COLD-MEM-9Q7R` without receiving the earlier message again.
- After the normal 60-second warm-pool eviction, another cold turn remounted the same cwd, logged `session/load ... loaded=true`, and recalled the same private marker.
- Keeping the skill body unchanged reused the same digest. Changing the body for the final probe created a second digest and left the first snapshot intact, confirming append-only behavior with no reconciliation or deletion.

The first immediate post-restart retry was rejected by the existing local-runner ownership guard. That is expected affinity behavior and is not caused by this PR. A stable `AGENTA_RUNNER_REPLICA_ID` avoids the lease wait in orchestrated restarts.

## Tests

- `pnpm exec vitest run --project unit tests/unit/sandbox-agent-pi-assets.test.ts tests/unit/sandbox-agent-orchestration.test.ts`: 65 passed.
- `pnpm run typecheck`: passed.
- `pnpm test`: 69 files and 1,066 tests passed.
- Live Daytona was not run. Daytona publication, reuse, mismatch failure, and the no-copy-to-private-agent-dir invariant are covered by the orchestration and asset unit tests.

## How to review

1. Start with `pi-assets.ts` for digesting, atomic publication, marker validation, and fail-closed behavior.
2. Read `workspace.ts` and `sandbox_agent.ts` for local and Daytona ordering.
3. Check the `pi-acp` patch for the narrow explicit-skill argument.
4. Finish with the orchestration and asset tests.

Depends on #5292. Closes #5283.