### PR TITLE
fix(hosting): bind Postgres and the dashboard to loopback by default

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -464,7 +464,7 @@ services:
         networks:
             - agenta-network
         ports:
-            - "${POSTGRES_PORT:-5432}:5432"
+            - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:
@@ -651,7 +651,7 @@ services:
             - agenta-network
         ports:
             - "${TRAEFIK_PORT:-80}:80"
-            - "${TRAEFIK_UI_PORT:-8080}:8080"
+            - "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -325,7 +325,7 @@ services:
         networks:
             - agenta-ee-gh-network
         ports:
-            - "${POSTGRES_PORT:-5432}:5432"
+            - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:
@@ -415,7 +415,7 @@ services:
             - agenta-ee-gh-network
         ports:
             - "${TRAEFIK_PORT:-80}:80"
-            - "${TRAEFIK_UI_PORT:-8080}:8080"
+            - "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
         # === LIFECYCLE ============================================ #
         restart: always
 

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -323,7 +323,7 @@ services:
         networks:
             - agenta-ee-gh-network
         ports:
-            - "${POSTGRES_PORT:-5432}:5432"
+            - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:
@@ -412,7 +412,7 @@ services:
             - agenta-ee-gh-network
         ports:
             - "${TRAEFIK_PORT:-80}:80"
-            - "${TRAEFIK_UI_PORT:-8080}:8080"
+            - "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
         # === LIFECYCLE ============================================ #
         restart: always
 

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -445,7 +445,7 @@ services:
         networks:
             - agenta-network
         ports:
-            - "${POSTGRES_PORT:-5432}:5432"
+            - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:
@@ -628,7 +628,7 @@ services:
             - agenta-network
         ports:
             - "${TRAEFIK_PORT:-80}:80"
-            - "${TRAEFIK_UI_PORT:-8080}:8080"
+            - "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -323,7 +323,7 @@ services:
         networks:
             - agenta-oss-gh-network
         ports:
-            - "${POSTGRES_PORT:-5432}:5432"
+            - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:
@@ -415,7 +415,7 @@ services:
             - agenta-oss-gh-network
         ports:
             - "${TRAEFIK_PORT:-80}:80"
-            - "${TRAEFIK_UI_PORT:-8080}:8080"
+            - "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
         # === LIFECYCLE ============================================ #
         restart: always
 

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -347,7 +347,7 @@ services:
         networks:
             - agenta-gh-ssl-network
         ports:
-            - "${POSTGRES_PORT:-5432}:5432"
+            - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:
@@ -429,7 +429,7 @@ services:
             - agenta-gh-ssl-network
         ports:
             - "${TRAEFIK_PORT:-80}:80"
-            - "${TRAEFIK_UI_PORT:-8080}:8080"
+            - "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
             - "${TRAEFIK_HTTPS_PORT:-443}:443"
         # === LIFECYCLE ============================================ #
         restart: always

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -340,7 +340,7 @@ services:
         networks:
             - agenta-oss-gh-network
         ports:
-            - "${POSTGRES_PORT:-5432}:5432"
+            - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:
@@ -432,7 +432,7 @@ services:
             - agenta-oss-gh-network
         ports:
             - "${TRAEFIK_PORT:-80}:80"
-            - "${TRAEFIK_UI_PORT:-8080}:8080"
+            - "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
         # === LIFECYCLE ============================================ #
         restart: always
 


### PR DESCRIPTION
## The exposure

Every docker-compose file publishes Postgres as `- "${POSTGRES_PORT:-5432}:5432"`. That default binds **0.0.0.0:5432**, so on a host with a public IP the database is reachable from the internet. The shipped env examples ship default credentials `username` / `password`, so a self-hoster who follows the quickstart hands anyone on the internet a login to their database.

Separately, several compose files run the Traefik dashboard and publish it as `- "${TRAEFIK_UI_PORT:-8080}:8080"`, also bound to **0.0.0.0**. Four of them enable the dashboard **without authentication** (`--api.insecure=true`, or `insecure: true` in the mounted `ssl/traefik.yml`), exposing an unauthenticated admin dashboard to the internet. The other three publish 8080 with no listener today, a dead publish that silently becomes a hole the moment someone adds the flag.

## The fix

Bind both datastore/admin ports to loopback by default. The public web entrypoint (`TRAEFIK_PORT` / `:80`) is deliberately left untouched.

- **Postgres** (7 files): `- "${POSTGRES_PORT:-5432}:5432"` -> `- "${POSTGRES_PORT:-127.0.0.1:5432}:5432"`. The default now binds loopback; the value stays env-overridable.
- **Traefik dashboard** (7 files): `- "${TRAEFIK_UI_PORT:-8080}:8080"` -> `- "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"`. Hard loopback prefix, since the shipped `.env.oss.gh` sets `TRAEFIK_UI_PORT=8080` explicitly and a `:-default` would not protect it.

Files: `oss/` and `ee/` × `docker-compose.{gh,gh.ssl,gh.local,dev}.yml` (7 total — ee has no `gh.ssl`).

Nothing else changes: no in-network URIs (those hardcode `@postgres:5432`), no healthchecks, no `.env*` example values, no redis/seaweedfs/supertokens.

## How to opt back in

A self-hoster who genuinely wants remote Postgres access sets it deliberately:

```
POSTGRES_PORT=0.0.0.0:5432
```

The dashboard is loopback-only by design (it is unauthenticated); reach it over an SSH tunnel, or edit the compose file if you must publish it.

## Why this is safe

A `127.0.0.1` bind still serves localhost, so local dev, tests, and anything on the host are unaffected. Verified against `POSTGRES_PORT` handling: `api/oss/src/utils/env.py` explicitly documents that `POSTGRES_PORT` only remaps the host-published port and must not feed connection URIs; in-network URIs hardcode `@postgres:5432` and healthchecks pass no `-p`. Re-grepped the current tree to confirm nothing reads `POSTGRES_PORT` as a bare integer.

`docker compose config` renders confirm the change on both editions:

- Default (empty/unset `POSTGRES_PORT`): Postgres publish renders `host_ip: 127.0.0.1`; dashboard renders `host_ip: 127.0.0.1`; the `:80` web entrypoint renders with **no** `host_ip` (stays public).
- Override `POSTGRES_PORT=5434`: renders `published: "5434"` with no `host_ip` (0.0.0.0) — the remote-access override still works.
- Empty `POSTGRES_PORT=` (as shipped in `.env.<lic>.gh`): `:-` treats empty as unset, so the loopback default applies.

## Follow-up (not in this PR)

The opt-in OTel overlay (`hosting/docker-compose/docker-compose.otel.yml`) publishes hardcoded `4317`/`4318` on 0.0.0.0. It is opt-in and lower priority; left as a noted follow-up.

https://claude.ai/code/session_01XhENr63WL9npkKrJGnzDc1
