### PR TITLE
fix(sdk): use Claude harness model identifiers

### DIFF
--- a/.agents/skills/sync-model-catalog/SKILL.md
+++ b/.agents/skills/sync-model-catalog/SKILL.md
@@ -52,18 +52,17 @@ in the output records the exact pi-ai version. The curated overlay is untouched 
 
 ### 2. Sync Claude to the live accepted set (needs a running runner)
 
-`claude_models.curated.json` must cover exactly the aliases the Claude harness accepts. Probe the
-live set: start a Claude session on a running runner and read the model config options (the same
-`getConfigOptions` call `allowedModels` uses in `services/runner/src/engines/sandbox_agent/model.ts`).
-Reconcile in two directions only: add a curated entry for any accepted alias the file lacks (seed its
-facts from pi-ai's `anthropic` block), and remove any entry the harness no longer accepts. This is how
-a new alias (e.g. a `fable` alias, if a Claude Code build starts accepting it) enters the catalog.
-Requires an authenticated Claude session, so it is a manual/periodic step, not a CI gate.
+`claude_models.curated.json` must cover the stable request values the Claude picker can send.
+Probe live sessions by reading the model config options (the same `getConfigOptions` call
+`allowedModels` uses in `services/runner/src/engines/sandbox_agent/model.ts`), but do not copy one
+session's set blindly. Account entitlements and promotions can add or remove context-hinted variants
+such as `claude-fable-5[1m]` while keeping the same model family.
 
-Note: today the accepted set is `default/sonnet/opus/haiku` plus their `[1m]` variants
-(`CLAUDE_MODEL_ALIASES` in `capabilities.py`). There is no `fable` alias yet; Fable reaches the
-picker through the Pi `anthropic` block. Do not add a `fable` Claude entry until the live probe
-confirms the harness accepts it.
+Use the stable bare canonical id when the runner can safely widen it to the session's hinted option.
+For Fable, publish `claude-fable-5`: it matches a bare live option exactly and the runner resolves it
+to `claude-fable-5[1m]` when that is the only offered variant. Do not publish the friendly forms
+`fable` or `fable[1m]`; the harness does not recognize that model family under those ids. Requires
+an authenticated Claude session, so this is a manual/periodic step, not a CI gate.
 
 ### 3. Refresh curated metadata from current public sources (before a release / on demand)
 

--- a/sdks/python/agenta/sdk/agents/capabilities.py
+++ b/sdks/python/agenta/sdk/agents/capabilities.py
@@ -83,22 +83,20 @@ PI_SUBSCRIPTION_MODELS: Dict[str, List[str]] = {
 }
 PI_SUBSCRIPTION_PROVIDERS: List[str] = list(PI_SUBSCRIPTION_MODELS)
 
-# Claude Code selects a model by alias, not a ``provider/id`` string. These are the aliases the
-# Claude harness accepts (``default``/``sonnet``/``opus``/``haiku``) plus their ``[1m]``
-# long-context variants. They live under the ``anthropic`` provider in the ``models`` map (Claude
-# reaches anthropic only). Revisit if the runner's accepted alias set changes (see
+# Claude Code selects a model by alias, not a ``provider/id`` string. These are stable request
+# values for the picker. A live Claude session can expose a context-hinted variant such as
+# ``claude-fable-5[1m]`` while promotional long-context access is available, then expose the bare
+# ``claude-fable-5`` value later. The runner safely widens a bare request to the hinted option
+# when that is the only available variant, so the catalog must keep the stable bare value. They
+# live under the ``anthropic`` provider in the ``models`` map (Claude reaches anthropic only).
+# Revisit if the model family changes (see the ``sync-model-catalog`` skill and
 # ``docs/design/agent-workflows/projects/model-config/``).
 CLAUDE_MODEL_ALIASES: List[str] = [
     "default",
     "sonnet",
-    "opus",
     "haiku",
-    "fable",
-    "default[1m]",
-    "sonnet[1m]",
     "opus[1m]",
-    "haiku[1m]",
-    "fable[1m]",
+    "claude-fable-5",
 ]
 
 # Both modes every harness supports today. (No ``default`` mode: the project default is just

--- a/sdks/python/agenta/sdk/agents/data/claude_models.curated.json
+++ b/sdks/python/agenta/sdk/agents/data/claude_models.curated.json
@@ -2,7 +2,7 @@
   "schema_version": "1",
   "_curation": {
     "harness": "claude",
-    "note": "Hand-curated. `id` is the bare Claude Code alias (model_selection = alias). Facts seeded from the pinned @earendil-works/pi-ai `anthropic` block; label/description/ratings written by a human from the current lineup. Covers exactly the accepted alias set (capabilities.py CLAUDE_MODEL_ALIASES). The current Anthropic frontier is Fable 5, above Opus, so descriptions and ratings place Opus one tier below it. `fable`/`fable[1m]` are included in the accepted alias set (the harness accepts them, confirmed in live use). Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest).",
+    "note": "Hand-curated. `id` is the stable Claude Code request value (model_selection = alias). Facts seeded from the pinned @earendil-works/pi-ai `anthropic` block; label/description/ratings written by a human from the current lineup. The live harness can add or remove context-hinted variants as account access changes, so the catalog uses the stable bare Fable id that the runner can widen to a `[1m]` option when available. The current Anthropic frontier is Fable 5, above Opus, so descriptions and ratings place Opus one tier below it. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest).",
     "sources": "@earendil-works/pi-ai@0.80.6 anthropic block; Anthropic model + pricing pages"
   },
   "models": [
@@ -17,24 +17,6 @@
       "label": "Default",
       "description": "The harness's recommended default model. Resolves to whatever the Claude Code build selects.",
       "ratings": null
-    },
-    {
-      "id": "opus",
-      "provider": "anthropic",
-      "source": "curated",
-      "name": "Claude Opus 4.8",
-      "pricing": {
-        "input_per_mtok": 5.0,
-        "output_per_mtok": 25.0,
-        "cache_read_per_mtok": 0.5,
-        "cache_write_per_mtok": 6.25,
-        "currency": "USD"
-      },
-      "context_window": 1000000,
-      "modalities": ["text", "image"],
-      "label": "Opus",
-      "description": "Strong reasoning one tier below the Fable frontier, at a lower price. A good default for hard work.",
-      "ratings": {"cost": 3, "intelligence": 4, "speed": 3}
     },
     {
       "id": "sonnet",
@@ -73,18 +55,6 @@
       "ratings": {"cost": 5, "intelligence": 2, "speed": 5}
     },
     {
-      "id": "default[1m]",
-      "provider": "anthropic",
-      "source": "curated",
-      "name": null,
-      "pricing": null,
-      "context_window": 1000000,
-      "modalities": ["text", "image"],
-      "label": "Default (1M context)",
-      "description": "The harness's recommended default model with the 1M-token context window.",
-      "ratings": null
-    },
-    {
       "id": "opus[1m]",
       "provider": "anthropic",
       "source": "curated",
@@ -103,43 +73,7 @@
       "ratings": {"cost": 3, "intelligence": 4, "speed": 3}
     },
     {
-      "id": "sonnet[1m]",
-      "provider": "anthropic",
-      "source": "curated",
-      "name": "Claude Sonnet 5",
-      "pricing": {
-        "input_per_mtok": 2.0,
-        "output_per_mtok": 10.0,
-        "cache_read_per_mtok": 0.2,
-        "cache_write_per_mtok": 2.5,
-        "currency": "USD"
-      },
-      "context_window": 1000000,
-      "modalities": ["text", "image"],
-      "label": "Sonnet (1M context)",
-      "description": "Balanced speed and capability with the 1M-token context window, cheaper than Opus.",
-      "ratings": {"cost": 4, "intelligence": 3, "speed": 4}
-    },
-    {
-      "id": "haiku[1m]",
-      "provider": "anthropic",
-      "source": "curated",
-      "name": "Claude Haiku 4.5",
-      "pricing": {
-        "input_per_mtok": 1.0,
-        "output_per_mtok": 5.0,
-        "cache_read_per_mtok": 0.1,
-        "cache_write_per_mtok": 1.25,
-        "currency": "USD"
-      },
-      "context_window": 1000000,
-      "modalities": ["text", "image"],
-      "label": "Haiku (1M context)",
-      "description": "The fastest, cheapest tier with the 1M-token context window.",
-      "ratings": {"cost": 5, "intelligence": 2, "speed": 5}
-    },
-    {
-      "id": "fable",
+      "id": "claude-fable-5",
       "provider": "anthropic",
       "source": "curated",
       "name": "Claude Fable 5",
@@ -154,24 +88,6 @@
       "modalities": ["text", "image"],
       "label": "Fable",
       "description": "The current Anthropic frontier: the strongest reasoning tier, above Opus.",
-      "ratings": {"cost": 2, "intelligence": 5, "speed": 3}
-    },
-    {
-      "id": "fable[1m]",
-      "provider": "anthropic",
-      "source": "curated",
-      "name": "Claude Fable 5",
-      "pricing": {
-        "input_per_mtok": 10.0,
-        "output_per_mtok": 50.0,
-        "cache_read_per_mtok": 1.0,
-        "cache_write_per_mtok": 12.5,
-        "currency": "USD"
-      },
-      "context_window": 1000000,
-      "modalities": ["text", "image"],
-      "label": "Fable (1M context)",
-      "description": "The current Anthropic frontier: the strongest reasoning tier, above Opus, with the 1M-token context window.",
       "ratings": {"cost": 2, "intelligence": 5, "speed": 3}
     }
   ]

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_capabilities.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_capabilities.py
@@ -150,9 +150,10 @@ def test_claude_models_are_the_alias_set_under_anthropic():
     models = HARNESS_CONNECTION_CAPABILITIES["claude"].models
     assert set(models) == {"anthropic"}
     assert models["anthropic"] == list(CLAUDE_MODEL_ALIASES)
