### PR TITLE
ci(railway): retry service resolution to survive the bootstrap→configure race

### DIFF
--- a/hosting/railway/oss/scripts/configure.sh
+++ b/hosting/railway/oss/scripts/configure.sh
@@ -87,6 +87,69 @@ _service_id() {
           | .serviceInstances.edges[].node | select(.serviceName==$n) | .serviceId][0] // empty' 2>/dev/null || true
 }
 
+# _refresh_status_json: re-fetch the cached status snapshot; keep the old one
+# if the fetch fails so a transient error cannot blank out working IDs.
+_refresh_status_json() {
+    local fresh
+    fresh="$(railway_call status --json 2>/dev/null || true)"
+    [ -n "$fresh" ] && RAILWAY_STATUS_JSON="$fresh"
+}
+
+# _service_id_with_retry <service-name> -> serviceId (empty when unresolved).
+# A service bootstrap created seconds earlier may not be visible in the status
+# snapshot yet (bootstrap→configure eventual-consistency race), so re-fetch the
+# snapshot and retry a few times before giving up. First-try hits (the normal
+# case) cost zero extra API calls and zero sleeps.
+_service_id_with_retry() {
+    local service="$1" svc_id attempt
+    local attempts="${RAILWAY_SERVICE_RESOLVE_ATTEMPTS:-6}"
+    local delay="${RAILWAY_SERVICE_RESOLVE_DELAY:-5}"
+
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
+        svc_id="$(_service_id "$service")"
+        if [ -n "$svc_id" ]; then
+            printf '%s' "$svc_id"
+            return 0
+        fi
+        if [ "$attempt" -lt "$attempts" ]; then
+            printf "Service id for '%s' not in status snapshot yet; re-fetching in %ds (attempt %d/%d)\n" \
+                "$service" "$delay" "$attempt" "$attempts" >&2
+            sleep "$delay"
+            _refresh_status_json
+        fi
+    done
+    # Empty output: the caller falls back to the CLI path.
+    return 0
+}
+
+# _cli_set_vars <service> KEY=VALUE ...
+# CLI-path variable set. "Service '<name>' not found" seconds after bootstrap
+# created it is the same eventual-consistency race, so retry that specific
+# failure a couple of times instead of failing the deploy on the first hit.
+# Other failures surface immediately (railway_call already retries transient
+# network errors internally).
+_cli_set_vars() {
+    local service="$1"
+    shift
+    local attempts="${RAILWAY_CLI_SET_ATTEMPTS:-3}"
+    local delay="${RAILWAY_SERVICE_RESOLVE_DELAY:-5}"
+    local try output
+
+    for ((try = 1; try <= attempts; try++)); do
+        if output="$(railway_call variable set --service "$service" --environment "$ENV_NAME" --skip-deploys "$@" 2>&1)"; then
+            return 0
+        fi
+        if [ "$try" -lt "$attempts" ] && printf '%s' "$output" | grep -qi "not found"; then
+            printf "railway variable set: service '%s' not visible yet, retrying in %ds (attempt %d/%d)\n" \
+                "$service" "$delay" "$try" "$attempts" >&2
+            sleep "$delay"
+            continue
+        fi
+        [ -n "$output" ] && printf '%s\n' "$output" >&2
+        return 1
+    done
+}
+
 # _vars_to_json KEY=VALUE ... -> {"KEY":"VALUE",...}  (split on the first '=')
 _vars_to_json() {
     local json='{}' kv key val
@@ -111,18 +174,18 @@ upsert_service_vars() {
     [ "$#" -gt 0 ] || return 0
 
     if [ -z "${RAILWAY_API_TOKEN:-}" ] || [ -z "$RAILWAY_PROJECT_ID" ]; then
-        railway_call variable set --service "$service" --environment "$ENV_NAME" --skip-deploys "$@" >/dev/null
+        _cli_set_vars "$service" "$@"
         return 0
     fi
 
     local svc_id
-    svc_id="$(_service_id "$service")"
+    svc_id="$(_service_id_with_retry "$service")"
     if [ -z "$svc_id" ]; then
         # Name didn't match the cached status JSON (e.g. unexpected casing). Don't
         # hard-fail the deploy where the CLI's --service would have worked; fall
         # back to it.
         printf "Could not resolve service id for '%s'; falling back to CLI variable set.\n" "$service" >&2
-        railway_call variable set --service "$service" --environment "$ENV_NAME" --skip-deploys "$@" >/dev/null
+        _cli_set_vars "$service" "$@"
         return 0
     fi
 


### PR DESCRIPTION
## Context
The v0.105.0 release PR's preview deploy (run 29363754807) failed with `Service 'cron' not found` about 40 seconds into the deploy job. The setup job's bootstrap had created the `cron` service 17 seconds earlier and reported success. `configure.sh` resolves service ids from a single `railway status --json` snapshot taken at startup, and a service created seconds before by a different job can be missing from that snapshot (Railway's API is eventually consistent). The CLI fallback (`railway variable set --service cron`) hit the same window, and `railway_call` classifies its "not found" as a deterministic error, so nothing retried and the deploy hard-failed. The dependent eu/acceptance web tests were skipped with it. The same job flips between green and red on unchanged branches, which is how this was diagnosed as a race rather than a regression.

## Changes
Two bounded retries in `configure.sh`, both no-ops on the happy path:

- `_service_id_with_retry`: when a service id is missing from the cached status snapshot, re-fetch `railway status --json` and retry resolution (6 attempts total, 5s sleeps; tunable via `RAILWAY_SERVICE_RESOLVE_ATTEMPTS` / `RAILWAY_SERVICE_RESOLVE_DELAY`) before falling back to the CLI path. A first-try hit costs zero extra API calls and zero sleeps. The default is 6 because in the observed incident the service was still invisible more than 35 seconds after bootstrap completed, so the retry budget (25s of resolve retries, roughly 35s including the CLI fallback) is sized to cover it; unneeded retries cost nothing.
- `_cli_set_vars`: the CLI fallback now retries specifically the "not found" failure (3 attempts, `RAILWAY_CLI_SET_ATTEMPTS`) instead of failing the deploy on the first hit. Any other failure surfaces immediately; transient network errors keep being handled inside `railway_call` as before.

Before: one status snapshot, one CLI attempt, `Service 'cron' not found`, deploy dead.
After: the snapshot is re-fetched while the just-created service becomes visible; the deploy only fails after both paths exhaust their bounded retries.

## Tests / notes
- I cannot test against live Railway from this environment. Happy-path behavior is unchanged by construction: first-try resolution takes the same code path with zero extra calls.
- `bash -n` passes. shellcheck was not available locally.
- Verified the retry logic with a local stubbed-`railway_call` harness (not committed): first-try hit makes no extra calls; an id appearing after a snapshot re-fetch resolves; exhaustion returns empty and falls back to the CLI; the CLI fallback retries "not found" and succeeds on the second attempt; deterministic errors (unauthorized) are not retried; a permanent "not found" still fails after the bounded 3 attempts. All 10 assertions pass.
- To validate for real: rerun the preview deploy ("14 - check PR preview") on this PR and on the release PR after merge; the deploy job checks out this `configure.sh`.
- Known sibling flake, not fixed here: `deploy-gateway.sh` failed on another PR with `Project "agenta-oss-pr-5319" not found in workspace` at `railway link`. That is a different script and failure point (raw `railway link`, project-level visibility), not the same one-line retry shape, so it is left for a follow-up if it recurs.

https://claude.ai/code/session_01Hyn9365BLPXDmNZShrQkmH