### PR TITLE
fix(website): structural accessibility (landmarks, icon-link names, dropdown state)

### DIFF
--- a/website/src/components/OpenStandards.astro
+++ b/website/src/components/OpenStandards.astro
@@ -16,6 +16,8 @@ const MASK =
 
 type Chip = {
   name?: string;
+  // Accessible name for icon-only chips (rendered as aria-label, never shown).
+  label?: string;
   mono?: boolean;
   logo?: string;
   href?: string;
@@ -24,27 +26,29 @@ type Chip = {
 
 type Row = { label: string; speed: number; chips: Chip[] };
 
-const mcp: Array<[string, string]> = [
-  ["github", "https://github.com"],
-  ["slack", "https://slack.com"],
-  ["linear", "https://linear.app"],
-  ["anthropic", "https://anthropic.com"],
-  ["notion", "https://notion.so"],
-  ["stripe", "https://stripe.com"],
-  ["postgresql", "https://postgresql.org"],
-  ["hubspot", "https://hubspot.com"],
-  ["posthog", "https://posthog.com"],
-  ["googledrive", "https://drive.google.com"],
-  ["zendesk", "https://zendesk.com"],
-  ["docker", "https://docker.com"],
-  ["figma", "https://figma.com"],
-  ["discord", "https://discord.com"],
-  ["asana", "https://asana.com"],
-  ["gitlab", "https://gitlab.com"],
-  ["airtable", "https://airtable.com"],
-  ["supabase", "https://supabase.com"],
-  ["mongodb", "https://mongodb.com"],
-  ["cloudflare", "https://cloudflare.com"],
+// [slug, href, accessible-name]. The MCPs row is logo-only (no visible text), so
+// each link carries an aria-label for screen readers / keyboard users.
+const mcp: Array<[string, string, string]> = [
+  ["github", "https://github.com", "GitHub"],
+  ["slack", "https://slack.com", "Slack"],
+  ["linear", "https://linear.app", "Linear"],
+  ["anthropic", "https://anthropic.com", "Anthropic"],
+  ["notion", "https://notion.so", "Notion"],
+  ["stripe", "https://stripe.com", "Stripe"],
+  ["postgresql", "https://postgresql.org", "PostgreSQL"],
+  ["hubspot", "https://hubspot.com", "HubSpot"],
+  ["posthog", "https://posthog.com", "PostHog"],
+  ["googledrive", "https://drive.google.com", "Google Drive"],
+  ["zendesk", "https://zendesk.com", "Zendesk"],
+  ["docker", "https://docker.com", "Docker"],
+  ["figma", "https://figma.com", "Figma"],
+  ["discord", "https://discord.com", "Discord"],
+  ["asana", "https://asana.com", "Asana"],
+  ["gitlab", "https://gitlab.com", "GitLab"],
+  ["airtable", "https://airtable.com", "Airtable"],
+  ["supabase", "https://supabase.com", "Supabase"],
+  ["mongodb", "https://mongodb.com", "MongoDB"],
+  ["cloudflare", "https://cloudflare.com", "Cloudflare"],
 ];
 
 const rows: Row[] = [
@@ -66,7 +70,7 @@ const rows: Row[] = [
   {
     label: "MCPs & tools",
     speed: 30,
-    chips: mcp.map(([slug, href]) => ({ logo: local(slug), href })),
+    chips: mcp.map(([slug, href, label]) => ({ logo: local(slug), href, label })),
   },
   {
     label: "Harness",
@@ -199,6 +203,7 @@ const isExternal = (href?: string) => !!href && href.startsWith("http");
                       target={isExternal(c.href) ? "_blank" : undefined}
                       rel={isExternal(c.href) ? "noopener" : undefined}
                       style={chipStyle(c)}
+                      aria-label={!c.name ? c.label : undefined}
                       aria-hidden={dup ? "true" : undefined}
                       tabindex={dup ? -1 : undefined}
                     >

--- a/website/src/components/SiteNav.astro
+++ b/website/src/components/SiteNav.astro
@@ -215,6 +215,25 @@ const triggerStyle = linkStyle + "border:none;background:transparent;";
     toggle.setAttribute("aria-expanded", open ? "true" : "false");
   });
 
+  // Hover/focus dropdowns open purely via CSS (:hover / :focus-within on
+  // .ag-navdd). The trigger's aria-expanded must track that open state for AT,
+  // so mirror the same two conditions onto it here. Semantic only — no visual
+  // change (the CSS still drives what's actually shown).
+  document.querySelectorAll<HTMLElement>(".ag-navdd").forEach((dd) => {
+    const trigger = dd.querySelector<HTMLButtonElement>(":scope > button");
+    if (!trigger) return;
+    const sync = (open: boolean) =>
+      trigger.setAttribute("aria-expanded", open ? "true" : "false");
+    dd.addEventListener("mouseenter", () => sync(true));
+    dd.addEventListener("mouseleave", () => sync(false));
+    dd.addEventListener("focusin", () => sync(true));
+    dd.addEventListener("focusout", () => {
+      // focusout fires before focus lands on the next target; defer so we can
+      // read whether focus is still inside this dropdown.
+      requestAnimationFrame(() => sync(dd.contains(document.activeElement)));
+    });
+  });
+
   // Nav-pill: landing only. The rAF loop toggles `.nav-scrolled` on <html> past
   // 24px so the sticky bar floats into the glass pill (styles in global.css). It
   // runs ONLY when a `nav[data-pill]` is present — inner pages render a static

--- a/website/src/components/TemplateExplorer.tsx
+++ b/website/src/components/TemplateExplorer.tsx
@@ -416,6 +416,7 @@ export default function TemplateExplorer() {
               {MODELS.map((m) => (
                 <span
                   key={m.name}
+                  role="img"
                   aria-label={m.name}
                   title={m.name}
                   style={{

--- a/website/src/content/posts/introducing-custom-workflows.mdx
+++ b/website/src/content/posts/introducing-custom-workflows.mdx
@@ -82,7 +82,7 @@ def generate(blog_post: str):
 
 You can read the [documentation](https://docs.agenta.ai/custom-workflows/overview) for more details, get started, and watch the announcement for a short demo.
 
-<iframe src="https://www.youtube.com/embed/eSAHuRLwG3M?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Custom Workflows demo" src="https://www.youtube.com/embed/eSAHuRLwG3M?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## The Technical Solution
 

--- a/website/src/content/posts/introducing-prompt-registry.mdx
+++ b/website/src/content/posts/introducing-prompt-registry.mdx
@@ -43,7 +43,7 @@ The main benefit is clarity. You can see what's in production and roll back inst
 
 The Prompt & Configuration Registry is available now for all Agenta users. Check out our demo video to see it in action:
 
-<iframe src="https://www.youtube.com/embed/ZwpHuXp2WiI?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Prompt & Configuration Registry demo" src="https://www.youtube.com/embed/ZwpHuXp2WiI?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## What's Next
 

--- a/website/src/content/posts/july-2025-product-updates.mdx
+++ b/website/src/content/posts/july-2025-product-updates.mdx
@@ -18,7 +18,7 @@ Here's what's new in July 2025 (and the last couple of months):
 
 ### Tool support in the playground:
 
-<iframe src="https://www.youtube.com/embed/SGqHOJf7tb8?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Tool support in the playground demo" src="https://www.youtube.com/embed/SGqHOJf7tb8?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 We released tool usage in the [Agenta playground](https://docs.agenta.ai/prompt-engineering/playground/using-the-playground) - a key feature for anyone building agents with LLMs.
 
@@ -32,7 +32,7 @@ The tool schema is saved with your prompt configuration, making integration easy
 
 ### Image support in the playground:
 
-<iframe src="https://www.youtube.com/embed/QCwhLRAYLuo?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Image support in the playground demo" src="https://www.youtube.com/embed/QCwhLRAYLuo?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Agenta now supports images in the [playground](https://docs.agenta.ai/prompt-engineering/playground/using-the-playground), [test sets](https://docs.agenta.ai/evaluation/create-test-sets), and [evaluations](https://docs.agenta.ai/evaluation/overview). This enables a systematic workflow for developing and testing applications that use vision models. Now you can:
 

--- a/website/src/content/posts/launch-week-2-day-1.mdx
+++ b/website/src/content/posts/launch-week-2-day-1.mdx
@@ -12,7 +12,7 @@ featured: false
 tags: ["Product Updates"]
 ---
 
-<iframe src="https://www.youtube.com/embed/gcYGRcNOJOg?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="New Evaluation Dashboard demo" src="https://www.youtube.com/embed/gcYGRcNOJOg?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Building reliable LLM apps is hard.
 

--- a/website/src/content/posts/launch-week-2-day-2-online-evaluation.mdx
+++ b/website/src/content/posts/launch-week-2-day-2-online-evaluation.mdx
@@ -22,7 +22,7 @@ And if you build AI apps for health or finance, it could be worse. One wrong ans
 
 Pre-production evals can’t catch everything. You will never know exactly how users will interact with your app. You will never see all the edge cases of real-world data until you’re in production.
 
-<iframe src="https://www.youtube.com/embed/rP3CiRmu3io?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Online Evaluation demo" src="https://www.youtube.com/embed/rP3CiRmu3io?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Today we're launching **Online Evaluation**. This feature closes the LLMOps feedback loop and solves this problem.
 

--- a/website/src/content/posts/launch-week-2-day-3-evaluation-sdk.mdx
+++ b/website/src/content/posts/launch-week-2-day-3-evaluation-sdk.mdx
@@ -12,7 +12,7 @@ featured: false
 tags: ["Product Update"]
 ---
 
-<iframe src="https://www.youtube.com/embed/1sZASEjvoOA?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Evaluation SDK demo" src="https://www.youtube.com/embed/1sZASEjvoOA?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Most LLM apps today are complex agents with multiple steps, tool calls, and retrieval flows.
 

--- a/website/src/content/posts/prompt-playground.mdx
+++ b/website/src/content/posts/prompt-playground.mdx
@@ -22,7 +22,7 @@ The original [OpenAI playground](https://platform.openai.com/) changed how we in
 
 We watched hundreds of teams build LLM applications and saw that success depends on rapid iteration - testing prompts, comparing models, and finding what works reliably. So we rebuilt our prompt engineering workflow from the ground up.
 
-<iframe src="https://www.youtube.com/embed/Eo3S52cejUY?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Prompt Playground 2.0 demo" src="https://www.youtube.com/embed/Eo3S52cejUY?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## What Makes Playground 2.0 Different
 

--- a/website/src/content/posts/structured-outputs-playground.mdx
+++ b/website/src/content/posts/structured-outputs-playground.mdx
@@ -39,7 +39,7 @@ Both modes are now available with a single click in the Agenta playground.
 
 ### Using structured output in the playground
 
-<iframe src="https://www.youtube.com/embed/08r4g5mO9lw?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Structured output in the playground demo" src="https://www.youtube.com/embed/08r4g5mO9lw?iv_load_policy=3&rel=0&modestbranding=1&playsinline=1&autoplay=0&mute=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 With Agenta's playground, implementing structured outputs is straightforward:
 

--- a/website/src/layouts/Site.astro
+++ b/website/src/layouts/Site.astro
@@ -56,7 +56,9 @@ const {
     style="width:100%;max-width:1440px;margin:0 auto;background:#0A0A0B;padding:0 12px;box-sizing:border-box;font-family:var(--font-sans);"
   >
     <SiteNav />
-    <slot />
+    <main>
+      <slot />
+    </main>
     {showCta && <CtaBand {...cta} />}
     <SiteFooter />
   </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -47,12 +47,14 @@ const orgJsonLd = {
     style="width:100%;max-width:1440px;margin:0 auto;background:var(--ag-d-bg-0);padding:0 12px;box-sizing:border-box;font-family:var(--font-sans);"
   >
     <SiteNav sticky />
-    <Hero />
-    <TemplateSection />
-    <HowItWorks />
-    <OpenStandards />
-    <Reliability />
-    <OpenSource />
+    <main>
+      <Hero />
+      <TemplateSection />
+      <HowItWorks />
+      <OpenStandards />
+      <Reliability />
+      <OpenSource />
+    </main>
     <CtaBand />
     <SiteFooter />
   </div>


### PR DESCRIPTION
## The constraint

Structural and semantic accessibility only. **Every change is invisible: colors, contrast, spacing, and layout render exactly as before.** Color and contrast findings are deliberately left untouched per founder decision.

This was verified by pixel-diffing full-page screenshots before and after, at 1440 and 412 widths, across the landing, pricing, blog index, and a blog post.

## Pixel-identity proof

Captures were stabilized by forcing `prefers-reduced-motion` (so the scroll-driven "How it works" renders its deterministic static layout) and freezing CSS animations (the logo marquee).

| Page | 1440 | 412 |
| --- | --- | --- |
| Landing | byte-identical | byte-identical |
| Pricing | byte-identical | byte-identical |
| Blog post | byte-identical | byte-identical |
| Blog index | identical* | identical* |

\* The blog index initially differed only inside the fixed card frames, where `loading="lazy"` hero images had decoded in one capture but not the other. Re-captured with all images deterministically decoded, both widths are **byte-identical**. To isolate this from the code change, the "before" blog index was rebuilt from `main` (no `<main>` wrapper) and compared against the "after" build with the same image-load protocol.

## Lighthouse accessibility (landing, desktop)

**Before: 87 → After: 96.**

Failing audits resolved:
- `landmark-one-main` — document had no `<main>` landmark.
- `link-name` — 20 logo-only marquee links had no accessible name.
- `aria-prohibited-attr` — 4 provider icon `<span>`s carried `aria-label` on a generic role.

The single remaining Lighthouse failure is `color-contrast`, which is out of scope by founder decision.

## What changed (structural only)

1. **Landmarks.** Added a `<main>` landmark. In `Site.astro` it wraps the page `<slot>`; on the landing it wraps the section stack. The nav (`<nav>`) and footer (`<footer>`) were already landmarks. The `<main>` replaces no styled node and introduces no style, so margin-collapse and layout are preserved (proven by the byte-identical diffs).
2. **Icon-link names.** The "MCPs & tools" marquee row is logo-only; each link now carries an `aria-label` (GitHub, Slack, PostgreSQL, and so on). Duplicated marquee copies stay `aria-hidden`.
3. **Dropdown state.** The nav's hover/focus dropdowns reported a static `aria-expanded="false"`. A small script now mirrors the CSS open state (`:hover` / `:focus-within`) onto the trigger's `aria-expanded`. Semantic only; the CSS still drives what is shown.
4. **Same-class extras.** `role="img"` on the four provider icon spans (makes their existing `aria-label` valid); `title` on 9 YouTube iframes across 8 blog posts.

Out of scope and untouched: all color and contrast findings. `lang` was already present; the interactive islands (hosting toggle, category filter, template explorer) were already labeled.

## Screenshots

Before/after full-page captures and the pixel-diff artifacts are saved under `debug/website-a11y-qa/`.

https://claude.ai/code/session_013Qe1Vf2yvj33BVd5W1q7HB
