### PR TITLE
fix(auth): correct exc_infp typo to exc_info in auto-join error logging

### DIFF
--- a/api/oss/src/core/auth/service.py
+++ b/api/oss/src/core/auth/service.py
@@ -551,7 +551,7 @@ class AuthService:
                         user_id=str(user_id),
                     )
             except Exception:
-                log.error("[AUTH] [AUTO-JOIN]", exc_infp=True)
+                log.error("[AUTH] [AUTO-JOIN]", exc_info=True)
 
         # 2. Domains-only enforcement: Check if user has access
         # This is enforced at the organization level via check_organization_access()


### PR DESCRIPTION
## Describe your changes

A one-character typo fix in the auth service: `exc_infp=True` → `exc_info=True`.

## What is the current behavior?

When an auto-join exception occurs during login, the error is logged with `exc_infp=True` which is not a valid parameter for `log.error()`. The traceback is silently dropped, making it impossible to debug auto-join failures in production.

## What is the new behavior?

The correct parameter name `exc_info=True` ensures the full traceback is included in the error log, allowing operators to diagnose auto-join failures.

## Checklist

- [x] I have performed a self-review of my code
