### PR TITLE
fix(runner): conciseError false-matches a bare "401" substring as auth failure

### DIFF
--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -47,7 +47,13 @@ export function conciseError(
   if (/credit balance is too low|exceeded your current quota|insufficient_quota/i.test(raw)) {
     return `${harness}: the model provider account has insufficient credit (check ${keyHint}).`;
   }
-  if (/authentication required|invalid api key|401|unauthorized/i.test(raw)) {
+  // `401` must stand alone (not digit-adjacent) so it doesn't false-match a bare HTTP status
+  // code embedded in an unrelated number — e.g. a `Date.now()`-based path/id that happens to
+  // contain "401" as a substring (a real, timestamp-dependent flake this caused).
+  if (
+    /authentication required|invalid api key|unauthorized/i.test(raw) ||
+    /(?<!\d)401(?!\d)/.test(raw)
+  ) {
     return `${harness}: model authentication failed — add ${keyHint} to the project vault, or log in (OAuth).`;
   }
   return msg || "agent run failed";


### PR DESCRIPTION
## Summary
`services/runner`'s `conciseError` reclassifies any error whose message contains a real HTTP `401`, `unauthorized`, `invalid api key`, or `authentication required` into a clean "model authentication failed" message. The `401` check had no word boundary, so it matched a bare `401` **anywhere** in the string — including as a substring of an unrelated number.

I hit this diagnosing an unrelated, seemingly random CI failure in `run-runner-tests`: `sandbox-agent-orchestration.test.ts > "preserves the durable cwd when failed mount detach is unsafe"` failed with:

```
Expected: /detach could not be confirmed.*refusing ephemeral cwd fallback/
Received: "claude: model authentication failed — add the project's Anthropic key to the project vault, or log in (OAuth)."
```

The real mount error *was* being produced and caught correctly — it just got silently overwritten. The test's cwd is `/tmp/agenta/unsafe-mount-<pid>-<Date.now()>`, and that run's `Date.now()` timestamp happened to contain the substring `401`, so `conciseError`'s regex matched it and threw away the actual "detach could not be confirmed... refusing ephemeral cwd fallback" message. This is timestamp-dependent: it passes on most runs and fails whenever the millisecond timestamp coincidentally contains "401" — which is what happened in CI.

## Changes
`401` now requires non-digit boundaries on both sides (`(?<!\d)401(?!\d)`), so it still matches a real bare status code like `"401 unauthorized"` but no longer matches inside a longer digit run like a 13-digit timestamp.

## Tests / notes
- `pnpm test` (all 1076 tests across 70 files) passes, including `sandbox-agent-errors.test.ts`'s existing 401-detection cases and the previously-failing mount-detach test.
- `pnpm run typecheck` passes.
- Confirmed the fix by temporarily instrumenting `conciseError` to print the raw error and call stack, reproducing the exact false-positive against the real mount-detach error text before fixing the regex.
