### PR TITLE
[5575] fix(sdk): Make the sandbox-refused error slug provider-neutral

### DIFF
--- a/sdks/python/agenta/sdk/agents/__init__.py
+++ b/sdks/python/agenta/sdk/agents/__init__.py
@@ -85,6 +85,7 @@ from .dtos import (
 from .errors import (
     AgentRunnerConfigurationError,
     LocalSandboxNotAllowedError,
+    SandboxNotAllowedError,
     ToolResolutionError,
     UnsupportedHarnessError,
 )
@@ -262,6 +263,7 @@ __all__ = [
     "Harness",
     # Errors
     "AgentRunnerConfigurationError",
+    "SandboxNotAllowedError",
     "LocalSandboxNotAllowedError",
     "UnsupportedHarnessError",
     "ToolResolutionError",

--- a/sdks/python/agenta/sdk/agents/errors.py
+++ b/sdks/python/agenta/sdk/agents/errors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from agenta.sdk.engines.running.errors import ERRORS_BASE_URL, ErrorStatus
 
@@ -11,6 +11,7 @@ from .tools.errors import ToolResolutionError
 
 __all__ = [
     "AgentRunnerConfigurationError",
+    "SandboxNotAllowedError",
     "LocalSandboxNotAllowedError",
     "UnsupportedHarnessError",
     "ToolResolutionError",
@@ -37,19 +38,25 @@ class AgentRunnerConfigurationError(RuntimeError):
     """Raised when a runner-backed adapter lacks a usable transport configuration."""
 
 
-class LocalSandboxNotAllowedError(ErrorStatus):
+class SandboxNotAllowedError(ErrorStatus):
     """A sandbox provider not in `AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS`; maps to HTTP 403."""
 
     code: int = 403
-    type: str = f"{ERRORS_BASE_URL}#v0:agent:local-sandbox-not-allowed"
+    type: str = f"{ERRORS_BASE_URL}#v0:agent:sandbox-provider-not-allowed"
 
     def __init__(
         self,
         sandbox: str = "local",
-        message: str = None,
+        message: Optional[str] = None,
     ) -> None:
         resolved = message or (
             f"sandbox '{sandbox}' is not enabled on this deployment "
             f"(add it to AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS to enable)"
         )
         super().__init__(code=self.code, type=self.type, message=resolved)
+        self.sandbox = sandbox
+
+
+# Backward-compatible alias: the class was named after the default 'local' provider even
+# though it covers every refused provider (#5575).
+LocalSandboxNotAllowedError = SandboxNotAllowedError

--- a/sdks/python/agenta/sdk/agents/handler.py
+++ b/sdks/python/agenta/sdk/agents/handler.py
@@ -33,7 +33,7 @@ from agenta.sdk.agents.connections import (
 )
 from agenta.sdk.agents.tools import ResolvedToolSet
 from agenta.sdk.agents.adapters import SandboxAgentBackend, make_harness
-from agenta.sdk.agents.errors import LocalSandboxNotAllowedError
+from agenta.sdk.agents.errors import SandboxNotAllowedError
 from agenta.sdk.agents.sandbox_providers import sandbox_provider_enabled
 from agenta.sdk.agents.mcp import ResolvedMCPServer
 from agenta.sdk.agents.platform import (
@@ -85,7 +85,7 @@ def _default_select_backend(agent_template: AgentTemplate) -> Backend:
     same `AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS` registry.
     """
     if not sandbox_provider_enabled(agent_template.sandbox):
-        raise LocalSandboxNotAllowedError(sandbox=agent_template.sandbox)
+        raise SandboxNotAllowedError(sandbox=agent_template.sandbox)
     url = os.getenv("AGENTA_RUNNER_INTERNAL_URL", "").strip() or None
     return SandboxAgentBackend(sandbox=agent_template.sandbox, url=url, cwd=os.getcwd())
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
@@ -419,14 +419,14 @@ async def test_composition_select_backend_is_deployment_specific():
 async def test_default_select_backend_refuses_local_sandbox_when_not_enabled(
     monkeypatch,
 ):
-    from agenta.sdk.agents import LocalSandboxNotAllowedError
+    from agenta.sdk.agents import SandboxNotAllowedError
     from agenta.sdk.agents.dtos import AgentTemplate
 
     monkeypatch.setenv("AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS", "daytona")
     comp = AgentComposition(resolve_connection=_no_connection)
     handler = make_agent_handler(comp)
 
-    with pytest.raises(LocalSandboxNotAllowedError):
+    with pytest.raises(SandboxNotAllowedError):
         await handler(
             request=_request(),
             messages=[{"role": "user", "content": "hi"}],

--- a/services/oss/src/agent/app.py
+++ b/services/oss/src/agent/app.py
@@ -19,8 +19,8 @@ import agenta as ag
 from agenta.sdk.agents import (
     AgentTemplate,
     Backend,
-    LocalSandboxNotAllowedError,
     SandboxAgentBackend,
+    SandboxNotAllowedError,
 )
 
 from agenta.sdk.agents.handler import (
@@ -79,7 +79,7 @@ def select_backend(agent_template: AgentTemplate) -> Backend:
     layer and the final authority.
     """
     if not sandbox_provider_enabled(agent_template.sandbox):
-        raise LocalSandboxNotAllowedError(sandbox=agent_template.sandbox)
+        raise SandboxNotAllowedError(sandbox=agent_template.sandbox)
     return SandboxAgentBackend(
         sandbox=agent_template.sandbox,
         url=runner_url(),

--- a/services/oss/tests/pytest/unit/agent/test_select_backend.py
+++ b/services/oss/tests/pytest/unit/agent/test_select_backend.py
@@ -9,8 +9,8 @@ import pytest
 from agenta.sdk.agents import (
     AgentTemplate,
     AgentRunnerConfigurationError,
-    LocalSandboxNotAllowedError,
     SandboxAgentBackend,
+    SandboxNotAllowedError,
 )
 
 from oss.src.agent.app import select_backend
@@ -81,8 +81,12 @@ def test_no_runner_url_requires_runner_assets(monkeypatch, tmp_path: Path):
 def test_local_sandbox_refused_when_not_enabled(monkeypatch):
     monkeypatch.setenv("AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS", "daytona")
 
-    with pytest.raises(LocalSandboxNotAllowedError):
+    with pytest.raises(SandboxNotAllowedError) as excinfo:
         select_backend(_sel("pi_core", "local"))
+
+    assert "'local'" in excinfo.value.message
+    assert excinfo.value.sandbox == "local"
+    assert excinfo.value.type.endswith("#v0:agent:sandbox-provider-not-allowed")
 
 
 def test_local_sandbox_allowed_by_default_when_unset(monkeypatch):
@@ -115,5 +119,12 @@ def test_daytona_sandbox_allowed_when_enabled(monkeypatch):
 def test_daytona_sandbox_refused_when_not_enabled(monkeypatch):
     monkeypatch.setenv("AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS", "local")
 
-    with pytest.raises(LocalSandboxNotAllowedError):
+    with pytest.raises(SandboxNotAllowedError) as excinfo:
         select_backend(_sel("pi_core", "daytona"))
+
+    # The envelope must not claim 'local' when another provider was refused (#5575):
+    # the message names the refused provider and the type slug is provider-neutral.
+    assert "'daytona'" in excinfo.value.message
+    assert excinfo.value.sandbox == "daytona"
+    assert excinfo.value.type.endswith("#v0:agent:sandbox-provider-not-allowed")
+    assert "local" not in excinfo.value.type


### PR DESCRIPTION
A client that branches on the error envelope's `type` slug sees `local-sandbox-not-allowed` even when daytona was the refused provider. The 403 raised when a run requests a sandbox provider outside `AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS` named the right provider in the message, but the slug was hardcoded to the local case.

**Before:** `v0:agent:local-sandbox-not-allowed` (for every refused provider)
**After:** `v0:agent:sandbox-provider-not-allowed`

The fix keeps the slug static and provider-neutral, matching the convention used by the other error slugs in the codebase. The refused provider still appears in the message and is now also stored on the exception as `.sandbox`. The class is renamed `LocalSandboxNotAllowedError` to `SandboxNotAllowedError`, with the old name kept as an exported alias so existing imports keep working.

**Wire visibility:** the `type` slug in the 403 envelope changes. A repo-wide grep found nothing matching the old slug string, so no code in the repo branches on it. The HTTP status and the message text are unchanged.

**Verification:** both unit suites pass (12 tests in the services `select_backend` suite, 14 in the SDK composition seam suite); ruff is clean.

Closes #5575

https://claude.ai/code/session_01Qitvc9dCiunLishsJYRzbp
