### PR TITLE
fix(hosting): default store region and pin runner replica id for self-host

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1082,7 +1082,7 @@ class StoreConfig(BaseModel):
     )
     access_key: str | None = os.getenv("AGENTA_STORE_ACCESS_KEY")
     secret_key: str | None = os.getenv("AGENTA_STORE_SECRET_KEY")
-    region: str = os.getenv("AGENTA_STORE_REGION", "us-east-1")
+    region: str = os.getenv("AGENTA_STORE_REGION") or "us-east-1"
     bucket: str | None = os.getenv("AGENTA_STORE_BUCKET") or "agenta-store"
     namespace: str | None = os.getenv("AGENTA_STORE_NAMESPACE") or None
 

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -241,7 +241,7 @@ services:
             - AGENTA_STORE_ENDPOINT_URL=${AGENTA_STORE_ENDPOINT_URL:-}
             - AGENTA_STORE_ACCESS_KEY=${AGENTA_STORE_ACCESS_KEY:-}
             - AGENTA_STORE_SECRET_KEY=${AGENTA_STORE_SECRET_KEY:-}
-            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-}
+            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
         # === NETWORK ============================================== #
@@ -274,6 +274,10 @@ services:
         environment:
             AGENTA_RUNNER_PORT: "8765"
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
+            # Stable id so a runner restart keeps ownership of its local-sandbox sessions;
+            # a random id would orphan them for the owner TTL. A fixed default is safe because
+            # compose runs a single runner. Override only if you scale to multiple runners.
+            AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -57,7 +57,7 @@ services:
             - AGENTA_STORE_ENDPOINT_URL=${AGENTA_STORE_ENDPOINT_URL:-}
             - AGENTA_STORE_ACCESS_KEY=${AGENTA_STORE_ACCESS_KEY:-}
             - AGENTA_STORE_SECRET_KEY=${AGENTA_STORE_SECRET_KEY:-}
-            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-}
+            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
         # === NETWORK ============================================== #
@@ -241,7 +241,7 @@ services:
             - AGENTA_STORE_ENDPOINT_URL=${AGENTA_STORE_ENDPOINT_URL:-}
             - AGENTA_STORE_ACCESS_KEY=${AGENTA_STORE_ACCESS_KEY:-}
             - AGENTA_STORE_SECRET_KEY=${AGENTA_STORE_SECRET_KEY:-}
-            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-}
+            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
         # === NETWORK ============================================== #
@@ -272,6 +272,10 @@ services:
         environment:
             AGENTA_RUNNER_PORT: "8765"
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
+            # Stable id so a runner restart keeps ownership of its local-sandbox sessions;
+            # a random id would orphan them for the owner TTL. A fixed default is safe because
+            # compose runs a single runner. Override only if you scale to multiple runners.
+            AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -239,7 +239,7 @@ services:
             - AGENTA_STORE_ENDPOINT_URL=${AGENTA_STORE_ENDPOINT_URL:-}
             - AGENTA_STORE_ACCESS_KEY=${AGENTA_STORE_ACCESS_KEY:-}
             - AGENTA_STORE_SECRET_KEY=${AGENTA_STORE_SECRET_KEY:-}
-            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-}
+            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
         # === NETWORK ============================================== #
@@ -272,6 +272,10 @@ services:
         environment:
             AGENTA_RUNNER_PORT: "8765"
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
+            # Stable id so a runner restart keeps ownership of its local-sandbox sessions;
+            # a random id would orphan them for the owner TTL. A fixed default is safe because
+            # compose runs a single runner. Override only if you scale to multiple runners.
+            AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -258,7 +258,7 @@ services:
             - AGENTA_STORE_ENDPOINT_URL=${AGENTA_STORE_ENDPOINT_URL:-}
             - AGENTA_STORE_ACCESS_KEY=${AGENTA_STORE_ACCESS_KEY:-}
             - AGENTA_STORE_SECRET_KEY=${AGENTA_STORE_SECRET_KEY:-}
-            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-}
+            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
         # === NETWORK ============================================== #
@@ -293,6 +293,10 @@ services:
         environment:
             AGENTA_RUNNER_PORT: "8765"
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
+            # Stable id so a runner restart keeps ownership of its local-sandbox sessions;
+            # a random id would orphan them for the owner TTL. A fixed default is safe because
+            # compose runs a single runner. Override only if you scale to multiple runners.
+            AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
             # API as reached FROM this container: the compose service name over the network
             # (http://api:8000, as the workers use), NOT the public http://localhost/api
             # which does not resolve inside a container. Used by the OTLP tracing-export

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -57,7 +57,7 @@ services:
             - AGENTA_STORE_ENDPOINT_URL=${AGENTA_STORE_ENDPOINT_URL:-}
             - AGENTA_STORE_ACCESS_KEY=${AGENTA_STORE_ACCESS_KEY:-}
             - AGENTA_STORE_SECRET_KEY=${AGENTA_STORE_SECRET_KEY:-}
