### PR TITLE
fix(runner): cap live tool results at transcript char budget

### DIFF
--- a/services/runner/src/tools/callback.ts
+++ b/services/runner/src/tools/callback.ts
@@ -24,8 +24,18 @@ export const EMPTY_OBJECT_SCHEMA = {
 };
 
 /** Bound a tool result body so a malformed/oversized upstream response cannot exhaust runner
- *  memory or blow out the model's context. Same cap and mechanism as tool-mcp-http.ts. */
+ *  memory. Same cap and mechanism as tool-mcp-http.ts. This is a *memory* backstop, not the
+ *  model-context budget — live turns use MODEL_TOOL_RESULT_MAX_CHARS for the text handed to
+ *  the model (parity with transcript rebuilds; see #5341). */
 export const MAX_BODY_BYTES = 1_000_000;
+
+/**
+ * Model-facing cap for ONE live tool result body (characters), matching
+ * `transcript.ts` TOOL_RESULT_RENDER_MAX_CHARS. Without this, a single oversized tool
+ * output (e.g. a full PR patch) enters context on the live turn and burns the window
+ * even though replay would have been capped at 4k (#5341 / RUN-TOOLCAP-1 follow-up).
+ */
+export const MODEL_TOOL_RESULT_MAX_CHARS = 4000;
 
 /**
  * Hard ceiling on the RAW wire body read off the socket, before any JSON parsing. Larger than
@@ -74,6 +84,20 @@ export function capToolResultText(text: string, maxBytes: number = MAX_BODY_BYTE
   const safeEnd = maxBytes - trailingIncompleteUtf8Length(buf, maxBytes);
   const truncated = buf.subarray(0, safeEnd).toString("utf-8");
   return `${truncated} [... ${buf.length - safeEnd} bytes omitted]`;
+}
+
+/** Cap a tool result for the *model* using the same char budget as transcript rebuilds.
+ *  Applied after the memory byte cap so live turns cannot dump multi-hundred-KB blobs
+ *  into context (#5341). */
+export function capToolResultForModel(
+  text: string,
+  maxChars: number = MODEL_TOOL_RESULT_MAX_CHARS,
+): string {
+  // First enforce the memory byte backstop, then the model char budget.
+  const memorySafe = capToolResultText(text, MAX_BODY_BYTES);
+  if (memorySafe.length <= maxChars) return memorySafe;
+  const omitted = memorySafe.length - maxChars;
+  return `${memorySafe.slice(0, maxChars)} [... ${omitted} chars omitted]`;
 }
 
 /**
@@ -219,16 +243,16 @@ export async function callAgentaTool(
         : undefined;
     if (statusMessage) {
       const detail = typeof content === "string" ? content : "";
-      return capToolResultText(
+      return capToolResultForModel(
         detail
           ? `tool call ${callRef} failed: ${statusMessage}\n${detail}`
           : `tool call ${callRef} failed: ${statusMessage}`,
       );
     }
-    if (typeof content === "string") return capToolResultText(content);
-    if (content != null) return capToolResultText(JSON.stringify(content));
-    return capToolResultText(bodyText);
+    if (typeof content === "string") return capToolResultForModel(content);
+    if (content != null) return capToolResultForModel(JSON.stringify(content));
+    return capToolResultForModel(bodyText);
   } catch {
-    return capToolResultText(bodyText);
+    return capToolResultForModel(bodyText);
   }
 }

--- a/services/runner/tests/unit/callback.test.ts
+++ b/services/runner/tests/unit/callback.test.ts
@@ -14,9 +14,11 @@ import assert from "node:assert/strict";
 import {
   callAgentaTool,
   capToolResultText,
+  capToolResultForModel,
   readBoundedResponseText,
   MAX_BODY_BYTES,
   MAX_RAW_RESPONSE_BYTES,
+  MODEL_TOOL_RESULT_MAX_CHARS,
 } from "../../src/tools/callback.ts";
 
 const realFetch = globalThis.fetch;
@@ -160,8 +162,9 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       "call-1",
       {},
     );
-    assert.ok(Buffer.byteLength(result, "utf-8") <= MAX_BODY_BYTES + 200);
-    assert.ok(result.includes("bytes omitted"));
+    // Live model path uses the 4k char budget (#5341), not the 1MB memory backstop alone.
+    assert.ok(result.length <= MODEL_TOOL_RESULT_MAX_CHARS + 40);
+    assert.ok(result.includes("chars omitted"));
   });
 
   it("caps an oversized non-string `content` (JSON.stringify'd) before returning it", async () => {
@@ -177,7 +180,8 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       "call-1",
       {},
     );
-    assert.ok(result.includes("bytes omitted"));
+    assert.ok(result.length <= MODEL_TOOL_RESULT_MAX_CHARS + 40);
+    assert.ok(result.includes("chars omitted"));
   });
 
   it("caps a raw oversized body when the response is not the expected envelope shape", async () => {
@@ -189,7 +193,8 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       "call-1",
       {},
     );
-    assert.ok(result.includes("bytes omitted"));
+    assert.ok(result.length <= MODEL_TOOL_RESULT_MAX_CHARS + 40);
+    assert.ok(result.includes("chars omitted"));
   });
 
   it("leaves a small result untouched", async () => {
@@ -298,5 +303,27 @@ describe("callAgentaTool error disclosure (RUN-TOOLERR-1)", () => {
       {},
     );
     assert.equal(result, "sent");
+  });
+});
+
+describe("capToolResultForModel (#5341)", () => {
+  it("leaves short results unchanged", () => {
+    assert.equal(capToolResultForModel("hello"), "hello");
+  });
+
+  it("caps at MODEL_TOOL_RESULT_MAX_CHARS with a chars-omitted marker", () => {
+    const text = "a".repeat(MODEL_TOOL_RESULT_MAX_CHARS + 500);
+    const capped = capToolResultForModel(text);
+    assert.ok(capped.startsWith("a".repeat(MODEL_TOOL_RESULT_MAX_CHARS)));
+    assert.ok(capped.includes("500 chars omitted"));
+    assert.ok(capped.length < text.length);
+  });
+
+  it("keeps live tool results far below the 1MB memory backstop", () => {
+    // A ~100KB patch must not reach the model whole on a live turn.
+    const text = "x".repeat(100_000);
+    const capped = capToolResultForModel(text);
+    assert.equal(capped.length <= MODEL_TOOL_RESULT_MAX_CHARS + 40, true);
+    assert.ok(capped.includes("chars omitted"));
   });
 });


### PR DESCRIPTION
## Summary
#5341: live agent turns could dump unbounded tool outputs into model context. Transcript rebuilds already cap at `TOOL_RESULT_RENDER_MAX_CHARS` (4000), but the live `/tools/call` path only enforced a **1MB memory** backstop (`MAX_BODY_BYTES`). A single Composio `get_pull_request` (~241k tokens observed in QA) still entered context and burned the window.

## Change
- Add `MODEL_TOOL_RESULT_MAX_CHARS = 4000` + `capToolResultForModel()` in `services/runner/src/tools/callback.ts`
- Live returns from `callAgentaTool` go through the char budget (after the byte memory cap)
- Unit tests: char-budget helper + updated RUN-TOOLCAP-1 expectations for the model-facing path

Memory backstop (`MAX_BODY_BYTES` / `readBoundedResponseText`) is unchanged.

## Test plan
- [x] `pnpm exec vitest run tests/unit/callback.test.ts` — **18 passed**

Fixes #5341
