### PR TITLE
fix(runner): refuse a Claude-on-Daytona run whose tools are all client-kind

### DIFF
--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -71,6 +71,25 @@ export const REMOTE_TOOLS_UNSUPPORTED_MESSAGE =
   "docs/design/agent-workflows/projects/in-sandbox-tool-mcp/.";
 
 /**
+ * A non-Pi harness (Claude) on Daytona receives tools through the in-sandbox stdio MCP shim,
+ * which advertises only EXECUTABLE (gateway/callback) tools. Client tools are intentionally
+ * omitted: the shim's blocking relay call cannot pause for a browser round-trip yet. So a run
+ * whose ENTIRE tool set is client-kind has nothing deliverable to advertise on Daytona — it
+ * would otherwise proceed, drop every tool silently, and return `ok:true` (the F1 zero-tools
+ * drop). `run-plan.ts` is the documented refusal point for this (see `mcp.ts`); refuse it up
+ * front, exactly as the non-Daytona remote case is refused. A MIX of client + executable tools
+ * is fine (the executable ones are delivered; the client ones are dropped), so this fires only
+ * when NO executable tool remains.
+ */
+export const DAYTONA_CLIENT_ONLY_TOOLS_UNSUPPORTED_MESSAGE =
+  "Client tools are not deliverable to a non-Pi harness on Daytona: the in-sandbox stdio MCP " +
+  "shim advertises only executable (gateway/callback) tools, and a client tool cannot pause " +
+  "for a browser round-trip through its blocking relay yet. This run's tool set is entirely " +
+  "client-kind, so nothing would be advertised and the run would silently get zero tools. Add " +
+  "an executable tool, use the Pi harness, run on the local sandbox, or remove the tools. " +
+  "Tracked in docs/design/agent-workflows/projects/in-sandbox-tool-mcp/.";
+
+/**
  * `runtime_provided` (subscription) auth means the harness authenticates from explicitly prepared
  * local runtime state (a mounted Pi/Claude login). That state lives only in the runner container
  * and is never shipped to a third-party sandbox (interface.md sections 5-6), so the combination is
@@ -413,6 +432,12 @@ export function buildRunPlan(
   if (!isPi && isRemoteSandbox && toolSpecs.length > 0) {
     if (!isDaytona) {
       return { ok: false, error: REMOTE_TOOLS_UNSUPPORTED_MESSAGE };
+    }
+    // On Daytona the shim advertises only executable tools; client tools are omitted. If the run
+    // carries tools but NONE are executable, nothing would be delivered — refuse instead of
+    // silently advertising an empty tool set (the F1 zero-tools drop mcp.ts's log warns about).
+    if (executableToolSpecsForRun.length === 0) {
+      return { ok: false, error: DAYTONA_CLIENT_ONLY_TOOLS_UNSUPPORTED_MESSAGE };
     }
   }
 

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -704,7 +704,12 @@ describe("buildRunPlan", () => {
       );
     });
 
-    it("allows claude x daytona x client-only tools with no shim specs", () => {
+    it("refuses claude x daytona x client-ONLY tools (nothing deliverable to advertise)", () => {
+      // The shim advertises only executable tools; client tools are omitted. A run whose entire
+      // tool set is client-kind has nothing to deliver on Daytona, so it must fail CLOSED up
+      // front rather than proceed, drop every tool, and return ok:true (the F1 zero-tools drop
+      // that mcp.ts's "run-plan should have refused this run" log points at).
+      let created = false;
       const result = buildRunPlan(
         {
           harness: "claude",
@@ -713,13 +718,26 @@ describe("buildRunPlan", () => {
           customTools: [{ name: "request_connection", kind: "client" }],
         } as AgentRunRequest,
         {
-          createDaytonaCwd: () => "/home/sandbox/agenta-fixed",
+          createDaytonaCwd: () => {
+            created = true;
+            return "/home/sandbox/agenta-fixed";
+          },
         },
       );
 
-      assert.equal(result.ok, true);
-      if (!result.ok) return;
-      assert.deepEqual(result.plan.executableToolSpecs, []);
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.match(result.error, /Client tools are not deliverable/);
+      assert.match(result.error, /entirely\s+client-kind/);
+      assert.match(
+        result.error,
+        /docs\/design\/agent-workflows\/projects\/in-sandbox-tool-mcp\//,
+      );
+      assert.equal(
+        created,
+        false,
+        "fails before any cwd is created (up-front gate)",
+      );
     });
 
     it("allows pi x daytona x client-only tools (Pi's extension + file relay deliver them)", () => {


### PR DESCRIPTION
## Symptom

A Claude run on a Daytona sandbox that requests **only** client-kind tools (for example a single `request_connection` browser tool) passes validation, starts, and then runs with **zero tools** and returns `ok: true`. The user asked for tools; the agent silently got none.

## Why

On Daytona a non-Pi harness receives its tools through the in-sandbox stdio MCP shim, which advertises only **executable** (gateway/callback) tools. Client tools are intentionally omitted (the shim's blocking relay call cannot pause for a browser round-trip yet).

The up-front gate in `run-plan.ts` only refused a remote-sandbox tool run when the provider was **not** Daytona:

```ts
if (!isPi && isRemoteSandbox && toolSpecs.length > 0) {
  if (!isDaytona) {
    return { ok: false, error: REMOTE_TOOLS_UNSUPPORTED_MESSAGE };
  }
}
```

So an all-client-tool set on Daytona fell through and advertised nothing. `mcp.ts` already knows this is wrong: its log for the case says `"...run-plan should have refused this run"`, and its doc comment lists `"client tools on Daytona"` as one of the "undeliverable combinations `run-plan.ts` refuses before a session is ever built." The refusal was documented but never implemented. This is the F1 silent zero-tools drop, one configuration over.

## Change

Implement the documented intent. Inside the Daytona branch of the same gate, refuse when nothing executable remains after excluding client-kind tools:

```ts
if (executableToolSpecsForRun.length === 0) {
  return { ok: false, error: DAYTONA_CLIENT_ONLY_TOOLS_UNSUPPORTED_MESSAGE };
}
```

The new message follows the `REMOTE_TOOLS_UNSUPPORTED_MESSAGE` style (states the constraint, the remedies, and the tracking doc). A **mix** of client + executable tools is unaffected: the executable ones are delivered and the client ones are dropped, exactly as before. Pi on Daytona is unaffected (it delivers client tools through its extension + file relay). Local Claude is unaffected (the loopback MCP channel carries client tools).

## Tests

- Flipped the now-incorrect unit test `allows claude x daytona x client-only tools` to expect refusal, asserting the message and that it fails before any cwd is created (an up-front gate).
- Existing coverage already pins the unaffected cases: `claude x daytona x mixed tools` (allowed, keeps only executable specs), `pi x daytona x client-only tools` (allowed), `claude x local x client-only tools` (allowed).
- Full runner suite green: `pnpm run typecheck` clean, `pnpm test` 1158 passed across 75 files.

## Scope / risk

Two files, additive gate branch plus one new message constant. No wire-shape change. Behavior change is strictly a loud up-front refusal replacing a silent zero-tools run.

https://claude.ai/code/session_01RZnMTx5et6hRo5EHN187tT
