### PR TITLE
fix(frontend): forbid style/link/meta tags in chat markdown rendering

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -68,6 +68,12 @@ export const MD_CLASS =
 /** Math support ($…$ / $$…$$) via KaTeX — registered once as a marked extension. */
 const LATEX_CONFIG = {extensions: Latex()}
 
+/** Chat content must never restyle the app document, so forbid document-affecting tags.
+ * A pasted HTML doc's <style>/<link> would otherwise mount into the live document and
+ * repaint the whole app. Inline `style` attributes on elements stay allowed (expected in
+ * LLM output). FORBID beats XMarkdown's own ADD_TAGS in DOMPurify, so this wins. */
+const DOMPURIFY_CONFIG = {FORBID_TAGS: ["style", "link", "meta", "base", "title"]}
+
 /** Flatten a code element's children (string / text nodes) to the raw source. */
 const childrenToText = (children: ReactNode): string => {
     if (typeof children === "string") return children
@@ -184,6 +190,7 @@ const Markdown = ({content, className}: {content: string; className?: string}) =
         className={className ? `${MD_CLASS} ${className}` : MD_CLASS}
         content={content}
         config={LATEX_CONFIG}
+        dompurifyConfig={DOMPURIFY_CONFIG}
         components={{...MD_COMPONENTS, a: Anchor}}
     />
 )


### PR DESCRIPTION
## Context
Pasting an HTML document into an agent playground chat could restyle the entire app. One real pasted message carried a `<style>` block with `body { background:#0A0A0B; display:flex; justify-content:center; align-items:center }`. That stylesheet mounted into the live document, so the whole playground turned black and the sidebar jumped to the center of the screen.

The shared `Markdown` component renders chat content with `XMarkdown`, which sanitizes HTML through DOMPurify. DOMPurify's default allowlist permits `<style>` (and `<link>`, `<meta>`, `<base>`, `<title>`). We were not passing a `dompurifyConfig`, so a `<style>` element in message content survived sanitization and applied globally.

## Changes
`Markdown` now passes a `dompurifyConfig` that forbids the document-affecting tags:

```
FORBID_TAGS: ["style", "link", "meta", "base", "title"]
```

DOMPurify's forbid list wins over XMarkdown's own `ADD_TAGS` merge, so these tags are always stripped from chat content. Inline `style` attributes on elements stay allowed, since LLM output legitimately uses them. This is the one shared renderer used by both message bubbles (`AgentMessage`) and reasoning/context blocks (`ContextLens`), so a single config covers every chat surface.

Before: a pasted `<style>body{background:red}</style>hello` mounted a live stylesheet and repainted the app.
After: the `<style>` element is dropped, only the text renders, and the app is untouched.

## Tests / notes
- Verified live on the dev stack. Sent `<style>body{background:red}</style>hello` in an agent playground chat. The message rendered as just "hello", the page stayed its normal color, and no `body { background:red }` rule appeared in any stylesheet or as a `<style>` node inside `.x-markdown`.
- `pnpm lint-fix` passes.
- No unit test added: the AgentChatSlice has no DOM/jsdom test harness for this component, and standing one up for a one-line config is out of scope.

## What to QA
- Open any agent playground chat and send a message containing `<style>body{background:red}</style>hello`. You should see the text "hello", and the app should keep its normal background (not turn red).
- Regression: send normal markdown (headings, tables, code blocks, inline `<mark>`/`<kbd>`, links). It should render as before, and inline `style="..."` on an element should still apply.
