### PR TITLE
[5580] fix(frontend): Skip the sessions query on the onboarding view

### DIFF
--- a/web/oss/src/components/AgentChatSlice/state/projectSessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/projectSessions.ts
@@ -7,6 +7,7 @@ import {atomWithQuery} from "jotai-tanstack-query"
 
 import {projectIdAtom} from "@/oss/state/project"
 
+import {ONBOARDING_SCOPE_KEY} from "./scope"
 import {
     GLOBAL_APP_KEY,
     reconcileServerSessionsAtomFamily,
@@ -21,10 +22,14 @@ import {
  *
  * Mirrors `liveness.ts`: ONE low-priority query per agent backs the whole list, revalidated on tab
  * refocus and on a slow interval, so it stays out of the live conversation's way. Disabled for the
- * non-agent scopes (`__global__`, the revision drawer) where there is no artifact id to match.
+ * non-agent scopes (`__global__`, the revision drawer, the pre-commit onboarding) where there is no
+ * artifact id to match — a synthetic key sent as a reference id would just 422 on the API.
  */
 const isQueryableScope = (appId: string): boolean =>
-    Boolean(appId) && appId !== GLOBAL_APP_KEY && !appId.startsWith("drawer:")
+    Boolean(appId) &&
+    appId !== GLOBAL_APP_KEY &&
+    appId !== ONBOARDING_SCOPE_KEY &&
+    !appId.startsWith("drawer:")
 
 export const projectSessionsQueryAtomFamily = atomFamily((appId: string) =>
     atomWithQuery<SessionStream[] | null>((get) => {


### PR DESCRIPTION
Every fresh landing on the playground onboarding view produced a failing `POST /sessions/query` request: the view uses the synthetic reference id `onboarding`, which is not a UUID, so the API answered 422 and the console logged an error. The query also refetched on window focus and on a 60s interval, so the noise repeated for as long as the tab stayed open.

**Before:** landing on the onboarding view fires `/sessions/query` with `"onboarding"` as the reference id, gets a 422, and logs a console error on every landing, focus, and 60s refetch.

**After:** the query never fires during onboarding. No request, no 422, no console error. With a real agent selected, behavior is unchanged.

## How it works

`projectSessions.ts` already gates the sessions query with `isQueryableScope`, which excludes the non-agent scope keys (`__global__` and `drawer:*`) so TanStack Query's `enabled` stays false for them. This change adds `ONBOARDING_SCOPE_KEY` to that same gate. When a real agent is selected, the scope key is the app UUID, so the gate passes and the query behaves exactly as before.

Closes #5580

https://claude.ai/code/session_01Qitvc9dCiunLishsJYRzbp
