### PR TITLE
fix(hosting): fix runner Dockerfile path in gh compose

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -266,7 +266,7 @@ services:
         # === IMAGE ================================================ #
         build:
             context: ../../../services/runner
-            dockerfile: docker/Dockerfile.gh
+            dockerfile: images/service/Dockerfile.gh
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -264,7 +264,7 @@ services:
         # === IMAGE ================================================ #
         build:
             context: ../../../services/runner
-            dockerfile: docker/Dockerfile.gh
+            dockerfile: images/service/Dockerfile.gh
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -285,7 +285,7 @@ services:
         # === IMAGE ================================================ #
         build:
             context: ../../../services/runner
-            dockerfile: docker/Dockerfile.gh
+            dockerfile: images/service/Dockerfile.gh
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"


### PR DESCRIPTION
## Summary
- The runner image folder moved from `services/runner/docker/` to `services/runner/images/service/` (in the recent hosting-layout restructure), but three `--gh` compose files still pointed the runner build at the old `docker/Dockerfile.gh`, so any `--gh` runner build failed with `lstat .../services/runner/docker: no such file`.
- Fixed the runner service's `dockerfile:` line (build context unchanged) in:
  - `hosting/docker-compose/oss/docker-compose.gh.local.yml`
  - `hosting/docker-compose/oss/docker-compose.gh.ssl.yml`
  - `hosting/docker-compose/ee/docker-compose.gh.local.yml`
- Swept for other stale `runner/docker/` references in `hosting/`, `.github/`, and `services/runner/README.md` — found none (the EE self-host README's runner build instructions were already up to date / it lists no runner build row at all).

## CI gap
Only `.github/workflows/42-railway-build.yml` builds the runner image; none of the `--gh` compose builds are exercised in CI, so this regression wasn't caught automatically. Worth a follow-up to add a `docker compose ... config` (or actual build) smoke check for the `--gh` compose files.

## Test plan
- [x] `docker compose -f hosting/docker-compose/oss/docker-compose.gh.local.yml --env-file hosting/docker-compose/oss/.env.oss.gh config --quiet` succeeds; runner's `dockerfile` renders as `images/service/Dockerfile.gh`
- [x] `docker compose -f hosting/docker-compose/oss/docker-compose.gh.ssl.yml --env-file hosting/docker-compose/oss/.env.oss.gh config --quiet` succeeds; same check
- [x] `docker compose -f hosting/docker-compose/ee/docker-compose.gh.local.yml config --quiet` succeeds (verified with an existing EE env file, since `.env.ee.gh` isn't present in this checkout); same check
- [x] Confirmed `services/runner/images/service/Dockerfile.gh` exists and `services/runner/docker/` does not