### PR TITLE
[5357] fix(runner): recognize client-tool settles as a resume in cold replay

### DIFF
--- a/services/runner/src/engines/sandbox_agent/transcript.ts
+++ b/services/runner/src/engines/sandbox_agent/transcript.ts
@@ -187,21 +187,41 @@ const APPROVAL_RESUME_CLOSING =
   "If a call is marked APPROVED and not yet run, execute exactly that call now with the " +
   "same arguments; do not restart the task. If it was DENIED, continue without it.";
 
+const CLIENT_RESUME_CLOSING =
+  "The user has responded to the request(s) above (for example an input form or a connection " +
+  "prompt); the result is shown in the history. Continue the task from where it paused, using " +
+  "that result; do not restart the task or ask again for anything the user already provided.";
+
+export type ResumeKind = "approval" | "client";
+
+/** A client-tool settle (elicitation answer, connection reference, decline/cancel) rides back as
+ * a non-approval `tool_result`. Approval envelopes carry `{approved}` and are handled separately. */
+function isClientToolSettle(block: ContentBlock): boolean {
+  return block?.type === "tool_result" && approvalDecisionOf(block) === undefined;
+}
+
 /**
- * An approval resume carries no NEW user text: the newest meaningful content is the
- * approval-decision envelope, and `resolvePromptText` falls back to a STALE earlier user
- * message. Closing the frame with that stale command makes a fresh model restart the whole
- * task instead of re-issuing the approved call (cold-replay failure report, turn 6d34b1ea).
- * Detected conservatively: an unresolved approved call (`lastPending`) sits in a message
- * AFTER the last user message that carries text.
+ * A resume carries no NEW user text: the newest meaningful content is a settled interaction, and
+ * `resolvePromptText` falls back to a STALE earlier user message. Closing the frame with that stale
+ * command makes a fresh model restart the whole task instead of continuing from the pause — it
+ * re-issues the approved call (cold-replay failure report, turn 6d34b1ea) or, for a client tool,
+ * re-asks for input the user just gave (issue #5357).
+ *
+ * Two shapes, detected conservatively as content AFTER the last user text message:
+ *   - approval: an unresolved approved call (`lastPending`) — needs the execute-the-call frame.
+ *   - client:  a client-tool settle in an ASSISTANT message — the settled `tool_result` rides back
+ *     in the assistant turn it paused on (the Vercel adapter preserves that role), so an executed
+ *     server-tool result in a `tool`/user turn is not mistaken for a resume.
+ * An approval pending call wins when both are present (it carries the stronger instruction).
  */
