### PR TITLE
[fix] Refresh workflow name after rename

### DIFF
--- a/web/oss/src/components/EntityIdentity/useRenameApp.ts
+++ b/web/oss/src/components/EntityIdentity/useRenameApp.ts
@@ -1,6 +1,10 @@
 import {useCallback} from "react"
 
-import {invalidateWorkflowsListCache, updateWorkflow} from "@agenta/entities/workflow"
+import {
+    invalidateWorkflowCache,
+    invalidateWorkflowsListCache,
+    updateWorkflow,
+} from "@agenta/entities/workflow"
 
 import {GenericObject} from "@/oss/lib/Types"
 import {useAppsData} from "@/oss/state/app"
@@ -48,6 +52,7 @@ export const useRenameApp = () => {
                     flags: {is_application: true},
                 })
                 invalidateWorkflowsListCache()
+                invalidateWorkflowCache(id)
                 await mutate()
                 await invalidateAppManagementWorkflowQueries()
                 return true

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -2699,6 +2699,11 @@ export function invalidateWorkflowCache(workflowId: string, options?: StoreOptio
     const store = getStore(options)
     try {
         const qc = store.get(queryClientAtom)
+        const projectId = store.get(workflowProjectIdAtom)
+        qc.invalidateQueries({
+            queryKey: ["workflows", "detail", projectId, workflowId],
+            exact: true,
+        })
         qc.invalidateQueries({queryKey: ["workflows", "revision", workflowId], exact: false})
         qc.invalidateQueries({queryKey: ["workflows", "artifact", workflowId], exact: false})
     } catch {


### PR DESCRIPTION
## Context

Renaming an workflow from its overview page saved the new name, but the page title kept showing the old one until the cache refreshed or the page reloaded. The rename path invalidated app-list and artefact caches, while the overview reads a separate workflow-detail cache.

## Changes

The shared workflow invalidator now also invalidates the exact overview-detail query for the current project and workflow.

Before, rename refreshed:

- `["workflows", "apps"]`
- `["workflows", "artifact", workflowId]`

After, it also refreshes:

- `["workflows", "detail", projectId, workflowId]`

The rename hook calls this shared invalidator after the metadata update.

## Tests / notes

- Ran focused Prettier and ESLint checks.
- Ran `pnpm --filter @agenta/entities types:check`.
- Ran `git diff --check`.

## What to QA

- Open an agent overview, rename the agent, and save. The overview title should show the new name immediately without a reload.
- Navigate away and back to the overview. The new name should remain visible.


## Preview

<img width="1304" height="832" alt="image" src="https://github.com/user-attachments/assets/52044957-a15e-4371-a4df-a4549ca1b570" />
