### PR TITLE
docs(docs): self-host runner image, Claude login, replica id, and app tools

### DIFF
--- a/docs/docs/self-host/01-quick-start.mdx
+++ b/docs/docs/self-host/01-quick-start.mdx
@@ -94,6 +94,7 @@ If Agenta doesn't start properly, check these common issues:
 6. Lack of memory provided to docker: If you are experiencing the web container restarting and dying unexpectedly, the most likely cause is that you are running out of memory. You may need to increase the memory allocated to docker (desktop).
 7. The runner container does not start and Docker reports `error gathering device information while adding custom device "/dev/fuse"`: the host has no FUSE device. See [Run agents locally](/self-host/agent-execution/run-agents-locally#troubleshooting).
 8. Docker reports `permission denied` while trying to connect to `/var/run/docker.sock`: your user cannot reach the Docker daemon. Run the commands as `root`, prefix them with `sudo`, or add your user to the `docker` group (`sudo usermod -aG docker $USER`, then open a new login shell). A member of the `docker` group can start a container that mounts the host filesystem, which makes the group equivalent to root on that machine.
+9. Docker reports `failed to resolve reference ... not found` or `manifest unknown` while pulling an image (for example `ghcr.io/agenta-ai/agenta-runner:latest`): the image tag you are pulling is not published to the registry. Pin the image tags to a published release version in your env file. See [How do I lock Agenta to a specific version?](/self-host/faq).
 
 :::info
 To set up a development environment with features like hot-reloading, refer to our [Development Guide](/contributing/guides/development-mode).

--- a/docs/docs/self-host/99-faq.mdx
+++ b/docs/docs/self-host/99-faq.mdx
@@ -7,11 +7,14 @@ sidebar_position: 8
 
 ## How do I lock Agenta to a specific version?
 
-Use the `AGENTA_WEB_IMAGE_TAG` and `AGENTA_API_IMAGE_TAG` environment variables.
+Set the image tag for each service. All four default to `latest`.
 
 ```bash
-AGENTA_WEB_IMAGE_TAG=v0.15.0
-AGENTA_API_IMAGE_TAG=v0.15.0
+AGENTA_WEB_IMAGE_TAG=v0.105.6
+AGENTA_API_IMAGE_TAG=v0.105.6
+AGENTA_SERVICES_IMAGE_TAG=v0.105.6
+AGENTA_RUNNER_IMAGE_TAG=v0.105.6
 ```
 
-These are set to `latest` by default.
+Use the same version for all four. To pull an image from a different name, set the matching
+`AGENTA_<service>_IMAGE_NAME` (for example `AGENTA_RUNNER_IMAGE_NAME`).

--- a/docs/docs/self-host/agents/01-use-your-own-subscription.mdx
+++ b/docs/docs/self-host/agents/01-use-your-own-subscription.mdx
@@ -47,38 +47,25 @@ ls ~/.claude/.credentials.json
 
 ## 2. Check that the runner can read it
 
-The runner container runs as the user `node`, uid 1000. A harness login file is mode `0600` and
-owned by you, so the container can read it through a bind mount only when your own uid is 1000.
+The runner container runs as uid 1000. A harness login file is mode `0600` and owned by you, so the
+container can read it through a bind mount only when your own uid is 1000.
 
 ```bash
 id -u
 ```
 
-If that prints `1000`, mount your login directly and continue with step 3.
+If that prints `1000`, mount your login directly in step 3.
 
-If it prints anything else, the container gets `Permission denied` on the file and the run fails as
-though you had never logged in. Copy the login into a directory owned by uid 1000 and mount the
-copy instead:
-
-```bash
-# Claude Code
-sudo mkdir -p /srv/agenta/harness
-sudo cp -r ~/.claude /srv/agenta/harness/claude
-sudo chown -R 1000:1000 /srv/agenta/harness/claude
-
-# Pi and ChatGPT/Codex
-sudo cp -r ~/.pi/agent /srv/agenta/harness/pi
-sudo chown -R 1000:1000 /srv/agenta/harness/pi
-```
-
-The harness refreshes its OAuth token inside the mount, so with a copy the refreshed token lands in
-the copy and not in your own login.
+If it prints anything else, the container cannot read the `0600` file, and the run fails as though
+you had never logged in. In step 3 you run the container as your own user by adding two lines. This
+mounts your real login directly, so a refreshed token stays in sync between the container and your
+own machine.
 
 ## 3. Mount the login into the runner
 
 Edit the `runner` service in your Compose file
 (`hosting/docker-compose/oss/docker-compose.gh.yml`). Add a read-write volume for your login and
-point the harness at it. Use your own login directory, or the copy from step 2 if you made one.
+point the harness at it.
 
 For **Pi** or **ChatGPT/Codex**:
 
@@ -99,6 +86,22 @@ runner:
   environment:
     CLAUDE_CONFIG_DIR: /agenta/harness/claude
 ```
+
+If your uid is not 1000 (step 2), also run the container as your own user so it can read the mounted
+login. Add `user:` with your `id -u`:`id -g`, and set `HOME` to a writable path. For Claude Code:
+
+```yaml
+runner:
+  user: "1001:1001" # your id -u:id -g
+  volumes:
+    - ~/.claude:/agenta/harness/claude:rw
+  environment:
+    HOME: /tmp
+    CLAUDE_CONFIG_DIR: /agenta/harness/claude
+```
+
+`HOME: /tmp` is required here. Running as a non-default user sets the container's home directory to a
+path the harness cannot write, and the harness writes working files under it.
 
 :::warning Do not set a provider API key on the runner
 A self-managed run inherits the provider keys present in the runner's environment (for example

--- a/docs/docs/self-host/agents/05-tools-and-triggers.mdx
+++ b/docs/docs/self-host/agents/05-tools-and-triggers.mdx
@@ -1,0 +1,52 @@
+---
+title: "App tools and triggers"
+sidebar_label: "App tools and triggers"
+description: "What an agent can connect to on a self-hosted deployment: which tools and triggers work out of the box, which need Composio, and why code tools are disabled."
+slug: /self-host/app-tools-and-triggers
+sidebar_position: 5
+---
+
+An agent on a self-hosted deployment can use several kinds of capability. Some work with no extra
+setup. Connecting to third-party apps needs a gateway. This page explains which is which.
+
+## Works without extra setup
+
+- **Built-in Agenta tools.** Available on every deployment.
+- **Schedule triggers.** Run an agent on a time schedule (for example, every morning). These read
+  from your own database and need no third-party service.
+
+## App tools and event triggers need Composio
+
+Connecting an agent to a third-party app goes through **Composio**, a tool gateway. This covers two
+things:
+
+- **App tools.** Letting an agent act in an outside app, such as opening a GitHub issue or sending a
+  Slack message.
+- **Event triggers.** Letting an outside app start a run, such as a new GitHub issue firing your
+  agent. This is different from a schedule trigger, which is time-based and needs no gateway.
+
+Without a Composio API key, these are unavailable. Tool and trigger discovery
+(`discover_tools`, `discover_triggers`) returns `404`, because the gateway they route through is not
+configured.
+
+To enable them, set a Composio API key. Composio has a free tier; create an account, get a key, then
+add it to your env file:
+
+```bash
+COMPOSIO_API_KEY=your-composio-api-key
+```
+
+Recreate the stack so the API picks it up:
+
+```bash
+docker compose -f hosting/docker-compose/oss/docker-compose.gh.yml \
+  --env-file hosting/docker-compose/oss/.env.oss.gh up -d
+```
+
+See [Configuration](/self-host/configuration#composio) for the full list of Composio variables.
+
+## Code tools are disabled
+
+The runner does not run custom code tools (an agent shelling out to `gh` or `curl`, for example).
+This is a security decision, not a configuration you can turn on. To let an agent act in an outside
+service, use an app tool through Composio instead.

--- a/docs/docs/self-host/agents/05-tools-and-triggers.mdx
+++ b/docs/docs/self-host/agents/05-tools-and-triggers.mdx
@@ -15,6 +15,20 @@ setup. Connecting to third-party apps needs a gateway. This page explains which 
 - **Schedule triggers.** Run an agent on a time schedule (for example, every morning). These read
   from your own database and need no third-party service.
 
+## Connect an MCP server
+
+An agent can use tools from an external MCP (Model Context Protocol) server over HTTP. You bring the
+server and configure it on the agent with its URL and any auth headers. This does not go through
+Composio.
+
+The runner must be able to reach the server. Outbound egress is restricted by default: plain
+`http://` and private, loopback, or cloud-metadata addresses are blocked. A public `https://` server
+works as-is. To use a server on `http` or a private network, allow it:
+
+```bash
+AGENTA_INSECURE_EGRESS_ALLOWED=true
+```
+
 ## App tools and event triggers need Composio
 
 Connecting an agent to a third-party app goes through **Composio**, a tool gateway. This covers two

--- a/docs/docs/self-host/reference/01-configuration.mdx
+++ b/docs/docs/self-host/reference/01-configuration.mdx
@@ -198,7 +198,7 @@ Set on the `runner` service.
 | `AGENTA_RUNNER_PORT` | Bind port | `8765` | no | Chart-managed (`8765`) |
 | `AGENTA_RUNNER_CONCURRENCY_LIMIT` | Maximum concurrent runs | `1000` | no | `agentRunner.env.AGENTA_RUNNER_CONCURRENCY_LIMIT` |
 | `AGENTA_RUNNER_LOG_LEVEL` | Log verbosity | `silent` | no | `agentRunner.logLevel` |
-| `AGENTA_RUNNER_REPLICA_ID` | Replica identity for logs | Generated when unset | no | `agentRunner.env.AGENTA_RUNNER_REPLICA_ID` |
+| `AGENTA_RUNNER_REPLICA_ID` | Runner identity for local-sandbox session ownership | Random per process when unset | no | `agentRunner.env.AGENTA_RUNNER_REPLICA_ID` |
 
 Every variable on this page treats an empty value as unset, so leaving a line blank selects the
 default rather than an empty string.
@@ -206,6 +206,14 @@ default rather than an empty string.
 The code default host is `127.0.0.1`. The bundled Compose files set `AGENTA_RUNNER_HOST=0.0.0.0`
 so the Services container can reach the runner across the Compose network. `AGENTA_RUNNER_PORT` and
 `AGENTA_RUNNER_CONCURRENCY_LIMIT` must be positive integers.
+
+`AGENTA_RUNNER_REPLICA_ID` is not a log label. A local-sandbox session is owned by the runner that
+created it, and the runner refuses to resume one on a different runner. When this value is unset the
+runner generates a fresh id on each start, so a restart orphans its local sessions until the previous
+owner record expires (the owner TTL, 120 seconds by default). The bundled Compose files set a stable
+value so a restart keeps ownership. The local sandbox is single-runner only: running more than one
+runner with the local provider is not supported, because there is no session-to-runner routing. To
+run multiple runners, use the Daytona provider, whose sessions any runner can resume.
 
 ### Routing and authentication
 


### PR DESCRIPTION
Documentation pass for the self-hosting hardening work, paired with the fixes in #5404 (store region + runner replica id) and agenta_cloud #1658 (publish the runner image).

## What changed

- **Quick start troubleshooting.** New entry for `failed to resolve reference ... not found` / `manifest unknown` when pulling an image (for example `agenta-runner:latest`), pointing at version pinning.
- **FAQ.** The version-pin answer listed only `AGENTA_WEB_IMAGE_TAG` and `AGENTA_API_IMAGE_TAG`. It now lists all four services (web, api, services, runner) and notes the `AGENTA_<service>_IMAGE_NAME` overrides.
- **Use your own subscription.** Replaced the copy-the-login method with running the runner as your own uid (`user:` + `HOME: /tmp`). Sharing the real login file coordinates like two local Claude/Pi sessions; a copy diverges and dies when the provider rotates the token. The uid override was tested against the runner image (reads and rewrites the mounted login as a non-1000 user, health check green).
- **Configuration reference.** `AGENTA_RUNNER_REPLICA_ID` was described as a log label. It actually drives local-sandbox session ownership; a churning value breaks session resume. Added the correction and the single-runner constraint (scale with Daytona).
- **New page: App tools and triggers.** Explains what needs Composio (app tools, event triggers) versus what works without it (schedule triggers), and that code tools are disabled by design.

## Validation

- `pnpm build` in `docs/` passes with no broken links.

https://claude.ai/code/session_01CLbtfd8SnNKLwxPZgj7LjN