### PR TITLE
feat(sdk): emit tool-output-denied so the UI can tell a denial from a failure

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -236,7 +236,21 @@ async def _agent_run_to_vercel_parts_impl(
                 # and the client throws. The commit-revision side-channel below is a plain
                 # data event, not a tool-result envelope, so it fires regardless.
                 has_tool_part = tool_call_id in seen_tool_calls
-                if has_tool_part and data.get("isError"):
+                if has_tool_part and data.get("denied"):
+                    # A user/policy DENIAL of a gated call. The runner stamps `denied` on the
+                    # closing result (which still rides `isError`, since the harness closes a
+                    # denied call as a failed tool call), so project the AI SDK's dedicated
+                    # `tool-output-denied` chunk — a decline the FE renders differently from a
+                    # breakage. That chunk is a strict object of ONLY `type` + `toolCallId`
+                    # (ai@6 uiMessageChunkSchema), so it carries no errorText/output.
+                    denied_part = {
+                        "type": "tool-output-denied",
+                        "toolCallId": tool_call_id,
+                    }
+                    if _conform(denied_part) is not None:
+                        content_parts_emitted += 1
+                    yield denied_part
+                elif has_tool_part and data.get("isError"):
                     error_part = {
                         "type": "tool-output-error",
                         "toolCallId": tool_call_id,
@@ -502,7 +516,21 @@ async def _agent_stream_to_vercel_stream_impl(
                 # and the client throws. The commit-revision side-channel below is a plain
                 # data event, not a tool-result envelope, so it fires regardless.
                 has_tool_part = tool_call_id in seen_tool_calls
-                if has_tool_part and data.get("isError"):
+                if has_tool_part and data.get("denied"):
+                    # A user/policy DENIAL of a gated call. The runner stamps `denied` on the
+                    # closing result (which still rides `isError`, since the harness closes a
+                    # denied call as a failed tool call), so project the AI SDK's dedicated
+                    # `tool-output-denied` chunk — a decline the FE renders differently from a
+                    # breakage. That chunk is a strict object of ONLY `type` + `toolCallId`
+                    # (ai@6 uiMessageChunkSchema), so it carries no errorText/output.
+                    denied_part = {
+                        "type": "tool-output-denied",
+                        "toolCallId": tool_call_id,
+                    }
+                    if _conform(denied_part) is not None:
+                        content_parts_emitted += 1
+                    yield denied_part
+                elif has_tool_part and data.get("isError"):
                     error_part = {
                         "type": "tool-output-error",
                         "toolCallId": tool_call_id,

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
@@ -39,13 +39,17 @@ _REQUIRED_STRING_FIELDS: Dict[str, List[str]] = {
     "tool-input-available": ["type", "toolCallId", "toolName"],
     "tool-output-available": ["type", "toolCallId"],
     "tool-output-error": ["type", "toolCallId", "errorText"],
+    "tool-output-denied": ["type", "toolCallId"],
     "tool-approval-request": ["type", "toolCallId", "approvalId"],
     "file": ["type", "url", "mediaType"],
     "error": ["type", "errorText"],
 }
-# `tool-approval-request` is the only strict object with an EXACT allowed key set (no extra
-# agenta-only fields may leak onto it).
-_EXACT_KEYS = {"tool-approval-request": {"type", "approvalId", "toolCallId"}}
+# These chunks are strict objects with an EXACT allowed key set (no extra agenta-only fields may
+# leak onto them). `tool-output-denied` is `{type, toolCallId}` only — no errorText/output.
+_EXACT_KEYS = {
+    "tool-approval-request": {"type", "approvalId", "toolCallId"},
+    "tool-output-denied": {"type", "toolCallId"},
+}
 
 
 def assert_conforms(part: Dict[str, Any]) -> None:
@@ -122,6 +126,62 @@ async def test_dev_twin_projection_conforms_to_vendored_schema() -> None:
     assert parts
     for part in parts:
         assert_conforms(part)
+
+
+# A denied gated call: the tool surfaces, then a denied-marked failed result closes it. Both
+# egress paths must project a conforming `tool-output-denied` chunk (not `tool-output-error`).
+_DENY_EVENTS: List[Dict[str, Any]] = [
+    {"type": "tool_call", "data": {"id": "c1", "name": "deleteFile", "input": {}}},
+    {
+        "type": "tool_result",
+        "data": {
+            "id": "c1",
+            "output": "denied by user",
+            "isError": True,
+            "denied": True,
+        },
+    },
+    {"type": "done", "data": {"stopReason": "stop"}},
+]
+
+
+@pytest.mark.asyncio
+async def test_live_deny_projects_conforming_denied_frame() -> None:
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(
+            _records(_DENY_EVENTS), trace_id="td"
+        )
+    ]
+    for part in parts:
+        assert_conforms(part)
+    denied = next(p for p in parts if p["type"] == "tool-output-denied")
+    assert denied["toolCallId"] == "c1"
+    assert not any(p["type"] == "tool-output-error" for p in parts)
+
+
+@pytest.mark.asyncio
+async def test_dev_twin_deny_projects_conforming_denied_frame() -> None:
+    # The dev-twin projects an AgentStream, whose Event.data is the FLAT runner AgentEvent (id /
+    # isError / denied at the top level), unlike the routing path's `{type, data}` envelope.
+    flat_deny_events = [
+        {"type": "tool_call", "id": "c1", "name": "deleteFile", "input": {}},
+        {
+            "type": "tool_result",
+            "id": "c1",
+            "output": "denied by user",
+            "isError": True,
+            "denied": True,
+        },
+        {"type": "done", "stopReason": "stop"},
+    ]
+    run = _run_with(flat_deny_events, result={"output": ""})
+    parts = [part async for part in agent_run_to_vercel_parts(run)]
+    for part in parts:
+        assert_conforms(part)
+    denied = next(p for p in parts if p["type"] == "tool-output-denied")
+    assert denied["toolCallId"] == "c1"
+    assert not any(p["type"] == "tool-output-error" for p in parts)
 
 
 @pytest.mark.asyncio

--- a/sdks/python/oss/tests/pytest/unit/agents/test_ui_messages.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_ui_messages.py
@@ -540,9 +540,10 @@ class TestUIMessageStream:
         approval = next(p for p in parts if p["type"] == "tool-approval-request")
         assert approval["toolCallId"] == "call_1"
 
-    async def test_tool_denial_rides_iserror_not_a_denied_field(self):
-        # No runner path ever sets a `denied` field on a tool_result — a human deny rides
-        # `isError: True` like any other tool failure, so it becomes tool-output-error.
+    async def test_tool_denial_marker_becomes_denied_frame(self):
+        # A denied gated call rides `isError: True` (the harness closes it as a failed tool call)
+        # PLUS the runner's structural `denied` marker. The marker projects the AI SDK's dedicated
+        # tool-output-denied chunk (a decline), never tool-output-error (a breakage).
         run = _run(
             events=[
                 {"type": "tool_call", "id": "c1", "name": "deleteFile", "input": {}},
@@ -550,6 +551,32 @@ class TestUIMessageStream:
                     "type": "tool_result",
                     "id": "c1",
                     "output": "denied by user",
+                    "isError": True,
+                    "denied": True,
+                },
+                {"type": "done"},
+            ],
+            result={"output": ""},
+        )
+        parts = await _collect(run, session_id="s1")
+        denied = next(p for p in parts if p["type"] == "tool-output-denied")
+        assert denied["toolCallId"] == "c1"
+        # The denied chunk is a strict object of only type + toolCallId (no errorText/output leak).
+        assert set(denied.keys()) == {"type", "toolCallId"}
+        types = [p["type"] for p in parts]
+        assert "tool-output-error" not in types
+        assert "tool-output-available" not in types
+
+    async def test_genuine_tool_error_without_marker_stays_error_frame(self):
+        # A real tool failure (no `denied` marker) still becomes tool-output-error, unchanged: the
+        # denied projection is gated strictly on the structural marker, never on the error text.
+        run = _run(
+            events=[
+                {"type": "tool_call", "id": "c1", "name": "deleteFile", "input": {}},
+                {
+                    "type": "tool_result",
+                    "id": "c1",
+                    "output": "disk full",
                     "isError": True,
                 },
                 {"type": "done"},

--- a/services/runner/src/engines/sandbox_agent/acp-interactions.ts
+++ b/services/runner/src/engines/sandbox_agent/acp-interactions.ts
@@ -37,7 +37,12 @@ export interface PiToolSpecMeta {
 
 export interface AttachPermissionResponderInput {
   session: any;
-  run: { emitEvent: (event: AgentEvent) => void; events?: () => AgentEvent[] };
+  run: {
+    emitEvent: (event: AgentEvent) => void;
+    events?: () => AgentEvent[];
+    /** Flag the gated call as a deny so its closing failed result projects `tool-output-denied`. */
+    markToolCallDenied?: (toolCallId: string | undefined) => void;
+  };
   responder: Responder;
   latch: PendingApprovalLatch;
   serverPermissions?: ReadonlyMap<string, ToolPermission>;
@@ -218,7 +223,13 @@ export function attachPermissionResponder({
     id: string,
     decision: PermissionDecision,
     availableReplies: string[],
+    toolCallId?: string,
   ): Promise<void> => {
+    // A deny replies `reject`, which makes the harness close the call as a FAILED tool call. Flag
+    // the id first so the closing result carries `denied` and the egress renders a decline, not a
+    // breakage. (A malformed-envelope / unknown-builtin fail-closed reject goes through
+    // `rejectRequest`, not here, so it stays a plain error — it is not a user/policy denial.)
+    if (decision === "deny") run.markToolCallDenied?.(toolCallId);
     try {
       await session.respondPermission(
         id,
@@ -337,7 +348,7 @@ export function attachPermissionResponder({
     if (verdict.kind === "allow" && envelope.gate === "pi-custom-tool") {
       onPiGateAllowed?.({ toolName: gate.toolName!, args: gate.args });
     }
-    await replyPermission(id, verdict.kind, availableReplies);
+    await replyPermission(id, verdict.kind, availableReplies, envelope.toolCallId);
   };
 
   async function handleRequest(req: any): Promise<void> {
@@ -421,7 +432,12 @@ export function attachPermissionResponder({
       pauseUserApproval(req, id, gate, "claude-acp-permission");
       return;
     }
-    await replyPermission(id, verdict.kind, availableReplies);
+    await replyPermission(
+      id,
+      verdict.kind,
+      availableReplies,
+      stringValue(toolCall?.toolCallId),
+    );
   }
 }
 

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -446,6 +446,11 @@ export async function runTurn(
       if (opts.resume.reply === "once") {
         executionGrants.grant(opts.resume.toolName, opts.resume.args);
       }
+      // A live-resume deny closes the seeded call as a failed tool call; flag it so the egress
+      // projects `tool-output-denied` (a decline), mirroring the cold decision-map deny path.
+      if (opts.resume.reply === "reject") {
+        run.markToolCallDenied(opts.resume.toolCallId);
+      }
       await env.session.respondPermission(
         opts.resume.permissionId,
         opts.resume.reply,

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -345,6 +345,14 @@ export type AgentEvent =
       /** Structured output (object), used for generative UI; `output` stays the text form. */
       data?: unknown;
       isError?: boolean;
+      /**
+       * The result is a USER/POLICY DENIAL of a gated call, not a genuine tool failure. A denied
+       * call still rides `isError: true` (the harness closes it as a failed tool call), so this
+       * structural marker is the only reliable way for the egress to project `tool-output-denied`
+       * (a decline) instead of `tool-output-error` (a breakage). Set by the runner at the deny
+       * mapping, never inferred from the error text.
+       */
+      denied?: boolean;
       render?: RenderHint;
     }
   // A human-in-the-loop request the harness raised (ACP reverse-RPC). The kind is our own

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -1086,6 +1086,12 @@ export interface SandboxAgentOtel {
     isExcluded: (id: string) => boolean,
     message: string,
   ): void;
+  /**
+   * Mark a tool-call id as DENIED (the runner replied `reject` to its gate). Its closing failed
+   * result then carries `denied: true` so the egress projects `tool-output-denied` (a decline)
+   * rather than `tool-output-error` (a breakage). No-op for a falsy id.
+   */
+  markToolCallDenied(toolCallId: string | undefined): void;
   /** Run token/cost totals from the stream, when the harness reported `usage_update`. */
   usage(): AgentUsage | undefined;
 }
@@ -1123,6 +1129,10 @@ export function createSandboxAgentOtel(
     string,
     { span?: Span; name: string; inputJson?: string }
   >();
+  // Tool-call ids the runner replied `reject` to for a HITL deny. The harness closes such a call
+  // as a FAILED tool call (`isError`), indistinguishable on the wire from a real breakage, so the
+  // deny mapping records the id here and `maybeCloseTool` stamps the closing result `denied`.
+  const deniedToolCallIds = new Set<string>();
 
   // Live emission. `record` is the single choke point for every event: it appends to the
   // result log and, on the streaming path, flushes the event the moment it is built — so
@@ -1449,12 +1459,21 @@ export function createSandboxAgentOtel(
       entry.span.end();
     }
     toolSpans.delete(id);
+    // A failed close for a call the runner denied is a decline, not a breakage: stamp `denied`
+    // so the egress projects `tool-output-denied`. The set is consumed so a later reuse of the
+    // id (should one ever occur) is not mis-flagged.
+    const denied = status === "failed" && deniedToolCallIds.delete(id);
     record({
       type: "tool_result",
       id,
       output: out,
       isError: status === "failed",
+      ...(denied ? { denied: true } : {}),
     });
+  }
+
+  function markToolCallDenied(toolCallId: string | undefined): void {
+    if (toolCallId) deniedToolCallIds.add(toolCallId);
   }
 
   function settleOpenToolCalls(
@@ -1596,6 +1615,7 @@ export function createSandboxAgentOtel(
     output: () => accumulated,
     events: () => events,
     settleOpenToolCalls,
+    markToolCallDenied,
     usage: () => usage,
   };
 }

--- a/services/runner/tests/unit/sandbox-agent-acp-interactions.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-acp-interactions.test.ts
@@ -133,6 +133,59 @@ describe("attachPermissionResponder", () => {
     assert.deepEqual(events, []);
   });
 
+  it("deny verdict flags the gated tool-call id denied so its result renders a decline", async () => {
+    const replies: Array<{ id: string; reply: string }> = [];
+    const { session, emit } = makeSession(async (id, reply) => {
+      replies.push({ id, reply });
+    });
+    const events: AgentEvent[] = [];
+    const denied: Array<string | undefined> = [];
+
+    attachPermissionResponder({
+      session,
+      run: {
+        emitEvent: (event) => events.push(event),
+        markToolCallDenied: (id) => denied.push(id),
+      },
+      responder: fakeResponder({ kind: "deny" }),
+      latch: new PendingApprovalLatch(),
+    });
+    emit({
+      id: "perm-1",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tool-7", name: "edit", rawInput: { path: "a" } },
+    });
+    await flushPromises();
+
+    assert.deepEqual(replies, [{ id: "perm-1", reply: "reject" }]);
+    // The gate's tool-call id is flagged BEFORE the reject reply, keyed by the real toolCallId.
+    assert.deepEqual(denied, ["tool-7"]);
+  });
+
+  it("allow verdict does NOT flag the tool-call id denied", async () => {
+    const { session, emit } = makeSession(async () => {});
+    const events: AgentEvent[] = [];
+    const denied: Array<string | undefined> = [];
+
+    attachPermissionResponder({
+      session,
+      run: {
+        emitEvent: (event) => events.push(event),
+        markToolCallDenied: (id) => denied.push(id),
+      },
+      responder: fakeResponder({ kind: "allow" }),
+      latch: new PendingApprovalLatch(),
+    });
+    emit({
+      id: "perm-1",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tool-7", name: "edit", rawInput: { path: "a" } },
+    });
+    await flushPromises();
+
+    assert.deepEqual(denied, []);
+  });
+
   it("pendingApproval emits, creates the interaction, pauses, and sends no reply", async () => {
     const replies: Array<{ id: string; reply: string }> = [];
     const { session, emit } = makeSession(async (id, reply) => {

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -978,6 +978,10 @@ function pausableHarness(opts: { clientTool?: boolean } = {}) {
           run.settled.push({ id, message });
         }
       },
+      denied: [] as string[],
+      markToolCallDenied(id: string | undefined) {
+        if (id) run.denied.push(id);
+      },
       traceId() {
         return "trace-1";
       },

--- a/services/runner/tests/unit/stream-events.test.ts
+++ b/services/runner/tests/unit/stream-events.test.ts
@@ -284,4 +284,36 @@ describe("createSandboxAgentOtel state machine", () => {
     assert.equal(calls.length, 1, "no refresh — args were present up front");
     assert.deepEqual(calls[0].input, { city: "Paris" }, "keeps the initial args");
   });
+
+  it("scenario 7: a denied gate stamps `denied` on the closing failed tool_result", () => {
+    // The runner replied `reject`, so it flags the id via markToolCallDenied. The harness then
+    // closes the call as a FAILED tool call; the tool_result must carry `denied: true` so the
+    // egress projects a decline, not a breakage.
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "claude", model: "anthropic/x", emit: (e) => emitted.push(e) });
+    run.start({ prompt: "x" });
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "deleteFile", rawInput: {} });
+    run.markToolCallDenied("c1");
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "failed", content: [{ content: { type: "text", text: "User refused permission" } }] });
+    run.finish();
+
+    const results = ofType(emitted, "tool_result");
+    assert.equal(results.length, 1, "one tool_result");
+    assert.equal(results[0].isError, true, "a denied close still rides isError");
+    assert.equal(results[0].denied, true, "the denied marker is stamped");
+  });
+
+  it("scenario 8: a genuine tool failure (no markToolCallDenied) is NOT flagged denied", () => {
+    const emitted: AgentEvent[] = [];
+    const run = createSandboxAgentOtel({ harness: "claude", model: "anthropic/x", emit: (e) => emitted.push(e) });
+    run.start({ prompt: "x" });
+    run.handleUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "deleteFile", rawInput: {} });
+    run.handleUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "failed", content: [{ content: { type: "text", text: "disk full" } }] });
+    run.finish();
+
+    const results = ofType(emitted, "tool_result");
+    assert.equal(results.length, 1, "one tool_result");
+    assert.equal(results[0].isError, true, "a real failure rides isError");
+    assert.equal(results[0].denied, undefined, "no denied marker on a genuine failure");
+  });
 });


### PR DESCRIPTION
## The problem

When a user **denies** a gated tool call in the agent playground, the UI showed it as a
tool *failure* — the same red error box a real breakage produces. A decline ("you chose not
to run this") and a breakage ("the tool crashed") are different things and should read
differently.

The cause is on the wire. A denial reaches the SDK as an `isError` tool result: the runner
replies `reject` to the approval gate, and the harness (Claude / Pi) then closes the call as
a *failed* tool call — indistinguishable, byte for byte, from a genuine tool error. The
Vercel egress had no way to tell them apart, so every denied call became a
`tool-output-error` frame.

## The fix

Add a **structural marker** at the runner's deny mapping, never a guess from the error text
(which varies by harness and version):

- The runner flags the denied tool-call id (`otel.markToolCallDenied`) at the point it
  decides to reject the gate, and the closing failed `tool_result` carries `denied: true`.
  This covers the cold decision-map deny (both the Claude ACP gate and the Pi ACP gate) and
  the live keep-alive resume-reject.
- The SDK egress (both projection sites in `stream.py`) projects the AI SDK's dedicated
  `tool-output-denied` chunk for a denied result, and keeps `tool-output-error` for a real
  failure.

The frontend already renders `output-denied` as a distinct decline (`ToolActivity.tsx`), so
no UI change was needed — the missing piece was purely the egress emitting the frame.

### The wire, before and after

A user denies a gated `bash` call, then the turn resumes:

```
before:  … tool-input-available  tool-output-error   text-delta …   (UI: red error box)
after:   … tool-input-available  tool-output-denied  text-delta …   (UI: "declined")
```

`tool-output-denied` is a strict `{type, toolCallId}` chunk in `ai@6`'s
`uiMessageChunkSchema` — no `errorText`/`output` — so the denied frame carries no leaked
error payload.

## Design record

D-022 in `docs/design/agent-workflows/projects/qa/final-sweep-decisions.md` — the deny path
was designed to emit `tool-output-denied`; this PR is the egress half that was still missing.

## Testing

- **Runner unit** (`pnpm test`, 1209 green): the otel marker stamps `denied` on a failed
  close only when flagged (and a genuine failure is left untouched); the ACP responder flags
  the gated id on a deny verdict and not on an allow. `pnpm run typecheck` clean.
- **SDK unit** (agents suite): both egress sites project `tool-output-denied` for a denied
  result and keep `tool-output-error` for an unmarked failure; the conformance test's
  vendored `ai@6` schema mirror now pins `tool-output-denied` as `{type, toolCallId}`. The
  pre-existing test that asserted "a deny rides isError, never a denied field" was updated to
  the new contract.
- **Live** (EE dev stack, claude / local sandbox / vault key): drove a real gated `bash`
  call through the product `/services/agent/v0/invoke` endpoint, denied it inline, and
  captured the resumed turn's frames:
  `… tool-input-available, tool-output-denied, text-start, … finish`. The release-gate
  **deny journey** — which asserts `outcome == "denied"`, a state only the new frame
  produces — went **green** (`denied: the gated command never executed (outcome=denied)`).

https://claude.ai/code/session_01DnWRxU3dCJ11hgDidm26vW
