### PR TITLE
feat(frontend): create an agent from a website template deep link

### DIFF
--- a/web/oss/src/components/pages/agent-home/assets/onboardingAnalytics.ts
+++ b/web/oss/src/components/pages/agent-home/assets/onboardingAnalytics.ts
@@ -24,7 +24,12 @@ export function classifyAgentIntent(message: string): string {
     return "other"
 }
 
-export type FirstAgentIntentSource = "template" | "composer" | "skipped" | "browse_templates"
+export type FirstAgentIntentSource =
+    | "template"
+    | "composer"
+    | "skipped"
+    | "browse_templates"
+    | "website_template"
 
 export interface FirstAgentIntentPayload {
     source: FirstAgentIntentSource

--- a/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
+++ b/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
@@ -8,6 +8,7 @@ import {
     activeTemplateAtom,
     claimTemplate,
     clearTemplate,
+    completeTemplateClaim,
     resolveTemplate,
 } from "@/oss/state/url/template"
 
@@ -29,28 +30,32 @@ import {useCreateAgent} from "./useCreateAgent"
  * seed held behind a Start button (`autoSendSeed: false`).
  */
 export function useConsumePendingTemplate(): boolean {
-    const pendingKey = useAtomValue(activeTemplateAtom)
+    const pending = useAtomValue(activeTemplateAtom)
+    const pendingKey = pending?.key
+    const capturedAt = pending?.capturedAt
     const {workspaceId, projectId} = useAtomValue(appIdentifiersAtom)
     const posthog = usePostHogAg()
     const createAgent = useCreateAgent()
 
-    const startedRef = useRef(false)
-    const [holding, setHolding] = useState<boolean>(() => Boolean(pendingKey))
+    const startedRef = useRef<string | null>(null)
+    const [holding, setHolding] = useState<boolean>(() => Boolean(pending))
 
     useEffect(() => {
-        if (!pendingKey) {
+        if (!pendingKey || capturedAt === undefined) {
+            startedRef.current = null
             setHolding(false)
             return
         }
 
+        const pendingGeneration = {key: pendingKey, capturedAt}
+        const generationId = pendingKey + ":" + capturedAt
         const template = resolveTemplate(pendingKey)
         if (!template) {
-            // Unknown or stale key: ignore, clear, and never fall back to another template.
             captureFirstAgentIntent(posthog, {
                 source: "website_template",
                 properties: {templateId: pendingKey, outcome: "invalid"},
             })
-            clearTemplate()
+            clearTemplate(pendingGeneration)
             setHolding(false)
             return
         }
@@ -58,15 +63,16 @@ export function useConsumePendingTemplate(): boolean {
         setHolding(true)
 
         // Do not create until the workspace and project are real; the effect re-runs when they
-        // resolve. This surface only renders on a project-scoped route, so both are present here.
+        // resolve. Scope the latch to this capture generation so a later template can proceed
+        // while the same page component remains mounted.
         if (!workspaceId || !projectId) return
-        if (startedRef.current) return
-        startedRef.current = true
+        if (startedRef.current === generationId) return
+        startedRef.current = generationId
 
         void (async () => {
-            const won = await claimTemplate(pendingKey)
+            const won = await claimTemplate(pendingGeneration)
             if (!won) {
-                // Another tab won the claim; release so this surface renders normally.
+                if (startedRef.current === generationId) startedRef.current = null
                 setHolding(false)
                 return
             }
@@ -83,14 +89,17 @@ export function useConsumePendingTemplate(): boolean {
             })
 
             try {
-                await createAgent({
+                const created = await createAgent({
                     name: template.name,
                     seedMessage: template.seedMessage,
                     autoSendSeed: false,
                 })
                 captureFirstAgentIntent(posthog, {
                     source: "website_template",
-                    properties: {templateId: template.key, outcome: "created"},
+                    properties: {
+                        templateId: template.key,
+                        outcome: created ? "created" : "failed",
+                    },
                 })
             } catch {
                 captureFirstAgentIntent(posthog, {
@@ -98,11 +107,12 @@ export function useConsumePendingTemplate(): boolean {
                     properties: {templateId: template.key, outcome: "failed"},
                 })
             } finally {
-                // Clear the pending key; createAgent has navigated to the new agent's playground.
-                clearTemplate()
+                await completeTemplateClaim(pendingGeneration)
+                clearTemplate(pendingGeneration)
+                if (startedRef.current === generationId) startedRef.current = null
             }
         })()
-    }, [pendingKey, workspaceId, projectId, posthog, createAgent])
+    }, [pendingKey, capturedAt, workspaceId, projectId, posthog, createAgent])
 
     return holding
 }

--- a/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
+++ b/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
@@ -1,0 +1,108 @@
+import {useEffect, useRef, useState} from "react"
+
+import {useAtomValue} from "jotai"
+
+import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
+import {appIdentifiersAtom} from "@/oss/state/appState"
+import {
+    activeTemplateAtom,
+    claimTemplate,
+    clearTemplate,
+    resolveTemplate,
+} from "@/oss/state/url/template"
+
+import {captureFirstAgentIntent} from "../assets/onboardingAnalytics"
+
+import {useCreateAgent} from "./useCreateAgent"
+
+/**
+ * Consume a pending website template at whichever first-run surface the user reaches. A new user
+ * lands on the native onboarding playground and a returning user on the agent home page, so this
+ * hook is mounted above both and consumes the key wherever the user actually is.
+ *
+ * Returns `true` while a valid template is being consumed, so the caller can hold the onboarding
+ * loader instead of flashing the normal surface (which would fire its own redirect and race this).
+ *
+ * The steps mirror the plan's consume requirements: validate the key by exact registry lookup
+ * (an unknown or stale key is ignored and cleared, never creating an agent); wait for a confirmed
+ * workspace and project; claim the key so it fires at most once; then create the agent with the
+ * seed held behind a Start button (`autoSendSeed: false`).
+ */
+export function useConsumePendingTemplate(): boolean {
+    const pendingKey = useAtomValue(activeTemplateAtom)
+    const {workspaceId, projectId} = useAtomValue(appIdentifiersAtom)
+    const posthog = usePostHogAg()
+    const createAgent = useCreateAgent()
+
+    const startedRef = useRef(false)
+    const [holding, setHolding] = useState<boolean>(() => Boolean(pendingKey))
+
+    useEffect(() => {
+        if (!pendingKey) {
+            setHolding(false)
+            return
+        }
+
+        const template = resolveTemplate(pendingKey)
+        if (!template) {
+            // Unknown or stale key: ignore, clear, and never fall back to another template.
+            captureFirstAgentIntent(posthog, {
+                source: "website_template",
+                properties: {templateId: pendingKey, outcome: "invalid"},
+            })
+            clearTemplate()
+            setHolding(false)
+            return
+        }
+
+        setHolding(true)
+
+        // Do not create until the workspace and project are real; the effect re-runs when they
+        // resolve. This surface only renders on a project-scoped route, so both are present here.
+        if (!workspaceId || !projectId) return
+        if (startedRef.current) return
+        startedRef.current = true
+
+        void (async () => {
+            const won = await claimTemplate(pendingKey)
+            if (!won) {
+                // Another tab won the claim; release so this surface renders normally.
+                setHolding(false)
+                return
+            }
+
+            captureFirstAgentIntent(posthog, {
+                source: "website_template",
+                properties: {
+                    templateId: template.key,
+                    template: template.name,
+                    templateCategory: template.category,
+                    outcome: "claimed",
+                },
+                intentValue: template.category || template.name,
+            })
+
+            try {
+                await createAgent({
+                    name: template.name,
+                    seedMessage: template.seedMessage,
+                    autoSendSeed: false,
+                })
+                captureFirstAgentIntent(posthog, {
+                    source: "website_template",
+                    properties: {templateId: template.key, outcome: "created"},
+                })
+            } catch {
+                captureFirstAgentIntent(posthog, {
+                    source: "website_template",
+                    properties: {templateId: template.key, outcome: "failed"},
+                })
+            } finally {
+                // Clear the pending key; createAgent has navigated to the new agent's playground.
+                clearTemplate()
+            }
+        })()
+    }, [pendingKey, workspaceId, projectId, posthog, createAgent])
+
+    return holding
+}

--- a/web/oss/src/components/pages/agent-home/hooks/useCreateAgent.ts
+++ b/web/oss/src/components/pages/agent-home/hooks/useCreateAgent.ts
@@ -59,7 +59,7 @@ export function useCreateAgent() {
             onCommitted,
             autoSendSeed,
         }: CreateAgentParams = {}) => {
-            if (inFlightRef.current) return
+            if (inFlightRef.current) return false
             inFlightRef.current = true
             try {
                 const agentName = name?.trim() || "New agent"
@@ -71,7 +71,7 @@ export function useCreateAgent() {
                     }))
                 if (!ephemeralId) {
                     message.error("Couldn't start agent creation — please retry")
-                    return
+                    return false
                 }
 
                 // Slug must be unique per project — the drawer used to collect a user-typed name, so
@@ -87,7 +87,7 @@ export function useCreateAgent() {
                 })
                 if (!result.success) {
                     message.error(extractApiErrorMessage(result.error))
-                    return
+                    return false
                 }
 
                 const appId = result.workflow?.workflow_id ?? result.workflow?.id
@@ -96,7 +96,7 @@ export function useCreateAgent() {
                     message.error(
                         "Agent created, but couldn't open its playground — find it under Agents",
                     )
-                    return
+                    return false
                 }
 
                 if (seedMessage?.trim()) {
@@ -113,8 +113,10 @@ export function useCreateAgent() {
                 } else {
                     void router.push(`${baseAppURL}/${appId}/playground?revisions=${revisionId}`)
                 }
+                return true
             } catch (error) {
                 message.error(extractApiErrorMessage(error))
+                return false
             } finally {
                 inFlightRef.current = false
             }

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/index.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic"
 
 import {PLAYGROUND_NATIVE_ONBOARDING} from "@/oss/components/pages/agent-home/assets/constants"
+import {useConsumePendingTemplate} from "@/oss/components/pages/agent-home/hooks/useConsumePendingTemplate"
 import OnboardingLoader from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingLoader"
 
 const AgentHome = dynamic(() => import("@/oss/components/pages/agent-home"))
@@ -14,5 +15,11 @@ const OnboardingEntry = dynamic(() => import("@/oss/components/pages/agent-home/
 })
 
 export default function Apps() {
+    // A website template deep-link is consumed here, above both first-run surfaces, so the create
+    // happens wherever the user lands. While a valid template is being consumed, hold the loader
+    // instead of rendering a surface that would fire its own redirect and race the create.
+    const consumingTemplate = useConsumePendingTemplate()
+    if (consumingTemplate) return <OnboardingLoader />
+
     return PLAYGROUND_NATIVE_ONBOARDING ? <OnboardingEntry /> : <AgentHome />
 }

--- a/web/oss/src/state/url/auth.ts
+++ b/web/oss/src/state/url/auth.ts
@@ -13,6 +13,8 @@ import {profileQueryAtom, userAtom} from "@/oss/state/profile/selectors/user"
 import {sessionExistsAtom, sessionLoadingAtom} from "@/oss/state/session"
 import {urlAtom} from "@/oss/state/url"
 
+import {captureTemplateFromUrl} from "./template"
+
 const isBrowser = typeof window !== "undefined"
 
 export interface InvitePayload {
@@ -223,6 +225,11 @@ export const syncAuthStateFromUrl = (nextUrl?: string) => {
             }
         }
         store.set(activeInviteAtom, invite ?? null)
+
+        // Capture a website template deep-link alongside the invite, from the same URL read. Runs
+        // again on a regional host after a region redirect, since the query string survives the
+        // switch but the stored key does not.
+        captureTemplateFromUrl(url)
 
         if (sessionLoading) {
             store.set(protectedRouteReadyAtom, false)

--- a/web/oss/src/state/url/template.test.ts
+++ b/web/oss/src/state/url/template.test.ts
@@ -8,6 +8,7 @@ import {
     captureTemplateFromUrl,
     claimTemplate,
     clearTemplate,
+    completeTemplateClaim,
     isValidTemplateKey,
     parseTemplateFromUrl,
     persistTemplateToStorage,
@@ -48,6 +49,13 @@ const installWindow = (href: string, locks?: unknown) => {
     vi.stubGlobal("window", fakeWindow)
     vi.stubGlobal("navigator", locks ? {locks} : {})
     return fakeWindow
+}
+
+const capturePending = (): {key: string; capturedAt: number} => {
+    captureTemplateFromUrl(new URL("https://cloud.agenta.ai/?template=" + KNOWN_KEY))
+    const pending = getDefaultStore().get(activeTemplateAtom)
+    if (!pending) throw new Error("Expected a pending template")
+    return pending
 }
 
 beforeEach(() => {
@@ -109,7 +117,7 @@ describe("captureTemplateFromUrl", () => {
         installWindow(`/?template=${KNOWN_KEY}`)
         const url = new URL(`https://cloud.agenta.ai/?template=${KNOWN_KEY}`)
         expect(captureTemplateFromUrl(url)).toBe(KNOWN_KEY)
-        expect(getDefaultStore().get(activeTemplateAtom)).toBe(KNOWN_KEY)
+        expect(getDefaultStore().get(activeTemplateAtom)?.key).toBe(KNOWN_KEY)
         expect(readTemplateFromStorage()?.key).toBe(KNOWN_KEY)
     })
 
@@ -126,11 +134,25 @@ describe("captureTemplateFromUrl", () => {
         expect(readTemplateFromStorage()?.capturedAt).toBe(first)
     })
 
+    it("does not renew an expired key while the stale parameter remains in the URL", () => {
+        const win = installWindow("/?template=" + KNOWN_KEY)
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+        const staleUrl = new URL("https://cloud.agenta.ai/?template=" + KNOWN_KEY)
+        captureTemplateFromUrl(staleUrl)
+
+        vi.setSystemTime(new Date("2026-01-01T00:31:00Z"))
+        expect(captureTemplateFromUrl(staleUrl)).toBeNull()
+        expect(readTemplateFromStorage()).toBeNull()
+        expect(getDefaultStore().get(activeTemplateAtom)).toBeNull()
+        expect(win.location.href).not.toContain("template=")
+    })
+
     it("falls back to the stored key when the URL has none (region recapture leaves storage intact)", () => {
         installWindow("/")
         persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})
         expect(captureTemplateFromUrl(new URL("https://cloud.agenta.ai/apps"))).toBe(KNOWN_KEY)
-        expect(getDefaultStore().get(activeTemplateAtom)).toBe(KNOWN_KEY)
+        expect(getDefaultStore().get(activeTemplateAtom)?.key).toBe(KNOWN_KEY)
     })
 })
 
@@ -138,7 +160,7 @@ describe("clearTemplate", () => {
     it("removes storage, the atom, and the template URL param so it cannot resurrect", () => {
         const win = installWindow(`/apps?template=${KNOWN_KEY}&other=1`)
         persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})
-        getDefaultStore().set(activeTemplateAtom, KNOWN_KEY)
+        getDefaultStore().set(activeTemplateAtom, {key: KNOWN_KEY, capturedAt: Date.now()})
 
         clearTemplate()
 
@@ -154,23 +176,58 @@ describe("clearTemplate", () => {
 describe("claimTemplate (at-most-once)", () => {
     it("best-effort fallback: only the first caller wins when Web Locks is absent", async () => {
         installWindow("/")
-        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
-        expect(await claimTemplate(KNOWN_KEY)).toBe(false)
+        const pending = capturePending()
+        expect(await claimTemplate(pending)).toBe(true)
+        expect(await claimTemplate(pending)).toBe(false)
     })
 
     it("Web Locks path: the lock serialises the claim so only one caller wins", async () => {
         const locks = {
-            request: (_name: string, cb: () => boolean) => Promise.resolve(cb()),
+            request: (_name: string, cb: () => unknown) => Promise.resolve(cb()),
         }
         installWindow("/", locks)
-        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
-        expect(await claimTemplate(KNOWN_KEY)).toBe(false)
+        const pending = capturePending()
+        expect(await claimTemplate(pending)).toBe(true)
+        expect(await claimTemplate(pending)).toBe(false)
     })
 
-    it("a fresh key can be claimed again after the previous template is cleared", async () => {
+    it("keeps a completed generation unavailable to a late tab after pending state clears", async () => {
         installWindow("/")
-        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
-        clearTemplate()
-        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
+        const pending = capturePending()
+        expect(await claimTemplate(pending)).toBe(true)
+        await completeTemplateClaim(pending)
+        clearTemplate(pending)
+
+        expect(await claimTemplate(pending)).toBe(false)
+    })
+
+    it("allows a newly captured generation of the same key", async () => {
+        installWindow("/")
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+        const first = capturePending()
+        expect(await claimTemplate(first)).toBe(true)
+        await completeTemplateClaim(first)
+        clearTemplate(first)
+
+        vi.setSystemTime(new Date("2026-01-01T00:00:01Z"))
+        const second = capturePending()
+        expect(second.capturedAt).not.toBe(first.capturedAt)
+        expect(await claimTemplate(second)).toBe(true)
+    })
+
+    it("expires an abandoned claim before a later visit with the same key", async () => {
+        const win = installWindow("/?template=" + KNOWN_KEY)
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+        const first = capturePending()
+        expect(await claimTemplate(first)).toBe(true)
+
+        vi.setSystemTime(new Date("2026-01-01T00:31:00Z"))
+        const staleUrl = new URL(win.location.href)
+        expect(captureTemplateFromUrl(staleUrl)).toBeNull()
+
+        const second = capturePending()
+        expect(await claimTemplate(second)).toBe(true)
     })
 })

--- a/web/oss/src/state/url/template.test.ts
+++ b/web/oss/src/state/url/template.test.ts
@@ -1,0 +1,176 @@
+import {getDefaultStore} from "jotai"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import {AGENT_TEMPLATES} from "../../components/pages/agent-home/assets/templates"
+
+import {
+    activeTemplateAtom,
+    captureTemplateFromUrl,
+    claimTemplate,
+    clearTemplate,
+    isValidTemplateKey,
+    parseTemplateFromUrl,
+    persistTemplateToStorage,
+    readTemplateFromStorage,
+    resolveTemplate,
+    TEMPLATE_TTL_MS,
+} from "./template"
+
+const KNOWN_KEY = AGENT_TEMPLATES[0].key
+
+class FakeStorage {
+    private map = new Map<string, string>()
+    getItem(key: string) {
+        return this.map.has(key) ? (this.map.get(key) as string) : null
+    }
+    setItem(key: string, value: string) {
+        this.map.set(key, String(value))
+    }
+    removeItem(key: string) {
+        this.map.delete(key)
+    }
+    clear() {
+        this.map.clear()
+    }
+}
+
+const installWindow = (href: string, locks?: unknown) => {
+    const storage = new FakeStorage()
+    const state = {} as unknown
+    const replaceState = vi.fn((_s: unknown, _t: string, url: string) => {
+        fakeWindow.location.href = new URL(url, "https://cloud.agenta.ai").href
+    })
+    const fakeWindow = {
+        localStorage: storage,
+        location: {href: new URL(href, "https://cloud.agenta.ai").href},
+        history: {state, replaceState},
+    }
+    vi.stubGlobal("window", fakeWindow)
+    vi.stubGlobal("navigator", locks ? {locks} : {})
+    return fakeWindow
+}
+
+beforeEach(() => {
+    getDefaultStore().set(activeTemplateAtom, null)
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+})
+
+describe("parseTemplateFromUrl", () => {
+    it("returns the key when the template param is present", () => {
+        const url = new URL("https://cloud.agenta.ai/?template=pr-reviewer")
+        expect(parseTemplateFromUrl(url)).toBe("pr-reviewer")
+    })
+
+    it("returns null when the template param is absent", () => {
+        expect(parseTemplateFromUrl(new URL("https://cloud.agenta.ai/"))).toBeNull()
+    })
+
+    it("trims surrounding whitespace and treats blank as absent", () => {
+        expect(parseTemplateFromUrl(new URL("https://cloud.agenta.ai/?template=%20%20"))).toBeNull()
+    })
+})
+
+describe("registry validation", () => {
+    it("resolves a known key to its template and validates it", () => {
+        expect(resolveTemplate(KNOWN_KEY)?.key).toBe(KNOWN_KEY)
+        expect(isValidTemplateKey(KNOWN_KEY)).toBe(true)
+    })
+
+    it("rejects an unknown or stale key without falling back to another template", () => {
+        expect(resolveTemplate("not-a-real-template")).toBeUndefined()
+        expect(isValidTemplateKey("not-a-real-template")).toBe(false)
+        expect(resolveTemplate(null)).toBeUndefined()
+        expect(isValidTemplateKey("")).toBe(false)
+    })
+})
+
+describe("storage round-trip and TTL", () => {
+    it("persists then reads back the key", () => {
+        installWindow("/")
+        persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})
+        expect(readTemplateFromStorage()?.key).toBe(KNOWN_KEY)
+    })
+
+    it("treats a key past its expiry as absent and removes it", () => {
+        installWindow("/")
+        persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now() - TEMPLATE_TTL_MS - 1})
+        expect(readTemplateFromStorage()).toBeNull()
+        // A second read confirms the expired entry was purged, not just filtered.
+        expect(readTemplateFromStorage()).toBeNull()
+    })
+})
+
+describe("captureTemplateFromUrl", () => {
+    it("captures the key from the URL and mirrors it into the atom", () => {
+        installWindow(`/?template=${KNOWN_KEY}`)
+        const url = new URL(`https://cloud.agenta.ai/?template=${KNOWN_KEY}`)
+        expect(captureTemplateFromUrl(url)).toBe(KNOWN_KEY)
+        expect(getDefaultStore().get(activeTemplateAtom)).toBe(KNOWN_KEY)
+        expect(readTemplateFromStorage()?.key).toBe(KNOWN_KEY)
+    })
+
+    it("stamps the capture time once and does not reset it on a later capture", () => {
+        installWindow(`/?template=${KNOWN_KEY}`)
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+        const url = new URL(`https://cloud.agenta.ai/?template=${KNOWN_KEY}`)
+        captureTemplateFromUrl(url)
+        const first = readTemplateFromStorage()?.capturedAt
+
+        vi.setSystemTime(new Date("2026-01-01T00:05:00Z"))
+        captureTemplateFromUrl(url)
+        expect(readTemplateFromStorage()?.capturedAt).toBe(first)
+    })
+
+    it("falls back to the stored key when the URL has none (region recapture leaves storage intact)", () => {
+        installWindow("/")
+        persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})
+        expect(captureTemplateFromUrl(new URL("https://cloud.agenta.ai/apps"))).toBe(KNOWN_KEY)
+        expect(getDefaultStore().get(activeTemplateAtom)).toBe(KNOWN_KEY)
+    })
+})
+
+describe("clearTemplate", () => {
+    it("removes storage, the atom, and the template URL param so it cannot resurrect", () => {
+        const win = installWindow(`/apps?template=${KNOWN_KEY}&other=1`)
+        persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})
+        getDefaultStore().set(activeTemplateAtom, KNOWN_KEY)
+
+        clearTemplate()
+
+        expect(readTemplateFromStorage()).toBeNull()
+        expect(getDefaultStore().get(activeTemplateAtom)).toBeNull()
+        expect(win.location.href).not.toContain("template=")
+        expect(win.location.href).toContain("other=1")
+        // A capture after clear must not bring the key back from the URL.
+        expect(captureTemplateFromUrl(new URL(win.location.href))).toBeNull()
+    })
+})
+
+describe("claimTemplate (at-most-once)", () => {
+    it("best-effort fallback: only the first caller wins when Web Locks is absent", async () => {
+        installWindow("/")
+        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
+        expect(await claimTemplate(KNOWN_KEY)).toBe(false)
+    })
+
+    it("Web Locks path: the lock serialises the claim so only one caller wins", async () => {
+        const locks = {
+            request: (_name: string, cb: () => boolean) => Promise.resolve(cb()),
+        }
+        installWindow("/", locks)
+        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
+        expect(await claimTemplate(KNOWN_KEY)).toBe(false)
+    })
+
+    it("a fresh key can be claimed again after the previous template is cleared", async () => {
+        installWindow("/")
+        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
+        clearTemplate()
+        expect(await claimTemplate(KNOWN_KEY)).toBe(true)
+    })
+})

