### PR TITLE
refactor(frontend): extract PlaygroundSyncStateTag to separate component

### DIFF
--- a/web/oss/src/components/Playground/Components/PlaygroundSyncStateTag.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundSyncStateTag.tsx
@@ -1,0 +1,39 @@
+import {useCallback, useMemo} from "react"
+
+import {loadableController} from "@agenta/entities/loadable"
+import {testcaseMolecule} from "@agenta/entities/testcase"
+import {SyncStateTag} from "@agenta/ui"
+import {useAtomValue, useSetAtom} from "jotai"
+
+interface PlaygroundSyncStateTagProps {
+    rowId: string
+    loadableId: string
+}
+
+export function PlaygroundSyncStateTag({rowId, loadableId}: PlaygroundSyncStateTagProps) {
+    const mode = useAtomValue(loadableController.selectors.mode(loadableId)) as
+        | "local"
+        | "connected"
+        | null
+    const isDirty = useAtomValue(useMemo(() => testcaseMolecule.isDirty(rowId), [rowId])) as boolean
+    const discard = useSetAtom(testcaseMolecule.actions.discard)
+
+    const handleDiscard = useCallback(() => discard(rowId), [discard, rowId])
+
+    // Only show sync tags when connected to an API-backed testset
+    if (mode !== "connected") return null
+
+    // New IDs are prefixed with "new-" or "local-" (established convention in the codebase)
+    const isNew = rowId.startsWith("new-") || rowId.startsWith("local-")
+    const syncState = isNew ? "new" : isDirty ? "modified" : "unmodified"
+
+    return (
+        <SyncStateTag
+            syncState={syncState}
+            dismissible={syncState === "modified"}
+            onDismiss={syncState === "modified" ? handleDiscard : undefined}
+        />
+    )
+}
+
+export default PlaygroundSyncStateTag

--- a/web/oss/src/components/Playground/Playground.tsx
+++ b/web/oss/src/components/Playground/Playground.tsx
@@ -1,12 +1,10 @@
-import {type FC, useCallback, useEffect, useMemo} from "react"
+import {type FC, useEffect} from "react"
 
 import {executeToolCall} from "@agenta/entities/gatewayTool"
-import {loadableController} from "@agenta/entities/loadable"
-import {testcaseMolecule} from "@agenta/entities/testcase"
 import {GatewayToolAssistantActions, type PlaygroundUIProviders} from "@agenta/playground-ui"
 import {useLocalDraftWarning} from "@agenta/playground-ui/hooks"
-import {preloadEditorPlugins, SyncStateTag} from "@agenta/ui"
-import {useAtomValue, useSetAtom} from "jotai"
+import {preloadEditorPlugins} from "@agenta/ui"
+import {useAtomValue} from "jotai"
 import dynamic from "next/dynamic"
 
 // Synchronous thin frame (Splitter + Tabs + region slots): its real structure paints immediately;
@@ -24,6 +22,7 @@ import {playgroundEarlyAgentStateAtom} from "@/oss/state/workflow"
 import AgentCatalogPrefetcher from "./Components/AgentCatalogPrefetcher"
 import PlaygroundMainView from "./Components/MainLayout"
 import PlaygroundHeader from "./Components/PlaygroundHeader"
+import PlaygroundSyncStateTag from "./Components/PlaygroundSyncStateTag"
 import {OSSPlaygroundShell} from "./OSSPlaygroundShell"
 import PlaygroundOnboarding from "./PlaygroundOnboarding"
 
@@ -37,40 +36,6 @@ const CatalogDrawer = dynamic(
     () => import("@agenta/entity-ui/gatewayTool").then((m) => m.CatalogDrawer),
     {ssr: false},
 )
-
-/**
- * Sync state tag slot — renders the sync state badge in each row header.
- * Shown only when connected to an API-backed testset.
- * - "new" (green): row was added locally and is not yet in the connected testset
- * - "modified" (blue): row has local edits not yet synced; shows discard × on hover
- * - "unmodified": no changes — nothing rendered
- */
-// TODO: This should not live here, it should be in the separate component
-function PlaygroundSyncStateTag({rowId, loadableId}: {rowId: string; loadableId: string}) {
-    const mode = useAtomValue(loadableController.selectors.mode(loadableId)) as
-        | "local"
-        | "connected"
-        | null
-    const isDirty = useAtomValue(useMemo(() => testcaseMolecule.isDirty(rowId), [rowId])) as boolean
-    const discard = useSetAtom(testcaseMolecule.actions.discard)
-
-    const handleDiscard = useCallback(() => discard(rowId), [discard, rowId])
-
-    // Only show sync tags when connected to an API-backed testset
-    if (mode !== "connected") return null
-
-    // New IDs are prefixed with "new-" or "local-" (established convention in the codebase)
-    const isNew = rowId.startsWith("new-") || rowId.startsWith("local-")
-    const syncState = isNew ? "new" : isDirty ? "modified" : "unmodified"
-
-    return (
-        <SyncStateTag
-            syncState={syncState}
-            dismissible={syncState === "modified"}
-            onDismiss={syncState === "modified" ? handleDiscard : undefined}
-        />
-    )
-}
 
 const Playground: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
     const uri = "playground" // Static value, no need for complex data subscription


### PR DESCRIPTION
#### 📝 What changed and why
Resolved a TODO in Playground.tsx by extracting the PlaygroundSyncStateTag component to its own file to make the main component clean and modular.

#### 🎥 UI changes
* No UI changes (pure code refactoring).

#### 🧪 What was tested locally
* Verified correct imports and exports.

#### 🔍 What still needs QA
* Verify sync state tags (green 'new' or blue 'modified' badges) render correctly when connected to a testset.

