### PR TITLE
fix(runner): keep the warm session when the client sends a minimal history

### DIFF
--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -49,6 +49,7 @@ import {
   computeCredentialEpoch,
   configFingerprint,
   credentialEpochMismatch,
+  carriesMinimalHistory,
   mountCredentialsExpired,
   expectedNextHistoryFingerprint,
   historyFingerprint,
@@ -595,9 +596,15 @@ export async function runWithKeepalive(
       existing.credentialEpoch,
       incomingEpoch,
     );
+    // A last-message-only client sends no prior conversation, so there is nothing to compare:
+    // `priorConversation` is empty and the fingerprint can never match what the last turn stored.
+    // Comparing anyway evicts the warm session on every turn of every conversation. The session
+    // id already binds the request to this conversation; the client simply no longer asserts it.
+    const clientAssertsHistory = !carriesMinimalHistory(request);
     let mismatch: string | undefined;
     if (cfgFp !== existing.configFingerprint) mismatch = "config";
-    else if (priorFp !== existing.historyFingerprint) mismatch = "history";
+    else if (clientAssertsHistory && priorFp !== existing.historyFingerprint)
+      mismatch = "history";
     else if (credMismatch) mismatch = credMismatch;
     else if (!tailIsFreshUserMessage(request)) mismatch = "tail";
 

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -476,6 +476,16 @@ describe("runWithKeepalive: validation mismatches degrade to cold", () => {
     assert.equal(calls.acquire, 2);
   });
 
+  it("a last-message-only turn 2 keeps the warm session (no history to compare)", async () => {
+    // The flag-on frontend sends ONLY the trailing user message, so `priorConversation` is
+    // empty and its fingerprint can never match what turn 1 stored. Comparing anyway evicted
+    // every conversation to cold on every turn.
+    const minimal = turn2("s1", { messages: [{ role: "user", content: "more" }] });
+    const { calls, env1 } = await parkThen(minimal);
+    assert.equal(env1.destroyed, 0, "the warm env must survive a minimal-history turn");
+    assert.equal(calls.acquire, 1, "no cold re-acquire");
+  });
+
   it("credential-epoch expiry evicts to cold", async () => {
     // The parked mount expiry is in the past, so the next turn's epoch check fails.
     const { calls, env1 } = await parkThen(turn2(), {


### PR DESCRIPTION
## The problem

With last-message-only on, every conversation ran cold from turn 2 onward. The warm-session optimisation was silently switched off for exactly the workload it was built for.

The keep-alive check fingerprints the prior conversation the client sent and compares it to what the previous turn stored. A last-message-only client sends no prior conversation, so `priorConversation(request)` is an empty array and its fingerprint can never match. The check therefore failed on every turn:

```
[keepalive] mismatch (history) key=...; evict + cold
[keepalive] mismatch (history) key=...; evict + cold
```

Three evictions in a last-message-only run, zero in the baseline. The cost is a sandbox torn down and rebuilt on every turn:

| | Baseline (full history) | Last-message-only |
|---|---|---|
| Turn 2 | 1570 ms | 4623 ms |
| Turn 3 | 1399 ms | 4252 ms |

The QA journey still reported PASS throughout, because it only checks that later turns beat the first one, and a cold turn still beats a cold turn that also had to create the sandbox.

This is the "cold evicted" state as distinct from plain cold: a warm sandbox existed and was thrown away.

## The fix

Skip the history comparison when the request carries only its own fresh user turn, using the shared `carriesMinimalHistory` predicate from the PR below.

The comparison exists to catch a client that rewound or edited the conversation under an existing session id. A minimal-history client makes no claim about the conversation at all, so there is nothing to verify; the session id already binds the request to it. Requests that do send a history are checked exactly as before, and so is the approval-resume path, which always sends the full history.

## Before / after

Turn 2 of a three-turn conversation returns to 1834 ms, in line with the full-history baseline, and the run shows zero evictions.

## Testing

New dispatch test asserts a minimal-history turn 2 keeps the live environment and triggers no cold re-acquire. Full runner unit suite green. Verified live: [QA results](https://github.com/Agenta-AI/agenta/pull/5486#issuecomment-5074679975).
