### PR TITLE
docs(self-host): copy-paste self-host prompt card

### DIFF
--- a/docs/docs/self-host/00-overview.mdx
+++ b/docs/docs/self-host/00-overview.mdx
@@ -11,13 +11,12 @@ own infrastructure. It has every feature of Agenta Cloud except the governance f
 under [Editions](#editions).
 
 :::tip Self-host with your coding agent
-Paste this into Claude Code, Cursor, or another coding agent and it will walk you through setup and testing:
+Paste this into Claude Code (or your coding agent) and it will walk you through setup and testing:
 
 ```
-Help me self-host Agenta (the open-source LLM agent platform, https://github.com/Agenta-AI/agenta). Follow the self-hosting docs at https://agenta.ai/docs/self-host/overview: ask me the key decisions, set it up, and confirm an agent runs.
+1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
+2. Help me self-host Agenta with its repository.
 ```
-
-For a guided, questionnaire-style flow, install the Agenta self-host skill first: `npx skills add Agenta-AI/agenta-skills` (Cursor, Codex, and others), or in Claude Code run `/plugin marketplace add Agenta-AI/agenta-skills`.
 :::
 
 ## Start here

--- a/docs/docs/self-host/00-overview.mdx
+++ b/docs/docs/self-host/00-overview.mdx
@@ -10,6 +10,14 @@ A self-hosted deployment runs the studio, the API, the agent runner, and their d
 own infrastructure. It has every feature of Agenta Cloud except the governance features listed
 under [Editions](#editions).
 
+:::tip Self-host with your coding agent
+Paste this prompt into your coding agent (Claude Code, Cursor, and similar) and it will set up and test a self-hosted Agenta with you.
+
+```
+I want to self-host Agenta
+```
+:::
+
 ## Start here
 
 - [Quick start](/self-host/quick-start) runs the full stack locally with Docker Compose.

--- a/docs/docs/self-host/00-overview.mdx
+++ b/docs/docs/self-host/00-overview.mdx
@@ -11,11 +11,13 @@ own infrastructure. It has every feature of Agenta Cloud except the governance f
 under [Editions](#editions).
 
 :::tip Self-host with your coding agent
-Paste this prompt into your coding agent (Claude Code, Cursor, and similar) and it will set up and test a self-hosted Agenta with you.
+Paste this into Claude Code, Cursor, or another coding agent and it will walk you through setup and testing:
 
 ```
-I want to self-host Agenta
+Help me self-host Agenta (the open-source LLM agent platform, https://github.com/Agenta-AI/agenta). Follow the self-hosting docs at https://agenta.ai/docs/self-host/overview: ask me the key decisions, set it up, and confirm an agent runs.
 ```
+
+For a guided, questionnaire-style flow, install the Agenta self-host skill first: `npx skills add Agenta-AI/agenta-skills` (Cursor, Codex, and others), or in Claude Code run `/plugin marketplace add Agenta-AI/agenta-skills`.
 :::
 
 ## Start here

--- a/docs/docs/self-host/01-quick-start.mdx
+++ b/docs/docs/self-host/01-quick-start.mdx
@@ -9,11 +9,13 @@ sidebar_position: 1
 This guide explains how to set up Agenta on your local machine using Docker Compose, either using the default port 80 or a custom port.
 
 :::tip Self-host with your coding agent
-Paste this prompt into your coding agent (Claude Code, Cursor, and similar) and it will set up and test a self-hosted Agenta with you.
+Paste this into Claude Code, Cursor, or another coding agent and it will walk you through setup and testing:
 
 ```
-I want to self-host Agenta
+Help me self-host Agenta (the open-source LLM agent platform, https://github.com/Agenta-AI/agenta). Follow the self-hosting docs at https://agenta.ai/docs/self-host/overview: ask me the key decisions, set it up, and confirm an agent runs.
 ```
+
+For a guided, questionnaire-style flow, install the Agenta self-host skill first: `npx skills add Agenta-AI/agenta-skills` (Cursor, Codex, and others), or in Claude Code run `/plugin marketplace add Agenta-AI/agenta-skills`.
 :::
 
 :::tip
@@ -22,14 +24,7 @@ Looking to deploy on Kubernetes instead? See the [Deploy on Kubernetes](/self-ho
 
 ## Prerequisites
 
-- Docker installed on your machine ([Download Docker](https://docs.docker.com/get-docker/))
-- Permission to reach the Docker daemon socket, `/var/run/docker.sock`. It is owned by `root` and the `docker` group. Run the commands below as `root`, prefix them with `sudo`, or add your user to the `docker` group:
-
-  ```bash
-  sudo usermod -aG docker $USER
-  ```
-
-  Then open a new login shell so the group applies. A member of the `docker` group can start a container that mounts the host filesystem, which makes the group equivalent to root on that machine.
+- Docker and Docker Compose installed ([Download Docker](https://docs.docker.com/get-docker/))
 
 ## Quick Setup (Port 80)
 
@@ -99,6 +94,7 @@ If Agenta doesn't start properly, check these common issues:
 5. Docker network layout: The Docker networks are defined in the compose files. See `hosting/docker-compose/oss/docker-compose.gh.yml` (OSS) or `hosting/docker-compose/ee/docker-compose.dev.yml` (EE) for the network names and service attachments.
 6. Lack of memory provided to docker: If you are experiencing the web container restarting and dying unexpectedly, the most likely cause is that you are running out of memory. You may need to increase the memory allocated to docker (desktop).
 7. The runner container does not start and Docker reports `error gathering device information while adding custom device "/dev/fuse"`: the host has no FUSE device. See [Run agents locally](/self-host/agent-execution/run-agents-locally#troubleshooting).
+8. Docker reports `permission denied` while trying to connect to `/var/run/docker.sock`: your user cannot reach the Docker daemon. Run the commands as `root`, prefix them with `sudo`, or add your user to the `docker` group (`sudo usermod -aG docker $USER`, then open a new login shell). A member of the `docker` group can start a container that mounts the host filesystem, which makes the group equivalent to root on that machine.
 
 :::info
 To set up a development environment with features like hot-reloading, refer to our [Development Guide](/contributing/guides/development-mode).

--- a/docs/docs/self-host/01-quick-start.mdx
+++ b/docs/docs/self-host/01-quick-start.mdx
@@ -9,13 +9,12 @@ sidebar_position: 1
 This guide explains how to set up Agenta on your local machine using Docker Compose, either using the default port 80 or a custom port.
 
 :::tip Self-host with your coding agent
-Paste this into Claude Code, Cursor, or another coding agent and it will walk you through setup and testing:
+Paste this into Claude Code (or your coding agent) and it will walk you through setup and testing:
 
 ```
-Help me self-host Agenta (the open-source LLM agent platform, https://github.com/Agenta-AI/agenta). Follow the self-hosting docs at https://agenta.ai/docs/self-host/overview: ask me the key decisions, set it up, and confirm an agent runs.
+1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
+2. Help me self-host Agenta with its repository.
 ```
-
-For a guided, questionnaire-style flow, install the Agenta self-host skill first: `npx skills add Agenta-AI/agenta-skills` (Cursor, Codex, and others), or in Claude Code run `/plugin marketplace add Agenta-AI/agenta-skills`.
 :::
 
 :::tip

--- a/docs/docs/self-host/01-quick-start.mdx
+++ b/docs/docs/self-host/01-quick-start.mdx
@@ -8,6 +8,14 @@ sidebar_position: 1
 
 This guide explains how to set up Agenta on your local machine using Docker Compose, either using the default port 80 or a custom port.
 
+:::tip Self-host with your coding agent
+Paste this prompt into your coding agent (Claude Code, Cursor, and similar) and it will set up and test a self-hosted Agenta with you.
+
+```
+I want to self-host Agenta
+```
+:::
+
 :::tip
 Looking to deploy on Kubernetes instead? See the [Deploy on Kubernetes](/self-host/guides/deploy-to-kubernetes) guide for Helm chart installation.
 :::


### PR DESCRIPTION
## What

Adds an identical `:::tip` prompt card near the top of the two self-host entry pages:

- `docs/docs/self-host/00-overview.mdx` (after the intro, above `## Start here`)
- `docs/docs/self-host/01-quick-start.mdx` (after the opening sentence, above the existing Kubernetes tip)

The card contains a one-click-copy fenced prompt:

```
I want to self-host Agenta
```

## Why

It pairs with the `self-host-agenta` skill: a reader can paste this single prompt into their coding agent (Claude Code, Cursor, and similar) and have it set up and test a self-hosted Agenta with them, instead of following the steps by hand. Putting it on both the overview and the quick-start puts the shortcut wherever a self-hoster lands first.

## Verification

`pnpm build` in `docs/` passes (valid MDX, no broken links; only pre-existing unrelated redirect/deprecation warnings).

https://claude.ai/code/session_01XhENr63WL9npkKrJGnzDc1