### PR TITLE
[5416] test(api): Regression and acceptance tests for mounts file/archive endpoints

### DIFF
--- a/api/oss/tests/pytest/acceptance/mounts/test_mounts_basics.py
+++ b/api/oss/tests/pytest/acceptance/mounts/test_mounts_basics.py
@@ -4,6 +4,8 @@ Covers: create, fetch, query (by session_id), edit, archive/unarchive, and
 path-injection rejection. Requires a running API (OSS or EE).
 """
 
+import io
+import zipfile
 from uuid import uuid4
 
 from oss.tests.pytest.utils.mounts import skip_if_mount_storage_unavailable
@@ -245,6 +247,15 @@ def _create_mount(authed_api):
     return resp.json()["mount"]["id"]
 
 
+def _write_file(authed_api, mount_id, path, content=b"x"):
+    resp = authed_api(
+        "PUT", f"/mounts/{mount_id}/files", params={"path": path}, data=content
+    )
+    skip_if_mount_storage_unavailable(resp)
+    assert resp.status_code == 200, resp.text
+    return resp
+
+
 class TestMountFileOps:
     def test_write_read_list_delete_roundtrip(self, authed_api):
         mount_id = _create_mount(authed_api)
@@ -379,3 +390,185 @@ class TestMountFileOps:
         fake_id = str(uuid4())
         resp = authed_api("GET", f"/mounts/{fake_id}/files")
         assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Shallow (depth=1) listing
+#
+# GET /mounts/{id}/files?depth=1[&with_counts&git_aware&include_gitignored] is the
+# lazy per-directory summary the drive drawer loads on open (#5400) — one delimiter
+# level, not the whole tree. Previously covered only by unit tests against the fake
+# store; no acceptance test exercised it against the real API + object store.
+# ---------------------------------------------------------------------------
+
+
+class TestMountShallowListing:
+    def test_shallow_listing_returns_top_level_only(self, authed_api):
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, "a.txt")
+        _write_file(authed_api, mount_id, "sub/b.txt")
+
+        resp = authed_api("GET", f"/mounts/{mount_id}/files", params={"depth": 1})
+        assert resp.status_code == 200, resp.text
+        by_path = {f["path"]: f for f in resp.json()["files"]}
+
+        assert by_path["a.txt"]["is_folder"] is False
+        assert by_path["sub"]["is_folder"] is True
+        assert "sub/b.txt" not in by_path
+
+    def test_shallow_listing_with_counts_reports_item_count(self, authed_api):
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, "dir/one.txt")
+        _write_file(authed_api, mount_id, "dir/two.txt")
+
+        resp = authed_api(
+            "GET",
+            f"/mounts/{mount_id}/files",
+            params={"depth": 1, "with_counts": "true"},
+        )
+        assert resp.status_code == 200, resp.text
+        by_path = {f["path"]: f for f in resp.json()["files"]}
+        assert by_path["dir"]["item_count"] == 2
+
+    def test_shallow_listing_git_aware_prunes_ignored_and_git(self, authed_api):
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, ".gitignore", b"node_modules/\n")
+        _write_file(authed_api, mount_id, "src/app.py")
+        _write_file(authed_api, mount_id, "node_modules/react/index.js")
+        _write_file(authed_api, mount_id, ".git/HEAD")
+
+        resp = authed_api(
+            "GET",
+            f"/mounts/{mount_id}/files",
+            params={"depth": 1, "git_aware": "true"},
+        )
+        assert resp.status_code == 200, resp.text
+        paths = {f["path"] for f in resp.json()["files"]}
+        assert paths == {".gitignore", "src"}
+
+    def test_shallow_listing_include_gitignored_reveals_ignored_but_hides_git(
+        self, authed_api
+    ):
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, ".gitignore", b"node_modules/\n")
+        _write_file(authed_api, mount_id, "src/app.py")
+        _write_file(authed_api, mount_id, "node_modules/react/index.js")
+        _write_file(authed_api, mount_id, ".git/HEAD")
+
+        resp = authed_api(
+            "GET",
+            f"/mounts/{mount_id}/files",
+            params={"depth": 1, "git_aware": "true", "include_gitignored": "true"},
+        )
+        assert resp.status_code == 200, resp.text
+        paths = {f["path"] for f in resp.json()["files"]}
+        assert paths == {".gitignore", "src", "node_modules"}
+
+    def test_shallow_listing_depth_two_rejected(self, authed_api):
+        # depth=1 is the only implemented shallow view; anything else must 422 loudly
+        # rather than silently falling through to the most expensive full-tree branch.
+        # No mount needs to exist: Query validation runs before the handler body.
+        fake_id = str(uuid4())
+        resp = authed_api("GET", f"/mounts/{fake_id}/files", params={"depth": 2})
+        assert resp.status_code == 422, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Download-all archive (POST /mounts/files/export)
+#
+# Streams a zip across one or more mounts (#5400), renamed from /files/archive in
+# #5412 to stop colliding with this router's own archive/unarchive lifecycle verb.
+# Previously untested at any layer beyond the work-list-building unit tests.
+# ---------------------------------------------------------------------------
+
+
+class TestMountArchiveExport:
+    def test_export_single_mount_returns_valid_zip(self, authed_api):
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, "a.txt", b"alpha")
+        _write_file(authed_api, mount_id, "b.txt", b"beta")
+
+        resp = authed_api(
+            "POST",
+            "/mounts/files/export",
+            json={"mounts": [{"mount_id": mount_id, "prefix": "", "path": ""}]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert "zip" in resp.headers.get("content-type", "")
+
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            assert set(zf.namelist()) == {"a.txt", "b.txt"}
+            assert zf.read("a.txt") == b"alpha"
+            assert zf.read("b.txt") == b"beta"
+
+    def test_export_applies_prefix_folding(self, authed_api):
+        # The folded drive layout: cwd + agent-files land under their own prefix in
+        # the zip so "download all" reproduces the drive's tree, not a flat dump.
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, "a.txt", b"alpha")
+
+        resp = authed_api(
+            "POST",
+            "/mounts/files/export",
+            json={"mounts": [{"mount_id": mount_id, "prefix": "cwd", "path": ""}]},
+        )
+        assert resp.status_code == 200, resp.text
+
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            assert zf.namelist() == ["cwd/a.txt"]
+
+    def test_export_scopes_to_source_path(self, authed_api):
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, "workspace/a.txt", b"in")
+        _write_file(authed_api, mount_id, "outside.txt", b"out")
+
+        resp = authed_api(
+            "POST",
+            "/mounts/files/export",
+            json={
+                "mounts": [{"mount_id": mount_id, "prefix": "", "path": "workspace"}]
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            assert zf.namelist() == ["workspace/a.txt"]
+
+    def test_export_missing_mount_returns_404(self, authed_api):
+        # Pins #5411: mounts are resolved EAGERLY, before the response starts
+        # streaming, so a missing mount is a real 404 — never a 200 with a broken zip.
+        fake_id = str(uuid4())
+
+        resp = authed_api(
+            "POST",
+            "/mounts/files/export",
+            json={"mounts": [{"mount_id": fake_id, "prefix": "", "path": ""}]},
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_export_path_traversal_in_request_returns_422(self, authed_api):
+        # source_path is validated before the mount is even resolved, so a fake
+        # mount_id is enough to isolate the check.
+        fake_id = str(uuid4())
+
+        resp = authed_api(
+            "POST",
+            "/mounts/files/export",
+            json={"mounts": [{"mount_id": fake_id, "prefix": "", "path": "../evil"}]},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_export_filename_reflected_in_content_disposition(self, authed_api):
+        mount_id = _create_mount(authed_api)
+        _write_file(authed_api, mount_id, "a.txt", b"alpha")
+
+        resp = authed_api(
+            "POST",
+            "/mounts/files/export",
+            json={
+                "mounts": [{"mount_id": mount_id, "prefix": "", "path": ""}],
+                "filename": "custom.zip",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert "custom.zip" in resp.headers.get("content-disposition", "")

--- a/api/oss/tests/pytest/unit/test_mounts_file_ops.py
+++ b/api/oss/tests/pytest/unit/test_mounts_file_ops.py
@@ -269,6 +269,7 @@ class FakeMountStorage:
         for k in keys:
             if k in b:
                 del b[k]
+                self._mtimes.get(bucket, {}).pop(k, None)
                 n += 1
         return n
 
@@ -570,6 +571,10 @@ class TestArchiveMtimeRegression:
         assert len(zip_bytes) > 0
         with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
             assert zf.namelist() == ["report.txt"]
+            # Not just "didn't crash" — the member's timestamp must be the CONVERTED value
+            # (1_700_000_000_000 ms -> 2023-11-14 22:13:20 UTC), so a regression that silently
+            # falls back to datetime.now() instead of the real mtime still fails this test.
+            assert zf.getinfo("report.txt").date_time == (2023, 11, 14, 22, 13, 20)
             assert zf.read("report.txt") == b"hello world"
 
 

--- a/api/oss/tests/pytest/unit/test_mounts_file_ops.py
+++ b/api/oss/tests/pytest/unit/test_mounts_file_ops.py
@@ -12,12 +12,17 @@ SeaweedFS coverage lands in the acceptance suite against the docker-compose
 stack.
 """
 
