### PR TITLE
[AGE-3962] fix(runner): surface Claude extended-thinking in the playground

### DIFF
--- a/services/runner/src/engines/sandbox_agent/claude-thinking.ts
+++ b/services/runner/src/engines/sandbox_agent/claude-thinking.ts
@@ -1,0 +1,25 @@
+/**
+ * Make the Claude harness surface its extended-thinking reasoning in the playground.
+ *
+ * Recent Claude models default extended-thinking `display` to `"omitted"`: the API returns
+ * signature-only thinking blocks whose text is empty. `@agentclientprotocol/claude-agent-acp`
+ * emits an `agent_thought_chunk` only when that text is non-empty, so on those models the
+ * runner never sees any reasoning and the UI shows none — while models that return thinking
+ * text (e.g. Haiku) work. Requesting `display: "summarized"` (the documented Anthropic default,
+ * which recent models override to `"omitted"`) makes the reasoning text come back for every
+ * model, without forcing a fixed budget: `type: "adaptive"` leaves the decision of whether/how
+ * much to think to the model. `"summarized"` still returns the thinking signature, so multi-turn
+ * thinking continuity is unaffected.
+ *
+ * Rides `_meta.claudeCode.options`, which `claude-agent-acp` spreads over its env-derived
+ * thinking config (so this wins). Same `_meta` channel the system-prompt append uses.
+ */
+export interface ClaudeThinkingMeta {
+  claudeCode: { options: { thinking: { type: "adaptive"; display: "summarized" } } };
+}
+
+export function claudeThinkingMeta(): ClaudeThinkingMeta {
+  return {
+    claudeCode: { options: { thinking: { type: "adaptive", display: "summarized" } } },
+  };
+}

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -93,6 +93,7 @@ import {
   combineAppendSystemPrompt,
   type ClaudeSystemPromptMeta,
 } from "./agent-mount-guidance.ts";
+import { claudeThinkingMeta } from "./claude-thinking.ts";
 import {
   routePermissionRequestToActiveTurn,
   routeSessionEventToActiveTurn,
@@ -927,10 +928,21 @@ export async function acquireEnvironment(
       environment.agentMountedPath && plan.acpAgent === "claude"
         ? claudeMountSystemPromptMeta(AGENT_MOUNT_SYSTEM_PROMPT_SEGMENT)
         : undefined;
+    // Claude-only: request visible ("summarized") extended-thinking display so the model's
+    // reasoning reaches the runner (and the playground). Without it, recent Claude models
+    // return signature-only thinking and no reasoning surfaces. See `claude-thinking.ts`.
+    const claudeThinking =
+      plan.acpAgent === "claude" ? claudeThinkingMeta() : undefined;
+    // Disjoint `_meta` keys (`systemPrompt` vs `claudeCode`), so a shallow merge keeps both.
+    // A future second `claudeCode` producer would need a deep merge here.
+    const claudeMeta =
+      claudeSystemPromptMeta || claudeThinking
+        ? { ...(claudeSystemPromptMeta ?? {}), ...(claudeThinking ?? {}) }
+        : undefined;
     const sessionInit = {
       cwd: plan.cwd,
       mcpServers: sessionMcp.servers,
-      ...(claudeSystemPromptMeta ? { _meta: claudeSystemPromptMeta } : {}),
+      ...(claudeMeta ? { _meta: claudeMeta } : {}),
     };
 
     // If this harness authored the conversation's most recent turn (staleness-guarded) and we

--- a/services/runner/tests/unit/claude-thinking.test.ts
+++ b/services/runner/tests/unit/claude-thinking.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { claudeThinkingMeta } from "../../src/engines/sandbox_agent/claude-thinking.ts";
+
+describe("claudeThinkingMeta", () => {
+  it("requests visible ('summarized') adaptive thinking under _meta.claudeCode.options", () => {
+    // Recent Claude models default `display` to "omitted" (signature-only, empty text), so no
+    // agent_thought_chunk is emitted and the playground shows no reasoning. This meta flips the
+    // display to "summarized" so reasoning surfaces, while `adaptive` leaves the think-or-not
+    // decision to the model.
+    assert.deepEqual(claudeThinkingMeta(), {
+      claudeCode: {
+        options: { thinking: { type: "adaptive", display: "summarized" } },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Problem

In the agent playground, the Claude Code harness shows no thinking for some models. **Sonnet and Opus show nothing; Haiku works** — even though all three stream fine. Closes #5355 (AGE-3962).

## Root cause

Recent Claude models default extended-thinking `display` to **`"omitted"`**: the Anthropic API returns signature-only thinking blocks whose text is empty. `@agentclientprotocol/claude-agent-acp` emits an `agent_thought_chunk` **only when that text is non-empty**, so on those models the runner never sees any reasoning and nothing renders — in streaming *or* batch. Models that return thinking text (e.g. Haiku) are unaffected. The runner set no thinking config, so recent models fell to the `omitted` default.

This is emission-side (the reasoning never reaches us), not a rendering bug.

## Fix

For the Claude harness, request visible (`"summarized"`) thinking display via `_meta.claudeCode.options.thinking` — the same `_meta` channel the system-prompt append already uses, which `claude-agent-acp` spreads over its env-derived thinking config (so it wins):

```ts
{ claudeCode: { options: { thinking: { type: "adaptive", display: "summarized" } } } }
```

- `type: "adaptive"` leaves the think-or-not decision to the model (no forced budget).
- `"summarized"` still returns the thinking **signature**, so multi-turn thinking continuity is unaffected.
- Guarded by `plan.acpAgent === "claude"` — **Pi harness is untouched** (it has its own reasoning path).

The change is model-agnostic within the Claude harness: it fixes Sonnet/Opus (same `omitted`-default cause) and leaves Haiku/default behavior unchanged (`summarized` is their existing default, now explicit).

## Before / after

- **Before:** Claude Code + Sonnet → no "Thought" in the playground.
- **After:** Claude Code + Sonnet → reasoning streams and renders as "Thought".

## Supersedes #5372

This PR **supersedes #5372** (same author's fix), ported onto the decomposed runner layout. The runner engine was split since #5372 was opened: the monolithic `sandbox_agent.ts` is now a thin facade over `engines/sandbox_agent/*`. #5372's new `claude-thinking.ts` module and its test are byte-identical here; its one session-init insertion (the import and the `claudeThinking` / `claudeMeta` merge) now lands in `engines/sandbox_agent/environment.ts`, next to where `claudeSystemPromptMeta` and the `sessionInit` payload are already assembled — the block that moved out of the monolith. No behavior change from #5372. #5372 can be closed in favor of this one.

## Testing

- New unit test for the `claudeThinkingMeta` helper.
- `pnpm run typecheck` clean; `pnpm test` green — **1205 tests** (was 1204, +1 for the new test).

https://claude.ai/code/session_01DnWRxU3dCJ11hgDidm26vW
