### PR TITLE
fix(hosting): runner containers leak zombie processes; run them under an init

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -382,6 +382,7 @@ services:
         # === IMAGE ================================================ #
         image: agenta-ee-dev-runner:latest
         # === EXECUTION ============================================ #
+        init: true
         # No file watcher (the box's inotify limit is shared across stacks). The Pi login is
         # bind-mounted read-write at /pi-agent and the harness runs directly out of it, so a
         # refreshed OAuth token persists to the host login instead of dying with the container.

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -270,6 +270,8 @@ services:
         build:
             context: ../../../services/runner
             dockerfile: docker/Dockerfile.gh
+        # === EXECUTION ============================================ #
+        init: true
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -272,6 +272,8 @@ services:
     runner:
         # === IMAGE ================================================ #
         image: ghcr.io/agenta-ai/${AGENTA_RUNNER_IMAGE_NAME:-internal-ee-agenta-runner}:${AGENTA_RUNNER_IMAGE_TAG:-latest}
+        # === EXECUTION ============================================ #
+        init: true
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -375,6 +375,7 @@ services:
         # === IMAGE ================================================ #
         image: agenta-oss-dev-runner:latest
         # === EXECUTION ============================================ #
+        init: true
         # The Pi login is bind-mounted read-write at /pi-agent and the harness runs directly out
         # of it, so a refreshed OAuth token persists to the host login instead of dying with the
         # container.

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -268,6 +268,8 @@ services:
         build:
             context: ../../../services/runner
             dockerfile: docker/Dockerfile.gh
+        # === EXECUTION ============================================ #
+        init: true
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -289,6 +289,8 @@ services:
         build:
             context: ../../../services/runner
             dockerfile: docker/Dockerfile.gh
+        # === EXECUTION ============================================ #
+        init: true
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -289,6 +289,8 @@ services:
     runner:
         # === IMAGE ================================================ #
         image: ghcr.io/agenta-ai/${AGENTA_RUNNER_IMAGE_NAME:-agenta-runner}:${AGENTA_RUNNER_IMAGE_TAG:-latest}
+        # === EXECUTION ============================================ #
+        init: true
         # === CONFIGURATION ======================================== #
         environment:
             AGENTA_RUNNER_PORT: "8765"


### PR DESCRIPTION
## Context
On a long-running dev deployment, one runner container had accumulated 3,010 zombie processes after 4 days of uptime; two other runner containers on the same box had 292 and 79. Zombies hold PID/task slots, so a busy runner eventually exhausts process limits.

The root cause is that the runner (a Node/tsx server) runs as PID 1 inside its container. Node reaps its own direct children, but harness runs spawn process trees, and when an intermediate process exits, its orphaned children re-parent to PID 1. Node never reaps those, so every orphaned grandchild stays a zombie forever. The compose files set `init: true` for other services (worker-streams, worker-queues, cron, the gh api), but the runner block never got it.

## Changes
Adds `init: true` to the `runner` service in every compose file that defines it:

- `oss/docker-compose.dev.yml`, `ee/docker-compose.dev.yml`
- `oss/docker-compose.gh.yml`, `ee/docker-compose.gh.yml`
- `oss/docker-compose.gh.local.yml`, `ee/docker-compose.gh.local.yml`
- `oss/docker-compose.gh.ssl.yml`

With the flag, Docker starts `docker-init` (tini) as PID 1. It reaps orphaned children and forwards signals; the runner process becomes its child. Same pattern the other services in these files already use, placed in the same `# === EXECUTION === #` section.

This is a runtime flag only. No image rebuild is needed; it takes effect the next time the container is recreated.

## Tests
- `docker compose -f <file> config` for all 7 files: each renders the runner service with `init: true`.
- Mechanism check with the existing runner image:
  - `docker run --init --rm --entrypoint cat <runner-image> /proc/1/comm` prints `docker-init`.
  - The same command without `--init` shows the container command itself as PID 1 (no reaper).
- `ee/docker-compose.dev.harness.local.yml` (a local-only overlay that only patches runner env/volumes) is untouched; it inherits `init` from the base file.

## What to QA
- Recreate the runner (`run.sh ... --recreate runner`) and run a few agent executions. `ps aux | grep defunct` inside the runner container should stay near zero instead of growing with every run.
- Regression: agent runs still stream and complete; stopping the container still shuts down cleanly (docker-init forwards SIGTERM).

https://claude.ai/code/session_01BhfwcD7KTfPE1FZpdCqJ19
