### PR TITLE
skill(self-host): self-host-agenta skill

### DIFF
--- a/.agents/skills/self-host-agenta/SKILL.md
+++ b/.agents/skills/self-host-agenta/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: self-host-agenta
+description: Router and field guide for self-hosting Agenta with Docker Compose. Use when a user or agent wants to stand up, expose, harden, or debug a self-hosted Agenta deployment (OSS or EE), or asks "how do I self-host Agenta", "run.sh flags", "my self-host redirects to http", "the runner can't be found", "supertokens won't start". Routes to the public self-host docs as the source of truth and adds the operational knowledge (decision tree, gotchas, hardening, troubleshooting, verification) that the docs do not carry.
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash
+user-invocable: true
+---
+
+# Self-host Agenta
+
+A thin router to the public self-host docs, plus the field knowledge that does not live
+there. The docs at **https://docs.agenta.ai/self-host** are the source of truth for every
+procedure. This skill points you at the right page, and carries the decisions, gotchas,
+hardening steps, failure modes, and smoke tests an operator needs on top of them.
+
+Do not paste doc content into answers. Link the slug, then add the operational detail from
+the resource files below.
+
+## Start here: the four decisions
+
+Every later command follows from four choices. Make them first. Full detail with the exact
+flags is in [resources/decisions.md](resources/decisions.md).
+
+1. **Edition** — OSS (`--oss`) or EE (`--ee`). EE adds access control, SSO, orgs.
+2. **Image source** — published images from released main (`--gh`), images built from your
+   working tree (`--gh --local --build`, for a feature branch), or hot-reload dev
+   (`--dev`). Pick `--gh` unless you are running unreleased code.
+3. **Exposure** — plain `IP:port`, a domain with TLS, or a Cloudflare/other tunnel. This
+   decides your URL env vars and whether you harden (see resources/harden.md).
+4. **Who can start runs** — if more than one person can reach the deployment, agents must
+   run in Daytona sandboxes, not locally in the runner container. See the isolation doc.
+
+## Routing table: "I want to X" -> doc
+
+| Goal | Page |
+|---|---|
+| First local deploy (port 80 or custom port) | https://docs.agenta.ai/self-host/quick-start |
+| Where to start / what applies to me | https://docs.agenta.ai/self-host/overview |
+| Every environment variable and what it does | https://docs.agenta.ai/self-host/configuration |
+| Network topology, ports, container DNS | https://docs.agenta.ai/self-host/infrastructure/networking |
+| How the services fit together | https://docs.agenta.ai/self-host/infrastructure/architecture |
+| Deploy on a remote server | https://docs.agenta.ai/self-host/guides/deploy-remotely |
+| Put it behind a domain with TLS | https://docs.agenta.ai/self-host/guides/using-ssl |
+| Deploy on Kubernetes (Helm) | https://docs.agenta.ai/self-host/guides/deploy-to-kubernetes |
+| Deploy on Railway | https://docs.agenta.ai/self-host/guides/deploy-on-railway |
+| Understand how a run reaches the runner | https://docs.agenta.ai/self-host/agent-execution/how-agents-run |
+| Run agents with my own Claude/ChatGPT/Pi login | https://docs.agenta.ai/self-host/use-your-own-subscription |
+| Run agents in a cloud sandbox (Daytona) | https://docs.agenta.ai/self-host/agent-execution/daytona |
+| Run agents locally in the runner container | https://docs.agenta.ai/self-host/agent-execution/run-agents-locally |
+| Add binaries, deps, folders, or CPU to agent runs | https://docs.agenta.ai/self-host/agent-execution/customize-the-agent-runtime |
+| Which sandbox provider is safe for my deployment | https://docs.agenta.ai/self-host/agent-execution/sandbox-isolation-and-security |
+| Every runner environment variable | https://docs.agenta.ai/self-host/agent-execution/runner-configuration |
+
+## Operational resources (the part not in the docs)
+
+Open the file that matches the phase you are in.
+
+- [resources/decisions.md](resources/decisions.md) — the four decisions above, expanded
+  into the exact `run.sh` flags and env vars each one sets.
+- [resources/operate.md](resources/operate.md) — `run.sh` flags, env-file resolution,
+  running multiple isolated instances, building a non-released branch, and when a URL
+  change needs a container recreate vs an image rebuild.
+- [resources/harden.md](resources/harden.md) — public-IP hardening: loopback-bind
+  Postgres and the Traefik dashboard, change the default DB creds, generate real
+  `AGENTA_AUTH_KEY` / `AGENTA_CRYPT_KEY`.
+- [resources/troubleshoot.md](resources/troubleshoot.md) — field-verified failures keyed
+  to the exact error text: runner CLI not found, `http://` redirects behind a proxy,
+  subscription login not read, docker.sock permission, empty supertokens URI.
+- [resources/verify.md](resources/verify.md) — the smoke tests that prove a deployment is
+  healthy: API health, runner health, the runner startup log, a Daytona sandbox count,
+  loopback-bound ports.
+
+## Ground rules
+
+- The docs are the source of truth. If a resource file and a doc disagree, the doc wins and
+  the resource file is stale. Fix it.
+- Verify every command before you hand it to an operator. These run against a real
+  deployment. The commands here were checked against the Compose files in `hosting/`.
+- Run commands from the repo root. `run.sh` resolves paths relative to it.
+</content>
+</invoke>

--- a/.agents/skills/self-host-agenta/resources/decisions.md
+++ b/.agents/skills/self-host-agenta/resources/decisions.md
@@ -1,0 +1,64 @@
+# The four decisions
+
+Make these before you run anything. Each one fixes flags and env vars you cannot change
+later without a redeploy.
+
+## 1. Edition: OSS or EE
+
+- **OSS** (`--oss`): the open-source stack. Web studio, API, workflow services, agent
+  runner, Postgres, Redis, object store.
+- **EE** (`--ee`): adds access control, SSO, and multi-org. EE DB name is
+  `agenta_ee_core`; OSS is `agenta_oss_core`.
+
+The edition selects the Compose folder (`hosting/docker-compose/oss/` or `.../ee/`) and the
+env-file family (`.env.oss.*` or `.env.ee.*`). `run.sh` derives both from `--oss` / `--ee`.
+
+## 2. Image source: gh, gh --local, or dev
+
+Three ways to get the container images. This decides whether you run released code, your
+branch, or a hot-reload dev loop.
+
+| You want | Flags | Stage | Images |
+|---|---|---|---|
+| Run the released product | `--gh` | `gh` | Pulled from `ghcr.io/agenta-ai/*` |
+| Run your own working tree (a feature branch) | `--gh --local --build` | `gh.local` | Built from your checkout |
+| Hot-reload dev with source bind-mounts | `--dev` | `dev` | Built locally, code mounted |
+
+- `--gh` pulls prebuilt images by default (`--no-pull` to skip). Use it for a normal
+  self-host.
+- `--local` requires `--gh` and switches to the `gh.local` Compose file, which builds the
+  images from your local source instead of pulling. Add `--build` to force the build (and
+  `--no-cache` for a clean build). This is how you self-host an unreleased branch.
+- `--dev` bind-mounts source and hot-reloads. It is a development loop, not a deployment.
+
+## 3. Exposure: plain port, domain + TLS, or tunnel
+
+How the outside world reaches the stack. This sets your URL env vars and decides whether
+you must harden (resources/harden.md).
+
+- **Plain `IP:port`** — Traefik publishes on port 80 by default (`TRAEFIK_PORT` to change).
+  Set the URL env vars to your host. A public IP means you MUST harden.
+- **Domain + TLS** — terminate TLS with the `--ssl` stage (OSS) or a proxy in front. See
+  https://docs.agenta.ai/self-host/guides/using-ssl and
+  https://docs.agenta.ai/self-host/guides/deploy-remotely .
+- **Cloudflare / other tunnel** — a proxy in front of Traefik. This is the case that
+  produces `http://` redirects unless you set the forwarded-header vars. See
+  troubleshoot.md entry 2.
+
+## 4. Who can start runs: local vs Daytona sandbox
+
+This is a safety decision, not a convenience one.
+
+- A **local run** executes inside the runner container. It is not isolated from other runs:
+  one user's agent can read another user's files and the mounted credentials.
+- A **Daytona sandbox** run executes in a per-run cloud sandbox, isolated from the host and
+  from other runs.
+
+Rule: if more than one person can start runs on the deployment, enable Daytona. Local runs
+are for a single trusted operator. Full model:
+https://docs.agenta.ai/self-host/agent-execution/sandbox-isolation-and-security .
+
+Enabling each provider:
+- Local: https://docs.agenta.ai/self-host/agent-execution/run-agents-locally
+- Daytona: https://docs.agenta.ai/self-host/agent-execution/daytona
+</content>

