### PR TITLE
fix(website): restore GA4 alongside PostHog (analytics continuity)

### DIFF
--- a/.github/workflows/16-website-production.yml
+++ b/.github/workflows/16-website-production.yml
@@ -51,6 +51,8 @@ jobs:
           # PostHog project key: public by design (ingest-only); analytics also
           # requires the runtime agenta.ai host guard, so previews stay silent.
           PUBLIC_POSTHOG_KEY: phc_cFT4a4081mXuKxYIrhIt6cmDwSjAO8zQlw9CFE05oSI
+          # GA4 measurement ID: public by design, same property as the pre-pivot site.
+          PUBLIC_GA_ID: G-368ZWZSH5D
         run: cd website && pnpm run build
 
       - name: Deploy production

--- a/website/src/components/Analytics.astro
+++ b/website/src/components/Analytics.astro
@@ -49,4 +49,26 @@
       respect_dnt: true,
     });
   }
+
+  // GA4 continuity with the pre-pivot site (same property; the measurement ID
+  // is public by design). Same gates as PostHog: real domain, indexable
+  // production build, DNT honored.
+  const gaId = import.meta.env.PUBLIC_GA_ID;
+  // @ts-expect-error one-time guard on window
+  if (gaId && !noindex && isRealSite && !dnt && !window.__agGaInit) {
+    // @ts-expect-error one-time guard on window
+    window.__agGaInit = true;
+    const s = document.createElement("script");
+    s.async = true;
+    s.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+    document.head.appendChild(s);
+    // @ts-expect-error gtag bootstrap
+    window.dataLayer = window.dataLayer || [];
+    // @ts-expect-error gtag bootstrap
+    function gtag() { window.dataLayer.push(arguments); }
+    // @ts-expect-error gtag bootstrap
+    gtag("js", new Date());
+    // @ts-expect-error gtag bootstrap
+    gtag("config", gaId);
+  }
 </script>


### PR DESCRIPTION
GA showed zero new users after the cutover because the Framer site injected GA4 via Framer's integration, and the rebuilt site shipped only PostHog — GA was never disconnected, it was never included.

This restores the same GA4 property (measurement ID G-368ZWZSH5D, recovered from the Wayback snapshot of the Framer site and matching the ID already documented in website/.env.example). It loads with the exact same gates as PostHog: only on agenta.ai/www, only in indexable production builds, honoring Do Not Track — so previews and dev send nothing. The production workflow provides the ID at build time.

Merging auto-deploys production and GA data resumes.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB