### PR TITLE
fix(api): relax drive path validation, harden archive, rename export route

### DIFF
--- a/api/oss/src/apis/fastapi/mounts/models.py
+++ b/api/oss/src/apis/fastapi/mounts/models.py
@@ -75,8 +75,9 @@ class MountsResponse(BaseModel):
 
 class MountFileListResponse(BaseModel):
     count: int = 0
-    # Full file count matching the request before any limit — lets a limited "latest N" listing
-    # still report the true total (the UI badge). Equals `count` for an unlimited listing.
+    # Entries this view would return BEFORE any limit — so a limited "latest N" listing still reports
+    # the true total (the UI badge). Its unit follows the view: leaf files only in the recency listing
+    # (order/limit set), files-plus-folders in the shallow (depth=1) and browse modes.
     total: int = 0
     # `total` is a FLOOR (the count-only scan hit its cap) — the UI shows "N+". False when exact.
     total_capped: bool = False

--- a/api/oss/src/apis/fastapi/mounts/router.py
+++ b/api/oss/src/apis/fastapi/mounts/router.py
@@ -191,13 +191,13 @@ class MountsRouter:
             response_model_exclude_none=True,
             status_code=status.HTTP_200_OK,
         )
-        # Registered BEFORE "/{mount_id}/archive" so `POST /files/archive` (download-all zip) isn't
-        # captured as archiving a mount literally named "files".
+        # Registered before the "/{mount_id}/..." routes so this literal path isn't captured as an
+        # operation on a mount named "files".
         self.router.add_api_route(
-            "/files/archive",
-            self.archive_mount_files,
+            "/files/export",
+            self.export_mount_files,
             methods=["POST"],
-            operation_id="archive_mount_files",
+            operation_id="export_mount_files",
             response_model=None,
             status_code=status.HTTP_200_OK,
         )
@@ -617,7 +617,7 @@ class MountsRouter:
 
     @intercept_exceptions()
     @handle_mount_exceptions()
