### PR TITLE
[fix] Sharpen the pixelated hero word and glow the announcement badge

### DIFF
--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -6,7 +6,9 @@ const GET_STARTED = "https://cloud.agenta.ai/";
 const READ_DOCS = "https://docs.agenta.ai/";
 
 // heroPre + [chip] + heroPost form the headline. The chip is the single
-// PP Mondwest highlighted word (yellow), per the type-role rules.
+// highlighted word (yellow), set in GT Alpina *italic* — the headline's own
+// serif, slanted — so it reads as the emphasized word (editorial/premium) while
+// staying crisp, instead of blending in like an upright mono word did.
 const heroPre = "The open-source workspace for your ";
 const heroChip = "agents";
 const heroPost = ".";
@@ -26,7 +28,7 @@ const SHOW_HERO_VIDEO = false;
     <div style="display:flex;flex-direction:column;align-items:center;gap:28px;">
       <a
         href="/blog/introducing-agenta-2-0"
-        style="display:inline-flex;align-items:center;gap:6px;height:22px;padding:0 12px;border-radius:999px;background:rgba(255,255,255,0.06);box-shadow:0 0 0 1px rgba(255,255,255,0.14);font:var(--text-caption);letter-spacing:0.03em;color:rgba(255,255,255,0.8);text-decoration:none;"
+        style="display:inline-flex;align-items:center;gap:6px;height:22px;padding:0 12px;border-radius:999px;background:rgba(255,255,255,0.06);box-shadow:0 0 0 1px rgba(255,255,255,0.14), 0 0 14px -2px rgba(242,242,92,0.35);font:var(--text-caption);letter-spacing:0.03em;color:rgba(255,255,255,0.8);text-decoration:none;animation:ag-badge-aura 5s ease-in-out infinite;"
         >Agenta 2.0 — read the announcement →</a
       >
       <h1
@@ -34,7 +36,7 @@ const SHOW_HERO_VIDEO = false;
         style="margin:0;font:var(--text-display-xl);color:#F7F6F4;max-width:920px;text-wrap:pretty;"
       >
         {heroPre}<span
-          style="display:inline-block;padding:0.02em 0.1em 0.08em;border-radius:10px;background:rgba(255,255,255,0.07);box-shadow:inset 0 1px 0.4px rgba(255,255,255,0.25), 0 0 0 1px rgba(255,255,255,0.06);font-family:var(--font-bitmap,'PP Mondwest',monospace);font-weight:400;line-height:1.06;color:var(--yellow-400);vertical-align:baseline;"
+          style="display:inline-block;padding:0.02em 0.18em 0.08em 0.12em;border-radius:10px;background:rgba(255,255,255,0.07);box-shadow:inset 0 1px 0.4px rgba(255,255,255,0.25), 0 0 0 1px rgba(255,255,255,0.06);font-family:var(--font-display);font-style:italic;font-weight:400;line-height:1.06;color:var(--yellow-400);vertical-align:baseline;"
           >{heroChip}</span
         ><span style="margin-left:-0.02em;">{heroPost}</span>
       </h1>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -52,6 +52,24 @@ a {
     transform: translateX(0);
   }
 }
+/* Announcement badge "aura": the outer glow breathes between the two brand
+   yellows (yellow-400 #f2f25c → yellow-500 #e7e712) for a premium, non-neon
+   shimmer. The 0%/100% frame equals the badge's resting inline box-shadow, so the
+   loop is seamless and reduced-motion users (animation neutralized below) keep
+   that subtle static glow. */
+@keyframes ag-badge-aura {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.14),
+      0 0 14px -2px rgba(242, 242, 92, 0.35);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px rgba(242, 242, 92, 0.35),
+      0 0 26px 0 rgba(231, 231, 18, 0.55);
+  }
+}
 
 /* ── reduced motion: honor the OS setting (WCAG 2.3.3) ────────
    Neutralizes the looping play-button pulse, the marquees, and one-shot


### PR DESCRIPTION
## Context
The highlighted word "agents" in the hero headline was set in PP Mondwest, a
bitmap/pixel font, so it rendered blocky and low-resolution next to the crisp
GT Alpina headline. It read as a rendering bug rather than a style choice.
Separately, the "Agenta 2.0" announcement badge was flat, and we wanted the hero
to feel a touch more premium.

## Changes
Two hero adjustments.

The word "agents" now uses GT Alpina italic, the headline's own serif face,
slanted. The brand yellow and the chip box already mark it as the special word,
so the italic sets it apart quietly and stays sharp at display size instead of
switching to a foreign pixel or mono face.

Before: `font-family: var(--font-bitmap, 'PP Mondwest', monospace)` (pixel/bitmap)
After:  `font-family: var(--font-display); font-style: italic` (GT Alpina italic)

The announcement badge gets a slow "aura" glow. Its outer box-shadow breathes
between the two brand yellows (yellow-400 #f2f25c to yellow-500 #e7e712) on a 5s
loop. The `ag-badge-aura` keyframes live in `global.css` next to the site's other
animations, and the badge references them with an inline `animation`, matching how
`HeroVideo.astro` wires `ag-pulse`. The resting glow is baked into the badge's
inline box-shadow and the 0%/100% keyframe equals it, so the loop is seamless.

## Tests / notes
- No new assets and no JS. The GT Alpina italic faces are already loaded.
- Reduced motion: the existing global `prefers-reduced-motion` rule neutralizes
  the animation. Because the resting glow is inline, those visitors still see a
  subtle static brand glow rather than nothing.
- Not yet checked in a running browser. Worth confirming the loop reads smooth
  and the italic sits well in the chip before merge.

## What to QA
- Open the marketing site home (`cd website && pnpm dev`, http://localhost:4321).
  The headline word "agents" is a crisp yellow italic serif, not pixelated.
- The "Agenta 2.0 — read the announcement" badge shows a soft yellow glow that
  gently breathes.
- Regression: turn on the OS "reduce motion" setting and reload. The badge glow
  holds steady with no animation, and the rest of the hero is unchanged.



## Preview 

<img width="2180" height="1090" alt="image" src="https://github.com/user-attachments/assets/e8c5cb63-bc07-4391-9a14-fd92f27be65d" />
