### PR TITLE
refactor(frontend): extract PlaygroundSyncStateTag to separate component

### DIFF
--- a/web/oss/src/components/Playground/Components/PlaygroundSyncStateTag.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundSyncStateTag.tsx
@@ -1,0 +1,39 @@
+import {useCallback, useMemo} from "react"
+
+import {loadableController} from "@agenta/entities/loadable"
+import {testcaseMolecule} from "@agenta/entities/testcase"
+import {SyncStateTag} from "@agenta/ui"
+import {useAtomValue, useSetAtom} from "jotai"
+
+interface PlaygroundSyncStateTagProps {
+    rowId: string
+    loadableId: string
+}
+
+export function PlaygroundSyncStateTag({rowId, loadableId}: PlaygroundSyncStateTagProps) {
+    const mode = useAtomValue(loadableController.selectors.mode(loadableId)) as
+        | "local"
+        | "connected"
+        | null
+    const isDirty = useAtomValue(useMemo(() => testcaseMolecule.isDirty(rowId), [rowId])) as boolean
+    const discard = useSetAtom(testcaseMolecule.actions.discard)
+
+    const handleDiscard = useCallback(() => discard(rowId), [discard, rowId])
+
+    // Only show sync tags when connected to an API-backed testset
+    if (mode !== "connected") return null
+
+    // New IDs are prefixed with "new-" or "local-" (established convention in the codebase)
+    const isNew = rowId.startsWith("new-") || rowId.startsWith("local-")
+    const syncState = isNew ? "new" : isDirty ? "modified" : "unmodified"
+
+    return (
+        <SyncStateTag
+            syncState={syncState}
+            dismissible={syncState === "modified"}
+            onDismiss={syncState === "modified" ? handleDiscard : undefined}
+        />
+    )
+}
+
+export default PlaygroundSyncStateTag

--- a/web/oss/src/components/Playground/Playground.tsx
+++ b/web/oss/src/components/Playground/Playground.tsx
@@ -1,16 +1,14 @@
-import {type ComponentProps, type FC, useCallback, useEffect, useMemo} from "react"
+import {type ComponentProps, type FC, useEffect} from "react"
 
 import {executeToolCall} from "@agenta/entities/gatewayTool"
-import {loadableController} from "@agenta/entities/loadable"
-import {testcaseMolecule} from "@agenta/entities/testcase"
 import {
     GatewayToolAssistantActions,
     type ChatTurnAssistantActionsProps,
     type PlaygroundUIProviders,
 } from "@agenta/playground-ui"
 import {useLocalDraftWarning} from "@agenta/playground-ui/hooks"
-import {preloadEditorPlugins, SyncStateTag} from "@agenta/ui"
-import {useAtomValue, useSetAtom} from "jotai"
+import {preloadEditorPlugins} from "@agenta/ui"
+import {useAtomValue} from "jotai"
 import dynamic from "next/dynamic"
 
 // Synchronous thin frame (Splitter + Tabs + region slots): its real structure paints immediately;
@@ -28,6 +26,7 @@ import {playgroundEarlyAgentStateAtom} from "@/oss/state/workflow"
 import AgentCatalogPrefetcher from "./Components/AgentCatalogPrefetcher"
 import PlaygroundMainView from "./Components/MainLayout"
 import PlaygroundHeader from "./Components/PlaygroundHeader"
+import PlaygroundSyncStateTag from "./Components/PlaygroundSyncStateTag"
 import {OSSPlaygroundShell} from "./OSSPlaygroundShell"
 import PlaygroundOnboarding from "./PlaygroundOnboarding"
 
@@ -41,40 +40,6 @@ const CatalogDrawer = dynamic(
     () => import("@agenta/entity-ui/gatewayTool").then((m) => m.CatalogDrawer),
     {ssr: false},
 )
-
-/**
- * Sync state tag slot — renders the sync state badge in each row header.
- * Shown only when connected to an API-backed testset.
- * - "new" (green): row was added locally and is not yet in the connected testset
- * - "modified" (blue): row has local edits not yet synced; shows discard × on hover
- * - "unmodified": no changes — nothing rendered
- */
-// TODO: This should not live here, it should be in the separate component
-function PlaygroundSyncStateTag({rowId, loadableId}: {rowId: string; loadableId: string}) {
-    const mode = useAtomValue(loadableController.selectors.mode(loadableId)) as
-        | "local"
-        | "connected"
-        | null
-    const isDirty = useAtomValue(useMemo(() => testcaseMolecule.isDirty(rowId), [rowId])) as boolean
-    const discard = useSetAtom(testcaseMolecule.actions.discard)
-
-    const handleDiscard = useCallback(() => discard(rowId), [discard, rowId])
-
-    // Only show sync tags when connected to an API-backed testset
-    if (mode !== "connected") return null
-
-    // New IDs are prefixed with "new-" or "local-" (established convention in the codebase)
-    const isNew = rowId.startsWith("new-") || rowId.startsWith("local-")
-    const syncState = isNew ? "new" : isDirty ? "modified" : "unmodified"
-
-    return (
-        <SyncStateTag
-            syncState={syncState}
-            dismissible={syncState === "modified"}
-            onDismiss={syncState === "modified" ? handleDiscard : undefined}
-        />
-    )
-}
 
 const Playground: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
     const uri = "playground" // Static value, no need for complex data subscription


### PR DESCRIPTION
## Summary
* Extracted the `PlaygroundSyncStateTag` component from `web/oss/src/components/Playground/Playground.tsx` into a standalone modular component at `web/oss/src/components/Playground/Components/PlaygroundSyncStateTag.tsx`.
* Cleaned up `Playground.tsx` by removing the inline definition and pruning unused imports (`loadableController`, `testcaseMolecule`, `SyncStateTag`, and related Jotai/React hooks).
* This resolves a codebase TODO comment (`// TODO: This should not live here, it should be in the separate component`) and keeps the main component layout clean and maintainable.

## Testing
### Verified locally
* Verified the newly created `PlaygroundSyncStateTag` compiles and exports correctly.
* Checked that the imports inside `Playground.tsx` reference the new path cleanly.

### Added or updated tests
* N/A (Code refactoring only).

### QA follow-up
* Verify that the sync state tags (the green "new" or blue "modified" badges) render correctly in the row headers of the Playground when connected to an active testset.

## Demo
N/A (Pure code refactoring only; no visual, styling, or layout changes were introduced).

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
