### PR TITLE
fix(frontend): gate paste and drag-to-attach on the file-uploads flag

### DIFF
--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-0.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-0.md
@@ -1,0 +1,66 @@
+# Stage 0 protocol: gate the ungated paste and drag-to-attach paths
+
+Stage 0 of [plan.md](../plan.md) closes the silent-failure gap: paste-to-attach and
+drag-and-drop-to-attach predated the `NEXT_PUBLIC_AGENT_FILE_UPLOADS` flag and were live ungated,
+so a pasted screenshot reached the runner and was flattened to a useless `[image]` placeholder with
+no warning. This protocol records what was done, what was found along the way, and every decision
+made during implementation that the plan did not spell out.
+
+## What was done
+
+One file changed: `web/oss/src/components/AgentChatSlice/AgentConversation.tsx`.
+
+- The shared guard `attachmentsBlocked` now includes `!uploadsEnabled`. This guard was already
+  called at every user-facing entry point (`onDragEnter`, `onDragOver`, `onDrop`, and the
+  `onPasteFile` callback), so one line gates all four paths with the same mechanism the feature
+  already used for "recording in flight" and "composer disabled".
+- Two comments that documented the old ungated behavior were corrected.
+
+Verified with `pnpm lint-fix` (clean on the touched file) and the repo's fast typecheck
+(`tsgo --noEmit`, zero errors).
+
+## Flag-off behavior
+
+- Dropping a file attaches nothing, shows no toast, and the drop overlay never appears; the drag
+  cursor shows "no drop".
+- Pasting a screenshot inserts nothing. Plain-text paste is untouched, because the rich-input layer
+  only intercepts pastes whose clipboard carries files.
+- With the flag on, the guard expression is byte-for-byte the old behavior.
+
+## Implicit decisions and their tradeoffs
+
+1. **The panel stays a drop target even when the flag is off; a drop is swallowed, not released to
+   the browser.** The handlers call `preventDefault()` before the guard returns. This ordering
+   pre-existed for the other blocked states, and the reason is that a browser's default action for
+   a dropped file is to navigate to it, which unloads the app and destroys the conversation.
+   Tradeoff: a person who drops a file gets no feedback beyond the "no drop" cursor. The
+   alternative, an explanatory toast, was rejected because Stage 0 gates a dark feature; the toast
+   would advertise a capability that does not exist yet.
+2. **A paste that carries files is consumed entirely, not degraded to its text part.** The
+   rich-input layer prevents the default paste for any clipboard that has files, to stop the editor
+   from inserting the junk HTML sibling of a pasted image. With the flag off, the file then goes
+   nowhere. Tradeoff: a clipboard carrying both a file and meaningful text loses the text. This
+   matches the pre-existing blocked-state behavior; the common case (a screenshot) would otherwise
+   paste junk markup.
+3. **The voice-recorder completion path is deliberately not gated by the uploads flag.** A finished
+   recording calls `addFiles` below the guard, and voice has its own flag
+   (`NEXT_PUBLIC_AGENT_VOICE_INPUT`). Consequence: if voice were enabled while uploads is off, a
+   recorded clip would still land in the attachment tray. Both flags are off by default today, so
+   the combination is unreachable, but the two flags independently guard overlapping machinery.
+   This becomes relevant in Stage 2 when the voice flag turns on; the Stage 2 work should decide
+   whether the recorder's output should respect the uploads flag.
+
+## Audit: other entry points to the attachment state
+
+- `validateIncoming` has exactly one caller (`addFiles` in `AgentConversation.tsx`); no other
+  component imports it.
+- The hidden file input in `ComposerAttachments.tsx` is not directly flag-gated but is unreachable
+  with the flag off: the tray renders only when attachments are open or files exist, and neither
+  can become true when the attach button is dead and `addFiles` is unreachable. Left unchanged.
+- Drive-staged files and the attachment viewer drawer were already gated.
+- The rich-input paste interception is ungated in the package layer but inert unless a consumer
+  passes `onPasteFile`; the only consumer's callback is now guarded.
+
+## Issues found
+
+None beyond the gap itself. No behavior change was needed outside the one guard.

--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-0.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-0.md
@@ -61,6 +61,20 @@ Verified with `pnpm lint-fix` (clean on the touched file) and the repo's fast ty
 - The rich-input paste interception is ungated in the package layer but inert unless a consumer
   passes `onPasteFile`; the only consumer's callback is now guarded.
 
+## Live QA (dev stack, 2026-07-31)
+
+Both flag states were verified in a browser against the running dev stack, with synthetic
+paste and drag events dispatched at the real composer.
+
+- Flag off: a pasted image file attaches nothing; plain-text paste inserts normally; a file
+  drag shows no overlay; the drop is swallowed (`preventDefault` fires, so the browser does
+  not navigate to the file) and attaches nothing.
+- Flag on: the attach button is enabled; a pasted image renders the attachment chip (file
+  counter "1 / 5"); plain-text paste is unaffected; a file drag shows the "Drop files here"
+  overlay. The guard is inert when the flag is true.
+
 ## Issues found
 
