### PR TITLE
ci(website): preview skips Dependabot PRs and fires on ready_for_review

### DIFF
--- a/.github/workflows/15-website-preview.yml
+++ b/.github/workflows/15-website-preview.yml
@@ -2,7 +2,7 @@ name: "15 - website preview"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'website/**'
       - '.github/workflows/15-website-preview.yml'
@@ -30,10 +30,13 @@ jobs:
     name: Build and deploy preview
     runs-on: ubuntu-latest
     # Fork PRs get no secrets: skip when the head repo is not this repo.
+    # Dependabot PRs run without repository secrets (GitHub policy), so the
+    # deploy could never succeed there; skip them cleanly instead of failing.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
-       !github.event.pull_request.draft)
+       !github.event.pull_request.draft &&
+       github.actor != 'dependabot[bot]')
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     steps:


### PR DESCRIPTION
Two small guards for the website preview workflow, both found in the field today:

1. Dependabot PRs run without repository secrets (GitHub policy), so the preview deploy can never succeed on them — the job now skips cleanly instead of failing red (seen on #5453).
2. The preview never ran when a draft PR flipped to ready, because ready_for_review was not in the trigger list (seen on #5450, where the run skipped while the PR was draft and nothing re-fired on the flip). Added the trigger; the draft guard already handles the skip-while-draft side.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB