### PR TITLE
fix(services): resume a run when its approval is answered outside the playground (#5593)

### DIFF
--- a/api/oss/src/core/sessions/interactions/dtos.py
+++ b/api/oss/src/core/sessions/interactions/dtos.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from oss.src.core.shared.dtos import Identifier, Lifecycle, Reference, Selector
 
@@ -21,8 +21,25 @@ class SessionInteractionStatus(str, Enum):
     cancelled = "cancelled"  # runner abandoned the gate; no one is waiting on the token
 
 
+class SessionInteractionRequest(BaseModel):
+    # The gated call this interaction is asking about.
+    #
+    # `tool_call_id` is the harness's id for the call, which the row's `token` is NOT (that is the
+    # permission gate's id). Both ride the live event stream, so the playground can answer without
+    # it; a caller building an answer from the stored row alone cannot, and names the wrong call.
+    # Optional because rows written before the field exists carry only the token.
+    #
+    # Extra keys are kept: producers other than the approval gate write their own request shapes
+    # here, and dropping what this model does not name would lose them on any round-trip.
+    model_config = ConfigDict(extra="allow")
+
+    tool: Optional[str] = None
+    args: Optional[Any] = None
+    tool_call_id: Optional[str] = None
+
+
 class SessionInteractionData(BaseModel):
-    request: Optional[Dict[str, Any]] = None
+    request: Optional[SessionInteractionRequest] = None
     references: Optional[Dict[str, Reference]] = None
     selector: Optional[Selector] = None
     resolution: Optional[Dict[str, Any]] = None

--- a/api/oss/tests/pytest/unit/sessions/test_interaction_request_tool_call_id.py
+++ b/api/oss/tests/pytest/unit/sessions/test_interaction_request_tool_call_id.py
@@ -1,0 +1,72 @@
+"""The durable interaction row must carry the harness's tool-call id.
+
+A row's ``token`` is the permission gate's id, not the id of the call the agent parked on. Both
+ride the live event stream, which is why the playground can answer a gate correctly; a caller
+working from the stored row alone (an inbox, a webhook, a CLI) has only the row, so the tool-call
+id has to be stored on it. See issue #5593.
+"""
+
+from uuid import uuid4
+
+from oss.src.core.sessions.interactions.dtos import (
+    SessionInteractionCreate,
+    SessionInteractionData,
+    SessionInteractionKind,
+    SessionInteractionRequest,
+)
+from oss.src.dbs.postgres.sessions.interactions.mappings import (
+    map_interaction_dto_to_dbe_create,
+)
+
+
+def test_create_persists_the_tool_call_id_alongside_the_gate_token():
+    project_id = uuid4()
+    dbe = map_interaction_dto_to_dbe_create(
+        project_id=project_id,
+        user_id=None,
+        interaction=SessionInteractionCreate(
+            project_id=project_id,
+            session_id="sess-1",
+            turn_id="turn-1",
+            token="gate-token",
+            kind=SessionInteractionKind.user_approval,
+            data=SessionInteractionData(
+                request=SessionInteractionRequest(
+                    tool="Write",
+                    args={"file_path": "/tmp/x"},
+                    tool_call_id="toolu_01abc",
+                )
+            ),
+        ),
+    )
+
+    assert dbe.token == "gate-token"
+    assert dbe.data["request"] == {
+        "tool": "Write",
+        "args": {"file_path": "/tmp/x"},
+        "tool_call_id": "toolu_01abc",
+    }
+
+
+def test_a_row_written_before_the_field_existed_still_parses():
+    # Rows already in the table carry only tool + args. They must keep loading, and must not
+    # invent a tool-call id.
+    data = SessionInteractionData.model_validate(
+        {"request": {"tool": "Terminal", "args": {"command": "ls"}}}
+    )
+
+    assert data.request is not None
+    assert data.request.tool == "Terminal"
+    assert data.request.tool_call_id is None
+
+
+def test_unknown_request_keys_survive_the_round_trip():
+    # Other producers write their own request shapes here; naming three fields must not drop
+    # everything else on a load-then-store cycle.
+    data = SessionInteractionData.model_validate(
+        {"request": {"tool": "test_run", "args": {}, "custom": {"a": 1}}}
+    )
+
+    assert data.model_dump(mode="json", exclude_none=True)["request"]["custom"] == {
+        "a": 1
+    }

--- a/api/oss/tests/pytest/unit/sessions/test_wp5_dao_fanout.py
+++ b/api/oss/tests/pytest/unit/sessions/test_wp5_dao_fanout.py
@@ -25,6 +25,7 @@ from oss.src.core.sessions.interactions.dtos import (
     SessionInteractionData,
     SessionInteractionKind,
     SessionInteractionQuery,
+    SessionInteractionRequest,
     SessionInteractionStatus,
     SessionInteractionTransition,
 )
@@ -182,7 +183,7 @@ async def test_interaction_transition_preserves_data_and_optionally_adds_resolut
     assert transitioned is not None
     assert transitioned.status == SessionInteractionStatus.resolved
     assert transitioned.data is not None
-    assert transitioned.data.request == request
+    assert transitioned.data.request == SessionInteractionRequest(**request)
     assert transitioned.data.resolution == {
         "verdict": "approved",
         "tool_call_id": "tool-1",
@@ -210,7 +211,9 @@ async def test_interaction_transition_preserves_data_and_optionally_adds_resolut
 
     assert transitioned_without_resolution is not None
     assert transitioned_without_resolution.data is not None
-    assert transitioned_without_resolution.data.request == request
+    assert transitioned_without_resolution.data.request == SessionInteractionRequest(
+        **request
+    )
     assert transitioned_without_resolution.data.resolution is None
 
 

--- a/services/runner/src/engines/sandbox_agent/acp-interactions.ts
+++ b/services/runner/src/engines/sandbox_agent/acp-interactions.ts
@@ -63,12 +63,18 @@ export interface AttachPermissionResponderInput {
    * the cold path can multiplex that mixed set. An approval gate does NOT fire it.
    */
   onNonParkablePause?: () => void;
-  /** Called on pause to record the pending gate as an interaction (fire-and-forget). */
+  /**
+   * Called on pause to record the pending gate as an interaction (fire-and-forget). `toolCallId`
+   * is the harness's id for the gated call, which is NOT the interaction token (that is the
+   * permission gate's id). Both ride the live `interaction_request` event; persisting the tool-call
+   * id too is what lets a caller working from the durable row alone name the right call.
+   */
   onCreateInteraction?: (
     token: string,
     toolName: string | undefined,
     toolArgs: unknown,
     kind: "user_approval" | "client_tool",
+    toolCallId: string | undefined,
   ) => void;
   /** Called after a stored decision was successfully forwarded to the harness. */
   onResolveInteraction?: (
@@ -195,7 +201,13 @@ export function attachPermissionResponder({
       },
     });
     createdInteractionIds.add(eventId);
-    onCreateInteraction?.(eventId, gate.toolName, gate.args, "user_approval");
+    onCreateInteraction?.(
+      eventId,
+      gate.toolName,
+      gate.args,
+      "user_approval",
+      toolCallId,
+    );
     onPause?.();
   };
 
@@ -224,7 +236,13 @@ export function attachPermissionResponder({
       },
     });
     createdInteractionIds.add(eventId);
-    onCreateInteraction?.(eventId, gate.toolName, gate.args, "client_tool");
+    onCreateInteraction?.(
+      eventId,
+      gate.toolName,
+      gate.args,
+      "client_tool",
+      toolCallId,
+    );
     onPause?.();
   };
 

