### PR TITLE
[AGE-4000] fix(runner): rebuild agent mounts before STS credentials expire

### DIFF
--- a/api/oss/src/core/mounts/service.py
+++ b/api/oss/src/core/mounts/service.py
@@ -61,6 +61,7 @@ _SESSION_CWD_NAME = "cwd"
 # the cwd store; that object is a runner artifact, never user content.
 _AGENT_FILES_LINK_NAME = "agent-files"
 
+
 def _slugify(value: str) -> str:
     return sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
 

--- a/api/oss/src/core/mounts/service.py
+++ b/api/oss/src/core/mounts/service.py
@@ -39,6 +39,7 @@ from oss.src.core.mounts.types import (
     MountStorageUnavailable,
 )
 from oss.src.core.shared.dtos import Reference, Windowing
+from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
 
 log = get_module_logger(__name__)
@@ -59,11 +60,6 @@ _SESSION_CWD_NAME = "cwd"
 # CWD MOUNT ROOT and nowhere else. geesefs degrades the symlink to a plain object of the same name in
 # the cwd store; that object is a runner artifact, never user content.
 _AGENT_FILES_LINK_NAME = "agent-files"
-
-# Default TTL (seconds) for signed mount credentials. Covers the mount lifetime for a
-# turn; geesefs holds the creds without refresh, so a turn outliving this hits ExpiredToken.
-_CREDENTIALS_TTL_SECONDS = 3600
-
 
 def _slugify(value: str) -> str:
     return sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
@@ -740,12 +736,13 @@ class MountsService:
         *,
         project_id: UUID,
         mount_id: UUID,
-        duration_seconds: int = _CREDENTIALS_TTL_SECONDS,
     ) -> MountCredentials:
         """Mint short-lived, prefix-scoped credentials for one mount.
 
         The master key signs the STS request API-side and never leaves; the returned
         key pair + session token are scoped to this mount's prefix and expire in minutes.
+        geesefs holds the credentials without refresh, so a turn outliving the TTL hits
+        ExpiredToken.
         """
         if self.mounts_store is None:
             raise MountStorageUnavailable()
