### PR TITLE
[fix] Rebase #5589 onto #5569 and fix the two blocking review findings

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -9,7 +9,7 @@ import {
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {UploadSimple} from "@phosphor-icons/react"
-import {type UIMessage} from "ai"
+import {type FileUIPart, type UIMessage} from "ai"
 import {Modal} from "antd"
 import {useAtomValue, useSetAtom, useStore} from "jotai"
 
@@ -410,7 +410,23 @@ const AgentConversation = ({
         ]
         if (!trimmed && fileObjs.length === 0) return
         if (!attachmentsSettled) return
-        const fileParts = fileObjs.length ? await filesToParts(fileObjs) : undefined
+        let fileParts: FileUIPart[] | undefined
+        if (fileObjs.length) {
+            const {parts, unreadable} = await filesToParts(fileObjs)
+            // Hold the send rather than quietly dropping bytes the user staged, and say which file
+            // failed through the same inline channel the other attachment refusals use.
+            if (unreadable.length) {
+                attachments.setRejections(
+                    unreadable.map((f) => ({
+                        name: f.name,
+                        reason: "couldn't be read — remove it and attach it again",
+                    })),
+                )
+                attachments.setAttachmentsOpen(true)
+                return
+            }
+            fileParts = parts
+        }
         // Glide to the bottom; the min-h-full active turn makes that show the new question at the top
         // with the answer streaming below. Park during the glide, follow again on settle. Clear any
         // prior "stopped" marker — it's resolved by asking again.

--- a/web/oss/src/components/AgentChatSlice/assets/files.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/files.ts
@@ -32,9 +32,29 @@ const fileToPart = (file: File): Promise<FileUIPart> =>
         reader.readAsDataURL(file)
     })
 
-/** Convert picked `File`s into `file` parts for `sendMessage({text, files})`. */
-export const filesToParts = (files: File[]): Promise<FileUIPart[]> =>
-    Promise.all(files.map(fileToPart))
+export interface FileReadResult {
+    parts: FileUIPart[]
+    /** Files the browser refused to read (revoked blob, moved/locked on disk), in input order. */
+    unreadable: File[]
+}
+
+/**
+ * Convert picked `File`s into `file` parts for `sendMessage({text, files})`.
+ *
+ * Never rejects. Every send path drops this promise (composer submit, voice take, empty-state
+ * Start, the first-run seed), so a `Promise.all` that threw on one unreadable file surfaced as an
+ * unhandled rejection and a send that silently did nothing. Failures come back as data instead.
+ */
+export const filesToParts = async (files: File[]): Promise<FileReadResult> => {
+    const settled = await Promise.allSettled(files.map(fileToPart))
+    const parts: FileUIPart[] = []
+    const unreadable: File[] = []
+    settled.forEach((result, i) => {
+        if (result.status === "fulfilled") parts.push(result.value)
+        else unreadable.push(files[i])
+    })
+    return {parts, unreadable}
+}
 
 /** The `file` parts of a message, in order. */
 export const fileParts = (message: UIMessage): FileUIPart[] =>

