### PR TITLE
feat: turn the session-storage rework on by default

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -426,9 +426,10 @@ services:
             AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM: ${AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM:-}
             AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES: ${AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES:-}
             # This service has no env_file (see above), so the session flags must be listed
-            # here or they can never be set. AGENTA_SESSIONS_RECONSTRUCT must be enabled
-            # together with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that
-            # carries only its last message loses the conversation.
+            # here or they can never be set. Both default ON: absent or empty means on, and
+            # only the literal "false" disables. Disable AGENTA_SESSIONS_RECONSTRUCT together
+            # with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that carries
+            # only its last message loses the conversation.
             AGENTA_SESSIONS_RECONSTRUCT: ${AGENTA_SESSIONS_RECONSTRUCT:-}
             AGENTA_RECORDS_DURABLE: ${AGENTA_RECORDS_DURABLE:-}
         # === STORAGE ============================================== #

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -298,9 +298,10 @@ services:
             AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM: ${AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM:-}
             AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES: ${AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES:-}
             # This service has no env_file (see above), so the session flags must be listed
-            # here or they can never be set. AGENTA_SESSIONS_RECONSTRUCT must be enabled
-            # together with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that
-            # carries only its last message loses the conversation.
+            # here or they can never be set. Both default ON: absent or empty means on, and
+            # only the literal "false" disables. Disable AGENTA_SESSIONS_RECONSTRUCT together
+            # with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that carries
+            # only its last message loses the conversation.
             AGENTA_SESSIONS_RECONSTRUCT: ${AGENTA_SESSIONS_RECONSTRUCT:-}
             AGENTA_RECORDS_DURABLE: ${AGENTA_RECORDS_DURABLE:-}
         # === SUBSCRIPTION MOUNTS (opt-in) ========================= #

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -111,16 +111,17 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # 5 min per tool call.
 # AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
 
-# --- Session history: last-message-only turns (all four default off) ---
+# --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns
 # from the durable session record log, which keeps requests and traces small on a long
-# conversation. The first two must be flipped together: with the web flag on and the runner
-# flag off, a turn arrives with no history at all.
-# AGENTA_SESSIONS_RECONSTRUCT=true
-# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=true
-# Records become the only copy of the conversation, so make writing them durable and keep
-# the structure of a record whose body exceeds the API size cap.
-# AGENTA_RECORDS_DURABLE=true
+# conversation. The three flags below default ON (absent or empty means on); set the
+# literal "false" to disable. Disable the first two together: with the web flag on and
+# the runner flag off, a turn arrives with no history at all.
+# AGENTA_SESSIONS_RECONSTRUCT=false
+# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=false
+# AGENTA_RECORDS_DURABLE=false
+# Smart truncation preserves the structure of a record whose body exceeds the API size
+# cap (higher-fidelity reconstruction). Still opt-in, default off.
 # AGENTA_RECORDS_SMART_TRUNCATION=true
 
 # ================================================================== #

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -113,16 +113,17 @@ AGENTA_RUNNER_TOKEN=replace-me
 # 5 min per tool call.
 # AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
 
-# --- Session history: last-message-only turns (all four default off) ---
+# --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns
 # from the durable session record log, which keeps requests and traces small on a long
-# conversation. The first two must be flipped together: with the web flag on and the runner
-# flag off, a turn arrives with no history at all.
-# AGENTA_SESSIONS_RECONSTRUCT=true
-# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=true
-# Records become the only copy of the conversation, so make writing them durable and keep
-# the structure of a record whose body exceeds the API size cap.
-# AGENTA_RECORDS_DURABLE=true
+# conversation. The three flags below default ON (absent or empty means on); set the
+# literal "false" to disable. Disable the first two together: with the web flag on and
+# the runner flag off, a turn arrives with no history at all.
+# AGENTA_SESSIONS_RECONSTRUCT=false
+# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=false
+# AGENTA_RECORDS_DURABLE=false
+# Smart truncation preserves the structure of a record whose body exceeds the API size
+# cap (higher-fidelity reconstruction). Still opt-in, default off.
 # AGENTA_RECORDS_SMART_TRUNCATION=true
 
 # ================================================================== #

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -412,9 +412,10 @@ services:
             AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM: ${AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM:-}
             AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES: ${AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES:-}
             # This service has no env_file (see above), so the session flags must be listed