@@ -758,7 +755,7 @@ class MountsService:
         creds = await self.mounts_store.sign_temp_credentials(
             bucket=bucket,
             prefix=prefix,
-            duration_seconds=duration_seconds,
+            duration_seconds=env.mounts.credentials_ttl_seconds,
         )
         return MountCredentials(
             endpoint=self.mounts_store.endpoint_url,

--- a/api/oss/src/core/store/storage.py
+++ b/api/oss/src/core/store/storage.py
@@ -20,12 +20,23 @@ from oss.src.core.mounts.types import MountFileNotFound, MountStorageUnavailable
 # STS responses are SOAP-ish XML under the 2011-06-15 namespace; strip it for tag lookups.
 _STS_NS = "{https://sts.amazonaws.com/doc/2011-06-15/}"
 
+# Mirrors the `maxSessionLength: 12h` we configure in the compose SeaweedFS IAM config; the two
+# must stay in sync.
+_SEAWEEDFS_MAX_SESSION_SECONDS = 43200
+
+# AWS GetFederationToken accepts DurationSeconds in [900, 129600].
+_AWS_MAX_FEDERATION_SECONDS = 129600
+
 
 def _parse_sts_credentials(xml_text: str) -> Credentials:
     """Parse an STS XML response (`AssumeRoleWithWebIdentity`) into a miniopy Credentials.
 
     Returns the scoped access/secret/session triple plus expiry; raises if the response
     carried no Credentials block (e.g. an STS error document slipped past the status check).
+
+    Fails closed on a missing or unparsable `Expiration`: the runner reads a missing expiry as
+    "never expires", so one malformed response would silently disable the reuse bound for the
+    lifetime of a pooled environment.
     """
     root = ElementTree.fromstring(xml_text)
     creds_el = root.find(f".//{_STS_NS}Credentials")
@@ -36,13 +47,15 @@ def _parse_sts_credentials(xml_text: str) -> Credentials:
         el = creds_el.find(f"{_STS_NS}{tag}")
         return el.text if el is not None else None
 
-    expiration = None
     raw_exp = _text("Expiration")
-    if raw_exp:
-        try:
-            expiration = datetime.fromisoformat(raw_exp.replace("Z", "+00:00"))
-        except ValueError:
-            expiration = None
+    if not raw_exp:
+        raise MountStorageUnavailable("STS response carried no credential expiry.")
+    try:
+        expiration = datetime.fromisoformat(raw_exp.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise MountStorageUnavailable(
+            "STS response carried an unparsable credential expiry."
+        ) from exc
 
     return Credentials(
         access_key=_text("AccessKeyId"),
@@ -229,14 +242,21 @@ class ObjectStore:
         """SeaweedFS path: unauthenticated `AssumeRoleWithWebIdentity` against the store endpoint."""
         host, secure = self._host_secure()
         endpoint = f"{'https' if secure else 'http'}://{host}"
+        # SeaweedFS validates DurationSeconds in [900, 43200], but the EFFECTIVE lifetime is
+        # min(DurationSeconds, web-identity token expiry, maxSessionLength). The token-expiry cap
+        # has no floor, so minting the token at the capped TTL is what lets a sub-900 TTL take
+        # effect (the QA lever); DurationSeconds only has to stay inside the validated range.
+        capped = min(duration_seconds, _SEAWEEDFS_MAX_SESSION_SECONDS)
         body = urlencode(
             {
                 "Action": "AssumeRoleWithWebIdentity",
                 "Version": "2011-06-15",
                 "RoleArn": webidentity.role_arn(),
                 "RoleSessionName": webidentity.STORE_SUBJECT,
-                "WebIdentityToken": webidentity.mint_web_identity_token(),
-                "DurationSeconds": str(duration_seconds),
+                "WebIdentityToken": webidentity.mint_web_identity_token(
+                    ttl_seconds=capped
+                ),
+                "DurationSeconds": str(max(capped, 900)),
                 "Policy": scope_policy,
             }
         )
@@ -261,9 +281,9 @@ class ObjectStore:
         """Remote-S3 path: SigV4-signed `GetFederationToken` against the store's STS endpoint.
 
         The STS endpoint defaults to the S3 endpoint (MinIO co-locates STS there); AWS splits
-        it onto `sts.<region>.amazonaws.com`, set via AGENTA_STORE_STS_ENDPOINT_URL. Duration is
-        clamped to STS's 900s floor. The request is signed with the store's master keys; the
-        returned credentials carry only the inline `Policy`'s permissions.
+        it onto `sts.<region>.amazonaws.com`, set via AGENTA_STORE_STS_ENDPOINT_URL. Duration
+        is clamped into STS's [900, 129600] range. The request is signed with the store's
+        master keys; the returned credentials carry only the inline `Policy`'s permissions.
         """
         endpoint = (self._sts_endpoint_url or self._endpoint_url or "").rstrip("/")
         if not endpoint:
@@ -275,7 +295,10 @@ class ObjectStore:
                 "Action": "GetFederationToken",
                 "Version": "2011-06-15",
                 "Name": webidentity.STORE_SUBJECT,
-                "DurationSeconds": str(max(duration_seconds, 900)),
+                # AWS rejects anything outside its own range; clamp rather than fail the sign.
+                "DurationSeconds": str(
+                    min(max(duration_seconds, 900), _AWS_MAX_FEDERATION_SECONDS)
+                ),
                 "Policy": scope_policy,
             }
         )

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1155,10 +1155,10 @@ class MountsConfig(BaseModel):
     # Lifetime of signed mount credentials, in seconds. The store backends clamp it to their
     # own STS bounds.
     credentials_ttl_seconds: int = Field(
-        default_factory=lambda: _parse_optional_positive_int_env(
-            "AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS"
+        default_factory=lambda: (
+            _parse_optional_positive_int_env("AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS")
+            or 3600
         )
-        or 3600
     )
 
     model_config = ConfigDict(extra="ignore")

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1152,6 +1152,15 @@ class StoreConfig(BaseModel):
 class MountsConfig(BaseModel):
     """Mounts-domain config. Store credentials live in StoreConfig."""
 
+    # Lifetime of signed mount credentials, in seconds. The store backends clamp it to their
+    # own STS bounds.
+    credentials_ttl_seconds: int = Field(
+        default_factory=lambda: _parse_optional_positive_int_env(
+            "AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS"
+        )
+        or 3600
+    )
+
     model_config = ConfigDict(extra="ignore")
 
 

--- a/api/oss/tests/pytest/unit/test_mounts_injection.py
+++ b/api/oss/tests/pytest/unit/test_mounts_injection.py
@@ -12,8 +12,10 @@ the service-side derivation (prefix, bucket, policy scope, XML parsing, master-k
 """
 
 from typing import Dict, Optional
+from urllib.parse import parse_qs
 from uuid import uuid4, uuid5, NAMESPACE_DNS
 
+import jwt
 import pytest
 
 from oss.src.core.mounts.dtos import Mount, MountCreate
@@ -409,7 +411,6 @@ class TestStsBackendFork:
         )
         assert cap.url == "http://minio:9000/"
         assert "Action=GetFederationToken" in cap.data
-        assert "DurationSeconds=900" in cap.data
 
     async def test_seaweedfs_uses_web_identity_against_endpoint(self, monkeypatch):
         import oss.src.core.store.storage as storage_mod
@@ -436,3 +437,148 @@ class TestStsBackendFork:
         assert "Action=AssumeRoleWithWebIdentity" in cap.data
         assert "WebIdentityToken=" in cap.data
         assert "Authorization" not in (cap.headers or {})
+
+
+# ---------------------------------------------------------------------------
+# Credential lifetime: STS duration clamps + web-identity token lifetime
+# ---------------------------------------------------------------------------
+
+
+def _seaweedfs_store():
+    from oss.src.core.store.storage import ObjectStore
+
+    return ObjectStore(
+        endpoint_url="http://seaweedfs:8333",
+        access_key=_MASTER_KEY,
+        secret_key=_MASTER_SECRET,
+        signing_key="dummy-signing-key",
+    )
+
+
+def _remote_s3_store():
+    from oss.src.core.store.storage import ObjectStore
+
+    return ObjectStore(
+        endpoint_url="https://s3.eu-central-1.amazonaws.com",
+        sts_endpoint_url="https://sts.eu-central-1.amazonaws.com",
+        access_key=_MASTER_KEY,
+        secret_key=_MASTER_SECRET,
+        region="eu-central-1",
+    )
+
+
+async def _capture_sign(
+    monkeypatch, *, store, duration_seconds: int, xml: str = _STS_XML
+):
+    """Sign against a captured POST; returns the request body fields as parsed form data."""
+    import oss.src.core.store.storage as storage_mod
+
+    cap = _CapturingPost(xml)
+    monkeypatch.setattr(storage_mod.aiohttp, "ClientSession", lambda: cap)
+    await store.sign_temp_credentials(
+        bucket=_BUCKET, prefix="mounts/p/m", duration_seconds=duration_seconds
+    )
+    return parse_qs(cap.data)
+
+
+def _token_lifetime_seconds(token: str) -> int:
+    claims = jwt.decode(token, options={"verify_signature": False})
+    return claims["exp"] - claims["iat"]
+
+
+@pytest.mark.asyncio
+class TestStsDurations:
+    @pytest.mark.parametrize(
+        "ttl, expected_duration, expected_token_lifetime",
+        [
+            # The requested hour, honestly: the token no longer caps the session at 15 minutes.
+            (3600, 3600, 3600),
+            # Sub-900 is a hard SeaweedFS request error, so DurationSeconds is floored and the
+            # short lifetime is delivered through the token expiry, which has no floor.
+            (120, 900, 120),
+            # Both capped at SeaweedFS's 12h maxSessionLength.
+            (90000, 43200, 43200),
+        ],
+    )
+    async def test_seaweedfs_clamps_duration_and_matches_token_lifetime(
+        self, monkeypatch, ttl, expected_duration, expected_token_lifetime
+    ):
+        fields = await _capture_sign(
+            monkeypatch, store=_seaweedfs_store(), duration_seconds=ttl
+        )
+
+        assert fields["Action"] == ["AssumeRoleWithWebIdentity"]
+        assert fields["DurationSeconds"] == [str(expected_duration)]
+        assert (
+            _token_lifetime_seconds(fields["WebIdentityToken"][0])
+            == expected_token_lifetime
+        )
+
+    @pytest.mark.parametrize(
+        "ttl, expected_duration",
+        [(60, 900), (3600, 3600), (200000, 129600)],
+    )
+    async def test_federation_token_duration_clamped_to_aws_range(
+        self, monkeypatch, ttl, expected_duration
+    ):
+        fields = await _capture_sign(
+            monkeypatch, store=_remote_s3_store(), duration_seconds=ttl
+        )
+
+        assert fields["Action"] == ["GetFederationToken"]
+        assert fields["DurationSeconds"] == [str(expected_duration)]
+
+
+_STS_XML_NO_EXPIRATION = _STS_XML.replace(
+    "<Expiration>2026-06-30T08:00:00Z</Expiration>", ""
+)
+
+_STS_XML_BAD_EXPIRATION = _STS_XML.replace(
+    "<Expiration>2026-06-30T08:00:00Z</Expiration>",
+    "<Expiration>not-a-date</Expiration>",
+)
+
+
+@pytest.mark.asyncio
+class TestStsExpiryFailsClosed:
+    @pytest.mark.parametrize("xml", [_STS_XML_NO_EXPIRATION, _STS_XML_BAD_EXPIRATION])
+    @pytest.mark.parametrize("store_factory", [_seaweedfs_store, _remote_s3_store])
+    async def test_sign_refuses_credentials_without_a_usable_expiry(
+        self, monkeypatch, store_factory, xml
+    ):
+        # The runner reads a missing expiry as "never expires", so an unusable one must not
+        # reach it as a signed credential.
+        with pytest.raises(MountStorageUnavailable):
+            await _capture_sign(
+                monkeypatch,
+                store=store_factory(),
+                duration_seconds=3600,
+                xml=xml,
+            )
+
+
+# ---------------------------------------------------------------------------
+# TTL configuration (env)
+# ---------------------------------------------------------------------------
+
+
+class TestMountsCredentialsTtlConfig:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, 3600),
+            ("120", 120),
+            # An unset compose passthrough delivers an empty string, not an absent variable.
+            ("", 3600),
+        ],
+    )
+    def test_credentials_ttl_reads_the_env_at_instantiation(
+        self, monkeypatch, value, expected
+    ):
+        from oss.src.utils.env import MountsConfig
+
+        if value is None:
+            monkeypatch.delenv("AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS", raising=False)
+        else:
+            monkeypatch.setenv("AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS", value)
+        assert MountsConfig().credentials_ttl_seconds == expected

--- a/docs/design/fix-sts-mount-expiry/README.md
+++ b/docs/design/fix-sts-mount-expiry/README.md
@@ -12,6 +12,7 @@ proposed fix.
 | [context.md](context.md) | What breaks for the user today, and why this work exists. |
 | [research.md](research.md) | How credentials flow end to end, what actually expires and when, where credentials are installed into mounts, which refresh mechanisms geesefs supports, and why the fix is safe on both SeaweedFS and real AWS. |
 | [plan.md](plan.md) | The chosen fix, the exact code changes per file, the test plan, and the live QA plan. |
+| [decisions.md](decisions.md) | Every decision the fix embeds, its trade-off, and how to back it out. |
 | [status.md](status.md) | Where this work stands right now. |
 
 ## Domain nouns, one sentence each

--- a/docs/design/fix-sts-mount-expiry/README.md
+++ b/docs/design/fix-sts-mount-expiry/README.md
@@ -1,0 +1,57 @@
+# Fix: agent mounts return EACCES after STS credentials expire
+
+Planning workspace for GitHub issue Agenta-AI/agenta#5516. Agent file mounts go
+"Permission denied" for many minutes at a time because the temporary store credentials
+behind them expire and nothing reacts. This workspace holds the investigation and the
+proposed fix.
+
+## What each file answers
+
+| File | Question it answers |
+| --- | --- |
+| [context.md](context.md) | What breaks for the user today, and why this work exists. |
+| [research.md](research.md) | How credentials flow end to end, what actually expires and when, where credentials are installed into mounts, which refresh mechanisms geesefs supports, and why the fix is safe on both SeaweedFS and real AWS. |
+| [plan.md](plan.md) | The chosen fix, the exact code changes per file, the test plan, and the live QA plan. |
+| [status.md](status.md) | Where this work stands right now. |
+
+## Domain nouns, one sentence each
+
+- **Runner**: the Node sidecar (`services/runner/`) that executes one agent turn per
+  HTTP `/run` request.
+- **Sandbox**: the isolated environment a turn runs in; "local" means the runner's own
+  host, "remote" means a Daytona cloud VM.
+- **Turn**: one user-message-to-agent-reply exchange; the runner's unit of work.
+- **Turn boundary**: the moment between two turns, when the runner decides whether to
+  reuse a live environment or build a fresh one.
+- **Session pool**: the runner's in-memory table of live environments parked between
+  turns so the next turn can continue without a rebuild.
+- **Mount**: a directory in the sandbox whose contents live in the object store, so
+  files survive sandbox teardown.
+- **Durable agent volume**: the per-agent mount (`agent-files/`) shared across all
+  sessions of one agent; long-lived by design.
+- **Session scratch**: the per-session working directory mount (`cwd`); re-signed at
+  every turn boundary.
+- **Mount credentials**: the temporary, prefix-scoped S3 key, secret, and session
+  token a mount's geesefs daemon holds; they carry an expiry and cannot be renewed
+  in place.
+- **Installed lease**: the expiry of the credentials a live environment's daemons
+  are actually running on, as opposed to the expiry of credentials signed later and
+  never given to them.
+- **geesefs**: the FUSE filesystem binary that presents an S3 prefix as a local
+  directory; each mount is one geesefs daemon process.
+- **S3**: the object-storage HTTP protocol; Agenta speaks it to whichever store backs
+  the deployment.
+- **SeaweedFS**: the S3-compatible store bundled with self-hosted Agenta.
+- **STS**: the "Security Token Service" protocol for minting temporary, scoped
+  S3 credentials; both SeaweedFS and AWS implement it.
+- **EACCES**: the "Permission denied" error code; geesefs returns it for every file
+  operation once the store answers 403.
+- **ENOTCONN**: the "Transport endpoint is not connected" error code; the kernel
+  returns it when a FUSE daemon has died but its mount point is still registered.
+
+## Related work
+
+- `docs/design/mount-file-viewer/`: the mounts file-listing UI; shares the same sign
+  endpoints, no credential-lifetime logic.
+- Draft PR #5247 and design issue #5215 introduced the durable agent mount this bug
+  hits hardest; its design workspace lives on that PR's branch, not on main.

--- a/docs/design/fix-sts-mount-expiry/context.md
+++ b/docs/design/fix-sts-mount-expiry/context.md
@@ -1,0 +1,67 @@
+# Context: why agent mounts break with "Permission denied"
+
+## What the user experiences
+
+An agent conversation works normally for a while. Then, mid-conversation, every file
+operation under the agent's durable folders starts failing with "Permission denied".
+The agent cannot read or write `agent-files/` or its working directory. The outage
+lasts minutes, then clears on its own when the runner happens to rebuild the
+environment.
+
+On the OSS deployment on 2026-07-25 we counted 16 such denial windows in one day. The
+longest lasted 14 minutes 10 seconds. Writers interrupted mid-operation left stale
+`.git/index.lock` and `.git/config.lock` files behind, which then wedged the
+following turns even after the mount recovered.
+
+The durable per-agent volume is hit hardest because it is long-lived and shared
+across sessions. The per-session scratch directory is re-signed at every turn
+boundary and mostly dodges the window.
+
+## Why it happens
+
+Agent mounts are geesefs FUSE mounts of an object-store prefix. The runner asks the
+API to mint temporary, prefix-scoped store credentials (STS credentials), then starts
+a geesefs daemon with those credentials as static environment variables. Nothing ever
+refreshes them.
+
+Three defects combine into the observed outages. The full evidence is in
+[research.md](research.md); in short:
+
+1. **The credentials expire far earlier than requested.** The API requests a
+   3600-second lifetime, but on SeaweedFS the credentials silently die after 900
+   seconds. SeaweedFS caps every STS session at the expiry of the web-identity token
+   the API authenticates with, and the API mints that token with a fixed 15-minute
+   lifetime.
+2. **The runner's own expiry bookkeeping drifts.** The session pool records when a
+   parked environment's mount credentials expire, and evicts the environment when
+   they do. But on every warm turn it overwrites that record with the expiry of a
+   freshly signed credential that never reaches the running geesefs daemons. After
+   the first warm turn the pool believes the mounts are fresh forever, so an active
+   conversation keeps reusing mounts whose real credentials died long ago.
+3. **Expired credentials are a silent failure mode.** A dead daemon (hard death)
+   returns ENOTCONN, which the runner detects and repairs mid-turn. Expired
+   credentials (soft death) leave the daemon alive and every operation returning
+   EACCES, which nothing detects.
+
+## Goals
+
+- An agent conversation never sees "Permission denied" from an expired mount
+  credential, in either deployment mode: self-hosted OSS with SeaweedFS, or real AWS
+  S3 with AWS STS.
+- The credential lifetime is configurable through an environment variable so QA can
+  shrink it and reproduce the failure quickly.
+- The fix stays small: no new daemons, no new wire fields, no credential-refresh
+  machinery inside the sandbox.
+
+## Non-goals
+
+- In-place credential refresh for a running geesefs daemon. Research.md enumerates
+  the mechanisms; all of them add real machinery, and none is needed once
+  credentials outlive every turn.
+- Cleaning up stale `.git/*.lock` files left by past outages. Those are a downstream
+  symptom; once mounts stop dying mid-write, no new locks are stranded.
+- Per-mount `RoleSessionName` (today every mount signs as the constant
+  `agenta-store`). That is isolation hygiene, orthogonal to expiry, and deferred.
+- Detecting EACCES in the agent's event stream to trigger mid-turn remounts. It is
+  false-positive-prone and redundant once credentials outlive every turn; see the
+  false-positive analysis in research.md.

--- a/docs/design/fix-sts-mount-expiry/decisions.md
+++ b/docs/design/fix-sts-mount-expiry/decisions.md
@@ -1,0 +1,212 @@
+# Decisions: what was chosen, why, and how to back each choice out
+
+Every decision this fix embeds, explicit or implicit, with its trade-off and the
+cheapest way to reverse it. Ordered from the ones that shape the fix down to
+mechanical details. "Backtrack" states what changing the decision costs later.
+
+## 1. Fix the two real defects, not the issue's headline remedies
+
+The issue proposed raising the TTL and adding refresh machinery. Research showed
+the requested TTL was already 3600 seconds; two defects made it a lie: the
+web-identity JWT was hardcoded to 15 minutes and capped every SeaweedFS session,
+and the runner's session pool overwrote its expiry bookkeeping on every warm turn
+with the expiry of credentials that never reached the running mounts. The fix
+repairs exactly those two defects.
+
+- Trade-off: none. This is smaller than any alternative and removes the root
+  cause instead of moving it.
+- Backtrack: not applicable; the defects are defects.
+
+## 2. Fresh credentials arrive by rebuilding at the turn boundary, not by
+refreshing a running daemon
+
+geesefs v0.43.0 offers no zero-machinery in-place refresh: it reads a
+credentials file exactly once (research.md section 3 rules the rewrite idea out
+against the vendored SDK source), and the two real refresh mechanisms
+(credential_process, the container-credentials endpoint) each add a
+credential-serving surface, with the remote variant putting API auth inside the
+agent-reachable sandbox. The session pool already evicts to a cold rebuild on
+credential grounds; the fix makes that designed mechanism truthful instead of
+adding a new one.
+
+- Trade-off: an active conversation rebuilds cold once per lease. At default
+  knobs the warm window is TTL (3600s) minus turn budget (2700s) minus skew
+  (60s), about 14 minutes, so long busy conversations pay a cold rebuild
+  roughly every 14 minutes. On the local sandbox that is sub-second-to-seconds;
+  on Daytona a credential eviction deletes the remote sandbox and the next turn
+  pays a full create. Before the fix those same conversations did not pay a
+  rebuild; they broke outright at minute 15.
+- Backtrack: if production shows the churn hurts, implement the
+  container-credentials endpoint (research.md section 3, mechanism 4). Nothing
+  in this fix blocks it; the lease bookkeeping stays correct either way.
+
+## 3. Default TTL stays 3600 seconds
+
+Raising the default to the SeaweedFS ceiling (43200s) would widen the warm
+window from ~14 minutes to ~11 hours, but every extra hour of lifetime is an
+hour a leaked prefix-scoped credential (and the now-matching web-identity JWT)
+stays usable.
+
+- Trade-off: more frequent cold rebuilds for long active conversations until
+  the rebuild rate is measured in production.
+- Backtrack: set `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS` on the API service.
+  No code change; the clamps keep any value legal per backend.
+
+## 4. The eviction margin is the full worst-case turn budget, plus fixed skew
+
+A parked environment is reused only when its lease covers `now + total turn
+deadline + 60s`. The total deadline (default 45 minutes,
+`AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS`) is the longest a turn started now could
+still be running, so no turn can start on credentials it could outlive.
+
+- Alternative considered: margin from the idle timeout (5 minutes), which would
+  widen the warm window to ~54 minutes. Rejected because a single long turn
+  could then cross expiry mid-flight, which is the bug this fix exists to
+  remove.
+- Trade-off: the margin is pessimistic; most turns finish in seconds.
+- Backtrack: lower `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` if turns are known to
+  be short on a deployment; the margin follows it automatically.
+
+## 5. Clock-skew allowance is a fixed 60-second constant, not a knob
+
+`MOUNT_LEASE_SKEW_MS` covers API/runner/store clock differences and the seconds
+a rebuild spends mounting. It protects an invariant, and a third time knob that
+operators must relate to the other two invites mis-setting.
+
+- Backtrack: one constant in `session-identity.ts`.
+
+## 6. A lease too short for the turn budget warns and runs; it never fails
+
+When the TTL is below budget plus skew, even a fresh mount cannot satisfy the
+reuse window, so every dispatch rebuilds cold and logs `lease-short` naming both
+knobs. The stricter alternative, refusing to start or failing configuration
+validation, was considered and rejected: it would turn one mis-set number into a
+full outage, proceeding is never worse than the pre-fix behavior, and QA lowers
+the TTL on purpose.
+
+- Trade-off: a misconfigured deployment churns instead of stopping; the log
+  line is the only signal.
+- Backtrack: tighten the same branch in `coldAndPark` if operations later
+  prefers fail-fast.
+
+## 7. The lease tracks the cwd and agent mounts only
+
+`installedMountExpiries` records the two durable mounts. The Daytona harness
+session-directory and transcript mounts are excluded: they are signed seconds
+after the cwd mount with the same TTL, so their expiry is never the minimum and
+tracking them would add entries that cannot change the outcome.
+
+- Trade-off: if that signing order or TTL parity ever changes, the exclusion
+  argument breaks silently.
+- Backtrack: add fields to `InstalledMountExpiries` and stamp the two remote
+  session-dir mount sites; `installedMountLease` already reduces over whatever
+  entries exist.
+
+## 8. A re-park always describes the live environment
+
+`reparkOrEvict` keeps the live environment's secrets hash unconditionally. On
+the idle path the mismatch gate has already proven the live and incoming hashes
+equal; on the approval-resume path the resume deliberately ignores the incoming
+credentials, so adopting its hash would relabel an environment running old
+secrets as if it ran new ones. An earlier draft made this a per-call-site flag;
+the unconditional form removes a default that would have been wrong to forget.
+
+- Backtrack: none needed; this is an invariant, not a preference.
+
+## 9. The incoming credential epoch no longer carries an expiry
+
+Both park sites now derive `mountExpiresAtMs` from the installed mounts, so the
+expiry of the credentials signed per dispatch had zero readers. The parameter
+was removed rather than left as a plausible-looking dead input that would
+mislead a reviewer into thinking dispatch signs govern reuse.
+
+- Backtrack: re-add the second argument to `computeCredentialEpoch` if a future
+  consumer appears.
+
+## 10. Signing fails closed on a missing or unparsable STS expiry
+
+`_parse_sts_credentials` raises `MountStorageUnavailable` instead of returning
+credentials with no expiry, because the runner reads a missing expiry as "never
+expires" and one malformed response would silently disable the reuse bound. Both
+signing branches are STS, so no legitimate no-expiry path exists. A refused sign
+degrades the turn to mount-less, the same handling as any other sign failure; it
+does not fail the turn.
+
+- Backtrack: relax the raise back to `None` only if a store appears whose STS
+  legitimately omits `Expiration` (none known).
+
+## 11. The web-identity JWT lives as long as the requested TTL, capped at 12h
+
+Minting the token with the requested lifetime is what makes the TTL real on
+SeaweedFS. The cap (`_SEAWEEDFS_MAX_SESSION_SECONDS`, mirroring the compose
+`maxSessionLength: 12h`) keeps any token from outliving the longest session it
+could mint.
+
+- Trade-off: the internal token's replay window widens from 15 minutes to the
+  TTL. The token never leaves the API-to-store network hop. The pre-existing
+  sharp edge is unchanged and documented in research.md section 4: that JWT
+  presented without a session policy grants the whole bucket, so it must stay
+  inside the API trust boundary.
+- Backtrack: none sensible; a shorter token re-caps the credential lifetime,
+  which is the bug.
+
+## 12. Sub-900-second lifetimes are a SeaweedFS-only QA lever
+
+SeaweedFS hard-validates `DurationSeconds` in [900, 43200] but caps the
+effective lifetime at the web-identity token's expiry with no floor, so a low
+TTL takes effect through the token. AWS `GetFederationToken` has a hard 900
+floor, requires long-term IAM-user credentials (root is capped at 3600s), and
+was not exercised live; it is covered by the request-level unit tests and the
+analysis in research.md section 4. The runner half keys only off the
+STS-reported `expires_at`, which both backends report truthfully, so it is
+backend-neutral by construction.
+
+- Trade-off: the fast live reproduction exists only on SeaweedFS deployments.
+- Backtrack: optional staging pass on AWS with TTL 900 and a >15-minute active
+  conversation, as listed in plan.md.
+
+## 13. The TTL is read through the shared env object, with fail-fast parsing
+
+`MountsConfig.credentials_ttl_seconds` follows the repo convention (config via
+`env`, never `os.getenv` at call sites) and uses a `default_factory` so the
+variable is read when the config object is built, which keeps tests plain.
+Parsing goes through the file's existing positive-int helper: unset or empty
+falls back to 3600; garbage or a non-positive value raises at startup, matching
+how every other knob in `env.py` behaves. Constructor injection of the TTL into
+`MountsService` was considered and rejected as against the repo's convention.
+
+- Backtrack: trivial; it is one field and one call site.
+
+## 14. The mid-turn event watcher was not extended to EACCES
+
+The acquisition probe already treats an EACCES listing as not-mounted and
+remounts. Extending the mid-turn watcher (which scans agent event text) to
+"Permission denied" would false-trigger constantly on legitimate agent output,
+and becomes unnecessary once no turn starts on credentials that can die under
+it.
+
+- Backtrack: revisit only if a new failure mode produces mid-turn EACCES with
+  live credentials; the ENOTCONN watcher shows the pattern to copy.
+
+## 15. Per-mount RoleSessionName stays deferred
+
+Every mount still shares one STS session identity (`agenta-store`). Worth
+fixing on isolation grounds; orthogonal to expiry and left out to keep this fix
+reviewable.
+
+## 16. Deferred efficiency follow-ups (noticed, deliberately not done here)
+
+- Every warm dispatch still signs mount credentials that are then unused (only
+  the pool key and a project-id fallback consume the result). Skipping that
+  sign on warm hits needs a lazy-sign restructure of the dispatch path; out of
+  scope.
+- `webidentity._private_key()` re-parses the PEM on every sign; a one-line
+  cache is a safe follow-up outside this diff's files.
+
+## 17. QA knobs ship as first-class passthroughs in all seven compose files
+
+`AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS` (api service) and
+`AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` (runner service) were added to the OSS and
+EE dev/gh/gh.local/gh.ssl compose files, unset by default, so operators and QA
+can set them without editing compose files. The live reproduction in this PR
+uses exactly these knobs.

--- a/docs/design/fix-sts-mount-expiry/plan.md
+++ b/docs/design/fix-sts-mount-expiry/plan.md
@@ -1,0 +1,626 @@
+# Plan: make mount credentials outlive every turn, and honor their expiry
+
+Four small changes. Three make the credential lifetime real, configurable, and
+trustworthy (API). One makes the runner track the credentials its mounts actually
+hold, and rebuild before they die (runner). No new daemons, no wire changes, no
+refresh machinery inside the sandbox.
+
+## The fix in one paragraph
+
+Today a mount credential requested for 3600 seconds really lives 900 seconds on
+SeaweedFS, because the web-identity token that authenticates the STS call expires
+after 15 minutes and SeaweedFS caps the session at that expiry. And even the true
+expiry is ignored: the session pool overwrites its expiry bookkeeping on every warm
+turn with a freshly signed credential that never reaches the running mounts. The fix
+mints the web-identity token with a lifetime matching the requested duration, makes
+that duration an env-configurable TTL, and refuses to hand out credentials whose
+expiry the store did not report. On the runner side the pooled environment records
+the expiry of the credentials actually installed in its geesefs daemons, and only
+that recorded value ever governs reuse. The pool then does what it was designed to
+do: evict the environment to a cold rebuild, with fresh credentials and fresh mounts,
+before the installed credentials can die under a turn. The required validity window
+is the worst-case turn duration plus a fixed clock-skew allowance, so no turn starts
+on credentials that could expire before it ends.
+
+## Scope against the issue's four fix directions
+
+1. **Detect EACCES like ENOTCONN**: partially already true, remainder deferred. The
+   acquisition probe (`isMounted`) already treats an EACCES `ls` failure as
+   not-mounted and remounts. Extending the mid-turn event watcher to EACCES is
+   deferred: "Permission denied" appears in legitimate agent output constantly, and
+   the trigger becomes unnecessary once credentials outlive every turn
+   (research.md section 5).
+2. **Refresh before expiry**: adopted in its boundary form. Fresh credentials arrive
+   via evict-to-cold at the turn boundary, which is the mechanism the credential
+   epoch was built for. In-place refresh of a running daemon (credential_process or
+   a container-credentials endpoint) is real machinery and is deferred
+   (research.md section 3).
+3. **Raise duration_seconds**: adopted as "make the already-requested 3600 real and
+   configurable". The default stays 3600.
+4. **Per-mount RoleSessionName**: deferred. Isolation hygiene, orthogonal to expiry.
+
+## Change 1: configurable TTL (API)
+
+### `api/oss/src/utils/env.py`
+
+`MountsConfig` is currently empty (env.py:1117):
+
+```python
+class MountsConfig(BaseModel):
+    """Mounts-domain config. Store credentials live in StoreConfig."""
+
+    model_config = ConfigDict(extra="ignore")
+```
+
+Add the TTL, following the existing `int(os.getenv(...) or "...")` pattern
+(compare `catalog_cache_ttl_seconds`, env.py:622). The `or` also absorbs an empty
+string, which is what an unset compose passthrough delivers:
+
+```python
+class MountsConfig(BaseModel):
+    """Mounts-domain config. Store credentials live in StoreConfig."""
+
+    # Lifetime of signed mount credentials. The store backends clamp it to their own
+    # STS bounds (SeaweedFS: effective floor via the web-identity token, hard range
+    # 900-43200 for DurationSeconds; AWS GetFederationToken: 900-129600). QA lowers
+    # it to force fast expiry; only SeaweedFS honors values below 900.
+    credentials_ttl_seconds: int = int(
+        os.getenv("AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS") or "3600"
+    )
+
+    model_config = ConfigDict(extra="ignore")
+```
+
+The config stays on the shared `env` object, per the repo convention that
+application config is read through `env` and never through a bare `os.getenv` at
+the call site.
+
+### `api/oss/src/core/mounts/service.py`
+
+Current (service.py:57-59 and 606-611):
+
+```python
+# Default TTL (seconds) for signed mount credentials. Covers the mount lifetime for a
+# turn; geesefs holds the creds without refresh, so a turn outliving this hits ExpiredToken.
+_CREDENTIALS_TTL_SECONDS = 3600
+...
+    async def sign_mount_credentials(
+        self,
+        *,
+        project_id: UUID,
+        mount_id: UUID,
+        duration_seconds: int = _CREDENTIALS_TTL_SECONDS,
+    ) -> MountCredentials:
+```
+
+Replace the module constant with the env value, resolved at call time (a default
+argument would freeze the import-time value):
+
+```python
+    async def sign_mount_credentials(
+        self,
+        *,
+        project_id: UUID,
+        mount_id: UUID,
+        duration_seconds: Optional[int] = None,
+    ) -> MountCredentials:
+        ...
+        ttl = (
+            duration_seconds
+            if duration_seconds is not None
+            else env.mounts.credentials_ttl_seconds
+        )
+        creds = await self.mounts_store.sign_temp_credentials(
+            bucket=bucket,
+            prefix=prefix,
+            duration_seconds=ttl,
+        )
+```
+
+Add `from oss.src.utils.env import env` to the imports. Delete
+`_CREDENTIALS_TTL_SECONDS` (both sign routes reach this method with the default, so
+no other caller changes).
+
+### `hosting/docker-compose/oss/docker-compose.dev.yml`
+
+The knob has to reach the container that signs. The dev `api` service declares only
+`DOCKER_NETWORK_MODE` under `environment:` and otherwise reads `env_file`
+(docker-compose.dev.yml:119-122), so a shell `export` before `run.sh` never arrives.
+Mirror the store variables' pattern (dev uses map form, the gh file uses list form,
+compare docker-compose.gh.yml:57-62):
+
+```yaml
+        environment:
+            DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
+            AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS: ${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
+```
+
+Add the same line to the `api` service of `docker-compose.gh.yml` (list form) so
+self-hosted operators can set it too.
+
+The QA below also lowers the runner's turn budget, and the `runner` service takes no
+`env_file` at all (docker-compose.dev.yml:380-408). Add the passthrough there as
+well:
+
+```yaml
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+```
+
+Both variables are optional. An empty value leaves the code default in place.
+
+## Change 2: make the requested duration real on SeaweedFS (API)
+
+### `api/oss/src/core/store/storage.py`
+
+Current `_sign_web_identity` body (storage.py:232-241):
+
+```python
+        body = urlencode(
+            {
+                "Action": "AssumeRoleWithWebIdentity",
+                "Version": "2011-06-15",
+                "RoleArn": webidentity.role_arn(),
+                "RoleSessionName": webidentity.STORE_SUBJECT,
+                "WebIdentityToken": webidentity.mint_web_identity_token(),
+                "DurationSeconds": str(duration_seconds),
+                "Policy": scope_policy,
+            }
+        )
+```
+
+Two problems: the token's fixed 15-minute lifetime caps the session (research.md
+section 2), and a sub-900 `DurationSeconds` is a hard SeaweedFS request error rather
+than a clamp. Fix both with two private, unit-testable helpers and a token cap:
+
+```python
+# SeaweedFS caps every session at 12h (`maxSessionLength`), so no web-identity token
+# needs to outlive the longest session it could mint.
+_SEAWEEDFS_MAX_SESSION_SECONDS = 43200
+
+
+# SeaweedFS validates DurationSeconds in [900, 43200] when present; the EFFECTIVE
+# lifetime is min(DurationSeconds, web-identity token expiry, maxSessionLength).
+# Minting the token with the requested lifetime makes the request honest, and lets
+# a sub-900 TTL (QA) take effect through the token-expiry cap, which has no floor.
+def _seaweedfs_duration_seconds(duration_seconds: int) -> int:
+    return min(max(duration_seconds, 900), _SEAWEEDFS_MAX_SESSION_SECONDS)
+
+
+# AWS GetFederationToken accepts DurationSeconds in [900, 129600].
+def _federation_duration_seconds(duration_seconds: int) -> int:
+    return min(max(duration_seconds, 900), 129600)
+```
+
+```python
+                "WebIdentityToken": webidentity.mint_web_identity_token(
+                    ttl_seconds=min(duration_seconds, _SEAWEEDFS_MAX_SESSION_SECONDS)
+                ),
+                "DurationSeconds": str(_seaweedfs_duration_seconds(duration_seconds)),
+```
+
+`mint_web_identity_token` already takes a keyword-only `ttl_seconds`
+(webidentity.py:104); no change there. The 15-minute constant
+(`_TOKEN_TTL_SECONDS`, webidentity.py:35) remains the default for any other caller.
+
+In `_sign_federation_token`, replace the bare floor (storage.py:278):
+
+```python
+                "DurationSeconds": str(max(duration_seconds, 900)),
+```
+
+with:
+
+```python
+                "DurationSeconds": str(_federation_duration_seconds(duration_seconds)),
+```
+
+Behavior notes, both modes:
+
+- SeaweedFS, default TTL 3600: token lives 3600s, `DurationSeconds` is 3600, effective
+  lifetime rises from 900s to the intended 3600s. The store-reported `Expiration`
+  stays authoritative and flows to the runner unchanged.
+- SeaweedFS, QA TTL 120: token lives 120s, `DurationSeconds` is 900 (clamped to pass
+  validation), effective lifetime 120s via the token-expiry cap.
+- AWS: the token change is inert (no web-identity path); TTL passes through with
+  AWS's own [900, 129600] bounds. Sub-900 QA values silently become 900, which the
+  QA plan accounts for.
+
+## Change 3: fail closed on a missing expiry (API)
+
+`_parse_sts_credentials` (storage.py:24-52) turns a missing or unparsable
+`Expiration` into `None`, the service passes that through as `expires_at`
+(service.py:639), and the runner reads a missing expiry as "never expires"
+(research.md section 1). One malformed STS response would therefore disable the
+entire safety mechanism silently, for the lifetime of the pooled environment.
+
+Both branches of `sign_temp_credentials` end in this parser and nothing else
+produces mount credentials, so raising here is exactly "the STS paths fail closed"
+(research.md section 1 records the check). Replace the swallow:
+
+```python
+    raw_exp = _text("Expiration")
+    if not raw_exp:
+        raise MountStorageUnavailable("STS response carried no credential expiry.")
+    try:
+        expiration = datetime.fromisoformat(raw_exp.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise MountStorageUnavailable(
+            "STS response carried an unparsable credential expiry."
+        ) from exc
+```
+
+A refused sign is not a failed turn. The runner already treats a missing mount as a
+degraded, mount-less run (`mount degraded kind=... cause=sign_returned_no_mount`,
+environment-setup.ts:118-122), which is the same outcome as any other sign failure.
+
+## Change 4: track the installed credentials and rebuild before they die (runner)
+
+### The installed lease
+
+The pooled environment must answer one question honestly: "when do the credentials
+that my running geesefs daemons actually hold expire?" Nothing tracks that today.
+The credential epoch is filled from the credentials signed for the current dispatch
+(`computeCredentialEpoch(request, signed?.expiresAt)`, server.ts:382), and those
+credentials never reach the daemons on a warm turn.
+
+Record the answer where it is known: at the moment a mount succeeds. Add to
+`SessionEnvironment` (`services/runner/src/engines/sandbox_agent/runtime-contracts.ts:179`,
+initialized alongside `mountedCwd` in environment-setup.ts:328-338):
+
+```ts
+  /**
+   * Expiry (epoch millis) of the credentials actually installed in each running geesefs
+   * daemon, recorded at successful mount time. Per mount, because a remount replaces one
+   * mount's credentials and must not inherit the other's. The environment's lease is the
+   * minimum over the entries; see `installedMountLease`.
+   */
+  installedMountExpiries: { cwd?: number; agent?: number };
+```
+
+The session cwd and agent mounts go through four call sites, and each stamps its own
+entry from the credentials it just used:
+
+- `mountLocalDurableCwd` (environment.ts:427) and `mountLocalAgentCwd`
+  (environment.ts:448), used both by the initial acquire (environment.ts:596,
+  environment.ts:599) and by the ENOTCONN remount helpers
+  (`reSignAndRemountLocalCwd`, environment.ts:511; `reSignAndRemountLocalAgentMount`,
+  environment.ts:479), which re-sign first and mount second. Stamping inside the
+  mount helpers therefore covers the remount path for free.
+- The two remote mounts, environment.ts:744 (durable cwd) and environment.ts:800
+  (agent mount).
+
+This also covers the acquire-time sign fallback: when the dispatch's up-front sign
+threw, `prepareEnvironmentSetup` signs its own credentials
+(environment-setup.ts:105-114) and the mount helper records whatever was actually
+used, not what the dispatch pre-signed.
+
+The lease itself is a pure helper next to the epoch code
+(`services/runner/src/engines/sandbox_agent/session-identity.ts`):
+
+```ts
+/** The environment's credential lease: the earliest expiry among its installed mounts. */
+export function installedMountLease(expiries: {
+  cwd?: number;
+  agent?: number;
+}): number | undefined {
+  const values = [expiries.cwd, expiries.agent].filter(
+    (v): v is number => v !== undefined,
+  );
+  return values.length ? Math.min(...values) : undefined;
+}
+```
+
+### Park and repark from the lease, never from the dispatch
+
+Both park paths in `services/runner/src/server.ts` read the environment instead of
+the incoming epoch. `parkFreshOrDestroy` (server.ts:460-470) currently parks with
+`credentialEpoch: incomingEpoch`. After a cold acquire the incoming credentials are
+usually the mounted ones, but not always (the acquire may have re-signed), so it
+takes the lease too:
+
+```ts
+      credentialEpoch: {
+        secretsHash: incomingEpoch.secretsHash,
+        mountExpiresAtMs: installedMountLease(env.installedMountExpiries),
+      },
+```
+
+`reparkOrEvict` (server.ts:497-506) is the drift defect. It must carry the installed
+lease forward, and on the approval-resume path it must also keep the live
+environment's secrets hash: that path deliberately ignores the resume request's
+re-minted credentials (server.ts:650-680), so adopting the incoming hash would
+re-label an environment running old secrets as if it ran the new ones.
+
+```ts
+  const reparkOrEvict = async (
+    live: LiveSession<SessionEnvironment>,
+    result: AgentRunResult,
+    opts?: { keepSecretsHash?: boolean },
+  ): Promise<void> => {
+    const env = live.environment;
+    env.clearTurn();
+    const update = {
+      configFingerprint: cfgFp,
+      historyFingerprint: nextHistoryFp(env),
+      credentialEpoch: {
+        // The resume path never re-baked secrets into this environment, so the parked
+        // hash still describes what it runs.
+        secretsHash: opts?.keepSecretsHash
+          ? live.credentialEpoch.secretsHash
+          : incomingEpoch.secretsHash,
+        // The environment runs on the credentials installed in its daemons, not on the
+        // ones this dispatch signed to compute the pool key.
+        mountExpiresAtMs: installedMountLease(env.installedMountExpiries),
+      },
+    };
+```
+
+The continuation path keeps calling `reparkOrEvict(live, result)` (server.ts:638);
+the approval-resume path calls `reparkOrEvict(live, result, { keepSecretsHash: true })`
+(server.ts:749).
+
+### Lease sufficiency is a separate question from identity
+
+A turn dispatched one minute before expiry would still die mid-turn, so reuse needs
+credentials valid through the end of the turn, not merely valid now. That is a
+different question from "is this the same environment the request expects", and it
+gets its own check rather than a future timestamp threaded through the identity
+comparison. `credentialEpochMismatch` (session-identity.ts:369) keeps its current
+meaning: secrets rotated, or credentials already dead. Next to it:
+
+```ts
+/**
+ * A fixed allowance for clock differences between the API, the store, and the runner, plus
+ * the seconds a cold rebuild spends mounting before the turn starts. Not operator-tunable:
+ * it protects an invariant, and a third time knob would only invite mis-setting it.
+ */
+export const MOUNT_LEASE_SKEW_MS = 60_000;
+
+/**
+ * Whether the parked mount credentials would expire before `requiredValidThroughMs`, i.e. the
+ * lease cannot cover a full worst-case turn. Distinct from `mountCredentialsExpired`, which
+ * asks only whether the lease is already dead.
+ */
+export function mountCredentialsExpireBy(
+  epoch: CredentialEpoch,
+  requiredValidThroughMs: number,
+): boolean {
+  return (
+    epoch.mountExpiresAtMs !== undefined &&
+    epoch.mountExpiresAtMs <= requiredValidThroughMs
+  );
+}
+```
+
+The dispatch resolves the run limits once and derives the window (server.ts, next to
+`incomingEpoch` at server.ts:382). `resolveRunLimits` is imported directly from
+`./engines/sandbox_agent/run-limits.ts`, as server.ts already imports other engine
+internals:
+
+```ts
+  // Resolved once per dispatch: the longest a turn started now could still be running.
+  const requiredValidThroughMs =
+    Date.now() + resolveRunLimits().totalMs + MOUNT_LEASE_SKEW_MS;
+```
+
+The idle-reuse branch (server.ts:569-577) gains the lease check after the identity
+check, with its own reason string, because credentials that are still valid at
+eviction time are expiring, not expired:
+
+```ts
+    const credMismatch = credentialEpochMismatch(
+      existing.credentialEpoch,
+      incomingEpoch,
+    );
+    let mismatch: string | undefined;
+    if (cfgFp !== existing.configFingerprint) mismatch = "config";
+    else if (priorFp !== existing.historyFingerprint) mismatch = "history";
+    else if (credMismatch) mismatch = credMismatch;
+    else if (
+      mountCredentialsExpireBy(existing.credentialEpoch, requiredValidThroughMs)
+    )
+      mismatch = "credentials-expiring";
+    else if (!tailIsFreshUserMessage(request)) mismatch = "tail";
+```
+
+The approval-resume branch (server.ts:678) keeps its hard-expiry check and gains the
+same lease check:
+
+```ts
+    } else if (mountCredentialsExpired(existing.credentialEpoch)) {
+      mismatch = "credentials-expired";
+    } else if (
+      mountCredentialsExpireBy(existing.credentialEpoch, requiredValidThroughMs)
+    ) {
+      mismatch = "credentials-expiring";
+    }
+```
+
+The skew allowance applies at both moments that matter. At dispatch it keeps a turn
+from starting on a lease it could outlive. After a cold rebuild it is respected by
+construction, because the lease is recorded after the mount succeeds, so the mount
+and provisioning time is already spent when the clock starts.
+
+### A short lease warns, it never fails the turn
+
+When the configured TTL is smaller than the turn budget plus skew, even a freshly
+mounted environment cannot satisfy `requiredValidThroughMs`, and every dispatch
+evicts to cold. That state is correct (fresh credentials every turn, no EACCES) and
+it is exactly what a QA-lowered TTL asks for, so it must not be an error. A hard
+failure would turn one mis-set number into a full outage, while proceeding is no
+worse than today's behavior. So the runner logs once per acquisition, naming both
+knobs and both values, and runs the turn:
+
+```ts
+    // Once per acquisition: the lease cannot cover a worst-case turn even when brand new.
+    klog(
+      `lease-short key=${key} leaseMs=${leaseMs} required=${requiredMs} ` +
+        `(AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS on the API vs ` +
+        `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=${totalMs}ms + skew ${MOUNT_LEASE_SKEW_MS}ms); ` +
+        `running anyway, every dispatch will rebuild cold`,
+    );
+```
+
+### What this yields per failure mode
+
+- Active conversation crossing expiry (the observed outages): the first dispatch
+  inside the required-validity window logs `mismatch (credentials-expiring)`,
+  evicts, rebuilds cold with fresh mounts. Sub-second blip instead of a
+  multi-minute window.
+- Turn longer than the remaining lease: cannot happen while the TTL exceeds the turn
+  budget plus skew, because the lease check already forced a cold rebuild.
+- Hard daemon death: unchanged, the existing ENOTCONN probe and watcher handle it,
+  and a successful remount now updates the lease it re-signed.
+- Sessionless runs: mount at acquire with fresh full-TTL credentials, turn bounded
+  by the 45-minute deadline. Covered.
+- Daytona remote: identical logic; the lease and the window are backend-neutral.
+
+### Rebuild rate, honestly
+
+With the default TTL of 3600s, the default turn budget of 2700s (45 minutes), and
+60s of skew, the warm-reuse window is about 840 seconds. An active conversation
+therefore rebuilds cold roughly every 14 minutes, not once an hour. That is the
+price of guaranteeing that no turn starts on credentials it could outlive, and it is
+no more churn than the 900-second lifetime produces today. A cold rebuild is
+cheap locally. On Daytona it is not: a credential eviction tears the environment
+down with reason `compatibility-mismatch`, which maps to `delete`
+(`teardownDisposition`, teardown.ts:23-37), so the remote sandbox is destroyed and
+the next turn pays a full create.
+
+The default stays 3600. Measure the rebuild rate in production first. If the churn
+hurts, the answer is in-place refresh through a container-credentials endpoint
+(research.md section 3, mechanism 4), not a 12-hour TTL: a longer TTL only moves the
+boundary, while every hour of extra lifetime is an hour a leaked credential stays
+usable.
+
+## Tests
+
+### API unit tests (pytest)
+
+Extend `api/oss/tests/pytest/unit/test_mounts_injection.py`, which already has the
+`_CapturingPost` seam that stands in for `aiohttp.ClientSession` and captures the one
+STS POST (test_mounts_injection.py:312-357):
+
+- SeaweedFS request, TTL 3600: captured body has `DurationSeconds=3600`, and the
+  captured `WebIdentityToken` decodes (PyJWT, `verify_signature: False`) to
+  `exp - iat == 3600`.
+- SeaweedFS request, TTL 120: body has `DurationSeconds=900` (the floor), token
+  `exp - iat == 120` (the sub-900 lever).
+- SeaweedFS request, TTL 90000: body has `DurationSeconds=43200` and the token is
+  capped at 43200 as well.
+- AWS `GetFederationToken`: TTL 60 becomes 900, 3600 passes through, 200000 becomes
+  129600.
+- Fail closed: an STS XML body with no `Expiration`, and one with
+  `<Expiration>not-a-date</Expiration>`, each raise `MountStorageUnavailable` from
+  `sign_temp_credentials`. The existing fixture XML carries a valid `Expiration`
+  (test_mounts_injection.py:348-357), so the current cases keep passing.
+- `MountsConfig.credentials_ttl_seconds`: default 3600; env override parses; an
+  empty string falls back to 3600 (construct `MountsConfig` under
+  `monkeypatch.setenv`).
+
+Run: `cd api && uv run --no-sync pytest oss/tests/pytest/unit/test_mounts_injection.py`.
+
+### Runner unit tests (vitest)
+
+Extend `services/runner/tests/unit/session-keepalive-dispatch.test.ts` (fake
+`KeepaliveEngine` plus real pool, the existing seam). No wall-clock waits: fake the
+date only, so the pool's own timers and the test's `flush()` keep working.
+
+```ts
+vi.useFakeTimers({ toFake: ["Date"] });
+vi.setSystemTime(T0);
+// ... vi.setSystemTime(T0 + delta) between dispatches
+vi.useRealTimers();
+```
+
+The fake engine gains a per-call sequence of signed expiries, and its
+`acquireEnvironment` stamps `installedMountExpiries` on the fake environment from the
+credentials it "mounted", exactly as the real mount helpers do. Cases:
+
+- **Repark keeps the installed lease**: turn 1 acquires with an expiry at T0+10min;
+  turn 2 runs warm while the dispatch signs a far-future expiry; advancing the clock
+  so the installed lease falls inside the required-validity window forces turn 3
+  cold (acquire called again). Without the fix turn 3 continues warm.
+- **Approval resume preserves both**: an `awaiting_approval` repark keeps the live
+  environment's secrets hash (a resume request carrying different secrets does not
+  relabel the parked environment) and its installed lease.
+- **The lease is the minimum**: an environment whose session-cwd mount expires
+  before its agent mount is evicted on the earlier of the two.
+- **Boundary cases**: a lease exactly at `now + totalMs + MOUNT_LEASE_SKEW_MS`
+  evicts (`credentials-expiring`); one millisecond beyond it continues warm; one
+  already in the past still reports `credentials-expired`. Drive `totalMs` through
+  `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS`, restored after each case.
+
+Run: `cd services/runner && pnpm test && pnpm run typecheck`.
+
+## Live QA (local OSS stack, SeaweedFS)
+
+Sequenced so the broken behavior is demonstrated with the same knobs that ship. The
+numbers are chosen so a whole turn plus the 60-second skew still fits inside one
+lease, which keeps the reproduction from depending on turn timing: TTL 120 seconds,
+runner turn budget 30 seconds, required validity 90 seconds.
+
+1. **Deploy the API half only** (TTL env, token fix, fail-closed parsing), runner
+   unpatched. Add `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=120` to
+   `hosting/docker-compose/oss/.env.oss.dev` (or export it, now that the compose
+   passthrough from Change 1 exists), then
+   `load-env hosting/docker-compose/oss/.env.oss.dev` and
+   `bash ./hosting/docker-compose/run.sh --oss --dev`. The dev API hot-reloads code
+   but not env, so use `--recreate api` to pick the variable up.
+2. **Reproduce the window**: start an agent session that touches its durable mount
+   every turn (prompt the agent to run `date >> agent-files/log.txt && cat
+   agent-files/log.txt`). Send turns every ~20 seconds. Within two turns past the
+   120-second mark the agent reports "Permission denied" on `agent-files/`, while
+   runner logs show `hit-continue` (warm reuse of the dead mount). This is the bug,
+   on demand.
+3. **Deploy the runner half**, same TTL, plus
+   `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=30000`. A lease now has to stay valid for 90
+   seconds (30s budget plus 60s skew), so turns dispatched in the first ~30 seconds
+   after a mount continue warm, and the next one logs
+   `mismatch (credentials-expiring) ... evict + cold`. That turn succeeds, and the
+   file written before the rebuild is still there (durability across the cold
+   remount). No denial window at any cadence.
+4. **Confirm the short-lease warning**: drop the TTL to 60 with the same 30-second
+   budget. Every dispatch rebuilds cold, each acquisition logs `lease-short` naming
+   both knobs, and turns still succeed.
+5. **Restore defaults** (unset both, recreate), then rerun the original long
+   scenario: an active conversation with periodic file writes for more than 20
+   minutes shows no denial window (previously it broke at 15 minutes) and rebuilds
+   cold about every 14 minutes.
+6. **AWS mode**: not exercised in this QA. The AWS path is covered by the clamp unit
+   tests and the analysis in research.md section 4; on real AWS the TTL floor is 900,
+   so the fast reproduction is SeaweedFS-only. Optional follow-up: one staging pass
+   with TTL 900 and a conversation longer than 15 minutes.
+
+Per the QA-recording rule, capture step 2 and step 3 as an MP4 for the PR.
+
+## Rollout notes
+
+- API and runner halves are independently safe. API-only: the effective SeaweedFS
+  lifetime rises from 900s to 3600s, windows become rarer but the drift remains.
+  Runner-only: the real lifetime stays 900s, which is below the turn budget plus
+  skew, so every dispatch rebuilds cold and logs `lease-short`. That is correct and
+  denial-free, just churny. Ship both together.
+- No wire change: `expires_at` already flows.
+- Operators: keep `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS` above
+  `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` (as seconds) plus 60 seconds of skew, or
+  every dispatch rebuilds cold and the runner says so in its log. SeaweedFS also
+  caps the TTL at its configured `maxSessionLength` (12h in our compose file);
+  values above 43200 are clamped in code before the request.
+- Real AWS deployments must sign with long-term IAM user credentials.
+  `GetFederationToken` rejects an assumed-role session, and root credentials cap the
+  duration at 3600 seconds regardless of the TTL (research.md section 4).
+- EE and production compose files need the same TTL passthrough as the OSS files
+  before the knob is usable there.
+- The web-identity JWT now lives as long as the TTL, capped at 12h (research.md
+  section 4 covers the widened-replay-window tradeoff; the token never leaves the
+  API-to-store hop).
+
+## Open questions for review
+
+1. **Remote transcript mounts**: on Daytona, the harness session and transcript
+   directories are separate mounts, each signed at acquire with its own credentials
+   (`mountHarnessSessionDirs`, environment.ts:766). They are signed seconds apart
+   from the durable cwd and agent mounts at the same TTL, so the lease already
+   bounds them within noise. Should they still get their own lease entries, or is
+   the current minimum-of-two the right stopping point?

--- a/docs/design/fix-sts-mount-expiry/research.md
+++ b/docs/design/fix-sts-mount-expiry/research.md
@@ -1,0 +1,345 @@
+# Research: how mount credentials flow, expire, and can be refreshed
+
+All paths are relative to the repo root. Line numbers reference the current tree.
+External sources: geesefs v0.43.0 (the pinned binary, see
+`services/runner/docker/Dockerfile.dev:24`, `Dockerfile.gh:34`, and
+`services/runner/images/sandbox/daytona/build_snapshot.py:59`) and SeaweedFS 4.37
+(the bundled store, see `hosting/docker-compose/oss/docker-compose.dev.yml:521`).
+
+## 1. The credential path, end to end
+
+### Signing (API side)
+
+- The runner calls `POST /sessions/mounts/sign` for the session scratch mount
+  (`api/oss/src/apis/fastapi/sessions/router.py:920`) and
+  `POST /mounts/agents/sign` for the durable agent mount
+  (`api/oss/src/apis/fastapi/mounts/router.py:151`). Both land in
+  `MountsService.sign_mount_credentials`
+  (`api/oss/src/core/mounts/service.py:606`), which requests a lifetime of
+  `_CREDENTIALS_TTL_SECONDS = 3600` (`service.py:59`).
+- `ObjectStore.sign_temp_credentials` (`api/oss/src/core/store/storage.py:188`)
+  builds one inline session policy scoped to the mount prefix, then branches on the
+  backend:
+  - **SeaweedFS** (selected when `AGENTA_STORE_SIGNING_KEY` is set,
+    `storage.py:93-97`): `_sign_web_identity` (`storage.py:226`) posts an
+    unauthenticated `AssumeRoleWithWebIdentity` carrying a self-minted RS256 JWT
+    (`webidentity.mint_web_identity_token`, `storage.py:238`) and
+    `DurationSeconds=str(duration_seconds)` (`storage.py:239`).
+  - **Remote S3-compatible store (AWS, MinIO)**: `_sign_federation_token`
+    (`storage.py:258`) posts a SigV4-signed `GetFederationToken` with
+    `DurationSeconds=str(max(duration_seconds, 900))` (`storage.py:278`).
+- The web-identity JWT is minted with a fixed 15-minute lifetime:
+  `_TOKEN_TTL_SECONDS = 15 * 60` (`api/oss/src/core/store/webidentity.py:35`),
+  used by `mint_web_identity_token` (`webidentity.py:104`).
+- The STS XML response is parsed into a miniopy `Credentials` including
+  `Expiration` (`storage.py:24-52`), and the service returns
+  `expires_at=getattr(creds, "_expiration", None)`
+  (`service.py:639`). miniopy-async stores the constructor's `expiration` as
+  `_expiration` (site-packages `miniopy_async/credentials/credentials.py:54`), so
+  the true store-side expiry reaches the wire as an ISO datetime
+  (`api/oss/src/core/mounts/dtos.py:132`).
+- **The expiry is optional the whole way down.** `_parse_sts_credentials` turns a
+  missing or unparsable `Expiration` into `None` (`storage.py:39-45`), the DTO field
+  is `Optional[datetime]` (`dtos.py:132`), and the runner reads a missing expiry as
+  "never expires": `computeCredentialEpoch` leaves `mountExpiresAtMs` undefined
+  (`session-identity.ts:333-347`) and both expiry checks return false on undefined
+  (`session-identity.ts:356-367`). One malformed STS response therefore disables the
+  whole reuse bound silently, for as long as that environment stays parked.
+  Fail-closing is safe on both backends: `sign_temp_credentials` is the only producer
+  of mount credentials, and both of its branches are STS calls that end in this one
+  parser (`storage.py:222-224`). No static or master-key path hands credentials to a
+  mount; the master keys are used only to sign the `GetFederationToken` request and
+  for the API's own file operations (`_client`, `storage.py:107`). So there is no
+  legitimate no-expiry case to preserve.
+
+### Mounting (runner side)
+
+- `signSessionMountCredentials` (`services/runner/src/engines/sandbox_agent/mount.ts:68`)
+  and `signAgentMountCredentials`
+  (`services/runner/src/engines/sandbox_agent/agent-mount.ts:39`) fetch the sign
+  endpoints and surface `expiresAt` on `MountCredentials` (`mount.ts:36`).
+- Locally, `mountStorage` (`mount.ts:299`) spawns
+  `geesefs --no-detect --fsync-on-close -f -o allow_other <bucket>:<prefix> <cwd>`
+  (`geesefsArgs`, `mount.ts:214`) with the credentials as static child environment
+  variables `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`
+  (`credEnv`, `mount.ts:237`). Remotely (Daytona), `mountStorageRemote`
+  (`mount.ts:641`) runs the same argv inside the sandbox.
+- Mounts are established once, during environment acquisition:
+  `environment.ts:596` and `environment.ts:599` (local session cwd + agent mount,
+  before the harness daemon spawns), `environment.ts:744` and `environment.ts:800`
+  (remote).
+- **Where the installed credentials come from.** The local mounts go through two
+  helpers, `mountLocalDurableCwd` (`environment.ts:427`) and `mountLocalAgentCwd`
+  (`environment.ts:448`), which read `environment.mountCreds` /
+  `environment.agentMountCreds` and pass them to geesefs. Those two fields are the
+  only description of what a daemon holds, and they are set in three places: the
+  acquire-time sign in `prepareEnvironmentSetup` (`environment-setup.ts:105-114`,
+  which signs for itself when the dispatch's up-front sign threw and passed
+  `undefined`), the agent-mount sign right after it (`environment-setup.ts:127-134`),
+  and the ENOTCONN re-sign helpers, which overwrite one field and remount through the
+  same helper (`environment.ts:479` and `environment.ts:511`). On Daytona the two
+  remote mounts read the same fields. Anything that records "what is installed" has
+  to hook these mount call sites, not the sign call sites: a sign whose credentials
+  never reach a daemon changes nothing about the running mount.
+- Daytona sandboxes additionally mount the harness session and transcript directories
+  (`mountHarnessSessionDirs`, `environment.ts:766`), each signing its own credentials
+  per directory (`mount.ts:735`) at the same TTL, seconds apart from the other two.
+
+### Liveness probing and hard-death recovery (already present)
+
+- `isMounted` (`mount.ts:255`) runs `mountpoint -q` then a real `ls -A`. Any `ls`
+  failure, ENOTCONN or otherwise, counts as not-mounted, so `mountStorage`
+  force-detaches and remounts. This probe runs only inside `mountStorage`, i.e.
+  only during acquisition.
+- Mid-turn, `remountLocalCwdAfterRuntimeEnotconn` (`environment.ts:540`) watches
+  every ACP event for ENOTCONN markers
+  (`containsTransportEndpointDisconnected`,
+  `services/runner/src/engines/sandbox_agent/runtime-policy.ts:136`) and re-signs +
+  remounts both local mounts, at most once per environment
+  (`LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT = 1`, `environment.ts:141`).
+- Nothing watches for EACCES. Expired credentials leave the daemon alive, so
+  neither `mountpoint -q` nor the ENOTCONN watcher fires.
+
+### Turn boundaries and the session pool (runner side)
+
+- Every dispatch with a session id signs fresh session-cwd credentials up front
+  (`engine.resolveKeepaliveMount`, called at
+  `services/runner/src/server.ts:363`; implementation
+  `environment.ts:225`). The result feeds two things: the pool key, and the
+  incoming credential epoch
+  (`computeCredentialEpoch(request, signed?.expiresAt)`, `server.ts:382`).
+- The credential epoch
+  (`services/runner/src/engines/sandbox_agent/session-identity.ts:326`) exists to
+  bound how long a parked environment may reuse its baked credentials:
+  `mountExpiresAtMs` holds the mount credential expiry, and
+  `credentialEpochMismatch` (`session-identity.ts:369`) evicts a parked
+  environment to a cold rebuild once that expiry passes.
+- **The drift defect**: after a warm turn, `reparkOrEvict` re-parks the same
+  environment with `credentialEpoch: incomingEpoch` (`server.ts:506`). The
+  incoming epoch carries the expiry of the credentials signed for THIS dispatch,
+  but those credentials were only used to compute the pool key; the running
+  geesefs daemons still hold the credentials from acquisition, and the warm path
+  never remounts (`hit-continue` goes straight to `runTurn`, `server.ts:587-600`).
+  So every warm turn pushes `mountExpiresAtMs` forward while the real mount
+  credentials age in place. An active conversation therefore never trips
+  `credentials-expired` and keeps running turns against a mount whose credentials
+  died at acquisition-time + TTL. A fresh park after a cold acquire
+  (`parkFreshOrDestroy`, `server.ts:470`) is usually right, because the incoming
+  credentials are normally the ones just mounted. It is not guaranteed: when the
+  up-front sign threw, the acquire signed its own credentials
+  (`environment-setup.ts:105-114`) and the incoming epoch describes a sign that never
+  reached a daemon.
+- Idle reaping is aggressive (`DEFAULT_TTL_MS = 60_000` local,
+  `DEFAULT_DAYTONA_TTL_MS = 120_000`, `session-identity.ts:33,40`), so quiet
+  sessions get torn down and remounted fresh anyway. Only conversations with
+  turns arriving faster than the idle TTL keep one environment alive long enough
+  to cross the credential expiry. That matches the field observation: active
+  sessions on the durable agent volume were hit hardest.
+- Evicting for a credential reason is not free on Daytona. The dispatch evicts with
+  teardown reason `compatibility-mismatch` (`server.ts:583`, `server.ts:689`), and
+  `teardownDisposition` maps that to `delete`, not `stop`
+  (`services/runner/src/engines/sandbox_agent/teardown.ts:23-37`). The remote sandbox
+  is destroyed and the next turn pays a full create; only clean, idle, and capacity
+  teardowns park the sandbox in a stopped state.
+- Turn length is bounded: `DEFAULT_TOTAL_DEADLINE_MS = 45 * 60_000`
+  (`services/runner/src/engines/sandbox_agent/run-limits.ts:37`), overridable via
+  `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS`.
+
+## 2. What actually expires, and when: the 15-minute cap
+
+The issue reports denial starting about 15 minutes after mount, yet the service
+requests 3600 seconds. Both numbers are real. SeaweedFS 4.37 caps every STS session
+at the expiry of the web-identity token presented to it
+(`weed/iam/sts/sts_service.go`, `calculateSessionDuration`):
+
+```go
+// If the source token has an expiration, cap the session duration to not exceed it
+if tokenExpiration != nil && !tokenExpiration.IsZero() {
+    timeUntilTokenExpiry := time.Until(*tokenExpiration)
+    ...
+    } else if timeUntilTokenExpiry < duration {
+        duration = timeUntilTokenExpiry
+    }
+}
+```
+
+Our JWT lives 15 minutes (`webidentity.py:35`), so every SeaweedFS mount credential
+dies after at most 900 seconds regardless of `DurationSeconds=3600`. The STS
+response's `Expiration` reflects the capped value (the response credentials are
+generated from the capped `expiresAt`), so the runner's epoch data was always
+truthful; only the repark drift (section 1) discarded it.
+
+Timeline of one observed outage, with the pieces above:
+
+1. Turn 1 (cold): sign, mount, park. Real expiry: T+15 min. Epoch records T+15 min.
+2. Turns 2..N (warm, active conversation): each dispatch signs fresh credentials,
+   overwrites the epoch with a new T'+15 min, never remounts.
+3. T+15 min: the store starts answering 403 to the daemons; geesefs maps 403 to
+   EACCES (`core/backend_s3.go`, `case 403: err = syscall.EACCES`). Every file
+   operation in the mount fails "Permission denied". `mountpoint -q` still passes.
+4. The outage persists until a turn fails hard enough to evict (history mismatch,
+   thrown continuation, idle reap), up to the observed 14 minutes.
+
+## 3. Mechanism space: getting fresh credentials into geesefs v0.43.0
+
+geesefs v0.43.0 vendors a fork of aws-sdk-go v1 under `s3ext/`. Credential
+resolution (`core/cfg/conf_s3.go:107-181`): explicit `AccessKey`/`SecretKey` flags
+become static credentials; otherwise the SDK session default chain runs with
+`SharedConfigState: session.SharedConfigEnable` (`conf_s3.go:157-161`), which
+resolves, in order: static env vars, shared config/credentials files (including
+`credential_process`), then remote providers (container endpoint, IMDS). Every
+option, verified against the pinned source:
+
+| # | Mechanism | Supported in v0.43.0? | Refreshes after expiry? | Verdict |
+| --- | --- | --- | --- | --- |
+| 1 | Static `AWS_*` env vars (current approach) | Yes | No. Static provider never expires. | Status quo; credentials die at TTL. |
+| 2 | Shared credentials file the runner rewrites (`~/.aws/credentials`, `--shared-config`) | Yes | **No.** `SharedCredentialsProvider.IsExpired()` returns `!p.retrieved` (`s3ext/aws/credentials/shared_credentials_provider.go:71-73`): the file is read once and never re-read. geesefs never calls `Expire()` on 403 either (`core/backend_s3.go` maps 403 to EACCES and treats it as non-retryable). | Ruled out. The "just rewrite a file" hope does not hold for this SDK generation. |
+| 3 | `credential_process` in a shared config profile | Yes (`s3ext/aws/session/credentials.go:107-109` wires `processcreds`) | **Yes.** `processcreds` honors the process output's `Expiration` and re-runs the process when it passes (`s3ext/aws/credentials/processcreds/provider.go:109-132`). | Viable locally: the runner would install a config file plus a helper that re-calls the sign endpoint. Requires dropping the `AWS_*` env (env wins the chain) and giving the helper long-lived API auth. On Daytona the helper would put API credentials inside the agent-reachable sandbox. Real machinery; deferred. |
+| 4 | Container credentials endpoint (`AWS_CONTAINER_CREDENTIALS_FULL_URI`) | Yes (`s3ext/aws/defaults/defaults.go:117-127`, `endpointcreds`) | **Yes.** `endpointcreds` sets expiry from the JSON response and re-fetches (`s3ext/aws/credentials/endpointcreds/provider.go:107-132`). | The strongest in-place-refresh option if ever needed: the runner serves a loopback JSON endpoint, geesefs polls it. Locally clean; remotely it needs a tunnel plus auth on the endpoint. Deferred for the same simplicity reason as #3. |
+| 5 | IMDS emulation (`169.254.169.254`, `ec2rolecreds`) | Yes (default chain) | Yes | Requires owning the link-local address inside every container/sandbox. Impractical; rejected. |
+| 6 | geesefs `--iam` / `--iam-url` built-in refresh | Yes, and it does refresh on a timer (`core/backend_s3.go:119-208`) | Yes, but | It replaces SigV4 signing entirely with a Yandex-style bearer header (`setIAMSigner` clears the Sign handler list and sets `X-YaCloud-SubjectToken`, `backend_s3.go:210-219`). SeaweedFS and AWS require SigV4. Rejected. |
+| 7 | geesefs `--role-arn` (SDK `stscreds.AssumeRoleProvider`, auto-refreshing) | Yes (`conf_s3.go:169-177`) | Yes | Needs long-lived base credentials on the mount host to assume with. That breaks the design invariant that the runner never holds bucket-wide keys (`mount.ts:5-7`). Rejected. |
+| 8 | Remount with fresh credentials at turn boundaries (evict the pooled environment to cold) | N/A (runner-side) | Yes | Already the designed behavior of the credential epoch; it is broken because the epoch tracks per-dispatch signing instead of what the daemons were given. Between turns nothing holds the mount, so a rebuild is safe. **Chosen.** |
+
+Conclusion: within geesefs v0.43.0 there is no zero-machinery way to refresh a
+running daemon's SigV4 credentials. The two real refresh mechanisms (#3, #4) both
+add a credential-serving surface, and the remote variant weakens the security
+boundary. Boundary remounting (#8) already exists as designed behavior; the fix
+repairs it by recording what each mount was actually given, and sizes the TTL so no
+turn can outlive its credentials.
+
+## 4. Self-hosted SeaweedFS versus real AWS S3
+
+The fix must be safe in both deployment modes. They differ in every relevant
+detail, so each is analyzed separately.
+
+### Self-hosted OSS: SeaweedFS 4.37 with its built-in STS
+
+- **STS verb**: `AssumeRoleWithWebIdentity`, authenticated by our RS256 JWT
+  validated against the API's JWKS
+  (`hosting/docker-compose/oss/docker-compose.dev.yml:540` configures the OIDC
+  provider; `webidentity.py` mints the token).
+- **DurationSeconds floor and ceiling**: when the request carries
+  `DurationSeconds`, SeaweedFS validates `900 <= v <= 43200`
+  (`weed/iam/sts/sts_service.go:839-841`, "DurationSeconds must be between 900 and
+  43200 seconds"). Values outside the range are a hard request error, not a clamp.
+- **Effective lifetime**: `min(DurationSeconds, web-identity token expiry,
+  maxSessionLength)` (`calculateSessionDuration`, `sts_service.go:1021-1054`).
+  `maxSessionLength` is 12h in our compose config (`docker-compose.dev.yml:540`).
+  The web-identity-token cap has **no 900-second floor**: a JWT that expires in 60
+  seconds yields 60-second credentials even when `DurationSeconds=900`. This is
+  the QA lever for sub-900 lifetimes.
+- **Expiry enforcement**: the session token is a stateless JWT whose `exp` is
+  validated on every S3 request (`weed/iam/sts/session_claims.go:137`). An expired
+  token gets 403; geesefs maps 403 to EACCES. Matches the field observation.
+- **Fix safety**: minting the web-identity JWT with a lifetime matching the
+  requested duration removes the silent cap, so the requested 3600s becomes real.
+  The JWT never leaves the API-to-store network hop; lengthening it from 15
+  minutes to the configured TTL widens the replay window of that internal token
+  accordingly, which is why the token lifetime is also capped at 43200 seconds: no
+  bearer token should outlive the longest session it can mint. The token only
+  permits assuming the store role, and prefix
+  isolation continues to rest on the inline session policy
+  (`storage.py:209-212`), unchanged by this fix. Note the pre-existing sharp
+  edge, also unchanged: anyone holding that JWT could assume the role without a
+  session policy and reach the whole bucket, which is why it must stay inside the
+  API trust boundary.
+
+### Real AWS S3 with real AWS STS
+
+- **STS verb**: `GetFederationToken`, SigV4-signed with the deployment's IAM user
+  keys against `AGENTA_STORE_STS_ENDPOINT_URL` (`storage.py:258-281`,
+  `api/oss/src/utils/env.py:1092`). No web-identity token exists on this path, so
+  the JWT change is inert here.
+- **Who may call it**: AWS accepts `GetFederationToken` only from the long-term
+  access keys of an IAM user. An assumed-role session or any other temporary
+  credential is rejected outright, and root-account keys, while accepted, cap every
+  federation token at 3600 seconds no matter what `DurationSeconds` asks for. An AWS
+  deployment must therefore provision a dedicated IAM user for the store and put its
+  keys in `AGENTA_STORE_ACCESS_KEY` / `AGENTA_STORE_SECRET_KEY`. The [900, 129600]
+  range below assumes that; under root keys the effective TTL ceiling is one hour.
+- **DurationSeconds floor and ceiling**: AWS enforces 900 minimum and 129600 (36h)
+  maximum for `GetFederationToken`. The code already clamps the floor
+  (`max(duration_seconds, 900)`, `storage.py:278`). QA cannot get sub-900
+  credentials from real AWS; the low-TTL reproduction is SeaweedFS-only.
+- **Effective lifetime**: exactly `DurationSeconds`; the response `Expiration` is
+  authoritative and flows to the runner the same way.
+- **Expiry enforcement**: S3 rejects expired session tokens with 403
+  `ExpiredToken`; geesefs maps it to EACCES identically.
+- **Fix safety**: the API change reduces to "the TTL constant becomes an env var,
+  clamped into [900, 129600]", plus refusing a response with no parsable
+  `Expiration`, which AWS always sends. The runner changes (record the installed
+  lease, require it to cover a full turn) key off the `expires_at` the STS response
+  reported, not off any backend assumption, so they behave identically against AWS.
+  No AWS-side configuration changes beyond the IAM user the store already needs.
+
+### Why one fix covers both
+
+The runner never inspects which backend signed its credentials. It receives
+`expires_at`, mounts, and later decides reuse-versus-rebuild from that timestamp.
+Both backends report a truthful `Expiration` and both enforce it with 403. The fix
+therefore lives in backend-neutral places: make the requested TTL real, configurable,
+and never silently absent at signing time, and make the runner honor the expiry of
+the credentials it actually installed.
+
+## 5. EACCES as a remount trigger: false-positive analysis
+
+The issue proposes treating EACCES like ENOTCONN. Two distinct places could do
+that, with very different risk:
+
+- **The acquisition probe** (`isMounted`, `mount.ts:255`) already does. It treats
+  ANY `ls -A` failure as not-mounted, EACCES included. False positives are not a
+  realistic concern there: the session policy grants read, write, and scoped list
+  on the entire mount prefix (`_scope_policy`, `storage.py:132`), so no path
+  inside the mount can legitimately deny a root listing while the credentials are
+  alive. A root-listing EACCES implies dead or invalid credentials, and remounting
+  is the right response to both. One caveat: geesefs caches directory listings
+  (default `--stat-cache-ttl` 30s, `core/cfg/flags.go:1075`), so an `ls` within
+  the cache window can pass while writes fail. The probe alone therefore cannot
+  reliably detect a soft death, which is another reason not to build the fix on
+  probing.
+- **The mid-turn event watcher** (`containsTransportEndpointDisconnected`,
+  `runtime-policy.ts:136`) scans full ACP event payloads for marker strings.
+  "ENOTCONN" is distinctive; "EACCES" and "Permission denied" are not. Agents
+  legitimately produce them constantly (reading `/root`, failed `sudo`, quoting
+  error messages). Each false trigger would burn the single-shot remount budget
+  (`environment.ts:141`) and race a live harness against an unmount. Extending the
+  watcher to EACCES is the false-positive-prone half of the proposal, and it is
+  unnecessary once credentials outlive every turn. Deferred.
+
+## 6. Test infrastructure
+
+- **Runner**: vitest, `services/runner/tests/unit/*.test.ts`, run with `pnpm test`
+  from `services/runner`. The keep-alive dispatch already has a fake-engine seam
+  (`tests/unit/session-keepalive-dispatch.test.ts` injects a `KeepaliveEngine`
+  into the real `runWithKeepalive` + `SessionPool`), which is exactly where the
+  installed-lease and lease-window tests belong. The fake engine hands the dispatch
+  its own `SessionEnvironment` stand-in, so a test can stamp installed mount
+  expiries on it directly. Mount behavior tests live in
+  `tests/unit/sandbox-agent-mount.test.ts` with injectable `runGeesefs` /
+  `checkMounted` seams.
+- **API**: pytest, `api/oss/tests/pytest/`. Unit tests for the mounts service
+  exist at `unit/test_mounts_service.py`; acceptance tests for mounts at
+  `acceptance/mounts/`. `ObjectStore` signing is already covered at
+  `unit/test_mounts_injection.py:306-438`, whose `_CapturingPost`
+  (`test_mounts_injection.py:312`) replaces `aiohttp.ClientSession` and captures the
+  single STS POST body and headers. That is the seam for asserting `DurationSeconds`
+  and the minted token, with no new mocking layer.
+- Commands: `cd services/runner && pnpm test && pnpm run typecheck`;
+  `cd api && py-run-tests` (or targeted `uv run --no-sync pytest`).
+
+## 7. Prior art
+
+- Draft PR #5247 ("agent mounts", design issue #5215) introduced the durable
+  agent mount; `agent-mount.ts:3` references its plan document
+  (`docs/design/agent-workflows/projects/agent-mounts/plan.md`), which lives on
+  that branch, not on main.
+- `docs/design/mount-file-viewer/` documents the mounts file-listing UI on top of
+  the same service; no credential-lifetime logic.
+- The ENOTCONN detection and single-shot remount machinery
+  (`environment.ts:478-567`) is prior art for the hard-death half of this bug and
+  stays untouched.
+- The mounts service comment at `service.py:57-58` already states the failure
+  mode ("geesefs holds the creds without refresh, so a turn outliving this hits
+  ExpiredToken"); what it misses is that SeaweedFS capped the real lifetime to
+  900s and that the pool's expiry bookkeeping drifts.

--- a/docs/design/fix-sts-mount-expiry/status.md
+++ b/docs/design/fix-sts-mount-expiry/status.md
@@ -1,6 +1,7 @@
 # Status
 
-**State**: planned and revised, awaiting Mahmoud's approval. No code changes made yet.
+**State**: implemented, live-validated, PR open for Mahmoud's review. Do not merge
+without his approval.
 
 - 2026-07-25: workspace created for issue Agenta-AI/agenta#5516. Research done
   against the pinned versions (geesefs v0.43.0 source, SeaweedFS 4.37 source,
@@ -14,17 +15,34 @@
   installed-credential lease and a required-validity window of one worst-case turn
   in the runner's session pool. Issue directions 1 (EACCES event sniffing) and 4
   (RoleSessionName) deferred; rationale in plan.md.
-- 2026-07-25: plan.md revised after an external design review. The runner half now
-  records the expiry of the credentials actually installed in each mount instead of
-  patching the repark path, lease sufficiency is checked separately from identity,
-  a fixed 60-second clock-skew allowance was added, the STS paths fail closed on a
-  missing expiry, the TTL knob is wired through docker-compose, and the QA numbers
-  were made insensitive to turn timing. The default TTL (3600, measured in
-  production, with in-place refresh as the follow-up if churn hurts) and the source
-  of the validity window (the runner's own run limits plus the fixed skew constant)
-  are settled in the plan.
-- Next: approval of plan.md, then implementation on a GitButler lane with the unit
-  tests and the recorded live QA described there.
-
-One open question remains at the end of plan.md: whether the Daytona harness
-transcript mounts need their own lease entries.
+- 2026-07-25: plan.md revised after an external design review (Codex gpt-5.6-sol
+  at xhigh reasoning; the requested gpt-5.6.10 model is not available on the
+  account). The runner half now records the expiry of the credentials actually
+  installed in each mount instead of patching the repark path, lease sufficiency
+  is checked separately from identity, a fixed 60-second clock-skew allowance was
+  added, the STS paths fail closed on a missing expiry, the TTL knob is wired
+  through docker-compose, and the QA numbers were made insensitive to turn timing.
+- 2026-07-25: implemented (API commit acaa86e288, runner commit 290cfc244b) on
+  the worktree branch `worktree-fix-sts-mount-expiry-5516` (worktree used instead
+  of a GitButler lane, per Mahmoud). Mahmoud decided the one open question from
+  plan.md: the Daytona harness transcript mounts do not get their own lease
+  entries (deferred; argument recorded in decisions.md item 7). A four-angle
+  cleanup review (reuse, simplification, efficiency, altitude) was applied; the
+  register of every decision, including the review-sourced ones, is decisions.md.
+- 2026-07-25: live QA on a dedicated stack deployed from the worktree
+  (SeaweedFS backend). All four phases passed: the bug reproduced on demand with
+  the pre-fix runner (11 consecutive denied turns starting 20 seconds after the
+  120-second lease expired, all warm-continued onto the dead mount), the fixed
+  runner ran the identical cadence with zero denials across eight lease-cycle
+  rebuilds, the `lease-short` warning fired as designed at TTL 60, and a
+  22-minute soak at default settings showed exactly one `credentials-expiring`
+  cold rebuild at the 14-minute mark and no denial (the old behavior broke at
+  minute 15). One extra finding from the reproduction: a write acknowledged at
+  the expiry boundary was silently lost in the geesefs cache flush, so the
+  pre-fix behavior could lose acknowledged data, not just deny access.
+- Remaining follow-ups (not this PR): in-place credential refresh via a
+  container-credentials endpoint if the ~14-minute cold-rebuild cadence of long
+  active conversations proves costly in production (decisions.md item 2), the
+  EE/production deployment repos need the TTL passthrough when the knob should
+  become settable there, per-mount RoleSessionName, and an optional AWS staging
+  pass at TTL 900.

--- a/docs/design/fix-sts-mount-expiry/status.md
+++ b/docs/design/fix-sts-mount-expiry/status.md
@@ -1,0 +1,30 @@
+# Status
+
+**State**: planned and revised, awaiting Mahmoud's approval. No code changes made yet.
+
+- 2026-07-25: workspace created for issue Agenta-AI/agenta#5516. Research done
+  against the pinned versions (geesefs v0.43.0 source, SeaweedFS 4.37 source,
+  miniopy-async in the api venv). Root cause is threefold and differs from the
+  issue's framing in one important way: the observed 900-second lifetime is not
+  `storage.py`'s default (the service requests 3600s) but SeaweedFS capping the
+  session at the API's 15-minute web-identity JWT, compounded by the runner's
+  session pool overwriting its mount-expiry bookkeeping on every warm turn.
+- Chosen fix: configurable TTL env var, web-identity token lifetime aligned to the
+  requested duration, and fail-closed parsing of the STS expiry (API), plus an
+  installed-credential lease and a required-validity window of one worst-case turn
+  in the runner's session pool. Issue directions 1 (EACCES event sniffing) and 4
+  (RoleSessionName) deferred; rationale in plan.md.
+- 2026-07-25: plan.md revised after an external design review. The runner half now
+  records the expiry of the credentials actually installed in each mount instead of
+  patching the repark path, lease sufficiency is checked separately from identity,
+  a fixed 60-second clock-skew allowance was added, the STS paths fail closed on a
+  missing expiry, the TTL knob is wired through docker-compose, and the QA numbers
+  were made insensitive to turn timing. The default TTL (3600, measured in
+  production, with in-place refresh as the follow-up if churn hurts) and the source
+  of the validity window (the runner's own run limits plus the fixed skew constant)
+  are settled in the plan.
+- Next: approval of plan.md, then implementation on a GitButler lane with the unit
+  tests and the recorded live QA described there.
+
+One open question remains at the end of plan.md: whether the Daytona harness
+transcript mounts need their own lease entries.

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -129,6 +129,8 @@ services:
             # address + shared token as the `services` container's runner_url().
             AGENTA_RUNNER_INTERNAL_URL: ${AGENTA_RUNNER_INTERNAL_URL:-http://runner:8765}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
+            # Unset leaves the code default (3600s) in place.
+            AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS: ${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
@@ -416,6 +418,9 @@ services:
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}
             AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER: ${AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER:-local}
+            # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
+            # plus 60s of skew, or every dispatch rebuilds the environment cold.
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}
             AGENTA_RUNNER_DAYTONA_TARGET: ${AGENTA_RUNNER_DAYTONA_TARGET:-}

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -51,6 +51,8 @@ services:
             - ${ENV_FILE:-./.env.ee.gh}
         environment:
             - SCRIPT_NAME=/api
+            # Unset leaves the code default (3600s) in place.
+            - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #
         networks:
             - agenta-ee-gh-network
@@ -285,6 +287,9 @@ services:
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}
             AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER: ${AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER:-local}
+            # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
+            # plus 60s of skew, or every dispatch rebuilds the environment cold.
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -64,6 +64,8 @@ services:
             - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
+            # Unset leaves the code default (3600s) in place.
+            - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #
         networks:
             - agenta-ee-gh-network
@@ -287,6 +289,9 @@ services:
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}
             AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER: ${AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER:-local}
+            # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
+            # plus 60s of skew, or every dispatch rebuilds the environment cold.
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -124,6 +124,8 @@ services:
             # address + shared token as the `services` container's runner_url().
             AGENTA_RUNNER_INTERNAL_URL: ${AGENTA_RUNNER_INTERNAL_URL:-http://runner:8765}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
+            # Unset leaves the code default (3600s) in place.
+            AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS: ${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
@@ -402,6 +404,9 @@ services:
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}
             AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER: ${AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER:-local}
+            # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
+            # plus 60s of skew, or every dispatch rebuilds the environment cold.
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}
             AGENTA_RUNNER_DAYTONA_TARGET: ${AGENTA_RUNNER_DAYTONA_TARGET:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -51,6 +51,8 @@ services:
             - ${ENV_FILE:-./.env.oss.gh}
         environment:
             - SCRIPT_NAME=/api
+            # Unset leaves the code default (3600s) in place.
+            - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #
         networks:
             - agenta-oss-gh-network
@@ -283,6 +285,9 @@ services:
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}
             AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER: ${AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER:-local}
+            # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
+            # plus 60s of skew, or every dispatch rebuilds the environment cold.
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -56,6 +56,8 @@ services:
             - ${ENV_FILE:-./.env.oss.gh}
         environment:
             - SCRIPT_NAME=/api
+            # Unset leaves the code default (3600s) in place.
+            - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #
         networks:
             - agenta-gh-ssl-network
@@ -308,6 +310,9 @@ services:
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}
             AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER: ${AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER:-local}
+            # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
+            # plus 60s of skew, or every dispatch rebuilds the environment cold.
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}
             AGENTA_RUNNER_DAYTONA_TARGET: ${AGENTA_RUNNER_DAYTONA_TARGET:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -64,6 +64,8 @@ services:
             - AGENTA_STORE_REGION=${AGENTA_STORE_REGION:-us-east-1}
             - AGENTA_STORE_BUCKET=${AGENTA_STORE_BUCKET:-}
             - AGENTA_STORE_SIGNING_KEY=${AGENTA_STORE_SIGNING_KEY:-}
+            # Unset leaves the code default (3600s) in place.
+            - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #
         networks:
             - agenta-oss-gh-network
@@ -304,6 +306,9 @@ services:
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}
             AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER: ${AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER:-local}
+            # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
+            # plus 60s of skew, or every dispatch rebuilds the environment cold.
+            AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/services/runner/src/engines/sandbox_agent/environment-setup.ts
+++ b/services/runner/src/engines/sandbox_agent/environment-setup.ts
@@ -335,6 +335,7 @@ export async function prepareEnvironmentSetup(
     sessionDestroyRequested: false,
     mountedCwd: undefined,
     agentMountedPath: undefined,
+    installedMountExpiries: {},
     durableCwdSafeToDelete: true,
     // Local runs get a plain rmSync cleanup for the throwaway cwd; Daytona has none on this host.
     workspace: plan.isDaytona

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -115,7 +115,7 @@ import {
   eligibleAgentSessionId,
   sessionContinuityStore,
 } from "./session-continuity.ts";
-import { projectScopeFor } from "./session-identity.ts";
+import { mountExpiryMs, projectScopeFor } from "./session-identity.ts";
 import {
   teardownDisposition,
   type TeardownReason,
@@ -434,6 +434,9 @@ export async function acquireEnvironment(
     );
     if (mounted) {
       environment.mountedCwd = plan.cwd;
+      environment.installedMountExpiries.cwd = mountExpiryMs(
+        environment.mountCreds.expiresAt,
+      );
       return true;
     }
     // A false result means mountStorage stopped the attempt and confirmed the path detached.
@@ -459,6 +462,9 @@ export async function acquireEnvironment(
         return false;
       }
       environment.agentMountedPath = mountPath;
+      environment.installedMountExpiries.agent = mountExpiryMs(
+        environment.agentMountCreds.expiresAt,
+      );
       await seedAgentReadme(mountPath, { log: logger });
       await linkAgentFiles(plan.cwd, mountPath, { log: logger });
       await activateAgentMountGuidance();
@@ -728,6 +734,9 @@ export async function acquireEnvironment(
             },
           ))
         ) {
+          environment.installedMountExpiries.cwd = mountExpiryMs(
+            environment.mountCreds.expiresAt,
+          );
           logger(`remote durable cwd active for session=${sessionForMount}`);
         }
         // Per-harness session/transcript-dir mounts, remote-only by construction (this whole
@@ -782,6 +791,9 @@ export async function acquireEnvironment(
           ))
         ) {
           environment.agentMountedPath = mountPath;
+          environment.installedMountExpiries.agent = mountExpiryMs(
+            environment.agentMountCreds.expiresAt,
+          );
           await seedAgentReadmeRemote(environment.sandbox, mountPath, {
             log: logger,
           });

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -21,6 +21,7 @@ import { type BuildRunPlanDeps, type RunPlan } from "./run-plan.ts";
 import { readStoredSandboxPointer } from "./sandbox-reconnect.ts";
 import { appendSessionTurn, hydrateHarnessSessionFromDurable } from "./session-continuity-durable.ts";
 import { type SessionContinuityStore } from "./session-continuity.ts";
+import { type InstalledMountExpiries } from "./session-identity.ts";
 import { type TeardownReason } from "./teardown.ts";
 import { uploadToolMcpAssets } from "./tool-mcp-assets.ts";
 import { prepareWorkspace } from "./workspace.ts";
@@ -227,6 +228,16 @@ export interface SessionEnvironment {
   sessionDestroyRequested: boolean;
   mountedCwd: string | undefined;
   agentMountedPath?: string;
+  /**
+   * Expiry (epoch millis) of the credentials actually installed in each running geesefs daemon,
+   * recorded at successful mount time. Per mount, because a remount replaces one mount's
+   * credentials and must not inherit the other's. The environment's lease is the minimum over the
+   * entries; see `installedMountLease`.
+   *
+   * The Daytona harness session-dir mounts are deliberately excluded: they are signed after the
+   * cwd mount with the same TTL, so their expiry is never the minimum.
+   */
+  installedMountExpiries: InstalledMountExpiries;
   durableCwdSafeToDelete: boolean;
   workspace: { cleanup: () => Promise<void> } | undefined;
   runtimeRemount: Promise<boolean> | undefined;

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -340,38 +340,82 @@ export function tailIsFreshUserMessage(request: AgentRunRequest): boolean {
 export interface CredentialEpoch {
   /** sha256 over canonical(secrets). In-memory only; never surfaced. */
   secretsHash: string;
-  /** Mount credential expiry as epoch millis, or undefined when the sign response had none. */
+  /**
+   * Parked epochs only: the environment's installed-mount lease as epoch millis, or undefined when
+   * it has no mounts. Incoming epochs never carry one.
+   */
   mountExpiresAtMs?: number;
 }
 
+/**
+ * A signed mount's `expiresAt` (ISO 8601, as it rides the sign response) as epoch millis, or
+ * undefined when absent or unparsable. The one conversion both the credential epoch and the
+ * installed-mount lease go through, so they can never disagree about what an expiry means.
+ */
+export function mountExpiryMs(
+  expiresAt: string | undefined,
+): number | undefined {
+  const parsed = expiresAt ? Date.parse(expiresAt) : NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * The epoch an INCOMING request carries: just the secret material. An incoming request has no
+ * mount lease of its own to contribute; a parked epoch's `mountExpiresAtMs` is stamped from the
+ * environment's installed mounts at park time (see `installedMountLease`).
+ */
 export function computeCredentialEpoch(
   request: AgentRunRequest,
-  mountExpiresAt?: string,
 ): CredentialEpoch {
   const material = canonicalJson({
     secrets: request.secrets ?? {},
   });
-  const parsed = mountExpiresAt ? Date.parse(mountExpiresAt) : NaN;
-  return {
-    secretsHash: sha256(material),
-    mountExpiresAtMs: Number.isFinite(parsed) ? parsed : undefined,
-  };
+  return { secretsHash: sha256(material) };
+}
+
+/**
+ * Expiry (epoch millis) of the credentials actually installed in each of an environment's running
+ * geesefs daemons. Per mount kind, because a remount replaces one mount's credentials and must not
+ * inherit the other's.
+ */
+export interface InstalledMountExpiries {
+  cwd?: number;
+  agent?: number;
+}
+
+/** The environment's credential lease: the earliest expiry among its installed mounts. */
+export function installedMountLease(
+  expiries: InstalledMountExpiries,
+): number | undefined {
+  const values = Object.values(expiries).filter(
+    (v): v is number => typeof v === "number",
+  );
+  return values.length ? Math.min(...values) : undefined;
+}
+
+/**
+ * Whether a lease is spent as of `asOfMs`: an undefined lease imposes no bound, and a lease landing
+ * exactly on `asOfMs` counts as spent. The one place the lease comparison lives, so "already dead"
+ * and "dead before the turn ends" can never drift apart.
+ */
+export function leaseExpiresBy(
+  leaseMs: number | undefined,
+  asOfMs: number,
+): boolean {
+  return leaseMs !== undefined && leaseMs <= asOfMs;
 }
 
 /**
  * Whether a parked session's MOUNT credentials have already expired, ignoring the secret material
- * hash entirely. This answers only "can the parked environment still write its durable cwd?".
- *
- * The approval-resume path uses this instead of `credentialEpochValid`: a resume must NOT require
- * the resume request's re-minted credentials to MATCH the parked ones (a fresh /run mints fresh
- * short-lived material every time, so they practically never match), but an expired mount means
- * the parked cwd can no longer be written, so it must still evict to cold.
+ * hash entirely. The approval-resume path uses this instead of `credentialEpochValid`: a resume
+ * must NOT require the resume request's re-minted credentials to MATCH the parked ones, but an
+ * expired mount means the parked cwd can no longer be written, so it must still evict to cold.
  */
 export function mountCredentialsExpired(
   epoch: CredentialEpoch,
   now = Date.now(),
 ): boolean {
-  return epoch.mountExpiresAtMs !== undefined && now >= epoch.mountExpiresAtMs;
+  return leaseExpiresBy(epoch.mountExpiresAtMs, now);
 }
 
 /**
@@ -388,6 +432,25 @@ export function credentialEpochMismatch(
   if (mountCredentialsExpired(parked, now)) return "credentials-expired";
   if (parked.secretsHash !== incoming.secretsHash) return "credentials-rotated";
   return undefined;
+}
+
+/**
+ * A fixed allowance for clock differences between the API, the store, and the runner, plus the
+ * seconds a cold rebuild spends mounting before the turn starts. Not operator-tunable: it protects
+ * an invariant, and a third time knob would only invite mis-setting it.
+ */
+export const MOUNT_LEASE_SKEW_MS = 60_000;
+
+/**
+ * Whether the parked mount credentials expire by `requiredValidThroughMs`, i.e. the lease cannot
+ * cover a full worst-case turn. Distinct from `mountCredentialsExpired`, which asks only whether
+ * the lease is already dead.
+ */
+export function mountCredentialsExpireBy(
+  epoch: CredentialEpoch,
+  requiredValidThroughMs: number,
+): boolean {
+  return leaseExpiresBy(epoch.mountExpiresAtMs, requiredValidThroughMs);
 }
 
 /**

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -50,7 +50,12 @@ import {
   configFingerprint,
   credentialEpochMismatch,
   carriesMinimalHistory,
+  installedMountLease,
+  leaseExpiresBy,
   mountCredentialsExpired,
+  mountCredentialsExpireBy,
+  MOUNT_LEASE_SKEW_MS,
+  type CredentialEpoch,
   expectedNextHistoryFingerprint,
   historyFingerprint,
   poolKeyFor,
@@ -71,6 +76,10 @@ import {
   loadRunnerConfig,
   runnerConfigSummary,
 } from "./config/runner-config.ts";
+import {
+  resolveRunLimits,
+  TOTAL_DEADLINE_ENV,
+} from "./engines/sandbox_agent/run-limits.ts";
 import { applyDaytonaSdkEnv } from "./engines/sandbox_agent/daytona-provider.ts";
 import { isEntrypoint } from "./entry.ts";
 import { insecureEgressAllowed } from "./tools/ssrf-guard.ts";
@@ -389,7 +398,11 @@ export async function runWithKeepalive(
   // the mount unconditionally past this point — a keep-alive gap may only ever cost a cold
   // restart, never a failed turn.
   const cfgFp = configFingerprint(request);
-  const incomingEpoch = computeCredentialEpoch(request, signed?.expiresAt);
+  const incomingEpoch = computeCredentialEpoch(request);
+  // Resolved once per dispatch: the longest a turn started now could still be running.
+  const turnBudgetMs = resolveRunLimits().totalMs;
+  const requiredValidThroughMs =
+    Date.now() + turnBudgetMs + MOUNT_LEASE_SKEW_MS;
 
   // The fingerprint the NEXT request's prior conversation is expected to hash to; the same
   // one works for an approval park, whose gated tool_call id the FE folds back into the
@@ -486,6 +499,16 @@ export async function runWithKeepalive(
     }
   };
 
+  // A parked epoch's expiry comes from the credentials installed in the environment's mounts, not
+  // from whatever this dispatch signed to compute the pool key.
+  const parkedEpoch = (
+    env: SessionEnvironment,
+    secretsHash: string,
+  ): CredentialEpoch => ({
+    secretsHash,
+    mountExpiresAtMs: installedMountLease(env.installedMountExpiries),
+  });
+
   // Park a freshly cold-acquired environment (new pool slot) as approval / idle, or tear it down.
   const parkFreshOrDestroy = async (
     env: SessionEnvironment,
@@ -497,7 +520,7 @@ export async function runWithKeepalive(
       environment: env,
       configFingerprint: cfgFp,
       historyFingerprint: nextHistoryFp(env),
-      credentialEpoch: incomingEpoch,
+      credentialEpoch: parkedEpoch(env, incomingEpoch.secretsHash),
       teardown: (reason: TeardownReason) => env.destroy({ reason }),
     };
     if (approvalToPark(env, result)) {
@@ -523,7 +546,10 @@ export async function runWithKeepalive(
     }
   };
 
-  // Re-park a checked-out pool session (same slot) as approval / idle, or evict it.
+  // Re-park a checked-out pool session (same slot) as approval / idle, or evict it. A re-park
+  // describes the LIVE environment, so it always keeps the live secrets hash: on the idle path the
+  // mismatch gate already proved the live and incoming hashes equal, and the approval-resume path
+  // deliberately keeps the live one (the resume's re-minted secrets were never baked in).
   const reparkOrEvict = async (
     live: LiveSession<SessionEnvironment>,
     result: AgentRunResult,
@@ -533,7 +559,7 @@ export async function runWithKeepalive(
     const update = {
       configFingerprint: cfgFp,
       historyFingerprint: nextHistoryFp(env),
-      credentialEpoch: incomingEpoch,
+      credentialEpoch: parkedEpoch(env, live.credentialEpoch.secretsHash),
     };
     if (approvalToPark(env, result)) {
       klog(
@@ -571,6 +597,17 @@ export async function runWithKeepalive(
     const acq = await engine.acquireEnvironment(request, signal, signed);
     if (!acq.ok) return { ok: false, error: acq.error };
     const env = acq.env;
+    const leaseMs = installedMountLease(env.installedMountExpiries);
+    if (leaseExpiresBy(leaseMs, requiredValidThroughMs)) {
+      // A misconfigured TTL must never fail a turn: warn once per acquisition and run it.
+      klog(
+        `lease-short key=${key} leaseExpiresAtMs=${leaseMs} ` +
+          `requiredValidThroughMs=${requiredValidThroughMs} ` +
+          `(AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS on the API vs ` +
+          `${TOTAL_DEADLINE_ENV}=${turnBudgetMs}ms + skew ${MOUNT_LEASE_SKEW_MS}ms); ` +
+          `running anyway, every dispatch will rebuild cold`,
+      );
+    }
     let result: AgentRunResult;
     try {
       // Park mode on: a Claude ACP permission gate this turn keeps the session alive instead of
@@ -610,6 +647,12 @@ export async function runWithKeepalive(
     else if (clientAssertsHistory && priorFp !== existing.historyFingerprint)
       mismatch = "history";
     else if (credMismatch) mismatch = credMismatch;
+    else if (
+      // Still-valid credentials that cannot cover a worst-case turn are expiring, not expired:
+      // rebuild at the boundary rather than let the turn die under the mount.
+      mountCredentialsExpireBy(existing.credentialEpoch, requiredValidThroughMs)
+    )
+      mismatch = "credentials-expiring";
     else if (!tailIsFreshUserMessage(request)) mismatch = "tail";
 
     if (mismatch) {
@@ -735,6 +778,10 @@ export async function runWithKeepalive(
         mismatch = "history";
       } else if (mountCredentialsExpired(existing.credentialEpoch)) {
         mismatch = "credentials-expired";
+      } else if (
+        mountCredentialsExpireBy(existing.credentialEpoch, requiredValidThroughMs)
+      ) {
+        mismatch = "credentials-expiring";
       }
     }
 

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -25,7 +25,12 @@ import {
   type KeepaliveEngine,
 } from "../../src/server.ts";
 import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
-import type { KeepaliveConfig } from "../../src/engines/sandbox_agent/session-identity.ts";
+import {
+  computeCredentialEpoch,
+  mountExpiryMs,
+  type InstalledMountExpiries,
+  type KeepaliveConfig,
+} from "../../src/engines/sandbox_agent/session-identity.ts";
 import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
 import {
   acquireEnvironment,
@@ -40,6 +45,7 @@ import {
   DEFERRED_NOT_EXECUTED_PREFIX,
   TOOL_NOT_EXECUTED_PAUSED,
 } from "../../src/tracing/otel.ts";
+import { captureStderr } from "../utils/capture-stderr.ts";
 
 function flush(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
@@ -94,6 +100,8 @@ interface DispatchFakeEnv {
   turnsCleared: number;
   lastTurnToolCallIds: string[];
   parkedApprovals: Map<string, ParkedApproval>;
+  /** Stamped at acquire from the credentials this env "mounted", as the real helpers do. */
+  installedMountExpiries: InstalledMountExpiries;
   parkedApproval?: ParkedApproval;
   approvalGateCount: number;
   nonParkablePauseCount: number;
@@ -133,6 +141,7 @@ function makeApprovalEngine(
       turnsCleared: 0,
       lastTurnToolCallIds: [],
       parkedApprovals: new Map(),
+      installedMountExpiries: {},
       parkedApproval: undefined,
       approvalGateCount: 0,
       nonParkablePauseCount: 0,
@@ -241,6 +250,8 @@ function makeApprovalEngine(
     async acquireEnvironment(_request, _signal, _presigned) {
       calls.acquire += 1;
       const env = makeEnv();
+      const expiry = mountExpiryMs(mountOpts.expiresAt);
+      if (expiry !== undefined) env.installedMountExpiries.cwd = expiry;
       calls.acquiredEnvs.push(env);
       return { ok: true, env: env as unknown as SessionEnvironment };
     },
@@ -363,24 +374,6 @@ function approveResumeMulti(
     ],
   };
 }
-
-function captureStderr() {
-  const lines: string[] = [];
-  const orig = process.stderr.write.bind(process.stderr);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (process.stderr as any).write = (chunk: any) => {
-    lines.push(String(chunk));
-    return true;
-  };
-  return {
-    lines,
-    restore: () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (process.stderr as any).write = orig;
-    },
-  };
-}
-
 describe("runWithKeepalive: approval park + resume", () => {
   it("parks a paused Claude gate in awaiting_approval, then answers it live on the resume (approve)", async () => {
     const { engine, calls } = makeApprovalEngine([
@@ -959,6 +952,58 @@ describe("runWithKeepalive: approval resume ignores re-minted credentials/config
     assert.equal(calls.acquire, 1, "no cold re-acquire");
     assert.equal(env1.destroyed, 0, "the parked session was reused");
     assert.equal(calls.resumes.length, 1, "answered live exactly once");
+  });
+
+  it("the repark after a resume keeps the parked secrets hash AND the installed mount lease", async () => {
+    // Six hours out, so neither the expiry bound nor the expiring-lease bound fires here.
+    const installedExpiresAt = new Date(
+      Date.now() + 6 * 3_600_000,
+    ).toISOString();
+    const { engine, calls } = makeApprovalEngine(
+      [
+        {
+          approvalPause: {
+            permissionId: "perm-1",
+            toolCallId: "tc-gate",
+            toolName: "commit",
+          },
+          toolCallIds: ["tc-gate"],
+        },
+        { result: { ok: true, output: "resumed", stopReason: "complete" } },
+      ],
+      { expiresAt: installedExpiresAt },
+    );
+    const ctx = makeCtx(engine);
+    const paused: AgentRunRequest = {
+      ...pauseTurn(),
+      secrets: { ANTHROPIC_API_KEY: "baked-at-acquire" },
+    };
+    await runWithKeepalive(paused, undefined, undefined, ctx);
+    assert.equal(ctx.pool.get(POOL_KEY)!.state, "awaiting_approval");
+
+    const resume = approveResume(true, {
+      secrets: { ANTHROPIC_API_KEY: "re-minted-on-the-resume" },
+    });
+    const r2 = await runWithKeepalive(resume, undefined, undefined, ctx);
+    assert.equal(r2.ok, true);
+    assert.equal(calls.acquire, 1, "the resume ran on the live environment");
+
+    const parked = ctx.pool.get(POOL_KEY)!;
+    assert.equal(
+      parked.credentialEpoch.secretsHash,
+      computeCredentialEpoch(paused).secretsHash,
+      "the repark keeps the hash of the secrets the environment actually baked",
+    );
+    assert.notEqual(
+      parked.credentialEpoch.secretsHash,
+      computeCredentialEpoch(resume).secretsHash,
+      "the resume's re-minted secrets never entered this environment",
+    );
+    assert.equal(
+      parked.credentialEpoch.mountExpiresAtMs,
+      Date.parse(installedExpiresAt),
+      "and the lease still describes the mounted credentials",
+    );
   });
 });
 

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -7,7 +7,7 @@
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/session-keepalive-dispatch.test.ts)
  */
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
 
 import type {
@@ -24,9 +24,16 @@ import {
   type KeepaliveEngine,
 } from "../../src/server.ts";
 import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
-import type { KeepaliveConfig } from "../../src/engines/sandbox_agent/session-identity.ts";
+import {
+  mountExpiryMs,
+  MOUNT_LEASE_SKEW_MS,
+  type InstalledMountExpiries,
+  type KeepaliveConfig,
+} from "../../src/engines/sandbox_agent/session-identity.ts";
+import { TOTAL_DEADLINE_ENV } from "../../src/engines/sandbox_agent/run-limits.ts";
 import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
 import type { SessionEnvironment } from "../../src/engines/sandbox_agent.ts";
+import { captureStderr } from "../utils/capture-stderr.ts";
 
 function flush(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
@@ -36,6 +43,11 @@ interface EngineOptions {
   mountProjectId?: string | null; // null => the signed mount carries no project id
   signReturnsNull?: boolean; // resolveKeepaliveMount resolves null (no mount at all)
   mountExpiresAt?: string;
+  /** Per-sign expiry (by 0-based `resolveKeepaliveMount` call index), else `mountExpiresAt`. A
+   *  warm dispatch signs credentials no running daemon ever receives, so the two diverge. */
+  mountExpiresAtSequence?: Array<string | undefined>;
+  /** The agent mount's installed expiry, stamped beside the session cwd's at acquire. */
+  agentMountExpiresAt?: string;
   /** Per-call runTurn results (by 0-based call index); default ok/complete. */
   turnResults?: AgentRunResult[];
   /** Per-call emitted tool-call ids the fake runTurn records on the env (by call index). */
@@ -54,6 +66,8 @@ interface FakeEnv {
   parkedApprovals: Map<string, unknown>;
   approvalGateCount: number;
   nonParkablePauseCount: number;
+  /** Stamped at acquire from the credentials this env "mounted", as the real helpers do. */
+  installedMountExpiries: InstalledMountExpiries;
   clearTurn: () => void;
   /** Replaceable body so a test can slow the teardown down; `destroy` stays a stable closure. */
   destroyImpl: () => Promise<void>;
@@ -84,6 +98,7 @@ function makeEngine(options: EngineOptions = {}) {
       parkedApprovals: new Map(),
       approvalGateCount: 0,
       nonParkablePauseCount: 0,
+      installedMountExpiries: {},
       clearTurn: () => {
         env.turnsCleared += 1;
       },
@@ -97,13 +112,15 @@ function makeEngine(options: EngineOptions = {}) {
     return env;
   };
 
-  const signedMount = (): MountCredentials => ({
+  const signedMount = (
+    expiresAt: string | undefined = options.mountExpiresAt,
+  ): MountCredentials => ({
     region: "us-east-1",
     bucket: "b",
     prefix: "mounts/proj/mount",
     accessKey: "AK",
     secretKey: "SK",
-    expiresAt: options.mountExpiresAt,
+    expiresAt,
     projectId:
       options.mountProjectId === null
         ? undefined
@@ -131,13 +148,22 @@ function makeEngine(options: EngineOptions = {}) {
 
   const engine: KeepaliveEngine = {
     async resolveKeepaliveMount(_request) {
+      const idx = calls.resolveMount;
       calls.resolveMount += 1;
       if (options.signReturnsNull) return null;
-      return signedMount();
+      return signedMount(
+        options.mountExpiresAtSequence?.[idx] ?? options.mountExpiresAt,
+      );
     },
-    async acquireEnvironment(_request, _signal, _presigned) {
+    async acquireEnvironment(_request, _signal, presigned) {
       calls.acquire += 1;
       const env = makeEnv();
+      // The real mount helpers stamp the expiry of the credentials the daemon received; a
+      // mount-less acquire leaves the entry unset (no lease at all).
+      const cwd = mountExpiryMs(presigned?.expiresAt);
+      if (cwd !== undefined) env.installedMountExpiries.cwd = cwd;
+      const agent = mountExpiryMs(options.agentMountExpiresAt);
+      if (agent !== undefined) env.installedMountExpiries.agent = agent;
       calls.acquiredEnvs.push(env);
       return { ok: true, env: env as unknown as SessionEnvironment };
     },
@@ -579,6 +605,11 @@ describe("runWithKeepalive: never-park rules", () => {
       ctx.pool.get("proj-rc:s1"),
       "the pool key scope is the run-context project id",
     );
+    assert.equal(
+      ctx.pool.get("proj-rc:s1")!.credentialEpoch.mountExpiresAtMs,
+      undefined,
+      "no installed mount means no lease, and no lease bounds nothing",
+    );
   });
 
   it("a mount without a project id => never parks; the presigned creds are threaded (single sign)", async () => {
@@ -834,5 +865,198 @@ describe("runWithKeepalive: races and failures", () => {
       true,
       "the old env's destroy completed BEFORE the cold acquire started",
     );
+  });
+});
+
+// --- The installed mount lease ---------------------------------------------- //
+//
+// A parked environment runs on the credentials its geesefs daemons were handed at mount time, not
+// on the ones each dispatch signs to compute the pool key. These cases pin that the pool parks the
+// installed lease and evicts to a cold rebuild before a worst-case turn could outlive it.
+
+const KEY = "proj-1:s1";
+const T0 = Date.UTC(2026, 0, 1, 12, 0, 0);
+const TURN_BUDGET_MS = 30_000;
+/** The window a lease must cover for a warm turn: the turn budget plus the fixed skew. */
+const REQUIRED_WINDOW_MS = TURN_BUDGET_MS + MOUNT_LEASE_SKEW_MS;
+
+const iso = (epochMs: number): string => new Date(epochMs).toISOString();
+
+/** Run `fn` with a short turn budget and a frozen clock (Date only: pool timers stay real). */
+async function withLeaseWindow(fn: () => Promise<void>): Promise<void> {
+  const previousBudget = process.env[TOTAL_DEADLINE_ENV];
+  process.env[TOTAL_DEADLINE_ENV] = String(TURN_BUDGET_MS);
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(T0);
+  try {
+    await fn();
+  } finally {
+    vi.useRealTimers();
+    if (previousBudget === undefined) delete process.env[TOTAL_DEADLINE_ENV];
+    else process.env[TOTAL_DEADLINE_ENV] = previousBudget;
+  }
+}
+
+// A third plain turn: its prior conversation is turn 2's full message list.
+function turn3(sessionId = "s1"): AgentRunRequest {
+  return {
+    harness: "claude",
+    model: "m1",
+    sessionId,
+    ...auth,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "more" },
+      { role: "assistant", content: "sure" },
+      { role: "user", content: "even more" },
+    ],
+  };
+}
+
+describe("runWithKeepalive: the installed mount lease governs reuse", () => {
+  it("a warm repark carries the INSTALLED lease, not the dispatch's fresh sign", async () => {
+    await withLeaseWindow(async () => {
+      const installed = T0 + 600_000; // the credentials the daemons actually hold
+      const { engine, calls } = makeEngine({
+        // Turn 2 signs far-future credentials that never reach a running mount.
+        mountExpiresAtSequence: [
+          iso(installed),
+          iso(T0 + 10 * 3_600_000),
+          iso(T0 + 10 * 3_600_000),
+        ],
+      });
+      const ctx = makeCtx(engine);
+
+      await runWithKeepalive(turn1(), undefined, undefined, ctx);
+      vi.setSystemTime(T0 + 5_000);
+      await runWithKeepalive(turn2(), undefined, undefined, ctx);
+      assert.equal(calls.acquire, 1, "turn 2 continues warm");
+      assert.equal(
+        ctx.pool.get(KEY)!.credentialEpoch.mountExpiresAtMs,
+        installed,
+        "the repark carried the installed lease, not the fresh sign",
+      );
+
+      // Turn 3 starts close enough to the installed expiry that a worst-case turn would outlive it.
+      vi.setSystemTime(installed - REQUIRED_WINDOW_MS + 1_000);
+      await runWithKeepalive(turn3(), undefined, undefined, ctx);
+      await flush();
+      assert.equal(
+        calls.acquire,
+        2,
+        "the expiring lease forced a cold rebuild",
+      );
+      assert.equal(calls.acquiredEnvs[0].destroyed, 1);
+    });
+  });
+
+  it("the lease is the MINIMUM of the installed mounts (evicts on the earlier one)", async () => {
+    await withLeaseWindow(async () => {
+      const cwdExpiry = T0 + 600_000;
+      const agentExpiry = T0 + 3_600_000;
+      const { engine, calls } = makeEngine({
+        mountExpiresAtSequence: [iso(cwdExpiry), iso(T0 + 10 * 3_600_000)],
+        agentMountExpiresAt: iso(agentExpiry),
+      });
+      const ctx = makeCtx(engine);
+
+      await runWithKeepalive(turn1(), undefined, undefined, ctx);
+      assert.equal(
+        ctx.pool.get(KEY)!.credentialEpoch.mountExpiresAtMs,
+        cwdExpiry,
+        "the parked lease is the earlier of the two mounts",
+      );
+
+      // Inside the earlier mount's window, still far from the later one's.
+      vi.setSystemTime(cwdExpiry - REQUIRED_WINDOW_MS + 1_000);
+      await runWithKeepalive(turn2(), undefined, undefined, ctx);
+      await flush();
+      assert.equal(calls.acquire, 2, "evicted on the earlier mount's expiry");
+    });
+  });
+
+  const boundaryCases = [
+    {
+      name: "a lease exactly at the required-validity edge evicts as expiring",
+      lease: (required: number) => required,
+      coldAcquires: 2,
+      reason: "credentials-expiring",
+    },
+    {
+      name: "a lease one millisecond beyond the edge continues warm",
+      lease: (required: number) => required + 1,
+      coldAcquires: 1,
+      reason: undefined,
+    },
+    {
+      name: "a lease already in the past still evicts as expired",
+      lease: () => T0 - 1,
+      coldAcquires: 2,
+      reason: "credentials-expired",
+    },
+  ];
+
+  for (const boundary of boundaryCases) {
+    it(boundary.name, async () => {
+      await withLeaseWindow(async () => {
+        const secondDispatchAt = T0 + 1_000;
+        const required = secondDispatchAt + REQUIRED_WINDOW_MS;
+        const { engine, calls } = makeEngine({
+          mountExpiresAtSequence: [
+            iso(boundary.lease(required)),
+            iso(T0 + 10 * 3_600_000),
+          ],
+        });
+        const ctx = makeCtx(engine);
+        const cap = captureStderr();
+        try {
+          await runWithKeepalive(turn1(), undefined, undefined, ctx);
+          vi.setSystemTime(secondDispatchAt);
+          await runWithKeepalive(turn2(), undefined, undefined, ctx);
+          await flush();
+        } finally {
+          cap.restore();
+        }
+        assert.equal(calls.acquire, boundary.coldAcquires);
+        if (boundary.reason) {
+          assert.ok(
+            cap.lines.some((line) =>
+              line.includes(`mismatch (${boundary.reason}) key=${KEY}`),
+            ),
+            `expected a ${boundary.reason} mismatch, got: ${cap.lines.join("")}`,
+          );
+        }
+      });
+    });
+  }
+
+  it("warns once per acquisition when even a fresh lease cannot cover a turn", async () => {
+    await withLeaseWindow(async () => {
+      const { engine } = makeEngine({
+        // Shorter than the turn budget plus skew: every dispatch will rebuild cold.
+        mountExpiresAtSequence: [iso(T0 + 45_000)],
+      });
+      const ctx = makeCtx(engine);
+      const cap = captureStderr();
+      let result: AgentRunResult;
+      try {
+        result = await runWithKeepalive(turn1(), undefined, undefined, ctx);
+      } finally {
+        cap.restore();
+      }
+      assert.equal(
+        result.ok,
+        true,
+        "a short lease warns, it never fails the turn",
+      );
+      const warnings = cap.lines.filter((line) => line.includes("lease-short"));
+      assert.equal(warnings.length, 1, "exactly one warning per acquisition");
+      assert.ok(
+        warnings[0].includes("AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS") &&
+          warnings[0].includes(`${TOTAL_DEADLINE_ENV}=${TURN_BUDGET_MS}ms`),
+        `the warning names both knobs: ${warnings[0]}`,
+      );
+    });
   });
 });

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -478,10 +478,10 @@ describe("credential epoch", () => {
   });
 
   it("valid until the mount expiry elapses; invalid once expired", () => {
-    const parked = computeCredentialEpoch(
-      { secrets: { A: "1" } },
-      "2026-01-01T00:00:10.000Z",
-    );
+    const parked = {
+      ...computeCredentialEpoch({ secrets: { A: "1" } }),
+      mountExpiresAtMs: Date.parse("2026-01-01T00:00:10.000Z"),
+    };
     const incoming = computeCredentialEpoch({ secrets: { A: "1" } });
     const before = Date.parse("2026-01-01T00:00:05.000Z");
     const after = Date.parse("2026-01-01T00:00:15.000Z");
@@ -500,10 +500,10 @@ describe("credential epoch", () => {
   });
 
   it("credentialEpochMismatch splits the reason: expired vs rotated vs none", () => {
-    const parked = computeCredentialEpoch(
-      { secrets: { A: "1" } },
-      "2026-01-01T00:00:10.000Z",
-    );
+    const parked = {
+      ...computeCredentialEpoch({ secrets: { A: "1" } }),
+      mountExpiresAtMs: Date.parse("2026-01-01T00:00:10.000Z"),
+    };
     const same = computeCredentialEpoch({ secrets: { A: "1" } });
     const rotated = computeCredentialEpoch({ secrets: { A: "2" } });
     const before = Date.parse("2026-01-01T00:00:05.000Z");
@@ -525,10 +525,10 @@ describe("credential epoch", () => {
   });
 
   it("mountCredentialsExpired checks only the mount lifetime, ignoring the secret hash", () => {
-    const parked = computeCredentialEpoch(
-      { secrets: { A: "1" } },
-      "2026-01-01T00:00:10.000Z",
-    );
+    const parked = {
+      ...computeCredentialEpoch({ secrets: { A: "1" } }),
+      mountExpiresAtMs: Date.parse("2026-01-01T00:00:10.000Z"),
+    };
     const before = Date.parse("2026-01-01T00:00:05.000Z");
     const after = Date.parse("2026-01-01T00:00:15.000Z");
     assert.equal(mountCredentialsExpired(parked, before), false);

--- a/services/runner/tests/utils/capture-stderr.ts
+++ b/services/runner/tests/utils/capture-stderr.ts
@@ -1,0 +1,24 @@
+/**
+ * Capture what the runner writes to stderr, so a test can assert on the greppable `[keepalive]`
+ * log lines. The runner logs through `process.stderr.write` directly (no logger seam), so the
+ * only way to observe a line is to swap the write. Always `restore()` in a `finally`.
+ */
+export function captureStderr(): {
+  lines: string[];
+  restore: () => void;
+} {
+  const lines: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stderr as any).write = (chunk: any) => {
+    lines.push(String(chunk));
+    return true;
+  };
+  return {
+    lines,
+    restore: () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.stderr as any).write = original;
+    },
+  };
+}


### PR DESCRIPTION
## Context

Fixes #5516. Any agent conversation that stayed active past 15 minutes hit a wall: every file access under the agent's mounts returned "Permission denied" for minutes at a time (16 windows in one day on the OSS deployment, the longest 14 minutes), interrupted writers left stale git lock files, and the live QA reproduction showed a write acknowledged at the boundary being silently lost.

Two defects combined to cause this, and neither is the one the issue title suggests:

1. The API already requests 3600-second mount credentials, but the web-identity token it mints to authenticate the STS call was hardcoded to 15 minutes, and SeaweedFS caps every session at that token's expiry. So every credential really lived 900 seconds.
2. The runner's session pool was built to evict environments before their credentials expire, but on every warm turn it overwrote its expiry bookkeeping with the expiry of a freshly signed credential that never reaches the running geesefs daemons. Active conversations therefore never tripped the eviction and kept running on dead mounts.

## Changes

**API** (`acaa86e288`): the web-identity token is minted with the requested lifetime (capped at the 12-hour session ceiling), `DurationSeconds` is clamped into each backend's valid range, the TTL becomes `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS` (default 3600, wired through all seven compose files), and signing now raises instead of returning never-expiring credentials when an STS response carries no usable `Expiration`.

Before: requested 3600s, effective lifetime 900s (token cap), and a malformed expiry silently meant "never expires".
After: requested 3600s, effective lifetime 3600s, and a missing expiry refuses the sign (the turn degrades to mount-less, same as any sign failure).

**Runner** (`290cfc244b`): the environment records the expiry of the credentials actually installed in each geesefs daemon at mount time (`installedMountExpiries`), both park paths derive the pool's expiry from that installed lease, and reuse requires the lease to cover a full worst-case turn plus 60 seconds of clock skew. When it cannot, the dispatch logs `mismatch (credentials-expiring)` and rebuilds cold at the turn boundary, before any writer can be interrupted.

Before: pool expiry = whatever the latest dispatch signed (never installed anywhere).
After: pool expiry = min expiry of the mounts actually running; no turn starts on credentials it could outlive.

No wire changes, no new daemons, no refresh machinery inside the sandbox. A TTL misconfigured below the turn budget warns (`lease-short`) and runs rather than failing; the worst case equals today's behavior.

## Why this is safe on both self-hosted SeaweedFS and real AWS S3

The runner never inspects which backend signed its credentials; it keys off the STS-reported `expires_at`, which both backends report truthfully and enforce with 403. On SeaweedFS the token-lifetime fix is what makes the TTL real. On AWS there is no web-identity path, so that change is inert; the TTL passes through `GetFederationToken` with AWS's own [900, 129600] bounds. The full two-backend analysis, including the AWS constraint that signing requires long-term IAM-user credentials, is in `docs/design/fix-sts-mount-expiry/research.md` section 4.

## Design docs

The planning workspace ships in this PR under `docs/design/fix-sts-mount-expiry/`: `context.md` (the problem), `research.md` (credential flow end to end, the geesefs v0.43.0 refresh-mechanism analysis, the SeaweedFS-vs-AWS section), `plan.md` (the fix and QA plan), `status.md`, and `decisions.md`, a register of every decision with its trade-off and how to back it out. Start with `decisions.md` if you want to challenge choices rather than read code.

## Tests

- Runner: `pnpm test` 1209 tests green, `pnpm run typecheck` clean. New vitest cases pin the bug deterministically with fake clocks: a warm repark keeps the installed lease (fails without the fix), approval resume preserves the live secrets hash and lease, the lease is the minimum across mounts, and boundary cases at exactly/past the required-validity window.
- API: `pytest` unit suite 1403 green. New request-level tests capture the actual STS POST and assert `DurationSeconds` clamping and the token's `exp - iat` for TTLs 120/3600/90000, plus fail-closed on missing and unparsable `Expiration`.
- Live QA on a dedicated stack deployed from this branch (SeaweedFS, TTL lowered to 120s so expiry happens in 2 minutes instead of 15): the pre-fix runner reproduced the bug on demand (11 consecutive denied turns, all warm-continuing onto the dead mount); the fixed runner ran the identical cadence with zero denials across 8 lease-cycle rebuilds and no data loss; a 22-minute soak at default settings showed exactly one cold rebuild at the 14-minute mark and no denial window. A screen recording of the reproduction and the fix follows as a PR comment.

## What to QA

- Self-host repro (optional, 5 minutes): on an OSS/EE dev stack from this branch, set `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=120` on the api service and `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=30000` on the runner, chat with an agent that appends to a file in `agent-files/` every ~20 seconds. Expect periodic `mismatch (credentials-expiring)` cold rebuilds in the runner log and never a "Permission denied".
- Regression: normal agent sessions (no knobs set) behave as before; sessions idle past a minute still tear down and remount fresh; the ENOTCONN hard-death recovery is untouched.

## Known trade-off to weigh in review

With default knobs, a continuously active conversation now rebuilds cold about every 14 minutes (TTL 3600 minus the 45-minute worst-case turn budget minus skew). That replaces the previous outcome, which was breaking outright at minute 15. If production shows the churn matters, the designated follow-up is in-place refresh via a container-credentials endpoint (`decisions.md` item 2), not a longer TTL.

https://claude.ai/code/session_01BKPLpy1rUTBj5XktkP5eKY
