### PR TITLE
[fix] Tell the user when the model catalog fails to load

### DIFF
--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -54,6 +54,8 @@ export {
 // Per-harness capability map from the `/inspect` response `meta` (agent playground picker).
 export {
     harnessCapabilitiesAtomFamily,
+    harnessCatalogFailedAtom,
+    retryHarnessCatalogAtom,
     contextWindowForModel,
     modalitiesForModel,
     type HarnessCapabilities,

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -16,6 +16,8 @@ export {workflowMolecule, type WorkflowMolecule} from "./molecule"
 
 export {
     harnessCapabilitiesAtomFamily,
+    harnessCatalogFailedAtom,
+    retryHarnessCatalogAtom,
     contextWindowForModel,
     modalitiesForModel,
     type HarnessCapabilities,

--- a/web/packages/agenta-entities/src/workflow/state/inspectMeta.ts
+++ b/web/packages/agenta-entities/src/workflow/state/inspectMeta.ts
@@ -124,6 +124,21 @@ export const harnessCapabilitiesAtomFamily = atomFamily((_harnessRef: string) =>
 )
 
 /**
+ * Whether the harness catalog request failed.
+ *
+ * A null capability map has two very different causes: a schema that predates the catalog (no
+ * `x-ag-harness-ref`, so the legacy controls are correct), or a catalog the browser could not
+ * reach. Without this flag the second case renders as the first, which reads as a stale
+ * frontend build rather than a failed request.
+ */
+export const harnessCatalogFailedAtom = atom((get) => get(harnessCatalogQueryAtom).isError)
+
+/** Retry the harness catalog after a failure. */
+export const retryHarnessCatalogAtom = atom(null, (get) => {
+    void get(harnessCatalogQueryAtom).refetch()
+})
+
+/**
  * The model's context window (max input tokens) from the harness catalog, matched by exact id — the
  * same `id`-keyed join the model picker uses. `null` when the catalog, harness, or entry is absent,
  * or the entry carries no `context_window`. Source of truth is the SDK model catalog

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -10,7 +10,11 @@ import {
     vaultSecretsQueryAtom,
 } from "@agenta/entities/secret"
 import type {SchemaProperty} from "@agenta/entities/shared"
-import {harnessCapabilitiesAtomFamily} from "@agenta/entities/workflow"
+import {
+    harnessCapabilitiesAtomFamily,
+    harnessCatalogFailedAtom,
+    retryHarnessCatalogAtom,
+} from "@agenta/entities/workflow"
 import {getEnabledSandboxProviders} from "@agenta/shared/api"
 import {normalizeProviderFamily} from "@agenta/shared/utils"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
@@ -26,8 +30,8 @@ import {
     Sparkle,
     Warning,
 } from "@phosphor-icons/react"
-import {Button, Popconfirm, Select, Typography} from "antd"
-import {atom, useAtomValue} from "jotai"
+import {Alert, Button, Popconfirm, Select, Typography} from "antd"
+import {atom, useAtomValue, useSetAtom} from "jotai"
 
 import {useHasChangedUnder, useRevertUnder} from "../../../drawers/shared/ChangedPathsContext"
 import {useFocusPaths, useHasFocusUnder} from "../../../drawers/shared/FocusPathsContext"
@@ -197,6 +201,11 @@ export function useModelHarness({
         useMemo(() => harnessCapabilitiesAtomFamily(harnessRefKey ?? ""), [harnessRefKey]),
     )
     const capabilities = harnessRefKey ? capabilitiesFromCatalog : null
+    const catalogFailed = useAtomValue(harnessCatalogFailedAtom)
+    const retryCatalog = useSetAtom(retryHarnessCatalogAtom)
+    // The schema asked for the catalog and we could not fetch it: say so instead of silently
+    // falling through to the pre-catalog controls, which look like an old build.
+    const catalogUnavailable = Boolean(harnessRefKey) && !capabilities && catalogFailed
     const mcpSupported = harnessSupportsUserMcp(capabilities, harnessValue)
 
     // Narrowed to the loaded flag (all this hook reads) — the raw query atom churns identity on
@@ -747,6 +756,20 @@ export function useModelHarness({
         </div>
     )
 
+    const catalogUnavailableNotice = (
+        <Alert
+            type="warning"
+            showIcon
+            message="Couldn't load the model catalog"
+            description="The harness and model options come from the server. Until it responds, only the basic controls are available."
+            action={
+                <Button size="small" onClick={() => retryCatalog()}>
+                    Retry
+                </Button>
+            }
+        />
+    )
+
     const modelHarnessControls = capabilities ? (
         <>
             {harnessKindInFocus ? (
@@ -808,6 +831,7 @@ export function useModelHarness({
         </>
     ) : (
         <>
+            {catalogUnavailable ? catalogUnavailableNotice : null}
             {harnessKindInFocus && harnessProps.kind && (
                 <RailField label="Harness" align="center" path="harness.kind">
                     <HarnessSelectControl


### PR DESCRIPTION
## Context

When the playground's "Model & harness" drawer cannot reach the harness catalog, it renders its pre-catalog layout: a flat single column with a plain model dropdown, no collapsible sections, no status icons. Nothing tells the user a request failed. It reads as a stale frontend build, which is exactly how it was misdiagnosed on a self-hosted deployment (the real cause was a server-side redirect, fixed in #5487).

The fallback itself is correct for one case. A schema without `x-ag-harness-ref` predates the catalog, and the basic controls are the right UI for it. The problem is that a failed fetch is indistinguishable from that case: both leave `capabilities` null, and `useModelHarness.tsx:624` branches on that single value.

## Changes

`harnessCatalogFailedAtom` exposes the catalog query's error state, and `retryHarnessCatalogAtom` refetches it. The drawer now separates the two causes:

    harnessRefKey present + capabilities null + query errored  ->  retry notice, then basic controls
    harnessRefKey absent                                       ->  basic controls, unchanged

When the schema asked for the catalog and the fetch failed, a warning with a Retry button appears above the controls. The pre-catalog path is untouched, so schemas that never used the catalog render exactly as before.

## Tests / notes

- This box has no `node_modules` (the web image builds in Docker), so `pnpm lint-fix` and the strict package `tsc` did not run locally. CI is the gate here. Worth a reviewer's eye on the antd `Alert` usage and the write-atom signature.
- The failure path is reachable by blocking `GET /api/workflows/catalog/harnesses/` in devtools, or on any deployment carrying the redirect bug from #5487.
- Copy is deliberately plain, no status codes or endpoint names, since this surfaces to end users.

## What to QA

- Open an agent variant's "Model & harness" drawer with the network tab blocking `workflows/catalog/harnesses`. A warning appears above the basic controls with a working Retry button. Retry with the block removed loads the full sectioned layout.
- Regression: open the same drawer normally. The Harness, Model, and Provider credentials sections render as before, with no notice.
- Regression: open a variant whose schema has no `x-ag-harness-ref`. The basic controls render with no warning, unchanged.