-            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-}
+            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
         # === NETWORK ============================================== #
@@ -258,7 +258,7 @@ services:
             - AGENTA_STORE_ENDPOINT_URL=${AGENTA_STORE_ENDPOINT_URL:-}
             - AGENTA_STORE_ACCESS_KEY=${AGENTA_STORE_ACCESS_KEY:-}
             - AGENTA_STORE_SECRET_KEY=${AGENTA_STORE_SECRET_KEY:-}
-            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-}
+            - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
         # === NETWORK ============================================== #
@@ -289,6 +289,10 @@ services:
         environment:
             AGENTA_RUNNER_PORT: "8765"
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
+            # Stable id so a runner restart keeps ownership of its local-sandbox sessions;
+            # a random id would orphan them for the owner TTL. A fixed default is safe because
+            # compose runs a single runner. Override only if you scale to multiple runners.
+            AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/kubernetes/helm/templates/runner-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/runner-deployment.yaml
@@ -67,6 +67,17 @@ spec:
               value: {{ join "," $enabledProviders | quote }}
             - name: AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER
               value: {{ default "local" $providers.default | quote }}
+            {{- /* Stable replica id for a single-runner install: a local-sandbox session is
+                   owned by the pod that created it, and a pod restart with a fresh random id
+                   would orphan those sessions for the owner TTL. A fixed value (the service
+                   name) is safe only at one replica; with several pods a shared id would make
+                   every pod claim every session, so we set it only when replicas == 1. Local
+                   multi-replica is unsupported anyway (no sticky routing); scale with Daytona.
+                   A Deployment renames the pod on restart, so a fixed value beats the pod name. */}}
+            {{- if and (eq (include "agenta.agentRunner.replicas" . | int) 1) (not (hasKey (default dict $runner.env) "AGENTA_RUNNER_REPLICA_ID")) }}
+            - name: AGENTA_RUNNER_REPLICA_ID
+              value: {{ include "agenta.agentRunner.serviceName" . | quote }}
+            {{- end }}
             {{- if not (hasKey (default dict $runner.env) "PI_CODING_AGENT_DIR") }}
             - name: PI_CODING_AGENT_DIR
               value: {{ default "/pi-agent" $runner.piAgentDir | quote }}


### PR DESCRIPTION
## Symptom

Two ways a self-hosted OSS stack breaks, both reported from the field:

1. **Agent runs hang forever.** The run never progresses because its object-store working directory never mounts.
2. **Agent runs fail after a runner restart** with `local sandbox requires a single runner: replica X is not the owner of session Y ... Refusing to cold-start on the wrong host`.

## Cause

**Store region.** The API only falls back to `us-east-1` when `AGENTA_STORE_REGION` is *unset* (`os.getenv("AGENTA_STORE_REGION", "us-east-1")`). But every `gh` compose file injects it as an empty string (`${AGENTA_STORE_REGION:-}`), which is "set" and defeats the fallback. The S3 client then gets an empty region and refuses every request (`MissingRegion`), so the run's file mount retries forever. This hits local self-hosters too: the local store is SeaweedFS, an S3-compatible server, and an S3 client must be given a region to sign requests even when the backend ignores the value.

**Runner replica id.** The runner mints a random replica id per process (`AGENTA_RUNNER_REPLICA_ID?.trim() || randomUUID()`). A local-sandbox session is owned by the container that created it. On restart the new random id no longer matches the recorded owner (kept in Redis for the ~120s owner TTL), so the runner refuses to resume its own sessions until the record expires.

## Fix

- **Region:** treat an empty string as unset in the API (`os.getenv(...) or "us-east-1"`), and default the compose value to `us-east-1`. Only empty/unset inputs change behavior; a real region flows through untouched. Applied to OSS and EE `gh` compose files.
- **Replica id:** pin a stable `AGENTA_RUNNER_REPLICA_ID` (default `local-runner-1`) in the single-runner compose files, overridable. In Helm, set a stable id **only when `replicas == 1`** (a shared id across pods would make every pod claim every session; local multi-replica is unsupported and should use Daytona). A Deployment renames the pod on restart, so a fixed value beats a pod-name reference.

## Before / after

- Before: fresh OSS `gh` self-host hangs on the first agent run; a `docker compose restart runner` breaks in-flight sessions for ~2 minutes.
- After: runs get their store mount immediately; a runner restart keeps ownership of its sessions.

## Validation

- `ruff check` clean on the API change.
- `helm lint` passes for OSS and EE example values; rendered chart sets the replica id at `replicas: 1` and omits it at `replicas: 2`.
- `docker compose config` renders for the OSS `gh` stack.

Note: Helm is not affected by the region bug (its template already defaults empty to `us-east-1`); the region fix here is API + compose only.

https://claude.ai/code/session_01CLbtfd8SnNKLwxPZgj7LjN