### PR TITLE
feat(runner): first-class current user turn and attachment delivery

### DIFF
--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -151,3 +151,79 @@ no nginx.
   a just-claimed attachment's bytes (data loss), and rows-first cannot retry a failed object
   delete (permanent orphans). The tombstone fixes both at the cost of one more state to reason
   about; it never appears on the wire.
+
+## WP2: the runner as consumer
+
+### The stack restructure, and what it means for PR #5598
+
+WP2's current-turn work builds on the approval-resume changes (PR #5598) in the same seams
+(`run-plan.ts`, `run-turn.ts`, and their tests): the empty-turn rejection and the prompt
+resolution are exactly where the approval-resume fix also lives. The two lanes started as
+parallel stacks, and the version-control tool correctly refused to commit dependent hunks into a
+parallel line (it silently dropped three files, caught by diffing the tree against the lane tip).
+The resolution was to linearize: `fix/approval-resume` moved into this train above WP1, and its
+PR base moved accordingly. Consequence, deliberately accepted: PR #5598 now merges as part of
+this train, after WP1, instead of independently. PR #5597 (the Pi built-ins fix below it) stays
+independently mergeable.
+
+### Implementation decisions worth knowing (beyond the plan)
+
+- One landed commit pair instead of the planned refactor/delivery split: the two parts share
+  hunks in seven files, and hunk-splitting across commits is the tool's most failure-prone
+  operation (it dropped hunks twice tonight). The refactor was still verified independently
+  before any delivery work (155 tests green on its own). The PR diff is identical either way.
+- `native_supported` was added as the success reason code (the plan enumerated only degradation
+  codes; a success event with no reason would be worse).
+- A mixed turn resolves every reference and emits every delivery event before surfacing the
+  first failure, so the record log always tells the whole story.
+- Restoration is injected into history reconstruction as a callback from the turn runner,
+  because the reconstruction module owns neither the sandbox nor the working directory.
+- Daytona symlink checks shell out to `test -L` per path component (its filesystem API cannot
+  identify links); argv-direct, so no shell injection surface.
+- Attachment ids joined the history fingerprint and model capabilities joined the config
+  fingerprint. A runner deploy already cold-starts every parked session (the pool is
+  process-local), so the hash change adds no second disruption; the consequence is stated in a
+  code comment at the fingerprint.
+
+### The review, and what it changed
+
+The adversarial review ran the new code against real request shapes and found two release
+blockers plus one bad degradation, all inside the refactor's predicted blast radius:
+
+1. **The rewritten empty-turn rejection discarded human approvals.** The tail-only reading
+   rejected any request whose tail was not a text-bearing user message, which includes an
+   in-band approval reply carrying the full transcript: a person approves a gated tool, the
+   parked session is gone (any redeploy), and the approval dies with "No user message to send".
+   Probed with three real shapes, all previously passing. Fixed by restoring the backward-scan
+   fallback inside the rejection while keeping the tail-only attachment clause, with the three
+   shapes pinned as tests.
+2. **One unrestorable historical attachment bricked its conversation forever.** The cold-start
+   restore threw on a single failed fetch, every retry is also cold, and the failure is
+   deterministic once the sweep has taken an unclaimed file. The chain starts at the deliberately
+   non-fatal claim, a tradeoff WP1 recorded in the reverse direction. Fixed: historical restore
+   degrades per file (the mention renders as no longer available), and never throws.
+3. **Legacy inline images hard-failed turns in five reachable configurations** (capability probe
+   unavailable, SVG and HEIC pastes, unknown harness, oversized image) where the runner
+   previously degraded silently. A pasted data-URL image is not an explicit native request; it
+   now degrades exactly as before when native delivery is not possible, and only a true contract
+   violation fails a turn.
+
+Smaller fixes from the same pass: cold restore checks existence before downloading (it
+re-fetched every referenced file on every cold start); current-turn fetch and write failures
+degrade that one attachment with honest reason codes (`fetch_failed`, `materialize_failed`)
+instead of failing the turn under a mislabeled `contract_violation`; an over-cap turn no longer
+persists a durable record for a run that is then rejected; the Daytona symlink check runs before
+directory creation and is time-bounded; mention lines moved into the latest-user-message position
+of the cold frame instead of before the replayed transcript; and the per-image provider cap keys
+on the resolved provider rather than the harness name.
+
+### Forced routes to double-check
+
+- **The linearization of PR #5598** (above): the alternative was re-expressing three files
+  against a base without the approval changes and accepting textual merge conflicts later; the
+  linear train was judged cleaner, and it is reversible by reverting the move before anything
+  merges.
+- **Legacy images degrade with no delivery event.** A degraded pasted image logs but emits no
+  `attachment_delivery` record, because the legacy path has no attachment id to key the event.
+  Honest visibility for pasted images arrives with WP4, when the front end switches them to real
+  attachments.

--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -217,6 +217,32 @@ directory creation and is time-bounded; mention lines moved into the latest-user
 of the cold frame instead of before the replayed transcript; and the per-image provider cap keys
 on the resolved provider rather than the harness name.
 
+### Live QA (dev stack, 2026-08-01)
+
+The runner was recreated on the shared stack (source is bind-mounted; no dependency change) and
+driven from a real browser on the QA account. Results:
+
+- **Text-only turn: pass.** The current-turn refactor did not disturb plain conversations.
+- **Image plus text: pass, and it is the milestone.** A pasted PNG reading "AGENTA 42" on a red
+  background came back as exactly `AGENTA 42`, with the model's reasoning describing the image.
+  This is the first time a file sent from the Agenta composer has reached a model's eyes. The
+  legacy dual read and the capability gate work end to end.
+- **Image-only: still failed on first QA.** The guard's four clauses all held for an image-only
+  legacy turn, because `currentUserTurn` counted only real attachment blocks and today's front
+  end sends inline data-URL blocks; with no typed text and no earlier user turn on the wire, the
+  turn looked empty. Every layer behind the guard was fine. Fixed by teaching the current-turn
+  reading that inline media makes a turn non-empty (shared predicate with the legacy dual read),
+  with the plan guard, freshness, and prompt assembly aligned, and re-verified live before the
+  PR left draft. The lesson mirrors WP1's boot blocker: unit suites and review both validated
+  the guard against approval shapes, but only driving the product's real wire shape caught this.
+- **Cold reload: pass.** The conversation and attachment chips restored, and a follow-up
+  question about the image was answered correctly from the re-delivered content.
+
+Two observability notes from QA, one fixed and one deferred: the legacy delivery path now logs
+its decision (it emits no `attachment_delivery` event, having no id to key one), and the stale
+"add your model provider key" banner after saving credentials is a pre-existing cosmetic bug
+unrelated to this stage.
+
 ### Forced routes to double-check
 
 - **The linearization of PR #5598** (above): the alternative was re-expressing three files

--- a/services/runner/src/engines/sandbox_agent/attachments.ts
+++ b/services/runner/src/engines/sandbox_agent/attachments.ts
@@ -29,17 +29,15 @@ export type AttachmentDeliveryOutcome =
   | "workspace_only"
   | "failed";
 
-export type AttachmentReasonCode =
+export type AttachmentDeliveryReasonCode =
   | "transport_unsupported"
   | "adapter_unsupported"
   | "model_modality_unknown"
   | "model_modality_unsupported"
   | "provider_inline_cap"
   | "fetch_failed"
-  | "contract_violation";
-
-export type AttachmentDeliveryReasonCode =
-  | AttachmentReasonCode
+  | "materialize_failed"
+  | "contract_violation"
   | "native_supported";
 
 export interface AttachmentPath {
@@ -58,8 +56,8 @@ export interface AttachmentGate {
 
 export interface ResolvedAttachment {
   ref: AttachmentRef;
-  bytes: Uint8Array;
-  path: AttachmentPath;
+  bytes?: Uint8Array;
+  path?: AttachmentPath;
   gate: AttachmentGate;
 }
 
@@ -79,6 +77,7 @@ export interface AttachmentSandbox {
   runProcess?: (query: {
     command: string;
     args: string[];
+    timeoutMs?: number;
   }) => Promise<{ exitCode?: number } | undefined>;
 }
 
@@ -159,7 +158,9 @@ export function collectAttachmentRefs(
   message: ChatMessage | null,
 ): AttachmentRef[] {
   if (!message) return [];
-  // Wire display fields are never trusted; API response headers replace them before use.
+  // Attachment refs deliberately belong only to user messages, so reuse currentUserTurn to
+  // enforce that role coupling. Current-turn delivery replaces wire display fields from the API;
+  // transcript replay may reuse fields from records the runner previously wrote.
   return currentUserTurn({ messages: [message] }).attachments;
 }
 
@@ -207,12 +208,24 @@ export function collectLegacyInlineImages(
   return images;
 }
 
+export function validateRef(
+  ref: AttachmentRef,
+): asserts ref is AttachmentRef & { filename: string } {
+  assertCanonicalAttachmentId(ref.attachmentId);
+  validatedFilename(ref);
+}
+
+export function relativeAttachmentPath(ref: AttachmentRef): string {
+  validateRef(ref);
+  return posix.join("attachments", ref.attachmentId, ref.filename);
+}
+
 export function attachmentWorkingPath(
   cwd: string,
   ref: AttachmentRef,
 ): AttachmentPath {
-  assertCanonicalAttachmentId(ref.attachmentId);
-  const filename = validatedFilename(ref);
+  validateRef(ref);
+  const filename = ref.filename;
   const root = resolve(cwd, "attachments");
   const directory = resolve(root, ref.attachmentId);
   const absolute = resolve(directory, filename);
@@ -224,13 +237,29 @@ export function attachmentWorkingPath(
     root,
     directory,
     absolute,
-    relative: posix.join("attachments", ref.attachmentId, filename),
+    relative: relativeAttachmentPath(ref),
   };
 }
 
 export function attachmentMention(ref: AttachmentRef): string {
-  const path = attachmentWorkingPath("/", ref);
-  return "[attached file: " + ref.filename + " at " + path.relative + "]";
+  validateRef(ref);
+  return (
+    "[attached file: " +
+    ref.filename +
+    " at " +
+    relativeAttachmentPath(ref) +
+    "]"
+  );
+}
+
+export function unavailableAttachmentMention(ref: AttachmentRef): string {
+  let filename = "attachment";
+  try {
+    filename = validatedFilename(ref);
+  } catch {
+    // A missing fetch leaves no authoritative filename. Do not render an unsafe wire value.
+  }
+  return "[attached file: " + filename + " - no longer available]";
 }
 
 function fileSystemError(error: unknown): NodeJS.ErrnoException {
@@ -318,6 +347,7 @@ async function rejectDaytonaSymlinks(
     const result = await sandbox.runProcess({
       command: "test",
       args: ["-L", path],
+      timeoutMs: 15_000,
     });
     if (result?.exitCode === 0) {
       throw new Error("attachment path contains a symbolic link");
@@ -337,12 +367,12 @@ async function daytonaMaterialize(
   ) {
     throw new Error("Daytona sandbox lacks attachment filesystem operations");
   }
-  await sandbox.mkdirFs({ path: path.directory });
   await rejectDaytonaSymlinks(sandbox, [
     path.root,
     path.directory,
     path.absolute,
   ]);
+  await sandbox.mkdirFs({ path: path.directory });
 
   // Daytona has no exclusive create; this check-then-write race is accepted.
   try {
@@ -431,8 +461,8 @@ function base64Length(byteLength: number): number {
 }
 
 export function attachmentCapabilityGate(input: {
-  harness: string;
   acpAgent: string;
+  provider?: string;
   capabilities: HarnessCapabilities;
   modelCapabilities?: AgentRunRequest["modelCapabilities"];
   mediaType: string;
@@ -483,9 +513,14 @@ export function attachmentCapabilityGate(input: {
     };
   }
 
+  const provider = input.provider?.trim().toLowerCase();
+  // Older callers omit provider, so retain the ACP-agent heuristic only as that fallback.
+  const usesAnthropicInlineLimit = provider
+    ? provider === "anthropic"
+    : input.acpAgent === "claude";
   if (
     kind === "image" &&
-    input.acpAgent === "claude" &&
+    usesAnthropicInlineLimit &&
     base64Length(input.byteLength) > CLAUDE_INLINE_BASE64_MAX_BYTES
   ) {
     return {
@@ -502,12 +537,14 @@ export function buildPromptBlocks(
   turnText: string,
   resolved: readonly ResolvedAttachment[],
   legacyImages: readonly InlineImage[] = [],
+  latestUserText: string = turnText,
 ): AcpPromptBlock[] {
   const blocks: AcpPromptBlock[] = [];
   for (const attachment of resolved) {
     if (
       attachment.gate.outcome === "native" &&
-      attachment.gate.kind === "image"
+      attachment.gate.kind === "image" &&
+      attachment.bytes
     ) {
       blocks.push({
         type: "image",
@@ -521,11 +558,31 @@ export function buildPromptBlocks(
   }
 
   const mentions = resolved.map((attachment) =>
-    attachmentMention(attachment.ref),
+    attachment.gate.outcome === "failed"
+      ? unavailableAttachmentMention(attachment.ref)
+      : attachmentMention(attachment.ref),
   );
+  let text = turnText;
+  if (mentions.length > 0) {
+    const renderedMentions = mentions.join("\n");
+    if (latestUserText && turnText.endsWith(latestUserText)) {
+      text =
+        turnText.slice(0, -latestUserText.length) +
+        renderedMentions +
+        "\n" +
+        latestUserText;
+    } else if (
+      !latestUserText &&
+      turnText.endsWith("Continue the conversation. The user now says:\n")
+    ) {
+      text = turnText + renderedMentions;
+    } else {
+      text = [renderedMentions, turnText].filter(Boolean).join("\n");
+    }
+  }
   blocks.push({
     type: "text",
-    text: [...mentions, ...(turnText ? [turnText] : [])].join("\n"),
+    text,
   });
   return blocks;
 }
@@ -562,6 +619,37 @@ function verifiedRef(
   };
 }
 
+async function workingCopyExists(
+  sandbox: AttachmentSandbox,
+  plan: MaterializePlan,
+  ref: AttachmentRef,
+): Promise<boolean> {
+  const path = attachmentWorkingPath(plan.cwd, ref);
+  if (plan.isDaytona) {
+    if (typeof sandbox.statFs !== "function") return false;
+    await rejectDaytonaSymlinks(sandbox, [
+      path.root,
+      path.directory,
+      path.absolute,
+    ]);
+    try {
+      await sandbox.statFs({ path: path.absolute });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  rejectLocalSymlinks([path.root, path.directory, path.absolute]);
+  try {
+    lstatSync(path.absolute);
+    return true;
+  } catch (error) {
+    if (fileSystemError(error).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
 export async function restoreReferencedWorkingCopies(
   sandbox: AttachmentSandbox,
   plan: MaterializePlan,
@@ -581,6 +669,7 @@ export async function restoreReferencedWorkingCopies(
   for (const ref of refs) unique.set(ref.attachmentId, ref);
   const pending = [...unique.values()];
   const resolved = new Map<string, AttachmentRef>();
+  const failed = new Map<string, AttachmentRef>();
   const concurrency = options.concurrency ?? attachmentRestoreConcurrency();
   const timeoutMs = options.timeoutMs ?? attachmentRestoreTimeoutMs();
   const log = options.log ?? (() => {});
@@ -589,39 +678,58 @@ export async function restoreReferencedWorkingCopies(
     while (pending.length > 0) {
       const ref = pending.shift();
       if (!ref) return;
-      await withTimeout(
-        (async () => {
-          assertCanonicalAttachmentId(ref.attachmentId);
-          const fetched = await fetchAttachment(
-            sessionId,
-            ref.attachmentId,
-            auth,
-          );
-          if (!fetched) throw new Error("attachment working copy restore failed");
-          const authoritative = verifiedRef(ref, fetched);
-          await materializeWorkingCopy(
-            sandbox,
-            plan,
-            authoritative,
-            fetched.bytes,
-          );
-          resolved.set(ref.attachmentId, authoritative);
-        })(),
-        timeoutMs,
-      ).catch((error) => {
+      try {
+        await withTimeout(
+          (async () => {
+            assertCanonicalAttachmentId(ref.attachmentId);
+            let recordPathIsUsable = true;
+            try {
+              validatedFilename(ref);
+            } catch {
+              recordPathIsUsable = false;
+            }
+            if (
+              recordPathIsUsable &&
+              (await workingCopyExists(sandbox, plan, ref))
+            ) {
+              // Historical refs come from runner-written durable records. Once their working copy
+              // exists, those record-sourced display fields are sufficient and no download is due.
+              resolved.set(ref.attachmentId, ref);
+              return;
+            }
+            const fetched = await fetchAttachment(
+              sessionId,
+              ref.attachmentId,
+              auth,
+            );
+            if (!fetched) {
+              throw new Error("attachment content is no longer available");
+            }
+            const authoritative = verifiedRef(ref, fetched);
+            await materializeWorkingCopy(
+              sandbox,
+              plan,
+              authoritative,
+              fetched.bytes,
+            );
+            resolved.set(ref.attachmentId, authoritative);
+          })(),
+          timeoutMs,
+        );
+      } catch (error) {
+        failed.set(ref.attachmentId, ref);
         log(
-          "attachment restore FAILED: " +
+          `attachment restore FAILED attachment=${ref.attachmentId}: ` +
             String(error instanceof Error ? error.message : error).slice(
               0,
               120,
             ),
         );
-        throw new Error("attachment working copy restore failed");
-      });
+      }
     }
   };
 
-  await Promise.all(
+  await Promise.allSettled(
     Array.from(
       { length: Math.min(concurrency, pending.length) },
       () => worker(),
@@ -640,14 +748,18 @@ export async function restoreReferencedWorkingCopies(
           return block;
         }
         const authoritative = resolved.get(block.attachmentId);
-        return authoritative
-          ? {
-              ...block,
-              attachmentId: authoritative.attachmentId,
-              filename: authoritative.filename,
-              mimeType: authoritative.mediaType,
-              size: authoritative.size,
-            }
+        if (authoritative) {
+          return {
+            ...block,
+            attachmentId: authoritative.attachmentId,
+            filename: authoritative.filename,
+            mimeType: authoritative.mediaType,
+            size: authoritative.size,
+          };
+        }
+        const unavailable = failed.get(block.attachmentId);
+        return unavailable
+          ? { type: "text", text: unavailableAttachmentMention(unavailable) }
           : block;
       }),
     };
@@ -662,6 +774,7 @@ export async function resolveCurrentTurnAttachments(input: {
   plan: DeliveryPlan;
   capabilities: HarnessCapabilities;
   modelCapabilities?: AgentRunRequest["modelCapabilities"];
+  provider?: string;
   emit: (event: {
     type: "attachment_delivery";
     attachmentId: string;
@@ -699,7 +812,14 @@ export async function resolveCurrentTurnAttachments(input: {
         outcome: "failed",
         reasonCode: "fetch_failed",
       });
-      failure ??= new Error("Attachment could not be fetched for this session.");
+      resolved.push({
+        ref,
+        gate: {
+          outcome: "failed",
+          reasonCode: "fetch_failed",
+          kind: attachmentKind(ref.mediaType),
+        },
+      });
       continue;
     }
 
@@ -718,15 +838,22 @@ export async function resolveCurrentTurnAttachments(input: {
         type: "attachment_delivery",
         attachmentId: ref.attachmentId,
         outcome: "failed",
-        reasonCode: "contract_violation",
+        reasonCode: "materialize_failed",
       });
-      failure ??= new Error("Attachment delivery failed.");
+      resolved.push({
+        ref: authoritative,
+        gate: {
+          outcome: "failed",
+          reasonCode: "materialize_failed",
+          kind: attachmentKind(authoritative.mediaType),
+        },
+      });
       continue;
     }
 
     const gate = attachmentCapabilityGate({
-      harness: input.plan.harness,
       acpAgent: input.plan.acpAgent,
+      provider: input.provider,
       capabilities: input.capabilities,
       modelCapabilities: input.modelCapabilities,
       mediaType: authoritative.mediaType ?? "",

--- a/services/runner/src/engines/sandbox_agent/attachments.ts
+++ b/services/runner/src/engines/sandbox_agent/attachments.ts
@@ -1,0 +1,769 @@
+import { randomUUID } from "node:crypto";
+import {
+  lstatSync,
+  linkSync,
+  mkdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { posix, resolve, sep } from "node:path";
+
+import { envInt, envTimerMs } from "../../env.ts";
+import {
+  currentUserTurn,
+  type AgentRunRequest,
+  type AttachmentRef,
+  type ChatMessage,
+  type ContentBlock,
+  type HarnessCapabilities,
+} from "../../protocol.ts";
+import {
+  fetchAttachment,
+  type FetchedAttachment,
+} from "../../sessions/attachments.ts";
+import { attachmentDeliveryUnsupportedMessage } from "./capabilities.ts";
+import type { RunPlan } from "./run-plan.ts";
+
+export type AttachmentDeliveryOutcome =
+  | "native"
+  | "workspace_only"
+  | "failed";
+
+export type AttachmentReasonCode =
+  | "transport_unsupported"
+  | "adapter_unsupported"
+  | "model_modality_unknown"
+  | "model_modality_unsupported"
+  | "provider_inline_cap"
+  | "fetch_failed"
+  | "contract_violation";
+
+export type AttachmentDeliveryReasonCode =
+  | AttachmentReasonCode
+  | "native_supported";
+
+export interface AttachmentPath {
+  root: string;
+  directory: string;
+  absolute: string;
+  relative: string;
+}
+
+export interface AttachmentGate {
+  outcome: AttachmentDeliveryOutcome;
+  reasonCode: AttachmentDeliveryReasonCode;
+  kind: "image" | "audio" | "document";
+  missing?: string;
+}
+
+export interface ResolvedAttachment {
+  ref: AttachmentRef;
+  bytes: Uint8Array;
+  path: AttachmentPath;
+  gate: AttachmentGate;
+}
+
+export interface InlineImage {
+  data: string;
+  mimeType: string;
+}
+
+export type AcpPromptBlock =
+  | { type: "image"; data: string; mimeType: string }
+  | { type: "text"; text: string };
+
+export interface AttachmentSandbox {
+  statFs?: (query: { path: string }) => Promise<unknown>;
+  mkdirFs?: (query: { path: string }) => Promise<unknown>;
+  writeFsFile?: (query: { path: string }, body: Uint8Array) => Promise<unknown>;
+  runProcess?: (query: {
+    command: string;
+    args: string[];
+  }) => Promise<{ exitCode?: number } | undefined>;
+}
+
+type MaterializePlan = Pick<RunPlan, "cwd" | "isDaytona">;
+type DeliveryPlan = Pick<RunPlan, "cwd" | "isDaytona" | "acpAgent" | "harness">;
+type Auth = () => string;
+type Log = (message: string) => void;
+
+const CANONICAL_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/;
+const NATIVE_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+const KNOWN_MODEL_MODALITIES = new Set([
+  "text",
+  "image",
+  "audio",
+  "document",
+  "documents",
+]);
+const CLAUDE_INLINE_BASE64_MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_RESTORE_CONCURRENCY = 4;
+const DEFAULT_RESTORE_TIMEOUT_MS = 15_000;
+
+// Adapter fidelity at the pinned versions: claude-agent-acp 0.58.1 and pi-acp 0.0.29.
+const ADAPTER_NATIVE_SUPPORT = {
+  claude: { image: true, audio: false, document: false },
+  pi: { image: true, audio: false, document: false },
+} as const;
+
+function attachmentLog(message: string): void {
+  process.stderr.write("[attachments] " + message + "\n");
+}
+
+export function attachmentRestoreConcurrency(): number {
+  return envInt(
+    "AGENTA_ATTACHMENTS_RESTORE_CONCURRENCY",
+    DEFAULT_RESTORE_CONCURRENCY,
+    { min: 1, max: 32, log: attachmentLog },
+  );
+}
+
+export function attachmentRestoreTimeoutMs(): number {
+  return envTimerMs(
+    "AGENTA_ATTACHMENTS_RESTORE_TIMEOUT_MS",
+    DEFAULT_RESTORE_TIMEOUT_MS,
+    { min: 1, log: attachmentLog },
+  );
+}
+
+export function assertCanonicalAttachmentId(attachmentId: string): void {
+  if (!CANONICAL_UUID.test(attachmentId)) {
+    throw new Error("attachment id must be a canonical UUID");
+  }
+}
+
+function validatedFilename(ref: AttachmentRef): string {
+  const filename = ref.filename;
+  if (
+    typeof filename !== "string" ||
+    filename.length === 0 ||
+    filename === "." ||
+    filename === ".." ||
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    CONTROL_CHARACTER.test(filename)
+  ) {
+    throw new Error("attachment filename must be a safe basename");
+  }
+  return filename;
+}
+
+export function collectAttachmentRefs(
+  message: ChatMessage | null,
+): AttachmentRef[] {
+  if (!message) return [];
+  // Wire display fields are never trusted; API response headers replace them before use.
+  return currentUserTurn({ messages: [message] }).attachments;
+}
+
+function parseDataUri(uri: string): InlineImage | null {
+  const match = /^data:([^;,]*)(;base64)?,(.*)$/s.exec(uri);
+  if (!match) return null;
+  const mimeType = match[1] || "image/png";
+  try {
+    const data = match[2]
+      ? match[3].replace(/\s/g, "")
+      : Buffer.from(decodeURIComponent(match[3]), "utf8").toString("base64");
+    return data ? { data, mimeType } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function collectLegacyInlineImages(
+  message: ChatMessage | null,
+): InlineImage[] {
+  if (!message || !Array.isArray(message.content)) return [];
+  const images: InlineImage[] = [];
+  for (const block of message.content) {
+    if (block?.type !== "image") continue;
+    if (typeof block.uri === "string" && block.uri.startsWith("data:")) {
+      const parsed = parseDataUri(block.uri);
+      if (parsed) {
+        images.push(parsed);
+        continue;
+      }
+    }
+    if (typeof block.data === "string" && block.data.length > 0) {
+      const parsed = block.data.startsWith("data:")
+        ? parseDataUri(block.data)
+        : {
+            data: block.data,
+            mimeType:
+              typeof block.mimeType === "string"
+                ? block.mimeType
+                : "image/png",
+          };
+      if (parsed) images.push(parsed);
+    }
+  }
+  return images;
+}
+
+export function attachmentWorkingPath(
+  cwd: string,
+  ref: AttachmentRef,
+): AttachmentPath {
+  assertCanonicalAttachmentId(ref.attachmentId);
+  const filename = validatedFilename(ref);
+  const root = resolve(cwd, "attachments");
+  const directory = resolve(root, ref.attachmentId);
+  const absolute = resolve(directory, filename);
+  const prefix = root.endsWith(sep) ? root : root + sep;
+  if (!directory.startsWith(prefix) || !absolute.startsWith(prefix)) {
+    throw new Error("attachment path escapes the attachments directory");
+  }
+  return {
+    root,
+    directory,
+    absolute,
+    relative: posix.join("attachments", ref.attachmentId, filename),
+  };
+}
+
+export function attachmentMention(ref: AttachmentRef): string {
+  const path = attachmentWorkingPath("/", ref);
+  return "[attached file: " + ref.filename + " at " + path.relative + "]";
+}
+
+function fileSystemError(error: unknown): NodeJS.ErrnoException {
+  return error as NodeJS.ErrnoException;
+}
+
+function safeUnlink(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if (fileSystemError(error).code !== "ENOENT") throw error;
+  }
+}
+
+function rejectLocalSymlinks(paths: readonly string[]): void {
+  for (const path of paths) {
+    try {
+      if (lstatSync(path).isSymbolicLink()) {
+        throw new Error("attachment path contains a symbolic link");
+      }
+    } catch (error) {
+      if (fileSystemError(error).code === "ENOENT") continue;
+      throw error;
+    }
+  }
+}
+
+function localMaterialize(
+  path: AttachmentPath,
+  bytes: Uint8Array,
+): "written" | "exists" {
+  mkdirSync(path.root, { recursive: true });
+  rejectLocalSymlinks([path.root]);
+  try {
+    mkdirSync(path.directory);
+  } catch (error) {
+    if (fileSystemError(error).code !== "EEXIST") throw error;
+  }
+  rejectLocalSymlinks([path.root, path.directory, path.absolute]);
+
+  const temporary = path.absolute + "." + randomUUID() + ".tmp";
+  let temporaryExists = false;
+  try {
+    writeFileSync(temporary, Buffer.from(bytes), { flag: "wx" });
+    temporaryExists = true;
+    try {
+      linkSync(temporary, path.absolute);
+      return "written";
+    } catch (error) {
+      const code = fileSystemError(error).code;
+      if (code === "EEXIST") return "exists";
+      if (
+        code !== "EPERM" &&
+        code !== "ENOSYS" &&
+        code !== "EOPNOTSUPP"
+      ) {
+        throw error;
+      }
+
+      safeUnlink(temporary);
+      temporaryExists = false;
+      try {
+        writeFileSync(path.absolute, Buffer.from(bytes), { flag: "wx" });
+        return "written";
+      } catch (fallbackError) {
+        if (fileSystemError(fallbackError).code === "EEXIST") {
+          return "exists";
+        }
+        throw fallbackError;
+      }
+    }
+  } finally {
+    if (temporaryExists) safeUnlink(temporary);
+  }
+}
+
+async function rejectDaytonaSymlinks(
+  sandbox: AttachmentSandbox,
+  paths: readonly string[],
+): Promise<void> {
+  if (typeof sandbox.runProcess !== "function") {
+    throw new Error("Daytona sandbox cannot verify attachment path components");
+  }
+  for (const path of paths) {
+    const result = await sandbox.runProcess({
+      command: "test",
+      args: ["-L", path],
+    });
+    if (result?.exitCode === 0) {
+      throw new Error("attachment path contains a symbolic link");
+    }
+  }
+}
+
+async function daytonaMaterialize(
+  sandbox: AttachmentSandbox,
+  path: AttachmentPath,
+  bytes: Uint8Array,
+): Promise<"written" | "exists"> {
+  if (
+    typeof sandbox.mkdirFs !== "function" ||
+    typeof sandbox.statFs !== "function" ||
+    typeof sandbox.writeFsFile !== "function"
+  ) {
+    throw new Error("Daytona sandbox lacks attachment filesystem operations");
+  }
+  await sandbox.mkdirFs({ path: path.directory });
+  await rejectDaytonaSymlinks(sandbox, [
+    path.root,
+    path.directory,
+    path.absolute,
+  ]);
+
+  // Daytona has no exclusive create; this check-then-write race is accepted.
+  try {
+    await sandbox.statFs({ path: path.absolute });
+    return "exists";
+  } catch {}
+
+  await sandbox.writeFsFile(
+    { path: path.absolute },
+    Buffer.from(bytes),
+  );
+  return "written";
+}
+
+export async function materializeWorkingCopy(
+  sandbox: AttachmentSandbox,
+  plan: MaterializePlan,
+  ref: AttachmentRef,
+  bytes: Uint8Array,
+): Promise<"written" | "exists"> {
+  const path = attachmentWorkingPath(plan.cwd, ref);
+  return plan.isDaytona
+    ? daytonaMaterialize(sandbox, path, bytes)
+    : localMaterialize(path, bytes);
+}
+
+function mediaBase(mediaType: string | undefined): string {
+  return String(mediaType ?? "")
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+}
+
+export function attachmentKind(
+  mediaType: string | undefined,
+): "image" | "audio" | "document" {
+  const base = mediaBase(mediaType);
+  if (NATIVE_IMAGE_TYPES.has(base)) return "image";
+  if (base.startsWith("audio/")) return "audio";
+  return "document";
+}
+
+function transportSupports(
+  kind: AttachmentGate["kind"],
+  capabilities: HarnessCapabilities,
+): boolean {
+  if (kind === "image") return capabilities.images === true;
+  if (kind === "document") return capabilities.fileAttachments === true;
+  return false;
+}
+
+function adapterSupports(
+  acpAgent: string,
+  kind: AttachmentGate["kind"],
+): boolean {
+  const adapter =
+    ADAPTER_NATIVE_SUPPORT[
+      acpAgent as keyof typeof ADAPTER_NATIVE_SUPPORT
+    ];
+  return adapter?.[kind] === true;
+}
+
+function modelModalityState(
+  modalities: string[] | undefined,
+  kind: AttachmentGate["kind"],
+): "supported" | "unsupported" | "unknown" {
+  if (!Array.isArray(modalities) || modalities.length === 0) {
+    return "unknown";
+  }
+  const normalized = modalities.map((value) =>
+    String(value).trim().toLowerCase(),
+  );
+  if (!normalized.some((value) => KNOWN_MODEL_MODALITIES.has(value))) {
+    return "unknown";
+  }
+  const supported =
+    kind === "document"
+      ? normalized.includes("document") ||
+        normalized.includes("documents")
+      : normalized.includes(kind);
+  return supported ? "supported" : "unsupported";
+}
+
+function base64Length(byteLength: number): number {
+  return Math.ceil(byteLength / 3) * 4;
+}
+
+export function attachmentCapabilityGate(input: {
+  harness: string;
+  acpAgent: string;
+  capabilities: HarnessCapabilities;
+  modelCapabilities?: AgentRunRequest["modelCapabilities"];
+  mediaType: string;
+  byteLength: number;
+  requireNative?: boolean;
+}): AttachmentGate {
+  const kind = attachmentKind(input.mediaType);
+  if (!transportSupports(kind, input.capabilities)) {
+    if (input.requireNative) {
+      return {
+        outcome: "failed",
+        reasonCode: "contract_violation",
+        kind,
+        missing: "transport capability",
+      };
+    }
+    return {
+      outcome: "workspace_only",
+      reasonCode: "transport_unsupported",
+      kind,
+    };
+  }
+
+  if (!adapterSupports(input.acpAgent, kind)) {
+    return {
+      outcome: "workspace_only",
+      reasonCode: "adapter_unsupported",
+      kind,
+    };
+  }
+
+  const modelState = modelModalityState(
+    input.modelCapabilities?.inputModalities,
+    kind,
+  );
+  if (modelState === "unknown") {
+    return {
+      outcome: "workspace_only",
+      reasonCode: "model_modality_unknown",
+      kind,
+    };
+  }
+  if (modelState === "unsupported") {
+    return {
+      outcome: "workspace_only",
+      reasonCode: "model_modality_unsupported",
+      kind,
+    };
+  }
+
+  if (
+    kind === "image" &&
+    input.acpAgent === "claude" &&
+    base64Length(input.byteLength) > CLAUDE_INLINE_BASE64_MAX_BYTES
+  ) {
+    return {
+      outcome: "workspace_only",
+      reasonCode: "provider_inline_cap",
+      kind,
+    };
+  }
+
+  return { outcome: "native", reasonCode: "native_supported", kind };
+}
+
+export function buildPromptBlocks(
+  turnText: string,
+  resolved: readonly ResolvedAttachment[],
+  legacyImages: readonly InlineImage[] = [],
+): AcpPromptBlock[] {
+  const blocks: AcpPromptBlock[] = [];
+  for (const attachment of resolved) {
+    if (
+      attachment.gate.outcome === "native" &&
+      attachment.gate.kind === "image"
+    ) {
+      blocks.push({
+        type: "image",
+        data: Buffer.from(attachment.bytes).toString("base64"),
+        mimeType: mediaBase(attachment.ref.mediaType),
+      });
+    }
+  }
+  for (const image of legacyImages) {
+    blocks.push({ type: "image", data: image.data, mimeType: image.mimeType });
+  }
+
+  const mentions = resolved.map((attachment) =>
+    attachmentMention(attachment.ref),
+  );
+  blocks.push({
+    type: "text",
+    text: [...mentions, ...(turnText ? [turnText] : [])].join("\n"),
+  });
+  return blocks;
+}
+
+async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("attachment restore timed out")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function verifiedRef(
+  ref: AttachmentRef,
+  fetched: FetchedAttachment,
+): AttachmentRef {
+  return {
+    attachmentId: ref.attachmentId,
+    filename: fetched.filename,
+    mediaType: fetched.mediaType,
+    size: fetched.bytes.byteLength,
+  };
+}
+
+export async function restoreReferencedWorkingCopies(
+  sandbox: AttachmentSandbox,
+  plan: MaterializePlan,
+  messages: readonly ChatMessage[],
+  sessionId: string,
+  auth: Auth,
+  options: {
+    concurrency?: number;
+    timeoutMs?: number;
+    log?: Log;
+  } = {},
+): Promise<ChatMessage[]> {
+  const refs = messages.flatMap((message) => collectAttachmentRefs(message));
+  if (refs.length === 0) return [...messages];
+
+  const unique = new Map<string, AttachmentRef>();
+  for (const ref of refs) unique.set(ref.attachmentId, ref);
+  const pending = [...unique.values()];
+  const resolved = new Map<string, AttachmentRef>();
+  const concurrency = options.concurrency ?? attachmentRestoreConcurrency();
+  const timeoutMs = options.timeoutMs ?? attachmentRestoreTimeoutMs();
+  const log = options.log ?? (() => {});
+
+  const worker = async (): Promise<void> => {
+    while (pending.length > 0) {
+      const ref = pending.shift();
+      if (!ref) return;
+      await withTimeout(
+        (async () => {
+          assertCanonicalAttachmentId(ref.attachmentId);
+          const fetched = await fetchAttachment(
+            sessionId,
+            ref.attachmentId,
+            auth,
+          );
+          if (!fetched) throw new Error("attachment working copy restore failed");
+          const authoritative = verifiedRef(ref, fetched);
+          await materializeWorkingCopy(
+            sandbox,
+            plan,
+            authoritative,
+            fetched.bytes,
+          );
+          resolved.set(ref.attachmentId, authoritative);
+        })(),
+        timeoutMs,
+      ).catch((error) => {
+        log(
+          "attachment restore FAILED: " +
+            String(error instanceof Error ? error.message : error).slice(
+              0,
+              120,
+            ),
+        );
+        throw new Error("attachment working copy restore failed");
+      });
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, pending.length) },
+      () => worker(),
+    ),
+  );
+
+  return messages.map((message) => {
+    if (!Array.isArray(message.content)) return message;
+    return {
+      ...message,
+      content: message.content.map((block) => {
+        if (
+          block?.type !== "attachment" ||
+          typeof block.attachmentId !== "string"
+        ) {
+          return block;
+        }
+        const authoritative = resolved.get(block.attachmentId);
+        return authoritative
+          ? {
+              ...block,
+              attachmentId: authoritative.attachmentId,
+              filename: authoritative.filename,
+              mimeType: authoritative.mediaType,
+              size: authoritative.size,
+            }
+          : block;
+      }),
+    };
+  });
+}
+
+export async function resolveCurrentTurnAttachments(input: {
+  message: ChatMessage | null;
+  sessionId: string;
+  auth: Auth;
+  sandbox: AttachmentSandbox;
+  plan: DeliveryPlan;
+  capabilities: HarnessCapabilities;
+  modelCapabilities?: AgentRunRequest["modelCapabilities"];
+  emit: (event: {
+    type: "attachment_delivery";
+    attachmentId: string;
+    outcome: AttachmentDeliveryOutcome;
+    reasonCode: string;
+    workingPath?: string;
+  }) => void;
+}): Promise<ResolvedAttachment[]> {
+  const refs = collectAttachmentRefs(input.message);
+  const resolved: ResolvedAttachment[] = [];
+  let failure: Error | null = null;
+  for (const ref of refs) {
+    try {
+      assertCanonicalAttachmentId(ref.attachmentId);
+    } catch {
+      input.emit({
+        type: "attachment_delivery",
+        attachmentId: ref.attachmentId,
+        outcome: "failed",
+        reasonCode: "contract_violation",
+      });
+      failure ??= new Error("Attachment reference is invalid.");
+      continue;
+    }
+
+    const fetched = await fetchAttachment(
+      input.sessionId,
+      ref.attachmentId,
+      input.auth,
+    );
+    if (!fetched) {
+      input.emit({
+        type: "attachment_delivery",
+        attachmentId: ref.attachmentId,
+        outcome: "failed",
+        reasonCode: "fetch_failed",
+      });
+      failure ??= new Error("Attachment could not be fetched for this session.");
+      continue;
+    }
+
+    const authoritative = verifiedRef(ref, fetched);
+    let path: AttachmentPath;
+    try {
+      path = attachmentWorkingPath(input.plan.cwd, authoritative);
+      await materializeWorkingCopy(
+        input.sandbox,
+        input.plan,
+        authoritative,
+        fetched.bytes,
+      );
+    } catch {
+      input.emit({
+        type: "attachment_delivery",
+        attachmentId: ref.attachmentId,
+        outcome: "failed",
+        reasonCode: "contract_violation",
+      });
+      failure ??= new Error("Attachment delivery failed.");
+      continue;
+    }
+
+    const gate = attachmentCapabilityGate({
+      harness: input.plan.harness,
+      acpAgent: input.plan.acpAgent,
+      capabilities: input.capabilities,
+      modelCapabilities: input.modelCapabilities,
+      mediaType: authoritative.mediaType ?? "",
+      byteLength: fetched.bytes.byteLength,
+    });
+    if (gate.outcome === "failed") {
+      input.emit({
+        type: "attachment_delivery",
+        attachmentId: ref.attachmentId,
+        outcome: "failed",
+        reasonCode: gate.reasonCode,
+        workingPath: path.relative,
+      });
+      failure ??= new Error(
+        attachmentDeliveryUnsupportedMessage(
+          input.plan.harness,
+          gate.kind,
+          gate.missing ?? "required capability",
+        ),
+      );
+      continue;
+    }
+
+    input.emit({
+      type: "attachment_delivery",
+      attachmentId: ref.attachmentId,
+      outcome: gate.outcome,
+      reasonCode: gate.reasonCode,
+      workingPath: path.relative,
+    });
+    resolved.push({
+      ref: authoritative,
+      bytes: fetched.bytes,
+      path,
+      gate,
+    });
+  }
+  if (failure) throw failure;
+  return resolved;
+}

--- a/services/runner/src/engines/sandbox_agent/attachments.ts
+++ b/services/runner/src/engines/sandbox_agent/attachments.ts
@@ -96,13 +96,6 @@ const NATIVE_IMAGE_TYPES = new Set([
   "image/gif",
   "image/webp",
 ]);
-const KNOWN_MODEL_MODALITIES = new Set([
-  "text",
-  "image",
-  "audio",
-  "document",
-  "documents",
-]);
 const CLAUDE_INLINE_BASE64_MAX_BYTES = 10 * 1024 * 1024;
 const DEFAULT_RESTORE_CONCURRENCY = 4;
 const DEFAULT_RESTORE_TIMEOUT_MS = 15_000;
@@ -439,22 +432,20 @@ function adapterSupports(
 function modelModalityState(
   modalities: string[] | undefined,
   kind: AttachmentGate["kind"],
-): "supported" | "unsupported" | "unknown" {
+): "supported" | "unknown" {
   if (!Array.isArray(modalities) || modalities.length === 0) {
     return "unknown";
   }
   const normalized = modalities.map((value) =>
     String(value).trim().toLowerCase(),
   );
-  if (!normalized.some((value) => KNOWN_MODEL_MODALITIES.has(value))) {
-    return "unknown";
-  }
   const supported =
     kind === "document"
       ? normalized.includes("document") ||
         normalized.includes("documents")
       : normalized.includes(kind);
-  return supported ? "supported" : "unsupported";
+  // Catalog modality lists are positive declarations, so absence is not a negative capability.
+  return supported ? "supported" : "unknown";
 }
 
 function base64Length(byteLength: number): number {
@@ -503,13 +494,6 @@ export function attachmentCapabilityGate(input: {
     return {
       outcome: "workspace_only",
       reasonCode: "model_modality_unknown",
-      kind,
-    };
-  }
-  if (modelState === "unsupported") {
-    return {
-      outcome: "workspace_only",
-      reasonCode: "model_modality_unsupported",
       kind,
     };
   }

--- a/services/runner/src/engines/sandbox_agent/attachments.ts
+++ b/services/runner/src/engines/sandbox_agent/attachments.ts
@@ -24,6 +24,7 @@ import {
 } from "../../sessions/attachments.ts";
 import { attachmentDeliveryUnsupportedMessage } from "./capabilities.ts";
 import type { RunPlan } from "./run-plan.ts";
+import { COLD_FRAME_USER_LABEL } from "./transcript.ts";
 
 export type AttachmentDeliveryOutcome =
   | "native"
@@ -96,7 +97,7 @@ const NATIVE_IMAGE_TYPES = new Set([
   "image/gif",
   "image/webp",
 ]);
-const CLAUDE_INLINE_BASE64_MAX_BYTES = 10 * 1024 * 1024;
+export const CLAUDE_INLINE_BASE64_MAX_BYTES = 10 * 1024 * 1024;
 const DEFAULT_RESTORE_CONCURRENCY = 4;
 const DEFAULT_RESTORE_TIMEOUT_MS = 15_000;
 
@@ -343,7 +344,14 @@ async function rejectDaytonaSymlinks(
       args: ["-L", path],
       timeoutMs: 15_000,
     });
-    if (result?.exitCode === 0) {
+    // A missing exit code means the check never ran, which is not evidence that the path is
+    // safe. Fail closed rather than materializing through an unverified component.
+    if (typeof result?.exitCode !== "number") {
+      throw new Error(
+        "sandbox did not report an exit code for the symlink check",
+      );
+    }
+    if (result.exitCode === 0) {
       throw new Error("attachment path contains a symbolic link");
     }
   }
@@ -429,6 +437,17 @@ function adapterSupports(
   return adapter?.[kind] === true;
 }
 
+// The catalog declares modalities as bare tokens ("text", "image"). Only tokens listed here
+// count as a declaration; anything else stays unrecognized, so a malformed or future value can
+// never read as a supported modality.
+const MODALITY_TOKENS: Record<string, AttachmentGate["kind"]> = {
+  image: "image",
+  images: "image",
+  audio: "audio",
+  document: "document",
+  documents: "document",
+};
+
 function modelModalityState(
   modalities: string[] | undefined,
   kind: AttachmentGate["kind"],
@@ -436,14 +455,11 @@ function modelModalityState(
   if (!Array.isArray(modalities) || modalities.length === 0) {
     return "unknown";
   }
-  const normalized = modalities.map((value) =>
-    String(value).trim().toLowerCase(),
+  const supported = modalities.some(
+    (value) =>
+      typeof value === "string" &&
+      MODALITY_TOKENS[value.trim().toLowerCase()] === kind,
   );
-  const supported =
-    kind === "document"
-      ? normalized.includes("document") ||
-        normalized.includes("documents")
-      : normalized.includes(kind);
   // Catalog modality lists are positive declarations, so absence is not a negative capability.
   return supported ? "supported" : "unknown";
 }
@@ -478,9 +494,11 @@ export function attachmentCapabilityGate(input: {
     };
   }
 
+  // `requireNative` means the caller cannot degrade to a workspace copy, so every layer that
+  // withholds native delivery is a failure for it, not a downgrade.
   if (!adapterSupports(input.acpAgent, kind)) {
     return {
-      outcome: "workspace_only",
+      outcome: input.requireNative ? "failed" : "workspace_only",
       reasonCode: "adapter_unsupported",
       kind,
     };
@@ -491,11 +509,17 @@ export function attachmentCapabilityGate(input: {
     kind,
   );
   if (modelState === "unknown") {
-    return {
-      outcome: "workspace_only",
-      reasonCode: "model_modality_unknown",
-      kind,
-    };
+    return input.requireNative
+      ? {
+          outcome: "failed",
+          reasonCode: "model_modality_unsupported",
+          kind,
+        }
+      : {
+          outcome: "workspace_only",
+          reasonCode: "model_modality_unknown",
+          kind,
+        };
   }
 
   const provider = input.provider?.trim().toLowerCase();
@@ -556,10 +580,7 @@ export function buildPromptBlocks(
         renderedMentions +
         "\n" +
         latestUserText;
-    } else if (
-      !latestUserText &&
-      turnText.endsWith("Continue the conversation. The user now says:\n")
-    ) {
+    } else if (!latestUserText && turnText.endsWith(COLD_FRAME_USER_LABEL)) {
       text = turnText + renderedMentions;
     } else {
       text = [renderedMentions, turnText].filter(Boolean).join("\n");

--- a/services/runner/src/engines/sandbox_agent/attachments.ts
+++ b/services/runner/src/engines/sandbox_agent/attachments.ts
@@ -11,6 +11,7 @@ import { posix, resolve, sep } from "node:path";
 import { envInt, envTimerMs } from "../../env.ts";
 import {
   currentUserTurn,
+  isLegacyInlineImageBlock,
   type AgentRunRequest,
   type AttachmentRef,
   type ChatMessage,
@@ -184,7 +185,7 @@ export function collectLegacyInlineImages(
   if (!message || !Array.isArray(message.content)) return [];
   const images: InlineImage[] = [];
   for (const block of message.content) {
-    if (block?.type !== "image") continue;
+    if (!isLegacyInlineImageBlock(block)) continue;
     if (typeof block.uri === "string" && block.uri.startsWith("data:")) {
       const parsed = parseDataUri(block.uri);
       if (parsed) {
@@ -580,10 +581,7 @@ export function buildPromptBlocks(
       text = [renderedMentions, turnText].filter(Boolean).join("\n");
     }
   }
-  blocks.push({
-    type: "text",
-    text,
-  });
+  if (text) blocks.push({ type: "text", text });
   return blocks;
 }
 

--- a/services/runner/src/engines/sandbox_agent/capabilities.ts
+++ b/services/runner/src/engines/sandbox_agent/capabilities.ts
@@ -60,6 +60,22 @@ export function toolDeliveryUnsupportedMessage(
   );
 }
 
+export function attachmentDeliveryUnsupportedMessage(
+  harness: string,
+  kind: string,
+  missing: string,
+): string {
+  return (
+    "harness \x27" +
+    harness +
+    "\x27 cannot receive a native " +
+    kind +
+    " attachment (" +
+    missing +
+    "); refusing the turn instead of dropping it."
+  );
+}
+
 /**
  * Map a sandbox-agent `AgentInfo` to our capability flags. Falls back to a per-harness static
  * guess when the probe is unavailable. Returns the flags AND where they came from, so a caller

--- a/services/runner/src/engines/sandbox_agent/engine.ts
+++ b/services/runner/src/engines/sandbox_agent/engine.ts
@@ -5,7 +5,10 @@ import {
 } from "../../protocol.ts";
 import { acquireEnvironment } from "./environment.ts";
 import { runTurn } from "./run-turn.ts";
-import { type SandboxAgentDeps } from "./runtime-contracts.ts";
+import {
+  type RunTurnOptions,
+  type SandboxAgentDeps,
+} from "./runtime-contracts.ts";
 
 /**
  * Whether a completed turn's environment may be parked: never on abort, client disconnect,
@@ -35,6 +38,7 @@ export async function runSandboxAgent(
   emit?: EmitEvent,
   signal?: AbortSignal,
   deps: SandboxAgentDeps = {},
+  turnOptions: Pick<RunTurnOptions, "credential"> = {},
 ): Promise<AgentRunResult> {
   const acquired = await acquireEnvironment(request, deps, signal);
   if (!acquired.ok) return { ok: false, error: acquired.error };
@@ -43,6 +47,7 @@ export async function runSandboxAgent(
   try {
     result = await runTurn(env, request, emit, signal, {
       loaded: env.loadedFromContinuity,
+      ...turnOptions,
     });
     return result;
   } finally {

--- a/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
+++ b/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
@@ -17,7 +17,7 @@
  * as a prior turn and then appended again from the inbound history.
  */
 
-import type { AgentRunRequest } from "../../protocol.ts";
+import type { AgentRunRequest, ChatMessage } from "../../protocol.ts";
 import { fetchSessionRecords } from "../../sessions/records-query.ts";
 import { recordsIncomplete } from "../../sessions/persist.ts";
 import { reconstructMessages } from "../../sessions/reconstruct.ts";
@@ -26,8 +26,11 @@ import {
   carriesMinimalHistory,
 } from "./session-identity.ts";
 
-// ON unless the literal "false"; absent AND empty both mean on (compose passes `${VAR:-}`,
-// which sets an empty string when the shell has no value).
+export interface ReconstructHistoryOptions {
+  restore?: (messages: ChatMessage[]) => Promise<ChatMessage[]>;
+}
+
+// ON unless the literal "false"; absent and empty both mean on.
 function reconstructEnabled(): boolean {
   return (
     String(process.env.AGENTA_SESSIONS_RECONSTRUCT ?? "").trim().toLowerCase() !== "false"
@@ -43,6 +46,7 @@ export async function reconstructHistoryIfNeeded(
   sessionId: string | undefined,
   auth: () => string,
   log?: (msg: string) => void,
+  options: ReconstructHistoryOptions = {},
 ): Promise<AgentRunRequest | null> {
   const inbound = request.messages ?? [];
   // An approval reply carries no task of its own, only the answered gate. Returning null for it
@@ -106,12 +110,16 @@ export async function reconstructHistoryIfNeeded(
     return null;
   }
 
-  const reconstructed = reconstructMessages(prior);
+  let reconstructed = reconstructMessages(prior);
   if (reconstructed.length === 0) {
     if (approvalReplyOnly) {
       refuse(`${prior.length} prior record(s) rebuilt into no messages`);
     }
     return null;
+  }
+
+  if (options.restore) {
+    reconstructed = await options.restore(reconstructed);
   }
 
   log?.(

--- a/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
+++ b/services/runner/src/engines/sandbox_agent/reconstruct-history.ts
@@ -30,7 +30,8 @@ export interface ReconstructHistoryOptions {
   restore?: (messages: ChatMessage[]) => Promise<ChatMessage[]>;
 }
 
-// ON unless the literal "false"; absent and empty both mean on.
+// Compose passes `${AGENTA_SESSIONS_RECONSTRUCT:-}`, so an empty value must mean on just like an
+// absent value. Only the literal "false" disables reconstruction.
 function reconstructEnabled(): boolean {
   return (
     String(process.env.AGENTA_SESSIONS_RECONSTRUCT ?? "").trim().toLowerCase() !== "false"

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -7,9 +7,10 @@ import {
   type AgentRunRequest,
   type ResolvedToolSpec,
   type SandboxPermission,
-  resolvePromptText,
+  currentUserTurn,
 } from "../../protocol.ts";
 import { executableToolSpecs } from "../../tools/public-spec.ts";
+import { attachmentCountError } from "../../sessions/attachments.ts";
 import { CODE_TOOL_UNSUPPORTED_MESSAGE } from "../../tools/code.ts";
 import { PI_USER_MCP_UNSUPPORTED_MESSAGE } from "../../tools/mcp-bridge.ts";
 import {
@@ -311,13 +312,20 @@ export function buildRunPlan(
     `harness '${harness}' resolved to ACP agent '${acpAgent}', but pi identity mapping disagrees`,
   );
 
-  const prompt = resolvePromptText(request);
+  const turn = currentUserTurn(request);
+  const attachmentError = attachmentCountError(turn.attachments.length);
+  if (attachmentError) return { ok: false, error: attachmentError };
+  const prompt = turn.text;
   // An out-of-band approval reply legitimately carries no user text: the human answered a parked
   // gate from the durable interaction row, not from the conversation. Its prior turns are rebuilt
   // from the record log inside `runTurn` (`reconstructHistoryIfNeeded`), which runs AFTER this
   // plan is built — so rejecting here would kill the run before the conversation could be
   // supplied. Every other empty-prompt request is still a caller bug and fails loudly.
-  if (!prompt && !carriesApprovalReplyOnly(request)) {
+  if (
+    !turn.text &&
+    turn.attachments.length === 0 &&
+    !carriesApprovalReplyOnly(request)
+  ) {
     return {
       ok: false,
       error: "No user message to send (prompt/messages empty).",

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -8,6 +8,7 @@ import {
   type ResolvedToolSpec,
   type SandboxPermission,
   currentUserTurn,
+  resolvePromptText,
 } from "../../protocol.ts";
 import { executableToolSpecs } from "../../tools/public-spec.ts";
 import { attachmentCountError } from "../../sessions/attachments.ts";
@@ -320,10 +321,12 @@ export function buildRunPlan(
   // gate from the durable interaction row, not from the conversation. Its prior turns are rebuilt
   // from the record log inside `runTurn` (`reconstructHistoryIfNeeded`), which runs AFTER this
   // plan is built — so rejecting here would kill the run before the conversation could be
-  // supplied. Every other empty-prompt request is still a caller bug and fails loudly.
+  // supplied. A historical user prompt also keeps structured continuation tails valid; only a
+  // request with no current attachment, no approval reply, and no user text anywhere is rejected.
   if (
     !turn.text &&
     turn.attachments.length === 0 &&
+    !resolvePromptText(request) &&
     !carriesApprovalReplyOnly(request)
   ) {
     return {

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -326,6 +326,7 @@ export function buildRunPlan(
   if (
     !turn.text &&
     turn.attachments.length === 0 &&
+    !turn.hasInlineMedia &&
     !resolvePromptText(request) &&
     !carriesApprovalReplyOnly(request)
   ) {

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -3,6 +3,7 @@ import {
   permissionsFromRequest,
 } from "../../permission-plan.ts";
 import {
+  currentUserTurn,
   resolvePromptText,
   type AgentRunRequest,
   type AgentRunResult,
@@ -44,6 +45,16 @@ import {
   relayWritesPausedAnswer,
 } from "./client-tools.ts";
 import { invalidateContinuity } from "./environment.ts";
+import {
+  attachmentCapabilityGate,
+  buildPromptBlocks,
+  collectAttachmentRefs,
+  collectLegacyInlineImages,
+  resolveCurrentTurnAttachments,
+  restoreReferencedWorkingCopies,
+  type AcpPromptBlock,
+} from "./attachments.ts";
+import { attachmentDeliveryUnsupportedMessage } from "./capabilities.ts";
 import { conciseError } from "./errors.ts";
 import {
   PAUSED,
@@ -151,11 +162,9 @@ export async function runTurn(
   });
 
   try {
-    // Server-side history reconstruction (on by default; AGENTA_SESSIONS_RECONSTRUCT=false
-    // disables): when the client sent a minimal history, rebuild prior turns from the durable
-    // record log so a cold turn still has full context. Runs before the current user turn is
-    // persisted, so records hold only prior turns. Reassigns `request` so every downstream
-    // reader (turnText, priorMessages, responder, otel) sees the same reconstructed history.
+    // Server-side history reconstruction rebuilds prior turns from the durable record log.
+    // The server already persisted this turn, so reconstruction filters its turn id.
+    // Reassign `request` so every downstream reader sees the same reconstructed history.
     // An out-of-band approval reply carries no user text of its own, so this must be decided from
     // the INBOUND request: reconstruction prepends the original user turn, after which
     // `resolvePromptText` would hand back that stale command and the model would restart the task.
@@ -169,12 +178,33 @@ export async function runTurn(
     // 500 from the records endpoint would lose the human's approval AND the parked session. Keep
     // the inbound request and continue. A cold turn still fails loudly, where it matters.
     let reconstructed: AgentRunRequest | null = null;
+    let historicalWorkingCopiesRestored = false;
+    let historicalAttachmentsPresent = false;
+    const restoreHistoricalWorkingCopies = async (
+      messages: NonNullable<AgentRunRequest["messages"]>,
+    ) => {
+      historicalWorkingCopiesRestored = true;
+      historicalAttachmentsPresent ||= messages.some(
+        (message) => collectAttachmentRefs(message).length > 0,
+      );
+      return restoreReferencedWorkingCopies(
+        env.sandbox,
+        plan,
+        messages,
+        sessionId,
+        () => runCredential(request),
+        { log: logger },
+      );
+    };
     try {
       reconstructed = await reconstructHistoryIfNeeded(
         request,
         sessionId,
         () => runCredential(request),
         logger,
+        !opts.continuation && !opts.resume
+          ? { restore: restoreHistoricalWorkingCopies }
+          : undefined,
       );
     } catch (err) {
       if (!opts.resume) throw err;
@@ -185,7 +215,24 @@ export async function runTurn(
     }
     if (reconstructed) request = reconstructed;
 
-    const promptText = resolvePromptText(request);
+    if (
+      !opts.continuation &&
+      !opts.resume &&
+      !historicalWorkingCopiesRestored
+    ) {
+      const messages = request.messages ?? [];
+      const current = currentUserTurn(request);
+      const historical = current.message ? messages.slice(0, -1) : messages;
+      const restored = await restoreHistoricalWorkingCopies(historical);
+      request = {
+        ...request,
+        messages: current.message ? [...restored, current.message] : restored,
+      };
+    }
+
+    const promptText = approvalReplyOnly
+      ? resolvePromptText(request)
+      : currentUserTurn(request).text;
     // Cold: replay the full transcript. Continuation or loaded: send only new text. When history
     // was rebuilt from records, recompute the transcript from it — the prebuilt plan.turnText
     // predates the reconstruction. An approval reply has no new text either way, so it sends the
@@ -195,7 +242,7 @@ export async function runTurn(
       ? approvalReplyOnly
         ? buildTurnText(inboundRequest, logger)
         : promptText
-      : reconstructed
+      : reconstructed || historicalAttachmentsPresent
         ? buildTurnText(request, logger)
         : plan.turnText;
 
@@ -234,6 +281,47 @@ export async function runTurn(
         { role: "user", content: promptText },
       ],
     });
+
+    let promptBlocks: AcpPromptBlock[] = [{ type: "text", text: turnText }];
+    if (!opts.resume) {
+      const current = currentUserTurn(request);
+      const refs = collectAttachmentRefs(current.message);
+      const resolved =
+        refs.length > 0
+          ? await resolveCurrentTurnAttachments({
+              message: current.message,
+              sessionId,
+              auth: () => runCredential(request),
+              sandbox: env.sandbox,
+              plan,
+              capabilities: env.capabilities,
+              modelCapabilities: request.modelCapabilities,
+              emit: (event) => run.emitEvent(event),
+            })
+          : [];
+      const legacyImages = collectLegacyInlineImages(current.message);
+      for (const image of legacyImages) {
+        const gate = attachmentCapabilityGate({
+          harness: plan.harness,
+          acpAgent: plan.acpAgent,
+          capabilities: env.capabilities,
+          modelCapabilities: { inputModalities: ["image"] },
+          mediaType: image.mimeType,
+          byteLength: Buffer.from(image.data, "base64").byteLength,
+          requireNative: true,
+        });
+        if (gate.outcome !== "native") {
+          throw new Error(
+            attachmentDeliveryUnsupportedMessage(
+              plan.harness,
+              gate.kind,
+              gate.missing ?? gate.reasonCode,
+            ),
+          );
+        }
+      }
+      promptBlocks = buildPromptBlocks(turnText, resolved, legacyImages);
+    }
 
     const sessionTurnClient = deps.appendSessionTurn ?? appendSessionTurn;
     const syncCred = runCredential(request);
@@ -800,7 +888,7 @@ export async function runTurn(
       if (opts.resume.carriedForward.length > 0) pause.pause();
     } else {
       promptPromise = Promise.resolve(
-        env.session.prompt([{ type: "text", text: turnText }]),
+        env.session.prompt(promptBlocks),
       );
       promptPromise.catch(() => {});
     }

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -54,7 +54,6 @@ import {
   restoreReferencedWorkingCopies,
   type AcpPromptBlock,
 } from "./attachments.ts";
-import { attachmentDeliveryUnsupportedMessage } from "./capabilities.ts";
 import { conciseError } from "./errors.ts";
 import {
   PAUSED,
@@ -107,6 +106,7 @@ export async function runTurn(
   opts: RunTurnOptions = {},
 ): Promise<AgentRunResult> {
   const { plan, logger, deps } = env;
+  const credential = opts.credential ?? (() => runCredential(request));
   const sessionId = env.sessionId;
   // Race marker for a user Stop (the control-plane `cancel`/`steer` command drops the alive lock, the
   // heartbeat aborts `signal`). Distinct from PAUSED/RUN_LIMIT_TRIPPED so the turn ends CLEANLY
@@ -162,6 +162,8 @@ export async function runTurn(
   });
 
   try {
+    // AGENTA_SESSIONS_RECONSTRUCT defaults on so minimal-history clients keep their conversation;
+    // only the literal "false" opts out. The compose default supplies an empty string, not "true".
     // Server-side history reconstruction rebuilds prior turns from the durable record log.
     // The server already persisted this turn, so reconstruction filters its turn id.
     // Reassign `request` so every downstream reader sees the same reconstructed history.
@@ -192,7 +194,7 @@ export async function runTurn(
         plan,
         messages,
         sessionId,
-        () => runCredential(request),
+        credential,
         { log: logger },
       );
     };
@@ -200,7 +202,7 @@ export async function runTurn(
       reconstructed = await reconstructHistoryIfNeeded(
         request,
         sessionId,
-        () => runCredential(request),
+        credential,
         logger,
         !opts.continuation && !opts.resume
           ? { restore: restoreHistoricalWorkingCopies }
@@ -291,36 +293,41 @@ export async function runTurn(
           ? await resolveCurrentTurnAttachments({
               message: current.message,
               sessionId,
-              auth: () => runCredential(request),
+              auth: credential,
               sandbox: env.sandbox,
               plan,
               capabilities: env.capabilities,
               modelCapabilities: request.modelCapabilities,
+              provider: request.provider,
               emit: (event) => run.emitEvent(event),
             })
           : [];
       const legacyImages = collectLegacyInlineImages(current.message);
+      const nativeLegacyImages = [];
       for (const image of legacyImages) {
         const gate = attachmentCapabilityGate({
-          harness: plan.harness,
           acpAgent: plan.acpAgent,
+          provider: request.provider,
           capabilities: env.capabilities,
           modelCapabilities: { inputModalities: ["image"] },
           mediaType: image.mimeType,
           byteLength: Buffer.from(image.data, "base64").byteLength,
-          requireNative: true,
         });
-        if (gate.outcome !== "native") {
-          throw new Error(
-            attachmentDeliveryUnsupportedMessage(
-              plan.harness,
-              gate.kind,
-              gate.missing ?? gate.reasonCode,
-            ),
+        if (gate.outcome === "native") {
+          nativeLegacyImages.push(image);
+        } else {
+          logger(
+            `[attachments] legacy inline image degraded kind=${gate.kind} ` +
+              `reason=${gate.reasonCode}`,
           );
         }
       }
-      promptBlocks = buildPromptBlocks(turnText, resolved, legacyImages);
+      promptBlocks = buildPromptBlocks(
+        turnText,
+        resolved,
+        nativeLegacyImages,
+        current.text,
+      );
     }
 
     const sessionTurnClient = deps.appendSessionTurn ?? appendSessionTurn;

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -313,14 +313,12 @@ export async function runTurn(
           mediaType: image.mimeType,
           byteLength: Buffer.from(image.data, "base64").byteLength,
         });
-        if (gate.outcome === "native") {
-          nativeLegacyImages.push(image);
-        } else {
-          logger(
-            `[attachments] legacy inline image degraded kind=${gate.kind} ` +
-              `reason=${gate.reasonCode}`,
-          );
-        }
+        if (gate.outcome === "native") nativeLegacyImages.push(image);
+        logger(
+          `[attachments] legacy inline image delivery=${
+            gate.outcome === "native" ? "native" : "degraded"
+          } reason=${gate.reasonCode}`,
+        );
       }
       promptBlocks = buildPromptBlocks(
         turnText,
@@ -328,6 +326,14 @@ export async function runTurn(
         nativeLegacyImages,
         current.text,
       );
+      if (promptBlocks.length === 0) {
+        promptBlocks = [
+          {
+            type: "text",
+            text: "[inline image could not be delivered to this harness]",
+          },
+        ];
+      }
     }
 
     const sessionTurnClient = deps.appendSessionTurn ?? appendSessionTurn;

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -309,7 +309,12 @@ export async function runTurn(
           acpAgent: plan.acpAgent,
           provider: request.provider,
           capabilities: env.capabilities,
-          modelCapabilities: { inputModalities: ["image"] },
+          // Legacy inline images predate the catalog, so a caller that declares nothing keeps
+          // the historical image-capable assumption; a caller that declares modalities is
+          // authoritative and its answer decides.
+          modelCapabilities: request.modelCapabilities ?? {
+            inputModalities: ["image"],
+          },
           mediaType: image.mimeType,
           byteLength: Buffer.from(image.data, "base64").byteLength,
         });

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -151,6 +151,8 @@ export interface ParkedApprovedExecution {
 
 /** Per-turn options for `runTurn`. Absent (flag off / cold) means today's byte-identical path. */
 export interface RunTurnOptions {
+  /** Latest session credential accessor; long turns may refresh the value between API calls. */
+  credential?: () => string;
   /** A live continuation: send only the new user text instead of the full cold transcript. */
   continuation?: boolean;
   /**

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -311,6 +311,36 @@ export function priorConversation(request: AgentRunRequest): ChatMessage[] {
 }
 
 /**
+ * True when the request ASSERTED a transcript beyond its own turn: its prior conversation (see
+ * `priorConversation`) still holds a user message. A last-message-only client never does (its
+ * prior conversation is empty), and neither does turn one of any conversation, which carries a
+ * single user message however the client sends history.
+ *
+ * A park records this so the resume knows how much of the incoming transcript the parked
+ * fingerprint can legitimately be compared against: a park whose request carried only the
+ * trailing user turn can only vouch for that turn and the tool calls it produced — see
+ * `historyTailFromLastUserTurn`.
+ */
+export function assertsPriorConversation(request: AgentRunRequest): boolean {
+  return priorConversation(request).some((message) => message.role === "user");
+}
+
+/**
+ * The tail of a conversation from its LAST user message onward (inclusive); the whole array when
+ * it holds no user message. This is exactly the span a minimal park's fingerprint covers: the
+ * one user turn its request carried plus that turn's own tool calls. Everything earlier is
+ * history the park never saw and therefore cannot check.
+ */
+export function historyTailFromLastUserTurn(
+  messages: readonly ChatMessage[],
+): ChatMessage[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") return messages.slice(i);
+  }
+  return messages.slice();
+}
+
+/**
  * The approval decision (allow/deny) the incoming request carries for a specific parked gate's
  * tool-call id, or undefined when the request has no approval envelope for that id. Reuses the
  * cold path's `approvalDecisionOf` (responder.ts) to parse the `{approved}` envelope, and matches

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -2,11 +2,13 @@ import { createHash } from "node:crypto";
 
 import {
   currentUserTurn,
+  isLegacyInlineImageBlock,
   type AgentRunRequest,
   type ChatMessage,
   type ContentBlock,
   messageText,
   resolvePromptText,
+  userTurnCarriesContent,
 } from "../../protocol.ts";
 import { approvalDecisionOf } from "../../responder.ts";
 import type { TeardownReason } from "./teardown.ts";
@@ -196,6 +198,28 @@ function collectToolCallIds(
 }
 
 /**
+ * One stable digest per legacy inline-media block: its media type plus a hash of the payload,
+ * so the fingerprint stays short whatever the image weighs.
+ */
+function inlineMediaDigests(
+  content: string | ContentBlock[] | undefined,
+): string[] {
+  if (!Array.isArray(content)) return [];
+  const digests: string[] = [];
+  for (const block of content) {
+    if (!isLegacyInlineImageBlock(block)) continue;
+    const payload =
+      typeof block.uri === "string" && block.uri.startsWith("data:")
+        ? block.uri
+        : String(block.data ?? "");
+    const mediaType =
+      typeof block.mimeType === "string" ? block.mimeType : "";
+    digests.push(sha256(`${mediaType}\n${payload}`));
+  }
+  return digests;
+}
+
+/**
  * A hash over the conversation the server received (the FE's pruned array): the ordered user
  * message texts, the ordered tool-call ids across every message, and the user-message count.
  * Assistant TEXT is deliberately ignored, so a live session that has already answered a plain
@@ -215,6 +239,7 @@ function collectToolCallIds(
 export function historyFingerprint(messages: readonly ChatMessage[]): string {
   const userTexts: string[] = [];
   const userAttachmentIds: string[][] = [];
+  const userInlineMedia: string[][] = [];
   const toolCallIds: string[] = [];
   const seenIds = new Set<string>();
   let promptCount = 0;
@@ -227,13 +252,22 @@ export function historyFingerprint(messages: readonly ChatMessage[]): string {
           (attachment) => attachment.attachmentId,
         ),
       );
+      // A legacy inline image carries no reference id, so hash its content: two histories that
+      // differ only in the image bytes must not share one warm harness.
+      userInlineMedia.push(inlineMediaDigests(message.content));
     }
     collectToolCallIds(message.content, toolCallIds, seenIds);
   }
   // Attachment ids change every canonical hash once; deploys already cold-start parked
   // sessions because the pool is process-local.
   return sha256(
-    canonicalJson({ userTexts, userAttachmentIds, toolCallIds, promptCount }),
+    canonicalJson({
+      userTexts,
+      userAttachmentIds,
+      userInlineMedia,
+      toolCallIds,
+      promptCount,
+    }),
   );
 }
 
@@ -336,14 +370,21 @@ export function carriesMinimalHistory(request: AgentRunRequest): boolean {
  */
 export function carriesApprovalReplyOnly(request: AgentRunRequest): boolean {
   if (resolvePromptText(request)) return false;
-  for (const message of request.messages ?? []) {
-    const content = message?.content;
+  // The reply must be the request's terminal tool envelope, not merely present somewhere: a
+  // history whose newest envelope is an unresolved call is a stalled conversation, and reading
+  // it as an approval reply would let it through the empty-prompt rejection.
+  const messages = request.messages ?? [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i]?.content;
     if (!Array.isArray(content)) continue;
-    for (const block of content) {
-      if (block?.type === "tool_result" && approvalDecisionOf(block) !== undefined) {
-        return true;
-      }
-    }
+    const envelope = content.filter(
+      (block) => block?.type === "tool_call" || block?.type === "tool_result",
+    );
+    if (envelope.length === 0) continue;
+    return envelope.some(
+      (block) =>
+        block.type === "tool_result" && approvalDecisionOf(block) !== undefined,
+    );
   }
   return false;
 }
@@ -355,12 +396,7 @@ export function carriesApprovalReplyOnly(request: AgentRunRequest): boolean {
  */
 export function tailIsFreshUserMessage(request: AgentRunRequest): boolean {
   const turn = currentUserTurn(request);
-  return (
-    turn.isFresh &&
-    (turn.text.trim() !== "" ||
-      turn.attachments.length > 0 ||
-      turn.hasInlineMedia)
-  );
+  return turn.isFresh && userTurnCarriesContent(turn);
 }
 
 /**

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -357,7 +357,9 @@ export function tailIsFreshUserMessage(request: AgentRunRequest): boolean {
   const turn = currentUserTurn(request);
   return (
     turn.isFresh &&
-    (turn.text.trim() !== "" || turn.attachments.length > 0)
+    (turn.text.trim() !== "" ||
+      turn.attachments.length > 0 ||
+      turn.hasInlineMedia)
   );
 }
 

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import {
+  currentUserTurn,
   type AgentRunRequest,
   type ChatMessage,
   type ContentBlock,
@@ -150,6 +151,7 @@ export function configFingerprint(request: AgentRunRequest): string {
     connection: request.connection ?? null,
     deployment: request.deployment ?? null,
     endpoint: request.endpoint ?? null,
+    modelCapabilities: request.modelCapabilities ?? null,
     credentialMode: request.credentialMode ?? null,
     agentsMd: request.agentsMd ?? null,
     systemPrompt: request.systemPrompt ?? null,
@@ -212,6 +214,7 @@ function collectToolCallIds(
  */
 export function historyFingerprint(messages: readonly ChatMessage[]): string {
   const userTexts: string[] = [];
+  const userAttachmentIds: string[][] = [];
   const toolCallIds: string[] = [];
   const seenIds = new Set<string>();
   let promptCount = 0;
@@ -219,10 +222,19 @@ export function historyFingerprint(messages: readonly ChatMessage[]): string {
     if (message.role === "user") {
       promptCount += 1;
       userTexts.push(messageText(message.content));
+      userAttachmentIds.push(
+        currentUserTurn({ messages: [message] }).attachments.map(
+          (attachment) => attachment.attachmentId,
+        ),
+      );
     }
     collectToolCallIds(message.content, toolCallIds, seenIds);
   }
-  return sha256(canonicalJson({ userTexts, toolCallIds, promptCount }));
+  // Attachment ids change every canonical hash once; deploys already cold-start parked
+  // sessions because the pool is process-local.
+  return sha256(
+    canonicalJson({ userTexts, userAttachmentIds, toolCallIds, promptCount }),
+  );
 }
 
 /**
@@ -337,22 +349,16 @@ export function carriesApprovalReplyOnly(request: AgentRunRequest): boolean {
 }
 
 /**
- * True when the request's tail is a fresh user message with text and NOT an approval envelope.
+ * True when the request's tail is a fresh user message with content and NOT an approval envelope.
  * A continuation only takes the live path for a plain new user turn; an approval reply (a
  * trailing tool-role message, or a user turn carrying a tool_result) stays cold here.
  */
 export function tailIsFreshUserMessage(request: AgentRunRequest): boolean {
-  const messages = request.messages ?? [];
-  const tail = messages[messages.length - 1];
-  if (!tail || tail.role !== "user") return false;
-  if (!messageText(tail.content).trim()) return false;
-  if (Array.isArray(tail.content)) {
-    const carriesToolTurn = tail.content.some(
-      (block) => block?.type === "tool_result" || block?.type === "tool_call",
-    );
-    if (carriesToolTurn) return false;
-  }
-  return true;
+  const turn = currentUserTurn(request);
+  return (
+    turn.isFresh &&
+    (turn.text.trim() !== "" || turn.attachments.length > 0)
+  );
 }
 
 /**

--- a/services/runner/src/engines/sandbox_agent/session-pool.ts
+++ b/services/runner/src/engines/sandbox_agent/session-pool.ts
@@ -32,6 +32,13 @@ export interface LiveSession<E = unknown> {
   environment: E;
   configFingerprint: string;
   historyFingerprint: string;
+  /**
+   * Whether the request this session parked from asserted a transcript beyond its own turn. A
+   * park can only vouch for what its request carried, so a false here tells the resume to compare
+   * the fingerprint against the incoming transcript's trailing user turn instead of all of it.
+   * Unset means "assume it did", which can only cost a cold restart.
+   */
+  historyAsserted: boolean;
   credentialEpoch: CredentialEpoch;
   state: SessionState;
   lastUsed: number;
@@ -48,6 +55,8 @@ export interface ParkInput<E> {
   environment: E;
   configFingerprint: string;
   historyFingerprint: string;
+  /** See `LiveSession.historyAsserted`. Omitted defaults to the strictest resume check. */
+  historyAsserted?: boolean;
   credentialEpoch: CredentialEpoch;
   teardown: (reason: TeardownReason) => Promise<void>;
 }
@@ -149,6 +158,8 @@ export class SessionPool<E = unknown> {
     update: {
       configFingerprint: string;
       historyFingerprint: string;
+      /** See `LiveSession.historyAsserted`. Omitted defaults to the strictest resume check. */
+      historyAsserted?: boolean;
       credentialEpoch: CredentialEpoch;
     },
     ttlMs: number,
@@ -173,6 +184,7 @@ export class SessionPool<E = unknown> {
     this.clearTimer(session);
     session.configFingerprint = update.configFingerprint;
     session.historyFingerprint = update.historyFingerprint;
+    session.historyAsserted = update.historyAsserted ?? true;
     session.credentialEpoch = update.credentialEpoch;
     session.state = state;
     session.lastUsed = Date.now();
@@ -218,6 +230,7 @@ export class SessionPool<E = unknown> {
       environment: input.environment,
       configFingerprint: input.configFingerprint,
       historyFingerprint: input.historyFingerprint,
+      historyAsserted: input.historyAsserted ?? true,
       credentialEpoch: input.credentialEpoch,
       state,
       lastUsed: Date.now(),

--- a/services/runner/src/engines/sandbox_agent/transcript.ts
+++ b/services/runner/src/engines/sandbox_agent/transcript.ts
@@ -5,6 +5,7 @@ import {
   currentUserTurn,
   messageText,
   resolvePromptText,
+  userTurnCarriesContent,
 } from "../../protocol.ts";
 import { approvalDecisionOf } from "../../responder.ts";
 import { attachmentMention } from "./attachments.ts";
@@ -239,6 +240,13 @@ const CLIENT_RESUME_CLOSING =
   "prompt); the result is shown in the history. Continue the task from where it paused, using " +
   "that result; do not restart the task or ask again for anything the user already provided.";
 
+/**
+ * The cold frame's closing label, immediately before the latest user text. Attachment mention
+ * placement keys on it, so both sides must read the same string.
+ */
+export const COLD_FRAME_USER_LABEL =
+  "Continue the conversation. The user now says:\n";
+
 export type ResumeKind = "approval" | "client";
 
 /** A client-tool settle (elicitation answer, connection reference, decline/cancel) rides back as
@@ -254,7 +262,7 @@ function isClientToolSettle(block: ContentBlock): boolean {
  * re-issues the approved call (cold-replay failure report, turn 6d34b1ea) or, for a client tool,
  * re-asks for input the user just gave (issue #5357).
  *
- * Two shapes, detected conservatively as content AFTER the last user text message:
+ * Two shapes, detected conservatively as content AFTER the last user message carrying content:
  *   - approval: an unresolved approved call (`lastPending`) — needs the execute-the-call frame.
  *   - client:  a client-tool settle in an ASSISTANT message — the settled `tool_result` rides back
  *     in the assistant turn it paused on (the Vercel adapter preserves that role), so an executed
@@ -266,13 +274,16 @@ function resumeKindFor(
   hints: Map<ContentBlock, ApprovalRenderHint>,
 ): ResumeKind | null {
   const messages = request.messages ?? [];
-  let lastUserTextIndex = -1;
+  let lastUserContentIndex = -1;
   let lastPendingApprovalIndex = -1;
   let lastClientSettleIndex = -1;
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
-    if (message.role === "user" && messageText(message.content)) {
-      lastUserTextIndex = i;
+    // An attachment-only or image-only turn is new user content just as much as text is, so it
+    // moves the boundary; otherwise a settled call before it reads as a resume and the model is
+    // told to repeat that call instead of answering the new turn.
+    if (userTurnCarriesContent(currentUserTurn({ messages: [message] }))) {
+      lastUserContentIndex = i;
     }
     const content = message.content;
     if (!Array.isArray(content)) continue;
@@ -283,10 +294,13 @@ function resumeKindFor(
       lastClientSettleIndex = i;
     }
   }
-  if (lastPendingApprovalIndex >= 0 && lastPendingApprovalIndex > lastUserTextIndex) {
+  if (
+    lastPendingApprovalIndex >= 0 &&
+    lastPendingApprovalIndex > lastUserContentIndex
+  ) {
     return "approval";
   }
-  if (lastClientSettleIndex >= 0 && lastClientSettleIndex > lastUserTextIndex) {
+  if (lastClientSettleIndex >= 0 && lastClientSettleIndex > lastUserContentIndex) {
     return "client";
   }
   return null;
@@ -343,7 +357,7 @@ export function buildTurnText(
       ? APPROVAL_RESUME_CLOSING
       : resumeKind === "client"
         ? CLIENT_RESUME_CLOSING
-        : `Continue the conversation. The user now says:\n${latest}`;
+        : `${COLD_FRAME_USER_LABEL}${latest}`;
   const turnText = `Conversation so far:\n${transcript}\n\n${closing}`;
   log?.(
     `[HITL] cold replay: transcript ${full.length}->${transcript.length} chars, ` +

--- a/services/runner/src/engines/sandbox_agent/transcript.ts
+++ b/services/runner/src/engines/sandbox_agent/transcript.ts
@@ -2,10 +2,12 @@ import {
   type AgentRunRequest,
   type ChatMessage,
   type ContentBlock,
+  currentUserTurn,
   messageText,
   resolvePromptText,
 } from "../../protocol.ts";
 import { approvalDecisionOf } from "../../responder.ts";
+import { attachmentMention } from "./attachments.ts";
 import {
   APPROVED_EXECUTION_RESULT_UNKNOWN,
   DEFERRED_NOT_EXECUTED_PREFIX,
@@ -201,6 +203,23 @@ export function messageTranscript(
           );
         }
       }
+    } else if (
+      block.type === "attachment" &&
+      typeof block.attachmentId === "string"
+    ) {
+      try {
+        parts.push(
+          attachmentMention({
+            attachmentId: block.attachmentId,
+            filename: block.filename,
+            mediaType: block.mimeType,
+            size: block.size,
+          }),
+        );
+      } catch {
+        // Preflight sees unverified display fields; runTurn rebuilds after API restore.
+        parts.push("[attachment pending verification]");
+      }
     } else if (block.type === "image") {
       parts.push("[image]");
     } else if (block.type === "resource") {
@@ -284,10 +303,11 @@ export function buildTurnText(
   request: AgentRunRequest,
   log?: (msg: string) => void,
 ): string {
-  const latest = resolvePromptText(request);
   const messages = request.messages ?? [];
   const resumeKind = resumeKindFor(request, approvalRenderHints(messages));
   const resume = resumeKind !== null;
+  const turn = currentUserTurn(request);
+  const latest = turn.message ? turn.text : resolvePromptText(request);
   // Normal turn: drop the prompt user message from the replay (it closes the frame).
   // Resume: nothing is re-presented in the frame, so replay every message — including the
   // stale command in place and the settled interaction (approval envelope or client-tool result).

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -691,6 +691,19 @@ export function currentUserTurn(request: AgentRunRequest): CurrentUserTurn {
 }
 
 /**
+ * True when the turn carries something the person actually sent: text, an attachment, or inline
+ * media. The single admission rule for "new user content", so callers that decide freshness,
+ * boundaries, or persistence cannot drift apart on an attachment-only or image-only turn.
+ */
+export function userTurnCarriesContent(turn: CurrentUserTurn): boolean {
+  return (
+    turn.text.trim() !== "" ||
+    turn.attachments.length > 0 ||
+    turn.hasInlineMedia
+  );
+}
+
+/**
  * Approval-resume fallback: scan backward for the most recent non-empty user text. Use
  * currentUserTurn for the current turn.
  */

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -10,11 +10,21 @@
 
 /** One piece of a message. `text` is all the playground sends today; the rest is plumbed. */
 export interface ContentBlock {
-  type: "text" | "image" | "resource" | "tool_call" | "tool_result" | string;
+  type:
+    | "text"
+    | "image"
+    | "resource"
+    | "attachment"
+    | "tool_call"
+    | "tool_result"
+    | string;
   text?: string;
   data?: string;
   mimeType?: string;
   uri?: string;
+  attachmentId?: string;
+  filename?: string;
+  size?: number;
   // Tool-turn carriers, used for structured-message continuation (cross-turn HITL): a
   // resolved tool call replays as a `tool_call` block plus a `tool_result` block so the
   // model resumes from the result instead of re-asking. The `/messages` egress folds the
@@ -28,8 +38,16 @@ export interface ContentBlock {
 
 export interface ChatMessage {
   role: string;
-  /** A plain string, or ACP-style content blocks (text/image/resource). */
+  /** A plain string, or ACP-style content blocks (text/image/resource/attachment). */
   content: string | ContentBlock[];
+}
+
+export interface AttachmentRef {
+  attachmentId: string;
+  /** Wire display fields are never trusted; delivery re-reads authoritative values from the API. */
+  filename?: string;
+  mediaType?: string;
+  size?: number;
 }
 
 /**
@@ -323,7 +341,7 @@ export type RenderHint =
   | { kind: "elicitation" };
 
 export type AgentEvent =
-  | { type: "message"; text: string }
+  | { type: "message"; text: string; attachments?: AttachmentRef[] }
   | { type: "thought"; text: string }
   | { type: "message_start"; id: string }
   | { type: "message_delta"; id: string; delta: string }
@@ -378,6 +396,14 @@ export type AgentEvent =
   | { type: "data"; name: string; data: unknown; transient?: boolean }
   | { type: "file"; url: string; mediaType: string }
   | {
+      type: "attachment_delivery";
+      attachmentId: string;
+      outcome: "native" | "workspace_only" | "failed";
+      /** Stable string code, never a display string. */
+      reasonCode: string;
+      workingPath?: string;
+    }
+  | {
       type: "usage";
       input?: number;
       output?: number;
@@ -430,6 +456,8 @@ export interface AgentRunRequest {
   appendSystemPrompt?: string;
   /** Model id ("gpt-5.5") or "provider/id" ("openai-codex/gpt-5.5"). */
   model?: string;
+  /** Resolved model input modalities. Omitted when the resolver cannot determine them. */
+  modelCapabilities?: { inputModalities?: string[] };
   /**
    * Provider family for the run, e.g. "openai" | "anthropic" | <custom-slug>. Non-secret.
    * Present only when the config carries a structured model ref. See the provider-model-auth
@@ -581,7 +609,82 @@ export function messageText(
     .join("");
 }
 
-/** The latest user turn: the last user message's text (the wire carries no standalone prompt). */
+export interface CurrentUserTurn {
+  /** The tail message when it is a user turn, else null. Never an earlier message. */
+  message: ChatMessage | null;
+  text: string;
+  attachments: AttachmentRef[];
+  /** A genuinely new user turn: role user, carrying no tool envelope. */
+  isFresh: boolean;
+  carriesToolEnvelope: boolean;
+}
+
+function carriesToolEnvelope(content: ChatMessage["content"]): boolean {
+  return (
+    Array.isArray(content) &&
+    content.some(
+      (block) => block?.type === "tool_call" || block?.type === "tool_result",
+    )
+  );
+}
+
+/** Read only the tail message when it is a user turn. */
+export function currentUserTurn(request: AgentRunRequest): CurrentUserTurn {
+  const messages = request.messages ?? [];
+  const tail = messages[messages.length - 1];
+  if (!tail || tail.role !== "user") {
+    return {
+      message: null,
+      text: "",
+      attachments: [],
+      isFresh: false,
+      carriesToolEnvelope: false,
+    };
+  }
+
+  const attachments: AttachmentRef[] = [];
+  if (Array.isArray(tail.content)) {
+    for (const block of tail.content) {
+      const attachmentBlock = block as ContentBlock & {
+        attachmentId?: unknown;
+        filename?: unknown;
+        size?: unknown;
+      };
+      if (
+        attachmentBlock?.type !== "attachment" ||
+        typeof attachmentBlock.attachmentId !== "string"
+      ) {
+        continue;
+      }
+      attachments.push({
+        attachmentId: attachmentBlock.attachmentId,
+        ...(typeof attachmentBlock.filename === "string"
+          ? { filename: attachmentBlock.filename }
+          : {}),
+        ...(typeof block.mimeType === "string"
+          ? { mediaType: block.mimeType }
+          : {}),
+        ...(typeof attachmentBlock.size === "number"
+          ? { size: attachmentBlock.size }
+          : {}),
+      });
+    }
+  }
+
+  const toolEnvelope = carriesToolEnvelope(tail.content);
+  return {
+    message: tail,
+    text: messageText(tail.content),
+    attachments,
+    isFresh: !toolEnvelope,
+    carriesToolEnvelope: toolEnvelope,
+  };
+}
+
+/**
+ * Approval-resume fallback: scan backward for the most recent non-empty user text. Use
+ * currentUserTurn for the current turn.
+ */
 export function resolvePromptText(request: AgentRunRequest): string {
   const messages = request.messages ?? [];
   for (let i = messages.length - 1; i >= 0; i--) {

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -44,7 +44,10 @@ export interface ChatMessage {
 
 export interface AttachmentRef {
   attachmentId: string;
-  /** Wire display fields are never trusted; delivery re-reads authoritative values from the API. */
+  /**
+   * Delivery never trusts wire display fields and re-reads them from the attachment API. Transcript
+   * replay may render the record-sourced fields the runner previously persisted for a warm turn.
+   */
   filename?: string;
   mediaType?: string;
   size?: number;

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -617,6 +617,8 @@ export interface CurrentUserTurn {
   message: ChatMessage | null;
   text: string;
   attachments: AttachmentRef[];
+  /** The tail carries a legacy inline image block rather than an attachment reference. */
+  hasInlineMedia: boolean;
   /** A genuinely new user turn: role user, carrying no tool envelope. */
   isFresh: boolean;
   carriesToolEnvelope: boolean;
@@ -640,14 +642,17 @@ export function currentUserTurn(request: AgentRunRequest): CurrentUserTurn {
       message: null,
       text: "",
       attachments: [],
+      hasInlineMedia: false,
       isFresh: false,
       carriesToolEnvelope: false,
     };
   }
 
   const attachments: AttachmentRef[] = [];
+  let hasInlineMedia = false;
   if (Array.isArray(tail.content)) {
     for (const block of tail.content) {
+      hasInlineMedia ||= isLegacyInlineImageBlock(block);
       const attachmentBlock = block as ContentBlock & {
         attachmentId?: unknown;
         filename?: unknown;
@@ -679,6 +684,7 @@ export function currentUserTurn(request: AgentRunRequest): CurrentUserTurn {
     message: tail,
     text: messageText(tail.content),
     attachments,
+    hasInlineMedia,
     isFresh: !toolEnvelope,
     carriesToolEnvelope: toolEnvelope,
   };
@@ -707,4 +713,19 @@ export function resolveRunSessionId(
   return request.sessionId && request.sessionId.trim()
     ? request.sessionId
     : fallback;
+}
+
+/**
+ * Recognize the legacy inline-image shapes still sent by the playground. Keep this shape
+ * predicate at the protocol boundary so current-turn admission and ACP image extraction cannot
+ * drift apart.
+ */
+export function isLegacyInlineImageBlock(
+  block: ContentBlock | null | undefined,
+): block is ContentBlock & { type: "image" } {
+  return (
+    block?.type === "image" &&
+    ((typeof block.uri === "string" && block.uri.startsWith("data:")) ||
+      (typeof block.data === "string" && block.data.length > 0))
+  );
 }

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -28,7 +28,11 @@ import type {
   EmitEvent,
   StreamRecord,
 } from "./protocol.ts";
-import { resolvePromptText } from "./protocol.ts";
+import { currentUserTurn } from "./protocol.ts";
+import {
+  attachmentCountError,
+  claimAttachments,
+} from "./sessions/attachments.ts";
 import {
   acquireEnvironment,
   destroyInFlightSandboxes,
@@ -1076,12 +1080,23 @@ async function runAndStreamWithApiBaseResolved(
     );
     // Record the inbound user turn first so the session record is the full conversation, not just
     // agent output. Guard on `tailIsFreshUserMessage`: an approval RESUME's tail is the tool_result
-    // envelope (no text), so `resolvePromptText` falls back to the ORIGINAL prompt and would
-    // re-persist it as a DUPLICATE user row. The guard writes the prompt only on the turn that first
-    // introduced it — a real new turn's tail IS a fresh user message; a resume's is not.
-    const promptText = resolvePromptText(request);
-    if (promptText && tailIsFreshUserMessage(request))
-      persist({ type: "message", text: promptText }, "user");
+    // envelope, so it must not re-persist the ORIGINAL prompt as a duplicate user row. The guard
+    // writes the prompt only on the turn that first introduced it.
+    const turn = currentUserTurn(request);
+    const attachmentError = attachmentCountError(turn.attachments.length);
+    if (tailIsFreshUserMessage(request)) {
+      persist(
+        { type: "message", text: turn.text, attachments: turn.attachments },
+        "user",
+      );
+      if (turn.attachments.length > 0 && !attachmentError) {
+        await claimAttachments(
+          sessionId,
+          turn.attachments.map((attachment) => attachment.attachmentId),
+          watchdog.credential,
+        );
+      }
+    }
     emitFn = persistingEmit;
     flushPersist = flush;
     persistError = (message) => persist({ type: "error", message }, "agent");

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -1139,6 +1139,8 @@ async function runAndStreamWithApiBaseResolved(
         "user",
       );
       if (turn.attachments.length > 0) {
+        // A failed claim is accepted as graceful loss: the worst case is that the sweeper
+        // reclaims the attachment and cold replay renders it as no longer available.
         await claimAttachments(
           sessionId,
           turn.attachments.map((attachment) => attachment.attachmentId),

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -167,6 +167,8 @@ function isAuthorized(req: IncomingMessage): boolean {
  */
 export interface RunAgentOptions {
   clientGone?: () => boolean;
+  /** Latest session credential; the alive watchdog refreshes it during long turns. */
+  credential?: () => string;
 }
 
 /** Run one request through an engine. Tests inject a fake to avoid a live harness. */
@@ -263,6 +265,7 @@ export interface KeepaliveEngine {
     signal?: AbortSignal,
     presignedMount?: MountCredentials | null,
     clientGone?: () => boolean,
+    credential?: () => string,
   ): Promise<AgentRunResult>;
 }
 
@@ -278,7 +281,14 @@ const realKeepaliveEngine: KeepaliveEngine = {
   },
   // Same acquire -> runTurn -> destroy composition as `runSandboxAgent`, with the presigned
   // mount threaded through so an up-front keep-alive sign is never repeated.
-  runCold: async (request, emit, signal, presignedMount, clientGone) => {
+  runCold: async (
+    request,
+    emit,
+    signal,
+    presignedMount,
+    clientGone,
+    credential,
+  ) => {
     const acquired = await acquireEnvironment(
       request,
       {},
@@ -290,6 +300,7 @@ const realKeepaliveEngine: KeepaliveEngine = {
     try {
       result = await runTurn(acquired.env, request, emit, signal, {
         loaded: acquired.env.loadedFromContinuity,
+        ...(credential ? { credential } : {}),
       });
       return result;
     } finally {
@@ -316,6 +327,8 @@ export interface KeepaliveContext {
   config: KeepaliveConfig;
   /** Reports a mid-turn client disconnect on the streaming edge (see `RunAgentOptions`). */
   clientGone?: () => boolean;
+  /** Latest session credential accessor supplied by the alive watchdog. */
+  credential?: () => string;
 }
 
 /**
@@ -351,7 +364,8 @@ export async function runWithKeepalive(
   signal: AbortSignal | undefined,
   ctx: KeepaliveContext,
 ): Promise<AgentRunResult> {
-  const { engine, pool, config, clientGone } = ctx;
+  const { engine, pool, config, clientGone, credential } = ctx;
+  const turnCredential = credential ? { credential } : {};
   const sessionId = request.sessionId?.trim();
   // Every execution carries an id: callers that omit `turnId` get one minted here, so the
   // turns-ledger append and interaction rows are never written without their execution id.
@@ -375,7 +389,14 @@ export async function runWithKeepalive(
   // never park; run cold as today
   // (no up-front sign happened, so the cold path signs itself: still exactly once).
   if (!sessionId) {
-    return engine.runCold(request, emit, signal, undefined, clientGone);
+    return engine.runCold(
+      request,
+      emit,
+      signal,
+      undefined,
+      clientGone,
+      credential,
+    );
   }
 
   // Sign the mount once, up front. The mount's owning project is the FALLBACK project scope; the
@@ -391,7 +412,14 @@ export async function runWithKeepalive(
   const scope = poolKeyFor(request, signed?.projectId);
   if (!scope) {
     klog(`miss (no project scope) session=${sessionId}; cold`);
-    return engine.runCold(request, emit, signal, signed, clientGone);
+    return engine.runCold(
+      request,
+      emit,
+      signal,
+      signed,
+      clientGone,
+      credential,
+    );
   }
   const key = scope.key;
   klog(`scope=${scope.source} key=${key} session=${sessionId}`);
@@ -620,6 +648,7 @@ export async function runWithKeepalive(
       result = await engine.runTurn(env, request, trackedEmit, signal, {
         approvalParkMode: true,
         loaded: env.loadedFromContinuity,
+        ...turnCredential,
       });
     } catch (err) {
       await env.destroy({ reason: "failed-turn" });
@@ -682,6 +711,7 @@ export async function runWithKeepalive(
           {
             continuation: true,
             approvalParkMode: true,
+            ...turnCredential,
           },
         );
       } catch (err) {
@@ -835,6 +865,7 @@ export async function runWithKeepalive(
           {
             approvalParkMode: true,
             resume: { decisions: resumeDecisions, carriedForward },
+            ...turnCredential,
           },
         );
       } catch (err) {
@@ -901,13 +932,18 @@ const keepalivePools: Record<
 
 const runAgent: RunAgent = (request, emit, signal, options) => {
   const provider = resolveKeepaliveDispatch(request, keepaliveConfigs);
-  if (!provider) return runSandboxAgent(request, emit, signal);
+  if (!provider) {
+    return runSandboxAgent(request, emit, signal, {}, {
+      ...(options?.credential ? { credential: options.credential } : {}),
+    });
+  }
   const config = keepaliveConfigs[provider];
   return runWithKeepalive(request, emit, signal, {
     engine: realKeepaliveEngine,
     pool: keepalivePools[provider],
     config,
     clientGone: options?.clientGone,
+    credential: options?.credential,
   });
 };
 
@@ -1023,13 +1059,28 @@ async function runAndStreamWithApiBaseResolved(
     res.write(JSON.stringify(record) + "\n");
   };
   const liveEmit: EmitEvent = (event) => writeRecord({ kind: "event", event });
+  const turn = currentUserTurn(request);
+  const attachmentError = attachmentCountError(turn.attachments.length);
+  if (attachmentError) {
+    writeRecord({
+      kind: "result",
+      result: { ok: false, error: attachmentError, events: [] },
+    });
+    res.end();
+    return;
+  }
 
   // For session-owned runs: wrap the live emitter so every event is also persisted
   // producer-side, independent of whether the client is still connected.
   let emitFn: EmitEvent = liveEmit;
   let flushPersist: (() => Promise<void>) | undefined;
   let persistError: ((message: string) => void) | undefined;
-  let aliveWatchdog: { release: () => Promise<void> } | undefined;
+  let aliveWatchdog:
+    | {
+        release: () => Promise<void>;
+        credential: () => string;
+      }
+    | undefined;
 
   if (sessionOwned) {
     // The request's api base (if any) is already scoped for this call via
@@ -1082,14 +1133,12 @@ async function runAndStreamWithApiBaseResolved(
     // agent output. Guard on `tailIsFreshUserMessage`: an approval RESUME's tail is the tool_result
     // envelope, so it must not re-persist the ORIGINAL prompt as a duplicate user row. The guard
     // writes the prompt only on the turn that first introduced it.
-    const turn = currentUserTurn(request);
-    const attachmentError = attachmentCountError(turn.attachments.length);
     if (tailIsFreshUserMessage(request)) {
       persist(
         { type: "message", text: turn.text, attachments: turn.attachments },
         "user",
       );
-      if (turn.attachments.length > 0 && !attachmentError) {
+      if (turn.attachments.length > 0) {
         await claimAttachments(
           sessionId,
           turn.attachments.map((attachment) => attachment.attachmentId),
@@ -1106,6 +1155,7 @@ async function runAndStreamWithApiBaseResolved(
   try {
     result = await run(request, emitFn, controller.signal, {
       clientGone: () => clientDisconnected,
+      credential: aliveWatchdog?.credential,
     });
     // A failed engine run ({ok:false}) already emitted its own error EVENT through the
     // persisting emitter, so no extra persist here (it would duplicate the record). Drain

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -50,6 +50,7 @@ import type { MountCredentials } from "./engines/sandbox_agent/mount.ts";
 import type { TeardownReason } from "./engines/sandbox_agent/teardown.ts";
 import {
   approvalDecisionForToolCall,
+  assertsPriorConversation,
   computeCredentialEpoch,
   configFingerprint,
   credentialEpochMismatch,
@@ -63,6 +64,7 @@ import {
   type CredentialEpoch,
   expectedNextHistoryFingerprint,
   historyFingerprint,
+  historyTailFromLastUserTurn,
   poolKeyFor,
   priorConversation,
   readKeepaliveConfig,
@@ -446,6 +448,10 @@ export async function runWithKeepalive(
       env.lastTurnToolCallIds ?? [],
     );
 
+  // A park can only assert what its request carried: a last-message-only turn hashes ONE user
+  // turn, so its fingerprint must not later be compared against a full transcript.
+  const historyAsserted = assertsPriorConversation(request);
+
   const resultTeardownReason = (result: AgentRunResult): TeardownReason =>
     shouldPark(result, signal, clientGone)
       ? "clean-resumable"
@@ -553,6 +559,7 @@ export async function runWithKeepalive(
       environment: env,
       configFingerprint: cfgFp,
       historyFingerprint: nextHistoryFp(env),
+      historyAsserted,
       credentialEpoch: parkedEpoch(env, incomingEpoch.secretsHash),
       teardown: (reason: TeardownReason) => env.destroy({ reason }),
     };
@@ -592,6 +599,7 @@ export async function runWithKeepalive(
     const update = {
       configFingerprint: cfgFp,
       historyFingerprint: nextHistoryFp(env),
+      historyAsserted,
       credentialEpoch: parkedEpoch(env, live.credentialEpoch.secretsHash),
     };
     if (approvalToPark(env, result)) {
@@ -808,7 +816,15 @@ export async function runWithKeepalive(
         });
       }
     }
-    const priorFp = historyFingerprint(priorConversation(request));
+    const incomingPrior = priorConversation(request);
+    // A park that asserted a full transcript is checked against the whole incoming one; a park
+    // that only ever saw its own trailing user turn is checked against that turn's slice of it,
+    // which still catches an edited tail (text, attachment ids, or tool-call ids).
+    const priorFp = historyFingerprint(
+      existing.historyAsserted
+        ? incomingPrior
+        : historyTailFromLastUserTurn(incomingPrior),
+    );
     // An out-of-band answer (an inbox, a webhook, a CLI) builds its reply from the durable
     // interaction row and carries no conversation at all, so its prior fingerprint can never equal
     // the parked one and comparing it would evict the very session that could resume — the

--- a/services/runner/src/sessions/attachments.ts
+++ b/services/runner/src/sessions/attachments.ts
@@ -12,7 +12,7 @@ export interface FetchedAttachment {
 type Auth = () => string;
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
-const DEFAULT_MAX_PER_TURN = 5;
+const DEFAULT_MAX_PER_TURN = 100;
 
 function log(message: string): void {
   process.stderr.write(`[sessions/attachments] ${message}\n`);

--- a/services/runner/src/sessions/attachments.ts
+++ b/services/runner/src/sessions/attachments.ts
@@ -13,6 +13,9 @@ type Auth = () => string;
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_PER_TURN = 100;
+// Aligned with the API's largest per-file cap (15 MB for audio, 10 MB for the rest): a body
+// beyond it cannot be a stored attachment, so refuse it before it is held in memory.
+const MAX_ATTACHMENT_BYTES = 16 * 1024 * 1024;
 
 function log(message: string): void {
   process.stderr.write(`[sessions/attachments] ${message}\n`);
@@ -106,18 +109,28 @@ export async function fetchAttachment(
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
-    const mediaType = response.headers.get("content-type")?.trim();
+    // Content-Type parameters (charset, boundary) are not part of the MIME identity the
+    // capability gate and the allowlist compare on, so keep the bare type.
+    const mediaType = response.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      .trim()
+      .toLowerCase();
     const filename = filenameFromContentDisposition(
       response.headers.get("content-disposition"),
     );
     if (!mediaType || !filename) {
       throw new Error("missing verified attachment headers");
     }
-    return {
-      bytes: new Uint8Array(await response.arrayBuffer()),
-      mediaType,
-      filename,
-    };
+    const declaredSize = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredSize) && declaredSize > MAX_ATTACHMENT_BYTES) {
+      throw new Error("attachment exceeds the maximum size");
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+      throw new Error("attachment exceeds the maximum size");
+    }
+    return { bytes, mediaType, filename };
   } catch (error) {
     log(
       `fetch FAILED session=${sessionId} attachment=${attachmentId}: ${errorDetail(error)}`,

--- a/services/runner/src/sessions/attachments.ts
+++ b/services/runner/src/sessions/attachments.ts
@@ -1,0 +1,157 @@
+import { basename } from "node:path";
+
+import { apiBase } from "../apiBase.ts";
+import { envInt, envTimerMs } from "../env.ts";
+
+export interface FetchedAttachment {
+  bytes: Uint8Array;
+  mediaType: string;
+  filename: string;
+}
+
+type Auth = () => string;
+
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_PER_TURN = 5;
+
+function log(message: string): void {
+  process.stderr.write(`[sessions/attachments] ${message}\n`);
+}
+
+export function attachmentCountError(count: number): string | null {
+  const max = envInt("AGENTA_ATTACHMENTS_MAX_PER_TURN", DEFAULT_MAX_PER_TURN, {
+    min: 1,
+    log,
+  });
+  return count > max
+    ? `A user turn may carry at most ${max} attachments.`
+    : null;
+}
+
+export function attachmentFetchTimeoutMs(): number {
+  return envTimerMs(
+    "AGENTA_ATTACHMENTS_FETCH_TIMEOUT_MS",
+    DEFAULT_FETCH_TIMEOUT_MS,
+    { min: 1, log },
+  );
+}
+
+function errorDetail(error: unknown): string {
+  return String(error instanceof Error ? error.message : error).slice(0, 120);
+}
+
+function decode5987(value: string): string | null {
+  const match = /^([^']*)'[^']*'(.*)$/.exec(value.trim());
+  if (!match) return null;
+  const charset = match[1].toLowerCase();
+  try {
+    if (charset === "utf-8" || charset === "utf8") {
+      return decodeURIComponent(match[2]);
+    }
+    if (charset === "iso-8859-1" || charset === "latin1") {
+      return match[2].replace(/%([0-9a-f]{2})/gi, (_, hex: string) =>
+        String.fromCharCode(Number.parseInt(hex, 16)),
+      );
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function sanitizeAttachmentFilename(filename: string): string | null {
+  const cleaned = basename(filename.replaceAll("\\", "/")).replace(
+    /[\u0000-\u001f\u007f]/g,
+    "",
+  );
+  return cleaned && cleaned !== "." && cleaned !== ".." ? cleaned : null;
+}
+
+export function filenameFromContentDisposition(
+  disposition: string | null,
+): string | null {
+  if (!disposition) return null;
+
+  const extended = /(?:^|;)\s*filename\*\s*=\s*([^;]+)/i.exec(disposition);
+  if (extended) {
+    const decoded = decode5987(extended[1]);
+    const sanitized = decoded && sanitizeAttachmentFilename(decoded);
+    if (sanitized) return sanitized;
+  }
+
+  const quoted = /(?:^|;)\s*filename\s*=\s*"((?:\\.|[^"])*)"/i.exec(
+    disposition,
+  );
+  if (quoted) {
+    const value = quoted[1].replace(/\\([\\"])/g, "$1");
+    return sanitizeAttachmentFilename(value);
+  }
+
+  const plain = /(?:^|;)\s*filename\s*=\s*([^;]+)/i.exec(disposition);
+  return plain ? sanitizeAttachmentFilename(plain[1].trim()) : null;
+}
+
+export async function fetchAttachment(
+  sessionId: string,
+  attachmentId: string,
+  auth: Auth,
+): Promise<FetchedAttachment | null> {
+  const url =
+    `${apiBase()}/sessions/attachments/${encodeURIComponent(attachmentId)}/content` +
+    `?session_id=${encodeURIComponent(sessionId)}`;
+  try {
+    const response = await fetch(url, {
+      headers: { authorization: auth() },
+      signal: AbortSignal.timeout(attachmentFetchTimeoutMs()),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+    const mediaType = response.headers.get("content-type")?.trim();
+    const filename = filenameFromContentDisposition(
+      response.headers.get("content-disposition"),
+    );
+    if (!mediaType || !filename) {
+      throw new Error("missing verified attachment headers");
+    }
+    return {
+      bytes: new Uint8Array(await response.arrayBuffer()),
+      mediaType,
+      filename,
+    };
+  } catch (error) {
+    log(
+      `fetch FAILED session=${sessionId} attachment=${attachmentId}: ${errorDetail(error)}`,
+    );
+    return null;
+  }
+}
+
+export async function claimAttachments(
+  sessionId: string,
+  attachmentIds: string[],
+  auth: Auth,
+): Promise<boolean> {
+  if (attachmentIds.length === 0) return true;
+  const url = `${apiBase()}/sessions/attachments/reference`;
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: auth(),
+      },
+      body: JSON.stringify({
+        session_id: sessionId,
+        attachment_ids: attachmentIds,
+      }),
+      signal: AbortSignal.timeout(attachmentFetchTimeoutMs()),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return true;
+  } catch (error) {
+    log(
+      `claim FAILED session=${sessionId} attachments=${attachmentIds.length}: ${errorDetail(error)}`,
+    );
+    return false;
+  }
+}

--- a/services/runner/src/sessions/reconstruct.ts
+++ b/services/runner/src/sessions/reconstruct.ts
@@ -14,8 +14,8 @@
  * Completeness: records store the coalesced text/tool events, so reconstruction covers text,
  * tool calls, and tool results (incl. still-parked calls, so a HITL answer arriving on the last
  * message binds to its reconstructed tool_call). Reasoning, usage, and one-way UI events are not
- * conversation context and are dropped. User attachments are NOT in the durable log (only the
- * prompt text is persisted), so a reconstructed user turn is text-only — a known v1 gap.
+ * conversation context and are dropped. User attachments ride the user message event and rebuild
+ * as attachment blocks followed by exactly one text block.
  */
 
 import type { AgentEvent, ChatMessage, ContentBlock } from "../protocol.ts";
@@ -105,7 +105,27 @@ export function reconstructMessages(
     if (row.record_source === "user") {
       flushAssistant();
       const text = event.type === "message" ? (event.text ?? "") : "";
-      messages.push({ role: "user", content: text });
+      const attachments =
+        event.type === "message" && Array.isArray(event.attachments)
+          ? event.attachments.filter(
+              (attachment) =>
+                attachment && typeof attachment.attachmentId === "string",
+            )
+          : [];
+      const content: string | ContentBlock[] =
+        attachments.length > 0
+          ? [
+              ...attachments.map((attachment) => ({
+                type: "attachment",
+                attachmentId: attachment.attachmentId,
+                filename: attachment.filename,
+                mimeType: attachment.mediaType,
+                size: attachment.size,
+              })),
+              { type: "text", text },
+            ]
+          : text;
+      messages.push({ role: "user", content });
       continue;
     }
 

--- a/services/runner/tests/unit/attachment-capability-gate.test.ts
+++ b/services/runner/tests/unit/attachment-capability-gate.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import { attachmentCapabilityGate } from "../../src/engines/sandbox_agent/attachments.ts";
+
+const IMAGE_INPUT = {
+  harness: "claude",
+  acpAgent: "claude",
+  capabilities: { images: true },
+  modelCapabilities: { inputModalities: ["text", "image"] },
+  mediaType: "image/png",
+  byteLength: 1024,
+};
+
+describe("attachment capability gate", () => {
+  it("delivers images natively through both pinned adapters", () => {
+    assert.equal(
+      attachmentCapabilityGate(IMAGE_INPUT).outcome,
+      "native",
+    );
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        harness: "pi_core",
+        acpAgent: "pi",
+      }).outcome,
+      "native",
+    );
+  });
+
+  it("treats absent, empty, and unrecognized modalities as unknown", () => {
+    for (const modelCapabilities of [
+      undefined,
+      { inputModalities: [] },
+      { inputModalities: ["vision"] },
+    ]) {
+      assert.deepEqual(
+        attachmentCapabilityGate({
+          ...IMAGE_INPUT,
+          modelCapabilities,
+        }),
+        {
+          outcome: "workspace_only",
+          reasonCode: "model_modality_unknown",
+          kind: "image",
+        },
+      );
+    }
+  });
+
+  it("distinguishes a known model that does not support images", () => {
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        modelCapabilities: { inputModalities: ["text"] },
+      }).reasonCode,
+      "model_modality_unsupported",
+    );
+  });
+
+  it("never delivers audio or documents natively on the pinned adapters", () => {
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        mediaType: "audio/mpeg",
+        modelCapabilities: { inputModalities: ["text", "audio"] },
+      }).outcome,
+      "workspace_only",
+    );
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        capabilities: { images: true, fileAttachments: true },
+        mediaType: "application/pdf",
+        modelCapabilities: {
+          inputModalities: ["text", "documents"],
+        },
+      }).reasonCode,
+      "adapter_unsupported",
+    );
+  });
+
+  it("fails an explicit native request when transport did not advertise it", () => {
+    assert.deepEqual(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        capabilities: { images: false },
+        requireNative: true,
+      }),
+      {
+        outcome: "failed",
+        reasonCode: "contract_violation",
+        kind: "image",
+        missing: "transport capability",
+      },
+    );
+  });
+
+  it("keeps an oversized Claude image workspace-only", () => {
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        byteLength: Math.floor(7.5 * 1024 * 1024) + 1,
+      }).reasonCode,
+      "provider_inline_cap",
+    );
+  });
+});

--- a/services/runner/tests/unit/attachment-capability-gate.test.ts
+++ b/services/runner/tests/unit/attachment-capability-gate.test.ts
@@ -4,8 +4,8 @@ import { describe, it } from "vitest";
 import { attachmentCapabilityGate } from "../../src/engines/sandbox_agent/attachments.ts";
 
 const IMAGE_INPUT = {
-  harness: "claude",
   acpAgent: "claude",
+  provider: "anthropic",
   capabilities: { images: true },
   modelCapabilities: { inputModalities: ["text", "image"] },
   mediaType: "image/png",
@@ -21,8 +21,8 @@ describe("attachment capability gate", () => {
     assert.equal(
       attachmentCapabilityGate({
         ...IMAGE_INPUT,
-        harness: "pi_core",
         acpAgent: "pi",
+        provider: "openai",
       }).outcome,
       "native",
     );
@@ -59,14 +59,13 @@ describe("attachment capability gate", () => {
   });
 
   it("never delivers audio or documents natively on the pinned adapters", () => {
-    assert.equal(
-      attachmentCapabilityGate({
-        ...IMAGE_INPUT,
-        mediaType: "audio/mpeg",
-        modelCapabilities: { inputModalities: ["text", "audio"] },
-      }).outcome,
-      "workspace_only",
-    );
+    const audio = attachmentCapabilityGate({
+      ...IMAGE_INPUT,
+      mediaType: "audio/mpeg",
+      modelCapabilities: { inputModalities: ["text", "audio"] },
+    });
+    assert.equal(audio.outcome, "workspace_only");
+    assert.equal(audio.reasonCode, "transport_unsupported");
     assert.equal(
       attachmentCapabilityGate({
         ...IMAGE_INPUT,
@@ -101,6 +100,26 @@ describe("attachment capability gate", () => {
       attachmentCapabilityGate({
         ...IMAGE_INPUT,
         byteLength: Math.floor(7.5 * 1024 * 1024) + 1,
+      }).reasonCode,
+      "provider_inline_cap",
+    );
+  });
+
+  it("keys the inline cap on provider, with ACP agent as the absent-provider fallback", () => {
+    const byteLength = Math.floor(7.5 * 1024 * 1024) + 1;
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        provider: "openai",
+        byteLength,
+      }).outcome,
+      "native",
+    );
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        provider: undefined,
+        byteLength,
       }).reasonCode,
       "provider_inline_cap",
     );

--- a/services/runner/tests/unit/attachment-capability-gate.test.ts
+++ b/services/runner/tests/unit/attachment-capability-gate.test.ts
@@ -48,13 +48,17 @@ describe("attachment capability gate", () => {
     }
   });
 
-  it("distinguishes a known model that does not support images", () => {
-    assert.equal(
+  it("treats absence from a positive modality list as unknown", () => {
+    assert.deepEqual(
       attachmentCapabilityGate({
         ...IMAGE_INPUT,
         modelCapabilities: { inputModalities: ["text"] },
-      }).reasonCode,
-      "model_modality_unsupported",
+      }),
+      {
+        outcome: "workspace_only",
+        reasonCode: "model_modality_unknown",
+        kind: "image",
+      },
     );
   });
 

--- a/services/runner/tests/unit/attachment-capability-gate.test.ts
+++ b/services/runner/tests/unit/attachment-capability-gate.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 
-import { attachmentCapabilityGate } from "../../src/engines/sandbox_agent/attachments.ts";
+import {
+  attachmentCapabilityGate,
+  CLAUDE_INLINE_BASE64_MAX_BYTES,
+} from "../../src/engines/sandbox_agent/attachments.ts";
+
+// The gate compares the base64 expansion (4 bytes out per 3 in) against the cap, so derive the
+// raw byte lengths that land either side of it.
+const AT_CAP_BYTES = Math.floor((CLAUDE_INLINE_BASE64_MAX_BYTES / 4) * 3);
+const OVER_CAP_BYTES = AT_CAP_BYTES + 3;
 
 const IMAGE_INPUT = {
   acpAgent: "claude",
@@ -33,6 +41,8 @@ describe("attachment capability gate", () => {
       undefined,
       { inputModalities: [] },
       { inputModalities: ["vision"] },
+      // A malformed entry is not a declaration and must never read as one.
+      { inputModalities: [{ kind: "image" } as unknown as string] },
     ]) {
       assert.deepEqual(
         attachmentCapabilityGate({
@@ -99,18 +109,40 @@ describe("attachment capability gate", () => {
     );
   });
 
-  it("keeps an oversized Claude image workspace-only", () => {
+  it("fails an explicit native request at the model layer too", () => {
+    assert.deepEqual(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        modelCapabilities: { inputModalities: ["text"] },
+        requireNative: true,
+      }),
+      {
+        outcome: "failed",
+        reasonCode: "model_modality_unsupported",
+        kind: "image",
+      },
+    );
+  });
+
+  it("keeps an oversized Claude image workspace-only and a just-under one native", () => {
     assert.equal(
       attachmentCapabilityGate({
         ...IMAGE_INPUT,
-        byteLength: Math.floor(7.5 * 1024 * 1024) + 1,
+        byteLength: OVER_CAP_BYTES,
       }).reasonCode,
       "provider_inline_cap",
+    );
+    assert.equal(
+      attachmentCapabilityGate({
+        ...IMAGE_INPUT,
+        byteLength: AT_CAP_BYTES,
+      }).outcome,
+      "native",
     );
   });
 
   it("keys the inline cap on provider, with ACP agent as the absent-provider fallback", () => {
-    const byteLength = Math.floor(7.5 * 1024 * 1024) + 1;
+    const byteLength = OVER_CAP_BYTES;
     assert.equal(
       attachmentCapabilityGate({
         ...IMAGE_INPUT,

--- a/services/runner/tests/unit/attachment-client.test.ts
+++ b/services/runner/tests/unit/attachment-client.test.ts
@@ -72,6 +72,63 @@ describe("attachment API client", () => {
     });
   });
 
+  it("returns null when a 200 response omits the verified headers", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      ),
+    );
+    assert.equal(
+      await fetchAttachment("session-1", ATTACHMENT_ID, () => "Bearer test"),
+      null,
+    );
+  });
+
+  it("strips content-type parameters from the media type", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(new Uint8Array([1]), {
+          status: 200,
+          headers: {
+            "content-type": "IMAGE/PNG; charset=binary",
+            "content-disposition": "attachment; filename=photo.png",
+          },
+        }),
+      ),
+    );
+    const fetched = await fetchAttachment(
+      "session-1",
+      ATTACHMENT_ID,
+      () => "Bearer test",
+    );
+    assert.equal(fetched?.mediaType, "image/png");
+  });
+
+  it("refuses a body that declares more than the per-attachment cap", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(new Uint8Array([1]), {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-disposition": "attachment; filename=photo.png",
+            "content-length": String(64 * 1024 * 1024),
+          },
+        }),
+      ),
+    );
+    assert.equal(
+      await fetchAttachment("session-1", ATTACHMENT_ID, () => "Bearer test"),
+      null,
+    );
+  });
+
   it("parses quoted filename when filename* is absent", () => {
     assert.equal(
       filenameFromContentDisposition(

--- a/services/runner/tests/unit/attachment-client.test.ts
+++ b/services/runner/tests/unit/attachment-client.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it, vi } from "vitest";
+
+import {
+  claimAttachments,
+  fetchAttachment,
+  filenameFromContentDisposition,
+} from "../../src/sessions/attachments.ts";
+
+const ATTACHMENT_ID = "019a52c2-14c0-7c14-b874-2f5798f9cd21";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("attachment API client", () => {
+  it("returns null for a 404 instead of throwing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("missing", { status: 404 })),
+    );
+    assert.equal(
+      await fetchAttachment("session-1", ATTACHMENT_ID, () => "Bearer test"),
+      null,
+    );
+  });
+
+  it("returns null when the bounded request times out", async () => {
+    vi.stubEnv("AGENTA_ATTACHMENTS_FETCH_TIMEOUT_MS", "1");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (_input: Parameters<typeof fetch>[0], init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const abort = () => reject(new Error("aborted"));
+            if (init?.signal?.aborted) abort();
+            else init?.signal?.addEventListener("abort", abort, { once: true });
+          }),
+      ),
+    );
+    assert.equal(
+      await fetchAttachment("session-1", ATTACHMENT_ID, () => "Bearer test"),
+      null,
+    );
+  });
+
+  it("uses verified headers and prefers RFC 5987 filename*", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-disposition":
+              "attachment; filename=\"fallback.png\"; filename*=UTF-8''..%2Ff%C3%B6%C3%B6.png",
+          },
+        }),
+      ),
+    );
+
+    const fetched = await fetchAttachment(
+      "session-1",
+      ATTACHMENT_ID,
+      () => "Bearer test",
+    );
+    assert.deepEqual(fetched, {
+      bytes: new Uint8Array([1, 2, 3]),
+      mediaType: "image/png",
+      filename: "föö.png",
+    });
+  });
+
+  it("parses quoted filename when filename* is absent", () => {
+    assert.equal(
+      filenameFromContentDisposition(
+        "attachment; filename=\"folder\\\\report.pdf\"",
+      ),
+      "report.pdf",
+    );
+  });
+
+  it("posts the exact claim contract with the run credential", async () => {
+    let request: { url: string; init?: RequestInit } | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        request = { url: String(input), init };
+        return new Response("{}", { status: 200 });
+      }),
+    );
+
+    assert.equal(
+      await claimAttachments(
+        "session-1",
+        [ATTACHMENT_ID],
+        () => "Bearer test",
+      ),
+      true,
+    );
+    assert.equal(request?.url.endsWith("/sessions/attachments/reference"), true);
+    assert.equal(request?.init?.method, "POST");
+    assert.deepEqual(JSON.parse(String(request?.init?.body)), {
+      session_id: "session-1",
+      attachment_ids: [ATTACHMENT_ID],
+    });
+    assert.equal(
+      (request?.init?.headers as Record<string, string>).authorization,
+      "Bearer test",
+    );
+  });
+
+  it("treats a claim failure as non-fatal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("no", { status: 503 })),
+    );
+    assert.equal(
+      await claimAttachments(
+        "session-1",
+        [ATTACHMENT_ID],
+        () => "Bearer test",
+      ),
+      false,
+    );
+  });
+});

--- a/services/runner/tests/unit/attachment-delivery-events.test.ts
+++ b/services/runner/tests/unit/attachment-delivery-events.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it, vi } from "vitest";
+
+import { resolveCurrentTurnAttachments } from "../../src/engines/sandbox_agent/attachments.ts";
+import type { AgentEvent, ChatMessage } from "../../src/protocol.ts";
+import { buildPersistingEmitter } from "../../src/sessions/persist.ts";
+
+const IDS = [
+  "11111111-1111-4111-8111-111111111111",
+  "22222222-2222-4222-8222-222222222222",
+];
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  while (roots.length > 0) {
+    rmSync(roots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("attachment delivery events", () => {
+  it("persists one stable outcome per current-turn attachment", async () => {
+    const ingested: Record<string, unknown>[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/content?")) {
+          const id = IDS.find((candidate) => url.includes(candidate));
+          return new Response(new Uint8Array([id === IDS[0] ? 1 : 2]), {
+            status: 200,
+            headers: {
+              "content-type": "image/png",
+              "content-disposition": `attachment; filename*=UTF-8\x27\x27${id}.png`,
+            },
+          });
+        }
+        if (url.endsWith("/sessions/records/ingest")) {
+          ingested.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+          return new Response("{}", { status: 200 });
+        }
+        throw new Error("unexpected URL " + url);
+      },
+    );
+
+    const cwd = mkdtempSync(join(tmpdir(), "agenta-delivery-events-"));
+    roots.push(cwd);
+    const message: ChatMessage = {
+      role: "user",
+      content: IDS.map((attachmentId) => ({
+        type: "attachment",
+        attachmentId,
+      })),
+    };
+    const live: AgentEvent[] = [];
+    const persisting = buildPersistingEmitter(
+      "session-1",
+      () => "ApiKey test",
+      (event) => live.push(event),
+    );
+
+    const resolved = await resolveCurrentTurnAttachments({
+      message,
+      sessionId: "session-1",
+      auth: () => "ApiKey test",
+      sandbox: {},
+      plan: {
+        cwd,
+        isDaytona: false,
+        acpAgent: "pi",
+        harness: "pi_core",
+      },
+      capabilities: { images: true },
+      modelCapabilities: { inputModalities: ["image"] },
+      emit: persisting.emit,
+    });
+    await persisting.flush();
+
+    assert.equal(resolved.length, 2);
+    const events = live.filter(
+      (event): event is Extract<AgentEvent, { type: "attachment_delivery" }> =>
+        event.type === "attachment_delivery",
+    );
+    assert.equal(events.length, 2);
+    assert.deepEqual(
+      events.map((event) => ({
+        id: event.attachmentId,
+        outcome: event.outcome,
+        reason: event.reasonCode,
+        path: event.workingPath,
+      })),
+      IDS.map((id) => ({
+        id,
+        outcome: "native",
+        reason: "native_supported",
+        path: `attachments/${id}/${id}.png`,
+      })),
+    );
+    assert.equal(ingested.length, 2);
+    assert.ok(
+      ingested.every((payload) => payload.record_type === "attachment_delivery"),
+    );
+  });
+
+  it("emits every outcome before failing a mixed current turn", async () => {
+    vi.stubGlobal(
+      "fetch",
+      async (input: Parameters<typeof fetch>[0]) => {
+        const url = String(input);
+        if (url.includes(IDS[0])) {
+          return new Response("missing", { status: 404 });
+        }
+        return new Response(new Uint8Array([2]), {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-disposition": `attachment; filename*=UTF-8''.png`,
+          },
+        });
+      },
+    );
+    const cwd = mkdtempSync(join(tmpdir(), "agenta-delivery-events-"));
+    roots.push(cwd);
+    const events: AgentEvent[] = [];
+
+    await assert.rejects(
+      () =>
+        resolveCurrentTurnAttachments({
+          message: {
+            role: "user",
+            content: IDS.map((attachmentId) => ({
+              type: "attachment",
+              attachmentId,
+            })),
+          },
+          sessionId: "session-1",
+          auth: () => "ApiKey test",
+          sandbox: {},
+          plan: {
+            cwd,
+            isDaytona: false,
+            acpAgent: "pi",
+            harness: "pi_core",
+          },
+          capabilities: { images: true },
+          modelCapabilities: { inputModalities: ["image"] },
+          emit: (event) => events.push(event),
+        }),
+      /could not be fetched/,
+    );
+    assert.deepEqual(
+      events.map((event) =>
+        event.type === "attachment_delivery"
+          ? [event.attachmentId, event.outcome, event.reasonCode]
+          : [],
+      ),
+      [
+        [IDS[0], "failed", "fetch_failed"],
+        [IDS[1], "native", "native_supported"],
+      ],
+    );
+  });
+});

--- a/services/runner/tests/unit/attachment-delivery-events.test.ts
+++ b/services/runner/tests/unit/attachment-delivery-events.test.ts
@@ -106,6 +106,16 @@ describe("attachment delivery events", () => {
     assert.ok(
       ingested.every((payload) => payload.record_type === "attachment_delivery"),
     );
+    assert.deepEqual(
+      ingested.map((payload) => payload.attributes),
+      IDS.map((id) => ({
+        type: "attachment_delivery",
+        attachmentId: id,
+        outcome: "native",
+        reasonCode: "native_supported",
+        workingPath: `attachments/${id}/${id}.png`,
+      })),
+    );
   });
 
   it("degrades a mixed current turn while emitting every outcome", async () => {

--- a/services/runner/tests/unit/attachment-delivery-events.test.ts
+++ b/services/runner/tests/unit/attachment-delivery-events.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it, vi } from "vitest";
 
-import { resolveCurrentTurnAttachments } from "../../src/engines/sandbox_agent/attachments.ts";
+import {
+  buildPromptBlocks,
+  resolveCurrentTurnAttachments,
+} from "../../src/engines/sandbox_agent/attachments.ts";
 import type { AgentEvent, ChatMessage } from "../../src/protocol.ts";
 import { buildPersistingEmitter } from "../../src/sessions/persist.ts";
 
@@ -105,7 +108,7 @@ describe("attachment delivery events", () => {
     );
   });
 
-  it("emits every outcome before failing a mixed current turn", async () => {
+  it("degrades a mixed current turn while emitting every outcome", async () => {
     vi.stubGlobal(
       "fetch",
       async (input: Parameters<typeof fetch>[0]) => {
@@ -126,31 +129,28 @@ describe("attachment delivery events", () => {
     roots.push(cwd);
     const events: AgentEvent[] = [];
 
-    await assert.rejects(
-      () =>
-        resolveCurrentTurnAttachments({
-          message: {
-            role: "user",
-            content: IDS.map((attachmentId) => ({
-              type: "attachment",
-              attachmentId,
-            })),
-          },
-          sessionId: "session-1",
-          auth: () => "ApiKey test",
-          sandbox: {},
-          plan: {
-            cwd,
-            isDaytona: false,
-            acpAgent: "pi",
-            harness: "pi_core",
-          },
-          capabilities: { images: true },
-          modelCapabilities: { inputModalities: ["image"] },
-          emit: (event) => events.push(event),
-        }),
-      /could not be fetched/,
-    );
+    const resolved = await resolveCurrentTurnAttachments({
+      message: {
+        role: "user",
+        content: IDS.map((attachmentId) => ({
+          type: "attachment",
+          attachmentId,
+        })),
+      },
+      sessionId: "session-1",
+      auth: () => "ApiKey test",
+      sandbox: {},
+      plan: {
+        cwd,
+        isDaytona: false,
+        acpAgent: "pi",
+        harness: "pi_core",
+      },
+      capabilities: { images: true },
+      modelCapabilities: { inputModalities: ["image"] },
+      emit: (event) => events.push(event),
+    });
+    assert.equal(resolved.length, 2);
     assert.deepEqual(
       events.map((event) =>
         event.type === "attachment_delivery"
@@ -162,5 +162,60 @@ describe("attachment delivery events", () => {
         [IDS[1], "native", "native_supported"],
       ],
     );
+    const blocks = buildPromptBlocks("continue", resolved);
+    const textBlock = blocks.at(-1);
+    assert.match(
+      textBlock?.type === "text" ? textBlock.text : "",
+      /attached file: attachment - no longer available/,
+    );
+  });
+
+  it("reports a current-turn filesystem failure as materialize_failed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      async () =>
+        new Response(new Uint8Array([2]), {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-disposition": "attachment; filename=photo.png",
+          },
+        }),
+    );
+    const root = mkdtempSync(join(tmpdir(), "agenta-delivery-events-"));
+    roots.push(root);
+    const cwd = join(root, "not-a-directory");
+    writeFileSync(cwd, "occupied");
+    const events: AgentEvent[] = [];
+
+    const resolved = await resolveCurrentTurnAttachments({
+      message: {
+        role: "user",
+        content: [{ type: "attachment", attachmentId: IDS[0] }],
+      },
+      sessionId: "session-1",
+      auth: () => "ApiKey test",
+      sandbox: {},
+      plan: {
+        cwd,
+        isDaytona: false,
+        acpAgent: "pi",
+        harness: "pi_core",
+      },
+      capabilities: { images: true },
+      modelCapabilities: { inputModalities: ["image"] },
+      emit: (event) => events.push(event),
+    });
+
+    assert.equal(resolved[0].gate.outcome, "failed");
+    assert.equal(resolved[0].gate.reasonCode, "materialize_failed");
+    assert.deepEqual(events, [
+      {
+        type: "attachment_delivery",
+        attachmentId: IDS[0],
+        outcome: "failed",
+        reasonCode: "materialize_failed",
+      },
+    ]);
   });
 });

--- a/services/runner/tests/unit/attachment-materialize.test.ts
+++ b/services/runner/tests/unit/attachment-materialize.test.ts
@@ -99,12 +99,18 @@ describe("attachment materialization", () => {
 
   it("writes identical bytes through the Daytona filesystem API", async () => {
     const written = new Map<string, Uint8Array>();
+    const operations: string[] = [];
     const sandbox = {
-      mkdirFs: async () => {},
+      mkdirFs: async () => {
+        operations.push("mkdir");
+      },
       statFs: async () => {
         throw new Error("missing");
       },
-      runProcess: async () => ({ exitCode: 1 }),
+      runProcess: async ({ timeoutMs }: { timeoutMs?: number }) => {
+        operations.push(`symlink-check:${timeoutMs}`);
+        return { exitCode: 1 };
+      },
       writeFsFile: async (
         { path }: { path: string },
         body: Uint8Array,
@@ -129,6 +135,12 @@ describe("attachment materialization", () => {
       written.get(attachmentWorkingPath(cwd, ref).absolute),
       bytes,
     );
+    assert.deepEqual(operations, [
+      "symlink-check:15000",
+      "symlink-check:15000",
+      "symlink-check:15000",
+      "mkdir",
+    ]);
   });
 
   it("restores referenced copies with bounded concurrency and never overwrites", async () => {
@@ -149,12 +161,14 @@ describe("attachment materialization", () => {
     );
     let active = 0;
     let maxActive = 0;
+    const fetchedIds: string[] = [];
     vi.stubGlobal("fetch", async (input: Parameters<typeof fetch>[0]) => {
       active += 1;
       maxActive = Math.max(maxActive, active);
       await new Promise((resolve) => setTimeout(resolve, 5));
       active -= 1;
       const id = ids.find((candidate) => String(input).includes(candidate));
+      if (id) fetchedIds.push(id);
       return new Response(new Uint8Array([1]), {
         status: 200,
         headers: {
@@ -169,7 +183,7 @@ describe("attachment materialization", () => {
         content: ids.map((attachmentId) => ({
           type: "attachment",
           attachmentId,
-          filename: "untrusted.png",
+          filename: attachmentId === ids[0] ? ".png" : "untrusted.png",
         })),
       },
     ];
@@ -184,6 +198,8 @@ describe("attachment materialization", () => {
     );
 
     assert.ok(maxActive <= 2);
+    assert.equal(fetchedIds.includes(ids[0]), false, "existing copy skips fetch");
+    assert.equal(fetchedIds.length, ids.length - 1);
     assert.deepEqual(
       readFileSync(attachmentWorkingPath(cwd, existing).absolute),
       Buffer.from([9]),
@@ -193,6 +209,71 @@ describe("attachment materialization", () => {
         ? restored[0].content[0].filename
         : undefined,
       `.png`,
+    );
+  });
+
+  it("a failed historical restore is survivable", async () => {
+    const cwd = root();
+    const logs: string[] = [];
+    vi.stubGlobal("fetch", async (input: Parameters<typeof fetch>[0]) => {
+      if (String(input).includes(ID_ONE)) {
+        return new Response("gone", { status: 404 });
+      }
+      return new Response(new Uint8Array([7, 8]), {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+          "content-disposition": "attachment; filename=healthy.txt",
+        },
+      });
+    });
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "attachment",
+            attachmentId: ID_ONE,
+            filename: "report.pdf",
+          },
+          {
+            type: "attachment",
+            attachmentId: ID_TWO,
+            filename: "healthy.txt",
+          },
+        ],
+      },
+    ];
+
+    const restored = await restoreReferencedWorkingCopies(
+      {},
+      { cwd, isDaytona: false },
+      messages,
+      "session-1",
+      () => "ApiKey test",
+      { log: (message) => logs.push(message) },
+    );
+
+    assert.deepEqual(
+      readFileSync(
+        attachmentWorkingPath(cwd, {
+          attachmentId: ID_TWO,
+          filename: "healthy.txt",
+        }).absolute,
+      ),
+      Buffer.from([7, 8]),
+    );
+    assert.equal(
+      Array.isArray(restored[0].content)
+        ? restored[0].content[0].text
+        : undefined,
+      "[attached file: report.pdf - no longer available]",
+    );
+    assert.ok(
+      logs.some(
+        (message) =>
+          message.includes(ID_ONE) && message.includes("no longer available"),
+      ),
     );
   });
 });

--- a/services/runner/tests/unit/attachment-materialize.test.ts
+++ b/services/runner/tests/unit/attachment-materialize.test.ts
@@ -143,6 +143,31 @@ describe("attachment materialization", () => {
     ]);
   });
 
+  it("refuses to write when the Daytona symlink check reports no exit code", async () => {
+    let written = 0;
+    const sandbox = {
+      mkdirFs: async () => {},
+      statFs: async () => {
+        throw new Error("missing");
+      },
+      runProcess: async () => undefined,
+      writeFsFile: async () => {
+        written += 1;
+      },
+    };
+
+    await assert.rejects(
+      materializeWorkingCopy(
+        sandbox,
+        { cwd: "/home/sandbox/cwd", isDaytona: true },
+        { attachmentId: ID_ONE, filename: "photo.png" },
+        new Uint8Array([1]),
+      ),
+      /did not report an exit code/,
+    );
+    assert.equal(written, 0);
+  });
+
   it("restores referenced copies with bounded concurrency and never overwrites", async () => {
     const cwd = root();
     const ids = [
@@ -197,7 +222,7 @@ describe("attachment materialization", () => {
       { concurrency: 2, timeoutMs: 1_000 },
     );
 
-    assert.ok(maxActive <= 2);
+    assert.equal(maxActive, 2, "the pool runs at the configured concurrency");
     assert.equal(fetchedIds.includes(ids[0]), false, "existing copy skips fetch");
     assert.equal(fetchedIds.length, ids.length - 1);
     assert.deepEqual(

--- a/services/runner/tests/unit/attachment-materialize.test.ts
+++ b/services/runner/tests/unit/attachment-materialize.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it, vi } from "vitest";
+
+import {
+  attachmentWorkingPath,
+  materializeWorkingCopy,
+  restoreReferencedWorkingCopies,
+} from "../../src/engines/sandbox_agent/attachments.ts";
+
+const ID_ONE = "019a52c2-14c0-7c14-b874-2f5798f9cd21";
+const ID_TWO = "019a52c2-14c0-7c14-b874-2f5798f9cd22";
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "agenta-attachment-write-"));
+  roots.push(value);
+  return value;
+}
+
+describe("attachment materialization", () => {
+  it("writes a missing local working copy", async () => {
+    const cwd = root();
+    const ref = { attachmentId: ID_ONE, filename: "photo.png" };
+    assert.equal(
+      await materializeWorkingCopy(
+        {},
+        { cwd, isDaytona: false },
+        ref,
+        new Uint8Array([1, 2, 3]),
+      ),
+      "written",
+    );
+    assert.deepEqual(
+      readFileSync(attachmentWorkingPath(cwd, ref).absolute),
+      Buffer.from([1, 2, 3]),
+    );
+  });
+
+  it("never overwrites an existing local working copy", async () => {
+    const cwd = root();
+    const ref = { attachmentId: ID_ONE, filename: "photo.png" };
+    await materializeWorkingCopy(
+      {},
+      { cwd, isDaytona: false },
+      ref,
+      new Uint8Array([1]),
+    );
+    const path = attachmentWorkingPath(cwd, ref).absolute;
+    writeFileSync(path, Buffer.from([9, 9]));
+
+    assert.equal(
+      await materializeWorkingCopy(
+        {},
+        { cwd, isDaytona: false },
+        ref,
+        new Uint8Array([2]),
+      ),
+      "exists",
+    );
+    assert.deepEqual(readFileSync(path), Buffer.from([9, 9]));
+  });
+
+  it("namespaces equal filenames by attachment id", async () => {
+    const cwd = root();
+    const first = { attachmentId: ID_ONE, filename: "same.txt" };
+    const second = { attachmentId: ID_TWO, filename: "same.txt" };
+    await materializeWorkingCopy(
+      {},
+      { cwd, isDaytona: false },
+      first,
+      new Uint8Array([1]),
+    );
+    await materializeWorkingCopy(
+      {},
+      { cwd, isDaytona: false },
+      second,
+      new Uint8Array([2]),
+    );
+    assert.notEqual(
+      attachmentWorkingPath(cwd, first).absolute,
+      attachmentWorkingPath(cwd, second).absolute,
+    );
+  });
+
+  it("writes identical bytes through the Daytona filesystem API", async () => {
+    const written = new Map<string, Uint8Array>();
+    const sandbox = {
+      mkdirFs: async () => {},
+      statFs: async () => {
+        throw new Error("missing");
+      },
+      runProcess: async () => ({ exitCode: 1 }),
+      writeFsFile: async (
+        { path }: { path: string },
+        body: Uint8Array,
+      ) => {
+        written.set(path, new Uint8Array(body));
+      },
+    };
+    const cwd = "/home/sandbox/cwd";
+    const ref = { attachmentId: ID_ONE, filename: "photo.png" };
+    const bytes = new Uint8Array([4, 5, 6]);
+
+    assert.equal(
+      await materializeWorkingCopy(
+        sandbox,
+        { cwd, isDaytona: true },
+        ref,
+        bytes,
+      ),
+      "written",
+    );
+    assert.deepEqual(
+      written.get(attachmentWorkingPath(cwd, ref).absolute),
+      bytes,
+    );
+  });
+
+  it("restores referenced copies with bounded concurrency and never overwrites", async () => {
+    const cwd = root();
+    const ids = [
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      "33333333-3333-4333-8333-333333333333",
+      "44444444-4444-4444-8444-444444444444",
+      "55555555-5555-4555-8555-555555555555",
+    ];
+    const existing = { attachmentId: ids[0], filename: `.png` };
+    await materializeWorkingCopy(
+      {},
+      { cwd, isDaytona: false },
+      existing,
+      new Uint8Array([9]),
+    );
+    let active = 0;
+    let maxActive = 0;
+    vi.stubGlobal("fetch", async (input: Parameters<typeof fetch>[0]) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      const id = ids.find((candidate) => String(input).includes(candidate));
+      return new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "content-disposition": `attachment; filename*=UTF-8''.png`,
+        },
+      });
+    });
+    const messages = [
+      {
+        role: "user",
+        content: ids.map((attachmentId) => ({
+          type: "attachment",
+          attachmentId,
+          filename: "untrusted.png",
+        })),
+      },
+    ];
+
+    const restored = await restoreReferencedWorkingCopies(
+      {},
+      { cwd, isDaytona: false },
+      messages,
+      "session-1",
+      () => "ApiKey test",
+      { concurrency: 2, timeoutMs: 1_000 },
+    );
+
+    assert.ok(maxActive <= 2);
+    assert.deepEqual(
+      readFileSync(attachmentWorkingPath(cwd, existing).absolute),
+      Buffer.from([9]),
+    );
+    assert.equal(
+      Array.isArray(restored[0].content)
+        ? restored[0].content[0].filename
+        : undefined,
+      `.png`,
+    );
+  });
+});

--- a/services/runner/tests/unit/attachment-path-safety.test.ts
+++ b/services/runner/tests/unit/attachment-path-safety.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "vitest";
+
+import {
+  attachmentWorkingPath,
+  materializeWorkingCopy,
+} from "../../src/engines/sandbox_agent/attachments.ts";
+
+const ATTACHMENT_ID = "019a52c2-14c0-7c14-b874-2f5798f9cd21";
+const roots: string[] = [];
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "agenta-attachment-path-"));
+  roots.push(value);
+  return value;
+}
+
+describe("attachment path safety", () => {
+  it("rejects a non-UUID id before constructing a working path", () => {
+    assert.throws(
+      () =>
+        attachmentWorkingPath(root(), {
+          attachmentId: "../escape",
+          filename: "safe.txt",
+        }),
+      /canonical UUID/,
+    );
+  });
+
+  it("rejects separators and dot path components in filenames", () => {
+    for (const filename of ["nested/file.txt", "nested\\file.txt", ".", ".."]) {
+      assert.throws(
+        () =>
+          attachmentWorkingPath(root(), {
+            attachmentId: ATTACHMENT_ID,
+            filename,
+          }),
+        /safe basename/,
+      );
+    }
+  });
+
+  it("keeps the resolved path under cwd/attachments", () => {
+    const cwd = root();
+    const path = attachmentWorkingPath(cwd, {
+      attachmentId: ATTACHMENT_ID,
+      filename: "safe.txt",
+    });
+    assert.equal(path.absolute.startsWith(path.root + "/"), true);
+    assert.equal(
+      path.relative,
+      "attachments/" + ATTACHMENT_ID + "/safe.txt",
+    );
+  });
+
+  it("rejects a symlinked parent component", async () => {
+    const cwd = root();
+    const outside = join(cwd, "outside");
+    mkdirSync(outside);
+    symlinkSync(outside, join(cwd, "attachments"));
+
+    await assert.rejects(
+      () =>
+        materializeWorkingCopy(
+          {},
+          { cwd, isDaytona: false },
+          { attachmentId: ATTACHMENT_ID, filename: "safe.txt" },
+          new Uint8Array([1]),
+        ),
+      /symbolic link/,
+    );
+  });
+});

--- a/services/runner/tests/unit/attachment-prompt-blocks.test.ts
+++ b/services/runner/tests/unit/attachment-prompt-blocks.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import {
+  attachmentWorkingPath,
+  buildPromptBlocks,
+  collectLegacyInlineImages,
+  type ResolvedAttachment,
+} from "../../src/engines/sandbox_agent/attachments.ts";
+import type { ChatMessage } from "../../src/protocol.ts";
+
+const ATTACHMENT_ID = "019a52c2-14c0-7c14-b874-2f5798f9cd21";
+
+function resolved(
+  outcome: "native" | "workspace_only",
+): ResolvedAttachment {
+  const ref = {
+    attachmentId: ATTACHMENT_ID,
+    filename: "photo.png",
+    mediaType: "image/png",
+    size: 3,
+  };
+  return {
+    ref,
+    bytes: new Uint8Array([1, 2, 3]),
+    path: attachmentWorkingPath("/cwd", ref),
+    gate: {
+      outcome,
+      reasonCode:
+        outcome === "native"
+          ? "native_supported"
+          : "model_modality_unknown",
+      kind: "image",
+    },
+  };
+}
+
+describe("attachment prompt blocks", () => {
+  it("puts native images first and emits exactly one mention-plus-text block", () => {
+    const blocks = buildPromptBlocks("describe this", [resolved("native")]);
+    assert.deepEqual(blocks, [
+      {
+        type: "image",
+        data: Buffer.from([1, 2, 3]).toString("base64"),
+        mimeType: "image/png",
+      },
+      {
+        type: "text",
+        text:
+          "[attached file: photo.png at attachments/" +
+          ATTACHMENT_ID +
+          "/photo.png]\ndescribe this",
+      },
+    ]);
+  });
+
+  it("keeps an attachment-only turn non-empty through its mention", () => {
+    const blocks = buildPromptBlocks("", [resolved("native")]);
+    assert.equal(blocks.length, 2);
+    assert.match(blocks[1].type === "text" ? blocks[1].text : "", /attached file/);
+  });
+
+  it("omits a workspace-only native block but keeps the mention and turn", () => {
+    const blocks = buildPromptBlocks("inspect it", [
+      resolved("workspace_only"),
+    ]);
+    assert.deepEqual(
+      blocks.map((block) => block.type),
+      ["text"],
+    );
+    assert.match(blocks[0].type === "text" ? blocks[0].text : "", /inspect it/);
+  });
+
+  it("reads the real uri data URL before the historical data fallback", () => {
+    const message = {
+      role: "user",
+      content: [
+        {
+          type: "image",
+          uri: "data:image/png;base64,dXJp",
+          data: "ZmFsbGJhY2s=",
+          mimeType: "image/jpeg",
+        },
+        {
+          type: "image",
+          data: "aGlzdG9yaWNhbA==",
+          mimeType: "image/webp",
+        },
+      ],
+    } as ChatMessage;
+    assert.deepEqual(collectLegacyInlineImages(message), [
+      { data: "dXJp", mimeType: "image/png" },
+      { data: "aGlzdG9yaWNhbA==", mimeType: "image/webp" },
+    ]);
+  });
+});

--- a/services/runner/tests/unit/attachment-prompt-blocks.test.ts
+++ b/services/runner/tests/unit/attachment-prompt-blocks.test.ts
@@ -7,6 +7,7 @@ import {
   collectLegacyInlineImages,
   type ResolvedAttachment,
 } from "../../src/engines/sandbox_agent/attachments.ts";
+import { COLD_FRAME_USER_LABEL } from "../../src/engines/sandbox_agent/transcript.ts";
 import type { ChatMessage } from "../../src/protocol.ts";
 
 const ATTACHMENT_ID = "019a52c2-14c0-7c14-b874-2f5798f9cd21";
@@ -72,7 +73,8 @@ describe("attachment prompt blocks", () => {
   it("places mentions in the latest-user section of a cold replay frame", () => {
     const turnText =
       "Conversation so far:\nassistant: ready\n\n" +
-      "Continue the conversation. The user now says:\ndescribe this";
+      COLD_FRAME_USER_LABEL +
+      "describe this";
     const blocks = buildPromptBlocks(
       turnText,
       [resolved("workspace_only")],
@@ -84,7 +86,7 @@ describe("attachment prompt blocks", () => {
     assert.equal(
       text,
       "Conversation so far:\nassistant: ready\n\n" +
-        "Continue the conversation. The user now says:\n" +
+        COLD_FRAME_USER_LABEL +
         "[attached file: photo.png at attachments/" +
         ATTACHMENT_ID +
         "/photo.png]\ndescribe this",
@@ -93,8 +95,7 @@ describe("attachment prompt blocks", () => {
 
   it("puts attachment-only mentions after the cold frame's closing label", () => {
     const turnText =
-      "Conversation so far:\nassistant: ready\n\n" +
-      "Continue the conversation. The user now says:\n";
+      "Conversation so far:\nassistant: ready\n\n" + COLD_FRAME_USER_LABEL;
     const blocks = buildPromptBlocks(
       turnText,
       [resolved("workspace_only")],

--- a/services/runner/tests/unit/attachment-prompt-blocks.test.ts
+++ b/services/runner/tests/unit/attachment-prompt-blocks.test.ts
@@ -12,7 +12,7 @@ import type { ChatMessage } from "../../src/protocol.ts";
 const ATTACHMENT_ID = "019a52c2-14c0-7c14-b874-2f5798f9cd21";
 
 function resolved(
-  outcome: "native" | "workspace_only",
+  outcome: "native" | "workspace_only" | "failed",
 ): ResolvedAttachment {
   const ref = {
     attachmentId: ATTACHMENT_ID,
@@ -29,6 +29,8 @@ function resolved(
       reasonCode:
         outcome === "native"
           ? "native_supported"
+          : outcome === "failed"
+            ? "fetch_failed"
           : "model_modality_unknown",
       kind: "image",
     },
@@ -58,6 +60,59 @@ describe("attachment prompt blocks", () => {
     const blocks = buildPromptBlocks("", [resolved("native")]);
     assert.equal(blocks.length, 2);
     assert.match(blocks[1].type === "text" ? blocks[1].text : "", /attached file/);
+  });
+
+  it("sends a legacy image-only prompt without an empty text block", () => {
+    assert.deepEqual(
+      buildPromptBlocks("", [], [{ data: "AQID", mimeType: "image/png" }]),
+      [{ type: "image", data: "AQID", mimeType: "image/png" }],
+    );
+  });
+
+  it("places mentions in the latest-user section of a cold replay frame", () => {
+    const turnText =
+      "Conversation so far:\nassistant: ready\n\n" +
+      "Continue the conversation. The user now says:\ndescribe this";
+    const blocks = buildPromptBlocks(
+      turnText,
+      [resolved("workspace_only")],
+      [],
+      "describe this",
+    );
+    const text = blocks[0].type === "text" ? blocks[0].text : "";
+
+    assert.equal(
+      text,
+      "Conversation so far:\nassistant: ready\n\n" +
+        "Continue the conversation. The user now says:\n" +
+        "[attached file: photo.png at attachments/" +
+        ATTACHMENT_ID +
+        "/photo.png]\ndescribe this",
+    );
+  });
+
+  it("puts attachment-only mentions after the cold frame's closing label", () => {
+    const turnText =
+      "Conversation so far:\nassistant: ready\n\n" +
+      "Continue the conversation. The user now says:\n";
+    const blocks = buildPromptBlocks(
+      turnText,
+      [resolved("workspace_only")],
+      [],
+      "",
+    );
+    const text = blocks[0].type === "text" ? blocks[0].text : "";
+
+    assert.match(text, /The user now says:\n\[attached file:/);
+    assert.ok(text.startsWith("Conversation so far:"));
+  });
+
+  it("renders a failed attachment as unavailable", () => {
+    const blocks = buildPromptBlocks("continue", [resolved("failed")]);
+    assert.equal(
+      blocks[0].type === "text" ? blocks[0].text : "",
+      "[attached file: photo.png - no longer available]\ncontinue",
+    );
   });
 
   it("omits a workspace-only native block but keeps the mention and turn", () => {

--- a/services/runner/tests/unit/current-user-turn.test.ts
+++ b/services/runner/tests/unit/current-user-turn.test.ts
@@ -43,6 +43,23 @@ describe("currentUserTurn", () => {
     ]);
     assert.equal(turn.isFresh, true);
     assert.equal(turn.carriesToolEnvelope, false);
+    assert.equal(turn.hasInlineMedia, false);
+  });
+
+  it("recognizes both legacy inline image shapes as media", () => {
+    for (const block of [
+      { type: "image", uri: "data:image/png;base64,AQID" },
+      { type: "image", data: "AQID", mimeType: "image/webp" },
+    ]) {
+      const turn = currentUserTurn({
+        messages: [{ role: "user", content: [block] }],
+      } as AgentRunRequest);
+
+      assert.equal(turn.text, "");
+      assert.deepEqual(turn.attachments, []);
+      assert.equal(turn.hasInlineMedia, true);
+      assert.equal(turn.isFresh, true);
+    }
   });
 
   it("marks an approval-resume tail as a tool envelope, not a fresh turn", () => {
@@ -90,6 +107,7 @@ describe("currentUserTurn", () => {
       text: "",
       attachments: [],
       isFresh: false,
+      hasInlineMedia: false,
       carriesToolEnvelope: false,
     });
   });

--- a/services/runner/tests/unit/current-user-turn.test.ts
+++ b/services/runner/tests/unit/current-user-turn.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import {
+  currentUserTurn,
+  type AgentRunRequest,
+  type ContentBlock,
+} from "../../src/protocol.ts";
+
+function attachmentBlock(
+  attachmentId: string,
+  filename = "photo.png",
+): ContentBlock {
+  return {
+    type: "attachment",
+    attachmentId,
+    filename,
+    mimeType: "image/png",
+    size: 123,
+  } as unknown as ContentBlock;
+}
+
+describe("currentUserTurn", () => {
+  it("reads an attachment-only tail without reusing earlier text", () => {
+    const turn = currentUserTurn({
+      messages: [
+        { role: "user", content: "earlier text" },
+        {
+          role: "user",
+          content: [attachmentBlock("019a52c2-14c0-7c14-b874-2f5798f9cd21")],
+        },
+      ],
+    });
+
+    assert.equal(turn.text, "");
+    assert.deepEqual(turn.attachments, [
+      {
+        attachmentId: "019a52c2-14c0-7c14-b874-2f5798f9cd21",
+        filename: "photo.png",
+        mediaType: "image/png",
+        size: 123,
+      },
+    ]);
+    assert.equal(turn.isFresh, true);
+    assert.equal(turn.carriesToolEnvelope, false);
+  });
+
+  it("marks an approval-resume tail as a tool envelope, not a fresh turn", () => {
+    const turn = currentUserTurn({
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolCallId: "call-1",
+              output: { approved: true },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(turn.text, "");
+    assert.equal(turn.isFresh, false);
+    assert.equal(turn.carriesToolEnvelope, true);
+  });
+
+  it("marks a text tail carrying a tool envelope as not fresh", () => {
+    const turn = currentUserTurn({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "continue" },
+            { type: "tool_call", toolCallId: "call-1" },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(turn.text, "continue");
+    assert.equal(turn.isFresh, false);
+    assert.equal(turn.carriesToolEnvelope, true);
+  });
+
+  it("returns an empty non-fresh turn for an empty conversation", () => {
+    assert.deepEqual(currentUserTurn({} as AgentRunRequest), {
+      message: null,
+      text: "",
+      attachments: [],
+      isFresh: false,
+      carriesToolEnvelope: false,
+    });
+  });
+});

--- a/services/runner/tests/unit/sandbox-agent-capabilities.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-capabilities.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import type { ResolvedToolSpec } from "../../src/protocol.ts";
+import { attachmentCapabilityGate } from "../../src/engines/sandbox_agent/attachments.ts";
 import {
   assert as invariant,
   assertRequiredCapabilities,
@@ -196,6 +197,27 @@ describe("assertRequiredCapabilities (fail loud on tool delivery)", () => {
       }),
     );
     assert.ok(logs.some((m) => m.includes("(static)")));
+  });
+});
+
+describe("pinned attachment adapter fidelity", () => {
+  it("keeps native image support on both pinned adapters", () => {
+    for (const [harness, acpAgent] of [
+      ["claude", "claude"],
+      ["pi_core", "pi"],
+    ] as const) {
+      assert.equal(
+        attachmentCapabilityGate({
+          harness,
+          acpAgent,
+          capabilities: { images: true },
+          modelCapabilities: { inputModalities: ["image"] },
+          mediaType: "image/png",
+          byteLength: 3,
+        }).outcome,
+        "native",
+      );
+    }
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-capabilities.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-capabilities.test.ts
@@ -202,13 +202,9 @@ describe("assertRequiredCapabilities (fail loud on tool delivery)", () => {
 
 describe("pinned attachment adapter fidelity", () => {
   it("keeps native image support on both pinned adapters", () => {
-    for (const [harness, acpAgent] of [
-      ["claude", "claude"],
-      ["pi_core", "pi"],
-    ] as const) {
+    for (const acpAgent of ["claude", "pi"] as const) {
       assert.equal(
         attachmentCapabilityGate({
-          harness,
           acpAgent,
           capabilities: { images: true },
           modelCapabilities: { inputModalities: ["image"] },

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -103,6 +103,7 @@ function fakeHarness(options: FakeOptions = {}) {
     recordedErrors: [] as Array<{ message: string; provider?: string }>,
   };
   const events: AgentEvent[] = [];
+  const logs: string[] = [];
   let eventHandler: ((event: any) => void) | undefined;
   let permissionHandler: ((request: any) => void) | undefined;
   // The in-flight prompt resolver, so a `destroySession` (the managed cancel) can resolve a
@@ -233,7 +234,7 @@ function fakeHarness(options: FakeOptions = {}) {
   };
 
   const deps: SandboxAgentDeps = {
-    log: () => {},
+    log: (message) => logs.push(message),
     createLocalCwd: (durable?: string) =>
       durable ?? options.cwd ?? "/tmp/agenta-fake-cwd",
     createDaytonaCwd: (durable?: string) =>
@@ -307,7 +308,7 @@ function fakeHarness(options: FakeOptions = {}) {
     }),
   };
 
-  return { calls, deps, events };
+  return { calls, deps, events, logs };
 }
 
 describe("PendingApprovalPauseController", () => {
@@ -416,12 +417,74 @@ describe("runSandboxAgent orchestration", () => {
     ]);
   });
 
+  it("delivers a legacy image-only turn as a non-empty image-only prompt", async () => {
+    const { calls, deps, logs } = fakeHarness({
+      capabilities: { images: true },
+    });
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "image", uri: "data:image/png;base64,AQID" }],
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(
+      calls.promptBlocks,
+      [{ type: "image", data: "AQID", mimeType: "image/png" }],
+    );
+    assert.ok(calls.promptBlocks.length > 0);
+    assert.deepEqual(
+      logs.filter((message) => message.includes("legacy inline image")),
+      [
+        "[attachments] legacy inline image delivery=native reason=native_supported",
+      ],
+    );
+  });
+
+  it("keeps a degraded legacy image-only prompt non-empty", async () => {
+    const { calls, deps } = fakeHarness({
+      capabilities: { images: false },
+    });
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "image", uri: "data:image/png;base64,AQID" }],
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.promptBlocks, [
+      {
+        type: "text",
+        text: "[inline image could not be delivered to this harness]",
+      },
+    ]);
+  });
   it("a legacy inline image degrades rather than throws", async () => {
     for (const testCase of [
       { mimeType: "image/png", capabilities: { images: false } },
       { mimeType: "image/svg+xml", capabilities: { images: true } },
     ]) {
-      const { calls, deps, events } = fakeHarness({
+      const { calls, deps, events, logs } = fakeHarness({
         capabilities: testCase.capabilities,
       });
       const result = await runSandboxAgent(
@@ -452,6 +515,10 @@ describe("runSandboxAgent orchestration", () => {
       assert.equal(
         events.some((event) => event.type === "attachment_delivery"),
         false,
+      );
+      assert.match(
+        logs.find((message) => message.includes("legacy inline image")) ?? "",
+        /delivery=degraded reason=[a-z_]+$/,
       );
     }
   });

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -3,7 +3,7 @@
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/sandbox-agent-orchestration.test.ts)
  */
-import { beforeEach, describe, it } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -31,6 +31,10 @@ beforeEach(() => {
   process.env.AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS = "local,daytona";
   process.env.AGENTA_RUNNER_DAYTONA_API_KEY = "test-key";
   resetRunnerConfigCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 function flushPromises(): Promise<void> {
@@ -410,6 +414,122 @@ describe("runSandboxAgent orchestration", () => {
       { type: "image", data: "AQID", mimeType: "image/png" },
       { type: "text", text: "inspect this" },
     ]);
+  });
+
+  it("a legacy inline image degrades rather than throws", async () => {
+    for (const testCase of [
+      { mimeType: "image/png", capabilities: { images: false } },
+      { mimeType: "image/svg+xml", capabilities: { images: true } },
+    ]) {
+      const { calls, deps, events } = fakeHarness({
+        capabilities: testCase.capabilities,
+      });
+      const result = await runSandboxAgent(
+        {
+          harness: "pi_core",
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "image",
+                  uri: `data:${testCase.mimeType};base64,AQID`,
+                },
+                { type: "text", text: "inspect this" },
+              ],
+            },
+          ],
+        },
+        undefined,
+        undefined,
+        deps,
+      );
+
+      assert.equal(result.ok, true, testCase.mimeType);
+      assert.deepEqual(calls.promptBlocks, [
+        { type: "text", text: "inspect this" },
+      ]);
+      assert.equal(
+        events.some((event) => event.type === "attachment_delivery"),
+        false,
+      );
+    }
+  });
+
+  it("a failed historical restore is survivable through a full cold turn", async () => {
+    const deadId = "11111111-1111-4111-8111-111111111111";
+    const healthyId = "22222222-2222-4222-8222-222222222222";
+    vi.stubGlobal("fetch", async (input: Parameters<typeof fetch>[0]) => {
+      if (String(input).includes(deadId)) {
+        return new Response("gone", { status: 404 });
+      }
+      if (String(input).includes(healthyId)) {
+        return new Response(new Uint8Array([7, 8]), {
+          status: 200,
+          headers: {
+            "content-type": "text/plain",
+            "content-disposition": "attachment; filename=healthy.txt",
+          },
+        });
+      }
+      throw new Error(`unexpected URL ${String(input)}`);
+    });
+    const cwd = join(
+      tmpdir(),
+      "agenta-attachment-restore-" + process.pid + "-" + Date.now(),
+    );
+    mkdirSync(cwd, { recursive: true });
+    const { calls, deps } = fakeHarness({ cwd });
+
+    try {
+      const result = await runSandboxAgent(
+        {
+          harness: "pi_core",
+          sessionId: "session-1",
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "attachment",
+                  attachmentId: deadId,
+                  filename: "report.pdf",
+                },
+                {
+                  type: "attachment",
+                  attachmentId: healthyId,
+                  filename: "healthy.txt",
+                },
+                { type: "text", text: "old request" },
+              ],
+            },
+            { role: "assistant", content: "ready" },
+            { role: "user", content: "continue" },
+          ],
+        },
+        undefined,
+        undefined,
+        deps,
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(
+        existsSync(join(cwd, "attachments", healthyId, "healthy.txt")),
+        true,
+      );
+      const promptText = calls.promptBlocks.at(-1)?.text ?? "";
+      assert.match(
+        promptText,
+        /\[attached file: report\.pdf - no longer available\]/,
+      );
+      assert.match(
+        promptText,
+        new RegExp(`attachments/${healthyId}/healthy\\.txt`),
+      );
+      assert.match(promptText, /The user now says:\ncontinue$/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("points local Pi and pi-acp at the conversation workspace transcript directory", async () => {

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -479,11 +479,12 @@ describe("runSandboxAgent orchestration", () => {
       },
     ]);
   });
-  it("a legacy inline image degrades rather than throws", async () => {
-    for (const testCase of [
-      { mimeType: "image/png", capabilities: { images: false } },
-      { mimeType: "image/svg+xml", capabilities: { images: true } },
-    ]) {
+  it.each([
+    { mimeType: "image/png", capabilities: { images: false } },
+    { mimeType: "image/svg+xml", capabilities: { images: true } },
+  ])(
+    "a legacy inline $mimeType image degrades rather than throws",
+    async (testCase) => {
       const { calls, deps, events, logs } = fakeHarness({
         capabilities: testCase.capabilities,
       });
@@ -520,7 +521,75 @@ describe("runSandboxAgent orchestration", () => {
         logs.find((message) => message.includes("legacy inline image")) ?? "",
         /delivery=degraded reason=[a-z_]+$/,
       );
-    }
+    },
+  );
+
+  it("degrades a legacy inline image when the caller's model declares no image input", async () => {
+    const { calls, deps, logs } = fakeHarness({
+      capabilities: { images: true },
+    });
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        modelCapabilities: { inputModalities: ["text"] },
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "image", uri: "data:image/png;base64,AQID" },
+              { type: "text", text: "inspect this" },
+            ],
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.promptBlocks, [
+      { type: "text", text: "inspect this" },
+    ]);
+    assert.equal(
+      logs.find((message) => message.includes("legacy inline image")),
+      "[attachments] legacy inline image delivery=degraded reason=model_modality_unknown",
+    );
+  });
+
+  it("delivers a legacy inline image natively when the caller declares no capabilities", async () => {
+    const { calls, deps, logs } = fakeHarness({
+      capabilities: { images: true },
+    });
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "image", uri: "data:image/png;base64,AQID" },
+              { type: "text", text: "inspect this" },
+            ],
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.promptBlocks, [
+      { type: "image", data: "AQID", mimeType: "image/png" },
+      { type: "text", text: "inspect this" },
+    ]);
+    assert.equal(
+      logs.find((message) => message.includes("legacy inline image")),
+      "[attachments] legacy inline image delivery=native reason=native_supported",
+    );
   });
 
   it("a failed historical restore is survivable through a full cold turn", async () => {

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -384,6 +384,34 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(calls.workspaceCleanup, 1);
   });
 
+  it("delivers the current legacy inline image before one text block", async () => {
+    const { calls, deps } = fakeHarness({ capabilities: { images: true } });
+
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "image", uri: "data:image/png;base64,AQID" },
+              { type: "text", text: "inspect this" },
+            ],
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      deps,
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.promptBlocks, [
+      { type: "image", data: "AQID", mimeType: "image/png" },
+      { type: "text", text: "inspect this" },
+    ]);
+  });
+
   it("points local Pi and pi-acp at the conversation workspace transcript directory", async () => {
     const cwd = join(
       tmpdir(),

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -95,33 +95,36 @@ describe("buildRunPlan", () => {
   });
 
   it("rejects more than the configured current-turn attachment count", () => {
+    // Override the cap rather than generating a default-sized batch, so the case stays small.
+    process.env.AGENTA_ATTACHMENTS_MAX_PER_TURN = "2";
     const attachmentIds = [
       "11111111-1111-4111-8111-111111111111",
       "22222222-2222-4222-8222-222222222222",
       "33333333-3333-4333-8333-333333333333",
-      "44444444-4444-4444-8444-444444444444",
-      "55555555-5555-4555-8555-555555555555",
-      "66666666-6666-4666-8666-666666666666",
     ];
-    const result = buildRunPlan(
-      {
-        messages: [
-          {
-            role: "user",
-            content: attachmentIds.map((attachmentId) => ({
-              type: "attachment",
-              attachmentId,
-            })),
-          },
-        ],
-      } as AgentRunRequest,
-      { createLocalCwd: () => "local-cwd" },
-    );
+    try {
+      const result = buildRunPlan(
+        {
+          messages: [
+            {
+              role: "user",
+              content: attachmentIds.map((attachmentId) => ({
+                type: "attachment",
+                attachmentId,
+              })),
+            },
+          ],
+        } as AgentRunRequest,
+        { createLocalCwd: () => "local-cwd" },
+      );
 
-    assert.deepEqual(result, {
-      ok: false,
-      error: "A user turn may carry at most 5 attachments.",
-    });
+      assert.deepEqual(result, {
+        ok: false,
+        error: "A user turn may carry at most 2 attachments.",
+      });
+    } finally {
+      delete process.env.AGENTA_ATTACHMENTS_MAX_PER_TURN;
+    }
   });
 
   it("still refuses a request whose only message is an unresolved tool call", () => {

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -78,14 +78,22 @@ describe("buildRunPlan", () => {
   });
 
   it("rejects more than the configured current-turn attachment count", () => {
+    const attachmentIds = [
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      "33333333-3333-4333-8333-333333333333",
+      "44444444-4444-4444-8444-444444444444",
+      "55555555-5555-4555-8555-555555555555",
+      "66666666-6666-4666-8666-666666666666",
+    ];
     const result = buildRunPlan(
       {
         messages: [
           {
             role: "user",
-            content: Array.from({ length: 6 }, (_, index) => ({
+            content: attachmentIds.map((attachmentId) => ({
               type: "attachment",
-              attachmentId: `11111111-1111-4111-8111-11111111111`,
+              attachmentId,
             })),
           },
         ],
@@ -153,6 +161,90 @@ describe("buildRunPlan", () => {
       result.ok && result.plan.turnText.includes("user APPROVED Write"),
       "the plan's turn text carries the approval-resume frame",
     );
+  });
+
+  it("accepts an in-band approval reply carrying the full transcript", () => {
+    const result = buildRunPlan(
+      {
+        harness: "claude",
+        messages: [
+          { role: "user", content: "write the report" },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_call",
+                toolCallId: "tc-1",
+                toolName: "Write",
+                input: { path: "report.md" },
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                toolCallId: "tc-1",
+                toolName: "Write",
+                output: { approved: true, interactionToken: "tok-1" },
+              },
+            ],
+          },
+        ],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+
+  it("accepts a tool-role tail when an earlier user message supplies the prompt", () => {
+    const result = buildRunPlan(
+      {
+        messages: [
+          { role: "user", content: "inspect the repository" },
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool_result",
+                toolCallId: "tc-1",
+                toolName: "read",
+                output: "contents",
+              },
+            ],
+          },
+        ],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+  });
+
+  it("accepts a client-tool-result tail when an earlier user message supplies the prompt", () => {
+    const result = buildRunPlan(
+      {
+        messages: [
+          { role: "user", content: "collect the form response" },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_result",
+                toolCallId: "client-1",
+                toolName: "request_input",
+                output: { value: "approved by finance" },
+              },
+            ],
+          },
+        ],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "/tmp/local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
   });
 
   it("normalizes an Agenta/Pi local run and filters executable tools", () => {

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -55,6 +55,50 @@ describe("buildRunPlan", () => {
     assert.equal(created, false);
   });
 
+  it("accepts an attachment-only current user turn", () => {
+    const result = buildRunPlan(
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "attachment",
+                attachmentId: "019a52c2-14c0-7c14-b874-2f5798f9cd21",
+              },
+            ],
+          },
+        ],
+      } as unknown as AgentRunRequest,
+      { createLocalCwd: () => "local-cwd" },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.plan.prompt, "");
+  });
+
+  it("rejects more than the configured current-turn attachment count", () => {
+    const result = buildRunPlan(
+      {
+        messages: [
+          {
+            role: "user",
+            content: Array.from({ length: 6 }, (_, index) => ({
+              type: "attachment",
+              attachmentId: `11111111-1111-4111-8111-11111111111`,
+            })),
+          },
+        ],
+      } as AgentRunRequest,
+      { createLocalCwd: () => "local-cwd" },
+    );
+
+    assert.deepEqual(result, {
+      ok: false,
+      error: "A user turn may carry at most 5 attachments.",
+    });
+  });
+
   it("still refuses a request whose only message is an unresolved tool call", () => {
     // No user text AND no approval envelope: a caller bug, not an approval reply.
     const result = buildRunPlan(

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -77,6 +77,23 @@ describe("buildRunPlan", () => {
     assert.equal(result.ok && result.plan.prompt, "");
   });
 
+  it("accepts both legacy image-only current user turn shapes", () => {
+    for (const content of [
+      [{ type: "image", uri: "data:image/png;base64,AQID" }],
+      [{ type: "image", data: "AQID", mimeType: "image/webp" }],
+    ]) {
+      const result = buildRunPlan(
+        {
+          messages: [{ role: "user", content }],
+        } as AgentRunRequest,
+        { createLocalCwd: () => "local-cwd" },
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(result.ok && result.plan.prompt, "");
+    }
+  });
+
   it("rejects more than the configured current-turn attachment count", () => {
     const attachmentIds = [
       "11111111-1111-4111-8111-111111111111",

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -453,7 +453,9 @@ describe("createAgentServer", () => {
       .mockImplementation(async (input, init) => {
         const url = String(input);
         if (url === `${s.url}/run`) return realFetch(input, init);
-        sessionApiCalls.push(url);
+        // Trace export is unrelated to session persistence; keep it out so an empty-list
+        // failure can only mean a persist or claim call happened.
+        if (!url.includes("/otlp/")) sessionApiCalls.push(url);
         return new Response("{}", { status: 200 });
       });
 

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -434,13 +434,12 @@ describe("createAgentServer", () => {
   });
 
   it("rejects an over-cap session turn before persistence or attachment claiming", async () => {
+    // Override the cap rather than generating a default-sized batch, so the case stays small.
+    process.env.AGENTA_ATTACHMENTS_MAX_PER_TURN = "2";
     const attachmentIds = [
       "11111111-1111-4111-8111-111111111111",
       "22222222-2222-4222-8222-222222222222",
       "33333333-3333-4333-8333-333333333333",
-      "44444444-4444-4444-8444-444444444444",
-      "55555555-5555-4555-8555-555555555555",
-      "66666666-6666-4666-8666-666666666666",
     ];
     let runCalls = 0;
     const s = await listen(async () => {
@@ -496,9 +495,10 @@ describe("createAgentServer", () => {
       assert.equal(records[0].result.ok, false);
       assert.equal(
         records[0].result.error,
-        "A user turn may carry at most 5 attachments.",
+        "A user turn may carry at most 2 attachments.",
       );
     } finally {
+      delete process.env.AGENTA_ATTACHMENTS_MAX_PER_TURN;
       fetchSpy.mockRestore();
       await s.close();
     }

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -503,6 +503,82 @@ describe("createAgentServer", () => {
       await s.close();
     }
   });
+
+  it("persists a legacy image-only tail without attachment references", async () => {
+    let runCalls = 0;
+    const s = await listen(async () => {
+      runCalls += 1;
+      return { ok: true, output: "done", events: [] };
+    });
+    const realFetch = globalThis.fetch.bind(globalThis);
+    const ingested: Array<Record<string, any>> = [];
+    const sessionApiCalls: string[] = [];
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === `${s.url}/run`) return realFetch(input, init);
+        sessionApiCalls.push(url);
+        if (url.endsWith("/sessions/streams/heartbeat")) {
+          return Response.json({
+            stream: { id: "stream-1" },
+            is_current_turn: true,
+          });
+        }
+        if (url.endsWith("/sessions/records/ingest")) {
+          ingested.push(JSON.parse(String(init?.body)));
+        }
+        return Response.json({});
+      });
+
+    try {
+      const res = await fetchSpy(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson", ...AUTH },
+        body: JSON.stringify({
+          harness: "pi_core",
+          sessionId: "session-1",
+          telemetry: {
+            exporters: {
+              otlp: {
+                endpoint: `${s.url}/otlp/v1/traces`,
+                headers: { authorization: "ApiKey test" },
+              },
+            },
+          },
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "image", uri: "data:image/png;base64,AQID" },
+              ],
+            },
+          ],
+        }),
+      });
+      await res.text();
+
+      assert.equal(runCalls, 1);
+      const userRecords = ingested.filter(
+        (record) => record.record_source === "user",
+      );
+      assert.equal(userRecords.length, 1);
+      assert.deepEqual(userRecords[0].attributes, {
+        type: "message",
+        text: "",
+        attachments: [],
+      });
+      assert.equal(
+        sessionApiCalls.some((url) =>
+          url.endsWith("/sessions/attachments/reference"),
+        ),
+        false,
+      );
+    } finally {
+      fetchSpy.mockRestore();
+      await s.close();
+    }
+  });
 });
 
 describe("normalizeKillProjectId (blank projectId scope-agreement)", () => {

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -7,7 +7,7 @@
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/server.test.ts)
  */
-import { afterEach, describe, it } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
 import * as http from "node:http";
 import type { AddressInfo } from "node:net";
@@ -26,6 +26,7 @@ const LIMIT_ENV = "AGENTA_RUNNER_CONCURRENCY_LIMIT";
 const previousLimit = process.env[LIMIT_ENV];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   if (previousToken === undefined) delete process.env[TOKEN_ENV];
   else process.env[TOKEN_ENV] = previousToken;
   if (previousLimit === undefined) delete process.env[LIMIT_ENV];
@@ -428,6 +429,77 @@ describe("createAgentServer", () => {
         "terminal result does not echo events",
       );
     } finally {
+      await s.close();
+    }
+  });
+
+  it("rejects an over-cap session turn before persistence or attachment claiming", async () => {
+    const attachmentIds = [
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      "33333333-3333-4333-8333-333333333333",
+      "44444444-4444-4444-8444-444444444444",
+      "55555555-5555-4555-8555-555555555555",
+      "66666666-6666-4666-8666-666666666666",
+    ];
+    let runCalls = 0;
+    const s = await listen(async () => {
+      runCalls += 1;
+      return { ok: true, output: "should not run", events: [] };
+    });
+    const realFetch = globalThis.fetch.bind(globalThis);
+    const sessionApiCalls: string[] = [];
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === `${s.url}/run`) return realFetch(input, init);
+        sessionApiCalls.push(url);
+        return new Response("{}", { status: 200 });
+      });
+
+    try {
+      const res = await fetchSpy(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson", ...AUTH },
+        body: JSON.stringify({
+          harness: "pi_core",
+          sessionId: "session-1",
+          telemetry: {
+            exporters: {
+              otlp: {
+                endpoint: `${s.url}/otlp/v1/traces`,
+                headers: { authorization: "ApiKey test" },
+              },
+            },
+          },
+          messages: [
+            {
+              role: "user",
+              content: attachmentIds.map((attachmentId) => ({
+                type: "attachment",
+                attachmentId,
+              })),
+            },
+          ],
+        }),
+      });
+      const records = (await res.text())
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, any>);
+
+      assert.equal(runCalls, 0);
+      assert.deepEqual(sessionApiCalls, []);
+      assert.equal(records.length, 1);
+      assert.equal(records[0].kind, "result");
+      assert.equal(records[0].result.ok, false);
+      assert.equal(
+        records[0].result.error,
+        "A user turn may carry at most 5 attachments.",
+      );
+    } finally {
+      fetchSpy.mockRestore();
       await s.close();
     }
   });

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -17,6 +17,7 @@ import type {
   AgentEvent,
   AgentRunRequest,
   AgentRunResult,
+  ChatMessage,
 } from "../../src/protocol.ts";
 import {
   runWithKeepalive,
@@ -949,6 +950,126 @@ describe("runWithKeepalive: approval resume validation degrades to cold", () => 
     assert.equal(calls.acquire, 1);
     assert.equal(calls.resumes.length, 1);
     assert.equal(calls.resumes[0].reply, "reject");
+  });
+});
+
+describe("runWithKeepalive: an approval park from a last-message-only turn", () => {
+  // Issue #5638. The playground sends only the new user turn on a normal message, so a gate that
+  // parks on turn 2+ records a fingerprint covering ONE user turn — while the approval resume
+  // carries the WHOLE transcript (the AI SDK rewrites the gated assistant message in place). The
+  // park is compared against the resume's trailing-user-turn slice, which still catches an edit.
+  const ATTACHMENT_A = "019a52c2-14c0-7c14-b874-2f5798f9cd21";
+  const ATTACHMENT_B = "019a52c2-14c0-7c14-b874-2f5798f9cd22";
+
+  /** Turn 2 as the frontend sends it: the fresh user turn alone, no prior conversation. */
+  function turnTwoOnly(content: ChatMessage["content"]): AgentRunRequest {
+    return {
+      harness: "claude",
+      model: "m1",
+      sessionId: "s1",
+      ...auth,
+      messages: [{ role: "user", content }],
+    };
+  }
+
+  /** The approval resume: turn 1, turn 2, the gated call, and the {approved} envelope. */
+  function fullTranscriptResume(tail: ChatMessage["content"]): AgentRunRequest {
+    return {
+      harness: "claude",
+      model: "m1",
+      sessionId: "s1",
+      ...auth,
+      messages: [
+        { role: "user", content: "do X" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "tc-turn1", toolName: "read" },
+            {
+              type: "tool_result",
+              toolCallId: "tc-turn1",
+              output: { ok: true },
+            },
+          ],
+        },
+        { role: "user", content: tail },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "tc-gate", toolName: "commit" },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolCallId: "tc-gate",
+              output: { approved: true },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  async function parkThenResume(
+    park: AgentRunRequest,
+    resume: AgentRunRequest,
+  ) {
+    const { engine, calls } = makeApprovalEngine([
+      {
+        approvalPause: {
+          permissionId: "perm-1",
+          toolCallId: "tc-gate",
+          toolName: "commit",
+        },
+        toolCallIds: ["tc-gate"],
+      },
+      { result: { ok: true, output: "resumed", stopReason: "complete" } },
+    ]);
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(park, undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    await runWithKeepalive(resume, undefined, undefined, ctx);
+    return { calls, env1, ctx };
+  }
+
+  it("resumes WARM when the full transcript's trailing turn matches the parked one", async () => {
+    const { calls, env1 } = await parkThenResume(
+      turnTwoOnly("do Y"),
+      fullTranscriptResume("do Y"),
+    );
+    assert.equal(env1.destroyed, 0, "the parked session was NOT evicted");
+    assert.equal(calls.acquire, 1, "no cold re-acquire");
+    assert.equal(calls.resumes.length, 1, "the gate was answered live");
+    assert.equal(calls.resumes[0].reply, "once");
+  });
+
+  it("evicts when the resume's trailing user text was edited", async () => {
+    const { calls, env1 } = await parkThenResume(
+      turnTwoOnly("do Y"),
+      fullTranscriptResume("do Y EDITED"),
+    );
+    assert.equal(env1.destroyed, 1, "the parked approval session is destroyed");
+    assert.equal(calls.acquire, 2, "cold-started a fresh env");
+    assert.equal(calls.resumes.length, 0, "no live respondPermission");
+  });
+
+  it("evicts when the resume's trailing turn swaps an attachment id", async () => {
+    const { calls, env1 } = await parkThenResume(
+      turnTwoOnly([
+        { type: "text", text: "do Y" },
+        { type: "attachment", attachmentId: ATTACHMENT_A },
+      ]),
+      fullTranscriptResume([
+        { type: "text", text: "do Y" },
+        { type: "attachment", attachmentId: ATTACHMENT_B },
+      ]),
+    );
+    assert.equal(env1.destroyed, 1, "the parked approval session is destroyed");
+    assert.equal(calls.acquire, 2, "cold-started a fresh env");
+    assert.equal(calls.resumes.length, 0, "no live respondPermission");
   });
 });
 

--- a/services/runner/tests/unit/session-persist.test.ts
+++ b/services/runner/tests/unit/session-persist.test.ts
@@ -63,7 +63,19 @@ describe("buildPersistingEmitter", () => {
       (e) => live.push(e),
     );
 
-    persist({ type: "message", text: "what time is it?" }, "user");
+    persist(
+      {
+        type: "message",
+        text: "what time is it?",
+        attachments: [
+          {
+            attachmentId: "019a52c2-14c0-7c14-b874-2f5798f9cd21",
+            filename: "clock.png",
+          },
+        ],
+      },
+      "user",
+    );
     emit({ type: "message", text: "it is noon" });
     emit({ type: "done" });
     await flush();
@@ -82,6 +94,12 @@ describe("buildPersistingEmitter", () => {
     );
     const userPayload = bodies[0]["attributes"] as Record<string, unknown>;
     assert.equal(userPayload["text"], "what time is it?");
+    assert.deepEqual(userPayload["attachments"], [
+      {
+        attachmentId: "019a52c2-14c0-7c14-b874-2f5798f9cd21",
+        filename: "clock.png",
+      },
+    ]);
   });
 
   it("coalesces message_start/delta/end into a single persisted message", async () => {

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -249,6 +249,16 @@ describe("configFingerprint", () => {
     );
   });
 
+  it("changes when resolved model capabilities change", () => {
+    assert.notEqual(
+      configFingerprint(base),
+      configFingerprint({
+        ...base,
+        modelCapabilities: { inputModalities: ["text", "image"] },
+      }),
+    );
+  });
+
   // Custom OpenAI-compatible warm-session safety (design Decision 7): a change to the connection,
   // model, or endpoint must cold-start rather than reuse a mismatched live session. No new
   // fingerprint field is needed — these already ride configFingerprint.
@@ -315,6 +325,17 @@ describe("historyFingerprint (pruned-array contract)", () => {
     assert.notEqual(
       historyFingerprint([u1]),
       historyFingerprint([{ role: "user", content: "hello!" }]),
+    );
+  });
+
+  it("changes when ordered user attachment ids change", () => {
+    const withAttachment = (attachmentId: string) => ({
+      role: "user",
+      content: [{ type: "attachment", attachmentId }],
+    });
+    assert.notEqual(
+      historyFingerprint([withAttachment("019a52c2-14c0-7c14-b874-2f5798f9cd21")]),
+      historyFingerprint([withAttachment("019a52c2-14c0-7c14-b874-2f5798f9cd22")]),
     );
   });
 
@@ -404,6 +425,25 @@ describe("tailIsFreshUserMessage", () => {
       false,
     );
   });
+  it("true for an attachment-only trailing user message", () => {
+    assert.equal(
+      tailIsFreshUserMessage({
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "attachment",
+                attachmentId: "019a52c2-14c0-7c14-b874-2f5798f9cd21",
+              },
+            ],
+          },
+        ],
+      } as unknown as AgentRunRequest),
+      true,
+    );
+  });
+
   it("false when the tail user turn carries a tool_result (approval reply)", () => {
     assert.equal(
       tailIsFreshUserMessage({

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -339,6 +339,42 @@ describe("historyFingerprint (pruned-array contract)", () => {
     );
   });
 
+  it("changes when the order of user attachment ids changes", () => {
+    const ids = [
+      "019a52c2-14c0-7c14-b874-2f5798f9cd21",
+      "019a52c2-14c0-7c14-b874-2f5798f9cd22",
+    ];
+    const withAttachments = (attachmentIds: string[]) => ({
+      role: "user",
+      content: attachmentIds.map((attachmentId) => ({
+        type: "attachment",
+        attachmentId,
+      })),
+    });
+    assert.notEqual(
+      historyFingerprint([withAttachments(ids)]),
+      historyFingerprint([withAttachments([...ids].reverse())]),
+    );
+  });
+
+  it("changes when a legacy inline image's content changes", () => {
+    const withImage = (data: string) => ({
+      role: "user",
+      content: [
+        { type: "image", uri: `data:image/png;base64,${data}` },
+        { type: "text", text: "describe this" },
+      ],
+    });
+    assert.notEqual(
+      historyFingerprint([withImage("AQID")]),
+      historyFingerprint([withImage("BAUG")]),
+    );
+    assert.equal(
+      historyFingerprint([withImage("AQID")]),
+      historyFingerprint([withImage("AQID")]),
+    );
+  });
+
   it("continuation symmetry: park(full [u1]) == check(prior of [u1,a1,u2]) for a plain turn", () => {
     const parked = historyFingerprint([u1]);
     const req: AgentRunRequest = {

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -444,6 +444,20 @@ describe("tailIsFreshUserMessage", () => {
     );
   });
 
+  it("true for both legacy inline-image-only trailing user messages", () => {
+    for (const block of [
+      { type: "image", uri: "data:image/png;base64,AQID" },
+      { type: "image", data: "AQID", mimeType: "image/webp" },
+    ]) {
+      assert.equal(
+        tailIsFreshUserMessage({
+          messages: [{ role: "user", content: [block] }],
+        } as AgentRunRequest),
+        true,
+      );
+    }
+  });
+
   it("false when the tail user turn carries a tool_result (approval reply)", () => {
     assert.equal(
       tailIsFreshUserMessage({

--- a/services/runner/tests/unit/session-reconstruct-history.test.ts
+++ b/services/runner/tests/unit/session-reconstruct-history.test.ts
@@ -308,4 +308,53 @@ describe("reconstructHistoryIfNeeded", () => {
     const out = await reconstructHistoryIfNeeded(req, "sess-1", auth);
     assert.equal(out, null);
   });
+
+  it("restores reconstructed attachment working copies before returning history", async () => {
+    vi.stubEnv("AGENTA_SESSIONS_RECONSTRUCT", "true");
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    recordsToReturn = [
+      {
+        turn_id: "turn-1",
+        record_source: "user",
+        attributes: {
+          type: "message",
+          text: "inspect",
+          attachments: [{ attachmentId, filename: "wire-name.png" }],
+        },
+      },
+    ];
+    let restoreCalls = 0;
+    const req = { messages: [userTurn], turnId: "turn-2" } as never;
+    const out = await reconstructHistoryIfNeeded(
+      req,
+      "sess-1",
+      auth,
+      undefined,
+      {
+        restore: async (messages) => {
+          restoreCalls += 1;
+          const content = messages[0].content;
+          assert.ok(Array.isArray(content));
+          return [
+            {
+              ...messages[0],
+              content: content.map((block) =>
+                block.type === "attachment"
+                  ? { ...block, filename: "verified-name.png" }
+                  : block,
+              ),
+            },
+          ];
+        },
+      },
+    );
+
+    assert.equal(restoreCalls, 1);
+    assert.equal(
+      Array.isArray(out?.messages?.[0].content)
+        ? out.messages[0].content[0].filename
+        : undefined,
+      "verified-name.png",
+    );
+  });
 });

--- a/services/runner/tests/unit/session-reconstruct.test.ts
+++ b/services/runner/tests/unit/session-reconstruct.test.ts
@@ -127,4 +127,38 @@ describe("reconstructMessages", () => {
   it("returns an empty history for no records", () => {
     assert.deepEqual(reconstructMessages([]), []);
   });
+
+  it("rebuilds user attachment references before exactly one text block", () => {
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    const out = reconstructMessages([
+      rec("user", {
+        type: "message",
+        text: "inspect this",
+        attachments: [
+          {
+            attachmentId,
+            filename: "report.pdf",
+            mediaType: "application/pdf",
+            size: 42,
+          },
+        ],
+      }),
+    ]);
+
+    assert.deepEqual(out, [
+      {
+        role: "user",
+        content: [
+          {
+            type: "attachment",
+            attachmentId,
+            filename: "report.pdf",
+            mimeType: "application/pdf",
+            size: 42,
+          },
+          { type: "text", text: "inspect this" },
+        ],
+      },
+    ]);
+  });
 });

--- a/services/runner/tests/unit/transcript.test.ts
+++ b/services/runner/tests/unit/transcript.test.ts
@@ -331,6 +331,47 @@ describe("buildTurnText approval-resume closing frame", () => {
     assert.ok(text.includes(`user: ${staleCommand}`), "stale command stays in history");
   });
 
+  it("keeps the normal closing frame when an attachment-only turn follows a settled call", () => {
+    const request: AgentRunRequest = {
+      messages: [
+        { role: "user", content: "help me schedule a report" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_call",
+              toolCallId: "call-1",
+              toolName: "__ag__request_input",
+              input: { message: "What color?", requestedSchema: {} },
+            },
+            {
+              type: "tool_result",
+              toolCallId: "call-1",
+              toolName: "__ag__request_input",
+              output: { action: "accept", content: { color: "green" } },
+            },
+          ] as ContentBlock[],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "attachment",
+              attachmentId: "019a52c2-14c0-7c14-b874-2f5798f9cd21",
+              filename: "brief.pdf",
+            },
+          ] as ContentBlock[],
+        },
+      ],
+    };
+    const text = buildTurnText(request);
+
+    // The attachment is the new turn, so the settled call must not be replayed as a resume.
+    assert.match(text, /Continue the conversation\. The user now says:/);
+    assert.doesNotMatch(text, /responded to the request/);
+    assert.doesNotMatch(text, /responded to the pending approval/);
+  });
+
   it("keeps the normal closing frame when a client-tool result precedes a new user turn", () => {
     const text = turnTextFor([
       { role: "user", content: "help me schedule a report" },

--- a/services/runner/tests/unit/transcript.test.ts
+++ b/services/runner/tests/unit/transcript.test.ts
@@ -455,4 +455,34 @@ describe("buildTurnText approval transcript hints", () => {
       /DENIED mcp__agenta-tools__commit_revision; executed below/,
     );
   });
+
+  it("keeps preflight tolerant of unverified attachment display fields", () => {
+    assert.equal(
+      messageTranscript([
+        {
+          type: "attachment",
+          attachmentId: "11111111-1111-4111-8111-111111111111",
+          filename: "../wire-name.png",
+        },
+      ]),
+      "[attachment pending verification]",
+    );
+  });
+
+  it("renders a historical attachment as its verified working-copy mention", () => {
+    const transcript = messageTranscript([
+      {
+        type: "attachment",
+        attachmentId: "11111111-1111-4111-8111-111111111111",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        size: 42,
+      },
+    ]);
+
+    assert.equal(
+      transcript,
+      "[attached file: report.pdf at attachments/11111111-1111-4111-8111-111111111111/report.pdf]",
+    );
+  });
 });

--- a/services/runner/tests/unit/wire-contract.test.ts
+++ b/services/runner/tests/unit/wire-contract.test.ts
@@ -37,6 +37,7 @@ const KNOWN_REQUEST_KEYS = [
   "sessionId",
   "agentsMd",
   "model",
+  "modelCapabilities",
   "provider",
   "connection",
   "deployment",


### PR DESCRIPTION
Sending an image without text fails the run with "Agent run failed: No user message to send (prompt/messages empty)", and an image sent with text is silently flattened before the model ever sees it. Both trace to the same root: the runner has no concept of "the current user turn", only "the most recent non-empty user text", and that assumption sits in four separate places. This PR is work package 2 of 4 of the Stage 1 plan (in-repo at `docs/design/agent-workflows/projects/agent-multi-modality/plans/stage-1-implementation.md`), stacked on the approval-resume fix #5598, which it builds on in the same seams.

**Before:** an image-only turn dies; an image-plus-text turn drops the image; an attachment reference has no consumer; a cold start rebuilds text only.
**After:** `currentUserTurn(request)` is the one authority on what the person just sent, and all four former text-derived sites use it. An attachment-only turn is valid. Attachment references resolve through the WP1 API (bounded fetch, claim on acceptance), working copies materialize at `cwd/attachments/<id>/<filename>` under strict path safety, native blocks reach the harness when the three-layer gate allows, every current-turn attachment gets a mention line so the prompt is never empty, historical attachments restore at cold start (bounded, degradable), and every outcome emits a persisted `attachment_delivery` event with a stable reason code. Today's front end keeps working unchanged: the dual read matches the base64 data-URL shape it actually sends, so a pasted image now reaches the model natively where the harness supports it.

The change was adversarially reviewed before this PR opened. The review probed real request shapes and found two release blockers plus one bad degradation, all inside the refactor's predicted blast radius, all fixed in the second and third commits:

- The rewritten empty-turn rejection discarded human approvals: an in-band approval reply carries the full transcript, so the tail-only reading rejected it. The rejection now falls back to the backward scan, and the three real shapes (in-band approval, tool-role tail, client-tool-result tail) are pinned as tests.
- One unrestorable historical attachment permanently bricked its conversation: the cold-start restore threw, and the failure was deterministic once the sweep had taken an unclaimed file. Restore now degrades per file to a "no longer available" mention.
- Legacy inline images hard-failed turns in five reachable configurations; they now degrade exactly as before this package when native delivery is not possible.

The full findings-and-rulings trail is in `protocols/stage-1.md` (committed on the WP1 branch below).

## Implicit decisions and their tradeoffs

- **This lane sits above the approval-resume fix (#5598) deliberately.** The current-turn work and the approval-resume fix touch the same seams, so the two lanes were linearized and #5598's base moved to the WP1 branch. Consequence: #5598 merges as part of this train, after WP1. Reversible before anything merges.
- **Unknown model modalities mean workspace-only, never assumed vision.** The `modelCapabilities` wire field arrives in WP3; until then, only legacy inline images (which carry their own bytes) deliver natively.
- **Attachment ids joined the history fingerprint and capabilities the config fingerprint.** A runner deploy already cold-starts all parked sessions, so no second disruption; the consequence is stated at the fingerprint code.
- **The claim is non-fatal by design** (a failed claim must not block a turn); the brick-risk that created was closed by making restore degradable rather than by making the claim fatal.

## Forced routes to double-check

- **Legacy images degrade with no delivery event**: the legacy path has no attachment id to key an event, so a degraded pasted image logs but does not appear in the records. Honest visibility for pasted images arrives with WP4, when the composer switches them to real attachments.
- **Daytona keeps a documented check-then-write race** on materialization: its filesystem API has no exclusive create, and the alternative is a shell round trip per file. Symlink checks run before any directory creation and are time-bounded.

## QA

1,375 runner tests pass; typecheck clean; the shared golden fixtures are byte-identical (the wire additions are all optional fields). Live QA ran on the dev stack against the deployed runner (full record in `protocols/stage-1.md`):

- **Image + text**: a pasted PNG reading "AGENTA 42" came back as exactly `AGENTA 42`, the model's reasoning describing the image. First time a composer-sent file reaches a model's perception.
- **Image-only (the original repro)**: first QA round still failed it, because the current-turn reading did not count today's legacy inline blocks; fixed (shared predicate across guard, freshness, persistence, prompt assembly) and re-verified live: a "VULCAN 91" image sent with no text ran and was read correctly, with the new delivery log line `legacy inline image delivery=native reason=native_supported`.
- **Text-only regression and cold reload**: both pass; a follow-up question after reload answered correctly from the re-delivered image.

https://claude.ai/code/session_01A1XQVjHPYJgVBHWSNUphtx
