### PR TITLE
[fix] Release the scroll guard when a transcript node swap cancels a pin

### DIFF
--- a/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
@@ -74,6 +74,9 @@ export const useTranscriptScroll = ({
     // Runs before the SC-1/SC-2 pin below, which is declared later.
     useLayoutEffect(() => {
         pinCleanupRef.current?.()
+        // Cancelling skips the pin's settle, which is what normally releases the guard. `intent`
+        // outlives this hook, so a leaked `true` would keep follow/anchoring off after a remount.
+        programmaticScrollRef.current = false
         anchorRef.current = null
         lastScrollTopRef.current = scrollNode?.scrollTop ?? 0
     }, [scrollNode])
@@ -155,6 +158,7 @@ export const useTranscriptScroll = ({
     useEffect(
         () => () => {
             pinCleanupRef.current?.()
+            programmaticScrollRef.current = false
             if (showJumpRafRef.current) cancelAnimationFrame(showJumpRafRef.current)
         },
         [],


### PR DESCRIPTION
Fix for a finding on #5569. Targets `fe-chore/agent-conversation-split` so it lands as part of that PR.

## Context

When the plain transcript container is replaced while a pin animation is still running, the chat stops following the streaming answer and message anchoring stops compensating for content that grows above the viewport. It stays broken until some later pin happens to finish on its own.

`animatePinTo` holds `programmaticScrollRef` true for the length of the glide, so the scroll handler and the resize observer ignore the in-between frames. It releases the guard inside the settle callback. The cancel path stored on `pinCleanupRef` removes the listeners and clears the fallback timer, but it never touches the guard, and cancelling skips settle by design. The node-swap layout effect calls that cancel path, so the guard leaks as `true`.

It leaks past the remount because `programmaticScrollRef` comes from `intent`, which the parent owns. The ref outlives this hook, so the stuck value is still there when the plain engine mounts again.

Three consumers bail out while the guard is set: the follow-to-bottom effect, the resize anchoring effect, and the scroll handler's anchoring branch.

The container is conditionally rendered (`AgentTranscript.tsx:43` and `:101`), so it swaps whenever virtualization takes over from an empty conversation, and whenever the transcript remounts within a session.

## Changes

Release the guard at the two places that cancel a pin for teardown: the node-swap layout effect and the unmount cleanup.

The guard is deliberately not released inside the shared cancel closure. `animatePinTo` calls that same closure to supersede a previous pin, and every caller sets the guard to `true` immediately before calling it, so clearing there would wipe the guard that was just set.

Ordering is safe. The node-swap effect is declared before the SC-1/SC-2 pin effect, and React runs layout effects in declaration order, so a pin that needs the guard sets it after this clears it.

## Notes

I could not run `pnpm lint-fix`, because the checkout I used has no `node_modules`. The change is two statements plus a comment and follows the surrounding style.

## What to QA

- With virtualization on, open a fresh agent chat with no messages and send one. The transcript follows the streaming answer to the bottom.
- Switch to another session mid-answer, then come back. Sending a new message still follows.
- Scroll up while an answer streams. The jump-to-latest pill appears, and clicking it glides to the bottom and resumes following.
- Regression: park the view partway up a long conversation while an answer streams below. The view should stay where you put it, and the message you are reading should not drift as content above it renders.
