### PR TITLE
feat(hosting): run.sh auto-includes local compose overrides and gains surgical --recreate/--rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ services/runner/tests/results/
 api/sdks
 services/sdks
 
+# Local-only docker-compose overrides auto-included by hosting/docker-compose/run.sh
+# (docker-compose.<stage>.<name>.local.yml, e.g. an operator's harness subscription mounts).
+# The committed gh.local stage files have no <name> segment, so they are NOT matched.
+hosting/docker-compose/*/docker-compose.*.*.local.yml
+
 # Helm chart packages (built artifacts)
 agenta-oss-*.tgz
 

--- a/docs/packs/hosting.md
+++ b/docs/packs/hosting.md
@@ -23,6 +23,13 @@ If conflicts, trust script.
 - clean rebuild: append `--no-cache` (requires `--build`)
 - skip pull step: append `--no-pull`
 - volume reset: append `--nuke`
+- extra compose file: append `--compose-file <name>` (repeatable; bare name resolves in the edition dir, or pass a path)
+- skip local overrides: append `--no-local-overrides` (by default run.sh auto-includes `docker-compose.<stage>.*.local.yml` from the edition dir and prints the effective file set)
+
+## Restart one service (surgical)
+- recreate in place: `bash ./hosting/docker-compose/run.sh --ee --dev --env-file <path> --recreate <service>`
+- rebuild then recreate: swap `--recreate` for `--rebuild` (honors `--no-cache`)
+- Both reuse the full compose set (base + local overrides), so a targeted restart never drops an override. Repeatable; unknown services are rejected.
 
 ## Logs
 General:  `docker compose logs -f --tail=200`

--- a/hosting/AGENTS.md
+++ b/hosting/AGENTS.md
@@ -33,6 +33,33 @@ COMPOSE_PROJECT_NAME=agenta-ee-dev-instance2 ./hosting/docker-compose/run.sh \
 - `--build` for a normal rebuild.
 - `--build --no-cache` to rebuild from scratch.
 
+### Local compose overrides (auto-included)
+
+`run.sh` auto-includes every `docker-compose.<stage>.*.local.yml` in the edition dir as an
+extra `-f`, sorted lexicographically, and prints the effective compose file set on every run.
+These files are gitignored (see the `.gitignore` pattern) and hold operator-local tweaks. One
+example is `docker-compose.dev.harness.local.yml`, which bind-mounts the runner's Claude/Pi
+subscription logins. Because `run.sh` assembles the same set every time, a routine
+`run.sh --build` can no longer silently recreate a service without its override.
+
+- `--no-local-overrides` skips the auto-include.
+- `--compose-file <name>` appends an extra file (repeatable; bare name resolves in the edition
+  dir like `-e`, or pass a path). Appended after the auto-included ones.
+
+### Restart one service (surgical)
+
+`run.sh --recreate <service>` and `--rebuild <service>` are the blessed entry point for
+single-service restarts. They run `up -d --no-deps --force-recreate <service>` (or `build`
+then recreate) with the **full assembled `-f` set** and the same env handling as a full run,
+so a targeted restart never drops a local override. Both are repeatable and reject unknown
+services. `--rebuild` honors `--no-cache`; a service with no build config of its own (e.g. the
+dev `web`/`runner`) is built via its `.<name>` anchor automatically.
+
+```bash
+run.sh --ee --dev --env-file .env.ee.dev.local --recreate runner   # recreate with all overrides
+run.sh --ee --dev --env-file .env.ee.dev.local --rebuild web        # rebuilds the .web anchor, recreates web
+```
+
 ### Key difference
 
 - **Main branch**: no prefix, uses `.env.ee.dev.local`.

--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -20,6 +20,10 @@ PULL_ENABLED=  # Stage-dependent default applied after parsing: gh→true, dev�
 NUKE=false  # Default to not nuking volumes
 DOWN=false  # Default to up; --down only stops containers
 WITH_TUNNEL=true  # Composio trigger-event tunnel; disable with --no-tunnel
+LOCAL_OVERRIDES=true  # Auto-include docker-compose.<stage>.*.local.yml; disable with --no-local-overrides
+declare -a EXTRA_COMPOSE_FILES=()  # Extra -f files from --compose-file (repeatable)
+declare -a RECREATE_SERVICES=()    # Services to surgically recreate via --recreate (repeatable)
+declare -a REBUILD_SERVICES=()     # Services to surgically rebuild + recreate via --rebuild (repeatable)
 
 show_usage() {
     echo "Usage: $0 [OPTIONS]"
@@ -50,6 +54,19 @@ show_usage() {
     echo "Environment:"
     echo "  -e, --env <path>        Use explicit env file (otherwise stage default)"
     echo "  --env-file <path>       Alias for --env"
+    echo ""
+    echo "Compose files:"
+    echo "  --no-local-overrides    Do NOT auto-include docker-compose.<stage>.*.local.yml"
+    echo "                          overrides from the edition dir (they are included by default)"
+    echo "  --compose-file <name>   Append an extra compose file (repeatable). Bare name is"
+    echo "                          resolved against the edition dir like -e; or pass an absolute path"
+    echo ""
+    echo "Service lifecycle (surgical; skips the full down/up):"
+    echo "  --recreate <service>    Recreate one service in place with the full compose set"
+    echo "                          (up -d --no-deps --force-recreate). Repeatable."
+    echo "  --rebuild <service>     Build one service (honoring --no-cache) then recreate it."
+    echo "                          Repeatable. A service with no build config uses its .<name>"
+    echo "                          build anchor when one exists."
     echo ""
     echo "Database:"
     echo "  --nuke                  Remove related volumes on shutdown"
@@ -236,6 +253,30 @@ while [[ "$#" -gt 0 ]]; do
         --no-tunnel)
             WITH_TUNNEL=false
             ;;
+        --no-local-overrides)
+            LOCAL_OVERRIDES=false
+            ;;
+        --compose-file)
+            if [[ -z "${2:-}" ]]; then
+                error_exit "Missing value for --compose-file."
+            fi
+            EXTRA_COMPOSE_FILES+=("$2")
+            shift
+            ;;
+        --recreate)
+            if [[ -z "${2:-}" ]]; then
+                error_exit "Missing value for --recreate."
+            fi
+            RECREATE_SERVICES+=("$2")
+            shift
+            ;;
+        --rebuild)
+            if [[ -z "${2:-}" ]]; then
+                error_exit "Missing value for --rebuild."
+            fi
+            REBUILD_SERVICES+=("$2")
+            shift
+            ;;
         --down)
             DOWN=true
             ;;
@@ -299,13 +340,56 @@ if [[ -z "$AGENTA_WEB_URL" ]]; then
 fi
 
 # Ensure required files exist
-COMPOSE_FILE="./hosting/docker-compose/${LICENSE}/docker-compose.${STAGE}.yml"
+COMPOSE_DIR="./hosting/docker-compose/${LICENSE}"
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.${STAGE}.yml"
 if [[ ! -f "$COMPOSE_FILE" ]]; then
     error_exit "Docker Compose file not found: $COMPOSE_FILE"
 fi
 
-# Construct Docker Compose command
-COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+# Assemble the effective compose file set: base file, then auto-included local overrides,
+# then any explicit --compose-file entries. Each becomes an additional `-f` in dependency
+# order (later files override earlier ones). This is the fix for the "dropped override"
+# footgun: a run.sh invocation and a hand-added override are otherwise mutually unaware, so
+# whichever `up`/recreate ran last silently won. Now run.sh always assembles the same set.
+declare -a COMPOSE_FILES=("$COMPOSE_FILE")
+
+# 1. Auto-include local overrides: docker-compose.<stage>.*.local.yml in the edition dir,
+#    lexicographically sorted (glob expansion is already sorted). These are gitignored and
+#    hold operator-local tweaks (e.g. the runner's harness subscription mounts). Skip with
+#    --no-local-overrides.
+if $LOCAL_OVERRIDES; then
+    shopt -s nullglob
+    for _override in "${COMPOSE_DIR}"/docker-compose."${STAGE}".*.local.yml; do
+        COMPOSE_FILES+=("$_override")
+    done
+    shopt -u nullglob
+fi
+
+# 2. Append explicit --compose-file entries. A bare name resolves against the edition dir
+#    (same convention as -e); a path (absolute or containing a slash) is used as-is.
+for _extra in ${EXTRA_COMPOSE_FILES[@]+"${EXTRA_COMPOSE_FILES[@]}"}; do
+    if [[ "$_extra" = /* || "$_extra" == ./* || "$_extra" == ../* || "$_extra" == */* ]]; then
+        _extra_path="$_extra"
+    else
+        _extra_path="${COMPOSE_DIR}/${_extra}"
+    fi
+    if [[ ! -f "$_extra_path" ]]; then
+        error_exit "Compose file not found: $_extra_path"
+    fi
+    COMPOSE_FILES+=("$_extra_path")
+done
+
+# Print the effective compose file set every run so a dropped/added override is never silent.
+echo "Compose files (${#COMPOSE_FILES[@]}):"
+for _f in "${COMPOSE_FILES[@]}"; do
+    echo "  - $_f"
+done
+
+# Construct Docker Compose command with every -f in order.
+COMPOSE_CMD="docker compose"
+for _f in "${COMPOSE_FILES[@]}"; do
+    COMPOSE_CMD+=" -f $_f"
+done
 
 # If ENV_FILE is not provided, set it explicitly
 # gh.local reuses the gh env file
