### PR TITLE
fix(website): open off-site links in a new tab

### DIFF
--- a/website/src/components/Button.astro
+++ b/website/src/components/Button.astro
@@ -5,8 +5,11 @@ interface Props {
   variant?: "primary" | "outline" | "dark" | "ghost";
   size?: "sm" | "md" | "lg";
   href?: string;
+  // Opens the link in a new tab (for destinations that leave the marketing site,
+  // e.g. the docs). No effect when rendered as a <button> (no href).
+  external?: boolean;
 }
-const { variant = "primary", size = "md", href } = Astro.props;
+const { variant = "primary", size = "md", href, external = false } = Astro.props;
 
 const sizes: Record<string, string> = {
   sm: "height:30px;padding:0 12px;",
@@ -26,4 +29,9 @@ const style = `display:inline-flex;align-items:center;justify-content:center;gap
 const Tag = href ? "a" : "button";
 ---
 
-<Tag class="ds-btn" href={href} style={style}><slot /></Tag>
+<Tag
+  class="ds-btn"
+  href={href}
+  target={href && external ? "_blank" : undefined}
+  rel={href && external ? "noopener" : undefined}
+  style={style}><slot /></Tag>

--- a/website/src/components/OpenSource.astro
+++ b/website/src/components/OpenSource.astro
@@ -80,12 +80,16 @@ const ossStrip = [
           <a
             class="ag-oss-chip"
             href="https://docs.agenta.ai/self-host/quick-start"
+            target="_blank"
+            rel="noopener"
             style="display:inline-flex;align-items:center;height:30px;padding:0 12px;border-radius:999px;background:rgba(255,255,255,0.05);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.12);font:500 12.5px/1 var(--font-sans);color:rgba(255,255,255,0.75);text-decoration:none;"
             >Docker Compose</a
           >
           <a
             class="ag-oss-chip"
             href="https://docs.agenta.ai/self-host/guides/deploy-to-kubernetes"
+            target="_blank"
+            rel="noopener"
             style="display:inline-flex;align-items:center;height:30px;padding:0 12px;border-radius:999px;background:rgba(255,255,255,0.05);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.12);font:500 12.5px/1 var(--font-sans);color:rgba(255,255,255,0.75);text-decoration:none;"
             >Helm charts</a
           >

--- a/website/src/components/SiteFooter.astro
+++ b/website/src/components/SiteFooter.astro
@@ -40,12 +40,12 @@ const columns: { heading: string; links: Link[] }[] = [
   },
   {
     heading: "Resources",
-    // Tutorial is hidden for now (Mahmoud). Changelog + Roadmap point at the same
-    // docs pages the live agenta.ai site links to and navigate same-tab.
+    // Tutorial is hidden for now (Mahmoud). Docs/Changelog/Roadmap point at the
+    // docs site, so they open in a new tab (external) like the live agenta.ai.
     links: [
       { label: "Docs", href: "https://docs.agenta.ai/", external: true },
-      { label: "Changelog", href: "https://agenta.ai/docs/changelog/main" },
-      { label: "Roadmap", href: "https://agenta.ai/docs/roadmap" },
+      { label: "Changelog", href: "https://agenta.ai/docs/changelog/main", external: true },
+      { label: "Roadmap", href: "https://agenta.ai/docs/roadmap", external: true },
       { label: "Blog", href: "/blog" },
       { label: "Status", href: "https://status.agenta.ai", external: true },
     ],

--- a/website/src/components/SiteNav.astro
+++ b/website/src/components/SiteNav.astro
@@ -11,10 +11,12 @@ const { sticky = false } = Astro.props;
 const BOOK_DEMO = "https://cal.com/mahmoud-mabrouk-ogzgey/demo?duration=30";
 const GET_STARTED = "https://cloud.agenta.ai/";
 
-// Top-level links that navigate directly.
-const links = [
+// Top-level links. First-party pages navigate same-tab; links that leave the
+// marketing site (Docs) open in a new tab via `external`.
+type NavLink = { label: string; href: string; external?: boolean };
+const links: NavLink[] = [
   { label: "Pricing", href: "/pricing" },
-  { label: "Docs", href: "https://docs.agenta.ai/" },
+  { label: "Docs", href: "https://docs.agenta.ai/", external: true },
   { label: "Blog", href: "/blog" },
 ];
 
@@ -30,9 +32,9 @@ const icoX = `<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke
 const icoLinkedin = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect width="4" height="12" x="2" y="9"/><circle cx="4" cy="4" r="2"/></svg>`;
 
 // Dropdown menus (open on hover / keyboard focus). Resources + Community mirror
-// live agenta.ai. Changelog/Roadmap point at the same docs pages the live site
-// links to and navigate same-tab (like Docs). Tutorial is hidden for now — flip
-// SHOW_TUTORIAL to bring it back with the item intact.
+// live agenta.ai. Changelog/Roadmap/Tutorial point at the docs site, so they
+// open in a new tab (external) to keep the marketing site open behind them.
+// Tutorial is hidden for now — flip SHOW_TUTORIAL to bring it back intact.
 const SHOW_TUTORIAL = false;
 type Item = { label: string; desc: string; href: string; icon: string; external?: boolean };
 const dropdowns: { label: string; items: Item[] }[] = [
@@ -40,10 +42,10 @@ const dropdowns: { label: string; items: Item[] }[] = [
     label: "Resources",
     items: [
       ...(SHOW_TUTORIAL
-        ? [{ label: "Tutorial", desc: "Get started with Agenta", href: "https://agenta.ai/docs/tutorials/cookbooks/capture-user-feedback", icon: icoHelp }]
+        ? [{ label: "Tutorial", desc: "Get started with Agenta", href: "https://agenta.ai/docs/tutorials/cookbooks/capture-user-feedback", icon: icoHelp, external: true }]
         : []),
-      { label: "Changelog", desc: "See our latest releases", href: "https://agenta.ai/docs/changelog/main", icon: icoHistory },
-      { label: "Roadmap", desc: "See what's coming next", href: "https://agenta.ai/docs/roadmap", icon: icoRoute },
+      { label: "Changelog", desc: "See our latest releases", href: "https://agenta.ai/docs/changelog/main", icon: icoHistory, external: true },
+      { label: "Roadmap", desc: "See what's coming next", href: "https://agenta.ai/docs/roadmap", icon: icoRoute, external: true },
     ],
   },
   {
@@ -114,7 +116,13 @@ const triggerStyle = linkStyle + "border:none;background:transparent;";
   <div class="ag-navlinks">
     {
       links.map((l) => (
-        <a class="ag-navlink" href={l.href} style={linkStyle}>
+        <a
+          class="ag-navlink"
+          href={l.href}
+          target={l.external ? "_blank" : undefined}
+          rel={l.external ? "noopener" : undefined}
+          style={linkStyle}
+        >
           {l.label}
         </a>
       ))
@@ -164,6 +172,8 @@ const triggerStyle = linkStyle + "border:none;background:transparent;";
     links.map((l) => (
       <a
         href={l.href}
+        target={l.external ? "_blank" : undefined}
+        rel={l.external ? "noopener" : undefined}
         style="display:flex;align-items:center;height:42px;padding:0 12px;border-radius:8px;font:var(--text-body-md);color:rgba(255,255,255,0.78);cursor:pointer;text-decoration:none;"
       >
         {l.label}

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -49,7 +49,7 @@ const sectionBorder = "border:1px solid rgba(255,255,255,0.07);margin-top:-1px;"
       >
         <Button href="/" variant="primary" size="lg">Back to home</Button>
         <Button href="/blog" variant="outline" size="lg">Read the blog</Button>
-        <Button href="https://agenta.ai/docs" variant="dark" size="lg"
+        <Button href="https://agenta.ai/docs" variant="dark" size="lg" external
           >Browse the docs</Button
         >
       </div>


### PR DESCRIPTION
## Context
Clicking Docs, Changelog, Roadmap, Status, or a self-host link on the marketing site navigated away in the same tab, so the site was gone and the visitor had to hit back to return. Off-site destinations should open in a new tab and leave the marketing site behind them, which is how the live agenta.ai already behaves.

This branch also carries two smaller fixes that were already in progress: the footer social icons were pointing at the wrong glyphs, and the HowItWorks scroll section needed polish. All three are described below.

## Changes

### Off-site links open in a new tab
`Button.astro` gains an `external` prop. When the button renders as a link, `external` adds `target="_blank" rel="noopener"`; as a `<button>` (no href) it does nothing.

Before:
`<Button href="https://agenta.ai/docs">Browse the docs</Button>`  → same-tab

After:
`<Button href="https://agenta.ai/docs" external>Browse the docs</Button>`  → new tab

The same `external` flag now drives the nav and footer link lists, which emit `target`/`rel` from it in both the desktop and mobile markup. Links flipped to external: the nav Docs link and the Resources dropdown (Changelog, Roadmap, and the hidden Tutorial), the footer Changelog and Roadmap (Docs and Status were already external), the two self-host chips in the OpenSource section (Docker Compose, Helm charts), and the 404 page's "Browse the docs" button. First-party routes (Pricing, Blog, internal pages) are untouched and still navigate in the same tab.

### Footer social icons
The repo's `social-*.svg` files aren't named by platform, and the footer pointed at the wrong ones: LinkedIn rendered the Slack glyph and Slack rendered an OpenAI mark. There was no real LinkedIn icon in the repo. Added a LinkedIn SVG and remapped each platform to its actual glyph.

Before:
- LinkedIn → `/icons/social-2.svg`  (the Slack glyph)
- Slack → `/icons/social-4.svg`  (an OpenAI mark)

After:
- LinkedIn → `/icons/social-linkedin.svg`  (new, real LinkedIn glyph)
- Slack → `/icons/social-2.svg`  (the real Slack glyph)

A comment now records which numbered file is which, since the filenames don't say.

### HowItWorks scroll and nav pill
- Pulled the pinned section length into a named `SECTION_VH` constant and dropped it from 500 to 320 (~67vh down to ~37vh of scroll per beat), so the six chat stages feel snappier.
- Changed the placeholder `$0.00` cost figures in the chat metadata to realistic numbers ($0.14 and $0.06).
- Added a top-edge fade mask on the scrolled chat card so revealed messages dissolve into the card instead of being sliced by a hard overflow cut. The static (reduced-motion / small-screen) layout has no overflow and is left unmasked.
- Rewrote the scroll→stage handler to coalesce a burst of scroll/resize events into one `requestAnimationFrame`, so the single `getBoundingClientRect` read happens at most once per frame.
- Nav pill: replaced the always-on `requestAnimationFrame` loop (which ran every frame forever, even while idle) with a passive scroll/resize listener that coalesces into one rAF per frame and only writes the `.nav-scrolled` class on an actual crossing of the 24px threshold.
- Tightened `--nav-pill-inset` from 24px to 12px so the floating pill sits closer to the top.

## Tests / notes
- Visual and client-side changes only; no data or routing logic touched.
- `rel="noopener"` is applied without `noreferrer`, which keeps the referrer for our own docs analytics while still closing the `window.opener` hole.
- The branch bundles three themes. If you'd rather review them as separate PRs, say so and I'll split them.

## What to QA
- Landing nav: click Docs. It opens the docs site in a new tab and the marketing site stays put. Open the Resources dropdown and confirm Changelog and Roadmap do the same.
- Footer: Docs, Changelog, Roadmap, and Status open in a new tab. Blog and the internal links still navigate in the same tab.
- OpenSource section: the Docker Compose and Helm charts chips open docs in a new tab.
- 404 page: "Browse the docs" opens a new tab; "Back to home" and "Read the blog" stay in the same tab.
- Footer social row: the four icons read X, LinkedIn, GitHub, Slack, each with the correct glyph and destination.
- HowItWorks (desktop): the six chat stages advance faster than before, the thread fades into the top of the card as it grows, and the metadata rows show non-zero costs ($0.14 / $0.06).
- Scroll the landing page: the nav collapses into the floating pill past ~24px and expands at the top; the pill sits a touch higher than before.
- Regression: internal links anywhere (Pricing, Blog, first-party pages) still open in the same tab, not a new one.
