### PR TITLE
[fix] Resolve MCP secrets from the project vault

### DIFF
--- a/sdks/python/agenta/sdk/agents/mcp/models.py
+++ b/sdks/python/agenta/sdk/agents/mcp/models.py
@@ -67,7 +67,7 @@ class MCPServerConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    name: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9._-]+$")
     connection: MCPConnection
     policy: MCPPolicy = Field(default_factory=MCPPolicy)
 

--- a/sdks/python/agenta/sdk/agents/platform/secrets.py
+++ b/sdks/python/agenta/sdk/agents/platform/secrets.py
@@ -3,8 +3,8 @@
 Two distinct vault reads, both best-effort (an outage returns empty rather than failing the
 run, since a project with no secret-bearing tools still runs):
 
-- `resolve_named_secrets` (`POST /secrets/resolve`): named secret values for code-tool and
-  MCP environments, resolved by explicit name. Pairs with the resolver's
+- `resolve_named_secrets` (`GET /secrets/{slug}`): named secret values for code-tool and
+  MCP environments, resolved by explicit slug. Pairs with the resolver's
   `MissingSecretPolicy.ERROR`, so a tool whose declared secret is absent then hard-fails.
 - `resolve_provider_keys` (`GET /secrets/`): the project's LLM provider keys, mapped to the
   env vars a harness reads. Optional by design: when the vault has none, the harness falls
@@ -15,7 +15,8 @@ Logs never include secret names or values, only counts.
 
 from __future__ import annotations
 
-from typing import Dict, Mapping, Optional, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence
+from urllib.parse import quote
 
 import httpx
 
@@ -32,7 +33,7 @@ async def resolve_named_secrets(
     *,
     connection: Optional[PlatformConnection] = None,
 ) -> Dict[str, str]:
-    """Resolve project vault secrets by name for tool and MCP environments. Best-effort."""
+    """Resolve text project secrets by slug for tool and MCP environments. Best-effort."""
     if not names:
         return {}
 
@@ -41,42 +42,46 @@ async def resolve_named_secrets(
     if not api_base:
         return {}
 
-    try:
-        async with httpx.AsyncClient(timeout=connection.timeout) as client:
-            response = await client.post(
-                f"{api_base}/secrets/resolve",
-                json={"names": list(names)},
-                headers=connection.headers(),
-            )
-        if response.status_code >= 400:
-            log.warning(
-                "agent: named-secret resolve HTTP %s for %d name(s)",
-                response.status_code,
-                len(names),
-            )
-            return {}
-        data = response.json() or {}
-    except Exception:  # pylint: disable=broad-except
-        log.warning(
-            "agent: named-secret resolve failed for %d name(s)",
-            len(names),
-            exc_info=True,
-        )
-        return {}
+    requested = list(dict.fromkeys(str(name) for name in names))
+    resolved: Dict[str, str] = {}
+    headers = connection.headers()
 
-    resolved = data.get("secrets") if isinstance(data, dict) else None
-    resolved = resolved if isinstance(resolved, dict) else {}
-    requested = {str(name) for name in names}
-    missing = [name for name in names if name not in resolved]
-    if missing:
-        log.warning("agent: %d named secret(s) unresolved", len(missing))
-    # Restrict to the requested set so an upstream that returns extras never leaks
-    # unrequested secrets into runtime memory.
-    return {
-        str(key): str(value)
-        for key, value in resolved.items()
-        if value is not None and str(key) in requested
-    }
+    async with httpx.AsyncClient(timeout=connection.timeout) as client:
+        for name in requested:
+            try:
+                response = await client.get(
+                    f"{api_base}/secrets/{quote(name, safe='')}",
+                    headers=headers,
+                )
+                if response.status_code == 404:
+                    continue
+                if response.status_code >= 400:
+                    log.warning(
+                        "agent: named-secret read HTTP %s", response.status_code
+                    )
+                    continue
+                value = _text_custom_secret_value(response.json())
+                if value is not None:
+                    resolved[name] = value
+            except Exception:  # pylint: disable=broad-except
+                log.warning("agent: named-secret read failed", exc_info=True)
+
+    missing_count = len(requested) - len(resolved)
+    if missing_count:
+        log.warning("agent: %d named secret(s) unresolved", missing_count)
+    return resolved
+
+
+def _text_custom_secret_value(payload: Any) -> Optional[str]:
+    """Extract only the vault shape MCP headers can safely consume."""
+    if not isinstance(payload, dict) or payload.get("kind") != "custom_secret":
+        return None
+    data = payload.get("data")
+    secret = data.get("secret") if isinstance(data, dict) else None
+    if not isinstance(secret, dict) or secret.get("format") != "text":
+        return None
+    content = secret.get("content")
+    return content if isinstance(content, str) else None
 
 
 class AgentaNamedSecretProvider:

--- a/sdks/python/oss/tests/pytest/unit/agents/mcp/test_resolver.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/mcp/test_resolver.py
@@ -48,6 +48,12 @@ def test_connection_is_required_and_legacy_flat_shape_is_rejected():
         )
 
 