-    # Aliases, not provider-prefixed ids.
-    assert "opus" in models["anthropic"]
+    # Exact harness config values, not provider-prefixed ids or friendly aliases.
     assert "opus[1m]" in models["anthropic"]
+    assert "claude-fable-5" in models["anthropic"]
+    assert "fable" not in models["anthropic"]
     assert all("/" not in alias for alias in models["anthropic"])
 
 

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
@@ -111,6 +111,16 @@ def test_claude_catalog_covers_exactly_the_accepted_alias_set():
         assert "/" not in entry.id  # bare aliases, not provider-prefixed
 
 
+def test_claude_catalog_uses_stable_harness_request_values():
+    assert CLAUDE_MODEL_ALIASES == [
+        "default",
+        "sonnet",
+        "haiku",
+        "opus[1m]",
+        "claude-fable-5",
+    ]
+
+
 def test_fable_ships_as_a_current_fact_via_the_pi_anthropic_block():
     # Fable is the current Anthropic frontier and reaches the picker through the Pi catalog even
     # though it is not (yet) a Claude Code alias.


### PR DESCRIPTION
## Problem

The Claude harness picks a model by sending a bare request value (an alias like `sonnet`, or a canonical id like `claude-fable-5`), not a `provider/id` string. The catalog had drifted from what the harness actually accepts:

- It listed the friendly forms `fable` and `fable[1m]`. The harness does not recognize the Fable model family under those ids, so selecting Fable could not resolve.
- It carried a full grid of `[1m]` long-context variants (`default[1m]`, `sonnet[1m]`, `haiku[1m]`, `fable[1m]`) as if they were stable request values. They are context-hinted variants that a session exposes or drops as account entitlements and promotions change, so pinning them in the catalog is unreliable.

## Fix

Publish the **stable** request values the picker can always send, and let the runner widen a bare id to a hinted variant when that is the only one offered.

- `CLAUDE_MODEL_ALIASES` now: `default`, `sonnet`, `haiku`, `opus[1m]`, `claude-fable-5`.
- For Fable, publish the bare canonical `claude-fable-5`: it matches a live bare option exactly, and the runner resolves it to `claude-fable-5[1m]` when that is the only variant on offer. The friendly `fable` / `fable[1m]` forms are gone.
- `claude_models.curated.json` trimmed to the stable set; the curation note and the `sync-model-catalog` skill now explain the stable-bare-id-plus-runner-widening rule so the catalog does not get re-pinned to one session's hinted set.

## Tests

`test_capabilities.py` and `test_model_catalog.py` updated to assert the exact harness config values — `claude-fable-5` present, friendly `fable` absent, no `provider/`-prefixed ids.
