### PR TITLE
fix(website): robots.txt also advertises the proxied docs sitemap

### DIFF
--- a/website/src/pages/robots.txt.ts
+++ b/website/src/pages/robots.txt.ts
@@ -11,7 +11,7 @@ export const GET: APIRoute = () => {
 
   const body = noindex
     ? "User-agent: *\nDisallow: /"
-    : "# Agenta marketing site (https://agenta.ai)\n# Allow all crawlers full access; point them at the generated sitemap index.\nUser-agent: *\nAllow: /\n\nSitemap: https://agenta.ai/sitemap-index.xml\n";
+    : "# Agenta marketing site (https://agenta.ai)\n# Allow all crawlers full access; point them at the generated sitemap index.\n# The docs sitemap is listed too because agenta.ai/docs/* proxies the docs site.\nUser-agent: *\nAllow: /\n\nSitemap: https://agenta.ai/sitemap-index.xml\nSitemap: https://agenta.ai/docs/sitemap.xml\n";
 
   return new Response(body, {
     headers: { "Content-Type": "text/plain; charset=utf-8" },


### PR DESCRIPTION
## What

One line: the marketing site's robots.txt now lists the docs sitemap (https://agenta.ai/docs/sitemap.xml) alongside its own sitemap index.

## Why

The agenta.ai zone has legacy Cloudflare routing that intercepts /robots.txt and serves a Framer-era body whose main purpose was advertising the proxied docs sitemap (agenta.ai/docs/* proxies the docs site). That override also points crawlers at /sitemap.xml, which 404s on the new site. Once the legacy route is removed, the site's own robots.txt serves — and with this change it keeps the docs sitemap advertised, so nothing is lost.

After merge: the production workflow redeploys automatically; removing the legacy robots.txt route in the Cloudflare zone completes the fix.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB