### PR TITLE
fix(web): honest sandbox picker + hide local-only permission options

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -69,6 +69,10 @@ case "$(printf '%s' "${AGENTA_SANDBOX_LOCAL_ALLOWED:-true}" | tr '[:upper:]' '[:
   *) export AGENTA_SANDBOX_LOCAL_ENABLED="false" ;;
 esac
 
+# Expose the full enabled-provider set (normalized to a lowercase, whitespace-free comma
+# list) so the picker can restrict its options to exactly what this deployment enabled.
+export AGENTA_ENABLED_SANDBOX_PROVIDERS="$(printf '%s' "${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+
 mkdir -p "${ENTRYPOINT_DIR}/${AGENTA_LICENSE}/public"
 
 # Derive frontend auth feature flags
@@ -209,6 +213,7 @@ window.__env = {
   NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MAX_LENGTH: "${SUPERTOKENS_PASSWORD_MAX_LENGTH}",
   NEXT_PUBLIC_SUPERTOKENS_PASSWORD_REGEX: "${SUPERTOKENS_PASSWORD_REGEX}",
   NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED: "${AGENTA_SANDBOX_LOCAL_ENABLED}",
+  NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS: "${AGENTA_ENABLED_SANDBOX_PROVIDERS}",
 };
 EOF
 

--- a/web/oss/src/lib/helpers/dynamicEnv.ts
+++ b/web/oss/src/lib/helpers/dynamicEnv.ts
@@ -63,6 +63,8 @@ export const processEnv = {
     NEXT_PUBLIC_AGENTA_TOOLS_ENABLED: process.env.NEXT_PUBLIC_AGENTA_TOOLS_ENABLED,
     NEXT_PUBLIC_AGENTA_BILLING_ENABLED: process.env.NEXT_PUBLIC_AGENTA_BILLING_ENABLED,
     NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED: process.env.NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED,
+    NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS:
+        process.env.NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS,
     NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MIN_LENGTH:
         process.env.NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MIN_LENGTH,
     NEXT_PUBLIC_SUPERTOKENS_PASSWORD_MAX_LENGTH:
@@ -85,6 +87,16 @@ const SANDBOX_LOCAL_TRUTHY = new Set(["true", "1", "t", "y", "yes", "on", "enabl
 export const isSandboxLocalEnabled = () => {
     const raw = getEnv("NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED") || "true"
     return SANDBOX_LOCAL_TRUTHY.has(raw.trim().toLowerCase())
+}
+
+// The sandbox providers this deployment enabled, normalized to lowercase ids. Unset/empty
+// falls back to ["local"] so the picker never hides every option.
+export const getEnabledSandboxProviders = (): string[] => {
+    const providers = getEnv("NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS")
+        .split(",")
+        .map((provider) => provider.trim().toLowerCase())
+        .filter(Boolean)
+    return providers.length > 0 ? providers : ["local"]
 }
 
 export const getEffectiveAuthConfig = () => {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -11,7 +11,7 @@ import {
 } from "@agenta/entities/secret"
 import type {SchemaProperty} from "@agenta/entities/shared"
 import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
-import {isSandboxLocalEnabled} from "@agenta/shared/api"
+import {getEnabledSandboxProviders} from "@agenta/shared/api"
 import {normalizeProviderFamily} from "@agenta/shared/utils"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
@@ -98,8 +98,8 @@ export function useModelHarness({
     const runnerProps = subProps("runner")
     const sandboxProps = subProps("sandbox")
     const sandboxOptions = useMemo(() => {
-        const options = getEnumOptions(sandboxProps.kind)
-        return isSandboxLocalEnabled() ? options : options.filter((o) => o.value !== "local")
+        const enabled = new Set(getEnabledSandboxProviders())
+        return getEnumOptions(sandboxProps.kind).filter((o) => enabled.has(o.value))
     }, [sandboxProps.kind])
 
     const asObject = useCallback(
@@ -715,7 +715,7 @@ export function useModelHarness({
                             />
                         </RailField>
                     ) : null}
-                    {sandboxProps.permissions ? (
+                    {sandboxProps.permissions && sandbox.kind !== "local" ? (
                         <>
                             {permissionOverrideHint}
                             {/* Renders its knobs as peer RailField rows (Network egress / Filesystem

--- a/web/packages/agenta-shared/src/api/env.ts
+++ b/web/packages/agenta-shared/src/api/env.ts
@@ -37,6 +37,8 @@ export const processEnv = {
     NEXT_PUBLIC_LOG_APP_ATOMS: process.env.NEXT_PUBLIC_LOG_APP_ATOMS,
     NEXT_PUBLIC_ENABLE_ATOM_LOGS: process.env.NEXT_PUBLIC_ENABLE_ATOM_LOGS,
     NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED: process.env.NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED,
+    NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS:
+        process.env.NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS,
 }
 
 /**
@@ -80,4 +82,14 @@ const SANDBOX_LOCAL_TRUTHY = new Set(["true", "1", "t", "y", "yes", "on", "enabl
 export const isSandboxLocalEnabled = (): boolean => {
     const raw = getEnv("NEXT_PUBLIC_AGENTA_SANDBOX_LOCAL_ENABLED") || "true"
     return SANDBOX_LOCAL_TRUTHY.has(raw.trim().toLowerCase())
+}
+
+/** The sandbox providers this deployment enabled, normalized to lowercase ids. Unset/empty
+ * falls back to `["local"]` so the picker never hides every option. */
+export const getEnabledSandboxProviders = (): string[] => {
+    const providers = getEnv("NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS")
+        .split(",")
+        .map((provider) => provider.trim().toLowerCase())
+        .filter(Boolean)
+    return providers.length > 0 ? providers : ["local"]
 }

--- a/web/packages/agenta-shared/src/api/index.ts
+++ b/web/packages/agenta-shared/src/api/index.ts
@@ -2,7 +2,14 @@
  * API utilities for Agenta packages.
  */
 
-export {getEnv, getAgentaApiUrl, getAgentaWebUrl, isSandboxLocalEnabled, processEnv} from "./env"
+export {
+    getEnv,
+    getAgentaApiUrl,
+    getAgentaWebUrl,
+    isSandboxLocalEnabled,
+    getEnabledSandboxProviders,
+    processEnv,
+} from "./env"
 export {
     axios,
     createAxiosInstance,


### PR DESCRIPTION
## Problem

The playground's "Execution environment" advanced panel was dishonest about what a deployment actually supports:

1. **The sandbox picker showed providers the deployment never enabled.** The only gate was a single boolean (`isSandboxLocalEnabled`) that could drop `local`, but nothing restricted the picker to the enabled *set*. If the schema enum listed `daytona`, the picker offered it even when the deployment enabled only `local` (or vice-versa). The runtime already knew the full provider list from `AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS`; it just collapsed it to a boolean.
2. **The provider-specific permission knobs showed for every provider.** The four `SandboxPermissionControl` knobs (network egress, allowlist, filesystem, enforcement) rendered whenever the schema exposed `sandbox.permissions`, regardless of the selected provider. Those boundaries are only meaningful for a real isolating provider (`daytona`); the `local` sandbox is the runner host and does not enforce them, so showing them for `local` is misleading.

## Change

**Honest picker (concern #1).** Expose the full enabled-provider set to the frontend and filter the picker to it.

- `web/entrypoint.sh` derives and injects `NEXT_PUBLIC_AGENTA_ENABLED_SANDBOX_PROVIDERS` (normalized lowercase, whitespace-free comma list) alongside the existing boolean derivation.
- Registered the new key in both `processEnv` maps (`dynamicEnv.ts`, `agenta-shared/api/env.ts`).
- New `getEnabledSandboxProviders()` helper next to `isSandboxLocalEnabled()`: splits the var, trims/lowercases, drops empties, and **defaults to `["local"]` when unset/empty** so the picker never hides every option.
- `useModelHarness.tsx` filters the picker options to the enabled set: `getEnumOptions(...).filter(o => enabled.has(o.value))`.

**Hide local-only permission options (concern #2).** Gate the `SandboxPermissionControl` block on the selected `sandbox.kind !== "local"`. For `local` the egress/permission block is hidden; for `daytona` it still shows.

## Before / After

- **Before:** picker offers `local` + `daytona` regardless of what the deployment enabled; permission knobs show for `local` even though they are not enforced there.
- **After:** picker offers only the enabled providers (safe `["local"]` fallback if the var is unset); permission knobs are hidden when the selected provider is `local`.

## Verification

- `pnpm --filter @agenta/shared types:check` and `pnpm --filter @agenta/entity-ui types:check` — clean.
- ESLint on the changed files — clean.
- Prettier — formatted.

Note: `web/{oss,ee}/public/__env.js` are gitignored local dev artifacts, so they are not part of this diff; the tracked source of truth is the two `processEnv` maps plus `entrypoint.sh`.

https://claude.ai/code/session_01XhENr63WL9npkKrJGnzDc1
