### PR TITLE
[5578] fix(frontend): Restore the Remove action in the members row menu

### DIFF
--- a/web/oss/src/components/pages/settings/WorkspaceManage/cellRenderers.tsx
+++ b/web/oss/src/components/pages/settings/WorkspaceManage/cellRenderers.tsx
@@ -32,7 +32,7 @@ export const Actions: React.FC<{
 }> = ({member, hidden, organizationId, workspaceId, onResendInvite, selfMenu}) => {
     const {user} = member
     const isMember = user.status === "member"
-    const {canModifyRoles, canInviteMembers} = useWorkspacePermissions()
+    const {canInviteMembers, canRemoveMembers} = useWorkspacePermissions()
 
     const [resendLoading, setResendLoading] = useState(false)
     const {refetch} = useOrgData()
@@ -41,7 +41,7 @@ export const Actions: React.FC<{
     const [renameValue, setRenameValue] = useState(user.username || "")
 
     if (hidden && !selfMenu) return null
-    if (!selfMenu && !canInviteMembers && !canModifyRoles) return null
+    if (!selfMenu && !canInviteMembers && !canRemoveMembers) return null
 
     const handleResendInvite = () => {
         if (!organizationId || !user.email || !workspaceId) return
@@ -128,7 +128,7 @@ export const Actions: React.FC<{
                                         },
                                     ]
                                   : []),
-                              ...(canModifyRoles
+                              ...(canRemoveMembers
                                   ? [
                                         {
                                             key: "remove",

--- a/web/oss/src/hooks/useWorkspacePermissions.ts
+++ b/web/oss/src/hooks/useWorkspacePermissions.ts
@@ -11,7 +11,7 @@ import {useProjectPermissions} from "./useProjectPermissions"
  */
 export const useWorkspacePermissions = () => {
     const {hasRBAC} = useEntitlements()
-    const {hasPermission, isOrgOwner} = useProjectPermissions()
+    const {hasPermission, hasRole, isOrgOwner} = useProjectPermissions()
 
     // OSS always enforces; EE only when RBAC-entitled.
     const rbacActive = !isEE() || hasRBAC
@@ -33,11 +33,21 @@ export const useWorkspacePermissions = () => {
     }, [hasPermission, rbacActive])
 
     /**
+     * Check if the current user can remove members from the workspace.
+     * Mirrors the backend gate on DELETE /workspaces/{id}/users (org owner or
+     * owner/admin role; allow-all for not-RBAC-entitled EE).
+     */
+    const canRemoveMembers = useMemo(() => {
+        return hasRole("owner") || hasRole("admin")
+    }, [hasRole])
+
+    /**
      * Check if the current user is the organization owner.
      */
     return {
         canInviteMembers,
         canModifyRoles,
+        canRemoveMembers,
         isOrgOwner,
     }
 }


### PR DESCRIPTION
On EE deployments whose organization does not have the RBAC entitlement, the "Remove" action never appears in a workspace member row's "..." menu — the menu renders empty (returns null), so owners and admins cannot remove members or revoke pending invitations from the UI. This is also what makes the `members.spec.ts` pending-member removal test time out waiting for the menu.

## Root cause

The row menu, including the Remove item and the menu's early return, was gated on `canModifyRoles`. That flag is hard-false for EE orgs without the RBAC entitlement. But member removal is not role modification: the backend gates `DELETE /workspaces/{id}/users` on being the org owner or having the owner/admin role (and allows all for non-entitled EE), so the frontend was strictly more restrictive than the API.

## Fix

Add a `canRemoveMembers` gate in `useWorkspacePermissions` (`hasRole("owner") || hasRole("admin")`; `hasRole` already returns true for org owners and for editions where RBAC is not active), mirroring the backend's check. The Remove item and the menu's early return now use it. The other items keep their existing gates: resend invitation stays on `canInviteMembers`, role editing stays on `canModifyRoles`.

## How to verify

1. On an EE deployment without the RBAC entitlement, invite a member so a pending row exists in Settings > Workspace.
2. Open the row's "..." menu: Remove now appears, and confirming the dialog removes the row.
3. Accepted member rows behave the same way; role editing and resend invitation are unchanged.

Closes #5578

https://claude.ai/code/session_01Qitvc9dCiunLishsJYRzbp