-    async def archive_mount_files(
+    async def export_mount_files(
         self,
         request: Request,
         *,

--- a/api/oss/src/apis/fastapi/mounts/router.py
+++ b/api/oss/src/apis/fastapi/mounts/router.py
@@ -10,6 +10,7 @@ from oss.src.core.access.permissions.types import Permission
 from oss.src.core.access.permissions.service import check_action_access
 from oss.src.apis.fastapi.shared.exceptions import FORBIDDEN_EXCEPTION
 
+from oss.src.core.mounts.dtos import MountArchiveSource
 from oss.src.core.mounts.service import MountsService
 from oss.src.core.mounts.types import (
     MountArtifactIdInvalid,
@@ -630,7 +631,14 @@ class MountsRouter:
         return await stream_mounts_archive(
             mounts_service=self.mounts_service,
             project_id=UUID(request.state.project_id),
-            mounts=[(m.mount_id, m.prefix, m.path) for m in archive_request.mounts],
+            mounts=[
+                MountArchiveSource(
+                    mount_id=m.mount_id,
+                    archive_prefix=m.prefix,
+                    source_path=m.path,
+                )
+                for m in archive_request.mounts
+            ],
             filename=archive_request.filename,
         )
 

--- a/api/oss/src/apis/fastapi/mounts/router.py
+++ b/api/oss/src/apis/fastapi/mounts/router.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, UploadFile, status
@@ -499,9 +499,11 @@ class MountsRouter:
         *,
         path: Optional[str] = Query(default=None),
         read: Optional[str] = Query(default=None),
-        order: Optional[str] = Query(default=None),
+        order: Optional[Literal["recent", "name", "path"]] = Query(default=None),
         limit: Optional[int] = Query(default=None, ge=0),
-        depth: Optional[int] = Query(default=None, ge=1),
+        # Only depth==1 is implemented (the shallow one-level summary); reject other values loudly
+        # instead of silently falling through to the most expensive full-tree branch.
+        depth: Optional[int] = Query(default=None, ge=1, le=1),
         with_counts: bool = Query(default=False),
         git_aware: bool = Query(default=False),
         include_gitignored: bool = Query(default=False),

--- a/api/oss/src/apis/fastapi/mounts/utils.py
+++ b/api/oss/src/apis/fastapi/mounts/utils.py
@@ -106,8 +106,8 @@ async def stream_mounts_archive(
 
     The drive folds cwd + agent-files into one tree, so each ``(mount_id, prefix)`` is placed under
     ``prefix/`` in the zip. The archive is streamed member-by-member (never buffered whole), and the
-    service prefetches file bodies with bounded concurrency. ``ZIP_AUTO`` picks zip32/zip64 per file
-    by size, so large drives and >4 GB archives are handled.
+    service prefetches file bodies with bounded concurrency. ``ZIP_AUTO`` picks zip32/zip64 per entry
+    by size; very large individual files are out of product scope for "download all".
     """
     work = await mounts_service.build_archive_work_list(
         project_id=project_id,

--- a/api/oss/src/apis/fastapi/mounts/utils.py
+++ b/api/oss/src/apis/fastapi/mounts/utils.py
@@ -22,13 +22,19 @@ def _content_disposition_attachment(filename: str) -> str:
 
     `filename` is client-supplied (a download path's basename or the archive name), so it must never
     be interpolated raw: a `"` or control char would break out of the quoted parameter and inject
-    further header directives. The quoted `filename` is stripped to a printable, quote-free ASCII-ish
-    fallback; `filename*` carries the exact (percent-encoded) value for clients that honour it.
+    further header directives. The quoted `filename` is stripped to an ASCII, printable, quote-free
+    fallback (the header is latin-1 encoded); `filename*` carries the exact (percent-encoded) value for
+    clients that honour it.
     """
     safe = (
-        "".join(c for c in filename if c.isprintable() and c not in '"\\') or "download"
+        "".join(
+            c for c in filename if c.isascii() and c.isprintable() and c not in '"\\'
+        )
+        or "download"
     )
-    return f"attachment; filename=\"{safe}\"; filename*=UTF-8''{quote(filename)}"
+    return (
+        f"attachment; filename=\"{safe}\"; filename*=UTF-8''{quote(filename, safe='')}"
+    )
 
 
 async def upload_mount_file(

--- a/api/oss/src/apis/fastapi/mounts/utils.py
+++ b/api/oss/src/apis/fastapi/mounts/utils.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from mimetypes import guess_type
 from posixpath import basename
 from stat import S_IFREG
-from typing import List, Optional, Tuple
+from typing import List, Optional
 from urllib.parse import quote
 from uuid import UUID
 
@@ -10,7 +10,12 @@ from fastapi import Response, UploadFile
 from fastapi.responses import StreamingResponse
 from stream_zip import ZIP_AUTO, async_stream_zip
 
-from oss.src.core.mounts.dtos import MountCredentials, MountFileWritten, MountQuery
+from oss.src.core.mounts.dtos import (
+    MountArchiveSource,
+    MountCredentials,
+    MountFileWritten,
+    MountQuery,
+)
 from oss.src.core.mounts.service import MountsService
 
 # Regular-file mode for archive members (owner rw, group/other r).
@@ -94,7 +99,7 @@ async def stream_mounts_archive(
     *,
     mounts_service: MountsService,
     project_id: UUID,
-    mounts: List[Tuple[UUID, str, str]],
+    mounts: List[MountArchiveSource],
     filename: str = "files.zip",
 ) -> StreamingResponse:
     """STREAM a zip of EVERY file across the given mounts as a binary download ("download all").

--- a/api/oss/src/core/mounts/dtos.py
+++ b/api/oss/src/core/mounts/dtos.py
@@ -71,8 +71,10 @@ class MountFile(BaseModel):
 
 class MountFileList(BaseModel):
     files: List[MountFile] = Field(default_factory=list)
-    # Total real files matching the request BEFORE any limit — so a limited "latest N" listing can
-    # still report the true file count (the UI badge) without shipping the whole tree.
+    # Entries this view would return BEFORE any limit — so a limited "latest N" listing still reports
+    # the true total (the UI badge) without shipping the whole tree. Its unit follows the view: leaf
+    # files only in the recency listing (order/limit set), files-plus-folders in the shallow (depth=1)
+    # and browse modes.
     total: int = 0
     # `total` is a FLOOR, not exact — the count-only scan hit its cap on a very large tree, so the UI
     # shows "N+". False for an exhaustive count.

--- a/api/oss/src/core/mounts/dtos.py
+++ b/api/oss/src/core/mounts/dtos.py
@@ -79,6 +79,16 @@ class MountFileList(BaseModel):
     total_capped: bool = False
 
 
+class MountArchiveSource(BaseModel):
+    """One mount to include in a download-all archive: which mount, which folder within it
+    (`source_path`; "" = the whole mount), and the prefix its files sit under in the zip (the folded
+    drive layout)."""
+
+    mount_id: UUID
+    source_path: str = ""
+    archive_prefix: str = ""
+
+
 class MountFileContent(BaseModel):
     path: str
     content: str

--- a/api/oss/src/core/mounts/service.py
+++ b/api/oss/src/core/mounts/service.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from oss.src.core.workflows.service import WorkflowsService
 
 from oss.src.core.mounts.dtos import (
+    MountArchiveSource,
     Mount,
     MountCreate,
     MountCredentials,
@@ -1108,7 +1109,7 @@ class MountsService:
         self,
         *,
         project_id: UUID,
-        mounts: List[Tuple[UUID, str, str]],
+        mounts: List[MountArchiveSource],
     ) -> List[Tuple[str, str, int, Optional[int]]]:
         """Build the ordered archive work list for the given mounts.
 
@@ -1121,15 +1122,17 @@ class MountsService:
         bucket = self._bucket()
 
         work: List[Tuple[str, str, int, Optional[int]]] = []
-        for mount_id, prefix, source_path in mounts:
-            if prefix:
-                validate_file_path(prefix)
-            if source_path:
-                validate_file_path(source_path)
-            mount = await self._resolve_mount(project_id=project_id, mount_id=mount_id)
+        for source in mounts:
+            if source.archive_prefix:
+                validate_file_path(source.archive_prefix)
+            if source.source_path:
+                validate_file_path(source.source_path)
+            mount = await self._resolve_mount(
+                project_id=project_id, mount_id=source.mount_id
+            )
             mount_base = self._storage_key(project_id=project_id, mount=mount)
-            pfx_segments = _safe_zip_segments(prefix)
-            src = source_path.strip("/")
+            pfx_segments = _safe_zip_segments(source.archive_prefix)
+            src = source.source_path.strip("/")
             # Scope the listing to a folder when `source_path` is set (folder download); the
             # rel path still keeps the folder, so the zip has "<folder>/…" entries.
             list_prefix = f"{mount_base}{src}/" if src else mount_base

--- a/api/oss/src/core/mounts/service.py
+++ b/api/oss/src/core/mounts/service.py
@@ -2,7 +2,7 @@ import asyncio
 from bisect import bisect_left, bisect_right
 from collections import deque
 from posixpath import basename
-from re import fullmatch, sub
+from re import sub
 from typing import AsyncIterator, TYPE_CHECKING, List, Optional, Tuple
 from uuid import UUID, uuid5, NAMESPACE_DNS
 
@@ -38,9 +38,9 @@ from oss.src.core.mounts.types import (
     MountStorageUnavailable,
 )
 from oss.src.core.shared.dtos import Reference, Windowing
+from oss.src.utils.logging import get_module_logger
 
-# Folder/file path segments: word chars, dots, spaces, hyphens — no path traversal.
-_SEGMENT_RE = r"[\w. -]+"
+log = get_module_logger(__name__)
 
 # Reserved slug prefix for service-minted (session) slugs; a caller may not author one.
 _RESERVED_SLUG_PREFIX = "__ag__"
@@ -107,21 +107,39 @@ def reject_reserved_slug(slug: str) -> None:
 
 
 def validate_file_path(path: str) -> None:
-    """Per-segment guard on a caller-supplied file/folder path.
+    """Guard a caller-supplied file/folder path against escaping the mount or corrupting a store key.
 
-    Rejects absolute paths, `..` traversal, and any segment that could escape
-    the mount prefix. Dots are allowed within a segment (filenames) but a bare
-    `..` segment is not.
+    Denylist, not allowlist: reject absolute paths, empty / `.` / `..` segments, and NUL or control
+    characters. Every other character real filenames contain — parentheses, brackets, `@ + , # ~ '`,
+    non-ASCII — is accepted, because the lazy-browse flow round-trips these paths on every expansion.
     """
     if path.startswith("/"):
         raise MountPathInvalid("File path must not be absolute.")
     if not path.strip("/"):
         raise MountPathInvalid("File path must not be empty.")
-    for segment in path.split("/"):
-        if not segment:
-            continue
-        if segment == ".." or not fullmatch(_SEGMENT_RE, segment):
+    if any(ord(c) < 0x20 or c == "\x7f" for c in path):
+        raise MountPathInvalid("File path must not contain control characters.")
+    for segment in path.strip("/").split("/"):
+        if segment in ("", ".", ".."):
             raise MountPathInvalid()
+
+
+def _zip_segments(path: str) -> List[str]:
+    """Split a zip entry path on BOTH separators — a backslash is a separator to Windows extractors,
+    so `..\\x` traverses just like `../x`."""
+    return path.replace("\\", "/").split("/")
+
+
+def _has_unsafe_zip_segment(segments: List[str]) -> bool:
+    """True if any segment is empty / `.` / `..` — i.e. the path could traverse out of the zip root
+    (zip-slip for whoever extracts)."""
+    return any(s in ("", ".", "..") for s in segments)
+
+
+def _safe_zip_segments(path: str) -> List[str]:
+    """Segments safe to place in a zip entry name: drop empty / `.` / `..` (both separators) so a
+    prefix can't mint a `../x` or `..\\x` entry."""
+    return [s for s in _zip_segments(path) if s not in ("", ".", "..")]
 
 
 def _is_internal_mount_path(path: str) -> bool:
@@ -1104,9 +1122,13 @@ class MountsService:
 
         work: List[Tuple[str, str, int, Optional[int]]] = []
         for mount_id, prefix, source_path in mounts:
+            if prefix:
+                validate_file_path(prefix)
+            if source_path:
+                validate_file_path(source_path)
             mount = await self._resolve_mount(project_id=project_id, mount_id=mount_id)
             mount_base = self._storage_key(project_id=project_id, mount=mount)
-            pfx = prefix.strip("/")
+            pfx_segments = _safe_zip_segments(prefix)
             src = source_path.strip("/")
             # Scope the listing to a folder when `source_path` is set (folder download); the
             # rel path still keeps the folder, so the zip has "<folder>/…" entries.
@@ -1122,9 +1144,17 @@ class MountsService:
                     if obj.key.startswith(mount_base)
                     else obj.key
                 )
-                if not rel:
+                rel_segments = _zip_segments(rel)
+                # Store keys come from signed-credential writers, so `rel` can carry `..` or a
+                # backslash. Don't REWRITE such a key — `a/../report.txt` would collapse onto a real
+                # `a/report.txt` and overwrite it on extraction — skip the member instead.
+                if _has_unsafe_zip_segment(rel_segments):
+                    log.warning(
+                        "mounts.archive: skipping member with unsafe store key",
+                        key=obj.key,
+                    )
                     continue
-                zip_path = f"{pfx}/{rel}" if pfx else rel
+                zip_path = "/".join([*pfx_segments, *rel_segments])
                 work.append((zip_path, obj.key, obj.size or 0, obj.mtime))
 
         return work

--- a/api/oss/tests/pytest/unit/test_mounts_file_ops.py
+++ b/api/oss/tests/pytest/unit/test_mounts_file_ops.py
@@ -17,6 +17,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from oss.src.apis.fastapi.mounts.utils import _content_disposition_attachment
 from oss.src.core.mounts import service as mounts_service_module
 from oss.src.core.mounts.dtos import Mount, MountFile
 from oss.src.core.mounts.service import (
@@ -63,9 +64,59 @@ class TestFilePathValidation:
         with pytest.raises(MountPathInvalid):
             validate_file_path("")
 
-    def test_rejects_special_chars(self):
+    def test_accepts_parentheses_and_brackets(self):
+        validate_file_path("app/(auth)/[slug]/page.tsx")
+
+    def test_accepts_at_sign(self):
+        validate_file_path("@scope/pkg/index.js")
+
+    def test_accepts_plus_signs(self):
+        validate_file_path("c++.md")
+
+    def test_accepts_comma(self):
+        validate_file_path("a,b.txt")
+
+    def test_accepts_hash(self):
+        validate_file_path("notes#1.txt")
+
+    def test_accepts_tilde(self):
+        validate_file_path("~backup")
+
+    def test_accepts_astral_plane_name(self):
+        validate_file_path("\U00020000dir/file.txt")
+
+    def test_rejects_empty_interior_segment(self):
         with pytest.raises(MountPathInvalid):
-            validate_file_path("file;rm -rf")
+            validate_file_path("a//b")
+
+    def test_rejects_dot_segment(self):
+        with pytest.raises(MountPathInvalid):
+            validate_file_path("a/./b")
+
+    def test_rejects_embedded_nul(self):
+        with pytest.raises(MountPathInvalid):
+            validate_file_path("a/b\x00c")
+
+    def test_rejects_control_character(self):
+        with pytest.raises(MountPathInvalid):
+            validate_file_path("a/b\x01c")
+
+
+class TestContentDispositionHeader:
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "中文报告.zip",
+            "photo\U0001f600.zip",
+            'a"; DROP TABLE.zip',
+            "a\nb.zip",
+        ],
+    )
+    def test_header_is_latin_1_safe_with_utf_8_filename(self, filename):
+        header = _content_disposition_attachment(filename)
+
+        header.encode("latin-1")
+        assert "filename*=UTF-8''" in header
 
 
 class TestRollupRecentEntries:
@@ -288,6 +339,42 @@ class TestArchiveWorkList:
             "prefix/one.txt",
             "prefix/nested/two.txt",
         }
+
+
+@pytest.mark.asyncio
+class TestArchiveZipSlip:
+    async def _work_for_keys(self, keys):
+        mount = _make_mount()
+        storage = FakeMountStorage()
+        service = MountsService(
+            mounts_dao=_StubDAO(mount),
+            mounts_store=storage,
+            bucket=_BUCKET,
+        )
+        mount_base = service._storage_key(project_id=mount.project_id, mount=mount)
+        bucket_store = storage._store.setdefault(_BUCKET, {})
+        for key in keys:
+            bucket_store[f"{mount_base}{key}"] = b"x"
+        return await service.build_archive_work_list(
+            project_id=mount.project_id,
+            mounts=[(mount.id, "", "")],
+        )
+
+    async def test_traversal_keys_are_skipped_not_rewritten(self):
+        # `../evil.txt` and `..\evil.txt` (backslash is a separator to Windows extractors) must not
+        # produce an entry that escapes the archive root; the safe sibling still ships.
+        work = await self._work_for_keys(["good.txt", "../evil.txt", "..\\evil.txt"])
+
+        zip_paths = {zip_path for zip_path, *_rest in work}
+        assert zip_paths == {"good.txt"}
+
+    async def test_traversal_key_does_not_alias_a_real_entry(self):
+        # `a/../report.txt` must NOT be rewritten to `a/report.txt` — that would overwrite the real
+        # `a/report.txt` on extraction. Skipping it leaves the genuine file intact and un-duplicated.
+        work = await self._work_for_keys(["a/report.txt", "a/../report.txt"])
+
+        zip_paths = [zip_path for zip_path, *_rest in work]
+        assert zip_paths == ["a/report.txt"]
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/tests/pytest/unit/test_mounts_file_ops.py
+++ b/api/oss/tests/pytest/unit/test_mounts_file_ops.py
@@ -19,7 +19,7 @@ import pytest
 
 from oss.src.apis.fastapi.mounts.utils import _content_disposition_attachment
 from oss.src.core.mounts import service as mounts_service_module
-from oss.src.core.mounts.dtos import Mount, MountFile
+from oss.src.core.mounts.dtos import Mount, MountArchiveSource, MountFile
 from oss.src.core.mounts.service import (
     MountsService,
     _rollup_recent_entries,
@@ -316,7 +316,7 @@ class TestArchiveWorkList:
         with pytest.raises(MountNotFound):
             await service.build_archive_work_list(
                 project_id=pid,
-                mounts=[(uuid4(), "", "")],
+                mounts=[MountArchiveSource(mount_id=uuid4())],
             )
 
     async def test_zip_paths_include_mount_prefix(self):
@@ -332,7 +332,7 @@ class TestArchiveWorkList:
 
         work = await service.build_archive_work_list(
             project_id=pid,
-            mounts=[(mid, "prefix", "")],
+            mounts=[MountArchiveSource(mount_id=mid, archive_prefix="prefix")],
         )
 
         assert {zip_path for zip_path, _key, _size, _mtime in work} == {
@@ -357,7 +357,7 @@ class TestArchiveZipSlip:
             bucket_store[f"{mount_base}{key}"] = b"x"
         return await service.build_archive_work_list(
             project_id=mount.project_id,
-            mounts=[(mount.id, "", "")],
+            mounts=[MountArchiveSource(mount_id=mount.id)],
         )
 
     async def test_traversal_keys_are_skipped_not_rewritten(self):

--- a/api/oss/tests/pytest/unit/test_mounts_service.py
+++ b/api/oss/tests/pytest/unit/test_mounts_service.py
@@ -95,6 +95,12 @@ class TestFilePathValidation:
         with pytest.raises(MountPathInvalid):
             validate_file_path("/")
 
-    def test_rejects_angle_brackets(self):
+    def test_accepts_punctuation_real_filenames_use(self):
+        # Denylist, not allowlist: only traversal / control chars are unsafe, so real folder names
+        # keep working (route groups, npm scopes, angle brackets, etc.).
+        validate_file_path("path/<injection>")
+        validate_file_path("app/(auth)/[slug]/page.tsx")
+
+    def test_rejects_control_char(self):
         with pytest.raises(MountPathInvalid):
-            validate_file_path("path/<injection>")
+            validate_file_path("path/a\x00b")

--- a/web/oss/src/components/Drives/driveMedia.ts
+++ b/web/oss/src/components/Drives/driveMedia.ts
@@ -229,7 +229,7 @@ export async function downloadMountArchive({
             const writable = await handle.createWritable()
             try {
                 const jwt = await getJWT()
-                const url = `${getAgentaApiUrl()}/mounts/files/archive?project_id=${encodeURIComponent(projectId)}`
+                const url = `${getAgentaApiUrl()}/mounts/files/export?project_id=${encodeURIComponent(projectId)}`
                 const response = await fetch(url, {
                     method: "POST",
                     headers: {
@@ -257,7 +257,7 @@ export async function downloadMountArchive({
 
     // ─── Buffered fallback (Safari / Firefox / no picker) ─────────────────────────────────────────
     try {
-        const response = await axios.post(`${getAgentaApiUrl()}/mounts/files/archive`, payload, {
+        const response = await axios.post(`${getAgentaApiUrl()}/mounts/files/export`, payload, {
             params: {project_id: projectId},
             responseType: "blob",
         })

--- a/web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts
+++ b/web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts
@@ -532,16 +532,16 @@ export class MountsClient {
      * @throws {@link AgentaApi.UnprocessableEntityError}
      *
      * @example
-     *     await client.mounts.archiveMountFiles()
+     *     await client.mounts.exportMountFiles()
      */
-    public archiveMountFiles(
+    public exportMountFiles(
         request: AgentaApi.MountArchiveRequest = {},
         requestOptions?: MountsClient.RequestOptions,
     ): core.HttpResponsePromise<unknown> {
-        return core.HttpResponsePromise.fromPromise(this.__archiveMountFiles(request, requestOptions));
+        return core.HttpResponsePromise.fromPromise(this.__exportMountFiles(request, requestOptions));
     }
 
-    private async __archiveMountFiles(
+    private async __exportMountFiles(
         request: AgentaApi.MountArchiveRequest = {},
         requestOptions?: MountsClient.RequestOptions,
     ): Promise<core.WithRawResponse<unknown>> {
@@ -556,7 +556,7 @@ export class MountsClient {
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)) ??
                     environments.AgentaApiEnvironment.Default,
-                "mounts/files/archive",
+                "mounts/files/export",
             ),
             method: "POST",
             headers: _headers,
@@ -591,7 +591,7 @@ export class MountsClient {
             }
         }
 
-        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/mounts/files/archive");
+        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/mounts/files/export");
     }
 
     /**


### PR DESCRIPTION
## Context

Part 2 of 2, stacked on #5411. These two PRs implement the pre-merge fixes agreed for #5400 ("[AGE-3965] refactor(drive): virtualize surfaces + unify Files drawer" by @ardaerzin) so it can merge on a sound base. #5411 carries the correctness fixes; this PR carries the contract, validation, and naming fixes. Its base is #5411's branch, so the diff here is only this PR's changes.

The headline is a validation bug that breaks #5400's own lazy-browse flow on real repositories. `validate_file_path` used a character allowlist, `[\w. -]+` per path segment, which rejects folders agents genuinely create: Next.js route groups like `app/(auth)/[slug]`, npm scopes like `@scope/pkg`, `c++.md`, and names containing `,`, `#`, `~`, or non-ASCII characters. Listings surface those names (agents write them through prefix-scoped signed credentials, which bypass validation), but every round-trip endpoint (expand, read, download) validates `path` and returned 422. So the file browser showed folders it could never open. The old UI fetched the whole tree in one call with no `path`, so this rarely fired. The new lazy flow sends `path` on every expansion, which promotes the latent restriction into a first-class product bug.

## Changes

**Relax path validation from an allowlist to a denylist.** `validate_file_path` now rejects only genuinely unsafe input: absolute paths, `.`/`..`/empty segments, NUL, and control characters. Everything else, including the real-world folder names above, passes. Realistic-name tests pin the new behavior.

**Harden the archive inputs in the same pass.** These changes pull the opposite direction from the relaxation above, so they belong in one commit. `ArchiveMount.path` and `prefix` are now validated. Zip members whose keys smuggle `..` or backslash traversal are skipped with a warning log instead of minting zip-slip entries that would escape the extraction directory on the client. The `Content-Disposition` filename fallback is ASCII-only, so CJK and emoji filenames no longer 500 on the latin-1 header encode.

**Rename `POST /files/archive` to `POST /files/export`.** "Archive" is this router's own soft-delete verb, registered three lines below, and the collision was what forced a route-ordering hack. The rename removes the ambiguity and the fragile ordering together. All three frontend call sites are updated. Renaming after the frontend ships against `/archive` would be a breaking change, so it lands now.

**Constrain the listing parameters.** `depth` gets `le=1` (the service only implements `depth == 1`; `depth=2` silently fell through to the most expensive full-tree branch). `order` becomes a `Literal` (any other string previously returned the flat view unsorted with no error). Invalid values now return 422 instead of silently choosing the wrong or most expensive path.

**Name the anonymous tuple.** The archive path's `(UUID, str, str)` triple becomes a `MountArchiveSource` DTO, threaded through the service, archive utils, router, and tests. `api/AGENTS.md` names bare-tuple returns as an anti-pattern, and every sibling method here returns a DTO. (The companion `MountFilePage` DTO from the original change is dropped: the flat paged listing it named was removed with the Files drawer's flat view in `387c62ebef`.)

**Document `total` and soften the archive docstring.** `total` counts the entries a view returns before any limit, but its unit follows the view: leaf files only in the recency listing (order and limit set), files-plus-folders in the shallow (`depth=1`) and browse modes. That per-view meaning is now documented. The archive docstring no longer claims to handle files over 4 GB, which the product owner has ruled out of scope.

## Verification

**Live QA (recorded).** A wire matrix and 60-second UI recording were run on an isolated docker stack against the pre-`387c62ebef` tip: special-character folder paths returning 200, constraint violations returning 422, export returning 404 on a bad mount, valid zips downloading, the CJK header staying safe, and the old `/archive` route being gone. All of these target surviving code and remain valid. The recording is attached as a comment on the base PR #5411 (the canonical copy for both PRs).

**Tests.** The mounts file-ops suite covers the relaxed validation, the export rename, the parameter constraints, and the zip-slip skip (`uv run pytest oss/tests/pytest/unit/test_mounts_file_ops.py -q`). The full API unit suite is green on the rebased tip.

**Independent review.** Codex reviewed this diff at high reasoning effort. Its one confirmed catch on this branch, a backslash-based zip-slip path, is fixed and regression-tested.

## Merge order

Merge #5411 into `fe-refactor/drive-surfaces` first, then this PR into #5411's branch, then #5400 into `main`. Merging is Mahmoud's decision. Ready for review, do not merge without Mahmoud's go.

https://claude.ai/code/session_01PTkjdoAPbhSEFR3ubpgzBU