-            # here or they can never be set. AGENTA_SESSIONS_RECONSTRUCT must be enabled
-            # together with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that
-            # carries only its last message loses the conversation.
+            # here or they can never be set. Both default ON: absent or empty means on, and
+            # only the literal "false" disables. Disable AGENTA_SESSIONS_RECONSTRUCT together
+            # with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that carries
+            # only its last message loses the conversation.
             AGENTA_SESSIONS_RECONSTRUCT: ${AGENTA_SESSIONS_RECONSTRUCT:-}
             AGENTA_RECORDS_DURABLE: ${AGENTA_RECORDS_DURABLE:-}
         # === STORAGE ============================================== #

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -315,9 +315,10 @@ services:
             AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM: ${AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM:-}
             AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES: ${AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES:-}
             # This service has no env_file (see above), so the session flags must be listed
-            # here or they can never be set. AGENTA_SESSIONS_RECONSTRUCT must be enabled
-            # together with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that
-            # carries only its last message loses the conversation.
+            # here or they can never be set. Both default ON: absent or empty means on, and
+            # only the literal "false" disables. Disable AGENTA_SESSIONS_RECONSTRUCT together
+            # with the web NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY, or a turn that carries
+            # only its last message loses the conversation.
             AGENTA_SESSIONS_RECONSTRUCT: ${AGENTA_SESSIONS_RECONSTRUCT:-}
             AGENTA_RECORDS_DURABLE: ${AGENTA_RECORDS_DURABLE:-}
         # === SUBSCRIPTION MOUNTS (opt-in) ========================= #

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -111,16 +111,17 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # 5 min per tool call.
 # AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
 
-# --- Session history: last-message-only turns (all four default off) ---
+# --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns
 # from the durable session record log, which keeps requests and traces small on a long
-# conversation. The first two must be flipped together: with the web flag on and the runner
-# flag off, a turn arrives with no history at all.
-# AGENTA_SESSIONS_RECONSTRUCT=true
-# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=true
-# Records become the only copy of the conversation, so make writing them durable and keep
-# the structure of a record whose body exceeds the API size cap.
-# AGENTA_RECORDS_DURABLE=true
+# conversation. The three flags below default ON (absent or empty means on); set the
+# literal "false" to disable. Disable the first two together: with the web flag on and
+# the runner flag off, a turn arrives with no history at all.
+# AGENTA_SESSIONS_RECONSTRUCT=false
+# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=false
+# AGENTA_RECORDS_DURABLE=false
+# Smart truncation preserves the structure of a record whose body exceeds the API size
+# cap (higher-fidelity reconstruction). Still opt-in, default off.
 # AGENTA_RECORDS_SMART_TRUNCATION=true
 
 # ================================================================== #

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -113,16 +113,17 @@ AGENTA_RUNNER_TOKEN=replace-me
 # 5 min per tool call.
 # AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
 
-# --- Session history: last-message-only turns (all four default off) ---
+# --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns
 # from the durable session record log, which keeps requests and traces small on a long
-# conversation. The first two must be flipped together: with the web flag on and the runner
-# flag off, a turn arrives with no history at all.
-# AGENTA_SESSIONS_RECONSTRUCT=true
-# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=true
-# Records become the only copy of the conversation, so make writing them durable and keep
-# the structure of a record whose body exceeds the API size cap.
-# AGENTA_RECORDS_DURABLE=true
+# conversation. The three flags below default ON (absent or empty means on); set the
+# literal "false" to disable. Disable the first two together: with the web flag on and
+# the runner flag off, a turn arrives with no history at all.
+# AGENTA_SESSIONS_RECONSTRUCT=false
+# NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=false
+# AGENTA_RECORDS_DURABLE=false
+# Smart truncation preserves the structure of a record whose body exceeds the API size
+# cap (higher-fidelity reconstruction). Still opt-in, default off.
 # AGENTA_RECORDS_SMART_TRUNCATION=true
 
 # ================================================================== #

