### PR TITLE
fix(hosting): expose the object store for Daytona sandboxes on self-hosted deployments

### DIFF
--- a/docs/docs/self-host/agents/02-daytona.mdx
+++ b/docs/docs/self-host/agents/02-daytona.mdx
@@ -117,17 +117,39 @@ resolve: a Compose service name such as `http://seaweedfs:8333` (the default for
 store), `localhost`, or a private IP. If it already points at a public S3 endpoint, as on Railway
 and on Kubernetes with public ingress, skip this step.
 
-Two ways to fix it:
+There are three ways to fix it. Most self-hosted deployments use the first.
 
-**Point the store at a public endpoint.** Use an external S3-compatible bucket, or expose the
-bundled store on a public hostname, and set the store endpoint to that URL:
+**Expose the bundled store through traefik.** The `gh` Compose stacks can publish the bundled
+store on its own subdomain. This is off by default. Pick a hostname such as `store.example.com`
+and add a DNS record that points it at the same server as your main domain. Then set these
+variables in your env file (`.env.oss.gh`, or `.env.oss.gh.ssl` on the `--ssl` stack):
 
 ```bash
-AGENTA_STORE_ENDPOINT_URL=https://<your-public-store-host>
+AGENTA_STORE_TRAEFIK_ENABLE=true
+AGENTA_STORE_DOMAIN=store.example.com
+AGENTA_STORE_ENDPOINT_URL=https://store.example.com
 ```
 