--- a/.agents/skills/self-host-agenta/resources/harden.md
+++ b/.agents/skills/self-host-agenta/resources/harden.md
@@ -1,0 +1,42 @@
+# Hardening a public-IP deployment
+
+Do this when the host has a public IP or is reachable by anyone but you. A default local
+deployment on a private network does not need it. The configuration reference lists every
+variable: https://docs.agenta.ai/self-host/configuration .
+
+## 1. Keep Postgres and the Traefik dashboard on loopback
+
+The published Compose ports for Postgres and the Traefik dashboard are bound to `127.0.0.1`:
+
+```yaml
+# postgres
+- "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
+# traefik dashboard
+- "127.0.0.1:${TRAEFIK_UI_PORT:-8080}:8080"
+```
+
+**As of PR #5308 this loopback bind is the default.** Before that, these ports bound to
+`0.0.0.0` and were reachable from the public internet. If you run an older stack, or if you
+override `POSTGRES_PORT` / `TRAEFIK_UI_PORT`, confirm they still bind to `127.0.0.1` and not
+`0.0.0.0`. Verify with the port check in verify.md.
+
+## 2. Change the default database credentials
+
+The example env files ship `username` / `password` as the Postgres user and password, wired
+into the DB URIs (`postgresql://username:password@postgres:5432/...`). Change both before
+exposing the host, and update every URI that embeds them (the core DB URIs and the
+supertokens URI). Do not leave the defaults on a reachable deployment.
+
+## 3. Generate real secret keys
+
+The example env files ship `AGENTA_AUTH_KEY=replace-me` and `AGENTA_CRYPT_KEY=replace-me`.
+Replace both with generated values:
+
+```bash
+openssl rand -hex 32   # run once per key
+```
+
+Set the results as `AGENTA_AUTH_KEY` and `AGENTA_CRYPT_KEY` in your env file. `AGENTA_CRYPT_KEY`
+encrypts stored secrets, so changing it later invalidates anything already encrypted with the
+old value. Generate it once, before first use.
+</content>

