### PR TITLE
[fix] Remove the redundant boolean annotation that fails TypeScript lint

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -758,7 +758,7 @@ const AgentConversation = ({
     )
     // Feature flag: the context-budget meter is hidden from the composer for now. The
     // component and its logic stay wired up; flip this to `true` to bring the UI back.
-    const showContextBudget: boolean = false
+    const showContextBudget = false
 
     // ── Playground-native onboarding ──────────────────────────────────────────
     // This chat panel IS the onboarding surface while the agent is ephemeral: the empty state shows the


### PR DESCRIPTION
## Context

The TypeScript lint job is red on `release/v0.105.9`. It has been red since the commit that hid the context-window meter from the agent composer (535f6a25d5), so it is not caused by PR #5461. That commit wrote the feature flag as `const showContextBudget: boolean = false`, and ESLint's `@typescript-eslint/no-inferrable-types` rejects an annotation the initialiser already implies.

## Changes

The annotation is gone. The line is now `const showContextBudget = false`, which keeps the flag exactly as it was for anyone flipping it back on.

## Tests / notes

- `pnpm lint` in `web/` passes, all 11 tasks.
- `tsc --noEmit` on `web/oss` reports nothing for this file. The narrower `false` type does not upset the one place the flag is read.
- The remaining lint output on that job is warnings only, from the TanStack Virtual React Compiler notices in `DriveExplorer.tsx` and `VirtualTileGrid.tsx`. Those do not fail the job and are untouched here.