### PR TITLE
[fix] Align demo agent defaults

### DIFF
--- a/sdks/python/agenta/sdk/utils/types.py
+++ b/sdks/python/agenta/sdk/utils/types.py
@@ -1056,7 +1056,7 @@ def _model_catalog_type() -> dict:
     }
 
 
-_DEFAULT_AGENT_MODEL = "gpt-5.5"
+_DEFAULT_AGENT_MODEL = "gpt-5.6-luna"
 _DEFAULT_AGENTS_MD = (
     "You are a friendly hello-world agent running on the Agenta agent service.\n\n"
     "- Greet the user warmly.\n"

--- a/services/oss/src/agent/config.py
+++ b/services/oss/src/agent/config.py
@@ -23,7 +23,7 @@ _DEFAULT_AGENT_DIR = _SERVICES_DIR / "runner"
 # Fallback config used when the editable files are missing or a field is absent.
 # Kept in sync with the catalog template and the `/inspect` schema defaults
 # (schemas.py: _DEFAULT_MODEL / _DEFAULT_AGENTS_MD).
-DEFAULT_MODEL = "gpt-5.5"
+DEFAULT_MODEL = "gpt-5.6-luna"
 DEFAULT_AGENTS_MD = (
     "You are a friendly hello-world agent running on the Agenta agent service.\n\n"
     "- Greet the user warmly.\n"

--- a/services/oss/tests/pytest/unit/agent/test_default_agent_template.py
+++ b/services/oss/tests/pytest/unit/agent/test_default_agent_template.py
@@ -82,3 +82,10 @@ def test_harness_default_is_pi_core_in_every_source():
     assert build_agent_v0_default()["harness"]["kind"] == "pi_core"
     assert _builtin_agent_default()["harness"]["kind"] == "pi_core"
     assert _inspect_agent_default()["harness"]["kind"] == "pi_core"
+
+
+def test_model_default_is_gpt_5_6_luna_in_every_source():
+    expected = {"provider": "openai", "model": "gpt-5.6-luna"}
+    assert build_agent_v0_default()["llm"] == expected
+    assert _builtin_agent_default()["llm"] == expected
+    assert _inspect_agent_default()["llm"] == expected

--- a/services/runner/config/agent.json
+++ b/services/runner/config/agent.json
@@ -1,4 +1,4 @@
 {
-  "model": "gpt-5.5",
+  "model": "gpt-5.6-luna",
   "tools": []
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/HarnessSelectControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/HarnessSelectControl.tsx
@@ -96,6 +96,8 @@ export interface HarnessSelectControlProps {
     label?: string
     /** Current value. */
     value: string | null | undefined
+    /** Optional visible values, used to hide supported but non-selectable harnesses. */
+    visibleValues?: string[]
     /** Change handler. */
     onChange: (value: string | null) => void
     /** Optional description for tooltip. */
@@ -115,6 +117,7 @@ export const HarnessSelectControl = memo(function HarnessSelectControl({
     schema,
     label,
     value,
+    visibleValues,
     onChange,
     description,
     withTooltip = true,
@@ -128,12 +131,13 @@ export const HarnessSelectControl = memo(function HarnessSelectControl({
     const metaWithLabel = (id: string): HarnessMeta => ({...metaFor(id), label: labelFor(id)})
 
     const options = useMemo(() => {
-        const values = Array.isArray(schema?.enum) ? (schema?.enum as unknown[]) : []
+        const values =
+            visibleValues ?? (Array.isArray(schema?.enum) ? (schema.enum as string[]) : [])
         return values.map((v) => {
             const id = String(v)
             return {value: id, label: titles[id] ?? metaFor(id).label}
         })
-    }, [schema, titles])
+    }, [schema, titles, visibleValues])
 
     const tooltipText = description ?? (schema?.description as string | undefined) ?? ""
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -59,6 +59,8 @@ const PERMISSION_POLICY_VALUES = new Set<string>(
     PERMISSION_POLICY_OPTIONS.map((option) => option.value),
 )
 
+const HIDDEN_HARNESSES = new Set(["pi_agenta"])
+
 function isPermissionPolicy(value: unknown): value is PermissionPolicy {
     return typeof value === "string" && PERMISSION_POLICY_VALUES.has(value)
 }
@@ -143,6 +145,16 @@ export function useModelHarness({
         },
         [config, onChange],
     )
+
+    const sandboxValue = typeof sandbox.kind === "string" ? sandbox.kind : null
+    useEffect(() => {
+        const availableValue = sandboxOptions.some((option) => option.value === sandboxValue)
+            ? sandboxValue
+            : (sandboxOptions[0]?.value ?? null)
+        if (availableValue && availableValue !== sandboxValue) {
+            setSection("sandbox", {...sandbox, kind: availableValue})
+        }
+    }, [sandbox, sandboxOptions, sandboxValue, setSection])
 
     // Model + credential connection (`llm`). It is ALWAYS a structured object (the harness-filtered
     // picker only ever produces one); a legacy bare string is read for display. composeModelValue
@@ -491,7 +503,12 @@ export function useModelHarness({
     // Harness list, from the inspect capabilities map. Model compatibility is shown per-card (below).
     // GAP (tracked): harness_capabilities covers model/provider/mode/hosting only — NOT tools/skills/
     // MCP — so switching harness can silently leave unsupported tools unwarned. See design.md.
-    const harnessList = capabilities ? Object.keys(capabilities) : []
+    const schemaHarnesses = Array.isArray(harnessProps.kind?.enum)
+        ? (harnessProps.kind.enum as unknown[]).map(String)
+        : []
+    const harnessList = (capabilities ? Object.keys(capabilities) : schemaHarnesses).filter(
+        (harnessId) => !HIDDEN_HARNESSES.has(harnessId),
+    )
 
     // Harness as a `[rail │ detail]` (experiment): the harness list on the rail with a model-compat dot,
     // the selected harness's providers / hosting / models + compatibility badge in the content panel.
@@ -648,6 +665,7 @@ export function useModelHarness({
                 <RailField label="Harness" align="center">
                     <HarnessSelectControl
                         schema={harnessProps.kind}
+                        visibleValues={harnessList}
                         value={(harness.kind as string | null) ?? null}
                         onChange={(v) => setSection("harness", {...harness, kind: v})}
                         withTooltip={withTooltip}


### PR DESCRIPTION
## Context

In the demo cloud deployment, Daytona is the only enabled execution environment, but a new agent still loads the unavailable local sandbox default. Users must open the execution settings and select Daytona before the agent can run. New agents also start on GPT-5.5 and expose the opinionated Pi (Agenta) harness even though that harness should not be selectable here.

## Changes

When the current sandbox value is missing from the enabled deployment options, the frontend now selects the first available option. A Daytona-only deployment therefore changes from an invalid local selection to Daytona automatically, while deployments that offer the configured default keep it unchanged.

The shared agent template, service fallback, and runner file now default to `openai/gpt-5.6-luna`. The harness picker filters `pi_agenta` from both the capability-backed rail and the schema-backed fallback picker. Plain Pi remains the default harness.

## How to review

Start with `useModelHarness.tsx` and `HarnessSelectControl.tsx` for the unavailable-sandbox fallback and harness visibility rules. Then check `types.py`, the service config, and `agent.json` for the synchronized model default. The service test pins the published SDK and inspect defaults to the same model.

## Tests / notes

- `pnpm lint-fix`
- `pnpm --filter @agenta/entity-ui run types:check`
- `pnpm --filter @agenta/entity-ui test:unit -- tests/unit/enumSelectControl.test.ts tests/unit/connectionUtils.test.ts` (201 passed)
- Focused service tests for the default template and config fallback (9 passed)
- Ruff format and check on the touched Python files

## What to QA

- Open a new agent in the Daytona-only demo deployment. Execution environment shows Daytona without a manual selection.
- Create a new agent. Its model is GPT-5.6 Luna and plain Pi remains selected.
- Open the harness picker. Pi (Agenta) is absent, while plain Pi and Claude Code remain available.