### PR TITLE
docs(readme): add Chinese, Japanese, and Korean README translations

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -4,12 +4,12 @@
       <picture >
         <source width="275" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/97e31bfc-b1fc-4d19-b443-5aedf6029017"  >
         <source width="275" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262"  >
-        <img alt="Shows the logo of agenta" src="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262" >
+        <img alt="Agenta 徽标" src="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262" >
       </picture>
   </a>
   
 <div align="center">
-  <strong> <h1> The open-source workspace for building and running agents </h1></strong>
+  <strong> <h1> 用于构建和运行智能体的开源工作空间 </h1></strong>
 
 
 <img width="1800" height="680" alt="agenta-github-banner" src="https://github.com/user-attachments/assets/afc83f8f-d644-4dc6-bae7-b26ed2512986" />
@@ -17,7 +17,7 @@
   ---
 
 
-  Build agents that **automate your work** by chatting with them. Share them with **your team**, connect them to the apps you use, and run them in the **background**.
+  通过对话构建能**自动完成工作**的智能体。把它们共享给**你的团队**，连接你日常使用的应用，并让它们在**后台**运行。
 
 </div>
 
@@ -25,8 +25,8 @@
 
 
 <h3 align="center">
-  <a href="https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Documentation</b></a> &bull;
-  <a href="https://agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Website</b></a> &bull;
+  <a href="https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>文档</b></a> &bull;
+  <a href="https://agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>官网</b></a> &bull;
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Agenta Cloud</b></a>
 </h3>
 
@@ -70,94 +70,94 @@
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2"  >
-        <img alt="Try Agenta Live Demo" src="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2" >
+        <img alt="试用 Agenta 在线演示" src="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2" >
       </picture>
   </a>
 </p>
 
 ---
 
-## What is Agenta?
+## 什么是 Agenta？
 
-Agenta is an open-source workspace where you build specialized agents that automate and augment your work.
+Agenta 是一个开源工作空间，你可以在其中构建专门的智能体，用来自动化并增强你的工作。
 
-You build agents by chatting with them. You describe the work, connect the apps they need, and improve them through feedback.
+你通过对话来构建智能体。你描述需要完成的工作，连接它们所需的应用，并通过反馈不断改进它们。
 
-You can work with your agents directly in chat and share them with your team.
+你可以在对话中直接与智能体协作，也可以把它们共享给你的团队。
 
-For recurring work, you can build background agents. These agents run on a schedule or when an event occurs.
+对于重复性的工作，你可以构建后台智能体。这类智能体会定时运行，或在某个事件发生时触发运行。
 
-## Why use Agenta?
+## 为什么选择 Agenta？
 
-### Use your Claude or ChatGPT subscription
+### 使用你的 Claude 或 ChatGPT 订阅
 
-When you self-host Agenta, you can run agents locally with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
+当你自托管 Agenta 时，可以使用现有的 Claude 或 ChatGPT 订阅在本地运行智能体。你不必把所有任务都改为通过按量计费的 API 运行。
 
-### Choose your harness and model
+### 自由选择运行框架和模型
 
-Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+无需重建智能体即可切换运行框架（harness）和模型。Agenta 已经支持几乎所有模型，无论是自托管的，还是通过 API 访问的。目前 Agenta 支持 Claude Code 和 Pi 两种运行框架，并且[计划支持更多](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)。
 
-### Build with open agent standards
+### 基于开放的智能体标准来构建
 
-Define your agent with `AGENTS.md`, skills, and MCP servers. You can bring skills and MCP servers from the agent ecosystem into Agenta.
+使用 `AGENTS.md`、技能（skills）和 MCP 服务器来定义你的智能体。你可以把智能体生态中的技能和 MCP 服务器引入 Agenta。
 
-### Make your agents more reliable over time
+### 让你的智能体随时间变得更可靠
 
-Agenta traces every run and keeps a version history of each agent configuration. Use this history to understand failures, compare changes, and improve your agents over time.
+Agenta 会追踪每一次运行，并为每个智能体的配置保存版本历史。借助这些历史记录，你可以分析失败原因、对比改动，并持续改进你的智能体。
 
-## Features
+## 功能特性
 
-**Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, or maintain a wiki.
+**为你和你的智能体打造的工作空间。** 在共享工作空间中与智能体一起处理文件。你们可以一起撰写文档、整理研究资料，或维护一个 Wiki。
 
-**Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
+**人工审批与权限控制。** 为每个工具单独设置权限。你可以决定后台智能体哪些操作能自动执行、哪些需要你批准、哪些被禁止。
 
-**Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
+**后台智能体。** 让智能体定时运行，或在已连接的应用中发生某个事件时启动它们。
 
-**Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
+**追踪、用量与成本。** 检查每一次模型调用和工具调用。跟踪每个智能体的模型请求、token 用量以及预估成本。
 
-**Team access.** The open-source version lets you share agents with your team and control access by role.
+**团队访问权限。** 开源版本允许你把智能体共享给团队，并按角色控制访问权限。
 
-**Integrations.** Connect your agents to the applications you use through MCP, or integrate with more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub.
+**集成能力。** 通过 MCP 把智能体连接到你日常使用的应用，或通过 Composio 集成 1000 多个应用，包括 Gmail、Slack、Notion 和 GitHub。
 
-## Get started
+## 快速开始
 
-### Try Agenta Cloud
+### 试用 Agenta Cloud
 
-The fastest way to try Agenta.
+体验 Agenta 最快的方式。
 
 <p align="center">
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
-        <img alt="Try Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
+        <img alt="试用 Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
       </picture>
   </a>
 </p>
 
-### Self-host Agenta
+### 自托管 Agenta
 
-Paste this into your agent and it will walk you through setup and testing:
+将以下内容粘贴到你的智能体中，它会引导你完成安装和测试：
 
 ```text
 1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
 2. Help me self-host Agenta with its repository.
 ```
 
-For more details, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
+更多细节请阅读[自托管文档](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme)。
 
-## Roadmap
+## 路线图
 
-**Harnesses**
+**运行框架**
 
 - [x] Claude Code
 - [x] Pi
 - [ ] Codex
 - [ ] Gemini
 - [ ] OpenCode
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [创建 issue，申请优先支持你需要的功能](https://github.com/Agenta-AI/agenta/issues)
 
-**Models**
+**模型**
 
 - [x] OpenAI
 - [x] Anthropic
@@ -173,81 +173,81 @@ For more details, read the [self-hosting documentation](https://agenta.ai/docs/s
 - [x] Azure
 - [x] AWS Bedrock
 - [x] MiniMax
-- [x] OpenAI-compatible models
-- [x] Self-hosted models (Ollama)
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [x] 兼容 OpenAI 的模型
+- [x] 自托管模型（Ollama）
+- [ ] [创建 issue，申请优先支持你需要的功能](https://github.com/Agenta-AI/agenta/issues)
 
-**Agent runtimes**
+**智能体运行时**
 
-- [x] Local runtime
-- [x] Daytona sandboxes
-- [x] Docker sandboxes
-- [ ] E2B sandboxes
+- [x] 本地运行时
+- [x] Daytona 沙箱
+- [x] Docker 沙箱
+- [ ] E2B 沙箱
 - [ ] AgentComputer
 - [ ] Vercel
 - [ ] Cloudflare
 - [ ] Modal
 - [ ] BoxLite
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [创建 issue，申请优先支持你需要的功能](https://github.com/Agenta-AI/agenta/issues)
 
-**Features**
+**功能**
 
-- [x] Schedules
-- [x] Events from connected apps
-- [x] MCP servers (API key + unauthenticated)
-- [ ] Generic webhook triggers
-- [ ] Additional MCP transports (OAuth)
-- [ ] Channels (Slack, Telegram, Discord, Teams)
-- [ ] Mobile version
+- [x] 定时任务
+- [x] 来自已连接应用的事件
+- [x] MCP 服务器（API 密钥 + 免认证）
+- [ ] 通用 webhook 触发器
+- [ ] 更多 MCP 传输方式（OAuth）
+- [ ] 渠道（Slack、Telegram、Discord、Teams）
+- [ ] 移动版
 
-See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
+查看[完整路线图](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)。想参与其中某一项吗？欢迎[发起讨论](https://github.com/Agenta-AI/agenta/discussions)或参与贡献。
 
-## How Agenta compares
+## Agenta 有何不同
 
-### n8n, Activepieces, and Zapier
+### n8n、Activepieces 和 Zapier
 
-These products are designed for building workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
+这些产品用于按预定义的步骤构建工作流。而 Agenta 面向的是那些需要智能体自行规划、使用工具并灵活调整方法的工作。对于可预测的流程，请使用工作流构建工具；当工作需要判断力，或当你希望同一个智能体既能在对话中与你协作、又能在后台运行时，请使用 Agenta。
 
 ### Claude Cowork
 
-Claude Cowork provides a workspace built around Claude. Agenta is open source and lets you choose your harness and model, inspect the components of your agents, and run them interactively or in the background.
+Claude Cowork 提供的是一个围绕 Claude 构建的工作空间。而 Agenta 是开源的：你可以自由选择运行框架和模型，检查智能体的各个组成部分，并以交互方式或在后台运行它们。
 
-### Claude Code, Codex, Pi, and OpenCode
+### Claude Code、Codex、Pi 和 OpenCode
 
-These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
+这些编程智能体提供了执行层，负责规划工作并使用工具。Agenta 围绕这个执行层提供共享工作空间，并加入文件、团队访问权限、触发器、版本管理和运行追踪等能力。Agenta 目前支持 Claude Code 和 Pi，更多运行框架的支持已列入路线图。
 
-## Community and contributing
+## 社区与贡献
 
-Agenta is open source under the MIT License. You can inspect the code, run it yourself, and help shape what we build next.
+Agenta 是基于 MIT 许可证的开源项目。你可以查看代码、自行运行，并帮助塑造我们接下来的方向。
 
-- [Read the documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
-- [Report a bug](https://github.com/Agenta-AI/agenta/issues)
-- [Request a feature or share an idea](https://github.com/Agenta-AI/agenta/discussions)
-- [Read the contributing guide](CONTRIBUTING.md)
-- [Join the Slack community](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
+- [阅读文档](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
+- [报告问题](https://github.com/Agenta-AI/agenta/issues)
+- [请求功能或分享想法](https://github.com/Agenta-AI/agenta/discussions)
+- [阅读贡献指南](CONTRIBUTING.md)
+- [加入 Slack 社区](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
 
-If Agenta is useful to you, star the repository and tell us what you build.
+如果 Agenta 对你有帮助，请给仓库点个 Star，并告诉我们你构建了什么。
 
-## ⭐ Star Agenta
+## ⭐ 给 Agenta 点个 Star
 
-**Consider giving us a star!** It helps us grow our community and gets Agenta in front of more developers.
+**欢迎给 Agenta 点个 Star！** 这有助于我们发展社区，也能让更多开发者看到 Agenta。
 </br>
 </br>
 <p align="center">
     <a href="https://github.com/agenta-ai/agenta">
 
-  <img width="300" alt="Star us" src="https://github.com/user-attachments/assets/2c8e580a-c930-4312-bf1b-08f631b41c62" />
+  <img width="300" alt="给 Agenta 点 Star" src="https://github.com/user-attachments/assets/2c8e580a-c930-4312-bf1b-08f631b41c62" />
     <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
 
 </p>
 
-## Contributors ✨
+## 贡献者 ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-69-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+感谢这些了不起的贡献者（[emoji 说明](https://allcontributors.org/docs/en/emoji-key)）：
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -351,4 +351,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
+本项目遵循 [all-contributors](https://github.com/all-contributors/all-contributors) 规范。欢迎任何形式的贡献！

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,12 +4,12 @@
       <picture >
         <source width="275" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/97e31bfc-b1fc-4d19-b443-5aedf6029017"  >
         <source width="275" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262"  >
-        <img alt="Shows the logo of agenta" src="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262" >
+        <img alt="Agenta のロゴ" src="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262" >
       </picture>
   </a>
   
 <div align="center">
-  <strong> <h1> The open-source workspace for building and running agents </h1></strong>
+  <strong> <h1> エージェントを構築し、実行するためのオープンソース・ワークスペース </h1></strong>
 
 
 <img width="1800" height="680" alt="agenta-github-banner" src="https://github.com/user-attachments/assets/afc83f8f-d644-4dc6-bae7-b26ed2512986" />
@@ -17,7 +17,7 @@
   ---
 
 
-  Build agents that **automate your work** by chatting with them. Share them with **your team**, connect them to the apps you use, and run them in the **background**.
+  対話するだけで、**あなたの作業を自動化する**エージェントを構築できます。**チーム**と共有し、普段使っているアプリと連携させ、**バックグラウンド**で実行しましょう。
 
 </div>
 
@@ -25,8 +25,8 @@
 
 
 <h3 align="center">
-  <a href="https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Documentation</b></a> &bull;
-  <a href="https://agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Website</b></a> &bull;
+  <a href="https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>ドキュメント</b></a> &bull;
+  <a href="https://agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>ウェブサイト</b></a> &bull;
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Agenta Cloud</b></a>
 </h3>
 
@@ -70,94 +70,94 @@
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2"  >
-        <img alt="Try Agenta Live Demo" src="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2" >
+        <img alt="Agenta のライブデモを試す" src="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2" >
       </picture>
   </a>
 </p>
 
 ---
 
-## What is Agenta?
+## Agenta とは？
 
-Agenta is an open-source workspace where you build specialized agents that automate and augment your work.
+Agenta は、あなたの作業を自動化・強化する専用エージェントを構築できるオープンソースのワークスペースです。
 
-You build agents by chatting with them. You describe the work, connect the apps they need, and improve them through feedback.
+エージェントは対話しながら構築します。やってほしい作業を説明し、必要なアプリを連携させ、フィードバックを通じて改善していきます。
 
-You can work with your agents directly in chat and share them with your team.
+エージェントとチャットで直接やり取りでき、チームと共有することもできます。
 
-For recurring work, you can build background agents. These agents run on a schedule or when an event occurs.
+繰り返し発生する作業には、バックグラウンドエージェントを構築できます。これらのエージェントは、設定したスケジュールに沿って、またはイベントが発生したときに実行されます。
 
-## Why use Agenta?
+## なぜ Agenta を使うのか？
 
-### Use your Claude or ChatGPT subscription
+### お使いの Claude や ChatGPT のサブスクリプションを活用
 
-When you self-host Agenta, you can run agents locally with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
+Agenta をセルフホストすると、既存の Claude や ChatGPT のサブスクリプションを使ってエージェントをローカルで実行できます。すべての作業を従量課金制の API 経由に切り替える必要はありません。
 
-### Choose your harness and model
+### ハーネスとモデルを自由に選択
 
-Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+エージェントを作り直すことなく、ハーネスとモデルを切り替えられます。Agenta は、セルフホスト型か API 経由かを問わず、ほぼすべてのモデルにすでに対応しています。現在サポートしているハーネスは Claude Code と Pi で、[今後さらに追加を予定](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)しています。
 
-### Build with open agent standards
+### オープンなエージェント標準で構築
 
-Define your agent with `AGENTS.md`, skills, and MCP servers. You can bring skills and MCP servers from the agent ecosystem into Agenta.
+エージェントは `AGENTS.md`、スキル、MCP サーバーで定義します。エージェントのエコシステムにあるスキルや MCP サーバーを Agenta に取り込むこともできます。
 
-### Make your agents more reliable over time
+### エージェントの信頼性を継続的に高める
 
-Agenta traces every run and keeps a version history of each agent configuration. Use this history to understand failures, compare changes, and improve your agents over time.
+Agenta はすべての実行をトレースし、各エージェント設定のバージョン履歴を保持します。この履歴を使って、失敗の原因を把握し、変更を比較し、エージェントを継続的に改善できます。
 
-## Features
+## 主な機能
 
-**Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, or maintain a wiki.
+**あなたとエージェントのためのワークスペース。** 共有ワークスペース上で、エージェントと一緒にファイルを扱えます。ドキュメントの作成、リサーチの整理、Wiki の運用などを共同で行えます。
 
-**Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
+**人間による承認と権限管理。** ツールごとに権限を設定できます。バックグラウンドエージェントが自動で実行できる操作、承認が必要な操作、禁止する操作を選べます。
 
-**Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
+**バックグラウンドエージェント。** エージェントをスケジュールで実行したり、連携アプリでイベントが発生したときに起動したりできます。
 
-**Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
+**トレース、使用量、コスト。** すべてのモデル呼び出しとツール呼び出しを確認できます。エージェントごとにモデルへのリクエスト、トークン使用量、推定コストを追跡できます。
 
-**Team access.** The open-source version lets you share agents with your team and control access by role.
+**チームでの利用。** オープンソース版では、エージェントをチームと共有し、ロールごとにアクセス権を管理できます。
 
-**Integrations.** Connect your agents to the applications you use through MCP, or integrate with more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub.
+**インテグレーション。** MCP を使って、普段使うアプリとエージェントを接続できます。また、Composio を使えば、エージェントを Gmail、Slack、Notion、GitHub など 1,000 以上のアプリと連携できます。
 
-## Get started
+## はじめる
 
-### Try Agenta Cloud
+### Agenta Cloud を試す
 
-The fastest way to try Agenta.
+Agenta を最も手早く試せる方法です。
 
 <p align="center">
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
-        <img alt="Try Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
+        <img alt="Agenta Cloud を試す" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
       </picture>
   </a>
 </p>
 
-### Self-host Agenta
+### Agenta をセルフホストする
 
-Paste this into your agent and it will walk you through setup and testing:
+以下をエージェントに貼り付けると、セットアップとテストを案内してくれます。
 
 ```text
 1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
 2. Help me self-host Agenta with its repository.
 ```
 
-For more details, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
+詳しくは[セルフホスティングのドキュメント](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme)をご覧ください。
 
-## Roadmap
+## ロードマップ
 
-**Harnesses**
+**ハーネス**
 
 - [x] Claude Code
 - [x] Pi
 - [ ] Codex
 - [ ] Gemini
 - [ ] OpenCode
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [Issue を作成して優先度を上げる](https://github.com/Agenta-AI/agenta/issues)
 
-**Models**
+**モデル**
 
 - [x] OpenAI
 - [x] Anthropic
@@ -173,81 +173,81 @@ For more details, read the [self-hosting documentation](https://agenta.ai/docs/s
 - [x] Azure
 - [x] AWS Bedrock
 - [x] MiniMax
-- [x] OpenAI-compatible models
-- [x] Self-hosted models (Ollama)
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [x] OpenAI 互換モデル
+- [x] セルフホスト型モデル（Ollama）
+- [ ] [Issue を作成して優先度を上げる](https://github.com/Agenta-AI/agenta/issues)
 
-**Agent runtimes**
+**エージェントランタイム**
 
-- [x] Local runtime
-- [x] Daytona sandboxes
-- [x] Docker sandboxes
-- [ ] E2B sandboxes
+- [x] ローカルランタイム
+- [x] Daytona サンドボックス
+- [x] Docker サンドボックス
+- [ ] E2B サンドボックス
 - [ ] AgentComputer
 - [ ] Vercel
 - [ ] Cloudflare
 - [ ] Modal
 - [ ] BoxLite
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [Issue を作成して優先度を上げる](https://github.com/Agenta-AI/agenta/issues)
 
-**Features**
+**機能**
 
-- [x] Schedules
-- [x] Events from connected apps
-- [x] MCP servers (API key + unauthenticated)
-- [ ] Generic webhook triggers
-- [ ] Additional MCP transports (OAuth)
-- [ ] Channels (Slack, Telegram, Discord, Teams)
-- [ ] Mobile version
+- [x] スケジュール
+- [x] 連携アプリからのイベント
+- [x] MCP サーバー（API キー + 認証なし）
+- [ ] 汎用 Webhook トリガー
+- [ ] MCP のトランスポート追加（OAuth）
+- [ ] チャンネル（Slack、Telegram、Discord、Teams）
+- [ ] モバイル版
 
-See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
+[完全なロードマップ](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)をご覧ください。いずれかの項目に協力していただける場合は、[ディスカッションを開始](https://github.com/Agenta-AI/agenta/discussions)するか、開発に参加してください。
 
-## How Agenta compares
+## 他のツールとの違い
 
-### n8n, Activepieces, and Zapier
+### n8n、Activepieces、Zapier
 
-These products are designed for building workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
+これらの製品は、あらかじめ定義したステップでワークフローを構築するためのものです。一方 Agenta は、エージェントが自ら計画を立て、ツールを使い、状況に応じてやり方を調整する必要のある作業のために設計されています。手順が決まっている処理にはワークフロービルダーを使ってください。判断が必要な作業や、同じエージェントとチャットで協働し、そのエージェントをバックグラウンドでも実行したい場合には Agenta が適しています。
 
 ### Claude Cowork
 
-Claude Cowork provides a workspace built around Claude. Agenta is open source and lets you choose your harness and model, inspect the components of your agents, and run them interactively or in the background.
+Claude Cowork は Claude を中心に据えたワークスペースを提供します。Agenta はオープンソースであり、ハーネスとモデルを自由に選び、エージェントの構成要素を確認し、対話形式でもバックグラウンドでも実行できます。
 
-### Claude Code, Codex, Pi, and OpenCode
+### Claude Code、Codex、Pi、OpenCode
 
-These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
+これらのコーディングエージェントは、作業を計画しツールを使う実行レイヤーを提供します。Agenta は、その実行レイヤーに、ファイル、チームアクセス、トリガー、バージョン、トレースを備えた共有ワークスペースを提供します。Agenta は現在 Claude Code と Pi に対応しており、より多くのハーネスへの対応をロードマップに掲げています。
 
-## Community and contributing
+## コミュニティとコントリビューション
 
-Agenta is open source under the MIT License. You can inspect the code, run it yourself, and help shape what we build next.
+Agenta は MIT ライセンスのオープンソースです。コードを確認し、自分で実行し、私たちが次に何を作るかを一緒に形づくることができます。
 
-- [Read the documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
-- [Report a bug](https://github.com/Agenta-AI/agenta/issues)
-- [Request a feature or share an idea](https://github.com/Agenta-AI/agenta/discussions)
-- [Read the contributing guide](CONTRIBUTING.md)
-- [Join the Slack community](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
+- [ドキュメントを読む](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
+- [バグを報告する](https://github.com/Agenta-AI/agenta/issues)
+- [機能をリクエストする／アイデアを共有する](https://github.com/Agenta-AI/agenta/discussions)
+- [コントリビューションガイドを読む](CONTRIBUTING.md)
+- [Slack コミュニティに参加する](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
 
-If Agenta is useful to you, star the repository and tell us what you build.
+Agenta が役に立ったら、リポジトリにスターを付けて、あなたが作ったものを教えてください。
 
-## ⭐ Star Agenta
+## ⭐ Agenta にスターを
 
-**Consider giving us a star!** It helps us grow our community and gets Agenta in front of more developers.
+**ぜひスターを付けてください！** コミュニティの成長につながり、より多くの開発者に Agenta を届けられます。
 </br>
 </br>
 <p align="center">
     <a href="https://github.com/agenta-ai/agenta">
 
-  <img width="300" alt="Star us" src="https://github.com/user-attachments/assets/2c8e580a-c930-4312-bf1b-08f631b41c62" />
+  <img width="300" alt="Agenta にスターを付ける" src="https://github.com/user-attachments/assets/2c8e580a-c930-4312-bf1b-08f631b41c62" />
     <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
 
 </p>
 
-## Contributors ✨
+## コントリビューター ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-69-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+すばらしいコントリビューターの皆さんに感謝します（[絵文字の凡例](https://allcontributors.org/docs/en/emoji-key)）：
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -351,4 +351,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
+このプロジェクトは [all-contributors](https://github.com/all-contributors/all-contributors) 仕様に準拠しています。どのような形の貢献も歓迎します！

--- a/README.kr.md
+++ b/README.kr.md
@@ -4,12 +4,12 @@
       <picture >
         <source width="275" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/97e31bfc-b1fc-4d19-b443-5aedf6029017"  >
         <source width="275" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262"  >
-        <img alt="Shows the logo of agenta" src="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262" >
+        <img alt="Agenta 로고" src="https://github.com/user-attachments/assets/fdc5f23f-2095-4cfc-9511-14c6851c1262" >
       </picture>
   </a>
   
 <div align="center">
-  <strong> <h1> The open-source workspace for building and running agents </h1></strong>
+  <strong> <h1> 에이전트를 만들고 실행하는 오픈소스 워크스페이스 </h1></strong>
 
 
 <img width="1800" height="680" alt="agenta-github-banner" src="https://github.com/user-attachments/assets/afc83f8f-d644-4dc6-bae7-b26ed2512986" />
@@ -17,7 +17,7 @@
   ---
 
 
-  Build agents that **automate your work** by chatting with them. Share them with **your team**, connect them to the apps you use, and run them in the **background**.
+  대화를 나누는 것만으로 **업무를 자동화하는** 에이전트를 만드세요. **팀**과 공유하고, 평소 사용하는 앱에 연결하고, **백그라운드**에서 실행하세요.
 
 </div>
 
@@ -25,8 +25,8 @@
 
 
 <h3 align="center">
-  <a href="https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Documentation</b></a> &bull;
-  <a href="https://agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Website</b></a> &bull;
+  <a href="https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>문서</b></a> &bull;
+  <a href="https://agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>웹사이트</b></a> &bull;
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme"><b>Agenta Cloud</b></a>
 </h3>
 
@@ -70,94 +70,94 @@
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2"  >
-        <img alt="Try Agenta Live Demo" src="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2" >
+        <img alt="Agenta 라이브 데모 사용해 보기" src="https://github.com/user-attachments/assets/a2069e7b-c3e0-4a5e-9e41-8ddc4660d1f2" >
       </picture>
   </a>
 </p>
 
 ---
 
-## What is Agenta?
+## Agenta란?
 
-Agenta is an open-source workspace where you build specialized agents that automate and augment your work.
+Agenta는 업무를 자동화하고 지원하는 특화 에이전트를 만들 수 있는 오픈소스 워크스페이스입니다.
 
-You build agents by chatting with them. You describe the work, connect the apps they need, and improve them through feedback.
+에이전트는 대화를 통해 만듭니다. 원하는 작업을 설명하고, 필요한 앱을 연결하고, 피드백을 통해 개선해 나갑니다.
 
-You can work with your agents directly in chat and share them with your team.
+에이전트와 채팅으로 직접 협업할 수 있고, 팀과 공유할 수도 있습니다.
 
-For recurring work, you can build background agents. These agents run on a schedule or when an event occurs.
+반복되는 업무에는 백그라운드 에이전트를 만들 수 있습니다. 이 에이전트는 설정한 일정에 따라, 또는 특정 이벤트가 발생할 때 실행됩니다.
 
-## Why use Agenta?
+## 왜 Agenta인가?
 
-### Use your Claude or ChatGPT subscription
+### 사용 중인 Claude 또는 ChatGPT 구독 활용
 
-When you self-host Agenta, you can run agents locally with your existing Claude or ChatGPT subscription. You do not need to move every task to metered API billing.
+Agenta를 셀프 호스팅하면 기존에 사용하던 Claude 또는 ChatGPT 구독으로 에이전트를 로컬에서 실행할 수 있습니다. 모든 작업을 사용량에 따라 과금되는 API로 전환할 필요는 없습니다.
 
-### Choose your harness and model
+### 하네스와 모델을 자유롭게 선택
 
-Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+에이전트를 다시 만들지 않고도 하네스와 모델을 전환할 수 있습니다. Agenta는 셀프 호스팅 방식이든 API를 통한 방식이든 거의 모든 모델을 이미 지원합니다. 현재 지원하는 하네스는 Claude Code와 Pi이며, [더 많은 하네스 지원을 계획](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)하고 있습니다.
 
-### Build with open agent standards
+### 개방형 에이전트 표준으로 구축
 
-Define your agent with `AGENTS.md`, skills, and MCP servers. You can bring skills and MCP servers from the agent ecosystem into Agenta.
+에이전트는 `AGENTS.md`, 스킬(skill), MCP 서버로 정의합니다. 에이전트 생태계의 스킬과 MCP 서버를 Agenta로 가져올 수도 있습니다.
 
-### Make your agents more reliable over time
+### 에이전트의 신뢰성을 지속적으로 높이기
 
-Agenta traces every run and keeps a version history of each agent configuration. Use this history to understand failures, compare changes, and improve your agents over time.
+Agenta는 모든 실행을 추적하고 각 에이전트 설정의 버전 기록을 보관합니다. 이 기록을 활용해 실패 원인을 파악하고, 변경 사항을 비교하고, 에이전트를 지속적으로 개선할 수 있습니다.
 
-## Features
+## 주요 기능
 
-**Workspaces for you and your agents.** Work with your agent on files in a shared workspace. Together, you can write documents, organize research, or maintain a wiki.
+**사용자와 에이전트를 위한 워크스페이스.** 공유 워크스페이스에서 에이전트와 함께 파일을 다룹니다. 문서를 작성하고, 리서치를 정리하고, 위키를 관리하는 일을 함께 할 수 있습니다.
 
-**Human approval and permissions.** Specify permissions for each tool. Choose which actions background agents can run automatically, which need your approval, and which are blocked.
+**사용자 승인과 권한 관리.** 각 도구에 대해 권한을 설정합니다. 백그라운드 에이전트가 자동으로 실행할 수 있는 작업, 승인이 필요한 작업, 차단할 작업을 선택할 수 있습니다.
 
-**Background agents.** Run agents on a schedule or start them when an event occurs in a connected app.
+**백그라운드 에이전트.** 에이전트를 일정에 따라 실행하거나, 연결된 앱에서 이벤트가 발생할 때 시작할 수 있습니다.
 
-**Tracing, usage, and cost.** Inspect every model and tool call. Track model requests, token usage, and estimated costs for each agent.
+**추적, 사용량, 비용.** 모든 모델 호출과 도구 호출을 확인할 수 있습니다. 에이전트별로 모델 요청, 토큰 사용량, 예상 비용을 추적합니다.
 
-**Team access.** The open-source version lets you share agents with your team and control access by role.
+**팀 접근 권한.** 오픈소스 버전에서는 에이전트를 팀과 공유하고 역할에 따라 접근 권한을 제어할 수 있습니다.
 
-**Integrations.** Connect your agents to the applications you use through MCP, or integrate with more than 1,000 apps through Composio, including Gmail, Slack, Notion, and GitHub.
+**연동.** MCP를 통해 평소 사용하는 앱에 에이전트를 연결하거나, Composio를 통해 Gmail, Slack, Notion, GitHub를 비롯한 1,000개 이상의 앱과 연동할 수 있습니다.
 
-## Get started
+## 시작하기
 
-### Try Agenta Cloud
+### Agenta Cloud 사용해 보기
 
-The fastest way to try Agenta.
+Agenta를 가장 빠르게 사용해 볼 수 있는 방법입니다.
 
 <p align="center">
   <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
       <picture >
         <source width="200" media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
         <source width="200" media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2"  >
-        <img alt="Try Agenta Cloud" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
+        <img alt="Agenta Cloud 사용해 보기" src="https://github.com/user-attachments/assets/3aa96780-b7e5-4b6f-bfee-8feaa36ff3b2" >
       </picture>
   </a>
 </p>
 
-### Self-host Agenta
+### Agenta 셀프 호스팅
 
-Paste this into your agent and it will walk you through setup and testing:
+아래 내용을 에이전트에 붙여넣으면 설치와 테스트 과정을 안내해 줍니다.
 
 ```text
 1. Install the Agenta self-hosting skill: npx skills add Agenta-AI/agenta-skills
 2. Help me self-host Agenta with its repository.
 ```
 
-For more details, read the [self-hosting documentation](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme).
+자세한 내용은 [셀프 호스팅 문서](https://agenta.ai/docs/self-host/quick-start?utm_source=github&utm_medium=referral&utm_campaign=readme)를 참고하세요.
 
-## Roadmap
+## 로드맵
 
-**Harnesses**
+**하네스**
 
 - [x] Claude Code
 - [x] Pi
 - [ ] Codex
 - [ ] Gemini
 - [ ] OpenCode
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [원하는 항목의 우선 지원을 요청하는 이슈 만들기](https://github.com/Agenta-AI/agenta/issues)
 
-**Models**
+**모델**
 
 - [x] OpenAI
 - [x] Anthropic
@@ -173,81 +173,81 @@ For more details, read the [self-hosting documentation](https://agenta.ai/docs/s
 - [x] Azure
 - [x] AWS Bedrock
 - [x] MiniMax
-- [x] OpenAI-compatible models
-- [x] Self-hosted models (Ollama)
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [x] OpenAI 호환 모델
+- [x] 셀프 호스팅 모델(Ollama)
+- [ ] [원하는 항목의 우선 지원을 요청하는 이슈 만들기](https://github.com/Agenta-AI/agenta/issues)
 
-**Agent runtimes**
+**에이전트 런타임**
 
-- [x] Local runtime
-- [x] Daytona sandboxes
-- [x] Docker sandboxes
-- [ ] E2B sandboxes
+- [x] 로컬 런타임
+- [x] Daytona 샌드박스
+- [x] Docker 샌드박스
+- [ ] E2B 샌드박스
 - [ ] AgentComputer
 - [ ] Vercel
 - [ ] Cloudflare
 - [ ] Modal
 - [ ] BoxLite
-- [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
+- [ ] [원하는 항목의 우선 지원을 요청하는 이슈 만들기](https://github.com/Agenta-AI/agenta/issues)
 
-**Features**
+**기능**
 
-- [x] Schedules
-- [x] Events from connected apps
-- [x] MCP servers (API key + unauthenticated)
-- [ ] Generic webhook triggers
-- [ ] Additional MCP transports (OAuth)
-- [ ] Channels (Slack, Telegram, Discord, Teams)
-- [ ] Mobile version
+- [x] 스케줄
+- [x] 연결된 앱의 이벤트
+- [x] MCP 서버(API 키 + 인증 없음)
+- [ ] 범용 웹훅 트리거
+- [ ] MCP 전송 방식 추가(OAuth)
+- [ ] 채널(Slack, Telegram, Discord, Teams)
+- [ ] 모바일 버전
 
-See the [complete roadmap](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme). Want to help with one of these items? [Open a discussion](https://github.com/Agenta-AI/agenta/discussions) or contribute.
+[전체 로드맵](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)을 확인하세요. 이 항목 중 하나를 함께 만들고 싶으신가요? [토론을 시작](https://github.com/Agenta-AI/agenta/discussions)하거나 기여해 주세요.
 
-## How Agenta compares
+## Agenta는 다른 도구와 어떻게 다른가?
 
-### n8n, Activepieces, and Zapier
+### n8n, Activepieces, Zapier
 
-These products are designed for building workflows with predefined steps. Agenta is designed for work that requires an agent to plan, use tools, and adapt its approach. Use a workflow builder for predictable processes. Use Agenta when the work needs judgment, or when you want the same agent to work with you in chat and run in the background.
+이 제품들은 미리 정의된 단계로 워크플로를 구축하기 위한 것입니다. 반면 Agenta는 에이전트가 스스로 계획을 세우고, 도구를 사용하고, 상황에 맞게 접근 방식을 조정해야 하는 작업을 위해 설계되었습니다. 예측 가능한 프로세스에는 워크플로 빌더를 사용하세요. 판단이 필요한 작업을 수행할 때, 또는 같은 에이전트와 채팅으로 협업하면서 그 에이전트를 백그라운드에서도 실행하고 싶을 때는 Agenta를 사용하세요.
 
 ### Claude Cowork
 
-Claude Cowork provides a workspace built around Claude. Agenta is open source and lets you choose your harness and model, inspect the components of your agents, and run them interactively or in the background.
+Claude Cowork는 Claude를 중심으로 구성된 워크스페이스를 제공합니다. Agenta는 오픈소스이며, 하네스와 모델을 직접 선택하고, 에이전트의 구성 요소를 확인하고, 대화형으로든 백그라운드로든 실행할 수 있습니다.
 
-### Claude Code, Codex, Pi, and OpenCode
+### Claude Code, Codex, Pi, OpenCode
 
-These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
+이 코딩 에이전트들은 작업을 계획하고 도구를 사용하는 실행 계층을 제공합니다. Agenta는 이 실행 계층에 파일, 팀 접근 권한, 트리거, 버전 기록, 실행 추적을 제공하는 공유 워크스페이스를 더합니다. Agenta는 현재 Claude Code와 Pi를 지원하며, 더 많은 하네스 지원이 로드맵에 있습니다.
 
-## Community and contributing
+## 커뮤니티와 기여
 
-Agenta is open source under the MIT License. You can inspect the code, run it yourself, and help shape what we build next.
+Agenta는 MIT 라이선스로 배포되는 오픈소스입니다. 코드를 살펴보고, 직접 실행하고, 우리가 다음에 무엇을 만들지 함께 결정할 수 있습니다.
 
-- [Read the documentation](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
-- [Report a bug](https://github.com/Agenta-AI/agenta/issues)
-- [Request a feature or share an idea](https://github.com/Agenta-AI/agenta/discussions)
-- [Read the contributing guide](CONTRIBUTING.md)
-- [Join the Slack community](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
+- [문서 읽기](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme)
+- [버그 신고하기](https://github.com/Agenta-AI/agenta/issues)
+- [기능 요청 또는 아이디어 공유하기](https://github.com/Agenta-AI/agenta/discussions)
+- [기여 가이드 읽기](CONTRIBUTING.md)
+- [Slack 커뮤니티 참여하기](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
 
-If Agenta is useful to you, star the repository and tell us what you build.
+Agenta가 도움이 되었다면 저장소에 스타를 눌러 주시고, 무엇을 만들었는지 알려 주세요.
 
-## ⭐ Star Agenta
+## ⭐ Agenta에 스타 누르기
 
-**Consider giving us a star!** It helps us grow our community and gets Agenta in front of more developers.
+**스타를 눌러 주세요!** 커뮤니티가 성장하는 데 도움이 되고, 더 많은 개발자에게 Agenta를 알릴 수 있습니다.
 </br>
 </br>
 <p align="center">
     <a href="https://github.com/agenta-ai/agenta">
 
-  <img width="300" alt="Star us" src="https://github.com/user-attachments/assets/2c8e580a-c930-4312-bf1b-08f631b41c62" />
+  <img width="300" alt="Agenta에 스타 누르기" src="https://github.com/user-attachments/assets/2c8e580a-c930-4312-bf1b-08f631b41c62" />
     <a href="https://cloud.agenta.ai?utm_source=github&utm_medium=referral&utm_campaign=readme">
 
 </p>
 
-## Contributors ✨
+## 기여자 ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-69-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+멋진 기여자 여러분께 감사드립니다([이모지 안내](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -351,4 +351,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
+이 프로젝트는 [all-contributors](https://github.com/all-contributors/all-contributors) 명세를 따릅니다. 어떤 형태의 기여든 환영합니다!


### PR DESCRIPTION
## What this adds

The README is our front door on GitHub, and today it exists only in English. Developers who read Simplified Chinese, Japanese, or Korean land on a wall of English and often bounce before they understand what Agenta is.

This PR adds a translated README for each of those three languages and a small language selector at the top of the English README so a reader can switch to their language in one click.

## Changes

- **`README.cn.md`, `README.ja.md`, `README.kr.md`** — full translations of the README, section for section. Product and technology names (Agenta, Claude, ChatGPT, Claude Code, Pi, MCP, Composio, Daytona, and so on) are intentionally kept in English, and the self-hosting install snippet is kept verbatim so copy and paste still works.
- **`README.md`** — a centered row of four language badges (English, 简体中文, 日本語, 한국어) added right under the top navigation links. Each badge links to the matching file. The same row appears at the top of every translated file so a reader can switch between any pair.

The three translations mirror the English structure exactly and share the identical contributors table (byte for byte), so the only per-file differences are the translated prose and the localized image alt text.

## How the translations were produced

I translated the prose against the current English README on the `release/v0.105.7` branch, then ran a second independent model over all three files as a native-level reviewer to catch meaning drift and machine-translation stiffness. I applied its fixes, the most important of which were:

- Removed a wrong gloss that described "harness" as the "execution environment" in the Japanese and Korean files. A harness and a runtime are different things, and the runtimes are listed separately in the roadmap.
- Corrected the integrations sentence in all three so it keeps the two distinct paths clear: connect the apps you use through MCP, or reach 1,000+ apps through Composio.
- Replaced several phrasings that read as translated-from-English with native product wording.

## Why this base branch

This PR is based on `release/v0.105.7` (PR #5403) because that branch holds the latest English README. Basing here keeps the diff limited to the four README files and keeps the translations matched to the exact English wording being shipped.

## How to review

You do not need to read all three languages. The highest-value checks:

1. Open the rendered `README.md` and confirm the language badge row shows up cleanly under the nav links and each badge links to the right file.
2. If you read any of the three languages, skim that file top to bottom for anything that reads oddly.
3. Confirm the contributors table and all images and badges render the same as in the English README.

A native speaker glance on any of the three before merge is welcome, especially Japanese.