-function isApprovalResume(
+function resumeKindFor(
   request: AgentRunRequest,
   hints: Map<ContentBlock, ApprovalRenderHint>,
-): boolean {
+): ResumeKind | null {
   const messages = request.messages ?? [];
   let lastUserTextIndex = -1;
-  let lastPendingIndex = -1;
+  let lastPendingApprovalIndex = -1;
+  let lastClientSettleIndex = -1;
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
     if (message.role === "user" && messageText(message.content)) {
@@ -210,10 +230,19 @@ function isApprovalResume(
     const content = message.content;
     if (!Array.isArray(content)) continue;
     if (content.some((block) => hints.get(block) === "lastPending")) {
-      lastPendingIndex = i;
+      lastPendingApprovalIndex = i;
+    }
+    if (message.role === "assistant" && content.some(isClientToolSettle)) {
+      lastClientSettleIndex = i;
     }
   }
-  return lastPendingIndex >= 0 && lastPendingIndex > lastUserTextIndex;
+  if (lastPendingApprovalIndex >= 0 && lastPendingApprovalIndex > lastUserTextIndex) {
+    return "approval";
+  }
+  if (lastClientSettleIndex >= 0 && lastClientSettleIndex > lastUserTextIndex) {
+    return "client";
+  }
+  return null;
 }
 
 /**
@@ -229,10 +258,11 @@ export function buildTurnText(
 ): string {
   const latest = resolvePromptText(request);
   const messages = request.messages ?? [];
-  const resume = isApprovalResume(request, approvalRenderHints(messages));
+  const resumeKind = resumeKindFor(request, approvalRenderHints(messages));
+  const resume = resumeKind !== null;
   // Normal turn: drop the prompt user message from the replay (it closes the frame).
-  // Approval resume: nothing is re-presented in the frame, so replay every message —
-  // including the stale command in place and an approval envelope on a trailing user turn.
+  // Resume: nothing is re-presented in the frame, so replay every message — including the
+  // stale command in place and the settled interaction (approval envelope or client-tool result).
   const prior = resume ? messages : priorMessages(request);
   const hints = approvalRenderHints(prior);
   const history = prior
@@ -260,15 +290,18 @@ export function buildTurnText(
     }
   }
 
-  const closing = resume
-    ? APPROVAL_RESUME_CLOSING
-    : `Continue the conversation. The user now says:\n${latest}`;
+  const closing =
+    resumeKind === "approval"
+      ? APPROVAL_RESUME_CLOSING
+      : resumeKind === "client"
+        ? CLIENT_RESUME_CLOSING
+        : `Continue the conversation. The user now says:\n${latest}`;
   const turnText = `Conversation so far:\n${transcript}\n\n${closing}`;
   log?.(
     `[HITL] cold replay: transcript ${full.length}->${transcript.length} chars, ` +
       `evicted ${evicted}/${history.length} messages, ` +
       `pendingNudge=${transcript.includes("has NOT run yet")}, ` +
-      `resumeFrame=${resume}, turnText ${turnText.length} chars`,
+      `resumeFrame=${resumeKind ?? "none"}, turnText ${turnText.length} chars`,
   );
   return turnText;
 }

--- a/services/runner/tests/unit/transcript.test.ts
+++ b/services/runner/tests/unit/transcript.test.ts
@@ -175,7 +175,7 @@ describe("buildTurnText history window", () => {
       assert.match(logs[0], /^\[HITL\] cold replay: /);
       assert.match(logs[0], /evicted 1\/2 messages/);
       assert.match(logs[0], /pendingNudge=false/);
-      assert.match(logs[0], /resumeFrame=false/);
+      assert.match(logs[0], /resumeFrame=none/);
       assert.match(logs[0], /turnText \d+ chars/);
     } finally {
       restoreEnv();
@@ -254,6 +254,69 @@ describe("buildTurnText approval-resume closing frame", () => {
 
     assert.match(text, /Continue the conversation\. The user now says:\ncontinue/);
     assert.doesNotMatch(text, /responded to the pending approval above/);
+  });
+
+  it("closes with the client-resume frame when the newest content is an elicitation answer (#5357)", () => {
+    const staleCommand = "help me schedule a report";
+    const request: AgentRunRequest = {
+      messages: [
+        { role: "user", content: staleCommand },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_call",
+              toolCallId: "call-1",
+              toolName: "__ag__request_input",
+              input: { message: "What color?", requestedSchema: {} },
+            },
+            {
+              type: "tool_result",
+              toolCallId: "call-1",
+              toolName: "__ag__request_input",
+              output: { action: "accept", content: { color: "green" } },
+            },
+          ] as ContentBlock[],
+        },
+      ],
+    };
+    const text = buildTurnText(request);
+
+    // The just-submitted answer must not be re-framed as a fresh request that restarts the task.
+    assert.match(text, /responded to the request/);
+    assert.match(text, /do not restart the task or ask again/);
+    assert.doesNotMatch(text, /The user now says/);
+    assert.doesNotMatch(text, /responded to the pending approval/);
+    // The answer stays visible in the replayed history and the stale command keeps its position.
+    assert.match(text, /request_input returned: .*green/);
+    assert.ok(text.includes(`user: ${staleCommand}`), "stale command stays in history");
+  });
+
+  it("keeps the normal closing frame when a client-tool result precedes a new user turn", () => {
+    const text = turnTextFor([
+      { role: "user", content: "help me schedule a report" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            toolCallId: "call-1",
+            toolName: "__ag__request_input",
+            input: { message: "What color?", requestedSchema: {} },
+          },
+          {
+            type: "tool_result",
+            toolCallId: "call-1",
+            toolName: "__ag__request_input",
+            output: { action: "accept", content: { color: "green" } },
+          },
+        ] as ContentBlock[],
+      },
+    ]);
+
+    // A settled client tool followed by NEW user text is a normal turn, not a resume.
+    assert.match(text, /Continue the conversation\. The user now says:\ncontinue/);
+    assert.doesNotMatch(text, /responded to the request/);
   });
 
   it("keeps the normal closing frame when the approved call already executed", () => {


### PR DESCRIPTION
Fixes #5357 (AGE-3964).

## Problem
After an agent calls `request_input` and the user submits the form, the **immediate resume turn** behaved as if the answer was never given — the agent re-asked, sometimes looping. The value only became usable on a later turn.

## Root cause
A `request_input` pause tears down the sandbox (client tools are non-parkable), so the resume is a **cold `/run`** and `buildTurnText` (`services/runner/src/engines/sandbox_agent/transcript.ts`) rebuilds the prompt from history.

It had two frames: an **approval-resume** frame (detected via `{approved}` envelopes) and a **normal-turn** frame. A `request_input` answer is a *non-approval* `tool_result`, so `isApprovalResume` returned false and it fell into the normal-turn path. On a resume there is no new user message, so `resolvePromptText` fell back to the **stale original prompt** and re-presented it as `"The user now says: <prompt>"` — the model read that as a fresh request and re-asked. The answer *was* in the transcript (why it "knows" a turn later), but the closing frame overrode it.

This is the same class of bug the approval-resume frame already fixed for approvals (turn `6d34b1ea`); it just never covered client-tool settles.

## Fix
Generalize resume detection: `isApprovalResume` → `resumeKindFor(...) → "approval" | "client" | null`.

- A **client resume** = a non-approval `tool_result` in an **assistant-role** message positioned after the last user-text message. The Vercel adapter keeps the settled `tool_result` inside the assistant turn it paused on, so an executed *server*-tool result in a `tool`/user turn is not mistaken for a resume (preserves the existing "approved call already executed" behavior).
- New `CLIENT_RESUME_CLOSING` frame: continue from the pause using the provided result; do not restart or re-ask.
- Approval wins when both are present. Covers `request_connection` and decline/cancel settles too.
- Log field `resumeFrame=` now emits `none|approval|client`.

## Tests
- Full runner suite green (1186 passed), `tsc --noEmit` clean.
- Added: client-resume frame on an elicitation answer (#5357); and a guard that a settled client tool *followed by* a new user turn stays a normal turn.

## Not in this PR / notes
- Runner-side only — needs a runner rebuild to take effect.
- Live end-to-end confirmation needs a running stack + real LLM (non-deterministic); the unit tests pin the exact prompt frame that was the root cause.