### PR TITLE
test(sdk): align bare Claude alias test with the curated alias list

### DIFF
--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
@@ -169,13 +169,13 @@ async def test_missing_provider_hint_is_harness_correct_for_claude(
 
 
 async def test_bare_claude_alias_resolves_to_anthropic(fake_http, connection):
-    # F-031: a bare Claude alias (haiku/sonnet/opus + [1m]) is unambiguously Anthropic, so the
-    # F-017 prefix rule must NOT reject it. It resolves against the vault's anthropic key the
-    # same way the documented `anthropic/haiku` form does, instead of failing loud.
+    # F-031: a bare Claude alias from the curated Claude alias list is unambiguously Anthropic,
+    # so the F-017 prefix rule must NOT reject it. It resolves against the vault's anthropic key
+    # the same way the documented `anthropic/haiku` form does, instead of failing loud.
     fake_http(
         connections, payload=[_provider_key("anthropic-prod", "anthropic", "sk-ant")]
     )
-    for alias in ("haiku", "sonnet", "opus", "opus[1m]"):
+    for alias in ("haiku", "sonnet", "opus[1m]"):
         resolved = await VaultConnectionResolver(connection).resolve(
             model=ModelRef.coerce(alias),
             context=RuntimeAuthContext(harness="claude"),


### PR DESCRIPTION
The required "12 - check unit tests" check is red on the release/v0.105.6 tip. The unit test `test_bare_claude_alias_resolves_to_anthropic` in `sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py` still iterates a bare `"opus"` alias, and the vault resolver derives its bare-Claude-alias acceptance from the curated `CLAUDE_MODEL_ALIASES` list, so bare `"opus"` now raises `MissingProviderError` and the assertion fails.

PR #5365 curated `CLAUDE_MODEL_ALIASES` down to the stable harness request values and updated `test_capabilities.py` and `test_model_catalog.py`, but missed this third test module. This change aligns the loop to the curated aliases (`haiku`, `sonnet`, `opus[1m]`) and updates the comment accordingly. Behavior note: a user-typed bare `"opus"` now needs the documented `anthropic/` prefix or one of the picker's curated values, and the runner widens hinted variants. No production code changes.