### PR TITLE
[AGE-4019] fix(frontend): Stop onboarding playground polling /sessions/query with a non-UUID scope

### DIFF
--- a/web/oss/src/components/AgentChatSlice/state/projectSessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/projectSessions.ts
@@ -5,13 +5,10 @@ import {atom, useAtomValue, useSetAtom} from "jotai"
 import {atomFamily} from "jotai/utils"
 import {atomWithQuery} from "jotai-tanstack-query"
 
+import {isValidUUID} from "@/oss/lib/helpers/validators"
 import {projectIdAtom} from "@/oss/state/project"
 
-import {
-    GLOBAL_APP_KEY,
-    reconcileServerSessionsAtomFamily,
-    type ServerSessionSummary,
-} from "./sessions"
+import {reconcileServerSessionsAtomFamily, type ServerSessionSummary} from "./sessions"
 
 /**
  * The durable session list for ONE agent, from the server — the cross-device source the sidebar
@@ -20,11 +17,11 @@ import {
  * (`references: [{id: appId}]`). Includes ended sessions (a row with `deleted_at` set).
  *
  * Mirrors `liveness.ts`: ONE low-priority query per agent backs the whole list, revalidated on tab
- * refocus and on a slow interval, so it stays out of the live conversation's way. Disabled for the
- * non-agent scopes (`__global__`, the revision drawer) where there is no artifact id to match.
+ * refocus and on a slow interval, so it stays out of the live conversation's way. Disabled for
+ * non-agent scopes (`__global__`, the revision drawer, the onboarding pseudo-scope) that have no
+ * real app UUID to match — the API validates `references[].id` as a UUID and 422s otherwise.
  */
-const isQueryableScope = (appId: string): boolean =>
-    Boolean(appId) && appId !== GLOBAL_APP_KEY && !appId.startsWith("drawer:")
+const isQueryableScope = (appId: string): boolean => Boolean(appId) && isValidUUID(appId)
 
 export const projectSessionsQueryAtomFamily = atomFamily((appId: string) =>
     atomWithQuery<SessionStream[] | null>((get) => {


### PR DESCRIPTION
## Summary
The onboarding playground (the "What do you want to build?" screen, shown when a project has no agents) fired `POST /sessions/query` on every load and refetch, and the API rejected it with a 422 every time.

The session-list query scopes by the chat's `appId`. The onboarding surface uses the pseudo-id `"onboarding"` instead of a real app UUID, and the API validates `references[].id` as a UUID, so the whole query was rejected. `isQueryableScope` in `projectSessions.ts` only excluded two hardcoded pseudo-scopes (`__global__`, `drawer:*`) and let everything else through, including `"onboarding"`.

Fix: `isQueryableScope` now requires the scope key to be a valid UUID (`isValidUUID(appId)`) instead of excluding specific known pseudo-scopes. This covers the onboarding scope and any future non-UUID scope key without another hardcoded exception. No visible breakage before this fix, but the sessions list for the onboarding scope could never load, and the recurring 422s added noise to the API logs.

## Testing
### Verified locally
- `eslint` on the changed file: clean.
- `tsc --noEmit` on the OSS project: no errors introduced.

### Added or updated tests
N/A

### QA follow-up
- Open a project with no agents so the onboarding playground loads. The network tab should show no `POST /sessions/query` requests, and no repeating 422s in the API logs.
- Regression: open an existing agent's chat panel. Its session list should still load (`POST /sessions/query` fires once with the app's UUID and succeeds).

## Demo
<!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
<!-- If this is not a UI change, write N/A. -->
<img width="1531" height="851" alt="Screenshot 2026-07-30 at 2 50 16 PM" src="https://github.com/user-attachments/assets/d59eb4e1-102c-43a9-a82b-aac488d9085e" />


## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)