### PR TITLE
test(web): fix the active-tab locator that broke five acceptance tests

### DIFF
--- a/web/oss/tests/playwright/acceptance/auto-evaluation/index.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/index.ts
@@ -126,7 +126,7 @@ const testAutoEval = () => {
             await goToAutoEvaluationStep(modal, "Test set")
 
             const expectedInputsNote = modal
-                .locator(".ant-tabs-content-active")
+                .locator(".ant-tabs-tabpane-active")
                 .last()
                 .locator("div")
                 .filter({

--- a/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
@@ -156,7 +156,7 @@ const goToAutoEvaluationStep = async (modal: Locator, step: string) => {
     await expect(tab).toBeVisible()
     await tab.click()
     await expect(tab).toHaveAttribute("aria-selected", "true")
-    await expect(modal.locator(".ant-tabs-content-active").last()).toBeVisible()
+    await expect(modal.locator(".ant-tabs-tabpane-active").last()).toBeVisible()
 }
 
 const selectAutoEvaluationModalTableInput = async ({
@@ -168,7 +168,7 @@ const selectAutoEvaluationModalTableInput = async ({
     rowText?: string
     inputType: "checkbox" | "radio"
 }) => {
-    const activePane = modal.locator(".ant-tabs-content-active").last()
+    const activePane = modal.locator(".ant-tabs-tabpane-active").last()
     const searchInput = activePane.locator('input[placeholder="Search"]').first()
     const inputSelector =
         'input[type="checkbox"], input[type="radio"], .ant-checkbox-input, .ant-radio-input'

--- a/web/oss/tests/playwright/acceptance/human-annotation/index.ts
+++ b/web/oss/tests/playwright/acceptance/human-annotation/index.ts
@@ -122,7 +122,7 @@ const humanAnnotationTests = () => {
             await goToHumanEvaluationStep(modal, "Test set")
 
             const expectedInputsNote = modal
-                .locator(".ant-tabs-content-active")
+                .locator(".ant-tabs-tabpane-active")
                 .last()
                 .locator("div")
                 .filter({hasText: /Expected input variables for selected variant\(s\):/})

--- a/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
@@ -518,11 +518,11 @@ const goToHumanEvaluationStep = async (modal: Locator, step: string) => {
     await expect(stepTab).toBeVisible()
     await stepTab.click()
     await expect(stepTab).toHaveAttribute("aria-selected", "true")
-    await expect(modal.locator(".ant-tabs-content-active").last()).toBeVisible()
+    await expect(modal.locator(".ant-tabs-tabpane-active").last()).toBeVisible()
 }
 
 const getActiveHumanEvaluationPane = (modal: Locator) =>
-    modal.locator(".ant-tabs-content-active").last()
+    modal.locator(".ant-tabs-tabpane-active").last()
 
 const selectHumanEvaluationModalTableInput = async ({
     modal,


### PR DESCRIPTION
## Symptom

Five Playwright acceptance tests time out after the full 60s in CI and fail the `run-web-tests (acceptance)` job — three auto-evaluation tests and two human-annotation tests. Each fails identically: `expect(locator).toBeVisible() failed / element(s) not found`, waiting on `.ant-modal ... .ant-tabs-content-active`. The build, the deploy, and the other eleven test jobs all pass, so this is a test-only failure, not a product or infra regression.

Failing job: https://github.com/Agenta-AI/agenta/actions/runs/29644311795/job/88080869634

## Root cause

Both evaluation suites drive a multi-step modal with a shared helper that clicks a tab, waits for `aria-selected="true"` (this passes), then waits for the tab's content pane using `modal.locator(".ant-tabs-content-active")`. That class **does not exist**. Ant Design renders the active tab pane as `.ant-tabs-tabpane-active`. A grep across the whole `web/` tree (OSS + EE) finds `ant-tabs-content-active` only inside these test files and in no component, so nothing ever renders it — the locator never resolves and every run waits out the 60s ceiling. The failure is fully deterministic (all five, every retry), the signature of a wrong selector, not flake.

Commit `2f81c122ed` (July 16) changed the locator from the correct `.ant-tabs-tabpane-active` to the non-existent `.ant-tabs-content-active`. It is already on `main`, so every PR since inherits the breakage; the v0.105.4 release runs were repeatedly cancelled, so this is the first completed acceptance run to surface it.

## Fix

Revert that one commit: change `.ant-tabs-content-active` back to `.ant-tabs-tabpane-active` in the six spots across the four acceptance test files. Test-only; no product code changes.

## Before / after

- **Before:** `modal.locator(".ant-tabs-content-active")` — matches nothing; modal step navigation hangs 60s; five tests time out.
- **After:** `modal.locator(".ant-tabs-tabpane-active")` — matches the real Ant Design active pane; the helper proceeds.

https://claude.ai/code/session_01DnWRxU3dCJ11hgDidm26vW