--- a/web/oss/src/state/url/template.ts
+++ b/web/oss/src/state/url/template.ts
@@ -22,7 +22,12 @@ export interface PendingTemplate {
     capturedAt: number
 }
 
-export const activeTemplateAtom = atom<string | null>(null)
+interface TemplateClaim extends PendingTemplate {
+    status: "claimed" | "completed"
+    updatedAt: number
+}
+
+export const activeTemplateAtom = atom<PendingTemplate | null>(null)
 
 const validTemplateKeys = new Set(AGENT_TEMPLATES.map((template) => template.key))
 
@@ -40,11 +45,9 @@ export const parseTemplateFromUrl = (url: URL): string | null => {
     return key ? key : null
 }
 
-export const readTemplateFromStorage = (): PendingTemplate | null => {
-    if (!hasWindow()) return null
+const parsePendingTemplate = (raw: string | null): PendingTemplate | null => {
+    if (!raw) return null
     try {
-        const raw = window.localStorage.getItem(TEMPLATE_STORAGE_KEY)
-        if (!raw) return null
         const parsed = JSON.parse(raw)
         if (
             parsed &&
@@ -52,16 +55,52 @@ export const readTemplateFromStorage = (): PendingTemplate | null => {
             parsed.key.trim() &&
             typeof parsed.capturedAt === "number"
         ) {
-            // Expiry is measured from capture time, so a key that outlives its window drops itself.
-            if (Date.now() - parsed.capturedAt > TEMPLATE_TTL_MS) {
-                window.localStorage.removeItem(TEMPLATE_STORAGE_KEY)
-                return null
-            }
             return {key: parsed.key.trim(), capturedAt: parsed.capturedAt}
         }
     } catch (error) {
-        console.error("Failed to read pending template from storage:", error)
+        console.error("Failed to parse pending template from storage:", error)
     }
+    return null
+}
+
+const readStoredTemplateRecord = (): PendingTemplate | null => {
+    if (!hasWindow()) return null
+    try {
+        return parsePendingTemplate(window.localStorage.getItem(TEMPLATE_STORAGE_KEY))
+    } catch (error) {
+        console.error("Failed to read pending template from storage:", error)
+        return null
+    }
+}
+
+const isExpired = (pending: PendingTemplate): boolean =>
+    Date.now() - pending.capturedAt > TEMPLATE_TTL_MS
+
+const samePendingTemplate = (
+    left: PendingTemplate | null,
+    right: PendingTemplate | null,
+): boolean => !!left && !!right && left.key === right.key && left.capturedAt === right.capturedAt
+
+const removeTemplateParamFromCurrentUrl = (expectedKey?: string) => {
+    if (!hasWindow()) return
+    try {
+        const url = new URL(window.location.href)
+        if (expectedKey && parseTemplateFromUrl(url) !== expectedKey) return
+        if (!url.searchParams.has(TEMPLATE_URL_PARAM)) return
+        url.searchParams.delete(TEMPLATE_URL_PARAM)
+        window.history.replaceState(window.history.state, "", url.pathname + url.search + url.hash)
+    } catch (error) {
+        console.error("Failed to clear template params from URL:", error)
+    }
+}
+
+export const readTemplateFromStorage = (): PendingTemplate | null => {
+    const pending = readStoredTemplateRecord()
+    if (!pending) return null
+    if (!isExpired(pending)) return pending
+
+    persistTemplateToStorage(null)
+    removeTemplateParamFromCurrentUrl(pending.key)
     return null
 }
 
@@ -88,58 +127,71 @@ export const persistTemplateToStorage = (pending: PendingTemplate | null) => {
 export const captureTemplateFromUrl = (url: URL): string | null => {
     const store = getDefaultStore()
     const urlKey = parseTemplateFromUrl(url)
+    const storedRecord = readStoredTemplateRecord()
+
+    if (storedRecord && isExpired(storedRecord)) {
+        persistTemplateToStorage(null)
+        if (urlKey === storedRecord.key) {
+            removeTemplateParamFromCurrentUrl(storedRecord.key)
+            store.set(activeTemplateAtom, null)
+            return null
+        }
+    }
 
     if (urlKey) {
-        const stored = readTemplateFromStorage()
-        if (!stored || stored.key !== urlKey) {
-            persistTemplateToStorage({key: urlKey, capturedAt: Date.now()})
-        }
-        store.set(activeTemplateAtom, urlKey)
+        const stored = storedRecord && !isExpired(storedRecord) ? storedRecord : null
+        const pending = stored?.key === urlKey ? stored : {key: urlKey, capturedAt: Date.now()}
+        if (!samePendingTemplate(stored, pending)) persistTemplateToStorage(pending)
+        store.set(activeTemplateAtom, pending)
         return urlKey
     }
 
     const stored = readTemplateFromStorage()
-    store.set(activeTemplateAtom, stored?.key ?? null)
+    store.set(activeTemplateAtom, stored)
     return stored?.key ?? null
 }
 
-const TEMPLATE_URL_PARAMS = [TEMPLATE_URL_PARAM]
-
 /**
- * Fully forget a pending template: the atom, storage, the claim flag, and the `template` query
- * param. Stripping the URL param matters for the same reason it does for invites — the capture
- * re-reads the URL on every navigation and would otherwise resurrect the key from a stale param.
+ * Fully forget a pending template and its URL parameter. The completed claim is deliberately
+ * retained for a bounded time so a late tab that captured the same generation cannot recreate it.
+ * Passing the expected generation prevents an older async consumer from clearing a newer visit.
  */
-export const clearTemplate = () => {
+export const clearTemplate = (expected?: PendingTemplate) => {
     const store = getDefaultStore()
-    store.set(activeTemplateAtom, null)
-    persistTemplateToStorage(null)
+    const stored = readStoredTemplateRecord()
+    const shouldClear = !expected || samePendingTemplate(stored, expected)
+    if (shouldClear) persistTemplateToStorage(null)
 
-    if (!hasWindow()) return
+    const active = store.get(activeTemplateAtom)
+    if (!expected || samePendingTemplate(active, expected)) store.set(activeTemplateAtom, null)
+
+    if (shouldClear) removeTemplateParamFromCurrentUrl(expected?.key)
+}
+
+const readTemplateClaim = (): TemplateClaim | null => {
+    if (!hasWindow()) return null
     try {
+        const raw = window.localStorage.getItem(TEMPLATE_CLAIM_KEY)
+        if (!raw) return null
+        const parsed = JSON.parse(raw)
+        if (
+            parsed &&
+            typeof parsed.key === "string" &&
+            typeof parsed.capturedAt === "number" &&
+            (parsed.status === "claimed" || parsed.status === "completed") &&
+            typeof parsed.updatedAt === "number"
+        ) {
+            if (Date.now() - parsed.updatedAt <= TEMPLATE_TTL_MS) return parsed as TemplateClaim
+        }
         window.localStorage.removeItem(TEMPLATE_CLAIM_KEY)
     } catch (error) {
-        console.error("Failed to clear template claim:", error)
+        console.error("Failed to read template claim:", error)
     }
-    try {
-        const url = new URL(window.location.href)
-        let changed = false
-        TEMPLATE_URL_PARAMS.forEach((param) => {
-            if (url.searchParams.has(param)) {
-                url.searchParams.delete(param)
-                changed = true
-            }
-        })
-        if (changed) {
-            window.history.replaceState(
-                window.history.state,
-                "",
-                `${url.pathname}${url.search}${url.hash}`,
-            )
-        }
-    } catch (error) {
-        console.error("Failed to clear template params from URL:", error)
-    }
+    return null
+}
+
+const writeTemplateClaim = (claim: TemplateClaim) => {
+    window.localStorage.setItem(TEMPLATE_CLAIM_KEY, JSON.stringify(claim))
 }
 
 /**
@@ -150,13 +202,18 @@ export const clearTemplate = () => {
  * narrow case the guarantee softens from at-most-once to best-effort. Returns true only for the
  * caller that wins the claim.
  */
-export const claimTemplate = async (key: string): Promise<boolean> => {
+export const claimTemplate = async (pending: PendingTemplate): Promise<boolean> => {
     if (!hasWindow()) return false
 
     const compareAndSet = (): boolean => {
         try {
-            if (window.localStorage.getItem(TEMPLATE_CLAIM_KEY) === key) return false
-            window.localStorage.setItem(TEMPLATE_CLAIM_KEY, key)
+            const currentPending = readStoredTemplateRecord()
+            if (!samePendingTemplate(currentPending, pending) || isExpired(pending)) return false
+
+            const existingClaim = readTemplateClaim()
+            if (samePendingTemplate(existingClaim, pending)) return false
+
+            writeTemplateClaim({...pending, status: "claimed", updatedAt: Date.now()})
             return true
         } catch (error) {
             console.error("Failed to claim pending template:", error)
@@ -167,11 +224,37 @@ export const claimTemplate = async (key: string): Promise<boolean> => {
     const locks = (navigator as Navigator & {locks?: LockManager})?.locks
     if (locks?.request) {
         try {
-            return await locks.request(`pendingTemplate:${key}`, compareAndSet)
+            return await locks.request("pendingTemplate:" + pending.key, compareAndSet)
         } catch (error) {
             console.error("Web Locks claim failed, falling back to best-effort:", error)
             return compareAndSet()
         }
     }
     return compareAndSet()
+}
+
+/** Keep the winning generation visible to late tabs until its bounded claim expires. */
+export const completeTemplateClaim = async (pending: PendingTemplate): Promise<void> => {
+    if (!hasWindow()) return
+
+    const complete = () => {
+        try {
+            const claim = readTemplateClaim()
+            if (!claim || !samePendingTemplate(claim, pending)) return
+            writeTemplateClaim({...claim, status: "completed", updatedAt: Date.now()})
+        } catch (error) {
+            console.error("Failed to complete template claim:", error)
+        }
+    }
+
+    const locks = (navigator as Navigator & {locks?: LockManager})?.locks
+    if (locks?.request) {
+        try {
+            await locks.request("pendingTemplate:" + pending.key, complete)
+            return
+        } catch (error) {
+            console.error("Web Locks completion failed, falling back to best-effort:", error)
+        }
+    }
+    complete()
 }

--- a/web/oss/src/state/url/template.ts
+++ b/web/oss/src/state/url/template.ts
@@ -1,0 +1,177 @@
+import {atom, getDefaultStore} from "jotai"
+
+import {AGENT_TEMPLATES} from "../../components/pages/agent-home/assets/templates"
+import type {AgentTemplate} from "../../components/pages/agent-home/assets/templates"
+
+// Capture / storage / TTL / validation / claim for a website template deep-link. Kept out of
+// auth.ts so that module does not become a registry of unrelated features; auth.ts only calls in.
+
+const hasWindow = () => typeof window !== "undefined"
+
+export const TEMPLATE_URL_PARAM = "template"
+const TEMPLATE_STORAGE_KEY = "pendingTemplate"
+const TEMPLATE_CLAIM_KEY = "pendingTemplateClaim"
+
+// A real signup can include email verification and a provider round-trip, so the key must outlive
+// several minutes; thirty is comfortably longer than any real signup and short enough that a
+// forgotten key cannot create an agent later.
+export const TEMPLATE_TTL_MS = 30 * 60 * 1000
+
+export interface PendingTemplate {
+    key: string
+    capturedAt: number
+}
+
+export const activeTemplateAtom = atom<string | null>(null)
+
+const validTemplateKeys = new Set(AGENT_TEMPLATES.map((template) => template.key))
+
+/** Exact-match lookup against the app registry; an unknown or stale key resolves to undefined. */
+export const resolveTemplate = (key: string | null | undefined): AgentTemplate | undefined => {
+    if (!key) return undefined
+    return AGENT_TEMPLATES.find((template) => template.key === key)
+}
+
+export const isValidTemplateKey = (key: string | null | undefined): boolean =>
+    !!key && validTemplateKeys.has(key)
+
+export const parseTemplateFromUrl = (url: URL): string | null => {
+    const key = url.searchParams.get(TEMPLATE_URL_PARAM)?.trim()
+    return key ? key : null
+}
+
+export const readTemplateFromStorage = (): PendingTemplate | null => {
+    if (!hasWindow()) return null
+    try {
+        const raw = window.localStorage.getItem(TEMPLATE_STORAGE_KEY)
+        if (!raw) return null
+        const parsed = JSON.parse(raw)
+        if (
+            parsed &&
+            typeof parsed.key === "string" &&
+            parsed.key.trim() &&
+            typeof parsed.capturedAt === "number"
+        ) {
+            // Expiry is measured from capture time, so a key that outlives its window drops itself.
+            if (Date.now() - parsed.capturedAt > TEMPLATE_TTL_MS) {
+                window.localStorage.removeItem(TEMPLATE_STORAGE_KEY)
+                return null
+            }
+            return {key: parsed.key.trim(), capturedAt: parsed.capturedAt}
+        }
+    } catch (error) {
+        console.error("Failed to read pending template from storage:", error)
+    }
+    return null
+}
+
+export const persistTemplateToStorage = (pending: PendingTemplate | null) => {
+    if (!hasWindow()) return
+    try {
+        if (pending && pending.key) {
+            window.localStorage.setItem(TEMPLATE_STORAGE_KEY, JSON.stringify(pending))
+        } else {
+            window.localStorage.removeItem(TEMPLATE_STORAGE_KEY)
+        }
+    } catch (error) {
+        console.error("Failed to persist pending template to storage:", error)
+    }
+}
+
+/**
+ * Capture the template key from the URL, mirroring the invite capture, and mirror it into the
+ * shared atom. The capture time is stamped once, on the first sighting of a key, so the TTL
+ * measures from arrival and a key that survives many navigations still ages. This also runs on a
+ * regional host after a region redirect: the query string is preserved across the switch but
+ * localStorage is not shared between hosts, so the key is re-saved under the host the user lands on.
+ */
+export const captureTemplateFromUrl = (url: URL): string | null => {
+    const store = getDefaultStore()
+    const urlKey = parseTemplateFromUrl(url)
+
+    if (urlKey) {
+        const stored = readTemplateFromStorage()
+        if (!stored || stored.key !== urlKey) {
+            persistTemplateToStorage({key: urlKey, capturedAt: Date.now()})
+        }
+        store.set(activeTemplateAtom, urlKey)
+        return urlKey
+    }
+
+    const stored = readTemplateFromStorage()
+    store.set(activeTemplateAtom, stored?.key ?? null)
+    return stored?.key ?? null
+}
+
+const TEMPLATE_URL_PARAMS = [TEMPLATE_URL_PARAM]
+
+/**
+ * Fully forget a pending template: the atom, storage, the claim flag, and the `template` query
+ * param. Stripping the URL param matters for the same reason it does for invites — the capture
+ * re-reads the URL on every navigation and would otherwise resurrect the key from a stale param.
+ */
+export const clearTemplate = () => {
+    const store = getDefaultStore()
+    store.set(activeTemplateAtom, null)
+    persistTemplateToStorage(null)
+
+    if (!hasWindow()) return
+    try {
+        window.localStorage.removeItem(TEMPLATE_CLAIM_KEY)
+    } catch (error) {
+        console.error("Failed to clear template claim:", error)
+    }
+    try {
+        const url = new URL(window.location.href)
+        let changed = false
+        TEMPLATE_URL_PARAMS.forEach((param) => {
+            if (url.searchParams.has(param)) {
+                url.searchParams.delete(param)
+                changed = true
+            }
+        })
+        if (changed) {
+            window.history.replaceState(
+                window.history.state,
+                "",
+                `${url.pathname}${url.search}${url.hash}`,
+            )
+        }
+    } catch (error) {
+        console.error("Failed to clear template params from URL:", error)
+    }
+}
+
+/**
+ * At-most-once claim. localStorage has no atomic compare-and-set, so two tabs could both read a
+ * key as unclaimed and both create. The Web Locks API serialises the read-claim-write across
+ * same-origin tabs, so only one caller can move the key from unclaimed to claimed. Where the API
+ * is unavailable the claim degrades to a best-effort local-storage compare-and-set, and in that
+ * narrow case the guarantee softens from at-most-once to best-effort. Returns true only for the
+ * caller that wins the claim.
+ */
+export const claimTemplate = async (key: string): Promise<boolean> => {
+    if (!hasWindow()) return false
+
+    const compareAndSet = (): boolean => {
+        try {
+            if (window.localStorage.getItem(TEMPLATE_CLAIM_KEY) === key) return false
+            window.localStorage.setItem(TEMPLATE_CLAIM_KEY, key)
+            return true
+        } catch (error) {
+            console.error("Failed to claim pending template:", error)
+            return false
+        }
+    }
+
+    const locks = (navigator as Navigator & {locks?: LockManager})?.locks
+    if (locks?.request) {
+        try {
+            return await locks.request(`pendingTemplate:${key}`, compareAndSet)
+        } catch (error) {
+            console.error("Web Locks claim failed, falling back to best-effort:", error)
+            return compareAndSet()
+        }
+    }
+    return compareAndSet()
+}


### PR DESCRIPTION
## What a user sees

A visitor on the marketing website clicks "Use this template" on a template card. They land on the app, sign up if they need an account, and arrive on onboarding with that template's prompt already staged: the empty-chat screen shows the prompt in a "We'll start with" card above a Start button. Nothing runs until they press Start. If they are already signed in, the same thing happens right away without a signup step.

This pull request is the app side of that flow. The website-side change, which adds `?template=<key>` to each card link, ships separately.

## How it works

The design is documented in `docs/design/website-templates-deeplink/` (plan PR #5422). The app reuses the exact technique the workspace-invite flow already uses to survive a full signup.

- **Capture.** A new module, `web/oss/src/state/url/template.ts`, reads the `template` query parameter and saves it to local storage with a capture-time timestamp. It is called from `syncAuthStateFromUrl`, right next to the invite capture, so both are read from the same URL on every navigation. The capture module is kept separate from `auth.ts` so that file does not become a registry of unrelated features.
- **Runtime validation.** The URL parameter is user-controlled, so the key is validated by exact lookup against the app template registry (`templates.ts`) at consume time. An unknown or stale key is ignored and cleared from storage, never creates an agent, and never falls back to another template.
- **Consume.** A new hook, `useConsumePendingTemplate`, is mounted in `/apps` above both first-run surfaces (the native onboarding playground for new users, the agent home page for returning users), so the create happens wherever the user lands. It waits for a confirmed workspace and project, claims the key, then calls `useCreateAgent({name, seedMessage, autoSendSeed: false})` so the seed renders behind a Start button rather than auto-sending.
- **At most once.** Local storage has no atomic compare-and-set, so the claim runs inside the Web Locks API (`navigator.locks.request`), which serializes the read-claim-write across same-origin tabs. Where the API is unavailable the claim degrades to a documented best-effort local-storage compare-and-set.
- **Region redirect.** The cloud can redirect a visitor from `cloud.agenta.ai` to `eu.cloud.agenta.ai` or `us.cloud.agenta.ai`, which drops local storage but preserves the query string. Because capture runs on every navigation, it re-runs on the regional host and re-saves the key there, so the flow works on both the US and EU clouds.
- **Analytics.** The consume path fires `first_agent_intent` events (source `website_template`) for the claim, a successful create, a failed create, and an invalid key, reusing the existing PostHog helper.

## Files

- `web/oss/src/state/url/template.ts` (new) — capture, storage, TTL, registry validation, clear, Web Locks claim.
- `web/oss/src/state/url/template.test.ts` (new) — unit tests.
- `web/oss/src/state/url/auth.ts` — one call to `captureTemplateFromUrl` next to the invite capture.
- `web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts` (new) — the consume hook.
- `web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/index.tsx` — mounts the consume hook.
- `web/oss/src/components/pages/agent-home/assets/onboardingAnalytics.ts` — adds the `website_template` analytics source.

## Tests

Unit tests (`template.test.ts`, 14 cases, all green) cover: parsing the parameter; storage round-trip; TTL expiry measured from capture time; capture stamping the time once and not resetting it; region recapture falling back to stored; clear removing storage, the atom, and the URL parameter so it cannot resurrect; registry validation rejecting an unknown key without substituting another; and the at-most-once claim under both the Web Locks path and the best-effort fallback.

These co-located `oss/src/**/*.test.ts` files follow the existing convention (`templates.test.ts`, `lastAuthMethod.test.ts`) and run under vitest. Note that `web/oss` has no vitest suite wired into CI today, so like the existing co-located tests they run via a direct vitest invocation, not the CI unit layer.

## QA

Live browser QA of the full signup flow was not performed (a headless signup E2E is not feasible in this environment). Wire-level walkthrough to verify manually on the local or cloud stack:

1. Open `https://<host>/?template=pr-reviewer` while signed out. In dev tools, confirm `localStorage.pendingTemplate` holds `{"key":"pr-reviewer","capturedAt":<ts>}` and the `template` param stays in the URL through the auth redirect.
2. Complete signup. On landing at `/w/<ws>/p/<proj>/apps`, confirm you are taken into a new agent's playground with the PR-reviewer prompt shown in the "We'll start with" card above a Start button, with no assistant response yet.
3. Confirm `localStorage.pendingTemplate` is cleared and the `template` param is gone from the URL.
4. Open `/?template=not-a-real-template`: confirm no agent is created, normal onboarding proceeds, and the stored key is cleared.
5. Region switch: on `cloud.agenta.ai/?template=pr-reviewer`, trigger a region switch and confirm the parameter survives to the regional host and is recaptured there.

An automated end-to-end Playwright test for the native-onboarding happy path is specified in the design plan and belongs with the website-side change that completes the flow.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB
