### PR TITLE
[fix] Stop trigger edit forms hydrating from stale cached details

### DIFF
--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSchedule.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSchedule.ts
@@ -100,6 +100,8 @@ export const useTriggerSchedule = (scheduleId?: string) => {
     return {
         schedule: scheduleId ? (query.data?.schedule ?? null) : null,
         isLoading: scheduleId ? query.isPending : false,
+        // Unlike isLoading, stays true while a refetch serves stale cache — edit forms need it.
+        isFetching: scheduleId ? query.isFetching : false,
         error: query.error,
         isMutating,
         create,

--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSubscription.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSubscription.ts
@@ -100,6 +100,8 @@ export const useTriggerSubscription = (subscriptionId?: string) => {
     return {
         subscription: subscriptionId ? (query.data?.subscription ?? null) : null,
         isLoading: subscriptionId ? query.isPending : false,
+        // Unlike isLoading, stays true while a refetch serves stale cache — edit forms need it.
+        isFetching: subscriptionId ? query.isFetching : false,
         error: query.error,
         isMutating,
         create,

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/schedule/ScheduleForm.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/schedule/ScheduleForm.tsx
@@ -83,6 +83,7 @@ export function ScheduleForm({
     const {
         schedule,
         isLoading: scheduleLoading,
+        isFetching: scheduleFetching,
         isMutating,
         create,
         edit,
@@ -177,6 +178,9 @@ export function ScheduleForm({
     const hydratedId = useRef<string | null>(null)
     useEffect(() => {
         if (!isEdit || !schedule) return
+        // A refetch serves the stale cache first. Latching on that would freeze the fields on old
+        // values (the fresh result hits the guard below and returns) and save them back.
+        if (scheduleFetching) return
         const loadedId = (schedule.id as string | undefined) ?? scheduleId ?? null
         if (hydratedId.current === loadedId) return
         hydratedId.current = loadedId
@@ -196,7 +200,7 @@ export function ScheduleForm({
             // Label is resolved from the revision id below, not stored as the raw id.
         }
         setInputsText(JSON.stringify(schedule.data?.inputs_fields ?? {}, null, 2))
-    }, [isEdit, schedule, scheduleId])
+    }, [isEdit, schedule, scheduleFetching, scheduleId])
 
     // Create-mode default-bind: when opened with `defaultReferences` (e.g. from an
     // agent's config panel), pre-bind the new schedule to that workflow so the user

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/subscription/SubscriptionForm.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/subscription/SubscriptionForm.tsx
@@ -83,6 +83,7 @@ export function SubscriptionForm({
     const {
         subscription,
         isLoading: subLoading,
+        isFetching: subFetching,
         isMutating,
         create,
         edit,
@@ -199,6 +200,9 @@ export function SubscriptionForm({
     const hydratedId = useRef<string | null>(null)
     useEffect(() => {
         if (!isEdit || !subscription) return
+        // A refetch serves the stale cache first. Latching on that would freeze the fields on old
+        // values (the fresh result hits the guard below and returns) and save them back.
+        if (subFetching) return
         const loadedId = (subscription.id as string | undefined) ?? subscriptionId ?? null
         if (hydratedId.current === loadedId) return
         hydratedId.current = loadedId
@@ -226,7 +230,7 @@ export function SubscriptionForm({
         if (subscription.data?.trigger_config) {
             configForm.setFieldsValue(subscription.data.trigger_config)
         }
-    }, [isEdit, subscription, subscriptionId, configForm])
+    }, [isEdit, subscription, subFetching, subscriptionId, configForm])
 
     // Create-mode default-bind to the playground agent (or `defaultReferences`).
     useEffect(() => {


### PR DESCRIPTION
Fix for a finding on #5571. Targets `fe-chore/trigger-drawers-split` so it lands as part of that PR.

## Context

Editing a trigger can silently save old values over new ones.

Both edit forms prefill their fields once per id and then latch, so a background refetch cannot overwrite edits in progress. The latch is set as soon as `subscription` (or `schedule`) is non-null. That is the bug: after any mutation the list query is invalidated, and the refetch serves the stale cache first. The form hydrates from that stale copy and marks the id hydrated. When the fresh response lands the effect runs again, hits the `hydratedId.current === loadedId` guard, and returns. The fields keep the old values, and saving writes them back.

The form had no way to tell. `useTriggerSubscription` and `useTriggerSchedule` expose `isLoading: query.isPending`, and `isPending` is true only when there is no cached data at all. During a background refetch there is cached data, so `isPending` is false.

`invalidateSubscriptions()` and `invalidateSchedules()` run after every create, edit, revoke, refresh, remove, and active toggle, so the stale window is easy to land in. Concretely: toggle a trigger off in the list, open its edit drawer straight away, rename it, save. The name change sticks and the active toggle flips back on.

Codex flagged this as P1 on `SubscriptionForm` and noted `ScheduleForm` shares the pattern. It does, at the identical guard.

## Changes

Both hooks now return `isFetching` alongside `isLoading`:

```
isLoading:  true only when there is no cached data      (unchanged)
isFetching: true whenever a request is in flight        (new)
```

Both forms skip hydration while `isFetching` is true, and `isFetching` joins the effect's dependency list so hydration runs as soon as the fresh result arrives. First load is unaffected: there is no cached data, so the existing `!subscription` guard already covers it.

## Notes

I could not run `pnpm lint-fix`, because the checkout I used has no `node_modules`. The hook returns are inferred object literals, so adding a field needs no type changes, and no existing caller destructures `isFetching`.

## What to QA

- Open a subscription trigger's edit drawer, change the name, save. Reopen it. The new name is there and nothing else changed.
- The reported path: toggle a trigger off in the list, immediately open its edit drawer, rename it, save. It stays off. Before this change it flipped back on.
- Same two checks on a schedule trigger.
- Regression: open an edit drawer, start typing in a field, and leave it open long enough for a background refetch. Your typing is not overwritten.
