### PR TITLE
fix(api): order session records by producer time so turns stop interleaving

### DIFF
--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -109,7 +109,17 @@ class RecordsDAO(RecordsDAOInterface):
                     RecordDBE.project_id == project_id,
                     RecordDBE.session_id == session_id,
                 )
-                .order_by(RecordDBE.created_at.asc(), RecordDBE.record_index.asc())
+                # Producer event time first: it is the only key that is monotonic across
+                # turns. `record_index` restarts at 0 every turn, and the worker can batch
+                # records from two turns into one write so they share `created_at` — the old
+                # (created_at, record_index) order then sorted the NEXT turn's first record
+                # ahead of the PREVIOUS turn's later ones, interleaving the conversation.
+                # Rows written before `timestamp` existed sort last within their ingest batch.
+                .order_by(
+                    RecordDBE.timestamp.asc().nullslast(),
+                    RecordDBE.created_at.asc(),
+                    RecordDBE.record_index.asc(),
+                )
             )
 
             dbes = (await session.execute(stmt)).scalars().all()


### PR DESCRIPTION
## The problem

A conversation rebuilt from the record log came back with its turns interleaved. A three-turn run reconstructed as `user, user, assistant, user`: the reply to the first question landed after the second question.

`get_records` ordered by `(created_at, record_index)`. Two facts make that wrong:

- `record_index` restarts at 0 on every turn, so it only orders records *within* a turn.
- The ingest worker batches records from adjacent turns into a single write, so those rows share a `created_at`.

When both happen together the tiebreak sorts the next turn's first record ahead of the previous turn's later ones. Straight from the table, with turn 2's user record jumping ahead of turn 1's agent record:

```
record_source | record_index | turn_id  | timestamp     | created_at
user          |            0 | turn-2   | 07.644        | 07.880223
agent         |            3 | turn-1   | 07.544        | 07.880223
```

Same `created_at`, so `record_index` 0 wins over 3, and turn 2's question sorts before turn 1's answer.

This ordering predates the last-message-only work. It did not matter while records fed a viewer. It matters now that the model's context is rebuilt from them.

## The fix

Order by the producer-stamped `timestamp` first. The runner already sets it on every record, and unlike the per-turn index it is monotonic across turns. Ingest time and the per-turn index stay as tiebreaks, and rows written before `timestamp` existed sort last within their batch rather than jumping the queue.

## Testing

Verified against the live table for a three-turn conversation: ordering by producer time reproduces the true conversation order, where the previous ordering did not. Found during the differential QA on [#5486](https://github.com/Agenta-AI/agenta/pull/5486#issuecomment-5074679975).

## Known follow-up

This fixes the ordering. It also surfaced a separate issue that is **not** fixed here: the worker writes a turn's records to Postgres after the next turn has already read them, so the immediately preceding turn's reply can still be missing at reconstruction time. That is a read-after-write question about the ingest pipeline, and it needs its own decision.
