### PR TITLE
fix(api): attach SessionsConfig so smart truncation stops dropping records

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -539,6 +539,7 @@ class AgentaConfig(BaseModel):
     otlp: OTLPConfig = OTLPConfig()
     redaction: RedactionConfig = RedactionConfig()
     services: ServicesConfig = ServicesConfig()
+    sessions: SessionsConfig = SessionsConfig()
     webhooks: WebhooksConfig = WebhooksConfig()
     workers: WorkersConfig = WorkersConfig()
 

--- a/api/oss/tests/pytest/unit/sessions/test_records_truncation.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_truncation.py
@@ -71,3 +71,14 @@ def test_non_dict_attributes_fall_back():
     huge = "z" * (MAX_ATTRIBUTES_BYTES * 2)
     out = _truncate_attributes(huge, MAX_ATTRIBUTES_BYTES, _size(huge))
     assert out == {"_truncated": True, "_original_bytes": _size(huge)}
+
+
+def test_smart_truncation_flag_is_reachable_from_the_env_object():
+    """The publish path reads `env.agenta.sessions.records.smart_truncation` inside a
+    try/except that swallows anything and drops the record. When `SessionsConfig` was not
+    attached to `AgentaConfig` this raised AttributeError, so every over-cap record was
+    discarded instead of truncated, and the tests above still passed because they call
+    `_truncate_attributes` directly and never touch the flag."""
+    from oss.src.utils.env import env
+
+    assert isinstance(env.agenta.sessions.records.smart_truncation, bool)


### PR DESCRIPTION
## The problem

Turning on `AGENTA_RECORDS_SMART_TRUNCATION` made oversized records worse, not better: instead of being truncated they were discarded entirely.

`SessionsConfig` was defined in `env.py` but never added to `AgentaConfig`, so the read raised. Confirmed against a running API container:

```
>>> env.agenta.sessions.records.smart_truncation
AttributeError: 'AgentaConfig' object has no attribute 'sessions'
```

That read sits inside the record-publish `try`, and its `except` logs and returns `False`. So any record body over the 64 KB cap failed to publish at all. The legacy path it was meant to improve on at least stored `{"_truncated": True}`, and since records are now the only copy of the conversation used to rebuild model context, a dropped record is lost context rather than a lost detail in a viewer.

The existing tests stayed green throughout, because they call `_truncate_attributes` directly and never read the flag. Originally spotted by CodeRabbit; this confirms it and fixes it.

## The fix

Attach `sessions: SessionsConfig` to `AgentaConfig`, and add a test that pins the config path itself rather than only the helper, so an unreachable flag fails the suite instead of passing it.

## Testing

`env.agenta.sessions.records.smart_truncation` now resolves to `True` in the running API where it previously raised. The sessions truncation tests pass, including the new guard. Context: [QA results](https://github.com/Agenta-AI/agenta/pull/5486#issuecomment-5074679975).