+import io
+import zipfile
 from typing import List, Tuple
 from uuid import UUID, uuid4
 
 import pytest
 
-from oss.src.apis.fastapi.mounts.utils import _content_disposition_attachment
+from oss.src.apis.fastapi.mounts.utils import (
+    _content_disposition_attachment,
+    stream_mounts_archive,
+)
 from oss.src.core.mounts import service as mounts_service_module
 from oss.src.core.mounts.dtos import Mount, MountArchiveSource, MountFile
 from oss.src.core.mounts.service import (
@@ -196,11 +201,17 @@ class FakeMountStorage:
     def __init__(self):
         # {bucket: {key: bytes}}
         self._store: dict[str, dict[str, bytes]] = {}
+        # {bucket: {key: epoch-ms}}; opt-in, only set where a test needs a realistic mtime.
+        self._mtimes: dict[str, dict[str, int]] = {}
+
+    def set_mtime(self, bucket: str, key: str, mtime: int) -> None:
+        self._mtimes.setdefault(bucket, {})[key] = mtime
 
     async def list_objects_v2(self, *, bucket: str, prefix: str) -> List[StoreObject]:
         b = self._store.get(bucket, {})
+        m = self._mtimes.get(bucket, {})
         return [
-            StoreObject(key=k, size=len(v))
+            StoreObject(key=k, size=len(v), mtime=m.get(k))
             for k, v in b.items()
             if k.startswith(prefix)
         ]
@@ -519,6 +530,47 @@ class TestArchiveZipNamespace:
         assert work[0][1].startswith(f"mounts/{_PROJECT_ID}/{first.id}/"), (
             "the first source's key must win"
         )
+
+
+@pytest.mark.asyncio
+class TestArchiveMtimeRegression:
+    async def test_export_survives_epoch_millisecond_mtime(self):
+        # Pins the bug fixed in #5400/#5411: StoreObject.mtime is epoch MILLISECONDS, but
+        # stream_mounts_archive builds a zip member's `datetime` from it. Without dividing by
+        # 1000 first, a realistic ms-scale value overflows datetime.fromtimestamp mid-stream —
+        # AFTER the 200 response headers are already on the wire — truncating the download to a
+        # broken/empty zip while the client still sees a success status.
+        mount = _make_mount()
+        storage = FakeMountStorage()
+        service = MountsService(
+            mounts_dao=_StubDAO(mount),
+            mounts_store=storage,
+            bucket=_BUCKET,
+        )
+        pid, mid = mount.project_id, mount.id
+
+        await service.write_file(
+            project_id=pid, mount_id=mid, path="report.txt", content=b"hello world"
+        )
+        key = f"mounts/{pid}/{mid}/report.txt"
+        storage.set_mtime(
+            _BUCKET, key, 1_700_000_000_000
+        )  # realistic epoch-ms LastModified
+
+        response = await stream_mounts_archive(
+            mounts_service=service,
+            project_id=pid,
+            mounts=[MountArchiveSource(mount_id=mid)],
+        )
+
+        zip_bytes = b"".join(
+            [chunk async for chunk in response.body_iterator]  # type: ignore[union-attr]
+        )
+
+        assert len(zip_bytes) > 0
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            assert zf.namelist() == ["report.txt"]
+            assert zf.read("report.txt") == b"hello world"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes Agenta-AI/agenta#5416

## Summary

The drive/mounts refactor (Agenta-AI/agenta#5400, refined pre-merge by Agenta-AI/agenta#5411/Agenta-AI/agenta#5412) shipped with thin  <br>regression coverage on two behaviors: the archive stream's mtime handling, and the new  <br>file-listing/download-all endpoints. Agenta-AI/agenta#5416 asked for three things; checking the current  <br>suite showed one of them (`_rollup_recent_entries` unit tests) already landed in Agenta-AI/agenta#5411, so  <br>this PR covers the two that were still open.

**Unit regression test for the archive mtime bug.** `StoreObject.mtime` is epoch  <br>milliseconds, and `stream_mounts_archive` converts it via  <br>`datetime.fromtimestamp(mtime / 1000, ...)`. Before that division, a realistic ms-scale  <br>value overflowed `datetime.fromtimestamp` inside the streaming generator, after the  <br>response's 200 headers were already sent, so the client got a truncated/broken zip with a  <br>success status. The new test stamps a stored file with a realistic epoch-ms mtime, streams  <br>the archive, and unzips the result to check it's byte-correct.

**Acceptance coverage for the two endpoints** Agenta-AI/agenta#5400 **shipped untested.** `GET /mounts/{id}/files?depth=1` (the shallow per-directory listing, plus `with_counts` and  <br>`git_aware`/`include_gitignored`), and `POST /mounts/files/export` (the download-all  <br>archive: prefix folding, `source_path` scoping, missing-mount 404, path-traversal  <br>rejection, filename in `Content-Disposition`).

No production code changes. Both additions are test-only, aside from a small additive  <br>`set_mtime` helper on the existing `FakeMountStorage` test fake.

## Testing

### Verified locally

* Confirmed the mtime regression test actually pins the bug: temporarily reverted the  <br>`/1000` division and watched it fail with `ValueError: year 55840 is out of range`,  <br>then restored the fix.
* `pytest oss/tests/pytest/unit/test_mounts_file_ops.py`: 51 passed (105 across the full  <br>mounts unit suite).
* Stood up the local OSS dev stack (real API + SeaweedFS) and ran  <br>`pytest oss/tests/pytest/acceptance/mounts/`: 45 passed, 0 skipped.
* `ruff format` + `ruff check`: clean.

### Added or updated tests

* `test_mounts_file_ops.py`: new `TestArchiveMtimeRegression` (1 test) pinning the mtime  <br>conversion bug.
* `test_mounts_basics.py`: new `TestMountShallowListing` (5 tests) and  <br>`TestMountArchiveExport` (6 tests) covering the two previously-untested endpoints.
* `_rollup_recent_entries` already has 5 unit tests from Agenta-AI/agenta#5411  <br>(`TestRollupRecentEntries`), so this PR doesn't touch it.

### QA follow-up

N/A — test-only change, no user-visible behavior to QA.

## Demo

N/A — not a UI change.

## Checklist

- [X] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [X] Relevant tests pass locally
- [X] Relevant linting and formatting pass locally
- [X] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

* [Contributing guide](<https://agenta.ai/docs/contributing/overview>)
* [Creating your first PR](<https://agenta.ai/docs/contributing/first-pr>)
* [Development mode](<https://agenta.ai/docs/contributing/guides/development-mode>)
* [Testing](<https://agenta.ai/docs/contributing/guides/testing>)
* [Formatting and linting](<https://agenta.ai/docs/contributing/guides/formatting-and-linting>)
* [Slack support](<https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw>)