### PR TITLE
fix(website): bundle the PostHog init so analytics actually loads

### DIFF
--- a/website/src/components/Analytics.astro
+++ b/website/src/components/Analytics.astro
@@ -12,11 +12,19 @@
 // be production, indexable builds too, so the gates above alone would let their
 // traffic reach the real PostHog project. Analytics initializes ONLY on the real
 // site (agenta.ai / www.agenta.ai); every *.workers.dev preview host is skipped.
-const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
-const noindex = import.meta.env.PUBLIC_NOINDEX === "true";
+//
+// This script must stay BUNDLED (no define:vars / is:inline): an inline script's
+// import("posthog-js") is a bare specifier the browser cannot resolve, so
+// analytics silently never loads. Vite statically replaces the PUBLIC_* env
+// reads in bundled client code, which is why no value handoff is needed.
 ---
 
-<script define:vars={{ posthogKey, noindex }}>
+<script>
+  import posthog from "posthog-js";
+
+  const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
+  const noindex = import.meta.env.PUBLIC_NOINDEX === "true";
+
   const dnt =
     navigator.doNotTrack === "1" ||
     // @ts-expect-error legacy vendor-prefixed flags
@@ -31,16 +39,14 @@ const noindex = import.meta.env.PUBLIC_NOINDEX === "true";
   if (posthogKey && !noindex && isRealSite && !dnt && !window.__agPosthogInit) {
     // @ts-expect-error one-time guard on window
     window.__agPosthogInit = true;
-    import("posthog-js").then(({ default: posthog }) => {
-      posthog.init(posthogKey, {
-        api_host: "https://alef.agenta.ai",
-        ui_host: "https://us.posthog.com",
-        person_profiles: "identified_only",
-        capture_pageview: true,
-        capture_pageleave: true,
-        autocapture: true,
-        respect_dnt: true,
-      });
+    posthog.init(posthogKey, {
+      api_host: "https://alef.agenta.ai",
+      ui_host: "https://us.posthog.com",
+      person_profiles: "identified_only",
+      capture_pageview: true,
+      capture_pageleave: true,
+      autocapture: true,
+      respect_dnt: true,
     });
   }
 </script>


### PR DESCRIPTION
## What

Analytics never initialized on the live site: the init script was emitted inline (via define:vars), and an inline script's `import("posthog-js")` is a bare module specifier the browser cannot resolve — it threw an unhandled promise rejection on every page load. Zero events reached PostHog.

## Fix

Make the script a bundled Astro client script. Vite statically replaces the `PUBLIC_POSTHOG_KEY` / `PUBLIC_NOINDEX` reads in bundled client code, so the inline value handoff was never needed. The host guard (agenta.ai / www only) and DNT handling are unchanged. Verified: the built Analytics chunk contains posthog-js and pages reference it; live event delivery confirmed on agenta.ai after a direct production deploy.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB