### PR TITLE
fix(runner): stop replaying the current prompt as a prior turn

### DIFF
--- a/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
+++ b/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
@@ -3,14 +3,19 @@
  * trusting a full inbound history — the server side of "client sends only the last message".
  *
  * Flag-gated (`AGENTA_SESSIONS_RECONSTRUCT`) and a strict no-op until BOTH the flag is on AND the
- * client actually sent a minimal history: when the client still sends the whole conversation
- * (`messages.length > 1`), reconstruction is skipped and behaviour is unchanged. Best-effort — any
- * miss (no session, no records, fetch failure) leaves the inbound history untouched.
+ * client actually sent a minimal history (`carriesMinimalHistory`). Best-effort — any miss (no
+ * session, no records, fetch failure) leaves the inbound history untouched.
+ *
+ * The record log already contains the CURRENT turn by the time this runs: the runner persists the
+ * inbound user message before it starts the engine, and acquiring a sandbox takes seconds. Its
+ * records are therefore dropped by `turn_id` here, or the current prompt would be reconstructed
+ * as a prior turn and then appended again from the inbound history.
  */
 
 import type { AgentRunRequest } from "../../protocol.ts";
 import { fetchSessionRecords } from "../../sessions/records-query.ts";
 import { reconstructMessages } from "../../sessions/reconstruct.ts";
+import { carriesMinimalHistory } from "./session-identity.ts";
 
 function reconstructEnabled(): boolean {
   return (
@@ -21,9 +26,6 @@ function reconstructEnabled(): boolean {
 /**
  * Returns a request whose `messages` are `[...reconstructed prior turns, ...inbound]` when
  * reconstruction applies, else `null` to keep the inbound history as-is.
- *
- * MUST be called before the current turn's user message is persisted, so the record log holds
- * only prior turns (no duplication of the incoming prompt).
  */
 export async function reconstructHistoryIfNeeded(
   request: AgentRunRequest,
@@ -33,18 +35,26 @@ export async function reconstructHistoryIfNeeded(
 ): Promise<AgentRunRequest | null> {
   if (!reconstructEnabled() || !sessionId) return null;
   const inbound = request.messages ?? [];
-  // The client already sent the conversation — nothing to rebuild.
-  if (inbound.length > 1) return null;
+  // The client still asserts the conversation itself — nothing to rebuild.
+  if (!carriesMinimalHistory(request)) return null;
 
   const records = await fetchSessionRecords(sessionId, auth);
-  if (!records || records.length === 0) return null;
+  if (!records) return null;
 
-  const reconstructed = reconstructMessages(records);
+  // Drop this turn's own records: the inbound message already carries the current prompt.
+  const currentTurnId = request.turnId?.trim();
+  const prior = currentTurnId
+    ? records.filter((row) => row.turn_id !== currentTurnId)
+    : records;
+  if (prior.length === 0) return null;
+
+  const reconstructed = reconstructMessages(prior);
   if (reconstructed.length === 0) return null;
 
   log?.(
     `[reconstruct] session=${sessionId} records=${records.length} ` +
-      `priorMessages=${reconstructed.length} inbound=${inbound.length}`,
+      `prior=${prior.length} priorMessages=${reconstructed.length} ` +
+      `inbound=${inbound.length}`,
   );
   return { ...request, messages: [...reconstructed, ...inbound] };
 }

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -291,6 +291,20 @@ export function approvalDecisionForToolCall(
 }
 
 /**
+ * True when the request carries exactly its own fresh user turn and no prior conversation —
+ * what a last-message-only client sends. The single predicate both sides agree on: the runner
+ * reconstructs prior turns only for such a request, and the keep-alive check skips its history
+ * comparison for one, because the client is no longer asserting the conversation at all.
+ *
+ * A message count alone is NOT enough: turn one of any conversation is also a single message,
+ * and a lone assistant message or an empty array are neither a fresh turn nor a full history.
+ */
+export function carriesMinimalHistory(request: AgentRunRequest): boolean {
+  const messages = request.messages ?? [];
+  return messages.length === 1 && tailIsFreshUserMessage(request);
+}
+
+/**
  * True when the request's tail is a fresh user message with text and NOT an approval envelope.
  * A continuation only takes the live path for a plain new user turn; an approval reply (a
  * trailing tool-role message, or a user turn carrying a tool_result) stays cold here.

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -49,6 +49,7 @@ import {
   computeCredentialEpoch,
   configFingerprint,
   credentialEpochMismatch,
+  carriesMinimalHistory,
   mountCredentialsExpired,
   expectedNextHistoryFingerprint,
   historyFingerprint,
@@ -595,9 +596,15 @@ export async function runWithKeepalive(
       existing.credentialEpoch,
       incomingEpoch,
     );
+    // A last-message-only client sends no prior conversation, so there is nothing to compare:
+    // `priorConversation` is empty and the fingerprint can never match what the last turn stored.
+    // Comparing anyway evicts the warm session on every turn of every conversation. The session
+    // id already binds the request to this conversation; the client simply no longer asserts it.
+    const clientAssertsHistory = !carriesMinimalHistory(request);
     let mismatch: string | undefined;
     if (cfgFp !== existing.configFingerprint) mismatch = "config";
-    else if (priorFp !== existing.historyFingerprint) mismatch = "history";
+    else if (clientAssertsHistory && priorFp !== existing.historyFingerprint)
+      mismatch = "history";
     else if (credMismatch) mismatch = credMismatch;
     else if (!tailIsFreshUserMessage(request)) mismatch = "tail";
 

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -476,6 +476,16 @@ describe("runWithKeepalive: validation mismatches degrade to cold", () => {
     assert.equal(calls.acquire, 2);
   });
 
+  it("a last-message-only turn 2 keeps the warm session (no history to compare)", async () => {
+    // The flag-on frontend sends ONLY the trailing user message, so `priorConversation` is
+    // empty and its fingerprint can never match what turn 1 stored. Comparing anyway evicted
+    // every conversation to cold on every turn.
+    const minimal = turn2("s1", { messages: [{ role: "user", content: "more" }] });
+    const { calls, env1 } = await parkThen(minimal);
+    assert.equal(env1.destroyed, 0, "the warm env must survive a minimal-history turn");
+    assert.equal(calls.acquire, 1, "no cold re-acquire");
+  });
+
   it("credential-epoch expiry evicts to cold", async () => {
     // The parked mount expiry is in the past, so the next turn's epoch check fails.
     const { calls, env1 } = await parkThen(turn2(), {

--- a/services/runner/tests/unit/session-reconstruct-history.test.ts
+++ b/services/runner/tests/unit/session-reconstruct-history.test.ts
@@ -88,4 +88,49 @@ describe("reconstructHistoryIfNeeded", () => {
     // Other request fields are preserved.
     assert.equal((out as { harness?: string }).harness, "pi");
   });
+
+  it("no-op when the request carries no messages at all", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    const req = { messages: [] } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.equal(out, null);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("no-op when the single inbound message is not a fresh user turn", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    const req = { messages: [{ role: "assistant", content: "a1" }] } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.equal(out, null);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("drops the current turn's own records so the prompt is not replayed twice", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    // The runner persists the inbound prompt BEFORE the engine starts, so by the time this
+    // runs the log already holds turn-2's own user record.
+    recordsToReturn = [
+      { turn_id: "turn-1", record_source: "user", attributes: { type: "message", text: "q1" } },
+      { turn_id: "turn-1", record_source: "agent", attributes: { type: "message", text: "a1" } },
+      { turn_id: "turn-2", record_source: "user", attributes: { type: "message", text: "hi again" } },
+    ];
+    const req = { messages: [userTurn], turnId: "turn-2" } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.ok(out);
+    assert.deepEqual(out!.messages, [
+      { role: "user", content: "q1" },
+      { role: "assistant", content: "a1" },
+      userTurn,
+    ]);
+  });
+
+  it("no-op when the only records belong to the current turn (first turn of a session)", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    recordsToReturn = [
+      { turn_id: "turn-1", record_source: "user", attributes: { type: "message", text: "hi again" } },
+    ];
+    const req = { messages: [userTurn], turnId: "turn-1" } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.equal(out, null);
+  });
 });


### PR DESCRIPTION
## The problem

Every first turn of every conversation sent the user's prompt to the model twice.

A one-line probe went in as `"Reply with exactly: PONG"` and reached the model as:

```json
[{"role": "user", "content": "Reply with exactly: PONG"},
 {"role": "user", "content": "Reply with exactly: PONG"}]
```

The runner persists the inbound user message before it starts the engine (`server.ts`), and acquiring a sandbox takes seconds, so by the time reconstruction reads the record log the current turn is already in it. Reconstruction returned that record as a prior turn, and the inbound message was then appended on top of it.

Two things made this easy to miss. It is **not** gated by the frontend flag: a first turn always carries exactly one message, so the `messages.length > 1` guard never blocked it, and it reproduced on 9 out of 9 first turns with the frontend flag off. And a duplicated prompt still produces a correct-looking answer, so every journey in the QA suite passed while it was happening.

The same guard also let reconstruction run for an empty message array and for a lone assistant message, which CodeRabbit flagged separately.

## The fix

Drop the current turn's own records by `turn_id` before folding, so the log contributes only prior turns regardless of when the write lands.

Replace the message-count guard with a shared `carriesMinimalHistory` predicate, so the runner and the keep-alive check agree on one definition of "this request carries only its own fresh user turn" instead of each inferring it from a count.

## Before / after

| | Before | After |
|---|---|---|
| First turn, message count | 2 (prompt twice) | 1 |
| Turn 3 of a 3-turn chat | `u, u, a, u, a, u` | `u, a, u, a, u` |
| Duplicated prompts across a QA run | 11 turns | 0 turns |

## Testing

Runner unit suite passes with 4 new cases pinning the empty array, the lone assistant message, the current-turn exclusion, and a first turn whose only records are its own. Confirmed live on a deployed stack: [QA results](https://github.com/Agenta-AI/agenta/pull/5486#issuecomment-5074679975).
