### PR TITLE
[feat] Make MCP secret authentication usable

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/McpServerFormView.tsx
@@ -3,12 +3,15 @@
  */
 import {useState} from "react"
 
-import {Input, Select} from "antd"
+import {customNamedSecretsAtom} from "@agenta/entities/secret"
+import {Input, Select, Tag} from "antd"
+import {useAtomValue} from "jotai"
 
 import {RailField, railInfoLabel} from "../../drawers/shared/RailField"
 
 type Dict = Record<string, string>
 type CredentialType = "none" | "header_secret_refs"
+type AuthenticationType = CredentialType | "oauth"
 
 interface McpCredentials {
     type?: CredentialType
@@ -34,48 +37,10 @@ export interface McpServerFormViewProps {
     disabled?: boolean
 }
 
-function KeyValueLines({
-    value,
-    onChange,
-    placeholder,
-    disabled,
-}: {
-    value: Dict | undefined
-    onChange: (next: Dict) => void
-    placeholder?: string
-    disabled?: boolean
-}) {
-    const [text, setText] = useState(() =>
-        Object.entries(value ?? {})
-            .map(([key, entryValue]) => `${key}=${entryValue}`)
-            .join("\n"),
-    )
-
-    const handle = (next: string) => {
-        setText(next)
-        const entries: Dict = {}
-        next.split("\n").forEach((line) => {
-            const separator = line.indexOf("=")
-            if (separator <= 0) return
-            const key = line.slice(0, separator).trim()
-            if (key) entries[key] = line.slice(separator + 1).trim()
-        })
-        onChange(entries)
-    }
-
-    return (
-        <Input.TextArea
-            value={text}
-            onChange={(event) => handle(event.target.value)}
-            placeholder={placeholder}
-            disabled={disabled}
-            autoSize={{minRows: 2, maxRows: 6}}
-            className="font-mono"
-        />
-    )
-}
+const MCP_SERVER_NAME_PATTERN = /^[A-Za-z0-9._-]{1,128}$/
 
 export function McpServerFormView({value, onChange, disabled}: McpServerFormViewProps) {
+    const namedSecrets = useAtomValue(customNamedSecretsAtom)
     const server = value as McpServer
     const connection = server.connection ?? {
         type: "http" as const,
@@ -84,6 +49,15 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
     }
     const credentials = connection.credentials ?? {type: "none" as const}
     const credentialType = credentials.type ?? "none"
+    const initialSecretHeader = Object.entries(credentials.headers ?? {})[0] ?? ["", ""]
+    const [secretHeader, setSecretHeader] = useState({
+        name: initialSecretHeader[0],
+        slug: initialSecretHeader[1],
+    })
+
+    const name = server.name ?? ""
+    const invalidName = Boolean(name) && !MCP_SERVER_NAME_PATTERN.test(name)
+    const selectedSecretExists = namedSecrets.some((secret) => secret.slug === secretHeader.slug)
 
     const setServer = (patch: Partial<McpServer>) => {
         onChange({...value, ...patch})
@@ -99,24 +73,47 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
         })
     }
 
-    const setCredentialType = (type: CredentialType) => {
+    const writeSecretHeader = (next: {name: string; slug: string}) => {
+        setSecretHeader(next)
+        setConnection({
+            credentials: {
+                type: "header_secret_refs",
+                headers: next.name && next.slug ? {[next.name]: next.slug} : {},
+            },
+        })
+    }
+
+    const setAuthenticationType = (type: AuthenticationType) => {
+        if (type === "oauth") return
         setConnection({
             credentials:
                 type === "none"
                     ? {type: "none"}
-                    : {type: "header_secret_refs", headers: credentials.headers ?? {}},
+                    : {
+                          type: "header_secret_refs",
+                          headers:
+                              secretHeader.name && secretHeader.slug
+                                  ? {[secretHeader.name]: secretHeader.slug}
+                                  : {},
+                      },
         })
     }
 
     return (
         <div className="flex flex-col gap-3">
-            <RailField label="Server name" align="center">
+            <RailField label="Server name">
                 <Input
-                    value={server.name ?? ""}
+                    value={name}
                     onChange={(event) => setServer({name: event.target.value})}
-                    placeholder="memory"
+                    placeholder="exa"
+                    status={invalidName ? "error" : undefined}
                     disabled={disabled}
                 />
+                {invalidName ? (
+                    <span className="mt-1 text-xs text-[var(--ag-colorError)]">
+                        Use only letters, numbers, dots, hyphens, or underscores.
+                    </span>
+                ) : null}
             </RailField>
 
             <RailField label="MCP URL" align="center">
@@ -128,48 +125,78 @@ export function McpServerFormView({value, onChange, disabled}: McpServerFormView
                 />
             </RailField>
 
-            <RailField label={railInfoLabel("Public headers", "Non-secret HTTP headers only")}>
-                <KeyValueLines
-                    value={connection.headers}
-                    onChange={(headers) =>
-                        setConnection({headers: Object.keys(headers).length ? headers : undefined})
-                    }
-                    placeholder="X-Workspace=my-workspace"
-                    disabled={disabled}
-                />
-            </RailField>
-
             <RailField label="Authentication" align="center">
-                <Select<CredentialType>
+                <Select<AuthenticationType>
                     className="w-full"
                     value={credentialType}
-                    onChange={setCredentialType}
+                    onChange={setAuthenticationType}
                     disabled={disabled}
                     options={[
                         {label: "None", value: "none"},
-                        {label: "Secret headers", value: "header_secret_refs"},
+                        {label: "Secret header", value: "header_secret_refs"},
+                        {
+                            label: (
+                                <span className="flex items-center justify-between gap-2">
+                                    OAuth
+                                    <Tag className="m-0 text-[10px]">Soon</Tag>
+                                </span>
+                            ),
+                            value: "oauth",
+                            disabled: true,
+                        },
                     ]}
                 />
             </RailField>
 
             {credentialType === "header_secret_refs" ? (
-                <RailField
-                    label={railInfoLabel(
-                        "Secret headers",
-                        "Map an HTTP header to a project secret name",
-                    )}
-                >
-                    <KeyValueLines
-                        value={credentials.headers}
-                        onChange={(headers) =>
-                            setConnection({
-                                credentials: {type: "header_secret_refs", headers},
-                            })
-                        }
-                        placeholder="Authorization=memory_token"
-                        disabled={disabled}
-                    />
-                </RailField>
+                <>
+                    <RailField
+                        label={railInfoLabel(
+                            "Header name",
+                            "The HTTP header required by the MCP server, for example x-api-key",
+                        )}
+                        align="center"
+                    >
+                        <Input
+                            value={secretHeader.name}
+                            onChange={(event) =>
+                                writeSecretHeader({
+                                    ...secretHeader,
+                                    name: event.target.value.trim(),
+                                })
+                            }
+                            placeholder="x-api-key"
+                            disabled={disabled}
+                        />
+                    </RailField>
+
+                    <RailField
+                        label={railInfoLabel(
+                            "Project secret",
+                            "The selected secret is resolved securely when the agent runs",
+                        )}
+                        align="center"
+                    >
+                        <Select
+                            className="w-full"
+                            value={selectedSecretExists ? secretHeader.slug : undefined}
+                            onChange={(slug) => writeSecretHeader({...secretHeader, slug})}
+                            placeholder={
+                                secretHeader.slug && !selectedSecretExists
+                                    ? "Selected secret is unavailable"
+                                    : "Select a project secret"
+                            }
+                            disabled={disabled}
+                            notFoundContent="No project secrets found"
+                            options={namedSecrets
+                                .filter((secret) => Boolean(secret.slug))
+                                .map((secret) => ({
+                                    label: secret.name || "Unnamed secret",
+                                    value: secret.slug as string,
+                                }))}
+                        />
+                    </RailField>
+                </>
             ) : null}
         </div>
     )

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
@@ -122,12 +122,27 @@ export const ITEM_KINDS: Record<ItemKind, ItemKindDef> = {
         }),
         draftInvalid: (draft) => {
             const name = String(draft.name ?? "").trim()
+            const validName = /^[A-Za-z0-9._-]{1,128}$/.test(name)
             const connection =
                 draft.connection && typeof draft.connection === "object"
                     ? (draft.connection as Record<string, unknown>)
                     : {}
             const url = String(connection.url ?? "").trim()
-            return !name || !url
+            const credentials =
+                connection.credentials && typeof connection.credentials === "object"
+                    ? (connection.credentials as Record<string, unknown>)
+                    : {}
+            const headers =
+                credentials.headers && typeof credentials.headers === "object"
+                    ? (credentials.headers as Record<string, unknown>)
+                    : {}
+            const missingSecretHeader =
+                credentials.type === "header_secret_refs" &&
+                !Object.entries(headers).some(
+                    ([headerName, secretSlug]) =>
+                        headerName.trim() && String(secretSlug ?? "").trim(),
+                )
+            return !validName || !url || missingSecretHeader
         },
     },
     skill: {


### PR DESCRIPTION
## Context

The MCP form required users to type raw `header=secret_slug` lines. It also exposed public headers even though the current product scope is remote HTTP MCP with optional vault-backed authentication. The format was hard to discover and made it easy to paste a secret value or display-name instead of the required stored reference.

## Changes

The form now has one authentication dropdown:

- None
- Secret header
- OAuth, disabled and marked `Soon`

Selecting Secret header shows a header-name input and a Project secret dropdown. The dropdown displays the human-readable vault secret name but stores its slug in the existing `header_secret_refs` configuration. Existing non-secret headers remain preserved in the config but are no longer shown in this MVP form.

The form also validates runtime-safe server names and prevents saving incomplete secret-header authentication.

Before:

```text
x-api-key=exa_api_key-ff0f855a67c6
```

After:

```text
Header name: x-api-key
Project secret: Exa API key
```

## Tests / notes

- `pnpm lint-fix` passed.
- `@agenta/entity-ui` build and lint passed.
- `@agenta/entity-ui` unit suite: 201 passed.
- Interactive browser QA was not available in this Codex session.

## What to QA

- Open an agent's MCP server drawer. Authentication shows None, Secret header, and disabled OAuth with a Soon tag.
- Select Secret header. The Project secret dropdown shows vault secret names, not slugs.
- Enter `x-api-key`, select the Exa secret, and save. The JSON view stores the selected secret slug under `connection.credentials.headers`; it never stores or displays the secret value.
- Enter a server name with spaces. The form shows a validation error and disables Save.
- Regression: edit a config that already contains non-secret `connection.headers`. Saving the structured form preserves those hidden headers.
