### PR TITLE
docs(agent-workflows): redesign trace continuation

### DIFF
--- a/docs/design/agent-chat-turn-continuation/README.md
+++ b/docs/design/agent-chat-turn-continuation/README.md
@@ -6,7 +6,7 @@ the AI SDK client continues the last assistant message on a resume, but our serv
 mints a fresh `msg-{trace_id}` per HTTP request, so the client's identity check fails
 and it pushes a full clone instead of replacing in place.
 
-Design-only workspace (2026-07-06). No product code changed here.
+Design-only workspace created 2026-07-06; trace continuation re-audited 2026-07-24. No product code changed here.
 
 ## Files
 
@@ -16,7 +16,9 @@ Design-only workspace (2026-07-06). No product code changed here.
 | `research.md` | The full verified flow: message-id lifecycle, why the client clones, frontend decision points, wire frames for normal/pause/resume, before/after playground mock. Read this to understand the system. |
 | `fix-options.md` | Options A/B/C evaluated, interface-role review, the trace-per-message implications, recommendation (A: server echoes the continuation id) |
 | `plan.md` | Implementation slices, unit + manual test plan, rollout |
-| `trace-continuation.md` | Follow-up design: propagate trace context across a turn's resumes so one turn = one trace (fixes the multi-trace trade-off v1 accepts). Decision pending. |
+| `trace-continuation.md` | Original 2026-07-06 trace-continuation proposal. Retained as research; superseded for implementation by `trace-continuation-v2.md`. |
+| `trace-continuation-v2.md` | Current design: keep protocol context in the session transport, replay it for approvals and client tools, aggregate usage, and refresh the growing trace's caches. |
+| `trace-continuation-complexity.md` | Exact work breakdown, dependencies, edge cases, test matrix, rollout order, and revised complexity estimate. |
 | `status.md` | Current progress and decisions |
 
 ## Related

--- a/docs/design/agent-chat-turn-continuation/status.md
+++ b/docs/design/agent-chat-turn-continuation/status.md
@@ -1,51 +1,54 @@
 # Status
 
-Last update: 2026-07-06 (design session, no code changed)
+Last update: 2026-07-24 (design re-audit, no product code changed)
 
 ## Where things stand
 
-- Research DONE. Every claim from the original findings doc verified against source,
-  with two precision corrections (see `research.md` section 8).
-- Design DONE. Recommendation: option A, server echoes the continuation id. See
-  `fix-options.md`.
-- Implementation of the messageId fix IN PROGRESS (PR #5088).
-- Follow-up DESIGNED, decision pending: trace-context propagation so one turn = one
-  trace (fixes the multi-trace footer/Inspect trade-off v1 accepts). See
-  `trace-continuation.md`; Mahmoud decides whether it becomes an issue or a PR.
+- Original message-identity research DONE. See `research.md` and `fix-options.md`.
+- Message identity fix MERGED in PR #5088 and present on `main`.
+- Trace-continuation follow-up RE-AUDITED against current `main`. The current
+  recommendation is in `trace-continuation-v2.md`; the exact scope and revised
+  Medium estimate are in `trace-continuation-complexity.md`.
+- Implementation remains OPEN in issue #5097. This workspace changes design docs only.
 
-## Key decisions
+## Decisions already shipped in #5088
 
-1. Fix lives in SDK routing (`routing.py`), not the adapter, frontend, or runner.
-   The adapter already accepts `message_id` (`stream.py:254-260`); routing just never
-   passes it.
-2. Continuation detection = "inbound last message has role assistant", mirroring the
-   AI SDK's own server helper (`ai/dist/index.js:4199-4208`). Not approval-specific,
-   so client-tool resumes are covered too.
-3. v1 accepts last-request `traceId`/`usage` on the merged turn (metadata merge,
-   `ai/dist/index.js:4563-4573`). Aggregated per-turn metrics are a parked follow-up.
-4. Batch channel gets the same rule as a second slice
-   (`_make_vercel_json_response`).
-5. The wrong usage numbers on resumes (`0/0/~62k`) are a runner bug
-   (`otel.ts:1185-1197`), filed separately, not fixed here.
+1. Assistant message identity lives in SDK routing, not the frontend or runner.
+2. Continuation detection is "the inbound last message has role assistant", matching
+   the AI SDK behavior. Approvals and client tools share it.
+3. The batch channel follows the same stable-message-id rule.
 
-## Blockers
+## Follow-up decisions
 
-None.
+1. `spanId` and `traceparent` are per-request protocol context owned by
+   `AgentChatTransport`, not persistent UI-message metadata.
+2. The transport keeps the latest trace/span context by stable assistant message id,
+   so sequential resumes form a causal chain in one trace.
+3. The UI message keeps stable `traceId` plus cumulative turn usage.
+4. A growing trace needs scoped, bounded cache refresh; one immediate invalidation can
+   race ingestion and cache a partial trace.
+5. The wrong resumed-turn usage (`0/0/~62k`) remains a runner bug. The frontend total
+   guard prevents that context-size number from corrupting the turn aggregate.
+
+## Product decision before implementation
+
+Confirm whether release acceptance requires one trace across a page reload. The
+recommended first slice guarantees one trace for approvals and client tools handled
+by the same mounted session transport. A reload intentionally starts a new transport
+and therefore a new trace epoch.
+
+Guaranteed reload continuity is a separate Medium slice: persist explicit trace/span
+context in session records and restore the latest completed context into the new
+transport.
 
 ## Next steps
 
-1. Mahmoud reviews this workspace (start with `research.md`, then `fix-options.md`).
-2. On approval, implement slice 1 per `plan.md` (implement-feature flow), then the
-   tests, then the manual playground scenario.
-3. File the runner usage issue and the root-cause-2 (phantom tool failure) issue.
+1. Review `trace-continuation-v2.md`, then `trace-continuation-complexity.md`.
+2. Decide the reload boundary above.
+3. Implement the slices in the order listed in `trace-continuation-complexity.md`.
 
 ## Deferred
 
-- Batch intra-response id-collision corner: an echoed continuation id can collide
-  with a positional `msg-{i}` id assigned to another message inside the same raw
-  batch JSON. Accepted for v1: the frontend replay only ever extracts one message,
-  so this is not client-visible.
-- Runner usage bug (resumes report `0/0/~62k`, `otel.ts:1185-1197`) still needs its
-  own issue filed; not fixed by this PR.
-- Manual playground click-through of the approval-resume scenario (`plan.md`
-  "Manual playground scenario") is still pending.
+- Runner usage extraction for resumed ACP turns.
+- Recomputing root-span cumulative metrics after late span ingestion.
+- Manual playground QA from the delivery plan.

--- a/docs/design/agent-chat-turn-continuation/trace-continuation-complexity.md
+++ b/docs/design/agent-chat-turn-continuation/trace-continuation-complexity.md
@@ -1,0 +1,237 @@
+# Trace continuation complexity and delivery plan
+
+This document turns `trace-continuation-v2.md` into reviewable work. It explains why
+issue #5097 is Medium complexity even though the server already understands
+`traceparent`.
+
+## Executive estimate
+
+| Scope                                               |        Complexity |      Expected effort | Why                                                                                                                                                         |
+| --------------------------------------------------- | ----------------: | -------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Live continuation in one mounted session            |            Medium | 3-5 engineering days | Additive SDK contract, transport override, cumulative usage semantics, two trace-cache invalidations, cross-channel tests, and live approval/client-tool QA |
+| Guaranteed continuation after server-only hydration | Additional Medium | 2-4 engineering days | Durable record contract, latest-span folding rule, backend and replay changes, compatibility tests                                                          |
+
+The first row is the recommended issue scope. The second row should be scheduled only
+if reload continuity is a release requirement.
+
+The estimate assumes the current message-id continuation behavior from #5088 remains
+stable. It excludes the runner's broken ACP input/output accounting.
+
+## Why this is not Small
+
+Sending one header is small. Shipping correct behavior is not, because the header
+changes the lifetime of a trace from "immutable after one request" to "incrementally
+extended by later requests".
+
+Four contracts must agree:
+
+1. **Response contract:** the browser needs the current `/invoke` span id, not only
+   the trace id.
+2. **Request contract:** only a genuine continuation may replay that context.
+3. **Message contract:** usage shown for one message must represent all requests that
+   built it.
+4. **Query-cache contract:** the same trace key must be refetched after later spans
+   arrive.
+
+Missing any one creates a plausible but wrong result:
+
+| Missing piece                 | User-visible failure                                                                |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| `spanId` in stream metadata   | Resume cannot construct a valid parent; it starts a new trace                       |
+| Strict continuation predicate | A new user turn can accidentally join the previous trace                            |
+| Cumulative usage rewrite      | Trace is unified but token/cost chips show only the last request                    |
+| Scoped cache invalidation     | Backend contains the full trace but metrics/drawer keep an earlier partial snapshot |
+| Batch parity                  | Behavior changes when stream negotiation falls back to JSON                         |
+
+## Work breakdown
+
+### Slice A: additive SDK metadata contract
+
+Complexity: Small.
+
+- Thread `WorkflowStreamingResponse.span_id` into the Vercel stream projection.
+- Emit `messageMetadata.spanId` on `finish`.
+- Keep the field optional for older or untraced responses.
+- Confirm error and no-output terminators still emit the metadata.
+
+Tests:
+
+- Stream with trace and span ids emits both.
+- Stream without span id emits no `spanId`.
+- Error-finally path still emits trace context.
+- Routing passes the response span id to the adapter.
+
+Risk: low. The field is additive and ignored by old consumers.
+
+### Slice B: transport continuation and cumulative usage
+
+Complexity: Medium.
+
+- Add a transport-local continuation map keyed by stable assistant message id.
+- Wrap `prepareSendMessagesRequest`: delegate first, then merge a validated
+  `traceparent` into the final prepared headers so it cannot be discarded.
+- Override `AgentChatTransport.sendMessages` to capture and strip response `spanId`,
+  advance the latest-span context, and aggregate usage.
+- Wrap the parsed chunk stream and rewrite finish usage cumulatively.
+- Add `spanId` to the batch JSON replay metadata.
+- Keep stream-to-batch 406 fallback behavior unchanged.
+
+Tests need a new transport-focused suite because no current test directly exercises
+`AgentChatTransport`.
+
+Required cases:
+
+1. Normal user send: no `traceparent`.
+2. Approval resume: header uses the transport context for the last assistant id.
+3. Denial resume: same behavior.
+4. Client-tool success and error: same behavior.
+5. Missing, malformed, or evicted context: no header.
+6. Regenerate/new user message: fresh trace.
+7. Existing authorization and message-format headers survive.
+8. The 406 stream-to-batch retry preserves `traceparent`.
+9. First finish usage passes through.
+10. Second and third request usage accumulates once each.
+11. `{input:0, output:0, total:62749}` contributes zero total.
+12. Total-only usage remains representable.
+13. Batch response copies both ids and follows the same aggregation rule.
+14. Aborted or errored request does not double-count a previous aggregate.
+
+Main uncertainty: stream transformation must preserve backpressure, errors, and every
+chunk unchanged except `finish.messageMetadata.usage`.
+
+### Slice C: scoped trace-cache invalidation
+
+Complexity: Small to Medium.
+
+- Add a growing-trace refresh action that accepts one trace id.
+- Invalidate both the lightweight summary and full trace query keys for the current
+  project.
+- Call it on each successful chat finish and use a bounded backoff for active queries;
+  one immediate refetch can race asynchronous ingestion and cache a partial trace.
+- Leave inactive queries stale for their next mount.
+- Preserve the aggressive not-found retry window for newly ingested spans.
+
+Tests:
+
+- Only the requested trace's summary and entity keys are invalidated.
+- Other trace ids remain cached.
+- A continuation finish starts the bounded refresh for the stable trace id.
+- Fake-timer coverage proves the backoff stops at its deadline and on teardown.
+- A successful early partial response does not stop later scheduled refetches.
+- Opening the drawer before approval and again after resume fetches the expanded tree.
+
+Main uncertainty: choose the shortest backoff window that reliably covers current
+ingestion lag without keeping active drawers noisy. The implementation should make the
+schedule explicit and testable.
+
+### Slice D: end-to-end QA and observability checks
+
+Complexity: Medium because it spans UI, network, and stored traces.
+
+Run these scenarios in both default streaming mode and forced batch/fallback mode
+where supported:
+
+| Scenario                               |         HTTP requests | Expected assistant messages |                         Expected traces |
+| -------------------------------------- | --------------------: | --------------------------: | --------------------------------------: |
+| Server tools, no gate                  |                     1 |                           1 |                                       1 |
+| Approve one gate                       |                     2 |                           1 |                                       1 |
+| Deny one gate                          |                     2 |                           1 |                                       1 |
+| Two sequential approvals               |                     3 |                           1 |                                       1 |
+| Client tool succeeds                   |                     2 |                           1 |                                       1 |
+| Client tool fails/cancels              |                     2 |                           1 |                                       1 |
+| New user turn after a gated turn       |                    +1 |                          +1 |                                      +1 |
+| Regenerate                             | 1 replacement request |         replacement message |                             fresh trace |
+| Reload parked turn from server records |              1 resume |                           1 | new trace unless durability slice ships |
+
+For each continuation scenario, verify:
+
+- Network request 2 carries the expected `traceparent`.
+- Every `/invoke` span has the same trace id and the expected parent chain.
+- The turn-level trace action opens the full waterfall.
+- Opening the drawer before and after resume shows the later subtree after refetch.
+- Token/cost chips use cumulative message usage, not only the last request.
+- Human think time does not appear as one long-running span.
+
+### Optional Slice E: durable reload continuity
+
+Complexity: Medium and deliberately separate.
+
+Likely ownership:
+
+- Runner or SDK record emission adds trace and span context to a durable terminal
+  event or record.
+- Session record DTO/storage preserves those fields.
+- Hydration restores the latest completed context into the new session transport.
+- Tests cover old records with neither field and turns with several resume records.
+
+The design must choose the latest completed `/invoke` span, not the first, so another
+resume continues the causal chain.
+
+## Dependency graph
+
+```mermaid
+flowchart LR
+    A[SDK finish includes spanId] --> B[Transport sends traceparent]
+    B --> C[One trace receives later spans]
+    B --> U[Transport emits cumulative usage]
+    C --> I[Invalidate summary and drawer caches]
+    C --> Q[End-to-end trace QA]
+    U --> Q
+    I --> Q
+    E[Optional durable record context] --> B
+```
+
+Slices A, B, and C can be separate commits but should ship behind one compatible PR
+stack or in dependency order. A may deploy before B safely. B without C should not be
+released because it produces stale trace UI after an approval.
+
+## Interfaces and ownership
+
+| Field or decision              | Semantic role                                 | Owner                                             | Lifetime                          |
+| ------------------------------ | --------------------------------------------- | ------------------------------------------------- | --------------------------------- |
+| `traceId` in transport context | Protocol context and observability identity   | SDK response; transport captures                  | Logical live turn                 |
+| `spanId`                       | Protocol context: parent for the next request | SDK response; transport captures and strips       | Latest completed request          |
+| `traceparent`                  | Standard W3C propagation header               | Frontend transport sends; SDK middleware consumes | One continuation request          |
+| `messageId`                    | Conversation identity and context-map key     | AI SDK and Vercel stream projection               | Logical assistant message         |
+| `traceId` on UI message        | Observability metadata for the trace action   | Transport forwards                                | Logical assistant message         |
+| `usage`                        | Turn-level metric data                        | Frontend transport aggregates                     | Logical assistant message         |
+| growing-trace refresh          | Cache lifecycle policy                        | Trace entity store                                | Bounded window after each request |
+
+`spanId` travels in `finish.messageMetadata` only because that is the AI SDK's
+additive finish extension point. Its semantic owner remains the transport, so the
+transport removes it before the UI message is persisted.
+
+Do not derive conversation identity from trace ids. #5088 intentionally separated
+those concerns: message id remains stable even if propagation is absent or malformed.
+
+## Failure behavior
+
+The feature is fail-open:
+
+- No transport context or span id: start a new trace.
+- Invalid ids: start a new trace.
+- Old backend: `spanId` is absent, so behavior remains current.
+- Old frontend: ignores `spanId`, so behavior remains current.
+- Trace query refetch fails: the message still renders and can retry; the agent run is
+  unaffected.
+
+The transport must never block a tool approval or client-tool continuation because
+observability context is unavailable.
+
+## Rollout
+
+1. Land SDK contract and unit tests.
+2. Land frontend transport, usage, and cache invalidation together.
+3. QA one approval and one client tool first; they prove both interaction producers
+   converge on the shared continuation path.
+4. QA two sequential gates; it proves the latest-span chain advances correctly.
+5. Compare trace counts and any dashboards that treat traces as runs.
+6. Decide whether to schedule durable reload continuity.
+
+## Out of scope
+
+- Fixing ACP's missing input/output split.
+- Recomputing historical root-span cumulative metrics after late ingest.
+- Changing trace-list counting or billing semantics without a separate decision.
+- Combining a whole chat session into one trace.
+- Changing the assistant-turn trace action introduced by the part 1 UI cleanup.

--- a/docs/design/agent-chat-turn-continuation/trace-continuation-v2.md
+++ b/docs/design/agent-chat-turn-continuation/trace-continuation-v2.md
@@ -1,0 +1,285 @@
+# Trace continuation v2: one live assistant turn, one trace
+
+Issue: #5097. Prerequisite: the stable assistant-message identity from merged PR
+#5088. This is a design document; it changes no product behavior.
+
+## Decision
+
+Keep continuation trace context in explicit, transport-local state keyed by the stable
+assistant message id:
+
+```ts
+interface TurnContinuationContext {
+  traceId: string;
+  spanId: string;
+  usage?: { input?: number; output?: number; total?: number; cost?: number };
+}
+```
+
+On a continuation request, `AgentChatTransport` validates that context and sends:
+
+```http
+traceparent: 00-{traceId}-{spanId}-01
+```
+
+The existing SDK middleware then creates the next `/invoke` span as a child of the
+previous request's `/invoke` span. Each approval or client-tool resume replaces the
+stored `spanId`, so a turn with several requests forms one causal chain inside one
+trace.
+
+The Vercel stream must use `finish.messageMetadata.spanId` as its additive wire
+channel because the AI SDK has no separate finish-context envelope. The Agenta
+transport captures that field as protocol context and removes it before forwarding the
+chunk to `useChat`; it is not persisted as descriptive UI-message metadata. The
+message keeps only the stable `traceId` used by the trace action and cumulative usage
+used by the metrics chip.
+
+This separation is deliberate:
+
+- `traceparent` and `spanId` are per-request protocol context owned by the transport.
+- `traceId` on the UI message is observability metadata used to open the trace.
+- `usage` is turn-level metric data displayed by the UI.
+- `messageId` is conversation identity and remains independent of tracing.
+
+## Why there can be several requests in one assistant turn
+
+A normal server tool runs inside the original HTTP request and therefore already
+belongs to its trace. A human interaction is different:
+
+1. The server streams an assistant message until it reaches a gate.
+2. The stream finishes so the browser can collect a human decision or client-side
+   result.
+3. The browser updates the existing assistant message.
+4. `useChat` automatically sends the whole history in another POST.
+5. The stable message id from #5088 makes the new stream extend the existing
+   assistant message instead of creating another bubble.
+
+Both interactive paths use the same step 4:
+
+- Approval: `addToolApprovalResponse` changes the part to `approval-responded`.
+- Client tool: `addToolOutput` changes the browser-owned tool part to
+  `output-available` or `output-error`.
+
+Both then pass through `agentShouldResumeAfterApproval` and
+`DefaultChatTransport.sendMessages`. There is no separate trace design for client
+tools. Approve, deny, client-tool success, and client-tool failure are four outcomes
+of the same continuation transport.
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+    participant U as User or client-tool widget
+    participant C as useChat
+    participant T as AgentChatTransport
+    participant S as SDK /invoke
+    participant R as Runner and harness
+
+    C->>T: initial send; last message is user
+    T->>S: POST without traceparent
+    S->>S: create trace t1, /invoke span s1
+    S->>R: run under 00-t1-s1-01
+    R-->>S: model and tool spans
+    S-->>T: finish metadata {traceId:t1, spanId:s1, usage:u1}
+    T->>T: store context t1, s1 by assistant id
+    T-->>C: assistant message stores traceId t1 and usage u1
+
+    Note over U,C: approval or client tool settles
+    C->>T: auto-resume existing assistant message
+    T->>T: look up context t1, s1 by assistant id
+    T->>S: POST + traceparent 00-t1-s1-01
+    S->>S: create /invoke span s2 under s1, still trace t1
+    S->>R: resumed run under 00-t1-s2-01
+    R-->>S: continuation spans
+    S-->>T: finish metadata {traceId:t1, spanId:s2, usage:u2}
+    T->>T: replace usage with aggregate(u1,u2)
+    T->>T: replace stored context with t1, s2
+    T-->>C: same assistant id, metadata has t1 and aggregate
+```
+
+For a second gate, the next request uses `00-t1-s2-01`; its span becomes `s3`.
+Nothing remains open while the human thinks. Parenting under an ended span is valid
+OpenTelemetry behavior: the trace and parent ids are sufficient.
+
+## Changes by layer
+
+### 1. SDK stream metadata
+
+The batch response already carries both `trace_id` and `span_id`. The Vercel streaming
+projection carries only `traceId`.
+
+Add optional `span_id` to `agent_stream_to_vercel_stream`, pass
+`WorkflowStreamingResponse.span_id` from `_make_stream_response`, and emit `spanId`
+beside `traceId` in the `finish.messageMetadata` object.
+
+Files:
+
+- `sdks/python/agenta/sdk/decorators/routing.py`
+- `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`
+- adapter and routing tests under
+  `sdks/python/oss/tests/pytest/unit/agents/`
+
+This is an additive wire change. Older frontends ignore `spanId`; older servers leave
+it absent and the new frontend starts a separate trace instead of inventing a parent.
+
+### 2. Frontend transport boundary
+
+`AgentChatTransport` owns both directions of the continuation protocol.
+
+In its constructor, wrap the caller's `prepareSendMessagesRequest` callback:
+
+1. Delegate first so the normal request builder resolves URL, auth, negotiation, and
+   body.
+2. Treat the request as a continuation only when the final message is the assistant
+   message identified by the AI SDK's `messageId`.
+3. Look up that message id in the transport-local context map.
+4. Merge a validated W3C `traceparent` into the prepared headers after delegation.
+
+The ordering is load-bearing. The current callback replaces the transport's candidate
+headers with `buildAgentRequest(...).headers`; adding `traceparent` only to
+`sendMessages(options.headers)` would be silently discarded. Wrapping the prepared
+result places protocol context at the final HTTP boundary. The negotiating fetch
+already preserves every non-`Accept` header on a 406 batch retry.
+
+Override `sendMessages` for the response direction. Transform the parsed
+`UIMessageChunk` stream and track the response message id from its `start` chunk. On
+`finish`:
+
+1. Validate and capture `{traceId, spanId}` into the context map under that message id.
+2. Combine current-request usage with the prior cumulative usage stored for the turn.
+3. Remove `spanId` from forwarded metadata because it is internal protocol context.
+4. Forward the stable `traceId` and cumulative usage; the AI SDK merges them onto the
+   same message.
+
+For batch fallback, `batchJsonToUiMessageStream` must copy both `trace_id` and
+`span_id` into its internal `finish.messageMetadata` so the same wrapper can capture
+and strip the span id. The map's lifetime is the transport's lifetime; the transport
+is already created per playground session.
+
+### 3. Usage aggregation
+
+The transport changes forwarded `finish.messageMetadata.usage` from "this HTTP
+request" to "this logical assistant turn". The already-rendered `getMessageUsage` and
+`TraceMetrics` code then need no new store or component API.
+
+Aggregation rules:
+
+- Add finite `input`, `output`, and `cost` values independently.
+- When both input and output are present for a request, derive that request's total as
+  `input + output`; do not trust a contradictory `total`.
+- When neither split value is present, preserve and add a finite reported `total`.
+- Never emit `NaN`, negative values, or values from malformed metadata.
+
+The total rule contains the current ACP defect. A resumed request that reports
+`{input: 0, output: 0, total: 62749}` contributes zero rather than adding a context
+window size to billed usage. This makes the UI honest about known tokens, but it does
+not repair missing runner usage.
+
+### 4. Growing-trace cache invalidation
+
+Today trace queries treat a found trace as immutable:
+
+- `traceSummaryQueryAtomFamily` uses `staleTime: Infinity`.
+- `traceEntityAtomFamily`, used by the full trace drawer, also uses
+  `staleTime: Infinity`.
+- `markTraceAsFresh` changes only not-found retry behavior; it does not invalidate a
+  found query.
+
+That is correct for ordinary traces and wrong for a trace that receives another
+continuation subtree. If the metrics row or drawer fetched `t1` while an approval was
+waiting, it will otherwise keep that partial snapshot forever.
+
+Add a trace-id-scoped growing-trace refresh action in the trace entity store and call
+it from the chat's `onFinish`. It must invalidate both
+`['trace-summary', projectId, traceId]` and
+`['trace-entity', projectId, traceId]`. Do not invalidate every trace in the project.
+
+One immediate invalidation is insufficient: ingestion is asynchronous, and an early
+refetch can successfully return the already-existing request-1 trace before the new
+spans arrive. A successful but partial response would then be cached forever. Use a
+bounded backoff window for active queries (for example immediate, 500 ms, 1.5 s, 3 s,
+and 5 s), while inactive queries only need to be left stale for their next mount.
+The refresh must stop at the deadline and on teardown.
+
+This is required for correctness, not an optimization.
+
+## Existing behavior that does not change
+
+- `OTelMiddleware` already extracts `traceparent`.
+- SDK tracing already uses the extracted context as the `/invoke` parent.
+- SDK-to-runner and runner-to-harness propagation already keep downstream spans in
+  that trace.
+- The tracing API already upserts spans by project and span identity.
+- Server tools that do not pause stay in their original request.
+- A new user message, regenerate, or resend-after-stop has a final user message and
+  therefore starts a new trace.
+- The single assistant-turn trace action from PR #5483 continues to open by
+  `message.metadata.traceId`; that id simply remains stable across resumes.
+
+## Trace shape and metrics
+
+The final trace is a chain of request subtrees:
+
+```text
+invoke request 1 (t1/s1)
+├── runner request 1
+│   ├── model
+│   └── gated tool announcement
+└── invoke resume 1 (t1/s2)
+    ├── runner resume 1
+    └── invoke resume 2 (t1/s3)
+        └── runner resume 2
+```
+
+Late spans are ingested in separate batches. The tracing service calculates
+cumulative token/cost/error values within each ingest payload, so it does not
+retroactively add resume metrics to the already-ingested root `s1`. Consequences:
+
+- The waterfall can show the complete turn after cache invalidation.
+- The message's cumulative usage is the authority for the playground token/cost chip.
+- Root-span cumulative metrics remain request-1 metrics.
+- The current latency chip remains root-request duration, not human think time or the
+  sum of request durations. Changing that meaning is outside the first slice.
+
+## Reload boundary
+
+The transport can continue a trace only while its session-local map contains both
+ids for the assistant message. Same-mount approval and client-tool resumes therefore
+join reliably. A remount or page reload creates a new transport and intentionally
+drops the map.
+
+Server-hydrated transcripts do not currently provide a durable span-context contract.
+Therefore the first implementation must fail open after reload: without a complete
+context entry, send no `traceparent` and start a new trace.
+
+If product acceptance requires one trace even after server-only hydration, add a
+separate durability slice:
+
+1. Persist each request's trace and span ids as explicit session-record context.
+2. Restore them into the transport continuation store, not generic UI metadata.
+3. Define which span wins when records from several continuation requests fold into
+   one assistant message; it must be the latest completed request.
+
+That slice crosses runner record emission, session storage DTOs, replay projection,
+and migration/backward-compatibility tests. It is not hidden inside the frontend
+change.
+
+## Safety rules
+
+- Accept only lowercase or uppercase hexadecimal ids of the W3C lengths; normalize to
+  lowercase.
+- Require both ids. Never construct a partial `traceparent`.
+- Apply propagation only to an assistant-message continuation, never a normal user
+  send.
+- Preserve prepared auth and negotiation headers; add `traceparent` only after the
+  normal request preparation finishes.
+- Use context attached to the exact assistant message being continued.
+- If validation fails, omit the header. Starting a new trace is safer than attaching
+  to the wrong trace.
+
+## Decision summary
+
+Use transport-local, latest-span trace context and a chained trace shape. Implement
+SDK wire metadata, transport propagation plus cumulative usage, and scoped growing-
+trace cache refresh together. Treat reload continuity as an explicit product choice
+and, if required, a separate durability slice.

--- a/docs/design/agent-chat-turn-continuation/trace-continuation.md
+++ b/docs/design/agent-chat-turn-continuation/trace-continuation.md
@@ -1,5 +1,11 @@
 # Trace continuation: one logical turn, one trace
 
+> Historical proposal, verified on 2026-07-06. The current implementation design is
+> `trace-continuation-v2.md`; the re-audit and revised estimate are in
+> `trace-continuation-complexity.md`. This file remains useful for the original
+> propagation and ingest research, but its ephemeral-store recommendation, flat trace
+> shape, and Small estimate are superseded.
+
 Follow-up design to the v1 messageId fix (`plan.md`). Design only, no code changed.
 Every claim below was verified against source on 2026-07-06, with file:line references.
 


### PR DESCRIPTION
## Context

Issue #5097 proposes joining the multiple HTTP requests behind one approval- or client-tool-resumed assistant turn into one OpenTelemetry trace.

The original design correctly found that the SDK already accepts inbound W3C `traceparent`, but its Small estimate omitted several current-system constraints: the browser still needs the response span id, request preparation replaces candidate transport headers, message usage is overwritten on each resume, and both trace-query paths cache a found trace as immutable even while later continuation spans are still being ingested.

This draft re-audits the proposal against current `main` and turns it into an implementation-ready complexity assessment. It changes documentation only.

## Changes

- Add a current v2 design with the full approval and client-tool continuation flow.
- Keep `spanId` and `traceparent` as transport-owned protocol context instead of persistent UI-message metadata.
- Use the stable assistant message id from merged PR #5088 as the transport context-map key.
- Define a chained trace shape: each resume is a child of the previous request span.
- Define cumulative per-turn usage rules, including the ACP `{input:0, output:0, total:~62k}` guard.
- Identify scoped, bounded growing-trace cache refresh as mandatory; a single invalidation can race asynchronous ingestion and cache a partial trace.
- Cover streaming, 406 batch fallback, approvals, denials, client-tool success/failure, sequential gates, regeneration, and failure behavior.
- Separate guaranteed continuity after a page reload into an explicit durability slice.
- Mark the 2026-07-06 proposal as historical and update workspace status.

## Complexity conclusion

- Same mounted-session continuation: **Medium, approximately 3–5 engineering days** across SDK metadata, frontend transport, usage aggregation, trace-cache lifecycle, tests, and live QA.
- Guaranteed continuation after server-only hydration/page reload: **an additional Medium, approximately 2–4 engineering days** across durable session records, restoration, and compatibility tests.

## Tests / notes

- `pnpm exec prettier --check` for the new v2 design, complexity plan, and rewritten status: passed.
- `git diff --check`: passed.
- Pre-commit secret scanning: passed.
- No product code changed.

## Decisions requested

1. Is one trace for same-mount approval and client-tool resumes sufficient for the first implementation?
2. Or must one logical turn remain one trace after a page reload/server-only hydration? If required, the durability slice belongs in release scope rather than being treated as an edge case.
3. Is root-request latency acceptable for the first slice, given that cumulative usage is corrected in the UI but root-span cumulative metrics are not recomputed after late ingest?

## What to review

- Start with `trace-continuation-v2.md` for the contract and end-to-end flow.
- Then review `trace-continuation-complexity.md` for slices, risks, test matrix, estimates, and rollout order.

Related to #5097.