--- a/.agents/skills/self-host-agenta/resources/operate.md
+++ b/.agents/skills/self-host-agenta/resources/operate.md
@@ -1,0 +1,81 @@
+# Operating the stack
+
+The operational mechanics behind `hosting/docker-compose/run.sh`. The docs cover the happy
+path; this covers the parts that bite.
+
+## run.sh: flags and what they resolve to
+
+`run.sh` lives at `hosting/docker-compose/run.sh`. Run it from the repo root:
+
+```bash
+bash ./hosting/docker-compose/run.sh --oss --gh --build
+```
+
+It derives a **stage** from your flags and picks the matching Compose file
+`hosting/docker-compose/<edition>/docker-compose.<stage>.yml`:
+
+- `--dev` -> stage `dev`
+- `--gh --local` -> stage `gh.local`
+- `--gh --ssl` -> stage `gh.ssl` (OSS only)
+- `--gh` -> stage `gh`
+
+Other flags: `--build` (build before up), `--no-cache` (clean build, needs `--build`),
+`--pull` / `--no-pull` (gh pulls by default, dev does not), `--down` (stop, keep volumes),
+`--nuke` (stop and drop volumes), `--no-web` (skip the web container), `--no-tunnel`
+(disable the Composio trigger tunnel; use it when the host already has a public ingress).
+
+## Env-file resolution: the bare-filename trap
+
+`run.sh` resolves `--env-file` (alias `-e`, `--env`) two ways, and this is easy to get
+wrong:
+
+- A **bare filename** (no slash) resolves **relative to the edition folder**:
+  `--env-file .env.oss.gh.custom` -> `hosting/docker-compose/oss/.env.oss.gh.custom`.
+- A **path** (contains a slash) is used **as-is**:
+  `--env-file hosting/docker-compose/oss/.env.oss.gh.custom` or an absolute path.
+
+If you pass no `--env-file`, `run.sh` defaults to `.env.<edition>.<stage>` in the edition
+folder, except that **`gh.local` reuses the `gh` env family** (`.env.<edition>.gh`), because
+the two stages share URLs and only differ in where the images come from.
+
+`run.sh` fails loud if the resolved env file is missing, rather than letting Compose fall
+back to its built-in port-80 default (which would make every web `/api` call 404). If you
+see "Env file not found", create the file or fix the path.
+
+## Multiple isolated instances on one host
+
+Each stack is namespaced by `COMPOSE_PROJECT_NAME` (default `agenta-<edition>-<stage>`, e.g.
+`agenta-oss-gh`). The Traefik provider constraint keys off it, so two stacks with different
+project names do not see each other's containers.
+
+To run a second isolated instance, give it a different `COMPOSE_PROJECT_NAME`, a separate
+env file, and non-colliding published ports (`TRAEFIK_PORT`, `POSTGRES_PORT`,
+`TRAEFIK_UI_PORT`). Then point `--env-file` at that env file.
+
+## Self-hosting a non-released branch
+
+Published `--gh` images track released main. To run code that is not released yet, build the
+images from your working tree:
+
+```bash
+bash ./hosting/docker-compose/run.sh --oss --gh --local --build
+```
+
+`--local` switches to the `gh.local` Compose file, which builds from your checkout instead
+of pulling. Rebuild (`--build`, or `--no-cache` for a clean build) whenever you change code
+that is baked into an image.
+
+## Recreate vs rebuild: the rule that saves you an afternoon
+
+The web image reads its URLs (`AGENTA_WEB_URL`, the API URL, and friends) **at container
+start**, not at build time. This changes what a given edit requires:
+
+- **Changed a URL or any runtime env var** -> **recreate** the container, do not rebuild.
+  Update the env file and re-run `run.sh` (or `docker compose up -d --force-recreate <svc>`).
+  A rebuild is wasted work.
+- **Changed `entrypoint.sh`, baked assets, or dependencies** -> **rebuild** the image
+  (`--build`, or `--no-cache`). A recreate alone runs the old image.
+
+If a URL change "did not take", you rebuilt when you needed to recreate, or the browser
+cached the old bundle. Recreate and hard-reload.
+</content>

--- a/.agents/skills/self-host-agenta/resources/troubleshoot.md
+++ b/.agents/skills/self-host-agenta/resources/troubleshoot.md
@@ -1,0 +1,106 @@
+# Troubleshooting
+
+Field-verified failures, keyed to the exact error text you will see. Each entry is
+symptom -> cause -> fix. If your symptom is not here, the configuration reference
+(https://docs.agenta.ai/self-host/configuration) and networking doc
+(https://docs.agenta.ai/self-host/infrastructure/networking) are the next stops.
+
+## 1. `could not find runner CLI at /app/runner/src/cli.ts`
+
+**Symptom.** An agent run fails and the Services logs show a message like
+`<backend> could not find runner CLI at /app/runner/src/cli.ts`.
+
+**Cause.** The Services API did not get a runner URL, so the SDK adapter fell back to
+launching the runner as a subprocess and looked for its CLI on disk. The Services image
+does not contain the runner, so the CLI is not there. This means `AGENTA_RUNNER_INTERNAL_URL`
+is unset or was overridden to empty in your env file.
+
+**Fix.** Point Services at the runner container over HTTP:
+
+```bash
+AGENTA_RUNNER_INTERNAL_URL=http://runner:8765
+```
+
+The Compose files default this to `http://runner:8765` already, so this bites when a custom
+env file blanks it out. Confirm your env file does not set `AGENTA_RUNNER_INTERNAL_URL=` to
+empty. Runner variables reference:
+https://docs.agenta.ai/self-host/agent-execution/runner-configuration .
+
+## 2. Behind a reverse proxy or Cloudflare, redirects come back as `http://` and drop `/api`
+
+**Symptom.** The stack works on a plain IP, but once you put a proxy (Cloudflare, an
+upstream nginx, a load balancer) in front, API calls 307/308-redirect to a `http://` URL and
+sometimes lose the `/api` prefix. Login loops or mixed-content errors follow.
+
+**Cause.** The API runs under gunicorn's Uvicorn worker, which only trusts forwarded
+headers (`X-Forwarded-Proto`, `X-Forwarded-For`) from clients in its trusted list. The
+immediate client is now the proxy, not loopback, so Uvicorn ignores the `https` signal and
+builds `http://` redirects. Traefik, in turn, does not trust forwarded headers from the
+upstream proxy by default.
+
+**Fix.** Trust the proxy at both hops.
+
+1. Tell Uvicorn to trust forwarded headers from any client, in your env file:
+
+   ```bash
+   FORWARDED_ALLOW_IPS=*
+   ```
+
+2. Tell Traefik to trust forwarded headers on the web entrypoint. Add to the `traefik`
+   service command in your Compose file:
+
+   ```yaml
+   - --entrypoints.web.forwardedHeaders.insecure=true
+   ```
+
+Set `FORWARDED_ALLOW_IPS=*` only when a trusted proxy sits in front of the stack. It tells
+Uvicorn to believe the `X-Forwarded-*` headers on every request.
+
+## 3. Subscription run behaves as if you never logged in
+
+**Symptom.** You mounted `~/.claude` (or another harness login) into the runner for a
+personal-subscription run, but the harness prompts to log in again or fails to authenticate.
+
+**Cause.** The runner container runs as the user `node`, uid 1000. A harness login file is
+mode `0600` and owned by your host user. If your host uid is not 1000, the container cannot
+read the file through the bind mount, so the login looks absent.
+
+**Fix.** Copy the login into a directory owned by uid 1000 and mount that directory
+**read-write** (the harness rewrites tokens). The subscription how-to has the exact commands
+and the `id -u` check: https://docs.agenta.ai/self-host/use-your-own-subscription .
+
+## 4. `permission denied ... /var/run/docker.sock`
+
+**Symptom.** A container or `run.sh` fails with `permission denied` on
+`/var/run/docker.sock`.
+
+**Cause.** Your user is not in the `docker` group and cannot reach the Docker daemon.
+
+**Fix.** Run as root, use `sudo`, or add yourself to the group and open a new shell:
+
+```bash
+sudo usermod -aG docker $USER   # then start a new shell
+```
+
+Docker-group membership is root-equivalent on the host. Grant it deliberately.
+
+## 5. Fresh OSS quick start: supertokens fails on an empty `POSTGRESQL_CONNECTION_URI`
+
+**Symptom.** On a first OSS `--gh` deploy, the supertokens container fails to start or
+cannot connect to Postgres, and its config shows an empty `POSTGRESQL_CONNECTION_URI`.
+
+**Cause.** The OSS `gh` Compose file maps
+`POSTGRESQL_CONNECTION_URI: ${POSTGRES_URI_SUPERTOKENS}` with **no fallback default**, but
+the OSS example env file ships `POSTGRES_URI_SUPERTOKENS` **commented out**. So the variable
+is empty and supertokens gets no connection string. (The EE Compose file has a `:-...`
+fallback, so EE does not hit this.)
+
+**Fix.** Uncomment the line in your OSS env file:
+
+```bash
+POSTGRES_URI_SUPERTOKENS=postgresql://username:password@postgres:5432/agenta_oss_supertokens
+```
+
+Match the credentials and DB name to your deployment. This is a pending fix in the OSS
+example / Compose defaults; treat it as a known gap until the fallback lands upstream.
+</content>

--- a/.agents/skills/self-host-agenta/resources/verify.md
+++ b/.agents/skills/self-host-agenta/resources/verify.md
@@ -1,0 +1,63 @@
+# Verifying a deployment
+
+Run these after every deploy or config change. They prove the stack is actually serving, not
+just that containers are "up". Replace `localhost` with your host and adjust the port if you
+changed `TRAEFIK_PORT`. Container names assume the default `COMPOSE_PROJECT_NAME`.
+
+## 1. API health -> 200
+
+The API mounts under `/api` (via `root_path` / `SCRIPT_NAME`), so through Traefik the health
+route is `/api/health`:
+
+```bash
+curl -fsS http://localhost/api/health && echo OK
+```
+
+A 200 with a JSON body means the API and its DB migrations are up. A 404 usually means the
+web/proxy URL vars are wrong (the env-file trap in operate.md).
+
+## 2. Runner health from inside the Services container
+
+Services reaches the runner over the internal Docker network at `http://runner:8765`. Check
+that path, not just the runner in isolation:
+
+```bash
+docker compose exec api curl -fsS http://runner:8765/health
+```
+
+The runner returns its identity (`status`, `runner`, `protocol`, `engines`, `harnesses`). If
+this fails but the runner container is up, Services and the runner are on different networks
+or `AGENTA_RUNNER_INTERNAL_URL` is wrong (troubleshoot.md entry 1).
+
+## 3. Runner startup log: the provider-config line
+
+On start the runner validates its configuration once and logs a single redacted summary. A
+bad provider list, a Daytona provider with no credential, or an invalid lifecycle value
+fails startup here rather than at first run:
+
+```bash
+docker compose logs runner | grep '\[sandbox-agent\]'
+```
+
+Look for the config summary and `http server listening on 0.0.0.0:8765`. You will also see
+one egress line: restricted mode (the default) or a WARNING if
+`AGENTA_INSECURE_EGRESS_ALLOWED` is set.
+
+## 4. Daytona: sandbox count returns to 0 after a run
+
+If Daytona is enabled, a healthy run creates a sandbox and tears it down when it finishes. A
+count that stays above 0 after runs complete means sandboxes are leaking. Check the count in
+your Daytona dashboard (or API) right after a run finishes; it should return to 0. The
+Daytona how-to has the smoke test: https://docs.agenta.ai/self-host/agent-execution/daytona .
+
+## 5. Published ports are loopback-bound
+
+On a public host, confirm Postgres and the Traefik dashboard are not exposed to the internet:
+
+```bash
+docker compose ps --format '{{.Service}}\t{{.Ports}}' | grep -E 'postgres|traefik'
+```
+
+The Postgres (`5432`) and dashboard (`8080`) mappings must show `127.0.0.1:`, not
+`0.0.0.0:`. If they show `0.0.0.0`, harden them (harden.md entry 1).
+</content>

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ services/runner/tests/results/
 .agents/*
 !.agents/skills/
 .agents/skills/*
+!.agents/skills/self-host-agenta/
 !.agents/skills/write-template-playbooks/
 !.claude/
 .claude/*


### PR DESCRIPTION
## What

Adds a `self-host-agenta` skill: a thin router to the public self-host docs plus the operational knowledge that does not belong in public docs.

The docs at https://docs.agenta.ai/self-host stay the source of truth. The skill links to them and carries what an operator needs on top: a decision tree, field-verified gotchas, hardening steps, troubleshooting keyed to real error text, and smoke tests.

## Structure

- `SKILL.md` — short router: the four up-front decisions, an "I want to X -> doc slug" routing table (16 pages), and pointers to the resource files.
- `resources/decisions.md` — edition, image source, exposure, and who-can-run choices, expanded into the exact `run.sh` flags each one sets.
- `resources/operate.md` — `run.sh` flags and env-file resolution, `COMPOSE_PROJECT_NAME` for multiple instances, building a non-released branch, and recreate-vs-rebuild.
- `resources/harden.md` — loopback-bind Postgres and the Traefik dashboard, change default DB creds, generate real auth/crypt keys.
- `resources/troubleshoot.md` — runner CLI not found, `http://` redirects behind a proxy, subscription login not read, docker.sock permission, empty supertokens URI.
- `resources/verify.md` — API health, runner health, runner startup log, Daytona sandbox count, loopback-bound ports.

Every command and env var was verified against the current `hosting/` Compose files and the runner/SDK/API source. Where a doc already covers something (subscription, Daytona, configuration reference), the skill links the slug and does not restate it.

The one-line `.gitignore` change un-ignores the new skill directory (`.agents/skills/*` is ignored by default; tracked skills carry an explicit negation, matching `write-template-playbooks`).

https://claude.ai/code/session_01XhENr63WL9npkKrJGnzDc1
