### PR TITLE
fix(frontend): name new agents after the message that created them

### DIFF
--- a/web/oss/src/components/pages/agent-home/assets/agentName.ts
+++ b/web/oss/src/components/pages/agent-home/assets/agentName.ts
@@ -1,0 +1,64 @@
+/** Words / characters kept when naming an agent after the message that created it. */
+const NAME_WORD_LIMIT = 3
+const NAME_CHAR_LIMIT = 32
+
+/** Trimmed off the end so a truncated name doesn't dangle ("Route support tickets to the"). */
+const TRAILING_FILLER = new Set([
+    "a",
+    "an",
+    "and",
+    "at",
+    "based",
+    "by",
+    "for",
+    "from",
+    "in",
+    "into",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "this",
+    "to",
+    "with",
+])
+
+/** Markdown the composer may emit — stripped so the name reads as plain prose. */
+const stripMarkdown = (message: string) =>
+    message
+        .replace(/```[\s\S]*?```/g, " ")
+        .replace(/`([^`]*)`/g, "$1")
+        .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+        .replace(/^\s*(?:[-*+]|\d+[.)]|#{1,6}|>)\s+/gm, " ")
+        .replace(/[*_~]/g, "")
+        .replace(/\s+/g, " ")
+        .trim()
+
+/**
+ * Name an agent after the message that created it. The composer paths pass no name, so every
+ * agent used to be "New agent" — and since the slug is minted from the name and is immutable,
+ * every slug became `new-agent-<suffix>` (#5397). Returns "" when there's nothing usable to
+ * name from; callers fall back to the generic default.
+ */
+export function deriveAgentNameFromMessage(message?: string): string {
+    const cleaned = stripMarkdown(message?.trim() || "")
+    if (!cleaned) return ""
+
+    let name = cleaned.split(" ").slice(0, NAME_WORD_LIMIT).join(" ")
+    if (name.length > NAME_CHAR_LIMIT) {
+        const cut = name.slice(0, NAME_CHAR_LIMIT)
+        const lastSpace = cut.lastIndexOf(" ")
+        name = lastSpace > 0 ? cut.slice(0, lastSpace) : cut
+    }
+
+    const words = name.split(" ")
+    while (words.length > 1 && TRAILING_FILLER.has(words[words.length - 1].toLowerCase())) {
+        words.pop()
+    }
+    name = words.join(" ").replace(/[\s.,;:!?/\\|—–-]+$/, "")
+    // An all-emoji / all-punctuation message would slug to nothing — keep the generic default.
+    if (!/[a-z0-9]/i.test(name)) return ""
+
+    return name.charAt(0).toUpperCase() + name.slice(1)
+}

--- a/web/oss/src/components/pages/agent-home/hooks/useCreateAgent.ts
+++ b/web/oss/src/components/pages/agent-home/hooks/useCreateAgent.ts
@@ -13,6 +13,8 @@ import {useRouter} from "next/router"
 import {agentFirstRunSeedAtom} from "@/oss/components/AgentChatSlice/state/firstRunSeed"
 import {urlAtom} from "@/oss/state/url"
 
+import {deriveAgentNameFromMessage} from "../assets/agentName"
+
 interface CreateAgentParams {
     /** Agent name; defaults to the ephemeral factory's name when omitted. */
     name?: string
@@ -62,7 +64,10 @@ export function useCreateAgent() {
             if (inFlightRef.current) return false
             inFlightRef.current = true
             try {
-                const agentName = name?.trim() || "New agent"
+                // Composer paths pass no name; naming from the seed keeps slugs distinguishable
+                // (the slug is minted from the name below and can't be changed afterwards).
+                const agentName =
+                    name?.trim() || deriveAgentNameFromMessage(seedMessage) || "New agent"
                 const ephemeralId =
                     entityId ??
                     (await createEphemeralAppFromTemplate({


### PR DESCRIPTION
## Context

Agents created from the home composer or from playground onboarding were all named
"New agent". The slug is minted from the name at creation and cannot be changed
afterwards, so every one of them landed as `new-agent-<random-suffix>`. After a few
creations the agent list is unreadable and the slugs are indistinguishable in API calls.

`useCreateAgent` fell back to the literal string "New agent" whenever the caller passed
no name, and both composer paths pass none. Template cards and the setup drawer pass a
real name and were never affected, which matches what the issue reported.

Fixes #5397.

## Changes

`useCreateAgent` now names the agent from the seed message the user already typed. It
falls back to "New agent" only when there is nothing usable to name from.

The new `deriveAgentNameFromMessage` helper strips the markdown the composer can emit
(code fences, inline code, links, list and heading markers, emphasis), keeps the first
3 words capped at 32 characters, drops trailing filler words so a truncated name does
not dangle, then capitalises the result. It returns an empty string for blank or
non-alphanumeric input, so the caller keeps the old default.

Same user message, before and after:

    message:  "Route incoming support tickets to the right team based on urgency"
    before:   name "New agent",              slug new-agent-mrzh96mpa1
    after:    name "Route incoming support", slug route-incoming-support-mrzh96mpa1

## Tests

- `tsc --noEmit` is clean across `web/oss`. ESLint and Prettier are clean on both files.
- Ran the helper over realistic composer inputs: markdown emphasis and inline code,
  multi-line bullet lists, a heading plus body, a markdown link, empty string,
  whitespace only, emoji only, and a single word. Blank and emoji-only inputs fall back
  to "New agent" as intended.
- For review: the 3-word / 32-character cap is the main tuning knob. It keeps slugs
  short but truncates mid-phrase on longer descriptions, so "Migrate all our legacy
  customer records from the old CRM" becomes "Migrate all our". Widening it is a
  one-line change if that reads badly in practice.

## What to QA

- On the agents home, type a description and create the agent without picking a
  template. The list shows a name taken from your description, and the slug in the edit
  modal matches that name.
- Repeat through playground onboarding (the project `/playground` route, which commits
  in place with no redirect). Same result.
- Submit with an empty composer. The agent is still created and is named "New agent".
- Regression: create from a template card and from the setup drawer. Names and slugs are
  unchanged from before this PR.
