### PR TITLE
chore(docs): reposition copy to the agents workspace

### DIFF
--- a/docs/docs/getting-started/01-introduction.mdx
+++ b/docs/docs/getting-started/01-introduction.mdx
@@ -1,15 +1,15 @@
 ---
 slug: /
 title: What is Agenta?
-description: "Agenta is an open-source LLMOps platform: prompt playground, prompt management, LLM evaluation, and LLM Observability all in one place."
+description: "Agenta is the open-source workspace for your agents. Build agents through chat, improve them with feedback, and share them with your whole team."
 id: introduction
 sidebar_position: 0
 ---
 
 
-Agenta is an **open-source LLMOps platform** that helps **AI engineers** and **subject matter experts** build reliable AI applications.
+Agenta is the **open-source workspace for your agents**. You build agents through chat, improve them with feedback, and share them with your whole team. It helps **AI engineers** and **subject matter experts** work on the same agents together.
 
-Agenta covers the entire LLM development lifecycle: **prompt management**, **evaluation**, and **observability**.
+Underneath, Agenta gives you everything you need to make those agents reliable: **prompt management**, **evaluation**, and **observability**.
 
 Learn how a typical workflow in Agenta looks like in this 5 minute walkthrough:
 

--- a/docs/docs/misc/01-opensource.mdx
+++ b/docs/docs/misc/01-opensource.mdx
@@ -1,7 +1,7 @@
 ---
 title: Open Source vs. Commercial
 sidebar_label: "OSS vs. Commercial"
-description: Agenta offers both MIT-licensed open source LLMOps tools and commercial features. Compare self-hosting options, feature availability, and licensing details.
+description: Agenta, the open-source workspace for your agents, offers both MIT-licensed open source features and commercial features. Compare self-hosting options, feature availability, and licensing details.
 ---
 
 ## Our Approach
@@ -12,7 +12,7 @@ We believe this approach offers the best balance. You get freedom to use all fun
 
 ### Why Open Source?
 
-Open source matters for an LLMOps platform like Agenta because it gives you:
+Open source matters for a workspace like Agenta because it gives you:
 
 1. **Flexibility**: Modify and customize the software to fit your needs.
 2. **Independence**: Avoid vendor lock-in, ensuring long-term project continuity.

--- a/docs/docs/tutorials/cookbooks/02-observability_langchain.mdx
+++ b/docs/docs/tutorials/cookbooks/02-observability_langchain.mdx
@@ -13,7 +13,7 @@ import GoogleColabButton from "@site/src/components/GoogleColabButton";
 
 ## Introduction
 
-This guide shows you how to set up tracing for a RAG application in Langchain using Agenta, the open-source LLMOps platform.
+This guide shows you how to set up tracing for a RAG application in Langchain using Agenta, the open-source workspace for your agents.
 
 Tracing allows us to debug effectively complex LLM applications. It allows us to view exact prompts sent and contexts retrieved.
 

--- a/docs/docusaurus.config.dev.ts
+++ b/docs/docusaurus.config.dev.ts
@@ -7,7 +7,7 @@ import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
 
 const config: Config = {
   title: "Docs - Agenta",
-  tagline: "The LLMOps platform.",
+  tagline: "The open-source workspace for your agents.",
   favicon: "images/favicon.ico",
   // Local development configuration
   url: "http://localhost:5000",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -8,7 +8,7 @@ import "dotenv/config";
 
 const config: Config = {
   title: "Docs - Agenta",
-  tagline: "The LLMOps platform.",
+  tagline: "The open-source workspace for your agents.",
   favicon: "images/favicon.ico",
   // Public site lives on the main domain under /docs
   url: "https://agenta.ai",
@@ -690,7 +690,7 @@ const config: Config = {
       "docusaurus-plugin-llms-txt",
       {
         title: "Agenta Documentation",
-        description: "The LLMOps platform for building and deploying LLM applications.",
+        description: "The open-source workspace for your agents — build them through chat, improve them with feedback, and share them with your team.",
         fullLLMsTxt: true,
       },
     ],

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agenta"
 version = "0.105.8"
-description = "The SDK for agenta is an open-source LLMOps platform."
+description = "Agenta — the open-source workspace for your agents. Build agents through chat, improve them with feedback, and share them with your team."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 license = "MIT"


### PR DESCRIPTION
## What a reader sees

The marketing site relaunched today on the new positioning, but several repo files still call Agenta "the open-source LLMOps platform." Those files feed PyPI, docs.agenta.ai, and LLM scrapers, so the old identity keeps leaking to readers. This repoints the identity copy to match the site:

- **PyPI package summary** (`agenta` on PyPI, from `sdks/python/pyproject.toml`):
  - Before: "The SDK for agenta is an open-source LLMOps platform."
  - After: "Agenta — the open-source workspace for your agents. Build agents through chat, improve them with feedback, and share them with your team."
- **Docs site title tag / tagline** (`docusaurus.config.ts` + `.dev.ts`):
  - Before: "The LLMOps platform."
  - After: "The open-source workspace for your agents."
- **Docs `llms.txt` header description** (the LLM-facing site summary):
  - Before: "The LLMOps platform for building and deploying LLM applications."
  - After: "The open-source workspace for your agents — build them through chat, improve them with feedback, and share them with your team."
- **Docs home / "What is Agenta?" intro** (`getting-started/01-introduction.mdx`) now leads with the agents-workspace framing and keeps the AI-engineers + subject-matter-experts audience line. Prompt management, evaluation, and observability are reframed as the supporting capabilities that make those agents reliable — kept, not removed.
- **Long-tail identity mentions**: the open-source page meta + body, and the LangChain tracing cookbook intro line.

## What this does not change

No factual capability claims are deleted — prompt management, evaluation, and observability remain documented in full. This is a copy/positioning pass only.

## Notes

- `docs/build/llms.txt` and `llms-full.txt` are gitignored build artifacts; they regenerate from these sources on the next docs deploy (verified locally after `pnpm build`), so they are not hand-edited or committed here.
- The PyPI summary itself only refreshes when the next `agenta` SDK release is published.
- The `web/_reference/agenta-sdk*` TypeScript packages are unpublished (three are `private: true`, none exist on npm, no publish workflow), so their descriptions were left untouched.
- Out of scope for this PR: eight `docs/docs/integrations/frameworks/*/observability.mdx` files still carry a repeated "What is Agenta?" boilerplate callout with the old wording; worth a follow-up sweep.

## Verification

`docs && pnpm build` succeeds; regenerated `llms.txt` carries the new copy.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB
