### PR TITLE
[fix] Make the website responsive on mobile

### DIFF
--- a/website/src/components/CopyPromptButton.tsx
+++ b/website/src/components/CopyPromptButton.tsx
@@ -37,6 +37,8 @@ export default function CopyPromptButton() {
         display: "inline-flex",
         alignItems: "center",
         gap: 6,
+        flexShrink: 0,
+        whiteSpace: "nowrap",
         height: 26,
         padding: "0 10px",
         borderRadius: 7,

--- a/website/src/components/HostingToggle.tsx
+++ b/website/src/components/HostingToggle.tsx
@@ -92,6 +92,7 @@ export default function HostingToggle({
     <div
       role="radiogroup"
       aria-label="Hosting"
+      className="hosting-toggle"
       onKeyDown={onKeyDown}
       style={{
         display: "flex",
@@ -116,11 +117,13 @@ export default function HostingToggle({
             aria-checked={selected}
             tabIndex={selected ? 0 : -1}
             onClick={() => selectIndex(index)}
+            className="hosting-tab"
             style={selected ? on : off}
           >
-            {option.label}
+            <span className="hosting-tab-label">{option.label}</span>
             {option.sublabel && (
               <span
+                className="hosting-tab-sub"
                 style={{
                   font: "var(--text-caption)",
                   color: "rgba(255,255,255,0.5)",

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -80,6 +80,7 @@ function GreenCheck() {
 function ToolRow({ label, meta }: { label: string; meta: string }) {
   return (
     <div
+      className="hiw-toolrow"
       style={{
         display: "flex",
         alignItems: "center",
@@ -92,6 +93,7 @@ function ToolRow({ label, meta }: { label: string; meta: string }) {
     >
       <GreenCheck />
       <span
+        className="hiw-toolrow-label"
         style={{
           font: "var(--app-text-mono)",
           fontSize: 12,
@@ -101,6 +103,7 @@ function ToolRow({ label, meta }: { label: string; meta: string }) {
         {label}
       </span>
       <span
+        className="hiw-toolrow-meta"
         style={{
           marginLeft: "auto",
           font: `400 12px/1 ${GEIST}`,
@@ -278,11 +281,20 @@ function renderBlock(i: number, wrap: CSSProperties): ReactNode {
                 Agent scheduled
               </span>
             </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                flexWrap: "wrap",
+              }}
+            >
               <span
                 style={{
                   display: "inline-flex",
                   alignItems: "center",
+                  flexShrink: 0,
+                  whiteSpace: "nowrap",
                   height: 24,
                   padding: "0 12px",
                   borderRadius: 999,

--- a/website/src/components/OpenSource.astro
+++ b/website/src/components/OpenSource.astro
@@ -64,6 +64,7 @@ const ossStrip = [
           >Open source</span
         >
         <span
+          class="ag-bighead"
           style="font:300 44px/1.1 'GT Alpina',serif;color:#F7F6F4;text-wrap:pretty;"
           >Self-host Agenta on your infrastructure</span
         >
@@ -94,13 +95,13 @@ const ossStrip = [
             >Helm charts</a
           >
         </div>
-        <div style="display:flex;gap:12px;margin-top:6px;">
+        <div class="ag-oss-btns" style="display:flex;gap:12px;margin-top:6px;">
           <a
             class="ag-key"
             href="https://github.com/Agenta-AI/agenta"
             target="_blank"
             rel="noopener"
-            style="--key-alpha:0.9;display:inline-flex;align-items:center;height:40px;padding:0 18px;border-radius:8px;background:var(--grad-btn-primary);box-shadow:var(--shadow-btn-primary);font:600 14px/1 var(--font-sans);color:var(--ink-900);text-decoration:none;"
+            style="--key-alpha:0.9;display:inline-flex;align-items:center;white-space:nowrap;height:40px;padding:0 18px;border-radius:8px;background:var(--grad-btn-primary);box-shadow:var(--shadow-btn-primary);font:600 14px/1 var(--font-sans);color:var(--ink-900);text-decoration:none;"
             >Explore on GitHub</a
           >
           <a
@@ -108,7 +109,7 @@ const ossStrip = [
             href="https://docs.agenta.ai/self-host/quick-start"
             target="_blank"
             rel="noopener"
-            style="display:inline-flex;align-items:center;height:40px;padding:0 18px;border-radius:8px;background:rgba(255,255,255,0.05);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.14);font:500 14px/1 var(--font-sans);color:#F7F6F4;text-decoration:none;"
+            style="display:inline-flex;align-items:center;white-space:nowrap;height:40px;padding:0 18px;border-radius:8px;background:rgba(255,255,255,0.05);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.14);font:500 14px/1 var(--font-sans);color:#F7F6F4;text-decoration:none;"
             >Self-hosting docs</a
           >
         </div>

--- a/website/src/components/OpenStandards.astro
+++ b/website/src/components/OpenStandards.astro
@@ -155,6 +155,7 @@ const isExternal = (href?: string) => !!href && href.startsWith("http");
         >Open standards</span
       >
       <span
+        class="ag-bighead"
         style="font:300 44px/1.1 var(--font-display,'GT Alpina',serif);color:#F7F6F4;"
         >One agent package, any stack</span
       >
@@ -175,12 +176,13 @@ const isExternal = (href?: string) => !!href && href.startsWith("http");
       {
         rows.map((r, i) => (
           <div
+            class="ag-io-row"
             style={
               "display:grid;grid-template-columns:130px 1fr;gap:16px;align-items:center;padding:17px 0;" +
               (i > 0 ? "border-top:1px solid rgba(255,255,255,0.06);" : "")
             }
           >
-            <span style={labelStyle}>{r.label}</span>
+            <span class="ag-io-label" style={labelStyle}>{r.label}</span>
             <div class="ag-io-view" style={"overflow:hidden;" + MASK}>
               <div
                 class="ag-io-track"
@@ -241,5 +243,28 @@ const isExternal = (href?: string) => !!href && href.startsWith("http");
   }
   .ag-io-view:hover .ag-io-track {
     animation-play-state: paused !important;
+  }
+
+  /* Phones: the 130px label column + 28px indent ate half the card, leaving the
+     marquees barely visible. Narrow the labels, drop the indent, and tighten the
+     row rhythm so the moving chip strips get much more width and the whole card
+     reads more compact. */
+  @media (max-width: 600px) {
+    .ag-interop {
+      padding-left: 16px !important;
+      padding-right: 16px !important;
+      gap: 40px !important;
+    }
+    .ag-io-row {
+      grid-template-columns: 96px 1fr !important;
+      gap: 12px !important;
+      padding: 12px 0 !important;
+    }
+    .ag-io-label {
+      padding-left: 12px !important;
+      font-size: 11px !important;
+      letter-spacing: 0.04em !important;
+      white-space: nowrap;
+    }
   }
 </style>

--- a/website/src/components/SectionTitle.astro
+++ b/website/src/components/SectionTitle.astro
@@ -26,10 +26,12 @@ const titleFont =
 ---
 
 <header
+  class="ag-sechead"
   style={`display:flex;flex-direction:column;gap:8px;align-items:${align === "center" ? "center" : "flex-start"};text-align:${align};max-width:${width};`}
 >
   {badge && <Badge variant={dark ? "dark" : "default"}>{badge}</Badge>}
   <h2
+    class={size === "xl" ? "ag-sectitle ag-sectitle-xl" : "ag-sectitle"}
     style={`margin:0;font:${titleFont};color:${dark ? "#FFFFFF" : "var(--text-heading)"};text-wrap:pretty;`}
   >
     {title}

--- a/website/src/components/SiteNav.astro
+++ b/website/src/components/SiteNav.astro
@@ -220,10 +220,27 @@ const triggerStyle = linkStyle + "border:none;background:transparent;";
   // Lightweight hamburger toggle (no framework). Replaces the DC menuOpen state.
   const toggle = document.getElementById("ag-menu-toggle");
   const menu = document.getElementById("ag-mobile-menu");
+  const closeMenu = () => {
+    menu?.classList.remove("is-open");
+    toggle?.setAttribute("aria-expanded", "false");
+  };
   toggle?.addEventListener("click", () => {
     const open = menu?.classList.toggle("is-open");
     toggle.setAttribute("aria-expanded", open ? "true" : "false");
   });
+  // Close when a menu entry is tapped (in-page anchors and same-tab navigations
+  // wouldn't otherwise dismiss the now-fixed overlay).
+  menu?.querySelectorAll("a").forEach((a) =>
+    a.addEventListener("click", closeMenu),
+  );
+  // Never leave the mobile overlay open once the layout returns to desktop.
+  window.addEventListener(
+    "resize",
+    () => {
+      if (window.innerWidth > 860) closeMenu();
+    },
+    { passive: true },
+  );
 
   // Nav-pill: landing only. Toggles `.nav-scrolled` on <html> past 24px so the
   // sticky bar floats into the glass pill (styles in global.css). Wired ONLY when

--- a/website/src/components/SiteNav.astro
+++ b/website/src/components/SiteNav.astro
@@ -221,8 +221,12 @@ const triggerStyle = linkStyle + "border:none;background:transparent;";
   const toggle = document.getElementById("ag-menu-toggle");
   const menu = document.getElementById("ag-mobile-menu");
   const closeMenu = () => {
+    // If focus is on a menu link when it hides (link tap, or resize to desktop),
+    // return it to the toggle so keyboard focus isn't dropped to <body>.
+    const focusInMenu = menu?.contains(document.activeElement) ?? false;
     menu?.classList.remove("is-open");
     toggle?.setAttribute("aria-expanded", "false");
+    if (focusInMenu) toggle?.focus();
   };
   toggle?.addEventListener("click", () => {
     const open = menu?.classList.toggle("is-open");

--- a/website/src/components/TemplateExplorer.tsx
+++ b/website/src/components/TemplateExplorer.tsx
@@ -351,6 +351,9 @@ export default function TemplateExplorer() {
               <div
                 style={{
                   display: "inline-flex",
+                  // Wrap so the 3-option switch can't overflow a narrow (~335px)
+                  // mobile panel and clip "pi.dev"; stays one row where it fits.
+                  flexWrap: "wrap",
                   gap: 3,
                   padding: 3,
                   borderRadius: 9,

--- a/website/src/pages/authors/[slug].astro
+++ b/website/src/pages/authors/[slug].astro
@@ -145,7 +145,7 @@ const sectionBorder = "border:1px solid rgba(255,255,255,0.07);margin-top:-1px;"
     {
       posts.length > 0 ? (
         <div
-          class="ag-grid"
+          class="ag-grid ag-authors-grid"
           style="display:grid;grid-template-columns:repeat(3,1fr);gap:24px;"
         >
           {posts.map((p) => (

--- a/website/src/pages/authors/index.astro
+++ b/website/src/pages/authors/index.astro
@@ -43,7 +43,7 @@ const sectionBorder = "border:1px solid rgba(255,255,255,0.07);margin-top:-1px;"
     style={`background:#0A0A0B;${sectionBorder}padding:48px 64px 88px;`}
   >
     <div
-      class="ag-grid"
+      class="ag-grid ag-authors-grid"
       style="display:grid;grid-template-columns:repeat(3,1fr);gap:24px;"
     >
       {

--- a/website/src/pages/blog/[slug].astro
+++ b/website/src/pages/blog/[slug].astro
@@ -257,10 +257,7 @@ const sectionBorder = "border:1px solid rgba(255,255,255,0.07);margin-top:-1px;"
       #post-related-grid {
         grid-template-columns: 1fr !important;
       }
-      .ag-pad {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-      }
+      /* .ag-pad side-padding is now a global rule (see global.css). */
       /* Hero image breathes proportionally less on phones. */
       .ag-post-head {
         padding-top: 44px !important;

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -224,10 +224,7 @@ const sectionBorder = "border:1px solid rgba(255,255,255,0.07);margin-top:-1px;"
       #blog-grid {
         grid-template-columns: 1fr !important;
       }
-      .ag-pad {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-      }
+      /* .ag-pad side-padding is now a global rule (see global.css). */
     }
   </style>
 </Site>

--- a/website/src/pages/contact.astro
+++ b/website/src/pages/contact.astro
@@ -35,6 +35,7 @@ const DEMO_URL =
         >Contact</span
       >
       <h1
+        class="ag-h1"
         style="margin:0 0 16px;font:var(--text-display-lg);color:#F7F6F4;text-wrap:pretty;"
       >
         Get in touch
@@ -55,6 +56,7 @@ const DEMO_URL =
 
       <!-- Book a demo panel -->
       <div
+        class="ag-info-panel"
         style="border:1px solid rgba(255,255,255,0.07);padding:40px 40px 40px;background:#100F11;display:flex;flex-direction:column;gap:20px;"
       >
         <div>
@@ -81,6 +83,7 @@ const DEMO_URL =
 
       <!-- Direct contact panel -->
       <div
+        class="ag-info-panel"
         style="border:1px solid rgba(255,255,255,0.07);padding:40px 40px 36px;background:#100F11;"
       >
         <h2
@@ -90,6 +93,7 @@ const DEMO_URL =
         </h2>
 
         <dl
+          class="ag-deflist"
           style="display:grid;grid-template-columns:160px 1fr;gap:12px 24px;font:var(--text-body-md);color:rgba(255,255,255,0.6);margin:0;"
         >
           <dt style="color:rgba(255,255,255,0.38);font:var(--text-label);">Email</dt>
@@ -123,6 +127,7 @@ const DEMO_URL =
 
       <!-- Community channels panel -->
       <div
+        class="ag-info-panel"
         style="border:1px solid rgba(255,255,255,0.07);padding:40px 40px 36px;background:#100F11;"
       >
         <h2

--- a/website/src/pages/imprint.astro
+++ b/website/src/pages/imprint.astro
@@ -22,6 +22,7 @@ import Site from "../layouts/Site.astro";
         >Legal</span
       >
       <h1
+        class="ag-h1"
         style="margin:0 0 16px;font:var(--text-display-lg);color:#F7F6F4;text-wrap:pretty;"
       >
         Imprint
@@ -43,6 +44,7 @@ import Site from "../layouts/Site.astro";
 
       <!-- Legal notice panel -->
       <div
+        class="ag-info-panel"
         style="border:1px solid rgba(255,255,255,0.07);padding:40px 40px 36px;background:#100F11;"
       >
         <h2
@@ -52,6 +54,7 @@ import Site from "../layouts/Site.astro";
         </h2>
 
         <dl
+          class="ag-deflist"
           style="display:grid;grid-template-columns:160px 1fr;gap:12px 24px;font:var(--text-body-md);color:rgba(255,255,255,0.6);margin:0;"
         >
           <dt style="color:rgba(255,255,255,0.38);font:var(--text-label);">Company</dt>
@@ -88,6 +91,7 @@ import Site from "../layouts/Site.astro";
 
       <!-- Contact panel -->
       <div
+        class="ag-info-panel"
         style="border:1px solid rgba(255,255,255,0.07);padding:40px 40px 36px;background:#100F11;"
       >
         <h2
@@ -97,6 +101,7 @@ import Site from "../layouts/Site.astro";
         </h2>
 
         <dl
+          class="ag-deflist"
           style="display:grid;grid-template-columns:160px 1fr;gap:12px 24px;font:var(--text-body-md);color:rgba(255,255,255,0.6);margin:0;"
         >
           <dt style="color:rgba(255,255,255,0.38);font:var(--text-label);">Phone</dt>

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -60,6 +60,7 @@ const linkStyle =
             >{hero.eyebrow}</span
           >
           <h1
+            class="ag-h1"
             style="margin:0;font:var(--text-display-lg);color:#F7F6F4;max-width:760px;text-wrap:pretty;"
           >
             {hero.headline}
@@ -100,23 +101,36 @@ const linkStyle =
         comparisonModes.map(({ cls, data }) => {
           const cols = data.columns.length;
           const COLS = `grid-template-columns:1.4fr repeat(${cols}, 1fr);`;
+          // Phone column template + min-width (used via CSS vars in the <=760 media
+          // query): a narrower sticky label track + fixed-width value columns so the
+          // pinned Features column never overlaps the plan columns it scrolls past.
+          const colsM = `128px repeat(${cols}, minmax(96px, 1fr))`;
+          const minwM = 128 + cols * 96;
           // Wide (cloud/4-col) table keeps full-size columns and scrolls sideways on
           // narrow viewports; the 2-col table is capped narrower so it reads cleanly.
           const tableStyle =
-            cols >= 3
+            (cols >= 3
               ? "min-width:920px;max-width:1336px;margin:0 auto;"
-              : "min-width:520px;max-width:900px;margin:0 auto;";
+              : "min-width:520px;max-width:900px;margin:0 auto;") +
+            `--cmp-cols-m:${colsM};--cmp-minw-m:${minwM}px;`;
           return (
             <div class={`cmp-wrap ${cls}`}>
               <SectionTitle dark badge="Compare" title={data.title} />
+
+              {/* Mobile-only affordance: the table scrolls sideways to reveal the
+                  other plan columns, which isn't obvious on a phone. */}
+              <span class="cmp-hint" aria-hidden="true">
+                Scroll sideways to compare all plans →
+              </span>
 
               <div class="cmp-scroll" data-scroll="dark">
                 <div class="cmp-table" style={tableStyle}>
                   {/* header row */}
                   <div
+                    class="cmp-row"
                     style={`display:grid;${COLS}align-items:end;padding:0 24px 18px;border-bottom:1px solid rgba(255,255,255,0.12);`}
                   >
-                    <span style="font:var(--text-label);color:rgba(255,255,255,0.5);">
+                    <span class="cmp-c0" style="font:var(--text-label);color:rgba(255,255,255,0.5);">
                       Features
                     </span>
                     {data.columns.map((c) => (
@@ -140,9 +154,10 @@ const linkStyle =
                       </div>
                       {g.rows.map((r) => (
                         <div
+                          class="cmp-row"
                           style={`display:grid;${COLS}align-items:center;padding:14px 24px;border-top:1px solid rgba(255,255,255,0.07);`}
                         >
-                          <span style="font:var(--text-body-sm);color:rgba(255,255,255,0.78);">
+                          <span class="cmp-c0" style="font:var(--text-body-sm);color:rgba(255,255,255,0.78);">
                             {linkify(r.label, links).map((part) => (part.href ? <a href={part.href} target={part.href.startsWith("mailto:") ? undefined : "_blank"} rel={part.href.startsWith("mailto:") ? undefined : "noopener"} style={linkStyle}>{part.text}</a> : <Fragment>{part.text}</Fragment>))}
                           </span>
                           {r.cells.map((cell) => (
@@ -295,6 +310,39 @@ const linkStyle =
     -webkit-overflow-scrolling: touch;
     padding: 0 24px;
     box-sizing: border-box;
+    /* Horizontal scroll-shadow: an edge shadow signals the table scrolls to
+       reveal the other plan columns, and fades out once scrolled to that end.
+       Pure CSS via background-attachment (local covers vs scroll shadows). */
+    background:
+      linear-gradient(to right, #0e0d0f 42%, rgba(14, 13, 15, 0)) left center,
+      linear-gradient(to left, #0e0d0f 42%, rgba(14, 13, 15, 0)) right center,
+      radial-gradient(
+          farthest-side at 0 50%,
+          rgba(0, 0, 0, 0.55),
+          rgba(0, 0, 0, 0)
+        )
+        left center,
+      radial-gradient(
+          farthest-side at 100% 50%,
+          rgba(0, 0, 0, 0.55),
+          rgba(0, 0, 0, 0)
+        )
+        right center;
+    background-repeat: no-repeat;
+    background-size:
+      34px 100%,
+      34px 100%,
+      16px 100%,
+      16px 100%;
+    background-attachment: local, local, scroll, scroll;
+  }
+  /* Scroll hint sits between the title and the table; phones only. */
+  .cmp-hint {
+    display: none;
+    font: var(--text-caption);
+    letter-spacing: 0.02em;
+    color: rgba(255, 255, 255, 0.45);
+    text-align: center;
   }
   /* The table never collapses: it keeps full-size columns and scrolls sideways
      when the viewport is narrower than its min-width (see RESPONSIVE.md). */
@@ -376,10 +424,45 @@ const linkStyle =
       padding: 72px 0;
     }
     .plan-grid,
-    .cmp-scroll,
     .faq-col {
       padding-left: 16px;
       padding-right: 16px;
+    }
+    /* The comparison table scrolls edge-to-edge on phones so the sticky label
+       column can pin flush to the screen edge (no sliver of the scrolling plan
+       columns peeking to its left). Row content keeps its own 24px gutter. */
+    .cmp-scroll {
+      padding-left: 0;
+      padding-right: 0;
+    }
+    /* Tighten the comparison block and reveal the scroll hint on phones. */
+    .cmp-wrap {
+      gap: 24px;
+    }
+    .cmp-hint {
+      display: block;
+    }
+    /* Narrower label track + fixed value columns on phones, so the sticky label
+       column leaves room for the plan values instead of covering them. */
+    .cmp-row {
+      grid-template-columns: var(--cmp-cols-m) !important;
+    }
+    .cmp-table {
+      min-width: var(--cmp-minw-m) !important;
+    }
+    /* Keep the feature-label column pinned while the plan columns scroll under
+       it, so a scrolled row's values always have their label for context. */
+    .cmp-c0 {
+      position: sticky;
+      left: 0;
+      z-index: 2;
+      /* Fill the full row height so the opaque background fully occludes the plan
+         columns scrolling behind it (a text-height box would let them peek). */
+      align-self: stretch;
+      display: flex;
+      align-items: center;
+      background: #0e0d0f;
+      box-shadow: 10px 0 12px -8px rgba(0, 0, 0, 0.55);
     }
   }
   @media (max-width: 680px) {

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -840,6 +840,7 @@ html,
   }
   .hosting-tab {
     flex: 1 1 0;
+    min-width: 0;
     flex-direction: column;
     gap: 1px !important;
     height: auto !important;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -606,6 +606,9 @@ html,
   text-decoration: underline;
   text-underline-offset: 2px;
   text-decoration-color: rgba(242, 242, 92, 0.55);
+  /* Long URLs/identifiers in prose links must break rather than force the page
+     wider than the phone viewport (they otherwise expand the layout to ~459px). */
+  overflow-wrap: anywhere;
 }
 .ag-prose a:hover {
   text-decoration-color: var(--yellow-400);
@@ -640,6 +643,9 @@ html,
   border-radius: 5px;
   padding: 0.12em 0.4em;
   color: #f7f6f4;
+  /* Inline code with a long token/URL must break rather than force the page
+     wider than the phone viewport. Fenced <pre> code is exempted below. */
+  overflow-wrap: anywhere;
 }
 .ag-prose pre {
   margin: 0 0 1.4em;
@@ -651,13 +657,16 @@ html,
   font-size: 14px;
   line-height: 1.6;
 }
-/* Fenced blocks (and any Shiki-highlighted <pre>) drop the inline-code chrome. */
+/* Fenced blocks (and any Shiki-highlighted <pre>) drop the inline-code chrome,
+   and keep normal wrapping so multi-line code scrolls (via .ag-prose pre) rather
+   than breaking mid-token like inline code. */
 .ag-prose pre code {
   background: none;
   border: none;
   padding: 0;
   font-size: inherit;
   color: rgba(255, 255, 255, 0.82);
+  overflow-wrap: normal;
 }
 .ag-prose blockquote {
   margin: 1.4em 0;
@@ -700,4 +709,177 @@ html,
   color: var(--text-on-dark-heading);
   font-weight: 600;
   background: rgba(255, 255, 255, 0.04);
+}
+
+/* ============================================================================
+   Mobile responsiveness fixes (audit 2026-07). These extend the existing
+   860 = mobile / 600 = phone convention to the pages, headings, and the mobile
+   menu that were never wired into it. Every rule sits inside a max-width query,
+   so desktop (>=861px) is untouched.
+============================================================================ */
+@media (max-width: 860px) {
+  /* Slim the nav bar/pill on mobile — 68px reads too chunky on a phone — and
+     tighten the side padding so the logo and hamburger sit closer to the edges. */
+  .ag-navshell,
+  .ag-nav-inner {
+    height: 54px;
+  }
+  .ag-nav-inner {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  /* Floating-nav mobile menu. The menu is a normal-flow sibling after <nav>, so
+     once the landing nav sticks and floats into its pill, opening the menu would
+     render it anchored near the top of the document — off-screen when scrolled
+     (measured top: -1081px at scrollY 1148). Pin it to the viewport under the
+     bar/pill so it is always reachable. Above 861px it stays display:none. */
+  .ag-mobile-menu.is-open {
+    position: fixed;
+    top: 58px;
+    left: 12px;
+    right: 12px;
+    z-index: 55;
+    margin-top: 0 !important;
+    max-height: calc(100dvh - 70px);
+    overflow-y: auto;
+    border-top: 1px solid rgba(255, 255, 255, 0.07) !important;
+    border-radius: 14px;
+    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.55);
+  }
+  /* When the landing nav has floated into its pill (inset 12px), drop the menu a
+     touch lower so it clears the pill's bottom edge. */
+  .nav-scrolled .ag-mobile-menu.is-open {
+    top: 70px;
+  }
+
+  /* Authors grids never collapsed (inline repeat(3,1fr)); 3-up -> 2-up on tablet.
+     Blog grids keep their own #id rules and are unaffected by this class rule. */
+  .ag-authors-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+
+  /* Shared section side-gutter (authors/blog/404). Previously this reduction
+     lived only inside the blog pages' scoped <style> blocks, so it never reached
+     the authors pages — promoted here so every .ag-pad section gets it. */
+  .ag-pad {
+    padding-left: 20px !important;
+    padding-right: 20px !important;
+  }
+
+  /* Keep large serif section headings off the screen edges. */
+  .ag-sechead {
+    padding-inline: 20px;
+  }
+
+  /* Heading scale — mirror the .ag-h1 mobile steps for every other big heading. */
+  .ag-sectitle {
+    font-size: 34px !important;
+    line-height: 1.14 !important;
+  }
+  .ag-sectitle-xl {
+    font-size: 40px !important;
+  }
+  .ag-dlg {
+    font-size: 34px !important;
+    line-height: 1.14 !important;
+  }
+  .ag-bighead {
+    font-size: 34px !important;
+  }
+}
+
+@media (max-width: 600px) {
+  /* Authors grids: single column on phones. */
+  .ag-authors-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  /* Imprint/contact definition lists: the fixed 160px label column squeezes the
+     value to a ~45px sliver that char-wraps addresses/emails. Stack label over
+     value on phones. */
+  .ag-deflist {
+    grid-template-columns: 1fr !important;
+    gap: 2px 0 !important;
+  }
+  .ag-deflist dt {
+    margin-top: 16px;
+  }
+  .ag-deflist dt:first-of-type {
+    margin-top: 0;
+  }
+  /* Give those panels back inner width on phones. */
+  .ag-info-panel {
+    padding-left: 22px !important;
+    padding-right: 22px !important;
+  }
+
+  /* Heading scale — phone step. */
+  .ag-sectitle {
+    font-size: 28px !important;
+  }
+  .ag-sectitle-xl {
+    font-size: 32px !important;
+  }
+  .ag-dlg {
+    font-size: 28px !important;
+  }
+  .ag-bighead {
+    font-size: 30px !important;
+  }
+}
+
+/* Small phones (<=440px): two content-driven CTA fixes that share this width. */
+@media (max-width: 440px) {
+  /* Pricing hosting toggle (React island): the two options
+     "Agenta Cloud (we host)" / "Self-hosted (you host)" no longer fit side by
+     side and the labels wrap mid-word. Go full-width and stack each option's
+     label over its sublabel so nothing breaks. */
+  .hosting-toggle {
+    width: 100%;
+  }
+  .hosting-tab {
+    flex: 1 1 0;
+    flex-direction: column;
+    gap: 1px !important;
+    height: auto !important;
+    padding: 9px 8px !important;
+    justify-content: center;
+    text-align: center;
+  }
+  .hosting-tab-label,
+  .hosting-tab-sub {
+    white-space: nowrap;
+  }
+
+  /* Open-source section CTAs: keep "Explore on GitHub" / "Self-hosting docs" side
+     by side (they otherwise stack). Split the row evenly and trim the type/padding
+     so both labels fit on one line each. */
+  .ag-oss-btns > a {
+    flex: 1 1 0;
+    min-width: 0;
+    justify-content: center;
+    padding: 0 8px !important;
+    font-size: 13px !important;
+  }
+}
+
+/* How-it-works "Automate" tool rows (React island): the file + timestamp meta
+   ("onboarding-v2-prd.md · 09:02") crowds the WRITE_FILE label on small phones.
+   Shrink the row's type a touch so it reads cleanly instead of wrapping tightly. */
+@media (max-width: 480px) {
+  .hiw-toolrow {
+    gap: 6px 9px !important;
+    padding: 8px 11px !important;
+    /* Let the file+time meta drop to its own line (as a whole) rather than
+       break the filename mid-word next to the label. */
+    flex-wrap: wrap !important;
+  }
+  .hiw-toolrow-label {
+    font-size: 11px !important;
+  }
+  .hiw-toolrow-meta {
+    font-size: 10.5px !important;
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
## Context

On phones (below about 430px) several parts of the marketing site broke. The floating nav menu opened off-screen once you scrolled, so it was unreachable. The authors and imprint/contact pages pushed the layout wider than the screen, which made the browser zoom the whole page out, and the imprint address fields char-wrapped one or two letters per line. Blog code blocks stretched the page past the viewport. The pricing plan-comparison table showed a single column with no hint that it scrolled, and its labels disappeared once you did scroll. Several buttons and headings wrapped mid-word or overflowed.

The root cause was the same in most cases. The site already has a responsive system (breakpoints at 860px and 600px), but a handful of pages, components, and headings were never wired into it, and a few React islands used inline styles that no media query could reach.

## Changes

The fixes all sit inside `max-width` media queries (plus a few universally-safe flex properties), so desktop rendering is unchanged.

**Nav menu.** The mobile menu was a normal-flow sibling after `<nav>`, so once the landing nav floated into its sticky pill the menu rendered near the top of the document, off-screen when scrolled. It is now `position: fixed` under the bar, so it always opens on screen. The bar itself is also slimmer on mobile (54px instead of 68px) with tighter side padding.

**Authors / imprint / contact.** The reusable `.ag-grid` / `.ag-pad` / definition-list rules only existed inside the blog pages' scoped styles, so these pages got no mobile treatment. Those rules are now global. The 3-column author grid collapses to 2-up then 1-up, and the fixed `160px 1fr` imprint/contact definition list stacks label over value instead of squeezing the value into a ~45px sliver.

**Blog posts.** Long inline code and links now break instead of forcing the page wider than the phone. A single long URL used to expand the layout to 459px on a 375px screen.

**Pricing comparison table.** It now shows a "scroll sideways to compare" hint and a scroll-shadow affordance, right-sizes its columns so more than one plan is visible at once, and pins the feature-label column so a scrolled row keeps its label.

**Headings and buttons.** Section titles, the pricing hero, and the open-source / imprint / contact headings step down on mobile, mirroring the existing `.ag-h1` steps. The hosting toggle, the templates harness switch, the "Automate" schedule pill, and the self-host CTAs no longer wrap mid-word.

## Tests / notes

- Ran the site locally and checked every affected page at 360, 375, 390, 414, and 768px, plus a desktop regression pass at 1280px.
- Verified with a console check that no page expands its layout viewport past the device width. Authors read 539px before and 375px after; a long blog post read 459px before and 375px after.
- `pnpm build` succeeds (48 pages).
- The website pre-commit prettier hook is scoped to `web/`, so it does not format `website/`. The files were written to match the surrounding style.

## What to QA

- On a phone-width viewport, scroll the landing page so the nav floats into its pill, then tap the hamburger. The menu opens on screen (before this it opened above the viewport).
- Open `/authors` and `/imprint` at ~375px. Cards stack and read cleanly; imprint labels sit above their values with no char-wrapping.
- Open `/pricing` at ~390px. The hosting toggle shows two clean tabs. Scroll the comparison table sideways and confirm the feature labels stay pinned while the plan columns move.
- Regression: view the same pages at desktop width. Nothing should have changed.

## Before / after 

<details>
<summary>Click to see the previews</summary>

<img width="1368" height="4098" alt="image" src="https://github.com/user-attachments/assets/37e522e8-42b0-4d69-b094-a1b5bbb969a8" />

<img width="1396" height="2982" alt="image" src="https://github.com/user-attachments/assets/871e5a69-9cf4-496a-b989-6cbb0745dcfb" />


<img width="1576" height="5108" alt="image" src="https://github.com/user-attachments/assets/edd9b778-d625-4357-aed3-0355783cbbe0" />


<img width="1470" height="1270" alt="image" src="https://github.com/user-attachments/assets/ed382497-a238-4f2f-95f9-df087782cbe2" />


And some other responsivness changes in many places

</details>