--- a/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
+++ b/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
@@ -8,7 +8,8 @@
  *
  * When it DOES apply it is no longer best-effort, because the client kept no copy of the
  * conversation: an unreadable log, or one known to have dropped a record, fails the turn rather
- * than letting the agent answer as though the conversation had just started.
+ * than letting the agent answer as though the conversation had just started. For an approval
+ * reply, which carries no task of its own, "nothing to rebuild" is itself such a failure.
  *
  * The record log already contains the CURRENT turn by the time this runs: the runner persists the
  * inbound user message before it starts the engine, and acquiring a sandbox takes seconds. Its
@@ -20,7 +21,10 @@ import type { AgentRunRequest } from "../../protocol.ts";
 import { fetchSessionRecords } from "../../sessions/records-query.ts";
 import { recordsIncomplete } from "../../sessions/persist.ts";
 import { reconstructMessages } from "../../sessions/reconstruct.ts";
-import { carriesMinimalHistory } from "./session-identity.ts";
+import {
+  carriesApprovalReplyOnly,
+  carriesMinimalHistory,
+} from "./session-identity.ts";
 
 // ON unless the literal "false"; absent AND empty both mean on (compose passes `${VAR:-}`,
 // which sets an empty string when the shell has no value).
@@ -40,10 +44,35 @@ export async function reconstructHistoryIfNeeded(
   auth: () => string,
   log?: (msg: string) => void,
 ): Promise<AgentRunRequest | null> {
-  if (!reconstructEnabled() || !sessionId) return null;
   const inbound = request.messages ?? [];
-  // The client still asserts the conversation itself — nothing to rebuild.
-  if (!carriesMinimalHistory(request)) return null;
+  // An approval reply carries no task of its own, only the answered gate. Returning null for it
+  // is not "keep the inbound history", it is "run with no conversation at all": `buildRunPlan`
+  // spares this shape the empty-prompt check, so the turn would go out as the approval-resume
+  // frame alone — no task, no context — and report success. A prior turn exists by construction
+  // for an approval reply, so every no-history path below is an anomaly for this shape and fails
+  // the turn instead. On a live resume `runTurn` catches this and continues on the inbound
+  // request, because the harness there still holds the conversation.
+  const approvalReplyOnly = carriesApprovalReplyOnly(request);
+  const refuse = (why: string): never => {
+    throw new Error(
+      `session ${sessionId ?? "(none)"}: cannot resume an approval reply with ` +
+        `no conversation to rebuild (${why})`,
+    );
+  };
+
+  if (!reconstructEnabled() || !sessionId) {
+    if (approvalReplyOnly) {
+      refuse(!sessionId ? "no session id" : "reconstruction is disabled");
+    }
+    return null;
+  }
+  // The client still asserts the conversation itself — nothing to rebuild. Two shapes assert
+  // nothing: a last-message-only client (a fresh user turn alone) and an out-of-band approval
+  // reply built from the durable interaction row (an approval envelope alone). Both need the
+  // prior turns rebuilt here or the agent answers as though the conversation had just started.
+  if (!carriesMinimalHistory(request) && !approvalReplyOnly) {
+    return null;
+  }
 
   // The client kept no copy of the conversation, so there is no history to fall back to. Answering
   // anyway would silently produce an agent that forgot everything, which reads as a correct reply.
@@ -66,10 +95,24 @@ export async function reconstructHistoryIfNeeded(
   const prior = currentTurnId
     ? records.filter((row) => row.turn_id !== currentTurnId)
     : records;
-  if (prior.length === 0) return null;
+  // Reachable in practice: a caller that builds its answer from the durable interaction row can
+  // echo the row's stored `turn_id`, which drops exactly the turn that parked.
+  if (prior.length === 0) {
+    if (approvalReplyOnly) {
+      refuse(
+        `the log holds no turn other than ${currentTurnId ?? "the current one"}`,
+      );
+    }
+    return null;
+  }
 
   const reconstructed = reconstructMessages(prior);
-  if (reconstructed.length === 0) return null;
+  if (reconstructed.length === 0) {
+    if (approvalReplyOnly) {
+      refuse(`${prior.length} prior record(s) rebuilt into no messages`);
+    }
+    return null;
+  }
 
   log?.(
     `[reconstruct] session=${sessionId} records=${records.length} ` +

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -28,6 +28,7 @@ import {
 } from "../skills.ts";
 import { assert } from "./capabilities.ts";
 import type { ClientToolPauseDisposition } from "./client-tools.ts";
+import { carriesApprovalReplyOnly } from "./session-identity.ts";
 import { buildTurnText } from "./transcript.ts";
 import {
   KNOWN_SANDBOX_PROVIDER_IDS,
@@ -311,7 +312,12 @@ export function buildRunPlan(
   );
 
   const prompt = resolvePromptText(request);
-  if (!prompt) {
+  // An out-of-band approval reply legitimately carries no user text: the human answered a parked
+  // gate from the durable interaction row, not from the conversation. Its prior turns are rebuilt
+  // from the record log inside `runTurn` (`reconstructHistoryIfNeeded`), which runs AFTER this
+  // plan is built — so rejecting here would kill the run before the conversation could be
+  // supplied. Every other empty-prompt request is still a caller bug and fails loudly.
+  if (!prompt && !carriesApprovalReplyOnly(request)) {
     return {
       ok: false,
       error: "No user message to send (prompt/messages empty).",

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -77,6 +77,7 @@ import {
   sessionContinuityStore,
 } from "./session-continuity.ts";
 import { reconstructHistoryIfNeeded } from "./reconstruct-history.ts";
+import { carriesApprovalReplyOnly } from "./session-identity.ts";
 import { buildTurnText, priorMessages } from "./transcript.ts";
 import { resolveRunUsage } from "./usage.ts";
 
@@ -155,20 +156,45 @@ export async function runTurn(
     // record log so a cold turn still has full context. Runs before the current user turn is
     // persisted, so records hold only prior turns. Reassigns `request` so every downstream
     // reader (turnText, priorMessages, responder, otel) sees the same reconstructed history.
-    const reconstructed = await reconstructHistoryIfNeeded(
-      request,
-      sessionId,
-      () => runCredential(request),
-      logger,
-    );
+    // An out-of-band approval reply carries no user text of its own, so this must be decided from
+    // the INBOUND request: reconstruction prepends the original user turn, after which
+    // `resolvePromptText` would hand back that stale command and the model would restart the task.
+    const approvalReplyOnly = carriesApprovalReplyOnly(request);
+    const inboundRequest = request;
+    // On a LIVE approval resume the rebuilt history is never sent to the harness: the resume
+    // continues the ORIGINAL prompt promise (`opts.resume` below), so `turnText` is discarded and
+    // the harness already holds the conversation. Reconstruction there only enriches the trace and
+    // the responder's view, so a failed records fetch must NOT fail the turn: `{ok:false}` makes
+    // the dispatch evict the live session and retry cold, where reconstruction throws again — one
+    // 500 from the records endpoint would lose the human's approval AND the parked session. Keep
+    // the inbound request and continue. A cold turn still fails loudly, where it matters.
+    let reconstructed: AgentRunRequest | null = null;
+    try {
+      reconstructed = await reconstructHistoryIfNeeded(
+        request,
+        sessionId,
+        () => runCredential(request),
+        logger,
+      );
+    } catch (err) {
+      if (!opts.resume) throw err;
+      const detail = err instanceof Error ? err.message : String(err);
+      logger(
+        `[reconstruct] live resume: keeping the inbound history (${detail})`,
+      );
+    }
     if (reconstructed) request = reconstructed;
 
     const promptText = resolvePromptText(request);
     // Cold: replay the full transcript. Continuation or loaded: send only new text. When history
     // was rebuilt from records, recompute the transcript from it — the prebuilt plan.turnText
-    // predates the reconstruction.
+    // predates the reconstruction. An approval reply has no new text either way, so it sends the
+    // approval-resume frame `buildTurnText` renders (the harness already holds the prior turns
+    // when the session was loaded natively; otherwise the rebuilt transcript comes with it).
     const turnText = sendLastMessageOnly(opts)
-      ? promptText
+      ? approvalReplyOnly
+        ? buildTurnText(inboundRequest, logger)
+        : promptText
       : reconstructed
         ? buildTurnText(request, logger)
         : plan.turnText;
@@ -458,6 +484,7 @@ export async function runTurn(
       toolName: string | undefined,
       toolArgs: unknown,
       kind: "user_approval" | "client_tool" = "user_approval",
+      toolCallId?: string,
     ): void => {
       const cred = runCredential(request);
       if (!cred) return;
@@ -468,7 +495,16 @@ export async function runTurn(
         request.turnId ?? "",
         token,
         kind,
-        { request: { tool: toolName ?? token, args: toolArgs }, references },
+        {
+          request: {
+            tool: toolName ?? token,
+            args: toolArgs,
+            // The gate id (`token`) and the harness's tool-call id differ; an out-of-band answer
+            // needs the latter to name the call it is answering.
+            ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+          },
+          references,
+        },
         () => cred,
       );
     };

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -5,6 +5,7 @@ import {
   type ChatMessage,
   type ContentBlock,
   messageText,
+  resolvePromptText,
 } from "../../protocol.ts";
 import { approvalDecisionOf } from "../../responder.ts";
 import type { TeardownReason } from "./teardown.ts";
@@ -302,6 +303,37 @@ export function approvalDecisionForToolCall(
 export function carriesMinimalHistory(request: AgentRunRequest): boolean {
   const messages = request.messages ?? [];
   return messages.length === 1 && tailIsFreshUserMessage(request);
+}
+
+/**
+ * True when the request is an OUT-OF-BAND approval reply: it carries an approval envelope and no
+ * prompt text. That is what a caller answering from the durable interaction row alone sends
+ * (an inbox, a webhook, a CLI) — the parked tool call plus its `{approved}` result, nothing else.
+ *
+ * "No prompt text" means exactly what `resolvePromptText` reads and nothing more: `text` blocks on
+ * a `role: "user"` message. Text carried any other way (a non-`text` block type, another role)
+ * does not disqualify a request here — deliberately, because this predicate decides whether the
+ * run has a prompt to SEND, and `resolvePromptText` is what produces that prompt. The two must
+ * agree; a stricter check here would classify a request as having a prompt the run then omits.
+ *
+ * Such a request is the mirror image of `carriesMinimalHistory`: it asserts no conversation, so
+ * the prior turns come from the durable record log and there is no history for the keep-alive
+ * check to compare. It also has no prompt to send, which is why `buildRunPlan` must not reject it
+ * for having none. A playground approval reply carries the full transcript (its user turns
+ * included) and is therefore NOT this shape.
+ */
+export function carriesApprovalReplyOnly(request: AgentRunRequest): boolean {
+  if (resolvePromptText(request)) return false;
+  for (const message of request.messages ?? []) {
+    const content = message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type === "tool_result" && approvalDecisionOf(block) !== undefined) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -49,6 +49,7 @@ import {
   computeCredentialEpoch,
   configFingerprint,
   credentialEpochMismatch,
+  carriesApprovalReplyOnly,
   carriesMinimalHistory,
   installedMountLease,
   leaseExpiresBy,
@@ -733,7 +734,8 @@ export async function runWithKeepalive(
     // park would evict a perfectly good live session on every approval (the "approve twice" bug).
     //
     // We keep the checks that DO bound the parked environment: the approval-decision match, the
-    // history fingerprint (an edited transcript must not continue wrongly), and a hard mount-expiry
+    // history fingerprint (an edited transcript must not continue wrongly, but only for a client
+    // that asserts a transcript at all — see `clientAssertsHistory` below), and a hard mount-expiry
     // bound — if the parked session's mount credentials are past expiry, its durable cwd can no
     // longer be written, so evict to cold.
     // Split parallel parked gates by tool-call id. Any non-empty answer set resumes live; untouched
@@ -773,8 +775,16 @@ export async function runWithKeepalive(
       }
     }
     const priorFp = historyFingerprint(priorConversation(request));
+    // An out-of-band answer (an inbox, a webhook, a CLI) builds its reply from the durable
+    // interaction row and carries no conversation at all, so its prior fingerprint can never equal
+    // the parked one and comparing it would evict the very session that could resume — the
+    // idle branch's `clientAssertsHistory` escape hatch, which this branch lacked. It cannot reuse
+    // `carriesMinimalHistory`: that helper wants a fresh user tail, and an approval reply is never
+    // one. The parked gate's tool-call id, matched above, is what binds this answer to this
+    // session; the history check only guards a client that DID assert a transcript.
+    const clientAssertsHistory = !carriesApprovalReplyOnly(request);
     if (!mismatch) {
-      if (priorFp !== existing.historyFingerprint) {
+      if (clientAssertsHistory && priorFp !== existing.historyFingerprint) {
         mismatch = "history";
       } else if (mountCredentialsExpired(existing.credentialEpoch)) {
         mismatch = "credentials-expired";

--- a/services/runner/src/sessions/interactions.ts
+++ b/services/runner/src/sessions/interactions.ts
@@ -16,8 +16,23 @@ export type InteractionResolution = {
 /** A platform entity reference (the API `Reference` shape). */
 type Reference = { id?: string; slug?: string; version?: string };
 
+/**
+ * The gated call a durable interaction row describes.
+ *
+ * `tool_call_id` is the HARNESS's id for the call, which the interaction `token` is not — the
+ * token is the permission gate's id. The live `interaction_request` event carries both, which is
+ * why the playground can answer correctly; a caller working from the stored row alone needs the
+ * tool-call id here or it names the wrong call. Optional: rows written before this field exist
+ * carry only the token, and every reader must tolerate that.
+ */
+export type InteractionRequest = {
+  tool: string;
+  args: unknown;
+  tool_call_id?: string;
+};
+
 export type InteractionData = {
-  request?: { tool: string; args: unknown };
+  request?: InteractionRequest;
   // Optional attribution for out-of-band re-invocation; inbox/audit rows exist without it.
   references?: Record<string, Reference>;
 };

--- a/services/runner/tests/unit/reconstruct-resume-nonfatal.test.ts
+++ b/services/runner/tests/unit/reconstruct-resume-nonfatal.test.ts
@@ -1,0 +1,247 @@
+/**
+ * A failed history reconstruction must not destroy a live approval resume.
+ *
+ * `carriesApprovalReplyOnly` makes `reconstructHistoryIfNeeded` run on the LIVE resume too, but the
+ * resume never sends the rebuilt history: it continues the ORIGINAL prompt promise, so `turnText`
+ * is discarded. If reconstruction threw there, `runTurn` returned `{ok:false}`, the dispatch
+ * evicted the live session and retried cold, and reconstruction threw again — one 500 from the
+ * records endpoint lost the human's approval AND the parked session. The resume path now keeps the
+ * inbound request and continues; the COLD path still fails loudly, which is where it matters.
+ *
+ * Run: pnpm exec vitest run tests/unit/reconstruct-resume-nonfatal.test.ts
+ */
+import { describe, it, beforeEach, vi } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentEvent, AgentRunRequest } from "../../src/protocol.ts";
+import {
+  acquireEnvironment,
+  runTurn,
+  type SandboxAgentDeps,
+} from "../../src/engines/sandbox_agent.ts";
+import { noteRecordsIncomplete } from "../../src/sessions/persist.ts";
+
+const SESSION_ID = "sess-resume-nonfatal";
+
+/** The out-of-band approval reply: the parked call plus its `{approved}` envelope, no user text. */
+const approvalReply: AgentRunRequest = {
+  harness: "claude",
+  model: "m1",
+  sessionId: SESSION_ID,
+  telemetry: {
+    exporters: { otlp: { headers: { authorization: "ApiKey run" } } },
+  } as never,
+  messages: [
+    {
+      role: "assistant",
+      content: [
+        { type: "tool_call", toolCallId: "tc-gate", toolName: "commit" },
+        {
+          type: "tool_result",
+          toolCallId: "tc-gate",
+          toolName: "commit",
+          output: { approved: true, interactionToken: "tc-gate" },
+        },
+      ],
+    },
+  ],
+};
+
+function fakeHarness() {
+  const calls = {
+    logs: [] as string[],
+    permissionReplies: [] as Array<{ id: string; reply: string }>,
+    promptCount: 0,
+  };
+
+  const session = {
+    id: "session-1",
+    onEvent(_handler: (event: unknown) => void) {},
+    onPermissionRequest(_handler: (request: unknown) => void) {},
+    async respondPermission(id: string, reply: string) {
+      calls.permissionReplies.push({ id, reply });
+    },
+    async prompt(_blocks: unknown) {
+      calls.promptCount += 1;
+      return {
+        stopReason: "complete",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    },
+  };
+
+  const sandbox = {
+    async createSession(_opts: unknown) {
+      return session;
+    },
+    async destroySession(_id: string) {},
+    async destroySandbox() {},
+    async dispose() {},
+  };
+
+  const makeRun = (): Record<string, unknown> => {
+    const emitted: AgentEvent[] = [];
+    return {
+      start() {},
+      handleUpdate() {},
+      emitEvent(event: AgentEvent) {
+        emitted.push(event);
+      },
+      usage() {
+        return { input: 0, output: 0, total: 0, cost: 0 };
+      },
+      setUsage() {},
+      finish() {
+        return "assistant output";
+      },
+      recordError() {},
+      output() {
+        return "assistant output";
+      },
+      async flush() {},
+      events() {
+        return emitted;
+      },
+      settleOpenToolCalls() {},
+      openToolCallIds() {
+        return [];
+      },
+      markToolCallDenied() {},
+      traceId() {
+        return "0123456789abcdef0123456789abcdef";
+      },
+    };
+  };
+
+  const deps: SandboxAgentDeps = {
+    log: (message) => calls.logs.push(message),
+    createLocalCwd: (durable?: string) => durable ?? "/tmp/agenta-fake-cwd",
+    createDaytonaCwd: (durable?: string) =>
+      durable ?? "/home/sandbox/agenta-fake-cwd",
+    resolveSkillDirs: () => ({ skills: [], cleanup: () => {} }),
+    buildDaemonEnv: () => ({}),
+    resolveDaemonBinary: () => "/bin/sandbox-agent",
+    buildSandboxProvider: () => ({ provider: true }) as never,
+    createPersist: () => ({}) as never,
+    startSandboxAgent: (async () => sandbox) as never,
+    prepareWorkspace: (async () => ({ cleanup: async () => {} })) as never,
+    probeCapabilities: async () =>
+      ({
+        source: "probed",
+        capabilities: {
+          mcpTools: true,
+          toolCalls: true,
+          usage: true,
+          streamingDeltas: true,
+        },
+      }) as never,
+    applyModel: async (_session, model) => model ?? "resolved-model",
+    createOtel: (() => makeRun()) as never,
+    startToolRelay: (() => ({ stop: async () => {} })) as never,
+    localRelayHost: (() => "local-relay-host") as never,
+    sandboxRelayHost: (() => "sandbox-relay-host") as never,
+    responderFactory: () => ({
+      async onPermission() {
+        return { kind: "allow" } as const;
+      },
+      async onClientTool() {
+        return { kind: "deny" } as const;
+      },
+    }),
+    hydrateHarnessSessionFromDurable: async () => {},
+    appendSessionTurn: Object.assign(async () => {}, {
+      complete: async () => {},
+    }) as never,
+  };
+
+  return { calls, deps };
+}
+
+describe("runTurn: a broken record log does not kill a live approval resume", () => {
+  beforeEach(() => {
+    // The turn's side-channel writes (session ownership, interaction resolve) are fire-and-forget;
+    // answer them locally so the suite never reaches for the network.
+    vi.stubGlobal("fetch", async () => new Response("{}", { status: 200 }));
+    // The hermetic setup pins reconstruction off for the engine suites; this file needs it on.
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    // Mark the log broken so reconstruction throws before it even queries (the same failure a
+    // 500 from the records endpoint produces, without a network stub).
+    noteRecordsIncomplete(SESSION_ID);
+  });
+
+  it("keeps the inbound request and completes the turn when reconstruction throws on a resume", async () => {
+    const { calls, deps } = fakeHarness();
+    const acquired = await acquireEnvironment(approvalReply, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+
+    const result = await runTurn(
+      acquired.env,
+      approvalReply,
+      undefined,
+      undefined,
+      {
+        approvalParkMode: true,
+        resume: {
+          decisions: [
+            {
+              permissionId: "perm-1",
+              reply: "once",
+              toolCallId: "tc-gate",
+              toolName: "commit",
+              args: { message: "hi" },
+              interactionToken: "tc-gate",
+              promptPromise: Promise.resolve({
+                stopReason: "complete",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              }),
+            },
+          ],
+          carriedForward: [],
+        },
+      },
+    );
+
+    assert.equal(
+      result.ok,
+      true,
+      "a records failure must not fail the turn that answers a parked gate",
+    );
+    assert.deepEqual(
+      calls.permissionReplies,
+      [{ id: "perm-1", reply: "once" }],
+      "the parked gate was still answered on the live session",
+    );
+    assert.ok(
+      calls.logs.some((line) => line.includes("[reconstruct] live resume")),
+      "the skipped reconstruction is logged exactly once, not swallowed",
+    );
+
+    await acquired.env.destroy();
+  });
+
+  it("still fails the turn loudly when reconstruction throws on a COLD turn", async () => {
+    const { deps } = fakeHarness();
+    const acquired = await acquireEnvironment(approvalReply, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+
+    // No `resume`: nothing holds this conversation, so answering from an unreadable log would
+    // let the agent reply as though the task had just started.
+    const result = await runTurn(
+      acquired.env,
+      approvalReply,
+      undefined,
+      undefined,
+      {
+        approvalParkMode: true,
+      },
+    );
+
+    assert.equal(result.ok, false, "a cold turn with no history must fail");
+    if (result.ok) return;
+    assert.match(String(result.error), /incomplete conversation/);
+
+    await acquired.env.destroy();
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-acp-interactions.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-acp-interactions.test.ts
@@ -197,6 +197,7 @@ describe("attachPermissionResponder", () => {
       toolName?: string;
       args: unknown;
       kind: string;
+      toolCallId?: string;
     }> = [];
     const pausedToolCalls: string[] = [];
     let pauses = 0;
@@ -208,8 +209,8 @@ describe("attachPermissionResponder", () => {
       onPause: () => {
         pauses += 1;
       },
-      onCreateInteraction: (token, toolName, args, kind) => {
-        created.push({ token, toolName, args, kind });
+      onCreateInteraction: (token, toolName, args, kind, toolCallId) => {
+        created.push({ token, toolName, args, kind, toolCallId });
       },
       onPausedToolCall: (id) => {
         pausedToolCalls.push(id);
@@ -226,12 +227,16 @@ describe("attachPermissionResponder", () => {
     assert.deepEqual(replies, []);
     assert.equal(pauses, 1);
     assert.deepEqual(pausedToolCalls, ["tool-9"]);
+    // The interaction token is the permission GATE's id; `toolCallId` is the harness's id for
+    // the gated call. Both are recorded so an answer built from the durable row alone can name
+    // the right call (issue #5593).
     assert.deepEqual(created, [
       {
         token: "perm-pause",
         toolName: "edit",
         args: { path: "a" },
         kind: "user_approval",
+        toolCallId: "tool-9",
       },
     ]);
     assert.deepEqual(events, [
@@ -357,6 +362,7 @@ describe("attachPermissionResponder", () => {
       toolName?: string;
       args: unknown;
       kind: string;
+      toolCallId?: string;
     }> = [];
     let pauses = 0;
 
@@ -368,8 +374,8 @@ describe("attachPermissionResponder", () => {
       onPause: () => {
         pauses += 1;
       },
-      onCreateInteraction: (token, toolName, args, kind) => {
-        created.push({ token, toolName, args, kind });
+      onCreateInteraction: (token, toolName, args, kind, toolCallId) => {
+        created.push({ token, toolName, args, kind, toolCallId });
       },
       onPausedToolCall: (id) => {
         pausedToolCalls.push(id);
@@ -397,6 +403,7 @@ describe("attachPermissionResponder", () => {
         toolName: "request_connection",
         args: { integration: "slack" },
         kind: "client_tool",
+        toolCallId: "tool-client",
       },
     ]);
     assert.deepEqual(events, [

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -55,6 +55,62 @@ describe("buildRunPlan", () => {
     assert.equal(created, false);
   });
 
+  it("still refuses a request whose only message is an unresolved tool call", () => {
+    // No user text AND no approval envelope: a caller bug, not an approval reply.
+    const result = buildRunPlan(
+      {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "tool_call", toolCallId: "tc-1", toolName: "Write" },
+            ],
+          },
+        ],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/unused" },
+    );
+
+    assert.deepEqual(result, {
+      ok: false,
+      error: "No user message to send (prompt/messages empty).",
+    });
+  });
+
+  it("accepts an out-of-band approval reply that carries no user text", () => {
+    // What a caller answering from the durable interaction row sends: the parked call plus its
+    // {approved} envelope, and nothing else. The conversation is rebuilt from the record log
+    // inside runTurn, which happens after this plan is built.
+    const result = buildRunPlan(
+      {
+        harness: "claude",
+        sessionId: "s1",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "tool_call", toolCallId: "tc-1", toolName: "Write" },
+              {
+                type: "tool_result",
+                toolCallId: "tc-1",
+                toolName: "Write",
+                output: { approved: true, interactionToken: "tok-1" },
+              },
+            ],
+          },
+        ],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.plan.prompt, "");
+    assert.ok(
+      result.ok && result.plan.turnText.includes("user APPROVED Write"),
+      "the plan's turn text carries the approval-resume frame",
+    );
+  });
+
   it("normalizes an Agenta/Pi local run and filters executable tools", () => {
     process.env.PI_CODING_AGENT_DIR = "/tmp/pi-agent";
     const logs: string[] = [];

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -889,6 +889,67 @@ describe("runWithKeepalive: approval resume validation degrades to cold", () => 
     assert.equal(calls.acquire, 2);
     assert.equal(calls.resumes.length, 0);
   });
+
+  it("an out-of-band answer carrying NO history resumes live instead of evicting", async () => {
+    // What an inbox / webhook / CLI sends: the parked call and its {approved} envelope, built
+    // from the durable interaction row, with no conversation attached. Its prior-history
+    // fingerprint can never equal the parked session's, so comparing it would evict the only
+    // session that could resume — issue #5593's "approval-mismatch (history)".
+    const outOfBand: AgentRunRequest = {
+      harness: "claude",
+      model: "m1",
+      sessionId: "s1",
+      ...auth,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "tc-gate", toolName: "commit" },
+            {
+              type: "tool_result",
+              toolCallId: "tc-gate",
+              toolName: "commit",
+              output: { approved: true, interactionToken: "tok-1" },
+            },
+          ],
+        },
+      ],
+    };
+    const { calls, env1 } = await parkThenResume(outOfBand);
+    assert.equal(env1.destroyed, 0, "the parked session was NOT evicted");
+    assert.equal(calls.acquire, 1, "no cold re-acquire");
+    assert.equal(calls.resumes.length, 1, "the gate was answered live");
+    assert.equal(calls.resumes[0].reply, "once");
+    assert.equal(calls.resumes[0].permissionId, "perm-1");
+  });
+
+  it("an out-of-band DENY carrying no history also resumes live", async () => {
+    const outOfBand: AgentRunRequest = {
+      harness: "claude",
+      model: "m1",
+      sessionId: "s1",
+      ...auth,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "tc-gate", toolName: "commit" },
+            {
+              type: "tool_result",
+              toolCallId: "tc-gate",
+              toolName: "commit",
+              output: { approved: false, interactionToken: "tok-1" },
+            },
+          ],
+        },
+      ],
+    };
+    const { calls, env1 } = await parkThenResume(outOfBand);
+    assert.equal(env1.destroyed, 0);
+    assert.equal(calls.acquire, 1);
+    assert.equal(calls.resumes.length, 1);
+    assert.equal(calls.resumes[0].reply, "reject");
+  });
 });
 
 describe("runWithKeepalive: approval resume ignores re-minted credentials/config", () => {
@@ -1714,6 +1775,14 @@ describe("runTurn: real approval park + respondPermission resume", () => {
       assert.equal(createCall.body["turn_id"], "turn-no-workflow-start");
       const createData = createCall.body["data"] as Record<string, unknown>;
       assert.equal("references" in createData, false);
+      // The row's `token` is the permission gate's id; `tool_call_id` is the harness's id for the
+      // gated call. An answer built from this row alone needs the latter (issue #5593).
+      assert.equal(createCall.body["token"], "perm-no-workflow");
+      assert.deepEqual(createData["request"], {
+        tool: "commit",
+        args: { message: "hi" },
+        tool_call_id: "tc-no-workflow",
+      });
 
       const parked = env.parkedApprovals.get("tc-no-workflow");
       assert.ok(parked);

--- a/services/runner/tests/unit/session-reconstruct-history.test.ts
+++ b/services/runner/tests/unit/session-reconstruct-history.test.ts
@@ -25,6 +25,19 @@ const { noteRecordsIncomplete } = await import("../../src/sessions/persist.ts");
 
 const auth = () => "Secret t";
 const userTurn = { role: "user", content: "hi again" };
+/** An out-of-band approval reply: the parked call plus its `{approved}` envelope, no user text. */
+const approvalReplyMessage = {
+  role: "assistant",
+  content: [
+    { type: "tool_call", toolCallId: "toolu_1", toolName: "Write" },
+    {
+      type: "tool_result",
+      toolCallId: "toolu_1",
+      toolName: "Write",
+      output: { approved: true, interactionToken: "tok-1" },
+    },
+  ],
+};
 
 beforeEach(() => {
   fetchCalls = 0;
@@ -164,6 +177,126 @@ describe("reconstructHistoryIfNeeded", () => {
       { role: "assistant", content: "a1" },
       userTurn,
     ]);
+  });
+
+  it("rebuilds the conversation for an out-of-band approval reply (no user text at all)", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    // A caller answering from the durable interaction row sends only the parked call and its
+    // {approved} envelope. It asserts no conversation, so the prior turns must come from the log
+    // or the agent answers as though the task had just started.
+    recordsToReturn = [
+      {
+        turn_id: "turn-1",
+        record_source: "user",
+        attributes: { type: "message", text: "write a test file" },
+      },
+      {
+        turn_id: "turn-1",
+        record_source: "agent",
+        attributes: {
+          type: "tool_call",
+          id: "toolu_1",
+          name: "Write",
+          input: { file_path: "/x" },
+        },
+      },
+    ];
+    const approvalReply = {
+      role: "assistant",
+      content: [
+        { type: "tool_call", toolCallId: "toolu_1", toolName: "Write" },
+        {
+          type: "tool_result",
+          toolCallId: "toolu_1",
+          toolName: "Write",
+          output: { approved: true, interactionToken: "tok-1" },
+        },
+      ],
+    };
+    const req = { messages: [approvalReply], turnId: "turn-2" } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.ok(out);
+    assert.equal(out!.messages!.length, 3);
+    assert.deepEqual(out!.messages![0], {
+      role: "user",
+      content: "write a test file",
+    });
+    assert.deepEqual(out!.messages![2], approvalReply);
+  });
+
+  it("no-op for a tool result that is not an approval envelope", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    const req = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_result", toolCallId: "toolu_1", output: "plain" },
+          ],
+        },
+      ],
+    } as never;
+    const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
+    assert.equal(out, null);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("refuses an approval reply whose prior turns were all dropped as the current turn", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    // Reachable: a caller building its answer from the durable interaction row echoes the row's
+    // stored `turn_id`, which is the turn that PARKED — so the filter drops every prior record.
+    // Returning null here would run the approval-resume frame alone: no task, no context, ok:true.
+    recordsToReturn = [
+      {
+        turn_id: "turn-1",
+        record_source: "user",
+        attributes: { type: "message", text: "write a test file" },
+      },
+    ];
+    const req = { messages: [approvalReplyMessage], turnId: "turn-1" } as never;
+    await assert.rejects(
+      () => reconstructHistoryIfNeeded(req, "sess-1", auth),
+      /cannot resume an approval reply/,
+    );
+  });
+
+  it("refuses an approval reply when the session id is missing", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    const req = { messages: [approvalReplyMessage] } as never;
+    await assert.rejects(
+      () => reconstructHistoryIfNeeded(req, undefined, auth),
+      /cannot resume an approval reply/,
+    );
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("refuses an approval reply when reconstruction is switched off", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "false");
+    const req = { messages: [approvalReplyMessage] } as never;
+    await assert.rejects(
+      () => reconstructHistoryIfNeeded(req, "sess-1", auth),
+      /cannot resume an approval reply/,
+    );
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("an ordinary minimal-history request keeps every silent no-op it had", async () => {
+    // The loud guards above are for the approval shape ONLY: a fresh user turn asserts its own
+    // task, so "nothing to rebuild" is a legitimate first turn, not an anomaly.
+    const minimal = { messages: [userTurn] } as never;
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "false");
+    assert.equal(await reconstructHistoryIfNeeded(minimal, "sess-1", auth), null);
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    assert.equal(await reconstructHistoryIfNeeded(minimal, undefined, auth), null);
+    recordsToReturn = [
+      {
+        turn_id: "t1",
+        record_source: "user",
+        attributes: { type: "message", text: "hi again" },
+      },
+    ];
+    const sameTurn = { messages: [userTurn], turnId: "t1" } as never;
+    assert.equal(await reconstructHistoryIfNeeded(sameTurn, "sess-1", auth), null);
   });
 
   it("no-op when the only records belong to the current turn (first turn of a session)", async () => {


### PR DESCRIPTION
## Context

An agent on a schedule stops and waits when it hits a tool that needs approval. Answering that approval from anywhere other than a live playground session did nothing. The row was marked answered, the agent service returned 200 with an empty body, and the run stayed stopped forever.

That blocks every out-of-band approval surface equally: an inbox, a webhook, a Slack button, a script.

Three separate defects, each reproduced against the running runner.

**The resumed run was refused for carrying no user message.** An approval reply has no new user text, and `buildRunPlan` refused any request without it. The runner can rebuild the earlier turns from its own record log, but that happens after the plan is built, so the request died before the conversation could be supplied.

```
{"kind":"result","result":{"ok":false,"error":"No user message to send (prompt/messages empty)."}}
```

The agent service raises after the response headers are already committed, which is why the caller saw a successful status and nothing in the body, and then reported `Workflow service closed the stream before emitting a started record`.

**Answering evicted the live session parked on the gate.** The approval branch compares the conversation the request carries against the parked one. A caller answering from a durable row carries none, so the runner concluded the transcript had been edited and tore the session down:

```
[keepalive] approval-mismatch (history) key=<project>:<session>; evict + cold
```

The ordinary continuation branch already had an escape hatch for callers that send no history. The approval branch never got one.

**The durable interaction row never stored the tool call id.** A parked gate has two ids, the permission gate id and the tool call id, and only the first was persisted. The playground works because it receives both on the live event stream. So an answer built from the stored row alone named the wrong call, and the resume path matches strictly on tool call id.

## Changes

`buildRunPlan` still refuses an empty prompt, except when the request is an approval reply and nothing else. A new predicate, `carriesApprovalReplyOnly`, decides that. History reconstruction accepts the same shape, so the earlier turns come from the record log.

The keep-alive approval branch now skips its history comparison for a caller that asserts no conversation, the same way the ordinary continuation branch already did. It needed its own condition rather than reusing the existing helper, because that one requires the last message to be a fresh user turn and an approval reply never is.

The tool call id is persisted when the gate is raised, so a caller can name the right call. Rows written before this still read back, and the frontend falls back to the old id for them.

## Tests

Verified end to end on a running deployment. An approval was answered out of band on a session whose park had already expired, so it took the cold path. The runner rebuilt two prior turns from the record log, recovered the stored decision, allowed the gate, and finished the turn. The file the agent had asked to write appeared on the mount with the approved contents, and the row moved to `resolved` carrying the real tool call id.

```
[HITL] cold replay: ... resumeFrame=approval
[reconstruct] session=... records=10 prior=10 priorMessages=2 inbound=1
[HITL] gate toolName="Write" permission=ask outcome=allow
complete OK session=... turn=1
```

Runner tests 1308 passing, six of them new. API session tests 144 passing, three of them new.

Two reviewers went at this adversarially. Neither could construct a request that gains anything through the loosened checks: the live resume answers the parked gate with the gate's own original arguments and never shows the model the incoming messages, any user text at all re-arms the history comparison, and gate binding stays strict on tool call id.

## Follow-ups this does not fix

An answer that matches no parked gate still evicts the live session instead of being refused. That policy is old, but it almost never fired while the playground was the only client answering approvals. A retry or a double click will now hit it. Filed as #5596.

Answering an approval marks the row as used before the resumed run is known to have started, so a failed resume loses the approval with no retry. Filed as #5592.

## What to QA

- Put an agent on a schedule so it stops for approval unattended. Answer the approval outside the playground. The run continues and the tool actually executes.
- Check the interaction row afterwards. It reads `resolved` and carries a `tool_call_id`.
- Regression: approve and deny in the playground as usual. Both still work, and denying still ends the call as declined rather than hanging.
- Regression: send an ordinary message to an agent mid-conversation. It continues from the live session rather than rebuilding from scratch.
- An approval created before this change carries no tool call id. Answering it still falls back to the old identifier.

Closes #5593