--- a/web/oss/src/components/AgentChatSlice/components/AgentTranscript.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTranscript.tsx
@@ -100,9 +100,7 @@ const AgentTranscript = ({
             )}
             {(!useVirtuoso || messages.length === 0) && (
                 <div
-                    ref={(el) => {
-                        scroll.scrollRef.current = el
-                    }}
+                    ref={scroll.attachScroll}
                     onScroll={scroll.onScroll}
                     // Capture a fresh SC-3 anchor before a click acts (expand/collapse a tool step,
                     // reasoning fold): those resize the transcript without a scroll, so onScroll never

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
@@ -1,5 +1,6 @@
 import {useEffect, useRef, useState} from "react"
 
+import {generateId} from "@agenta/shared/utils"
 import type {UploadFile} from "antd"
 
 import {
@@ -12,8 +13,11 @@ import {attachmentsBySession} from "../state/sessionEphemera"
 
 import {useAttachmentUploads} from "./useAttachmentUploads"
 
+// `uid` is the tray's React key, its preview-URL key, and the remove / view / retry handle, so it
+// has to be unique per TRAY ROW. Deriving it from name+mtime+size collided whenever the same file
+// was attached twice (paste then drop) — one remove then wiped both rows and their previews.
 const toUploadFile = (file: File): UploadFile => ({
-    uid: `${file.name}-${file.lastModified}-${file.size}`,
+    uid: `att-${generateId()}`,
     name: file.name,
     status: "done",
     originFileObj: file as UploadFile["originFileObj"],
@@ -62,8 +66,11 @@ export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
         const {accepted, rejections} = validateIncoming(incoming, files.length, limits)
         const allRejections = [...extraRejections, ...rejections]
         if (accepted.length) {
-            setFiles((prev) => [...prev, ...accepted.map(toUploadFile)])
-            uploads.enqueue(accepted.map((f) => `${f.name}-${f.lastModified}-${f.size}`))
+            // Stage once and enqueue the MINTED uids — re-deriving them here is what let the tray
+            // row and its upload disagree about which entry they addressed.
+            const staged = accepted.map(toUploadFile)
+            setFiles((prev) => [...prev, ...staged])
+            uploads.enqueue(staged.map((f) => f.uid))
         }
         setRejections(allRejections)
         // Open for rejections too. Otherwise dropping something unsupported writes a message into

--- a/web/oss/src/components/AgentChatSlice/hooks/useOnboardingChat.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useOnboardingChat.ts
@@ -180,7 +180,14 @@ export const useOnboardingChat = ({
     // Holds the pending IDE-bubble typewriter timer so it can be cancelled on unmount (tab close,
     // rewind, route change) — otherwise the recursive chain keeps calling setMessages on a stale closure.
     const ideBubbleTimerRef = useRef<number | null>(null)
+    // The ref holds ONE handle, so anything that starts (or invalidates) a chain must cancel the
+    // previous one first — overwriting the handle would strand the old chain beyond every cleanup.
+    const cancelIdeBubble = useCallback(() => {
+        if (ideBubbleTimerRef.current) window.clearTimeout(ideBubbleTimerRef.current)
+        ideBubbleTimerRef.current = null
+    }, [])
     const streamIdeBubble = useCallback(() => {
+        cancelIdeBubble()
         const prompt = richInputRef.current?.getMarkdown().trim() ?? ""
         const promptQuote = prompt
             .split("\n")
@@ -219,23 +226,21 @@ export const useOnboardingChat = ({
             if (shown < full.length) ideBubbleTimerRef.current = window.setTimeout(tick, 28)
         }
         ideBubbleTimerRef.current = window.setTimeout(tick, 120)
-    }, [setMessages])
+    }, [setMessages, cancelIdeBubble])
 
     // Cancel any in-flight IDE-bubble animation on unmount so its timer chain can't fire post-unmount.
-    useEffect(
-        () => () => {
-            if (ideBubbleTimerRef.current) window.clearTimeout(ideBubbleTimerRef.current)
-        },
-        [],
-    )
+    useEffect(() => cancelIdeBubble, [cancelIdeBubble])
 
     // After an IDE hand-off (onboarding + messages exist but nothing was committed), the chat is a
     // dead-end — there's no agent to talk to. Disable the composer and offer a single "Start over".
     const ideHandoffActive = onboardingActive && messages.length > 0
     const handleStartOver = useCallback(() => {
+        // Start over wipes the transcript the chain is typing into — stop it, or it keeps ticking
+        // against messages that no longer exist (and outlives the next chain's handle).
+        cancelIdeBubble()
         setMessages(() => [])
         richInputRef.current?.setMarkdown("")
-    }, [setMessages])
+    }, [setMessages, cancelIdeBubble])
 
     // Strip era (TEMPLATE_STRIP_MODE): the bare "what do you want to build?" hero (no messages yet,
     // nothing pending, not browsing the template gallery) is when the onboarding TemplateStrip docks

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -59,39 +59,40 @@ export const useSessionHydration = ({
         // StrictMode's mount→unmount→mount cycle re-runs the fetch (the first run is cancelled)
         // instead of latching a ref that leaves the transcript blank.
         let cancelled = false
-        // Post-restore revalidation: the first result may be the disk-restored log (paints
-        // instantly); when the guaranteed background refetch lands, adopt it under the same
-        // guards as the SWR effect below — never mid-stream, only when strictly ahead.
-        const adoptRefreshed = (freshMsgs: UIMessage[]) => {
+        // How long a transcript this effect has already handed to `setMessages`. `messagesRef` only
+        // catches up on the next React commit, so two adoptions landing before that commit would
+        // both read the pre-adoption length and let the older snapshot win. The high-water mark
+        // makes the guard order-independent.
+        let adoptedLength = initialMessages.length
+        // ONE adopter for both deliveries: the initial result (disk-restored log, paints instantly)
+        // and the guaranteed background refetch. Never mid-stream, only when strictly ahead.
+        const adopt = (msgs: UIMessage[]) => {
             if (cancelled || busyRef.current) return
-            if (freshMsgs.length <= messagesRef.current.length) return
-            freshMsgs.forEach((m) => {
+            if (msgs.length <= Math.max(adoptedLength, messagesRef.current.length)) return
+            adoptedLength = msgs.length
+            // Restored history renders settled (no live fade-in) and pinned to the bottom.
+            msgs.forEach((m) => {
                 seenIdsRef.current.add(m.id)
                 restoredIdsRef.current.add(m.id)
             })
             intent.armJump()
-            // The restore said "no records" but the server has some — clear the notice.
+            // The restore may have said "no records" while the server has some — clear the notice.
             setHydratedEmpty(false)
-            setMessages(freshMsgs)
-            persistMessages({id: sessionId, messages: freshMsgs})
+            setMessages(msgs)
+            persistMessages({id: sessionId, messages: msgs})
         }
-        loadSessionMessages(sessionId, adoptRefreshed)
+        loadSessionMessages(sessionId, adopt)
             .then((msgs) => {
                 if (cancelled) return
                 if (!msgs || msgs.length === 0) {
                     // Known session, but the server has no records for it → history was pruned or
                     // never persisted. Flag it so the transcript shows the "unavailable" notice.
-                    setHydratedEmpty(true)
+                    // Only when nothing has been adopted yet — a refetch that already landed is
+                    // real history, and this stale first result must not blank it out.
+                    if (adoptedLength === initialMessages.length) setHydratedEmpty(true)
                     return
                 }
-                // Restored history renders settled (no live fade-in) and pinned to the bottom.
-                msgs.forEach((m) => {
-                    seenIdsRef.current.add(m.id)
-                    restoredIdsRef.current.add(m.id)
-                })
-                intent.armJump()
-                setMessages(msgs)
-                persistMessages({id: sessionId, messages: msgs})
+                adopt(msgs)
             })
             .finally(() => {
                 if (!cancelled) setIsHydrating(false)
@@ -115,9 +116,15 @@ export const useSessionHydration = ({
         // As with the hydration effect above: no persistent ref, so StrictMode's double-mount
         // re-runs the revalidation rather than latching it out.
         let cancelled = false
+        // `messagesRef` only catches up on the next React commit, so a transcript this effect just
+        // adopted is invisible to the guard until then. Hold it here too and compare against
+        // whichever is longer — the checks below read the tail, not just the count, so this keeps
+        // the whole snapshot rather than a length.
+        let adopted: UIMessage[] | null = null
         const adopt = (serverMsgs: UIMessage[] | null) => {
             if (cancelled || !serverMsgs || serverMsgs.length === 0) return
-            const prev = messagesRef.current
+            const onScreen = messagesRef.current
+            const prev = adopted && adopted.length > onScreen.length ? adopted : onScreen
             if (busyRef.current) return
             // Adopt the server transcript when it is strictly ahead by count, OR when our LOCAL tail
             // is stuck paused (mid-approval) while the server has moved past it to a terminal turn — a
@@ -138,6 +145,7 @@ export const useSessionHydration = ({
                 !serverTail.metadata?.paused &&
                 getPendingApprovals(serverMsgs).length === 0
             if (!serverAheadByCount && !(localTailPaused && serverTailComplete)) return
+            adopted = serverMsgs
             serverMsgs.forEach((m) => {
                 seenIdsRef.current.add(m.id)
                 restoredIdsRef.current.add(m.id)

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -1,4 +1,4 @@
-import {type MutableRefObject, useCallback, useEffect, useState} from "react"
+import {type MutableRefObject, useCallback, useEffect, useRef, useState} from "react"
 
 import {shouldAdoptServerTranscript} from "@agenta/entities/session"
 import {type UIMessage} from "ai"
@@ -105,6 +105,10 @@ export const useSessionHydration = ({
             persistMessages({id: sessionId, messages: serverMsgs, recordCount})
             return true
         },
+        // `intent`'s MEMBERS, not `intent`: `useScrollIntent` returns a fresh object every render,
+        // so the object itself would recreate this callback each render and churn everything keyed
+        // on it. `armJump` (useCallback []) and `stickRef` (useRef) are stable for the life of the
+        // conversation.
         [
             sessionId,
             messagesRef,
@@ -114,9 +118,16 @@ export const useSessionHydration = ({
             recordWatermarkRef,
             setMessages,
             persistMessages,
-            intent,
+            intent.armJump,
+            intent.stickRef,
         ],
     )
+    // The remote-run poll below must NOT re-arm its timer on re-renders: the liveness query alone
+    // re-renders this hook ~every 15s while a run is live elsewhere, and restarting a fresh 15s
+    // timer on each of those starves the poll and resets its backoff. The effect reads the CURRENT
+    // adopter through this ref and keys only on the poll's real inputs.
+    const adoptServerTranscriptRef = useRef(adoptServerTranscript)
+    adoptServerTranscriptRef.current = adoptServerTranscript
 
     useEffect(() => {
         // A session created brand-new in this browser and not yet run has no backend records —
@@ -207,10 +218,11 @@ export const useSessionHydration = ({
         const poll = async () => {
             let grew = false
             try {
+                const adopt = adoptServerTranscriptRef.current
                 const transcript = await loadSessionMessages(sessionId, (fresh) => {
-                    if (!cancelled && adoptServerTranscript(fresh, {armJump: false})) grew = true
+                    if (!cancelled && adopt(fresh, {armJump: false})) grew = true
                 })
-                if (!cancelled && adoptServerTranscript(transcript, {armJump: false})) grew = true
+                if (!cancelled && adopt(transcript, {armJump: false})) grew = true
             } catch {
                 // `loadSessionMessages` already swallows + logs; keep polling regardless.
             } finally {
@@ -227,7 +239,9 @@ export const useSessionHydration = ({
             cancelled = true
             if (timer) clearTimeout(timer)
         }
-    }, [runningElsewhere, sessionId, adoptServerTranscript])
+        // Deliberately NOT keyed on `adoptServerTranscript` — the poll reads it through the ref
+        // above, so a re-render can't cancel a pending tick or reset the backoff.
+    }, [runningElsewhere, sessionId])
 
     return {isHydrating, hydratedEmpty, runningElsewhere}
 }

--- a/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useLayoutEffect, useRef} from "react"
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from "react"
 
 import {type ChatStatus, type UIMessage} from "ai"
 
@@ -25,7 +25,16 @@ export const useTranscriptScroll = ({
     useVirtuoso: boolean
 }) => {
     const {stickRef, armBottomRef, animateBottomRef, programmaticScrollRef, setShowJump} = intent
-    const scrollRef = useRef<HTMLDivElement>(null)
+    // The container is conditionally rendered (Virtuoso replaces it, and an empty conversation
+    // renders it even under Virtuoso), so it can unmount and remount within one session. The ref is
+    // for synchronous reads inside handlers; the STATE is what effects that bind listeners to the
+    // node key on — otherwise they'd stay attached to a node that has since been detached.
+    const scrollRef = useRef<HTMLDivElement | null>(null)
+    const [scrollNode, setScrollNode] = useState<HTMLDivElement | null>(null)
+    const attachScroll = useCallback((el: HTMLDivElement | null) => {
+        scrollRef.current = el
+        setScrollNode(el)
+    }, [])
     // Teardown for the in-flight smooth scroll (removes its listeners + fallback timer).
     const pinCleanupRef = useRef<(() => void) | null>(null)
     // Last observed scrollTop. A content shrink (tool gutter collapsing, reasoning folding) clamps
@@ -191,7 +200,7 @@ export const useTranscriptScroll = ({
     // pins. Re-subscribed when the message set changes (a part growing fires on the same wrapper).
     useEffect(() => {
         if (useVirtuoso) return
-        const el = scrollRef.current
+        const el = scrollNode
         if (!el) return
         const onResize = (entries: ResizeObserverEntry[]) => {
             // Pin each rendered row's REAL height as its own `content-visibility` placeholder, so it
@@ -247,7 +256,7 @@ export const useTranscriptScroll = ({
         ro.observe(el)
         el.querySelectorAll("[data-mid]").forEach((w) => ro.observe(w))
         return () => ro.disconnect()
-    }, [messages.length, scrollToBottom, useVirtuoso])
+    }, [messages.length, scrollToBottom, useVirtuoso, scrollNode])
 
     // SC-1 (submit) / SC-2 (restore): scroll the log to the bottom, once, when armed. With the active
     // turn reserving a viewport (min-h-full + top padding to clear the fade), "bottom" shows the new
@@ -289,8 +298,10 @@ export const useTranscriptScroll = ({
     // (exactly like a scroll). New content keeps arriving offscreen and the jump pill offers the way
     // back. Keyboard / wheel / touch already release because they scroll (onScroll). The composer is
     // exempt: its selections and links aren't inside the log, so `el.contains(...)` ignores them.
+    // Keyed on the NODE, not on mount: the container remounts when the engine changes, and a
+    // mount-only binding would keep listening on the detached one for the rest of the session.
     useEffect(() => {
-        const el = scrollRef.current
+        const el = scrollNode
         if (!el) return
         const release = () => {
             if (!stickRef.current) return
@@ -312,7 +323,9 @@ export const useTranscriptScroll = ({
             document.removeEventListener("selectionchange", onSelectionChange)
             el.removeEventListener("click", onClick)
         }
-    }, [])
+    }, [scrollNode])
 
-    return {scrollRef, onScroll, recordAnchor, jumpToLatest}
+    // `attachScroll` is the ONLY way in: handing out `scrollRef` too would let a caller attach the
+    // node without the state ever knowing, which is the split this hook exists to close.
+    return {attachScroll, onScroll, recordAnchor, jumpToLatest}
 }

--- a/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useTranscriptScroll.ts
@@ -67,6 +67,17 @@ export const useTranscriptScroll = ({
         anchorRef.current = null
     }, [])
 
+    // Everything above is measured AGAINST a specific container, so a node swap invalidates all of
+    // it: the scroll baseline (a stale one makes the first scroll-down-to-edge on the new node fail
+    // `scrollTop > prevTop`, so follow doesn't re-arm), the SC-3 anchor (its offset was taken in the
+    // old node's coordinate space), and any glide still animating the node that just went away.
+    // Runs before the SC-1/SC-2 pin below, which is declared later.
+    useLayoutEffect(() => {
+        pinCleanupRef.current?.()
+        anchorRef.current = null
+        lastScrollTopRef.current = scrollNode?.scrollTop ?? 0
+    }, [scrollNode])
+
     // ── DT4 autoscroll: stick to the bottom of the scrollable area while following ──
     // The fill (min-h-full turn group) makes "question at top" the scroll bottom for a short answer
     // and the answer's end the bottom for a long one, so scrollHeight is the right target (+ pb-6 gap).

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -668,13 +668,13 @@ const writeMessagesWithQuotaGuard = (
     set: Setter,
     next: Record<string, UIMessage[]>,
     keepId: string,
-): string[] => {
+): {evicted: string[]; persisted: boolean} => {
     let candidate = next
     const evicted: string[] = []
     for (;;) {
         try {
             set(sessionMessagesAtom, candidate)
-            return evicted
+            return {evicted, persisted: true}
         } catch (e) {
             if (!isQuotaExceeded(e)) throw e
             // Object keys keep insertion order, so the first non-active id is the oldest.
@@ -682,7 +682,7 @@ const writeMessagesWithQuotaGuard = (
             if (oldest === undefined) {
                 // Even the active session alone won't fit — keep it in memory, skip persistence.
                 console.warn("[agent-chat] message store over quota; skipping persistence")
-                return evicted
+                return {evicted, persisted: false}
             }
             evicted.push(oldest)
             candidate = {...candidate}
@@ -729,13 +729,18 @@ export const persistSessionMessagesAtom = atom(
         set,
         {id, messages, recordCount}: {id: string; messages: UIMessage[]; recordCount?: number},
     ) => {
-        const evicted = writeMessagesWithQuotaGuard(
+        const {evicted, persisted} = writeMessagesWithQuotaGuard(
             set,
             {...get(sessionMessagesAtom), [id]: messages},
             id,
         )
         const counts = {...get(sessionRecordCountsAtom)}
-        if (recordCount === undefined) delete counts[id]
+        // If the transcript write itself was skipped (a single session over quota), the persisted
+        // store still holds the OLD messages — filing the NEW watermark against them would make
+        // `shouldAdoptServerTranscript` reject the complete server log as "not newer" on every
+        // future open, freezing the stale cache. The stores must never diverge (see
+        // `dropSessionMessages`), so drop the watermark and let the next open re-sync.
+        if (!persisted || recordCount === undefined) delete counts[id]
         else counts[id] = recordCount
         // A quota eviction dropped those transcripts, so their watermarks go too.
         for (const evictedId of evicted) delete counts[evictedId]


### PR DESCRIPTION
Rebase and review fixes for #5589, as part of the 0.106.2 release pass. Targets `fix/5530-agent-session-multi-tab` so it lands as part of that PR.

Arda is away, so this resolves the conflict and takes the two Codex findings that block the feature. The other two findings are filed as issues rather than fixed here, per the reasoning below.

## Context

#5589 conflicted with its own base. It was rebased onto `fe-chore/agent-conversation-split`, and two more commits then landed on that branch: `01f11b7ba5` (closes five latent defects in the agent chat slice) and `79056cbc4c` (drops per-node scroll measurements). One file conflicted, `useSessionHydration.ts`, in three places.

Only `01f11b7ba5` was ever involved. `79056cbc4c` touches a different file and merged cleanly. Of `01f11b7ba5`'s five fixes, exactly one lands in this file: routing the hydration path's initial result through the same guard as its refetch, with a synchronous high-water mark instead of a ref that lags a React commit.

## The conflict resolution

Git auto-merged the code sitting between the conflict markers, so the merged file already referenced `adoptedLength` from `01f11b7ba5`. Taking #5589's side wholesale would leave a dangling reference that does not compile, and the obvious way to "fix" that (dropping the condition) would silently revert one of the five defect fixes with no test to catch it.

So the resolution keeps #5589's structure and ports the guard into it, using a local `adopted` flag set when the refetch adopts.

For the third hunk the two sides differ in mechanism, not goal. It resolves to #5589's watermark, because `adoptServerTranscript` writes the watermark synchronously before any React commit, so a racing delivery with equal-or-fewer records is rejected regardless of arrival order. That is the property `01f11b7ba5` was adding, reached a different way. The invariant is now written as a comment on the watermark write, so it does not stay tribal knowledge.

## The two review fixes

**The poll timer reset itself every render.** `useScrollIntent` returns a fresh object each render, so `adoptServerTranscript` was rebuilt each render and the polling effect tore down its 15 second timer and re-armed with reset backoff. The hook re-renders on the liveness query's own 15 second beat, so during a remote run the record catch-up raced its own canceller at the same period. When the remote run ends, polling stops for good, so a starved poll leaves the transcript stale until the session is reopened. That is the feature this PR ships.

The deps now name stable members (`intent.armJump`, a `useCallback([])`, and `intent.stickRef`, a ref) rather than the per-render object. The poll effect also reads the adopter through a ref and keys only on `[runningElsewhere, sessionId]`, so the timer's stability no longer depends on auditing every other dependency.

The poll was deliberately not rewritten as `atomWithQuery`. That section of `web/AGENTS.md` prescribes it for data fetching; this is a side-effecting adoption loop with growth-reset backoff, and the chained-timeout shape is intentional so a slow fetch cannot stack on itself.

**A skipped transcript write still saved its watermark.** When a session is too large for localStorage the write is skipped, but `persistSessionMessagesAtom` filed the new `recordCount` anyway. After a reload the old or missing messages pair with a newer watermark, so `shouldAdoptServerTranscript` rejects the complete server log as not newer and the cache stays stale, potentially forever for a session that never runs again. This breaks the invariant the same file documents on `dropSessionMessages`, that the two stores must never diverge.

The quota guard now returns `{evicted, persisted}`, and the atom deletes that session's watermark when `persisted` is false. An absent watermark reads as 0, so the next open re-syncs from the durable log.

## Filed rather than fixed

Two Codex findings are real but were left alone on purpose, because fixing either means a design decision Arda should own. Both are tracked as issues.

The first is that liveness stops polling when its result is empty, so a tab that never regains focus will not notice a run starting elsewhere. The stop is deliberate and Arda's comment cites the request budget. Clicking into the tab heals it and nothing is lost.

The second is that a watermark-less transcript can be overwritten by a lagging server copy with the same message count, during the ingest lag after your own run. It self-heals on the next open. Any real fix adds a completion guard to the shared adoption rule and changes its test contract.

## Tests

- `tsc --noEmit` on the oss project: clean.
- `eslint` on the three changed files: clean. Worth noting because the poll effect deliberately omits the adopter from its dependency list.
- `@agenta/entities` unit suite: 931 tests across 65 files pass, including `session-transcript-adoption.test.ts`. The adoption rule itself is untouched.

Neither `useSessionHydration` nor the session persistence atoms have direct tests, so these checks prove nothing broke, not that the two fixes work. The quota guard is the testable one if someone wants positive coverage.

## What to QA

- Open a session in two browsers. Drive it from the first through a tool call and an approval. Refresh the second mid-turn. It should converge on the complete transcript rather than caching a partial one.
- With a run happening in another browser, watch the strip above the composer. It should appear, and the transcript should catch up while the run continues, not only when it ends.
- Regression: run a normal single-browser session with a tool approval. The transcript follows the streaming answer and the approval resumes in place.
