### PR TITLE
docs(self-host): correct runner-token wording and a stale image-folder path

### DIFF
--- a/docs/docs/self-host/concepts/03-sandbox-isolation-and-security.mdx
+++ b/docs/docs/self-host/concepts/03-sandbox-isolation-and-security.mdx
@@ -61,7 +61,7 @@ worktree, a subscription login) puts it inside that boundary and inside reach of
 |---|---|
 | The model key for the run | Yes. The harness needs it to call the model. |
 | The run's own working directory | Yes. |
-| The runner container's environment | Yes, including `AGENTA_RUNNER_DAYTONA_API_KEY` and `AGENTA_RUNNER_TOKEN` when they are set. |
+| The runner container's environment | Yes, including `AGENTA_RUNNER_TOKEN` and, when it is set, `AGENTA_RUNNER_DAYTONA_API_KEY`. |
 | Anything you mounted into the runner container | Yes, including a personal subscription login. |
 | Anything on the host you did not mount | No. |
 

--- a/services/runner/images/sandbox/daytona/build_snapshot.py
+++ b/services/runner/images/sandbox/daytona/build_snapshot.py
@@ -19,7 +19,7 @@ recipe additionally installs python3 and typescript/ts-node.
 
 Run: DAYTONA_API_KEY=... DAYTONA_TARGET=eu uv run build_snapshot.py [--force]
 
-Licensing (see services/runner/images/service/README.md):
+Licensing (see services/runner/docker/README.md):
     This script is the build recipe we ship, NOT a snapshot we distribute. Whoever
     runs it builds the snapshot in their own Daytona account: Agenta Cloud builds
     its own for internal use; self-hosters build their own. We never hand anyone a


### PR DESCRIPTION
Two factual corrections in the self-host docs.

## Runner-token wording

The local-run env table on the sandbox-isolation concept page said the runner container's environment crosses into a run "including \`AGENTA_RUNNER_DAYTONA_API_KEY\` and \`AGENTA_RUNNER_TOKEN\` when they are set." That "when they are set" qualifier is wrong for the token: \`AGENTA_RUNNER_TOKEN\` is mandatory. The runner refuses to start without it and there is no unauthenticated mode (see `docs/docs/self-host/reference/01-configuration.mdx`). Only \`AGENTA_RUNNER_DAYTONA_API_KEY\` is optional.

Before: `Yes, including AGENTA_RUNNER_DAYTONA_API_KEY and AGENTA_RUNNER_TOKEN when they are set.`
After: `Yes, including AGENTA_RUNNER_TOKEN and, when it is set, AGENTA_RUNNER_DAYTONA_API_KEY.`

## Stale README path

`build_snapshot.py` pointed the licensing note at `services/runner/images/service/README.md`, which no longer exists. The licensing section lives at `services/runner/docker/README.md`. Path reference fixed; no other change.