-**Or tunnel the bundled store.** The dev Compose stack ships an ngrok service that publishes the
-bundled store on a public URL, which the runner discovers automatically. Create an
+Recreate the stack. On the `--ssl` stack, traefik requests a Let's Encrypt certificate for the
+new hostname from the same resolver it uses for your main domain. On the plain `gh` stack, traefik
+serves the store on port 80 and your own proxy terminates TLS. The router matches on the hostname
+and never rewrites the path, which the S3 request signature requires, so do not place the store
+behind a path prefix.
+
+To verify, run an agent on Daytona (step 5) and write a file. The runner logs
+`remote mounted ... (verified alive)` for the session instead of a `mount degraded` line, and the
+file is still there on the next turn.
+
+**Point the store at an external S3 endpoint.** Use an external S3-compatible bucket (AWS S3,
+Cloudflare R2, MinIO) that is already reachable from the internet, and set the store endpoint to
+its URL:
+
+```bash
+AGENTA_STORE_ENDPOINT_URL=https://<your-bucket-endpoint>
+```
+
+**Tunnel the bundled store (dev only).** The dev Compose stack ships an ngrok service that
+publishes the bundled store on a public URL, which the runner discovers automatically. Create an
 [ngrok authtoken](https://dashboard.ngrok.com/get-started/your-authtoken), put it in your env file,
 and start the stack with the `with-tunnel` profile:
 

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -458,8 +458,17 @@ services:
         ports:
             - "127.0.0.1:${AGENTA_STORE_PORT:-8333}:8333"
         # === LABELS =============================================== #
+        # Off by default. Daytona cloud sandboxes reach the store over the internet, so set
+        # AGENTA_STORE_TRAEFIK_ENABLE=true and AGENTA_STORE_DOMAIN=<store-host> to publish the
+        # S3 endpoint on its own subdomain, terminate TLS at your own proxy, then point
+        # AGENTA_STORE_ENDPOINT_URL at https://<store-host>. The router is Host-only (no path
+        # rewrite), which SeaweedFS S3 SigV4 requires.
         labels:
-            - "traefik.enable=false"
+            - "traefik.enable=${AGENTA_STORE_TRAEFIK_ENABLE:-false}"
+            - "traefik.http.routers.store.rule=Host(`${AGENTA_STORE_DOMAIN:-store.localhost}`)"
+            - "traefik.http.routers.store.entrypoints=web"
+            - "traefik.http.routers.store.service=store"
+            - "traefik.http.services.store.loadbalancer.server.port=8333"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -376,5 +376,14 @@ AGENTA_STORE_SIGNING_KEY=replace-me
 # api replica works with this unset. If you scale the api past one replica, set the SAME PEM on
 # every replica or STS token minting fails intermittently (SeaweedFS caches one JWKS).
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+#
+# Publish the bundled store on the internet (Daytona sandboxes only). Daytona runs each agent in a
+# cloud sandbox that reaches the store from outside the deployment, so the internal `seaweedfs:8333`
+# endpoint is unreachable and agent file writes are silently dropped. Set both vars below to expose
+# the store on its own subdomain through traefik, add a DNS record for that host, then set
+# AGENTA_STORE_ENDPOINT_URL=https://store.example.com. Leave this off for local sandboxes.
+# See https://docs.agenta.ai/self-host/agent-execution/daytona
+# AGENTA_STORE_TRAEFIK_ENABLE=true
+# AGENTA_STORE_DOMAIN=store.example.com
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —
 # set inline per-service in compose, not here; see docs/designs/workers-sprawl/specs.md

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -468,8 +468,19 @@ services:
         ports:
             - "127.0.0.1:${AGENTA_STORE_PORT:-8333}:8333"
         # === LABELS =============================================== #
+        # Off by default. Daytona cloud sandboxes reach the store over the internet, so set
+        # AGENTA_STORE_TRAEFIK_ENABLE=true and AGENTA_STORE_DOMAIN=<store-host> to publish the
+        # S3 endpoint on its own subdomain with a Let's Encrypt cert, then point
+        # AGENTA_STORE_ENDPOINT_URL at https://<store-host>. The router is Host-only (no path
+        # rewrite), which SeaweedFS S3 SigV4 requires.
         labels:
-            - "traefik.enable=false"
+            - "traefik.enable=${AGENTA_STORE_TRAEFIK_ENABLE:-false}"
+            - "traefik.http.routers.store.rule=Host(`${AGENTA_STORE_DOMAIN:-store.localhost}`)"
+            - "traefik.http.routers.store.entrypoints=web,web-secure"
+            - "traefik.http.routers.store.service=store"
+            - "traefik.http.routers.store.tls=true"
+            - "traefik.http.routers.store.tls.certresolver=myResolver"
+            - "traefik.http.services.store.loadbalancer.server.port=8333"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -475,8 +475,17 @@ services:
         ports:
             - "127.0.0.1:${AGENTA_STORE_PORT:-8333}:8333"
         # === LABELS =============================================== #
+        # Off by default. Daytona cloud sandboxes reach the store over the internet, so set
+        # AGENTA_STORE_TRAEFIK_ENABLE=true and AGENTA_STORE_DOMAIN=<store-host> to publish the
+        # S3 endpoint on its own subdomain, terminate TLS at your own proxy, then point
+        # AGENTA_STORE_ENDPOINT_URL at https://<store-host>. The router is Host-only (no path
+        # rewrite), which SeaweedFS S3 SigV4 requires.
         labels:
-            - "traefik.enable=false"
+            - "traefik.enable=${AGENTA_STORE_TRAEFIK_ENABLE:-false}"
+            - "traefik.http.routers.store.rule=Host(`${AGENTA_STORE_DOMAIN:-store.localhost}`)"
+            - "traefik.http.routers.store.entrypoints=web"
+            - "traefik.http.routers.store.service=store"
+            - "traefik.http.services.store.loadbalancer.server.port=8333"
         # === LIFECYCLE ============================================ #
         restart: always
         healthcheck:

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -376,5 +376,14 @@ AGENTA_STORE_SIGNING_KEY=replace-me
 # api replica works with this unset. If you scale the api past one replica, set the SAME PEM on
 # every replica or STS token minting fails intermittently (SeaweedFS caches one JWKS).
 # AGENTA_STORE_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+#
+# Publish the bundled store on the internet (Daytona sandboxes only). Daytona runs each agent in a
+# cloud sandbox that reaches the store from outside the deployment, so the internal `seaweedfs:8333`
+# endpoint is unreachable and agent file writes are silently dropped. Set both vars below to expose
+# the store on its own subdomain through traefik, add a DNS record for that host, then set
+# AGENTA_STORE_ENDPOINT_URL=https://store.example.com. Leave this off for local sandboxes.
+# See https://docs.agenta.ai/self-host/agent-execution/daytona
+# AGENTA_STORE_TRAEFIK_ENABLE=true
+# AGENTA_STORE_DOMAIN=store.example.com
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —
 # set inline per-service in compose, not here; see docs/designs/workers-sprawl/specs.md


### PR DESCRIPTION
## Symptom

On a self-hosted (`gh`) deployment using Daytona cloud sandboxes, every file an agent writes is silently lost. Working directories do not persist across turns, and the only trace is a `mount degraded` line in the runner logs.

## Cause

A Daytona sandbox runs geesefs (FUSE over S3) inside the cloud, so it reaches the store over the internet using the endpoint in the signed mount credentials. The `gh` compose bundles SeaweedFS bound to loopback with `traefik.enable=false`, so that endpoint (`http://seaweedfs:8333`) is unreachable from Daytona. The runner's reachability check fails, it finds no ngrok tunnel (those exist only in the `dev` compose), and it skips the mount without failing the turn. Dev never reproduces this because the dev stack ships the ngrok tunnel.

## Fix (config + docs only, no runner/API code changes)

The API already carries the store endpoint into the signed mount credentials through the existing `AGENTA_STORE_ENDPOINT_URL` variable (`MountCredentials.endpoint = store.endpoint_url` in `api/oss/src/core/mounts/service.py`). The missing piece was a way to expose the bundled store publicly. This PR adds an opt-in traefik router on the `seaweedfs` service, off by default:

```yaml
labels:
    - "traefik.enable=${AGENTA_STORE_TRAEFIK_ENABLE:-false}"
    - "traefik.http.routers.store.rule=Host(`${AGENTA_STORE_DOMAIN:-store.localhost}`)"
    - "traefik.http.routers.store.entrypoints=web,web-secure"   # web only on the plain gh stack
    - "traefik.http.routers.store.service=store"
    - "traefik.http.routers.store.tls=true"                     # ssl stack only
    - "traefik.http.routers.store.tls.certresolver=myResolver"  # ssl stack only
    - "traefik.http.services.store.loadbalancer.server.port=8333"
```

An operator opts in with two variables in the env file, plus a public store endpoint:

```bash
AGENTA_STORE_TRAEFIK_ENABLE=true
AGENTA_STORE_DOMAIN=store.example.com
AGENTA_STORE_ENDPOINT_URL=https://store.example.com
```

When unset, `traefik.enable=false` makes traefik ignore the store, so the change is inert on existing deployments. The router matches on the hostname and never rewrites the path, which SeaweedFS S3 SigV4 requires, so the store gets its own subdomain rather than a path prefix.

Applied to the three `gh` variants that can serve a public host:
- `oss/docker-compose.gh.ssl.yml`: full TLS via the existing `myResolver` Let's Encrypt resolver.
- `oss/docker-compose.gh.yml` and `ee/docker-compose.gh.yml`: port-80 router, TLS terminated at the operator's own proxy (EE has no bundled-TLS stack).

`gh.local` is left untouched: it is local-only and a Daytona cloud sandbox cannot reach it.

### Docs and env examples

- `docs/docs/self-host/agents/02-daytona.mdx`: rewrote "Make the store reachable from the sandbox" to lead with the concrete traefik recipe (hostname, DNS record, the three env vars, verification), followed by the external-S3 and dev-only ngrok options.
- `oss/env.oss.gh.example` and `ee/env.ee.gh.example`: documented the two new opt-in vars next to `AGENTA_STORE_ENDPOINT_URL`.

## Key finding

The endpoint chain works without any code change. `AGENTA_STORE_ENDPOINT_URL` already feeds the signed credentials, and it is already plumbed onto the `api` and `worker` services in every `gh` compose file. The one caveat: the API uses a single store endpoint for both its own in-network client and the sandbox credentials, so setting it to a public URL routes the API's own store traffic back through traefik (hairpin). That is the accepted single-endpoint design, and it is what the existing docs already recommend.

## Verification

1. On an `--ssl` gh deployment, set `AGENTA_STORE_TRAEFIK_ENABLE=true`, `AGENTA_STORE_DOMAIN=store.example.com`, `AGENTA_STORE_ENDPOINT_URL=https://store.example.com`, and add a DNS record for the store host. Recreate the stack.
2. Confirm traefik issued a cert and the store answers: `curl -I https://store.example.com` returns an S3 response (not a 404 from the web app).
3. Run an agent on Daytona and have it write a file.
4. The runner log flips from `mount degraded ... cause=sign_returned_no_mount` to `remote mounted <bucket>:<prefix> -> <cwd> (verified alive)`.
5. Start a second turn and confirm the file written in step 3 is still there.

Without the override, step 4 shows the `mount degraded` line and step 5 finds the file gone.

https://claude.ai/code/session_01Hyn9365BLPXDmNZShrQkmH
