### PR TITLE
docs(readme): reposition around building and running agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   </a>
   
 <div align="center">
-  <strong> <h1> The Open-source LLMOps Platform </h1></strong>
-  Build reliable LLM applications with prompt management, evaluation, and observability.
+  <strong> <h1> The open-source workspace for building and running agents </h1></strong>
+  Build agents that automate your work by chatting with them. Share them with your team, connect them to the apps you use, and run them in the background.
 </div>
 
 
@@ -76,102 +76,137 @@
 
 ## What is Agenta?
 
-Agenta is a platform for building production-grade LLM applications. It helps **engineering** and **product teams** create reliable LLM apps faster through integrated prompt management, evaluation, and observability.
+Agenta is an open-source workspace where you build specialized agents that automate and augment your work.
 
-## Core Features
+You build agents by chatting with them. You describe the work, connect the apps they need, and improve them through feedback.
 
-### 🧪 Prompt Management & Prompt Engineering
-Collaborate with Subject Matter Experts (SMEs) on prompt engineering and make sure nothing breaks in production.
+You can work with your agents directly in chat and share them with your team.
 
-- **Interactive LLM Playground**: Compare prompts side by side against your test cases
-- **Multi-Model Support**: Experiment with 50+ LLM models or [bring-your-own models](https://agenta.ai/docs/prompt-engineering/playground/custom-providers?utm_source=github&utm_medium=referral&utm_campaign=readme)
-- **Version Control**: Version prompts and configurations with branching and environments
-- **Complex Configurations**: Enable SMEs to collaborate on [complex configuration schemas](https://agenta.ai/docs/custom-workflows/overview?utm_source=github&utm_medium=referral&utm_campaign=readme) beyond simple prompts
+For recurring work, you can build background agents. These agents run on a schedule or when an event occurs.
 
-[Explore prompt management →](https://agenta.ai/docs/prompt-engineering/concepts?utm_source=github&utm_medium=referral&utm_campaign=readme)
+## Why use Agenta?
 
-### 📊 LLM Evaluation
-Evaluate your LLM applications systematically with both human and automated feedback.
-- **Flexible Testsets**: Create testcases from production data, playground experiments, or upload CSVs
-- **Pre-built and Custom Evaluators**: Use LLM-as-judge, one of our 20+ pre-built evaluators, or your custom evaluators
-- **UI and API Access**: Run evaluations via UI (for SMEs) or programmatically (for engineers)
-- **Human Feedback Integration**: Collect and incorporate expert annotations
+### Use your Claude or ChatGPT subscription
 
-[Explore evaluation frameworks →](https://agenta.ai/docs/evaluation/overview?utm_source=github&utm_medium=referral&utm_campaign=readme)
+When you self-host Agenta, you can run agents with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
 
-### 📡 LLM Observability
-Get visibility into your LLM applications in production.
-- **Cost & Performance Tracking**: Monitor spending, latency, and usage patterns
-- **LLM Tracing**: Debug complex workflows with detailed traces
-- **Open Standards**: OpenTelemetry native tracing compatible with OpenLLMetry, and OpenInference
-- **Integrations**: Comes with pre-built integrations for most models and frameworks
+### Choose your harness and model
 
-[Learn about observability →](https://agenta.ai/docs/observability/overview?utm_source=github&utm_medium=referral&utm_campaign=readme)
+Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with more harnesses planned. See the [support matrix](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
-## 📸 Screenshots
+### Build with open agent standards
 
-<img alt="Playground" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/a4f67ac4-1acc-40c6-7a1a-5616eee7bb00/large" />
-<img alt="Prompt Management" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/65f697d0-3221-4e3c-7232-f350b1976a00/large" />
-<img alt="Evaluation" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/19b5b77e-6945-4419-15b9-cfea197e1300/large" />
-<img  alt="Observability" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/efc8a24c-2a2a-427c-f285-7d8b41200700/large" />
+Define your agent with AGENTS.md, skills, and MCP servers. Bring skills and MCP servers from the wider agent ecosystem into Agenta, then inspect and adapt them for your agent.
 
-## 🚀 Getting Started 
+### Make your agents more reliable over time
 
-### Agenta Cloud (Recommended):
-The easiest way to get started is through Agenta Cloud. Free tier available with no credit card required.
+Agenta traces every run and keeps a version history of each agent configuration. Use this history to understand failures, compare changes, and improve your agents over time.
+
+## Features
+
+- **Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, and maintain a wiki.
+- **Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
+- **Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
+- **Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
+- **Team access.** The open-source version lets you share agents with your team and control access by role.
+- **Integrations.** Connect your agents to more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub. Use MCP servers to connect other services.
+
+## Roadmap
+
+Agenta is still evolving. Checked items are available today. Unchecked items are directions we plan to support.
+
+**Harnesses**
+
+- [x] Claude Code
+- [x] Pi
+- [ ] Codex
+- [ ] OpenCode
+- [ ] More harnesses
+
+**Models**
+
+- [x] Models accessed through provider APIs
+- [ ] OpenAI-compatible models
+- [ ] Self-hosted models
+
+**Agent runtimes**
+
+- [x] Local runtime
+- [x] Daytona sandboxes
+- [ ] Docker sandboxes
+- [ ] E2B sandboxes
+
+**Triggers and connections**
+
+- [x] Schedules
+- [x] Events from connected apps
+- [x] MCP servers
+- [ ] Generic webhook triggers
+- [ ] Additional MCP transports
+
+See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
+
+## How Agenta compares
+
+### n8n, Activepieces, and Zapier
+
+These products are designed for workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
+
+### Claude Cowork
+
+Claude Cowork provides a workspace built around Claude. Agenta is open source and lets you choose your harness and model, inspect the components of your agents, and run them interactively or in the background.
+
+### Claude Code, Codex, Pi, and OpenCode
+
+These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
+
+## Get started
+
+### Try Agenta Cloud
+
+The fastest way to try Agenta.
 
 <p align="center">
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
-        <img alt="Try Agenta Live Demo" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
+        <img alt="Try Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
       </picture>
   </a>
 </p>
 
-  
-   
-### Self-hosting Agenta
+### Self-host with Docker
 
-1. Clone Agenta:
-```bash
-git clone https://github.com/Agenta-AI/agenta && cd agenta
-```
-2. Copy configuration:
-
-Before starting the services, create the environment file from the example:
+You need Docker and Docker Compose.
 
 ```bash
+git clone https://github.com/Agenta-AI/agenta
+cd agenta
 cp hosting/docker-compose/oss/env.oss.gh.example hosting/docker-compose/oss/.env.oss.gh
+docker compose \
+  -f hosting/docker-compose/oss/docker-compose.gh.yml \
+  --env-file hosting/docker-compose/oss/.env.oss.gh \
+  --profile with-web \
+  --profile with-traefik \
+  up -d
 ```
 
-3. Start Agenta services:
-```bash
-docker compose -f hosting/docker-compose/oss/docker-compose.gh.yml --env-file hosting/docker-compose/oss/.env.oss.gh --profile with-web --profile with-traefik up -d
-```
+Open http://localhost.
 
-4. Access Agenta at `http://localhost`.
+For configuration, remote deployment, and upgrades, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
-For deploying on a remote host, or using different ports refer to our [self-hosting](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme) and [remote deployment documentation](https://agenta.ai/docs/self-host/guides/deploy-remotely?utm_source=github&utm_medium=referral&utm_campaign=readme).
+## Community and contributing
 
-## 💬 Community
+Agenta is open source under the MIT License. You can inspect the code, run it yourself, and help shape what we build next.
 
-Find help, explore resources, or get involved:
+- [Read the documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
+- [Report a bug](https://github.com/Agenta-AI/agenta/issues)
+- [Request a feature or share an idea](https://github.com/Agenta-AI/agenta/discussions)
+- [Read the contributing guide](CONTRIBUTING.md)
+- [Join the Slack community](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
 
-### 🧰 Support
-
-- **📚 [Documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)** – Full guides and API reference  
-- **📋 [Changelog](https://agenta.ai/docs/changelog?utm_source=github&utm_medium=referral&utm_campaign=readme)** – Track recent updates  
-- **💬 [Slack Community](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)** – Ask questions and get support  
-
-### 🤝 Contribute
-
-We welcome contributions of all kinds, from filing issues and sharing ideas to improving the codebase. Check out our [CONTRIBUTING.md](CONTRIBUTING.md) and:
-
-- **🐛 [Report bugs](https://github.com/Agenta-AI/agenta/issues)** – Help us by reporting problems you encounter  
-- **💡 [Share ideas and feedback](https://github.com/Agenta-AI/agenta/discussions)** – Suggest features or vote on ideas
-- **🔧 [Contribute to the codebase](https://agenta.ai/docs/contributing/overview?utm_source=github&utm_medium=referral&utm_campaign=readme)** – Read the guide and open a pull request
+If Agenta is useful to you, star the repository and tell us what you build.
 
 ## ⭐ Star Agenta
 
@@ -296,7 +331,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
-
-## Disabling Anonymized Tracking
-
-By default, Agenta automatically reports anonymized basic usage statistics. This helps us understand how Agenta is used and track its overall usage and growth. This data does not include any sensitive information. To disable anonymized telemetry set `AGENTA_TELEMETRY_ENABLED` to `false` in your `.env` file.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,8 @@
   Build agents that automate your work by chatting with them. Share them with your team, connect them to the apps you use, and run them in the background.
 </div>
 
-
-  <br />
-      <div align="center" >
-        <a href="https://www.youtube.com/watch?v=zZJfqkc608M" target="_blank">
-          <picture >
-            <img alt="Agenta platform walkthrough" src="https://github.com/user-attachments/assets/992d4880-86ce-44bc-bfe4-e9eae9b731c8" >
-          </picture>
-        </a>
-    </div>
 </div>
+
 ---
 
 <h3 align="center">
@@ -41,11 +33,9 @@
   <a href="https://github.com/Agenta-AI/agenta/blob/main/CONTRIBUTING.md">
     <img src="https://img.shields.io/badge/PRs-Welcome-brightgreen" alt="PRs welcome" />
   </a>
-  <img src="https://img.shields.io/github/contributors/Agenta-AI/agenta" alt="Contributors">
   <a href="https://pypi.org/project/agenta/">
     <img src="https://img.shields.io/pypi/dm/agenta" alt="PyPI - Downloads">
   </a>
-  <img src="https://img.shields.io/github/last-commit/Agenta-AI/agenta" alt="Last Commit">
 </br>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
         </a>
     </div>
 </div>
-
 ---
 
 <h3 align="center">
@@ -52,13 +51,13 @@
 
 <p align="center">
     <a href="https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw">
-        <img src="https://img.shields.io/badge/JOIN US ON SLACK-4A154B?style=for-the-badge&logo=slack&logoColor=white" />
+        <img src="https://custom-icon-badges.demolab.com/badge/Slack-4A154B?logo=slack&logoColor=fff" alt="Join us on Slack" />
     </a>
     <a href="https://www.linkedin.com/company/agenta-ai/">
-        <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" />
+        <img src="https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff" alt="Follow Agenta on LinkedIn" />
     </a>
     <a  href="https://twitter.com/agenta_ai">
-        <img src="https://img.shields.io/twitter/follow/agenta_ai?style=social" height="28" />
+        <img src="https://img.shields.io/twitter/follow/agenta_ai?style=social" height="28" alt="Follow @agenta_ai on X" />
     </a>
 </p>
 
@@ -88,15 +87,15 @@ For recurring work, you can build background agents. These agents run on a sched
 
 ### Use your Claude or ChatGPT subscription
 
-When you self-host Agenta, you can run agents with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
+When you self-host Agenta, you can run agents locally with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
 
 ### Choose your harness and model
 
-Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with more harnesses planned. See the [support matrix](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ### Build with open agent standards
 
-Define your agent with AGENTS.md, skills, and MCP servers. Bring skills and MCP servers from the wider agent ecosystem into Agenta, then inspect and adapt them for your agent.
+Define your agent with `AGENTS.md`, skills, and MCP servers. You can bring skills and MCP servers from the agent ecosystem into Agenta.
 
 ### Make your agents more reliable over time
 
@@ -104,61 +103,17 @@ Agenta traces every run and keeps a version history of each agent configuration.
 
 ## Features
 
-- **Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, and maintain a wiki.
-- **Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
-- **Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
-- **Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
-- **Team access.** The open-source version lets you share agents with your team and control access by role.
-- **Integrations.** Connect your agents to more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub. Use MCP servers to connect other services.
+**Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, or maintain a wiki.
 
-## Roadmap
+**Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
 
-Agenta is still evolving. Checked items are available today. Unchecked items are directions we plan to support.
+**Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
 
-**Harnesses**
+**Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
 
-- [x] Claude Code
-- [x] Pi
-- [ ] Codex
-- [ ] OpenCode
-- [ ] More harnesses
+**Team access.** The open-source version lets you share agents with your team and control access by role.
 
-**Models**
-
-- [x] Models accessed through provider APIs
-- [ ] OpenAI-compatible models
-- [ ] Self-hosted models
-
-**Agent runtimes**
-
-- [x] Local runtime
-- [x] Daytona sandboxes
-- [ ] Docker sandboxes
-- [ ] E2B sandboxes
-
-**Triggers and connections**
-
-- [x] Schedules
-- [x] Events from connected apps
-- [x] MCP servers
-- [ ] Generic webhook triggers
-- [ ] Additional MCP transports
-
-See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
-
-## How Agenta compares
-
-### n8n, Activepieces, and Zapier
-
-These products are designed for workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
-
-### Claude Cowork
-
-Claude Cowork provides a workspace built around Claude. Agenta is open source and lets you choose your harness and model, inspect the components of your agents, and run them interactively or in the background.
-
-### Claude Code, Codex, Pi, and OpenCode
-
-These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
+**Integrations.** Connect your agents to the applications you use through MCP, or integrate with more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub.
 
 ## Get started
 
@@ -176,25 +131,86 @@ The fastest way to try Agenta.
   </a>
 </p>
 
-### Self-host with Docker
+### Self-host Agenta
 
-You need Docker and Docker Compose.
+Paste this into your agent and it will walk you through setup and testing:
 
-```bash
-git clone https://github.com/Agenta-AI/agenta
-cd agenta
-cp hosting/docker-compose/oss/env.oss.gh.example hosting/docker-compose/oss/.env.oss.gh
-docker compose \
-  -f hosting/docker-compose/oss/docker-compose.gh.yml \
-  --env-file hosting/docker-compose/oss/.env.oss.gh \
-  --profile with-web \
-  --profile with-traefik \
-  up -d
+```text
+1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
+2. Help me self-host Agenta with its repository.
 ```
 
-Open http://localhost.
+For more details, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
-For configuration, remote deployment, and upgrades, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
+## Roadmap
+
+**Harnesses**
+
+- [x] Claude Code
+- [x] Pi
+- [ ] Codex
+- [ ] Gemini
+- [ ] OpenCode
+- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+
+**Models**
+
+- [x] OpenAI
+- [x] Anthropic
+- [x] OpenRouter
+- [x] Mistral AI
+- [x] Cohere
+- [x] Anyscale
+- [x] Perplexity AI
+- [x] DeepInfra
+- [x] Together AI
+- [x] Groq
+- [x] Google Gemini
+- [x] Azure
+- [x] AWS Bedrock
+- [x] MiniMax
+- [x] OpenAI-compatible models
+- [x] Self-hosted models (Ollama)
+- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+
+**Agent runtimes**
+
+- [x] Local runtime
+- [x] Daytona sandboxes
+- [x] Docker sandboxes
+- [ ] E2B sandboxes
+- [ ] AgentComputer
+- [ ] Vercel
+- [ ] Cloudflare
+- [ ] Modal
+- [ ] BoxLite
+- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+
+**Features**
+
+- [x] Schedules
+- [x] Events from connected apps
+- [x] MCP servers (API key + unauthenticated)
+- [ ] Generic webhook triggers
+- [ ] Additional MCP transports (OAuth)
+- [ ] Channels (Slack, Telegram, Discord, Teams)
+- [ ] Mobile version
+
+See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
+
+## How Agenta compares
+
+### n8n, Activepieces, and Zapier
+
+These products are designed for building workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
+
+### Claude Cowork
+
+Claude Cowork provides a workspace built around Claude. Agenta is open source and lets you choose your harness and model, inspect the components of your agents, and run them interactively or in the background.
+
+### Claude Code, Codex, Pi, and OpenCode
+
+These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
 
 ## Community and contributing
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -11,18 +11,6 @@
 <div align="center">
   <strong> <h1> The open-source workspace for building and running agents </h1></strong>
   Build agents that automate your work by chatting with them. Share them with your team, connect them to the apps you use, and run them in the background.
-</div>
-  <br />
-      <div align="center" >
-        <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
-          <picture >
-        <source media="(prefers-color-scheme: dark)" srcset="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/6fa19a9d-9785-4acf-5d08-e81b1e38b100/large"  >
-        <source media="(prefers-color-scheme: light)" srcset="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/6fa19a9d-9785-4acf-5d08-e81b1e38b100/large"  >
-        <img alt="Shows the logo of agenta" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/6fa19a9d-9785-4acf-5d08-e81b1e38b100/large" >
-          </picture>
-        </a>
-    </div>
-</div>
 
 ---
 
@@ -88,15 +76,15 @@ For recurring work, you can build background agents. These agents run on a sched
 
 ### Use your Claude or ChatGPT subscription
 
-When you self-host Agenta, you can run agents with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
+When you self-host Agenta, you can run agents locally with your existing Claude or ChatGPT subscription with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). 
 
 ### Choose your harness and model
 
-Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with more harnesses planned. See the [support matrix](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or through API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ### Build with open agent standards
 
-Define your agent with AGENTS.md, skills, and MCP servers. Bring skills and MCP servers from the wider agent ecosystem into Agenta, then inspect and adapt them for your agent.
+Define your agent with `AGENTS.md`, skills, and MCP servers. You can bring skills and MCP servers from the agent ecosystem into Agenta.
 
 ### Make your agents more reliable over time
 
@@ -104,12 +92,17 @@ Agenta traces every run and keeps a version history of each agent configuration.
 
 ## Features
 
-- **Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, and maintain a wiki.
-- **Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
-- **Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
-- **Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
-- **Team access.** The open-source version lets you share agents with your team and control access by role.
-- **Integrations.** Connect your agents to more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub. Use MCP servers to connect other services.
+**Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, or maintain a wiki.
+
+**Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
+
+**Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
+
+**Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
+
+**Team access.** The open-source version lets you share agents with your team and control access by role.
+
+**Integrations.** Connect your agents to the applications you use through MCP, or integrate with more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub.
 
 ## Roadmap
 
@@ -120,29 +113,54 @@ Agenta is still evolving. Checked items are available today. Unchecked items are
 - [x] Claude Code
 - [x] Pi
 - [ ] Codex
+- [ ] Gemini
 - [ ] OpenCode
-- [ ] More harnesses
+- [ ] [Create an issue to add yours to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
 
 **Models**
 
-- [x] Models accessed through provider APIs
-- [ ] OpenAI-compatible models
-- [ ] Self-hosted models
+- [x] OpenAI
+- [x] Anthropic
+- [x] Openrouter
+- [x] OpenAI
+- [x] Mistral AI
+-	[x] Cohere
+-	[x] Anyscale
+-	[x] Perplexity AI
+-	[x] DeepInfra
+-	[x] Together AI
+-	[x] Groq
+-	[x] Google Gemini
+-	[x] Azure
+-	[x] AWS Bedrock
+-	[x] MiniMax
+- [x] OpenAI-compatible models
+- [x] Self-hosted models (Ollama)
+- [ ] [Create an issue to add yours to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
 
 **Agent runtimes**
 
 - [x] Local runtime
 - [x] Daytona sandboxes
-- [ ] Docker sandboxes
+- [x] Docker sandboxes
 - [ ] E2B sandboxes
+- [ ] AgentComputer
+- [ ] Vercel
+- [ ] Cloudflare
+- [ ] Modal
+- [ ] BoxLite
+- [ ] [Create an issue to add yours to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
 
-**Triggers and connections**
+
+**Features**
 
 - [x] Schedules
 - [x] Events from connected apps
-- [x] MCP servers
+- [x] MCP servers (API key + unauthenticated)
 - [ ] Generic webhook triggers
-- [ ] Additional MCP transports
+- [ ] Additional MCP transports (Oauth)
+- [ ] Channels (Slack, Telegram, Discord, Teams)
+- [ ] Mobile version
 
 See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -41,10 +41,10 @@
 
 <p align="center">
     <a href="https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw">
-        <img src="https://img.shields.io/badge/JOIN US ON SLACK-4A154B?style=for-the-badge&logo=slack&logoColor=white" />
+        <img src="https://custom-icon-badges.demolab.com/badge/Slack-4A154B?logo=slack&logoColor=fff" />
     </a>
     <a href="https://www.linkedin.com/company/agenta-ai/">
-        <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" />
+        <img src="https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff" />
     </a>
     <a  href="https://twitter.com/agenta_ai">
         <img src="https://img.shields.io/twitter/follow/agenta_ai?style=social" height="28" />

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -41,13 +41,13 @@
 
 <p align="center">
     <a href="https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw">
-        <img src="https://custom-icon-badges.demolab.com/badge/Slack-4A154B?logo=slack&logoColor=fff" />
+        <img src="https://custom-icon-badges.demolab.com/badge/Slack-4A154B?logo=slack&logoColor=fff" alt="Join us on Slack" />
     </a>
     <a href="https://www.linkedin.com/company/agenta-ai/">
-        <img src="https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff" />
+        <img src="https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff" alt="Follow Agenta on LinkedIn" />
     </a>
     <a  href="https://twitter.com/agenta_ai">
-        <img src="https://img.shields.io/twitter/follow/agenta_ai?style=social" height="28" />
+        <img src="https://img.shields.io/twitter/follow/agenta_ai?style=social" height="28" alt="Follow @agenta_ai on X" />
     </a>
 </p>
 
@@ -77,11 +77,11 @@ For recurring work, you can build background agents. These agents run on a sched
 
 ### Use your Claude or ChatGPT subscription
 
-When you self-host Agenta, you can run agents locally with your existing Claude or ChatGPT subscription with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). 
+When you self-host Agenta, you can run agents locally with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
 
 ### Choose your harness and model
 
-Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or through API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ### Build with open agent standards
 
@@ -125,7 +125,7 @@ The fastest way to try Agenta.
 
 Paste this into your agent and it will walk you through setup and testing:
 
-```
+```text
 1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
 2. Help me self-host Agenta with its repository.
 ```
@@ -141,28 +141,27 @@ For more details, read the [self-hosting documentation](https://agenta.ai/docs/s
 - [ ] Codex
 - [ ] Gemini
 - [ ] OpenCode
-- [ ] [Create an issue to add yours to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
 
 **Models**
 
 - [x] OpenAI
 - [x] Anthropic
-- [x] Openrouter
-- [x] OpenAI
+- [x] OpenRouter
 - [x] Mistral AI
--	[x] Cohere
--	[x] Anyscale
--	[x] Perplexity AI
--	[x] DeepInfra
--	[x] Together AI
--	[x] Groq
--	[x] Google Gemini
--	[x] Azure
--	[x] AWS Bedrock
--	[x] MiniMax
+- [x] Cohere
+- [x] Anyscale
+- [x] Perplexity AI
+- [x] DeepInfra
+- [x] Together AI
+- [x] Groq
+- [x] Google Gemini
+- [x] Azure
+- [x] AWS Bedrock
+- [x] MiniMax
 - [x] OpenAI-compatible models
 - [x] Self-hosted models (Ollama)
-- [ ] [Create an issue to add yours to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
 
 **Agent runtimes**
 
@@ -175,8 +174,7 @@ For more details, read the [self-hosting documentation](https://agenta.ai/docs/s
 - [ ] Cloudflare
 - [ ] Modal
 - [ ] BoxLite
-- [ ] [Create an issue to add yours to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
-
+- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
 
 **Features**
 
@@ -184,7 +182,7 @@ For more details, read the [self-hosting documentation](https://agenta.ai/docs/s
 - [x] Events from connected apps
 - [x] MCP servers (API key + unauthenticated)
 - [ ] Generic webhook triggers
-- [ ] Additional MCP transports (Oauth)
+- [ ] Additional MCP transports (OAuth)
 - [ ] Channels (Slack, Telegram, Discord, Teams)
 - [ ] Mobile version
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -7,10 +7,12 @@
         <img alt="Shows the logo of agenta" src="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262" >
       </picture>
   </a>
-
+  
 <div align="center">
   <strong> <h1> The open-source workspace for building and running agents </h1></strong>
   Build agents that automate your work by chatting with them. Share them with your team, connect them to the apps you use, and run them in the background.
+</div>
+
 </div>
 
 ---
@@ -31,11 +33,9 @@
   <a href="https://github.com/Agenta-AI/agenta/blob/main/CONTRIBUTING.md">
     <img src="https://img.shields.io/badge/PRs-Welcome-brightgreen" alt="PRs welcome" />
   </a>
-  <img src="https://img.shields.io/github/contributors/Agenta-AI/agenta" alt="Contributors">
   <a href="https://pypi.org/project/agenta/">
     <img src="https://img.shields.io/pypi/dm/agenta" alt="PyPI - Downloads">
   </a>
-  <img src="https://img.shields.io/github/last-commit/Agenta-AI/agenta" alt="Last Commit">
 </br>
 </p>
 
@@ -230,7 +230,7 @@ If Agenta is useful to you, star the repository and tell us what you build.
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-50-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-68-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -302,6 +302,31 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/jp-agenta"><img src="https://avatars.githubusercontent.com/u/174311389?v=4?s=100" width="100px;" alt="jp-agenta"/><br /><sub><b>jp-agenta</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=jp-agenta" title="Code">💻</a> <a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Ajp-agenta" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://mrunhap.github.io"><img src="https://avatars.githubusercontent.com/u/24653356?v=4?s=100" width="100px;" alt="Mr Unhappy"/><br /><sub><b>Mr Unhappy</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Amrunhap" title="Bug reports">🐛</a> <a href="#infra-mrunhap" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/morenobonaventura"><img src="https://avatars.githubusercontent.com/u/2118854?v=4?s=100" width="100px;" alt="Moreno Bonaventura"/><br /><sub><b>Moreno Bonaventura</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Amorenobonaventura" title="Bug reports">🐛</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://ikazoy.me/"><img src="https://avatars.githubusercontent.com/u/385109?v=4?s=100" width="100px;" alt="Yoshiki Ozaki"/><br /><sub><b>Yoshiki Ozaki</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Aikazoy" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ahmed-agenta"><img src="https://avatars.githubusercontent.com/u/194256084?v=4?s=100" width="100px;" alt="ahmed-agenta"/><br /><sub><b>ahmed-agenta</b></sub></a><br /><a href="#design-ahmed-agenta" title="Design">🎨</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/VahantSharma"><img src="https://avatars.githubusercontent.com/u/172914890?v=4?s=100" width="100px;" alt="Vahant Sharma"/><br /><sub><b>Vahant Sharma</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=VahantSharma" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/muzman123"><img src="https://avatars.githubusercontent.com/u/66068301?v=4?s=100" width="100px;" alt="Muhammad Muzammil"/><br /><sub><b>Muhammad Muzammil</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=muzman123" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/CyrusNamjoo"><img src="https://avatars.githubusercontent.com/u/209579763?v=4?s=100" width="100px;" alt="Sirous Namjoo"/><br /><sub><b>Sirous Namjoo</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=CyrusNamjoo" title="Documentation">📖</a> <a href="#example-CyrusNamjoo" title="Examples">💡</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/adityadewan22-hub"><img src="https://avatars.githubusercontent.com/u/225586510?v=4?s=100" width="100px;" alt="adityadewan22-hub"/><br /><sub><b>adityadewan22-hub</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=adityadewan22-hub" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/majiayu000"><img src="https://avatars.githubusercontent.com/u/19658300?v=4?s=100" width="100px;" alt="lif"/><br /><sub><b>lif</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=majiayu000" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="http://karimkohel.com"><img src="https://avatars.githubusercontent.com/u/46066647?v=4?s=100" width="100px;" alt="karim kohel"/><br /><sub><b>karim kohel</b></sub></a><br /><a href="#example-karimkohel" title="Examples">💡</a> <a href="https://github.com/Agenta-AI/agenta/commits?author=karimkohel" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Vishesh-Paliwal"><img src="https://avatars.githubusercontent.com/u/142072830?v=4?s=100" width="100px;" alt="Vishesh Paliwal"/><br /><sub><b>Vishesh Paliwal</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=Vishesh-Paliwal" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/aviu16"><img src="https://avatars.githubusercontent.com/u/162624394?v=4?s=100" width="100px;" alt="Eve"/><br /><sub><b>Eve</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=aviu16" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://endoze.github.io"><img src="https://avatars.githubusercontent.com/u/997161?v=4?s=100" width="100px;" alt="Endoze"/><br /><sub><b>Endoze</b></sub></a><br /><a href="#infra-endoze" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/Agenta-AI/agenta/commits?author=endoze" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/anshk8"><img src="https://avatars.githubusercontent.com/u/141085661?v=4?s=100" width="100px;" alt="Ansh Kakkar"/><br /><sub><b>Ansh Kakkar</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Aanshk8" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Devarsh05"><img src="https://avatars.githubusercontent.com/u/116822773?v=4?s=100" width="100px;" alt="Devarsh Prajapati"/><br /><sub><b>Devarsh Prajapati</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3ADevarsh05" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/axelray-dev"><img src="https://avatars.githubusercontent.com/u/110029405?v=4?s=100" width="100px;" alt="AxelRay"/><br /><sub><b>AxelRay</b></sub></a><br /><a href="#platform-axelray-dev" title="Packaging/porting to new platform">📦</a> <a href="https://github.com/Agenta-AI/agenta/commits?author=axelray-dev" title="Documentation">📖</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Sanket2329"><img src="https://avatars.githubusercontent.com/u/196506711?v=4?s=100" width="100px;" alt="Sanket Shakya"/><br /><sub><b>Sanket Shakya</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=Sanket2329" title="Code">💻</a> <a href="#platform-Sanket2329" title="Packaging/porting to new platform">📦</a> <a href="https://github.com/Agenta-AI/agenta/commits?author=Sanket2329" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/unfitcoder101"><img src="https://avatars.githubusercontent.com/u/175036458?v=4?s=100" width="100px;" alt="unfitcoder101"/><br /><sub><b>unfitcoder101</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3Aunfitcoder101" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Shunmuka"><img src="https://avatars.githubusercontent.com/u/137101604?v=4?s=100" width="100px;" alt="Shunmuka Valsa"/><br /><sub><b>Shunmuka Valsa</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=Shunmuka" title="Code">💻</a> <a href="#platform-Shunmuka" title="Packaging/porting to new platform">📦</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/NamHT4Devlop"><img src="https://avatars.githubusercontent.com/u/122743792?v=4?s=100" width="100px;" alt="Hồ Trung Nam"/><br /><sub><b>Hồ Trung Nam</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/commits?author=NamHT4Devlop" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Koushik-Salammagari"><img src="https://avatars.githubusercontent.com/u/138836560?v=4?s=100" width="100px;" alt="Koushik-Salammagari"/><br /><sub><b>Koushik-Salammagari</b></sub></a><br /><a href="https://github.com/Agenta-AI/agenta/issues?q=author%3AKoushik-Salammagari" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
 </table>

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -12,6 +12,7 @@
   <strong> <h1> The open-source workspace for building and running agents </h1></strong>
   Build agents that automate your work by chatting with them. Share them with your team, connect them to the apps you use, and run them in the background.
 </div>
+
 ---
 
 <h3 align="center">

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -11,7 +11,7 @@
 <div align="center">
   <strong> <h1> The open-source workspace for building and running agents </h1></strong>
   Build agents that automate your work by chatting with them. Share them with your team, connect them to the apps you use, and run them in the background.
-
+</div>
 ---
 
 <h3 align="center">

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -105,9 +105,34 @@ Agenta traces every run and keeps a version history of each agent configuration.
 
 **Integrations.** Connect your agents to the applications you use through MCP, or integrate with more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub.
 
-## Roadmap
+## Get started
 
-Agenta is still evolving. Checked items are available today. Unchecked items are directions we plan to support.
+### Try Agenta Cloud
+
+The fastest way to try Agenta.
+
+<p align="center">
+  <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
+      <picture >
+        <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
+        <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
+        <img alt="Try Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
+      </picture>
+  </a>
+</p>
+
+### Self-host Agenta
+
+Paste this into your agent and it will walk you through setup and testing:
+
+```
+1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
+2. Help me self-host Agenta with its repository.
+```
+
+For more details, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
+
+## Roadmap
 
 **Harnesses**
 
@@ -169,7 +194,7 @@ See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=
 
 ### n8n, Activepieces, and Zapier
 
-These products are designed for workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
+These products are designed for building workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
 
 ### Claude Cowork
 
@@ -178,52 +203,6 @@ Claude Cowork provides a workspace built around Claude. Agenta is open source an
 ### Claude Code, Codex, Pi, and OpenCode
 
 These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
-
-## Get started
-
-### Try Agenta Cloud
-
-The fastest way to try Agenta.
-
-<p align="center">
-  <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
-      <picture >
-        <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
-        <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
-        <img alt="Try Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
-      </picture>
-  </a>
-</p>
-
-### Self-host with Docker
-
-You need Docker and Docker Compose.
-
-```bash
-git clone https://github.com/Agenta-AI/agenta
-cd agenta
-cp hosting/docker-compose/oss/env.oss.gh.example hosting/docker-compose/oss/.env.oss.gh
-docker compose \
-  -f hosting/docker-compose/oss/docker-compose.gh.yml \
-  --env-file hosting/docker-compose/oss/.env.oss.gh \
-  --profile with-web \
-  --profile with-traefik \
-  up -d
-```
-
-Open http://localhost.
-
-For configuration, remote deployment, and upgrades, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
-
-### Python SDK
-
-This package is the Agenta Python SDK. Install it with:
-
-```bash
-pip install -U agenta
-```
-
-For usage, read the [documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ## Community and contributing
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -9,8 +9,8 @@
   </a>
 
 <div align="center">
-  <strong> <h1> The Open-source LLMOps Platform </h1></strong>
-  Build reliable LLM applications faster with integrated prompt management, evaluation, and observability.
+  <strong> <h1> The open-source workspace for building and running agents </h1></strong>
+  Build agents that automate your work by chatting with them. Share them with your team, connect them to the apps you use, and run them in the background.
 </div>
   <br />
       <div align="center" >
@@ -76,95 +76,147 @@
 
 ## What is Agenta?
 
-Agenta is a platform for building production-grade LLM applications. It helps **engineering** and **product teams** create reliable LLM apps faster through integrated prompt management, evaluation, and observability.
+Agenta is an open-source workspace where you build specialized agents that automate and augment your work.
 
-## Core Features
+You build agents by chatting with them. You describe the work, connect the apps they need, and improve them through feedback.
 
-### 🧪 Prompt Engineering & Management
-Collaborate with Subject Matter Experts (SMEs) on prompt engineering and make sure nothing breaks in production.
+You can work with your agents directly in chat and share them with your team.
 
-- **Interactive Playground**: Compare prompts side by side against your test cases
-- **Multi-Model Support**: Experiment with 50+ LLM models or [bring-your-own models](https://agenta.ai/docs/prompt-engineering/playground/custom-providers?utm_source=github&utm_medium=referral&utm_campaign=readme)
-- **Version Control**: Version prompts and configurations with branching and environments
-- **Complex Configurations**: Enable SMEs to collaborate on [complex configuration schemas](https://agenta.ai/docs/custom-workflows/overview?utm_source=github&utm_medium=referral&utm_campaign=readme) beyond simple prompts
+For recurring work, you can build background agents. These agents run on a schedule or when an event occurs.
 
-[Explore prompt management →](https://agenta.ai/docs/prompt-engineering/concepts?utm_source=github&utm_medium=referral&utm_campaign=readme)
+## Why use Agenta?
 
-### 📊 Evaluation & Testing
-Evaluate your LLM applications systematically with both human and automated feedback.
-- **Flexible Testsets**: Create testcases from production data, playground experiments, or upload CSVs
-- **Pre-built and Custom Evaluators**: Use LLM-as-judge, one of our 20+ pre-built evaluators, or you custom evaluators
-- **UI and API Access**: Run evaluations via UI (for SMEs) or programmatically (for engineers)
-- **Human Feedback Integration**: Collect and incorporate expert annotations
+### Use your Claude or ChatGPT subscription
 
-[Explore evaluation frameworks →](https://agenta.ai/docs/evaluation/overview?utm_source=github&utm_medium=referral&utm_campaign=readme)
+When you self-host Agenta, you can run agents with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
 
-### 📡 Observability & Monitoring
-Get visibility into your LLM applications in production.
-- **Cost & Performance Tracking**: Monitor spending, latency, and usage patterns
-- **Tracing**: Debug complex workflows with detailed traces
-- **Open Standards**: OpenTelemetry native tracing compatible with OpenLLMetry, and OpenInference
-- **Integrations**: Comes with pre-built integrations for most models and frameworks
+### Choose your harness and model
 
-[Learn about observability →](https://agenta.ai/docs/observability/overview?utm_source=github&utm_medium=referral&utm_campaign=readme)
+Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with more harnesses planned. See the [support matrix](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
-## 📸 Screenshots
+### Build with open agent standards
 
-<img alt="Playground" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/a4f67ac4-1acc-40c6-7a1a-5616eee7bb00/large" />
-<img alt="Prompt Management" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/65f697d0-3221-4e3c-7232-f350b1976a00/large" />
-<img alt="Evaluation" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/19b5b77e-6945-4419-15b9-cfea197e1300/large" />
-<img  alt="Observability" src="https://imagedelivery.net/UNvjPBCIZFONpkVPQTxVuA/efc8a24c-2a2a-427c-f285-7d8b41200700/large" />
+Define your agent with AGENTS.md, skills, and MCP servers. Bring skills and MCP servers from the wider agent ecosystem into Agenta, then inspect and adapt them for your agent.
 
-## 🚀 Getting Started 
+### Make your agents more reliable over time
 
-### Agenta Cloud (Recommended):
-The easiest way to get started is through Agenta Cloud. Free tier available with no credit card required.
+Agenta traces every run and keeps a version history of each agent configuration. Use this history to understand failures, compare changes, and improve your agents over time.
+
+## Features
+
+- **Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, and maintain a wiki.
+- **Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
+- **Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
+- **Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
+- **Team access.** The open-source version lets you share agents with your team and control access by role.
+- **Integrations.** Connect your agents to more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub. Use MCP servers to connect other services.
+
+## Roadmap
+
+Agenta is still evolving. Checked items are available today. Unchecked items are directions we plan to support.
+
+**Harnesses**
+
+- [x] Claude Code
+- [x] Pi
+- [ ] Codex
+- [ ] OpenCode
+- [ ] More harnesses
+
+**Models**
+
+- [x] Models accessed through provider APIs
+- [ ] OpenAI-compatible models
+- [ ] Self-hosted models
+
+**Agent runtimes**
+
+- [x] Local runtime
+- [x] Daytona sandboxes
+- [ ] Docker sandboxes
+- [ ] E2B sandboxes
+
+**Triggers and connections**
+
+- [x] Schedules
+- [x] Events from connected apps
+- [x] MCP servers
+- [ ] Generic webhook triggers
+- [ ] Additional MCP transports
+
+See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
+
+## How Agenta compares
+
+### n8n, Activepieces, and Zapier
+
+These products are designed for workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
+
+### Claude Cowork
+
+Claude Cowork provides a workspace built around Claude. Agenta is open source and lets you choose your harness and model, inspect the components of your agents, and run them interactively or in the background.
+
+### Claude Code, Codex, Pi, and OpenCode
+
+These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
+
+## Get started
+
+### Try Agenta Cloud
+
+The fastest way to try Agenta.
 
 <p align="center">
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
-        <img alt="Try Agenta Live Demo" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
+        <img alt="Try Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
       </picture>
   </a>
 </p>
 
-  
-   
-### Self-hosting Agenta
+### Self-host with Docker
 
-1. Clone Agenta:
+You need Docker and Docker Compose.
+
 ```bash
-git clone https://github.com/Agenta-AI/agenta && cd agenta
+git clone https://github.com/Agenta-AI/agenta
+cd agenta
+cp hosting/docker-compose/oss/env.oss.gh.example hosting/docker-compose/oss/.env.oss.gh
+docker compose \
+  -f hosting/docker-compose/oss/docker-compose.gh.yml \
+  --env-file hosting/docker-compose/oss/.env.oss.gh \
+  --profile with-web \
+  --profile with-traefik \
+  up -d
 ```
 
-2. Start Agenta services:
+Open http://localhost.
+
+For configuration, remote deployment, and upgrades, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
+
+### Python SDK
+
+This package is the Agenta Python SDK. Install it with:
+
 ```bash
-docker compose -f hosting/docker-compose/oss/docker-compose.gh.yml --env-file hosting/docker-compose/oss/.env.oss.gh --profile with-web --profile with-traefik up -d
+pip install -U agenta
 ```
 
-3. Access Agenta at `http://localhost`.
+For usage, read the [documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
-For deploying on a remote host, or using different ports refers to our [self-hosting](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme) and [remote deployment documentation](https://agenta.ai/docs/self-host/guides/deploy-remotely?utm_source=github&utm_medium=referral&utm_campaign=readme).
+## Community and contributing
 
-## 💬 Community
+Agenta is open source under the MIT License. You can inspect the code, run it yourself, and help shape what we build next.
 
-Find help, explore resources, or get involved:
+- [Read the documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
+- [Report a bug](https://github.com/Agenta-AI/agenta/issues)
+- [Request a feature or share an idea](https://github.com/Agenta-AI/agenta/discussions)
+- [Read the contributing guide](CONTRIBUTING.md)
+- [Join the Slack community](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
 
-### 🧰 Support
-
-- **📚 [Documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)** – Full guides and API reference  
-- **📋 [Changelog](https://agenta.ai/docs/changelog?utm_source=github&utm_medium=referral&utm_campaign=readme)** – Track recent updates  
-- **💬 [Slack Community](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)** – Ask questions and get support  
-
-### 🤝 Contribute
-
-We welcome contributions of all kinds — from filing issues and sharing ideas to improving the codebase.
-
-- **🐛 [Report bugs](https://github.com/Agenta-AI/agenta/issues)** – Help us by reporting problems you encounter  
-- **💡 [Share ideas and feedback](https://github.com/Agenta-AI/agenta/discussions)** – Suggest features or vote on ideas
-- **🔧 [Contribute to the codebase](https://agenta.ai/docs/contributing/overview?utm_source=github&utm_medium=referral&utm_campaign=readme)** – Read the guide and open a pull request
+If Agenta is useful to you, star the repository and tell us what you build.
 
 ## ⭐ Star Agenta
 
@@ -264,7 +316,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
-
-## Disabling Anonymized Tracking
-
-By default, Agenta automatically reports anonymized basic usage statistics. This helps us understand how Agenta is used and track its overall usage and growth. This data does not include any sensitive information. To disable anonymized telemetry set `AGENTA_TELEMETRY_ENABLED` to `false` in your `.env` file.


### PR DESCRIPTION
## Context

The top-level README and the Python SDK README both opened by calling Agenta an "LLMOps platform" and led with prompt management, evaluation, and observability. That framing no longer matches what people come to Agenta to do. They build agents, work on them with a team, and run them. The old copy buried that story under infrastructure language.

## Changes

Both READMEs are rewritten around the new positioning: an open-source workspace for building and running agents. The narrative is now build an agent by chatting with it, share it with your team, and run it in the background.

Before (top of each README):

> Agenta is an open-source LLMOps platform... prompt management, evaluation, and observability.

After:

> Agenta is an open-source workspace for building and running agents... build an agent by chatting with it, share it with a team, run it in the background.

Two files change: the top-level `README.md` and `sdks/python/README.md`. All existing design chrome is preserved: the logo, the badges, the contributors table, and the star and cloud call-to-action buttons.

The stale telemetry section is removed. It documented an opt-out flag that no longer does anything, so leaving the instructions in place would tell readers to set a flag with no effect.

## Notes

- Three inline documentation links point at the docs home as placeholders for now: the "support matrix" link, the "complete roadmap" link, and the roadmap "(documentation)" labels. They will be repointed once the real deep-link pages exist.
- No code or behavior changes. Documentation only.

https://claude.ai/code/session_01DnitLJdk54jARsPSEQdAjH
