### PR TITLE
fix(hosting): bundle SeaweedFS store in gh compose

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -77,6 +77,8 @@ services:
                 condition: service_healthy
             redis-durable:
                 condition: service_healthy
+            seaweedfs:
+                condition: service_healthy
         # === LABELS =============================================== #
         labels:
             - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
@@ -392,6 +394,65 @@ services:
             retries: 5
             start_period: 5s
 
+    seaweedfs:
+        # === IMAGE ================================================ #
+        # The bundled durable object store for session/agent mounts. Without it, runner mount
+        # signing returns 503 and agent file writes are silently lost. Pinned (not :latest) so the
+        # IAM/STS subsystem stays on a known-good build — it has regressed across releases.
+        image: chrislusf/seaweedfs:4.37
+        # === EXECUTION ============================================ #
+        # ONLY FOR SEAWEEDFS (the bundled store). Real S3/R2/MinIO ship their own STS/IAM and ignore
+        # all of this. Two configs, both generated from env (no committed files):
+        #  - s3.json: the master identity only (admin; the API holds these creds, never the runner).
+        #  - iam.json: the ADVANCED IAM config — the only path SeaweedFS authorizes STS credentials.
+        #    An OIDC provider points at the API's self-served JWKS; the API mints a short-lived
+        #    RS256 web-identity token and calls AssumeRoleWithWebIdentity to assume `agenta-store`.
+        entrypoint:
+            - sh
+            - -c
+            - |
+              cat > /etc/seaweedfs/s3.json <<EOF
+              {"identities":[{"name":"agenta","credentials":[{"accessKey":"$${AGENTA_STORE_ACCESS_KEY}","secretKey":"$${AGENTA_STORE_SECRET_KEY}"}],"actions":["Admin","Read","Write","List","Tagging"]}]}
+              EOF
+              cat > /etc/seaweedfs/iam.json <<EOF
+              {"sts":{"tokenDuration":"1h","maxSessionLength":"12h","issuer":"seaweedfs-sts","signingKey":"$${AGENTA_STORE_SIGNING_KEY}"},"providers":[{"name":"agenta","type":"oidc","enabled":true,"config":{"issuer":"$${AGENTA_STORE_JWT_ISSUER}","clientId":"agenta-store","jwksUri":"$${AGENTA_STORE_JWT_ISSUER}/.well-known/jwks.json"}}],"policies":[{"name":"store-rw","document":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::$${AGENTA_STORE_BUCKET}","arn:aws:s3:::$${AGENTA_STORE_BUCKET}/*"]}]}}],"roles":[{"roleName":"agenta-store","roleArn":"arn:aws:iam::role/agenta-store","attachedPolicies":["store-rw"],"trustPolicy":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"agenta"},"Action":["sts:AssumeRoleWithWebIdentity"]}]}}]}
+              EOF
+              exec weed server -dir=/data -ip=seaweedfs -volume.max=64 -s3 -s3.port=8333 -s3.config=/etc/seaweedfs/s3.json -s3.iam.config=/etc/seaweedfs/iam.json
+        # === CONFIGURATION ======================================== #
+        env_file:
+            - ${ENV_FILE:-./.env.ee.gh}
+        environment:
+            # The entrypoint bakes these into s3.json/iam.json via raw shell expansion, so they must
+            # be present in this service's env (defaults here are for the bundled store, the same way
+            # supertokens carries its own connection URI). Keys come from the env file — secrets never
+            # get a baked-in default. Override the whole trio via the env file to use S3/R2/MinIO.
+            AGENTA_STORE_ACCESS_KEY: ${AGENTA_STORE_ACCESS_KEY}
+            AGENTA_STORE_SECRET_KEY: ${AGENTA_STORE_SECRET_KEY}
+            AGENTA_STORE_BUCKET: ${AGENTA_STORE_BUCKET:-agenta-store}
+            AGENTA_STORE_SIGNING_KEY: ${AGENTA_STORE_SIGNING_KEY}
+            AGENTA_STORE_JWT_ISSUER: ${AGENTA_STORE_JWT_ISSUER:-http://api:8000}
+        # === STORAGE ============================================== #
+        volumes:
+            - seaweed-data:/data
+        # === NETWORK ============================================== #
+        networks:
+            - agenta-ee-gh-network
+        # Loopback-only by default (never expose the store to a public IP); override AGENTA_STORE_PORT
+        # to change. In-network services reach it directly at seaweedfs:8333, no publish needed.
+        ports:
+            - "${AGENTA_STORE_PORT:-127.0.0.1:8333}:8333"
+        # === LABELS =============================================== #
+        labels:
+            - "traefik.enable=false"
+        # === LIFECYCLE ============================================ #
+        restart: always
+        healthcheck:
+            test: ["CMD-SHELL", "curl -sf http://localhost:9333/cluster/healthz >/dev/null || exit 1"]
+            interval: 5s
+            timeout: 5s
+            retries: 30
+            start_period: 5s
+
     traefik:
         # === IMAGE ================================================ #
         image: traefik:2
@@ -480,3 +541,4 @@ volumes:
     postgres-data:
     redis-volatile-data:
     redis-durable-data:
+    seaweed-data:

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -317,17 +317,24 @@ POSTHOG_API_KEY=phc_3urGRy5TL1HhaHnRYL0JSHxJxigRVackhphHtozUmdp
 # ================================================================== #
 # Object store (durable session mounts)
 # ================================================================== #
-# Durable S3-compatible store for session/agent mounts. Docs (vars, SeaweedFS setup, namespaces):
+# These defaults drive the SeaweedFS object store BUNDLED in this compose file (the `seaweedfs`
+# service), so agent/session mounts work out of the box. They are kept consistent with that
+# service's own config. To use an external S3-compatible store (AWS S3, Cloudflare R2, MinIO)
+# instead, point ENDPOINT_URL/ACCESS_KEY/SECRET_KEY/BUCKET at it and clear SIGNING_KEY (its
+# presence selects the bundled-SeaweedFS signing path). Docs (a how-to covers external stores):
 # https://docs.agenta.ai/self-host/configuration#store-durable-object-store
-# Required: ACCESS_KEY / SECRET_KEY. Commented lines show defaults.
+# ACCESS_KEY/SECRET_KEY/SIGNING_KEY are secrets (REPLACE in production!), same pattern as
+# AGENTA_AUTH_KEY/AGENTA_CRYPT_KEY above. The `seaweedfs` service and the api/worker/cron all
+# read these same values, so any shared replacement still works out of the box. Generate the
+# signing key with: openssl rand -base64 32
 AGENTA_STORE_ACCESS_KEY=replace-me
 AGENTA_STORE_SECRET_KEY=replace-me
-# AGENTA_STORE_ENDPOINT_URL=
+AGENTA_STORE_ENDPOINT_URL=http://seaweedfs:8333
+AGENTA_STORE_BUCKET=agenta-store
+AGENTA_STORE_SIGNING_KEY=replace-me
 # AGENTA_STORE_STS_ENDPOINT_URL=
 # AGENTA_STORE_REGION=us-east-1
-# AGENTA_STORE_BUCKET=agenta-store
 # AGENTA_STORE_NAMESPACE=
-# AGENTA_STORE_SIGNING_KEY=
 # AGENTA_STORE_JWT_ISSUER=http://api:8000
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -75,6 +75,8 @@ services:
                 condition: service_healthy
             redis-durable:
                 condition: service_healthy
+            seaweedfs:
+                condition: service_healthy
         # === LABELS =============================================== #
         labels:
             - "traefik.http.routers.api.rule=PathPrefix(`/api/`)"
@@ -409,6 +411,65 @@ services:
             retries: 5
             start_period: 5s
 
+    seaweedfs:
+        # === IMAGE ================================================ #
+        # The bundled durable object store for session/agent mounts. Without it, runner mount
+        # signing returns 503 and agent file writes are silently lost. Pinned (not :latest) so the
+        # IAM/STS subsystem stays on a known-good build — it has regressed across releases.
+        image: chrislusf/seaweedfs:4.37
+        # === EXECUTION ============================================ #
+        # ONLY FOR SEAWEEDFS (the bundled store). Real S3/R2/MinIO ship their own STS/IAM and ignore
+        # all of this. Two configs, both generated from env (no committed files):
+        #  - s3.json: the master identity only (admin; the API holds these creds, never the runner).
+        #  - iam.json: the ADVANCED IAM config — the only path SeaweedFS authorizes STS credentials.
+        #    An OIDC provider points at the API's self-served JWKS; the API mints a short-lived
+        #    RS256 web-identity token and calls AssumeRoleWithWebIdentity to assume `agenta-store`.
+        entrypoint:
+            - sh
+            - -c
+            - |
+              cat > /etc/seaweedfs/s3.json <<EOF
+              {"identities":[{"name":"agenta","credentials":[{"accessKey":"$${AGENTA_STORE_ACCESS_KEY}","secretKey":"$${AGENTA_STORE_SECRET_KEY}"}],"actions":["Admin","Read","Write","List","Tagging"]}]}
+              EOF
+              cat > /etc/seaweedfs/iam.json <<EOF
+              {"sts":{"tokenDuration":"1h","maxSessionLength":"12h","issuer":"seaweedfs-sts","signingKey":"$${AGENTA_STORE_SIGNING_KEY}"},"providers":[{"name":"agenta","type":"oidc","enabled":true,"config":{"issuer":"$${AGENTA_STORE_JWT_ISSUER}","clientId":"agenta-store","jwksUri":"$${AGENTA_STORE_JWT_ISSUER}/.well-known/jwks.json"}}],"policies":[{"name":"store-rw","document":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::$${AGENTA_STORE_BUCKET}","arn:aws:s3:::$${AGENTA_STORE_BUCKET}/*"]}]}}],"roles":[{"roleName":"agenta-store","roleArn":"arn:aws:iam::role/agenta-store","attachedPolicies":["store-rw"],"trustPolicy":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"agenta"},"Action":["sts:AssumeRoleWithWebIdentity"]}]}}]}
+              EOF
+              exec weed server -dir=/data -ip=seaweedfs -volume.max=64 -s3 -s3.port=8333 -s3.config=/etc/seaweedfs/s3.json -s3.iam.config=/etc/seaweedfs/iam.json
+        # === CONFIGURATION ======================================== #
+        env_file:
+            - ${ENV_FILE:-./.env.oss.gh}
+        environment:
+            # The entrypoint bakes these into s3.json/iam.json via raw shell expansion, so they must
+            # be present in this service's env (defaults here are for the bundled store, the same way
+            # supertokens carries its own connection URI). Keys come from the env file — secrets never
+            # get a baked-in default. Override the whole trio via the env file to use S3/R2/MinIO.
+            AGENTA_STORE_ACCESS_KEY: ${AGENTA_STORE_ACCESS_KEY}
+            AGENTA_STORE_SECRET_KEY: ${AGENTA_STORE_SECRET_KEY}
+            AGENTA_STORE_BUCKET: ${AGENTA_STORE_BUCKET:-agenta-store}
+            AGENTA_STORE_SIGNING_KEY: ${AGENTA_STORE_SIGNING_KEY}
+            AGENTA_STORE_JWT_ISSUER: ${AGENTA_STORE_JWT_ISSUER:-http://api:8000}
+        # === STORAGE ============================================== #
+        volumes:
+            - seaweed-data:/data
+        # === NETWORK ============================================== #
+        networks:
+            - agenta-oss-gh-network
+        # Loopback-only by default (never expose the store to a public IP); override AGENTA_STORE_PORT
+        # to change. In-network services reach it directly at seaweedfs:8333, no publish needed.
+        ports:
+            - "${AGENTA_STORE_PORT:-127.0.0.1:8333}:8333"
+        # === LABELS =============================================== #
+        labels:
+            - "traefik.enable=false"
+        # === LIFECYCLE ============================================ #
+        restart: always
+        healthcheck:
+            test: ["CMD-SHELL", "curl -sf http://localhost:9333/cluster/healthz >/dev/null || exit 1"]
+            interval: 5s
+            timeout: 5s
+            retries: 30
+            start_period: 5s
+
     traefik:
         # === ACTIVATION =========================================== #
         profiles:
@@ -524,3 +585,4 @@ volumes:
     postgres-data:
     redis-volatile-data:
     redis-durable-data:
+    seaweed-data:

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -317,17 +317,24 @@ POSTHOG_API_KEY=phc_hmVSxIjTW1REBHXgj2aw4HW9X6CXb6FzerBgP9XenC7
 # ================================================================== #
 # Object store (durable session mounts)
 # ================================================================== #
-# Durable S3-compatible store for session/agent mounts. Docs (vars, SeaweedFS setup, namespaces):
+# These defaults drive the SeaweedFS object store BUNDLED in this compose file (the `seaweedfs`
+# service), so agent/session mounts work out of the box. They are kept consistent with that
+# service's own config. To use an external S3-compatible store (AWS S3, Cloudflare R2, MinIO)
+# instead, point ENDPOINT_URL/ACCESS_KEY/SECRET_KEY/BUCKET at it and clear SIGNING_KEY (its
+# presence selects the bundled-SeaweedFS signing path). Docs (a how-to covers external stores):
 # https://docs.agenta.ai/self-host/configuration#store-durable-object-store
-# Required: ACCESS_KEY / SECRET_KEY. Commented lines show defaults.
+# ACCESS_KEY/SECRET_KEY/SIGNING_KEY are secrets (REPLACE in production!), same pattern as
+# AGENTA_AUTH_KEY/AGENTA_CRYPT_KEY above. The `seaweedfs` service and the api/worker/cron all
+# read these same values, so any shared replacement still works out of the box. Generate the
+# signing key with: openssl rand -base64 32
 AGENTA_STORE_ACCESS_KEY=replace-me
 AGENTA_STORE_SECRET_KEY=replace-me
-# AGENTA_STORE_ENDPOINT_URL=
+AGENTA_STORE_ENDPOINT_URL=http://seaweedfs:8333
+AGENTA_STORE_BUCKET=agenta-store
+AGENTA_STORE_SIGNING_KEY=replace-me
 # AGENTA_STORE_STS_ENDPOINT_URL=
 # AGENTA_STORE_REGION=us-east-1
-# AGENTA_STORE_BUCKET=agenta-store
 # AGENTA_STORE_NAMESPACE=
-# AGENTA_STORE_SIGNING_KEY=
 # AGENTA_STORE_JWT_ISSUER=http://api:8000
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —


### PR DESCRIPTION
## Problem

The published OSS/EE `gh` compose ships **no object store**. A self-hoster who follows the quick-start gets an API whose runner mount signing returns **503**, so agent file writes are silently lost. The env examples even set `AGENTA_STORE_ACCESS_KEY/SECRET_KEY=replace-me` — non-empty, so `StoreConfig.enabled` flips `True` and the API points at a store host that does not exist. This blocked agent QA on the `gh` stack.

## Fix

Bundle SeaweedFS into the published gh compose, matching the working dev stack so the store works out of the box.

- **Add a `seaweedfs` service** to both `oss/docker-compose.gh.yml` and `ee/docker-compose.gh.yml`, lifted verbatim from `docker-compose.dev.yml`: pinned image `chrislusf/seaweedfs:4.37`, the env-generated `s3.json` (master identity) + `iam.json` (OIDC/STS advanced IAM), `seaweed-data` volume, and the `/cluster/healthz` healthcheck.
- **Publish its port on loopback** (`${AGENTA_STORE_PORT:-127.0.0.1:8333}:8333`), consistent with the recent Postgres/Traefik loopback hardening. In-network services reach it directly at `seaweedfs:8333`.
- **Wire `api` to depend on it healthy**; `api`/`worker-streams`/`worker-queues`/`cron` already receive `AGENTA_STORE_*` (explicit block on api/services, `env_file` injection on workers/cron).
- **Fix the env examples**: real working defaults (`AGENTA_STORE_ACCESS_KEY=agenta-dev`, `AGENTA_STORE_SECRET_KEY=agenta-dev-secret`, `AGENTA_STORE_ENDPOINT_URL=http://seaweedfs:8333`, `AGENTA_STORE_BUCKET=agenta-store`, `AGENTA_STORE_SIGNING_KEY=<base64 dev key>`), copied from the confirmed-working dev stack. A comment explains these drive the bundled store and can be swapped for external S3/R2/MinIO (a docs how-to will cover that).

## Verification

- `docker compose -f <gh> --env-file <example> config` parses for **OSS and EE**; the `seaweedfs` service renders, its published port is `host_ip: 127.0.0.1`, and `api`/`worker-streams`/`worker-queues`/`cron`/`seaweedfs` all carry the `AGENTA_STORE_*` vars.
- Standalone smoke: `seaweedfs` boots **healthy**, generates `s3.json`/`iam.json` from env, and its S3 API enforces auth (403 on anonymous list = API up and authorizing).
- Full `gh` stack bring-up was not run (heavy ghcr image pulls); this is a verbatim copy of the working dev SeaweedFS with the same store values, verified by config render + standalone smoke.