+@pytest.mark.parametrize("name", ["has spaces", "slash/name", ""])
+def test_server_name_must_be_a_runtime_safe_identifier(name):
+    with pytest.raises(ValidationError, match="name"):
+        server(name=name)
+
+
 async def test_resolves_public_and_secret_headers():
     resolved = await MCPResolver(
         secret_provider=DictSecretProvider({"memory_token": "secret-value"})

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_secrets_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_secrets_http.py
@@ -10,22 +10,23 @@ from agenta.sdk.agents.platform import (
 from agenta.sdk.agents.platform import secrets
 
 
-# --- named secrets (POST /secrets/resolve) ---------------------------------
+# --- named secrets (GET /secrets/{slug}) -----------------------------------
 
 
 async def test_named_secrets_are_resolved(fake_http, connection):
     capture = fake_http(
         secrets,
-        payload={"secrets": {"TOKEN": "value", "EMPTY": None}},
+        payload={
+            "kind": "custom_secret",
+            "slug": "TOKEN",
+            "data": {"secret": {"format": "text", "content": "value"}},
+        },
     )
-    resolved = await resolve_named_secrets(
-        ["TOKEN", "EMPTY", "MISSING"], connection=connection
-    )
+    resolved = await resolve_named_secrets(["TOKEN"], connection=connection)
     assert resolved == {"TOKEN": "value"}
     assert capture == {
-        "method": "POST",
-        "url": "https://api.x/api/secrets/resolve",
-        "json": {"names": ["TOKEN", "EMPTY", "MISSING"]},
+        "method": "GET",
+        "url": "https://api.x/api/secrets/TOKEN",
         "headers": {
             "Content-Type": "application/json",
             "Authorization": "Access tok",
@@ -33,14 +34,29 @@ async def test_named_secrets_are_resolved(fake_http, connection):
     }
 
 
-async def test_named_secrets_restrict_to_requested(fake_http, connection):
-    # An upstream that returns extras must not leak unrequested secrets into memory.
+async def test_named_secret_slug_is_url_encoded(fake_http, connection):
+    capture = fake_http(
+        secrets,
+        payload={
+            "kind": "custom_secret",
+            "data": {"secret": {"format": "text", "content": "value"}},
+        },
+    )
+    assert await resolve_named_secrets(["TOKEN/name"], connection=connection) == {
+        "TOKEN/name": "value"
+    }
+    assert capture["url"] == "https://api.x/api/secrets/TOKEN%2Fname"
+
+
+async def test_named_secrets_reject_non_text_values(fake_http, connection):
     fake_http(
         secrets,
-        payload={"secrets": {"TOKEN": "value", "UNREQUESTED": "leak"}},
+        payload={
+            "kind": "custom_secret",
+            "data": {"secret": {"format": "json", "content": {"TOKEN": "value"}}},
+        },
     )
-    resolved = await resolve_named_secrets(["TOKEN"], connection=connection)
-    assert resolved == {"TOKEN": "value"}
+    assert await resolve_named_secrets(["TOKEN"], connection=connection) == {}
 
 
 async def test_named_secrets_without_api_base_return_empty(fake_http):

--- a/services/oss/tests/pytest/integration/agent/tools/test_secrets_http.py
+++ b/services/oss/tests/pytest/integration/agent/tools/test_secrets_http.py
@@ -11,16 +11,19 @@ pytestmark = pytest.mark.integration
 async def test_named_secrets_are_resolved_by_tools_adapter(install_http):
     capture = install_http(
         platform_secrets,
-        payload={"secrets": {"TOKEN": "value", "EMPTY": None}},
+        payload={
+            "kind": "custom_secret",
+            "slug": "TOKEN",
+            "data": {"secret": {"format": "text", "content": "value"}},
+        },
     )
 
-    resolved = await secrets.resolve_named_secrets(["TOKEN", "EMPTY", "MISSING"])
+    resolved = await secrets.resolve_named_secrets(["TOKEN"])
 
     assert resolved == {"TOKEN": "value"}
     assert capture == {
-        "method": "POST",
-        "url": "https://api.x/api/secrets/resolve",
-        "json": {"names": ["TOKEN", "EMPTY", "MISSING"]},
+        "method": "GET",
+        "url": "https://api.x/api/secrets/TOKEN",
         "headers": {
             "Content-Type": "application/json",
             "Authorization": "Access tok",


### PR DESCRIPTION
## Context

MCP servers with secret-header authentication failed before the run reached the harness. The agent service called `POST /secrets/resolve`, but that endpoint does not exist. Tests mocked the missing route, so they passed while real runs reported the selected vault secret as missing.

## Changes

Named-secret resolution now uses the existing project-scoped `GET /secrets/{slug}` endpoint with the caller's authorization. It accepts only text custom secrets and returns only values explicitly requested by the MCP configuration.

MCP server names now use the runtime-safe identifier accepted by harness tool namespaces: letters, numbers, dots, hyphens, and underscores, up to 128 characters. Invalid names fail during config validation instead of producing a server that the harness cannot expose.

Before:

```text
POST /secrets/resolve {"names": ["exa_api_key-..."]} -> 404
```

After:

```text
GET /secrets/exa_api_key-... -> custom_secret text content
```

## Tests / notes

- `ruff format` and `ruff check --fix` passed for the changed Python files.
- SDK agent tests: 20 passed.
- Service secret-adapter integration tests: 3 passed.
- No new endpoint, feature flag, OAuth path, compatibility layer, or vault-wide secret read was added.
