### PR TITLE
fix(website): landing meta description matches the site's own copy

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -31,7 +31,7 @@ const orgJsonLd = {
 
 <Base
   title="Agenta — The open-source workspace for your agents"
-  description="Agenta is the open-source workspace for building AI agents and automations. Design and version prompts, evaluate quality, and monitor production — self-hosted or in the cloud."
+  description="Agenta is the open-source workspace for your agents. Build agents through chat, improve them with feedback, and share them with your whole team — self-hosted or in the cloud."
 >
   <Fragment slot="head">
     <script

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -13,7 +13,8 @@ const body = `# Agenta
 
 ## About
 
-- Design and version prompts, evaluate quality, and monitor production.
+- Build agents through chat: describe the job, give the agent context and tools, and improve it through real work and feedback.
+- Share agents with your team, and run them on a schedule or when an event happens in a connected app.
 - Consequential actions can wait for human approval before they run.
 - Prompts, skills, and tools are versioned like code, so you can roll back to any revision.
 - MIT-licensed and yours to run: self-host on your own infrastructure to keep your agents and data with you.


### PR DESCRIPTION
One-line copy fix: the landing page's meta description (what Google shows under the homepage result) still described prompt design/versioning/monitoring. It now mirrors the hero's actual copy: build agents through chat, improve with feedback, share with the team. Same fix applied to the matching line in /llms.txt.

Merging auto-deploys production via the 16-website-production workflow.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB