### PR TITLE
fix(frontend): remove repeated tool trace links

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -417,9 +417,6 @@ const AgentMessage = ({
         }
         renderItems.push({kind: "part", part, index: i})
     })
-    // The tool group's "View full trace" opens the same per-turn trace the action row does.
-    const onViewTrace = traceId ? () => openTraceDrawer({traceId}) : undefined
-
     const renderLeafPart = (part: UIMessage["parts"][number], i: number) => {
         // Stable, globally-unique key per rendered part. The part index alone collides
         // across messages that React reconciles together (duplicate-key warnings); the
@@ -484,7 +481,6 @@ const AgentMessage = ({
                             parts={item.parts}
                             isStreaming={isStreaming}
                             detailed={detailed}
-                            onViewTrace={onViewTrace}
                         />
                     )
                 }

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -3,7 +3,6 @@ import {memo} from "react"
 import {detectFileActivity, type FileActivity} from "@agenta/entities/session"
 import {HeightCollapse} from "@agenta/ui"
 import {
-    ArrowSquareOut,
     CaretRight,
     CheckCircle,
     Clock,
@@ -267,8 +266,6 @@ interface ToolActivityProps {
     /** Build mode: render the full step log (per-tool input + output/error inline), instead of the
      * calm collapsed "Used N tools" summary Chat mode shows. */
     detailed?: boolean
-    /** Open the turn's trace drawer (full input/output). Absent if the turn has no trace yet. */
-    onViewTrace?: () => void
 }
 
 /**
@@ -282,12 +279,7 @@ interface ToolActivityProps {
  * An `approval-requested` tool is marked "Awaiting approval" in every mode; the Approve/Deny action
  * lives in the persistent ApprovalDock. The FE only renders tool calls — it never executes them.
  */
-const ToolActivity = ({
-    parts,
-    isStreaming = false,
-    detailed = false,
-    onViewTrace,
-}: ToolActivityProps) => {
+const ToolActivity = ({parts, isStreaming = false, detailed = false}: ToolActivityProps) => {
     const anyUnsettled = parts.some((p) => !isSettled(p.state as string))
     const live = isStreaming && anyUnsettled
     const approvalPending = parts.some((p) => (p.state as string) === "approval-requested")
@@ -332,16 +324,6 @@ const ToolActivity = ({
                             <DriveFileCard key={a.path} path={a.path} op={a.op} />
                         ))}
                     </div>
-                ) : null}
-                {detailed && onViewTrace ? (
-                    <button
-                        type="button"
-                        onClick={onViewTrace}
-                        className="mt-1 flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-0 py-0.5 text-xs text-colorPrimary transition-colors hover:underline"
-                    >
-                        <ArrowSquareOut size={12} />
-                        View full trace
-                    </button>
                 ) : null}
             </div>
         )
@@ -402,16 +384,6 @@ const ToolActivity = ({
                             live={false}
                         />
                     ))}
-                    {onViewTrace && (
-                        <button
-                            type="button"
-                            onClick={onViewTrace}
-                            className="mt-1 flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-0 py-0.5 text-xs text-colorPrimary transition-colors hover:underline"
-                        >
-                            <ArrowSquareOut size={12} />
-                            View full trace
-                        </button>
-                    )}
                 </div>
             </HeightCollapse>
         </div>


### PR DESCRIPTION
## Context

Tool-heavy agent turns currently repeat **View full trace** after each rendered tool group. Those controls all open the same assistant-turn trace, and the assistant hover toolbar already exposes that turn-level action alongside token and cost metrics.

The repetition is especially noisy when reasoning, step markers, or text split one assistant response into several tool groups.

## Changes

- Remove the trace action from Build-mode tool activity.
- Remove the trace action from expanded Chat-mode tool summaries.
- Keep the single trace action in the assistant-turn hover toolbar.
- Leave the temporary approval-dock trace action unchanged; it remains useful while a turn is paused for approval.

Before:

```text
Tool step A
View full trace
Tool step B
View full trace
```

After:

```text
Tool step A
Tool step B

Hover assistant turn: metrics | View trace
```

## Tests / notes

- `pnpm lint-fix` from `web`: passed. Two existing TanStack Virtual compiler warnings remain in Drive components.
- Pre-commit formatting, frontend lint, and staged secret scanning: passed.
- `pnpm --filter @agenta/oss types:check` and `pnpm --filter @agenta/ee types:check` still fail on existing repository-wide TypeScript errors outside these two files.
- Follow-up issue #5097 tracks the deeper case where approval or client-tool continuation requests can create multiple backend traces for one visible assistant turn.

## What to QA

- In Build mode, run an agent that makes multiple server tool calls. Tool steps should render without repeated trace links.
- Hover the assistant turn. Metrics and one **View trace** action should remain and open the trace drawer.
- Pause on an approval in Build mode. The approval dock should still show its contextual **View full trace** action before Approve/Deny.
- In Chat mode, expand a settled tool summary. Tool rows should still expand without an extra trace link.