### PR TITLE
[chore] Split AgentConversation into hooks and views

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -9,7 +9,7 @@ import {
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {UploadSimple} from "@phosphor-icons/react"
-import {type UIMessage} from "ai"
+import {type FileUIPart, type UIMessage} from "ai"
 import {Modal} from "antd"
 import {useAtomValue, useSetAtom, useStore} from "jotai"
 
@@ -410,7 +410,23 @@ const AgentConversation = ({
         ]
         if (!trimmed && fileObjs.length === 0) return
         if (!attachmentsSettled) return
-        const fileParts = fileObjs.length ? await filesToParts(fileObjs) : undefined
+        let fileParts: FileUIPart[] | undefined
+        if (fileObjs.length) {
+            const {parts, unreadable} = await filesToParts(fileObjs)
+            // Hold the send rather than quietly dropping bytes the user staged, and say which file
+            // failed through the same inline channel the other attachment refusals use.
+            if (unreadable.length) {
+                attachments.setRejections(
+                    unreadable.map((f) => ({
+                        name: f.name,
+                        reason: "couldn't be read — remove it and attach it again",
+                    })),
+                )
+                attachments.setAttachmentsOpen(true)
+                return
+            }
+            fileParts = parts
+        }
         // Glide to the bottom; the min-h-full active turn makes that show the new question at the top
         // with the answer streaming below. Park during the glide, follow again on settle. Clear any
         // prior "stopped" marker — it's resolved by asking again.

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -149,6 +149,7 @@ const AgentConversation = ({
         markLiveGate,
         resumeOrphaned,
         isSeen,
+        runningElsewhere,
     } = useAgentChatSession({entityId, sessionId, initialMessages, intent: scrollIntent})
 
     // Turn Inspector: open state, the focused turn, and the assistant → turn-number mapping.
@@ -636,6 +637,7 @@ const AgentConversation = ({
                                 entityId={entityId}
                                 messages={messages}
                                 busy={busy}
+                                runningElsewhere={runningElsewhere}
                                 hitlPending={hitlPending}
                                 queue={{queued, removeQueued, clearQueue}}
                                 modelKey={modelKey}

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -1,60 +1,17 @@
-import {
-    lazy,
-    Suspense,
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useMemo,
-    useRef,
-    useState,
-    type MutableRefObject,
-} from "react"
+import {useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject} from "react"
 
-import {
-    commandSessionStream,
-    killSession,
-    revalidateSessionMountsAtom,
-    revalidateSessionRecordsAtom,
-} from "@agenta/entities/session"
-import {markTraceAsFresh} from "@agenta/entities/trace"
 import {
     contextWindowForModel,
     harnessCapabilitiesAtomFamily,
     modalitiesForModel,
-    invalidateAgentCommittedRevisionCache,
-    workflowBuildKitOverlayReadyAtomFamily,
     workflowMolecule,
 } from "@agenta/entities/workflow"
-import {
-    agentShouldResumeAfterApproval,
-    buildAgentRequest,
-    buildTurnCapture,
-    playgroundController,
-    type LiveAgentInteraction,
-} from "@agenta/playground"
-import {agentSelfCommitSignalAtom, simulatedAgentRunAtomFamily} from "@agenta/shared/state"
-import {generateId} from "@agenta/shared/utils"
-import {HeightCollapse} from "@agenta/ui"
+import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
-import {useChat} from "@ai-sdk/react"
-import {Bubble} from "@ant-design/x"
-import {
-    ArrowDown,
-    ArrowRight,
-    Code,
-    Hourglass,
-    Paperclip,
-    TreeStructure,
-    UploadSimple,
-} from "@phosphor-icons/react"
-import {useQueryClient} from "@tanstack/react-query"
+import {UploadSimple} from "@phosphor-icons/react"
 import {type UIMessage} from "ai"
-import {App, Button, Modal, Tag, Tooltip} from "antd"
-import type {UploadFile} from "antd"
-import {useAtom, useAtomValue, useSetAtom, useStore} from "jotai"
-import {AnimatePresence, motion} from "motion/react"
-import {useRouter} from "next/router"
-import {Virtuoso, type Components, type VirtuosoHandle} from "react-virtuoso"
+import {Modal} from "antd"
+import {useAtomValue, useSetAtom, useStore} from "jotai"
 
 import {ContextRail} from "@/oss/components/Drives/ContextRail"
 import {DriveFileLinkProvider} from "@/oss/components/Drives/DriveFileLinkProvider"
@@ -64,137 +21,50 @@ import {
     filesDrawerOpenAtomFamily,
     filesDrawerStagedAtomFamily,
 } from "@/oss/components/Drives/SessionFilesDrawer"
-import {
-    IDE_INSTALL_COMMAND,
-    TEMPLATE_STRIP_MODE,
-} from "@/oss/components/pages/agent-home/assets/constants"
-import {
-    captureFirstAgentIntent,
-    classifyAgentIntent,
-    truncateForCapture,
-} from "@/oss/components/pages/agent-home/assets/onboardingAnalytics"
-import {type AgentTemplate} from "@/oss/components/pages/agent-home/assets/templates"
-import OnboardingBrowseTemplates from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingBrowseTemplates"
-import {useOptionalOnboardingContext} from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingContext"
-import Reveal from "@/oss/components/pages/agent-home/PlaygroundOnboarding/Reveal"
+import {TEMPLATE_STRIP_MODE} from "@/oss/components/pages/agent-home/assets/constants"
 import {openTraceDrawerAtom} from "@/oss/components/SharedDrawers/TraceDrawer/store/traceDrawerStore"
-import TemplateStrip from "@/oss/components/TemplateStrip"
-import {buildCodingAgentClipboard} from "@/oss/components/TemplateStrip/assets/codingAgentClipboard"
 import {STRIP_COPY} from "@/oss/components/TemplateStrip/assets/constants"
-import AgentIntentActions from "@/oss/components/TemplateStrip/components/AgentIntentActions"
 import CopiedToast from "@/oss/components/TemplateStrip/components/CopiedToast"
-import {useTemplateProvenance} from "@/oss/components/TemplateStrip/hooks/useTemplateProvenance"
-import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
-import {projectIdAtom} from "@/oss/state/project"
-import {playgroundInspectorEnabledAtom} from "@/oss/state/settings/featureFlags"
 
-import {AgentChatTransport} from "./assets/AgentChatTransport"
-import {
-    type AttachmentRejection,
-    DEFAULT_ATTACHMENT_LIMITS,
-    describeAccepted,
-    validateIncoming,
-} from "./assets/attachments"
-import {
-    doesAgentChatStopKillSession,
-    isAgentFileUploadsEnabled,
-    isAgentVoiceInputEnabled,
-} from "./assets/constants"
+import {describeAccepted} from "./assets/attachments"
+import {CONTENT_VISIBILITY_ENABLED} from "./assets/conversationLayout"
 import {filesToParts} from "./assets/files"
-import {loadSessionMessages} from "./assets/loadSession"
+import {isEmptyAssistantTurn, isVisiblePart} from "./assets/messageParts"
 import {messageText, sideEffectingToolsInRange} from "./assets/rewind"
-import {SESSION_SPRING} from "./assets/sessionMotion"
+import {ignoreStreamRejection} from "./assets/runError"
 import {getMessageTraceId} from "./assets/trace"
-import AgentChatEmptyState from "./components/AgentChatEmptyState"
-import AgentChatHistoryUnavailable from "./components/AgentChatHistoryUnavailable"
-import {ComposerSkeleton, TranscriptSkeleton} from "./components/AgentChatSkeleton"
-import AgentMessage from "./components/AgentMessage"
-import ApprovalDock, {getPendingApprovals} from "./components/ApprovalDock"
+import AgentComposerDock from "./components/AgentComposerDock"
+import AgentTranscript from "./components/AgentTranscript"
+import AgentTurn from "./components/AgentTurn"
+import {getPendingApprovals} from "./components/ApprovalDock"
 import AttachmentViewerDrawer from "./components/AttachmentViewerDrawer"
-import type {ClientToolOutputHandler} from "./components/clientTools"
-import ComposerAttachments from "./components/ComposerAttachments"
-import ConnectModelBanner from "./components/ConnectModelBanner"
-import ContextBudgetIndicator from "./components/ContextBudgetIndicator"
 import {Inspector} from "./components/Inspector/Inspector"
-import {invalidateSessionInspector} from "./components/Inspector/invalidate"
-import {
-    closeInspectorAtom,
-    inspectorTargetAtom,
-    openInspectorTurnAtom,
-} from "./components/Inspector/state"
-import InteractionDock, {getPendingConnectInteraction} from "./components/InteractionDock"
-import MicPermissionNotice from "./components/MicPermissionNotice"
-import QueuedMessages from "./components/QueuedMessages"
-import RecordingBar from "./components/RecordingBar"
-import RevealCollapse from "./components/RevealCollapse"
+import {getPendingConnectInteraction} from "./components/InteractionDock"
 import RightPanelSplit from "./components/RightPanel/RightPanelSplit"
-import VoiceInputButton from "./components/VoiceInputButton"
+import TranscriptPlaceholder from "./components/TranscriptPlaceholder"
 import {useAgentChatQueue, type QueuedMessage} from "./hooks/useAgentChatQueue"
+import {useAgentChatSession} from "./hooks/useAgentChatSession"
 import {useAgentModelKeyStatus} from "./hooks/useAgentModelKeyStatus"
-import {useAttachmentUploads} from "./hooks/useAttachmentUploads"
-import {useAudioRecorder} from "./hooks/useAudioRecorder"
-import {useFileActivityDetector} from "./hooks/useFileActivityDetector"
-import {expandedKeysForMessages, pruneExpandedAtom} from "./state/expandState"
-import {agentFirstRunSeedAtom} from "./state/firstRunSeed"
-import {chatPanelMaximizedAtom} from "./state/panelLayout"
+import {useComposerAttachments} from "./hooks/useComposerAttachments"
+import {useComposerDraft} from "./hooks/useComposerDraft"
+import {useFirstRunSeed} from "./hooks/useFirstRunSeed"
+import {useOnboardingChat} from "./hooks/useOnboardingChat"
+import {useScrollIntent} from "./hooks/useScrollIntent"
+import {useTranscriptScroll} from "./hooks/useTranscriptScroll"
+import {useTurnInspector} from "./hooks/useTurnInspector"
+import {useVirtuosoTranscript} from "./hooks/useVirtuosoTranscript"
+import {useVoiceComposer} from "./hooks/useVoiceComposer"
 import {useChatScopeKey} from "./state/scope"
-import {
-    attachmentsBySession,
-    clearSessionFresh,
-    composerDraftBySession,
-    isSessionFresh,
-    virtStateBySession,
-} from "./state/sessionEphemera"
+import {clearSessionFresh} from "./state/sessionEphemera"
 import {
     type SessionRunStatus,
     activeSessionIdAtomFamily,
     autoTitleSessionAtomFamily,
     bumpSessionActivityAtomFamily,
     firstUserText,
-    persistSessionMessagesAtom,
     sessionMessagesAtom,
     setSessionStatusAtom,
-    stampMessagesCreatedAtAtom,
 } from "./state/sessions"
-import {captureTurnRequestAtom} from "./state/turnCaptures"
-import {
-    agentChatItemEstimateAtom,
-    agentChatOverscanAtom,
-    agentChatVirtualizeAtom,
-    isAgentChatVirtualizationAvailable,
-} from "./state/virtualization"
-
-// The composer carries Lexical — the heaviest dependency of this chunk — out of the
-// conversation's synchronous mount; React.lazy (not next/dynamic) so the imperative handle
-// ref forwards. Its fallback is the same ComposerSkeleton the frame reserves for this slot.
-const RichChatInput = lazy(() =>
-    import("@agenta/ui/rich-chat-input").then((m) => ({default: m.RichChatInput})),
-)
-
-/** A stream error/abort is already surfaced via `useChat`'s `onError` + the in-chat `error`
- * alert; swallow the floating `sendMessage`/`regenerate` rejection so it doesn't bubble to the
- * Next.js dev Runtime Error overlay (F-033). */
-const ignoreStreamRejection = () => {}
-
-/** Height of the top-edge fade, in px. Shared by the CSS mask and the SC-1 pin so a pinned turn
- * lands BELOW the fade (otherwise the freshly-asked question renders partially faded). */
-const TOP_FADE_PX = 28
-/** Height of the bottom-edge fade, matching the top so content dissolves into the composer edge. */
-const BOTTOM_FADE_PX = 28
-/** Edge fades for the message scroll area: transparent at the very top, fully opaque by TOP_FADE_PX,
- * then fading back to transparent over the last BOTTOM_FADE_PX. Applied as a CSS mask so the content
- * itself fades (correct in any theme). */
-const EDGE_FADE_MASK = `linear-gradient(to bottom, transparent 0, #000 ${TOP_FADE_PX}px, #000 calc(100% - ${BOTTOM_FADE_PX}px), transparent 100%)`
-/** Centered reading column for the chat body. Caps line length / bubble width so a wide (maximized)
- * panel doesn't sprawl into oversized bubbles and over-spaced turns; freed side space is whitespace. */
-const CHAT_COLUMN = "mx-auto w-full max-w-[880px]"
-
-/** Single source of truth for the (currently DISABLED) content-visibility optimization. Disabled in
- * 5f0fa73d06 — it caused a scrollbar-shrink on first scroll-through — but the mechanism is kept so it
- * can be re-enabled with a fix. Gates BOTH the CSS class and the SC-3 intrinsic-size measurement, so
- * while off neither the styling nor the measurement runs. Typed `boolean` so the guards aren't
- * flagged as always-false. Under Virtuoso it must stay off regardless (it corrupts item measurement). */
-const CONTENT_VISIBILITY_ENABLED = false as boolean
 
 /**
  * One agent conversation for a single session tab. A `useChat` whose transport is fed by the
@@ -210,182 +80,6 @@ const CONTENT_VISIBILITY_ENABLED = false as boolean
  *  - DT5 a11y: the message log is an aria-live region; controls are keyboard-operable.
  */
 
-/** A part the transcript actually renders — non-empty text/reasoning, files, sources, tools. */
-const isVisiblePart = (p: UIMessage["parts"][number]): boolean =>
-    (p.type === "text" && Boolean((p as {text?: string}).text?.trim())) ||
-    (p.type === "reasoning" && Boolean((p as {text?: string}).text?.trim())) ||
-    p.type === "file" ||
-    p.type === "source-url" ||
-    p.type.startsWith("tool-") ||
-    p.type === "dynamic-tool"
-
-/** A settled assistant turn with no content at all — no answer, reasoning, tool, file, or
- * source part. Mirrors AgentMessage's `!hasContent`; used to collapse a run of "no response"
- * bubbles (e.g. repeated failed runs) down to the first one. */
-const isEmptyAssistantTurn = (m: UIMessage): boolean =>
-    m.role === "assistant" && !m.parts.some(isVisiblePart)
-
-interface ParsedRunError {
-    message: string
-    code?: number
-}
-
-/**
- * Best-effort human reason from a useChat stream error. The server may hand us a clean string
- * ("Agent run failed: …") or a JSON envelope (`{status:{code,message,…}}` / `{message}`) — pull
- * the message out of either and drop the stacktrace / docs-url noise so it reads cleanly inline.
- */
-const parseAgentRunError = (err: unknown): ParsedRunError => {
-    const raw =
-        err instanceof Error ? err.message : typeof err === "string" ? err : String(err ?? "")
-    const fallback = raw.trim() || "The agent run failed."
-    try {
-        const obj = JSON.parse(raw) as Record<string, unknown>
-        const status = (obj?.status && typeof obj.status === "object" ? obj.status : obj) as Record<
-            string,
-            unknown
-        >
-        const message =
-            typeof status?.message === "string"
-                ? status.message
-                : typeof obj?.message === "string"
-                  ? (obj.message as string)
-                  : null
-        if (message) {
-            return {message, code: typeof status?.code === "number" ? status.code : undefined}
-        }
-    } catch {
-        // raw isn't JSON — it's already the human message.
-    }
-    return {message: fallback}
-}
-
-/** The last real content element in the log (the last turn's last child). Used to measure the REAL
- * content bottom and ignore the min-h-full reserve that pads a streaming turn — so the jump pill and
- * stick-to-bottom track the latest message, not the bottom of the empty reserved space. */
-const lastContentEl = (el: HTMLElement): HTMLElement | null => {
-    const wrappers = el.querySelectorAll<HTMLElement>("[data-mid]")
-    const wrapper = wrappers[wrappers.length - 1]
-    if (!wrapper) return null
-    return (wrapper.lastElementChild as HTMLElement | null) ?? wrapper
-}
-
-/** True when the latest message content sits at or above the viewport bottom (i.e. fully visible). */
-const atLiveEdge = (el: HTMLElement): boolean => {
-    const last = lastContentEl(el)
-    if (!last) return true
-    return last.getBoundingClientRect().bottom - el.getBoundingClientRect().bottom < 24
-}
-
-/** SPIKE(virtuoso): context passed to the Virtuoso Header/Footer slots (top padding + active turn). */
-interface VirtCtx {
-    header: React.ReactNode
-    footer: React.ReactNode
-}
-
-/**
- * One message row. Carries `data-mid` (load-bearing for the pin / anchor / ResizeObserver, which all
- * query it). A message added after mount (`enter`) fades in — OPACITY ONLY, deliberately: opacity
- * doesn't change geometry, so it can't move the scroll position or trip the SC-3 ResizeObserver. A
- * restored thread's messages render with `enter=false` (no cascade). Honors reduced-motion: the
- * initial transparency and the transition are both `motion-safe`, so it's instant-visible otherwise.
- */
-const MessageRow = ({
-    mid,
-    enter,
-    children,
-    inspected = false,
-    onInspect,
-    offscreenSkip = false,
-}: {
-    mid: string
-    enter: boolean
-    children: React.ReactNode
-    /** This turn is the Turn Inspector's current target — tint it. */
-    inspected?: boolean
-    /** Set (assistant turns, inspector open) → click the row to re-focus the inspector on it. */
-    onInspect?: () => void
-    /** Settled row → `content-visibility:auto` so the browser skips its layout/paint while off-screen.
-     * `contain-intrinsic-size: auto` remembers the real height after first paint, so leaving the
-     * viewport causes no layout shift (heights here range ~85–1022px; no fixed estimate works). */
-    offscreenSkip?: boolean
-}) => {
-    const [shown, setShown] = useState(!enter)
-    // Reveal one frame after mount so the opacity transition plays. Deps are [] (NOT
-    // [enter]) on purpose: an `enter` flip when a sibling turn arrives must not cancel
-    // this rAF, or a just-sent message strands at opacity-0 for the whole agent run.
-    useEffect(() => {
-        const raf = requestAnimationFrame(() => setShown(true))
-        return () => cancelAnimationFrame(raf)
-    }, [])
-    // Click-to-refocus: only while the inspector is open, and never over an interactive control or
-    // an active text selection (so buttons, links, and copy-select still work).
-    const handleClick = onInspect
-        ? (e: React.MouseEvent) => {
-              if ((e.target as HTMLElement).closest("button, a, input, textarea, [role='button']"))
-                  return
-              if (!window.getSelection()?.isCollapsed) return
-              onInspect()
-          }
-        : undefined
-    // While the inspector is open, every turn is interactive: padded + rounded so the fill has
-    // breathing room, and cursor-pointer everywhere (clicking the selected turn just re-selects it).
-    // Hover is a light fill; the SELECTED turn is a held fill + a left accent bar, so "the one the
-    // inspector is showing" reads distinctly from a passing hover. Background + accent-bar both
-    // transition, so selection glides between turns instead of snapping. `box-border` is required
-    // (preflight off → content-box) so the padding doesn't overflow the 880px column.
-    const interactive = Boolean(onInspect)
-    // `shown || !enter` is a belt-and-suspenders: a settled row (id seen) is always visible.
-    return (
-        <div
-            data-mid={mid}
-            onClick={handleClick}
-            className={`${CHAT_COLUMN} flex flex-col gap-1 motion-safe:transition-[opacity,background-color,box-shadow] motion-safe:duration-200 motion-safe:ease-out ${
-                offscreenSkip ? "[content-visibility:auto] [contain-intrinsic-size:auto_240px]" : ""
-            } ${shown || !enter ? "opacity-100" : "motion-safe:opacity-0"} ${
-                interactive ? "box-border cursor-pointer rounded-lg px-3 py-2.5" : ""
-            } ${
-                inspected
-                    ? "bg-[var(--ag-colorFillSecondary)] shadow-[inset_2px_0_0_var(--ag-colorPrimary)]"
-                    : interactive
-                      ? "hover:bg-[var(--ag-colorFillTertiary)]"
-                      : ""
-            }`}
-        >
-            {children}
-        </div>
-    )
-}
-
-/** Compact three-dot pulse for the meta row under the last turn — the run-in-progress signal.
- * Deliberately NOT a Bubble: it shares one line with "Inspect turn" instead of adding a
- * bubble-sized row of its own. */
-const WorkingDots = () => (
-    <span
-        role="status"
-        aria-label="Agent is working"
-        className="flex items-center gap-1 px-1 py-0.5"
-    >
-        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-duration:1.2s]" />
-        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-delay:0.2s] [animation-duration:1.2s]" />
-        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-delay:0.4s] [animation-duration:1.2s]" />
-    </span>
-)
-
-/** The WorkingDots slot while the run is PARKED on the user (approval / connect / elicitation).
- * The stream reads "ready" there, so without this the turn looks finished while the queue silently
- * holds new sends. Deliberately static: motion says "the agent is working" — here it's your move. */
-const WaitingForInput = () => (
-    <span
-        role="status"
-        aria-label="Agent is waiting for your input"
-        className="flex items-center gap-1.5 px-1 py-0.5 text-xs text-colorTextTertiary"
-    >
-        <Hourglass size={12} />
-        Waiting for your input
-    </span>
-)
-
 const AgentConversation = ({
     entityId,
     sessionId,
@@ -400,74 +94,9 @@ const AgentConversation = ({
     // Workflow artifact id for this conversation — the key for the agent's durable `agent-files`
     // mount, folded into the session drive by the Drive surfaces below (via the drive context).
     const artifactId = useAtomValue(workflowMolecule.selectors.workflowId(entityId))
-    const persistMessages = useSetAtom(persistSessionMessagesAtom)
-    const stampMessagesCreatedAt = useSetAtom(stampMessagesCreatedAtAtom)
-    const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
     const setSessionStatus = useSetAtom(setSessionStatusAtom)
-    const inspectorTarget = useAtomValue(inspectorTargetAtom)
-    const openInspectorTurn = useSetAtom(openInspectorTurnAtom)
-    const closeInspector = useSetAtom(closeInspectorAtom)
-    const buildMode = !useAtomValue(chatPanelMaximizedAtom)
-    const inspectorEnabled = useAtomValue(playgroundInspectorEnabledAtom)
-    // The Inspector is a personal debug tool in BUILD mode. Chat mode has no inspector (the
-    // context rail owns the right dock there).
-    const inspectorOpen = inspectorEnabled && buildMode && inspectorTarget?.sessionId === sessionId
-    const turnInspectorOpen = inspectorOpen && inspectorTarget?.focusedTurn != null
-    // The assistant turn the panel is focused on. Turn ids are 1-based indices (records group by
-    // `done`); the inspected assistant message is the Nth assistant message.
-    const inspectedTurn = turnInspectorOpen ? (inspectorTarget?.focusedTurn ?? null) : null
-    // Leaving Build for Chat closes the Inspector entirely.
-    useEffect(() => {
-        if ((!buildMode || !inspectorEnabled) && inspectorTarget?.sessionId === sessionId) {
-            closeInspector()
-        }
-    }, [buildMode, inspectorEnabled, inspectorTarget?.sessionId, sessionId, closeInspector])
-
-    // Map an assistant message to its 1-based turn number (records/turns align 1:1 with the
-    // assistant messages — one per `done`).
-    const turnOfAssistant = (assistantMessageId: string): number => {
-        let n = 0
-        for (const m of messages) {
-            if (m.role === "assistant") {
-                n += 1
-                if (m.id === assistantMessageId) return n
-            }
-        }
-        return n || 1
-    }
-
-    // Restored from the per-session store on remount (route re-entry, tab close/reopen) —
-    // pending attachments survive alongside the composer draft. Rejections stay transient.
-    const [files, setFiles] = useState<UploadFile[]>(
-        () => attachmentsBySession.get(sessionId) ?? [],
-    )
-    useEffect(() => {
-        if (files.length > 0) attachmentsBySession.set(sessionId, files)
-        else attachmentsBySession.delete(sessionId)
-    }, [files, sessionId])
-    // Files turned away by the guardrails (too big, wrong type, over the count), shown inline.
-    const [rejections, setRejections] = useState<AttachmentRejection[]>([])
-    // The attachment currently open in the Files-drawer preview (its uid), or null when closed.
-    const [viewingUid, setViewingUid] = useState<string | null>(null)
-    const [attachmentsOpen, setAttachmentsOpen] = useState(false)
-    // Single limits object so it can later be swapped for capability-derived limits.
-    const limits = DEFAULT_ATTACHMENT_LIMITS
-    const atMax = files.length >= limits.maxCount
-    // Drag-over state for the whole-panel drop overlay (depth counter avoids child flicker).
-    const dragDepthRef = useRef(0)
-    const [isDragging, setIsDragging] = useState(false)
-    // Whether the LAST assistant turn was user-stopped. You can only cancel the in-flight (last) turn,
-    // so this is a single boolean gated on position at render time — independent of message ids (which
-    // can be missing/duplicated in restore/error paths and would otherwise smear the tag onto every
-    // turn). Cleared on the next send/resend.
-    const [stopped, setStopped] = useState(false)
     // Seed once from the persisted store (read imperatively so our own writes don't feed back).
     const [initialMessages] = useState(() => store.get(sessionMessagesAtom)[sessionId] ?? [])
-    // Ids already on screen — restored/settled turns don't re-animate; only turns added live fade in.
-    const seenIdsRef = useRef<Set<string>>(new Set(initialMessages.map((m) => m.id)))
-    // Immutable snapshot of the restored ids (seenIdsRef grows) — the first-seen stamping
-    // effect below skips these so a reload can't masquerade as the turns' send time.
-    const restoredIdsRef = useRef<Set<string>>(new Set(initialMessages.map((m) => m.id)))
     // Themed confirm dialogs. The static `Modal.confirm` renders detached from the app's
     // ConfigProvider, so it loses the theme (white box in dark mode). The hook form's
     // `contextHolder` is rendered in-tree, so its dialogs inherit the theme — same look as the
@@ -476,201 +105,61 @@ const AgentConversation = ({
 
     const richInputRef = useRef<RichChatInputHandle>(null)
 
-    // Composer entrance plays once per PANEL mount — additional session panes mount the
-    // composer fully shown (the replayed fade read as a "composer reload" on session switch).
-    // Frozen at mount: recomputing per render would flip Reveal's `enabled` mid-entrance
-    // (the latch effect below runs before the fade completes).
-    const [playComposerEntrance] = useState(() => !revealPlayedRef.current)
-    useEffect(() => {
-        revealPlayedRef.current = true
-    }, [revealPlayedRef])
+    const composer = useComposerDraft({sessionId, richInputRef, revealPlayedRef})
 
-    // A brand-new session mounts a fresh pane — drop the cursor straight into the composer so the
-    // user can type immediately. Frozen at mount (fresh-until-first-send) and driven through the
-    // editor's own AutoFocusPlugin, which fires on the lazy Lexical mount rather than racing it.
-    const [autoFocusComposer] = useState(() => isSessionFresh(sessionId))
+    // Pending attachments for this session + the whole-panel drop target.
+    const attachments = useComposerAttachments({sessionId})
+    const {
+        uploadsEnabled,
+        files,
+        viewingUid,
+        setViewingUid,
+        limits,
+        atMax,
+        attachmentsSettled,
+        isDragging,
+        addFiles,
+    } = attachments
 
-    // Per-session unsent draft: restore once at mount (initialMarkdown is mount-only) and
-    // capture edits debounced — markdown is read from the handle at capture time, not per
-    // keystroke (serialization isn't free).
-    const [initialDraft] = useState(() => composerDraftBySession.get(sessionId))
-    const draftTimerRef = useRef(0)
-    const handleComposerChange = useCallback(
-        (text: string) => {
-            window.clearTimeout(draftTimerRef.current)
-            draftTimerRef.current = window.setTimeout(() => {
-                const md = richInputRef.current?.getMarkdown() ?? text
-                if (md.trim()) composerDraftBySession.set(sessionId, md)
-                else composerDraftBySession.delete(sessionId)
-            }, 400)
-        },
-        [sessionId],
-    )
-    useEffect(
-        () => () => {
-            window.clearTimeout(draftTimerRef.current)
-            // Best-effort final capture on unmount (guarded — the editor may be detached).
-            const md = richInputRef.current?.getMarkdown()
-            if (md !== undefined) {
-                if (md.trim()) composerDraftBySession.set(sessionId, md)
-                else composerDraftBySession.delete(sessionId)
-            }
-        },
-        [sessionId],
-    )
-    const scrollRef = useRef<HTMLDivElement>(null)
-    // ── SPIKE(react-virtuoso): windowing variant, evaluated against content-visibility. ──
-    // Controlled live from the playground settings dropdown (Virtualization section). When on, the
-    // SC-1..4 scroll effects below are disabled (Virtuoso owns measurement/anchoring) and the
-    // transcript renders via <Virtuoso>; overscan / row-estimate are tunable there too.
-    // Virtualize only when the env flag is present AND it's enabled in the settings — no other gates.
-    const virtEnabledInSettings = useAtomValue(agentChatVirtualizeAtom)
-    const useVirtuoso = isAgentChatVirtualizationAvailable() && virtEnabledInSettings
-    const virtOverscan = useAtomValue(agentChatOverscanAtom)
-    const virtItemEstimate = useAtomValue(agentChatItemEstimateAtom)
-    const virtuosoRef = useRef<VirtuosoHandle>(null)
-    // Snapshot captured by a previous mount of this session (route re-entry). Read once at
-    // mount — `restoreStateFrom` is a mount-time-only Virtuoso prop.
-    const [virtRestoreState] = useState(() =>
-        useVirtuoso ? virtStateBySession.get(sessionId) : undefined,
-    )
-    const router = useRouter()
-    useEffect(() => {
-        if (!useVirtuoso) return
-        const capture = () => {
-            // getState is synchronous; guard the handle for the unmount-cleanup path.
-            virtuosoRef.current?.getState((snapshot) => {
-                virtStateBySession.set(sessionId, snapshot)
-            })
-        }
-        // routeChangeStart fires while the transcript is still mounted and measured — the
-        // reliable capture point. The cleanup capture is best-effort (the handle may already
-        // be detached there), covering non-route unmounts like a revision-type swap.
-        router.events.on("routeChangeStart", capture)
-        return () => {
-            router.events.off("routeChangeStart", capture)
-            capture()
-        }
-    }, [useVirtuoso, sessionId, router])
-    // Stick to the bottom of the scrollable area. This is the ONE source of truth for auto-scroll:
-    // the active turn reserves a viewport (min-h-full), so "bottom" puts the latest question at the
-    // top with the answer streaming into the space below — the pin is emergent, not computed. A real
-    // user scroll-up releases it (onScroll); jump-to-latest re-arms it.
-    const stickRef = useRef(true)
-    const [showJump, setShowJump] = useState(false)
-    // Arm a one-shot scroll to the bottom: on a fresh submit (glide) and on restoring a saved thread
-    // (instant). Combined with min-h-full this is the whole SC-1/SC-2 positioning — no per-element pin.
-    const armBottomRef = useRef(initialMessages.length > 0)
-    const animateBottomRef = useRef(false)
-    // Set while WE move the scroll (the bottom glide / SC-3 compensation). onScroll ignores the
-    // resulting event so our own scroll isn't mistaken for the user reaching/leaving the live edge.
-    const programmaticScrollRef = useRef(false)
-    // Teardown for the in-flight smooth scroll (removes its listeners + fallback timer).
-    const pinCleanupRef = useRef<(() => void) | null>(null)
-    // Last observed scrollTop. A content shrink (tool gutter collapsing, reasoning folding) clamps
-    // scrollTop to the new smaller bottom and fires a scroll event that isn't a user gesture; comparing
-    // against this lets onScroll tell a real scroll-DOWN-to-edge from that clamp (which only decreases).
-    const lastScrollTopRef = useRef(0)
-    // rAF handle coalescing the jump-pill measurement (querySelectorAll + getBoundingClientRect) to once
-    // per frame — a fast wheel/drag and every streamed render would otherwise re-measure a dirtied layout.
-    const showJumpRafRef = useRef(0)
+    // What the transcript should do next (follow / arm a pin / show the pill), shared by the
+    // producers below (send, queue release, history adoption) and whichever scroll engine is
+    // active. Declared here so every producer can state intent without touching the DOM.
+    const scrollIntent = useScrollIntent({initialArmed: initialMessages.length > 0})
+    const {showJump} = scrollIntent
 
-    // `useChat` pins its `Chat` (and thus this transport) for the life of the session `id`; it is
-    // NOT recreated when `entityId` changes (only on an `id` change). So the request builder must
-    // read the CURRENT entity through a ref — capturing `entityId` by value would send every turn
-    // with the revision that was displayed when the session first mounted, even after a switch or a
-    // self-commit. Reading `entityIdRef.current` at send time keeps runs on the live revision.
-    const entityIdRef = useRef(entityId)
-    entityIdRef.current = entityId
-
-    // Turn Inspector capture write, read via ref so the transport `useMemo` doesn't depend on it.
-    const captureTurnRequest = useSetAtom(captureTurnRequestAtom)
-    const captureRef = useRef(captureTurnRequest)
-    captureRef.current = captureTurnRequest
-
-    // Transport feeds the v6 stream request from the playground pipeline. `api` here is a
-    // placeholder that `prepareSendMessagesRequest` overrides per request.
-    const transport = useMemo(
-        () =>
-            new AgentChatTransport({
-                api: "",
-                prepareSendMessagesRequest: async ({messages, id}) => {
-                    const req = await buildAgentRequest(entityIdRef.current, messages, {
-                        sessionId: id ?? sessionId,
-                    })
-                    if (!req) {
-                        throw new Error(
-                            "This agent workflow has no invocation URL — it can’t be run yet.",
-                        )
-                    }
-                    captureRef.current(buildTurnCapture(req, generateId(), Date.now()))
-                    return {api: req.invocationUrl, headers: req.headers, body: req.requestBody}
-                },
-            }),
-        [sessionId],
-    )
-
-    const revalidateSessionMounts = useSetAtom(revalidateSessionMountsAtom)
-    const revalidateSessionRecords = useSetAtom(revalidateSessionRecordsAtom)
-    // Only a gate settled in this mount may trigger an automatic resume; hydrated answers stay inert.
-    const liveGateInteractionRef = useRef<LiveAgentInteraction | null>(null)
-
+    // The chat stream for this tab: transport, useChat, history hydration, persistence,
+    // self-commit pickup, stop/kill and teardown.
     const {
         messages,
-        sendMessage,
         status,
-        stop,
+        busy,
+        error,
+        sendMessage,
         regenerate,
         setMessages,
         addToolApprovalResponse,
-        addToolOutput,
-        error,
-    } = useChat({
-        id: sessionId,
-        messages: initialMessages,
-        transport,
-        // Coalesce stream deltas to ~1 UI commit / 50ms so a fast token stream doesn't drive a
-        // render per token; caps commit frequency independently of the per-commit memo win.
-        experimental_throttle: 50,
-        // Approve AND deny both resume — a deny-only decision must re-send so the runner
-        // gets the denial round-trip and the model continues (no `approval-responded` limbo).
-        sendAutomaticallyWhen: ({messages}) => {
-            const shouldDispatch = agentShouldResumeAfterApproval({
-                messages,
-                liveInteraction: liveGateInteractionRef.current,
-            })
-            if (shouldDispatch) liveGateInteractionRef.current = null
-            return shouldDispatch
-        },
-        // The turn's trace may not be ingested yet when the row asks for its summary —
-        // marking it fresh lets the trace queries retry through the ingestion lag
-        // (historical traces get no such grace; a 404 there means the trace is gone).
-        // A finished turn may also have written files: mark the session's drive data stale so
-        // every mount surface (open or opened later) refetches — no live channel exists for this.
-        onFinish: ({message}) => {
-            markTraceAsFresh(getMessageTraceId(message))
-            revalidateSessionMounts(sessionId)
-            revalidateSessionRecords(sessionId)
-        },
-        onError: (err) => {
-            // Render the error in-chat (the `error` alert below); swallow it here so an
-            // aborted/errored stream doesn't bubble unhandled to the Next.js dev overlay (F-033).
-            console.warn("[AgentChatPanel] useChat error (rendered in-chat):", err)
-        },
-    })
+        messagesRef,
+        busyRef,
+        isHydrating,
+        hydratedEmpty,
+        stopped,
+        setStopped,
+        handleStop,
+        handleClientToolOutput,
+        markLiveGate,
+        resumeOrphaned,
+        isSeen,
+    } = useAgentChatSession({entityId, sessionId, initialMessages, intent: scrollIntent})
 
-    const busy = status === "submitted" || status === "streaming"
-
-    // `messages`/`busy` change every token; consumers that must stay referentially stable
-    // (`handleRewind`, the hydration/SWR adoption guards) read them through refs instead.
-    const messagesRef = useRef(messages)
-    messagesRef.current = messages
-    const busyRef = useRef(busy)
-    busyRef.current = busy
-
-    // Mid-stream drive signals: settled write-ish tool calls append file-activity entries (and
-    // throttle-revalidate the drives) as the turn streams, not just at onFinish.
-    useFileActivityDetector({sessionId, messages})
+    // Turn Inspector: open state, the focused turn, and the assistant → turn-number mapping.
+    const {
+        buildMode,
+        inspectorEnabled,
+        inspectorOpen,
+        inspectedTurn,
+        openInspectorTurn,
+        turnNumbers,
+    } = useTurnInspector({sessionId, messages})
 
     // Quick Look + Files-window hosts: cards/tiles/rail request via atoms; these resolve against
     // THIS conversation's drive: the link provider makes filename mentions clickable, and the
@@ -679,100 +168,6 @@ const AgentConversation = ({
     const filesWindowHost = <SessionFilesDrawer sessionId={sessionId} />
     const setFilesWindowOpen = useSetAtom(filesDrawerOpenAtomFamily(sessionId))
     const setFilesStaged = useSetAtom(filesDrawerStagedAtomFamily(sessionId))
-
-    // Hybrid history: localStorage holds only the session INDEX; the durable conversation CONTENT
-    // lives in the backend record log. Cache-first — when this tab opens with no locally-cached
-    // messages (a session this browser never ran, or after a storage clear), hydrate once from the
-    // server (`queryRecords` → v6 messages) and seed. Locally-cached sessions skip the fetch, so no
-    // regression for own runs.
-    // A to-be-hydrated session (empty local cache, not brand-new) shows a transcript skeleton
-    // instead of the "start a chat" hero, so a session WITH server history doesn't flash the empty
-    // state before its records land. Seeded synchronously so the first paint is already the skeleton.
-    const [isHydrating, setIsHydrating] = useState(
-        () => initialMessages.length === 0 && !isSessionFresh(sessionId),
-    )
-    // Set when server hydration for a KNOWN (non-fresh, uncached) session returns no records — its
-    // durable history was pruned by retention or never persisted. Drives the "history unavailable"
-    // notice so a wiped session isn't mistaken for a brand-new chat.
-    const [hydratedEmpty, setHydratedEmpty] = useState(false)
-    useEffect(() => {
-        // A session created brand-new in this browser and not yet run has no backend records —
-        // skip the guaranteed-empty query (cleared on first send; after a reload it re-hydrates).
-        if (initialMessages.length > 0 || isSessionFresh(sessionId)) {
-            setIsHydrating(false)
-            return
-        }
-        // No persistent "already-hydrated" ref: the `cancelled` flag is the whole guard, so React
-        // StrictMode's mount→unmount→mount cycle re-runs the fetch (the first run is cancelled)
-        // instead of latching a ref that leaves the transcript blank.
-        let cancelled = false
-        // Post-restore revalidation: the first result may be the disk-restored log (paints
-        // instantly); when the guaranteed background refetch lands, adopt it under the same
-        // guards as the SWR effect below — never mid-stream, only when strictly ahead.
-        const adoptRefreshed = (freshMsgs: UIMessage[]) => {
-            if (cancelled || busyRef.current) return
-            if (freshMsgs.length <= messagesRef.current.length) return
-            freshMsgs.forEach((m) => {
-                seenIdsRef.current.add(m.id)
-                restoredIdsRef.current.add(m.id)
-            })
-            armBottomRef.current = true
-            // The restore said "no records" but the server has some — clear the notice.
-            setHydratedEmpty(false)
-            setMessages(freshMsgs)
-            persistMessages({id: sessionId, messages: freshMsgs})
-        }
-        loadSessionMessages(sessionId, adoptRefreshed)
-            .then((msgs) => {
-                if (cancelled) return
-                if (!msgs || msgs.length === 0) {
-                    // Known session, but the server has no records for it → history was pruned or
-                    // never persisted. Flag it so the transcript shows the "unavailable" notice.
-                    setHydratedEmpty(true)
-                    return
-                }
-                // Restored history renders settled (no live fade-in) and pinned to the bottom.
-                msgs.forEach((m) => {
-                    seenIdsRef.current.add(m.id)
-                    restoredIdsRef.current.add(m.id)
-                })
-                armBottomRef.current = true
-                setMessages(msgs)
-                persistMessages({id: sessionId, messages: msgs})
-            })
-            .finally(() => {
-                if (!cancelled) setIsHydrating(false)
-            })
-        return () => {
-            cancelled = true
-        }
-        // Seed once per mounted session tab; `sessionId` is stable for this instance.
-    }, [sessionId])
-
-    // Settle a parked client tool (#4920). The dispatcher calls this from a widget (e.g. the connect
-    // widget) with the structured reference; `addToolOutput` matches the part by `toolCallId` on the
-    // last turn and the resume predicate auto-resends. `tool` is only the typed-tools key — matching
-    // is by id — so a cast onto the untyped UIMessage tool map is safe.
-    const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
-        ({toolName, toolCallId, output, errorText}) => {
-            liveGateInteractionRef.current = {kind: "client_tool", id: toolCallId}
-            if (errorText !== undefined) {
-                addToolOutput({
-                    state: "output-error",
-                    tool: toolName as never,
-                    toolCallId,
-                    errorText,
-                }).catch(ignoreStreamRejection)
-            } else {
-                addToolOutput({
-                    tool: toolName as never,
-                    toolCallId,
-                    output: (output ?? {}) as never,
-                }).catch(ignoreStreamRejection)
-            }
-        },
-        [addToolOutput],
-    )
 
     // ── "Run in playground" seam (producer: a trigger drawer's Run-in-playground) ──
     // A trigger fires server-side and never reaches the playground; this lets a user
@@ -792,11 +187,22 @@ const AgentConversation = ({
     // (cross-tab / cross-device) before it's opened. The atom no-ops once the session has a title,
     // so this fires at most once and never overwrites an explicit rename.
     const autoTitleSession = useSetAtom(autoTitleSessionAtomFamily(scopeKey))
-    const bumpSessionActivity = useSetAtom(bumpSessionActivityAtomFamily(scopeKey))
     const firstUserMessage = useMemo(() => firstUserText(messages), [messages])
     useEffect(() => {
         if (firstUserMessage) autoTitleSession({id: sessionId, text: firstUserMessage})
     }, [firstUserMessage, sessionId, autoTitleSession])
+
+    // Stamp last-message time when a live turn finishes streaming (issue #5553: order history by
+    // last message). Gated on the streaming→settled transition so hydration/restore — which sets
+    // messages while `status` stays "ready" — never back-dates an old session to "now".
+    const bumpSessionActivity = useSetAtom(bumpSessionActivityAtomFamily(scopeKey))
+    const prevStatusRef = useRef(status)
+    useEffect(() => {
+        if (prevStatusRef.current === "streaming" && status !== "streaming") {
+            bumpSessionActivity(sessionId)
+        }
+        prevStatusRef.current = status
+    }, [status, sessionId, bumpSessionActivity])
 
     // Model connection: is the project vault empty (no key of any kind), the agent not self-managed,
     // and the user never set up a key before? Drives the connect-a-model banner AND disables the
@@ -825,284 +231,60 @@ const AgentConversation = ({
         return modalities ? modalities.includes("audio") : null
     }, [harnessCapabilities, modelKey.harness, modelKey.model])
 
-    // ── Playground-native onboarding ──────────────────────────────────────────
-    // This chat panel IS the onboarding surface while the agent is ephemeral: the empty state shows the
-    // "what do you want to build?" hero and the composer renders Create-agent / Continue-in-IDE controls
-    // (submit = commit the ephemeral in place, not send). Read from the OnboardingContext, present ONLY
-    // inside the onboarding playground — null everywhere else, so every other chat usage is unchanged.
-    const onboarding = useOptionalOnboardingContext()
-    const onboardingActive = !!onboarding && !onboarding.realEntityId
-    // Post-commit chrome (the connect-model banner) stays hidden through the commit + first send, then
-    // eases in a beat later (see `chromeRevealed`) so it doesn't move the composer during the send.
-    const chromeHidden = !!onboarding && !onboarding.chromeRevealed
-    const onboardingPosthog = usePostHogAg()
-    const {message: appMessage} = App.useApp()
-
-    // ── Template strip (TEMPLATE_STRIP_MODE) ─────────────────────────────────
-    // One provenance instance per panel, shared by the onboarding hero strip (S5) and the
-    // agent empty-chat strip (S6): pick fills the composer + docks the chip above it.
-    const stripProvenance = useTemplateProvenance({
-        composerApi: {
-            setText: (text) => richInputRef.current?.setMarkdown(text),
-            getText: () => richInputRef.current?.getMarkdown() ?? "",
-        },
+    // Playground-native onboarding: the hero, Create-agent / Continue-in-IDE, the template strip
+    // and the optimistic first turn. Every value is inert outside the onboarding playground.
+    const onboardingChat = useOnboardingChat({
+        entityId,
+        richInputRef,
+        messages,
+        setMessages,
+        setStopped,
+        intent: scrollIntent,
     })
-    // Provenance is scoped to ONE agent revision. `AgentConversation` survives an `entityId`
-    // change in place (see the self-commit `switchEntity` above and a revision swap) — without
-    // this, a template picked against the old entity would leak its name into the new one. Drop
-    // only the chip, not the composer text: a commit must not wipe the user's in-progress draft (#5246).
-    useEffect(() => {
-        stripProvenance.clearProvenance()
-    }, [entityId, stripProvenance.clearProvenance])
-    // S6 gate: fresh agent only (`version` v0/v1 = creation, same seed-vs-history convention used
-    // elsewhere); unknown while loading counts as not-fresh so the strip never flashes in.
-    const revisionQuery = useAtomValue(workflowMolecule.selectors.query(entityId))
-    const revisionVersion = revisionQuery.data?.version
-    const isFreshAgentRevision =
-        !revisionQuery.isPending && typeof revisionVersion === "number" && revisionVersion <= 1
-    const [copiedToastOpen, setCopiedToastOpen] = useState(false)
-    const handleStripPick = useCallback(
-        (template: AgentTemplate) => {
-            stripProvenance.pick(template)
-            captureFirstAgentIntent(onboardingPosthog, {
-                source: "template",
-                properties: {
-                    template: template.name,
-                    templateId: template.key,
-                    templateCategory: template.category,
-                    mode: "strip",
-                    surface: onboardingActive ? "onboarding" : "agent-chat",
-                },
-                intentValue: template.category || template.name,
-            })
-        },
-        [stripProvenance.pick, onboardingPosthog, onboardingActive],
-    )
-    const handleCodingAgentCopy = useCallback(async () => {
-        const text = richInputRef.current?.getMarkdown().trim() ?? ""
-        try {
-            await navigator.clipboard.writeText(buildCodingAgentClipboard(text))
-            setCopiedToastOpen(true)
-        } catch {
-            appMessage.error("Couldn't copy — copy it manually")
-            return
-        }
-        captureFirstAgentIntent(onboardingPosthog, {
-            source: "composer",
-            properties: {action: "coding_agent_copy", message: truncateForCapture(text)},
-        })
-    }, [appMessage, onboardingPosthog])
+    const {onboardingActive, ideHandoffActive} = onboardingChat
 
-    // Optimistic first turn: the description the user submitted with "Create agent", shown as a sent
-    // user message + assistant loading placeholder DURING commit + until the real conversation takes
-    // over — so the onboarding hero never flashes back and the switch reads as one continuous chat.
-    const [pendingFirstTurn, setPendingFirstTurn] = useState<string | null>(null)
+    // The composer's voice surface. A finished take either becomes the message outright (empty
+    // composer) or joins the tray — `handleSubmit` / `addFiles` are declared around it, so both
+    // are reached through the callbacks rather than by ordering the hooks around them.
+    const voice = useVoiceComposer({
+        richInputRef,
+        stagedCount: files.length,
+        onAttach: (file) => addFiles([file]),
+        onSendVoiceMessage: (file) => handleSubmit("", [file]),
+    })
+    const {voiceRecorder} = voice
 
-    const handleCreateAgent = useCallback(() => {
-        if (!onboarding || onboarding.committing) return
-        const text = richInputRef.current?.getMarkdown().trim() ?? ""
-        // Resolve BEFORE clearing the composer below — `resolveTemplateName` compares against the
-        // live text, so reading it after the clear would always see "" and never match the seed.
-        const templateName = stripProvenance.resolveTemplateName(text)
-        setPendingFirstTurn(text || null)
-        // The text becomes the sent first turn — clear the composer so it doesn't linger into the chat.
-        richInputRef.current?.setMarkdown("")
-        // Free-text submit (never a template — those go straight through `onboarding.commit` from the
-        // template pickers below, source "template"), so no double-fire with those call sites.
-        if (text) {
-            captureFirstAgentIntent(onboardingPosthog, {
-                source: "composer",
-                properties: {message: truncateForCapture(text)},
-                intentValue: classifyAgentIntent(text),
-            })
-        }
-        onboarding.commit(text, templateName)
-        if (TEMPLATE_STRIP_MODE) stripProvenance.clear()
-    }, [onboarding, onboardingPosthog, stripProvenance.clear, stripProvenance.resolveTemplateName])
+    // While a take is in flight the composer is covered by the recording bar, and a drop landing
+    // now could take the last tray slot — which would reject (and destroy) the recording on
+    // attach. Guarded at the entry points, not in `addFiles`, because the recorder's own
+    // completion goes straight there and must always get through.
+    /**
+     * Attachments are refused while a take is in flight (the composer is covered, and a late drop
+     * could steal the tray slot the recording needs) and while the composer itself is disabled —
+     * accepting files into an input you cannot send from is a dead end.
+     */
+    const composerDisabled = onboardingActive ? ideHandoffActive : modelBlocked
+    const attachmentsBlocked = () => voiceRecorder.active || composerDisabled
+    const dropTarget = attachments.bindDropTarget(attachmentsBlocked)
 
-    // Also cover the template-click commit path (which goes straight through `commit()`, not the
-    // Create button): whenever a commit is in flight, show its seed as the optimistic turn and clear
-    // any lingering composer text (e.g. a "Try" chip the user had prefilled).
-    useEffect(() => {
-        if (onboarding?.committing && onboarding.committingSeed) {
-            setPendingFirstTurn(onboarding.committingSeed)
-            richInputRef.current?.setMarkdown("")
-        }
-    }, [onboarding?.committing, onboarding?.committingSeed])
-
-    // Once the real conversation has a message (auto-send fired post-commit), the placeholder handed
-    // off — drop it so the real turn owns the view.
-    useEffect(() => {
-        if (messages.length > 0 && pendingFirstTurn) setPendingFirstTurn(null)
-    }, [messages.length, pendingFirstTurn])
-
-    // Commit failed (committing went true→false without producing a real agent): restore the hero so
-    // the user can retry, rather than stranding the placeholder with an eternal spinner.
-    const sawCommittingRef = useRef(false)
-    useEffect(() => {
-        if (onboarding?.committing) {
-            sawCommittingRef.current = true
-        } else if (sawCommittingRef.current && !onboarding?.realEntityId && messages.length === 0) {
-            sawCommittingRef.current = false
-            setPendingFirstTurn(null)
-        }
-    }, [onboarding?.committing, onboarding?.realEntityId, messages.length])
-
-    const pendingFirstMessage = useMemo<UIMessage>(
-        () => ({
-            id: "pending-first-turn",
-            role: "user",
-            parts: [{type: "text", text: pendingFirstTurn ?? ""}],
-        }),
-        [pendingFirstTurn],
-    )
-
-    // "Continue in IDE" — the user's prompt lands as a real user turn, and a streamed-looking assistant
-    // bubble hands off the install command + prompt (a pseudo response; there's no agent to run
-    // pre-commit). Two clear steps: install the skill, then give the coding agent the prompt — the prompt
-    // is NOT inside the shell block (it's not a command). Clears the composer so the text isn't duplicated.
-    // Holds the pending IDE-bubble typewriter timer so it can be cancelled on unmount (tab close,
-    // rewind, route change) — otherwise the recursive chain keeps calling setMessages on a stale closure.
-    const ideBubbleTimerRef = useRef<number | null>(null)
-    const streamIdeBubble = useCallback(() => {
-        const prompt = richInputRef.current?.getMarkdown().trim() ?? ""
-        const promptQuote = prompt
-            .split("\n")
-            .map((line) => `> ${line}`)
-            .join("\n")
-        const full = prompt
-            ? `Prefer to build in your IDE? Install the Agenta skill for Claude Code, Cursor, or any coding agent:\n\n\`\`\`bash\n${IDE_INSTALL_COMMAND}\n\`\`\`\n\nThen hand it your prompt:\n\n${promptQuote}`
-            : `Prefer to build in your IDE? Install the Agenta skill for Claude Code, Cursor, or any coding agent:\n\n\`\`\`bash\n${IDE_INSTALL_COMMAND}\n\`\`\`\n\nThen describe the agent you want it to build.`
-        const id = `ide-${generateId()}`
-        const userId = `ide-user-${generateId()}`
-        stickRef.current = false
-        armBottomRef.current = true
-        animateBottomRef.current = true
-        setShowJump(false)
-        setStopped(false)
-        // Clear the composer — the prompt is now the sent user turn (and the editor is disabled after this).
-        richInputRef.current?.setMarkdown("")
-        setMessages(
-            (prev) =>
-                [
-                    ...prev,
-                    ...(prompt
-                        ? [{id: userId, role: "user", parts: [{type: "text", text: prompt}]}]
-                        : []),
-                    {id, role: "assistant", parts: [{type: "text", text: ""}]},
-                ] as typeof prev,
-        )
-        let shown = 0
-        const chunk = Math.max(3, Math.ceil(full.length / 36))
-        const tick = () => {
-            shown = Math.min(full.length, shown + chunk)
-            const text = full.slice(0, shown)
-            setMessages(
-                (prev) =>
-                    prev.map((m) =>
-                        m.id === id ? {...m, parts: [{type: "text", text}]} : m,
-                    ) as typeof prev,
-            )
-            if (shown < full.length) ideBubbleTimerRef.current = window.setTimeout(tick, 28)
-        }
-        ideBubbleTimerRef.current = window.setTimeout(tick, 120)
-    }, [setMessages])
-
-    // Cancel any in-flight IDE-bubble animation on unmount so its timer chain can't fire post-unmount.
-    useEffect(
-        () => () => {
-            if (ideBubbleTimerRef.current) window.clearTimeout(ideBubbleTimerRef.current)
-        },
-        [],
-    )
-
-    // After an IDE hand-off (onboarding + messages exist but nothing was committed), the chat is a
-    // dead-end — there's no agent to talk to. Disable the composer and offer a single "Start over".
-    const ideHandoffActive = onboardingActive && messages.length > 0
-    const handleStartOver = useCallback(() => {
-        setMessages([])
-        richInputRef.current?.setMarkdown("")
-    }, [setMessages])
-
-    // First-run seed: a freshly-created agent (from Home's composer/template) surfaces its starting
-    // prompt in the empty state (see AgentChatEmptyState) rather than pre-filling the composer, so it
-    // reads as "here's what we'll do" not stray user input. Consumed once by the active session on a
-    // fresh conversation, matching either the revision or app id, then cleared.
-    const [firstRunSeed, setFirstRunSeed] = useAtom(agentFirstRunSeedAtom)
-    const [firstRunPrompt, setFirstRunPrompt] = useState<string | null>(null)
-    // An explicit-"go" seed (the onboarding Create-agent click) sends as soon as the model is ready.
-    const [firstRunAutoSend, setFirstRunAutoSend] = useState(false)
-    const seedConsumedRef = useRef(false)
-    useEffect(() => {
-        if (seedConsumedRef.current || !firstRunSeed) return
-        if (entityId !== firstRunSeed.revisionId && entityId !== firstRunSeed.appId) return
-        if (activeSessionId !== sessionId || messages.length > 0) return
-        seedConsumedRef.current = true
-        setFirstRunPrompt(firstRunSeed.seedMessage)
-        setFirstRunAutoSend(!!firstRunSeed.autoSend)
-        setFirstRunSeed(null)
-    }, [firstRunSeed, entityId, activeSessionId, sessionId, messages.length, setFirstRunSeed])
+    // First-run seed + its overlay-gated auto-start. `handleSubmit` is declared below, so the
+    // seed fires through a ref.
+    const handleSubmitRef = useRef<(text: string) => void | Promise<void>>(() => {})
+    const {firstRunPrompt} = useFirstRunSeed({
+        entityId,
+        sessionId,
+        activeSessionId,
+        messagesCount: messages.length,
+        modelBlocked,
+        handleSubmitRef,
+    })
     const consumedRunNonceRef = useRef<number | null>(null)
-
-    // SWR revalidate-on-open: a cached session paints instantly from localStorage; in the background
-    // we refetch the durable records ONCE (low-priority) and adopt the server transcript ONLY IF it's
-    // strictly ahead of what we're showing (a turn finished on another device). We never clobber a
-    // transcript that's live (`busyRef`), or that the server isn't strictly ahead of — so a local
-    // optimistic/unsent tail is safe. Cache-MISS sessions are hydrated by the effect above; fresh
-    // never-run sessions have no server records. Reconciliation is by message COUNT, not content:
-    // detecting a same-length server-side edit/regenerate is deferred, as is focus/interval
-    // revalidation. FOLLOWUP(sessions,swr): see docs/designs/sessions/frontend-integration.md.
-    useEffect(() => {
-        if (initialMessages.length === 0 || isSessionFresh(sessionId)) return
-        // As with the hydration effect above: no persistent ref, so StrictMode's double-mount
-        // re-runs the revalidation rather than latching it out.
-        let cancelled = false
-        const adopt = (serverMsgs: UIMessage[] | null) => {
-            if (cancelled || !serverMsgs || serverMsgs.length === 0) return
-            const prev = messagesRef.current
-            if (busyRef.current) return
-            // Adopt the server transcript when it is strictly ahead by count, OR when our LOCAL tail
-            // is stuck paused (mid-approval) while the server has moved past it to a terminal turn — a
-            // resume that completed on another device. Count alone misses the latter (same bubble
-            // count) and was silently propped up by the now-removed duplicate user row; the server's
-            // `paused` flag rides the runner's `done.stopReason` through `transcriptToMessages`.
-            const serverAheadByCount = serverMsgs.length > prev.length
-            const localTailPaused = getPendingApprovals(prev).length > 0
-            const serverTail = serverMsgs[serverMsgs.length - 1] as
-                | {role?: string; metadata?: {paused?: boolean}}
-                | undefined
-            // The paused-tail exception adopts a resume that completed elsewhere, so the server must
-            // NOT be behind (>= guards against a lagging snapshot discarding newer local approval
-            // state) and its tail must be a finished assistant turn — not a shorter, older stream.
-            const serverTailComplete =
-                serverMsgs.length >= prev.length &&
-                serverTail?.role === "assistant" &&
-                !serverTail.metadata?.paused &&
-                getPendingApprovals(serverMsgs).length === 0
-            if (!serverAheadByCount && !(localTailPaused && serverTailComplete)) return
-            serverMsgs.forEach((m) => {
-                seenIdsRef.current.add(m.id)
-                restoredIdsRef.current.add(m.id)
-            })
-            armBottomRef.current = true
-            setMessages(serverMsgs)
-            persistMessages({id: sessionId, messages: serverMsgs})
-        }
-        // The first result may itself be the disk-restored records log; the callback re-applies
-        // the same guarded adoption when the guaranteed background revalidation lands.
-        loadSessionMessages(sessionId, adopt).then(adopt)
-        return () => {
-            cancelled = true
-        }
-        // Once per mounted session tab; `sessionId` is stable for this instance.
-    }, [sessionId])
 
     // Send one released queued message. Stable (only depends on `sendMessage`) so the queue's
     // release effect doesn't churn on every token.
     const sendQueued = useCallback(
         (item: QueuedMessage) => {
-            stickRef.current = true
-            setShowJump(false)
+            scrollIntent.follow()
             // A real send means this session has run — drop the never-run marker so a later
             // cache-cleared reopen hydrates from the server.
             clearSessionFresh(sessionId)
@@ -1120,19 +302,6 @@ const AgentConversation = ({
         },
         [sendMessage, sessionId],
     )
-
-    // Orphan detection for the queue's pre-resume hold: the tail is a RESTORED message (this
-    // mount never streamed it) shaped like "auto-resume imminent", and no gate was settled live
-    // in this mount. The SDK only evaluates `sendAutomaticallyWhen` on live events (approval
-    // response, tool output, stream finish) — never on mount — so this resume can't fire and
-    // must not hold the queue. Short-circuits cheap on the streaming hot path: any live send
-    // makes the tail non-restored.
-    const lastMessage = messages[messages.length - 1]
-    const resumeOrphaned =
-        !liveGateInteractionRef.current &&
-        !!lastMessage &&
-        restoredIdsRef.current.has(lastMessage.id) &&
-        agentShouldResumeAfterApproval({messages})
 
     // Queue messages typed while a turn is streaming or paused on a HITL approval; released
     // one-by-one once the turn truly settles (never mid-approval). A user stop is the exception —
@@ -1152,7 +321,7 @@ const AgentConversation = ({
     // after a reload genuinely auto-resumes, so the queue's pre-resume hold must apply to it.
     const handleApprovalResponse = useCallback(
         (args: {id: string; approved: boolean; message?: string}) => {
-            liveGateInteractionRef.current = {kind: "approval", id: args.id}
+            markLiveGate({kind: "approval", id: args.id})
             addToolApprovalResponse({id: args.id, approved: args.approved})
             // Steer: a denial that carries a redirect answers the gate AND sends the instruction as a
             // follow-up turn. It must be its OWN turn, not bundled into the deny-resume: resuming a
@@ -1165,7 +334,7 @@ const AgentConversation = ({
             const steer = args.message?.trim()
             if (!args.approved && steer) submit({text: steer})
         },
-        [addToolApprovalResponse, submit],
+        [addToolApprovalResponse, markLiveGate, submit],
     )
 
     // Pending HITL gates for the paused turn, surfaced in the persistent ApprovalDock above the
@@ -1214,656 +383,22 @@ const AgentConversation = ({
         if (pendingRun.newSession) return
         if (consumedRunNonceRef.current === pendingRun.nonce) return
         consumedRunNonceRef.current = pendingRun.nonce
-        stickRef.current = true
-        setShowJump(false)
+        scrollIntent.follow()
         submit({text: pendingRun.text})
         setPendingRun(null)
     }, [pendingRun, activeSessionId, sessionId, submit, setPendingRun])
 
-    // Surface a stream failure inline: stamp the parsed error onto the failing assistant turn so
-    // it renders as a red error bubble with the real reason (and persists with the session via the
-    // effect below), instead of a transient top banner + a generic "no response". FE-only — it
-    // uses the error useChat already has; the backend doesn't need to attach it to the trace.
-    useEffect(() => {
-        if (!error) return
-        const parsed = parseAgentRunError(error)
-        setMessages((prev) => {
-            const last = prev.length > 0 ? prev[prev.length - 1] : undefined
-            const existing = (last?.metadata as {runError?: {message?: string}} | undefined)
-                ?.runError
-            if (last?.role === "assistant") {
-                if (existing?.message === parsed.message) return prev // already stamped
-                const next = [...prev]
-                next[next.length - 1] = {
-                    ...last,
-                    metadata: {...(last.metadata as object | undefined), runError: parsed},
-                }
-                return next
-            }
-            // No trailing assistant turn (failed before one existed) — add a minimal carrier.
-            return [
-                ...prev,
-                {
-                    id: `run-error-${generateId()}`,
-                    role: "assistant",
-                    parts: [],
-                    metadata: {runError: parsed},
-                } as (typeof prev)[number],
-            ]
-        })
-    }, [error, setMessages])
-
-    // Persist the conversation whenever its stream settles (skip mid-stream).
-    useEffect(() => {
-        if (status === "streaming") return
-        persistMessages({id: sessionId, messages})
-    }, [messages, status, sessionId, persistMessages])
-
-    // Stamp last-message time when a live turn finishes streaming (issue #5553: order history by
-    // last message). Gated on the streaming→settled transition so hydration/restore — which sets
-    // messages while `status` stays "ready" — never back-dates an old session to "now".
-    const prevStatusRef = useRef(status)
-    useEffect(() => {
-        if (prevStatusRef.current === "streaming" && status !== "streaming") {
-            bumpSessionActivity(sessionId)
-        }
-        prevStatusRef.current = status
-    }, [status, sessionId, bumpSessionActivity])
-
-    // Bound the in-message expand-state store: on settle, drop entries whose owning message is gone
-    // (rewound / evicted / closed). Live = every open session's persisted messages ∪ this active one.
-    // `store.get` reads without subscribing, so this never adds re-renders on the streaming hot path.
-    const pruneExpanded = useSetAtom(pruneExpandedAtom)
-    useEffect(() => {
-        if (status === "streaming") return
-        const persisted = store.get(sessionMessagesAtom)
-        const live = new Set<string>()
-        for (const sid in persisted)
-            for (const key of expandedKeysForMessages(persisted[sid])) live.add(key)
-        for (const key of expandedKeysForMessages(messages)) live.add(key)
-        pruneExpanded(live)
-    }, [messages, status, store, pruneExpanded])
-
-    // Stamp a first-seen timestamp on any newly-appeared LIVE message (user + assistant).
-    // Restored rows are excluded: their first-seen is the reload moment, not the turn's time —
-    // stamping them made old turns read "just now" until (or forever if) the trace never loads.
-    // Unstamped, their timestamp slot shows a pending placeholder, then the trace's real time.
-    useEffect(() => {
-        stampMessagesCreatedAt(
-            messages.filter((m) => !restoredIdsRef.current.has(m.id)).map((m) => m.id),
-        )
-    }, [messages, stampMessagesCreatedAt])
-
-    // ── #4920 Application 1: refresh the config on a committed revision ──
-    // When the agent commits a new revision of itself, the backend emits a one-way
-    // `data-committed-revision` part (same channel as `data-trace`), whether the tool asked first
-    // or ran directly. On receipt we invalidate the latest-revision and
-    // inspect caches so the config panel, section drawers, and build-kit view all re-read the new
-    // config. Deduped by revision id so a re-render (token stream) doesn't re-invalidate.
-    const committedRevisionsSeenRef = useRef<Set<string>>(new Set())
-    const setAgentCommitSignal = useSetAtom(agentSelfCommitSignalAtom)
-    useEffect(() => {
-        for (const message of messages) {
-            for (const part of message.parts) {
-                if ((part as {type?: string}).type !== "data-committed-revision") continue
-                const data = (part as {data?: {revisionId?: string; version?: string}}).data
-                // A stable key per commit: prefer the revision id, fall back to the whole payload.
-                const key = data?.revisionId ?? JSON.stringify(data ?? {}) ?? "committed"
-                if (committedRevisionsSeenRef.current.has(key)) continue
-                committedRevisionsSeenRef.current.add(key)
-                invalidateAgentCommittedRevisionCache()
-                if (data?.revisionId && data.revisionId !== entityId) {
-                    // Capture the OUTGOING revision's parameters before switching, so the config
-                    // panel can show what the agent changed (per-section indicators + summary).
-                    const prevParameters = store.get(
-                        workflowMolecule.selectors.configuration(entityId),
-                    )
-                    setAgentCommitSignal({
-                        revisionId: data.revisionId,
-                        version: data.version,
-                        prevParameters: prevParameters ?? null,
-                        at: Date.now(),
-                    })
-                    switchEntity({currentEntityId: entityId, newEntityId: data.revisionId})
-                }
-            }
-        }
-    }, [messages, entityId, switchEntity, store, setAgentCommitSignal])
-
-    // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
-    const markStopped = useCallback(() => {
-        const last = messages[messages.length - 1]
-        if (last && last.role === "assistant") setStopped(true)
-    }, [messages])
-
-    const projectId = useAtomValue(projectIdAtom)
-    const queryClient = useQueryClient()
-
-    const handleStop = useCallback(() => {
-        markStopped()
-        stop() // abort the client stream immediately
-        if (!projectId || !sessionId) return
-        // Opt-in hard kill (NEXT_PUBLIC_AGENT_CHAT_STOP_KILLS_SESSION): tear the whole session down.
-        if (doesAgentChatStopKillSession()) {
-            killSession({sessionId, projectId})
-                .then((ok) => {
-                    if (ok) {
-                        queryClient.invalidateQueries({queryKey: ["session-liveness"]})
-                        // Refresh an open Inspector's Runtime lens so its Lifecycle/State reflect the
-                        // kill immediately (mirrors the panel's own Kill button).
-                        void invalidateSessionInspector(queryClient, sessionId)
-                    }
-                })
-                .catch(() => {})
-            return
-        }
-        // Default Stop: cooperatively cancel the CURRENT TURN. The control-plane `cancel` command
-        // (no inputs, no force) drops the alive lock; the runner closes the turn as interrupted and
-        // the session STAYS OPEN so a follow-up prompt resumes it — instead of the old behaviour where
-        // the client stream aborted but the runner kept running and billing.
-        commandSessionStream({sessionId, projectId}).catch(() => {})
-    }, [markStopped, stop, projectId, sessionId, queryClient])
-
-    // ── D9 teardown: abort the in-flight stream on unmount (tab close / revision swap) ──
-    // Keyed on sessionId: closing a tab or swapping the revision unmounts this conversation
-    // and should tear down its stream.
-    useEffect(() => {
-        return () => {
-            stop()
-        }
-    }, [sessionId, stop])
-
-    // ── SC-3: anchor-based scroll preservation ──
-    // We do scroll-anchoring ourselves (Safari has no CSS overflow-anchor, and it would fight our
-    // programmatic pins). While NOT following, remember the topmost visible message; when content above
-    // it changes height (an image loads, markdown/code renders, a tool card expands), we compensate
-    // scrollTop so that message stays on the same line. Growth BELOW the anchor (the streaming answer)
-    // doesn't move it, so it's left alone.
-    const anchorRef = useRef<{id: string; top: number} | null>(null)
-    const recordAnchor = useCallback(() => {
-        const el = scrollRef.current
-        if (!el) return
-        const containerTop = el.getBoundingClientRect().top
-        for (const w of el.querySelectorAll<HTMLElement>("[data-mid]")) {
-            const r = w.getBoundingClientRect()
-            // First message whose bottom is still below the viewport top = the topmost visible one.
-            if (r.bottom > containerTop + 1) {
-                anchorRef.current = {id: w.dataset.mid ?? "", top: r.top - containerTop}
-                return
-            }
-        }
-        anchorRef.current = null
-    }, [])
-
-    // ── DT4 autoscroll: stick to the bottom of the scrollable area while following ──
-    // The fill (min-h-full turn group) makes "question at top" the scroll bottom for a short answer
-    // and the answer's end the bottom for a long one, so scrollHeight is the right target (+ pb-6 gap).
-    // Only writes when not already pinned: the ResizeObserver (below) and the follow effect both pin on
-    // the same streamed growth, so the guard drops the redundant write (and the scroll event it fires).
-    const scrollToBottom = useCallback(() => {
-        const el = scrollRef.current
-        if (!el) return
-        const target = el.scrollHeight - el.clientHeight
-        if (el.scrollTop < target - 0.5) el.scrollTop = target
-    }, [])
-
-    // Recompute jump-pill visibility, coalesced to one rAF per frame. The measurement (atLiveEdge →
-    // querySelectorAll + getBoundingClientRect) is display-only, so a one-frame lag is invisible; the
-    // correctness-critical follow decision (stickRef) and SC-3 anchor stay synchronous in onScroll.
-    const scheduleShowJump = useCallback(() => {
-        if (showJumpRafRef.current) return
-        showJumpRafRef.current = requestAnimationFrame(() => {
-            showJumpRafRef.current = 0
-            const el = scrollRef.current
-            if (!el) return
-            setShowJump(!stickRef.current && !atLiveEdge(el))
-        })
-    }, [])
-
-    // Smoothly scroll the log to `target` (the SC-1 pin / jump-to-latest). Uses the browser's NATIVE
-    // smooth scroll so it runs on the compositor — smooth even while React re-renders streamed tokens,
-    // and natively interruptible. The caller holds programmaticScrollRef across it so onScroll / the
-    // ResizeObserver ignore the in-between frames; `scrollend` (or a fallback timeout) settles it. A
-    // real user wheel/touch hands control straight back. Honors prefers-reduced-motion (instant).
-    const animatePinTo = useCallback((el: HTMLDivElement, target: number, onSettle: () => void) => {
-        pinCleanupRef.current?.()
-        const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
-        if (reduce || Math.abs(target - el.scrollTop) < 2) {
-            el.scrollTop = target
-            onSettle()
-            return
-        }
-        let done = false
-        let timer = 0
-        const cleanup = () => {
-            el.removeEventListener("scrollend", onEnd)
-            el.removeEventListener("wheel", onUser)
-            el.removeEventListener("touchstart", onUser)
-            if (timer) clearTimeout(timer)
-            pinCleanupRef.current = null
-        }
-        // Reached the target (scrollend, or the fallback timer) → settle: recordAnchor + release guard.
-        const onEnd = () => {
-            if (done) return
-            done = true
-            cleanup()
-            onSettle()
-        }
-        // User grabbed the scroll mid-glide → stop guarding so their scroll is honored; don't settle.
-        const onUser = () => {
-            if (done) return
-            done = true
-            cleanup()
-            programmaticScrollRef.current = false
-        }
-        el.addEventListener("scrollend", onEnd)
-        el.addEventListener("wheel", onUser, {passive: true})
-        el.addEventListener("touchstart", onUser, {passive: true})
-        timer = window.setTimeout(onEnd, 700) // fallback where scrollend is unsupported (older Safari)
-        // Cancel without settling (a newer pin supersedes this one, or we unmount).
-        pinCleanupRef.current = () => {
-            done = true
-            cleanup()
-        }
-        el.scrollTo({top: target, behavior: "smooth"})
-    }, [])
-
-    // Stop any in-flight pin animation on unmount (tab close / revision swap).
-    useEffect(
-        () => () => {
-            pinCleanupRef.current?.()
-            if (showJumpRafRef.current) cancelAnimationFrame(showJumpRafRef.current)
-        },
-        [],
-    )
-
-    // After each commit, mark on-screen messages as seen so they don't re-animate on later renders
-    // (e.g. streaming tokens). Done in an effect, not during render, so StrictMode's double invoke
-    // doesn't mark a brand-new message before its first paint and rob it of the fade.
-    useEffect(() => {
-        for (const m of messages) seenIdsRef.current.add(m.id)
-    }, [messages])
-
-    useEffect(() => {
-        if (useVirtuoso) return
-        // Don't instant-jump while a programmatic glide (SC-1 submit / jump-to-latest) owns the
-        // scroll — that snap would override the animation. The glide's own settle re-pins to bottom.
-        if (stickRef.current && !programmaticScrollRef.current) scrollToBottom()
-    }, [messages, status, scrollToBottom, useVirtuoso])
-
-    const onScroll = useCallback(() => {
-        const el = scrollRef.current
-        if (!el) return
-        // Track scrollTop even for our own pins (recorded, then ignored) so the next real event has an
-        // accurate baseline to compare against.
-        const prevTop = lastScrollTopRef.current
-        lastScrollTopRef.current = el.scrollTop
-        // Ignore the scroll event our own pin produced — only a real user scroll changes follow state.
-        if (programmaticScrollRef.current) return
-        // Follow ONLY when at the very bottom of the scrollable area; a partial scroll must not enable
-        // it (that was the yank). Re-arm follow ONLY when the user actively scrolls DOWN to the edge (or
-        // is already following): a content shrink (tool gutter collapsing to "Used N tools", reasoning
-        // folding) clamps scrollTop to the new smaller bottom and fires a scroll event, but a clamp only
-        // ever DECREASES scrollTop, so `> prevTop` rejects it — otherwise the next token would snap the
-        // min-h-full active turn to the top (reported as the chat "jumping to the top" mid-stream).
-        const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24
-        stickRef.current = atBottom && (stickRef.current || el.scrollTop > prevTop)
-        // Anchor is correctness-critical for SC-3 (the RO reads it next resize) → capture synchronously.
-        if (!stickRef.current) recordAnchor()
-        // Pill is display-only → coalesce its costly measurement to one rAF/frame.
-        scheduleShowJump()
-    }, [recordAnchor, scheduleShowJump])
-
-    const jumpToLatest = useCallback(() => {
-        const el = scrollRef.current
-        if (!el) return
-        setShowJump(false)
-        // Glide to the bottom like the SC-1 pin. Resume follow (stickRef) only ON SETTLE — flipping
-        // it true now would let the per-token follow effect jam to the bottom mid-glide. The final
-        // scrollToBottom catches any content that streamed in during the animation.
-        programmaticScrollRef.current = true
-        animatePinTo(el, el.scrollHeight, () => {
-            el.scrollTop = el.scrollHeight
-            stickRef.current = true
-            programmaticScrollRef.current = false
-        })
-    }, [animatePinTo])
-
-    // SC-3: when any message resizes (image load, markdown/code render, tool-card expand), hold the
-    // reader's place. Following → keep pinned to the bottom; otherwise compensate scrollTop so the
-    // anchored (topmost visible) message stays on the same line. Guarded so it never fights our own
-    // pins. Re-subscribed when the message set changes (a part growing fires on the same wrapper).
-    useEffect(() => {
-        if (useVirtuoso) return
-        const el = scrollRef.current
-        if (!el) return
-        const onResize = (entries: ResizeObserverEntry[]) => {
-            // Pin each rendered row's REAL height as its own `content-visibility` placeholder, so it
-            // keeps the exact same box when it later scrolls off-screen. Only meaningful while
-            // content-visibility is enabled — otherwise `containIntrinsicSize` is inert, so skip the
-            // whole measurement to avoid a getBoundingClientRect + style write per row on every resize.
-            if (CONTENT_VISIBILITY_ENABLED) {
-                for (const e of entries) {
-                    const node = e.target as HTMLElement
-                    if (node === el) continue // the viewport itself is not a row — never pin it
-                    const check = node.checkVisibility as
-                        | ((o?: {contentVisibilityAuto?: boolean}) => boolean)
-                        | undefined
-                    if (check && !check.call(node, {contentVisibilityAuto: true})) continue
-                    const h = Math.round(node.getBoundingClientRect().height)
-                    if (h > 0) node.style.containIntrinsicSize = `auto ${h}px`
-                }
-            }
-            if (programmaticScrollRef.current) return
-            if (stickRef.current) {
-                scrollToBottom() // guarded: no-op if the follow effect already pinned this growth
-                return
-            }
-            const a = anchorRef.current
-            if (!a) return
-            let node: HTMLElement | null = null
-            try {
-                node = el.querySelector<HTMLElement>(`[data-mid="${a.id}"]`)
-            } catch {
-                node = null
-            }
-            if (!node) return
-            const delta = node.getBoundingClientRect().top - el.getBoundingClientRect().top - a.top
-            // A stale anchor (its node scrolled far off after a programmatic jump / follow) yields an
-            // implausible delta; applying it would slam the scroll to the top. Drop it and let the next
-            // scroll / pointer-down re-anchor. A real collapse/expand moves the anchor well under a viewport.
-            if (Math.abs(delta) > el.clientHeight) {
-                anchorRef.current = null
-                return
-            }
-            if (Math.abs(delta) > 0.5) {
-                programmaticScrollRef.current = true
-                el.scrollTop += delta
-                requestAnimationFrame(() => {
-                    programmaticScrollRef.current = false
-                })
-            }
-        }
-        const ro = new ResizeObserver(onResize)
-        // Observe the VIEWPORT too: the lazy composer/session-bar regions outside it hydrate a
-        // beat after mount and change this element's clientHeight — rows alone don't resize then,
-        // so without this the clamp shifts the view (following → re-pin; reading → hold anchor).
-        ro.observe(el)
-        el.querySelectorAll("[data-mid]").forEach((w) => ro.observe(w))
-        return () => ro.disconnect()
-    }, [messages.length, scrollToBottom, useVirtuoso])
-
-    // SC-1 (submit) / SC-2 (restore): scroll the log to the bottom, once, when armed. With the active
-    // turn reserving a viewport (min-h-full + top padding to clear the fade), "bottom" shows the new
-    // question pinned at the top and the answer streaming into the space below — no per-element pin to
-    // compute, nothing to keep re-aligning as content arrives. A fresh submit glides; a restore jumps.
-    // Follow (stickRef) resumes only ON SETTLE so the per-token follow effect can't jam mid-glide.
-    useLayoutEffect(() => {
-        if (useVirtuoso) return
-        if (!armBottomRef.current) return
-        const el = scrollRef.current
-        if (!el) return
-        armBottomRef.current = false
-        programmaticScrollRef.current = true
-        const settle = () => {
-            el.scrollTop = el.scrollHeight // catch anything that streamed in during the glide
-            stickRef.current = true
-            programmaticScrollRef.current = false
-        }
-        if (animateBottomRef.current) {
-            animateBottomRef.current = false
-            animatePinTo(el, el.scrollHeight, settle)
-        } else {
-            el.scrollTop = el.scrollHeight
-            requestAnimationFrame(settle)
-        }
-    }, [messages, animatePinTo, useVirtuoso])
-
-    // Keep the jump pill honest as content streams/settles: show it when the real latest message is
-    // below the fold (e.g. a long answer growing past the viewport while parked at the top), and hide
-    // it once that message is visible or while we're following. Coalesced (not a sync layout read per
-    // streamed render) — the pill is display-only, so one frame of lag is imperceptible.
-    useEffect(() => {
-        if (useVirtuoso) return
-        scheduleShowJump()
-    }, [messages, status, scheduleShowJump, useVirtuoso])
-
-    // SC-4: interaction is intent, not just scrolling. While following, a real text selection inside
-    // the transcript — or opening a link in it — means the reader is engaging here, so release follow
-    // (exactly like a scroll). New content keeps arriving offscreen and the jump pill offers the way
-    // back. Keyboard / wheel / touch already release because they scroll (onScroll). The composer is
-    // exempt: its selections and links aren't inside the log, so `el.contains(...)` ignores them.
-    useEffect(() => {
-        const el = scrollRef.current
-        if (!el) return
-        const release = () => {
-            if (!stickRef.current) return
-            stickRef.current = false
-            setShowJump(!atLiveEdge(el))
-        }
-        const onSelectionChange = () => {
-            if (!stickRef.current) return
-            const sel = window.getSelection()
-            if (!sel || sel.isCollapsed || sel.rangeCount === 0) return
-            if (sel.anchorNode && el.contains(sel.anchorNode)) release()
-        }
-        const onClick = (e: MouseEvent) => {
-            if ((e.target as HTMLElement | null)?.closest("a")) release()
-        }
-        document.addEventListener("selectionchange", onSelectionChange)
-        el.addEventListener("click", onClick)
-        return () => {
-            document.removeEventListener("selectionchange", onSelectionChange)
-            el.removeEventListener("click", onClick)
-        }
-    }, [])
-
-    // ── SPIKE(virtuoso) scroll wiring (only active when the flag is on) ──
-    // Follow = stick to the bottom. Virtuoso's `followOutput` fires on item-count changes only, but the
-    // active turn streams inside the Footer (not an item), so drive stick manually on each update.
-    const virtFollowRef = useRef(true)
-    // While true (a short window after a submit), the follow tracks the bottom SMOOTHLY — so the sent
-    // question glides to the top and the streaming answer is tracked continuously (each token retargets
-    // the in-flight smooth scroll). Otherwise it snaps instantly to keep up with fast streaming.
-    const virtSmoothRef = useRef(false)
-    const virtSmoothTimerRef = useRef(0)
-    useEffect(() => {
-        if (!useVirtuoso || !virtFollowRef.current) return
-        const behavior: ScrollBehavior = virtSmoothRef.current ? "smooth" : "auto"
-        const id = requestAnimationFrame(() => virtuosoRef.current?.scrollTo({top: 1e9, behavior}))
-        return () => cancelAnimationFrame(id)
-    }, [messages, status, useVirtuoso])
-    // SC-1 reserve for the virtuoso path: `min-h-full` doesn't work inside Virtuoso's Footer (100%
-    // resolves against its content-sized list, not the viewport), so measure the scroller's height and
-    // reserve it explicitly on the active-turn Footer — that's what lets a sent question pin to the top.
-    const virtRoRef = useRef<ResizeObserver | null>(null)
-    const [virtViewportH, setVirtViewportH] = useState(0)
-    const setVirtScroller = useCallback((el: HTMLElement | Window | null) => {
-        virtRoRef.current?.disconnect()
-        const node = el instanceof HTMLElement ? el : null
-        if (!node) return
-        setVirtViewportH(node.clientHeight)
-        const ro = new ResizeObserver(() => setVirtViewportH(node.clientHeight))
-        ro.observe(node)
-        virtRoRef.current = ro
-    }, [])
-    useEffect(
-        () => () => {
-            virtRoRef.current?.disconnect()
-            window.clearTimeout(virtSmoothTimerRef.current)
-        },
-        [],
-    )
-    // SC-1/2 equivalent: on submit/restore (armBottomRef), re-arm follow to the bottom once Virtuoso has
-    // mounted + measured (question-at-top emerges from the Footer's viewport reserve). A submit tracks
-    // smoothly for a short window; a restore snaps. The follow effect above does the per-token scrolling.
-    useLayoutEffect(() => {
-        if (!useVirtuoso || !armBottomRef.current) return
-        const animate = animateBottomRef.current
-        armBottomRef.current = false
-        animateBottomRef.current = false
-        virtFollowRef.current = true
-        setShowJump(false)
-        virtSmoothRef.current = animate
-        window.clearTimeout(virtSmoothTimerRef.current)
-        if (animate) {
-            virtSmoothTimerRef.current = window.setTimeout(() => {
-                virtSmoothRef.current = false
-            }, 600)
-        }
-        requestAnimationFrame(() =>
-            requestAnimationFrame(() =>
-                virtuosoRef.current?.scrollTo({top: 1e9, behavior: animate ? "smooth" : "auto"}),
-            ),
-        )
-    }, [messages, useVirtuoso])
-    const virtJumpToLatest = useCallback(() => {
-        virtFollowRef.current = true
-        setShowJump(false)
-        virtuosoRef.current?.scrollTo({top: 1e9, behavior: "smooth"})
-    }, [])
-    // Stable component identities (Virtuoso remounts these if their identity changes). They read live
-    // content from `context`, which we pass fresh each render — so they re-render without remounting.
-    const virtComponents = useMemo<Components<UIMessage, VirtCtx>>(
-        () => ({
-            Header: ({context}) => <>{context?.header ?? null}</>,
-            Footer: ({context}) => <>{context?.footer ?? null}</>,
-        }),
-        [],
-    )
-
-    const toUploadFile = (file: File): UploadFile => ({
-        uid: `${file.name}-${file.lastModified}-${file.size}`,
-        name: file.name,
-        status: "done",
-        originFileObj: file as UploadFile["originFileObj"],
+    // Exactly one scroll engine owns the transcript: Virtuoso when it's enabled in the playground
+    // settings, the SC-1..4 DOM engine otherwise (each bails on the other's flag). Both act on the
+    // shared `scrollIntent`, so producers never care which is live.
+    const virt = useVirtuosoTranscript({intent: scrollIntent, sessionId, messages, status})
+    const useVirtuoso = virt.enabled
+    const scroll = useTranscriptScroll({
+        intent: scrollIntent,
+        messages,
+        status,
+        useVirtuoso,
     })
-
-    // Upload lifecycle for the tray (progress / error / retry). The transport is not wired yet, so
-    // no uploader is passed — files stay "done" and enqueue is a no-op. When upload lands, provide
-    // an uploader here and the whole flow runs; the tray already renders every state.
-    const uploads = useAttachmentUploads(files, setFiles, undefined)
-    // A staged attachment blocks send only once uploads exist: while any is uploading or has failed,
-    // the message isn't ready. All-"done" today, so this is inert until the transport is wired.
-    const attachmentsSettled = !files.some((f) => f.status === "uploading" || f.status === "error")
-
-    /** Add files from paste / programmatic sources through the guardrails. */
-    const addFiles = (incoming: File[], extraRejections: AttachmentRejection[] = []) => {
-        const {accepted, rejections} = validateIncoming(incoming, files.length, limits)
-        const allRejections = [...extraRejections, ...rejections]
-        if (accepted.length) {
-            setFiles((prev) => [...prev, ...accepted.map(toUploadFile)])
-            uploads.enqueue(accepted.map((f) => `${f.name}-${f.lastModified}-${f.size}`))
-        }
-        setRejections(allRejections)
-        // Open for rejections too. Otherwise dropping something unsupported writes a message into
-        // a closed panel and reads as nothing having happened at all.
-        if (accepted.length || allRejections.length) setAttachmentsOpen(true)
-    }
-
-    const removeFile = (uid: string) => setFiles((prev) => prev.filter((f) => f.uid !== uid))
-
-    // Voice-message recording: the clip lands in the attachment tray like any file. Owned here so
-    // the recording takeover (RecordingBar) can cover the whole composer while capturing.
-    /**
-     * A voice message recorded into an otherwise-empty composer IS the message, so the take is
-     * sent on confirm rather than parked in the tray. With text or other attachments staged, the
-     * person is mid-composition, so it attaches instead and they send when ready.
-     *
-     * Decided when recording STARTS: the composer is covered by the recording bar and drops are
-     * blocked while capturing, so neither the text nor the tray can change in between.
-     */
-    // Flagged off until the agent service accepts audio parts (`NEXT_PUBLIC_AGENT_VOICE_INPUT`).
-    const voiceEnabled = isAgentVoiceInputEnabled()
-    // Attach button + attachment preview + drive uploads (`NEXT_PUBLIC_AGENT_FILE_UPLOADS`). Paste
-    // and drag-to-attach predate the flag and stay on.
-    const uploadsEnabled = isAgentFileUploadsEnabled()
-    const [voiceWillSend, setVoiceWillSend] = useState(false)
-    const voiceRecorder = useAudioRecorder((file) => {
-        if (voiceWillSend) handleSubmit("", [file])
-        else addFiles([file])
-    })
-    const startVoiceMessage = () => {
-        const hasText = !!(richInputRef.current?.getMarkdown() ?? "").trim()
-        setVoiceWillSend(!hasText && files.length === 0)
-        voiceRecorder.start()
-    }
-    // Dictation runs inside the mic button (its transcript changes far too often to lift here), so
-    // it reports failures up for the shared notice.
-    const [dictationError, setDictationError] = useState<string | null>(null)
-    // Locks the editor while speech is coming in, so typing can't interleave with the transcript.
-    const [dictating, setDictating] = useState(false)
-    const micError = voiceRecorder.error ?? dictationError
-    const dismissMicError = () => {
-        setDictationError(null)
-        voiceRecorder.dismissError()
-    }
-
-    // Native drag-and-drop onto the whole panel. A depth counter ignores dragenter/leave from
-    // nested children so the overlay doesn't flicker; only file drags (not text) are handled.
-    const isFileDrag = (e: React.DragEvent) => Array.from(e.dataTransfer.types).includes("Files")
-    // While a take is in flight the composer is covered by the recording bar, and a drop landing
-    // now could take the last tray slot — which would reject (and destroy) the recording on
-    // attach. Guarded at the entry points, not in `addFiles`, because the recorder's own
-    // completion goes straight there and must always get through.
-    /**
-     * Attachments are refused while a take is in flight (the composer is covered, and a late drop
-     * could steal the tray slot the recording needs) and while the composer itself is disabled —
-     * accepting files into an input you cannot send from is a dead end.
-     */
-    const composerDisabled = onboardingActive ? ideHandoffActive : modelBlocked
-    const attachmentsBlocked = () => voiceRecorder.active || composerDisabled
-
-    // The panel is ALWAYS a drop target for file drags — preventDefault on enter/over/drop even when
-    // blocked. Otherwise the browser's default action for a file drop is to navigate to it, which
-    // unloads the SPA and discards the whole conversation. Whether we ACCEPT the files is signalled
-    // separately (the overlay + the drop cursor), not by declining to be a drop target.
-    const onDragEnter = (e: React.DragEvent) => {
-        if (!isFileDrag(e)) return
-        e.preventDefault()
-        if (attachmentsBlocked()) return
-        dragDepthRef.current += 1
-        setIsDragging(true)
-    }
-    const onDragOver = (e: React.DragEvent) => {
-        if (!isFileDrag(e)) return
-        e.preventDefault()
-        // Honest cursor: "no drop" while blocked — but we stay a target so the drop is still swallowed.
-        e.dataTransfer.dropEffect = attachmentsBlocked() ? "none" : "copy"
-    }
-    const onDragLeave = (e: React.DragEvent) => {
-        if (!isFileDrag(e)) return
-        dragDepthRef.current -= 1
-        if (dragDepthRef.current <= 0) {
-            dragDepthRef.current = 0
-            setIsDragging(false)
-        }
-    }
-    const onDrop = (e: React.DragEvent) => {
-        if (!isFileDrag(e)) return
-        e.preventDefault()
-        dragDepthRef.current = 0
-        setIsDragging(false)
-        if (attachmentsBlocked()) return
-
-        // A dropped folder still arrives in `files` — as a typeless, zero-byte entry that the
-        // guardrails would reject as "not a supported file type", which is misleading. Name it.
-        // `webkitGetAsEntry` is only valid synchronously, during this event.
-        const folderNames = Array.from(e.dataTransfer.items ?? [])
-            .map((item) => (item.kind === "file" ? item.webkitGetAsEntry() : null))
-            .filter((entry): entry is FileSystemEntry => !!entry?.isDirectory)
-            .map((entry) => entry.name)
-
-        const dropped = Array.from(e.dataTransfer.files).filter(
-            (f) => !folderNames.includes(f.name),
-        )
-        const folderRejections = folderNames.map((name) => ({
-            name,
-            reason: "is a folder — drop the files inside it",
-        }))
-
-        if (dropped.length || folderRejections.length) addFiles(dropped, folderRejections)
-    }
 
     const handleSubmit = async (text: string, extraFiles: File[] = []) => {
         const trimmed = text.trim()
@@ -1879,83 +414,17 @@ const AgentConversation = ({
         // Glide to the bottom; the min-h-full active turn makes that show the new question at the top
         // with the answer streaming below. Park during the glide, follow again on settle. Clear any
         // prior "stopped" marker — it's resolved by asking again.
-        stickRef.current = false
-        armBottomRef.current = true
-        animateBottomRef.current = true
-        setShowJump(false)
+        scrollIntent.armGlide()
         setStopped(false)
         // One path: `submit` sends now or queues behind held messages via the shared release gate.
         submit({text: trimmed, fileParts})
         // The message left the composer — drop its persisted draft (and any pending capture).
-        window.clearTimeout(draftTimerRef.current)
-        composerDraftBySession.delete(sessionId)
-        // Sending consumes the template provenance along with the composer text.
-        if (TEMPLATE_STRIP_MODE) stripProvenance.clear()
-        setFiles([])
-        setRejections([])
-        setAttachmentsOpen(false)
+        composer.clearDraft()
+        onboardingChat.consumeTemplateProvenance()
+        attachments.clearAttachments()
     }
 
-    // First-run auto-start: a freshly-created agent lands with a seeded prompt, but its model is often
-    // gated (no provider key yet). Connecting the key IS the go-ahead — so once the gate clears we send
-    // the seeded prompt automatically, rather than making them click Start a second time ("no explicit
-    // action twice"). Fires once, while the conversation is still empty, when EITHER: the model just
-    // unblocked (was gated), OR the seed is an explicit "go" (`firstRunAutoSend` — the onboarding
-    // Create-agent click) and the model is ready. A redirect-seed that merely arrived with a ready model
-    // still waits for Start. `handleSubmit` is read via a ref so the transition drives the send.
-    const handleSubmitRef = useRef(handleSubmit)
     handleSubmitRef.current = handleSubmit
-    const autoStartedSeedRef = useRef(false)
-    const seedWasBlockedRef = useRef(false)
-    // Turn 1 must run WITH the build-kit overlay, but the overlay fetch can resolve after the seed
-    // lands — so gate the auto-send on the overlay having settled (present or definitively absent).
-    const overlayReady = useAtomValue(workflowBuildKitOverlayReadyAtomFamily(entityId))
-    // Bounded wait: a broken overlay endpoint must not hang the first turn forever. Once a seed is
-    // pending, wait at most 10s for the overlay, then send anyway (kit-less) with a warning.
-    const [overlayWaitElapsed, setOverlayWaitElapsed] = useState(false)
-    // A new entity/session or a fresh pending seed restarts the bounded wait from zero.
-    useEffect(() => {
-        setOverlayWaitElapsed(false)
-    }, [entityId, firstRunPrompt])
-    // Arm the timeout only when the auto-send is blocked on nothing BUT the overlay: a pending seed
-    // whose model is ready and which would otherwise fire this turn. Otherwise a still-gated model
-    // (or an already-sent seed) would burn the 10s window before the overlay ever mattered.
-    const sendBlockedOnlyOnOverlay =
-        Boolean(firstRunPrompt) &&
-        !autoStartedSeedRef.current &&
-        !modelBlocked &&
-        (seedWasBlockedRef.current || firstRunAutoSend) &&
-        messages.length === 0 &&
-        !overlayReady
-    useEffect(() => {
-        if (!sendBlockedOnlyOnOverlay || overlayWaitElapsed) return
-        const timer = setTimeout(() => {
-            console.warn(
-                "[AgentChat] build-kit overlay not ready after 10s; sending seed without it",
-            )
-            setOverlayWaitElapsed(true)
-        }, 10_000)
-        return () => clearTimeout(timer)
-    }, [sendBlockedOnlyOnOverlay, overlayWaitElapsed])
-    useEffect(() => {
-        if (!firstRunPrompt || autoStartedSeedRef.current) return
-        if (modelBlocked) {
-            seedWasBlockedRef.current = true
-            return
-        }
-        if ((!seedWasBlockedRef.current && !firstRunAutoSend) || messages.length > 0) return
-        // Hold the auto-send until the build-kit overlay settles (or the 10s bound elapses).
-        if (!overlayReady && !overlayWaitElapsed) return
-        autoStartedSeedRef.current = true
-        handleSubmitRef.current(firstRunPrompt)
-    }, [
-        firstRunPrompt,
-        firstRunAutoSend,
-        modelBlocked,
-        messages.length,
-        overlayReady,
-        overlayWaitElapsed,
-    ])
 
     const handleRewind = useCallback(
         (message: UIMessage) => {
@@ -2007,133 +476,71 @@ const AgentConversation = ({
     // settles instead of being yanked away (which clamped the scroll and jumped the view).
     const reserveActive = activeStart > 0
 
+    // Stable per-session callbacks so <AgentTurn>'s memo holds across streamed commits.
+    const handleInspectTurn = useCallback(
+        (turn: number) => openInspectorTurn({sessionId, turn}),
+        [openInspectorTurn, sessionId],
+    )
+    const handleResend = useCallback(
+        (messageId: string) => {
+            setStopped(false)
+            regenerate({messageId}).catch(ignoreStreamRejection)
+        },
+        [regenerate, setStopped],
+    )
+
     const renderMessage = (message: UIMessage, index: number) => {
         const isLast = index === messages.length - 1
-        // New since mount → fade in once. Mark seen immediately so a re-render mid-stream (tokens
-        // arriving) doesn't re-arm the animation; the row keeps its mounted state by key anyway.
-        // Don't mutate seenIdsRef here — that runs during render (unsafe under StrictMode's double
-        // invoke). Marking happens in an effect after commit.
-        const enter = !seenIdsRef.current.has(message.id)
-        // A user turn has no trace of its own; borrow the paired (next) assistant turn's trace so its
-        // timestamp dates from the run, not this browser's first-seen stamp.
-        const turnTraceId =
-            message.role === "user" && messages[index + 1]
-                ? getMessageTraceId(messages[index + 1])
-                : undefined
-        // Whenever the inspector PANEL is open, every assistant turn is click-to-focus — click any
-        // turn to re-point the inspector at it; the current target tints. Gated on the panel being
-        // open (not on a turn already being focused), so opening the inspector on session scope
-        // still lets you click a turn to drill in.
         const isAssistantTurn = message.role === "assistant"
-        const isInspected =
-            isAssistantTurn &&
-            inspectedTurn != null &&
-            turnOfAssistant(message.id) === inspectedTurn
-        const onInspect =
-            inspectorOpen && isAssistantTurn
-                ? () => openInspectorTurn({sessionId, turn: turnOfAssistant(message.id)})
-                : undefined
-        const showInspect = inspectorEnabled && buildMode && isAssistantTurn
-        const showWorking =
-            isLast && busy && (!isAssistantTurn || message.parts.some(isVisiblePart))
-        // Paused on the user (never concurrently with showWorking — hitlPending implies not busy):
-        // the "waiting" chip keeps the turn from reading as finished while the queue holds sends.
-        const showWaiting = isLast && isAssistantTurn && !busy && hitlPending
+        const turn = turnNumbers.get(message.id)
+        const isInspected = isAssistantTurn && inspectedTurn != null && turn === inspectedTurn
         return (
-            <MessageRow
+            <AgentTurn
                 key={message.id}
-                mid={message.id}
-                enter={enter}
+                message={message}
+                // New since mount → fade in once. seenIdsRef is marked in an effect after commit,
+                // never during render (unsafe under StrictMode's double invoke).
+                enter={!isSeen(message.id)}
+                isLast={isLast}
+                isStreaming={busy && isLast}
+                precededByEmptyAssistant={index > 0 && isEmptyAssistantTurn(messages[index - 1])}
+                // A user turn has no trace of its own; borrow the paired (next) assistant turn's
+                // trace so its timestamp dates from the run, not this browser's first-seen stamp.
+                turnTraceId={
+                    message.role === "user" && messages[index + 1]
+                        ? getMessageTraceId(messages[index + 1])
+                        : undefined
+                }
                 inspected={isInspected}
-                onInspect={onInspect}
-                // Content-visibility on settled rows — gated by CONTENT_VISIBILITY_ENABLED (currently
-                // off) and never under Virtuoso (it windows + would corrupt measurement).
+                // Whenever the inspector PANEL is open, every assistant turn is click-to-focus —
+                // gated on the panel being open, not on a turn already being focused.
+                rowInspectable={inspectorOpen && isAssistantTurn}
+                showInspect={inspectorEnabled && buildMode && isAssistantTurn}
+                turn={turn}
+                onInspectTurn={handleInspectTurn}
+                showWorking={
+                    isLast && busy && (!isAssistantTurn || message.parts.some(isVisiblePart))
+                }
+                // Paused on the user (never concurrently with showWorking — hitlPending implies not
+                // busy): keeps the turn from reading as finished while the queue holds sends.
+                showWaiting={isLast && isAssistantTurn && !busy && hitlPending}
+                showStopped={stopped && isLast && isAssistantTurn}
+                resendDisabled={busy}
+                onResend={handleResend}
+                onRewind={handleRewind}
+                onClientToolOutput={handleClientToolOutput}
+                // Content-visibility on settled rows — gated by CONTENT_VISIBILITY_ENABLED
+                // (currently off) and never under Virtuoso (it windows + corrupts measurement).
                 offscreenSkip={CONTENT_VISIBILITY_ENABLED && !useVirtuoso && index < activeStart}
-            >
-                <AgentMessage
-                    message={message}
-                    isStreaming={busy && isLast}
-                    isLastMessage={isLast}
-                    onRewind={handleRewind}
-                    onClientToolOutput={handleClientToolOutput}
-                    precededByEmptyAssistant={
-                        index > 0 && isEmptyAssistantTurn(messages[index - 1])
-                    }
-                    turnTraceId={turnTraceId}
-                />
-                {/* Stopped tag + Resend belong only to the LAST assistant turn (the one you cancelled),
-                    gated on position so it can never smear onto past turns. Cleared on resend / ask. */}
-                {stopped && isLast && message.role === "assistant" && (
-                    <div className="flex items-center gap-2 self-start pl-1">
-                        <Tag className="!m-0 !text-[11px]">Stopped</Tag>
-                        <Button
-                            type="link"
-                            size="small"
-                            className="!px-0 !text-xs"
-                            disabled={busy}
-                            onClick={() => {
-                                setStopped(false)
-                                regenerate({messageId: message.id}).catch(ignoreStreamRejection)
-                            }}
-                        >
-                            Resend
-                        </Button>
-                    </div>
-                )}
-                {/* Meta row: "Inspect turn" + the working dots share ONE compact line under the
-                    turn. The dots run for the WHOLE busy run — so gaps with no streaming output
-                    (approval-resume cold-replay, between steps, server tool waits) never read as
-                    frozen — and drop the moment the run settles. The affordance renders FIRST so
-                    its left edge stays put (and aligned with older turns') when the trailing dots
-                    unmount — no settle-time layout shift. An EMPTY streaming assistant turn
-                    already renders its own loading bubble (AgentMessage), so the dots skip it —
-                    exactly one indicator while busy. */}
-                {(showWorking || showInspect || showWaiting) && (
-                    <div className="flex items-center gap-2 self-start">
-                        {showInspect && (
-                            <button
-                                type="button"
-                                onClick={() =>
-                                    openInspectorTurn({
-                                        sessionId,
-                                        turn: turnOfAssistant(message.id),
-                                    })
-                                }
-                                className="flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-xs text-colorTextSecondary transition-colors hover:text-colorPrimary"
-                            >
-                                <TreeStructure size={12} />
-                                {isInspected ? "Inspecting turn" : "Inspect turn"}
-                            </button>
-                        )}
-                        {showWorking && <WorkingDots />}
-                        {showWaiting && <WaitingForInput />}
-                    </div>
-                )}
-            </MessageRow>
+            />
         )
     }
-
-    // Strip era (TEMPLATE_STRIP_MODE): the bare "what do you want to build?" hero (no messages yet,
-    // nothing pending, not browsing the template gallery) is when the onboarding TemplateStrip docks
-    // directly above the composer, mirroring the agent-chat strip's bottom-anchored rhythm.
-    const showBareOnboardingHero =
-        TEMPLATE_STRIP_MODE &&
-        onboardingActive &&
-        messages.length === 0 &&
-        !pendingFirstTurn &&
-        !onboarding?.browseAll
 
     return (
         // Ambient drive session: in-thread file cards + rail resolve files against THIS
         // conversation without prop-threading through the message tree.
         <DriveSessionProvider sessionId={sessionId} artifactId={artifactId}>
-            <div
-                className="ag-canvas relative flex h-full min-h-0 w-full flex-row"
-                onDragEnter={onDragEnter}
-                onDragOver={onDragOver}
-                onDragLeave={onDragLeave}
-                onDrop={onDrop}
-            >
+            <div className="ag-canvas relative flex h-full min-h-0 w-full flex-row" {...dropTarget}>
                 {/* Themed confirm dialogs (rewind-past-a-tool) mount through this holder. */}
                 {modalContextHolder}
                 {quickLookHost}
@@ -2196,483 +603,63 @@ const AgentConversation = ({
                             )}
                             {/* Stream errors are surfaced inline on the failing turn (red error bubble with the
                 real reason), stamped in the effect above — no separate top-level banner. */}
-                            <div className="ag-canvas relative flex min-h-0 flex-1 flex-col">
-                                {useVirtuoso && messages.length > 0 && (
-                                    <Virtuoso<UIMessage, VirtCtx>
-                                        ref={virtuosoRef}
-                                        scrollerRef={setVirtScroller}
-                                        data={messages.slice(0, activeStart)}
-                                        className="ag-canvas flex-1 [overflow-anchor:none]"
-                                        style={{
-                                            maskImage: EDGE_FADE_MASK,
-                                            WebkitMaskImage: EDGE_FADE_MASK,
-                                        }}
-                                        // Wide buffer so rows are rendered AND measured before they enter view — the
-                                        // height correction (85–1022px vs the estimate) then happens off-screen, so
-                                        // real content scrolls in without blanks or jitter. Tunable from settings.
-                                        increaseViewportBy={{
-                                            top: virtOverscan,
-                                            bottom: Math.round(virtOverscan * 0.66),
-                                        }}
-                                        defaultItemHeight={virtItemEstimate}
-                                        // A prior mount's snapshot restores true row heights + scroll in the
-                                        // first frame; only a genuinely first visit anchors by index (the two
-                                        // props conflict, so exactly one is passed).
-                                        {...(virtRestoreState
-                                            ? {restoreStateFrom: virtRestoreState}
-                                            : {
-                                                  initialTopMostItemIndex: {
-                                                      index: Math.max(0, activeStart - 1),
-                                                      align: "end" as const,
-                                                  },
-                                              })}
-                                        computeItemKey={(_i, m) => m.id}
-                                        itemContent={(index, m) => (
-                                            <div className="px-3 pb-3">
-                                                {renderMessage(m, index)}
-                                            </div>
-                                        )}
-                                        atBottomStateChange={(atBottom) => {
-                                            virtFollowRef.current = atBottom
-                                            setShowJump(!atBottom)
-                                        }}
-                                        context={{
-                                            header: <div className="pt-8" />,
-                                            footer:
-                                                activeStart < messages.length ? (
-                                                    <div
-                                                        // `pb-8` ≥ the 28px bottom fade so the meta row clears it at rest.
-                                                        className={`flex flex-col gap-3 px-3 pb-8${reserveActive ? " pt-8" : ""}`}
-                                                        // Explicit viewport-height reserve (min-h-full is inert in the
-                                                        // Footer) so scrolling to bottom pins the question to the top.
-                                                        style={
-                                                            reserveActive && virtViewportH
-                                                                ? {minHeight: virtViewportH}
-                                                                : undefined
-                                                        }
-                                                    >
-                                                        {messages
-                                                            .slice(activeStart)
-                                                            .map((m, i) =>
-                                                                renderMessage(m, activeStart + i),
-                                                            )}
-                                                    </div>
-                                                ) : null,
-                                        }}
-                                        components={virtComponents}
+                            <AgentTranscript
+                                messages={messages}
+                                activeStart={activeStart}
+                                reserveActive={reserveActive}
+                                renderMessage={renderMessage}
+                                virt={virt}
+                                scroll={scroll}
+                                showJump={showJump}
+                                placeholder={
+                                    <TranscriptPlaceholder
+                                        entityId={entityId}
+                                        pendingFirstTurn={onboardingChat.pendingFirstTurn}
+                                        pendingFirstMessage={onboardingChat.pendingFirstMessage}
+                                        onboardingActive={onboardingActive}
+                                        browseAll={onboardingChat.onboarding?.browseAll}
+                                        isHydrating={isHydrating}
+                                        hydratedEmpty={hydratedEmpty}
+                                        firstRunPrompt={firstRunPrompt}
+                                        canStart={!modelBlocked}
+                                        onStart={handleSubmit}
+                                        onPrefill={(text: string) =>
+                                            richInputRef.current?.setMarkdown(text)
+                                        }
+                                        onRewind={handleRewind}
+                                        onClientToolOutput={handleClientToolOutput}
                                     />
-                                )}
-                                {(!useVirtuoso || messages.length === 0) && (
-                                    <div
-                                        ref={(el) => {
-                                            scrollRef.current = el
-                                        }}
-                                        onScroll={onScroll}
-                                        // Capture a fresh SC-3 anchor before a click acts (expand/collapse a tool step,
-                                        // reasoning fold): those resize the transcript without a scroll, so onScroll never
-                                        // refreshes the anchor and the ResizeObserver would compensate against a stale one.
-                                        onPointerDownCapture={recordAnchor}
-                                        role="log"
-                                        aria-live="polite"
-                                        aria-label="Agent conversation"
-                                        // `pt-8`/`pb-8` (32px) ≥ the 28px fades so the first message and the last turn's
-                                        // meta row (Inspect turn + streaming dots) clear them at rest; the bottom pad
-                                        // + `[overflow-anchor:none]` are the SC scroll-engineering essentials (browser
-                                        // anchoring off so our pin/anchor logic owns the scroll position).
-                                        className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden p-3 pt-8 pb-8 [overflow-anchor:none]"
-                                        // Fade content into the top edge (under the tab bar) and the bottom edge (into the
-                                        // composer) as it scrolls. A gradient mask on the scroll container: transparent at
-                                        // each edge → opaque across the middle. GPU-composited, no JS, theme-agnostic.
-                                        style={{
-                                            maskImage: EDGE_FADE_MASK,
-                                            WebkitMaskImage: EDGE_FADE_MASK,
-                                        }}
-                                    >
-                                        {messages.length === 0 &&
-                                            (pendingFirstTurn ? (
-                                                // Optimistic first turn: the submitted description as a sent user bubble +
-                                                // an assistant loading placeholder (mirrors a real `status:"submitted"`
-                                                // turn), so the commit reads as one continuous chat, not an empty state.
-                                                <MessageRow mid="pending-first-turn" enter>
-                                                    <AgentMessage
-                                                        message={pendingFirstMessage}
-                                                        isLastMessage
-                                                        onRewind={handleRewind}
-                                                        onClientToolOutput={handleClientToolOutput}
-                                                    />
-                                                    <Bubble
-                                                        placement="start"
-                                                        variant="borderless"
-                                                        loading
-                                                        content=""
-                                                    />
-                                                </MessageRow>
-                                            ) : onboardingActive && onboarding?.browseAll ? (
-                                                // "Browse all templates" swaps the hero for the full gallery IN PLACE.
-                                                <OnboardingBrowseTemplates />
-                                            ) : isHydrating ? (
-                                                // Server-history hydration in flight — skeleton, not the "start a
-                                                // chat" hero, so a durable session doesn't flash the empty state.
-                                                <TranscriptSkeleton />
-                                            ) : hydratedEmpty && !onboardingActive ? (
-                                                // Known session whose records hydrated empty (pruned/expired) — a
-                                                // soft notice, not the new-chat hero. Composer below stays usable.
-                                                <AgentChatHistoryUnavailable />
-                                            ) : (
-                                                <AgentChatEmptyState
-                                                    entityId={entityId}
-                                                    onStart={handleSubmit}
-                                                    firstRunPrompt={firstRunPrompt}
-                                                    canStart={!modelBlocked}
-                                                    onboarding={onboardingActive}
-                                                    onPrefill={(text) =>
-                                                        richInputRef.current?.setMarkdown(text)
-                                                    }
-                                                />
-                                            ))}
-                                        {messages
-                                            .slice(0, activeStart)
-                                            .map((m, i) => renderMessage(m, i))}
-                                        {activeStart < messages.length && (
-                                            // The active turn reserves a viewport (min-h-full) when there's prior
-                                            // conversation, so sticking to the bottom shows the question at the top with the
-                                            // answer streaming into the space below — the "pin" is this layout, not JS.
-                                            // `pt-8` keeps the question clear of the top fade once it reaches the top.
-                                            <div
-                                                className={`flex flex-col gap-3${reserveActive ? " min-h-full pt-8" : ""}`}
-                                            >
-                                                {messages
-                                                    .slice(activeStart)
-                                                    .map((m, i) =>
-                                                        renderMessage(m, activeStart + i),
-                                                    )}
-                                            </div>
-                                        )}
-                                    </div>
-                                )}
+                                }
+                            />
 
-                                {/* Always mounted so it can fade + slide in/out; hidden state is non-interactive and
-                    keeps `-translate-x-1/2` (Tailwind composes x/y translate on one transform). */}
-                                <Button
-                                    size="small"
-                                    shape="round"
-                                    icon={<ArrowDown size={14} />}
-                                    onClick={useVirtuoso ? virtJumpToLatest : jumpToLatest}
-                                    tabIndex={showJump ? 0 : -1}
-                                    aria-hidden={!showJump}
-                                    // Solid elevated surface + border + shadow so the pill reads clearly when it
-                                    // floats over streamed text (a transparent pill let the text bleed through).
-                                    className={`!absolute bottom-2 left-1/2 -translate-x-1/2 !border !border-solid !border-colorBorderSecondary !bg-colorBgElevated shadow-md transition-[opacity,transform] duration-200 ease-out ${
-                                        showJump
-                                            ? "translate-y-0 opacity-100"
-                                            : "pointer-events-none translate-y-3 opacity-0"
-                                    }`}
-                                    aria-label="Jump to latest message"
-                                >
-                                    Jump to latest
-                                </Button>
-                            </div>
-
-                            {/* Queue sits BETWEEN the messages and the composer, so showing it never shifts the
-                composer (and the editor) upward. Streaming itself is signalled by the composer's
-                send button (it becomes a spinning Stop button), so there's no "Streaming…" row. */}
-                            <RevealCollapse open={queued.length > 0} className={CHAT_COLUMN}>
-                                <div className="flex items-center gap-2 px-3 pb-2">
-                                    <QueuedMessages
-                                        queued={queued}
-                                        onRemove={removeQueued}
-                                        onClear={clearQueue}
-                                        held={hitlPending}
-                                    />
-                                </div>
-                            </RevealCollapse>
-
-                            {/* Rich markdown composer (Lexical). Enter sends; attachments via header/prefix slots.
-                Wrapper `px-3` keeps the session-bar gutter; the input centers on CHAT_COLUMN so it
-                aligns with the (also centered) message column when the panel is wide. The persistent
-                HITL approval dock lives in this same block (above the input) — always mounted so it
-                animates in/out, and inside the composer region so the paused gate can't scroll out
-                of reach and its collapse adds no gap to the surrounding column. */}
-                            {/* The whole composer fades + rises in ONCE on mount (Reveal), so the input joins the
-                    empty-state/hero entrance instead of popping. Mount-only: it never remounts across the
-                    onboarding→chat transitions, so this never reintroduces layout shift on state changes. */}
-                            <Reveal className="px-3" enabled={playComposerEntrance}>
-                                {/* Agent empty-chat strip (S6): docked above the composer, unmounts once a
-                        message exists or a first-run prompt is pending. Build-mode + fresh-agent
-                        only — never in maximized chat mode, and gone for good after any commit. */}
-                                {TEMPLATE_STRIP_MODE &&
-                                !onboardingActive &&
-                                buildMode &&
-                                isFreshAgentRevision &&
-                                messages.length === 0 &&
-                                !firstRunPrompt &&
-                                !pendingFirstTurn ? (
-                                    <div className={`${CHAT_COLUMN} mb-3`}>
-                                        <TemplateStrip
-                                            surface="agent-chat"
-                                            selectedTemplateKey={
-                                                stripProvenance.selectedTemplateKey
-                                            }
-                                            onPick={handleStripPick}
-                                            surfaceColorVar="--ag-surface-chat"
-                                        />
-                                    </div>
-                                ) : null}
-                                {/* Always mounted so it animates in/out (RevealCollapse) instead of popping. Pre-commit
-                        onboarding SUPPRESSES it — the provider-key check is deferred until the agent is
-                        committed (Create-agent then runs the connect→unlock→auto-send flow on the real agent). */}
-                                <div className={CHAT_COLUMN}>
-                                    <ConnectModelBanner {...modelKey} suppressed={chromeHidden} />
-                                </div>
-                                <ApprovalDock
-                                    className={CHAT_COLUMN}
-                                    approvals={pendingApprovals}
-                                    onApprovalResponse={handleApprovalResponse}
-                                    onViewTrace={openPausedTurnTrace}
-                                    entityId={entityId}
-                                />
-                                {/* Parked client-tool interactions (connect): same placement contract as the
-                        approval dock — the paused gate can't scroll out of reach, and "Not now"
-                        is the escape hatch that resumes the run without connecting. */}
-                                <InteractionDock
-                                    className={CHAT_COLUMN}
-                                    pending={pendingInteraction}
-                                    onOutput={handleClientToolOutput}
-                                />
-                                {/* Owner call: a template pick must not shift the composer, so no chip renders here
-                        (unlike the home surface) — the strip card's own selected state is the
-                        "which template" indicator; the composer text is the only other feedback. */}
-                                {/* Onboarding strip: docked directly above the composer (mb-3 gap), mirroring the
-                        agent-chat strip's rhythm — hero stays top-aligned above the flex space, and
-                        the strip + composer read as one bottom-anchored cluster. */}
-                                {showBareOnboardingHero ? (
-                                    <div className={`${CHAT_COLUMN} mb-3`}>
-                                        <TemplateStrip
-                                            surface="onboarding"
-                                            selectedTemplateKey={
-                                                stripProvenance.selectedTemplateKey
-                                            }
-                                            onPick={handleStripPick}
-                                            surfaceColorVar="--ag-surface-chat"
-                                        />
-                                    </div>
-                                ) : null}
-                                {/* Composer region hydrates independently (Lexical chunk); the fallback is the
-                        same skeleton the pane-level gates render for this slot, so the box never
-                        changes shape — the editor just materializes inside it. */}
-                                {voiceEnabled ? (
-                                    <MicPermissionNotice
-                                        className={CHAT_COLUMN}
-                                        open={!!micError && !voiceRecorder.active}
-                                        message={micError}
-                                        onDismiss={dismissMicError}
-                                    />
-                                ) : null}
-                                {/* `mb-3` lives here, not on the input, so the recording overlay
-                                (inset-0) covers the composer box exactly. */}
-                                <div className="relative mb-3">
-                                    <Suspense
-                                        fallback={<ComposerSkeleton className={CHAT_COLUMN} />}
-                                    >
-                                        <RichChatInput
-                                            ref={richInputRef}
-                                            autoFocus={autoFocusComposer}
-                                            dictating={voiceEnabled && dictating}
-                                            className={CHAT_COLUMN}
-                                            // Onboarding: submit = commit the ephemeral — Enter creates the agent
-                                            // (matching the composer's "↵ Send" hint); ⌘/Shift+Enter inserts newlines
-                                            // for longer descriptions.
-                                            onSubmit={
-                                                onboardingActive
-                                                    ? () => handleCreateAgent()
-                                                    : handleSubmit
-                                            }
-                                            disabled={
-                                                onboardingActive ? ideHandoffActive : modelBlocked
-                                            }
-                                            hideSendButton={onboardingActive}
-                                            placeholder={
-                                                onboardingActive
-                                                    ? ideHandoffActive
-                                                        ? "Continue in your IDE from the steps above — or start over."
-                                                        : STRIP_COPY.describeAgentPlaceholder
-                                                    : modelBlocked
-                                                      ? "Connect a model to start chatting…"
-                                                      : hitlPending
-                                                        ? "The agent is waiting for your response — new messages will be queued"
-                                                        : "Ask the agent… (Enter to send, ⌘/Ctrl+Enter for newline)"
-                                            }
-                                            initialMarkdown={initialDraft}
-                                            onChange={handleComposerChange}
-                                            onPasteFile={(pasted) => {
-                                                if (!attachmentsBlocked())
-                                                    addFiles(Array.from(pasted))
-                                            }}
-                                            sendForceEnabled={
-                                                files.length > 0 && attachmentsSettled
-                                            }
-                                            streaming={busy}
-                                            onStop={handleStop}
-                                            prefix={
-                                                // Left cluster of the composer toolbar: voice mic + the (gated)
-                                                // attach button + the context token-budget readout, filling the
-                                                // otherwise-empty left space next to the attachments icon.
-                                                <div className="flex items-center gap-2">
-                                                    {voiceEnabled ? (
-                                                        <VoiceInputButton
-                                                            inputRef={richInputRef}
-                                                            onStartAudio={startVoiceMessage}
-                                                            // During onboarding the composer commits the
-                                                            // ephemeral via handleCreateAgent, but a voice
-                                                            // MESSAGE routes through handleSubmit → submit,
-                                                            // bypassing that commit. So offer dictation
-                                                            // only (it just fills the description text) —
-                                                            // voice-message returns once the agent exists.
-                                                            audioSupported={
-                                                                !onboardingActive &&
-                                                                voiceRecorder.supported
-                                                            }
-                                                            audioPending={voiceRecorder.pending}
-                                                            audioPerceivable={audioPerceivable}
-                                                            attachmentsFull={atMax}
-                                                            onDictationError={setDictationError}
-                                                            onDictatingChange={setDictating}
-                                                            disabled={
-                                                                onboardingActive
-                                                                    ? ideHandoffActive
-                                                                    : modelBlocked
-                                                            }
-                                                        />
-                                                    ) : null}
-                                                    {/* Attach button stays dead until the agent service is ready
-                                                for inline file parts (`NEXT_PUBLIC_AGENT_FILE_UPLOADS`);
-                                                paste / drag-to-add still work either way. */}
-                                                    <Tooltip
-                                                        title={
-                                                            !uploadsEnabled
-                                                                ? "Attach files coming soon"
-                                                                : atMax
-                                                                  ? `Up to ${limits.maxCount} files`
-                                                                  : "Attach files"
-                                                        }
-                                                    >
-                                                        <Button
-                                                            type="text"
-                                                            icon={<Paperclip size={16} />}
-                                                            // Paste, drop and voice all attach
-                                                            // already; leaving the obvious control
-                                                            // dead was the odd one out. Gated with
-                                                            // them on the composer being usable.
-                                                            disabled={
-                                                                !uploadsEnabled || composerDisabled
-                                                            }
-                                                            onClick={() =>
-                                                                setAttachmentsOpen((open) => !open)
-                                                            }
-                                                            aria-label="Attach files"
-                                                        />
-                                                    </Tooltip>
-                                                    {/* Context-budget meter temporarily hidden from the UI.
-                                                Logic is retained — flip `showContextBudget` to re-enable.
-                                                Only meaningful in a real conversation, so still gated on
-                                                onboarding (no turns / no usage yet). */}
-                                                    {showContextBudget && !onboardingActive ? (
-                                                        <ContextBudgetIndicator
-                                                            messages={messages}
-                                                            maxTokens={contextMaxTokens}
-                                                        />
-                                                    ) : null}
-                                                </div>
-                                            }
-                                            header={
-                                                <HeightCollapse
-                                                    open={attachmentsOpen || files.length > 0}
-                                                >
-                                                    <ComposerAttachments
-                                                        files={files}
-                                                        rejections={rejections}
-                                                        limits={limits}
-                                                        audioPerceivable={audioPerceivable}
-                                                        onAdd={addFiles}
-                                                        onRemove={removeFile}
-                                                        onDismissRejections={() =>
-                                                            setRejections([])
-                                                        }
-                                                        onView={
-                                                            uploadsEnabled
-                                                                ? setViewingUid
-                                                                : undefined
-                                                        }
-                                                        onRetry={uploads.retry}
-                                                    />
-                                                </HeightCollapse>
-                                            }
-                                            trailing={
-                                                onboardingActive ? (
-                                                    ideHandoffActive ? (
-                                                        <Button
-                                                            onClick={handleStartOver}
-                                                            className="!shadow-none"
-                                                        >
-                                                            Start over
-                                                        </Button>
-                                                    ) : TEMPLATE_STRIP_MODE ? (
-                                                        // Strip era: the SAME action cluster as the home hero composer
-                                                        // (shared component), with the one-click copy + toast handoff.
-                                                        <AgentIntentActions
-                                                            onCreate={handleCreateAgent}
-                                                            onCodingAgentCopy={
-                                                                handleCodingAgentCopy
-                                                            }
-                                                            loading={!!onboarding?.committing}
-                                                        />
-                                                    ) : (
-                                                        <div className="flex items-center gap-2">
-                                                            <Button
-                                                                icon={<Code size={14} />}
-                                                                onClick={streamIdeBubble}
-                                                                className="!shadow-none"
-                                                            >
-                                                                Continue in IDE
-                                                            </Button>
-                                                            <Button
-                                                                type="primary"
-                                                                icon={<ArrowRight size={14} />}
-                                                                iconPosition="end"
-                                                                loading={!!onboarding?.committing}
-                                                                onClick={handleCreateAgent}
-                                                                className="!shadow-none"
-                                                            >
-                                                                Create agent
-                                                            </Button>
-                                                        </div>
-                                                    )
-                                                ) : undefined
-                                            }
-                                        />
-                                    </Suspense>
-                                    {/* Cross-fades over the composer instead of popping; same spring
-                                    as the rest of the slice's chrome. */}
-                                    <AnimatePresence initial={false}>
-                                        {voiceEnabled && voiceRecorder.takeoverVisible && (
-                                            <motion.div
-                                                key="recording"
-                                                initial={{opacity: 0, y: 4}}
-                                                animate={{opacity: 1, y: 0}}
-                                                exit={{opacity: 0, y: 4}}
-                                                transition={SESSION_SPRING}
-                                                className="pointer-events-none absolute inset-0 flex justify-center"
-                                            >
-                                                <RecordingBar
-                                                    recorder={voiceRecorder}
-                                                    willSend={voiceWillSend}
-                                                    className={`${CHAT_COLUMN} h-full`}
-                                                />
-                                            </motion.div>
-                                        )}
-                                    </AnimatePresence>
-                                </div>
-                            </Reveal>
+                            <AgentComposerDock
+                                entityId={entityId}
+                                messages={messages}
+                                busy={busy}
+                                hitlPending={hitlPending}
+                                queue={{queued, removeQueued, clearQueue}}
+                                modelKey={modelKey}
+                                modelBlocked={modelBlocked}
+                                contextMaxTokens={contextMaxTokens}
+                                showContextBudget={showContextBudget}
+                                buildMode={buildMode}
+                                firstRunPrompt={firstRunPrompt}
+                                pendingApprovals={pendingApprovals}
+                                onApprovalResponse={handleApprovalResponse}
+                                onViewTrace={openPausedTurnTrace}
+                                pendingInteraction={pendingInteraction}
+                                onClientToolOutput={handleClientToolOutput}
+                                onSubmit={handleSubmit}
+                                onStop={handleStop}
+                                richInputRef={richInputRef}
+                                composer={composer}
+                                attachments={attachments}
+                                onboardingChat={onboardingChat}
+                                voice={voice}
+                                audioPerceivable={audioPerceivable}
+                                composerDisabled={composerDisabled}
+                                attachmentsBlocked={attachmentsBlocked}
+                            />
                         </div>
                         {/* Chat-mode context rail (spec E1): docked right of the transcript, Files
                             pinned on top. Always mounted so hide/show SLIDES (width transition) —
@@ -2692,9 +679,9 @@ const AgentConversation = ({
 
                 {TEMPLATE_STRIP_MODE ? (
                     <CopiedToast
-                        open={copiedToastOpen}
+                        open={onboardingChat.copiedToastOpen}
                         text={STRIP_COPY.copiedToast}
-                        onDone={() => setCopiedToastOpen(false)}
+                        onDone={() => onboardingChat.setCopiedToastOpen(false)}
                     />
                 ) : null}
             </div>

--- a/web/oss/src/components/AgentChatSlice/assets/conversationLayout.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/conversationLayout.ts
@@ -1,0 +1,19 @@
+/** Height of the top-edge fade, in px. Shared by the CSS mask and the SC-1 pin so a pinned turn
+ * lands BELOW the fade (otherwise the freshly-asked question renders partially faded). */
+export const TOP_FADE_PX = 28
+/** Height of the bottom-edge fade, matching the top so content dissolves into the composer edge. */
+export const BOTTOM_FADE_PX = 28
+/** Edge fades for the message scroll area: transparent at the very top, fully opaque by TOP_FADE_PX,
+ * then fading back to transparent over the last BOTTOM_FADE_PX. Applied as a CSS mask so the content
+ * itself fades (correct in any theme). */
+export const EDGE_FADE_MASK = `linear-gradient(to bottom, transparent 0, #000 ${TOP_FADE_PX}px, #000 calc(100% - ${BOTTOM_FADE_PX}px), transparent 100%)`
+/** Centered reading column for the chat body. Caps line length / bubble width so a wide (maximized)
+ * panel doesn't sprawl into oversized bubbles and over-spaced turns; freed side space is whitespace. */
+export const CHAT_COLUMN = "mx-auto w-full max-w-[880px]"
+
+/** Single source of truth for the (currently DISABLED) content-visibility optimization. Disabled in
+ * 5f0fa73d06 — it caused a scrollbar-shrink on first scroll-through — but the mechanism is kept so it
+ * can be re-enabled with a fix. Gates BOTH the CSS class and the SC-3 intrinsic-size measurement, so
+ * while off neither the styling nor the measurement runs. Typed `boolean` so the guards aren't
+ * flagged as always-false. Under Virtuoso it must stay off regardless (it corrupts item measurement). */
+export const CONTENT_VISIBILITY_ENABLED = false as boolean

--- a/web/oss/src/components/AgentChatSlice/assets/files.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/files.ts
@@ -32,9 +32,29 @@ const fileToPart = (file: File): Promise<FileUIPart> =>
         reader.readAsDataURL(file)
     })
 
-/** Convert picked `File`s into `file` parts for `sendMessage({text, files})`. */
-export const filesToParts = (files: File[]): Promise<FileUIPart[]> =>
-    Promise.all(files.map(fileToPart))
+export interface FileReadResult {
+    parts: FileUIPart[]
+    /** Files the browser refused to read (revoked blob, moved/locked on disk), in input order. */
+    unreadable: File[]
+}
+
+/**
+ * Convert picked `File`s into `file` parts for `sendMessage({text, files})`.
+ *
+ * Never rejects. Every send path drops this promise (composer submit, voice take, empty-state
+ * Start, the first-run seed), so a `Promise.all` that threw on one unreadable file surfaced as an
+ * unhandled rejection and a send that silently did nothing. Failures come back as data instead.
+ */
+export const filesToParts = async (files: File[]): Promise<FileReadResult> => {
+    const settled = await Promise.allSettled(files.map(fileToPart))
+    const parts: FileUIPart[] = []
+    const unreadable: File[] = []
+    settled.forEach((result, i) => {
+        if (result.status === "fulfilled") parts.push(result.value)
+        else unreadable.push(files[i])
+    })
+    return {parts, unreadable}
+}
 
 /** The `file` parts of a message, in order. */
 export const fileParts = (message: UIMessage): FileUIPart[] =>

--- a/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
@@ -21,10 +21,20 @@ import {transcriptToMessages} from "./transcriptToMessages"
  * authoritative). Because this return is a one-shot copy, `onRefreshed` re-delivers the
  * transcript when that revalidation lands — callers apply it behind their own adoption guards.
  */
+export interface SessionTranscript {
+    messages: UIMessage[]
+    /**
+     * How many durable records this transcript was built from. The log is append-only and ordered,
+     * so this is an EXACT "has the server moved on?" watermark — unlike a message count, which
+     * `transcriptToMessages` deliberately holds flat while a turn grows (issue #5530).
+     */
+    recordCount: number
+}
+
 export const loadSessionMessages = async (
     sessionId: string,
-    onRefreshed?: (messages: UIMessage[]) => void,
-): Promise<UIMessage[] | null> => {
+    onRefreshed?: (transcript: SessionTranscript) => void,
+): Promise<SessionTranscript | null> => {
     // Fetch through the shared records query cache (same key as `sessionRecordsQueryFamily`) so
     // hydration, revalidation, and the Inspector's atom subscribers share ONE network flight per
     // stale window instead of each issuing a raw duplicate request. A failure resolves to `null`
@@ -36,11 +46,14 @@ export const loadSessionMessages = async (
             void refreshed.then((fresh) => {
                 if (!fresh || fresh.length === 0) return
                 const freshMsgs = transcriptToMessages(fresh)
-                if (freshMsgs && freshMsgs.length > 0) onRefreshed(freshMsgs)
+                if (freshMsgs && freshMsgs.length > 0) {
+                    onRefreshed({messages: freshMsgs, recordCount: fresh.length})
+                }
             })
         }
         if (!records || records.length === 0) return null
-        return transcriptToMessages(records)
+        const messages = transcriptToMessages(records)
+        return messages ? {messages, recordCount: records.length} : null
     } catch (err) {
         console.warn("[loadSessionMessages] hydration fetch failed:", err)
         return null

--- a/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
@@ -1,0 +1,31 @@
+import {type UIMessage} from "ai"
+
+/** A part the transcript actually renders — non-empty text/reasoning, files, sources, tools. */
+export const isVisiblePart = (p: UIMessage["parts"][number]): boolean =>
+    (p.type === "text" && Boolean((p as {text?: string}).text?.trim())) ||
+    (p.type === "reasoning" && Boolean((p as {text?: string}).text?.trim())) ||
+    p.type === "file" ||
+    p.type === "source-url" ||
+    p.type.startsWith("tool-") ||
+    p.type === "dynamic-tool"
+
+/** A settled assistant turn with no content at all — no answer, reasoning, tool, file, or
+ * source part. Mirrors AgentMessage's `!hasContent`; used to collapse a run of "no response"
+ * bubbles (e.g. repeated failed runs) down to the first one. */
+export const isEmptyAssistantTurn = (m: UIMessage): boolean =>
+    m.role === "assistant" && !m.parts.some(isVisiblePart)
+
+/** Assistant message id → its 1-based turn number (records/turns align 1:1 with the assistant
+ * messages — one per `done`). Built once per message set: the per-message scan it replaces was
+ * O(n) inside a render loop, so the transcript paid O(n²) on every streamed commit. */
+export const assistantTurnNumbers = (messages: UIMessage[]): Map<string, number> => {
+    const turns = new Map<string, number>()
+    let n = 0
+    for (const m of messages) {
+        if (m.role === "assistant") {
+            n += 1
+            turns.set(m.id, n)
+        }
+    }
+    return turns
+}

--- a/web/oss/src/components/AgentChatSlice/assets/runError.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/runError.ts
@@ -1,0 +1,39 @@
+/** A stream error/abort is already surfaced via `useChat`'s `onError` + the in-chat `error`
+ * alert; swallow the floating `sendMessage`/`regenerate` rejection so it doesn't bubble to the
+ * Next.js dev Runtime Error overlay (F-033). */
+export const ignoreStreamRejection = () => {}
+
+export interface ParsedRunError {
+    message: string
+    code?: number
+}
+
+/**
+ * Best-effort human reason from a useChat stream error. The server may hand us a clean string
+ * ("Agent run failed: …") or a JSON envelope (`{status:{code,message,…}}` / `{message}`) — pull
+ * the message out of either and drop the stacktrace / docs-url noise so it reads cleanly inline.
+ */
+export const parseAgentRunError = (err: unknown): ParsedRunError => {
+    const raw =
+        err instanceof Error ? err.message : typeof err === "string" ? err : String(err ?? "")
+    const fallback = raw.trim() || "The agent run failed."
+    try {
+        const obj = JSON.parse(raw) as Record<string, unknown>
+        const status = (obj?.status && typeof obj.status === "object" ? obj.status : obj) as Record<
+            string,
+            unknown
+        >
+        const message =
+            typeof status?.message === "string"
+                ? status.message
+                : typeof obj?.message === "string"
+                  ? (obj.message as string)
+                  : null
+        if (message) {
+            return {message, code: typeof status?.code === "number" ? status.code : undefined}
+        }
+    } catch {
+        // raw isn't JSON — it's already the human message.
+    }
+    return {message: fallback}
+}

--- a/web/oss/src/components/AgentChatSlice/assets/scrollGeometry.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/scrollGeometry.ts
@@ -1,0 +1,16 @@
+/** The last real content element in the log (the last turn's last child). Used to measure the REAL
+ * content bottom and ignore the min-h-full reserve that pads a streaming turn — so the jump pill and
+ * stick-to-bottom track the latest message, not the bottom of the empty reserved space. */
+export const lastContentEl = (el: HTMLElement): HTMLElement | null => {
+    const wrappers = el.querySelectorAll<HTMLElement>("[data-mid]")
+    const wrapper = wrappers[wrappers.length - 1]
+    if (!wrapper) return null
+    return (wrapper.lastElementChild as HTMLElement | null) ?? wrapper
+}
+
+/** True when the latest message content sits at or above the viewport bottom (i.e. fully visible). */
+export const atLiveEdge = (el: HTMLElement): boolean => {
+    const last = lastContentEl(el)
+    if (!last) return true
+    return last.getBoundingClientRect().bottom - el.getBoundingClientRect().bottom < 24
+}

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -304,3 +304,50 @@ describe("transcriptToMessages paused end-marker", () => {
         expect((messages?.[0].metadata as {paused?: boolean} | undefined)?.paused).toBeUndefined()
     })
 })
+
+/**
+ * Regression guard for issue #5530. The adoption guard must not go back to comparing message
+ * counts: a turn grows IN PLACE here, so the count is identical before and after it completes.
+ * If a mapper change ever makes these counts differ, revisit `shouldAdoptServerTranscript` —
+ * do not "simplify" it back to a count comparison on the strength of that change.
+ */
+describe("transcriptToMessages turn growth is invisible to a message count", () => {
+    const midTurn = (): SessionRecord[] => [
+        ...approvalRecords(),
+        record("record-done-paused", {type: "done", stopReason: "paused"}),
+    ]
+
+    const completed = (): SessionRecord[] => [
+        ...midTurn(),
+        record("record-response", {
+            type: "interaction_response",
+            id: "approval-1",
+            kind: "user_approval",
+            payload: {toolCallId: "tool-1", approved: true},
+        }),
+        record("record-result", {
+            type: "tool_result",
+            id: "tool-1",
+            output: {stdout: "a.txt\nb.txt"},
+        }),
+        record("record-answer", {type: "message", text: "There are two files."}),
+        record("record-done", {type: "done"}),
+    ]
+
+    it("renders the same number of messages before and after the turn finishes", () => {
+        const partial = transcriptToMessages(midTurn())
+        const full = transcriptToMessages(completed())
+
+        expect(partial).toHaveLength(1)
+        expect(full).toHaveLength(1)
+        // Same messages, far more content — and far more records behind it.
+        expect(completed().length).toBeGreaterThan(midTurn().length)
+    })
+
+    it("carries strictly more content in the completed turn", () => {
+        const partial = transcriptToMessages(midTurn())
+        const full = transcriptToMessages(completed())
+
+        expect(full?.[0].parts.length).toBeGreaterThan(partial?.[0].parts.length ?? 0)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -32,6 +32,7 @@ import MicPermissionNotice from "./MicPermissionNotice"
 import QueuedMessages from "./QueuedMessages"
 import RecordingBar from "./RecordingBar"
 import RevealCollapse from "./RevealCollapse"
+import RunningElsewhereStrip from "./RunningElsewhereStrip"
 import VoiceInputButton from "./VoiceInputButton"
 
 // The composer carries Lexical — the heaviest dependency of this chunk — out of the
@@ -51,6 +52,7 @@ const AgentComposerDock = ({
     entityId,
     messages,
     busy,
+    runningElsewhere,
     hitlPending,
     queue,
     modelKey,
@@ -78,6 +80,8 @@ const AgentComposerDock = ({
     entityId: string
     messages: UIMessage[]
     busy: boolean
+    /** The backend reports a live run for this session that this browser is not driving. */
+    runningElsewhere: boolean
     hitlPending: boolean
     queue: {
         queued: QueuedMessage[]
@@ -201,6 +205,11 @@ const AgentComposerDock = ({
                 <div className={CHAT_COLUMN}>
                     <ConnectModelBanner {...modelKey} suppressed={chromeHidden} />
                 </div>
+                {/* Sits with the other docked strips so a session running in another browser reads
+                    as busy instead of frozen (#5530). */}
+                {runningElsewhere && !chromeHidden ? (
+                    <RunningElsewhereStrip className={CHAT_COLUMN} />
+                ) : null}
                 <ApprovalDock
                     className={CHAT_COLUMN}
                     approvals={pendingApprovals}

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -1,0 +1,424 @@
+import {type RefObject, Suspense, lazy} from "react"
+
+import {HeightCollapse} from "@agenta/ui"
+import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
+import {ArrowRight, Code, Paperclip} from "@phosphor-icons/react"
+import {type UIMessage} from "ai"
+import {Button, Tooltip} from "antd"
+import {AnimatePresence, motion} from "motion/react"
+
+import {TEMPLATE_STRIP_MODE} from "@/oss/components/pages/agent-home/assets/constants"
+import Reveal from "@/oss/components/pages/agent-home/PlaygroundOnboarding/Reveal"
+import TemplateStrip from "@/oss/components/TemplateStrip"
+import {STRIP_COPY} from "@/oss/components/TemplateStrip/assets/constants"
+import AgentIntentActions from "@/oss/components/TemplateStrip/components/AgentIntentActions"
+
+import {CHAT_COLUMN} from "../assets/conversationLayout"
+import {SESSION_SPRING} from "../assets/sessionMotion"
+import {type QueuedMessage} from "../hooks/useAgentChatQueue"
+import {type useComposerAttachments} from "../hooks/useComposerAttachments"
+import {type useComposerDraft} from "../hooks/useComposerDraft"
+import {type useOnboardingChat} from "../hooks/useOnboardingChat"
+import {type useVoiceComposer} from "../hooks/useVoiceComposer"
+
+import {ComposerSkeleton} from "./AgentChatSkeleton"
+import ApprovalDock, {type getPendingApprovals} from "./ApprovalDock"
+import type {ClientToolOutputHandler} from "./clientTools"
+import ComposerAttachments from "./ComposerAttachments"
+import ConnectModelBanner from "./ConnectModelBanner"
+import ContextBudgetIndicator from "./ContextBudgetIndicator"
+import InteractionDock, {type getPendingConnectInteraction} from "./InteractionDock"
+import MicPermissionNotice from "./MicPermissionNotice"
+import QueuedMessages from "./QueuedMessages"
+import RecordingBar from "./RecordingBar"
+import RevealCollapse from "./RevealCollapse"
+import VoiceInputButton from "./VoiceInputButton"
+
+// The composer carries Lexical — the heaviest dependency of this chunk — out of the
+// conversation's synchronous mount; React.lazy (not next/dynamic) so the imperative handle
+// ref forwards. Its fallback is the same ComposerSkeleton the frame reserves for this slot.
+const RichChatInput = lazy(() =>
+    import("@agenta/ui/rich-chat-input").then((m) => ({default: m.RichChatInput})),
+)
+
+/**
+ * Everything below the transcript: the held-message queue, the connect-model banner, the HITL
+ * approval and interaction docks, the template strips, the voice surface, and the composer itself.
+ * The docks live in this block (not inline in the transcript) so a paused gate can never scroll out
+ * of reach.
+ */
+const AgentComposerDock = ({
+    entityId,
+    messages,
+    busy,
+    hitlPending,
+    queue,
+    modelKey,
+    modelBlocked,
+    contextMaxTokens,
+    showContextBudget,
+    buildMode,
+    firstRunPrompt,
+    pendingApprovals,
+    onApprovalResponse,
+    onViewTrace,
+    pendingInteraction,
+    onClientToolOutput,
+    onSubmit,
+    onStop,
+    richInputRef,
+    composer,
+    attachments,
+    onboardingChat,
+    voice,
+    audioPerceivable,
+    composerDisabled,
+    attachmentsBlocked,
+}: {
+    entityId: string
+    messages: UIMessage[]
+    busy: boolean
+    hitlPending: boolean
+    queue: {
+        queued: QueuedMessage[]
+        removeQueued: (id: string) => void
+        clearQueue: () => void
+    }
+    modelKey: React.ComponentProps<typeof ConnectModelBanner>
+    modelBlocked: boolean
+    contextMaxTokens: number | null
+    showContextBudget: boolean
+    buildMode: boolean
+    firstRunPrompt: string | null
+    pendingApprovals: ReturnType<typeof getPendingApprovals>
+    onApprovalResponse: (args: {id: string; approved: boolean; message?: string}) => void
+    onViewTrace?: () => void
+    pendingInteraction: ReturnType<typeof getPendingConnectInteraction>
+    onClientToolOutput: ClientToolOutputHandler
+    onSubmit: (text: string) => void | Promise<void>
+    onStop: () => void
+    richInputRef: RefObject<RichChatInputHandle | null>
+    composer: ReturnType<typeof useComposerDraft>
+    attachments: ReturnType<typeof useComposerAttachments>
+    onboardingChat: ReturnType<typeof useOnboardingChat>
+    voice: ReturnType<typeof useVoiceComposer>
+    /** Whether the selected model can take audio in; `null` where the catalog does not say. */
+    audioPerceivable: boolean | null
+    /** The composer itself is unusable (IDE hand-off / no model key). */
+    composerDisabled: boolean
+    /** Read at event time — attachments are refused right now (a take in flight, or the above). */
+    attachmentsBlocked: () => boolean
+}) => {
+    const {
+        onboarding,
+        onboardingActive,
+        chromeHidden,
+        selectedTemplateKey,
+        handleStripPick,
+        isFreshAgentRevision,
+        pendingFirstTurn,
+        handleCreateAgent,
+        streamIdeBubble,
+        ideHandoffActive,
+        handleStartOver,
+        handleCodingAgentCopy,
+        showBareOnboardingHero,
+    } = onboardingChat
+    const {
+        uploadsEnabled,
+        files,
+        rejections,
+        setRejections,
+        attachmentsOpen,
+        setAttachmentsOpen,
+        setViewingUid,
+        limits,
+        atMax,
+        attachmentsSettled,
+        addFiles,
+        removeFile,
+        uploads,
+    } = attachments
+    const {
+        voiceEnabled,
+        voiceRecorder,
+        voiceWillSend,
+        startVoiceMessage,
+        dictating,
+        setDictating,
+        setDictationError,
+        micError,
+        dismissMicError,
+    } = voice
+    return (
+        <>
+            {/* Queue sits BETWEEN the messages and the composer, so showing it never shifts the
+                composer (and the editor) upward. Streaming itself is signalled by the composer's
+                send button (it becomes a spinning Stop button), so there's no "Streaming…" row. */}
+            <RevealCollapse open={queue.queued.length > 0} className={CHAT_COLUMN}>
+                <div className="flex items-center gap-2 px-3 pb-2">
+                    <QueuedMessages
+                        queued={queue.queued}
+                        onRemove={queue.removeQueued}
+                        onClear={queue.clearQueue}
+                        held={hitlPending}
+                    />
+                </div>
+            </RevealCollapse>
+
+            {/* Rich markdown composer (Lexical). Enter sends; attachments via header/prefix slots.
+                Wrapper `px-3` keeps the session-bar gutter; the input centers on CHAT_COLUMN so it
+                aligns with the (also centered) message column when the panel is wide. The persistent
+                HITL approval dock lives in this same block (above the input) — always mounted so it
+                animates in/out, and inside the composer region so the paused gate can't scroll out
+                of reach and its collapse adds no gap to the surrounding column. */}
+            {/* The whole composer fades + rises in ONCE on mount (Reveal), so the input joins the
+                empty-state/hero entrance instead of popping. Mount-only: it never remounts across the
+                onboarding→chat transitions, so this never reintroduces layout shift on state changes. */}
+            <Reveal className="px-3" enabled={composer.playComposerEntrance}>
+                {/* Agent empty-chat strip (S6): docked above the composer, unmounts once a
+                    message exists or a first-run prompt is pending. Build-mode + fresh-agent
+                    only — never in maximized chat mode, and gone for good after any commit. */}
+                {TEMPLATE_STRIP_MODE &&
+                !onboardingActive &&
+                buildMode &&
+                isFreshAgentRevision &&
+                messages.length === 0 &&
+                !firstRunPrompt &&
+                !pendingFirstTurn ? (
+                    <div className={`${CHAT_COLUMN} mb-3`}>
+                        <TemplateStrip
+                            surface="agent-chat"
+                            selectedTemplateKey={selectedTemplateKey}
+                            onPick={handleStripPick}
+                            surfaceColorVar="--ag-surface-chat"
+                        />
+                    </div>
+                ) : null}
+                {/* Always mounted so it animates in/out (RevealCollapse) instead of popping. Pre-commit
+                    onboarding SUPPRESSES it — the provider-key check is deferred until the agent is
+                    committed (Create-agent then runs the connect→unlock→auto-send flow on the real agent). */}
+                <div className={CHAT_COLUMN}>
+                    <ConnectModelBanner {...modelKey} suppressed={chromeHidden} />
+                </div>
+                <ApprovalDock
+                    className={CHAT_COLUMN}
+                    approvals={pendingApprovals}
+                    onApprovalResponse={onApprovalResponse}
+                    onViewTrace={onViewTrace}
+                    entityId={entityId}
+                />
+                {/* Parked client-tool interactions (connect): same placement contract as the
+                    approval dock — the paused gate can't scroll out of reach, and "Not now"
+                    is the escape hatch that resumes the run without connecting. */}
+                <InteractionDock
+                    className={CHAT_COLUMN}
+                    pending={pendingInteraction}
+                    onOutput={onClientToolOutput}
+                />
+                {/* Owner call: a template pick must not shift the composer, so no chip renders here
+                    (unlike the home surface) — the strip card's own selected state is the
+                    "which template" indicator; the composer text is the only other feedback. */}
+                {/* Onboarding strip: docked directly above the composer (mb-3 gap), mirroring the
+                    agent-chat strip's rhythm — hero stays top-aligned above the flex space, and
+                    the strip + composer read as one bottom-anchored cluster. */}
+                {showBareOnboardingHero ? (
+                    <div className={`${CHAT_COLUMN} mb-3`}>
+                        <TemplateStrip
+                            surface="onboarding"
+                            selectedTemplateKey={selectedTemplateKey}
+                            onPick={handleStripPick}
+                            surfaceColorVar="--ag-surface-chat"
+                        />
+                    </div>
+                ) : null}
+                {/* Composer region hydrates independently (Lexical chunk); the fallback is the
+                    same skeleton the pane-level gates render for this slot, so the box never
+                    changes shape — the editor just materializes inside it. */}
+                {voiceEnabled ? (
+                    <MicPermissionNotice
+                        className={CHAT_COLUMN}
+                        open={!!micError && !voiceRecorder.active}
+                        message={micError}
+                        onDismiss={dismissMicError}
+                    />
+                ) : null}
+                {/* `mb-3` lives here, not on the input, so the recording overlay
+                (inset-0) covers the composer box exactly. */}
+                <div className="relative mb-3">
+                    <Suspense fallback={<ComposerSkeleton className={CHAT_COLUMN} />}>
+                        <RichChatInput
+                            ref={richInputRef}
+                            autoFocus={composer.autoFocusComposer}
+                            dictating={voiceEnabled && dictating}
+                            className={CHAT_COLUMN}
+                            // Onboarding: submit = commit the ephemeral — Enter creates the agent
+                            // (matching the composer's "↵ Send" hint); ⌘/Shift+Enter inserts newlines
+                            // for longer descriptions.
+                            onSubmit={onboardingActive ? () => handleCreateAgent() : onSubmit}
+                            disabled={onboardingActive ? ideHandoffActive : modelBlocked}
+                            hideSendButton={onboardingActive}
+                            placeholder={
+                                onboardingActive
+                                    ? ideHandoffActive
+                                        ? "Continue in your IDE from the steps above — or start over."
+                                        : STRIP_COPY.describeAgentPlaceholder
+                                    : modelBlocked
+                                      ? "Connect a model to start chatting…"
+                                      : hitlPending
+                                        ? "The agent is waiting for your response — new messages will be queued"
+                                        : "Ask the agent… (Enter to send, ⌘/Ctrl+Enter for newline)"
+                            }
+                            initialMarkdown={composer.initialDraft}
+                            onChange={composer.handleComposerChange}
+                            onPasteFile={(pasted) => {
+                                if (!attachmentsBlocked()) addFiles(Array.from(pasted))
+                            }}
+                            sendForceEnabled={files.length > 0 && attachmentsSettled}
+                            streaming={busy}
+                            onStop={onStop}
+                            prefix={
+                                // Left cluster of the composer toolbar: voice mic + the (gated)
+                                // attach button + the context token-budget readout, filling the
+                                // otherwise-empty left space next to the attachments icon.
+                                <div className="flex items-center gap-2">
+                                    {voiceEnabled ? (
+                                        <VoiceInputButton
+                                            inputRef={richInputRef}
+                                            onStartAudio={startVoiceMessage}
+                                            // During onboarding the composer commits the
+                                            // ephemeral via handleCreateAgent, but a voice
+                                            // MESSAGE routes through handleSubmit → submit,
+                                            // bypassing that commit. So offer dictation
+                                            // only (it just fills the description text) —
+                                            // voice-message returns once the agent exists.
+                                            audioSupported={
+                                                !onboardingActive && voiceRecorder.supported
+                                            }
+                                            audioPending={voiceRecorder.pending}
+                                            audioPerceivable={audioPerceivable}
+                                            attachmentsFull={atMax}
+                                            onDictationError={setDictationError}
+                                            onDictatingChange={setDictating}
+                                            disabled={
+                                                onboardingActive ? ideHandoffActive : modelBlocked
+                                            }
+                                        />
+                                    ) : null}
+                                    {/* Attach button stays dead until the agent service is ready
+                                    for inline file parts (`NEXT_PUBLIC_AGENT_FILE_UPLOADS`);
+                                    paste / drag-to-add still work either way. */}
+                                    <Tooltip
+                                        title={
+                                            !uploadsEnabled
+                                                ? "Attach files coming soon"
+                                                : atMax
+                                                  ? `Up to ${limits.maxCount} files`
+                                                  : "Attach files"
+                                        }
+                                    >
+                                        <Button
+                                            type="text"
+                                            icon={<Paperclip size={16} />}
+                                            // Paste, drop and voice all attach
+                                            // already; leaving the obvious control
+                                            // dead was the odd one out. Gated with
+                                            // them on the composer being usable.
+                                            disabled={!uploadsEnabled || composerDisabled}
+                                            onClick={() => setAttachmentsOpen((open) => !open)}
+                                            aria-label="Attach files"
+                                        />
+                                    </Tooltip>
+                                    {/* Context-budget meter temporarily hidden from the UI.
+                                    Logic is retained — flip `showContextBudget` to re-enable.
+                                    Only meaningful in a real conversation, so still gated on
+                                    onboarding (no turns / no usage yet). */}
+                                    {showContextBudget && !onboardingActive ? (
+                                        <ContextBudgetIndicator
+                                            messages={messages}
+                                            maxTokens={contextMaxTokens}
+                                        />
+                                    ) : null}
+                                </div>
+                            }
+                            header={
+                                <HeightCollapse open={attachmentsOpen || files.length > 0}>
+                                    <ComposerAttachments
+                                        files={files}
+                                        rejections={rejections}
+                                        limits={limits}
+                                        audioPerceivable={audioPerceivable}
+                                        onAdd={addFiles}
+                                        onRemove={removeFile}
+                                        onDismissRejections={() => setRejections([])}
+                                        onView={uploadsEnabled ? setViewingUid : undefined}
+                                        onRetry={uploads.retry}
+                                    />
+                                </HeightCollapse>
+                            }
+                            trailing={
+                                onboardingActive ? (
+                                    ideHandoffActive ? (
+                                        <Button onClick={handleStartOver} className="!shadow-none">
+                                            Start over
+                                        </Button>
+                                    ) : TEMPLATE_STRIP_MODE ? (
+                                        // Strip era: the SAME action cluster as the home hero composer
+                                        // (shared component), with the one-click copy + toast handoff.
+                                        <AgentIntentActions
+                                            onCreate={handleCreateAgent}
+                                            onCodingAgentCopy={handleCodingAgentCopy}
+                                            loading={!!onboarding?.committing}
+                                        />
+                                    ) : (
+                                        <div className="flex items-center gap-2">
+                                            <Button
+                                                icon={<Code size={14} />}
+                                                onClick={streamIdeBubble}
+                                                className="!shadow-none"
+                                            >
+                                                Continue in IDE
+                                            </Button>
+                                            <Button
+                                                type="primary"
+                                                icon={<ArrowRight size={14} />}
+                                                iconPosition="end"
+                                                loading={!!onboarding?.committing}
+                                                onClick={handleCreateAgent}
+                                                className="!shadow-none"
+                                            >
+                                                Create agent
+                                            </Button>
+                                        </div>
+                                    )
+                                ) : undefined
+                            }
+                        />
+                    </Suspense>
+                    {/* Cross-fades over the composer instead of popping; same spring
+                    as the rest of the slice's chrome. */}
+                    <AnimatePresence initial={false}>
+                        {voiceEnabled && voiceRecorder.takeoverVisible && (
+                            <motion.div
+                                key="recording"
+                                initial={{opacity: 0, y: 4}}
+                                animate={{opacity: 1, y: 0}}
+                                exit={{opacity: 0, y: 4}}
+                                transition={SESSION_SPRING}
+                                className="pointer-events-none absolute inset-0 flex justify-center"
+                            >
+                                <RecordingBar
+                                    recorder={voiceRecorder}
+                                    willSend={voiceWillSend}
+                                    className={`${CHAT_COLUMN} h-full`}
+                                />
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
+                </div>
+            </Reveal>
+        </>
+    )
+}
+
+export default AgentComposerDock

--- a/web/oss/src/components/AgentChatSlice/components/AgentTranscript.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTranscript.tsx
@@ -100,9 +100,7 @@ const AgentTranscript = ({
             )}
             {(!useVirtuoso || messages.length === 0) && (
                 <div
-                    ref={(el) => {
-                        scroll.scrollRef.current = el
-                    }}
+                    ref={scroll.attachScroll}
                     onScroll={scroll.onScroll}
                     // Capture a fresh SC-3 anchor before a click acts (expand/collapse a tool step,
                     // reasoning fold): those resize the transcript without a scroll, so onScroll never

--- a/web/oss/src/components/AgentChatSlice/components/AgentTranscript.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTranscript.tsx
@@ -1,0 +1,169 @@
+import {type ReactNode} from "react"
+
+import {ArrowDown} from "@phosphor-icons/react"
+import {type UIMessage} from "ai"
+import {Button} from "antd"
+import {Virtuoso} from "react-virtuoso"
+
+import {EDGE_FADE_MASK} from "../assets/conversationLayout"
+import {type ScrollIntent} from "../hooks/useScrollIntent"
+import {type useTranscriptScroll} from "../hooks/useTranscriptScroll"
+import {type VirtCtx, type useVirtuosoTranscript} from "../hooks/useVirtuosoTranscript"
+
+/**
+ * The scrollable message log and its jump-to-latest pill. Renders through whichever engine is
+ * live — Virtuoso when it's enabled in the playground settings, the plain scroll container
+ * otherwise — so both variants stay side by side under one set of layout decisions.
+ */
+const AgentTranscript = ({
+    messages,
+    activeStart,
+    reserveActive,
+    renderMessage,
+    placeholder,
+    virt,
+    scroll,
+    showJump,
+}: {
+    messages: UIMessage[]
+    /** Index where the ACTIVE turn (last user message + its response) starts. */
+    activeStart: number
+    /** The active turn reserves a viewport, so the question can sit at the top. */
+    reserveActive: boolean
+    renderMessage: (message: UIMessage, index: number) => ReactNode
+    /** Shown in place of the log while there are no messages. */
+    placeholder: ReactNode
+    virt: ReturnType<typeof useVirtuosoTranscript>
+    scroll: ReturnType<typeof useTranscriptScroll>
+    showJump: ScrollIntent["showJump"]
+}) => {
+    const useVirtuoso = virt.enabled
+    return (
+        <div className="ag-canvas relative flex min-h-0 flex-1 flex-col">
+            {useVirtuoso && messages.length > 0 && (
+                <Virtuoso<UIMessage, VirtCtx>
+                    ref={virt.virtuosoRef}
+                    scrollerRef={virt.setScroller}
+                    data={messages.slice(0, activeStart)}
+                    className="ag-canvas flex-1 [overflow-anchor:none]"
+                    style={{
+                        maskImage: EDGE_FADE_MASK,
+                        WebkitMaskImage: EDGE_FADE_MASK,
+                    }}
+                    // Wide buffer so rows are rendered AND measured before they enter view — the
+                    // height correction (85–1022px vs the estimate) then happens off-screen, so
+                    // real content scrolls in without blanks or jitter. Tunable from settings.
+                    increaseViewportBy={{
+                        top: virt.overscan,
+                        bottom: Math.round(virt.overscan * 0.66),
+                    }}
+                    defaultItemHeight={virt.itemEstimate}
+                    // A prior mount's snapshot restores true row heights + scroll in the
+                    // first frame; only a genuinely first visit anchors by index (the two
+                    // props conflict, so exactly one is passed).
+                    {...(virt.restoreState
+                        ? {restoreStateFrom: virt.restoreState}
+                        : {
+                              initialTopMostItemIndex: {
+                                  index: Math.max(0, activeStart - 1),
+                                  align: "end" as const,
+                              },
+                          })}
+                    computeItemKey={(_i, m) => m.id}
+                    itemContent={(index, m) => (
+                        <div className="px-3 pb-3">{renderMessage(m, index)}</div>
+                    )}
+                    atBottomStateChange={virt.onAtBottomStateChange}
+                    context={{
+                        header: <div className="pt-8" />,
+                        footer:
+                            activeStart < messages.length ? (
+                                <div
+                                    // `pb-8` ≥ the 28px bottom fade so the meta row clears it at rest.
+                                    className={`flex flex-col gap-3 px-3 pb-8${reserveActive ? " pt-8" : ""}`}
+                                    // Explicit viewport-height reserve (min-h-full is inert in the
+                                    // Footer) so scrolling to bottom pins the question to the top.
+                                    style={
+                                        reserveActive && virt.viewportH
+                                            ? {minHeight: virt.viewportH}
+                                            : undefined
+                                    }
+                                >
+                                    {messages
+                                        .slice(activeStart)
+                                        .map((m, i) => renderMessage(m, activeStart + i))}
+                                </div>
+                            ) : null,
+                    }}
+                    components={virt.components}
+                />
+            )}
+            {(!useVirtuoso || messages.length === 0) && (
+                <div
+                    ref={(el) => {
+                        scroll.scrollRef.current = el
+                    }}
+                    onScroll={scroll.onScroll}
+                    // Capture a fresh SC-3 anchor before a click acts (expand/collapse a tool step,
+                    // reasoning fold): those resize the transcript without a scroll, so onScroll never
+                    // refreshes the anchor and the ResizeObserver would compensate against a stale one.
+                    onPointerDownCapture={scroll.recordAnchor}
+                    role="log"
+                    aria-live="polite"
+                    aria-label="Agent conversation"
+                    // `pt-8`/`pb-8` (32px) ≥ the 28px fades so the first message and the last turn's
+                    // meta row (Inspect turn + streaming dots) clear them at rest; the bottom pad
+                    // + `[overflow-anchor:none]` are the SC scroll-engineering essentials (browser
+                    // anchoring off so our pin/anchor logic owns the scroll position).
+                    className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden p-3 pt-8 pb-8 [overflow-anchor:none]"
+                    // Fade content into the top edge (under the tab bar) and the bottom edge (into the
+                    // composer) as it scrolls. A gradient mask on the scroll container: transparent at
+                    // each edge → opaque across the middle. GPU-composited, no JS, theme-agnostic.
+                    style={{
+                        maskImage: EDGE_FADE_MASK,
+                        WebkitMaskImage: EDGE_FADE_MASK,
+                    }}
+                >
+                    {messages.length === 0 && placeholder}
+                    {messages.slice(0, activeStart).map((m, i) => renderMessage(m, i))}
+                    {activeStart < messages.length && (
+                        // The active turn reserves a viewport (min-h-full) when there's prior
+                        // conversation, so sticking to the bottom shows the question at the top with the
+                        // answer streaming into the space below — the "pin" is this layout, not JS.
+                        // `pt-8` keeps the question clear of the top fade once it reaches the top.
+                        <div
+                            className={`flex flex-col gap-3${reserveActive ? " min-h-full pt-8" : ""}`}
+                        >
+                            {messages
+                                .slice(activeStart)
+                                .map((m, i) => renderMessage(m, activeStart + i))}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {/* Always mounted so it can fade + slide in/out; hidden state is non-interactive and
+                keeps `-translate-x-1/2` (Tailwind composes x/y translate on one transform). */}
+            <Button
+                size="small"
+                shape="round"
+                icon={<ArrowDown size={14} />}
+                onClick={useVirtuoso ? virt.jumpToLatest : scroll.jumpToLatest}
+                tabIndex={showJump ? 0 : -1}
+                aria-hidden={!showJump}
+                // Solid elevated surface + border + shadow so the pill reads clearly when it
+                // floats over streamed text (a transparent pill let the text bleed through).
+                className={`!absolute bottom-2 left-1/2 -translate-x-1/2 !border !border-solid !border-colorBorderSecondary !bg-colorBgElevated shadow-md transition-[opacity,transform] duration-200 ease-out ${
+                    showJump
+                        ? "translate-y-0 opacity-100"
+                        : "pointer-events-none translate-y-3 opacity-0"
+                }`}
+                aria-label="Jump to latest message"
+            >
+                Jump to latest
+            </Button>
+        </div>
+    )
+}
+
+export default AgentTranscript

--- a/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
@@ -1,0 +1,131 @@
+import {memo, useCallback} from "react"
+
+import {TreeStructure} from "@phosphor-icons/react"
+import {type UIMessage} from "ai"
+import {Button, Tag} from "antd"
+
+import AgentMessage from "./AgentMessage"
+import type {ClientToolOutputHandler} from "./clientTools"
+import MessageRow from "./MessageRow"
+import {WaitingForInput, WorkingDots} from "./TurnActivity"
+
+interface AgentTurnProps {
+    message: UIMessage
+    /** Fade in once — this turn arrived after mount. */
+    enter: boolean
+    isLast: boolean
+    isStreaming: boolean
+    /** The previous turn is a settled assistant turn with no content at all. */
+    precededByEmptyAssistant: boolean
+    /** A user turn borrows the paired assistant turn's trace so its timestamp dates from the run. */
+    turnTraceId?: string
+    /** This turn is the inspector's current target — tint it. */
+    inspected: boolean
+    /** Inspector panel open + assistant turn → clicking the row re-points the inspector here. */
+    rowInspectable: boolean
+    /** Show the "Inspect turn" affordance in the meta row. */
+    showInspect: boolean
+    /** 1-based turn number, or undefined for a user turn. */
+    turn?: number
+    onInspectTurn: (turn: number) => void
+    showWorking: boolean
+    showWaiting: boolean
+    showStopped: boolean
+    resendDisabled: boolean
+    onResend: (messageId: string) => void
+    onRewind: (message: UIMessage) => void
+    onClientToolOutput: ClientToolOutputHandler
+    /** Settled row → `content-visibility:auto` while off-screen. */
+    offscreenSkip: boolean
+}
+
+/**
+ * One turn in the transcript: the message itself plus its trailing affordances (the Stopped/Resend
+ * pair and the meta row). Memoized — the transcript re-renders on every streamed token, and without
+ * this every settled turn above the active one re-rendered with it. Every prop is a primitive or a
+ * stable callback so the memo actually holds.
+ */
+const AgentTurn = ({
+    message,
+    enter,
+    isLast,
+    isStreaming,
+    precededByEmptyAssistant,
+    turnTraceId,
+    inspected,
+    rowInspectable,
+    showInspect,
+    turn,
+    onInspectTurn,
+    showWorking,
+    showWaiting,
+    showStopped,
+    resendDisabled,
+    onResend,
+    onRewind,
+    onClientToolOutput,
+    offscreenSkip,
+}: AgentTurnProps) => {
+    const inspect = useCallback(() => onInspectTurn(turn ?? 1), [onInspectTurn, turn])
+    return (
+        <MessageRow
+            mid={message.id}
+            enter={enter}
+            inspected={inspected}
+            onInspect={rowInspectable ? inspect : undefined}
+            offscreenSkip={offscreenSkip}
+        >
+            <AgentMessage
+                message={message}
+                isStreaming={isStreaming}
+                isLastMessage={isLast}
+                onRewind={onRewind}
+                onClientToolOutput={onClientToolOutput}
+                precededByEmptyAssistant={precededByEmptyAssistant}
+                turnTraceId={turnTraceId}
+            />
+            {/* Stopped tag + Resend belong only to the LAST assistant turn (the one you cancelled),
+                gated on position so it can never smear onto past turns. Cleared on resend / ask. */}
+            {showStopped && (
+                <div className="flex items-center gap-2 self-start pl-1">
+                    <Tag className="!m-0 !text-[11px]">Stopped</Tag>
+                    <Button
+                        type="link"
+                        size="small"
+                        className="!px-0 !text-xs"
+                        disabled={resendDisabled}
+                        onClick={() => onResend(message.id)}
+                    >
+                        Resend
+                    </Button>
+                </div>
+            )}
+            {/* Meta row: "Inspect turn" + the working dots share ONE compact line under the
+                turn. The dots run for the WHOLE busy run — so gaps with no streaming output
+                (approval-resume cold-replay, between steps, server tool waits) never read as
+                frozen — and drop the moment the run settles. The affordance renders FIRST so
+                its left edge stays put (and aligned with older turns') when the trailing dots
+                unmount — no settle-time layout shift. An EMPTY streaming assistant turn
+                already renders its own loading bubble (AgentMessage), so the dots skip it —
+                exactly one indicator while busy. */}
+            {(showWorking || showInspect || showWaiting) && (
+                <div className="flex items-center gap-2 self-start">
+                    {showInspect && (
+                        <button
+                            type="button"
+                            onClick={inspect}
+                            className="flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-xs text-colorTextSecondary transition-colors hover:text-colorPrimary"
+                        >
+                            <TreeStructure size={12} />
+                            {inspected ? "Inspecting turn" : "Inspect turn"}
+                        </button>
+                    )}
+                    {showWorking && <WorkingDots />}
+                    {showWaiting && <WaitingForInput />}
+                </div>
+            )}
+        </MessageRow>
+    )
+}
+
+export default memo(AgentTurn)

--- a/web/oss/src/components/AgentChatSlice/components/MessageRow.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/MessageRow.tsx
@@ -1,0 +1,79 @@
+import {useEffect, useState} from "react"
+
+import {CHAT_COLUMN} from "../assets/conversationLayout"
+
+/**
+ * One message row. Carries `data-mid` (load-bearing for the pin / anchor / ResizeObserver, which all
+ * query it). A message added after mount (`enter`) fades in — OPACITY ONLY, deliberately: opacity
+ * doesn't change geometry, so it can't move the scroll position or trip the SC-3 ResizeObserver. A
+ * restored thread's messages render with `enter=false` (no cascade). Honors reduced-motion: the
+ * initial transparency and the transition are both `motion-safe`, so it's instant-visible otherwise.
+ */
+const MessageRow = ({
+    mid,
+    enter,
+    children,
+    inspected = false,
+    onInspect,
+    offscreenSkip = false,
+}: {
+    mid: string
+    enter: boolean
+    children: React.ReactNode
+    /** This turn is the Turn Inspector's current target — tint it. */
+    inspected?: boolean
+    /** Set (assistant turns, inspector open) → click the row to re-focus the inspector on it. */
+    onInspect?: () => void
+    /** Settled row → `content-visibility:auto` so the browser skips its layout/paint while off-screen.
+     * `contain-intrinsic-size: auto` remembers the real height after first paint, so leaving the
+     * viewport causes no layout shift (heights here range ~85–1022px; no fixed estimate works). */
+    offscreenSkip?: boolean
+}) => {
+    const [shown, setShown] = useState(!enter)
+    // Reveal one frame after mount so the opacity transition plays. Deps are [] (NOT
+    // [enter]) on purpose: an `enter` flip when a sibling turn arrives must not cancel
+    // this rAF, or a just-sent message strands at opacity-0 for the whole agent run.
+    useEffect(() => {
+        const raf = requestAnimationFrame(() => setShown(true))
+        return () => cancelAnimationFrame(raf)
+    }, [])
+    // Click-to-refocus: only while the inspector is open, and never over an interactive control or
+    // an active text selection (so buttons, links, and copy-select still work).
+    const handleClick = onInspect
+        ? (e: React.MouseEvent) => {
+              if ((e.target as HTMLElement).closest("button, a, input, textarea, [role='button']"))
+                  return
+              if (!window.getSelection()?.isCollapsed) return
+              onInspect()
+          }
+        : undefined
+    // While the inspector is open, every turn is interactive: padded + rounded so the fill has
+    // breathing room, and cursor-pointer everywhere (clicking the selected turn just re-selects it).
+    // Hover is a light fill; the SELECTED turn is a held fill + a left accent bar, so "the one the
+    // inspector is showing" reads distinctly from a passing hover. Background + accent-bar both
+    // transition, so selection glides between turns instead of snapping. `box-border` is required
+    // (preflight off → content-box) so the padding doesn't overflow the 880px column.
+    const interactive = Boolean(onInspect)
+    // `shown || !enter` is a belt-and-suspenders: a settled row (id seen) is always visible.
+    return (
+        <div
+            data-mid={mid}
+            onClick={handleClick}
+            className={`${CHAT_COLUMN} flex flex-col gap-1 motion-safe:transition-[opacity,background-color,box-shadow] motion-safe:duration-200 motion-safe:ease-out ${
+                offscreenSkip ? "[content-visibility:auto] [contain-intrinsic-size:auto_240px]" : ""
+            } ${shown || !enter ? "opacity-100" : "motion-safe:opacity-0"} ${
+                interactive ? "box-border cursor-pointer rounded-lg px-3 py-2.5" : ""
+            } ${
+                inspected
+                    ? "bg-[var(--ag-colorFillSecondary)] shadow-[inset_2px_0_0_var(--ag-colorPrimary)]"
+                    : interactive
+                      ? "hover:bg-[var(--ag-colorFillTertiary)]"
+                      : ""
+            }`}
+        >
+            {children}
+        </div>
+    )
+}
+
+export default MessageRow

--- a/web/oss/src/components/AgentChatSlice/components/RunningElsewhereStrip.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/RunningElsewhereStrip.tsx
@@ -1,0 +1,34 @@
+import clsx from "clsx"
+
+/**
+ * "This session is running somewhere else" — shown when the backend reports a live run for the
+ * session while THIS browser isn't the one streaming it (another tab, another device).
+ *
+ * Issue #5530: a second browser gave no sign at all that anything was happening, so a session that
+ * was mid-turn looked identical to an idle one. There is no push channel to browsers today, so the
+ * transcript catches up by polling the durable record log — this strip is what makes that
+ * legible instead of looking frozen.
+ *
+ * Matches the `running` dot in the session bar (`bg-colorInfo`, pulsing) so the two read as one
+ * signal.
+ */
+const RunningElsewhereStrip = ({className}: {className?: string}) => (
+    <div
+        className={clsx(
+            "mb-2 box-border flex items-center gap-2 rounded-lg border border-solid px-3 py-2",
+            "border-colorBorder bg-colorFillQuaternary",
+            className,
+        )}
+        role="status"
+    >
+        <span className="relative flex size-2 shrink-0">
+            <span className="absolute inline-flex size-full animate-ping rounded-full bg-colorInfo opacity-60" />
+            <span className="relative inline-flex size-2 rounded-full bg-colorInfo" />
+        </span>
+        <span className="text-xs text-colorTextSecondary">
+            This session is running somewhere else — the transcript updates as the turn progresses.
+        </span>
+    </div>
+)
+
+export default RunningElsewhereStrip

--- a/web/oss/src/components/AgentChatSlice/components/TranscriptPlaceholder.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TranscriptPlaceholder.tsx
@@ -1,0 +1,83 @@
+import {Bubble} from "@ant-design/x"
+import {type UIMessage} from "ai"
+
+import OnboardingBrowseTemplates from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingBrowseTemplates"
+
+import AgentChatEmptyState from "./AgentChatEmptyState"
+import AgentChatHistoryUnavailable from "./AgentChatHistoryUnavailable"
+import {TranscriptSkeleton} from "./AgentChatSkeleton"
+import AgentMessage from "./AgentMessage"
+import type {ClientToolOutputHandler} from "./clientTools"
+import MessageRow from "./MessageRow"
+
+/**
+ * What the transcript shows with no messages yet. Five mutually-exclusive states, in priority
+ * order: an optimistic first turn mid-commit, the template gallery, the hydration skeleton, the
+ * "history unavailable" notice, and otherwise the start-a-chat hero.
+ */
+const TranscriptPlaceholder = ({
+    entityId,
+    pendingFirstTurn,
+    pendingFirstMessage,
+    onboardingActive,
+    browseAll,
+    isHydrating,
+    hydratedEmpty,
+    firstRunPrompt,
+    canStart,
+    onStart,
+    onPrefill,
+    onRewind,
+    onClientToolOutput,
+}: {
+    entityId: string
+    pendingFirstTurn: string | null
+    pendingFirstMessage: UIMessage
+    onboardingActive: boolean
+    browseAll?: boolean
+    isHydrating: boolean
+    hydratedEmpty: boolean
+    firstRunPrompt: string | null
+    canStart: boolean
+    onStart: (text: string) => void | Promise<void>
+    onPrefill: (text: string) => void
+    onRewind: (message: UIMessage) => void
+    onClientToolOutput: ClientToolOutputHandler
+}) => {
+    if (pendingFirstTurn) {
+        // Optimistic first turn: the submitted description as a sent user bubble + an assistant
+        // loading placeholder (mirrors a real `status:"submitted"` turn), so the commit reads as
+        // one continuous chat, not an empty state.
+        return (
+            <MessageRow mid="pending-first-turn" enter>
+                <AgentMessage
+                    message={pendingFirstMessage}
+                    isLastMessage
+                    onRewind={onRewind}
+                    onClientToolOutput={onClientToolOutput}
+                />
+                <Bubble placement="start" variant="borderless" loading content="" />
+            </MessageRow>
+        )
+    }
+    // "Browse all templates" swaps the hero for the full gallery IN PLACE.
+    if (onboardingActive && browseAll) return <OnboardingBrowseTemplates />
+    // Server-history hydration in flight — skeleton, not the "start a chat" hero, so a durable
+    // session doesn't flash the empty state.
+    if (isHydrating) return <TranscriptSkeleton />
+    // Known session whose records hydrated empty (pruned/expired) — a soft notice, not the
+    // new-chat hero. Composer below stays usable.
+    if (hydratedEmpty && !onboardingActive) return <AgentChatHistoryUnavailable />
+    return (
+        <AgentChatEmptyState
+            entityId={entityId}
+            onStart={onStart}
+            firstRunPrompt={firstRunPrompt}
+            canStart={canStart}
+            onboarding={onboardingActive}
+            onPrefill={onPrefill}
+        />
+    )
+}
+
+export default TranscriptPlaceholder

--- a/web/oss/src/components/AgentChatSlice/components/TurnActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TurnActivity.tsx
@@ -1,0 +1,30 @@
+import {Hourglass} from "@phosphor-icons/react"
+
+/** Compact three-dot pulse for the meta row under the last turn — the run-in-progress signal.
+ * Deliberately NOT a Bubble: it shares one line with "Inspect turn" instead of adding a
+ * bubble-sized row of its own. */
+export const WorkingDots = () => (
+    <span
+        role="status"
+        aria-label="Agent is working"
+        className="flex items-center gap-1 px-1 py-0.5"
+    >
+        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-duration:1.2s]" />
+        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-delay:0.2s] [animation-duration:1.2s]" />
+        <span className="inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-colorTextTertiary [animation-delay:0.4s] [animation-duration:1.2s]" />
+    </span>
+)
+
+/** The WorkingDots slot while the run is PARKED on the user (approval / connect / elicitation).
+ * The stream reads "ready" there, so without this the turn looks finished while the queue silently
+ * holds new sends. Deliberately static: motion says "the agent is working" — here it's your move. */
+export const WaitingForInput = () => (
+    <span
+        role="status"
+        aria-label="Agent is waiting for your input"
+        className="flex items-center gap-1.5 px-1 py-0.5 text-xs text-colorTextTertiary"
+    >
+        <Hourglass size={12} />
+        Waiting for your input
+    </span>
+)

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -34,6 +34,7 @@ import {expandedKeysForMessages, pruneExpandedAtom} from "../state/expandState"
 import {
     persistSessionMessagesAtom,
     sessionMessagesAtom,
+    sessionRecordCountsReadAtom,
     stampMessagesCreatedAtAtom,
 } from "../state/sessions"
 import {captureTurnRequestAtom} from "../state/turnCaptures"
@@ -74,6 +75,15 @@ export const useAgentChatSession = ({
     // Immutable snapshot of the restored ids (seenIdsRef grows) — the first-seen stamping
     // effect below skips these so a reload can't masquerade as the turns' send time.
     const restoredIdsRef = useRef<Set<string>>(new Set(initialMessages.map((m) => m.id)))
+    // How many durable records the transcript we're RENDERING was built from — the exact test for
+    // "has the server moved on?" (issue #5530). Message counts can't see a turn growing in place:
+    // `transcriptToMessages` folds a paused turn into its resume and only closes a message on
+    // `done`, so a mid-turn snapshot and the finished turn have the SAME count and a count-based
+    // guard rejects the finished server copy forever. Cleared the moment a live turn starts, since
+    // we can't know what the server logged for it — the next open then re-syncs from the log.
+    const recordWatermarkRef = useRef<number | undefined>(
+        store.get(sessionRecordCountsReadAtom)[sessionId],
+    )
     // Whether the LAST assistant turn was user-stopped. You can only cancel the in-flight (last) turn,
     // so this is a single boolean gated on position at render time — independent of message ids (which
     // can be missing/duplicated in restore/error paths and would otherwise smear the tag onto every
@@ -184,6 +194,7 @@ export const useAgentChatSession = ({
         busyRef,
         seenIdsRef,
         restoredIdsRef,
+        recordWatermarkRef,
         setMessages,
         persistMessages,
         intent,
@@ -266,10 +277,19 @@ export const useAgentChatSession = ({
         })
     }, [error, setMessages])
 
+    // A live turn makes the transcript no longer a copy of the server's, and we can't know how many
+    // records the runner logged for it — so drop the watermark and let the next open re-sync from
+    // the durable log. MUST stay declared above the persist effect: on the commit where `status`
+    // flips to "submitted", effects run in declaration order, so clearing here is what stops the
+    // persist below from filing a locally-extended transcript under a server watermark.
+    useEffect(() => {
+        if (status === "submitted" || status === "streaming") recordWatermarkRef.current = undefined
+    }, [status])
+
     // Persist the conversation whenever its stream settles (skip mid-stream).
     useEffect(() => {
         if (status === "streaming") return
-        persistMessages({id: sessionId, messages})
+        persistMessages({id: sessionId, messages, recordCount: recordWatermarkRef.current})
     }, [messages, status, sessionId, persistMessages])
 
     // Bound the in-message expand-state store: on settle, drop entries whose owning message is gone

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -1,0 +1,409 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
+
+import {
+    commandSessionStream,
+    killSession,
+    revalidateSessionMountsAtom,
+    revalidateSessionRecordsAtom,
+} from "@agenta/entities/session"
+import {markTraceAsFresh} from "@agenta/entities/trace"
+import {invalidateAgentCommittedRevisionCache, workflowMolecule} from "@agenta/entities/workflow"
+import {
+    agentShouldResumeAfterApproval,
+    buildAgentRequest,
+    buildTurnCapture,
+    playgroundController,
+    type LiveAgentInteraction,
+} from "@agenta/playground"
+import {agentSelfCommitSignalAtom} from "@agenta/shared/state"
+import {generateId} from "@agenta/shared/utils"
+import {useChat} from "@ai-sdk/react"
+import {useQueryClient} from "@tanstack/react-query"
+import {type UIMessage} from "ai"
+import {useAtomValue, useSetAtom, useStore} from "jotai"
+
+import {projectIdAtom} from "@/oss/state/project"
+
+import {AgentChatTransport} from "../assets/AgentChatTransport"
+import {doesAgentChatStopKillSession} from "../assets/constants"
+import {ignoreStreamRejection, parseAgentRunError} from "../assets/runError"
+import {getMessageTraceId} from "../assets/trace"
+import type {ClientToolOutputHandler} from "../components/clientTools"
+import {invalidateSessionInspector} from "../components/Inspector/invalidate"
+import {expandedKeysForMessages, pruneExpandedAtom} from "../state/expandState"
+import {
+    persistSessionMessagesAtom,
+    sessionMessagesAtom,
+    stampMessagesCreatedAtAtom,
+} from "../state/sessions"
+import {captureTurnRequestAtom} from "../state/turnCaptures"
+
+import {useFileActivityDetector} from "./useFileActivityDetector"
+import {type ScrollIntent} from "./useScrollIntent"
+import {useSessionHydration} from "./useSessionHydration"
+
+/**
+ * The chat stream for one session tab: transport, `useChat`, and every side effect that belongs to
+ * the conversation itself — history hydration, persistence, error stamping, self-commit pickup,
+ * stop/kill, and teardown. Everything the UI layers on top (queue, approvals, onboarding, the
+ * composer) consumes this hook's return rather than reaching for `useChat` directly.
+ *
+ * Design decisions baked in (docs/design/agent-workflows/playground-agent-generation.md):
+ *  - D9  teardown: abort the in-flight stream on unmount (tab close / revision swap).
+ *  - DT3 cancelled state: a stopped stream tags its partial bubble "Stopped" + offers Resend.
+ */
+export const useAgentChatSession = ({
+    entityId,
+    sessionId,
+    initialMessages,
+    intent,
+}: {
+    entityId: string
+    sessionId: string
+    /** Mount seed read from the persisted store by the caller (it also seeds the scroll intent). */
+    initialMessages: UIMessage[]
+    intent: ScrollIntent
+}) => {
+    const store = useStore()
+    const persistMessages = useSetAtom(persistSessionMessagesAtom)
+    const stampMessagesCreatedAt = useSetAtom(stampMessagesCreatedAtAtom)
+    const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
+
+    // Ids already on screen — restored/settled turns don't re-animate; only turns added live fade in.
+    const seenIdsRef = useRef<Set<string>>(new Set(initialMessages.map((m) => m.id)))
+    // Immutable snapshot of the restored ids (seenIdsRef grows) — the first-seen stamping
+    // effect below skips these so a reload can't masquerade as the turns' send time.
+    const restoredIdsRef = useRef<Set<string>>(new Set(initialMessages.map((m) => m.id)))
+    // Whether the LAST assistant turn was user-stopped. You can only cancel the in-flight (last) turn,
+    // so this is a single boolean gated on position at render time — independent of message ids (which
+    // can be missing/duplicated in restore/error paths and would otherwise smear the tag onto every
+    // turn). Cleared on the next send/resend.
+    const [stopped, setStopped] = useState(false)
+
+    // `useChat` pins its `Chat` (and thus this transport) for the life of the session `id`; it is
+    // NOT recreated when `entityId` changes (only on an `id` change). So the request builder must
+    // read the CURRENT entity through a ref — capturing `entityId` by value would send every turn
+    // with the revision that was displayed when the session first mounted, even after a switch or a
+    // self-commit. Reading `entityIdRef.current` at send time keeps runs on the live revision.
+    const entityIdRef = useRef(entityId)
+    entityIdRef.current = entityId
+
+    // Turn Inspector capture write, read via ref so the transport `useMemo` doesn't depend on it.
+    const captureTurnRequest = useSetAtom(captureTurnRequestAtom)
+    const captureRef = useRef(captureTurnRequest)
+    captureRef.current = captureTurnRequest
+
+    // Transport feeds the v6 stream request from the playground pipeline. `api` here is a
+    // placeholder that `prepareSendMessagesRequest` overrides per request.
+    const transport = useMemo(
+        () =>
+            new AgentChatTransport({
+                api: "",
+                prepareSendMessagesRequest: async ({messages, id}) => {
+                    const req = await buildAgentRequest(entityIdRef.current, messages, {
+                        sessionId: id ?? sessionId,
+                    })
+                    if (!req) {
+                        throw new Error(
+                            "This agent workflow has no invocation URL — it can’t be run yet.",
+                        )
+                    }
+                    captureRef.current(buildTurnCapture(req, generateId(), Date.now()))
+                    return {api: req.invocationUrl, headers: req.headers, body: req.requestBody}
+                },
+            }),
+        [sessionId],
+    )
+
+    const revalidateSessionMounts = useSetAtom(revalidateSessionMountsAtom)
+    const revalidateSessionRecords = useSetAtom(revalidateSessionRecordsAtom)
+    // Only a gate settled in this mount may trigger an automatic resume; hydrated answers stay inert.
+    const liveGateInteractionRef = useRef<LiveAgentInteraction | null>(null)
+
+    const {
+        messages,
+        sendMessage,
+        status,
+        stop,
+        regenerate,
+        setMessages,
+        addToolApprovalResponse,
+        addToolOutput,
+        error,
+    } = useChat({
+        id: sessionId,
+        messages: initialMessages,
+        transport,
+        // Coalesce stream deltas to ~1 UI commit / 50ms so a fast token stream doesn't drive a
+        // render per token; caps commit frequency independently of the per-commit memo win.
+        experimental_throttle: 50,
+        // Approve AND deny both resume — a deny-only decision must re-send so the runner
+        // gets the denial round-trip and the model continues (no `approval-responded` limbo).
+        sendAutomaticallyWhen: ({messages}) => {
+            const shouldDispatch = agentShouldResumeAfterApproval({
+                messages,
+                liveInteraction: liveGateInteractionRef.current,
+            })
+            if (shouldDispatch) liveGateInteractionRef.current = null
+            return shouldDispatch
+        },
+        // The turn's trace may not be ingested yet when the row asks for its summary —
+        // marking it fresh lets the trace queries retry through the ingestion lag
+        // (historical traces get no such grace; a 404 there means the trace is gone).
+        // A finished turn may also have written files: mark the session's drive data stale so
+        // every mount surface (open or opened later) refetches — no live channel exists for this.
+        onFinish: ({message}) => {
+            markTraceAsFresh(getMessageTraceId(message))
+            revalidateSessionMounts(sessionId)
+            revalidateSessionRecords(sessionId)
+        },
+        onError: (err) => {
+            // Render the error in-chat (the `error` alert below); swallow it here so an
+            // aborted/errored stream doesn't bubble unhandled to the Next.js dev overlay (F-033).
+            console.warn("[AgentChatPanel] useChat error (rendered in-chat):", err)
+        },
+    })
+
+    const busy = status === "submitted" || status === "streaming"
+
+    // `messages`/`busy` change every token; consumers that must stay referentially stable
+    // (`handleRewind`, the hydration/SWR adoption guards) read them through refs instead.
+    const messagesRef = useRef(messages)
+    messagesRef.current = messages
+    const busyRef = useRef(busy)
+    busyRef.current = busy
+
+    // Mid-stream drive signals: settled write-ish tool calls append file-activity entries (and
+    // throttle-revalidate the drives) as the turn streams, not just at onFinish.
+    useFileActivityDetector({sessionId, messages})
+
+    const {isHydrating, hydratedEmpty} = useSessionHydration({
+        sessionId,
+        initialMessages,
+        messagesRef,
+        busyRef,
+        seenIdsRef,
+        restoredIdsRef,
+        setMessages,
+        persistMessages,
+        intent,
+    })
+
+    // A decision made in THIS mount marks the resume as live — a restored approval-requested tail
+    // the user answers after a reload genuinely auto-resumes, so the queue's pre-resume hold applies.
+    const markLiveGate = useCallback((interaction: LiveAgentInteraction) => {
+        liveGateInteractionRef.current = interaction
+    }, [])
+
+    // Settle a parked client tool (#4920). The dispatcher calls this from a widget (e.g. the connect
+    // widget) with the structured reference; `addToolOutput` matches the part by `toolCallId` on the
+    // last turn and the resume predicate auto-resends. `tool` is only the typed-tools key — matching
+    // is by id — so a cast onto the untyped UIMessage tool map is safe.
+    const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
+        ({toolName, toolCallId, output, errorText}) => {
+            liveGateInteractionRef.current = {kind: "client_tool", id: toolCallId}
+            if (errorText !== undefined) {
+                addToolOutput({
+                    state: "output-error",
+                    tool: toolName as never,
+                    toolCallId,
+                    errorText,
+                }).catch(ignoreStreamRejection)
+            } else {
+                addToolOutput({
+                    tool: toolName as never,
+                    toolCallId,
+                    output: (output ?? {}) as never,
+                }).catch(ignoreStreamRejection)
+            }
+        },
+        [addToolOutput],
+    )
+
+    // Orphan detection for the queue's pre-resume hold: the tail is a RESTORED message (this
+    // mount never streamed it) shaped like "auto-resume imminent", and no gate was settled live
+    // in this mount. The SDK only evaluates `sendAutomaticallyWhen` on live events (approval
+    // response, tool output, stream finish) — never on mount — so this resume can't fire and
+    // must not hold the queue. Short-circuits cheap on the streaming hot path: any live send
+    // makes the tail non-restored.
+    const lastMessage = messages[messages.length - 1]
+    const resumeOrphaned =
+        !liveGateInteractionRef.current &&
+        !!lastMessage &&
+        restoredIdsRef.current.has(lastMessage.id) &&
+        agentShouldResumeAfterApproval({messages})
+
+    // Surface a stream failure inline: stamp the parsed error onto the failing assistant turn so
+    // it renders as a red error bubble with the real reason (and persists with the session via the
+    // effect below), instead of a transient top banner + a generic "no response". FE-only — it
+    // uses the error useChat already has; the backend doesn't need to attach it to the trace.
+    useEffect(() => {
+        if (!error) return
+        const parsed = parseAgentRunError(error)
+        setMessages((prev) => {
+            const last = prev.length > 0 ? prev[prev.length - 1] : undefined
+            const existing = (last?.metadata as {runError?: {message?: string}} | undefined)
+                ?.runError
+            if (last?.role === "assistant") {
+                if (existing?.message === parsed.message) return prev // already stamped
+                const next = [...prev]
+                next[next.length - 1] = {
+                    ...last,
+                    metadata: {...(last.metadata as object | undefined), runError: parsed},
+                }
+                return next
+            }
+            // No trailing assistant turn (failed before one existed) — add a minimal carrier.
+            return [
+                ...prev,
+                {
+                    id: `run-error-${generateId()}`,
+                    role: "assistant",
+                    parts: [],
+                    metadata: {runError: parsed},
+                } as (typeof prev)[number],
+            ]
+        })
+    }, [error, setMessages])
+
+    // Persist the conversation whenever its stream settles (skip mid-stream).
+    useEffect(() => {
+        if (status === "streaming") return
+        persistMessages({id: sessionId, messages})
+    }, [messages, status, sessionId, persistMessages])
+
+    // Bound the in-message expand-state store: on settle, drop entries whose owning message is gone
+    // (rewound / evicted / closed). Live = every open session's persisted messages ∪ this active one.
+    // `store.get` reads without subscribing, so this never adds re-renders on the streaming hot path.
+    const pruneExpanded = useSetAtom(pruneExpandedAtom)
+    useEffect(() => {
+        if (status === "streaming") return
+        const persisted = store.get(sessionMessagesAtom)
+        const live = new Set<string>()
+        for (const sid in persisted)
+            for (const key of expandedKeysForMessages(persisted[sid])) live.add(key)
+        for (const key of expandedKeysForMessages(messages)) live.add(key)
+        pruneExpanded(live)
+    }, [messages, status, store, pruneExpanded])
+
+    // Stamp a first-seen timestamp on any newly-appeared LIVE message (user + assistant).
+    // Restored rows are excluded: their first-seen is the reload moment, not the turn's time —
+    // stamping them made old turns read "just now" until (or forever if) the trace never loads.
+    // Unstamped, their timestamp slot shows a pending placeholder, then the trace's real time.
+    useEffect(() => {
+        stampMessagesCreatedAt(
+            messages.filter((m) => !restoredIdsRef.current.has(m.id)).map((m) => m.id),
+        )
+    }, [messages, stampMessagesCreatedAt])
+
+    // ── #4920 Application 1: refresh the config on a committed revision ──
+    // When the agent commits a new revision of itself, the backend emits a one-way
+    // `data-committed-revision` part (same channel as `data-trace`), whether the tool asked first
+    // or ran directly. On receipt we invalidate the latest-revision and
+    // inspect caches so the config panel, section drawers, and build-kit view all re-read the new
+    // config. Deduped by revision id so a re-render (token stream) doesn't re-invalidate.
+    const committedRevisionsSeenRef = useRef<Set<string>>(new Set())
+    const setAgentCommitSignal = useSetAtom(agentSelfCommitSignalAtom)
+    useEffect(() => {
+        for (const message of messages) {
+            for (const part of message.parts) {
+                if ((part as {type?: string}).type !== "data-committed-revision") continue
+                const data = (part as {data?: {revisionId?: string; version?: string}}).data
+                // A stable key per commit: prefer the revision id, fall back to the whole payload.
+                const key = data?.revisionId ?? JSON.stringify(data ?? {}) ?? "committed"
+                if (committedRevisionsSeenRef.current.has(key)) continue
+                committedRevisionsSeenRef.current.add(key)
+                invalidateAgentCommittedRevisionCache()
+                if (data?.revisionId && data.revisionId !== entityId) {
+                    // Capture the OUTGOING revision's parameters before switching, so the config
+                    // panel can show what the agent changed (per-section indicators + summary).
+                    const prevParameters = store.get(
+                        workflowMolecule.selectors.configuration(entityId),
+                    )
+                    setAgentCommitSignal({
+                        revisionId: data.revisionId,
+                        version: data.version,
+                        prevParameters: prevParameters ?? null,
+                        at: Date.now(),
+                    })
+                    switchEntity({currentEntityId: entityId, newEntityId: data.revisionId})
+                }
+            }
+        }
+    }, [messages, entityId, switchEntity, store, setAgentCommitSignal])
+
+    // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
+    const markStopped = useCallback(() => {
+        const last = messages[messages.length - 1]
+        if (last && last.role === "assistant") setStopped(true)
+    }, [messages])
+
+    const projectId = useAtomValue(projectIdAtom)
+    const queryClient = useQueryClient()
+
+    const handleStop = useCallback(() => {
+        markStopped()
+        stop() // abort the client stream immediately
+        if (!projectId || !sessionId) return
+        // Opt-in hard kill (NEXT_PUBLIC_AGENT_CHAT_STOP_KILLS_SESSION): tear the whole session down.
+        if (doesAgentChatStopKillSession()) {
+            killSession({sessionId, projectId})
+                .then((ok) => {
+                    if (ok) {
+                        queryClient.invalidateQueries({queryKey: ["session-liveness"]})
+                        // Refresh an open Inspector's Runtime lens so its Lifecycle/State reflect the
+                        // kill immediately (mirrors the panel's own Kill button).
+                        void invalidateSessionInspector(queryClient, sessionId)
+                    }
+                })
+                .catch(() => {})
+            return
+        }
+        // Default Stop: cooperatively cancel the CURRENT TURN. The control-plane `cancel` command
+        // (no inputs, no force) drops the alive lock; the runner closes the turn as interrupted and
+        // the session STAYS OPEN so a follow-up prompt resumes it — instead of the old behaviour where
+        // the client stream aborted but the runner kept running and billing.
+        commandSessionStream({sessionId, projectId}).catch(() => {})
+    }, [markStopped, stop, projectId, sessionId, queryClient])
+
+    // ── D9 teardown: abort the in-flight stream on unmount (tab close / revision swap) ──
+    // Keyed on sessionId: closing a tab or swapping the revision unmounts this conversation
+    // and should tear down its stream.
+    useEffect(() => {
+        return () => {
+            stop()
+        }
+    }, [sessionId, stop])
+
+    // After each commit, mark on-screen messages as seen so they don't re-animate on later renders
+    // (e.g. streaming tokens). Done in an effect, not during render, so StrictMode's double invoke
+    // doesn't mark a brand-new message before its first paint and rob it of the fade.
+    useEffect(() => {
+        for (const m of messages) seenIdsRef.current.add(m.id)
+    }, [messages])
+
+    /** Has this id already been painted? Drives the one-shot fade-in on a live turn. */
+    const isSeen = useCallback((id: string) => seenIdsRef.current.has(id), [])
+
+    return {
+        messages,
+        status,
+        busy,
+        error,
+        sendMessage,
+        regenerate,
+        setMessages,
+        addToolApprovalResponse,
+        messagesRef,
+        busyRef,
+        isHydrating,
+        hydratedEmpty,
+        stopped,
+        setStopped,
+        handleStop,
+        handleClientToolOutput,
+        markLiveGate,
+        resumeOrphaned,
+        isSeen,
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -187,7 +187,7 @@ export const useAgentChatSession = ({
     // throttle-revalidate the drives) as the turn streams, not just at onFinish.
     useFileActivityDetector({sessionId, messages})
 
-    const {isHydrating, hydratedEmpty} = useSessionHydration({
+    const {isHydrating, hydratedEmpty, runningElsewhere} = useSessionHydration({
         sessionId,
         initialMessages,
         messagesRef,
@@ -195,6 +195,7 @@ export const useAgentChatSession = ({
         seenIdsRef,
         restoredIdsRef,
         recordWatermarkRef,
+        busy,
         setMessages,
         persistMessages,
         intent,
@@ -418,6 +419,7 @@ export const useAgentChatSession = ({
         busyRef,
         isHydrating,
         hydratedEmpty,
+        runningElsewhere,
         stopped,
         setStopped,
         handleStop,

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
@@ -1,0 +1,165 @@
+import {useEffect, useRef, useState} from "react"
+
+import type {UploadFile} from "antd"
+
+import {
+    type AttachmentRejection,
+    DEFAULT_ATTACHMENT_LIMITS,
+    validateIncoming,
+} from "../assets/attachments"
+import {isAgentFileUploadsEnabled} from "../assets/constants"
+import {attachmentsBySession} from "../state/sessionEphemera"
+
+import {useAttachmentUploads} from "./useAttachmentUploads"
+
+const toUploadFile = (file: File): UploadFile => ({
+    uid: `${file.name}-${file.lastModified}-${file.size}`,
+    name: file.name,
+    status: "done",
+    originFileObj: file as UploadFile["originFileObj"],
+})
+
+/**
+ * Pending composer attachments for one session — the tray, its guardrails, the upload lifecycle,
+ * the preview target, and the whole-panel drag-and-drop that feeds them. Files survive a remount
+ * (route re-entry, tab close/reopen) alongside the composer draft; rejections stay transient.
+ */
+export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
+    // Attach button + attachment preview + drive uploads (`NEXT_PUBLIC_AGENT_FILE_UPLOADS`). Paste
+    // and drag-to-attach predate the flag and stay on.
+    const uploadsEnabled = isAgentFileUploadsEnabled()
+    // Restored from the per-session store on remount (route re-entry, tab close/reopen) —
+    // pending attachments survive alongside the composer draft. Rejections stay transient.
+    const [files, setFiles] = useState<UploadFile[]>(
+        () => attachmentsBySession.get(sessionId) ?? [],
+    )
+    useEffect(() => {
+        if (files.length > 0) attachmentsBySession.set(sessionId, files)
+        else attachmentsBySession.delete(sessionId)
+    }, [files, sessionId])
+    // Files turned away by the guardrails (too big, wrong type, over the count), shown inline.
+    const [rejections, setRejections] = useState<AttachmentRejection[]>([])
+    // The attachment currently open in the Files-drawer preview (its uid), or null when closed.
+    const [viewingUid, setViewingUid] = useState<string | null>(null)
+    const [attachmentsOpen, setAttachmentsOpen] = useState(false)
+    // Single limits object so it can later be swapped for capability-derived limits.
+    const limits = DEFAULT_ATTACHMENT_LIMITS
+    const atMax = files.length >= limits.maxCount
+    // Drag-over state for the whole-panel drop overlay (depth counter avoids child flicker).
+    const dragDepthRef = useRef(0)
+    const [isDragging, setIsDragging] = useState(false)
+
+    // Upload lifecycle for the tray (progress / error / retry). The transport is not wired yet, so
+    // no uploader is passed — files stay "done" and enqueue is a no-op. When upload lands, provide
+    // an uploader here and the whole flow runs; the tray already renders every state.
+    const uploads = useAttachmentUploads(files, setFiles, undefined)
+    // A staged attachment blocks send only once uploads exist: while any is uploading or has failed,
+    // the message isn't ready. All-"done" today, so this is inert until the transport is wired.
+    const attachmentsSettled = !files.some((f) => f.status === "uploading" || f.status === "error")
+
+    /** Add files from paste / programmatic sources through the guardrails. */
+    const addFiles = (incoming: File[], extraRejections: AttachmentRejection[] = []) => {
+        const {accepted, rejections} = validateIncoming(incoming, files.length, limits)
+        const allRejections = [...extraRejections, ...rejections]
+        if (accepted.length) {
+            setFiles((prev) => [...prev, ...accepted.map(toUploadFile)])
+            uploads.enqueue(accepted.map((f) => `${f.name}-${f.lastModified}-${f.size}`))
+        }
+        setRejections(allRejections)
+        // Open for rejections too. Otherwise dropping something unsupported writes a message into
+        // a closed panel and reads as nothing having happened at all.
+        if (accepted.length || allRejections.length) setAttachmentsOpen(true)
+    }
+
+    const removeFile = (uid: string) => setFiles((prev) => prev.filter((f) => f.uid !== uid))
+
+    // Native drag-and-drop onto the whole panel. A depth counter ignores dragenter/leave from
+    // nested children so the overlay doesn't flicker; only file drags (not text) are handled.
+    const isFileDrag = (e: React.DragEvent) => Array.from(e.dataTransfer.types).includes("Files")
+
+    /**
+     * Bind the panel's drop target. `isBlocked` is a predicate, read at EVENT time and never at
+     * bind time: whether attachments are refused right now is the conversation's call (a voice take
+     * in flight, a disabled composer), so this hook asks rather than tracking it.
+     */
+    const bindDropTarget = (isBlocked: () => boolean) => {
+        // The panel is ALWAYS a drop target for file drags — preventDefault on enter/over/drop even when
+        // blocked. Otherwise the browser's default action for a file drop is to navigate to it, which
+        // unloads the SPA and discards the whole conversation. Whether we ACCEPT the files is signalled
+        // separately (the overlay + the drop cursor), not by declining to be a drop target.
+        const onDragEnter = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            e.preventDefault()
+            if (isBlocked()) return
+            dragDepthRef.current += 1
+            setIsDragging(true)
+        }
+        const onDragOver = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            e.preventDefault()
+            // Honest cursor: "no drop" while blocked — but we stay a target so the drop is still swallowed.
+            e.dataTransfer.dropEffect = isBlocked() ? "none" : "copy"
+        }
+        const onDragLeave = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            dragDepthRef.current -= 1
+            if (dragDepthRef.current <= 0) {
+                dragDepthRef.current = 0
+                setIsDragging(false)
+            }
+        }
+        const onDrop = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            e.preventDefault()
+            dragDepthRef.current = 0
+            setIsDragging(false)
+            if (isBlocked()) return
+
+            // A dropped folder still arrives in `files` — as a typeless, zero-byte entry that the
+            // guardrails would reject as "not a supported file type", which is misleading. Name it.
+            // `webkitGetAsEntry` is only valid synchronously, during this event.
+            const folderNames = Array.from(e.dataTransfer.items ?? [])
+                .map((item) => (item.kind === "file" ? item.webkitGetAsEntry() : null))
+                .filter((entry): entry is FileSystemEntry => !!entry?.isDirectory)
+                .map((entry) => entry.name)
+
+            const dropped = Array.from(e.dataTransfer.files).filter(
+                (f) => !folderNames.includes(f.name),
+            )
+            const folderRejections = folderNames.map((name) => ({
+                name,
+                reason: "is a folder — drop the files inside it",
+            }))
+
+            if (dropped.length || folderRejections.length) addFiles(dropped, folderRejections)
+        }
+        return {onDragEnter, onDragOver, onDragLeave, onDrop}
+    }
+
+    /** Everything the composer just sent has left — drop the pending set and any rejection notice. */
+    const clearAttachments = () => {
+        setFiles([])
+        setRejections([])
+        setAttachmentsOpen(false)
+    }
+
+    return {
+        uploadsEnabled,
+        files,
+        rejections,
+        setRejections,
+        attachmentsOpen,
+        setAttachmentsOpen,
+        viewingUid,
+        setViewingUid,
+        limits,
+        atMax,
+        attachmentsSettled,
+        isDragging,
+        addFiles,
+        removeFile,
+        uploads,
+        clearAttachments,
+        bindDropTarget,
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
@@ -1,5 +1,6 @@
 import {useEffect, useRef, useState} from "react"
 
+import {generateId} from "@agenta/shared/utils"
 import type {UploadFile} from "antd"
 
 import {
@@ -12,8 +13,11 @@ import {attachmentsBySession} from "../state/sessionEphemera"
 
 import {useAttachmentUploads} from "./useAttachmentUploads"
 
+// `uid` is the tray's React key, its preview-URL key, and the remove / view / retry handle, so it
+// has to be unique per TRAY ROW. Deriving it from name+mtime+size collided whenever the same file
+// was attached twice (paste then drop) — one remove then wiped both rows and their previews.
 const toUploadFile = (file: File): UploadFile => ({
-    uid: `${file.name}-${file.lastModified}-${file.size}`,
+    uid: `att-${generateId()}`,
     name: file.name,
     status: "done",
     originFileObj: file as UploadFile["originFileObj"],
@@ -62,8 +66,11 @@ export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
         const {accepted, rejections} = validateIncoming(incoming, files.length, limits)
         const allRejections = [...extraRejections, ...rejections]
         if (accepted.length) {
-            setFiles((prev) => [...prev, ...accepted.map(toUploadFile)])
-            uploads.enqueue(accepted.map((f) => `${f.name}-${f.lastModified}-${f.size}`))
+            // Stage once and enqueue the MINTED uids — re-deriving them here is what let the tray
+            // row and its upload disagree about which entry they addressed.
+            const staged = accepted.map(toUploadFile)
+            setFiles((prev) => [...prev, ...staged])
+            uploads.enqueue(staged.map((f) => f.uid))
         }
         setRejections(allRejections)
         // Open for rejections too. Otherwise dropping something unsupported writes a message into

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerDraft.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerDraft.ts
@@ -1,0 +1,77 @@
+import {type RefObject, useCallback, useEffect, useRef, useState} from "react"
+
+import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
+
+import {composerDraftBySession, isSessionFresh} from "../state/sessionEphemera"
+
+/**
+ * The composer's per-session unsent draft and its mount-time entrance flags. Markdown is read off
+ * the editor handle at capture time rather than per keystroke — serialization isn't free.
+ */
+export const useComposerDraft = ({
+    sessionId,
+    richInputRef,
+    revealPlayedRef,
+}: {
+    sessionId: string
+    richInputRef: RefObject<RichChatInputHandle | null>
+    /** Shared across the panel's session panes: the composer entrance plays only once. */
+    revealPlayedRef: React.MutableRefObject<boolean>
+}) => {
+    // Composer entrance plays once per PANEL mount — additional session panes mount the
+    // composer fully shown (the replayed fade read as a "composer reload" on session switch).
+    // Frozen at mount: recomputing per render would flip Reveal's `enabled` mid-entrance
+    // (the latch effect below runs before the fade completes).
+    const [playComposerEntrance] = useState(() => !revealPlayedRef.current)
+    useEffect(() => {
+        revealPlayedRef.current = true
+    }, [revealPlayedRef])
+
+    // A brand-new session mounts a fresh pane — drop the cursor straight into the composer so the
+    // user can type immediately. Frozen at mount (fresh-until-first-send) and driven through the
+    // editor's own AutoFocusPlugin, which fires on the lazy Lexical mount rather than racing it.
+    const [autoFocusComposer] = useState(() => isSessionFresh(sessionId))
+
+    // Per-session unsent draft: restore once at mount (initialMarkdown is mount-only) and
+    // capture edits debounced — markdown is read from the handle at capture time, not per
+    // keystroke (serialization isn't free).
+    const [initialDraft] = useState(() => composerDraftBySession.get(sessionId))
+    const draftTimerRef = useRef(0)
+    const handleComposerChange = useCallback(
+        (text: string) => {
+            window.clearTimeout(draftTimerRef.current)
+            draftTimerRef.current = window.setTimeout(() => {
+                const md = richInputRef.current?.getMarkdown() ?? text
+                if (md.trim()) composerDraftBySession.set(sessionId, md)
+                else composerDraftBySession.delete(sessionId)
+            }, 400)
+        },
+        [sessionId],
+    )
+    useEffect(
+        () => () => {
+            window.clearTimeout(draftTimerRef.current)
+            // Best-effort final capture on unmount (guarded — the editor may be detached).
+            const md = richInputRef.current?.getMarkdown()
+            if (md !== undefined) {
+                if (md.trim()) composerDraftBySession.set(sessionId, md)
+                else composerDraftBySession.delete(sessionId)
+            }
+        },
+        [sessionId],
+    )
+
+    /** The message left the composer — drop its persisted draft and any pending capture. */
+    const clearDraft = useCallback(() => {
+        window.clearTimeout(draftTimerRef.current)
+        composerDraftBySession.delete(sessionId)
+    }, [sessionId])
+
+    return {
+        playComposerEntrance,
+        autoFocusComposer,
+        initialDraft,
+        handleComposerChange,
+        clearDraft,
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.ts
@@ -1,0 +1,106 @@
+import {type MutableRefObject, useEffect, useRef, useState} from "react"
+
+import {workflowBuildKitOverlayReadyAtomFamily} from "@agenta/entities/workflow"
+import {useAtom, useAtomValue} from "jotai"
+
+import {agentFirstRunSeedAtom} from "../state/firstRunSeed"
+
+/**
+ * First-run seed: a freshly-created agent (from Home's composer/template) surfaces its starting
+ * prompt in the empty state (see AgentChatEmptyState) rather than pre-filling the composer, so it
+ * reads as "here's what we'll do" not stray user input. Consumed once by the active session on a
+ * fresh conversation, matching either the revision or app id, then cleared.
+ *
+ * Also owns the auto-start: the seeded agent's model is usually gated (no provider key yet), and
+ * connecting the key IS the go-ahead — so once the gate clears the seed sends itself rather than
+ * making the user click Start a second time ("no explicit action twice").
+ */
+export const useFirstRunSeed = ({
+    entityId,
+    sessionId,
+    activeSessionId,
+    messagesCount,
+    modelBlocked,
+    handleSubmitRef,
+}: {
+    entityId: string
+    sessionId: string
+    activeSessionId: string | null | undefined
+    messagesCount: number
+    modelBlocked: boolean
+    /** Read at fire time so the transition drives the send, not a stale closure. */
+    handleSubmitRef: MutableRefObject<(text: string) => void | Promise<void>>
+}) => {
+    const [firstRunSeed, setFirstRunSeed] = useAtom(agentFirstRunSeedAtom)
+    const [firstRunPrompt, setFirstRunPrompt] = useState<string | null>(null)
+    // An explicit-"go" seed (the onboarding Create-agent click) sends as soon as the model is ready.
+    const [firstRunAutoSend, setFirstRunAutoSend] = useState(false)
+    const seedConsumedRef = useRef(false)
+    useEffect(() => {
+        if (seedConsumedRef.current || !firstRunSeed) return
+        if (entityId !== firstRunSeed.revisionId && entityId !== firstRunSeed.appId) return
+        if (activeSessionId !== sessionId || messagesCount > 0) return
+        seedConsumedRef.current = true
+        setFirstRunPrompt(firstRunSeed.seedMessage)
+        setFirstRunAutoSend(!!firstRunSeed.autoSend)
+        setFirstRunSeed(null)
+    }, [firstRunSeed, entityId, activeSessionId, sessionId, messagesCount, setFirstRunSeed])
+
+    // Fires once, while the conversation is still empty, when EITHER: the model just unblocked (was
+    // gated), OR the seed is an explicit "go" (`firstRunAutoSend` — the onboarding Create-agent
+    // click) and the model is ready. A redirect-seed that merely arrived with a ready model still
+    // waits for Start.
+    const autoStartedSeedRef = useRef(false)
+    const seedWasBlockedRef = useRef(false)
+    // Turn 1 must run WITH the build-kit overlay, but the overlay fetch can resolve after the seed
+    // lands — so gate the auto-send on the overlay having settled (present or definitively absent).
+    const overlayReady = useAtomValue(workflowBuildKitOverlayReadyAtomFamily(entityId))
+    // Bounded wait: a broken overlay endpoint must not hang the first turn forever. Once a seed is
+    // pending, wait at most 10s for the overlay, then send anyway (kit-less) with a warning.
+    const [overlayWaitElapsed, setOverlayWaitElapsed] = useState(false)
+    // A new entity/session or a fresh pending seed restarts the bounded wait from zero.
+    useEffect(() => {
+        setOverlayWaitElapsed(false)
+    }, [entityId, firstRunPrompt])
+    // Arm the timeout only when the auto-send is blocked on nothing BUT the overlay: a pending seed
+    // whose model is ready and which would otherwise fire this turn. Otherwise a still-gated model
+    // (or an already-sent seed) would burn the 10s window before the overlay ever mattered.
+    const sendBlockedOnlyOnOverlay =
+        Boolean(firstRunPrompt) &&
+        !autoStartedSeedRef.current &&
+        !modelBlocked &&
+        (seedWasBlockedRef.current || firstRunAutoSend) &&
+        messagesCount === 0 &&
+        !overlayReady
+    useEffect(() => {
+        if (!sendBlockedOnlyOnOverlay || overlayWaitElapsed) return
+        const timer = setTimeout(() => {
+            console.warn(
+                "[AgentChat] build-kit overlay not ready after 10s; sending seed without it",
+            )
+            setOverlayWaitElapsed(true)
+        }, 10_000)
+        return () => clearTimeout(timer)
+    }, [sendBlockedOnlyOnOverlay, overlayWaitElapsed])
+    useEffect(() => {
+        if (!firstRunPrompt || autoStartedSeedRef.current) return
+        if (modelBlocked) {
+            seedWasBlockedRef.current = true
+            return
+        }
+        if ((!seedWasBlockedRef.current && !firstRunAutoSend) || messagesCount > 0) return
+        // Hold the auto-send until the build-kit overlay settles (or the 10s bound elapses).
+        if (!overlayReady && !overlayWaitElapsed) return
+        autoStartedSeedRef.current = true
+        handleSubmitRef.current(firstRunPrompt)
+    }, [
+        firstRunPrompt,
+        firstRunAutoSend,
+        modelBlocked,
+        messagesCount,
+        overlayReady,
+        overlayWaitElapsed,
+    ])
+
+    return {firstRunPrompt}
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useOnboardingChat.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useOnboardingChat.ts
@@ -180,7 +180,14 @@ export const useOnboardingChat = ({
     // Holds the pending IDE-bubble typewriter timer so it can be cancelled on unmount (tab close,
     // rewind, route change) — otherwise the recursive chain keeps calling setMessages on a stale closure.
     const ideBubbleTimerRef = useRef<number | null>(null)
+    // The ref holds ONE handle, so anything that starts (or invalidates) a chain must cancel the
+    // previous one first — overwriting the handle would strand the old chain beyond every cleanup.
+    const cancelIdeBubble = useCallback(() => {
+        if (ideBubbleTimerRef.current) window.clearTimeout(ideBubbleTimerRef.current)
+        ideBubbleTimerRef.current = null
+    }, [])
     const streamIdeBubble = useCallback(() => {
+        cancelIdeBubble()
         const prompt = richInputRef.current?.getMarkdown().trim() ?? ""
         const promptQuote = prompt
             .split("\n")
@@ -219,23 +226,21 @@ export const useOnboardingChat = ({
             if (shown < full.length) ideBubbleTimerRef.current = window.setTimeout(tick, 28)
         }
         ideBubbleTimerRef.current = window.setTimeout(tick, 120)
-    }, [setMessages])
+    }, [setMessages, cancelIdeBubble])
 
     // Cancel any in-flight IDE-bubble animation on unmount so its timer chain can't fire post-unmount.
-    useEffect(
-        () => () => {
-            if (ideBubbleTimerRef.current) window.clearTimeout(ideBubbleTimerRef.current)
-        },
-        [],
-    )
+    useEffect(() => cancelIdeBubble, [cancelIdeBubble])
 
     // After an IDE hand-off (onboarding + messages exist but nothing was committed), the chat is a
     // dead-end — there's no agent to talk to. Disable the composer and offer a single "Start over".
     const ideHandoffActive = onboardingActive && messages.length > 0
     const handleStartOver = useCallback(() => {
+        // Start over wipes the transcript the chain is typing into — stop it, or it keeps ticking
+        // against messages that no longer exist (and outlives the next chain's handle).
+        cancelIdeBubble()
         setMessages(() => [])
         richInputRef.current?.setMarkdown("")
-    }, [setMessages])
+    }, [setMessages, cancelIdeBubble])
 
     // Strip era (TEMPLATE_STRIP_MODE): the bare "what do you want to build?" hero (no messages yet,
     // nothing pending, not browsing the template gallery) is when the onboarding TemplateStrip docks

--- a/web/oss/src/components/AgentChatSlice/hooks/useOnboardingChat.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useOnboardingChat.ts
@@ -1,0 +1,274 @@
+import {type RefObject, useCallback, useEffect, useMemo, useRef, useState} from "react"
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {generateId} from "@agenta/shared/utils"
+import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
+import {type UIMessage} from "ai"
+import {App} from "antd"
+import {useAtomValue} from "jotai"
+
+import {
+    IDE_INSTALL_COMMAND,
+    TEMPLATE_STRIP_MODE,
+} from "@/oss/components/pages/agent-home/assets/constants"
+import {
+    captureFirstAgentIntent,
+    classifyAgentIntent,
+    truncateForCapture,
+} from "@/oss/components/pages/agent-home/assets/onboardingAnalytics"
+import {type AgentTemplate} from "@/oss/components/pages/agent-home/assets/templates"
+import {useOptionalOnboardingContext} from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingContext"
+import {buildCodingAgentClipboard} from "@/oss/components/TemplateStrip/assets/codingAgentClipboard"
+import {useTemplateProvenance} from "@/oss/components/TemplateStrip/hooks/useTemplateProvenance"
+import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
+
+import {type ScrollIntent} from "./useScrollIntent"
+
+/**
+ * Playground-native onboarding. This chat panel IS the onboarding surface while the agent is
+ * ephemeral: the empty state shows the "what do you want to build?" hero and the composer renders
+ * Create-agent / Continue-in-IDE controls (submit = commit the ephemeral in place, not send). Read
+ * from the OnboardingContext, present ONLY inside the onboarding playground — every value here is
+ * inert (`onboardingActive: false`) elsewhere, so other chat usages are unchanged.
+ */
+export const useOnboardingChat = ({
+    entityId,
+    richInputRef,
+    messages,
+    setMessages,
+    setStopped,
+    intent,
+}: {
+    entityId: string
+    richInputRef: RefObject<RichChatInputHandle | null>
+    messages: UIMessage[]
+    setMessages: (updater: (prev: UIMessage[]) => UIMessage[]) => void
+    setStopped: (stopped: boolean) => void
+    intent: ScrollIntent
+}) => {
+    const onboarding = useOptionalOnboardingContext()
+    const onboardingActive = !!onboarding && !onboarding.realEntityId
+    // Post-commit chrome (the connect-model banner) stays hidden through the commit + first send, then
+    // eases in a beat later (see `chromeRevealed`) so it doesn't move the composer during the send.
+    const chromeHidden = !!onboarding && !onboarding.chromeRevealed
+    const onboardingPosthog = usePostHogAg()
+    const {message: appMessage} = App.useApp()
+
+    // ── Template strip (TEMPLATE_STRIP_MODE) ─────────────────────────────────
+    // One provenance instance per panel, shared by the onboarding hero strip (S5) and the
+    // agent empty-chat strip (S6): pick fills the composer + docks the chip above it.
+    const stripProvenance = useTemplateProvenance({
+        composerApi: {
+            setText: (text) => richInputRef.current?.setMarkdown(text),
+            getText: () => richInputRef.current?.getMarkdown() ?? "",
+        },
+    })
+    // Provenance is scoped to ONE agent revision. `AgentConversation` survives an `entityId`
+    // change in place (see the self-commit `switchEntity` and a revision swap) — without
+    // this, a template picked against the old entity would leak its name into the new one. Drop
+    // only the chip, not the composer text: a commit must not wipe the user's in-progress draft (#5246).
+    useEffect(() => {
+        stripProvenance.clearProvenance()
+    }, [entityId, stripProvenance.clearProvenance])
+    // S6 gate: fresh agent only (`version` v0/v1 = creation, same seed-vs-history convention used
+    // elsewhere); unknown while loading counts as not-fresh so the strip never flashes in.
+    const revisionQuery = useAtomValue(workflowMolecule.selectors.query(entityId))
+    const revisionVersion = revisionQuery.data?.version
+    const isFreshAgentRevision =
+        !revisionQuery.isPending && typeof revisionVersion === "number" && revisionVersion <= 1
+    const [copiedToastOpen, setCopiedToastOpen] = useState(false)
+    const handleStripPick = useCallback(
+        (template: AgentTemplate) => {
+            stripProvenance.pick(template)
+            captureFirstAgentIntent(onboardingPosthog, {
+                source: "template",
+                properties: {
+                    template: template.name,
+                    templateId: template.key,
+                    templateCategory: template.category,
+                    mode: "strip",
+                    surface: onboardingActive ? "onboarding" : "agent-chat",
+                },
+                intentValue: template.category || template.name,
+            })
+        },
+        [stripProvenance.pick, onboardingPosthog, onboardingActive],
+    )
+    const handleCodingAgentCopy = useCallback(async () => {
+        const text = richInputRef.current?.getMarkdown().trim() ?? ""
+        try {
+            await navigator.clipboard.writeText(buildCodingAgentClipboard(text))
+            setCopiedToastOpen(true)
+        } catch {
+            appMessage.error("Couldn't copy — copy it manually")
+            return
+        }
+        captureFirstAgentIntent(onboardingPosthog, {
+            source: "composer",
+            properties: {action: "coding_agent_copy", message: truncateForCapture(text)},
+        })
+    }, [appMessage, onboardingPosthog])
+
+    // Optimistic first turn: the description the user submitted with "Create agent", shown as a sent
+    // user message + assistant loading placeholder DURING commit + until the real conversation takes
+    // over — so the onboarding hero never flashes back and the switch reads as one continuous chat.
+    const [pendingFirstTurn, setPendingFirstTurn] = useState<string | null>(null)
+
+    const handleCreateAgent = useCallback(() => {
+        if (!onboarding || onboarding.committing) return
+        const text = richInputRef.current?.getMarkdown().trim() ?? ""
+        // Resolve BEFORE clearing the composer below — `resolveTemplateName` compares against the
+        // live text, so reading it after the clear would always see "" and never match the seed.
+        const templateName = stripProvenance.resolveTemplateName(text)
+        setPendingFirstTurn(text || null)
+        // The text becomes the sent first turn — clear the composer so it doesn't linger into the chat.
+        richInputRef.current?.setMarkdown("")
+        // Free-text submit (never a template — those go straight through `onboarding.commit` from the
+        // template pickers below, source "template"), so no double-fire with those call sites.
+        if (text) {
+            captureFirstAgentIntent(onboardingPosthog, {
+                source: "composer",
+                properties: {message: truncateForCapture(text)},
+                intentValue: classifyAgentIntent(text),
+            })
+        }
+        onboarding.commit(text, templateName)
+        if (TEMPLATE_STRIP_MODE) stripProvenance.clear()
+    }, [onboarding, onboardingPosthog, stripProvenance.clear, stripProvenance.resolveTemplateName])
+
+    // Also cover the template-click commit path (which goes straight through `commit()`, not the
+    // Create button): whenever a commit is in flight, show its seed as the optimistic turn and clear
+    // any lingering composer text (e.g. a "Try" chip the user had prefilled).
+    useEffect(() => {
+        if (onboarding?.committing && onboarding.committingSeed) {
+            setPendingFirstTurn(onboarding.committingSeed)
+            richInputRef.current?.setMarkdown("")
+        }
+    }, [onboarding?.committing, onboarding?.committingSeed])
+
+    // Once the real conversation has a message (auto-send fired post-commit), the placeholder handed
+    // off — drop it so the real turn owns the view.
+    useEffect(() => {
+        if (messages.length > 0 && pendingFirstTurn) setPendingFirstTurn(null)
+    }, [messages.length, pendingFirstTurn])
+
+    // Commit failed (committing went true→false without producing a real agent): restore the hero so
+    // the user can retry, rather than stranding the placeholder with an eternal spinner.
+    const sawCommittingRef = useRef(false)
+    useEffect(() => {
+        if (onboarding?.committing) {
+            sawCommittingRef.current = true
+        } else if (sawCommittingRef.current && !onboarding?.realEntityId && messages.length === 0) {
+            sawCommittingRef.current = false
+            setPendingFirstTurn(null)
+        }
+    }, [onboarding?.committing, onboarding?.realEntityId, messages.length])
+
+    const pendingFirstMessage = useMemo<UIMessage>(
+        () => ({
+            id: "pending-first-turn",
+            role: "user",
+            parts: [{type: "text", text: pendingFirstTurn ?? ""}],
+        }),
+        [pendingFirstTurn],
+    )
+
+    // "Continue in IDE" — the user's prompt lands as a real user turn, and a streamed-looking assistant
+    // bubble hands off the install command + prompt (a pseudo response; there's no agent to run
+    // pre-commit). Two clear steps: install the skill, then give the coding agent the prompt — the prompt
+    // is NOT inside the shell block (it's not a command). Clears the composer so the text isn't duplicated.
+    // Holds the pending IDE-bubble typewriter timer so it can be cancelled on unmount (tab close,
+    // rewind, route change) — otherwise the recursive chain keeps calling setMessages on a stale closure.
+    const ideBubbleTimerRef = useRef<number | null>(null)
+    const streamIdeBubble = useCallback(() => {
+        const prompt = richInputRef.current?.getMarkdown().trim() ?? ""
+        const promptQuote = prompt
+            .split("\n")
+            .map((line) => `> ${line}`)
+            .join("\n")
+        const full = prompt
+            ? `Prefer to build in your IDE? Install the Agenta skill for Claude Code, Cursor, or any coding agent:\n\n\`\`\`bash\n${IDE_INSTALL_COMMAND}\n\`\`\`\n\nThen hand it your prompt:\n\n${promptQuote}`
+            : `Prefer to build in your IDE? Install the Agenta skill for Claude Code, Cursor, or any coding agent:\n\n\`\`\`bash\n${IDE_INSTALL_COMMAND}\n\`\`\`\n\nThen describe the agent you want it to build.`
+        const id = `ide-${generateId()}`
+        const userId = `ide-user-${generateId()}`
+        intent.armGlide()
+        setStopped(false)
+        // Clear the composer — the prompt is now the sent user turn (and the editor is disabled after this).
+        richInputRef.current?.setMarkdown("")
+        setMessages(
+            (prev) =>
+                [
+                    ...prev,
+                    ...(prompt
+                        ? [{id: userId, role: "user", parts: [{type: "text", text: prompt}]}]
+                        : []),
+                    {id, role: "assistant", parts: [{type: "text", text: ""}]},
+                ] as typeof prev,
+        )
+        let shown = 0
+        const chunk = Math.max(3, Math.ceil(full.length / 36))
+        const tick = () => {
+            shown = Math.min(full.length, shown + chunk)
+            const text = full.slice(0, shown)
+            setMessages(
+                (prev) =>
+                    prev.map((m) =>
+                        m.id === id ? {...m, parts: [{type: "text", text}]} : m,
+                    ) as typeof prev,
+            )
+            if (shown < full.length) ideBubbleTimerRef.current = window.setTimeout(tick, 28)
+        }
+        ideBubbleTimerRef.current = window.setTimeout(tick, 120)
+    }, [setMessages])
+
+    // Cancel any in-flight IDE-bubble animation on unmount so its timer chain can't fire post-unmount.
+    useEffect(
+        () => () => {
+            if (ideBubbleTimerRef.current) window.clearTimeout(ideBubbleTimerRef.current)
+        },
+        [],
+    )
+
+    // After an IDE hand-off (onboarding + messages exist but nothing was committed), the chat is a
+    // dead-end — there's no agent to talk to. Disable the composer and offer a single "Start over".
+    const ideHandoffActive = onboardingActive && messages.length > 0
+    const handleStartOver = useCallback(() => {
+        setMessages(() => [])
+        richInputRef.current?.setMarkdown("")
+    }, [setMessages])
+
+    // Strip era (TEMPLATE_STRIP_MODE): the bare "what do you want to build?" hero (no messages yet,
+    // nothing pending, not browsing the template gallery) is when the onboarding TemplateStrip docks
+    // directly above the composer, mirroring the agent-chat strip's bottom-anchored rhythm.
+    const showBareOnboardingHero =
+        TEMPLATE_STRIP_MODE &&
+        onboardingActive &&
+        messages.length === 0 &&
+        !pendingFirstTurn &&
+        !onboarding?.browseAll
+
+    /** Sending consumes the template provenance along with the composer text. */
+    const consumeTemplateProvenance = useCallback(() => {
+        if (TEMPLATE_STRIP_MODE) stripProvenance.clear()
+    }, [stripProvenance.clear])
+
+    return {
+        onboarding,
+        onboardingActive,
+        chromeHidden,
+        selectedTemplateKey: stripProvenance.selectedTemplateKey,
+        handleStripPick,
+        isFreshAgentRevision,
+        copiedToastOpen,
+        setCopiedToastOpen,
+        handleCodingAgentCopy,
+        pendingFirstTurn,
+        pendingFirstMessage,
+        handleCreateAgent,
+        streamIdeBubble,
+        ideHandoffActive,
+        handleStartOver,
+        showBareOnboardingHero,
+        consumeTemplateProvenance,
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useScrollIntent.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useScrollIntent.ts
@@ -1,0 +1,59 @@
+import {useCallback, useRef, useState} from "react"
+
+/**
+ * Shared scroll INTENT for one conversation: the handful of refs that say what the transcript
+ * should do next, owned in one place so the producers (send / queue release / history adoption)
+ * and the engines (`useTranscriptScroll`, `useVirtuosoTranscript`) never have to know about each
+ * other. They're refs, not state, so writing intent costs no render — which is why a send can
+ * declare "glide to the bottom" mid-stream without touching the streaming hot path.
+ *
+ * Exactly three verbs, one per call-site shape:
+ *  - `armGlide()` — SC-1 submit: park follow, arm ONE animated pin to the bottom.
+ *  - `armJump()`  — SC-2 restore: arm ONE instant jump (adopted server history). Follow untouched.
+ *  - `follow()`   — a send that leaves now (queue release / channelled run): stick from here.
+ */
+export const useScrollIntent = ({initialArmed}: {initialArmed: boolean}) => {
+    // Stick to the bottom of the scrollable area. This is the ONE source of truth for auto-scroll:
+    // the active turn reserves a viewport (min-h-full), so "bottom" puts the latest question at the
+    // top with the answer streaming into the space below — the pin is emergent, not computed. A real
+    // user scroll-up releases it (onScroll); jump-to-latest re-arms it.
+    const stickRef = useRef(true)
+    const [showJump, setShowJump] = useState(false)
+    // Arm a one-shot scroll to the bottom: on a fresh submit (glide) and on restoring a saved thread
+    // (instant). Combined with min-h-full this is the whole SC-1/SC-2 positioning — no per-element pin.
+    const armBottomRef = useRef(initialArmed)
+    const animateBottomRef = useRef(false)
+    // Set while WE move the scroll (the bottom glide / SC-3 compensation). onScroll ignores the
+    // resulting event so our own scroll isn't mistaken for the user reaching/leaving the live edge.
+    const programmaticScrollRef = useRef(false)
+
+    const armGlide = useCallback(() => {
+        stickRef.current = false
+        armBottomRef.current = true
+        animateBottomRef.current = true
+        setShowJump(false)
+    }, [])
+
+    const armJump = useCallback(() => {
+        armBottomRef.current = true
+    }, [])
+
+    const follow = useCallback(() => {
+        stickRef.current = true
+        setShowJump(false)
+    }, [])
+
+    return {
+        showJump,
+        setShowJump,
+        armGlide,
+        armJump,
+        follow,
+        stickRef,
+        armBottomRef,
+        animateBottomRef,
+        programmaticScrollRef,
+    }
+}
+
+export type ScrollIntent = ReturnType<typeof useScrollIntent>

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -59,39 +59,40 @@ export const useSessionHydration = ({
         // StrictMode's mount→unmount→mount cycle re-runs the fetch (the first run is cancelled)
         // instead of latching a ref that leaves the transcript blank.
         let cancelled = false
-        // Post-restore revalidation: the first result may be the disk-restored log (paints
-        // instantly); when the guaranteed background refetch lands, adopt it under the same
-        // guards as the SWR effect below — never mid-stream, only when strictly ahead.
-        const adoptRefreshed = (freshMsgs: UIMessage[]) => {
+        // How long a transcript this effect has already handed to `setMessages`. `messagesRef` only
+        // catches up on the next React commit, so two adoptions landing before that commit would
+        // both read the pre-adoption length and let the older snapshot win. The high-water mark
+        // makes the guard order-independent.
+        let adoptedLength = initialMessages.length
+        // ONE adopter for both deliveries: the initial result (disk-restored log, paints instantly)
+        // and the guaranteed background refetch. Never mid-stream, only when strictly ahead.
+        const adopt = (msgs: UIMessage[]) => {
             if (cancelled || busyRef.current) return
-            if (freshMsgs.length <= messagesRef.current.length) return
-            freshMsgs.forEach((m) => {
+            if (msgs.length <= Math.max(adoptedLength, messagesRef.current.length)) return
+            adoptedLength = msgs.length
+            // Restored history renders settled (no live fade-in) and pinned to the bottom.
+            msgs.forEach((m) => {
                 seenIdsRef.current.add(m.id)
                 restoredIdsRef.current.add(m.id)
             })
             intent.armJump()
-            // The restore said "no records" but the server has some — clear the notice.
+            // The restore may have said "no records" while the server has some — clear the notice.
             setHydratedEmpty(false)
-            setMessages(freshMsgs)
-            persistMessages({id: sessionId, messages: freshMsgs})
+            setMessages(msgs)
+            persistMessages({id: sessionId, messages: msgs})
         }
-        loadSessionMessages(sessionId, adoptRefreshed)
+        loadSessionMessages(sessionId, adopt)
             .then((msgs) => {
                 if (cancelled) return
                 if (!msgs || msgs.length === 0) {
                     // Known session, but the server has no records for it → history was pruned or
                     // never persisted. Flag it so the transcript shows the "unavailable" notice.
-                    setHydratedEmpty(true)
+                    // Only when nothing has been adopted yet — a refetch that already landed is
+                    // real history, and this stale first result must not blank it out.
+                    if (adoptedLength === initialMessages.length) setHydratedEmpty(true)
                     return
                 }
-                // Restored history renders settled (no live fade-in) and pinned to the bottom.
-                msgs.forEach((m) => {
-                    seenIdsRef.current.add(m.id)
-                    restoredIdsRef.current.add(m.id)
-                })
-                intent.armJump()
-                setMessages(msgs)
-                persistMessages({id: sessionId, messages: msgs})
+                adopt(msgs)
             })
             .finally(() => {
                 if (!cancelled) setIsHydrating(false)
@@ -115,9 +116,15 @@ export const useSessionHydration = ({
         // As with the hydration effect above: no persistent ref, so StrictMode's double-mount
         // re-runs the revalidation rather than latching it out.
         let cancelled = false
+        // `messagesRef` only catches up on the next React commit, so a transcript this effect just
+        // adopted is invisible to the guard until then. Hold it here too and compare against
+        // whichever is longer — the checks below read the tail, not just the count, so this keeps
+        // the whole snapshot rather than a length.
+        let adopted: UIMessage[] | null = null
         const adopt = (serverMsgs: UIMessage[] | null) => {
             if (cancelled || !serverMsgs || serverMsgs.length === 0) return
-            const prev = messagesRef.current
+            const onScreen = messagesRef.current
+            const prev = adopted && adopted.length > onScreen.length ? adopted : onScreen
             if (busyRef.current) return
             // Adopt the server transcript when it is strictly ahead by count, OR when our LOCAL tail
             // is stuck paused (mid-approval) while the server has moved past it to a terminal turn — a
@@ -138,6 +145,7 @@ export const useSessionHydration = ({
                 !serverTail.metadata?.paused &&
                 getPendingApprovals(serverMsgs).length === 0
             if (!serverAheadByCount && !(localTailPaused && serverTailComplete)) return
+            adopted = serverMsgs
             serverMsgs.forEach((m) => {
                 seenIdsRef.current.add(m.id)
                 restoredIdsRef.current.add(m.id)

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -2,11 +2,24 @@ import {type MutableRefObject, useCallback, useEffect, useState} from "react"
 
 import {shouldAdoptServerTranscript} from "@agenta/entities/session"
 import {type UIMessage} from "ai"
+import {useAtomValue} from "jotai"
 
 import {loadSessionMessages, type SessionTranscript} from "../assets/loadSession"
+import {sessionLivenessAtomFamily} from "../state/liveness"
 import {isSessionFresh} from "../state/sessionEphemera"
 
 import {type ScrollIntent} from "./useScrollIntent"
+
+/** Catch-up cadence while a session runs elsewhere — matches the records query's own staleTime and
+ * the liveness poll, so a tick refetches instead of resolving from a still-fresh cache. */
+const REMOTE_RUN_POLL_MS = 15_000
+
+/** Ceiling once the log goes quiet. `is_running` is Redis-TTL'd at an hour (the runner clears it at
+ * turn end; the TTL is only the crash backstop), so a runner that dies mid-turn leaves the flag set
+ * for a long time — without a backoff that is a full-log refetch every 15s for an hour. Real growth
+ * resets to the fast cadence, so a long turn that is simply quiet (a slow tool call emits no
+ * records until it returns) is still followed. */
+const REMOTE_RUN_POLL_MAX_MS = 60_000
 
 /**
  * Hybrid history for one session tab. localStorage holds only the session INDEX; the durable
@@ -23,6 +36,7 @@ export const useSessionHydration = ({
     seenIdsRef,
     restoredIdsRef,
     recordWatermarkRef,
+    busy,
     setMessages,
     persistMessages,
     intent,
@@ -35,6 +49,8 @@ export const useSessionHydration = ({
     restoredIdsRef: MutableRefObject<Set<string>>
     /** Records the rendered transcript was built from; `undefined` once a live turn supersedes it. */
     recordWatermarkRef: MutableRefObject<number | undefined>
+    /** THIS browser is streaming the turn — reactive, so the catch-up poll can start/stop on it. */
+    busy: boolean
     setMessages: (messages: UIMessage[]) => void
     persistMessages: (args: {id: string; messages: UIMessage[]; recordCount?: number}) => void
     intent: ScrollIntent
@@ -75,7 +91,10 @@ export const useSessionHydration = ({
                 seenIdsRef.current.add(m.id)
                 restoredIdsRef.current.add(m.id)
             })
-            if (armJump) intent.armJump()
+            // Opening a session jumps to the live edge; a background catch-up must NOT — it would
+            // yank a reader who scrolled up. Following the growth is `stickRef`'s call, the same
+            // rule the live stream uses.
+            if (armJump || intent.stickRef.current) intent.armJump()
             recordWatermarkRef.current = recordCount
             setMessages(serverMsgs)
             persistMessages({id: sessionId, messages: serverMsgs, recordCount})
@@ -157,5 +176,44 @@ export const useSessionHydration = ({
         // Once per mounted session tab; `sessionId` is stable for this instance.
     }, [sessionId])
 
-    return {isHydrating, hydratedEmpty}
+    // ── Follow a run happening somewhere else (#5530) ──────────────────────────
+    // There is no push channel to browsers: the runner publishes every event to Redis, but the only
+    // consumer is the ingest worker that writes them to the DB. So a session driven from another tab
+    // or device is followed by re-reading the durable log on a timer, and the adoption guard above
+    // decides whether anything actually changed. `isRunning` also covers OUR stream, so exclude the
+    // case where this browser is the one driving.
+    const {nest} = useAtomValue(sessionLivenessAtomFamily(sessionId))
+    const runningElsewhere = nest.isRunning && !busy
+
+    useEffect(() => {
+        if (!runningElsewhere) return
+        let cancelled = false
+        let timer: ReturnType<typeof setTimeout> | undefined
+        let delay = REMOTE_RUN_POLL_MS
+        const poll = async () => {
+            let grew = false
+            try {
+                const transcript = await loadSessionMessages(sessionId, (fresh) => {
+                    if (!cancelled && adoptServerTranscript(fresh, {armJump: false})) grew = true
+                })
+                if (!cancelled && adoptServerTranscript(transcript, {armJump: false})) grew = true
+            } catch {
+                // `loadSessionMessages` already swallows + logs; keep polling regardless.
+            } finally {
+                // Chained, not `setInterval`: the log is ~200KB and backend-slow, so a slow fetch
+                // must never stack requests on top of itself.
+                if (!cancelled) {
+                    delay = grew ? REMOTE_RUN_POLL_MS : Math.min(delay * 2, REMOTE_RUN_POLL_MAX_MS)
+                    timer = setTimeout(poll, delay)
+                }
+            }
+        }
+        timer = setTimeout(poll, delay)
+        return () => {
+            cancelled = true
+            if (timer) clearTimeout(timer)
+        }
+    }, [runningElsewhere, sessionId, adoptServerTranscript])
+
+    return {isHydrating, hydratedEmpty, runningElsewhere}
 }

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -1,4 +1,4 @@
-import {type MutableRefObject, useCallback, useEffect, useState} from "react"
+import {type MutableRefObject, useCallback, useEffect, useRef, useState} from "react"
 
 import {shouldAdoptServerTranscript} from "@agenta/entities/session"
 import {type UIMessage} from "ai"
@@ -105,6 +105,10 @@ export const useSessionHydration = ({
             persistMessages({id: sessionId, messages: serverMsgs, recordCount})
             return true
         },
+        // `intent`'s MEMBERS, not `intent`: `useScrollIntent` returns a fresh object every render,
+        // so the object itself would recreate this callback each render and churn everything keyed
+        // on it. `armJump` (useCallback []) and `stickRef` (useRef) are stable for the life of the
+        // conversation.
         [
             sessionId,
             messagesRef,
@@ -114,9 +118,16 @@ export const useSessionHydration = ({
             recordWatermarkRef,
             setMessages,
             persistMessages,
-            intent,
+            intent.armJump,
+            intent.stickRef,
         ],
     )
+    // The remote-run poll below must NOT re-arm its timer on re-renders: the liveness query alone
+    // re-renders this hook ~every 15s while a run is live elsewhere, and restarting a fresh 15s
+    // timer on each of those starves the poll and resets its backoff. The effect reads the CURRENT
+    // adopter through this ref and keys only on the poll's real inputs.
+    const adoptServerTranscriptRef = useRef(adoptServerTranscript)
+    adoptServerTranscriptRef.current = adoptServerTranscript
 
     useEffect(() => {
         // A session created brand-new in this browser and not yet run has no backend records —
@@ -207,10 +218,11 @@ export const useSessionHydration = ({
         const poll = async () => {
             let grew = false
             try {
+                const adopt = adoptServerTranscriptRef.current
                 const transcript = await loadSessionMessages(sessionId, (fresh) => {
-                    if (!cancelled && adoptServerTranscript(fresh, {armJump: false})) grew = true
+                    if (!cancelled && adopt(fresh, {armJump: false})) grew = true
                 })
-                if (!cancelled && adoptServerTranscript(transcript, {armJump: false})) grew = true
+                if (!cancelled && adopt(transcript, {armJump: false})) grew = true
             } catch {
                 // `loadSessionMessages` already swallows + logs; keep polling regardless.
             } finally {
@@ -227,7 +239,9 @@ export const useSessionHydration = ({
             cancelled = true
             if (timer) clearTimeout(timer)
         }
-    }, [runningElsewhere, sessionId, adoptServerTranscript])
+        // Deliberately NOT keyed on `adoptServerTranscript` — the poll reads it through the ref
+        // above, so a re-render can't cancel a pending tick or reset the backoff.
+    }, [runningElsewhere, sessionId])
 
     return {isHydrating, hydratedEmpty, runningElsewhere}
 }

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -1,9 +1,9 @@
-import {type MutableRefObject, useEffect, useState} from "react"
+import {type MutableRefObject, useCallback, useEffect, useState} from "react"
 
+import {shouldAdoptServerTranscript} from "@agenta/entities/session"
 import {type UIMessage} from "ai"
 
-import {loadSessionMessages} from "../assets/loadSession"
-import {getPendingApprovals} from "../components/ApprovalDock"
+import {loadSessionMessages, type SessionTranscript} from "../assets/loadSession"
 import {isSessionFresh} from "../state/sessionEphemera"
 
 import {type ScrollIntent} from "./useScrollIntent"
@@ -12,7 +12,8 @@ import {type ScrollIntent} from "./useScrollIntent"
  * Hybrid history for one session tab. localStorage holds only the session INDEX; the durable
  * conversation CONTENT lives in the backend record log — so a tab either paints from cache and
  * revalidates (SWR), or hydrates from the server once (cache miss). Both paths adopt the server
- * transcript under the same guards: never mid-stream, and never behind what's on screen.
+ * transcript through the SAME guard: never mid-stream, and only when the record log has grown past
+ * what's on screen.
  */
 export const useSessionHydration = ({
     sessionId,
@@ -21,6 +22,7 @@ export const useSessionHydration = ({
     busyRef,
     seenIdsRef,
     restoredIdsRef,
+    recordWatermarkRef,
     setMessages,
     persistMessages,
     intent,
@@ -31,8 +33,10 @@ export const useSessionHydration = ({
     busyRef: MutableRefObject<boolean>
     seenIdsRef: MutableRefObject<Set<string>>
     restoredIdsRef: MutableRefObject<Set<string>>
+    /** Records the rendered transcript was built from; `undefined` once a live turn supersedes it. */
+    recordWatermarkRef: MutableRefObject<number | undefined>
     setMessages: (messages: UIMessage[]) => void
-    persistMessages: (args: {id: string; messages: UIMessage[]}) => void
+    persistMessages: (args: {id: string; messages: UIMessage[]; recordCount?: number}) => void
     intent: ScrollIntent
 }) => {
     // Cache-first — when this tab opens with no locally-cached messages (a session this browser
@@ -48,6 +52,48 @@ export const useSessionHydration = ({
     // durable history was pruned by retention or never persisted. Drives the "history unavailable"
     // notice so a wiped session isn't mistaken for a brand-new chat.
     const [hydratedEmpty, setHydratedEmpty] = useState(false)
+
+    /**
+     * The ONE adoption guard, shared by both paths below (they used to carry divergent copies, and
+     * the hydration one had the same #5530 blind spot). Adopts the durable transcript when the
+     * record log has grown past what we're rendering. Returns whether it adopted.
+     */
+    const adoptServerTranscript = useCallback(
+        (transcript: SessionTranscript | null, {armJump = true} = {}): boolean => {
+            if (!transcript) return false
+            const {messages: serverMsgs, recordCount} = transcript
+            const adopt = shouldAdoptServerTranscript({
+                serverRecordCount: recordCount,
+                serverMessageCount: serverMsgs.length,
+                localMessageCount: messagesRef.current.length,
+                watermark: recordWatermarkRef.current,
+                busy: busyRef.current,
+            })
+            if (!adopt) return false
+            // Restored history renders settled (no live fade-in) and pinned to the bottom.
+            serverMsgs.forEach((m) => {
+                seenIdsRef.current.add(m.id)
+                restoredIdsRef.current.add(m.id)
+            })
+            if (armJump) intent.armJump()
+            recordWatermarkRef.current = recordCount
+            setMessages(serverMsgs)
+            persistMessages({id: sessionId, messages: serverMsgs, recordCount})
+            return true
+        },
+        [
+            sessionId,
+            messagesRef,
+            busyRef,
+            seenIdsRef,
+            restoredIdsRef,
+            recordWatermarkRef,
+            setMessages,
+            persistMessages,
+            intent,
+        ],
+    )
+
     useEffect(() => {
         // A session created brand-new in this browser and not yet run has no backend records —
         // skip the guaranteed-empty query (cleared on first send; after a reload it re-hydrates).
@@ -60,38 +106,21 @@ export const useSessionHydration = ({
         // instead of latching a ref that leaves the transcript blank.
         let cancelled = false
         // Post-restore revalidation: the first result may be the disk-restored log (paints
-        // instantly); when the guaranteed background refetch lands, adopt it under the same
-        // guards as the SWR effect below — never mid-stream, only when strictly ahead.
-        const adoptRefreshed = (freshMsgs: UIMessage[]) => {
-            if (cancelled || busyRef.current) return
-            if (freshMsgs.length <= messagesRef.current.length) return
-            freshMsgs.forEach((m) => {
-                seenIdsRef.current.add(m.id)
-                restoredIdsRef.current.add(m.id)
-            })
-            intent.armJump()
+        // instantly); adopt the background refetch when it lands.
+        loadSessionMessages(sessionId, (fresh) => {
+            if (cancelled) return
             // The restore said "no records" but the server has some — clear the notice.
-            setHydratedEmpty(false)
-            setMessages(freshMsgs)
-            persistMessages({id: sessionId, messages: freshMsgs})
-        }
-        loadSessionMessages(sessionId, adoptRefreshed)
-            .then((msgs) => {
+            if (adoptServerTranscript(fresh)) setHydratedEmpty(false)
+        })
+            .then((transcript) => {
                 if (cancelled) return
-                if (!msgs || msgs.length === 0) {
+                if (!transcript || transcript.messages.length === 0) {
                     // Known session, but the server has no records for it → history was pruned or
                     // never persisted. Flag it so the transcript shows the "unavailable" notice.
                     setHydratedEmpty(true)
                     return
                 }
-                // Restored history renders settled (no live fade-in) and pinned to the bottom.
-                msgs.forEach((m) => {
-                    seenIdsRef.current.add(m.id)
-                    restoredIdsRef.current.add(m.id)
-                })
-                intent.armJump()
-                setMessages(msgs)
-                persistMessages({id: sessionId, messages: msgs})
+                adoptServerTranscript(transcript)
             })
             .finally(() => {
                 if (!cancelled) setIsHydrating(false)
@@ -103,48 +132,21 @@ export const useSessionHydration = ({
     }, [sessionId])
 
     // SWR revalidate-on-open: a cached session paints instantly from localStorage; in the background
-    // we refetch the durable records ONCE (low-priority) and adopt the server transcript ONLY IF it's
-    // strictly ahead of what we're showing (a turn finished on another device). We never clobber a
-    // transcript that's live (`busyRef`), or that the server isn't strictly ahead of — so a local
-    // optimistic/unsent tail is safe. Cache-MISS sessions are hydrated by the effect above; fresh
-    // never-run sessions have no server records. Reconciliation is by message COUNT, not content:
-    // detecting a same-length server-side edit/regenerate is deferred, as is focus/interval
-    // revalidation. FOLLOWUP(sessions,swr): see docs/designs/sessions/frontend-integration.md.
+    // we refetch the durable records ONCE (low-priority) and adopt the server transcript when the
+    // record log has grown past ours. Cache-MISS sessions are hydrated by the effect above; fresh
+    // never-run sessions have no server records.
+    //
+    // The old count-based guard also carried a special case for "local tail paused, server tail
+    // complete" — a resume that finished on another device, invisible to a message count. The
+    // record watermark sees that growth directly, so the special case is gone rather than extended.
     useEffect(() => {
         if (initialMessages.length === 0 || isSessionFresh(sessionId)) return
         // As with the hydration effect above: no persistent ref, so StrictMode's double-mount
         // re-runs the revalidation rather than latching it out.
         let cancelled = false
-        const adopt = (serverMsgs: UIMessage[] | null) => {
-            if (cancelled || !serverMsgs || serverMsgs.length === 0) return
-            const prev = messagesRef.current
-            if (busyRef.current) return
-            // Adopt the server transcript when it is strictly ahead by count, OR when our LOCAL tail
-            // is stuck paused (mid-approval) while the server has moved past it to a terminal turn — a
-            // resume that completed on another device. Count alone misses the latter (same bubble
-            // count) and was silently propped up by the now-removed duplicate user row; the server's
-            // `paused` flag rides the runner's `done.stopReason` through `transcriptToMessages`.
-            const serverAheadByCount = serverMsgs.length > prev.length
-            const localTailPaused = getPendingApprovals(prev).length > 0
-            const serverTail = serverMsgs[serverMsgs.length - 1] as
-                | {role?: string; metadata?: {paused?: boolean}}
-                | undefined
-            // The paused-tail exception adopts a resume that completed elsewhere, so the server must
-            // NOT be behind (>= guards against a lagging snapshot discarding newer local approval
-            // state) and its tail must be a finished assistant turn — not a shorter, older stream.
-            const serverTailComplete =
-                serverMsgs.length >= prev.length &&
-                serverTail?.role === "assistant" &&
-                !serverTail.metadata?.paused &&
-                getPendingApprovals(serverMsgs).length === 0
-            if (!serverAheadByCount && !(localTailPaused && serverTailComplete)) return
-            serverMsgs.forEach((m) => {
-                seenIdsRef.current.add(m.id)
-                restoredIdsRef.current.add(m.id)
-            })
-            intent.armJump()
-            setMessages(serverMsgs)
-            persistMessages({id: sessionId, messages: serverMsgs})
+        const adopt = (transcript: SessionTranscript | null) => {
+            if (cancelled) return
+            adoptServerTranscript(transcript)
         }
         // The first result may itself be the disk-restored records log; the callback re-applies
         // the same guarded adoption when the guaranteed background revalidation lands.

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -1,0 +1,159 @@
+import {type MutableRefObject, useEffect, useState} from "react"
+
+import {type UIMessage} from "ai"
+
+import {loadSessionMessages} from "../assets/loadSession"
+import {getPendingApprovals} from "../components/ApprovalDock"
+import {isSessionFresh} from "../state/sessionEphemera"
+
+import {type ScrollIntent} from "./useScrollIntent"
+
+/**
+ * Hybrid history for one session tab. localStorage holds only the session INDEX; the durable
+ * conversation CONTENT lives in the backend record log — so a tab either paints from cache and
+ * revalidates (SWR), or hydrates from the server once (cache miss). Both paths adopt the server
+ * transcript under the same guards: never mid-stream, and never behind what's on screen.
+ */
+export const useSessionHydration = ({
+    sessionId,
+    initialMessages,
+    messagesRef,
+    busyRef,
+    seenIdsRef,
+    restoredIdsRef,
+    setMessages,
+    persistMessages,
+    intent,
+}: {
+    sessionId: string
+    initialMessages: UIMessage[]
+    messagesRef: MutableRefObject<UIMessage[]>
+    busyRef: MutableRefObject<boolean>
+    seenIdsRef: MutableRefObject<Set<string>>
+    restoredIdsRef: MutableRefObject<Set<string>>
+    setMessages: (messages: UIMessage[]) => void
+    persistMessages: (args: {id: string; messages: UIMessage[]}) => void
+    intent: ScrollIntent
+}) => {
+    // Cache-first — when this tab opens with no locally-cached messages (a session this browser
+    // never ran, or after a storage clear), hydrate once from the server (`queryRecords` → v6
+    // messages) and seed. Locally-cached sessions skip the fetch, so no regression for own runs.
+    // A to-be-hydrated session (empty local cache, not brand-new) shows a transcript skeleton
+    // instead of the "start a chat" hero, so a session WITH server history doesn't flash the empty
+    // state before its records land. Seeded synchronously so the first paint is already the skeleton.
+    const [isHydrating, setIsHydrating] = useState(
+        () => initialMessages.length === 0 && !isSessionFresh(sessionId),
+    )
+    // Set when server hydration for a KNOWN (non-fresh, uncached) session returns no records — its
+    // durable history was pruned by retention or never persisted. Drives the "history unavailable"
+    // notice so a wiped session isn't mistaken for a brand-new chat.
+    const [hydratedEmpty, setHydratedEmpty] = useState(false)
+    useEffect(() => {
+        // A session created brand-new in this browser and not yet run has no backend records —
+        // skip the guaranteed-empty query (cleared on first send; after a reload it re-hydrates).
+        if (initialMessages.length > 0 || isSessionFresh(sessionId)) {
+            setIsHydrating(false)
+            return
+        }
+        // No persistent "already-hydrated" ref: the `cancelled` flag is the whole guard, so React
+        // StrictMode's mount→unmount→mount cycle re-runs the fetch (the first run is cancelled)
+        // instead of latching a ref that leaves the transcript blank.
+        let cancelled = false
+        // Post-restore revalidation: the first result may be the disk-restored log (paints
+        // instantly); when the guaranteed background refetch lands, adopt it under the same
+        // guards as the SWR effect below — never mid-stream, only when strictly ahead.
+        const adoptRefreshed = (freshMsgs: UIMessage[]) => {
+            if (cancelled || busyRef.current) return
+            if (freshMsgs.length <= messagesRef.current.length) return
+            freshMsgs.forEach((m) => {
+                seenIdsRef.current.add(m.id)
+                restoredIdsRef.current.add(m.id)
+            })
+            intent.armJump()
+            // The restore said "no records" but the server has some — clear the notice.
+            setHydratedEmpty(false)
+            setMessages(freshMsgs)
+            persistMessages({id: sessionId, messages: freshMsgs})
+        }
+        loadSessionMessages(sessionId, adoptRefreshed)
+            .then((msgs) => {
+                if (cancelled) return
+                if (!msgs || msgs.length === 0) {
+                    // Known session, but the server has no records for it → history was pruned or
+                    // never persisted. Flag it so the transcript shows the "unavailable" notice.
+                    setHydratedEmpty(true)
+                    return
+                }
+                // Restored history renders settled (no live fade-in) and pinned to the bottom.
+                msgs.forEach((m) => {
+                    seenIdsRef.current.add(m.id)
+                    restoredIdsRef.current.add(m.id)
+                })
+                intent.armJump()
+                setMessages(msgs)
+                persistMessages({id: sessionId, messages: msgs})
+            })
+            .finally(() => {
+                if (!cancelled) setIsHydrating(false)
+            })
+        return () => {
+            cancelled = true
+        }
+        // Seed once per mounted session tab; `sessionId` is stable for this instance.
+    }, [sessionId])
+
+    // SWR revalidate-on-open: a cached session paints instantly from localStorage; in the background
+    // we refetch the durable records ONCE (low-priority) and adopt the server transcript ONLY IF it's
+    // strictly ahead of what we're showing (a turn finished on another device). We never clobber a
+    // transcript that's live (`busyRef`), or that the server isn't strictly ahead of — so a local
+    // optimistic/unsent tail is safe. Cache-MISS sessions are hydrated by the effect above; fresh
+    // never-run sessions have no server records. Reconciliation is by message COUNT, not content:
+    // detecting a same-length server-side edit/regenerate is deferred, as is focus/interval
+    // revalidation. FOLLOWUP(sessions,swr): see docs/designs/sessions/frontend-integration.md.
+    useEffect(() => {
+        if (initialMessages.length === 0 || isSessionFresh(sessionId)) return
+        // As with the hydration effect above: no persistent ref, so StrictMode's double-mount
+        // re-runs the revalidation rather than latching it out.
+        let cancelled = false
+        const adopt = (serverMsgs: UIMessage[] | null) => {
+            if (cancelled || !serverMsgs || serverMsgs.length === 0) return
+            const prev = messagesRef.current
+            if (busyRef.current) return
+            // Adopt the server transcript when it is strictly ahead by count, OR when our LOCAL tail
+            // is stuck paused (mid-approval) while the server has moved past it to a terminal turn — a
+            // resume that completed on another device. Count alone misses the latter (same bubble
+            // count) and was silently propped up by the now-removed duplicate user row; the server's
+            // `paused` flag rides the runner's `done.stopReason` through `transcriptToMessages`.
+            const serverAheadByCount = serverMsgs.length > prev.length
+            const localTailPaused = getPendingApprovals(prev).length > 0
+            const serverTail = serverMsgs[serverMsgs.length - 1] as
+                | {role?: string; metadata?: {paused?: boolean}}
+                | undefined
+            // The paused-tail exception adopts a resume that completed elsewhere, so the server must
+            // NOT be behind (>= guards against a lagging snapshot discarding newer local approval
+            // state) and its tail must be a finished assistant turn — not a shorter, older stream.
+            const serverTailComplete =
+                serverMsgs.length >= prev.length &&
+                serverTail?.role === "assistant" &&
+                !serverTail.metadata?.paused &&
+                getPendingApprovals(serverMsgs).length === 0
+            if (!serverAheadByCount && !(localTailPaused && serverTailComplete)) return
+            serverMsgs.forEach((m) => {
+                seenIdsRef.current.add(m.id)
+                restoredIdsRef.current.add(m.id)
+            })
+            intent.armJump()
+            setMessages(serverMsgs)
+            persistMessages({id: sessionId, messages: serverMsgs})
+        }
+        // The first result may itself be the disk-restored records log; the callback re-applies
+        // the same guarded adoption when the guaranteed background revalidation lands.
+        loadSessionMessages(sessionId, adopt).then(adopt)
+        return () => {
+            cancelled = true
+        }
+        // Once per mounted session tab; `sessionId` is stable for this instance.
+    }, [sessionId])
+
+    return {isHydrating, hydratedEmpty}
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useLayoutEffect, useRef} from "react"
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from "react"
 
 import {type ChatStatus, type UIMessage} from "ai"
 
@@ -25,7 +25,16 @@ export const useTranscriptScroll = ({
     useVirtuoso: boolean
 }) => {
     const {stickRef, armBottomRef, animateBottomRef, programmaticScrollRef, setShowJump} = intent
-    const scrollRef = useRef<HTMLDivElement>(null)
+    // The container is conditionally rendered (Virtuoso replaces it, and an empty conversation
+    // renders it even under Virtuoso), so it can unmount and remount within one session. The ref is
+    // for synchronous reads inside handlers; the STATE is what effects that bind listeners to the
+    // node key on — otherwise they'd stay attached to a node that has since been detached.
+    const scrollRef = useRef<HTMLDivElement | null>(null)
+    const [scrollNode, setScrollNode] = useState<HTMLDivElement | null>(null)
+    const attachScroll = useCallback((el: HTMLDivElement | null) => {
+        scrollRef.current = el
+        setScrollNode(el)
+    }, [])
     // Teardown for the in-flight smooth scroll (removes its listeners + fallback timer).
     const pinCleanupRef = useRef<(() => void) | null>(null)
     // Last observed scrollTop. A content shrink (tool gutter collapsing, reasoning folding) clamps
@@ -191,7 +200,7 @@ export const useTranscriptScroll = ({
     // pins. Re-subscribed when the message set changes (a part growing fires on the same wrapper).
     useEffect(() => {
         if (useVirtuoso) return
-        const el = scrollRef.current
+        const el = scrollNode
         if (!el) return
         const onResize = (entries: ResizeObserverEntry[]) => {
             // Pin each rendered row's REAL height as its own `content-visibility` placeholder, so it
@@ -247,7 +256,7 @@ export const useTranscriptScroll = ({
         ro.observe(el)
         el.querySelectorAll("[data-mid]").forEach((w) => ro.observe(w))
         return () => ro.disconnect()
-    }, [messages.length, scrollToBottom, useVirtuoso])
+    }, [messages.length, scrollToBottom, useVirtuoso, scrollNode])
 
     // SC-1 (submit) / SC-2 (restore): scroll the log to the bottom, once, when armed. With the active
     // turn reserving a viewport (min-h-full + top padding to clear the fade), "bottom" shows the new
@@ -289,8 +298,10 @@ export const useTranscriptScroll = ({
     // (exactly like a scroll). New content keeps arriving offscreen and the jump pill offers the way
     // back. Keyboard / wheel / touch already release because they scroll (onScroll). The composer is
     // exempt: its selections and links aren't inside the log, so `el.contains(...)` ignores them.
+    // Keyed on the NODE, not on mount: the container remounts when the engine changes, and a
+    // mount-only binding would keep listening on the detached one for the rest of the session.
     useEffect(() => {
-        const el = scrollRef.current
+        const el = scrollNode
         if (!el) return
         const release = () => {
             if (!stickRef.current) return
@@ -312,7 +323,9 @@ export const useTranscriptScroll = ({
             document.removeEventListener("selectionchange", onSelectionChange)
             el.removeEventListener("click", onClick)
         }
-    }, [])
+    }, [scrollNode])
 
-    return {scrollRef, onScroll, recordAnchor, jumpToLatest}
+    // `attachScroll` is the ONLY way in: handing out `scrollRef` too would let a caller attach the
+    // node without the state ever knowing, which is the split this hook exists to close.
+    return {attachScroll, onScroll, recordAnchor, jumpToLatest}
 }

--- a/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
@@ -74,6 +74,9 @@ export const useTranscriptScroll = ({
     // Runs before the SC-1/SC-2 pin below, which is declared later.
     useLayoutEffect(() => {
         pinCleanupRef.current?.()
+        // Cancelling skips the pin's settle, which is what normally releases the guard. `intent`
+        // outlives this hook, so a leaked `true` would keep follow/anchoring off after a remount.
+        programmaticScrollRef.current = false
         anchorRef.current = null
         lastScrollTopRef.current = scrollNode?.scrollTop ?? 0
     }, [scrollNode])
@@ -155,6 +158,7 @@ export const useTranscriptScroll = ({
     useEffect(
         () => () => {
             pinCleanupRef.current?.()
+            programmaticScrollRef.current = false
             if (showJumpRafRef.current) cancelAnimationFrame(showJumpRafRef.current)
         },
         [],

--- a/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
@@ -67,6 +67,17 @@ export const useTranscriptScroll = ({
         anchorRef.current = null
     }, [])
 
+    // Everything above is measured AGAINST a specific container, so a node swap invalidates all of
+    // it: the scroll baseline (a stale one makes the first scroll-down-to-edge on the new node fail
+    // `scrollTop > prevTop`, so follow doesn't re-arm), the SC-3 anchor (its offset was taken in the
+    // old node's coordinate space), and any glide still animating the node that just went away.
+    // Runs before the SC-1/SC-2 pin below, which is declared later.
+    useLayoutEffect(() => {
+        pinCleanupRef.current?.()
+        anchorRef.current = null
+        lastScrollTopRef.current = scrollNode?.scrollTop ?? 0
+    }, [scrollNode])
+
     // ── DT4 autoscroll: stick to the bottom of the scrollable area while following ──
     // The fill (min-h-full turn group) makes "question at top" the scroll bottom for a short answer
     // and the answer's end the bottom for a long one, so scrollHeight is the right target (+ pb-6 gap).

--- a/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
@@ -1,0 +1,318 @@
+import {useCallback, useEffect, useLayoutEffect, useRef} from "react"
+
+import {type ChatStatus, type UIMessage} from "ai"
+
+import {CONTENT_VISIBILITY_ENABLED} from "../assets/conversationLayout"
+import {atLiveEdge} from "../assets/scrollGeometry"
+
+import {type ScrollIntent} from "./useScrollIntent"
+
+/**
+ * SC-1…4 scroll engineering for the plain (non-virtualized) transcript: submit/restore pins,
+ * stick-to-bottom, anchor-based preservation on resize, and the jump-to-latest pill. Owns the
+ * scroll container ref and every DOM measurement; reads/writes what to do next through the shared
+ * `intent`. Inert while Virtuoso is on — it owns measurement and anchoring itself.
+ */
+export const useTranscriptScroll = ({
+    intent,
+    messages,
+    status,
+    useVirtuoso,
+}: {
+    intent: ScrollIntent
+    messages: UIMessage[]
+    status: ChatStatus
+    useVirtuoso: boolean
+}) => {
+    const {stickRef, armBottomRef, animateBottomRef, programmaticScrollRef, setShowJump} = intent
+    const scrollRef = useRef<HTMLDivElement>(null)
+    // Teardown for the in-flight smooth scroll (removes its listeners + fallback timer).
+    const pinCleanupRef = useRef<(() => void) | null>(null)
+    // Last observed scrollTop. A content shrink (tool gutter collapsing, reasoning folding) clamps
+    // scrollTop to the new smaller bottom and fires a scroll event that isn't a user gesture; comparing
+    // against this lets onScroll tell a real scroll-DOWN-to-edge from that clamp (which only decreases).
+    const lastScrollTopRef = useRef(0)
+    // rAF handle coalescing the jump-pill measurement (querySelectorAll + getBoundingClientRect) to once
+    // per frame — a fast wheel/drag and every streamed render would otherwise re-measure a dirtied layout.
+    const showJumpRafRef = useRef(0)
+
+    // ── SC-3: anchor-based scroll preservation ──
+    // We do scroll-anchoring ourselves (Safari has no CSS overflow-anchor, and it would fight our
+    // programmatic pins). While NOT following, remember the topmost visible message; when content above
+    // it changes height (an image loads, markdown/code renders, a tool card expands), we compensate
+    // scrollTop so that message stays on the same line. Growth BELOW the anchor (the streaming answer)
+    // doesn't move it, so it's left alone.
+    const anchorRef = useRef<{id: string; top: number} | null>(null)
+    const recordAnchor = useCallback(() => {
+        const el = scrollRef.current
+        if (!el) return
+        const containerTop = el.getBoundingClientRect().top
+        for (const w of el.querySelectorAll<HTMLElement>("[data-mid]")) {
+            const r = w.getBoundingClientRect()
+            // First message whose bottom is still below the viewport top = the topmost visible one.
+            if (r.bottom > containerTop + 1) {
+                anchorRef.current = {id: w.dataset.mid ?? "", top: r.top - containerTop}
+                return
+            }
+        }
+        anchorRef.current = null
+    }, [])
+
+    // ── DT4 autoscroll: stick to the bottom of the scrollable area while following ──
+    // The fill (min-h-full turn group) makes "question at top" the scroll bottom for a short answer
+    // and the answer's end the bottom for a long one, so scrollHeight is the right target (+ pb-6 gap).
+    // Only writes when not already pinned: the ResizeObserver (below) and the follow effect both pin on
+    // the same streamed growth, so the guard drops the redundant write (and the scroll event it fires).
+    const scrollToBottom = useCallback(() => {
+        const el = scrollRef.current
+        if (!el) return
+        const target = el.scrollHeight - el.clientHeight
+        if (el.scrollTop < target - 0.5) el.scrollTop = target
+    }, [])
+
+    // Recompute jump-pill visibility, coalesced to one rAF per frame. The measurement (atLiveEdge →
+    // querySelectorAll + getBoundingClientRect) is display-only, so a one-frame lag is invisible; the
+    // correctness-critical follow decision (stickRef) and SC-3 anchor stay synchronous in onScroll.
+    const scheduleShowJump = useCallback(() => {
+        if (showJumpRafRef.current) return
+        showJumpRafRef.current = requestAnimationFrame(() => {
+            showJumpRafRef.current = 0
+            const el = scrollRef.current
+            if (!el) return
+            setShowJump(!stickRef.current && !atLiveEdge(el))
+        })
+    }, [])
+
+    // Smoothly scroll the log to `target` (the SC-1 pin / jump-to-latest). Uses the browser's NATIVE
+    // smooth scroll so it runs on the compositor — smooth even while React re-renders streamed tokens,
+    // and natively interruptible. The caller holds programmaticScrollRef across it so onScroll / the
+    // ResizeObserver ignore the in-between frames; `scrollend` (or a fallback timeout) settles it. A
+    // real user wheel/touch hands control straight back. Honors prefers-reduced-motion (instant).
+    const animatePinTo = useCallback((el: HTMLDivElement, target: number, onSettle: () => void) => {
+        pinCleanupRef.current?.()
+        const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+        if (reduce || Math.abs(target - el.scrollTop) < 2) {
+            el.scrollTop = target
+            onSettle()
+            return
+        }
+        let done = false
+        let timer = 0
+        const cleanup = () => {
+            el.removeEventListener("scrollend", onEnd)
+            el.removeEventListener("wheel", onUser)
+            el.removeEventListener("touchstart", onUser)
+            if (timer) clearTimeout(timer)
+            pinCleanupRef.current = null
+        }
+        // Reached the target (scrollend, or the fallback timer) → settle: recordAnchor + release guard.
+        const onEnd = () => {
+            if (done) return
+            done = true
+            cleanup()
+            onSettle()
+        }
+        // User grabbed the scroll mid-glide → stop guarding so their scroll is honored; don't settle.
+        const onUser = () => {
+            if (done) return
+            done = true
+            cleanup()
+            programmaticScrollRef.current = false
+        }
+        el.addEventListener("scrollend", onEnd)
+        el.addEventListener("wheel", onUser, {passive: true})
+        el.addEventListener("touchstart", onUser, {passive: true})
+        timer = window.setTimeout(onEnd, 700) // fallback where scrollend is unsupported (older Safari)
+        // Cancel without settling (a newer pin supersedes this one, or we unmount).
+        pinCleanupRef.current = () => {
+            done = true
+            cleanup()
+        }
+        el.scrollTo({top: target, behavior: "smooth"})
+    }, [])
+
+    // Stop any in-flight pin animation on unmount (tab close / revision swap).
+    useEffect(
+        () => () => {
+            pinCleanupRef.current?.()
+            if (showJumpRafRef.current) cancelAnimationFrame(showJumpRafRef.current)
+        },
+        [],
+    )
+
+    useEffect(() => {
+        if (useVirtuoso) return
+        // Don't instant-jump while a programmatic glide (SC-1 submit / jump-to-latest) owns the
+        // scroll — that snap would override the animation. The glide's own settle re-pins to bottom.
+        if (stickRef.current && !programmaticScrollRef.current) scrollToBottom()
+    }, [messages, status, scrollToBottom, useVirtuoso])
+
+    const onScroll = useCallback(() => {
+        const el = scrollRef.current
+        if (!el) return
+        // Track scrollTop even for our own pins (recorded, then ignored) so the next real event has an
+        // accurate baseline to compare against.
+        const prevTop = lastScrollTopRef.current
+        lastScrollTopRef.current = el.scrollTop
+        // Ignore the scroll event our own pin produced — only a real user scroll changes follow state.
+        if (programmaticScrollRef.current) return
+        // Follow ONLY when at the very bottom of the scrollable area; a partial scroll must not enable
+        // it (that was the yank). Re-arm follow ONLY when the user actively scrolls DOWN to the edge (or
+        // is already following): a content shrink (tool gutter collapsing to "Used N tools", reasoning
+        // folding) clamps scrollTop to the new smaller bottom and fires a scroll event, but a clamp only
+        // ever DECREASES scrollTop, so `> prevTop` rejects it — otherwise the next token would snap the
+        // min-h-full active turn to the top (reported as the chat "jumping to the top" mid-stream).
+        const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24
+        stickRef.current = atBottom && (stickRef.current || el.scrollTop > prevTop)
+        // Anchor is correctness-critical for SC-3 (the RO reads it next resize) → capture synchronously.
+        if (!stickRef.current) recordAnchor()
+        // Pill is display-only → coalesce its costly measurement to one rAF/frame.
+        scheduleShowJump()
+    }, [recordAnchor, scheduleShowJump])
+
+    const jumpToLatest = useCallback(() => {
+        const el = scrollRef.current
+        if (!el) return
+        setShowJump(false)
+        // Glide to the bottom like the SC-1 pin. Resume follow (stickRef) only ON SETTLE — flipping
+        // it true now would let the per-token follow effect jam to the bottom mid-glide. The final
+        // scrollToBottom catches any content that streamed in during the animation.
+        programmaticScrollRef.current = true
+        animatePinTo(el, el.scrollHeight, () => {
+            el.scrollTop = el.scrollHeight
+            stickRef.current = true
+            programmaticScrollRef.current = false
+        })
+    }, [animatePinTo])
+
+    // SC-3: when any message resizes (image load, markdown/code render, tool-card expand), hold the
+    // reader's place. Following → keep pinned to the bottom; otherwise compensate scrollTop so the
+    // anchored (topmost visible) message stays on the same line. Guarded so it never fights our own
+    // pins. Re-subscribed when the message set changes (a part growing fires on the same wrapper).
+    useEffect(() => {
+        if (useVirtuoso) return
+        const el = scrollRef.current
+        if (!el) return
+        const onResize = (entries: ResizeObserverEntry[]) => {
+            // Pin each rendered row's REAL height as its own `content-visibility` placeholder, so it
+            // keeps the exact same box when it later scrolls off-screen. Only meaningful while
+            // content-visibility is enabled — otherwise `containIntrinsicSize` is inert, so skip the
+            // whole measurement to avoid a getBoundingClientRect + style write per row on every resize.
+            if (CONTENT_VISIBILITY_ENABLED) {
+                for (const e of entries) {
+                    const node = e.target as HTMLElement
+                    if (node === el) continue // the viewport itself is not a row — never pin it
+                    const check = node.checkVisibility as
+                        | ((o?: {contentVisibilityAuto?: boolean}) => boolean)
+                        | undefined
+                    if (check && !check.call(node, {contentVisibilityAuto: true})) continue
+                    const h = Math.round(node.getBoundingClientRect().height)
+                    if (h > 0) node.style.containIntrinsicSize = `auto ${h}px`
+                }
+            }
+            if (programmaticScrollRef.current) return
+            if (stickRef.current) {
+                scrollToBottom() // guarded: no-op if the follow effect already pinned this growth
+                return
+            }
+            const a = anchorRef.current
+            if (!a) return
+            let node: HTMLElement | null = null
+            try {
+                node = el.querySelector<HTMLElement>(`[data-mid="${a.id}"]`)
+            } catch {
+                node = null
+            }
+            if (!node) return
+            const delta = node.getBoundingClientRect().top - el.getBoundingClientRect().top - a.top
+            // A stale anchor (its node scrolled far off after a programmatic jump / follow) yields an
+            // implausible delta; applying it would slam the scroll to the top. Drop it and let the next
+            // scroll / pointer-down re-anchor. A real collapse/expand moves the anchor well under a viewport.
+            if (Math.abs(delta) > el.clientHeight) {
+                anchorRef.current = null
+                return
+            }
+            if (Math.abs(delta) > 0.5) {
+                programmaticScrollRef.current = true
+                el.scrollTop += delta
+                requestAnimationFrame(() => {
+                    programmaticScrollRef.current = false
+                })
+            }
+        }
+        const ro = new ResizeObserver(onResize)
+        // Observe the VIEWPORT too: the lazy composer/session-bar regions outside it hydrate a
+        // beat after mount and change this element's clientHeight — rows alone don't resize then,
+        // so without this the clamp shifts the view (following → re-pin; reading → hold anchor).
+        ro.observe(el)
+        el.querySelectorAll("[data-mid]").forEach((w) => ro.observe(w))
+        return () => ro.disconnect()
+    }, [messages.length, scrollToBottom, useVirtuoso])
+
+    // SC-1 (submit) / SC-2 (restore): scroll the log to the bottom, once, when armed. With the active
+    // turn reserving a viewport (min-h-full + top padding to clear the fade), "bottom" shows the new
+    // question pinned at the top and the answer streaming into the space below — no per-element pin to
+    // compute, nothing to keep re-aligning as content arrives. A fresh submit glides; a restore jumps.
+    // Follow (stickRef) resumes only ON SETTLE so the per-token follow effect can't jam mid-glide.
+    useLayoutEffect(() => {
+        if (useVirtuoso) return
+        if (!armBottomRef.current) return
+        const el = scrollRef.current
+        if (!el) return
+        armBottomRef.current = false
+        programmaticScrollRef.current = true
+        const settle = () => {
+            el.scrollTop = el.scrollHeight // catch anything that streamed in during the glide
+            stickRef.current = true
+            programmaticScrollRef.current = false
+        }
+        if (animateBottomRef.current) {
+            animateBottomRef.current = false
+            animatePinTo(el, el.scrollHeight, settle)
+        } else {
+            el.scrollTop = el.scrollHeight
+            requestAnimationFrame(settle)
+        }
+    }, [messages, animatePinTo, useVirtuoso])
+
+    // Keep the jump pill honest as content streams/settles: show it when the real latest message is
+    // below the fold (e.g. a long answer growing past the viewport while parked at the top), and hide
+    // it once that message is visible or while we're following. Coalesced (not a sync layout read per
+    // streamed render) — the pill is display-only, so one frame of lag is imperceptible.
+    useEffect(() => {
+        if (useVirtuoso) return
+        scheduleShowJump()
+    }, [messages, status, scheduleShowJump, useVirtuoso])
+
+    // SC-4: interaction is intent, not just scrolling. While following, a real text selection inside
+    // the transcript — or opening a link in it — means the reader is engaging here, so release follow
+    // (exactly like a scroll). New content keeps arriving offscreen and the jump pill offers the way
+    // back. Keyboard / wheel / touch already release because they scroll (onScroll). The composer is
+    // exempt: its selections and links aren't inside the log, so `el.contains(...)` ignores them.
+    useEffect(() => {
+        const el = scrollRef.current
+        if (!el) return
+        const release = () => {
+            if (!stickRef.current) return
+            stickRef.current = false
+            setShowJump(!atLiveEdge(el))
+        }
+        const onSelectionChange = () => {
+            if (!stickRef.current) return
+            const sel = window.getSelection()
+            if (!sel || sel.isCollapsed || sel.rangeCount === 0) return
+            if (sel.anchorNode && el.contains(sel.anchorNode)) release()
+        }
+        const onClick = (e: MouseEvent) => {
+            if ((e.target as HTMLElement | null)?.closest("a")) release()
+        }
+        document.addEventListener("selectionchange", onSelectionChange)
+        el.addEventListener("click", onClick)
+        return () => {
+            document.removeEventListener("selectionchange", onSelectionChange)
+            el.removeEventListener("click", onClick)
+        }
+    }, [])
+
+    return {scrollRef, onScroll, recordAnchor, jumpToLatest}
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useTurnInspector.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTurnInspector.ts
@@ -1,0 +1,57 @@
+import {useEffect, useMemo} from "react"
+
+import {type UIMessage} from "ai"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import {playgroundInspectorEnabledAtom} from "@/oss/state/settings/featureFlags"
+
+import {assistantTurnNumbers} from "../assets/messageParts"
+import {
+    closeInspectorAtom,
+    inspectorTargetAtom,
+    openInspectorTurnAtom,
+} from "../components/Inspector/state"
+import {chatPanelMaximizedAtom} from "../state/panelLayout"
+
+/**
+ * Turn Inspector wiring for one session: whether the panel is open, which turn it targets, and the
+ * assistant-message → turn-number mapping the transcript needs to tint and re-focus rows.
+ */
+export const useTurnInspector = ({
+    sessionId,
+    messages,
+}: {
+    sessionId: string
+    messages: UIMessage[]
+}) => {
+    const inspectorTarget = useAtomValue(inspectorTargetAtom)
+    const openInspectorTurn = useSetAtom(openInspectorTurnAtom)
+    const closeInspector = useSetAtom(closeInspectorAtom)
+    const buildMode = !useAtomValue(chatPanelMaximizedAtom)
+    const inspectorEnabled = useAtomValue(playgroundInspectorEnabledAtom)
+    // The Inspector is a personal debug tool in BUILD mode. Chat mode has no inspector (the
+    // context rail owns the right dock there).
+    const inspectorOpen = inspectorEnabled && buildMode && inspectorTarget?.sessionId === sessionId
+    const turnInspectorOpen = inspectorOpen && inspectorTarget?.focusedTurn != null
+    // The assistant turn the panel is focused on. Turn ids are 1-based indices (records group by
+    // `done`); the inspected assistant message is the Nth assistant message.
+    const inspectedTurn = turnInspectorOpen ? (inspectorTarget?.focusedTurn ?? null) : null
+    // Leaving Build for Chat closes the Inspector entirely.
+    useEffect(() => {
+        if ((!buildMode || !inspectorEnabled) && inspectorTarget?.sessionId === sessionId) {
+            closeInspector()
+        }
+    }, [buildMode, inspectorEnabled, inspectorTarget?.sessionId, sessionId, closeInspector])
+
+    // Assistant message id → 1-based turn number, built once per message set.
+    const turnNumbers = useMemo(() => assistantTurnNumbers(messages), [messages])
+
+    return {
+        buildMode,
+        inspectorEnabled,
+        inspectorOpen,
+        inspectedTurn,
+        openInspectorTurn,
+        turnNumbers,
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useVirtuosoTranscript.tsx
+++ b/web/oss/src/components/AgentChatSlice/hooks/useVirtuosoTranscript.tsx
@@ -1,0 +1,168 @@
+import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react"
+
+import {type ChatStatus, type UIMessage} from "ai"
+import {useAtomValue} from "jotai"
+import {useRouter} from "next/router"
+import {type Components, type VirtuosoHandle} from "react-virtuoso"
+
+import {virtStateBySession} from "../state/sessionEphemera"
+import {
+    agentChatItemEstimateAtom,
+    agentChatOverscanAtom,
+    agentChatVirtualizeAtom,
+    isAgentChatVirtualizationAvailable,
+} from "../state/virtualization"
+
+import {type ScrollIntent} from "./useScrollIntent"
+
+/** SPIKE(virtuoso): context passed to the Virtuoso Header/Footer slots (top padding + active turn). */
+export interface VirtCtx {
+    header: React.ReactNode
+    footer: React.ReactNode
+}
+
+/**
+ * SPIKE(react-virtuoso): windowing variant of the transcript, evaluated against content-visibility.
+ * Owns the Virtuoso handle, the per-session scroll snapshot, the manual follow (Virtuoso's
+ * `followOutput` can't see the Footer-hosted active turn), and the explicit viewport reserve that
+ * replaces `min-h-full`. `enabled` gates BOTH this wiring and `useTranscriptScroll` — exactly one
+ * engine owns the scroll at a time.
+ */
+export const useVirtuosoTranscript = ({
+    intent,
+    sessionId,
+    messages,
+    status,
+}: {
+    intent: ScrollIntent
+    sessionId: string
+    messages: UIMessage[]
+    status: ChatStatus
+}) => {
+    const {armBottomRef, animateBottomRef, setShowJump} = intent
+    // Controlled live from the playground settings dropdown (Virtualization section). When on, the
+    // SC-1..4 scroll effects are disabled (Virtuoso owns measurement/anchoring) and the transcript
+    // renders via <Virtuoso>; overscan / row-estimate are tunable there too.
+    // Virtualize only when the env flag is present AND it's enabled in the settings — no other gates.
+    const virtEnabledInSettings = useAtomValue(agentChatVirtualizeAtom)
+    const useVirtuoso = isAgentChatVirtualizationAvailable() && virtEnabledInSettings
+    const virtOverscan = useAtomValue(agentChatOverscanAtom)
+    const virtItemEstimate = useAtomValue(agentChatItemEstimateAtom)
+    const virtuosoRef = useRef<VirtuosoHandle>(null)
+    // Snapshot captured by a previous mount of this session (route re-entry). Read once at
+    // mount — `restoreStateFrom` is a mount-time-only Virtuoso prop.
+    const [virtRestoreState] = useState(() =>
+        useVirtuoso ? virtStateBySession.get(sessionId) : undefined,
+    )
+    const router = useRouter()
+    useEffect(() => {
+        if (!useVirtuoso) return
+        const capture = () => {
+            // getState is synchronous; guard the handle for the unmount-cleanup path.
+            virtuosoRef.current?.getState((snapshot) => {
+                virtStateBySession.set(sessionId, snapshot)
+            })
+        }
+        // routeChangeStart fires while the transcript is still mounted and measured — the
+        // reliable capture point. The cleanup capture is best-effort (the handle may already
+        // be detached there), covering non-route unmounts like a revision-type swap.
+        router.events.on("routeChangeStart", capture)
+        return () => {
+            router.events.off("routeChangeStart", capture)
+            capture()
+        }
+    }, [useVirtuoso, sessionId, router])
+
+    // ── SPIKE(virtuoso) scroll wiring (only active when the flag is on) ──
+    // Follow = stick to the bottom. Virtuoso's `followOutput` fires on item-count changes only, but the
+    // active turn streams inside the Footer (not an item), so drive stick manually on each update.
+    const virtFollowRef = useRef(true)
+    // While true (a short window after a submit), the follow tracks the bottom SMOOTHLY — so the sent
+    // question glides to the top and the streaming answer is tracked continuously (each token retargets
+    // the in-flight smooth scroll). Otherwise it snaps instantly to keep up with fast streaming.
+    const virtSmoothRef = useRef(false)
+    const virtSmoothTimerRef = useRef(0)
+    useEffect(() => {
+        if (!useVirtuoso || !virtFollowRef.current) return
+        const behavior: ScrollBehavior = virtSmoothRef.current ? "smooth" : "auto"
+        const id = requestAnimationFrame(() => virtuosoRef.current?.scrollTo({top: 1e9, behavior}))
+        return () => cancelAnimationFrame(id)
+    }, [messages, status, useVirtuoso])
+    // SC-1 reserve for the virtuoso path: `min-h-full` doesn't work inside Virtuoso's Footer (100%
+    // resolves against its content-sized list, not the viewport), so measure the scroller's height and
+    // reserve it explicitly on the active-turn Footer — that's what lets a sent question pin to the top.
+    const virtRoRef = useRef<ResizeObserver | null>(null)
+    const [virtViewportH, setVirtViewportH] = useState(0)
+    const setVirtScroller = useCallback((el: HTMLElement | Window | null) => {
+        virtRoRef.current?.disconnect()
+        const node = el instanceof HTMLElement ? el : null
+        if (!node) return
+        setVirtViewportH(node.clientHeight)
+        const ro = new ResizeObserver(() => setVirtViewportH(node.clientHeight))
+        ro.observe(node)
+        virtRoRef.current = ro
+    }, [])
+    useEffect(
+        () => () => {
+            virtRoRef.current?.disconnect()
+            window.clearTimeout(virtSmoothTimerRef.current)
+        },
+        [],
+    )
+    // SC-1/2 equivalent: on submit/restore (armBottomRef), re-arm follow to the bottom once Virtuoso has
+    // mounted + measured (question-at-top emerges from the Footer's viewport reserve). A submit tracks
+    // smoothly for a short window; a restore snaps. The follow effect above does the per-token scrolling.
+    useLayoutEffect(() => {
+        if (!useVirtuoso || !armBottomRef.current) return
+        const animate = animateBottomRef.current
+        armBottomRef.current = false
+        animateBottomRef.current = false
+        virtFollowRef.current = true
+        setShowJump(false)
+        virtSmoothRef.current = animate
+        window.clearTimeout(virtSmoothTimerRef.current)
+        if (animate) {
+            virtSmoothTimerRef.current = window.setTimeout(() => {
+                virtSmoothRef.current = false
+            }, 600)
+        }
+        requestAnimationFrame(() =>
+            requestAnimationFrame(() =>
+                virtuosoRef.current?.scrollTo({top: 1e9, behavior: animate ? "smooth" : "auto"}),
+            ),
+        )
+    }, [messages, useVirtuoso])
+    const virtJumpToLatest = useCallback(() => {
+        virtFollowRef.current = true
+        setShowJump(false)
+        virtuosoRef.current?.scrollTo({top: 1e9, behavior: "smooth"})
+    }, [])
+    // Virtuoso's own edge detection is the follow signal here (the manual effect above only acts
+    // while following), and it doubles as the pill's visibility.
+    const onAtBottomStateChange = useCallback((atBottom: boolean) => {
+        virtFollowRef.current = atBottom
+        setShowJump(!atBottom)
+    }, [])
+    // Stable component identities (Virtuoso remounts these if their identity changes). They read live
+    // content from `context`, which we pass fresh each render — so they re-render without remounting.
+    const virtComponents = useMemo<Components<UIMessage, VirtCtx>>(
+        () => ({
+            Header: ({context}) => <>{context?.header ?? null}</>,
+            Footer: ({context}) => <>{context?.footer ?? null}</>,
+        }),
+        [],
+    )
+
+    return {
+        enabled: useVirtuoso,
+        virtuosoRef,
+        restoreState: virtRestoreState,
+        overscan: virtOverscan,
+        itemEstimate: virtItemEstimate,
+        viewportH: virtViewportH,
+        setScroller: setVirtScroller,
+        components: virtComponents,
+        jumpToLatest: virtJumpToLatest,
+        onAtBottomStateChange,
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useVoiceComposer.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useVoiceComposer.ts
@@ -1,0 +1,73 @@
+import {type RefObject, useState} from "react"
+
+import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
+
+import {isAgentVoiceInputEnabled} from "../assets/constants"
+
+import {useAudioRecorder} from "./useAudioRecorder"
+
+/**
+ * The composer's voice surface for one session: the recorder that backs the recording takeover,
+ * the send-vs-attach decision for a finished take, and the shared mic/dictation error the notice
+ * above the composer renders. Dictation itself lives inside the mic button (its transcript changes
+ * far too often to lift here) and only reports up through here.
+ */
+export const useVoiceComposer = ({
+    richInputRef,
+    stagedCount,
+    onAttach,
+    onSendVoiceMessage,
+}: {
+    richInputRef: RefObject<RichChatInputHandle | null>
+    /** How many attachments are already staged — part of the send-vs-attach decision. */
+    stagedCount: number
+    /** Park the take in the attachment tray. */
+    onAttach: (file: File) => void
+    /** Send the take outright as its own message. */
+    onSendVoiceMessage: (file: File) => void
+}) => {
+    // Voice-message recording: the clip lands in the attachment tray like any file. Owned here so
+    // the recording takeover (RecordingBar) can cover the whole composer while capturing.
+    /**
+     * A voice message recorded into an otherwise-empty composer IS the message, so the take is
+     * sent on confirm rather than parked in the tray. With text or other attachments staged, the
+     * person is mid-composition, so it attaches instead and they send when ready.
+     *
+     * Decided when recording STARTS: the composer is covered by the recording bar and drops are
+     * blocked while capturing, so neither the text nor the tray can change in between.
+     */
+    // Flagged off until the agent service accepts audio parts (`NEXT_PUBLIC_AGENT_VOICE_INPUT`).
+    const voiceEnabled = isAgentVoiceInputEnabled()
+    const [voiceWillSend, setVoiceWillSend] = useState(false)
+    const voiceRecorder = useAudioRecorder((file) => {
+        if (voiceWillSend) onSendVoiceMessage(file)
+        else onAttach(file)
+    })
+    const startVoiceMessage = () => {
+        const hasText = !!(richInputRef.current?.getMarkdown() ?? "").trim()
+        setVoiceWillSend(!hasText && stagedCount === 0)
+        voiceRecorder.start()
+    }
+    // Dictation runs inside the mic button (its transcript changes far too often to lift here), so
+    // it reports failures up for the shared notice.
+    const [dictationError, setDictationError] = useState<string | null>(null)
+    // Locks the editor while speech is coming in, so typing can't interleave with the transcript.
+    const [dictating, setDictating] = useState(false)
+    const micError = voiceRecorder.error ?? dictationError
+    const dismissMicError = () => {
+        setDictationError(null)
+        voiceRecorder.dismissError()
+    }
+
+    return {
+        voiceEnabled,
+        voiceRecorder,
+        voiceWillSend,
+        startVoiceMessage,
+        dictating,
+        setDictating,
+        setDictationError,
+        micError,
+        dismissMicError,
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -7,7 +7,7 @@ import {
 import {generateId} from "@agenta/shared/utils"
 import type {UIMessage} from "ai"
 import {atom, type Getter, type Setter} from "jotai"
-import {atomFamily, atomWithStorage, selectAtom} from "jotai/utils"
+import {atomFamily, atomWithStorage, createJSONStorage, selectAtom} from "jotai/utils"
 
 import {routerAppIdAtom} from "@/oss/state/app/atoms/fetcher"
 import {projectIdAtom} from "@/oss/state/project"
@@ -91,11 +91,25 @@ export const defaultScopeKeyAtom = atom((get) => {
 // effect sees an empty list in that window and creates a stray session on every reload/HMR.
 const STORAGE_OPTS = {getOnInit: true} as const
 
+/**
+ * localStorage WITHOUT jotai's cross-browser-tab sync. The default storage subscribes to the
+ * `storage` event, so a write in one browser tab replaced these records live in every other one —
+ * and since the open-tab list drives the antd `Tabs` items, an incoming replacement UNMOUNTED a
+ * streaming conversation, orphaning its `useChat` stream mid-turn (the in-flight transcript is not
+ * persisted until the stream settles, so it was lost). Each browser tab now owns its view; storage
+ * is still shared, so a reload picks up whatever was last written.
+ */
+const tabLocalStorage = <T>() => {
+    const storage = createJSONStorage<T>()
+    delete storage.subscribe
+    return storage
+}
+
 /** Full per-scope session history (open AND closed). */
 const sessionsByAppAtom = atomWithStorage<Record<string, AgentChatSession[]>>(
     "agenta:agent-chat:sessions",
     {},
-    undefined,
+    tabLocalStorage(),
     STORAGE_OPTS,
 )
 
@@ -109,14 +123,14 @@ const sessionsByAppAtom = atomWithStorage<Record<string, AgentChatSession[]>>(
 const openIdsByAppAtom = atomWithStorage<Record<string, string[]>>(
     "agenta:agent-chat:open-sessions",
     {},
-    undefined,
+    tabLocalStorage(),
     STORAGE_OPTS,
 )
 
 const activeByAppAtom = atomWithStorage<Record<string, string>>(
     "agenta:agent-chat:active-session",
     {},
-    undefined,
+    tabLocalStorage(),
     STORAGE_OPTS,
 )
 
@@ -125,7 +139,7 @@ const activeByAppAtom = atomWithStorage<Record<string, string>>(
 export const sessionMessagesAtom = atomWithStorage<Record<string, UIMessage[]>>(
     "agenta:agent-chat:messages",
     {},
-    undefined,
+    tabLocalStorage(),
     STORAGE_OPTS,
 )
 

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -668,13 +668,13 @@ const writeMessagesWithQuotaGuard = (
     set: Setter,
     next: Record<string, UIMessage[]>,
     keepId: string,
-): string[] => {
+): {evicted: string[]; persisted: boolean} => {
     let candidate = next
     const evicted: string[] = []
     for (;;) {
         try {
             set(sessionMessagesAtom, candidate)
-            return evicted
+            return {evicted, persisted: true}
         } catch (e) {
             if (!isQuotaExceeded(e)) throw e
             // Object keys keep insertion order, so the first non-active id is the oldest.
@@ -682,7 +682,7 @@ const writeMessagesWithQuotaGuard = (
             if (oldest === undefined) {
                 // Even the active session alone won't fit — keep it in memory, skip persistence.
                 console.warn("[agent-chat] message store over quota; skipping persistence")
-                return evicted
+                return {evicted, persisted: false}
             }
             evicted.push(oldest)
             candidate = {...candidate}
@@ -729,13 +729,18 @@ export const persistSessionMessagesAtom = atom(
         set,
         {id, messages, recordCount}: {id: string; messages: UIMessage[]; recordCount?: number},
     ) => {
-        const evicted = writeMessagesWithQuotaGuard(
+        const {evicted, persisted} = writeMessagesWithQuotaGuard(
             set,
             {...get(sessionMessagesAtom), [id]: messages},
             id,
         )
         const counts = {...get(sessionRecordCountsAtom)}
-        if (recordCount === undefined) delete counts[id]
+        // If the transcript write itself was skipped (a single session over quota), the persisted
+        // store still holds the OLD messages — filing the NEW watermark against them would make
+        // `shouldAdoptServerTranscript` reject the complete server log as "not newer" on every
+        // future open, freezing the stale cache. The stores must never diverge (see
+        // `dropSessionMessages`), so drop the watermark and let the next open re-sync.
+        if (!persisted || recordCount === undefined) delete counts[id]
         else counts[id] = recordCount
         // A quota eviction dropped those transcripts, so their watermarks go too.
         for (const evictedId of evicted) delete counts[evictedId]

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -143,6 +143,24 @@ export const sessionMessagesAtom = atomWithStorage<Record<string, UIMessage[]>>(
     STORAGE_OPTS,
 )
 
+/**
+ * Per-session adoption watermark: how many durable records the CACHED transcript above was built
+ * from. Absent means "not server-derived" (a locally-streamed turn, or a pre-#5530 cache) and reads
+ * as 0, so the next open re-syncs from the server once.
+ *
+ * Private on purpose — it must only ever move together with `sessionMessagesAtom`, so every write
+ * goes through `persistSessionMessagesAtom` and every delete through `dropSessionMessages`.
+ */
+const sessionRecordCountsAtom = atomWithStorage<Record<string, number>>(
+    "agenta:agent-chat:record-counts",
+    {},
+    tabLocalStorage(),
+    STORAGE_OPTS,
+)
+
+/** Read-only view of the watermarks; the guards read one non-reactively via `store.get`. */
+export const sessionRecordCountsReadAtom = atom((get) => get(sessionRecordCountsAtom))
+
 /** Open tab ids for a scope, with the pre-upgrade fallback (everything open). Pure read helper
  * for the writers below — never mutates. */
 const currentOpenIds = (get: Getter, key: string): string[] => {
@@ -328,11 +346,7 @@ export const deleteSessionAtomFamily = atomFamily((key: string) =>
             set(activeByAppAtom, {...active, [key]: open.filter((x) => x !== id)[0] ?? ""})
         }
 
-        const messages = {...get(sessionMessagesAtom)}
-        if (id in messages) {
-            delete messages[id]
-            set(sessionMessagesAtom, messages)
-        }
+        dropSessionMessages(get, set, [id])
 
         clearSessionEphemera(id)
 
@@ -484,16 +498,8 @@ export const reconcileServerSessionsAtomFamily = atomFamily((key: string) =>
             if (active[key] && droppedSet.has(active[key])) {
                 set(activeByAppAtom, {...active, [key]: nextOpen[0] ?? ""})
             }
-            const messages = {...get(sessionMessagesAtom)}
-            let msgsChanged = false
-            for (const id of dropped) {
-                if (id in messages) {
-                    delete messages[id]
-                    msgsChanged = true
-                }
-                clearSessionEphemera(id)
-            }
-            if (msgsChanged) set(sessionMessagesAtom, messages)
+            dropSessionMessages(get, set, dropped)
+            for (const id of dropped) clearSessionEphemera(id)
         }
     }),
 )
@@ -567,18 +573,8 @@ export const resetScopeAtomFamily = atomFamily((key: string) =>
             delete next[key]
             set(activeByAppAtom, next)
         }
-        if (ids.length) {
-            const messages = {...get(sessionMessagesAtom)}
-            let changed = false
-            for (const id of ids) {
-                if (id in messages) {
-                    delete messages[id]
-                    changed = true
-                }
-                clearSessionEphemera(id)
-            }
-            if (changed) set(sessionMessagesAtom, messages)
-        }
+        dropSessionMessages(get, set, ids)
+        for (const id of ids) clearSessionEphemera(id)
     }),
 )
 
@@ -672,12 +668,13 @@ const writeMessagesWithQuotaGuard = (
     set: Setter,
     next: Record<string, UIMessage[]>,
     keepId: string,
-): void => {
+): string[] => {
     let candidate = next
+    const evicted: string[] = []
     for (;;) {
         try {
             set(sessionMessagesAtom, candidate)
-            return
+            return evicted
         } catch (e) {
             if (!isQuotaExceeded(e)) throw e
             // Object keys keep insertion order, so the first non-active id is the oldest.
@@ -685,19 +682,64 @@ const writeMessagesWithQuotaGuard = (
             if (oldest === undefined) {
                 // Even the active session alone won't fit — keep it in memory, skip persistence.
                 console.warn("[agent-chat] message store over quota; skipping persistence")
-                return
+                return evicted
             }
+            evicted.push(oldest)
             candidate = {...candidate}
             delete candidate[oldest]
         }
     }
 }
 
-/** Write a session's messages to the persisted store (called when its stream settles). */
+/**
+ * Drop cached transcripts AND their watermarks for `ids` — the two stores must never diverge, or a
+ * re-adopted session would be judged against a watermark belonging to a transcript that's gone.
+ * The single deletion path for both; every caller that forgets a session routes through here.
+ */
+const dropSessionMessages = (get: Getter, set: Setter, ids: string[]): void => {
+    if (ids.length === 0) return
+    const messages = {...get(sessionMessagesAtom)}
+    const counts = {...get(sessionRecordCountsAtom)}
+    let messagesChanged = false
+    let countsChanged = false
+    for (const id of ids) {
+        if (id in messages) {
+            delete messages[id]
+            messagesChanged = true
+        }
+        if (id in counts) {
+            delete counts[id]
+            countsChanged = true
+        }
+    }
+    if (messagesChanged) set(sessionMessagesAtom, messages)
+    if (countsChanged) set(sessionRecordCountsAtom, counts)
+}
+
+/**
+ * Write a session's messages to the persisted store (called when its stream settles), together with
+ * the record watermark the transcript reflects. Pass `recordCount: undefined` for a locally-streamed
+ * transcript — we can't know how many records the server logged for it, and clearing the watermark
+ * makes the next open re-sync from the durable log rather than trust a stale number.
+ */
 export const persistSessionMessagesAtom = atom(
     null,
-    (get, set, {id, messages}: {id: string; messages: UIMessage[]}) => {
-        writeMessagesWithQuotaGuard(set, {...get(sessionMessagesAtom), [id]: messages}, id)
+    (
+        get,
+        set,
+        {id, messages, recordCount}: {id: string; messages: UIMessage[]; recordCount?: number},
+    ) => {
+        const evicted = writeMessagesWithQuotaGuard(
+            set,
+            {...get(sessionMessagesAtom), [id]: messages},
+            id,
+        )
+        const counts = {...get(sessionRecordCountsAtom)}
+        if (recordCount === undefined) delete counts[id]
+        else counts[id] = recordCount
+        // A quota eviction dropped those transcripts, so their watermarks go too.
+        for (const evictedId of evicted) delete counts[evictedId]
+        set(sessionRecordCountsAtom, counts)
     },
 )
 

--- a/web/packages/agenta-entities/src/session/core/transcriptAdoption.ts
+++ b/web/packages/agenta-entities/src/session/core/transcriptAdoption.ts
@@ -1,0 +1,47 @@
+/**
+ * When a client should replace the transcript it is rendering with the server's durable one.
+ *
+ * The durable record log is append-only and ordered, so "the server has more RECORDS than my
+ * transcript was built from" is an exact test for "the server moved on". Message counts are not:
+ * the agent-chat mapper only closes a message on a `done` record and deliberately folds a paused
+ * turn into its resume, so a turn that grows in place — tool results landing, an approval
+ * round-trip completing — keeps the same message count from start to finish.
+ *
+ * Issue #5530: a browser that snapshotted a session mid-turn (while another browser drove it) was
+ * left with a partial transcript whose message count already matched the finished one. The
+ * count-based guard concluded the server was not ahead and kept the partial copy — on every
+ * subsequent reload, permanently.
+ */
+export interface TranscriptAdoptionInput {
+    /** Durable records the SERVER transcript was built from. */
+    serverRecordCount: number
+    /** Messages in the server transcript. */
+    serverMessageCount: number
+    /** Messages currently rendered locally. */
+    localMessageCount: number
+    /** Records the rendered transcript was built from; `undefined` = not server-derived. */
+    watermark: number | undefined
+    /** This client is streaming the turn, so it — not the log — is the authority. */
+    busy: boolean
+}
+
+export const shouldAdoptServerTranscript = ({
+    serverRecordCount,
+    serverMessageCount,
+    localMessageCount,
+    watermark,
+    busy,
+}: TranscriptAdoptionInput): boolean => {
+    // Nothing to adopt.
+    if (serverMessageCount === 0) return false
+    // A live local stream outranks the log until it settles.
+    if (busy) return false
+    // THE trigger: the log grew past what we render. An absent watermark reads as 0, so a
+    // locally-streamed or pre-#5530 cache re-syncs from the server once on its next open.
+    if (serverRecordCount <= (watermark ?? 0)) return false
+    // Floor, never a trigger: ingest lag can serve a snapshot shorter than what we render, and
+    // trading down would drop the tail. Equal length is fine — that is the #5530 case, where the
+    // same messages carry far more content.
+    if (serverMessageCount < localMessageCount) return false
+    return true
+}

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -67,6 +67,7 @@ export {
     type SessionStreamNest,
     type SandboxLiveness,
 } from "./core/liveness"
+export {shouldAdoptServerTranscript, type TranscriptAdoptionInput} from "./core/transcriptAdoption"
 export {deriveMountRows, mountBreadcrumbs, type MountRow} from "./core/mountBrowser"
 export {
     sessionRecordsQueryFamily,

--- a/web/packages/agenta-entities/tests/unit/session-transcript-adoption.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-transcript-adoption.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Pins the transcript-adoption rule (`core/transcriptAdoption.ts`) — the whole of issue #5530,
+ * where a browser that snapshotted a session mid-turn stayed stuck on the partial copy forever
+ * because the guard compared MESSAGE counts and a turn grows in place.
+ *
+ * The rule has one trigger (the record log grew past our watermark) and two vetoes (a live local
+ * stream; a server snapshot shorter than what we render). These lock all three.
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    shouldAdoptServerTranscript,
+    type TranscriptAdoptionInput,
+} from "../../src/session/core/transcriptAdoption"
+
+/** A finished server turn (40 records) against a snapshot taken mid-turn (12 records). */
+const input = (overrides: Partial<TranscriptAdoptionInput> = {}): TranscriptAdoptionInput => ({
+    serverRecordCount: 40,
+    serverMessageCount: 2,
+    localMessageCount: 2,
+    watermark: 12,
+    busy: false,
+    ...overrides,
+})
+
+describe("shouldAdoptServerTranscript", () => {
+    it("adopts a turn that grew IN PLACE — the issue #5530 case", () => {
+        // Identical message counts, far more records. A count-based guard rejects this forever.
+        expect(shouldAdoptServerTranscript(input())).toBe(true)
+    })
+
+    it("rejects when the log has not grown past the rendered transcript", () => {
+        expect(shouldAdoptServerTranscript(input({serverRecordCount: 12}))).toBe(false)
+        expect(shouldAdoptServerTranscript(input({serverRecordCount: 11}))).toBe(false)
+    })
+
+    it("re-syncs a transcript with no watermark, then stops repeating", () => {
+        // A locally-streamed turn, or a cache written before the watermark existed.
+        expect(shouldAdoptServerTranscript(input({watermark: undefined}))).toBe(true)
+        // Once adopted, the watermark equals the log and the next pass is a no-op.
+        expect(shouldAdoptServerTranscript(input({watermark: 40, serverRecordCount: 40}))).toBe(
+            false,
+        )
+    })
+
+    it("never trades a longer local transcript for a lagging server snapshot", () => {
+        // Ingest lag: ahead in records, not yet caught up in messages.
+        expect(
+            shouldAdoptServerTranscript(
+                input({serverMessageCount: 2, localMessageCount: 3, watermark: undefined}),
+            ),
+        ).toBe(false)
+    })
+
+    it("never clobbers a live local stream", () => {
+        expect(shouldAdoptServerTranscript(input({busy: true}))).toBe(false)
+        // Even a far-ahead server copy waits for the stream to settle.
+        expect(shouldAdoptServerTranscript(input({busy: true, serverRecordCount: 9999}))).toBe(
+            false,
+        )
+    })
+
+    it("ignores an empty server transcript", () => {
+        expect(shouldAdoptServerTranscript(input({serverMessageCount: 0}))).toBe(false)
+    })
+})


### PR DESCRIPTION
## Context

`AgentConversation.tsx` had grown to 2692 lines. One component body held the chat stream, two scroll engines, history hydration, onboarding, the composer, attachments, voice input, and the whole transcript render. Touching any one of those meant reading all of them, and the file was still growing (two feature branches landed in it this cycle).

## Changes

The blocker was never the length. It was four mutable scroll refs (`stick`, `armBottom`, `animateBottom`, `programmaticScroll`) written from five call sites and read by two separate sets of effects. Nothing could be lifted out while those refs were shared ambient state.

`useScrollIntent` now owns them behind three verbs, one per call-site shape:

```
armGlide()   submit: park follow, arm ONE animated pin to the bottom
armJump()    restore/adopt: arm ONE instant jump, follow untouched
follow()     a send that leaves now (queue release, channelled run)
```

Producers state intent. They never touch a ref. With that seam the rest moves out whole:

```
assets/      conversationLayout, runError, messageParts, scrollGeometry
hooks/       useScrollIntent, useTranscriptScroll, useVirtuosoTranscript,
             useAgentChatSession, useSessionHydration, useComposerDraft,
             useComposerAttachments, useVoiceComposer, useTurnInspector,
             useOnboardingChat, useFirstRunSeed
components/  MessageRow, TurnActivity, AgentTurn, AgentTranscript,
             TranscriptPlaceholder, AgentComposerDock
```

`AgentConversation.tsx` is 679 lines and reads as a composition root.

Two changes are not pure moves, both deliberate:

`AgentTurn` is memoized. Previously `renderMessage` built every row inline, so each streamed token re-rendered every settled turn above the active one. Turn numbers are also precomputed once per message set. The old `turnOfAssistant` rescanned the message list per rendered row, which made the transcript O(n^2) on every commit.

`useComposerAttachments` returns `bindDropTarget(isBlocked)` rather than a static handler object. The blocked-drop guard depends on the recorder, which depends on `addFiles`, which would be circular. The predicate is read at event time, so no ref crosses the boundary.

## Tests

- `pnpm --filter @agenta/oss exec tsc --noEmit` passes with zero errors, as do `@agenta/entity-ui` and `@agenta/ee`.
- `pnpm lint-fix` across the repo makes no changes. Prettier clean.
- Effect bodies, dependency arrays and `useState` lazy initializers moved verbatim, comments included. Several of those comments document real races and StrictMode hazards, so they were not rewritten.
- This branch was rebuilt against current `release/v0.106.1` rather than rebased, because the voice input and file upload features landed inside the regions this refactor deletes. Verified line by line: of 357 lines those features added, every behavioural one is present. `NEXT_PUBLIC_AGENT_VOICE_INPUT` and `NEXT_PUBLIC_AGENT_FILE_UPLOADS` both still reach live code.

Not runtime verified. The gates above are static.

## What to QA

- Send a message while scrolled up. The jump pill appears, and clicking it glides to the bottom.
- Ask something with a long answer. The question pins to the top and holds there while the answer streams in.
- Expand a tool card while reading scrolled-up history. Your place holds, the view does not jump.
- Reload mid approval. The queue holds new sends, and answering the gate resumes the run.
- Record a voice message with `NEXT_PUBLIC_AGENT_VOICE_INPUT` on. Empty composer sends it. Composer with text attaches it instead.
- Drag a blocked file type onto the panel. The tab does not navigate away and the cursor shows "no drop".
- Regression: switch sessions and switch revisions. The transcript and composer draft survive both.
