### PR TITLE
feat(frontend): OpenAI-compatible endpoint label and harness-gated picker

### DIFF
--- a/web/oss/src/components/pages/settings/Secrets/SecretProviderTable/index.tsx
+++ b/web/oss/src/components/pages/settings/Secrets/SecretProviderTable/index.tsx
@@ -203,7 +203,7 @@ const SecretProviderTable = ({type}: {type: "standard" | "custom"}) => {
                             size="small"
                             onClick={() => setIsConfigProviderOpen(true)}
                         >
-                            Custom Provider
+                            OpenAI-compatible endpoint
                         </Button>
                     ) : (
                         <Button

--- a/web/oss/tests/playwright/acceptance/settings/model-hub.ts
+++ b/web/oss/tests/playwright/acceptance/settings/model-hub.ts
@@ -1,9 +1,3 @@
-import {test} from "@agenta/web-tests/tests/fixtures/base.fixture"
-
-import {expect} from "@agenta/web-tests/utils"
-import {expectAuthenticatedSession} from "../utils/auth"
-import {createScenarios} from "../utils/scenarios"
-import {buildAcceptanceTags} from "../utils/tags"
 import {
     TestCoverage,
     TestcaseType,
@@ -15,6 +9,12 @@ import {
     TestRoleType,
     TestSpeedType,
 } from "@agenta/web-tests/playwright/config/testTags"
+import {test} from "@agenta/web-tests/tests/fixtures/base.fixture"
+import {expect} from "@agenta/web-tests/utils"
+
+import {expectAuthenticatedSession} from "../utils/auth"
+import {createScenarios} from "../utils/scenarios"
+import {buildAcceptanceTags} from "../utils/tags"
 
 /**
  * E2E: Model Hub & API Keys Management
@@ -67,7 +67,7 @@ const modelHubTests = () => {
 
         await scenarios.then('the "Custom providers" table lists the "mock" provider', async () => {
             const customProvidersSection = page
-                .getByText("Custom Provider", {exact: true})
+                .getByText("OpenAI-compatible endpoint", {exact: true})
                 .locator("xpath=ancestor::section[1]")
                 .first()
             const providersTable = customProvidersSection.getByRole("table").first()
@@ -206,14 +206,14 @@ const modelHubTests = () => {
                 "the user creates a new custom provider via the drawer",
                 async () => {
                     const customProvidersSection = page
-                        .getByText("Custom Provider", {exact: true})
+                        .getByText("OpenAI-compatible endpoint", {exact: true})
                         .locator("xpath=ancestor::section[1]")
                         .first()
 
                     // The section's own label IS the trigger button now — "Create" was
-                    // renamed to "Custom Provider".
+                    // renamed to "OpenAI-compatible endpoint".
                     const createButton = customProvidersSection.getByRole("button", {
-                        name: "Custom Provider",
+                        name: "OpenAI-compatible endpoint",
                         exact: true,
                     })
                     await expect(createButton).toBeVisible({timeout: 15000})
@@ -225,7 +225,7 @@ const modelHubTests = () => {
                         timeout: 15000,
                     })
 
-                    // Select "Custom Provider" from the provider type dropdown
+                    // Select "OpenAI-compatible endpoint" from the provider type dropdown
                     const providerSelect = drawer.locator(".ant-select").first()
                     await expect(providerSelect).toBeVisible({timeout: 15000})
                     await providerSelect.click()
@@ -235,7 +235,7 @@ const modelHubTests = () => {
 
                     const optionTexts = (await options.allTextContents()).map((t) => t.trim())
                     const customProviderIndex = optionTexts.findIndex(
-                        (t) => t === "Custom Provider",
+                        (t) => t === "OpenAI-compatible endpoint",
                     )
 
                     // Click the target option directly — keyboard ArrowDown navigation is unreliable with AntD v5 selects
@@ -266,7 +266,7 @@ const modelHubTests = () => {
                 "the new custom provider row appears in the Custom providers table",
                 async () => {
                     const customProvidersSection = page
-                        .getByText("Custom Provider", {exact: true})
+                        .getByText("OpenAI-compatible endpoint", {exact: true})
                         .locator("xpath=ancestor::section[1]")
                         .first()
 
@@ -285,7 +285,7 @@ const modelHubTests = () => {
 
             await scenarios.when("the user deletes the newly created custom provider", async () => {
                 const customProvidersSection = page
-                    .getByText("Custom Provider", {exact: true})
+                    .getByText("OpenAI-compatible endpoint", {exact: true})
                     .locator("xpath=ancestor::section[1]")
                     .first()
 
@@ -306,7 +306,7 @@ const modelHubTests = () => {
 
             await scenarios.then("the deleted provider row is no longer visible", async () => {
                 const customProvidersSection = page
-                    .getByText("Custom Provider", {exact: true})
+                    .getByText("OpenAI-compatible endpoint", {exact: true})
                     .locator("xpath=ancestor::section[1]")
                     .first()
 

--- a/web/packages/agenta-entities/src/secret/core/types.ts
+++ b/web/packages/agenta-entities/src/secret/core/types.ts
@@ -95,7 +95,9 @@ export const PROVIDER_LABELS: Record<string, string> = {
     bedrock: "AWS Bedrock",
     azure: "Azure OpenAI",
     minimax: "MiniMax",
-    custom: "Custom Provider",
+    // Stored value stays "custom"; only the user-visible label changes. The v1 custom deployment
+    // speaks the OpenAI Chat Completions dialect, so name it for what it connects to.
+    custom: "OpenAI-compatible endpoint",
 }
 
 export const PROVIDER_KINDS: Record<string, string> = {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx
@@ -84,7 +84,7 @@ const CUSTOM_PROVIDER_ROWS: {kind: string; label: string}[] = [
     {kind: CustomProviderKind.Azure, label: "Azure OpenAI"},
     {kind: CustomProviderKind.Bedrock, label: "AWS Bedrock"},
     {kind: CustomProviderKind.VertexAi, label: "Vertex AI"},
-    {kind: CustomProviderKind.Custom, label: "Custom provider"},
+    {kind: CustomProviderKind.Custom, label: "OpenAI-compatible endpoint"},
 ]
 
 /** Family spellings that must compare equal across catalog names, vault env names, and titles. */
@@ -413,7 +413,7 @@ export function ProviderCredentialsSection({
                                         label={secret.name ?? "?"}
                                     />
                                 }
-                                label={secret.name ?? "Custom provider"}
+                                label={secret.name ?? "OpenAI-compatible endpoint"}
                                 trailing={
                                     <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
                                 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts
@@ -432,6 +432,10 @@ export function vaultPickedProviderFamily(
     const family = familyFromModelId(modelId, capabilities)
     if (family) return family
     if (metadataProvider && !isDeploymentProviderKind(metadataProvider)) return metadataProvider
+    // The OpenAI-compatible (`custom`) deployment defaults to openai rather than deferring to the
+    // caller's prior (likely unrelated) provider fallback.
+    if (metadataProvider?.toLowerCase() === OPENAI_COMPATIBLE_KIND)
+        return OPENAI_COMPATIBLE_DEFAULT_FAMILY
     return null
 }
 
@@ -443,6 +447,13 @@ export function vaultPickedProviderFamily(
 // either flavor (its provider Select offers both azure/bedrock/vertex_ai/custom AND every standard
 // provider), so both must be recognized here or one flavor's connections silently vanish.
 const DEPLOYMENT_KINDS = new Set(["direct", "custom", "azure", "bedrock", "vertex_ai", "sagemaker"])
+
+// The `custom` deployment kind is the "OpenAI-compatible endpoint": its models are bare ids that
+// encode no vendor, and the v1 runner speaks the OpenAI Chat Completions dialect. So it resolves to
+// the `openai` provider family — used both to default a provider-less pick and to gate visibility
+// (a harness must reach openai, not just consume the `custom` deployment).
+const OPENAI_COMPATIBLE_KIND = "custom"
+const OPENAI_COMPATIBLE_DEFAULT_FAMILY = "openai"
 
 /**
  * Whether a custom_provider `kind` names a DEPLOYMENT surface (a hosting mechanism, not itself a
@@ -466,7 +477,15 @@ function harnessReachesCustomProviderKind(
 ): boolean {
     if (isDeploymentProviderKind(kind)) {
         const consumable = allowedDeployments(capabilities, harness)
-        return consumable.includes("*") || consumable.some((d) => d.toLowerCase() === kind)
+        const deploymentOk =
+            consumable.includes("*") || consumable.some((d) => d.toLowerCase() === kind)
+        if (!deploymentOk) return false
+        // An OpenAI-compatible (`custom`) deployment resolves to the openai provider family, so the
+        // harness must ALSO reach openai — otherwise a Claude-only-Anthropic harness that consumes
+        // `custom` would still be offered an OpenAI-compatible connection it cannot run.
+        if (kind === OPENAI_COMPATIBLE_KIND)
+            return harnessAllowsProvider(capabilities, harness, OPENAI_COMPATIBLE_DEFAULT_FAMILY)
+        return true
     }
     const providers = allowedProviders(capabilities, harness)
     return providers.includes("*") || providers.some((p) => p.toLowerCase() === kind)

--- a/web/packages/agenta-entity-ui/tests/unit/connectionUtils.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/connectionUtils.test.ts
@@ -54,6 +54,15 @@ const CAPABILITIES: HarnessCapabilitiesMap = {
             },
         },
     },
+    // A Pi-family harness that consumes the OpenAI-compatible `custom` deployment AND reaches the
+    // openai provider family — the one combination an OpenAI-compatible connection may surface for.
+    pi_openai_compat: {
+        providers: ["openai"],
+        deployments: ["direct", "custom"],
+        connection_modes: ["agenta", "self_managed"],
+        model_selection: "provider/id",
+        models: {openai: ["gpt-5.5"]},
+    },
 }
 
 describe("connectionUtils: modelIdFromConfig", () => {
@@ -359,17 +368,57 @@ describe("connectionUtils: vaultModelGroups (custom_provider connections)", () =
         ).toEqual([])
     })
 
-    it("gates a deployment-kind connection (custom/bedrock/vertex_ai) against consumable deployments, not providers", () => {
-        // claude's capability entry declares "custom" as a consumable deployment.
+    it("gates a NON-custom deployment kind (bedrock) against consumable deployments only", () => {
+        // claude declares "bedrock" as a consumable deployment; its models encode their own family,
+        // so deployment consumption alone is the gate (no single-family provider check).
+        expect(
+            vaultModelGroups(
+                [
+                    {
+                        name: "my-bedrock",
+                        provider: "bedrock",
+                        models: ["eu.anthropic.claude-haiku-4-5"],
+                    },
+                ],
+                CAPABILITIES,
+                "claude",
+            ),
+        ).toHaveLength(1)
+        // pi_core only consumes "direct" — a "bedrock" deployment connection stays hidden there.
+        expect(
+            vaultModelGroups(
+                [
+                    {
+                        name: "my-bedrock",
+                        provider: "bedrock",
+                        models: ["eu.anthropic.claude-haiku-4-5"],
+                    },
+                ],
+                CAPABILITIES,
+                "pi_core",
+            ),
+        ).toEqual([])
+    })
+
+    it("gates an OpenAI-compatible (custom) connection by BOTH consumable deployment and openai reach", () => {
+        // A harness that consumes `custom` AND reaches openai is offered it.
+        expect(
+            vaultModelGroups(
+                [{name: "my-gateway", provider: "custom", models: ["gpt-oss"]}],
+                CAPABILITIES,
+                "pi_openai_compat",
+            ),
+        ).toHaveLength(1)
+        // claude consumes `custom` but only reaches anthropic — the OpenAI-compatible connection is
+        // NOT offered (it resolves to the openai family Claude cannot run).
         expect(
             vaultModelGroups(
                 [{name: "my-gateway", provider: "custom", models: ["gpt-oss"]}],
                 CAPABILITIES,
                 "claude",
             ),
-        ).toHaveLength(1)
-        // pi_core only consumes "direct" — a "custom" deployment connection stays hidden there
-        // (matches the runner: Pi ignores a resolved custom endpoint/base_url in v1).
+        ).toEqual([])
+        // pi_core does not consume `custom` at all — hidden regardless of provider reach.
         expect(
             vaultModelGroups(
                 [{name: "my-gateway", provider: "custom", models: ["gpt-oss"]}],
@@ -387,6 +436,14 @@ describe("connectionUtils: vaultModelGroups (custom_provider connections)", () =
                 "pi_core",
             ),
         ).toHaveLength(1)
+        // A custom connection is also offered under a missing map (both gates read permissive).
+        expect(
+            vaultModelGroups(
+                [{name: "my-gateway", provider: "custom", models: ["gpt-oss"]}],
+                null,
+                "pi_core",
+            ),
+        ).toHaveLength(1)
     })
 
     it("skips connections with no slug or no models", () => {
@@ -400,6 +457,41 @@ describe("connectionUtils: vaultModelGroups (custom_provider connections)", () =
                 "pi_core",
             ),
         ).toEqual([])
+    })
+
+    // Regression pins: the OpenAI-compatible feature adds a `custom`-only branch. Every flow that
+    // does NOT involve a custom connection must stay byte-identical to pre-feature behavior.
+    it("regression: an empty vault yields no groups on any harness (default picker state)", () => {
+        expect(vaultModelGroups([], CAPABILITIES, "pi_core")).toEqual([])
+        expect(vaultModelGroups([], CAPABILITIES, "claude")).toEqual([])
+        expect(vaultModelGroups(null, CAPABILITIES, "claude")).toEqual([])
+    })
+
+    it("regression: a Claude harness still sees its reachable (anthropic) vault connection unchanged", () => {
+        expect(
+            vaultModelGroups(
+                [{name: "my-anthropic", provider: "anthropic", models: ["a1"]}],
+                CAPABILITIES,
+                "claude",
+            ),
+        ).toHaveLength(1)
+    })
+
+    it("regression: a non-custom deployment connection to Claude is unchanged by the custom gate", () => {
+        // Claude consumes bedrock; the new openai-family check must NOT touch non-custom kinds.
+        expect(
+            vaultModelGroups(
+                [
+                    {
+                        name: "my-bedrock",
+                        provider: "bedrock",
+                        models: ["eu.anthropic.claude-haiku-4-5"],
+                    },
+                ],
+                CAPABILITIES,
+                "claude",
+            ),
+        ).toHaveLength(1)
     })
 })
 
@@ -450,5 +542,40 @@ describe("connectionUtils: vaultPickedProviderFamily (F1 — vault pick must per
 
     it("still resolves the family from metadata alone when the id is absent", () => {
         expect(vaultPickedProviderFamily(null, "openai", CAPABILITIES)).toBe("openai")
+    })
+
+    it("defaults an OpenAI-compatible (custom) connection with a bare model id to openai", () => {
+        // The `custom` kind is a deployment surface (not itself a family), but the OpenAI-compatible
+        // endpoint speaks the OpenAI dialect — so a provider-less pick resolves to openai instead of
+        // deferring to the caller's prior-provider fallback (design Decision 8).
+        expect(vaultPickedProviderFamily("gpt-oss", "custom", CAPABILITIES)).toBe("openai")
+        expect(vaultPickedProviderFamily("qwen2.5-coder:7b", "custom", CAPABILITIES)).toBe("openai")
+    })
+
+    it("still prefers an explicit id-encoded family over the custom openai default", () => {
+        // If the id itself encodes a known family, that wins even for a custom connection.
+        expect(
+            vaultPickedProviderFamily("eu.anthropic.claude-haiku-4-5", "custom", CAPABILITIES),
+        ).toBe("anthropic")
+    })
+})
+
+describe("connectionUtils: custom pick persists openai family AND keeps the connection slug", () => {
+    // Mirrors what `useModelHarness.writeModel` composes for a picked OpenAI-compatible option: the
+    // resolved family (openai, from vaultPickedProviderFamily) plus the option's own connection slug
+    // (threaded through `metadata.connectionSlug`). Neither may be dropped.
+    it("composes a ModelRef with provider openai and the preserved agenta slug", () => {
+        const provider = vaultPickedProviderFamily("gpt-oss", "custom", CAPABILITIES)
+        const ref = composeModelValue({
+            modelId: "gpt-oss",
+            provider,
+            mode: "agenta",
+            slug: "my-gateway",
+        })
+        expect(ref).toEqual({
+            model: "gpt-oss",
+            provider: "openai",
+            connection: {mode: "agenta", slug: "my-gateway"},
+        })
     })
 })

--- a/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
@@ -146,7 +146,7 @@ async function waitForModelsPageReady(page: Page): Promise<void> {
                     .isVisible()
                     .catch(() => false)
                 const createButtonEnabled = await customProvidersSection
-                    .getByRole("button", {name: "Custom Provider"})
+                    .getByRole("button", {name: "OpenAI-compatible endpoint"})
                     .isEnabled()
                     .catch(() => false)
 
@@ -190,9 +190,9 @@ async function navigateToModels(page: Page, uiHelpers: UIHelpers): Promise<void>
 
 function getCustomProvidersSection(page: Page): Locator {
     // The custom-providers section no longer has a dedicated header label — its
-    // section-identifying text IS the "Custom Provider" trigger button now.
+    // section-identifying text IS the "OpenAI-compatible endpoint" trigger button now.
     return page
-        .getByText("Custom Provider", {exact: true})
+        .getByText("OpenAI-compatible endpoint", {exact: true})
         .locator("xpath=ancestor::section[1]")
         .first()
 }


### PR DESCRIPTION
# feat(frontend): OpenAI-compatible endpoint label and harness-gated picker

## Context

The vault provider kind `custom` was labeled "Custom provider" in the settings and connection
forms. The name did not say what the kind is: a single-key OpenAI-compatible Chat Completions
endpoint at a base URL you name. Selecting a custom connection also did not set a provider family,
so a bare model from a custom connection could carry over whatever provider was selected before it.

This change relabels the kind and makes the picker pick the right family. It pairs with the backend
change that lets these connections run on Pi.

## Changes

The `custom` provider-kind label now reads "OpenAI-compatible endpoint". The stored value is
unchanged; only the display string moves.

Selecting a custom connection defaults the provider family to `openai` and preserves the connection
slug. Selecting an explicitly family-qualified model keeps that family. Switching from an unrelated
prior provider no longer leaks the prior provider into the new custom selection.

The picker is harness-gated. Custom vault models appear only where the harness reaches them. Pi
shows compatible custom connections when its custom deployment is enabled; Claude does not show an
OpenAI-compatible bare-model connection. Existing explicit Anthropic gateway behavior is unchanged.

Before: `PROVIDER_LABELS.custom` rendered "Custom provider", and a custom selection could submit the
previously selected provider. After: it renders "OpenAI-compatible endpoint", and a bare-model
custom selection writes provider `openai` with the exact slug.

## Scope / risk

- The change is display and picker logic only. Stored and submitted kind stays `custom`.
- Custom entries stay hidden until the backend capability ships, because the picker is gated on the
  harness deployment set. This PR should merge after or with the backend PR
  (`feat(agents): OpenAI-compatible endpoints for Pi via vault custom connections`). Merged alone,
  the label changes but no new connection can run.
- The Playwright `model-hub.ts` strings are updated to match the new label. A live Playwright run is
  still outstanding (tracked in the project open-issues log).

## How to QA

1. Open the model-hub settings. The provider kind previously shown as "Custom provider" now reads
   "OpenAI-compatible endpoint". The connection you already have is unchanged.
2. Create or edit a custom connection, then pick it and a bare model for a Pi agent. Expected: the
   provider resolves to `openai` and the connection slug is preserved in the submitted config.
3. Switch a selection from an unrelated provider to a custom connection. Expected: the new selection
   does not carry the old provider.
4. Regression, Claude: open the picker for a Claude template. Expected: an OpenAI-compatible
   bare-model connection does not appear; an existing Anthropic gateway still does.

Test command:

```
cd web/packages/agenta-entity-ui && pnpm exec vitest run
```

Evidence: entity-ui suite 208 passed. The manual UI click-through passed on the EE dev stack
(2026-07-14 and 2026-07-15).

https://claude.ai/code/session_01AYBi6cYuQCR87dAD3ZdPWc