@@ -352,6 +436,75 @@ fi
 
 if $WITH_TUNNEL; then
     COMPOSE_CMD+=" --profile with-tunnel"
+fi
+
+# --------------------------------------------------------------------------------------------
+# Surgical service lifecycle: --recreate / --rebuild
+#
+# When either is given, operate on the named services in place with the FULL assembled -f set
+# and the same env handling as a full run (exported ENV_FILE + --env-file), instead of the
+# blanket down/up. This is the blessed entry point for single-service restarts: because it
+# reuses the same compose file set assembled above, a targeted recreate can never drop a local
+# override the way a hand-rolled `docker compose ... up -d --no-deps <svc>` does.
+# --------------------------------------------------------------------------------------------
+if [[ ${#RECREATE_SERVICES[@]} -gt 0 || ${#REBUILD_SERVICES[@]} -gt 0 ]]; then
+    if $DOWN; then
+        error_exit "--down cannot be combined with --recreate/--rebuild."
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        error_exit "--recreate/--rebuild require 'jq' (used to validate services and detect build config)."
+    fi
+
+    # Resolve the compose model once, honoring the assembled -f set and active profiles.
+    CONFIG_JSON="$($COMPOSE_CMD config --format json 2>/dev/null)" \
+        || error_exit "Failed to read compose config for the assembled file set."
+    AVAILABLE_SERVICES="$(printf '%s' "$CONFIG_JSON" | jq -r '.services | keys[]' | sort | tr '\n' ' ')"
+
+    service_exists() { printf '%s' "$CONFIG_JSON" | jq -e --arg s "$1" '.services | has($s)' >/dev/null 2>&1; }
+    has_build() { printf '%s' "$CONFIG_JSON" | jq -e --arg s "$1" '.services[$s].build != null' >/dev/null 2>&1; }
+
+    validate_service() {
+        if ! service_exists "$1"; then
+            error_exit "Unknown service '$1'. Available services: ${AVAILABLE_SERVICES}"
+        fi
+    }
+
+    # --rebuild: build (optionally --no-cache) then recreate. A service with no build config of
+    # its own uses its `.<name>` build anchor when one exists (dev images build via `.web`,
+    # `.runner`, etc. behind profiles; the runtime service only references the built image).
+    for _svc in ${REBUILD_SERVICES[@]+"${REBUILD_SERVICES[@]}"}; do
+        validate_service "$_svc"
+        _build_target="$_svc"
+        if ! has_build "$_svc"; then
+            if service_exists ".$_svc" && has_build ".$_svc"; then
+                _build_target=".$_svc"
+                echo "Service '$_svc' has no build config; building its '.$_svc' anchor instead."
+            else
+                error_exit "Service '$_svc' has no build config and no buildable '.$_svc' anchor."
+            fi
+        fi
+        if $NO_CACHE; then
+            echo "Rebuilding '$_build_target' (no cache)..."
+            $COMPOSE_CMD build --no-cache "$_build_target" || error_exit "Build failed for $_build_target"
+        else
+            echo "Rebuilding '$_build_target'..."
+            $COMPOSE_CMD build "$_build_target" || error_exit "Build failed for $_build_target"
+        fi
+        echo "Recreating '$_svc'..."
+        AGENTA_WEB_URL="$AGENTA_WEB_URL" $COMPOSE_CMD up -d --no-deps --force-recreate "$_svc" \
+            || error_exit "Failed to recreate $_svc"
+    done
+
+    # --recreate: force-recreate in place, no build.
+    for _svc in ${RECREATE_SERVICES[@]+"${RECREATE_SERVICES[@]}"}; do
+        validate_service "$_svc"
+        echo "Recreating '$_svc'..."
+        AGENTA_WEB_URL="$AGENTA_WEB_URL" $COMPOSE_CMD up -d --no-deps --force-recreate "$_svc" \
+            || error_exit "Failed to recreate $_svc"
+    done
+
+    echo "✅ Surgical service operation complete."
+    exit 0
 fi
 
 if $NO_CACHE; then


### PR DESCRIPTION
## Symptom

The dev stack's runner is composed with an extra local override, `hosting/docker-compose/ee/docker-compose.dev.harness.local.yml`, which bind-mounts the operator's Claude/Pi subscription logins. `run.sh` hardcoded exactly one compose file (`-f docker-compose.<stage>.yml`), so a routine `run.sh --build` recreated the runner **without** that override and broke self-managed (`runtime_provided`) agent auth: runs failed with `runtime_provided local run requires a mounted subscription`.

Root cause: `run.sh` and hand-added overrides were mutually unaware. Whichever ran last silently won, and there was no blessed way to restart a single service with the full compose set.

## What changed

`run.sh` now assembles and prints the effective compose file set on every run, and gains a surgical single-service path.

1. **Auto-include local overrides.** After the base compose file, glob `docker-compose.<stage>.*.local.yml` in the edition dir (lexicographically sorted), append each as an extra `-f`. A `Compose files (N):` block prints the effective set every run, so a dropped or added override is never silent. `--no-local-overrides` skips them.
2. **`--compose-file <name>` (repeatable).** Extra compose files by bare name (resolved against the edition dir like `-e`) or path, appended after the auto-included ones.
3. **`--recreate <service>` / `--rebuild <service>` (repeatable).** Surgical restart with the **full assembled `-f` set** and the same env handling as a full run (exported `ENV_FILE` + `--env-file`), instead of the blanket down/up:
   - `--recreate` runs `up -d --no-deps --force-recreate <service>`.
   - `--rebuild` runs `build` (honoring `--no-cache`) then the recreate. A service with no build config of its own (the dev `web`/`runner` reference an image built by a `.web`/`.runner` anchor behind a profile) is built via its `.<name>` anchor, and the script says so.
   - Both reject unknown services, validated against `docker compose config --services`.

Because the surgical path reuses the same assembled compose set, a targeted restart can never drop a local override the way a hand-rolled `docker compose ... up -d --no-deps <svc>` does.

Backward compatible: with no new flags and no `.local.yml` files present, behavior is unchanged aside from the new `Compose files:` info line.

`.gitignore` now ignores `docker-compose.<stage>.<name>.local.yml` in both edition dirs (the committed `gh.local` stage files have no `<name>` segment, so they stay tracked). Docs updated in `hosting/AGENTS.md` and `docs/packs/hosting.md`.

## Verification

Config-level only (no container was recreated/restarted):

- `bash -n` passes.
- With a temp `docker-compose.dev.zztest.local.yml` in the ee dir: the printout lists base + `docker-compose.dev.harness.local.yml` + the temp file (sorted), and `docker compose ... config -q` passes with the assembled set. Temp file removed after.
- `--no-local-overrides` drops back to base only; `--compose-file <name>` appends after the auto-included ones.
- `--recreate bogus` and `--rebuild` reject unknown services; `--down` + `--recreate` is refused.
- Build-anchor resolution confirmed: `--rebuild web` builds `.web`, `--rebuild runner` builds `.runner`.

https://claude.ai/code/session_019TK4ow9a3dXUNY657djbQr