### PR TITLE
test(web): migrate session-mounts-store test to the object-param mountFilesQueryFamily

### DIFF
--- a/web/packages/agenta-entities/tests/unit/session-mounts-store.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-mounts-store.test.ts
@@ -69,11 +69,11 @@ describe("session mounts store", () => {
         const {store} = makeStore()
 
         const unsubMounts = store.sub(sessionMountsQueryFamily(SESSION_ID), () => {})
-        const unsubFiles = store.sub(mountFilesQueryFamily(MOUNT.id), () => {})
+        const unsubFiles = store.sub(mountFilesQueryFamily({mountId: MOUNT.id}), () => {})
         try {
             await waitForAssertion(() => {
                 expect(store.get(sessionMountsQueryFamily(SESSION_ID)).data).toEqual([MOUNT])
-                expect(store.get(mountFilesQueryFamily(MOUNT.id)).data).toEqual([
+                expect(store.get(mountFilesQueryFamily({mountId: MOUNT.id})).data).toEqual([
                     {path: "notes.md", size: 12, is_folder: false},
                 ])
             })
@@ -91,11 +91,11 @@ describe("session mounts store", () => {
         const {store, queryClient} = makeStore()
 
         const unsubMounts = store.sub(sessionMountsQueryFamily(SESSION_ID), () => {})
-        const unsubFiles = store.sub(mountFilesQueryFamily(MOUNT.id), () => {})
+        const unsubFiles = store.sub(mountFilesQueryFamily({mountId: MOUNT.id}), () => {})
         try {
             await waitForAssertion(() => {
                 expect(store.get(sessionMountsQueryFamily(SESSION_ID)).data).toEqual([MOUNT])
-                expect(store.get(mountFilesQueryFamily(MOUNT.id)).data).toEqual([])
+                expect(store.get(mountFilesQueryFamily({mountId: MOUNT.id})).data).toEqual([])
             })
 
             // The turn wrote a file; the next fetch returns it.
@@ -103,7 +103,7 @@ describe("session mounts store", () => {
             store.set(revalidateSessionMountsAtom, SESSION_ID)
 
             await waitForAssertion(() => {
-                expect(store.get(mountFilesQueryFamily(MOUNT.id)).data).toEqual([
+                expect(store.get(mountFilesQueryFamily({mountId: MOUNT.id})).data).toEqual([
                     {path: "new.txt", size: 1, is_folder: false},
                 ])
             })
@@ -127,7 +127,7 @@ describe("session mounts store", () => {
         ).toBe(true)
 
         // ...and the next subscriber (re-expanding the drive) refetches.
-        const unsubAgain = store.sub(mountFilesQueryFamily(MOUNT.id), () => {})
+        const unsubAgain = store.sub(mountFilesQueryFamily({mountId: MOUNT.id}), () => {})
         try {
             await waitForAssertion(() => {
                 expect(queryMountFilesMock.mock.calls.length).toBeGreaterThan(callsBefore)


### PR DESCRIPTION
## Symptom

Two unit tests fail on main's own tip (verified in a clean clone of `origin/main`), which turns the required **run-web-unit-tests** check red for every open PR:

```
FAIL tests/unit/session-mounts-store.test.ts
  > fetches a session's mounts and one file tree per mount, shared by key
  > revalidate refetches ACTIVE queries and marks known mount files stale
AssertionError: expected undefined to deeply equal [...]
```

Both assert on `mountFilesQueryFamily(...)` data, which stays `undefined` forever.

## Cause

The drive-surfaces data layer (#5400, commit e2803844a, landed via the v0.105.7 release merge) changed `mountFilesQueryFamily`'s parameter from a plain `mountId: string` to `{mountId, includeGitignored?}` so the git-ignored toggle can key its own cache entry. All product callers were migrated (`useSessionDrive.ts`, `useLazyDriveTree.tsx`), but this unit test still passes the bare string. Destructuring `{mountId}` from a string yields `undefined`, so the query's `enabled` guard stays false, the fetch never runs, and `data` is `undefined`.

The store's behavior is correct; only the test was left on the old contract.

## Fix

Update the test's six `mountFilesQueryFamily(MOUNT.id)` call sites to `mountFilesQueryFamily({mountId: MOUNT.id})`. No product code changes.

## Tests

Full `agenta-entities` unit suite:

```
Test Files  63 passed (63)
     Tests  904 passed (904)
```

`pnpm exec tsc --noEmit` in the package: clean.
