### PR TITLE
feat(frontend): approval friction UX and context-driven config sections (Arda's port)

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -3,8 +3,10 @@ import {memo, useEffect, useMemo, useRef, useState} from "react"
 import {HeightCollapse} from "@agenta/ui"
 import {ArrowSquareOut, CaretRight, ShieldCheck} from "@phosphor-icons/react"
 import type {ToolUIPart, UIMessage} from "ai"
-import {Button, Typography} from "antd"
+import {Button, Switch, Typography} from "antd"
 import {useAtomValue} from "jotai"
+
+import {useAlwaysAllowTool} from "@/oss/hooks/useAlwaysAllowTool"
 
 import {partToolName, resolveToolDisplay} from "../assets/toolDisplay"
 import {chatPanelMaximizedAtom} from "../state/panelLayout"
@@ -125,20 +127,46 @@ const ApprovalDock = ({
     className,
 }: ApprovalDockProps) => {
     const open = approvals.length > 0
-    // Latch the last non-empty set so the card stays visible while the dock animates closed — a
-    // leave transition needs its content to persist through the height collapse.
+    // A resolve can answer SEVERAL gates at once — "Approve all", or "Approve" with the always-allow
+    // toggle on (which also clears that tool's other pending gates, since the user asked not to be
+    // prompted for it again). Each response settles asynchronously (the SDK's serial job queue), so
+    // the pending set shrinks across renders; without a latch the dock would step through the batch
+    // ("1 of 3 → 1 of 2"). `resolvingIds` holds the gates we fired responses for; while any is still
+    // pending we FREEZE the shown set so the card holds steady and the dock closes in one step (or,
+    // if only some gates were covered, then steps to the uncovered remainder).
+    const [resolvingIds, setResolvingIds] = useState<readonly string[] | null>(null)
+    const [resolveSource, setResolveSource] = useState<"all" | "one" | null>(null)
+    const resolving =
+        resolvingIds !== null && approvals.some((a) => resolvingIds.includes(a.approvalId))
+    // Latch the last non-empty set so the card stays visible while the dock animates closed (a leave
+    // transition needs its content through the height collapse) AND so a multi-gate resolve doesn't
+    // step through the batch.
     const shownRef = useRef(approvals)
-    if (open) shownRef.current = approvals
+    if (open && !resolving) shownRef.current = approvals
     const shown = shownRef.current
     const current = shown[0]
     const count = shown.length
 
     const [responding, setResponding] = useState(false)
+    // Armed "always allow this tool" intent for the current gate — applied only when the user
+    // clicks Approve, never on its own (the switch must not progress the flow).
+    const [alwaysAllowArmed, setAlwaysAllowArmed] = useState(false)
 
-    // The current gate changed (we answered one, the next slid in) — re-enable.
+    // The current gate changed (we answered one, the next slid in) — re-enable and disarm. Held
+    // during a resolve (current is frozen), so it fires only on a real step or a new batch.
     useEffect(() => {
         setResponding(false)
+        setResolveSource(null)
+        setAlwaysAllowArmed(false)
     }, [current?.approvalId])
+
+    // Once every gate we fired has settled (left the pending set), drop the latch — the dock then
+    // closes if nothing remains, or re-latches onto the uncovered gates (a mixed-tool batch).
+    useEffect(() => {
+        if (resolvingIds !== null && !approvals.some((a) => resolvingIds.includes(a.approvalId))) {
+            setResolvingIds(null)
+        }
+    }, [approvals, resolvingIds])
 
     // Friendly bodies are Chat-mode (maximized) sugar and need a revision to diff against;
     // Build and the entityId-less host keep the exact-payload card.
@@ -152,28 +180,54 @@ const ApprovalDock = ({
     // A source badge we can state factually from the tool name — not a guessed risk level.
     const source = friendly?.kind === "mcp" ? "MCP tool" : null
 
+    // "Always allow this tool": writes a config permission so the runner stops gating this tool
+    // (per-tool `permission` for gateway/custom-function tools; `harness.permissions.allow` for
+    // harness builtins like bash). Platform ops (commit_revision, schedules) and MCP are not
+    // eligible, so they always stay gated. The write happens on APPROVE (see `respond`), never when
+    // the switch is toggled — the switch only arms the intent. buildAgentRequest re-reads the draft
+    // on resume, so the grant takes effect for the current run and every future one.
+    const {infoFor, grant} = useAlwaysAllowTool(entityId)
+    const grantInfo = current ? infoFor(current.toolName) : null
+    const canAlwaysAllow = Boolean(grantInfo?.eligible && !grantInfo.alreadyAllowed)
+
     const respond = (approved: boolean) => {
         if (responding || !current) return
         setResponding(true)
+        setResolveSource("one")
+        // Apply the armed grant only on approve — never on deny, and never from the switch alone.
+        if (approved && alwaysAllowArmed && canAlwaysAllow) {
+            grant(current.toolName)
+            // "Always allow <tool>" also clears this tool's OTHER pending gates in the batch: the
+            // user said they don't want to be prompted for it again, so its siblings auto-approve
+            // in one step instead of making them click through 2/3, 3/3. Other tools stay gated and
+            // are shown next.
+            const covered = shown.filter((a) => a.toolName === current.toolName)
+            if (covered.length > 1) {
+                setResolvingIds(covered.map((a) => a.approvalId))
+                covered.forEach((a) => onApprovalResponse({id: a.approvalId, approved: true}))
+                return
+            }
+        }
         onApprovalResponse({id: current.approvalId, approved})
     }
     const approveAll = () => {
         if (responding) return
         setResponding(true)
+        setResolveSource("all")
+        if (alwaysAllowArmed && canAlwaysAllow && current) grant(current.toolName)
+        // Freeze the card so the dock doesn't step through the batch as each response settles — it
+        // holds "1 of N" and closes once all are answered (see `resolvingIds`).
+        setResolvingIds(shown.map((a) => a.approvalId))
         shown.forEach((a) => onApprovalResponse({id: a.approvalId, approved: true}))
     }
 
-    // Always mounted; enter + leave animate via the grid-rows 0fr↔1fr height collapse (+ opacity),
-    // the same idiom as the reasoning block and composer attachments. `inert` while closed drops the
-    // (clipped, latched) card from tab order + a11y so a keyboard user can't reach hidden buttons.
+    // Always mounted; enter + leave animate via the shared HeightCollapse (CSS height + fade,
+    // reduced-motion-proof) — the same primitive the queue, connect banner, and config sections use.
+    // `inert` while closed drops the (clipped, latched) card from tab order + a11y so a keyboard user
+    // can't reach hidden buttons.
     return (
-        <div
-            className={`grid transition-[grid-template-rows,opacity] duration-200 ease-out ${
-                open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
-            } ${className ?? ""}`}
-            inert={!open}
-        >
-            <div className="min-h-0 overflow-hidden">
+        <HeightCollapse open={open} className={className} durationMs={240} fade inert>
+            <div className="min-h-0">
                 {current ? (
                     // The friendly two-pane body needs more air than the one-line payload card.
                     <div
@@ -275,7 +329,11 @@ const ApprovalDock = ({
                             ) : null}
                             <div className="ml-auto flex items-center gap-1.5">
                                 {count > 1 ? (
-                                    <Button disabled={responding} onClick={approveAll}>
+                                    <Button
+                                        loading={responding && resolveSource === "all"}
+                                        disabled={responding}
+                                        onClick={approveAll}
+                                    >
                                         Approve all
                                     </Button>
                                 ) : null}
@@ -284,17 +342,44 @@ const ApprovalDock = ({
                                 </Button>
                                 <Button
                                     type="primary"
-                                    loading={responding}
+                                    disabled={responding}
+                                    loading={responding && resolveSource === "one"}
                                     onClick={() => respond(true)}
                                 >
                                     {renderer?.approveLabel ?? "Approve"}
                                 </Button>
                             </div>
                         </div>
+
+                        {/* Always-allow: arms a config write-through so this tool stops asking. The
+                            switch only ARMS the intent (it must not progress the flow); the grant is
+                            applied when the user clicks Approve. Shown only for gateway /
+                            custom-function / builtin gates that aren't already allowed. */}
+                        {canAlwaysAllow ? (
+                            <div className="flex items-center gap-2 border-0 border-t border-solid border-colorBorderSecondary pt-2.5">
+                                <Switch
+                                    checked={alwaysAllowArmed}
+                                    disabled={responding}
+                                    onChange={setAlwaysAllowArmed}
+                                />
+                                <div className="flex min-w-0 flex-col">
+                                    <Text className="!text-xs">
+                                        Always allow{" "}
+                                        <span className="font-medium">
+                                            {friendly?.label ?? current.toolName}
+                                        </span>{" "}
+                                        for this agent
+                                    </Text>
+                                    <Text type="secondary" className="!text-[11px]">
+                                        Applies when you approve; commit to use it in triggers.
+                                    </Text>
+                                </div>
+                            </div>
+                        ) : null}
                     </div>
                 ) : null}
             </div>
-        </div>
+        </HeightCollapse>
     )
 }
 

--- a/web/oss/src/components/AgentChatSlice/components/RevealCollapse.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/RevealCollapse.tsx
@@ -1,12 +1,14 @@
 import {type ReactNode} from "react"
 
+import {HeightCollapse} from "@agenta/ui"
+
 /**
- * Appear/disappear collapse for chat-composer chrome (connect-model banner, queued messages, HITL dock).
- * Animates height 0↔auto via the grid `0fr`↔`1fr` trick plus opacity — the same idiom the ApprovalDock
- * and the config sections use, so everything that enters/leaves the composer region does so consistently.
- * Content is clipped by `overflow-hidden` while collapsing; `inert` drops the hidden subtree from tab
- * order + a11y. Callers that render nothing when "closed" should latch their last content so it persists
- * through the leave (see `ConnectModelBanner`).
+ * Appear/disappear collapse for chat-composer chrome (connect-model banner, queued messages, HITL
+ * dock). A thin wrapper over the shared {@link HeightCollapse} with `fade` + `inert`, so everything
+ * that enters/leaves the composer region collapses the SAME CSS-native, reduced-motion-proof way as
+ * the config accordion sections and the config-pane notices — one language, no `motion-safe` gate.
+ * Callers that render nothing when "closed" should latch their last content so it persists through
+ * the leave (see `ConnectModelBanner`).
  */
 const RevealCollapse = ({
     open,
@@ -17,14 +19,9 @@ const RevealCollapse = ({
     className?: string
     children: ReactNode
 }) => (
-    <div
-        className={`grid motion-safe:transition-[grid-template-rows,opacity] motion-safe:duration-300 motion-safe:ease-out ${
-            open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
-        } ${className ?? ""}`}
-        inert={!open}
-    >
-        <div className="min-h-0 overflow-hidden">{children}</div>
-    </div>
+    <HeightCollapse open={open} className={className} durationMs={240} fade inert>
+        {children}
+    </HeightCollapse>
 )
 
 export default RevealCollapse

--- a/web/oss/src/components/Playground/Components/AgentCommitNotice.tsx
+++ b/web/oss/src/components/Playground/Components/AgentCommitNotice.tsx
@@ -1,49 +1,28 @@
-import {useEffect, useLayoutEffect, useRef, useState} from "react"
+import {useLayoutEffect, useRef, useState} from "react"
 
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {agentSelfCommitSignalAtom} from "@agenta/shared/state"
+import {HeightCollapse} from "@agenta/ui"
 import {Robot} from "@phosphor-icons/react"
 import {Button} from "antd"
 import {useAtom, useAtomValue} from "jotai"
 
 /**
- * Agent self-commit notice, rendered by MainLayout as the LAST row of the config pane's
- * flex column — BELOW the scrolling sections, so it is pinned to the pane's bottom edge
- * regardless of content height or scroll position, and can never shift the sections.
- * Shown while the shared signal targets the displayed revision; Dismiss clears it (and
- * the teal section dots with it). Enters/exits with an opacity + rise transition.
+ * Agent self-commit notice, rendered by MainLayout as the LAST row of the config pane's flex column
+ * — BELOW the scrolling sections, so it is pinned to the pane's bottom edge regardless of content
+ * height or scroll position, and can never shift the sections. Shown while the shared signal targets
+ * the displayed revision; Dismiss clears it (and the teal section dots with it). Collapses in/out via
+ * the shared {@link HeightCollapse} (fade + a small Y slide) — the same CSS-native, reduced-motion-
+ * proof primitive the composer dock and the draft-change notice use.
  */
 const AgentCommitNotice = ({revisionId}: {revisionId: string}) => {
     const [signal, setSignal] = useAtom(agentSelfCommitSignalAtom)
     const active = Boolean(signal && revisionId && signal.revisionId === revisionId)
 
-    // Latch the last matching signal so the content stays rendered through the exit fade.
+    // Latch the last matching signal so the content stays rendered through the collapse-out.
     const lastSignalRef = useRef(signal)
     if (signal && active) lastSignalRef.current = signal
     const shownSignal = lastSignalRef.current
-
-    // Enter/exit: `render` keeps the node mounted through the exit transition; `shown`
-    // drives the opacity/translate classes. Double rAF so the hidden state paints first.
-    const [render, setRender] = useState(active)
-    const [shown, setShown] = useState(false)
-    useEffect(() => {
-        if (active) {
-            setRender(true)
-            // Cancel BOTH frames: killing only the outer id lets an already-scheduled inner
-            // rAF flash the notice back in after the hide branch ran.
-            let innerRaf = 0
-            const raf = requestAnimationFrame(() => {
-                innerRaf = requestAnimationFrame(() => setShown(true))
-            })
-            return () => {
-                cancelAnimationFrame(raf)
-                cancelAnimationFrame(innerRaf)
-            }
-        }
-        setShown(false)
-        const t = window.setTimeout(() => setRender(false), 240)
-        return () => window.clearTimeout(t)
-    }, [active])
 
     // Commit message comes from the committed revision entity (the stream part carries only
     // id/version) — also covers the notice surviving a reload while the signal is set.
@@ -66,63 +45,61 @@ const AgentCommitNotice = ({revisionId}: {revisionId: string}) => {
         const el = messageRef.current
         if (!el || expanded) return
         setOverflowing(el.scrollHeight - el.clientHeight > 1)
-    }, [commitMessage, expanded, render])
+    }, [commitMessage, expanded, active])
 
-    if (!render || !shownSignal) return null
-
-    const rawVersion = shownSignal.version ? String(shownSignal.version) : null
+    const rawVersion = shownSignal?.version ? String(shownSignal.version) : null
     const version = rawVersion ? (rawVersion.startsWith("v") ? rawVersion : `v${rawVersion}`) : null
 
     return (
-        <div
-            className={`shrink-0 border-0 border-t border-solid border-colorBorderSecondary bg-[var(--ag-colorBgElevated)] px-4 py-2.5 motion-safe:transition-[opacity,transform] motion-safe:duration-200 motion-safe:ease-out ${
-                shown ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0"
-            }`}
-        >
-            <div className="flex items-start justify-between gap-3">
-                <div className="flex min-w-0 items-start gap-2.5">
-                    <span className="mt-px flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--ag-c-13C2C2,#13c2c2)_15%,transparent)] text-[var(--ag-c-13C2C2,#13c2c2)]">
-                        <Robot size={15} weight="fill" />
-                    </span>
-                    <div className="flex min-w-0 flex-col gap-0.5">
-                        <span className="text-xs font-medium leading-5 text-colorText">
-                            Agent updated this configuration{version ? ` in ${version}` : ""} —
-                            changed sections are marked
-                        </span>
-                        {commitMessage ? (
-                            <div className="flex min-w-0 flex-col items-start gap-0.5">
-                                <p
-                                    ref={messageRef}
-                                    className={`m-0 min-w-0 break-words text-[11px] leading-4 text-colorTextSecondary ${
-                                        expanded
-                                            ? "max-h-24 overflow-y-auto pr-1"
-                                            : "line-clamp-2 overflow-hidden"
-                                    }`}
-                                >
-                                    “{commitMessage}”
-                                </p>
-                                {overflowing || expanded ? (
-                                    <button
-                                        type="button"
-                                        className="cursor-pointer border-0 bg-transparent p-0 text-[11px] font-medium leading-4 text-colorPrimary hover:underline"
-                                        onClick={() => setExpanded((v) => !v)}
-                                    >
-                                        {expanded ? "Show less" : "Show more"}
-                                    </button>
+        <HeightCollapse open={active} durationMs={240} fade slideY={12} inert className="shrink-0">
+            {shownSignal ? (
+                <div className="border-0 border-t border-solid border-colorBorderSecondary bg-[var(--ag-colorBgElevated)] px-4 py-2.5">
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 items-start gap-2.5">
+                            <span className="mt-px flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--ag-c-13C2C2,#13c2c2)_15%,transparent)] text-[var(--ag-c-13C2C2,#13c2c2)]">
+                                <Robot size={15} weight="fill" />
+                            </span>
+                            <div className="flex min-w-0 flex-col gap-0.5">
+                                <span className="text-xs font-medium leading-5 text-colorText">
+                                    Agent updated this configuration
+                                    {version ? ` in ${version}` : ""} — changed sections are marked
+                                </span>
+                                {commitMessage ? (
+                                    <div className="flex min-w-0 flex-col items-start gap-0.5">
+                                        <p
+                                            ref={messageRef}
+                                            className={`m-0 min-w-0 break-words text-[11px] leading-4 text-colorTextSecondary ${
+                                                expanded
+                                                    ? "max-h-24 overflow-y-auto pr-1"
+                                                    : "line-clamp-2 overflow-hidden"
+                                            }`}
+                                        >
+                                            “{commitMessage}”
+                                        </p>
+                                        {overflowing || expanded ? (
+                                            <button
+                                                type="button"
+                                                className="cursor-pointer border-0 bg-transparent p-0 text-[11px] font-medium leading-4 text-colorPrimary hover:underline"
+                                                onClick={() => setExpanded((v) => !v)}
+                                            >
+                                                {expanded ? "Show less" : "Show more"}
+                                            </button>
+                                        ) : null}
+                                    </div>
                                 ) : null}
                             </div>
-                        ) : null}
+                        </div>
+                        <Button
+                            type="text"
+                            className="!h-6 shrink-0 !px-2 !text-xs"
+                            onClick={() => setSignal(null)}
+                        >
+                            Dismiss
+                        </Button>
                     </div>
                 </div>
-                <Button
-                    type="text"
-                    className="!h-6 shrink-0 !px-2 !text-xs"
-                    onClick={() => setSignal(null)}
-                >
-                    Dismiss
-                </Button>
-            </div>
-        </div>
+            ) : null}
+        </HeightCollapse>
     )
 }
 

--- a/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
+++ b/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
@@ -1,0 +1,88 @@
+import {useEffect, useRef} from "react"
+
+import {draftConfigChangeSignalAtom} from "@agenta/shared/state"
+import {HeightCollapse} from "@agenta/ui"
+import {ArrowCounterClockwise, ShieldCheck, X} from "@phosphor-icons/react"
+import {Button} from "antd"
+import {useAtom} from "jotai"
+
+import {useAlwaysAllowTool} from "@/oss/hooks/useAlwaysAllowTool"
+
+/**
+ * "Always allowed" notice — the draft-blue counterpart of {@link AgentCommitNotice}, pinned to the
+ * bottom of the config pane. Surfaces a per-tool permission the user just granted from the approval
+ * dock, with Undo, CONTAINED to the config panel (where the write lands) rather than a floating
+ * toast that pulls focus away. Reads the same draft-change signal that pulses the affected section.
+ * Undo reverts the write and clears; Dismiss just clears. Collapses in/out via the shared
+ * {@link HeightCollapse} (fade + a small Y slide) — the same CSS-native, reduced-motion-proof
+ * primitive the composer dock, queued messages, and accordion sections use.
+ */
+const AlwaysAllowedNotice = ({revisionId}: {revisionId: string}) => {
+    const [signal, setSignal] = useAtom(draftConfigChangeSignalAtom)
+    const active = Boolean(
+        signal &&
+        revisionId &&
+        signal.revisionId === revisionId &&
+        signal.origin === "approval-dock",
+    )
+    const {revoke} = useAlwaysAllowTool(revisionId)
+
+    // Latch the last matching signal so content stays rendered through the collapse-out.
+    const lastRef = useRef(signal)
+    if (signal && active) lastRef.current = signal
+    const shown = lastRef.current
+
+    // Auto-dismiss 5s after the change (keyed on `at`, so a fresh grant restarts the clock). The
+    // persistent section draft dot is independent of this signal, so it stays after the banner goes.
+    useEffect(() => {
+        if (!active) return
+        const t = window.setTimeout(() => setSignal(null), 5000)
+        return () => window.clearTimeout(t)
+    }, [active, signal?.at, setSignal])
+
+    const label = shown?.label ?? "this tool"
+
+    return (
+        <HeightCollapse open={active} durationMs={260} fade slideY={16} inert className="shrink-0">
+            <div className="border-0 border-t border-solid border-[color-mix(in_srgb,var(--ag-colorPrimary)_35%,var(--ag-colorBorderSecondary))] bg-[color-mix(in_srgb,var(--ag-colorPrimary)_9%,var(--ag-colorBgElevated))] px-4 py-2.5">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-start gap-2.5">
+                        <span className="mt-px flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--ag-colorPrimary)_14%,transparent)] text-colorPrimary">
+                            <ShieldCheck size={15} weight="fill" />
+                        </span>
+                        <div className="flex min-w-0 flex-col gap-0.5">
+                            <span className="truncate text-xs font-medium leading-5 text-colorText">
+                                Always allowing <span className="font-semibold">{label}</span>
+                            </span>
+                            <span className="text-[11px] leading-4 text-colorTextSecondary">
+                                Saved to this draft — this tool won&apos;t ask again.
+                            </span>
+                        </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                        <Button
+                            type="text"
+                            className="!h-6 !gap-1 !rounded-md !px-2 !text-xs !font-medium !text-colorPrimary !bg-[color-mix(in_srgb,var(--ag-colorPrimary)_12%,transparent)] hover:!bg-[color-mix(in_srgb,var(--ag-colorPrimary)_22%,transparent)]"
+                            icon={<ArrowCounterClockwise size={12} weight="bold" />}
+                            onClick={() => {
+                                if (shown?.toolName) revoke(shown.toolName)
+                                setSignal(null)
+                            }}
+                        >
+                            Undo
+                        </Button>
+                        <Button
+                            type="text"
+                            aria-label="Dismiss"
+                            className="!h-6 !w-6 !px-0 !text-colorTextTertiary hover:!bg-colorFillTertiary hover:!text-colorText"
+                            icon={<X size={13} />}
+                            onClick={() => setSignal(null)}
+                        />
+                    </div>
+                </div>
+            </div>
+        </HeightCollapse>
+    )
+}
+
+export default AlwaysAllowedNotice

--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -27,7 +27,9 @@ import {playgroundEarlyAgentStateAtom} from "@/oss/state/workflow"
 
 import {usePlaygroundScrollSync} from "../../hooks/usePlaygroundScrollSync"
 import AgentCommitNotice from "../AgentCommitNotice"
+import AlwaysAllowedNotice from "../AlwaysAllowedNotice"
 import PlaygroundVariantConfig from "../PlaygroundVariantConfig"
+import ProviderKeyNotice from "../ProviderKeyNotice"
 import type {BaseContainerProps} from "../types"
 const PlaygroundFocusDrawer = dynamic(() => import("../PlaygroundFocusDrawerAdapter"), {
     ssr: false,
@@ -437,7 +439,11 @@ const PlaygroundMainView = ({
                                 </>
                             </section>
                             {!isComparisonView && isAgentConfig && primaryConfigId ? (
-                                <AgentCommitNotice revisionId={primaryConfigId} />
+                                <>
+                                    <ProviderKeyNotice revisionId={primaryConfigId} />
+                                    <AlwaysAllowedNotice revisionId={primaryConfigId} />
+                                    <AgentCommitNotice revisionId={primaryConfigId} />
+                                </>
                             ) : null}
                         </div>
                     </SplitterPanel>

--- a/web/oss/src/components/Playground/Components/ProviderKeyNotice.tsx
+++ b/web/oss/src/components/Playground/Components/ProviderKeyNotice.tsx
@@ -1,0 +1,73 @@
+import {useEffect, useRef} from "react"
+
+import {providerKeyAddedSignalAtom} from "@agenta/shared/state"
+import {HeightCollapse} from "@agenta/ui"
+import {CheckCircle, X} from "@phosphor-icons/react"
+import {Button} from "antd"
+import {useAtom} from "jotai"
+
+/**
+ * "API key added" notice — the success-green sibling of {@link AgentCommitNotice} /
+ * {@link AlwaysAllowedNotice}, pinned to the bottom of the config pane. Confirms that a provider key
+ * the user just connected from the "Connect key" flow has landed and the agent can now run, CONTAINED
+ * to the config panel (where the change happened) instead of a floating toast that pulls focus away.
+ * Collapses in/out via the shared {@link HeightCollapse} (fade + a small Y slide) — the same
+ * CSS-native, reduced-motion-proof primitive the other notices use. Auto-dismisses after a few
+ * seconds; Dismiss clears it early.
+ */
+const ProviderKeyNotice = ({revisionId}: {revisionId: string}) => {
+    const [signal, setSignal] = useAtom(providerKeyAddedSignalAtom)
+    const active = Boolean(signal && revisionId && signal.revisionId === revisionId)
+
+    // Latch the last matching signal so content stays rendered through the collapse-out.
+    const lastRef = useRef(signal)
+    if (signal && active) lastRef.current = signal
+    const shown = lastRef.current
+
+    // Auto-dismiss 6s after the key lands (keyed on `at`, so a fresh save restarts the clock).
+    useEffect(() => {
+        if (!active) return
+        const t = window.setTimeout(() => setSignal(null), 6000)
+        return () => window.clearTimeout(t)
+    }, [active, signal?.at, setSignal])
+
+    const provider = shown?.provider
+
+    return (
+        <HeightCollapse open={active} durationMs={260} fade slideY={16} inert className="shrink-0">
+            <div className="border-0 border-t border-solid border-[color-mix(in_srgb,var(--ag-colorSuccess)_35%,var(--ag-colorBorderSecondary))] bg-[color-mix(in_srgb,var(--ag-colorSuccess)_9%,var(--ag-colorBgElevated))] px-4 py-2.5">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-start gap-2.5">
+                        <span className="mt-px flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--ag-colorSuccess)_14%,transparent)] text-colorSuccess">
+                            <CheckCircle size={15} weight="fill" />
+                        </span>
+                        <div className="flex min-w-0 flex-col gap-0.5">
+                            <span className="truncate text-xs font-medium leading-5 text-colorText">
+                                {provider ? (
+                                    <>
+                                        <span className="font-semibold">{provider}</span> API key
+                                        added
+                                    </>
+                                ) : (
+                                    "API key added"
+                                )}
+                            </span>
+                            <span className="text-[11px] leading-4 text-colorTextSecondary">
+                                The agent is ready to run.
+                            </span>
+                        </div>
+                    </div>
+                    <Button
+                        type="text"
+                        aria-label="Dismiss"
+                        className="!h-6 !w-6 shrink-0 !px-0 !text-colorTextTertiary hover:!bg-colorFillTertiary hover:!text-colorText"
+                        icon={<X size={13} />}
+                        onClick={() => setSignal(null)}
+                    />
+                </div>
+            </div>
+        </HeightCollapse>
+    )
+}
+
+export default ProviderKeyNotice

--- a/web/oss/src/hooks/useAlwaysAllowTool.tsx
+++ b/web/oss/src/hooks/useAlwaysAllowTool.tsx
@@ -1,0 +1,128 @@
+import {useCallback, useMemo, useRef} from "react"
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {
+    findGrantableHarnessTool,
+    findGrantableTool,
+    gateRulePattern,
+    withHarnessToolAllow,
+    withToolPermission,
+} from "@agenta/entity-ui/drill-in"
+import {draftConfigChangeSignalAtom} from "@agenta/shared/state"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import {resolveToolDisplay} from "@/oss/components/AgentChatSlice/assets/toolDisplay"
+
+export interface ToolGrantInfo {
+    /** The gate maps to a per-tool-config tool (gateway or custom function) whose permission we can set. */
+    eligible: boolean
+    /** The matched tool is already `allow` — the affordance would be a no-op, so hide it. */
+    alreadyAllowed: boolean
+}
+
+const INELIGIBLE: ToolGrantInfo = {eligible: false, alreadyAllowed: false}
+
+/**
+ * "Always allow this tool" for the approval card.
+ *
+ * Config write-through into the draft agent config; `buildAgentRequest` reads the draft, so a grant
+ * takes effect on the paused run's resume and every future run, and a commit carries it to triggers.
+ * Two fields, routed by tool class:
+ *   - a gateway / custom-function tool has a `tools[]` entry → per-tool `permission: "allow"`
+ *     (`specPermission`, the highest-precedence gate). Checked FIRST — it outranks any rule, and a
+ *     verbatim rule pattern would otherwise also match its slug.
+ *   - any other harness tool (`bash`, `Terminal`, `Write`, …) has no enforceable per-tool permission
+ *     → an allow-rule in `harness.permissions.allow`, keyed by the gate name VERBATIM: the runner
+ *     matches `pattern === gate.toolName`, and that string is exactly what the card shows (the
+ *     runner stamps it as `resolvedName`, which the egress prefers). Never canonicalize it.
+ * Platform ops (`commit_revision`, schedules), client tools, and MCP tools return `eligible: false`
+ * and always stay gated (see `gateRulePattern`).
+ *
+ * On grant we raise a single draft-change signal that the config pane consumes two ways: the section
+ * it landed in pulses for attention, and a contained banner (`AlwaysAllowedNotice`) offers Undo —
+ * both kept inside the config panel where the change is, rather than a floating toast. `revoke` is
+ * the exact inverse (`"ask"` for tools, `allowed:false` for harness rules).
+ */
+export function useAlwaysAllowTool(entityId?: string) {
+    const config = useAtomValue(
+        useMemo(() => workflowMolecule.selectors.configuration(entityId ?? ""), [entityId]),
+    )
+    // Latest config for the deferred Undo click, so it never reverts against a stale snapshot.
+    const configRef = useRef(config)
+    configRef.current = config
+    const setConfiguration = useSetAtom(workflowMolecule.actions.updateConfiguration)
+    // Marks the config section this grant lands in so it can pulse for attention — the user
+    // acted here in the dock, but the write shows up over in the (maybe off-screen) config pane.
+    const raiseDraftSignal = useSetAtom(draftConfigChangeSignalAtom)
+
+    const infoFor = useCallback(
+        (toolName: string): ToolGrantInfo => {
+            if (!entityId) return INELIGIBLE
+            // Gateway / custom-function tools carry a per-tool `permission` in `tools[]`. First:
+            // it outranks a rule, and a verbatim rule pattern would also match its slug.
+            const tool = findGrantableTool(config, toolName)
+            if (tool) return {eligible: true, alreadyAllowed: tool.permission === "allow"}
+            // Any other harness tool (bash, Terminal, Write, …) → `harness.permissions.allow`.
+            const harnessTool = findGrantableHarnessTool(config, toolName)
+            if (harnessTool) return {eligible: true, alreadyAllowed: harnessTool.allowed}
+            // Platform ops (commit_revision, schedules), client tools, MCP → never grantable.
+            return INELIGIBLE
+        },
+        [entityId, config],
+    )
+
+    // Inverse of grant: put the tool back to gated. Reads the LATEST config (ref), since Undo fires
+    // seconds after the grant and the draft may have moved on.
+    const revoke = useCallback(
+        (toolName: string): boolean => {
+            if (!entityId) return false
+            const cfg = configRef.current
+            // Same routing as `grant` — `tools[]` first, then the harness allow-rule.
+            const tool = findGrantableTool(cfg, toolName)
+            const pattern = tool ? null : gateRulePattern(toolName)
+            const next = tool
+                ? withToolPermission(cfg, toolName, "ask")
+                : pattern
+                  ? withHarnessToolAllow(cfg, pattern, false)
+                  : null
+            if (!next) return false
+            setConfiguration(entityId, next)
+            return true
+        },
+        [entityId, setConfiguration],
+    )
+
+    const grant = useCallback(
+        (toolName: string): boolean => {
+            if (!entityId) return false
+            // Route to the field that matches the gate's tool class (see infoFor). `tools[]` first:
+            // its per-tool permission outranks a rule, and a verbatim pattern would match its slug.
+            const tool = findGrantableTool(config, toolName)
+            const pattern = tool ? null : gateRulePattern(toolName)
+            const next = tool
+                ? withToolPermission(config, toolName, "allow")
+                : pattern
+                  ? withHarnessToolAllow(config, pattern, true)
+                  : null
+            if (!next) return false
+            setConfiguration(entityId, next)
+            // A harness allow-rule writes `harness.permissions`, which surfaces in the Advanced →
+            // Permissions group (and classifies as an "advanced" draft change); gateway/custom-function
+            // tools write `tools[]`, surfaced in the Tools section. Pulse the section the change lands in.
+            raiseDraftSignal({
+                revisionId: entityId,
+                sectionKeys: [tool ? "tools" : "advanced"],
+                origin: "approval-dock",
+                summary: `Always allow ${toolName}`,
+                // Friendly display (matches the approval card) — a gateway tool's raw name is a slug.
+                label: resolveToolDisplay(toolName).label,
+                toolName,
+                at: Date.now(),
+            })
+            return true
+        },
+        [entityId, config, setConfiguration, raiseDraftSignal],
+    )
+
+    return {infoFor, grant, revoke}
+}

--- a/web/oss/tailwind.config.ts
+++ b/web/oss/tailwind.config.ts
@@ -139,6 +139,19 @@ export const createConfig = (content: string[] = []): Config => {
                 fontFamily: {
                     sans: ["var(--font-inter)"],
                 },
+                // Config-section title shimmer: sweeps a masked highlight overlay across the
+                // title (see ConfigAccordionSection). Ungated by motion-safe on purpose, to match
+                // the motion/react dot ripple it pairs with.
+                keyframes: {
+                    "config-shimmer": {
+                        "0%": {maskPosition: "180% 0", WebkitMaskPosition: "180% 0"},
+                        "100%": {maskPosition: "-80% 0", WebkitMaskPosition: "-80% 0"},
+                    },
+                },
+                // 2 sweeps, then hold off-screen (forwards) so it ends invisibly — no end flash.
+                animation: {
+                    "config-shimmer": "config-shimmer 1.8s ease-in-out 2 forwards",
+                },
                 colors: {
                     ...antdTailwind,
                     // Theme-aware scales (override the static antd-tailwind values

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentOperationsSections.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentOperationsSections.tsx
@@ -90,7 +90,9 @@ export function AgentOperationsSections({
                         {countSummary(triggerCount, "trigger")}
                     </span>
                 </div>
-                <div className="px-4 py-3">
+                {/* pb-3 only: the first ConfigAccordionSection row carries its own py-3 header, so a
+                    top py-3 here would double into a dead band under the header bar (mirrors Config). */}
+                <div className="px-4 pb-3">
                     <TriggerManagementSection entityId={revisionId} disabled={disabled} />
                 </div>
             </section>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -25,20 +25,14 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {toolActionAvailabilityKey, useToolActionAvailability} from "@agenta/entities/gatewayTool"
 import type {SchemaProperty} from "@agenta/entities/shared"
-import {
-    agentCreationPrefsAtom,
-    workflowBuildKitEnabledAtomFamily,
-    workflowMolecule,
-} from "@agenta/entities/workflow"
-import {
-    agentItemIdentity,
-    classifyAgentChanges,
-    stableStringify,
-} from "@agenta/entities/workflow/commitDiff"
-import {agentSelfCommitSignalAtom, openAgentConfigSectionAtom} from "@agenta/shared/state"
+import {agentCreationPrefsAtom, workflowBuildKitEnabledAtomFamily} from "@agenta/entities/workflow"
+import {agentItemIdentity, stableStringify} from "@agenta/entities/workflow/commitDiff"
+import {draftConfigChangeSignalAtom, openAgentConfigSectionAtom} from "@agenta/shared/state"
 import {stripAgentaMetadataDeep} from "@agenta/shared/utils"
+import {HeightCollapse} from "@agenta/ui/components"
 import {
     ConfigAccordionSection,
+    useRecentFlag,
     type SectionIndicatorTone,
 } from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
@@ -56,6 +50,7 @@ import {Button, Tooltip, Typography} from "antd"
 import deepEqual from "fast-deep-equal"
 import {useAtom, useAtomValue, useStore} from "jotai"
 
+import {ChangedPathsProvider} from "../../drawers/shared"
 import {useOptionalDrillIn} from "../components/MoleculeDrillInContext"
 
 import {AddTextLink} from "./AddTextLink"
@@ -66,6 +61,12 @@ import {AgentToolSelectorPopover} from "./agentTemplate/AgentToolSelectorPopover
 import {ConfigItemList} from "./agentTemplate/ConfigItemList"
 import {ITEM_KINDS, type ItemKind} from "./agentTemplate/itemKinds"
 import {InstructionsFileRow, type ItemRowStatus} from "./agentTemplate/ItemRow"
+import {SectionChangeBody} from "./agentTemplate/SectionChangeBody"
+import {
+    revertPathsTo,
+    useAgentSectionChanges,
+    type PanelSectionKey,
+} from "./agentTemplate/sectionChanges"
 import {ToolManagementList} from "./agentTemplate/ToolManagementList"
 import {useAgentTools} from "./agentTemplate/useAgentTools"
 import {useConfigItemDrawer} from "./agentTemplate/useConfigItemDrawer"
@@ -75,6 +76,7 @@ import {connectionFromConfig, modelIdFromConfig} from "./connectionUtils"
 import {InstructionsDrawer} from "./InstructionsDrawer"
 import {JsonObjectEditor} from "./JsonObjectEditor"
 import {SectionDrawer} from "./SectionDrawer"
+import {SectionQuickAction} from "./SectionQuickAction"
 import {parseGatewayTool, type ParsedGatewayTool, type ToolObj} from "./toolUtils"
 import {useAgentTriggers} from "./TriggerManagementSection"
 import {WorkflowReferenceSelector} from "./WorkflowReferenceSelector"
@@ -105,17 +107,27 @@ export interface AgentTemplateControlProps {
     className?: string
 }
 
-// Draft body for the Model & harness / Advanced section drawers. Isolated into its own component so
-// `useModelHarness` (harness-catalog + vault-secrets + build-kit-overlay subscriptions) runs ONLY
-// while a section drawer is open — `SectionDrawer` uses `destroyOnClose`, so this mounts on open and
-// unmounts on close. Previously a second `useModelHarness` ran in the always-mounted parent,
-// subscribing on every agent-config render even with both drawers shut.
-const ModelHarnessSectionDrawerBody = ({
+// A section's body, in its own component so `useModelHarness` runs HERE rather than in the parent.
+// Two reasons, both load-bearing:
+//  1. Context. The hook itself reads the changed-paths / focus filters (to mark rows, open the group
+//     that changed, and narrow to it). React resolves context at the READER's position, so the hook
+//     must run BELOW the providers — wrapping its output in them does nothing. A body rendered from
+//     the parent's `mh` silently ignores both filters.
+//  2. Cost. `useModelHarness` carries harness-catalog + vault-secrets + build-kit-overlay
+//     subscriptions; mounting it per body keeps them scoped to a body that is actually on screen
+//     (`SectionDrawer` uses `destroyOnClose`; the inline body mounts only while a section has
+//     uncommitted changes).
+const ModelHarnessSectionBody = ({
     section,
     ...params
-}: {section: "model-harness" | "advanced"} & Parameters<typeof useModelHarness>[0]) => {
+}: {
+    section: "model-harness" | "advanced"
+} & Parameters<typeof useModelHarness>[0]) => {
     const mh = useModelHarness(params)
-    return <>{section === "advanced" ? mh.advancedDrawerBody : mh.modelHarnessDrawerBody}</>
+    if (section === "advanced") {
+        return <>{mh.advancedDrawerBody}</>
+    }
+    return <>{mh.modelHarnessDrawerBody}</>
 }
 
 // The four list sections whose open-state is controlled so the accordion can auto-expand when
@@ -293,45 +305,51 @@ export function AgentTemplateControl({
     // NEW revision, diff the configs per section and mark the changed ones. The computed
     // set is FROZEN on first non-empty result so the user's own subsequent edits don't
     // drift into the "agent changed this" indication. Dismiss (or the next commit) clears.
-    const commitSignal = useAtomValue(agentSelfCommitSignalAtom)
-    const frozenAgentDiffRef = useRef<{signalAt: number; keys: Set<string>} | null>(null)
-    const agentChangedKeys = useMemo(() => {
-        if (!commitSignal || !revisionId || commitSignal.revisionId !== revisionId) return null
-        if (frozenAgentDiffRef.current?.signalAt === commitSignal.at) {
-            return frozenAgentDiffRef.current.keys
-        }
-        try {
-            const sectionIdToKey: Record<string, string> = {
-                model: "model-harness",
-                instructions: "instructions",
-                tools: "tools",
-                mcps: "mcp",
-                skills: "skills",
-                params: "advanced",
-            }
-            const changed = classifyAgentChanges(commitSignal.prevParameters, {agent: value})
-            const keys = new Set(
-                changed.map((s) => sectionIdToKey[s.id]).filter((k): k is string => Boolean(k)),
-            )
-            if (keys.size === 0) return null
-            frozenAgentDiffRef.current = {signalAt: commitSignal.at, keys}
-            return keys
-        } catch {
-            return null
-        }
-    }, [commitSignal, revisionId, value])
+    // Both change sources for this revision, computed ONCE (see `sectionChanges`): `draft` is the
+    // durable live-vs-committed diff, `agent` is the frozen self-commit diff. Every consumer —
+    // header indicators, the drawers' property marks — reads this same result.
+    const sectionChanges = useAgentSectionChanges(revisionId, config)
+    const agentChangedKeys = sectionChanges.agent?.panelKeys ?? null
     const agentChangeIndicator = useCallback(
         (sectionKey: string) => {
-            if (!agentChangedKeys?.has(sectionKey)) return undefined
-            const raw = commitSignal?.version ? String(commitSignal.version) : null
-            const version = raw ? (raw.startsWith("v") ? raw : `v${raw}`) : null
+            if (!agentChangedKeys?.has(sectionKey as PanelSectionKey)) return undefined
+            const version = sectionChanges.agentVersion
             return {
                 tone: "agent" as const,
                 tooltip: `Updated by the agent${version ? ` in ${version}` : ""}`,
             }
         },
-        [agentChangedKeys, commitSignal?.version],
+        [agentChangedKeys, sectionChanges.agentVersion],
     )
+
+    // ── Draft change from another pane (e.g. "always allow" in the approval dock) ────────
+    // A user-initiated, UNCOMMITTED write to this revision's draft config already shows the
+    // section's static "draft" dot (headerIndicator). When the write came from another pane,
+    // make THAT dot pulse briefly for attention — the user acted in the dock, not here — instead
+    // of adding a competing indicator. Rides on whatever tone the section already carries.
+    const draftSignal = useAtomValue(draftConfigChangeSignalAtom)
+    const draftActive = Boolean(draftSignal && revisionId && draftSignal.revisionId === revisionId)
+    // Covers the two 1.8s pulse sweeps (~3.6s) plus a small buffer, so the ripple/shimmer finish
+    // on their invisible end frame before unmounting — no end-of-pulse flash.
+    const draftRecent = useRecentFlag(draftActive ? draftSignal!.at : null, 3900)
+    const withDraftPulse = useCallback(
+        (
+            sectionKey: string,
+            base: {tone: SectionIndicatorTone; tooltip?: React.ReactNode} | undefined,
+        ): {tone: SectionIndicatorTone; tooltip?: React.ReactNode; pulse?: boolean} | undefined => {
+            if (!draftActive || !draftRecent || !draftSignal!.sectionKeys.includes(sectionKey)) {
+                return base
+            }
+            if (base) return {...base, pulse: true}
+            return {
+                tone: "draft",
+                tooltip: `${draftSignal!.summary ?? "Changed here"} — pending, applies on the next run`,
+                pulse: true,
+            }
+        },
+        [draftActive, draftRecent, draftSignal],
+    )
+
     // Model & harness + Advanced own a lot of coupled, stateful logic (the model/connection state
     // feeds both sections), so they live in their own hook that returns the summaries + bodies.
     //
@@ -340,7 +358,7 @@ export function AgentTemplateControl({
     //    means a section header NEVER reflects the drawer's unsaved draft
     //    (the reported bug: editing in the open drawer updated the background summary).
     //  - The DRAFT instance (config + build-kit buffer) that drives the OPEN section drawer's body
-    //    now lives inside `ModelHarnessSectionDrawerBody`, mounted only while the drawer is open, so
+    //    now lives inside `ModelHarnessSectionBody`, mounted only while a drawer/inline body is on screen, so
     //    its harness/vault/overlay subscriptions don't run in the background.
     const mh = useModelHarness({schema, config, onChange, disabled, withTooltip, revisionId})
     const draftBuildKitOverride = useMemo(
@@ -441,41 +459,81 @@ export function AgentTemplateControl({
     // ── Draft + validation indicators ─────────────────────────────────────────
     // Committed (server) template to diff the live config against. Null for a never-saved
     // draft — then only validation (not draft) indicators show.
-    const committedConfig = useAtomValue(
-        useMemo(
-            () => workflowMolecule.selectors.serverConfiguration(revisionId ?? ""),
-            [revisionId],
-        ),
-    ) as Record<string, unknown> | null
-    const committed = useMemo(() => {
-        if (!committedConfig) return null
-        const agent = committedConfig.agent
-        const template =
-            agent && typeof agent === "object" && !Array.isArray(agent) ? agent : committedConfig
-        // Strip agenta metadata so it compares like-for-like against the live value.
-        return stripAgentaMetadataDeep(template) as Record<string, unknown>
-    }, [committedConfig])
+    // The same committed baseline the section diff uses (see `useAgentSectionChanges`) — read once
+    // there rather than subscribing to `serverConfiguration` a second time and re-unwrapping it.
+    const committed = sectionChanges.committed
 
-    // Header rollup: which sections changed vs the commit. Reuses the commit-diff classifier so
-    // the grouping matches (model+harness together; advanced = runner/sandbox/params).
-    const draftSectionKeys = useMemo(() => {
-        const keys = new Set<string>()
-        if (!committed) return keys
-        const map: Record<string, string> = {
-            model: "model-harness",
-            instructions: "instructions",
-            tools: "tools",
-            mcps: "mcp",
-            skills: "skills",
-            params: "advanced",
-        }
-        const local = stripAgentaMetadataDeep(config) as Record<string, unknown>
-        for (const s of classifyAgentChanges(local, committed)) {
-            const k = map[s.id]
-            if (k) keys.add(k)
-        }
-        return keys
-    }, [config, committed])
+    // Header rollup: which sections changed vs the commit — from the shared diff above, so the
+    // grouping matches the classifier's (model+harness together; advanced = runner/sandbox/params)
+    // and the indicators, the drawers' property marks, and any summary can never disagree.
+    const draftSectionKeys = sectionChanges.draft.panelKeys
+
+    // Revert for the SECTION DRAWERS: restore the given paths to their committed values through the
+    // drawer's scoped draft (`applyDraftConfig`), never straight to the entity — so an undo behaves
+    // like any other edit in there and Cancel/Save still mean what they say.
+    const drawerChangedPaths = useMemo(
+        () => ({
+            ...sectionChanges.draft,
+            revert: (paths: string[]) =>
+                applyDraftConfig(revertPathsTo(draftConfig ?? config, committed, paths)),
+        }),
+        [sectionChanges.draft, applyDraftConfig, committed, draftConfig, config],
+    )
+
+    // Revert for the PANEL's own inline bodies: writes the entity draft straight through `onChange`,
+    // matching how the panel's other inline sections (Tools, Instructions) already behave. Distinct
+    // from `drawerChangedPaths` above — the drawer has a scoped draft to respect, the panel doesn't.
+    const panelChangedPaths = useMemo(
+        () => ({
+            ...sectionChanges.draft,
+            revert: (paths: string[]) => onChange(revertPathsTo(config, committed, paths)),
+        }),
+        [sectionChanges.draft, onChange, config, committed],
+    )
+    // The inline body for a drawer-backed section: its own controls, narrowed to what changed — the
+    // same affordance as the Connect-key field, with a different filter (see SectionChangeBody).
+    // The body is a COMPONENT rendered inside the providers, never `mh`'s pre-built output: the hook
+    // reads these filters itself, and context resolves at the reader's position.
+    const changeBodyFor = useCallback(
+        (key: PanelSectionKey) => {
+            // The classifier already assigns each changed path to its own section bucket; read this
+            // section's paths from there so Advanced never picks up an instructions/tools/mcp/skills edit.
+            const section = sectionChanges.draft.sectionsByKey.get(key)
+            const sectionPaths = (section?.scalarChanges ?? []).map((c) => c.key)
+            if (!sectionPaths.length) return null
+            return (
+                <SectionChangeBody
+                    paths={sectionPaths}
+                    onOpenDetails={() => openSectionDrawer(key as "model-harness" | "advanced")}
+                    disabled={disabled}
+                    changes={panelChangedPaths}
+                >
+                    <ModelHarnessSectionBody
+                        section={key as "model-harness" | "advanced"}
+                        schema={schema}
+                        config={config}
+                        onChange={onChange}
+                        disabled={disabled}
+                        withTooltip={withTooltip}
+                        revisionId={revisionId}
+                        savedHarnessValue={savedHarnessValue}
+                    />
+                </SectionChangeBody>
+            )
+        },
+        [
+            sectionChanges.draft,
+            openSectionDrawer,
+            panelChangedPaths,
+            disabled,
+            schema,
+            config,
+            onChange,
+            withTooltip,
+            revisionId,
+            savedHarnessValue,
+        ],
+    )
 
     // Match unchanged values before identity so deleting an earlier item cannot make positional
     // identities mark every surviving row as edited. Identity then distinguishes new from edited.
@@ -646,7 +704,7 @@ export function AgentTemplateControl({
         if (invalid) return {tone: "invalid", tooltip: invalid}
         const incomplete = sectionIncompleteTip(key)
         if (incomplete) return {tone: "incomplete", tooltip: incomplete}
-        if (draftSectionKeys.has(key))
+        if (draftSectionKeys.has(key as PanelSectionKey))
             return {
                 tone: "draft",
                 tooltip: DRAFT_TIP[key] ?? "Unsaved changes — not yet committed.",
@@ -709,7 +767,43 @@ export function AgentTemplateControl({
         </Tooltip>
     )
 
-    // Each config section as a descriptor rendered by the accordion. Schema-gated, like before.
+    // The inline "what changed" bodies for the two drawer-backed sections. Null when the section is
+    // clean (or the variant is off), which is what keeps it a plain drawer-opening row.
+    const modelChangeBody = changeBodyFor("model-harness")
+    const advancedChangeBody = changeBodyFor("advanced")
+
+    /**
+     * Only a BLOCKING problem opens a section by itself. "Can't run without a provider key" is a
+     * demand and earns the interruption; "you changed something" is an answer to a question the
+     * reader may not be asking — the header indicator already says a change is there, and expanding
+     * every changed section on mount would greet them with an unfolded panel every edit. So the
+     * change body is what the section shows WHEN OPENED, not a reason to open it.
+     */
+    const needsProviderKeyInline = Boolean(mh.needsProviderKey && mh.providerCredentialsInline)
+
+    // Graceful exit: when the key lands, `needsProviderKeyInline` flips false and the section would
+    // swap straight to its resolved (drawer-opening) row — the inline pane vanishing in one frame.
+    // Hold the inline branch mounted for one collapse cycle so the pane can animate closed instead.
+    // The transition is detected during render (not in an effect) so there's never an un-held frame
+    // where the pane has already been replaced by the resolved row.
+    const KEY_PANE_EXIT_MS = 320
+    const prevNeedsKeyInlineRef = useRef(needsProviderKeyInline)
+    const [keyPaneExiting, setKeyPaneExiting] = useState(false)
+    if (prevNeedsKeyInlineRef.current !== needsProviderKeyInline) {
+        if (prevNeedsKeyInlineRef.current && !needsProviderKeyInline) setKeyPaneExiting(true)
+        prevNeedsKeyInlineRef.current = needsProviderKeyInline
+    }
+    useEffect(() => {
+        if (!keyPaneExiting) return
+        const t = window.setTimeout(() => setKeyPaneExiting(false), KEY_PANE_EXIT_MS)
+        return () => window.clearTimeout(t)
+    }, [keyPaneExiting])
+    // Show (and keep mounting) the inline pane while it's needed OR animating out.
+    const showKeyPane =
+        (needsProviderKeyInline || keyPaneExiting) && Boolean(mh.providerCredentialsInline)
+
+    // Each config section as a descriptor, so it can be rendered in any layout (accordion /
+    // tabs / cards) without duplicating the content. Schema-gated, like before.
     const sections = [
         mh.hasModelOrHarness && {
             key: "model-harness",
@@ -717,8 +811,37 @@ export function AgentTemplateControl({
             title: "Model & harness",
             summary: mh.modelSummary,
             indicator: headerIndicator("model-harness"),
-            defaultOpen: true,
-            onOpen: () => openSectionDrawer("model-harness"),
+            defaultOpen: needsProviderKeyInline,
+            // What the section surfaces inline, in precedence order. Dropping `onOpen` is what makes
+            // a section expand inline instead of routing to the drawer.
+            //   1. Required info missing (no provider key) — BLOCKING, so it wins: the same key field
+            //      the drawer uses, right here.
+            //   2. Uncommitted changes — informational: what changed (see `changeBodyFor`).
+            //   3. Neither — the plain drawer row it has always been.
+            ...(showKeyPane
+                ? {
+                      // The body owns its padding (inside the collapse) so it can collapse to zero
+                      // height with no residual — the section body wrapper adds none.
+                      bodyClassName: "",
+                      content: (
+                          <HeightCollapse open={needsProviderKeyInline} fade>
+                              <div className="flex flex-col gap-3 pb-4 pt-3">
+                                  <SectionQuickAction
+                                      onOpenDetails={() => openSectionDrawer("model-harness")}
+                                      disabled={disabled}
+                                  >
+                                      {mh.providerCredentialsInline}
+                                  </SectionQuickAction>
+                              </div>
+                          </HeightCollapse>
+                      ),
+                  }
+                : modelChangeBody
+                  ? {content: modelChangeBody}
+                  : {
+                        onOpen: () => openSectionDrawer("model-harness"),
+                        content: mh.modelHarnessDrawerBody,
+                    }),
         },
         hasInstructions && {
             key: "instructions",
@@ -841,9 +964,17 @@ export function AgentTemplateControl({
             icon: <SlidersHorizontal size={16} />,
             title: "Advanced",
             indicator: headerIndicator("advanced"),
+            // Never self-opening: nothing in Advanced blocks a run (see `needsProviderKeyInline`).
             defaultOpen: false,
             summary: mh.advancedSummary,
-            onOpen: () => openSectionDrawer("advanced"),
+            // Uncommitted changes → show them inline (dropping `onOpen` is what expands a section
+            // instead of routing to the drawer). Nothing changed → the plain drawer row.
+            ...(advancedChangeBody
+                ? {content: advancedChangeBody}
+                : {
+                      onOpen: () => openSectionDrawer("advanced"),
+                      content: mh.advancedDrawerBody,
+                  }),
         },
     ].filter(Boolean) as {
         key: string
@@ -854,8 +985,8 @@ export function AgentTemplateControl({
         indicator?: {tone: SectionIndicatorTone; tooltip?: string}
         defaultOpen?: boolean
         onOpen?: () => void
-        // Only the inline (non-`onOpen`) sections render a body; drawer-opening sections omit it.
-        content?: React.ReactNode
+        bodyClassName?: string
+        content: React.ReactNode
     }[]
 
     // Keep the item + instruction drawers MOUNTED while they animate closed. Their editing state
@@ -887,8 +1018,17 @@ export function AgentTemplateControl({
                             titleBadge={sectionBadge(s.key)}
                             summary={s.summary}
                             extra={s.extra}
-                            indicator={s.indicator ?? agentChangeIndicator(s.key)}
+                            indicator={withDraftPulse(
+                                s.key,
+                                s.indicator ?? agentChangeIndicator(s.key),
+                            )}
                             onOpen={s.onOpen}
+                            bodyClassName={s.bodyClassName}
+                            // The panel body sits in the config section's `px-4` field wrapper
+                            // (PlaygroundConfigSection), so the expanded header's fill bleeds 16px
+                            // each side to the panel edges while its text stays aligned with the
+                            // content below.
+                            headerBand="-mx-4 px-4"
                             noDivider={index === sections.length - 1}
                             {...(controlled
                                 ? {
@@ -981,17 +1121,24 @@ export function AgentTemplateControl({
                 dirty={sectionDirty}
                 width={mh.modelHarnessDrawerWidth}
             >
-                <ModelHarnessSectionDrawerBody
-                    section="model-harness"
-                    schema={schema}
-                    config={draftConfig ?? config}
-                    onChange={applyDraftConfig}
-                    disabled={disabled}
-                    withTooltip={withTooltip}
-                    revisionId={revisionId}
-                    buildKitEnabledOverride={draftBuildKitOverride}
-                    savedHarnessValue={savedHarnessValue}
-                />
+                {/* Marks the exact properties that changed since the commit (and opens the
+                    sub-sections holding them). Must sit ABOVE the body: `useModelHarness` reads the
+                    context at its own position, so a provider rendered *by* the body wouldn't reach
+                    it. Scoped to the draft diff — the drawer's own unsaved edits are its Save gate's
+                    business, not "what changed since the commit". */}
+                <ChangedPathsProvider changes={drawerChangedPaths}>
+                    <ModelHarnessSectionBody
+                        section="model-harness"
+                        schema={schema}
+                        config={draftConfig ?? config}
+                        onChange={applyDraftConfig}
+                        disabled={disabled}
+                        withTooltip={withTooltip}
+                        revisionId={revisionId}
+                        buildKitEnabledOverride={draftBuildKitOverride}
+                        savedHarnessValue={savedHarnessValue}
+                    />
+                </ChangedPathsProvider>
             </SectionDrawer>
 
             <SectionDrawer
@@ -1004,17 +1151,19 @@ export function AgentTemplateControl({
                 dirty={sectionDirty}
                 width={880}
             >
-                <ModelHarnessSectionDrawerBody
-                    section="advanced"
-                    schema={schema}
-                    config={draftConfig ?? config}
-                    onChange={applyDraftConfig}
-                    disabled={disabled}
-                    withTooltip={withTooltip}
-                    revisionId={revisionId}
-                    buildKitEnabledOverride={draftBuildKitOverride}
-                    savedHarnessValue={savedHarnessValue}
-                />
+                <ChangedPathsProvider changes={drawerChangedPaths}>
+                    <ModelHarnessSectionBody
+                        section="advanced"
+                        schema={schema}
+                        config={draftConfig ?? config}
+                        onChange={applyDraftConfig}
+                        disabled={disabled}
+                        withTooltip={withTooltip}
+                        revisionId={revisionId}
+                        buildKitEnabledOverride={draftBuildKitOverride}
+                        savedHarnessValue={savedHarnessValue}
+                    />
+                </ChangedPathsProvider>
             </SectionDrawer>
 
             {workflowReference?.enabled && (

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ClaudePermissionsControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ClaudePermissionsControl.tsx
@@ -135,7 +135,15 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
 
     return (
         <>
-            <RailField label={railInfoLabel(modeLabel, modeDescription)} align="center">
+            {/* `path` marks the row when it has an uncommitted change (see ChangedPathsProvider).
+                These are the flattened dot-paths the commit-diff classifier emits for this slice —
+                `harness.permissions.*` — so an approval card's "Always allow" grant (which appends
+                to `allow`) marks the Allow-rules row it actually wrote to. */}
+            <RailField
+                label={railInfoLabel(modeLabel, modeDescription)}
+                align="center"
+                path="harness.permissions.default_mode"
+            >
                 <Select<ClaudePermissionMode>
                     value={current.defaultMode ?? undefined}
                     onChange={(v) => write({defaultMode: v ?? null})}
@@ -148,6 +156,7 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
             </RailField>
 
             <RailField
+                path="harness.permissions.allow"
                 label={railInfoLabel(
                     "Allow rules",
                     'Per-tool allow rules, one per line (e.g. "Read", "Bash(npm run:*)").',
@@ -164,6 +173,7 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
             </RailField>
 
             <RailField
+                path="harness.permissions.ask"
                 label={railInfoLabel(
                     "Ask rules",
                     "Per-tool rules that prompt before use, one per line.",
@@ -180,6 +190,7 @@ export const ClaudePermissionsControl = memo(function ClaudePermissionsControl({
             </RailField>
 
             <RailField
+                path="harness.permissions.deny"
                 label={railInfoLabel(
                     "Deny rules",
                     "Per-tool rules that are always blocked, one per line.",

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/PiAutoApproveControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/PiAutoApproveControl.tsx
@@ -1,0 +1,80 @@
+/**
+ * PiAutoApproveControl
+ *
+ * The harness "auto-approve" list: tools that run WITHOUT asking, persisted as allow-rule patterns
+ * in `harness.permissions.allow`. A harness tool carries no enforceable per-tool permission, so an
+ * allow-rule is the only lever; `wire_author_permission_rules` turns each entry into a runner rule
+ * while `runner.permissions.default` (the Policy above) is untouched — so platform ops like
+ * `commit_revision` keep gating.
+ *
+ * This is the panel counterpart to the approval card's "Always allow <tool>" toggle: a grant made
+ * there lands here and can be removed here. It lists what was actually granted rather than a fixed
+ * menu, because the patterns must match the runner's gate names VERBATIM (`bash`, `Terminal`, …),
+ * which are harness/runtime-specific and not knowable up front.
+ */
+import {memo, useCallback, useMemo} from "react"
+
+import {Tag, Typography} from "antd"
+
+import {RailField, railInfoLabel} from "../../drawers/shared/RailField"
+
+export interface PiAutoApproveControlProps {
+    /** The harness `permissions` object (`harness.permissions`); may be absent. */
+    value?: Record<string, unknown> | null
+    /** Called with the next `harness.permissions` object. */
+    onChange: (permissions: Record<string, unknown>) => void
+    disabled?: boolean
+}
+
+export const PiAutoApproveControl = memo(function PiAutoApproveControl({
+    value,
+    onChange,
+    disabled = false,
+}: PiAutoApproveControlProps) {
+    const allow = useMemo(() => {
+        const list =
+            value && typeof value === "object" && Array.isArray((value as {allow?: unknown}).allow)
+                ? ((value as {allow: unknown[]}).allow as unknown[])
+                : []
+        return list.filter((v): v is string => typeof v === "string")
+    }, [value])
+
+    const remove = useCallback(
+        (pattern: string) => {
+            const base = value && typeof value === "object" ? value : {}
+            onChange({...base, allow: allow.filter((entry) => entry !== pattern)})
+        },
+        [allow, value, onChange],
+    )
+
+    return (
+        <RailField
+            // The path an approval-card grant writes — so the row that changed is the row that's
+            // marked when the user opens the drawer asking "what did that just change?".
+            path="harness.permissions.allow"
+            label={railInfoLabel(
+                "Auto-approve",
+                "Tools that run without asking. Added from an approval card's “Always allow”. Everything else still prompts, and commit stays gated.",
+            )}
+        >
+            {allow.length ? (
+                <div className="flex flex-wrap gap-1">
+                    {allow.map((pattern) => (
+                        <Tag
+                            key={pattern}
+                            closable={!disabled}
+                            onClose={() => remove(pattern)}
+                            className="!m-0 !font-mono !text-[11px]"
+                        >
+                            {pattern}
+                        </Tag>
+                    ))}
+                </div>
+            ) : (
+                <Typography.Text type="secondary" className="!text-[11px]">
+                    Nothing auto-approved — every gated tool asks each time.
+                </Typography.Text>
+            )}
+        </RailField>
+    )
+})

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SandboxPermissionControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SandboxPermissionControl.tsx
@@ -110,7 +110,13 @@ export function SandboxPermissionControl({
 
     return (
         <>
-            <RailField label={railInfoLabel("Network egress", NETWORK_EGRESS_HINT)} align="center">
+            {/* `path` = the dot-path the commit-diff classifier flattens this knob to, so a row with
+                an uncommitted change marks itself (see ChangedPathsProvider). */}
+            <RailField
+                label={railInfoLabel("Network egress", NETWORK_EGRESS_HINT)}
+                align="center"
+                path="sandbox.permissions.network.mode"
+            >
                 <Select<NetworkMode>
                     value={current.networkMode}
                     onChange={(v) => write({networkMode: v})}
@@ -121,7 +127,10 @@ export function SandboxPermissionControl({
             </RailField>
 
             {current.networkMode === "allowlist" ? (
-                <RailField label={railInfoLabel("Allowlist", ALLOWLIST_HINT)}>
+                <RailField
+                    label={railInfoLabel("Allowlist", ALLOWLIST_HINT)}
+                    path="sandbox.permissions.network.allowlist"
+                >
                     <Input.TextArea
                         value={current.allowlist.join("\n")}
                         onChange={(e) =>
@@ -140,7 +149,11 @@ export function SandboxPermissionControl({
                 </RailField>
             ) : null}
 
-            <RailField label={railInfoLabel("Filesystem", FILESYSTEM_HINT)} align="center">
+            <RailField
+                label={railInfoLabel("Filesystem", FILESYSTEM_HINT)}
+                align="center"
+                path="sandbox.permissions.filesystem"
+            >
                 <Select<FilesystemMode>
                     value={current.filesystem ?? undefined}
                     onChange={(v) => write({filesystem: (v as FilesystemMode | undefined) ?? null})}
@@ -152,7 +165,11 @@ export function SandboxPermissionControl({
                 />
             </RailField>
 
-            <RailField label={railInfoLabel("Enforcement", ENFORCEMENT_HINT)} align="center">
+            <RailField
+                label={railInfoLabel("Enforcement", ENFORCEMENT_HINT)}
+                align="center"
+                path="sandbox.permissions.enforcement"
+            >
                 <Select<Enforcement>
                     value={current.enforcement}
                     onChange={(v) => write({enforcement: v})}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SectionQuickAction.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SectionQuickAction.tsx
@@ -1,0 +1,45 @@
+/**
+ * SectionQuickAction
+ *
+ * The inline body a config section shows when required info is missing — a "resolve it right here"
+ * affordance instead of the plain row that only opens a drawer. It pairs the minimal control that
+ * fixes the gap (the SAME input the section's drawer uses, passed as `children`) with a link to the
+ * full drawer for everything else. First use: the Model & harness section's "Connect key" state
+ * (the provider API-key field). Kept generic so other sections can adopt the same pattern.
+ */
+import type {ReactNode} from "react"
+
+import {ArrowSquareOut} from "@phosphor-icons/react"
+import {Button} from "antd"
+
+export interface SectionQuickActionProps {
+    /** The minimal control that resolves the missing info (e.g. the provider API-key field). */
+    children: ReactNode
+    /** Opens the section's full configuration drawer. */
+    onOpenDetails: () => void
+    /** Link label; defaults to "Detailed configuration". */
+    detailsLabel?: string
+    disabled?: boolean
+}
+
+export function SectionQuickAction({
+    children,
+    onOpenDetails,
+    detailsLabel = "Detailed configuration",
+    disabled,
+}: SectionQuickActionProps) {
+    return (
+        <div className="flex flex-col gap-3">
+            {children}
+            <Button
+                type="text"
+                onClick={onOpenDetails}
+                disabled={disabled}
+                className="!h-auto w-fit !px-0 !text-xs !text-[var(--ag-colorPrimary)]"
+                icon={<ArrowSquareOut size={13} />}
+            >
+                {detailsLabel}
+            </Button>
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx
@@ -73,6 +73,25 @@ export interface ProviderCredentialsSectionProps {
 
     // presentation
     disabled?: boolean
+    /**
+     * Compact/inline variant: no `ConfigAccordionSection` wrapper (no "Provider credentials" header
+     * or badge — the host section already owns those) and no provider rail (the selected model
+     * already fixes the provider). Just the mode toggle over the selected provider's key form or the
+     * self-managed card. Used when the pane is embedded inline under another section's header.
+     */
+    bare?: boolean
+    /** Bare variant only: the model picker node, rendered in the header row to the left of the mode
+     * toggle (`[ model select ⋯ API key | Subscription ]`). */
+    modelControl?: ReactNode
+    /** The displayed revision, threaded to the key form so a save can raise the "API key added"
+     * config-pane banner scoped to it. */
+    revisionId?: string | null
+
+    /** Uncommitted-change indicator for the section header (drawer / change surfaces) — mirrors the
+     * Harness/Model sections. Ignored in the `bare` variant (it renders no section header). */
+    indicator?: {tone: "draft" | "invalid" | "incomplete" | "agent"; tooltip?: ReactNode}
+    /** Section-scoped revert control, rendered in the header beside the mode toggle. */
+    revertControl?: ReactNode
 }
 
 const STANDARD_PREFIX = "std:"
@@ -180,6 +199,49 @@ function RailRow({
     )
 }
 
+/** The same rail entry laid out horizontally — a chip for the top-rail (rotated) layout. `dashed`
+ * marks an "add" action (opens the Configure drawer) vs a selectable provider. */
+function RailChip({
+    active,
+    dashed,
+    disabled,
+    onClick,
+    tile,
+    label,
+    trailing,
+}: {
+    active?: boolean
+    dashed?: boolean
+    disabled?: boolean
+    onClick: () => void
+    tile: ReactNode
+    label: string
+    trailing?: ReactNode
+}) {
+    return (
+        <button
+            type="button"
+            disabled={disabled}
+            onClick={onClick}
+            className={cn(
+                "flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-solid px-2 text-[13px] transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                active
+                    ? "border-[var(--ag-colorBorder)] bg-[var(--ag-colorFillSecondary)] font-medium text-[var(--ag-colorText)]"
+                    : cn(
+                          "bg-transparent text-[var(--ag-colorTextSecondary)] hover:bg-[var(--ag-colorFillTertiary)] hover:text-[var(--ag-colorText)]",
+                          dashed
+                              ? "border-dashed border-[var(--ag-colorBorder)]"
+                              : "border-[var(--ag-colorBorderSecondary)]",
+                      ),
+            )}
+        >
+            {tile}
+            <span className="truncate">{label}</span>
+            {trailing}
+        </button>
+    )
+}
+
 export function ProviderCredentialsSection({
     mode,
     onModeChange,
@@ -191,6 +253,11 @@ export function ProviderCredentialsSection({
     providerNeedsKey,
     openConfigureProvider,
     disabled,
+    bare,
+    modelControl,
+    revisionId,
+    indicator,
+    revertControl,
 }: ProviderCredentialsSectionProps) {
     const standardSecrets = useAtomValue(standardSecretsAtom)
     const customSecrets = useAtomValue(customSecretsAtom)
@@ -276,9 +343,9 @@ export function ProviderCredentialsSection({
     const toggleOptions = useMemo(
         () =>
             [
-                modeOptions.includes("agenta") ? {label: "Use API key", value: "agenta"} : null,
+                modeOptions.includes("agenta") ? {label: "API key", value: "agenta"} : null,
                 modeOptions.includes("self_managed")
-                    ? {label: "Use subscription", value: "self_managed"}
+                    ? {label: "Subscription", value: "self_managed"}
                     : null,
             ].filter((option): option is {label: string; value: ConnectionMode} => option !== null),
         [modeOptions],
@@ -287,12 +354,287 @@ export function ProviderCredentialsSection({
     const showToggle = toggleOptions.length > 1
     const guideUrl = selfHostingGuideUrl || DEFAULT_SELF_HOSTING_GUIDE_URL
 
+    // Shared segmented styling: a subtle elevated track (not a stark black rectangle on the near-black
+    // panel) with a theme-inverted selected fill (antd's default thumb resolves near-white in light
+    // mode, so the active segment would be invisible). Reused by the mode + provider-type toggles.
+    const segmentedClassName = cn(
+        "rounded-md border border-solid border-[var(--ag-colorBorder)] !bg-[var(--ag-colorFillTertiary)]",
+        "[&_.ant-segmented-item-selected]:!bg-[var(--ag-colorText)] [&_.ant-segmented-item-selected]:!text-[var(--ag-colorBgContainer)] [&_.ant-segmented-item-selected]:!shadow-none",
+        "[&_.ant-segmented-thumb]:!bg-[var(--ag-colorText)] [&_.ant-segmented-thumb]:!shadow-none",
+    )
+
+    const toggle = showToggle ? (
+        <Segmented
+            size="small"
+            value={mode}
+            disabled={disabled}
+            onChange={(value) => onModeChange(value as ConnectionMode)}
+            options={toggleOptions}
+            className={segmentedClassName}
+        />
+    ) : null
+
+    const selfManagedCard = (
+        <div className="flex flex-col items-start gap-3 rounded-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] p-4">
+            <div className="flex h-[38px] w-[38px] items-center justify-center rounded-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillQuaternary)]">
+                <Terminal size={18} className="text-[var(--ag-colorTextSecondary)]" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <Typography.Text className="!text-[14.5px] !font-semibold">
+                    Self-managed
+                </Typography.Text>
+                <ul className="m-0 flex list-disc flex-col gap-0.5 pl-4">
+                    <li>
+                        <Typography.Text type="secondary" className="!text-xs !leading-relaxed">
+                            Use a Claude Code or Codex subscription, or any credential the harness
+                            reads from its own environment (env vars, prior logins).
+                        </Typography.Text>
+                    </li>
+                    <li>
+                        <Typography.Text type="secondary" className="!text-xs !leading-relaxed">
+                            Agenta stores and injects no key.
+                        </Typography.Text>
+                    </li>
+                    <li>
+                        <Typography.Text
+                            type="secondary"
+                            className="!text-xs !font-semibold !leading-relaxed"
+                        >
+                            Requires a self-hosted Agenta deployment.
+                        </Typography.Text>
+                    </li>
+                </ul>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+                <a
+                    href={guideUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="rounded-md border border-solid border-[var(--ag-colorBorder)] px-2.5 py-1 text-xs font-medium text-[var(--ag-colorText)] no-underline hover:bg-[var(--ag-colorFillTertiary)]"
+                >
+                    Read the self-hosting guide →
+                </a>
+                {isCloud ? (
+                    // fallback until colorErrorBg token lands
+                    <span className="rounded-full border border-solid border-[var(--ag-colorErrorBorder)] bg-[var(--ag-colorErrorBg,rgba(255,77,79,0.12))] px-2 py-0.5 text-[11px] text-[var(--ag-colorErrorText)]">
+                        Unavailable in the cloud
+                    </span>
+                ) : null}
+            </div>
+        </div>
+    )
+
+    // Read-only summary for a configured custom connection (its key edit lives in Settings → Secrets).
+    const renderCustomSummary = (secret: LlmProvider) => (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-0.5">
+                <Typography.Text className="!text-[14.5px] !font-semibold">
+                    {secret.name}
+                </Typography.Text>
+                <Typography.Text type="secondary" className="!text-xs !leading-snug">
+                    {PROVIDER_LABELS[secret.provider ?? ""] ?? secret.provider}
+                    {" · manage this connection in Settings → Secrets."}
+                </Typography.Text>
+            </div>
+            {secret.models?.length ? (
+                <div className="flex flex-col gap-0.5">
+                    <span className="text-[11px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                        Models
+                    </span>
+                    <span className="text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
+                        {secret.models.join(" · ")}
+                    </span>
+                </div>
+            ) : null}
+        </div>
+    )
+
+    // The selected provider's key form (or a read-only custom-provider summary / empty note). Shared
+    // by the section's master-detail pane and the bare inline variant.
+    const providerDetail = selectedStandardSecret ? (
+        // Keyed by provider name: ProviderKeyField's internal draft-key useState otherwise survives a
+        // rail switch, letting provider A's half-typed key get saved under provider B. In the bare
+        // (compact) view the selected chip already names the provider, so drop the detail header.
+        <ProviderKeyField
+            key={selectedStandardSecret.name}
+            provider={selectedStandardSecret}
+            disabled={disabled}
+            hideHeader={bare}
+            revisionId={revisionId}
+        />
+    ) : selectedCustomProvider ? (
+        renderCustomSummary(selectedCustomProvider)
+    ) : (
+        <Typography.Text type="secondary" className="!text-xs !leading-snug">
+            No provider configured for this model yet — add one from the list.
+        </Typography.Text>
+    )
+
+    // Custom-provider "Use custom provider" rows (open the Configure drawer), shared by rail + compact.
+    const addProviderRows =
+        openConfigureProvider && visibleAddRows.length
+            ? visibleAddRows.map((row) => (
+                  <RailRow
+                      key={row.kind}
+                      disabled={disabled}
+                      onClick={() => openConfigureProvider(row.kind)}
+                      tile={<ProviderTile family={row.kind} label={row.label} />}
+                      label={row.label}
+                      trailing={
+                          <Plus size={12} className="shrink-0 text-[var(--ag-colorTextTertiary)]" />
+                      }
+                  />
+              ))
+            : null
+
+    const railDetail = (
+        <div className="flex min-h-[236px] overflow-hidden rounded-[10px] border border-solid border-[var(--ag-colorBorderSecondary)]">
+            <div className="flex w-[190px] shrink-0 flex-col gap-0.5 overflow-y-auto border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillQuaternary)] p-2">
+                {visibleStandardSecrets.map((secret) => (
+                    <RailRow
+                        key={secret.name}
+                        active={activeKey === `${STANDARD_PREFIX}${secret.name}`}
+                        disabled={disabled}
+                        onClick={() => setManualKey(`${STANDARD_PREFIX}${secret.name}`)}
+                        tile={
+                            <ProviderTile
+                                family={standardSecretFamily(secret)}
+                                label={secret.title ?? secret.name ?? "?"}
+                            />
+                        }
+                        label={secret.title ?? secret.name ?? "Provider"}
+                        trailing={
+                            secret.key ? (
+                                <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+                            ) : undefined
+                        }
+                    />
+                ))}
+                {visibleCustomSecrets.map((secret) => (
+                    <RailRow
+                        key={secret.id ?? secret.name}
+                        active={activeKey === `${CUSTOM_PREFIX}${secret.name}`}
+                        disabled={disabled}
+                        onClick={() => setManualKey(`${CUSTOM_PREFIX}${secret.name}`)}
+                        tile={
+                            <ProviderTile
+                                family={(secret.provider ?? "").toLowerCase()}
+                                label={secret.name ?? "?"}
+                            />
+                        }
+                        label={secret.name ?? "Custom provider"}
+                        trailing={
+                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+                        }
+                    />
+                ))}
+                {addProviderRows ? (
+                    <div className="mt-1.5 flex flex-col gap-0.5 border-0 border-t border-solid border-[var(--ag-colorBorderSecondary)] pt-1.5">
+                        <span className="px-2.5 pb-0.5 pt-1 text-[10px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                            Use custom provider
+                        </span>
+                        {addProviderRows}
+                    </div>
+                ) : null}
+            </div>
+
+            <div className="flex min-w-0 flex-1 flex-col p-4">{providerDetail}</div>
+        </div>
+    )
+
+    // Top-rail (rotated master-detail): the same provider list as `railDetail`, but the rail runs
+    // horizontally across the top and the detail (the OpenAI heading + key form) fills the width
+    // below. Suits the narrow inline column, where a side rail leaves the key form cramped. Reuses
+    // the shared `activeKey`/`setManualKey`/`providerDetail` so selection stays consistent.
+    const topRail = (
+        <div className="overflow-hidden rounded-[10px] border border-solid border-[var(--ag-colorBorderSecondary)]">
+            <div className="flex items-center gap-1.5 overflow-x-auto border-0 border-b border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillQuaternary)] p-2.5 [scrollbar-width:thin] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[var(--ag-colorFillSecondary)] [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:h-1.5">
+                {visibleStandardSecrets.map((secret) => (
+                    <RailChip
+                        key={secret.name}
+                        active={activeKey === `${STANDARD_PREFIX}${secret.name}`}
+                        disabled={disabled}
+                        onClick={() => setManualKey(`${STANDARD_PREFIX}${secret.name}`)}
+                        tile={
+                            <ProviderTile
+                                family={standardSecretFamily(secret)}
+                                label={secret.title ?? secret.name ?? "?"}
+                            />
+                        }
+                        label={secret.title ?? secret.name ?? "Provider"}
+                        trailing={
+                            secret.key ? (
+                                <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+                            ) : undefined
+                        }
+                    />
+                ))}
+                {visibleCustomSecrets.map((secret) => (
+                    <RailChip
+                        key={secret.id ?? secret.name}
+                        active={activeKey === `${CUSTOM_PREFIX}${secret.name}`}
+                        disabled={disabled}
+                        onClick={() => setManualKey(`${CUSTOM_PREFIX}${secret.name}`)}
+                        tile={
+                            <ProviderTile
+                                family={(secret.provider ?? "").toLowerCase()}
+                                label={secret.name ?? "?"}
+                            />
+                        }
+                        label={secret.name ?? "Custom provider"}
+                        trailing={
+                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
+                        }
+                    />
+                ))}
+                {openConfigureProvider && visibleAddRows.length
+                    ? visibleAddRows.map((row) => (
+                          <RailChip
+                              key={row.kind}
+                              dashed
+                              disabled={disabled}
+                              onClick={() => openConfigureProvider(row.kind)}
+                              tile={<ProviderTile family={row.kind} label={row.label} />}
+                              label={row.label}
+                              trailing={
+                                  <Plus
+                                      size={12}
+                                      className="shrink-0 text-[var(--ag-colorTextTertiary)]"
+                                  />
+                              }
+                          />
+                      ))
+                    : null}
+            </div>
+            <div className="p-4">{providerDetail}</div>
+        </div>
+    )
+
+    // Compact inline variant: a `[ model select ⋯ API key | Subscription ]` header row over the
+    // top-rail provider strip (or the self-managed card) — no accordion header/badge; the host
+    // section owns those.
+    if (bare) {
+        return (
+            <div className="flex flex-col gap-3">
+                {/* Header: model picker takes the remaining width, mode toggle sits right. */}
+                {modelControl || toggle ? (
+                    <div className="flex items-center gap-3">
+                        <div className="min-w-0 flex-1">{modelControl}</div>
+                        {toggle}
+                    </div>
+                ) : null}
+                {mode === "self_managed" ? selfManagedCard : topRail}
+            </div>
+        )
+    }
+
     return (
         <ConfigAccordionSection
             size="compact"
             icon={<Key size={15} />}
             title="Provider credentials"
             status={providerNeedsKey ? "warning" : "complete"}
+            indicator={indicator}
             titleBadge={
                 providerNeedsKey ? (
                     <span className="rounded-full border border-solid border-[var(--ag-colorWarningBorder)] bg-[var(--ag-colorWarningBg)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--ag-colorWarningText)]">
@@ -304,189 +646,15 @@ export function ProviderCredentialsSection({
             summaryCollapsedOnly
             noDivider
             extra={
-                showToggle ? (
-                    <Segmented
-                        size="small"
-                        value={mode}
-                        disabled={disabled}
-                        onChange={(value) => onModeChange(value as ConnectionMode)}
-                        options={toggleOptions}
-                        className={cn(
-                            "rounded-md border border-solid border-[var(--ag-colorBorder)]",
-                            // antd's default selected-thumb bg/track bg both resolve to
-                            // near-white in light mode, so the "active" segment is invisible —
-                            // force a strong, theme-inverted fill instead (dark-navy-on-white
-                            // in light mode, near-white-on-near-black in dark mode).
-                            "[&_.ant-segmented-item-selected]:!bg-[var(--ag-colorText)] [&_.ant-segmented-item-selected]:!text-[var(--ag-colorBgContainer)] [&_.ant-segmented-item-selected]:!shadow-none",
-                            "[&_.ant-segmented-thumb]:!bg-[var(--ag-colorText)] [&_.ant-segmented-thumb]:!shadow-none",
-                        )}
-                    />
+                revertControl || toggle ? (
+                    <div className="flex items-center gap-1">
+                        {revertControl}
+                        {toggle}
+                    </div>
                 ) : undefined
             }
         >
-            {mode === "self_managed" ? (
-                <div className="flex flex-col items-start gap-3 rounded-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] p-4">
-                    <div className="flex h-[38px] w-[38px] items-center justify-center rounded-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillQuaternary)]">
-                        <Terminal size={18} className="text-[var(--ag-colorTextSecondary)]" />
-                    </div>
-                    <div className="flex flex-col gap-1">
-                        <Typography.Text className="!text-[14.5px] !font-semibold">
-                            Self-managed
-                        </Typography.Text>
-                        <ul className="m-0 flex list-disc flex-col gap-0.5 pl-4">
-                            <li>
-                                <Typography.Text
-                                    type="secondary"
-                                    className="!text-xs !leading-relaxed"
-                                >
-                                    Use a Claude Code or Codex subscription, or any credential the
-                                    harness reads from its own environment (env vars, prior logins).
-                                </Typography.Text>
-                            </li>
-                            <li>
-                                <Typography.Text
-                                    type="secondary"
-                                    className="!text-xs !leading-relaxed"
-                                >
-                                    Agenta stores and injects no key.
-                                </Typography.Text>
-                            </li>
-                            <li>
-                                <Typography.Text
-                                    type="secondary"
-                                    className="!text-xs !font-semibold !leading-relaxed"
-                                >
-                                    Requires a self-hosted Agenta deployment.
-                                </Typography.Text>
-                            </li>
-                        </ul>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                        <a
-                            href={guideUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="rounded-md border border-solid border-[var(--ag-colorBorder)] px-2.5 py-1 text-xs font-medium text-[var(--ag-colorText)] no-underline hover:bg-[var(--ag-colorFillTertiary)]"
-                        >
-                            Read the self-hosting guide →
-                        </a>
-                        {isCloud ? (
-                            // fallback until colorErrorBg token lands
-                            <span className="rounded-full border border-solid border-[var(--ag-colorErrorBorder)] bg-[var(--ag-colorErrorBg,rgba(255,77,79,0.12))] px-2 py-0.5 text-[11px] text-[var(--ag-colorErrorText)]">
-                                Unavailable in the cloud
-                            </span>
-                        ) : null}
-                    </div>
-                </div>
-            ) : (
-                <div className="flex min-h-[236px] overflow-hidden rounded-[10px] border border-solid border-[var(--ag-colorBorderSecondary)]">
-                    <div className="flex w-[190px] shrink-0 flex-col gap-0.5 overflow-y-auto border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillQuaternary)] p-2">
-                        {visibleStandardSecrets.map((secret) => (
-                            <RailRow
-                                key={secret.name}
-                                active={activeKey === `${STANDARD_PREFIX}${secret.name}`}
-                                disabled={disabled}
-                                onClick={() => setManualKey(`${STANDARD_PREFIX}${secret.name}`)}
-                                tile={
-                                    <ProviderTile
-                                        family={standardSecretFamily(secret)}
-                                        label={secret.title ?? secret.name ?? "?"}
-                                    />
-                                }
-                                label={secret.title ?? secret.name ?? "Provider"}
-                                trailing={
-                                    secret.key ? (
-                                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
-                                    ) : undefined
-                                }
-                            />
-                        ))}
-                        {visibleCustomSecrets.map((secret) => (
-                            <RailRow
-                                key={secret.id ?? secret.name}
-                                active={activeKey === `${CUSTOM_PREFIX}${secret.name}`}
-                                disabled={disabled}
-                                onClick={() => setManualKey(`${CUSTOM_PREFIX}${secret.name}`)}
-                                tile={
-                                    <ProviderTile
-                                        family={(secret.provider ?? "").toLowerCase()}
-                                        label={secret.name ?? "?"}
-                                    />
-                                }
-                                label={secret.name ?? "OpenAI-compatible endpoint"}
-                                trailing={
-                                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ag-colorSuccess)]" />
-                                }
-                            />
-                        ))}
-                        {openConfigureProvider && visibleAddRows.length ? (
-                            <div className="mt-1.5 flex flex-col gap-0.5 border-0 border-t border-solid border-[var(--ag-colorBorderSecondary)] pt-1.5">
-                                <span className="px-2.5 pb-0.5 pt-1 text-[10px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
-                                    Add custom provider
-                                </span>
-                                {visibleAddRows.map((row) => (
-                                    <RailRow
-                                        key={row.kind}
-                                        disabled={disabled}
-                                        onClick={() => openConfigureProvider(row.kind)}
-                                        tile={<ProviderTile family={row.kind} label={row.label} />}
-                                        label={row.label}
-                                        trailing={
-                                            <Plus
-                                                size={12}
-                                                className="shrink-0 text-[var(--ag-colorTextTertiary)]"
-                                            />
-                                        }
-                                    />
-                                ))}
-                            </div>
-                        ) : null}
-                    </div>
-
-                    <div className="flex min-w-0 flex-1 flex-col p-4">
-                        {selectedStandardSecret ? (
-                            // Keyed by provider name: ProviderKeyField's internal draft-key
-                            // useState otherwise survives a rail switch, letting provider A's
-                            // half-typed key get saved under provider B.
-                            <ProviderKeyField
-                                key={selectedStandardSecret.name}
-                                provider={selectedStandardSecret}
-                                disabled={disabled}
-                            />
-                        ) : selectedCustomProvider ? (
-                            <div className="flex flex-col gap-3">
-                                <div className="flex flex-col gap-0.5">
-                                    <Typography.Text className="!text-[14.5px] !font-semibold">
-                                        {selectedCustomProvider.name}
-                                    </Typography.Text>
-                                    <Typography.Text
-                                        type="secondary"
-                                        className="!text-xs !leading-snug"
-                                    >
-                                        {PROVIDER_LABELS[selectedCustomProvider.provider ?? ""] ??
-                                            selectedCustomProvider.provider}
-                                        {" · manage this connection in Settings → Secrets."}
-                                    </Typography.Text>
-                                </div>
-                                {selectedCustomProvider.models?.length ? (
-                                    <div className="flex flex-col gap-0.5">
-                                        <span className="text-[11px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
-                                            Models
-                                        </span>
-                                        <span className="text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
-                                            {selectedCustomProvider.models.join(" · ")}
-                                        </span>
-                                    </div>
-                                ) : null}
-                            </div>
-                        ) : (
-                            <Typography.Text type="secondary" className="!text-xs !leading-snug">
-                                No provider configured for this model yet — add one from the list.
-                            </Typography.Text>
-                        )}
-                    </div>
-                </div>
-            )}
+            {mode === "self_managed" ? selfManagedCard : railDetail}
         </ConfigAccordionSection>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderKeyField.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderKeyField.tsx
@@ -1,9 +1,13 @@
-import {useState} from "react"
+import {useEffect, useRef, useState} from "react"
 
 import {useVaultSecret} from "@agenta/entities/secret"
+import {providerKeyAddedSignalAtom} from "@agenta/shared/state"
 import type {LlmProvider} from "@agenta/shared/types"
+import {useAccordionSectionOpen} from "@agenta/ui/components/presentational"
 import {CheckCircle} from "@phosphor-icons/react"
 import {App, Button, Input, Typography} from "antd"
+import type {InputRef} from "antd"
+import {useSetAtom} from "jotai"
 
 /**
  * Right-pane "API key" form for a standard provider — the Provider credentials section's key form
@@ -12,19 +16,55 @@ import {App, Button, Input, Typography} from "antd"
  * exists, and an encryption footnote. Saves to the project vault via `useVaultSecret`, which also
  * arms `providerKeySetupDoneAtom` — no drawer Save step, so the "Connect key" gate clears reactively.
  */
-const ProviderKeyField = ({provider, disabled}: {provider: LlmProvider; disabled?: boolean}) => {
+const ProviderKeyField = ({
+    provider,
+    disabled,
+    hideHeader,
+    revisionId,
+}: {
+    provider: LlmProvider
+    disabled?: boolean
+    /** Drop the name + "Standard provider · …" subtitle — used where a selected rail chip already
+     * names the provider, so repeating it in the detail is noise. */
+    hideHeader?: boolean
+    /** The displayed revision, so a successful save can raise the "API key added" config-pane banner
+     * scoped to it. */
+    revisionId?: string | null
+}) => {
     const {message} = App.useApp()
     const {handleModifyVaultSecret} = useVaultSecret()
+    const raiseKeyAddedSignal = useSetAtom(providerKeyAddedSignalAtom)
     const [key, setKey] = useState("")
     const [saving, setSaving] = useState(false)
+    const inputRef = useRef<InputRef>(null)
+
+    // Focus the key input when the enclosing section is open (and each time it re-opens), not just on
+    // mount: the section body stays mounted while collapsed, so a mount-time `autoFocus` would fire
+    // while hidden. Only when there's no key yet — an existing key isn't waiting to be typed.
+    const sectionOpen = useAccordionSectionOpen()
+    const hasKey = !!provider.key
+    useEffect(() => {
+        if (!sectionOpen || hasKey || disabled) return
+        const t = window.setTimeout(() => inputRef.current?.focus(), 0)
+        return () => window.clearTimeout(t)
+    }, [sectionOpen, hasKey, disabled])
 
     const save = async () => {
         const trimmed = key.trim()
         if (!trimmed || saving || disabled) return
+        const isFirstKey = !provider.key
         setSaving(true)
         try {
             await handleModifyVaultSecret({...provider, key: trimmed})
             setKey("")
+            // Only the FIRST key connection unblocks the run — a replace doesn't need the banner.
+            if (isFirstKey && revisionId) {
+                raiseKeyAddedSignal({
+                    revisionId,
+                    provider: provider.title ?? provider.name ?? undefined,
+                    at: Date.now(),
+                })
+            }
         } catch {
             // Security-sensitive write — never fail silently; keep the typed value so the user can retry.
             message.error("Couldn't save the provider key. Please try again.")
@@ -33,36 +73,43 @@ const ProviderKeyField = ({provider, disabled}: {provider: LlmProvider; disabled
         }
     }
 
-    const hasKey = !!provider.key
-
     return (
-        <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-0.5">
-                <Typography.Text className="!text-[14.5px] !font-semibold">
-                    {provider.title}
-                </Typography.Text>
-                <Typography.Text type="secondary" className="!text-xs !leading-snug">
-                    Standard provider · add your key and we auto-list its models.
-                </Typography.Text>
-                {hasKey ? (
-                    <Typography.Text className="!mt-1 !inline-flex !items-center !gap-1 !text-[11px] !text-[var(--ag-colorSuccess)]">
+        <div className="flex flex-col gap-3">
+            {hideHeader ? (
+                hasKey ? (
+                    <Typography.Text className="!inline-flex !items-center !gap-1 !text-[11px] !text-[var(--ag-colorSuccess)]">
                         <CheckCircle size={13} weight="fill" />
                         Key configured · enter a new value to replace it.
                     </Typography.Text>
-                ) : null}
-            </div>
+                ) : null
+            ) : (
+                <div className="flex flex-col gap-0.5">
+                    <Typography.Text className="!text-[13px] !font-semibold">
+                        {provider.title}
+                    </Typography.Text>
+                    <Typography.Text type="secondary" className="!text-xs !leading-snug">
+                        Standard provider · add your key and we auto-list its models.
+                    </Typography.Text>
+                    {hasKey ? (
+                        <Typography.Text className="!mt-1 !inline-flex !items-center !gap-1 !text-[11px] !text-[var(--ag-colorSuccess)]">
+                            <CheckCircle size={13} weight="fill" />
+                            Key configured · enter a new value to replace it.
+                        </Typography.Text>
+                    ) : null}
+                </div>
+            )}
             <div className="flex flex-col gap-1.5">
                 <Typography.Text className="!text-xs !font-medium">
                     API key <span className="text-[var(--ag-colorError)]">*</span>
                 </Typography.Text>
                 <div className="flex items-center gap-2">
                     <Input.Password
+                        ref={inputRef}
                         value={key}
                         onChange={(e) => setKey(e.target.value)}
                         onPressEnter={save}
                         placeholder="sk-…"
                         className="flex-1 font-mono"
-                        autoFocus={!hasKey}
                         disabled={disabled}
                     />
                     <Button

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/SectionChangeBody.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/SectionChangeBody.tsx
@@ -1,0 +1,58 @@
+/**
+ * SectionChangeBody
+ *
+ * What a drawer-backed config section (Model & harness / Advanced) shows INLINE when it has
+ * uncommitted changes: **its own controls, narrowed to the properties that changed**, plus a link to
+ * the drawer for everything else.
+ *
+ * This is the same affordance as the Model & harness "Connect key" state — show the control that
+ * owns the thing needing attention, not a description of it, and not the whole drawer. "Needs a key"
+ * and "changed since the commit" are one pattern with different filters; only the filter differs.
+ *
+ * Deliberately NOT a second rendering of the change. Earlier attempts at a summary card and a
+ * `before → after` list both re-rendered values the real controls already render (and did it worse —
+ * a truncated `["Terminal","Write",…]` where the control shows clean lines), and would have to be
+ * kept in sync with them forever. Rows already declare their `path`, so a filter is the whole
+ * mechanism.
+ *
+ * `children` must be the body COMPONENT, not pre-built JSX from a `useModelHarness` call made
+ * higher up: that hook reads these filters itself, and React resolves context at the reader's
+ * position — so it has to run beneath these providers or it silently ignores them.
+ */
+import type {ReactNode} from "react"
+
+import {ChangedPathsProvider, type ChangedPaths} from "../../../drawers/shared/ChangedPathsContext"
+import {FocusPathsProvider} from "../../../drawers/shared/FocusPathsContext"
+import {SectionQuickAction} from "../SectionQuickAction"
+
+export interface SectionChangeBodyProps {
+    /** The section's body component — rendered beneath the filters below. */
+    children: ReactNode
+    /** The changed property paths to narrow to. */
+    paths: string[]
+    /** Opens the section's full drawer. */
+    onOpenDetails: () => void
+    /** Marks + per-row revert for the rows that survive the filter. */
+    changes: ChangedPaths
+    disabled?: boolean
+}
+
+export function SectionChangeBody({
+    children,
+    paths,
+    onOpenDetails,
+    changes,
+    disabled,
+}: SectionChangeBodyProps) {
+    return (
+        <SectionQuickAction
+            onOpenDetails={onOpenDetails}
+            detailsLabel="Detailed configuration"
+            disabled={disabled}
+        >
+            <ChangedPathsProvider changes={changes}>
+                <FocusPathsProvider paths={paths}>{children}</FocusPathsProvider>
+            </ChangedPathsProvider>
+        </SectionQuickAction>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/sectionChanges.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/sectionChanges.ts
@@ -1,0 +1,262 @@
+/**
+ * sectionChanges — one source of truth for "what changed in this agent config, per config-panel
+ * section".
+ *
+ * The commit-diff classifier's sections were deliberately built to mirror this panel's ("Grouped to
+ * mirror the agent-template control sections", `commitDiff/classify.ts`), so the panel reuses it
+ * verbatim instead of re-diffing: `model` → Model & harness, `params` → Advanced (the runner /
+ * sandbox / harness knobs), and the lists map 1:1. This module owns that mapping plus the lookups
+ * the panel and its drawers need:
+ *   - which sections changed (header indicators),
+ *   - the section's render-ready `ChangeSection` (the inline "what changed" body),
+ *   - the changed scalar dot-paths (`harness.permissions.allow`) so a drawer can mark the exact
+ *     property row and open the sub-section that holds it.
+ *
+ * Two independent sources, one shape:
+ *   - `draft` — the live template vs the COMMITTED one. Durable: it stands until committed.
+ *   - `agent` — what the agent's own self-commit changed, frozen at the signal so the user's later
+ *     edits don't drift into "the agent changed this".
+ *
+ * Neither is `draftConfigChangeSignalAtom`: that is a TRANSIENT "look here" pulse (~4s), not a
+ * description of what changed. Anything durable must read from here.
+ */
+import {useMemo, useRef} from "react"
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {
+    classifyAgentChanges,
+    type ChangeSection,
+    type ScalarChange,
+    type SectionId,
+} from "@agenta/entities/workflow/commitDiff"
+import {agentSelfCommitSignalAtom} from "@agenta/shared/state"
+import {stripAgentaMetadataDeep} from "@agenta/shared/utils"
+import {useAtomValue} from "jotai"
+
+/** The accordion keys the config panel renders. */
+export type PanelSectionKey =
+    | "model-harness"
+    | "instructions"
+    | "tools"
+    | "mcp"
+    | "skills"
+    | "advanced"
+
+/**
+ * Classifier section id → config-panel key. Typed against `SectionId`, so adding or renaming a
+ * classifier section fails the build here instead of silently dropping that section from every
+ * rollup (the previous two hand-rolled `Record<string, string>` copies did the latter).
+ */
+export const SECTION_ID_TO_PANEL_KEY: Record<SectionId, PanelSectionKey> = {
+    model: "model-harness",
+    instructions: "instructions",
+    tools: "tools",
+    mcps: "mcp",
+    skills: "skills",
+    params: "advanced",
+}
+
+export interface SectionChanges {
+    /** Render-ready change detail, keyed by the PANEL key the caller renders (not `SectionId`). */
+    sectionsByKey: Map<PanelSectionKey, ChangeSection>
+    /** Panel keys carrying any change — the header-indicator rollup. */
+    panelKeys: Set<PanelSectionKey>
+    /** Every changed scalar dot-path, e.g. `harness.permissions.allow`, `runner.permissions.default`. */
+    changedPaths: Set<string>
+    /** Whether this exact dot-path changed (marks one property row). */
+    isChanged: (path: string) => boolean
+    /** Whether anything under this dotted subtree changed (opens the sub-section that owns it). */
+    hasChangedUnder: (prefix: string) => boolean
+    /** Changed paths under a subtree (all of them with no prefix) — the input to a scoped revert. */
+    pathsUnder: (prefix?: string) => string[]
+    /** The recorded before → after for a property, so a row can say what it changed FROM. */
+    changeFor: (path: string) => ScalarChange | undefined
+}
+
+/** Fold classifier output into the panel's lookups. Pure — the hook below just supplies the diffs. */
+export function toSectionChanges(sections: ChangeSection[]): SectionChanges {
+    const sectionsByKey = new Map<PanelSectionKey, ChangeSection>()
+    const changedPaths = new Set<string>()
+    const byPath = new Map<string, ScalarChange>()
+    for (const section of sections) {
+        const key = SECTION_ID_TO_PANEL_KEY[section.id]
+        if (!key) continue
+        sectionsByKey.set(key, section)
+        for (const scalar of section.scalarChanges ?? []) {
+            changedPaths.add(scalar.key)
+            byPath.set(scalar.key, scalar)
+        }
+    }
+    const under = (prefix?: string) => {
+        if (!prefix) return [...changedPaths]
+        const scoped = `${prefix}.`
+        return [...changedPaths].filter((path) => path === prefix || path.startsWith(scoped))
+    }
+    return {
+        sectionsByKey,
+        panelKeys: new Set(sectionsByKey.keys()),
+        changedPaths,
+        isChanged: (path) => changedPaths.has(path),
+        hasChangedUnder: (prefix) => under(prefix).length > 0,
+        pathsUnder: under,
+        changeFor: (path) => byPath.get(path),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Revert
+// ---------------------------------------------------------------------------
+
+const isObj = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null && !Array.isArray(v)
+
+/** Read a dot-path out of an object, or `undefined`. */
+function getPath(source: Record<string, unknown>, path: string): unknown {
+    let cursor: unknown = source
+    for (const key of path.split(".")) {
+        if (!isObj(cursor)) return undefined
+        cursor = cursor[key]
+    }
+    return cursor
+}
+
+/** Whether a dot-path exists (so "present but undefined" isn't confused with "absent"). */
+function hasPath(source: Record<string, unknown>, path: string): boolean {
+    const keys = path.split(".")
+    let cursor: unknown = source
+    for (const key of keys.slice(0, -1)) {
+        if (!isObj(cursor)) return false
+        cursor = cursor[key]
+    }
+    return isObj(cursor) && keys[keys.length - 1] in cursor
+}
+
+/**
+ * Immutably set (or delete) a dot-path. Deleting prunes ancestor objects that are left empty, so
+ * reverting the only key of a slice the commit never had doesn't leave `permissions: {}` behind —
+ * which would read as "still changed" to a shape comparison even though nothing is.
+ */
+function withPath(
+    source: Record<string, unknown>,
+    path: string,
+    value: unknown,
+    remove: boolean,
+): Record<string, unknown> {
+    const [key, ...rest] = path.split(".")
+    const next = {...source}
+    if (!rest.length) {
+        if (remove) delete next[key]
+        else next[key] = value
+        return next
+    }
+    const child = isObj(source[key]) ? (source[key] as Record<string, unknown>) : {}
+    const updated = withPath(child, rest.join("."), value, remove)
+    if (remove && Object.keys(updated).length === 0) delete next[key]
+    else next[key] = updated
+    return next
+}
+
+/**
+ * Restore `paths` in `draft` to their `committed` values — deleting the key entirely when the commit
+ * doesn't have it (i.e. the draft ADDED it). Returns a new object; never mutates. Paths are the
+ * classifier's flattened dot-paths, so an array leaf (`harness.permissions.allow`) is restored whole.
+ */
+export function revertPathsTo(
+    draft: Record<string, unknown>,
+    committed: Record<string, unknown> | null,
+    paths: string[],
+): Record<string, unknown> {
+    if (!committed) return draft
+    let next = draft
+    for (const path of paths) {
+        next = hasPath(committed, path)
+            ? withPath(next, path, getPath(committed, path), false)
+            : withPath(next, path, undefined, true)
+    }
+    return next
+}
+
+export const EMPTY_SECTION_CHANGES: SectionChanges = toSectionChanges([])
+
+/** Unwrap `parameters` to the agent template, stripping metadata so both sides compare like-for-like. */
+function templateOf(parameters: Record<string, unknown> | null): Record<string, unknown> | null {
+    if (!parameters) return null
+    const agent = parameters.agent
+    const template =
+        agent && typeof agent === "object" && !Array.isArray(agent) ? agent : parameters
+    return stripAgentaMetadataDeep(template) as Record<string, unknown>
+}
+
+export interface AgentSectionChanges {
+    /** Live template vs committed — the unsaved-changes diff. Empty for a never-saved draft. */
+    draft: SectionChanges
+    /** What the agent's last self-commit changed, or null when there is no live signal for this revision. */
+    agent: SectionChanges | null
+    /** Normalized version label for the agent commit, e.g. "v7". */
+    agentVersion: string | null
+    /**
+     * The committed (server) template this diff is against — metadata-stripped, agent-wrapper
+     * unwrapped. Exposed so per-item baselines (new/edited row status) read the SAME baseline as the
+     * section diff instead of re-deriving it. Null for a never-saved draft.
+     */
+    committed: Record<string, unknown> | null
+}
+
+/**
+ * Both change sources for one revision. Replaces the panel's two ad-hoc `classifyAgentChanges` call
+ * sites (and their duplicated id→key maps) so the diff is computed once and every consumer — header
+ * indicators, the inline summary, the drawer's property marks — reads the same result.
+ */
+export function useAgentSectionChanges(
+    revisionId: string | null | undefined,
+    config: Record<string, unknown>,
+): AgentSectionChanges {
+    // Committed (server) template. Null for a never-saved draft → no draft diff, validation only.
+    const committedConfig = useAtomValue(
+        useMemo(
+            () => workflowMolecule.selectors.serverConfiguration(revisionId ?? ""),
+            [revisionId],
+        ),
+    ) as Record<string, unknown> | null
+    const committed = useMemo(() => templateOf(committedConfig), [committedConfig])
+
+    const draft = useMemo(() => {
+        if (!committed) return EMPTY_SECTION_CHANGES
+        try {
+            const local = stripAgentaMetadataDeep(config) as Record<string, unknown>
+            return toSectionChanges(classifyAgentChanges(local, committed))
+        } catch {
+            return EMPTY_SECTION_CHANGES
+        }
+    }, [config, committed])
+
+    // The agent commits itself and the playground switches in place; once this control renders the
+    // NEW revision we diff it against the captured previous parameters. FROZEN on the first
+    // non-empty result so the user's own later edits don't drift into "the agent changed this".
+    const commitSignal = useAtomValue(agentSelfCommitSignalAtom)
+    const frozenRef = useRef<{signalAt: number; changes: SectionChanges} | null>(null)
+    const agent = useMemo(() => {
+        if (!commitSignal || !revisionId || commitSignal.revisionId !== revisionId) return null
+        if (frozenRef.current?.signalAt === commitSignal.at) return frozenRef.current.changes
+        try {
+            // local = the NEW config, remote = the PREVIOUS revision's. Order is load-bearing now
+            // that we render before→after: reversing it would report every add as a removal.
+            const local = templateOf({agent: config})
+            const remote = templateOf(commitSignal.prevParameters as Record<string, unknown>)
+            if (!local || !remote) return null
+            const changes = toSectionChanges(classifyAgentChanges(local, remote))
+            if (!changes.panelKeys.size) return null
+            frozenRef.current = {signalAt: commitSignal.at, changes}
+            return changes
+        } catch {
+            return null
+        }
+    }, [commitSignal, revisionId, config])
+
+    const agentVersion = useMemo(() => {
+        const raw = commitSignal?.version ? String(commitSignal.version) : null
+        return raw ? (raw.startsWith("v") ? raw : `v${raw}`) : null
+    }, [commitSignal?.version])
+
+    return {draft, agent, agentVersion, committed}
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -2,7 +2,7 @@
  * useModelHarness — the Model & harness + Advanced sections (the panel's most stateful part). One
  * hook because the model/connection state feeds both; returns each section's summary + bodies.
  */
-import {useCallback, useEffect, useMemo, useRef} from "react"
+import {useCallback, useEffect, useMemo, useRef, type ReactNode} from "react"
 
 import {
     customSecretsAtom,
@@ -17,10 +17,20 @@ import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {cn} from "@agenta/ui/styles"
-import {Check, Cube, Lightbulb, ShieldCheck, Sparkle, Warning} from "@phosphor-icons/react"
-import {Select, Typography} from "antd"
+import {
+    ArrowCounterClockwise,
+    Check,
+    Cube,
+    Lightbulb,
+    ShieldCheck,
+    Sparkle,
+    Warning,
+} from "@phosphor-icons/react"
+import {Button, Popconfirm, Select, Typography} from "antd"
 import {useAtomValue} from "jotai"
 
+import {useHasChangedUnder, useRevertUnder} from "../../../drawers/shared/ChangedPathsContext"
+import {useFocusPaths, useHasFocusUnder} from "../../../drawers/shared/FocusPathsContext"
 import {RailField, railInfoLabel} from "../../../drawers/shared/RailField"
 import {SectionRail} from "../../../drawers/shared/SectionRail"
 import {ClaudePermissionsControl} from "../ClaudePermissionsControl"
@@ -40,6 +50,7 @@ import {
 import {EnumSelectControl, getEnumOptions} from "../EnumSelectControl"
 import {GroupedChoiceControl} from "../GroupedChoiceControl"
 import {HarnessSelectControl} from "../HarnessSelectControl"
+import {PiAutoApproveControl} from "../PiAutoApproveControl"
 import {PiSettingsControl} from "../PiSettingsControl"
 import {SandboxPermissionControl} from "../SandboxPermissionControl"
 
@@ -399,6 +410,91 @@ export function useModelHarness({
         enabledOverride: buildKitEnabledOverride,
     })
 
+    // Which Advanced sub-sections own an uncommitted change (see `ChangedPathsProvider`). Drives
+    // `defaultOpen` so a drawer opened from a "something changed" indicator lands with the changed
+    // group ALREADY expanded instead of three closed rows. Mount-time is the right moment:
+    // `SectionDrawer` uses `destroyOnClose`, so this re-evaluates on every open.
+    const sandboxChanged = useHasChangedUnder("sandbox")
+    const runnerChanged = useHasChangedUnder("runner")
+    // Only `harness.permissions` belongs to this group — `harness.kind` is the Model & harness
+    // section's, so a harness selection must not light the Permissions header (or its group-revert).
+    const harnessPermsChanged = useHasChangedUnder("harness.permissions")
+    const permissionsChanged = runnerChanged || harnessPermsChanged
+    const changedIndicator = (changed: boolean) =>
+        changed ? ({tone: "draft", tooltip: "Unsaved changes in this group."} as const) : undefined
+
+    // Section-scoped undo: restore every changed property in this group to its committed value. The
+    // per-row dot reverts ONE property; this is "undo the whole group". Null when nothing changed or
+    // the surface offers no revert, so the header keeps its normal actions.
+    const revertSandbox = useRevertUnder("sandbox")
+    const revertRunner = useRevertUnder("runner")
+    const revertHarnessPerms = useRevertUnder("harness.permissions")
+    const revertPermissions = useCallback(() => {
+        revertRunner?.()
+        revertHarnessPerms?.()
+    }, [revertRunner, revertHarnessPerms])
+
+    // Model & harness sub-sections (drawer): each owns one property bucket — harness.kind / llm.model /
+    // llm.connection.* — so the same mark + section-scoped revert the Advanced groups get. Scoped to
+    // `harness.kind` (NOT all of `harness`) so a permissions edit doesn't light up the Harness header.
+    const harnessKindChanged = useHasChangedUnder("harness.kind")
+    const modelChanged = useHasChangedUnder("llm.model")
+    const credentialsChanged = useHasChangedUnder("llm.connection")
+    const revertHarnessKind = useRevertUnder("harness.kind")
+    const revertModel = useRevertUnder("llm.model")
+    const revertCredentials = useRevertUnder("llm.connection")
+    // Confirmed, because unlike the per-row undo (which is reached THROUGH the popover showing the
+    // exact value it restores — see `RailField`) this one discards every change in the group at once
+    // and names none of them.
+    const revertAction = (onRevert: (() => void) | null) =>
+        onRevert ? (
+            <Popconfirm
+                title="Revert this group?"
+                description="Every unsaved change in it goes back to the committed value."
+                okText="Revert"
+                cancelText="Cancel"
+                placement="bottomRight"
+                onConfirm={onRevert}
+            >
+                <Button
+                    type="text"
+                    icon={<ArrowCounterClockwise size={13} />}
+                    // The header is a toggle — don't collapse the group while undoing inside it.
+                    onClick={(e) => e.stopPropagation()}
+                    disabled={disabled}
+                    className="!h-auto !px-1 !py-0.5 !text-[11px] !text-[var(--ag-colorTextSecondary)]"
+                >
+                    Revert
+                </Button>
+            </Popconfirm>
+        ) : undefined
+
+    // FOCUS (see FocusPathsContext): when a surface narrows to the properties that matter — e.g. the
+    // config panel showing only what changed — a group renders only if it owns one of them, and the
+    // rows filter themselves. Chrome follows the content: with changes in ONE group there is nothing
+    // to disambiguate, so it renders FLAT (just the controls, like the Connect-key field); spread
+    // across several, the group headers earn their keep by saying which change belongs where.
+    const focus = useFocusPaths()
+    const sandboxInFocus = useHasFocusUnder("sandbox")
+    const runnerInFocus = useHasFocusUnder("runner")
+    // Split like the changed/revert side: harness.kind focuses the Model & harness section,
+    // harness.permissions the Permissions group — so neither pulls the other into focus.
+    const harnessKindInFocus = useHasFocusUnder("harness.kind")
+    const harnessPermsInFocus = useHasFocusUnder("harness.permissions")
+    const permissionsInFocus = runnerInFocus || harnessPermsInFocus
+    const focusedGroupCount = (sandboxInFocus ? 1 : 0) + (permissionsInFocus ? 1 : 0)
+    const flatFocus = focus.active && focusedGroupCount <= 1
+
+    // Same, for the Model & harness inline body: its three groups own harness.kind / llm.model /
+    // llm.connection.*, so under a change filter only the group(s) that actually changed render (a
+    // model swap shows the Model group, and Provider credentials too only if it moved the connection),
+    // flat when just one survives — instead of unfolding the entire section.
+    const modelInFocus = useHasFocusUnder("llm.model")
+    const credentialsInFocus = useHasFocusUnder("llm.connection")
+    const modelHarnessFocusedCount =
+        (harnessKindInFocus ? 1 : 0) + (modelInFocus ? 1 : 0) + (credentialsInFocus ? 1 : 0)
+    const modelHarnessFlatFocus = focus.active && modelHarnessFocusedCount <= 1
+
     const hasAdvanced = Boolean(
         sandboxProps.kind ||
         sandboxProps.permissions ||
@@ -468,6 +564,7 @@ export function useModelHarness({
                     : "Model"
             }
             align="center"
+            path="llm.model"
         >
             {modelControl}
         </RailField>
@@ -596,18 +693,33 @@ export function useModelHarness({
 
     // Provider credentials section: identical in both the capability-aware and flat layouts below,
     // rendered once and reused so the two branches don't carry a duplicate prop list.
-    const providerCredentialsSection = props.llm ? (
+    const providerCredentialsProps = props.llm
+        ? {
+              mode: connection.mode,
+              onModeChange: (m: ConnectionMode) => writeModel({mode: m}),
+              selectedProviderFamily,
+              selectedConnectionSlug: connection.slug ?? null,
+              modeOptions,
+              isCloud,
+              selfHostingGuideUrl: deployment?.selfHostingGuideUrl,
+              providerNeedsKey,
+              openConfigureProvider: openConfigureProviderAdopting,
+              disabled,
+              revisionId: revisionId ?? null,
+              indicator: changedIndicator(credentialsChanged),
+              revertControl: revertAction(revertCredentials),
+          }
+        : null
+    // The full pane (own header + rail) for the drawer body; the `bare` variant (toggle + key form /
+    // self-managed, no header, no rail) for the inline "Connect key" quick-action under the section.
+    const providerCredentialsSection = providerCredentialsProps ? (
+        <ProviderCredentialsSection {...providerCredentialsProps} />
+    ) : null
+    const providerCredentialsInline = providerCredentialsProps ? (
         <ProviderCredentialsSection
-            mode={connection.mode}
-            onModeChange={(m) => writeModel({mode: m})}
-            selectedProviderFamily={selectedProviderFamily}
-            selectedConnectionSlug={connection.slug ?? null}
-            modeOptions={modeOptions}
-            isCloud={isCloud}
-            selfHostingGuideUrl={deployment?.selfHostingGuideUrl}
-            providerNeedsKey={providerNeedsKey}
-            openConfigureProvider={openConfigureProviderAdopting}
-            disabled={disabled}
+            {...providerCredentialsProps}
+            bare
+            modelControl={modelControl}
         />
     ) : null
 
@@ -615,54 +727,83 @@ export function useModelHarness({
     // left (each card owns its model-compat state), version history on the right — same two-panel
     // shape as the Advanced drawer. Without capabilities: the plain harness select, single column.
     // Shared Model & harness controls — rendered by both the wide drawer body and the tabs-inline body.
+    // A focused (change/connect-key) surface renders only the groups that own a changed property, and
+    // drops to FLAT chrome when just one survives; unfocused (drawer/tabs) everything renders as-is.
+    const modelControlGroup = (
+        <div className="flex flex-col gap-2 py-0.5">
+            {modelControl}
+            {!focus.active && hasInspectModels ? (
+                <Typography.Text type="secondary" className="!text-[11px] !leading-snug">
+                    Filtered to the models this harness can reach. Selecting a model also sets its
+                    provider.
+                </Typography.Text>
+            ) : null}
+        </div>
+    )
+
     const modelHarnessControls = capabilities ? (
         <>
-            <ConfigAccordionSection
-                size="compact"
-                icon={<Cube size={15} />}
-                title="Harness"
-                status={harnessValue ? "complete" : "default"}
-                summary={selectedHarnessLabel ?? undefined}
-                summaryCollapsedOnly
-            >
-                <div className="flex gap-2.5 rounded-md bg-[var(--ag-colorFillQuaternary)] p-3">
-                    <Lightbulb
-                        size={16}
-                        className="mt-0.5 shrink-0 text-[var(--ag-colorTextSecondary)]"
-                    />
-                    <span className="text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
-                        The harness is the runtime that executes your agent. It decides which
-                        providers, hosting and connection options you can use.
-                    </span>
-                </div>
-                {harnessSection}
-            </ConfigAccordionSection>
+            {harnessKindInFocus ? (
+                modelHarnessFlatFocus ? (
+                    harnessSection
+                ) : (
+                    <ConfigAccordionSection
+                        size="compact"
+                        icon={<Cube size={15} />}
+                        title="Harness"
+                        status={harnessValue ? "complete" : "default"}
+                        indicator={changedIndicator(harnessKindChanged)}
+                        extra={revertAction(revertHarnessKind)}
+                        summary={selectedHarnessLabel ?? undefined}
+                        summaryCollapsedOnly
+                    >
+                        {focus.active ? null : (
+                            <div className="flex gap-2.5 rounded-md bg-[var(--ag-colorFillQuaternary)] p-3">
+                                <Lightbulb
+                                    size={16}
+                                    className="mt-0.5 shrink-0 text-[var(--ag-colorTextSecondary)]"
+                                />
+                                <span className="text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
+                                    The harness is the runtime that executes your agent. It decides
+                                    which providers, hosting and connection options you can use.
+                                </span>
+                            </div>
+                        )}
+                        {harnessSection}
+                    </ConfigAccordionSection>
+                )
+            ) : null}
 
-            <ConfigAccordionSection
-                size="compact"
-                icon={<Sparkle size={15} />}
-                title="Model"
-                status={!modelId || !selectedKeepsModel ? "warning" : "complete"}
-                summary={modelId ?? undefined}
-                summaryCollapsedOnly
-            >
-                <div className="flex flex-col gap-2 py-0.5">
-                    {modelControl}
-                    {hasInspectModels ? (
-                        <Typography.Text type="secondary" className="!text-[11px] !leading-snug">
-                            Filtered to the models this harness can reach. Selecting a model also
-                            sets its provider.
-                        </Typography.Text>
-                    ) : null}
-                </div>
-            </ConfigAccordionSection>
+            {modelInFocus ? (
+                modelHarnessFlatFocus ? (
+                    // Flat (a change surface narrowed to just the model): a labelled RailField row, so
+                    // the changed control marks itself and its label opens the committed-value + Restore
+                    // popover — the same property-scoped affordance the Advanced rows get.
+                    <RailField label="Model" align="center" path="llm.model">
+                        {modelControl}
+                    </RailField>
+                ) : (
+                    <ConfigAccordionSection
+                        size="compact"
+                        icon={<Sparkle size={15} />}
+                        title="Model"
+                        status={!modelId || !selectedKeepsModel ? "warning" : "complete"}
+                        indicator={changedIndicator(modelChanged)}
+                        extra={revertAction(revertModel)}
+                        summary={modelId ?? undefined}
+                        summaryCollapsedOnly
+                    >
+                        {modelControlGroup}
+                    </ConfigAccordionSection>
+                )
+            ) : null}
 
-            {providerCredentialsSection}
+            {credentialsInFocus ? providerCredentialsSection : null}
         </>
     ) : (
         <>
-            {harnessProps.kind && (
-                <RailField label="Harness" align="center">
+            {harnessKindInFocus && harnessProps.kind && (
+                <RailField label="Harness" align="center" path="harness.kind">
                     <HarnessSelectControl
                         schema={harnessProps.kind}
                         visibleValues={harnessList}
@@ -673,8 +814,8 @@ export function useModelHarness({
                     />
                 </RailField>
             )}
-            {modelPicker}
-            {providerCredentialsSection}
+            {modelInFocus ? modelPicker : null}
+            {credentialsInFocus ? providerCredentialsSection : null}
         </>
     )
 
@@ -701,119 +842,194 @@ export function useModelHarness({
     // Each group is a `ConfigAccordionSection` (the shared drawer section shell used by the trigger
     // and tools drawers); inside, configuration reads as the drawer's `[rail | content]` rhythm via
     // `SectionRail` (mode groups) and `RailField` (labelled control rows).
+    /**
+     * One Advanced group. Under a focus filter it disappears unless it owns a focused property, and
+     * drops its chrome entirely when it's the only survivor — the body (the real controls) is the
+     * same either way, so nothing is rendered twice.
+     */
+    const advancedGroup = (
+        opts: {
+            inFocus: boolean
+            defaultOpen: boolean
+            indicator: ReturnType<typeof changedIndicator>
+            extra: ReactNode
+            icon: ReactNode
+            title: string
+            summary?: string
+            caption: ReactNode
+        },
+        body: ReactNode,
+    ) => {
+        if (!opts.inFocus) return null
+        // Flat: just the focused control(s) — the group header would only restate the section.
+        if (flatFocus) return <div className="flex flex-col gap-3">{body}</div>
+        return (
+            <ConfigAccordionSection
+                size="compact"
+                defaultOpen={opts.defaultOpen}
+                indicator={opts.indicator}
+                extra={opts.extra}
+                icon={opts.icon}
+                title={opts.title}
+                summary={opts.summary}
+                summaryCollapsedOnly
+            >
+                {opts.caption}
+                {body}
+            </ConfigAccordionSection>
+        )
+    }
+
+    const executionBody = (
+        <>
+            {sandboxProps.kind ? (
+                <RailField label="Sandbox" align="center" path="sandbox.kind">
+                    <EnumSelectControl
+                        schema={sandboxProps.kind}
+                        options={sandboxOptions}
+                        value={(sandbox.kind as string | null) ?? null}
+                        onChange={(v) => setSection("sandbox", {...sandbox, kind: v})}
+                        withTooltip={withTooltip}
+                        disabled={disabled}
+                    />
+                </RailField>
+            ) : null}
+            {sandboxProps.permissions && sandbox.kind !== "local" ? (
+                <>
+                    {focus.active ? null : permissionOverrideHint}
+                    {/* Renders its knobs as peer RailField rows (Network egress / Filesystem
+                        / Enforcement) sharing this section's rail — no nested sub-form. */}
+                    <SandboxPermissionControl
+                        value={(sandbox.permissions as Record<string, unknown> | null) ?? null}
+                        onChange={(v) => setSection("sandbox", {...sandbox, permissions: v})}
+                        disabled={disabled}
+                    />
+                </>
+            ) : null}
+        </>
+    )
+
+    const permissionsBody = (
+        <>
+            {runnerPermissionSchema ? (
+                <RailField label="Policy" align="center" path="runner.permissions.default">
+                    <Select<PermissionPolicy>
+                        value={currentRunnerPermission}
+                        onChange={(v) =>
+                            setSection("runner", {
+                                ...runner,
+                                permissions: {...runnerPermissions, default: v},
+                            })
+                        }
+                        options={runnerPermissionOptions}
+                        optionLabelProp="title"
+                        disabled={disabled}
+                        className="w-full"
+                    />
+                </RailField>
+            ) : null}
+            {hasClaudePermissions ? (
+                <>
+                    {/* Caption then peer rail rows (mode / allow / ask / deny) sharing the
+                        section rail — the control renders its own RailField rows. */}
+                    {focus.active ? null : (
+                        <span className="w-fit rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
+                            Claude harness
+                        </span>
+                    )}
+                    <ClaudePermissionsControl
+                        value={claudePermissions}
+                        onChange={setClaudePermissions}
+                        disabled={disabled}
+                        // Mode options + labels come from the harness `permissions`
+                        // sub-schema (`default_mode` enum) so they follow the template.
+                        modeSchema={
+                            (
+                                harnessProps.permissions?.properties as
+                                    | Record<string, SchemaProperty>
+                                    | undefined
+                            )?.default_mode
+                        }
+                    />
+                </>
+            ) : null}
+            {hasPiSettings ? (
+                <>
+                    {focus.active ? null : (
+                        <span className="w-fit rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
+                            Pi harness
+                        </span>
+                    )}
+                    {/* Availability, not permission — it declares no config path, so a focus
+                        filter drops it and only the changed permission rows remain. */}
+                    {focus.active ? null : (
+                        <PiSettingsControl
+                            tools={agentTools}
+                            onChange={setAgentTools}
+                            disabled={disabled}
+                        />
+                    )}
+                    <PiAutoApproveControl
+                        value={(harness.permissions as Record<string, unknown> | null) ?? null}
+                        onChange={(permissions) => setSection("harness", {...harness, permissions})}
+                        disabled={disabled}
+                    />
+                </>
+            ) : null}
+        </>
+    )
+
     const advancedControls = (
         <>
-            {buildKitSection}
+            {/* Playground-only overlay — it owns no committed property, so a focus filter drops it. */}
+            {focus.active ? null : buildKitSection}
 
-            {hasExecutionGroup ? (
-                <ConfigAccordionSection
-                    size="compact"
-                    defaultOpen={false}
-                    icon={<Cube size={15} />}
-                    title="Execution environment"
-                    summary={sandbox.kind ? `Sandbox: ${String(sandbox.kind)}` : undefined}
-                    summaryCollapsedOnly
-                >
-                    <Typography.Text type="secondary" className="text-[11px] leading-snug">
-                        Where the agent&apos;s tools and code run, and what that sandbox may touch.
-                    </Typography.Text>
-                    {sandboxProps.kind ? (
-                        <RailField label="Sandbox" align="center">
-                            <EnumSelectControl
-                                schema={sandboxProps.kind}
-                                options={sandboxOptions}
-                                value={(sandbox.kind as string | null) ?? null}
-                                onChange={(v) => setSection("sandbox", {...sandbox, kind: v})}
-                                withTooltip={withTooltip}
-                                disabled={disabled}
-                            />
-                        </RailField>
-                    ) : null}
-                    {sandboxProps.permissions && sandbox.kind !== "local" ? (
-                        <>
-                            {permissionOverrideHint}
-                            {/* Renders its knobs as peer RailField rows (Network egress / Filesystem
-                                / Enforcement) sharing this section's rail — no nested sub-form. */}
-                            <SandboxPermissionControl
-                                value={
-                                    (sandbox.permissions as Record<string, unknown> | null) ?? null
-                                }
-                                onChange={(v) =>
-                                    setSection("sandbox", {...sandbox, permissions: v})
-                                }
-                                disabled={disabled}
-                            />
-                        </>
-                    ) : null}
-                </ConfigAccordionSection>
-            ) : null}
+            {hasExecutionGroup
+                ? advancedGroup(
+                      {
+                          inFocus: sandboxInFocus,
+                          defaultOpen: sandboxChanged,
+                          indicator: changedIndicator(sandboxChanged),
+                          extra: revertAction(revertSandbox),
+                          icon: <Cube size={15} />,
+                          title: "Execution environment",
+                          summary: sandbox.kind ? `Sandbox: ${String(sandbox.kind)}` : undefined,
+                          caption: (
+                              <Typography.Text
+                                  type="secondary"
+                                  className="text-[11px] leading-snug"
+                              >
+                                  Where the agent&apos;s tools and code run, and what that sandbox
+                                  may touch.
+                              </Typography.Text>
+                          ),
+                      },
+                      executionBody,
+                  )
+                : null}
 
-            {hasPermissionsGroup ? (
-                <ConfigAccordionSection
-                    size="compact"
-                    defaultOpen={false}
-                    icon={<ShieldCheck size={15} />}
-                    title="Permissions"
-                    summary={runnerPermissionSummary}
-                    summaryCollapsedOnly
-                >
-                    <Typography.Text type="secondary" className="text-[11px] leading-snug">
-                        What the agent may do on its own before it must ask.
-                    </Typography.Text>
-                    {runnerPermissionSchema ? (
-                        <RailField label="Policy" align="center">
-                            <Select<PermissionPolicy>
-                                value={currentRunnerPermission}
-                                onChange={(v) =>
-                                    setSection("runner", {
-                                        ...runner,
-                                        permissions: {...runnerPermissions, default: v},
-                                    })
-                                }
-                                options={runnerPermissionOptions}
-                                optionLabelProp="title"
-                                disabled={disabled}
-                                className="w-full"
-                            />
-                        </RailField>
-                    ) : null}
-                    {hasClaudePermissions ? (
-                        <>
-                            {/* Caption then peer rail rows (mode / allow / ask / deny) sharing the
-                                section rail — the control renders its own RailField rows. */}
-                            <span className="w-fit rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
-                                Claude harness
-                            </span>
-                            <ClaudePermissionsControl
-                                value={claudePermissions}
-                                onChange={setClaudePermissions}
-                                disabled={disabled}
-                                // Mode options + labels come from the harness `permissions`
-                                // sub-schema (`default_mode` enum) so they follow the template.
-                                modeSchema={
-                                    (
-                                        harnessProps.permissions?.properties as
-                                            | Record<string, SchemaProperty>
-                                            | undefined
-                                    )?.default_mode
-                                }
-                            />
-                        </>
-                    ) : null}
-                    {hasPiSettings ? (
-                        <>
-                            <span className="w-fit rounded-full bg-[var(--ant-color-fill-secondary)] px-2 text-[10px] text-[var(--ant-color-primary-text)]">
-                                Pi harness
-                            </span>
-                            <PiSettingsControl
-                                tools={agentTools}
-                                onChange={setAgentTools}
-                                disabled={disabled}
-                            />
-                        </>
-                    ) : null}
-                </ConfigAccordionSection>
-            ) : null}
+            {hasPermissionsGroup
+                ? advancedGroup(
+                      {
+                          inFocus: permissionsInFocus,
+                          defaultOpen: permissionsChanged,
+                          indicator: changedIndicator(permissionsChanged),
+                          extra: permissionsChanged ? revertAction(revertPermissions) : undefined,
+                          icon: <ShieldCheck size={15} />,
+                          title: "Permissions",
+                          summary: runnerPermissionSummary,
+                          caption: (
+                              <Typography.Text
+                                  type="secondary"
+                                  className="text-[11px] leading-snug"
+                              >
+                                  What the agent may do on its own before it must ask.
+                              </Typography.Text>
+                          ),
+                      },
+                      permissionsBody,
+                  )
+                : null}
         </>
     )
 
@@ -834,6 +1050,10 @@ export function useModelHarness({
         // The selected model's provider has a standard vault slot but no key yet — the config panel
         // highlights the Model & harness section and the chat gates on it until it's connected.
         needsProviderKey: providerNeedsKey,
+        // The compact `bare` credentials pane (mode toggle + selected provider's key form or
+        // self-managed card; no nested header/badge, no rail) for the inline "Connect key"
+        // quick-action under the section header — aligned with the drawer without duplicating it.
+        providerCredentialsInline,
         // A model is selected but the chosen harness can't run it — a *model* problem (the harness
         // itself stays valid), so the config panel flags the Model & harness section as invalid.
         modelUnsupported: !!modelId && !selectedKeepsModel,

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/index.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/index.ts
@@ -69,6 +69,15 @@ export {ToolSelectorPopover} from "./ToolSelectorPopover"
 export type {ToolSelectorPopoverProps} from "./ToolSelectorPopover"
 export {TOOL_PROVIDERS_META, TOOL_SPECS} from "./toolUtils"
 export type {ToolObj, ToolFunction} from "./toolUtils"
+export {
+    findGrantableTool,
+    withToolPermission,
+    gateRulePattern,
+    readHarnessAllowList,
+    findGrantableHarnessTool,
+    withHarnessToolAllow,
+} from "./toolPermission"
+export type {GrantableTool, ToolPermission, GrantableHarnessTool} from "./toolPermission"
 
 export {McpServerItemControl} from "./McpServerItemControl"
 export type {McpServerItemControlProps} from "./McpServerItemControl"

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts
@@ -1,0 +1,230 @@
+/**
+ * toolPermission — locate a runtime tool gate's config entry and set its per-tool permission.
+ *
+ * The approval card's "always allow this tool" writes a per-tool `permission` onto the matching
+ * entry in the agent template's `tools[]` (config write-through: the run reads the draft config, so
+ * the change takes effect on the in-flight resume and every future run; a commit carries it to
+ * triggers). Only tools that live in the committed `tools[]` AND carry a per-tool `permission` slot
+ * are grantable: gateway (Composio) tools and custom function tools. Platform ops (overlay-injected,
+ * e.g. `commit_revision`), builtins, MCP servers (per-server permission, not per-tool), and workflow
+ * references are deliberately NOT matched here, so they can never be auto-allowed from the card —
+ * `commit_revision` and destructive ops stay gated by construction.
+ *
+ * The matcher mirrors the runtime wire name: a gateway gate arrives as the slug
+ * `tools__{provider}__{integration}__{action}__{connection}` (see `parseGatewayToolName`), and a
+ * custom function tool arrives as its bare `function.name`.
+ */
+import {parseGatewayToolSlug} from "@agenta/shared/utils"
+
+import {parseGatewayTool} from "./toolUtils"
+
+export type ToolPermission = "allow" | "ask" | "deny"
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+    Boolean(v && typeof v === "object" && !Array.isArray(v))
+
+const asPermission = (v: unknown): ToolPermission | undefined =>
+    v === "allow" || v === "ask" || v === "deny" ? v : undefined
+
+interface TemplateLocation {
+    template: Record<string, unknown>
+    /** Rebuild the full `parameters` object from an updated template. */
+    wrap: (nextTemplate: Record<string, unknown>) => Record<string, unknown>
+}
+
+/**
+ * The agent template lives at `parameters.agent` (the playground shape) or IS the parameters (a bare
+ * template). Mirror `buildAgentRequest`'s `withAgentRunDefaults` so a write lands exactly where the
+ * run reads from.
+ */
+function locateTemplate(parameters: Record<string, unknown>): TemplateLocation {
+    if (isRecord(parameters.agent)) {
+        const agent = parameters.agent
+        return {template: agent, wrap: (next) => ({...parameters, agent: next})}
+    }
+    return {template: parameters, wrap: (next) => next}
+}
+
+/**
+ * Index of the `tools[]` entry a runtime gate `toolName` refers to, or -1. A gateway tool (canonical
+ * `{type:"gateway"}` or a legacy function-name slug) matches by its {provider, integration, action,
+ * connection} identity; a custom function tool matches by `function.name`.
+ */
+function matchToolIndex(tools: unknown[], toolName: string): number {
+    const slug = parseGatewayToolSlug(toolName)
+    for (let i = 0; i < tools.length; i++) {
+        const entry = tools[i]
+        if (!isRecord(entry)) continue
+        if (slug) {
+            const g = parseGatewayTool(entry)
+            if (
+                g &&
+                g.provider === slug.provider &&
+                g.integration === slug.integration &&
+                g.action === slug.action &&
+                g.connection === slug.connection
+            ) {
+                return i
+            }
+            continue
+        }
+        const fn = isRecord(entry.function) ? entry.function : null
+        if (fn && typeof fn.name === "string" && fn.name === toolName) return i
+    }
+    return -1
+}
+
+export interface GrantableTool {
+    /** The current per-tool permission on the matched entry, if one is set. */
+    permission?: ToolPermission
+}
+
+// ---------------------------------------------------------------------------
+// Harness tools (bash / Terminal / Write / …): the `harness.permissions.allow` path
+// ---------------------------------------------------------------------------
+//
+// A harness tool carries NO per-tool `permission` (a builtin's own permission is dropped as
+// unenforceable). The only lever is an authored allow-rule: `harness.permissions.allow += [<gate
+// name>]` flows through `wire_author_permission_rules` into a runner rule
+// `{pattern, permission:"allow"}`, while `runner.permissions.default` stays as authored so platform
+// ops (commit_revision, schedules) keep gating. Works on Pi AND Claude — `_parse_harness_slice`
+// reads `harness.permissions` for any harness.
+//
+// THE PATTERN IS THE GATE NAME, VERBATIM. The runner matches rules with `pattern === gate.toolName`
+// (permission-plan.ts `ruleMatches`), and `gate.toolName` is exactly what the approval card shows:
+// the runner stamps it onto the gate as `resolvedName` (acp-interactions.ts) and the SDK's
+// `_approval_tool_name` prefers that field for the part. Do NOT "canonicalize" the name — an ACP
+// gate reports `bash`/`Terminal` verbatim (buildGateDescriptor: `spec?.name ?? displayName`), so a
+// rule for `Bash` would silently never match.
+
+/** Platform ops (overlay-injected). These must ALWAYS gate — never auto-allowable from the card. */
+const PLATFORM_OPS = new Set([
+    "discover_tools",
+    "query_workflows",
+    "query_spans",
+    "test_run",
+    "commit_revision",
+    "annotate_trace",
+    "discover_triggers",
+    "create_schedule",
+    "create_subscription",
+    "list_schedules",
+    "list_subscriptions",
+    "list_deliveries",
+    "list_connections",
+    "test_subscription",
+    "remove_schedule",
+    "remove_subscription",
+    "pause_schedule",
+    "resume_schedule",
+    "pause_subscription",
+    "resume_subscription",
+])
+
+/** Browser-fulfilled client tools — they carry their own widget/decline UI; never auto-allowable. */
+const CLIENT_TOOLS = new Set(["request_connection", "request_input"])
+
+/**
+ * The runner rule pattern for a gate, or `null` when the gate must never be auto-allowed:
+ * a platform op, a client tool, or an MCP tool — `wire_author_permission_rules` DROPS `mcp__`
+ * patterns from the runner plan, so such a rule would silently never take effect (MCP is governed
+ * per-server instead).
+ */
+export function gateRulePattern(toolName: string): string | null {
+    if (!toolName) return null
+    if (PLATFORM_OPS.has(toolName) || CLIENT_TOOLS.has(toolName)) return null
+    if (toolName.startsWith("mcp__")) return null
+    return toolName
+}
+
+/** The authored `harness.permissions.allow` patterns. */
+export function readHarnessAllowList(parameters: unknown): string[] {
+    if (!isRecord(parameters)) return []
+    const {template} = locateTemplate(parameters)
+    const harness = isRecord(template.harness) ? template.harness : {}
+    const permissions = isRecord(harness.permissions) ? harness.permissions : {}
+    return Array.isArray(permissions.allow)
+        ? (permissions.allow.filter((v) => typeof v === "string") as string[])
+        : []
+}
+
+export interface GrantableHarnessTool {
+    /** The runner rule pattern — the gate name, verbatim. */
+    pattern: string
+    /** Already present in `harness.permissions.allow`. */
+    allowed: boolean
+}
+
+/**
+ * Classify a gate as an allow-rule-able harness tool and report whether it's already allowed, or
+ * `null` when it must stay gated. Callers must check `findGrantableTool` FIRST: a gateway/custom
+ * tool has a `tools[]` entry whose per-tool `permission` outranks any rule.
+ */
+export function findGrantableHarnessTool(
+    parameters: unknown,
+    toolName: string,
+): GrantableHarnessTool | null {
+    const pattern = gateRulePattern(toolName)
+    if (!pattern || !isRecord(parameters)) return null
+    return {pattern, allowed: readHarnessAllowList(parameters).includes(pattern)}
+}
+
+/** Return a new `parameters` with `pattern` present (or absent, when `allowed` is false) in
+ *  `harness.permissions.allow`. Preserves the rest of the harness/permissions object. */
+export function withHarnessToolAllow(
+    parameters: unknown,
+    pattern: string,
+    allowed: boolean,
+): Record<string, unknown> | null {
+    if (!isRecord(parameters) || !pattern) return null
+    const {template, wrap} = locateTemplate(parameters)
+    const harness = isRecord(template.harness) ? {...template.harness} : {}
+    const permissions = isRecord(harness.permissions) ? {...harness.permissions} : {}
+    const current = Array.isArray(permissions.allow)
+        ? (permissions.allow.filter((v) => typeof v === "string") as string[])
+        : []
+    const has = current.includes(pattern)
+    if (allowed === has) return wrap({...template, harness: {...harness, permissions}})
+    const nextAllow = allowed ? [...current, pattern] : current.filter((name) => name !== pattern)
+    return wrap({
+        ...template,
+        harness: {...harness, permissions: {...permissions, allow: nextAllow}},
+    })
+}
+
+/**
+ * Find the grantable `tools[]` entry for a gate, or `null` when the gate is not a per-tool-config
+ * tool (platform op, builtin, MCP, reference, or an unknown name). A `null` result is the signal to
+ * hide the "always allow" affordance.
+ */
+export function findGrantableTool(parameters: unknown, toolName: string): GrantableTool | null {
+    if (!isRecord(parameters) || !toolName) return null
+    const {template} = locateTemplate(parameters)
+    const tools = Array.isArray(template.tools) ? (template.tools as unknown[]) : []
+    const i = matchToolIndex(tools, toolName)
+    if (i < 0) return null
+    return {permission: asPermission((tools[i] as Record<string, unknown>).permission)}
+}
+
+/**
+ * Return a new `parameters` with the gate's tool entry set to `permission` (or its `permission` key
+ * removed when `undefined` = inherit). Returns `null` when the gate is not grantable, so the caller
+ * leaves the config untouched.
+ */
+export function withToolPermission(
+    parameters: unknown,
+    toolName: string,
+    permission: ToolPermission | undefined,
+): Record<string, unknown> | null {
+    if (!isRecord(parameters) || !toolName) return null
+    const {template, wrap} = locateTemplate(parameters)
+    const tools = Array.isArray(template.tools) ? (template.tools as unknown[]) : []
+    const i = matchToolIndex(tools, toolName)
+    if (i < 0) return null
+    const entry = isRecord(tools[i]) ? {...(tools[i] as Record<string, unknown>)} : {}
+    if (permission === undefined) delete entry.permission
+    else entry.permission = permission
+    const nextTools = tools.slice()
+    nextTools[i] = entry
+    return wrap({...template, tools: nextTools})
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection.tsx
@@ -1824,16 +1824,20 @@ function PlaygroundConfigSection({
                 return <div className="px-4 py-1.5">{props.defaultRender()}</div>
             }
 
-            // The agent_config body is always expanded (its header is suppressed above), so it renders
-            // without the HeightCollapse toggle.
+            // The agent body is always expanded (its header is suppressed above), so it renders
+            // without the HeightCollapse toggle. Match BOTH markers (modern `agent-template`,
+            // legacy `agent_config`) — same detection as the header suppressor above.
             const fieldSchema = schema?.properties
                 ? (schema.properties as Record<string, Record<string, unknown>>)[fieldKey]
                 : null
+            const isAgentBody = (v: unknown) => v === "agent-template" || v === "agent_config"
             if (
-                fieldSchema?.["x-ag-type-ref"] === "agent_config" ||
-                fieldSchema?.["x-ag-type"] === "agent_config"
+                isAgentBody(fieldSchema?.["x-ag-type-ref"]) ||
+                isAgentBody(fieldSchema?.["x-ag-type"])
             ) {
-                return <div className="px-4 py-3">{props.defaultRender()}</div>
+                // pb-3 only: the first section row (ConfigAccordionSection) carries its own py-3
+                // header, so a top py-3 here would double into a dead 24px band under the header bar.
+                return <div className="px-4 pb-3">{props.defaultRender()}</div>
             }
 
             return (
@@ -1858,10 +1862,10 @@ function PlaygroundConfigSection({
 
     if (isConfigLoading) {
         if (loadingFallback) {
-            // px-4 py-3 mirrors the field-content wrapper the real sections (and the lazy
-            // control's Suspense fallback) render inside — without it the fallback skeleton
-            // sits 16px wider / 12px higher and visibly shifts when the schema lands.
-            return <div className={clsx("px-4 py-3", className)}>{loadingFallback}</div>
+            // px-4 pb-3 mirrors the field-content wrapper the real sections (and the lazy
+            // control's Suspense fallback) render inside — same inset, so the fallback skeleton
+            // doesn't shift when the schema lands.
+            return <div className={clsx("px-4 pb-3", className)}>{loadingFallback}</div>
         }
         return (
             <div className={clsx("p-4 flex flex-col gap-3", className)}>

--- a/web/packages/agenta-entity-ui/src/DrillInView/index.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/index.ts
@@ -267,6 +267,12 @@ export {
     normalizeMessages,
     denormalizeMessages,
     getOptionsFromSchema,
+    findGrantableTool,
+    withToolPermission,
+    gateRulePattern,
+    readHarnessAllowList,
+    findGrantableHarnessTool,
+    withHarnessToolAllow,
     type OptionGroup,
 } from "./SchemaControls"
 
@@ -291,6 +297,9 @@ export type {
     ObjectSchemaControlProps,
     SchemaPropertyRendererProps,
     FieldsDetectionContextValue,
+    GrantableTool,
+    ToolPermission,
+    GrantableHarnessTool,
 } from "./SchemaControls"
 
 // Operational panel regions (Triggers, Mounts) — siblings of the Configuration section.

--- a/web/packages/agenta-entity-ui/src/drawers/shared/ChangedPathsContext.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/ChangedPathsContext.tsx
@@ -1,0 +1,109 @@
+/**
+ * ChangedPathsContext
+ *
+ * Carries "which config properties have uncommitted changes" — as dot-paths like
+ * `harness.permissions.allow` / `runner.permissions.default` / `sandbox.kind` — down to the rail
+ * rows that render them. A drawer can then mark the exact property row that changed and open the
+ * sub-section that holds it, without prop-drilling a path map through a large render.
+ *
+ * Deliberately structural and dependency-free: it knows nothing about the agent template or the
+ * commit-diff classifier, so this shared drawer primitive stays usable by any config surface. The
+ * agent panel's `SectionChanges` (see `SchemaControls/agentTemplate/sectionChanges.ts`) satisfies
+ * `ChangedPaths` by shape and can be passed straight in.
+ *
+ * With no provider, nothing is marked — every existing caller keeps working untouched.
+ */
+import {createContext, useContext, useMemo, type ReactNode} from "react"
+
+export interface ChangedPaths {
+    /** Whether this exact property path changed. */
+    isChanged: (path: string) => boolean
+    /** Whether anything under this dotted subtree changed. */
+    hasChangedUnder: (prefix: string) => boolean
+    /** Changed paths under a subtree (all of them with no prefix) — the input to a scoped revert. */
+    pathsUnder: (prefix?: string) => string[]
+    /**
+     * What this property changed FROM — so a row can answer "changed, but from what?" without the
+     * reader opening a commit diff. Pre-formatted display strings (the classifier already renders
+     * them); `before: undefined` means the committed config had no value for it.
+     */
+    changeFor?: (path: string) => {before?: string; after?: string} | undefined
+    /**
+     * Restore these paths to their committed values. Supplied by the HOST, because where the write
+     * lands differs by surface: inside a section drawer it must go through that drawer's scoped
+     * draft (so Cancel/Save still mean what they say), while the panel writes the entity draft
+     * directly. Absent = the surface offers no revert, and the affordance stays hidden.
+     */
+    revert?: (paths: string[]) => void
+}
+
+const NONE: ChangedPaths = {
+    isChanged: () => false,
+    hasChangedUnder: () => false,
+    pathsUnder: () => [],
+}
+
+const ChangedPathsContext = createContext<ChangedPaths>(NONE)
+
+export function ChangedPathsProvider({
+    changes,
+    children,
+}: {
+    changes: ChangedPaths
+    children: ReactNode
+}) {
+    return <ChangedPathsContext.Provider value={changes}>{children}</ChangedPathsContext.Provider>
+}
+
+/** Whether this exact property path has an uncommitted change (marks one rail row). */
+export function useChangedPath(path: string | undefined): boolean {
+    const changes = useContext(ChangedPathsContext)
+    return useMemo(() => (path ? changes.isChanged(path) : false), [changes, path])
+}
+
+/**
+ * What this property changed from → to, when the surface can say. Null when it's unchanged, so a
+ * caller can render the row's "changed" affordance and its explanation from one lookup.
+ */
+export function useChangedDetail(
+    path: string | undefined,
+): {before?: string; after?: string} | null {
+    const changes = useContext(ChangedPathsContext)
+    return useMemo(() => {
+        if (!path || !changes.isChanged(path)) return null
+        return changes.changeFor?.(path) ?? null
+    }, [changes, path])
+}
+
+/**
+ * Revert ONE property, for a key-scoped undo on its row. Null when the path is unchanged or the
+ * surface offers no revert, so the caller renders a plain marker instead of an action.
+ */
+export function useRevertPath(path: string | undefined): (() => void) | null {
+    const changes = useContext(ChangedPathsContext)
+    return useMemo(() => {
+        const {revert, isChanged} = changes
+        if (!revert || !path || !isChanged(path)) return null
+        return () => revert([path])
+    }, [changes, path])
+}
+
+/** Whether anything under this dotted subtree changed — drives a sub-section's `defaultOpen`. */
+export function useHasChangedUnder(prefix: string | undefined): boolean {
+    const changes = useContext(ChangedPathsContext)
+    return useMemo(() => (prefix ? changes.hasChangedUnder(prefix) : false), [changes, prefix])
+}
+
+/**
+ * Revert a subtree, for a section-scoped "undo these changes" action. Returns null when the surface
+ * offers no revert or the subtree is unchanged, so the caller renders nothing.
+ */
+export function useRevertUnder(prefix: string | undefined): (() => void) | null {
+    const changes = useContext(ChangedPathsContext)
+    return useMemo(() => {
+        const {revert, pathsUnder} = changes
+        if (!revert || !prefix) return null
+        const paths = pathsUnder(prefix)
+        return paths.length ? () => revert(paths) : null
+    }, [changes, prefix])
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/FocusPathsContext.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/FocusPathsContext.tsx
@@ -1,0 +1,74 @@
+/**
+ * FocusPathsContext
+ *
+ * Narrows a config surface to just the properties that matter right now — the section's REAL
+ * controls, filtered, rather than a second rendering of them.
+ *
+ * This is the general form of the Model & harness "Connect key" affordance: when something needs
+ * attention, show the control that owns it and link out for the rest. "Needs a key" and "changed
+ * since the commit" are then the same pattern with different filters, over one set of controls.
+ *
+ * Mechanism: rows already declare their `path` (see {@link RailField}), so a filter is all that's
+ * needed — a focused row renders itself, an unfocused one renders nothing, and the group that owns
+ * no focused path hides. No parallel "what changed" UI to build or keep in sync.
+ *
+ * Inactive by default (no provider = everything renders), so the drawers and every other host are
+ * untouched.
+ */
+import {createContext, useContext, useMemo, type ReactNode} from "react"
+
+export interface FocusPaths {
+    /** A filter is in force — rows and groups outside it hide. */
+    active: boolean
+    /** Whether this exact property is in focus. */
+    isFocused: (path: string) => boolean
+    /** Whether this dotted subtree contains anything in focus (does this group survive?). */
+    hasFocusUnder: (prefix: string) => boolean
+}
+
+/** No filter: everything renders. */
+const NONE: FocusPaths = {active: false, isFocused: () => true, hasFocusUnder: () => true}
+
+const FocusPathsContext = createContext<FocusPaths>(NONE)
+
+export function FocusPathsProvider({
+    paths,
+    children,
+}: {
+    /** The properties to narrow to. `null` = no filter (render everything). */
+    paths: string[] | null
+    children: ReactNode
+}) {
+    const value = useMemo<FocusPaths>(() => {
+        if (!paths) return NONE
+        const set = new Set(paths)
+        return {
+            active: true,
+            isFocused: (path) => set.has(path),
+            hasFocusUnder: (prefix) =>
+                [...set].some((path) => path === prefix || path.startsWith(`${prefix}.`)),
+        }
+    }, [paths])
+    return <FocusPathsContext.Provider value={value}>{children}</FocusPathsContext.Provider>
+}
+
+/** The active filter — for a caller that needs to branch on it (e.g. flat vs grouped chrome). */
+export function useFocusPaths(): FocusPaths {
+    return useContext(FocusPathsContext)
+}
+
+/** Whether a row should render: true unless a filter is in force that excludes it. A row with no
+ *  `path` can't be matched, so it hides under a filter rather than leaking in as noise. */
+export function useIsPathVisible(path: string | undefined): boolean {
+    const focus = useContext(FocusPathsContext)
+    return useMemo(() => !focus.active || (!!path && focus.isFocused(path)), [focus, path])
+}
+
+/** Whether a group survives the filter — i.e. it owns at least one focused property. */
+export function useHasFocusUnder(prefix: string | undefined): boolean {
+    const focus = useContext(FocusPathsContext)
+    return useMemo(
+        () => !focus.active || (!!prefix && focus.hasFocusUnder(prefix)),
+        [focus, prefix],
+    )
+}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -11,13 +11,23 @@
  */
 import type {ReactNode} from "react"
 
-import {Info} from "@phosphor-icons/react"
-import {Tooltip} from "antd"
+import {ArrowCounterClockwise, Info} from "@phosphor-icons/react"
+import {Button, Popover, Tooltip} from "antd"
+
+import {useChangedDetail, useChangedPath, useRevertPath} from "./ChangedPathsContext"
+import {useIsPathVisible} from "./FocusPathsContext"
 
 export interface RailFieldProps {
     label: ReactNode
     /** Vertical alignment of the label against the content. @default "top" */
     align?: "top" | "center"
+    /**
+     * This row's config dot-path (e.g. `runner.permissions.default`). When it has an uncommitted
+     * change — per the surrounding {@link ChangedPathsProvider} — the label marks itself and opens
+     * the change's detail, so a surface shows WHICH property changed rather than just that
+     * something did. Opt-in: without a path (or a provider) the row renders exactly as before.
+     */
+    path?: string
     children: ReactNode
 }
 
@@ -34,15 +44,98 @@ export const railInfoLabel = (label: ReactNode, hint: ReactNode): ReactNode => (
     </span>
 )
 
-export function RailField({label, align = "top", children}: RailFieldProps) {
+// Unpack the classifier's JSON.stringify'd scalar back to what the field shows (one rule per line),
+// naming the empty cases rather than printing wire syntax like `[]`.
+export function formatCommitted(before: string | undefined): {text: string; muted: boolean} {
+    if (before === undefined) return {text: "Not set", muted: true}
+    let value: unknown = before
+    try {
+        value = JSON.parse(before)
+    } catch {
+        // A plain string the classifier passed through as-is.
+    }
+    if (Array.isArray(value)) {
+        return value.length
+            ? {text: value.map((entry) => String(entry)).join("\n"), muted: false}
+            : {text: "Empty", muted: true}
+    }
+    if (value && typeof value === "object") {
+        return Object.keys(value).length
+            ? {text: JSON.stringify(value, null, 2), muted: false}
+            : {text: "Empty", muted: true}
+    }
+    const text = String(value ?? "")
+    return text.trim() ? {text, muted: false} : {text: "Empty", muted: true}
+}
+
+// The committed value ("changed from what?") and its undo on one surface: the value shown IS the
+// revert's confirmation, so no separate confirm step is needed.
+function ChangedDetail({
+    before,
+    onRevert,
+}: {
+    before: string | undefined
+    onRevert: (() => void) | null
+}) {
+    const {text, muted} = formatCommitted(before)
+    return (
+        <div className="flex w-[200px] flex-col gap-2">
+            <div className="text-[11px] uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+                Committed value
+            </div>
+            <div
+                className={`max-h-28 overflow-auto whitespace-pre-wrap break-words rounded border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillQuaternary)] px-2 py-1 text-xs ${
+                    muted
+                        ? "italic text-[var(--ag-colorTextTertiary)]"
+                        : "font-mono text-[var(--ag-colorText)]"
+                }`}
+            >
+                {text}
+            </div>
+            {onRevert ? (
+                <Button
+                    icon={<ArrowCounterClockwise size={13} />}
+                    onClick={onRevert}
+                    block
+                    className="!text-xs"
+                >
+                    {before === undefined ? "Remove change" : "Restore"}
+                </Button>
+            ) : null}
+        </div>
+    )
+}
+
+export function RailField({label, align = "top", path, children}: RailFieldProps) {
+    const changed = useChangedPath(path)
+    const detail = useChangedDetail(path)
+    const revert = useRevertPath(path)
+    // Focus filter (see FocusPathsContext): each row self-filters on its own `path`.
+    const visible = useIsPathVisible(path)
+    if (!visible) return null
     return (
         <div className="flex gap-3">
             <div
-                className={`box-border w-[116px] shrink-0 px-2.5 text-xs text-[var(--ag-colorTextSecondary)] ${
+                className={`box-border w-[116px] shrink-0 px-2.5 text-xs ${
                     align === "center" ? "self-center" : "pt-1.5"
-                }`}
+                } ${changed ? "text-[var(--ag-colorText)]" : "text-[var(--ag-colorTextSecondary)]"}`}
             >
-                {label}
+                {/* The label carries the change via emphasis (colorTextSecondary → colorText) plus a
+                    colorInfo dotted underline — no marker glyph, so changed and unchanged rows share
+                    the same box. */}
+                {changed ? (
+                    <Popover
+                        trigger="click"
+                        placement="topLeft"
+                        content={<ChangedDetail before={detail?.before} onRevert={revert} />}
+                    >
+                        <span className="cursor-pointer underline decoration-[var(--ag-colorInfo)] decoration-dotted underline-offset-4">
+                            {label}
+                        </span>
+                    </Popover>
+                ) : (
+                    label
+                )}
             </div>
             <div className="flex min-w-0 max-w-prose flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
                 {children}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/index.ts
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/index.ts
@@ -6,6 +6,28 @@
 export {RailField, railInfoLabel, type RailFieldProps} from "./RailField"
 export {SectionRail, type SectionRailItem, type SectionRailProps} from "./SectionRail"
 
+// "Which properties have uncommitted changes" — lets a rail row mark the exact changed property and
+// a sub-section open itself when it owns one. Structural, so any config surface can provide it.
+export {
+    ChangedPathsProvider,
+    useChangedDetail,
+    useChangedPath,
+    useHasChangedUnder,
+    useRevertPath,
+    useRevertUnder,
+    type ChangedPaths,
+} from "./ChangedPathsContext"
+
+// Narrow a surface to the properties that matter right now — the real controls, filtered, rather
+// than a second rendering of them. Rows self-filter on the `path` they already declare.
+export {
+    FocusPathsProvider,
+    useFocusPaths,
+    useIsPathVisible,
+    useHasFocusUnder,
+    type FocusPaths,
+} from "./FocusPathsContext"
+
 // Grouped-section primitives (uppercase sub-headers + collapsible provider cards) shared with the
 // config panel's Tools/Triggers sections, so app-layer previews render identical provider groups.
 export {

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerDeliveriesDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerDeliveriesDrawer.tsx
@@ -257,7 +257,7 @@ export default function TriggerDeliveriesDrawer() {
                 setState(null)
             }}
             title={`Deliveries${state?.name ? ` · ${state.name}` : ""}`}
-            width={820}
+            size={820}
             destroyOnClose
             styles={{
                 body: {padding: 0, display: "flex", flexDirection: "column", overflow: "hidden"},

--- a/web/packages/agenta-entity-ui/tests/unit/formatCommitted.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/formatCommitted.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for `formatCommitted`, the pure helper behind a changed rail row's "committed value"
+ * popover.
+ *
+ * It exists because the two sides disagree on what a value looks like: the commit-diff classifier
+ * stores scalars through `JSON.stringify` (`commitDiff/classify.ts` → `fmtScalar`) because it is
+ * COMPARING them, while the popover is SHOWING them to a person. Left unformatted that leaked wire
+ * syntax into the UI — an untouched allow-list rendered as a bare `[]`. These pin the unwrapping,
+ * and that the empty/absent cases get named rather than printing punctuation at the reader.
+ *
+ * Runs under @agenta/entity-ui's vitest runner.
+ */
+import {describe, expect, it} from "vitest"
+
+import {formatCommitted} from "../../src/drawers/shared/RailField"
+
+describe("formatCommitted — the classifier's wire value, as a reader sees it", () => {
+    it("names the absent and empty cases instead of showing their punctuation", () => {
+        // `[]` is what the popover actually leaked before this existed.
+        expect(formatCommitted(undefined)).toEqual({text: "Not set", muted: true})
+        expect(formatCommitted("[]")).toEqual({text: "Empty", muted: true})
+        expect(formatCommitted("{}")).toEqual({text: "Empty", muted: true})
+        expect(formatCommitted('""')).toEqual({text: "Empty", muted: true})
+        expect(formatCommitted("   ")).toEqual({text: "Empty", muted: true})
+    })
+
+    it("unwraps a stringified list to one entry per line, matching the control that renders it", () => {
+        // The allow-rules field is a textarea of one rule per line — not `["Terminal","Write"]`.
+        expect(formatCommitted('["Terminal","Write"]')).toEqual({
+            text: "Terminal\nWrite",
+            muted: false,
+        })
+    })
+
+    it("keeps a plain scalar as itself", () => {
+        expect(formatCommitted("ask")).toEqual({text: "ask", muted: false})
+        expect(formatCommitted("42")).toEqual({text: "42", muted: false})
+    })
+
+    it("pretty-prints a non-empty object rather than showing one long line", () => {
+        expect(formatCommitted('{"mode":"deny"}')).toEqual({
+            text: '{\n  "mode": "deny"\n}',
+            muted: false,
+        })
+    })
+
+    it("passes through a string that only looks like JSON, without throwing", () => {
+        // fmtScalar sends non-objects through `String(v)`, so an instruction can reach here unquoted.
+        expect(formatCommitted("{not json")).toEqual({text: "{not json", muted: false})
+    })
+})

--- a/web/packages/agenta-entity-ui/tests/unit/sectionChanges.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/sectionChanges.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Pins the CONTRACT between the commit-diff classifier and the config panel/drawer.
+ *
+ * The drawer marks a changed property by hardcoding its dot-path on a `RailField`
+ * (`path="harness.permissions.allow"`), and sub-sections open via `hasChangedUnder("harness")`.
+ * Those strings only work if they match what `classifyAgentChanges` actually flattens to — and a
+ * mismatch fails SILENTLY (no mark, no error), so it must be asserted rather than assumed.
+ *
+ * These tests therefore diff realistic before/after templates the same way the panel does (bare
+ * agent template on both sides) and assert the emitted `scalarChanges` keys verbatim.
+ */
+import {classifyAgentChanges} from "@agenta/entities/workflow/commitDiff"
+import {describe, expect, it} from "vitest"
+
+import {
+    revertPathsTo,
+    SECTION_ID_TO_PANEL_KEY,
+    toSectionChanges,
+} from "../../src/DrillInView/SchemaControls/agentTemplate/sectionChanges"
+
+/** The bare agent template both sides of the panel's diff use (`parameters.agent`, unwrapped). */
+const template = (overrides: Record<string, unknown> = {}) => ({
+    instructions: {agents_md: "You are a friendly hello-world agent."},
+    llm: {model: "gpt-5", provider: "openai"},
+    tools: [],
+    harness: {kind: "claude"},
+    runner: {permissions: {default: "allow_reads"}},
+    sandbox: {kind: "local"},
+    ...overrides,
+})
+
+const changesFor = (local: Record<string, unknown>, remote: Record<string, unknown>) =>
+    toSectionChanges(classifyAgentChanges(local, remote))
+
+describe("SECTION_ID_TO_PANEL_KEY", () => {
+    it("maps every classifier section id to a panel key", () => {
+        expect(SECTION_ID_TO_PANEL_KEY).toEqual({
+            model: "model-harness",
+            instructions: "instructions",
+            tools: "tools",
+            mcps: "mcp",
+            skills: "skills",
+            params: "advanced",
+        })
+    })
+})
+
+describe("changed paths — the strings the drawer hardcodes", () => {
+    it("an approval grant to harness.permissions.allow lands on the Advanced section at that exact path", () => {
+        const committed = template()
+        const draft = template({harness: {kind: "claude", permissions: {allow: ["Terminal"]}}})
+        const changes = changesFor(draft, committed)
+
+        expect(changes.panelKeys.has("advanced")).toBe(true)
+        expect(changes.changedPaths.has("harness.permissions.allow")).toBe(true)
+        expect(changes.isChanged("harness.permissions.allow")).toBe(true)
+    })
+
+    // The row's popover answers "changed from what?" with `before` — so a change the classifier
+    // reports MUST also be retrievable by its path, or the row marks itself and then has nothing to
+    // say. `before: undefined` is meaningful (the commit didn't set it) and must survive as itself.
+    it("recalls what a changed property was committed as, by path", () => {
+        const changes = changesFor(
+            template({runner: {permissions: {default: "allow"}}}),
+            template({runner: {permissions: {default: "ask"}}}),
+        )
+
+        expect(changes.changeFor("runner.permissions.default")?.before).toBe("ask")
+        expect(changes.changeFor("runner.permissions.default")?.after).toBe("allow")
+        expect(changes.changeFor("sandbox.kind")).toBeUndefined()
+    })
+
+    it("reports a property the commit never had as added, with no before value", () => {
+        const changes = changesFor(
+            template({harness: {kind: "claude", permissions: {allow: ["Terminal"]}}}),
+            template(),
+        )
+        const change = changes.changeFor("harness.permissions.allow")
+
+        expect(change).toBeDefined()
+        expect(change?.before).toBeUndefined()
+    })
+
+    it("opens the Permissions group (harness/runner) but not Execution environment (sandbox)", () => {
+        const committed = template()
+        const draft = template({harness: {kind: "claude", permissions: {allow: ["Terminal"]}}})
+        const changes = changesFor(draft, committed)
+
+        expect(changes.hasChangedUnder("harness")).toBe(true)
+        expect(changes.hasChangedUnder("runner")).toBe(false)
+        expect(changes.hasChangedUnder("sandbox")).toBe(false)
+    })
+
+    it("emits runner.permissions.default for a Policy change", () => {
+        const committed = template()
+        const draft = template({runner: {permissions: {default: "allow"}}})
+        const changes = changesFor(draft, committed)
+
+        expect(changes.changedPaths.has("runner.permissions.default")).toBe(true)
+        expect(changes.hasChangedUnder("runner")).toBe(true)
+    })
+
+    it("emits sandbox.kind and the nested sandbox.permissions.* paths", () => {
+        const committed = template()
+        const draft = template({
+            sandbox: {
+                kind: "daytona",
+                permissions: {network: {mode: "off"}, filesystem: "readonly"},
+            },
+        })
+        const changes = changesFor(draft, committed)
+
+        expect(changes.changedPaths.has("sandbox.kind")).toBe(true)
+        expect(changes.changedPaths.has("sandbox.permissions.network.mode")).toBe(true)
+        expect(changes.changedPaths.has("sandbox.permissions.filesystem")).toBe(true)
+        expect(changes.hasChangedUnder("sandbox")).toBe(true)
+    })
+
+    it("keeps harness.kind on Model & harness, NOT Advanced (the buckets are split there)", () => {
+        const committed = template()
+        const draft = template({harness: {kind: "pi_core"}})
+        const changes = changesFor(draft, committed)
+
+        expect(changes.panelKeys.has("model-harness")).toBe(true)
+        expect(changes.panelKeys.has("advanced")).toBe(false)
+        expect(changes.changedPaths.has("harness.kind")).toBe(true)
+    })
+
+    it("reports nothing changed for an identical template", () => {
+        const changes = changesFor(template(), template())
+        expect(changes.panelKeys.size).toBe(0)
+        expect(changes.changedPaths.size).toBe(0)
+        expect(changes.hasChangedUnder("harness")).toBe(false)
+    })
+})
+
+describe("revertPathsTo", () => {
+    it("restores a changed value to the committed one, and the diff then reports clean", () => {
+        const committed = template()
+        const draft = template({runner: {permissions: {default: "allow"}}})
+
+        const reverted = revertPathsTo(draft, committed, ["runner.permissions.default"])
+
+        expect(reverted).toEqual(committed)
+        expect(changesFor(reverted, committed).changedPaths.size).toBe(0)
+    })
+
+    it("DELETES a key the commit never had (an added property), pruning the empty slice it leaves", () => {
+        const committed = template() // harness: {kind: "claude"} — no `permissions`
+        const draft = template({harness: {kind: "claude", permissions: {allow: ["Terminal"]}}})
+
+        const reverted = revertPathsTo(draft, committed, ["harness.permissions.allow"])
+
+        // Not `permissions: {}` left behind — the slice is pruned, so the diff is truly clean.
+        expect(reverted.harness).toEqual({kind: "claude"})
+        expect(changesFor(reverted, committed).changedPaths.size).toBe(0)
+    })
+
+    it("reverts only the named path, leaving other changes intact (key-scoped undo)", () => {
+        const committed = template()
+        const draft = template({
+            harness: {kind: "claude", permissions: {allow: ["Terminal"]}},
+            runner: {permissions: {default: "allow"}},
+        })
+
+        const reverted = revertPathsTo(draft, committed, ["harness.permissions.allow"])
+        const changes = changesFor(reverted, committed)
+
+        expect(changes.changedPaths.has("harness.permissions.allow")).toBe(false)
+        expect(changes.changedPaths.has("runner.permissions.default")).toBe(true)
+    })
+
+    it("reverts a whole subtree from pathsUnder (section-scoped undo)", () => {
+        const committed = template()
+        const draft = template({
+            sandbox: {kind: "daytona", permissions: {filesystem: "readonly"}},
+        })
+        const paths = changesFor(draft, committed).pathsUnder("sandbox")
+
+        const reverted = revertPathsTo(draft, committed, paths)
+
+        expect(reverted).toEqual(committed)
+    })
+
+    it("restores an array leaf whole, and never mutates the input", () => {
+        const committed = template({harness: {kind: "claude", permissions: {allow: ["Read"]}}})
+        const draft = template({
+            harness: {kind: "claude", permissions: {allow: ["Read", "Terminal"]}},
+        })
+        const snapshot = JSON.stringify(draft)
+
+        const reverted = revertPathsTo(draft, committed, ["harness.permissions.allow"]) as {
+            harness: {permissions: {allow: string[]}}
+        }
+
+        expect(reverted.harness.permissions.allow).toEqual(["Read"])
+        expect(JSON.stringify(draft)).toBe(snapshot)
+    })
+
+    it("is a no-op without a committed baseline (a never-saved draft has nothing to revert to)", () => {
+        const draft = template()
+        expect(revertPathsTo(draft, null, ["runner.permissions.default"])).toBe(draft)
+    })
+})
+
+describe("hasChangedUnder", () => {
+    it("matches the subtree, not a same-prefixed sibling key", () => {
+        const changes = toSectionChanges([
+            {
+                id: "params",
+                title: "Advanced",
+                tags: [],
+                totalCount: 1,
+                scalarChanges: [
+                    {key: "harnessing.thing", before: "a", after: "b", kind: "changed"},
+                ],
+            },
+        ])
+        // "harnessing.thing" must NOT make the `harness` group look changed.
+        expect(changes.hasChangedUnder("harness")).toBe(false)
+        expect(changes.hasChangedUnder("harnessing")).toBe(true)
+    })
+
+    it("treats an exact path as changed under itself", () => {
+        const changes = toSectionChanges([
+            {
+                id: "params",
+                title: "Advanced",
+                tags: [],
+                totalCount: 1,
+                scalarChanges: [{key: "harness", before: "a", after: "b", kind: "changed"}],
+            },
+        ])
+        expect(changes.hasChangedUnder("harness")).toBe(true)
+    })
+})

--- a/web/packages/agenta-entity-ui/tests/unit/toolPermission.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/toolPermission.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for the approval-card "always allow this tool" config write-through.
+ *
+ * `findGrantableTool` / `withToolPermission` map a runtime gate's wire `toolName` back to its entry
+ * in the agent template's `tools[]` and set a per-tool `permission`. Only gateway (canonical or
+ * legacy slug) and custom function tools are grantable; platform ops, builtins, MCP, and references
+ * must be left ungrantable so `commit_revision` and destructive ops stay gated. Runs under
+ * @agenta/entity-ui's own vitest runner.
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    findGrantableHarnessTool,
+    findGrantableTool,
+    gateRulePattern,
+    readHarnessAllowList,
+    withHarnessToolAllow,
+    withToolPermission,
+} from "../../src/DrillInView/SchemaControls/toolPermission"
+
+const GATEWAY_SLUG = "tools__composio__gmail__GMAIL_SEND_EMAIL__conn1"
+
+const canonicalGateway = (extra: Record<string, unknown> = {}) => ({
+    type: "gateway",
+    provider: "composio",
+    integration: "gmail",
+    action: "GMAIL_SEND_EMAIL",
+    connection: "conn1",
+    ...extra,
+})
+
+const legacyGateway = (extra: Record<string, unknown> = {}) => ({
+    type: "function",
+    function: {name: GATEWAY_SLUG},
+    ...extra,
+})
+
+const customFn = (name: string, extra: Record<string, unknown> = {}) => ({
+    type: "function",
+    function: {name, parameters: {type: "object", properties: {}}},
+    ...extra,
+})
+
+const wrap = (tools: unknown[]) => ({
+    agent: {tools, runner: {permissions: {default: "allow_reads"}}},
+})
+
+describe("findGrantableTool", () => {
+    it("matches a canonical gateway entry by its {provider,integration,action,connection} identity", () => {
+        const params = wrap([canonicalGateway()])
+        expect(findGrantableTool(params, GATEWAY_SLUG)).toEqual({permission: undefined})
+    })
+
+    it("matches a legacy gateway function-name slug", () => {
+        const params = wrap([legacyGateway()])
+        expect(findGrantableTool(params, GATEWAY_SLUG)).not.toBeNull()
+    })
+
+    it("matches a custom function tool by function.name", () => {
+        const params = wrap([customFn("get_weather")])
+        expect(findGrantableTool(params, "get_weather")).toEqual({permission: undefined})
+    })
+
+    it("reports the current permission when one is set", () => {
+        const params = wrap([canonicalGateway({permission: "allow"})])
+        expect(findGrantableTool(params, GATEWAY_SLUG)).toEqual({permission: "allow"})
+    })
+
+    it("does not match a platform op, builtin, reference, or unknown gate", () => {
+        const params = wrap([
+            {type: "platform", op: "commit_revision"},
+            {type: "builtin", name: "read"},
+            {type: "reference", name: "some_workflow"},
+        ])
+        expect(findGrantableTool(params, "commit_revision")).toBeNull()
+        expect(findGrantableTool(params, "read")).toBeNull()
+        expect(findGrantableTool(params, "mcp__linear__create_issue")).toBeNull()
+    })
+
+    it("returns null for a missing config / empty tools", () => {
+        expect(findGrantableTool(null, GATEWAY_SLUG)).toBeNull()
+        expect(findGrantableTool(wrap([]), GATEWAY_SLUG)).toBeNull()
+    })
+})
+
+describe("withToolPermission", () => {
+    it("sets permission on the matched entry and leaves the others untouched", () => {
+        const other = customFn("keep_me")
+        const params = wrap([canonicalGateway(), other])
+        const next = withToolPermission(params, GATEWAY_SLUG, "allow") as {
+            agent: {tools: Record<string, unknown>[]}
+        }
+        expect(next.agent.tools[0].permission).toBe("allow")
+        expect(next.agent.tools[1]).toEqual(other)
+    })
+
+    it("removes the permission key when inheriting (undefined)", () => {
+        const params = wrap([canonicalGateway({permission: "allow"})])
+        const next = withToolPermission(params, GATEWAY_SLUG, undefined) as {
+            agent: {tools: Record<string, unknown>[]}
+        }
+        expect("permission" in next.agent.tools[0]).toBe(false)
+    })
+
+    it("returns null (no write) for an ungrantable gate", () => {
+        const params = wrap([{type: "platform", op: "commit_revision"}])
+        expect(withToolPermission(params, "commit_revision", "allow")).toBeNull()
+    })
+
+    it("does not mutate the input parameters", () => {
+        const params = wrap([canonicalGateway()])
+        const snapshot = JSON.stringify(params)
+        withToolPermission(params, GATEWAY_SLUG, "allow")
+        expect(JSON.stringify(params)).toBe(snapshot)
+    })
+
+    it("supports a bare template (no agent wrapper)", () => {
+        const bare = {tools: [canonicalGateway()]}
+        const next = withToolPermission(bare, GATEWAY_SLUG, "allow") as {
+            tools: Record<string, unknown>[]
+        }
+        expect(next.tools[0].permission).toBe("allow")
+    })
+})
+
+const wrapHarness = (permissions?: Record<string, unknown>) => ({
+    agent: {
+        tools: [],
+        runner: {permissions: {default: "allow_reads"}},
+        harness: {kind: "pi_agenta", ...(permissions ? {permissions} : {})},
+    },
+})
+
+describe("gateRulePattern", () => {
+    // The runner matches `pattern === gate.toolName`, and the card shows that exact string
+    // (stamped as `resolvedName`). Canonicalizing would silently never match — an ACP gate
+    // reports `bash`/`Terminal` verbatim, so a rule for `Bash` would be a no-op.
+    it("returns the gate name VERBATIM — never canonicalized", () => {
+        expect(gateRulePattern("bash")).toBe("bash")
+        expect(gateRulePattern("Terminal")).toBe("Terminal")
+        expect(gateRulePattern("Bash")).toBe("Bash")
+        expect(gateRulePattern("Write")).toBe("Write")
+    })
+
+    it("refuses platform ops so commit/destructive ops always gate", () => {
+        expect(gateRulePattern("commit_revision")).toBeNull()
+        expect(gateRulePattern("create_schedule")).toBeNull()
+        expect(gateRulePattern("remove_subscription")).toBeNull()
+        expect(gateRulePattern("test_run")).toBeNull()
+    })
+
+    it("refuses client tools and MCP tools (mcp__ rules are dropped from the runner plan)", () => {
+        expect(gateRulePattern("request_connection")).toBeNull()
+        expect(gateRulePattern("request_input")).toBeNull()
+        expect(gateRulePattern("mcp__linear__create_issue")).toBeNull()
+        expect(gateRulePattern("")).toBeNull()
+    })
+})
+
+describe("findGrantableHarnessTool", () => {
+    it("classifies an arbitrary harness gate verbatim and reports not-yet-allowed", () => {
+        expect(findGrantableHarnessTool(wrapHarness(), "Terminal")).toEqual({
+            pattern: "Terminal",
+            allowed: false,
+        })
+        expect(findGrantableHarnessTool(wrapHarness(), "bash")).toEqual({
+            pattern: "bash",
+            allowed: false,
+        })
+    })
+
+    it("reports allowed when the pattern is in harness.permissions.allow", () => {
+        const params = wrapHarness({allow: ["Terminal"]})
+        expect(findGrantableHarnessTool(params, "Terminal")).toEqual({
+            pattern: "Terminal",
+            allowed: true,
+        })
+        expect(readHarnessAllowList(params)).toEqual(["Terminal"])
+    })
+
+    it("returns null for a platform op", () => {
+        expect(findGrantableHarnessTool(wrapHarness(), "commit_revision")).toBeNull()
+    })
+})
+
+describe("withHarnessToolAllow", () => {
+    it("adds the pattern to harness.permissions.allow (creating the slice)", () => {
+        const next = withHarnessToolAllow(wrapHarness(), "Terminal", true) as {
+            agent: {harness: {permissions: {allow: string[]}}}
+        }
+        expect(next.agent.harness.permissions.allow).toEqual(["Terminal"])
+    })
+
+    it("is idempotent — no duplicate when already present", () => {
+        const next = withHarnessToolAllow(wrapHarness({allow: ["bash"]}), "bash", true) as {
+            agent: {harness: {permissions: {allow: string[]}}}
+        }
+        expect(next.agent.harness.permissions.allow).toEqual(["bash"])
+    })
+
+    it("removes the pattern when allowed is false, preserving other entries", () => {
+        const next = withHarnessToolAllow(
+            wrapHarness({allow: ["bash", "Terminal"]}),
+            "bash",
+            false,
+        ) as {agent: {harness: {permissions: {allow: string[]}}}}
+        expect(next.agent.harness.permissions.allow).toEqual(["Terminal"])
+    })
+
+    it("preserves other permission keys (e.g. default_mode)", () => {
+        const next = withHarnessToolAllow(wrapHarness({default_mode: "default"}), "Bash", true) as {
+            agent: {harness: {permissions: Record<string, unknown>}}
+        }
+        expect(next.agent.harness.permissions.default_mode).toBe("default")
+        expect(next.agent.harness.permissions.allow).toEqual(["Bash"])
+    })
+
+    it("does not mutate the input parameters", () => {
+        const params = wrapHarness({allow: ["Terminal"]})
+        const snapshot = JSON.stringify(params)
+        withHarnessToolAllow(params, "bash", true)
+        expect(JSON.stringify(params)).toBe(snapshot)
+    })
+})

--- a/web/packages/agenta-shared/src/state/draftConfigChangeSignal.ts
+++ b/web/packages/agenta-shared/src/state/draftConfigChangeSignal.ts
@@ -1,0 +1,31 @@
+import {atom} from "jotai"
+
+/**
+ * Raised when an interaction OUTSIDE the config pane mutates the DRAFT agent config
+ * (e.g. flipping "always allow" in the approval dock writes a per-tool permission).
+ * The draft/uncommitted counterpart of {@link agentSelfCommitSignalAtom}: that one marks
+ * a COMMITTED self-commit in agent teal; this one marks an UNCOMMITTED, user-initiated
+ * change in draft blue, so the config sections it touched can pulse for attention even
+ * when the user's eyes are on the chat.
+ *
+ * Config-scoped by design — files (time-based recency) and triggers (persisted, not draft)
+ * keep their own "changed" engines; only the shared visual language is reused.
+ * Cleared by the next draft change or by dismissal.
+ */
+export interface DraftConfigChangeSignal {
+    /** The draft revision whose config changed. */
+    revisionId: string
+    /** Config section keys to light up, e.g. ["tools"] or ["model-harness"]. */
+    sectionKeys: string[]
+    /** Where the change came from — extensible provenance for future callers. */
+    origin: "approval-dock"
+    /** Short human summary for the tooltip, e.g. "Always allow search_web". */
+    summary?: string
+    /** Friendly label for the config-pane banner, e.g. "Send email". */
+    label?: string
+    /** The tool the change targeted, so the banner's Undo can revert it. */
+    toolName?: string
+    at: number
+}
+
+export const draftConfigChangeSignalAtom = atom<DraftConfigChangeSignal | null>(null)

--- a/web/packages/agenta-shared/src/state/index.ts
+++ b/web/packages/agenta-shared/src/state/index.ts
@@ -11,6 +11,10 @@ export {openAgentConfigSectionAtom} from "./openConfigSection"
 export type {AgentConfigSection} from "./openConfigSection"
 export {agentSelfCommitSignalAtom} from "./agentCommitSignal"
 export type {AgentSelfCommitSignal} from "./agentCommitSignal"
+export {draftConfigChangeSignalAtom} from "./draftConfigChangeSignal"
+export type {DraftConfigChangeSignal} from "./draftConfigChangeSignal"
+export {providerKeyAddedSignalAtom} from "./providerKeyAddedSignal"
+export type {ProviderKeyAddedSignal} from "./providerKeyAddedSignal"
 export {atomWithRefresh} from "jotai/utils"
 export {
     atomWithCompare,

--- a/web/packages/agenta-shared/src/state/providerKeyAddedSignal.ts
+++ b/web/packages/agenta-shared/src/state/providerKeyAddedSignal.ts
@@ -1,0 +1,18 @@
+import {atom} from "jotai"
+
+/**
+ * Raised when a provider API key is saved from the config pane's "Connect key" flow (the inline
+ * provider-credentials pane or its drawer). Drives the success banner pinned to the bottom of the
+ * config pane — the same pattern as {@link agentSelfCommitSignalAtom} /
+ * {@link draftConfigChangeSignalAtom}, in success green: it confirms the agent can now run without
+ * pulling focus away with a floating toast. Cleared by dismissal or after an auto-dismiss timeout.
+ */
+export interface ProviderKeyAddedSignal {
+    /** The displayed revision the key was connected for. */
+    revisionId: string
+    /** Friendly provider name for the banner, e.g. "OpenAI". */
+    provider?: string
+    at: number
+}
+
+export const providerKeyAddedSignalAtom = atom<ProviderKeyAddedSignal | null>(null)

--- a/web/packages/agenta-ui/package.json
+++ b/web/packages/agenta-ui/package.json
@@ -97,6 +97,7 @@
         "lexical": "^0.46.0",
         "lucide-react": "^0.479.0",
         "marked": "^17.0.4",
+        "motion": "^12.0.0",
         "prismjs": "^1.30.0",
         "react-resizable": "^3.0.5",
         "uuid": "^11.1.1"

--- a/web/packages/agenta-ui/src/components/HeightCollapse.tsx
+++ b/web/packages/agenta-ui/src/components/HeightCollapse.tsx
@@ -10,13 +10,34 @@ export interface HeightCollapseProps {
     durationMs?: number
     animate?: boolean
     collapsedHeight?: number
+    /**
+     * Also fade opacity 0↔1 with the height. Use for docked chrome/notices where content appearing
+     * sharply as the box unfolds looks abrupt; omit to keep the plain height-only collapse used by
+     * the tool gutter, accordion sections, etc. Default false.
+     */
+    fade?: boolean
+    /**
+     * Also translate the content on the Y axis: it sits `slideY`px below its resting place while
+     * closed and eases to 0 on open (and back on close) — a subtle slide for bottom-docked notices.
+     * Pair with `fade` so the collapsing frames read cleanly. Default 0 (no translate).
+     */
+    slideY?: number
+    /**
+     * Apply the `inert` attribute while FULLY closed, dropping the hidden subtree from tab order +
+     * a11y (e.g. an approval dock's buttons must not be reachable when collapsed). Opt-in so a
+     * `collapsedHeight > 0` peek keeps its still-visible content interactive. Default false.
+     */
+    inert?: boolean
 }
 
 /**
  * HeightCollapse
  *
- * CSS-native collapse that transitions `height` between pixel values and `auto`
- * using `interpolate-size: allow-keywords`.
+ * CSS-native collapse that transitions `height` between pixel values and `auto` using
+ * `interpolate-size: allow-keywords`. Plain CSS transitions (NOT `motion-safe`-gated), so it
+ * animates regardless of the OS reduced-motion setting. The single collapse primitive for chrome
+ * that enters/leaves a column — accordion sections, the tool gutter, and (via `fade`/`slideY`) the
+ * composer dock, queued messages, and the config-pane notices — so everything moves the same way.
  */
 export function HeightCollapse({
     open,
@@ -26,24 +47,53 @@ export function HeightCollapse({
     durationMs = 300,
     animate = true,
     collapsedHeight = 0,
+    fade = false,
+    slideY = 0,
+    inert = false,
 }: HeightCollapseProps) {
     const collapsedHeightPx = useMemo(() => `${Math.max(0, collapsedHeight)}px`, [collapsedHeight])
 
-    const style = useMemo(
+    const easing = "cubic-bezier(0.4, 0, 0.2, 1)"
+
+    const outerStyle = useMemo(
         () =>
             ({
                 height: open ? "auto" : collapsedHeightPx,
+                opacity: fade ? (open ? 1 : 0) : undefined,
                 interpolateSize: "allow-keywords",
-                transitionProperty: animate ? "height" : "none",
+                transitionProperty: animate ? (fade ? "height, opacity" : "height") : "none",
                 transitionDuration: animate ? `${durationMs}ms` : "0ms",
-                transitionTimingFunction: animate ? "cubic-bezier(0.4, 0, 0.2, 1)" : "linear",
+                transitionTimingFunction: animate ? easing : "linear",
             }) as React.CSSProperties,
-        [open, collapsedHeightPx, animate, durationMs],
+        [open, collapsedHeightPx, animate, fade, durationMs],
     )
 
+    const innerStyle = useMemo<React.CSSProperties | undefined>(
+        () =>
+            slideY
+                ? {
+                      transform: open ? "translateY(0)" : `translateY(${slideY}px)`,
+                      transitionProperty: animate ? "transform" : "none",
+                      transitionDuration: animate ? `${durationMs}ms` : "0ms",
+                      transitionTimingFunction: animate ? easing : "linear",
+                  }
+                : undefined,
+        [slideY, open, animate, durationMs],
+    )
+
+    // `inert` only while fully collapsed — a peek (collapsedHeight > 0) stays interactive.
+    const isInert = inert && !open && collapsedHeight === 0
+
     return (
-        <div className={clsx("overflow-hidden", className)} style={style} aria-hidden={!open}>
-            <div className={contentClassName}>{children}</div>
+        <div
+            className={clsx("overflow-hidden", className)}
+            style={outerStyle}
+            aria-hidden={!open}
+            inert={isInert}
+        >
+            <div className={contentClassName} style={innerStyle}>
+                {children}
+            </div>
         </div>
     )
 }

--- a/web/packages/agenta-ui/src/components/presentational/index.ts
+++ b/web/packages/agenta-ui/src/components/presentational/index.ts
@@ -63,6 +63,8 @@ export {
     SectionSkeleton,
     ConfigAccordionSection,
     sectionIndicatorColor,
+    useAccordionSectionOpen,
+    useRecentFlag,
     type SectionCardProps,
     type SectionHeaderRowProps,
     type SectionLabelProps,

--- a/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
@@ -26,15 +26,38 @@
  * </ConfigAccordionSection>
  * ```
  */
-import {type ReactNode, useCallback, useEffect, useRef, useState} from "react"
+import {
+    createContext,
+    type ReactNode,
+    useCallback,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from "react"
 
 import {CaretDown, CaretRight, Lock} from "@phosphor-icons/react"
 import {Tooltip, Typography} from "antd"
+import {motion} from "motion/react"
 
 import {cn} from "../../../utils/styles"
 import {HeightCollapse} from "../../HeightCollapse"
 
 const {Text} = Typography
+
+/**
+ * Whether the enclosing accordion section is currently expanded. Because the body stays MOUNTED while
+ * collapsed (height-0 via {@link HeightCollapse}), a child can't rely on mount to know it just became
+ * visible — an `autoFocus` fires while hidden and never again. Read this instead to (re)act on open,
+ * e.g. focus a field when its section unfolds. Defaults to `true` outside a section, so a child used
+ * elsewhere behaves as always-open.
+ */
+const SectionOpenContext = createContext<boolean>(true)
+
+/** Read whether the enclosing {@link ConfigAccordionSection} is expanded. See {@link SectionOpenContext}. */
+export function useAccordionSectionOpen(): boolean {
+    return useContext(SectionOpenContext)
+}
 
 export type SectionIndicatorTone = "draft" | "invalid" | "incomplete" | "agent"
 
@@ -105,9 +128,11 @@ export interface ConfigAccordionSectionProps {
      * Change/validation indicator for the leading icon: tints the icon, adds a status dot,
      * and (with `tooltip`) explains it on hover. Takes precedence over `status`. Used by the
      * agent config panel to flag sections with unsaved edits (`"draft"`), a blocking problem
-     * (`"invalid"`), or an optional gap (`"incomplete"`).
+     * (`"invalid"`), or an optional gap (`"incomplete"`). `pulse` plays a one-shot attention
+     * ring behind the dot (e.g. a change made from another pane); the caller owns how long it
+     * stays true (see `useRecentFlag`).
      */
-    indicator?: {tone: SectionIndicatorTone; tooltip?: ReactNode}
+    indicator?: {tone: SectionIndicatorTone; tooltip?: ReactNode; pulse?: boolean}
     /** Only show `summary` while the section is collapsed. @default false (always). */
     summaryCollapsedOnly?: boolean
     /**
@@ -117,6 +142,17 @@ export interface ConfigAccordionSectionProps {
     titleBadge?: ReactNode
     /** Additional CSS class for the section wrapper. */
     className?: string
+    /**
+     * Opt in to the expanded-header "band" — a faint fill + bottom divider while the section is open,
+     * so the header reads as a header rather than blending into its content.
+     *
+     * The value is the BLEED class the host needs to pull the fill out to its own edges while the
+     * header text stays aligned with the content below, e.g. `"-mx-4 px-4"` inside a `px-4` container.
+     * It has to come from the host because this primitive is used in containers with different
+     * padding (config panel, drawers, nested sections) and a hardcoded bleed would overflow or
+     * under-fill in the others. Omit for no band (the default — every existing usage is unchanged).
+     */
+    headerBand?: string
     /**
      * Fade + subtle rise the section in on mount (opacity/transform only — no layout impact). Off by
      * default so existing usages are unchanged; the agent config panel opts in (staggered via
@@ -132,6 +168,13 @@ export interface ConfigAccordionSectionProps {
      * collapsible, `defaultOpen` sections only — a no-op everywhere else.
      */
     animateInitialOpen?: boolean
+    /**
+     * Override the body wrapper classes (the padded flex column around `children`). Defaults to
+     * `"flex flex-col gap-3 pb-4 pt-3"`. Pass a padding-free value when the body owns its own spacing
+     * — e.g. content that must collapse to zero height with no residual padding for an exit
+     * transition.
+     */
+    bodyClassName?: string
     /** Section body. */
     children?: ReactNode
 }
@@ -158,9 +201,11 @@ export function ConfigAccordionSection({
     summaryCollapsedOnly = false,
     titleBadge,
     className,
+    headerBand,
     revealOnMount = false,
     revealDelayMs = 0,
     animateInitialOpen = false,
+    bodyClassName = "flex flex-col gap-3 pb-4 pt-3",
     children,
 }: ConfigAccordionSectionProps) {
     // Height (0→auto via the grid `0fr`→`1fr` trick) + opacity reveal on mount (opt-in). `revealed`
@@ -209,6 +254,9 @@ export function ConfigAccordionSection({
         !opensDrawer && !locked && (collapsible ? (isControlled ? open : internalOpen) : true)
     const canToggle = !opensDrawer && collapsible && !locked
     const headerActs = canToggle || opensDrawer
+    // Whether the expanded-header band (fill + bottom divider) is currently shown. `isOpen` is already
+    // false when the section opens a drawer or is locked.
+    const banded = isOpen && !!headerBand
 
     const activate = useCallback(() => {
         if (opensDrawer) {
@@ -225,7 +273,32 @@ export function ConfigAccordionSection({
         <div
             className={cn(
                 "flex flex-col",
-                !noDivider && "border-0 border-b border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]",
+                // Expanded-section band (opt-in via `headerBand`): the whole expanded section shares a
+                // subtle bleeding fill so it reads as one grouped, active region set apart from the flat
+                // collapsed headers, using fill rather than a border. This `bg` is the BODY/content
+                // shade; the header layers a second fill on top (below) so it reads a touch stronger —
+                // the header/content contrast is what keeps two stacked expanded sections from blending
+                // into one block (no corner rounding — flush-stacked fills read cleaner than notched
+                // rounded blocks). Only COLORS change between states (the bleed is always applied; the
+                // fill + row divider fade via `transition-colors` in step with the body's height
+                // collapse) — nothing layout-affecting toggles, so the header never shifts and
+                // opening/closing stays jump-free. The banded section drops the row divider (its fill
+                // separates it); collapsed rows keep it.
+                headerBand
+                    ? cn(
+                          headerBand,
+                          "border-0 border-b border-solid transition-colors duration-300 ease-out",
+                          banded
+                              ? "border-transparent bg-[var(--ag-colorFillQuaternary)]"
+                              : cn(
+                                    "bg-transparent",
+                                    noDivider
+                                        ? "border-transparent"
+                                        : "border-[var(--ag-c-EAEFF5,#eaeff5)]",
+                                ),
+                      )
+                    : !noDivider &&
+                          "border-0 border-b border-solid border-[var(--ag-c-EAEFF5,#eaeff5)]",
                 className,
             )}
         >
@@ -246,6 +319,14 @@ export function ConfigAccordionSection({
                     "flex items-center justify-between gap-2 py-3 select-none",
                     locked && "cursor-not-allowed opacity-60",
                     headerActs && "cursor-pointer",
+                    // Header fill: bled to the section edges and layered over the section's body fill so
+                    // the header reads a touch stronger than the content beneath it. Fades with the band.
+                    headerBand &&
+                        cn(
+                            headerBand,
+                            "transition-colors duration-300 ease-out",
+                            banded ? "bg-[var(--ag-colorFillQuaternary)]" : "bg-transparent",
+                        ),
                 )}
             >
                 <div className="flex min-w-0 items-center gap-2">
@@ -256,6 +337,23 @@ export function ConfigAccordionSection({
                                 style={{color: iconColor}}
                             >
                                 {icon}
+                                {/* Attention ripple: expands + fades out from behind the dot,
+                                    repeating while the caller holds `pulse` true (e.g. a change
+                                    from another pane). Uses `motion` so it animates reliably. */}
+                                {indicator?.pulse ? (
+                                    <motion.span
+                                        className="absolute -right-1 -top-0.5 h-2 w-2 rounded-full"
+                                        style={{background: dotColor ?? undefined}}
+                                        initial={{opacity: 0, scale: 1}}
+                                        animate={{opacity: [0, 0.5, 0], scale: [1, 2, 3]}}
+                                        transition={{
+                                            duration: 1.8,
+                                            ease: "easeOut",
+                                            repeat: 1,
+                                            times: [0, 0.25, 1],
+                                        }}
+                                    />
+                                ) : null}
                                 {/* Always mounted: state changes play as scale/opacity/color
                                     transitions instead of the dot popping in and out. */}
                                 <span
@@ -269,14 +367,43 @@ export function ConfigAccordionSection({
                             </span>
                         </Tooltip>
                     ) : null}
-                    <Text
-                        className={cn(
-                            "min-w-0 truncate font-medium",
-                            size === "compact" ? "text-xs" : "text-sm",
-                        )}
-                    >
-                        {title}
-                    </Text>
+                    {/* Title. The base text stays fully opaque/crisp; while `pulse` holds, a blue
+                        DUPLICATE laid exactly on top is revealed through a moving mask, so a glint
+                        sweeps across the letters (in cadence with the dot ripple) without ever
+                        fading the real text. Sweep = the `config-shimmer` CSS keyframe (motion is
+                        unreliable at animating mask/background position). */}
+                    <span className="relative flex min-w-0">
+                        <Text
+                            className={cn(
+                                "min-w-0 truncate font-medium",
+                                size === "compact" ? "text-xs" : "text-sm",
+                            )}
+                        >
+                            {title}
+                        </Text>
+                        {indicator?.pulse ? (
+                            <span
+                                aria-hidden
+                                className={cn(
+                                    "animate-config-shimmer pointer-events-none absolute inset-0 truncate font-medium",
+                                    size === "compact" ? "text-xs" : "text-sm",
+                                )}
+                                style={{
+                                    color: dotColor ?? undefined,
+                                    WebkitMaskImage:
+                                        "linear-gradient(100deg, transparent 8%, #000 50%, transparent 92%)",
+                                    maskImage:
+                                        "linear-gradient(100deg, transparent 8%, #000 50%, transparent 92%)",
+                                    WebkitMaskSize: "220% 100%",
+                                    maskSize: "220% 100%",
+                                    WebkitMaskRepeat: "no-repeat",
+                                    maskRepeat: "no-repeat",
+                                }}
+                            >
+                                {title}
+                            </span>
+                        ) : null}
+                    </span>
                     {titleBadge ? <span className="shrink-0">{titleBadge}</span> : null}
                 </div>
 
@@ -316,7 +443,13 @@ export function ConfigAccordionSection({
 
             {opensDrawer ? null : (
                 <HeightCollapse open={isOpen}>
-                    <div className="flex flex-col gap-3 pb-4">{children}</div>
+                    {/* Top padding gives the body room below the header band (which carries the
+                        fill + bottom divider), so it reads as content, not a header continuation. */}
+                    <div className={bodyClassName}>
+                        <SectionOpenContext.Provider value={isOpen}>
+                            {children}
+                        </SectionOpenContext.Provider>
+                    </div>
                 </HeightCollapse>
             )}
         </div>

--- a/web/packages/agenta-ui/src/components/presentational/section/index.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/section/index.tsx
@@ -174,4 +174,6 @@ export {
     type ConfigAccordionSectionProps,
     sectionIndicatorColor,
     type SectionIndicatorTone,
+    useAccordionSectionOpen,
 } from "./ConfigAccordionSection"
+export {useRecentFlag} from "./useRecentFlag"

--- a/web/packages/agenta-ui/src/components/presentational/section/useRecentFlag.ts
+++ b/web/packages/agenta-ui/src/components/presentational/section/useRecentFlag.ts
@@ -1,0 +1,26 @@
+import {useEffect, useState} from "react"
+
+/**
+ * True for `windowMs` after `at`, then false. A caller-owned "just happened" clock for
+ * transient attention cues (e.g. a pulsing section indicator). Re-arms whenever `at`
+ * changes, and self-stops with a single timer so idle surfaces don't re-render. Mirrors
+ * the time-based recency the Drives files use, in a package-safe form.
+ */
+export function useRecentFlag(at: number | null | undefined, windowMs = 8000): boolean {
+    const [recent, setRecent] = useState(() => at != null && Date.now() - at < windowMs)
+    useEffect(() => {
+        if (at == null) {
+            setRecent(false)
+            return
+        }
+        const elapsed = Date.now() - at
+        if (elapsed >= windowMs) {
+            setRecent(false)
+            return
+        }
+        setRecent(true)
+        const id = window.setTimeout(() => setRecent(false), windowMs - elapsed)
+        return () => window.clearTimeout(id)
+    }, [at, windowMs])
+    return recent
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1388,6 +1388,9 @@ importers:
       marked:
         specifier: ^17.0.4
         version: 17.0.6
+      motion:
+        specifier: ^12.0.0
+        version: 12.38.0(@emotion/is-prop-valid@0.7.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0


### PR DESCRIPTION
These are Arda Erzin's six commits from his parallel branch (#5426), ported with authorship preserved onto the sessions integration branch per the reconciliation ruling. They carry the always-allow toggle, the approve-all batch resolve, the context-driven config sections with an inline provider key, a drawer sizing fix, and the Claude Code harness entry for the EE dev compose.

The machinery commits from his original branch were superseded by the approvals train already merged into this base (see the reconciliation document in docs/design/agent-workflows/projects/sessions-takeover/). One repeat QA pass of the approval dock against per-card dispatch is flagged in his handoff as the known follow-up.