-None beyond the gap itself. No behavior change was needed outside the one guard.
+None beyond the gap itself. No behavior change was needed outside the one guard. During
+flag-on QA the Next.js dev server dropped the login session once after a hot-reload cycle;
+that is a dev-server artifact unrelated to this change.

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -265,7 +265,7 @@ const AgentConversation = ({
      * accepting files into an input you cannot send from is a dead end.
      */
     const composerDisabled = onboardingActive ? ideHandoffActive : modelBlocked
-    const attachmentsBlocked = () => voiceRecorder.active || composerDisabled
+    const attachmentsBlocked = () => !uploadsEnabled || voiceRecorder.active || composerDisabled
     const dropTarget = attachments.bindDropTarget(attachmentsBlocked)
 
     // First-run seed + its overlay-gated auto-start. `handleSubmit` is declared below, so the

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -314,9 +314,7 @@ const AgentComposerDock = ({
                                             }
                                         />
                                     ) : null}
-                                    {/* Attach button stays dead until the agent service is ready
-                                    for inline file parts (`NEXT_PUBLIC_AGENT_FILE_UPLOADS`);
-                                    paste / drag-to-add still work either way. */}
+                                    {/* Gate the attach button until inline file parts are supported. */}
                                     <Tooltip
                                         title={
                                             !uploadsEnabled

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
@@ -29,8 +29,7 @@ const toUploadFile = (file: File): UploadFile => ({
  * (route re-entry, tab close/reopen) alongside the composer draft; rejections stay transient.
  */
 export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
-    // Attach button + attachment preview + drive uploads (`NEXT_PUBLIC_AGENT_FILE_UPLOADS`). Paste
-    // and drag-to-attach predate the flag and stay on.
+    // Gate every attachment path on NEXT_PUBLIC_AGENT_FILE_UPLOADS until file parts are supported.
     const uploadsEnabled = isAgentFileUploadsEnabled()
     // Restored from the per-session store on remount (route re-entry, tab close/reopen) —
     // pending attachments survive alongside the composer draft. Rejections stay transient.


### PR DESCRIPTION
Pasting a screenshot or dropping a file into the agent chat attaches it even though the file-uploads feature is dark: the attach button is gated on `NEXT_PUBLIC_AGENT_FILE_UPLOADS`, but the paste and drag-and-drop paths predate the flag and are live ungated. Because the backend delivery does not exist yet, the runner flattens the file to a `[image]` placeholder and the model never sees it, with no warning to the user.

**Before:** with the flag off, paste and drag-and-drop still attach files, which then silently fail at the runner.
**After:** with the flag off, no path attaches a file. A drop shows the "no drop" cursor and is swallowed (releasing it would let the browser navigate to the file and unload the app); a paste that carries a file inserts nothing, while plain-text paste is untouched. With the flag on, the guard expression is byte-for-byte the old behavior.

The change is one line: the shared `attachmentsBlocked` guard, already consulted by every entry point (drag-enter, drag-over, drop, paste), now includes the flag. Two stale comments documenting the old ungated behavior are corrected.

This is Stage 0 of the agent multi-modality plan (`docs/design/agent-workflows/projects/agent-multi-modality/plan.md`), stacked on the design PR #5439. The stage protocol, including the audit of all other entry points to the attachment state, is in this PR at `docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-0.md`.

## Implicit decisions and their tradeoffs

Full detail in the protocol file; the two worth your eyes:

- A paste whose clipboard carries both a file and text loses the text when the flag is off, because the rich-input layer prevents the default paste for any file-carrying clipboard (otherwise a pasted screenshot inserts junk HTML). This matches the pre-existing blocked states (recorder active, composer disabled).
- The voice-recorder completion path is deliberately not gated by the uploads flag; it has its own flag, and both are off by default. If voice ever turns on while uploads is off, a recording would still land in the attachment tray. Stage 2 (the audio release) should decide whether the recorder respects the uploads flag; flagged in the protocol.

## Forced routes to double-check

None. Nothing here was a single-option path; the guard mechanism already existed and the change extends it.

## QA

`pnpm lint-fix` and the fast typecheck (`tsgo --noEmit`) pass. Live QA ran on the dev stack in both flag states, with synthetic paste and drag events dispatched at the real composer (full record in the protocol file in this PR):

- **Flag off:** a pasted image attaches nothing; plain-text paste inserts normally; a file drag shows no overlay; the drop is swallowed (no browser navigation) and attaches nothing.
- **Flag on:** the attach button is enabled; a pasted image renders the attachment chip (counter "1 / 5"); text paste unaffected; dragging a file shows the "Drop files here" overlay. The guard is inert when the flag is true.

https://claude.ai/code/session_01A1XQVjHPYJgVBHWSNUphtx
