### PR TITLE
fix(frontend): resolve the refractor chunk failure that remounts the playground and closes the Advanced drawer

### DIFF
--- a/web/oss/next.config.ts
+++ b/web/oss/next.config.ts
@@ -135,16 +135,16 @@ const COMMON_CONFIG: NextConfig = {
                       loader: "swc-loader",
                   })
 
-                  // Ignore problematic ESM imports from @ant-design/x that we don't use
-                  // This prevents build errors for mermaid and refractor packages
+                  // Ignore the mermaid import from @ant-design/x — we don't use that surface.
+                  // NOTE: do not ignore `refractor/*` here. react-syntax-highlighter's PrismAsync
+                  // dynamically imports `refractor/all` at runtime; stubbing it out throws
+                  // "Cannot find module 'refractor/all'" when a chat code block renders, which trips
+                  // the app error boundary and remounts the playground. refractor@5 resolves every
+                  // subpath rsh imports, so the import must be left intact.
                   config.plugins.push(
                       new webpack.IgnorePlugin({
                           resourceRegExp: /^mermaid$/,
                           contextRegExp: /@ant-design[\\/]x/,
-                      }),
-                      new webpack.IgnorePlugin({
-                          resourceRegExp: /^refractor\/.+$/,
-                          contextRegExp: /react-syntax-highlighter/,
                       }),
                   )
 


### PR DESCRIPTION
## Symptom

In the agent playground, opening the Configuration panel's **Advanced** drawer and
clicking a section row ("Execution environment" or "Permissions") intermittently
(~1-in-4) closed the whole drawer instead of expanding the section. In one case the click
fell through the closing overlay and opened the Turn inspector for an off-screen chat turn.
Repro and evidence: `docs/design/agent-workflows/projects/qa/ui-exploration-20260714.md`
(bug 2).

## Console evidence captured at every failure

- `[EXCEPTION] Error: Cannot find module 'refractor/all'` from a lazy-loaded chunk,
  each time followed by a duplicate burst of app-boot console lines (organizations
  fetches, atomFamily/loadable deprecation warnings) — the signature of a partial React
  tree remount.
- `[WARNING] Detected store mutation during atom read` (Jotai) — a separate anti-pattern,
  not the cause here (see follow-up below).

## Root cause

`web/oss/next.config.ts` registered a production-only webpack `IgnorePlugin`:

```js
new webpack.IgnorePlugin({
    resourceRegExp: /^refractor\/.+$/,
    contextRegExp: /react-syntax-highlighter/,
})
```

It stubbed out **every** `refractor/*` import made by `react-syntax-highlighter`,
including `refractor/all`. The agent chat markdown renderer
(`web/oss/src/components/AgentChatSlice/assets/markdown.tsx`) highlights fenced code
blocks with `PrismAsync`, which at runtime does a dynamic
`import('refractor/all')` to load languages on demand. With the import stubbed, that
lazy chunk threw `Cannot find module 'refractor/all'` the first time a chat message with
a code block rendered.

### Causal chain (drawer close)

1. A chat turn renders a fenced code block → `PrismAsync` dynamically imports
   `refractor/all`.
2. The IgnorePlugin-stubbed chunk throws `Cannot find module 'refractor/all'`.
3. The Layout error boundary (`web/oss/src/components/Layout/Layout.tsx` wraps the page
   `{children}` in `<ErrorBoundary>`) catches it and remounts the playground subtree
   (the duplicate app-boot burst).
4. The open Advanced drawer is a descendant of that subtree, so it unmounts — the drawer
   "closes" instead of the section expanding.

**Why intermittent (~25%):** the throw only fires when the visible chat content contains
a fenced code block whose language triggers PrismAsync's `refractor/all` load. Turns
without a code block never hit the broken chunk, so only some interactions repro.

**Click fall-through:** a consequence of the same remount — during the unmount window the
drawer overlay is gone, so the click lands on whatever is behind it (the off-screen Turn
inspector). No separate fix needed.

The plugin was stale: `refractor@5.0.0` is installed and resolves every subpath rsh
imports — all 297 async languages plus `./all` and `./core` (0 missing). The comment even
claimed it was about "@ant-design/x that we don't use", but the refractor entry was scoped
to `react-syntax-highlighter`, which the app **does** use.

## Fix

Remove the `refractor` `IgnorePlugin` (keep the legitimate `mermaid` one for
`@ant-design/x`). The dynamic `refractor/all` chunk now resolves and loads, so no
exception, no error-boundary remount, and the drawer stays open.

### Before / after

- **Before:** production build stubs `refractor/all` → chat code block render throws →
  playground remounts → Advanced drawer closes on section click (~1-in-4).
- **After:** `refractor/all` loads as a lazy chunk → code blocks highlight normally →
  no remount → drawer sections expand as expected.

`web/ee/next.config.ts` imports the OSS config, so this single change covers both editions.

## Verification

- Confirmed `refractor@5.0.0` exports `./all`, `./core`, and every one of the 297 language
  subpaths `react-syntax-highlighter@16.1.1` async-imports (diffed the two package trees:
  zero missing).
- Confirmed the webpack branch (and thus the IgnorePlugin) applies only to production
  builds (`!isDevelopment`), matching the live repro on a deployed build and explaining why
  dev/turbopack never showed it.
- **Production build verified clean**: ran `pnpm build-oss` (webpack production branch,
  `NODE_ENV=production`) with the plugin removed — exit 0, all 7 turbo tasks successful,
  no refractor/rsh resolution errors, so the plugin's original "prevent build errors"
  motivation did not resurface. The emitted chunk `79590.*` (the exact chunk number that
  threw `Cannot find module 'refractor/all'` in the QA capture) now weighs ~380K and
  contains the refractor language definitions instead of a stub.
- `prettier --write` on the touched file: unchanged.

Manual verification (deployed build, per the findings doc): open an agent playground, send
a message that renders a fenced code block, then open the Advanced drawer and click
"Execution environment" / "Permissions" repeatedly through several open/close cycles. The
section should expand every time with no `Cannot find module 'refractor/all'` exception and
no drawer self-dismiss.

## Follow-up (out of scope)

The Jotai `Detected store mutation during atom read` warning is a separate state
anti-pattern, not the cause of this remount. Left untouched here; worth a dedicated pass.

https://claude.ai/code/session_01Hyn9365BLPXDmNZShrQkmH

