### PR TITLE
[5534] fix(hosting): normalize run.sh env file paths

### DIFF
--- a/docs/packs/hosting.md
+++ b/docs/packs/hosting.md
@@ -19,7 +19,7 @@ If conflicts, trust script.
   `bash ./hosting/docker-compose/run.sh --oss --gh`
 
 ## Extensions
-- set env file: append `--env-file <path>`
+- set env file: append `--env-file <path>`; bare names resolve in the edition dir, and paths are normalized before Compose reads service-level `env_file` entries
 - clean rebuild: append `--no-cache` (requires `--build`)
 - skip pull step: append `--no-pull`
 - volume reset: append `--nuke`

--- a/hosting/AGENTS.md
+++ b/hosting/AGENTS.md
@@ -86,5 +86,7 @@ PROJECT=agenta-ee-dev-wp-b2-rendering hosting/docker-compose/recreate-web.sh
 ```
 
 If you must run `docker compose` directly, pass `ENV_FILE=<file>` **and**
-`--env-file <path>` — both, every time. `run.sh` now also fails loud when its resolved env file
+`--env-file <path>` — both, every time. `run.sh` accepts either a bare env filename
+(from the edition dir) or a path and normalizes it before Compose reads service-level
+`env_file` entries. `run.sh` now also fails loud when its resolved env file
 is missing instead of silently using the port-80 default.

--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -52,7 +52,9 @@ show_usage() {
     echo "  --web-url <URL>         Override AGENTA_WEB_URL"
     echo ""
     echo "Environment:"
-    echo "  -e, --env <path>        Use explicit env file (otherwise stage default)"
+    echo "  -e, --env <path>        Use explicit env file (otherwise stage default). Bare names"
+    echo "                          resolve in the edition dir; paths are normalized before"
+    echo "                          being passed to Compose."
     echo "  --env-file <path>       Alias for --env"
     echo ""
     echo "Compose files:"
@@ -418,11 +420,15 @@ Refusing to start: Docker Compose would silently fall back to its built-in defau
 Pass an existing --env-file (e.g. --env-file .env.$LICENSE.$STAGE.local) or create the file."
 fi
 
-# Export the ENV_FILE to the environment
-export ENV_FILE="$ENV_FILE"
+# Export ENV_FILE as an absolute path for Compose's env_file: ${ENV_FILE:-...}
+# entries. A slash-containing --env-file may be valid from the repo root while the
+# compose file resolves env_file relative to its edition directory; using an
+# absolute value avoids double-joining hosting/docker-compose/<license>/...
+ENV_FILE_ABS_PATH="$(cd "$(dirname "$ENV_FILE_PATH")" && pwd)/$(basename "$ENV_FILE_PATH")"
+export ENV_FILE="$ENV_FILE_ABS_PATH"
 
 # Always append --env-file flag to COMPOSE_CMD
-COMPOSE_CMD+=" --env-file $ENV_FILE_PATH"
+COMPOSE_CMD+=" --env-file $ENV_FILE_ABS_PATH"
 
 if [[ "$WEB_MODE" == "docker" ]]; then
     COMPOSE_CMD+=" --profile with-web"

--- a/hosting/docker-compose/tests/run-sh-env-file-path.sh
+++ b/hosting/docker-compose/tests/run-sh-env-file-path.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RUN_SH="$ROOT/hosting/docker-compose/run.sh"
+ENV_FILE_REL="hosting/docker-compose/ee/.env.ee.dev.sessions"
+ENV_FILE_ABS="$ROOT/$ENV_FILE_REL"
+
+cleanup() {
+    rm -f "$ENV_FILE_ABS"
+    if [[ -n "${TMPDIR_RUN_SH_ENV_FILE_TEST:-}" ]]; then
+        rm -rf "$TMPDIR_RUN_SH_ENV_FILE_TEST"
+    fi
+}
+trap cleanup EXIT
+
+TMPDIR_RUN_SH_ENV_FILE_TEST="$(mktemp -d)"
+mkdir -p "$TMPDIR_RUN_SH_ENV_FILE_TEST/bin"
+
+# The helper only needs the file to exist; the fake docker command below avoids
+# touching a real Docker daemon while still verifying what run.sh exports to
+# Compose's env_file interpolation.
+touch "$ENV_FILE_ABS"
+
+cat >"$TMPDIR_RUN_SH_ENV_FILE_TEST/bin/docker" <<'FAKE_DOCKER'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${RUN_SH_TEST_LOG:?RUN_SH_TEST_LOG must be set}"
+printf 'ENV_FILE=%s\n' "${ENV_FILE:-}" >>"$RUN_SH_TEST_LOG"
+printf 'ARGS=%s\n' "$*" >>"$RUN_SH_TEST_LOG"
+
+case "$*" in
+    *" config --format json"*)
+        case "${ENV_FILE:-}" in
+            /*)
+                printf '{"services":{"api":{"build":null}}}'
+                ;;
+            *[!/]*/*)
+                printf 'relative slash-containing ENV_FILE would be resolved relative to the compose file\n' >&2
+                exit 17
+                ;;
+            *)
+                printf '{"services":{"api":{"build":null}}}'
+                ;;
+        esac
+        ;;
+    *" up -d --no-deps --force-recreate api"*)
+        exit 0
+        ;;
+    *)
+        printf 'unexpected fake docker invocation: %s\n' "$*" >&2
+        exit 18
+        ;;
+esac
+FAKE_DOCKER
+chmod +x "$TMPDIR_RUN_SH_ENV_FILE_TEST/bin/docker"
+
+export PATH="$TMPDIR_RUN_SH_ENV_FILE_TEST/bin:$PATH"
+export RUN_SH_TEST_LOG="$TMPDIR_RUN_SH_ENV_FILE_TEST/docker.log"
+RUN_SH_TEST_OUT="$TMPDIR_RUN_SH_ENV_FILE_TEST/run-sh.out"
+
+(
+    cd "$ROOT"
+    bash "$RUN_SH" --ee --dev --env-file "$ENV_FILE_REL" --recreate api >"$RUN_SH_TEST_OUT"
+)
+
+grep -F "ENV_FILE=$ENV_FILE_ABS" "$RUN_SH_TEST_LOG" >/dev/null
+grep -F -- "--env-file $ENV_FILE_ABS" "$RUN_SH_TEST_LOG" >/dev/null
+grep -F "Surgical service operation complete" "$RUN_SH_TEST_OUT" >/dev/null
+
+echo "run.sh accepts slash-containing --env-file paths by normalizing them for Compose"


### PR DESCRIPTION
## Summary
- Normalize `run.sh --env-file` to an absolute path before exporting `ENV_FILE` for Compose service-level `env_file` interpolation.
- Keep the same normalized path for Docker Compose's `--env-file` flag so slash-containing repo-relative paths no longer double-resolve under `hosting/docker-compose/<license>/`.
- Document accepted env-file forms and add a focused fake-Docker regression harness for the surgical `--recreate` flow.

Fixes #5534

## Testing
### Verified locally
- `bash -n hosting/docker-compose/run.sh hosting/docker-compose/tests/run-sh-env-file-path.sh`
- `hosting/docker-compose/tests/run-sh-env-file-path.sh`
- `shellcheck --exclude=SC1090,SC2086 hosting/docker-compose/run.sh hosting/docker-compose/tests/run-sh-env-file-path.sh`
- `git diff --check`

### Added or updated tests
- Added `hosting/docker-compose/tests/run-sh-env-file-path.sh`, which fakes `docker compose` and fails if `ENV_FILE` remains a relative slash-containing path during `--recreate` config resolution.

### QA follow-up
- A real Docker Compose stack smoke with the release QA env file, if available locally.
- CLA bot may require follow-up signature by the account owner after opening.

## Demo
CLI demo transcript for the focused regression harness:

![CLI demo transcript](https://raw.githubusercontent.com/cyphercodes/agenta/fix/run-sh-env-file-path/hosting/docker-compose/tests/run-sh-env-file-path-demo.svg)

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