--- a/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
+++ b/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
@@ -2,9 +2,9 @@
  * Seam that lets the runner rebuild prior conversation from the durable record log instead of
  * trusting a full inbound history — the server side of "client sends only the last message".
  *
- * Flag-gated (`AGENTA_SESSIONS_RECONSTRUCT`) and a strict no-op until BOTH the flag is on AND the
- * client actually sent a minimal history (`carriesMinimalHistory`). When it does not apply, the
- * inbound history is left untouched.
+ * Flag-gated (`AGENTA_SESSIONS_RECONSTRUCT`, ON unless set to the literal "false") and a strict
+ * no-op until BOTH the flag is on AND the client actually sent a minimal history
+ * (`carriesMinimalHistory`). When it does not apply, the inbound history is left untouched.
  *
  * When it DOES apply it is no longer best-effort, because the client kept no copy of the
  * conversation: an unreadable log, or one known to have dropped a record, fails the turn rather
@@ -22,9 +22,11 @@ import { recordsIncomplete } from "../../sessions/persist.ts";
 import { reconstructMessages } from "../../sessions/reconstruct.ts";
 import { carriesMinimalHistory } from "./session-identity.ts";
 
+// ON unless the literal "false"; absent AND empty both mean on (compose passes `${VAR:-}`,
+// which sets an empty string when the shell has no value).
 function reconstructEnabled(): boolean {
   return (
-    String(process.env.AGENTA_SESSIONS_RECONSTRUCT ?? "").toLowerCase() === "true"
+    String(process.env.AGENTA_SESSIONS_RECONSTRUCT ?? "").trim().toLowerCase() !== "false"
   );
 }
 

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -150,11 +150,11 @@ export async function runTurn(
   });
 
   try {
-    // Server-side history reconstruction (flag-gated, no-op by default): when the client sent a
-    // minimal history, rebuild prior turns from the durable record log so a cold turn still has
-    // full context. Runs before the current user turn is persisted, so records hold only prior
-    // turns. Reassigns `request` so every downstream reader (turnText, priorMessages, responder,
-    // otel) sees the same reconstructed history.
+    // Server-side history reconstruction (on by default; AGENTA_SESSIONS_RECONSTRUCT=false
+    // disables): when the client sent a minimal history, rebuild prior turns from the durable
+    // record log so a cold turn still has full context. Runs before the current user turn is
+    // persisted, so records hold only prior turns. Reassigns `request` so every downstream
+    // reader (turnText, priorMessages, responder, otel) sees the same reconstructed history.
     const reconstructed = await reconstructHistoryIfNeeded(
       request,
       sessionId,

--- a/services/runner/src/sessions/persist.ts
+++ b/services/runner/src/sessions/persist.ts
@@ -14,10 +14,11 @@
  *  - The run is never blocked on persistence mid-stream (chain is fire-and-forget).
  *  - The run DOES drain before teardown so the last event is not lost to the race.
  *  - A persist failure is logged and swallowed; the SDK's in-memory replay store is the
- *    backstop. Three retries with linear backoff before the event is dropped. With
- *    `AGENTA_RECORDS_DURABLE=true` the retry is stronger (more attempts, exponential backoff)
- *    and a drop is COUNTED per session (see `takePersistFailures`), so the turn-end drain can
- *    tell whether the durable history is complete enough to reconstruct model context from.
+ *    backstop. By default (durable mode, on unless `AGENTA_RECORDS_DURABLE=false`) the retry
+ *    is strong (more attempts, exponential backoff) and a drop is COUNTED per session (see
+ *    `takePersistFailures`), so the turn-end drain can tell whether the durable history is
+ *    complete enough to reconstruct model context from. With the flag set to "false", three
+ *    retries with linear backoff before the event is dropped, uncounted (legacy path).
  *  - `record_source` marks who authored the record: "agent" for engine-emitted events,
  *    "user" for the inbound user turn persisted at run start.
  */
@@ -39,10 +40,12 @@ const DURABLE_INGEST_MAX_RETRIES = 6;
 // stops being a tuning knob and becomes a hung turn.
 const DURABLE_INGEST_MAX_RETRIES_CAP = 12;
 
-/** Durable-records upgrades (stronger retry + drop counting) are opt-in and read at call time
- * so the flag can be toggled per test. Off → the fire-and-forget legacy path, unchanged. */
+/** Durable-records upgrades (stronger retry + drop counting) are ON unless the flag is the
+ * literal "false"; read at call time so the flag can be toggled per test. Absent AND empty both
+ * mean on — the compose files pass the var through as `${AGENTA_RECORDS_DURABLE:-}`, which sets
+ * an empty string when unset. "false" → the fire-and-forget legacy path, unchanged. */
 function durableRecordsEnabled(): boolean {
-  return String(process.env.AGENTA_RECORDS_DURABLE ?? "").toLowerCase() === "true";
+  return String(process.env.AGENTA_RECORDS_DURABLE ?? "").trim().toLowerCase() !== "false";
 }
 
 /** Attempts before a durable-mode drop; env-overridable for ops tuning (and fast tests). */

--- a/services/runner/tests/setup/hermetic-env.ts
+++ b/services/runner/tests/setup/hermetic-env.ts
@@ -52,11 +52,18 @@ const SCRUBBED = [
 
 for (const name of SCRUBBED) delete process.env[name];
 
+// Server-side history reconstruction defaults ON, so any single-user-message turn with a
+// session id would reach for a live records endpoint mid-test. Engine suites are not
+// reconstruction tests: pin it off here. session-reconstruct-history.test.ts deletes the pin
+// in its own beforeEach to exercise the real default.
+process.env.AGENTA_SESSIONS_RECONSTRUCT = "false";
+
 // Re-scrub per test: a prior test may have set one and not restored it. Also drop the memoized
 // runner config so the next `loadRunnerConfig()` re-parses the scrubbed environment.
 beforeEach(() => {
   for (const name of SCRUBBED) delete process.env[name];
   // Restore the stub bundle so a prior test's override (to force a failed install) cannot leak.
   process.env.SANDBOX_AGENT_EXTENSION_BUNDLE = STUB_EXTENSION_BUNDLE;
+  process.env.AGENTA_SESSIONS_RECONSTRUCT = "false";
   resetRunnerConfigCache();
 });

--- a/services/runner/tests/unit/session-persist.test.ts
+++ b/services/runner/tests/unit/session-persist.test.ts
@@ -468,7 +468,8 @@ describe("buildPersistingEmitter API contract", () => {
 });
 
 describe("durable records (AGENTA_RECORDS_DURABLE)", () => {
-  it("legacy (flag off): a permanent failure is dropped and NOT counted", async () => {
+  it('legacy (explicitly "false"): a permanent failure is dropped and NOT counted', async () => {
+    vi.stubEnv("AGENTA_RECORDS_DURABLE", "false");
     fetchFailCount = 99; // never succeeds
     const { emit, flush } = buildPersistingEmitter("sess-legacy", () => "t");
     emit({ type: "message", text: "x" });
@@ -492,6 +493,29 @@ describe("durable records (AGENTA_RECORDS_DURABLE)", () => {
     assert.equal(takePersistFailures("sess-durable"), 2);
     // take clears the count.
     assert.equal(takePersistFailures("sess-durable"), 0);
+  });
+
+  it("durable is the default: an absent flag counts the drop", async () => {
+    vi.stubEnv("AGENTA_RECORDS_INGEST_MAX_RETRIES", "2"); // keep the test fast
+    fetchFailCount = 99;
+    const { emit } = buildPersistingEmitter("sess-default", () => "t");
+    emit({ type: "message", text: "x" });
+    await drainPersist("sess-default");
+
+    assert.equal(postedBodies.length, 0);
+    assert.equal(takePersistFailures("sess-default"), 1);
+  });
+
+  it('an empty flag (compose "${VAR:-}" passthrough) still means durable', async () => {
+    vi.stubEnv("AGENTA_RECORDS_DURABLE", "");
+    vi.stubEnv("AGENTA_RECORDS_INGEST_MAX_RETRIES", "2");
+    fetchFailCount = 99;
+    const { emit } = buildPersistingEmitter("sess-empty", () => "t");
+    emit({ type: "message", text: "x" });
+    await drainPersist("sess-empty");
+
+    assert.equal(postedBodies.length, 0);
+    assert.equal(takePersistFailures("sess-empty"), 1);
   });
 
   it("durable: the turn-end flush consumes the drop count (warns + clears)", async () => {

--- a/services/runner/tests/unit/session-reconstruct-history.test.ts
+++ b/services/runner/tests/unit/session-reconstruct-history.test.ts
@@ -1,7 +1,8 @@
 /**
  * Unit tests for the reconstruction seam (reconstruct-history.ts).
  *
- * The safety contract: a strict no-op until BOTH the flag is on AND the client sent a minimal
+ * The safety contract: the flag is ON by default (only the literal "false" disables it), and
+ * reconstruction is a strict no-op until BOTH the flag is on AND the client sent a minimal
  * history. Anything else leaves the inbound history untouched (returns null).
  */
 import { describe, it, beforeEach, vi } from "vitest";
@@ -30,14 +31,41 @@ beforeEach(() => {
   recordsToReturn = [];
   fetchShouldFail = false;
   vi.unstubAllEnvs();
+  // The hermetic setup pins the flag off for the engine suites; this file tests the real
+  // default, so drop the pin (absent = on).
+  delete process.env.AGENTA_SESSIONS_RECONSTRUCT;
 });
 
 describe("reconstructHistoryIfNeeded", () => {
-  it("no-op when the flag is off (never even queries)", async () => {
+  it('no-op when the flag is explicitly "false" (never even queries)', async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "false");
     const req = { messages: [userTurn] } as never;
     const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
     assert.equal(out, null);
     assert.equal(fetchCalls, 0);
+  });
+
+  it("on by default: an absent flag reconstructs a minimal history", async () => {
+    recordsToReturn = [
+      { record_source: "user", attributes: { type: "message", text: "q1" } },
+      { record_source: "agent", attributes: { type: "message", text: "a1" } },
+    ];
+    const req = { messages: [userTurn], harness: "pi" } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.notEqual(out, null);
+    assert.equal(fetchCalls, 1);
+  });
+
+  it('an empty flag (compose "${VAR:-}" passthrough) still means on', async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "");
+    recordsToReturn = [
+      { record_source: "user", attributes: { type: "message", text: "q1" } },
+      { record_source: "agent", attributes: { type: "message", text: "a1" } },
+    ];
+    const req = { messages: [userTurn], harness: "pi" } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.notEqual(out, null);
+    assert.equal(fetchCalls, 1);
   });
 
   it("no-op when the client already sent a full history", async () => {

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -401,7 +401,7 @@ export async function buildAgentRequest(
     // Strip answer-less assistant turns so a "no response" turn can't poison the next request.
     const history = messages.filter(hasAnswer)
 
-    // Last-message-only (flag-gated; MUST pair with the backend's AGENTA_SESSIONS_RECONSTRUCT).
+    // Last-message-only (on by default; disable ONLY together with the backend's AGENTA_SESSIONS_RECONSTRUCT).
     // On a fresh user turn, send just the trailing user message and let the runner rebuild prior
     // turns from the durable record log — smaller request + trace payloads. A HITL resume, whose
     // trailing turn carries the settled answer (not a user turn), keeps the full history so the

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -183,8 +183,8 @@ describe("buildAgentRequest", () => {
         const u2 = {role: "user", parts: [{type: "text", text: "q2"}]}
 
         // Runtime override path (getEnv checks globalThis.__env before the build-time snapshot).
-        const enableFlag = () => {
-            ;(globalThis as any).__env = {NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY: "true"}
+        const setFlag = (value: string) => {
+            ;(globalThis as any).__env = {NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY: value}
         }
         afterEach(() => {
             delete (globalThis as any).__env
@@ -196,25 +196,32 @@ describe("buildAgentRequest", () => {
             return (req!.requestBody.data as any).inputs.messages
         }
 
-        it("sends only the trailing user message when enabled", async () => {
-            enableFlag()
+        it("sends only the trailing user message by default (flag absent)", async () => {
             expect(await outMessages([u1, a1, u2])).toEqual([u2])
         })
 
-        it("sends the full history by default (flag off)", async () => {
-            const out = await outMessages([u1, a1, u2])
-            expect(out).toEqual([u1, a1, u2])
+        it("sends only the trailing user message when explicitly enabled", async () => {
+            setFlag("true")
+            expect(await outMessages([u1, a1, u2])).toEqual([u2])
         })
 
-        it("keeps the full history on a resume (trailing assistant) even when enabled", async () => {
-            enableFlag()
+        it('an empty value (compose "${VAR:-}" passthrough) keeps the default on', async () => {
+            setFlag("")
+            expect(await outMessages([u1, a1, u2])).toEqual([u2])
+        })
+
+        it('sends the full history when explicitly disabled ("false")', async () => {
+            setFlag("false")
+            expect(await outMessages([u1, a1, u2])).toEqual([u1, a1, u2])
+        })
+
+        it("keeps the full history on a resume (trailing assistant) even when on", async () => {
             const out = await outMessages([u1, a1])
             expect(out.length).toBeGreaterThan(1)
             expect(out[out.length - 1].role).toBe("assistant")
         })
 
         it("sends the full history when there is no session id", async () => {
-            enableFlag()
             expect(await outMessages([u1, a1, u2], "")).toEqual([u1, a1, u2])
         })
     })

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -47,6 +47,7 @@ import {
     workflowBuildKitEnabledAtomFamily,
     workflowMolecule,
 } from "@agenta/entities/workflow"
+import {processEnv} from "@agenta/shared/api"
 import {projectIdAtom} from "@agenta/shared/state"
 
 import {
@@ -60,6 +61,10 @@ import {executionHeadersAtom} from "../../src/state/execution/webWorkerIntegrati
 const REAL_APP = "11111111-1111-4111-8111-111111111111"
 const REAL_VARIANT = "22222222-2222-4222-8222-222222222222"
 const REAL_REV = "33333333-3333-4333-8333-333333333333"
+
+type TestRuntimeGlobal = typeof globalThis & {
+    __env?: Record<string, string>
+}
 
 const set = (store: any, sel: any, id: string, value: unknown) =>
     store.set(sel(id) as PrimitiveAtom<unknown>, value)
@@ -184,10 +189,12 @@ describe("buildAgentRequest", () => {
 
         // Runtime override path (getEnv checks globalThis.__env before the build-time snapshot).
         const setFlag = (value: string) => {
-            ;(globalThis as any).__env = {NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY: value}
+            ;(globalThis as TestRuntimeGlobal).__env = {
+                NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY: value,
+            }
         }
         afterEach(() => {
-            delete (globalThis as any).__env
+            delete (globalThis as TestRuntimeGlobal).__env
         })
 
         const outMessages = async (msgs: unknown[], sessionId = "s1") => {
@@ -206,12 +213,23 @@ describe("buildAgentRequest", () => {
         })
 
         it('an empty value (compose "${VAR:-}" passthrough) keeps the default on', async () => {
+            const buildTimeValue = processEnv.NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY
+            processEnv.NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY = "false"
             setFlag("")
-            expect(await outMessages([u1, a1, u2])).toEqual([u2])
+            try {
+                expect(await outMessages([u1, a1, u2])).toEqual([u2])
+            } finally {
+                processEnv.NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY = buildTimeValue
+            }
         })
 
         it('sends the full history when explicitly disabled ("false")', async () => {
             setFlag("false")
+            expect(await outMessages([u1, a1, u2])).toEqual([u1, a1, u2])
+        })
+
+        it("treats trimmed, case-insensitive false as disabled", async () => {
+            setFlag(" FALSE ")
             expect(await outMessages([u1, a1, u2])).toEqual([u1, a1, u2])
         })
 

--- a/web/packages/agenta-shared/src/api/env.ts
+++ b/web/packages/agenta-shared/src/api/env.ts
@@ -87,13 +87,14 @@ export const isSandboxLocalEnabled = (): boolean => {
 
 /**
  * Send only the trailing user message per agent turn and let the runner rebuild prior history
- * from the durable record log. Default OFF — enable ONLY where the backend runs with
- * `AGENTA_SESSIONS_RECONSTRUCT=true` (they must be flipped together), or a cold turn loses its
+ * from the durable record log. ON unless set to the literal "false"; absent AND empty both mean
+ * on (compose passes `${VAR:-}`, which sets an empty string when unset). Disable it ONLY
+ * together with the backend `AGENTA_SESSIONS_RECONSTRUCT=false`, or a cold turn loses its
  * context.
  */
 export const isSessionsLastMessageOnlyEnabled = (): boolean => {
-    const raw = getEnv("NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY") || "false"
-    return SANDBOX_LOCAL_TRUTHY.has(raw.trim().toLowerCase())
+    const raw = getEnv("NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY")
+    return raw.trim().toLowerCase() !== "false"
 }
 
 /** The sandbox providers this deployment enabled, normalized to lowercase ids. Unset/empty

--- a/web/packages/agenta-shared/src/api/env.ts
+++ b/web/packages/agenta-shared/src/api/env.ts
@@ -49,7 +49,7 @@ export const processEnv = {
 export const getEnv = (envKey: string): string => {
     // Check for runtime config first (browser/worker)
     const runtimeEnv = (globalThis as RuntimeGlobal).__env
-    if (runtimeEnv && Object.keys(runtimeEnv).length > 0 && runtimeEnv[envKey]) {
+    if (runtimeEnv && Object.prototype.hasOwnProperty.call(runtimeEnv, envKey)) {
         return runtimeEnv[envKey]
     }
 


### PR DESCRIPTION
## Context

The session-storage rework shipped dark in v0.106.1: durable record persistence in the runner (`AGENTA_RECORDS_DURABLE`), history reconstruction from records (`AGENTA_SESSIONS_RECONSTRUCT`), and last-message-only sends from the web app (`NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY`). All three defaulted to off and only the literal `"true"` enabled them. The feature was QA'd on a dedicated stack with the flags on and the findings from that pass are fixed and merged, so the flags should now be the default path.

## Change

All three read sites flip to **on unless explicitly disabled**: the predicate is now `value !== "false"` (case-insensitive, trimmed) instead of `value === "true"`.

Absent AND empty both mean on, deliberately. The compose files pass the variables through as `${VAR:-}`, which materializes an **empty string** when the variable is unset in the shell, and a compose `environment:` entry overrides `env_file`. A changed fallback string alone would therefore have left every compose deployment off. Only the literal `"false"` disables.

Before: unset, empty, or anything but `"true"` → feature off.
After: unset, empty, or anything but `"false"` → feature on. Set the variable to `false` to disable.

Also in this commit:
- Stale "off by default / flag-gated no-op" comments corrected at the read sites and in the compose files; the four `env.*.example` files now document the flags as default-on with `=false` to disable.
- `services/runner/tests/setup/hermetic-env.ts` pins `AGENTA_SESSIONS_RECONSTRUCT=false`: with the new default, 75 engine unit tests would otherwise reach for a live records endpoint. The reconstruct suite deletes the pin to test the real default.
- Unit tests updated and extended: each flag now has explicit absent=on, empty=on, and `"false"`=off cases.

`AGENTA_RECORDS_SMART_TRUNCATION` (a fourth, API-side flag) is out of scope and stays opt-in.

## Tests

- Runner: 1292/1292 unit tests green (82 files) + typecheck clean.
- `@agenta/playground`: 211/211 green. `@agenta/shared`: 294/294 green.
- `pnpm lint-fix` clean, reformatted nothing.

## What to QA

- A fresh EE dev deploy with none of the three variables set: sessions persist durably (runner logs show `[sessions/persist] ingest OK`), a resumed conversation reconstructs from records, and the web app sends only the trailing message on a turn.
- Set all three to `false` and recreate runner + web: behavior returns to the pre-rework path (full history sent, no durable ingest).
- Regression: the runner unit suite stays hermetic (no network calls from engine tests).


https://claude.ai/code/session_01HyTAyASedjizTRN7sTbw4W