### PR TITLE
feat(frontend): attachment transport, references, and rendering for the agent chat

### DIFF
--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -308,3 +308,53 @@ dissolves on the next rebase.
 - **The catalogs cannot express document or audio support today**, so native document delivery
   (Stage 2) will need the catalog schema to grow before the gate can ever say yes; the gate's
   absence-means-unknown rule is what keeps that honest in the meantime.
+
+## WP4: frontend transport and rendering
+
+### Implementation decisions worth knowing (beyond the plan)
+
+- The shared composer package (`RichChatInput`, `SubmitPlugin`, `SendButton` in `agenta-ui`)
+  gained send-only disabling. The review enumerated all three consumers; the new props default
+  to today's behavior, so the two non-attachment surfaces are untouched.
+- The tray uid doubles as the upload idempotency key (stated in a comment at the generation
+  site); that identity is what makes retry reuse safe. `generateId()` is used instead of
+  `crypto.randomUUID`, which is undefined on plain-HTTP dev deployments.
+- Send blocks (with a tooltip) until every tray upload settles; a failed upload never falls back
+  to base64. Removing a chip aborts its in-flight request.
+- Static composer limits stay; capability-derived limits remain the Stage 2 item.
+- web/oss joined the unit-test loop with an explicit include list; the 13 pre-existing orphaned
+  test files stay excluded and are tracked in issue #5618.
+
+### The review, and what it changed
+
+Fourteen findings, four merge blockers, all fixed before the PR opened:
+
+1. The acceptance Playwright spec sat one directory outside the collected test root and would
+   never have run anywhere; it now lives with its siblings, carries the suite's tags, and has no
+   silent environment skip.
+2. Voice messages routed through the upload transport unconditionally, so with voice on and
+   uploads off a recording died in a permanent error chip; the recorder now uses references only
+   when the uploads flag is on and keeps its inline path otherwise, preserving the flags'
+   independence (the seam WP2's protocol had predicted would matter).
+3. `size` sat top-level on the file part, where the AI SDK's validation strips it, so every
+   persisted turn would silently lose the field; it moved into the `providerMetadata.agenta`
+   envelope beside the id.
+4. A hardcoded perception map contradicted the model-capability data the same component already
+   computes for the voice controls; perception now derives from the shared memoized fact, with
+   absent-or-unknown meaning the workspace-only notice.
+
+The remaining ten: an error taxonomy for uploads (cap and quota named, Retry-After honored,
+old-backend 404 explained, non-retryable states without a retry button), abort-on-remove, a
+double-send guard over the voice path's upload await, delivery notices joined to filenames,
+lowercase-pinned id validation matching the adapter, a filename fallback that never renders the
+URL tail, no eager full-file downloads on render, junit reporting for the new test setup, restored
+comment rationales, and feedback for swallowed Enter presses.
+
+### Forced routes to double-check
+
+- **The one-line CI glob addition** (publishing web/oss's junit report) is left uncommitted: the
+  session's push credential lacks the GitHub `workflow` scope, and a commit touching workflow
+  files is rejected at push. The vitest gate itself works without it (the runner discovers the
+  script); only the published report is missing until someone with the scope lands the line.
+- **The Fern/OpenAPI regeneration** for typed accessors elsewhere in the sessions domain is a
+  stated follow-up, deliberately not bundled into this package's diff.

--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -446,3 +446,32 @@ Decisions worth restating, with their reasons:
 Skipped with rebuttals on the threads: response-model count computation (breaks the file's
 uniform convention), nginx body-size scoping and a purpose enum (low value against churn), and a
 provider-independent inline base64 ceiling (only one provider needs a cap today).
+
+## The rebase onto release/v0.107.0 (2026-08-01, evening)
+
+Release branch `release/v0.107.0` was cut from main (which had meanwhile absorbed 106.2). The
+whole workspace retargeted onto it. The 106.2 release had split `AgentConversation.tsx` into
+hooks and views and shipped its own upload plumbing, so the frontend commits could not replay
+textually; each conflicted commit was resolved by porting its INTENT into the new structure,
+one commit at a time, preserving history-faithful intermediate states (one mid-history test
+failure existed in the original branch at that same point and healed when the next commit
+replayed, exactly as in the original).
+
+Where things moved: the composer attachment machinery now lives in
+`hooks/useComposerAttachments.ts` (upload-on-attach, staged files, settle rule, scoped clear),
+paste/drag guards partly in `components/AgentComposerDock.tsx`, message rendering behind
+`components/AgentTurn.tsx`. The base's own defect fixes (unreadable-file hold, multi-tab
+follow, turn memoization) survived unchanged; the port passes `undefined` instead of an empty
+map where a fresh-Map prop would have defeated the base's turn memo.
+
+Verification on the new base: zero rebase casualties. Runner 1389, API 1597 + 304 DB-backed,
+SDK 705, services 101, web suites green; the one real overlap (the sandbox-error rename)
+merged with the back-compat alias intact. One latent train bug surfaced by the DB-backed run
+(the approval-resume lane typed `SessionInteractionData.request` but an older DAO test still
+compared a raw dict) was fixed on its lane.
+
+Two additions rode the retarget: `feat/agent-file-uploads-default-on` (PR #5633) makes the
+uploads flag opt-out per the product owner's rollout call, and `fix/drive-folder-drop-walk`
+(PR #5635, closes #5626) adds the directory walk the drawer lacked, stacked on the multipart
+transport fix (#5625). The Fern spec on the rebased stack is byte-identical to the one the
+committed client was generated from, so no regeneration was needed.

--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -358,3 +358,33 @@ comment rationales, and feedback for swallowed Enter presses.
   script); only the published report is missing until someone with the scope lands the line.
 - **The Fern/OpenAPI regeneration** for typed accessors elsewhere in the sessions domain is a
   stated follow-up, deliberately not bundled into this package's diff.
+
+## The end-to-end QA (dev stack, all four packages deployed, 2026-08-01)
+
+All four containers were recreated and the complete path driven from a real browser on the QA
+account. First round: everything behind the front end passed at wire level (a referenced upload
+delivered natively and read back verbatim; a ZIP claimed, materialized, and read from the
+workspace by the agent; reload-from-records rendering with real filenames and zero base64 in the
+DOM; the over-cap error naming the limit with no retry offer), but every composer upload failed
+with 422. The cause was a two-line front-end omission: the shared axios instance defaults to a
+JSON content type and silently JSON-serializes a FormData, collapsing the file to an empty
+object; the existing multipart callers in the codebase pass the explicit header and the new
+transport did not. With the header added, the re-run passed both blocked cases: upload 200 with
+a real multipart body, the run request carrying the reference and no base64, the reply reading
+the image's text, and the ZIP's named workspace-only notice followed by the agent reading the
+archive's marker.
+
+Observations recorded for follow-up, none blocking:
+
+- **ZIP-container sniffing mislabels.** A plain `.zip` stores as the Word-document media type
+  (both share the container signature and the sniffer scores the more specific format higher).
+  Delivery classification and the notice were still correct; only the stored label is wrong.
+  Tracked as a classifier refinement.
+- **A corrupt image surfaces as a raw provider 400** in the chat rather than a friendly message
+  (found via a QA-side transcription error, reproduced deliberately).
+- **The model may perceive via either channel.** With both the native block and the working copy
+  present, one run answered through its read tool rather than native vision; the guarantee D1
+  promises (the bytes reach the model) held either way.
+- Pre-existing and unrelated: the stale provider-key banner, the billing cron's date validation
+  error, and an approvals-lane behavior ("Deny and send note" answering "not handled") flagged
+  on PR #5598.

--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -388,3 +388,12 @@ Observations recorded for follow-up, none blocking:
 - Pre-existing and unrelated: the stale provider-key banner, the billing cron's date validation
   error, and an approvals-lane behavior ("Deny and send note" answering "not handled") flagged
   on PR #5598.
+
+### Product-owner correction (2026-08-01)
+
+The in-message delivery notice ("<filename>: the model did not perceive this file. The agent
+can use it at attachments/…") was removed at the product owner's direction. Its wording and
+placement were implementation-invented; decision D6's "visible notice" is satisfied by the chip
+hint alone (the crossed-eye indicator with its tooltip). The `attachment_delivery` events keep
+flowing and persisting unchanged; the front end parses and ignores them, so a future surface
+can render them without wire changes.

--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -389,11 +389,22 @@ Observations recorded for follow-up, none blocking:
   error, and an approvals-lane behavior ("Deny and send note" answering "not handled") flagged
   on PR #5598.
 
-### Product-owner correction (2026-08-01)
+### Product-owner corrections (2026-08-01)
 
-The in-message delivery notice ("<filename>: the model did not perceive this file. The agent
-can use it at attachments/…") was removed at the product owner's direction. Its wording and
-placement were implementation-invented; decision D6's "visible notice" is satisfied by the chip
-hint alone (the crossed-eye indicator with its tooltip). The `attachment_delivery` events keep
-flowing and persisting unchanged; the front end parses and ignores them, so a future surface
-can render them without wire changes.
+Three corrections after the product owner saw the shipped surfaces:
+
+1. **The in-message delivery notice was removed** ("<filename>: the model did not perceive this
+   file. The agent can use it at attachments/…"). Its wording and placement were
+   implementation-invented.
+2. **The chip-level hint was removed too** (the crossed-eye indicator with "The model may not
+   perceive this file…"). The first release therefore ships no notice UI at all; decision D6's
+   "visible notice" is deferred to a future surface the product owner designs. The
+   `attachment_delivery` events keep flowing and persisting unchanged, and the front end parses
+   and ignores them, so that future surface needs no wire changes. The upload error messages
+   were reviewed and kept.
+3. **The per-turn attachment count rose from 5 to 100** (front-end constant and the runner's
+   `AGENTA_ATTACHMENTS_MAX_PER_TURN` default). The old 5 was the dark-shipped composer default
+   with no motivating constraint; provider count caps are far higher. Because the per-session
+   count quota was also 100, one full turn would have consumed it, so the session count quota
+   rose to 1,000; the 256 MB per-session byte quota and the 20-pending cap stay the real
+   bounds. The design docs' matrix numbers were updated in the same pass.

--- a/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/protocols/stage-1.md
@@ -408,3 +408,41 @@ Three corrections after the product owner saw the shipped surfaces:
    count quota was also 100, one full turn would have consumed it, so the session count quota
    rose to 1,000; the 256 MB per-session byte quota and the 20-pending cap stay the real
    bounds. The design docs' matrix numbers were updated in the same pass.
+
+## The external-review fix wave (2026-08-01)
+
+After the train went up for review, three sources produced findings: a Codex sweep across the
+implementation PRs (11 comments), CodeRabbit's open threads, and CodeRabbit's stack-wide review
+body. The product owner adjudicated every item one by one; the accepted set landed as one wave of
+lane-scoped fix commits (api 56bc0b6526 + 973ade3965, runner 208fb31218 + 020b56dea6, sdk
+df5321bc8c, services bf070f7309, frontend aa1cb47a7f, docs 5cd13b49c2 and 64c52a8b04 with
+212d6470a2 and 200c360c60). Every thread got a reply naming its commit; addressed threads were
+resolved.
+
+Decisions worth restating, with their reasons:
+
+- **A failed attachment claim stays non-fatal** (CodeRabbit wanted the result consumed). A swept
+  attachment already degrades to a "no longer available" mention on cold replay; failing the turn
+  over reference bookkeeping would trade a graceful loss for a hard one. Documented at the call
+  site.
+- **The stale-after-24h staged upload is a recorded v1 limitation.** The failure needs a tab left
+  open for a day with a staged file; the fix (revalidate at send) is medium-sized and deferred.
+- **The reference contract rose to 100 ids** to match the 100-file turn the product owner set;
+  the mismatch (composer 100, claim contract 50) would have silently unreferenced files on large
+  turns, which the sweep would then delete.
+- **Legacy inline images now respect supplied model capabilities.** The image-assuming literal
+  applies only when the resolver sent nothing, preserving legacy behavior exactly where legacy
+  behavior is the only information available.
+- **The "fresh user content" rule became one shared predicate** (text, attachments, or inline
+  media) used by turn authority, resume classification, and freshness; the three had drifted
+  before and each drift was a bug.
+- **The denied-tool corruption found during QA was root-caused to the client-tool dispatcher**
+  (a denied part auto-settled as "not handled by this client", erasing the denial from history).
+  Fixed with tests in PR #5630, stacked above WP4 because the owning files predate the train.
+- **Two CodeRabbit "Major" flags on the built-ins open-questions doc stay open questions**
+  (unconfined local sandbox, tool-name collisions). They are product decisions the doc already
+  records; the feature is dev-only behind a flag.
+
+Skipped with rebuttals on the threads: response-model count computation (breaks the file's
+uniform convention), nginx body-size scoping and a purpose enum (low value against churn), and a
+provider-independent inline base64 ceiling (only one provider needs a cap today).

--- a/docs/design/agent-workflows/projects/agent-multi-modality/status.md
+++ b/docs/design/agent-workflows/projects/agent-multi-modality/status.md
@@ -38,8 +38,8 @@ See [README.md](README.md). In short: [context.md](context.md) for the plain sto
 
 | Stage | Scope | State |
 | --- | --- | --- |
-| 0 | Close the silent-failure gap: gate the ungated paste and drag path on `NEXT_PUBLIC_AGENT_FILE_UPLOADS` | not started (optional) |
-| 1 | First user-visible release: the attachment resource and storage, the record-schema extension, the runner's resolve-materialize-and-deliver seam for images, structured capability errors, the minimum security and limits work (per the settled matrix in [design.md](design.md), including the gateway raise to 32 MB), and the front-end transport and reference wiring | not started |
+| 0 | Close the silent-failure gap: gate the ungated paste and drag path on `NEXT_PUBLIC_AGENT_FILE_UPLOADS` | in review (PR #5604) |
+| 1 | First user-visible release: the attachment resource and storage, the record-schema extension, the runner's resolve-materialize-and-deliver seam for images, structured capability errors, the minimum security and limits work (per the settled matrix in [design.md](design.md), including the gateway raise to 32 MB), and the front-end transport and reference wiring | in review as four stacked PRs (#5607 API, #5615 runner, #5617 SDK, #5619 front end), end-to-end QA green on the dev stack; the trail is in [protocols/stage-1.md](protocols/stage-1.md) |
 | 2 | The audio release: turn on the voice UI, dictation as the only audio-to-text, recordings on the D6 workspace-only path (D14); the document plan (blocked on adapter work), the capability-alias rollout, derived front-end limits | not started (documents blocked on adapter work) |
 | 3 | Findability polish and cleanup: "Shared by you" origin, reference-counting cleanup refinement, read-only credential scope, verify the edit-then-find flow | not started |
 
@@ -73,10 +73,12 @@ in [plan.md](plan.md) Stage 2.
 
 ## Next actions
 
-- Start implementation: Stage 1 of [plan.md](plan.md), optionally preceded by Stage 0.
-- Decide whether Stage 0 ships on its own or folds into Stage 1.
-- Build the Stage 1 upload route against the settled matrix ([design.md](design.md), "The
-  media-type, validation, and limits matrix"), including the compose gateway raise to 32 MB.
+- Review and merge the Stage 1 train bottom-up (#5604, #5607, #5598, #5615, #5597, #5617,
+  #5619), then flip `NEXT_PUBLIC_AGENT_FILE_UPLOADS` in production as the rollout's fifth act.
+- Follow-ups recorded in [protocols/stage-1.md](protocols/stage-1.md): the CI report glob line
+  (needs a workflow-scoped push), the Fern client regeneration, and the zip-container
+  classifier refinement.
+- Then Stage 2 of [plan.md](plan.md).
 
 ## Artifacts
 

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -119,6 +119,8 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # the runner flag off, a turn arrives with no history at all.
 # AGENTA_SESSIONS_RECONSTRUCT=false
 # NEXT_PUBLIC_SESSIONS_LAST_MESSAGE_ONLY=false
+# Agent chat attachments (dev default on; production flips separately)
+NEXT_PUBLIC_AGENT_FILE_UPLOADS=true
 # AGENTA_RECORDS_DURABLE=false
 # Smart truncation preserves the structure of a record whose body exceeds the API size
 # cap (higher-fidelity reconstruction). Still opt-in, default off.

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -28,7 +28,7 @@ import CopiedToast from "@/oss/components/TemplateStrip/components/CopiedToast"
 
 import {attachmentLimitsForModalities, describeAccepted} from "./assets/attachments"
 import {CONTENT_VISIBILITY_ENABLED} from "./assets/conversationLayout"
-import {attachmentNamesByMessage, filesToInlineParts, filesToParts} from "./assets/files"
+import {filesToInlineParts, filesToParts} from "./assets/files"
 import {runWithInFlightSubmit} from "./assets/inFlightSubmit"
 import {isEmptyAssistantTurn, isVisiblePart} from "./assets/messageParts"
 import {messageText, sideEffectingToolsInRange} from "./assets/rewind"
@@ -529,23 +529,16 @@ const AgentConversation = ({
         [regenerate, setStopped],
     )
 
-    // Delivery notices name their file from the preceding user turn's attachment references.
-    const deliveryAttachmentNames = useMemo(() => attachmentNamesByMessage(messages), [messages])
-
     const renderMessage = (message: UIMessage, index: number) => {
         const isLast = index === messages.length - 1
         const isAssistantTurn = message.role === "assistant"
         const turn = turnNumbers.get(message.id)
         const isInspected = isAssistantTurn && inspectedTurn != null && turn === inspectedTurn
-        // Undefined (not an empty map) for turns with no attachments above them, so the memo on
-        // every settled turn still holds while a run streams.
-        const attachmentNames = deliveryAttachmentNames.get(message.id)
         return (
             <AgentTurn
                 key={message.id}
                 message={message}
                 sessionId={sessionId}
-                attachmentNames={attachmentNames?.size ? attachmentNames : undefined}
                 // New since mount → fade in once. seenIdsRef is marked in an effect after commit,
                 // never during render (unsafe under StrictMode's double invoke).
                 enter={!isSeen(message.id)}

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -26,7 +26,7 @@ import {openTraceDrawerAtom} from "@/oss/components/SharedDrawers/TraceDrawer/st
 import {STRIP_COPY} from "@/oss/components/TemplateStrip/assets/constants"
 import CopiedToast from "@/oss/components/TemplateStrip/components/CopiedToast"
 
-import {attachmentLimitsForModalities, describeAccepted} from "./assets/attachments"
+import {describeAccepted} from "./assets/attachments"
 import {CONTENT_VISIBILITY_ENABLED} from "./assets/conversationLayout"
 import {filesToInlineParts, filesToParts} from "./assets/files"
 import {runWithInFlightSubmit} from "./assets/inFlightSubmit"
@@ -213,19 +213,18 @@ const AgentConversation = ({
         () => modalitiesForModel(harnessCapabilities, modelKey.harness, modelKey.model),
         [harnessCapabilities, modelKey.harness, modelKey.model],
     )
-    // Perception is derived from the model's modalities; absent or unknown stays workspace-only,
-    // matching the runner's delivery rule.
-    const limits = useMemo(() => attachmentLimitsForModalities(modelModalities), [modelModalities])
-    // The same memoized fact the voice controls read.
-    const audioPerceivable = limits.perceived.audio
+    // Voice defaults follow the model's audio modality; unknown stays workspace-only, matching
+    // the runner's rule.
+    const audioPerceivable = Boolean(modelModalities?.includes("audio"))
 
     // Pending attachments for this session + the whole-panel drop target.
-    const attachments = useComposerAttachments({sessionId, limits})
+    const attachments = useComposerAttachments({sessionId})
     const {
         uploadsEnabled,
         files,
         viewingUid,
         setViewingUid,
+        limits,
         atMax,
         attachmentsSettled,
         isDragging,

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -26,9 +26,10 @@ import {openTraceDrawerAtom} from "@/oss/components/SharedDrawers/TraceDrawer/st
 import {STRIP_COPY} from "@/oss/components/TemplateStrip/assets/constants"
 import CopiedToast from "@/oss/components/TemplateStrip/components/CopiedToast"
 
-import {describeAccepted} from "./assets/attachments"
+import {attachmentLimitsForModalities, describeAccepted} from "./assets/attachments"
 import {CONTENT_VISIBILITY_ENABLED} from "./assets/conversationLayout"
-import {filesToParts} from "./assets/files"
+import {attachmentNamesByMessage, filesToInlineParts, filesToParts} from "./assets/files"
+import {runWithInFlightSubmit} from "./assets/inFlightSubmit"
 import {isEmptyAssistantTurn, isVisiblePart} from "./assets/messageParts"
 import {messageText, sideEffectingToolsInRange} from "./assets/rewind"
 import {ignoreStreamRejection} from "./assets/runError"
@@ -106,20 +107,6 @@ const AgentConversation = ({
     const richInputRef = useRef<RichChatInputHandle>(null)
 
     const composer = useComposerDraft({sessionId, richInputRef, revealPlayedRef})
-
-    // Pending attachments for this session + the whole-panel drop target.
-    const attachments = useComposerAttachments({sessionId})
-    const {
-        uploadsEnabled,
-        files,
-        viewingUid,
-        setViewingUid,
-        limits,
-        atMax,
-        attachmentsSettled,
-        isDragging,
-        addFiles,
-    } = attachments
 
     // What the transcript should do next (follow / arm a pin / show the pill), shared by the
     // producers below (send, queue release, history adoption) and whichever scroll engine is
@@ -222,15 +209,28 @@ const AgentConversation = ({
     // component and its logic stay wired up; flip this to `true` to bring the UI back.
     const showContextBudget = false
 
-    /**
-     * Whether the selected model can actually take audio in. `null` means the catalog does not
-     * say — treated as unknown, never as "no", so a missing field can't quietly demote voice.
-     * Drives which voice mode leads; it never refuses an attachment (design decision D6).
-     */
-    const audioPerceivable = useMemo(() => {
-        const modalities = modalitiesForModel(harnessCapabilities, modelKey.harness, modelKey.model)
-        return modalities ? modalities.includes("audio") : null
-    }, [harnessCapabilities, modelKey.harness, modelKey.model])
+    const modelModalities = useMemo(
+        () => modalitiesForModel(harnessCapabilities, modelKey.harness, modelKey.model),
+        [harnessCapabilities, modelKey.harness, modelKey.model],
+    )
+    // Perception is derived from the model's modalities; absent or unknown stays workspace-only,
+    // matching the runner's delivery rule.
+    const limits = useMemo(() => attachmentLimitsForModalities(modelModalities), [modelModalities])
+    // The same memoized fact the voice controls read.
+    const audioPerceivable = limits.perceived.audio
+
+    // Pending attachments for this session + the whole-panel drop target.
+    const attachments = useComposerAttachments({sessionId, limits})
+    const {
+        uploadsEnabled,
+        files,
+        viewingUid,
+        setViewingUid,
+        atMax,
+        attachmentsSettled,
+        isDragging,
+        addFiles,
+    } = attachments
 
     // Playground-native onboarding: the hero, Create-agent / Continue-in-IDE, the template strip
     // and the optimistic first turn. Every value is inert outside the onboarding playground.
@@ -401,33 +401,7 @@ const AgentConversation = ({
         useVirtuoso,
     })
 
-    const handleSubmit = async (text: string, extraFiles: File[] = []) => {
-        const trimmed = text.trim()
-        const fileObjs = [
-            ...files
-                .map((f) => f.originFileObj as File | undefined)
-                .filter((f): f is File => Boolean(f)),
-            ...extraFiles,
-        ]
-        if (!trimmed && fileObjs.length === 0) return
-        if (!attachmentsSettled) return
-        let fileParts: FileUIPart[] | undefined
-        if (fileObjs.length) {
-            const {parts, unreadable} = await filesToParts(fileObjs)
-            // Hold the send rather than quietly dropping bytes the user staged, and say which file
-            // failed through the same inline channel the other attachment refusals use.
-            if (unreadable.length) {
-                attachments.setRejections(
-                    unreadable.map((f) => ({
-                        name: f.name,
-                        reason: "couldn't be read — remove it and attach it again",
-                    })),
-                )
-                attachments.setAttachmentsOpen(true)
-                return
-            }
-            fileParts = parts
-        }
+    const finishSubmit = (trimmed: string, fileParts?: FileUIPart[]) => {
         // Glide to the bottom; the min-h-full active turn makes that show the new question at the top
         // with the answer streaming below. Park during the glide, follow again on settle. Clear any
         // prior "stopped" marker — it's resolved by asking again.
@@ -440,6 +414,55 @@ const AgentConversation = ({
         onboardingChat.consumeTemplateProvenance()
         attachments.clearAttachments()
     }
+
+    // A voice take awaits its upload, so the guard keeps a second send from starting meanwhile.
+    const inFlightSubmitRef = useRef(false)
+    const handleSubmit = (text: string, extraFiles: File[] = []) =>
+        runWithInFlightSubmit(inFlightSubmitRef, async () => {
+            const trimmed = text.trim()
+            if (!trimmed && files.length === 0 && extraFiles.length === 0) return
+            if (!attachmentsSettled) return
+
+            if (!uploadsEnabled) {
+                // Voice and upload flags are independent; this seam preserves the inline recorder path.
+                const inlineFiles = [
+                    ...files
+                        .map((file) => file.originFileObj as File | undefined)
+                        .filter((file): file is File => Boolean(file)),
+                    ...extraFiles,
+                ]
+                let fileParts: FileUIPart[] | undefined
+                if (inlineFiles.length) {
+                    const {parts, unreadable} = await filesToInlineParts(inlineFiles)
+                    // Hold the send rather than quietly dropping bytes the user staged, and say which
+                    // file failed through the same inline channel the other attachment refusals use.
+                    if (unreadable.length) {
+                        attachments.setRejections(
+                            unreadable.map((file) => ({
+                                name: file.name,
+                                reason: "couldn't be read — remove it and attach it again",
+                            })),
+                        )
+                        attachments.setAttachmentsOpen(true)
+                        return
+                    }
+                    fileParts = parts
+                }
+                finishSubmit(trimmed, fileParts)
+                return
+            }
+
+            // A take sent outright never entered the tray, so it uploads here before the send.
+            const uploadedExtras = extraFiles.length
+                ? await attachments.uploadExtraFiles(extraFiles)
+                : []
+            if (!uploadedExtras) return
+            const outboundFiles = [...files, ...uploadedExtras]
+            const fileParts = outboundFiles.length
+                ? filesToParts(outboundFiles, sessionId)
+                : undefined
+            finishSubmit(trimmed, fileParts)
+        })
 
     handleSubmitRef.current = handleSubmit
 
@@ -506,15 +529,23 @@ const AgentConversation = ({
         [regenerate, setStopped],
     )
 
+    // Delivery notices name their file from the preceding user turn's attachment references.
+    const deliveryAttachmentNames = useMemo(() => attachmentNamesByMessage(messages), [messages])
+
     const renderMessage = (message: UIMessage, index: number) => {
         const isLast = index === messages.length - 1
         const isAssistantTurn = message.role === "assistant"
         const turn = turnNumbers.get(message.id)
         const isInspected = isAssistantTurn && inspectedTurn != null && turn === inspectedTurn
+        // Undefined (not an empty map) for turns with no attachments above them, so the memo on
+        // every settled turn still holds while a run streams.
+        const attachmentNames = deliveryAttachmentNames.get(message.id)
         return (
             <AgentTurn
                 key={message.id}
                 message={message}
+                sessionId={sessionId}
+                attachmentNames={attachmentNames?.size ? attachmentNames : undefined}
                 // New since mount → fade in once. seenIdsRef is marked in an effect after commit,
                 // never during render (unsafe under StrictMode's double invoke).
                 enter={!isSeen(message.id)}
@@ -631,6 +662,7 @@ const AgentConversation = ({
                                 placeholder={
                                     <TranscriptPlaceholder
                                         entityId={entityId}
+                                        sessionId={sessionId}
                                         pendingFirstTurn={onboardingChat.pendingFirstTurn}
                                         pendingFirstMessage={onboardingChat.pendingFirstMessage}
                                         onboardingActive={onboardingActive}

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -400,7 +400,11 @@ const AgentConversation = ({
         useVirtuoso,
     })
 
-    const finishSubmit = (trimmed: string, fileParts?: FileUIPart[]) => {
+    const finishSubmit = (
+        trimmed: string,
+        fileParts: FileUIPart[] | undefined,
+        consumedUids: string[],
+    ) => {
         // Glide to the bottom; the min-h-full active turn makes that show the new question at the top
         // with the answer streaming below. Park during the glide, follow again on settle. Clear any
         // prior "stopped" marker — it's resolved by asking again.
@@ -411,7 +415,7 @@ const AgentConversation = ({
         // The message left the composer — drop its persisted draft (and any pending capture).
         composer.clearDraft()
         onboardingChat.consumeTemplateProvenance()
-        attachments.clearAttachments()
+        attachments.clearAttachments(consumedUids)
     }
 
     // A voice take awaits its upload, so the guard keeps a second send from starting meanwhile.
@@ -421,6 +425,7 @@ const AgentConversation = ({
             const trimmed = text.trim()
             if (!trimmed && files.length === 0 && extraFiles.length === 0) return
             if (!attachmentsSettled) return
+            const stagedUids = files.map((file) => file.uid)
 
             if (!uploadsEnabled) {
                 // Voice and upload flags are independent; this seam preserves the inline recorder path.
@@ -447,7 +452,7 @@ const AgentConversation = ({
                     }
                     fileParts = parts
                 }
-                finishSubmit(trimmed, fileParts)
+                finishSubmit(trimmed, fileParts, stagedUids)
                 return
             }
 
@@ -460,7 +465,7 @@ const AgentConversation = ({
             const fileParts = outboundFiles.length
                 ? filesToParts(outboundFiles, sessionId)
                 : undefined
-            finishSubmit(trimmed, fileParts)
+            finishSubmit(trimmed, fileParts, stagedUids)
         })
 
     handleSubmitRef.current = handleSubmit

--- a/web/oss/src/components/AgentChatSlice/assets/attachmentMedia.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/attachmentMedia.ts
@@ -1,0 +1,98 @@
+import {useEffect, useMemo, useState} from "react"
+
+import {useAtomValue} from "jotai"
+import {atomFamily} from "jotai/utils"
+import {atomWithQuery} from "jotai-tanstack-query"
+
+import axios from "@/oss/lib/api/assets/axiosConfig"
+import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
+
+export function attachmentContentUrl(sessionId: string, attachmentId: string): string {
+    const params = new URLSearchParams({session_id: sessionId})
+    return `${getAgentaApiUrl()}/sessions/attachments/${encodeURIComponent(attachmentId)}/content?${params.toString()}`
+}
+
+export async function fetchAttachmentBlob({
+    sessionId,
+    attachmentId,
+}: {
+    sessionId: string
+    attachmentId: string
+}): Promise<Blob | null> {
+    if (!sessionId || !attachmentId) return null
+    try {
+        // Axios (not Fern): Fern JSON-parses response bodies, mangling binary payloads.
+        const response = await axios.get(attachmentContentUrl(sessionId, attachmentId), {
+            responseType: "blob",
+        })
+        return response.data as Blob
+    } catch {
+        return null
+    }
+}
+
+/** Attachment blobs are dropped as soon as the last renderer unmounts. */
+export const attachmentBlobQueryFamily = atomFamily(
+    ({sessionId, attachmentId}: {sessionId: string; attachmentId: string}) =>
+        atomWithQuery<Blob | null>(() => ({
+            queryKey: ["sessions", "attachment-blob", sessionId, attachmentId],
+            queryFn: () => fetchAttachmentBlob({sessionId, attachmentId}),
+            enabled: Boolean(sessionId && attachmentId),
+            staleTime: Infinity,
+            gcTime: 0,
+            refetchOnWindowFocus: false,
+        })),
+    (a, b) => a.sessionId === b.sessionId && a.attachmentId === b.attachmentId,
+)
+
+export function useAttachmentObjectUrl(
+    sessionId: string | null | undefined,
+    attachmentId: string | null | undefined,
+): {url: string | null; isPending: boolean; failed: boolean} {
+    const query = useAtomValue(
+        attachmentBlobQueryFamily({sessionId: sessionId ?? "", attachmentId: attachmentId ?? ""}),
+    )
+    const blob = query.data ?? null
+    const url = useMemo(() => (blob ? URL.createObjectURL(blob) : null), [blob])
+    useEffect(() => {
+        return () => {
+            if (url) URL.revokeObjectURL(url)
+        }
+    }, [url])
+    return {url, isPending: query.isPending, failed: !query.isPending && !blob}
+}
+
+/** Try the direct content URL first, then fall back to an authenticated axios blob. */
+export function useAttachmentMediaSrc(
+    sessionId: string | null | undefined,
+    attachmentId: string | null | undefined,
+): {src: string | null; isPending: boolean; failed: boolean; onError: () => void} {
+    const directUrl =
+        sessionId && attachmentId ? attachmentContentUrl(sessionId, attachmentId) : null
+    const [mode, setMode] = useState<"direct" | "blob">(directUrl ? "direct" : "blob")
+
+    useEffect(() => {
+        setMode(directUrl ? "direct" : "blob")
+    }, [directUrl])
+
+    const blobQuery = useAtomValue(
+        attachmentBlobQueryFamily({
+            sessionId: mode === "blob" ? (sessionId ?? "") : "",
+            attachmentId: mode === "blob" ? (attachmentId ?? "") : "",
+        }),
+    )
+    const blob = mode === "blob" ? (blobQuery.data ?? null) : null
+    const blobUrl = useMemo(() => (blob ? URL.createObjectURL(blob) : null), [blob])
+    useEffect(() => {
+        return () => {
+            if (blobUrl) URL.revokeObjectURL(blobUrl)
+        }
+    }, [blobUrl])
+
+    return {
+        src: mode === "direct" ? directUrl : blobUrl,
+        isPending: mode === "blob" && blobQuery.isPending,
+        failed: mode === "blob" && !blobQuery.isPending && !blob,
+        onError: () => setMode("blob"),
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/assets/attachmentTransport.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/attachmentTransport.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+// jsdom's File has no `text()`, and this suite asserts on the multipart body it builds.
+import type {AxiosProgressEvent} from "axios"
+import {CanceledError} from "axios"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+import axios from "@/oss/lib/api/assets/axiosConfig"
+
+import {AttachmentUploadError, uploadAttachment} from "./attachmentTransport"
+
+vi.mock("@/oss/lib/api/assets/axiosConfig", () => ({
+    default: {post: vi.fn()},
+}))
+
+vi.mock("@/oss/lib/helpers/api", () => ({
+    getAgentaApiUrl: vi.fn(() => "https://api.example.test"),
+}))
+
+const attachmentId = "0198f489-8c20-7000-8000-000000000001"
+const idempotencyKey = "0198f489-8c20-7000-8000-000000000002"
+const response = {
+    count: 1,
+    attachment: {
+        attachment_id: attachmentId,
+        filename: "notes.txt",
+        media_type: "text/plain",
+        size: 5,
+        created_at: "2026-07-31T12:00:00Z",
+    },
+}
+
+describe("uploadAttachment", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it("posts the multipart fields and returns a validated response", async () => {
+        vi.mocked(axios.post).mockResolvedValue({data: response})
+        const file = new File(["hello"], "notes.txt", {type: "text/plain"})
+
+        await expect(
+            uploadAttachment({file, sessionId: "session-1", idempotencyKey}),
+        ).resolves.toEqual(response)
+
+        const [url, body, config] = vi.mocked(axios.post).mock.calls[0]
+        expect(url).toBe("https://api.example.test/sessions/attachments")
+        expect(config?.params).toEqual({session_id: "session-1"})
+        expect(body).toBeInstanceOf(FormData)
+        const form = body as FormData
+        expect(form.get("idempotency_key")).toBe(idempotencyKey)
+        const uploaded = form.get("file") as File
+        expect(uploaded.name).toBe("notes.txt")
+        await expect(uploaded.text()).resolves.toBe("hello")
+    })
+
+    it("reports upload progress", async () => {
+        vi.mocked(axios.post).mockResolvedValue({data: response})
+        const onProgress = vi.fn()
+
+        await uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+            onProgress,
+        })
+
+        const config = vi.mocked(axios.post).mock.calls[0][2]
+        config?.onUploadProgress?.({loaded: 1, total: 4} as AxiosProgressEvent)
+        expect(onProgress).toHaveBeenCalledWith(25)
+    })
+
+    it("forwards the abort signal and preserves cancellation", async () => {
+        const controller = new AbortController()
+        vi.mocked(axios.post).mockImplementation(
+            (_url, _body, config) =>
+                new Promise((_resolve, reject) => {
+                    config?.signal?.addEventListener("abort", () => {
+                        reject(new CanceledError("canceled"))
+                    })
+                }),
+        )
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+            signal: controller.signal,
+        })
+        controller.abort()
+
+        await expect(upload).rejects.toBeInstanceOf(CanceledError)
+        expect(vi.mocked(axios.post).mock.calls[0][2]?.signal).toBe(controller.signal)
+    })
+
+    it("turns a network failure into a retryable user-safe error", async () => {
+        vi.mocked(axios.post).mockRejectedValue(new Error("socket path and token details"))
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toMatchObject({
+            name: "AttachmentUploadError",
+            message: "Couldn't upload the file. Try again.",
+            retryable: true,
+        })
+    })
+
+    it.each([
+        [413, "text/plain", "This file exceeds the 10.0 MB document limit."],
+        [422, "text/plain", "This file isn't valid."],
+        [429, "text/plain", "This session's attachment quota is full."],
+        [404, "text/plain", "This backend does not support attachments yet."],
+    ])("maps HTTP %s to a short non-retryable error", async (status, mediaType, message) => {
+        vi.mocked(axios.post).mockRejectedValue({
+            isAxiosError: true,
+            response: {status, headers: {}},
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt", {type: mediaType}),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toMatchObject({message, retryable: false})
+    })
+
+    it("honours Retry-After for an upload already in flight", async () => {
+        vi.mocked(axios.post).mockRejectedValue({
+            isAxiosError: true,
+            response: {status: 409, headers: {"retry-after": "7"}},
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toMatchObject({
+            message: "This file is already uploading. Retry in 7s.",
+            retryable: true,
+            retryAfterSeconds: 7,
+        })
+    })
+
+    it("logs schema drift and throws a controlled retryable error", async () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+        vi.mocked(axios.post).mockResolvedValue({
+            data: {...response, attachment: {...response.attachment, attachment_id: "not-a-uuid"}},
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toBeInstanceOf(AttachmentUploadError)
+        expect(consoleError).toHaveBeenCalledWith(
+            "[uploadAttachment] Validation failed:",
+            expect.any(Object),
+        )
+        consoleError.mockRestore()
+    })
+
+    it("rejects uppercase attachment ids emitted outside the canonical server contract", async () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+        vi.mocked(axios.post).mockResolvedValue({
+            data: {
+                ...response,
+                attachment: {...response.attachment, attachment_id: attachmentId.toUpperCase()},
+            },
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toBeInstanceOf(AttachmentUploadError)
+        consoleError.mockRestore()
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/attachmentTransport.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/attachmentTransport.ts
@@ -1,0 +1,131 @@
+import {safeParseWithLogging} from "@agenta/entities/shared"
+import {isAxiosError, isCancel} from "axios"
+import {z} from "zod"
+
+import axios from "@/oss/lib/api/assets/axiosConfig"
+import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
+
+import {DEFAULT_ATTACHMENT_LIMITS, formatBytes, kindForType} from "./attachments"
+
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+const sessionAttachmentResponseSchema = z.object({
+    count: z.number().int().nonnegative(),
+    attachment: z.object({
+        // The server emits lowercase ids, and the adapter deliberately rejects uppercase variants.
+        attachment_id: z.string().regex(CANONICAL_UUID),
+        filename: z.string(),
+        media_type: z.string(),
+        size: z.number().int().nonnegative(),
+        created_at: z.string(),
+    }),
+})
+
+export type SessionAttachmentResponse = z.infer<typeof sessionAttachmentResponseSchema>
+
+export class AttachmentUploadError extends Error {
+    readonly retryable: boolean
+    readonly retryAfterSeconds?: number
+
+    constructor(
+        message = "Couldn't upload the file. Try again.",
+        {
+            retryable = true,
+            retryAfterSeconds,
+        }: {retryable?: boolean; retryAfterSeconds?: number} = {},
+    ) {
+        super(message)
+        this.name = "AttachmentUploadError"
+        this.retryable = retryable
+        this.retryAfterSeconds = retryAfterSeconds
+    }
+}
+
+const retryAfterSeconds = (value: unknown): number | undefined => {
+    const parsed = Number(Array.isArray(value) ? value[0] : value)
+    return Number.isFinite(parsed) && parsed >= 0 ? Math.ceil(parsed) : undefined
+}
+
+const errorForResponse = (error: unknown, file: File): AttachmentUploadError => {
+    if (!isAxiosError(error) || !error.response) return new AttachmentUploadError()
+
+    switch (error.response.status) {
+        case 413: {
+            const kind = kindForType(file.type || "application/octet-stream")
+            const limit = formatBytes(DEFAULT_ATTACHMENT_LIMITS.maxBytes[kind])
+            const label = kind === "other" ? "file" : kind
+            return new AttachmentUploadError(`This file exceeds the ${limit} ${label} limit.`, {
+                retryable: false,
+            })
+        }
+        case 422:
+            return new AttachmentUploadError("This file isn't valid.", {retryable: false})
+        case 429:
+            return new AttachmentUploadError("This session's attachment quota is full.", {
+                retryable: false,
+            })
+        case 409: {
+            const retryIn = retryAfterSeconds(error.response.headers?.["retry-after"])
+            if (retryIn !== undefined) {
+                return new AttachmentUploadError(
+                    `This file is already uploading. Retry in ${retryIn}s.`,
+                    {retryAfterSeconds: retryIn},
+                )
+            }
+            return new AttachmentUploadError("This upload conflicts with an earlier file.", {
+                retryable: false,
+            })
+        }
+        case 404:
+            return new AttachmentUploadError("This backend does not support attachments yet.", {
+                retryable: false,
+            })
+        default:
+            return new AttachmentUploadError()
+    }
+}
+
+export async function uploadAttachment({
+    file,
+    sessionId,
+    idempotencyKey,
+    onProgress,
+    signal,
+}: {
+    file: File
+    sessionId: string
+    idempotencyKey: string
+    onProgress?: (percent: number) => void
+    signal?: AbortSignal
+}): Promise<SessionAttachmentResponse> {
+    const form = new FormData()
+    form.append("file", file, file.name)
+    form.append("idempotency_key", idempotencyKey)
+
+    try {
+        // Axios (not Fern): the Fern client uses fetch, which can't stream upload progress.
+        // The explicit header matters: the shared instance defaults to application/json, and
+        // axios then JSON-serializes the FormData, collapsing the File to {}.
+        const response = await axios.post(`${getAgentaApiUrl()}/sessions/attachments`, form, {
+            params: {session_id: sessionId},
+            headers: {"Content-Type": "multipart/form-data"},
+            signal,
+            onUploadProgress: (event) => {
+                if (onProgress && event.total) {
+                    onProgress(Math.round((event.loaded / event.total) * 100))
+                }
+            },
+        })
+        const validated = safeParseWithLogging(
+            sessionAttachmentResponseSchema,
+            response.data,
+            "[uploadAttachment]",
+        )
+        if (!validated) throw new AttachmentUploadError()
+        return validated
+    } catch (error) {
+        if (signal?.aborted || isCancel(error)) throw error
+        if (error instanceof AttachmentUploadError) throw error
+        throw errorForResponse(error, file)
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/assets/attachments.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/attachments.test.ts
@@ -1,23 +1,10 @@
 import {describe, expect, it} from "vitest"
 
-import {
-    attachmentLimitsForModalities,
-    DEFAULT_ATTACHMENT_LIMITS,
-    kindForType,
-    type AttachmentLimits,
-    validateIncoming,
-} from "./attachments"
+import {DEFAULT_ATTACHMENT_LIMITS, kindForType, validateIncoming} from "./attachments"
 
 const MB = 1024 * 1024
 
 const file = (name: string, type: string, size: number): File => ({name, type, size}) as File
-
-const limits = (overrides: Partial<AttachmentLimits> = {}): AttachmentLimits => ({
-    ...DEFAULT_ATTACHMENT_LIMITS,
-    maxBytes: {...DEFAULT_ATTACHMENT_LIMITS.maxBytes},
-    perceived: {...DEFAULT_ATTACHMENT_LIMITS.perceived},
-    ...overrides,
-})
 
 describe("attachment validation", () => {
     it("accepts an unrecognized media type through the other bucket", () => {
@@ -53,35 +40,5 @@ describe("attachment validation", () => {
                 reason: `exceeds the ${DEFAULT_ATTACHMENT_LIMITS.maxCount}-file limit`,
             },
         ])
-    })
-
-    it("accepts a non-perceived kind and exposes its courtesy-notice flag", () => {
-        const archive = file("bundle.zip", "application/zip", 1)
-        const workspaceOnly = limits({
-            perceived: {...DEFAULT_ATTACHMENT_LIMITS.perceived, other: false},
-        })
-
-        expect(validateIncoming([archive], 0, workspaceOnly).accepted).toEqual([archive])
-        expect(workspaceOnly.perceived[kindForType(archive.type)]).toBe(false)
-    })
-})
-
-describe("attachment perception", () => {
-    it("derives perceived kinds from the selected model modalities", () => {
-        expect(attachmentLimitsForModalities(["text", "image", "audio"]).perceived).toEqual({
-            image: true,
-            audio: true,
-            document: false,
-            other: false,
-        })
-    })
-
-    it("treats unknown modalities as workspace-only", () => {
-        expect(attachmentLimitsForModalities(null).perceived).toEqual({
-            image: false,
-            audio: false,
-            document: false,
-            other: false,
-        })
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/attachments.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/attachments.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from "vitest"
+
+import {
+    attachmentLimitsForModalities,
+    DEFAULT_ATTACHMENT_LIMITS,
+    kindForType,
+    type AttachmentLimits,
+    validateIncoming,
+} from "./attachments"
+
+const MB = 1024 * 1024
+
+const file = (name: string, type: string, size: number): File => ({name, type, size}) as File
+
+const limits = (overrides: Partial<AttachmentLimits> = {}): AttachmentLimits => ({
+    ...DEFAULT_ATTACHMENT_LIMITS,
+    maxBytes: {...DEFAULT_ATTACHMENT_LIMITS.maxBytes},
+    perceived: {...DEFAULT_ATTACHMENT_LIMITS.perceived},
+    ...overrides,
+})
+
+describe("attachment validation", () => {
+    it("accepts an unrecognized media type through the other bucket", () => {
+        const archive = file("bundle.zip", "application/zip", 1)
+
+        expect(kindForType(archive.type)).toBe("other")
+        expect(validateIncoming([archive], 0)).toEqual({accepted: [archive], rejections: []})
+    })
+
+    it("enforces the 10 MB cap for the other bucket", () => {
+        const archive = file("bundle.zip", "application/zip", 10 * MB + 1)
+
+        const result = validateIncoming([archive], 0)
+
+        expect(result.accepted).toEqual([])
+        expect(result.rejections).toEqual([
+            {
+                name: "bundle.zip",
+                reason: "is too large (10.0 MB) · max 10.0 MB for other files",
+            },
+        ])
+    })
+
+    it("enforces the per-message count cap", () => {
+        const image = file("photo.png", "image/png", 1)
+
+        const result = validateIncoming([image], DEFAULT_ATTACHMENT_LIMITS.maxCount)
+
+        expect(result.accepted).toEqual([])
+        expect(result.rejections).toEqual([
+            {
+                name: "photo.png",
+                reason: `exceeds the ${DEFAULT_ATTACHMENT_LIMITS.maxCount}-file limit`,
+            },
+        ])
+    })
+
+    it("accepts a non-perceived kind and exposes its courtesy-notice flag", () => {
+        const archive = file("bundle.zip", "application/zip", 1)
+        const workspaceOnly = limits({
+            perceived: {...DEFAULT_ATTACHMENT_LIMITS.perceived, other: false},
+        })
+
+        expect(validateIncoming([archive], 0, workspaceOnly).accepted).toEqual([archive])
+        expect(workspaceOnly.perceived[kindForType(archive.type)]).toBe(false)
+    })
+})
+
+describe("attachment perception", () => {
+    it("derives perceived kinds from the selected model modalities", () => {
+        expect(attachmentLimitsForModalities(["text", "image", "audio"]).perceived).toEqual({
+            image: true,
+            audio: true,
+            document: false,
+            other: false,
+        })
+    })
+
+    it("treats unknown modalities as workspace-only", () => {
+        expect(attachmentLimitsForModalities(null).perceived).toEqual({
+            image: false,
+            audio: false,
+            document: false,
+            other: false,
+        })
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/attachments.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/attachments.ts
@@ -1,25 +1,13 @@
-/**
- * Attachment guardrails for the agent composer. Files are sent inline as base64 `data:` URLs
- * (see `files.ts`), so an unbounded picker puts arbitrary bytes straight into the request body.
- * These limits cap the count, per-kind size, and types.
- *
- * NOTE on ceilings: while attachments ride the request body, the real limit is the gateway's
- * `client_max_body_size` (10 MB on the compose stack), and base64 inflates by ~33% on top of the
- * whole resent history. These caps are deliberately per-kind rather than generous. They can rise
- * once attachments travel as references instead of bytes.
- *
- * The limits are a single value object, not scattered constants, so they can be derived from the
- * selected model / harness capabilities and passed down in place of `DEFAULT_ATTACHMENT_LIMITS` —
- * narrowing `kinds` is the seam that capability gating plugs into.
- */
+/** Attachment guardrails for files uploaded before an agent turn is sent by reference. */
 
-export type AttachmentKind = "image" | "audio" | "document"
+export type AttachmentKind = "image" | "audio" | "document" | "other"
 
 /** Media types per kind: exact types (`application/pdf`) or `type/` prefixes (`image/`). */
 const KIND_TYPES: Record<AttachmentKind, string[]> = {
     image: ["image/"],
     audio: ["audio/"],
     document: ["application/pdf", "text/", "application/json"],
+    other: [],
 }
 
 /** `accept` hints for the native picker (a hint only — drag/paste is validated regardless). */
@@ -27,12 +15,14 @@ const KIND_ACCEPT_ATTR: Record<AttachmentKind, string> = {
     image: "image/*",
     audio: "audio/*",
     document: "application/pdf,text/plain,text/markdown,text/csv,.md,.csv,application/json",
+    other: "",
 }
 
 const KIND_NOUN: Record<AttachmentKind, string> = {
     image: "images",
     audio: "audio",
     document: "documents",
+    other: "other files",
 }
 
 export interface AttachmentLimits {
@@ -40,44 +30,66 @@ export interface AttachmentLimits {
     maxCount: number
     /** Kinds the composer accepts. Narrowing this is how capability gating plugs in. */
     kinds: AttachmentKind[]
-    /** Max bytes per file, per kind (before base64 inflation, which adds ~33% on the wire). */
+    /** Max bytes per file, per kind. */
     maxBytes: Record<AttachmentKind, number>
+    /** Pre-send perception approximation; delivery events remain authoritative. */
+    perceived: Record<AttachmentKind, boolean>
 }
 
 const MB = 1024 * 1024
 
 export const DEFAULT_ATTACHMENT_LIMITS: AttachmentLimits = {
     maxCount: 5,
-    kinds: ["image", "audio", "document"],
+    kinds: ["image", "audio", "document", "other"],
     maxBytes: {
         // A photo off a phone clears 5 MB routinely.
         image: 10 * MB,
         // Our own recordings cap near 2.4 MB; the headroom is for uploaded clips.
         audio: 15 * MB,
         document: 10 * MB,
+        other: 10 * MB,
+    },
+    perceived: {
+        image: true,
+        audio: false,
+        document: false,
+        other: false,
     },
 }
 
-/** Which kind a media type belongs to, or null when it is not something we take at all. */
-export const kindForType = (mediaType: string): AttachmentKind | null => {
-    for (const kind of Object.keys(KIND_TYPES) as AttachmentKind[]) {
+/** Keep unknown or absent modalities workspace-only, matching the runner's delivery rule. */
+export const attachmentLimitsForModalities = (
+    modalities: string[] | null | undefined,
+): AttachmentLimits => ({
+    ...DEFAULT_ATTACHMENT_LIMITS,
+    perceived: {
+        image: Boolean(modalities?.includes("image")),
+        audio: Boolean(modalities?.includes("audio")),
+        document: Boolean(modalities?.includes("document")),
+        other: Boolean(modalities?.includes("other")),
+    },
+})
+
+/** Which kind a media type belongs to. */
+export const kindForType = (mediaType: string): AttachmentKind => {
+    for (const kind of ["image", "audio", "document"] as const) {
         const matches = KIND_TYPES[kind].some((t) =>
             t.endsWith("/") ? mediaType.startsWith(t) : mediaType === t,
         )
         if (matches) return kind
     }
-    return null
+    return "other"
 }
 
 /** Whether a media type is allowed under the limits (right kind, and that kind is enabled). */
 export const isAcceptedType = (mediaType: string, limits: AttachmentLimits): boolean => {
     const kind = kindForType(mediaType)
-    return !!kind && limits.kinds.includes(kind)
+    return limits.kinds.includes(kind)
 }
 
 /** `accept` attribute for the native file picker, built from the enabled kinds. */
 export const acceptAttrFor = (limits: AttachmentLimits): string =>
-    limits.kinds.map((k) => KIND_ACCEPT_ATTR[k]).join(",")
+    limits.kinds.includes("other") ? "" : limits.kinds.map((k) => KIND_ACCEPT_ATTR[k]).join(",")
 
 /** Human summary of what is accepted, e.g. "Images, audio, and documents". */
 export const describeAccepted = (limits: AttachmentLimits): string => {
@@ -127,7 +139,7 @@ export const validateIncoming = (
         const type = file.type || "application/octet-stream"
         const kind = kindForType(type)
 
-        if (!kind || !limits.kinds.includes(kind)) {
+        if (!limits.kinds.includes(kind)) {
             rejections.push({name: file.name, reason: "isn't a supported file type"})
             continue
         }

--- a/web/oss/src/components/AgentChatSlice/assets/attachments.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/attachments.ts
@@ -32,14 +32,12 @@ export interface AttachmentLimits {
     kinds: AttachmentKind[]
     /** Max bytes per file, per kind. */
     maxBytes: Record<AttachmentKind, number>
-    /** Pre-send perception approximation; delivery events remain authoritative. */
-    perceived: Record<AttachmentKind, boolean>
 }
 
 const MB = 1024 * 1024
 
 export const DEFAULT_ATTACHMENT_LIMITS: AttachmentLimits = {
-    maxCount: 5,
+    maxCount: 100,
     kinds: ["image", "audio", "document", "other"],
     maxBytes: {
         // A photo off a phone clears 5 MB routinely.
@@ -49,26 +47,7 @@ export const DEFAULT_ATTACHMENT_LIMITS: AttachmentLimits = {
         document: 10 * MB,
         other: 10 * MB,
     },
-    perceived: {
-        image: true,
-        audio: false,
-        document: false,
-        other: false,
-    },
 }
-
-/** Keep unknown or absent modalities workspace-only, matching the runner's delivery rule. */
-export const attachmentLimitsForModalities = (
-    modalities: string[] | null | undefined,
-): AttachmentLimits => ({
-    ...DEFAULT_ATTACHMENT_LIMITS,
-    perceived: {
-        image: Boolean(modalities?.includes("image")),
-        audio: Boolean(modalities?.includes("audio")),
-        document: Boolean(modalities?.includes("document")),
-        other: Boolean(modalities?.includes("other")),
-    },
-})
 
 /** Which kind a media type belongs to. */
 export const kindForType = (mediaType: string): AttachmentKind => {

--- a/web/oss/src/components/AgentChatSlice/assets/constants.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/constants.ts
@@ -36,8 +36,7 @@ export const isAgentVoiceInputEnabled = (): boolean =>
  * File uploads and attachments — the composer attach button + attachment preview, and every drive
  * upload entry point (upload button, drop-to-upload in the Files drawer, drop-to-stage on a recents
  * peek). Off by default: the composer→model delivery contract is still open on the backend. Enable
- * with `NEXT_PUBLIC_AGENT_FILE_UPLOADS=true`. Paste/drag-to-attach on the composer predates this and
- * is not gated.
+ * with `NEXT_PUBLIC_AGENT_FILE_UPLOADS=true`. The composer gates button, paste, and drag paths.
  */
 export const isAgentFileUploadsEnabled = (): boolean =>
     (getEnv("NEXT_PUBLIC_AGENT_FILE_UPLOADS") || "").toLowerCase() === "true"

--- a/web/oss/src/components/AgentChatSlice/assets/files.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/files.test.ts
@@ -1,12 +1,10 @@
-import type {FileUIPart, UIMessage} from "ai"
 import type {UploadFile} from "antd"
 import {describe, expect, it} from "vitest"
 
 import type {SessionAttachmentResponse} from "./attachmentTransport"
-import {attachmentNamesByMessage, filePartName, filesToParts} from "./files"
+import {filePartName, filesToParts} from "./files"
 
 const firstAttachmentId = "019c1e0a-f911-7000-8000-000000000001"
-const secondAttachmentId = "019c1e0a-f911-7000-8000-000000000002"
 
 const upload = (attachmentId: string): UploadFile<SessionAttachmentResponse> => ({
     uid: attachmentId,
@@ -46,33 +44,5 @@ describe("attachment file parts", () => {
                 url: "https://api.example.test/attachments/id/content",
             }),
         ).toBe("attachment")
-    })
-
-    it("joins each delivery id to the preceding user message filename", () => {
-        const file = (attachmentId: string, filename: string): FileUIPart => ({
-            type: "file",
-            mediaType: "text/plain",
-            filename,
-            url: `https://api.example.test/${attachmentId}/content`,
-            providerMetadata: {agenta: {attachmentId}},
-        })
-        const messages = [
-            {
-                id: "user-1",
-                role: "user",
-                parts: [
-                    file(firstAttachmentId, "first.txt"),
-                    file(secondAttachmentId, "second.txt"),
-                ],
-            },
-            {id: "assistant-1", role: "assistant", parts: []},
-        ] as UIMessage[]
-
-        expect(attachmentNamesByMessage(messages).get("assistant-1")).toEqual(
-            new Map([
-                [firstAttachmentId, "first.txt"],
-                [secondAttachmentId, "second.txt"],
-            ]),
-        )
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/files.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/files.test.ts
@@ -1,0 +1,78 @@
+import type {FileUIPart, UIMessage} from "ai"
+import type {UploadFile} from "antd"
+import {describe, expect, it} from "vitest"
+
+import type {SessionAttachmentResponse} from "./attachmentTransport"
+import {attachmentNamesByMessage, filePartName, filesToParts} from "./files"
+
+const firstAttachmentId = "019c1e0a-f911-7000-8000-000000000001"
+const secondAttachmentId = "019c1e0a-f911-7000-8000-000000000002"
+
+const upload = (attachmentId: string): UploadFile<SessionAttachmentResponse> => ({
+    uid: attachmentId,
+    name: "notes.txt",
+    status: "done",
+    response: {
+        count: 1,
+        attachment: {
+            attachment_id: attachmentId,
+            filename: "notes.txt",
+            media_type: "text/plain",
+            size: 42,
+            created_at: "2026-07-31T12:00:00Z",
+        },
+    },
+})
+
+describe("attachment file parts", () => {
+    it("stores size under providerMetadata.agenta", () => {
+        const part = filesToParts([upload(firstAttachmentId)], "session-1")[0]
+
+        expect(part).toMatchObject({
+            type: "file",
+            filename: "notes.txt",
+            providerMetadata: {
+                agenta: {attachmentId: firstAttachmentId, size: 42},
+            },
+        })
+        expect(part).not.toHaveProperty("size")
+    })
+
+    it("uses attachment when a replayed part has no filename", () => {
+        expect(
+            filePartName({
+                type: "file",
+                mediaType: "text/plain",
+                url: "https://api.example.test/attachments/id/content",
+            }),
+        ).toBe("attachment")
+    })
+
+    it("joins each delivery id to the preceding user message filename", () => {
+        const file = (attachmentId: string, filename: string): FileUIPart => ({
+            type: "file",
+            mediaType: "text/plain",
+            filename,
+            url: `https://api.example.test/${attachmentId}/content`,
+            providerMetadata: {agenta: {attachmentId}},
+        })
+        const messages = [
+            {
+                id: "user-1",
+                role: "user",
+                parts: [
+                    file(firstAttachmentId, "first.txt"),
+                    file(secondAttachmentId, "second.txt"),
+                ],
+            },
+            {id: "assistant-1", role: "assistant", parts: []},
+        ] as UIMessage[]
+
+        expect(attachmentNamesByMessage(messages).get("assistant-1")).toEqual(
+            new Map([
+                [firstAttachmentId, "first.txt"],
+                [secondAttachmentId, "second.txt"],
+            ]),
+        )
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/files.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/files.ts
@@ -88,25 +88,3 @@ export const attachmentIdForPart = (part: FileUIPart): string | null => {
 
 /** A readable label for a file part. */
 export const filePartName = (part: FileUIPart): string => part.filename || "attachment"
-
-/** Attachment names visible to delivery notices, keyed by their following assistant message. */
-export const attachmentNamesByMessage = (
-    messages: UIMessage[],
-): Map<string, ReadonlyMap<string, string>> => {
-    const result = new Map<string, ReadonlyMap<string, string>>()
-    let precedingUserFiles = new Map<string, string>()
-
-    for (const message of messages) {
-        if (message.role === "user") {
-            precedingUserFiles = new Map()
-            for (const part of fileParts(message)) {
-                const attachmentId = attachmentIdForPart(part)
-                if (attachmentId) precedingUserFiles.set(attachmentId, filePartName(part))
-            }
-        } else {
-            result.set(message.id, precedingUserFiles)
-        }
-    }
-
-    return result
-}

--- a/web/oss/src/components/AgentChatSlice/assets/files.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/files.ts
@@ -1,21 +1,39 @@
 import type {FileUIPart, UIMessage} from "ai"
+import type {UploadFile} from "antd"
 
-/**
- * Multi-modality helpers for the agent chat slice. Attachments are kept entirely on the
- * client: there is no upload server, so a selected file is read into a `data:` URL and
- * sent inline as an AI SDK v6 `file` part (`{type, mediaType, filename, url}`). The service
- * receives the bytes in the request body — same channel as the text.
- */
+import {attachmentContentUrl} from "./attachmentMedia"
+import type {SessionAttachmentResponse} from "./attachmentTransport"
+
+/** Helpers for sending and rendering attachment references without embedding file bytes. */
 
 export type FileKind = "image" | "audio" | "video" | "file"
 
-/** Map an IANA media type to the `FileCard` `type` / a render branch. */
+/** Map an IANA media type to the `FileCard` `type` or a render branch. */
 export const fileKind = (mediaType: string): FileKind => {
     if (mediaType.startsWith("image/")) return "image"
     if (mediaType.startsWith("audio/")) return "audio"
     if (mediaType.startsWith("video/")) return "video"
     return "file"
 }
+
+/** Convert uploaded tray entries into reference-carrying AI SDK file parts. */
+export const filesToParts = (
+    files: UploadFile<SessionAttachmentResponse>[],
+    sessionId: string,
+): FileUIPart[] =>
+    files.map((file) => {
+        const attachment = file.response?.attachment
+        if (!attachment) throw new Error(`Attachment upload is incomplete: ${file.name}`)
+        return {
+            type: "file",
+            mediaType: attachment.media_type,
+            filename: attachment.filename,
+            url: attachmentContentUrl(sessionId, attachment.attachment_id),
+            providerMetadata: {
+                agenta: {attachmentId: attachment.attachment_id, size: attachment.size},
+            },
+        }
+    })
 
 /** Read one `File` into a `data:` URL `file` part. */
 const fileToPart = (file: File): Promise<FileUIPart> =>
@@ -39,13 +57,13 @@ export interface FileReadResult {
 }
 
 /**
- * Convert picked `File`s into `file` parts for `sendMessage({text, files})`.
+ * Preserve the pre-upload voice path by reading recorder files into inline data URLs.
  *
  * Never rejects. Every send path drops this promise (composer submit, voice take, empty-state
  * Start, the first-run seed), so a `Promise.all` that threw on one unreadable file surfaced as an
  * unhandled rejection and a send that silently did nothing. Failures come back as data instead.
  */
-export const filesToParts = async (files: File[]): Promise<FileReadResult> => {
+export const filesToInlineParts = async (files: File[]): Promise<FileReadResult> => {
     const settled = await Promise.allSettled(files.map(fileToPart))
     const parts: FileUIPart[] = []
     const unreadable: File[] = []
@@ -58,8 +76,37 @@ export const filesToParts = async (files: File[]): Promise<FileReadResult> => {
 
 /** The `file` parts of a message, in order. */
 export const fileParts = (message: UIMessage): FileUIPart[] =>
-    message.parts.filter((p) => p.type === "file") as FileUIPart[]
+    message.parts.filter((part) => part.type === "file") as FileUIPart[]
 
-/** A readable label for a file part (filename, else the tail of its URL). */
-export const filePartName = (part: FileUIPart): string =>
-    part.filename || part.url.split("/").pop()?.split("?")[0] || "file"
+/** The Agenta attachment id carried by a reference part, if present. */
+export const attachmentIdForPart = (part: FileUIPart): string | null => {
+    const agenta = part.providerMetadata?.agenta
+    if (!agenta || typeof agenta !== "object") return null
+    const attachmentId = (agenta as {attachmentId?: unknown}).attachmentId
+    return typeof attachmentId === "string" && attachmentId ? attachmentId : null
+}
+
+/** A readable label for a file part. */
+export const filePartName = (part: FileUIPart): string => part.filename || "attachment"
+
+/** Attachment names visible to delivery notices, keyed by their following assistant message. */
+export const attachmentNamesByMessage = (
+    messages: UIMessage[],
+): Map<string, ReadonlyMap<string, string>> => {
+    const result = new Map<string, ReadonlyMap<string, string>>()
+    let precedingUserFiles = new Map<string, string>()
+
+    for (const message of messages) {
+        if (message.role === "user") {
+            precedingUserFiles = new Map()
+            for (const part of fileParts(message)) {
+                const attachmentId = attachmentIdForPart(part)
+                if (attachmentId) precedingUserFiles.set(attachmentId, filePartName(part))
+            }
+        } else {
+            result.set(message.id, precedingUserFiles)
+        }
+    }
+
+    return result
+}

--- a/web/oss/src/components/AgentChatSlice/assets/inFlightSubmit.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/inFlightSubmit.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, it, vi} from "vitest"
+
+import {runWithInFlightSubmit} from "./inFlightSubmit"
+
+describe("in-flight submit guard", () => {
+    it("drops a second submit while the first await is unresolved", async () => {
+        let release!: () => void
+        const pending = new Promise<void>((resolve) => {
+            release = resolve
+        })
+        const task = vi.fn(() => pending)
+        const inFlight = {current: false}
+
+        const first = runWithInFlightSubmit(inFlight, task)
+        const second = runWithInFlightSubmit(inFlight, task)
+
+        await expect(second).resolves.toBeUndefined()
+        expect(task).toHaveBeenCalledTimes(1)
+
+        release()
+        await first
+        await runWithInFlightSubmit(inFlight, task)
+        expect(task).toHaveBeenCalledTimes(2)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/inFlightSubmit.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/inFlightSubmit.ts
@@ -1,0 +1,17 @@
+export interface InFlightSubmitRef {
+    current: boolean
+}
+
+/** Admit one async submit at a time and always release the guard when it settles. */
+export async function runWithInFlightSubmit<T>(
+    inFlight: InFlightSubmitRef,
+    task: () => Promise<T>,
+): Promise<T | undefined> {
+    if (inFlight.current) return undefined
+    inFlight.current = true
+    try {
+        return await task()
+    } finally {
+        inFlight.current = false
+    }
+}

--- a/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
@@ -1,10 +1,13 @@
 import {type UIMessage} from "ai"
 
-/** A part the transcript actually renders — non-empty text/reasoning, files, sources, tools. */
+/** A part the transcript renders: non-empty prose, files, non-native delivery notices, sources,
+ * or tools. */
 export const isVisiblePart = (p: UIMessage["parts"][number]): boolean =>
     (p.type === "text" && Boolean((p as {text?: string}).text?.trim())) ||
     (p.type === "reasoning" && Boolean((p as {text?: string}).text?.trim())) ||
     p.type === "file" ||
+    (p.type === "data-attachment-delivery" &&
+        (p as {data?: {outcome?: string}}).data?.outcome !== "native") ||
     p.type === "source-url" ||
     p.type.startsWith("tool-") ||
     p.type === "dynamic-tool"

--- a/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
@@ -1,13 +1,10 @@
 import {type UIMessage} from "ai"
 
-/** A part the transcript renders: non-empty prose, files, non-native delivery notices, sources,
- * or tools. */
+/** A part the transcript renders: non-empty prose, files, sources, or tools. */
 export const isVisiblePart = (p: UIMessage["parts"][number]): boolean =>
     (p.type === "text" && Boolean((p as {text?: string}).text?.trim())) ||
     (p.type === "reasoning" && Boolean((p as {text?: string}).text?.trim())) ||
     p.type === "file" ||
-    (p.type === "data-attachment-delivery" &&
-        (p as {data?: {outcome?: string}}).data?.outcome !== "native") ||
     p.type === "source-url" ||
     p.type.startsWith("tool-") ||
     p.type === "dynamic-tool"

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -392,25 +392,21 @@ describe("transcriptToMessages attachments", () => {
         )
     })
 
-    it("rebuilds attachment delivery as the live data notice part", () => {
-        const part = firstPart([
-            record("record-delivery", {
-                type: "attachment_delivery",
-                attachmentId: "019c1e0a-f911-7000-8000-000000000001",
-                outcome: "workspace_only",
-                reasonCode: "model_modality_unknown",
-                workingPath: "attachments/019c1e0a-f911-7000-8000-000000000001/archive.zip",
-            }),
-        ])
-
-        expect(part).toEqual({
-            type: "data-attachment-delivery",
-            data: {
-                attachmentId: "019c1e0a-f911-7000-8000-000000000001",
-                outcome: "workspace_only",
-                reasonCode: "model_modality_unknown",
-                workingPath: "attachments/019c1e0a-f911-7000-8000-000000000001/archive.zip",
-            },
+    it("ignores an attachment delivery record instead of rendering a part", () => {
+        const delivery = record("record-delivery", {
+            type: "attachment_delivery",
+            attachmentId: "019c1e0a-f911-7000-8000-000000000001",
+            outcome: "workspace_only",
+            reasonCode: "model_modality_unknown",
+            workingPath: "attachments/019c1e0a-f911-7000-8000-000000000001/archive.zip",
         })
+
+        expect(transcriptToMessages([delivery])).toBeNull()
+        expect(
+            transcriptToMessages([
+                record("record-text", {type: "message", text: "Done."}),
+                delivery,
+            ])?.[0].parts,
+        ).toEqual([{type: "text", text: "Done."}])
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -351,3 +351,66 @@ describe("transcriptToMessages turn growth is invisible to a message count", () 
         expect(full?.[0].parts.length).toBeGreaterThan(partial?.[0].parts.length ?? 0)
     })
 })
+
+describe("transcriptToMessages attachments", () => {
+    it("rebuilds user attachment references as file parts with filenames", () => {
+        const messages = transcriptToMessages([
+            record(
+                "record-user",
+                {
+                    type: "message",
+                    text: "Inspect this",
+                    attachments: [
+                        {
+                            attachmentId: "019c1e0a-f911-7000-8000-000000000001",
+                            filename: "diagram.png",
+                            mediaType: "image/png",
+                            size: 42,
+                        },
+                    ],
+                },
+                "user",
+            ),
+        ])
+
+        expect(messages?.[0]).toMatchObject({
+            role: "user",
+            parts: [
+                {type: "text", text: "Inspect this"},
+                {
+                    type: "file",
+                    filename: "diagram.png",
+                    mediaType: "image/png",
+                    providerMetadata: {
+                        agenta: {attachmentId: "019c1e0a-f911-7000-8000-000000000001", size: 42},
+                    },
+                },
+            ],
+        })
+        expect((messages?.[0].parts[1] as {url: string}).url).toContain(
+            "/sessions/attachments/019c1e0a-f911-7000-8000-000000000001/content?session_id=session-1",
+        )
+    })
+
+    it("rebuilds attachment delivery as the live data notice part", () => {
+        const part = firstPart([
+            record("record-delivery", {
+                type: "attachment_delivery",
+                attachmentId: "019c1e0a-f911-7000-8000-000000000001",
+                outcome: "workspace_only",
+                reasonCode: "model_modality_unknown",
+                workingPath: "attachments/019c1e0a-f911-7000-8000-000000000001/archive.zip",
+            }),
+        ])
+
+        expect(part).toEqual({
+            type: "data-attachment-delivery",
+            data: {
+                attachmentId: "019c1e0a-f911-7000-8000-000000000001",
+                outcome: "workspace_only",
+                reasonCode: "model_modality_unknown",
+                workingPath: "attachments/019c1e0a-f911-7000-8000-000000000001/archive.zip",
+            },
+        })
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -1,6 +1,8 @@
 import type {SessionRecord} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 
+import {attachmentContentUrl} from "./attachmentMedia"
+
 /**
  * Replay adapter — durable session-record `AgentEvent`s → v6 `UIMessage[]`.
  *
@@ -105,6 +107,7 @@ function applyEvent(
     draft: DraftMessage,
     payload: Record<string, unknown>,
     index: TranscriptIndex,
+    sessionId: string,
 ): void {
     const type = payload.type as string | undefined
     const str = (v: unknown): string => (typeof v === "string" ? v : v == null ? "" : String(v))
@@ -112,6 +115,25 @@ function applyEvent(
     switch (type) {
         case "message": {
             draft.parts.push({type: "text", text: str(payload.text)})
+            const attachments = Array.isArray(payload.attachments) ? payload.attachments : []
+            for (const raw of attachments) {
+                if (!raw || typeof raw !== "object") continue
+                const attachment = raw as Record<string, unknown>
+                const attachmentId = str(attachment.attachmentId)
+                if (!attachmentId) continue
+                draft.parts.push({
+                    type: "file",
+                    url: attachmentContentUrl(sessionId, attachmentId),
+                    mediaType: str(attachment.mediaType) || "application/octet-stream",
+                    filename: str(attachment.filename) || undefined,
+                    providerMetadata: {
+                        agenta: {
+                            attachmentId,
+                            size: typeof attachment.size === "number" ? attachment.size : undefined,
+                        },
+                    },
+                })
+            }
             return
         }
         case "message_start": {
@@ -236,6 +258,19 @@ function applyEvent(
                 type: "file",
                 url: str(payload.url),
                 mediaType: str(payload.mediaType),
+                filename: str(payload.filename) || undefined,
+            })
+            return
+        }
+        case "attachment_delivery": {
+            draft.parts.push({
+                type: "data-attachment-delivery",
+                data: {
+                    attachmentId: str(payload.attachmentId),
+                    outcome: str(payload.outcome),
+                    reasonCode: str(payload.reasonCode),
+                    ...(payload.workingPath == null ? {} : {workingPath: str(payload.workingPath)}),
+                },
             })
             return
         }
@@ -314,7 +349,7 @@ export function transcriptToMessages(records: SessionRecord[]): UIMessage[] | nu
             drafts.push(current)
         }
         if (traceId && !current.traceId) current.traceId = traceId
-        applyEvent(current, p, index)
+        applyEvent(current, p, index, row.session_id)
     }
 
     const messages = drafts

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -262,18 +262,6 @@ function applyEvent(
             })
             return
         }
-        case "attachment_delivery": {
-            draft.parts.push({
-                type: "data-attachment-delivery",
-                data: {
-                    attachmentId: str(payload.attachmentId),
-                    outcome: str(payload.outcome),
-                    reasonCode: str(payload.reasonCode),
-                    ...(payload.workingPath == null ? {} : {workingPath: str(payload.workingPath)}),
-                },
-            })
-            return
-        }
         case "error": {
             // No error part in the renderer; surface the text so the failure stays visible.
             draft.parts.push({type: "text", text: str(payload.message)})
@@ -296,7 +284,7 @@ function applyEvent(
             draft.usage = next
             return
         }
-        // done / data / render-hints carry no renderable message part — drop.
+        // done / data / render-hints / attachment_delivery carry no renderable message part — drop.
         default:
             return
     }

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -139,6 +139,7 @@ const AgentComposerDock = ({
         limits,
         atMax,
         attachmentsSettled,
+        uploadBlockReason,
         addFiles,
         removeFile,
         uploads,
@@ -284,6 +285,8 @@ const AgentComposerDock = ({
                                 if (!attachmentsBlocked()) addFiles(Array.from(pasted))
                             }}
                             sendForceEnabled={files.length > 0 && attachmentsSettled}
+                            sendDisabled={files.length > 0 && !attachmentsSettled}
+                            sendDisabledReason={uploadBlockReason}
                             streaming={busy}
                             onStop={onStop}
                             prefix={
@@ -354,12 +357,12 @@ const AgentComposerDock = ({
                                         files={files}
                                         rejections={rejections}
                                         limits={limits}
-                                        audioPerceivable={audioPerceivable}
                                         onAdd={addFiles}
                                         onRemove={removeFile}
                                         onDismissRejections={() => setRejections([])}
                                         onView={uploadsEnabled ? setViewingUid : undefined}
                                         onRetry={uploads.retry}
+                                        canRetry={uploads.canRetry}
                                     />
                                 </HeightCollapse>
                             }

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -12,7 +12,6 @@ import {
     Check,
     Clock,
     Copy,
-    EyeSlash,
     Robot,
     TreeStructure,
     User,
@@ -92,8 +91,6 @@ const TraceMetrics = ({traceId, usage}: {traceId: string; usage?: MessageUsageMe
 interface AgentMessageProps {
     message: UIMessage
     sessionId: string
-    /** Filenames from the preceding user turn, keyed by attachment id. */
-    attachmentNames?: ReadonlyMap<string, string>
     /** This is the last message AND the conversation is streaming — i.e. the one being
      * generated right now. Only it shows the loading state; settled turns never do. */
     isStreaming?: boolean
@@ -320,45 +317,6 @@ const AttachmentFilePart = ({file, sessionId}: {file: FileUIPart; sessionId: str
     )
 }
 
-interface AttachmentDeliveryPart {
-    type: "data-attachment-delivery"
-    data: {
-        attachmentId: string
-        outcome: "native" | "workspace_only" | "failed"
-        reasonCode: string
-        workingPath?: string
-    }
-}
-
-const AttachmentDeliveryNotice = ({
-    part,
-    filename,
-}: {
-    part: AttachmentDeliveryPart
-    filename?: string
-}) => {
-    if (part.data.outcome === "native") return null
-    const failed = part.data.outcome === "failed"
-    const label = filename || "Attachment"
-    return (
-        <div
-            className={`flex items-center gap-1.5 text-xs ${
-                failed ? "text-colorError" : "text-colorTextSecondary"
-            }`}
-            role={failed ? "alert" : "status"}
-        >
-            {failed ? <XCircle size={14} /> : <EyeSlash size={14} />}
-            <span>
-                {failed
-                    ? `${label}: could not be delivered to the agent.`
-                    : part.data.workingPath
-                      ? `${label}: the model did not perceive this file. The agent can use it at ${part.data.workingPath}.`
-                      : `${label}: the model did not perceive this file. The agent can still use it with tools.`}
-            </span>
-        </div>
-    )
-}
-
 /**
  * Read-only renderer for one agent conversation message, rendered inside an Ant Design X
  * `Bubble`. Walks `message.parts` in order (text → markdown, reasoning, tool calls +
@@ -372,7 +330,6 @@ const AgentMessage = ({
     isLastMessage = false,
     onRewind,
     onClientToolOutput,
-    attachmentNames,
     precededByEmptyAssistant = false,
     turnTraceId,
 }: AgentMessageProps) => {
@@ -421,8 +378,6 @@ const AgentMessage = ({
             (p.type === "text" && (p as {text?: string}).text) ||
             isToolPart(p.type) ||
             p.type === "file" ||
-            (p.type === "data-attachment-delivery" &&
-                (p as {data?: {outcome?: string}}).data?.outcome !== "native") ||
             p.type === "source-url",
     )
     const hasReasoning = message.parts.some(
@@ -573,17 +528,6 @@ const AgentMessage = ({
                     stateKey={reasoningKey(message.id, i)}
                     text={reasoning.text}
                     streaming={reasoning.state === "streaming"}
-                />
-            )
-        }
-        if (part.type === "data-attachment-delivery") {
-            return (
-                <AttachmentDeliveryNotice
-                    key={partKey}
-                    part={part as unknown as AttachmentDeliveryPart}
-                    filename={attachmentNames?.get(
-                        (part as unknown as AttachmentDeliveryPart).data.attachmentId,
-                    )}
                 />
             )
         }

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -1,4 +1,4 @@
-import {memo, useMemo, useRef, useState} from "react"
+import {memo, useEffect, useMemo, useRef, useState} from "react"
 
 import {traceDataSummaryAtomFamily} from "@agenta/entities/loadable"
 import {buildRenderMap} from "@agenta/playground"
@@ -12,6 +12,7 @@ import {
     Check,
     Clock,
     Copy,
+    EyeSlash,
     Robot,
     TreeStructure,
     User,
@@ -23,7 +24,8 @@ import {useAtomValue, useSetAtom} from "jotai"
 
 import {openTraceDrawerAtom} from "@/oss/components/SharedDrawers/TraceDrawer/store/traceDrawerStore"
 
-import {fileKind, filePartName} from "../assets/files"
+import {useAttachmentMediaSrc} from "../assets/attachmentMedia"
+import {attachmentIdForPart, fileKind, filePartName} from "../assets/files"
 import Markdown from "../assets/markdown"
 import {
     getMessageRunError,
@@ -89,6 +91,9 @@ const TraceMetrics = ({traceId, usage}: {traceId: string; usage?: MessageUsageMe
 
 interface AgentMessageProps {
     message: UIMessage
+    sessionId: string
+    /** Filenames from the preceding user turn, keyed by attachment id. */
+    attachmentNames?: ReadonlyMap<string, string>
     /** This is the last message AND the conversation is streaming — i.e. the one being
      * generated right now. Only it shows the loading state; settled turns never do. */
     isStreaming?: boolean
@@ -228,6 +233,132 @@ const avatarFor = (isUser: boolean) => (
     <Avatar size="small" icon={isUser ? <User size={16} /> : <Robot size={16} />} />
 )
 
+const triggerDownload = (href: string, name: string) => {
+    const link = document.createElement("a")
+    link.href = href
+    link.download = name
+    link.hidden = true
+    document.body.append(link)
+    link.click()
+    link.remove()
+}
+
+const AttachmentFilePart = ({file, sessionId}: {file: FileUIPart; sessionId: string}) => {
+    const attachmentId = attachmentIdForPart(file)
+    const kind = fileKind(file.mediaType)
+    const source = useAttachmentMediaSrc(attachmentId ? sessionId : null, attachmentId)
+    const src = attachmentId ? source.src : file.url
+    const name = filePartName(file)
+    const [fallbackDownloadPending, setFallbackDownloadPending] = useState(false)
+
+    useEffect(() => {
+        if (!fallbackDownloadPending) return
+        if (source.src?.startsWith("blob:")) {
+            triggerDownload(source.src, name)
+            setFallbackDownloadPending(false)
+        } else if (source.failed) {
+            setFallbackDownloadPending(false)
+        }
+    }, [fallbackDownloadPending, name, source.failed, source.src])
+
+    const handleDownload = async (event: React.MouseEvent<HTMLAnchorElement>) => {
+        if (!attachmentId || !src || src.startsWith("blob:")) return
+        event.preventDefault()
+        try {
+            const response = await fetch(src, {credentials: "include"})
+            if (!response.ok) throw new Error("Direct attachment download failed")
+            const objectUrl = URL.createObjectURL(await response.blob())
+            triggerDownload(objectUrl, name)
+            window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1_000)
+        } catch {
+            // The direct route can lack browser credentials; activate the lazy axios/blob fallback.
+            setFallbackDownloadPending(true)
+            source.onError()
+        }
+    }
+
+    if (kind === "audio") {
+        return (
+            <AudioPlayer
+                src={src ?? ""}
+                name={name}
+                onError={attachmentId ? source.onError : undefined}
+                className="max-w-[320px] rounded-lg border border-solid border-colorBorderSecondary px-2 py-1.5"
+            />
+        )
+    }
+
+    return (
+        <FileCard
+            name={name}
+            type={kind}
+            src={src ?? undefined}
+            size="small"
+            loading={attachmentId ? source.isPending : false}
+            className="max-w-full"
+            imageProps={kind === "image" && attachmentId ? {onError: source.onError} : undefined}
+            videoProps={kind === "video" && attachmentId ? {onError: source.onError} : undefined}
+            description={
+                kind === "file" ? (
+                    src ? (
+                        <a
+                            href={src}
+                            download={name}
+                            onClick={handleDownload}
+                            className="text-xs text-colorPrimary"
+                        >
+                            {file.mediaType}
+                        </a>
+                    ) : (
+                        <span className="text-xs text-colorTextTertiary">
+                            {source.failed ? "Download unavailable" : file.mediaType}
+                        </span>
+                    )
+                ) : undefined
+            }
+        />
+    )
+}
+
+interface AttachmentDeliveryPart {
+    type: "data-attachment-delivery"
+    data: {
+        attachmentId: string
+        outcome: "native" | "workspace_only" | "failed"
+        reasonCode: string
+        workingPath?: string
+    }
+}
+
+const AttachmentDeliveryNotice = ({
+    part,
+    filename,
+}: {
+    part: AttachmentDeliveryPart
+    filename?: string
+}) => {
+    if (part.data.outcome === "native") return null
+    const failed = part.data.outcome === "failed"
+    const label = filename || "Attachment"
+    return (
+        <div
+            className={`flex items-center gap-1.5 text-xs ${
+                failed ? "text-colorError" : "text-colorTextSecondary"
+            }`}
+            role={failed ? "alert" : "status"}
+        >
+            {failed ? <XCircle size={14} /> : <EyeSlash size={14} />}
+            <span>
+                {failed
+                    ? `${label}: could not be delivered to the agent.`
+                    : part.data.workingPath
+                      ? `${label}: the model did not perceive this file. The agent can use it at ${part.data.workingPath}.`
+                      : `${label}: the model did not perceive this file. The agent can still use it with tools.`}
+            </span>
+        </div>
+    )
+}
+
 /**
  * Read-only renderer for one agent conversation message, rendered inside an Ant Design X
  * `Bubble`. Walks `message.parts` in order (text → markdown, reasoning, tool calls +
@@ -236,10 +367,12 @@ const avatarFor = (isUser: boolean) => (
  */
 const AgentMessage = ({
     message,
+    sessionId,
     isStreaming = false,
     isLastMessage = false,
     onRewind,
     onClientToolOutput,
+    attachmentNames,
     precededByEmptyAssistant = false,
     turnTraceId,
 }: AgentMessageProps) => {
@@ -288,6 +421,8 @@ const AgentMessage = ({
             (p.type === "text" && (p as {text?: string}).text) ||
             isToolPart(p.type) ||
             p.type === "file" ||
+            (p.type === "data-attachment-delivery" &&
+                (p as {data?: {outcome?: string}}).data?.outcome !== "native") ||
             p.type === "source-url",
     )
     const hasReasoning = message.parts.some(
@@ -441,43 +576,23 @@ const AgentMessage = ({
                 />
             )
         }
+        if (part.type === "data-attachment-delivery") {
+            return (
+                <AttachmentDeliveryNotice
+                    key={partKey}
+                    part={part as unknown as AttachmentDeliveryPart}
+                    filename={attachmentNames?.get(
+                        (part as unknown as AttachmentDeliveryPart).data.attachmentId,
+                    )}
+                />
+            )
+        }
         // Multi-modality: render attachments (sent by the user or returned by the
         // agent) as X `FileCard`s — images preview inline, other kinds show a typed
         // file chip with a download link.
         if (part.type === "file") {
-            const file = part as FileUIPart
-            const kind = fileKind(file.mediaType)
-            // A voice message is playable in the transcript, not an inert card.
-            if (kind === "audio") {
-                return (
-                    <AudioPlayer
-                        key={partKey}
-                        src={file.url}
-                        name={filePartName(file)}
-                        className="max-w-[320px] rounded-lg border border-solid border-colorBorderSecondary px-2 py-1.5"
-                    />
-                )
-            }
             return (
-                <FileCard
-                    key={partKey}
-                    name={filePartName(file)}
-                    type={kind}
-                    src={file.url}
-                    size="small"
-                    className="max-w-full"
-                    description={
-                        kind === "file" ? (
-                            <a
-                                href={file.url}
-                                download={filePartName(file)}
-                                className="text-xs text-colorPrimary"
-                            >
-                                {file.mediaType}
-                            </a>
-                        ) : undefined
-                    }
-                />
+                <AttachmentFilePart key={partKey} file={part as FileUIPart} sessionId={sessionId} />
             )
         }
         return null

--- a/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
@@ -12,8 +12,6 @@ import {WaitingForInput, WorkingDots} from "./TurnActivity"
 interface AgentTurnProps {
     message: UIMessage
     sessionId: string
-    /** Filenames from the preceding user turn, keyed by attachment id. */
-    attachmentNames?: ReadonlyMap<string, string>
     /** Fade in once — this turn arrived after mount. */
     enter: boolean
     isLast: boolean
@@ -51,7 +49,6 @@ interface AgentTurnProps {
 const AgentTurn = ({
     message,
     sessionId,
-    attachmentNames,
     enter,
     isLast,
     isStreaming,
@@ -83,7 +80,6 @@ const AgentTurn = ({
             <AgentMessage
                 message={message}
                 sessionId={sessionId}
-                attachmentNames={attachmentNames}
                 isStreaming={isStreaming}
                 isLastMessage={isLast}
                 onRewind={onRewind}

--- a/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
@@ -11,6 +11,9 @@ import {WaitingForInput, WorkingDots} from "./TurnActivity"
 
 interface AgentTurnProps {
     message: UIMessage
+    sessionId: string
+    /** Filenames from the preceding user turn, keyed by attachment id. */
+    attachmentNames?: ReadonlyMap<string, string>
     /** Fade in once — this turn arrived after mount. */
     enter: boolean
     isLast: boolean
@@ -47,6 +50,8 @@ interface AgentTurnProps {
  */
 const AgentTurn = ({
     message,
+    sessionId,
+    attachmentNames,
     enter,
     isLast,
     isStreaming,
@@ -77,6 +82,8 @@ const AgentTurn = ({
         >
             <AgentMessage
                 message={message}
+                sessionId={sessionId}
+                attachmentNames={attachmentNames}
                 isStreaming={isStreaming}
                 isLastMessage={isLast}
                 onRewind={onRewind}

--- a/web/oss/src/components/AgentChatSlice/components/AudioPlayer.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AudioPlayer.tsx
@@ -16,7 +16,17 @@ const fmt = (seconds: number): string => {
  * in the composer tray before sending, and in the transcript afterwards — so both surfaces share
  * this rather than showing an inert file chip.
  */
-const AudioPlayer = ({src, name, className}: {src: string; name: string; className?: string}) => {
+const AudioPlayer = ({
+    src,
+    name,
+    className,
+    onError,
+}: {
+    src: string
+    name: string
+    className?: string
+    onError?: () => void
+}) => {
     const audioRef = useRef<HTMLAudioElement>(null)
     // True while we nudge the element to resolve an unknown duration (below); the seek would
     // otherwise show up as a wild current-time reading.
@@ -113,7 +123,13 @@ const AudioPlayer = ({src, name, className}: {src: string; name: string; classNa
                     />
                 </div>
             </div>
-            <audio ref={audioRef} src={src} preload="metadata" className="hidden" />
+            <audio
+                ref={audioRef}
+                src={src}
+                preload="metadata"
+                onError={onError}
+                className="hidden"
+            />
         </div>
     )
 }

--- a/web/oss/src/components/AgentChatSlice/components/ComposerAttachments.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ComposerAttachments.tsx
@@ -52,11 +52,14 @@ const RemoveButton = ({
     name,
     onRemove,
     overlay,
+    persistent,
 }: {
     name: string
     onRemove: () => void
     /** Sits on top of a thumbnail rather than inline in a chip. */
     overlay?: boolean
+    /** Skips the hover reveal: on a scrimmed tile a hidden control reads as no control. */
+    persistent?: boolean
 }) => (
     <button
         type="button"
@@ -67,7 +70,7 @@ const RemoveButton = ({
         }}
         className={
             overlay
-                ? "absolute right-1 top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border-0 bg-[rgba(0,0,0,0.6)] text-white opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                ? `absolute right-1 top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border-0 bg-[rgba(0,0,0,0.6)] text-white transition-opacity ${persistent ? "" : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"}`
                 : "flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full border-0 bg-transparent text-colorTextTertiary transition-colors hover:bg-colorFillTertiary hover:text-colorText"
         }
     >
@@ -81,10 +84,12 @@ const StatusOverlay = ({
     file,
     onRetry,
     canRetry,
+    onRemove,
 }: {
     file: UploadFile
     onRetry?: (uid: string) => void
     canRetry: boolean
+    onRemove: () => void
 }) => {
     if (file.status === "uploading") {
         const pct = Math.max(0, Math.min(100, Math.round(file.percent ?? 0)))
@@ -120,6 +125,8 @@ const StatusOverlay = ({
                             <ArrowClockwise size={14} weight="bold" />
                         </button>
                     )}
+                    {/* The scrim covers the tile's own remove, so a failure must stay removable here. */}
+                    <RemoveButton name={file.name} onRemove={onRemove} overlay persistent />
                 </div>
             </Tooltip>
         )
@@ -395,6 +402,7 @@ const ComposerAttachments = ({
                                                 file={f}
                                                 onRetry={onRetry}
                                                 canRetry={canRetry?.(f.uid) ?? true}
+                                                onRemove={remove}
                                             />
                                         </motion.div>
                                     )

--- a/web/oss/src/components/AgentChatSlice/components/ComposerAttachments.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ComposerAttachments.tsx
@@ -2,7 +2,6 @@ import {useEffect, useRef, useState, type ReactNode} from "react"
 
 import {
     ArrowClockwise,
-    EyeSlash,
     File as FileIcon,
     FileText,
     Image as ImageIcon,
@@ -22,7 +21,6 @@ import {
     type AttachmentRejection,
     describeAccepted,
     formatBytes,
-    kindForType,
 } from "../assets/attachments"
 import {SESSION_SPRING} from "../assets/sessionMotion"
 
@@ -146,21 +144,6 @@ const Chip = ({
     >
         {children}
     </div>
-)
-
-const WorkspaceOnlyIndicator = ({name, overlay}: {name: string; overlay?: boolean}) => (
-    <Tooltip title="The model may not perceive this file. It will still be available to the agent’s tools.">
-        <span
-            aria-label={`${name} is workspace-only`}
-            className={
-                overlay
-                    ? "absolute bottom-1 left-1 flex h-5 w-5 items-center justify-center rounded-full bg-[rgba(0,0,0,0.6)] text-white"
-                    : "flex h-5 w-5 shrink-0 items-center justify-center text-colorTextTertiary"
-            }
-        >
-            <EyeSlash size={13} />
-        </span>
-    </Tooltip>
 )
 
 interface ComposerAttachmentsProps {
@@ -317,10 +300,6 @@ const ComposerAttachments = ({
                                 {files.map((f) => {
                                     const file = f.originFileObj as File | undefined
                                     const type = file?.type || ""
-                                    const workspaceOnly =
-                                        !limits.perceived[
-                                            kindForType(type || "application/octet-stream")
-                                        ]
                                     const Icon = iconForType(type)
                                     const size = file ? formatBytes(file.size) : ""
                                     const url = previews[f.uid]
@@ -343,9 +322,6 @@ const ComposerAttachments = ({
                                                         name={f.name}
                                                         className="min-w-0 flex-1"
                                                     />
-                                                    {workspaceOnly && (
-                                                        <WorkspaceOnlyIndicator name={f.name} />
-                                                    )}
                                                     <RemoveButton name={f.name} onRemove={remove} />
                                                 </Chip>
                                             ) : type.startsWith("image/") && url ? (
@@ -376,12 +352,6 @@ const ComposerAttachments = ({
                                                                 className="h-full w-full object-cover"
                                                             />
                                                         </>
-                                                    )}
-                                                    {workspaceOnly && (
-                                                        <WorkspaceOnlyIndicator
-                                                            name={f.name}
-                                                            overlay
-                                                        />
                                                     )}
                                                     <RemoveButton
                                                         name={f.name}
@@ -418,9 +388,6 @@ const ComposerAttachments = ({
                                                             </Text>
                                                         )}
                                                     </div>
-                                                    {workspaceOnly && (
-                                                        <WorkspaceOnlyIndicator name={f.name} />
-                                                    )}
                                                     <RemoveButton name={f.name} onRemove={remove} />
                                                 </Chip>
                                             )}

--- a/web/oss/src/components/AgentChatSlice/components/ComposerAttachments.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ComposerAttachments.tsx
@@ -2,7 +2,7 @@ import {useEffect, useRef, useState, type ReactNode} from "react"
 
 import {
     ArrowClockwise,
-    EarSlash,
+    EyeSlash,
     File as FileIcon,
     FileText,
     Image as ImageIcon,
@@ -22,6 +22,7 @@ import {
     type AttachmentRejection,
     describeAccepted,
     formatBytes,
+    kindForType,
 } from "../assets/attachments"
 import {SESSION_SPRING} from "../assets/sessionMotion"
 
@@ -77,8 +78,16 @@ const RemoveButton = ({
 )
 
 /** Upload state drawn over a tile: a progress scrim while uploading, a retry-able error otherwise.
- * Reads antd's `UploadFile` fields, so the (future) upload flow only has to set status/percent. */
-const StatusOverlay = ({file, onRetry}: {file: UploadFile; onRetry?: (uid: string) => void}) => {
+ * Reads antd's `UploadFile` fields, so the upload flow only has to set status/percent. */
+const StatusOverlay = ({
+    file,
+    onRetry,
+    canRetry,
+}: {
+    file: UploadFile
+    onRetry?: (uid: string) => void
+    canRetry: boolean
+}) => {
     if (file.status === "uploading") {
         const pct = Math.max(0, Math.min(100, Math.round(file.percent ?? 0)))
         return (
@@ -100,7 +109,7 @@ const StatusOverlay = ({file, onRetry}: {file: UploadFile; onRetry?: (uid: strin
         return (
             <Tooltip title={typeof file.error === "string" ? file.error : "Upload failed"}>
                 <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-[var(--ant-color-error-bg)] ring-1 ring-inset ring-colorError">
-                    {onRetry && (
+                    {onRetry && canRetry && (
                         <button
                             type="button"
                             aria-label={`Retry ${file.name}`}
@@ -139,13 +148,25 @@ const Chip = ({
     </div>
 )
 
+const WorkspaceOnlyIndicator = ({name, overlay}: {name: string; overlay?: boolean}) => (
+    <Tooltip title="The model may not perceive this file. It will still be available to the agent’s tools.">
+        <span
+            aria-label={`${name} is workspace-only`}
+            className={
+                overlay
+                    ? "absolute bottom-1 left-1 flex h-5 w-5 items-center justify-center rounded-full bg-[rgba(0,0,0,0.6)] text-white"
+                    : "flex h-5 w-5 shrink-0 items-center justify-center text-colorTextTertiary"
+            }
+        >
+            <EyeSlash size={13} />
+        </span>
+    </Tooltip>
+)
+
 interface ComposerAttachmentsProps {
     files: UploadFile[]
     rejections: AttachmentRejection[]
     limits: AttachmentLimits
-    /** Whether the model can take audio in; `null` when unknown. `false` marks an attached clip
-     * as workspace-only, since the model itself won't hear it (design decision D6). */
-    audioPerceivable: boolean | null
     /** Add picked files through the caller's guardrails (`validateIncoming`). */
     onAdd: (incoming: File[]) => void
     onRemove: (uid: string) => void
@@ -154,6 +175,8 @@ interface ComposerAttachmentsProps {
     onView?: (uid: string) => void
     /** Retry a failed upload (wired to the upload flow). */
     onRetry?: (uid: string) => void
+    /** Whether this upload error can be retried. */
+    canRetry?: (uid: string) => boolean
 }
 
 /**
@@ -167,12 +190,12 @@ const ComposerAttachments = ({
     files,
     rejections,
     limits,
-    audioPerceivable,
     onAdd,
     onRemove,
     onDismissRejections,
     onView,
     onRetry,
+    canRetry,
 }: ComposerAttachmentsProps) => {
     const inputRef = useRef<HTMLInputElement>(null)
     const [previews, setPreviews] = useState<Record<string, string>>({})
@@ -294,6 +317,10 @@ const ComposerAttachments = ({
                                 {files.map((f) => {
                                     const file = f.originFileObj as File | undefined
                                     const type = file?.type || ""
+                                    const workspaceOnly =
+                                        !limits.perceived[
+                                            kindForType(type || "application/octet-stream")
+                                        ]
                                     const Icon = iconForType(type)
                                     const size = file ? formatBytes(file.size) : ""
                                     const url = previews[f.uid]
@@ -310,31 +337,17 @@ const ComposerAttachments = ({
                                             exit="exit"
                                         >
                                             {type.startsWith("audio/") && url ? (
-                                                <Tooltip
-                                                    title={
-                                                        audioPerceivable === false
-                                                            ? "The model can’t hear this — attached for the agent’s tools only."
-                                                            : undefined
-                                                    }
-                                                >
-                                                    <Chip className="w-[248px]">
-                                                        <AudioPlayer
-                                                            src={url}
-                                                            name={f.name}
-                                                            className="min-w-0 flex-1"
-                                                        />
-                                                        {audioPerceivable === false && (
-                                                            <EarSlash
-                                                                size={14}
-                                                                className="shrink-0 text-colorTextTertiary"
-                                                            />
-                                                        )}
-                                                        <RemoveButton
-                                                            name={f.name}
-                                                            onRemove={remove}
-                                                        />
-                                                    </Chip>
-                                                </Tooltip>
+                                                <Chip className="w-[248px]">
+                                                    <AudioPlayer
+                                                        src={url}
+                                                        name={f.name}
+                                                        className="min-w-0 flex-1"
+                                                    />
+                                                    {workspaceOnly && (
+                                                        <WorkspaceOnlyIndicator name={f.name} />
+                                                    )}
+                                                    <RemoveButton name={f.name} onRemove={remove} />
+                                                </Chip>
                                             ) : type.startsWith("image/") && url ? (
                                                 <div
                                                     role={onView ? "button" : undefined}
@@ -363,6 +376,12 @@ const ComposerAttachments = ({
                                                                 className="h-full w-full object-cover"
                                                             />
                                                         </>
+                                                    )}
+                                                    {workspaceOnly && (
+                                                        <WorkspaceOnlyIndicator
+                                                            name={f.name}
+                                                            overlay
+                                                        />
                                                     )}
                                                     <RemoveButton
                                                         name={f.name}
@@ -399,10 +418,17 @@ const ComposerAttachments = ({
                                                             </Text>
                                                         )}
                                                     </div>
+                                                    {workspaceOnly && (
+                                                        <WorkspaceOnlyIndicator name={f.name} />
+                                                    )}
                                                     <RemoveButton name={f.name} onRemove={remove} />
                                                 </Chip>
                                             )}
-                                            <StatusOverlay file={f} onRetry={onRetry} />
+                                            <StatusOverlay
+                                                file={f}
+                                                onRetry={onRetry}
+                                                canRetry={canRetry?.(f.uid) ?? true}
+                                            />
                                         </motion.div>
                                     )
                                 })}

--- a/web/oss/src/components/AgentChatSlice/components/TranscriptPlaceholder.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TranscriptPlaceholder.tsx
@@ -17,6 +17,7 @@ import MessageRow from "./MessageRow"
  */
 const TranscriptPlaceholder = ({
     entityId,
+    sessionId,
     pendingFirstTurn,
     pendingFirstMessage,
     onboardingActive,
@@ -31,6 +32,7 @@ const TranscriptPlaceholder = ({
     onClientToolOutput,
 }: {
     entityId: string
+    sessionId: string
     pendingFirstTurn: string | null
     pendingFirstMessage: UIMessage
     onboardingActive: boolean
@@ -52,6 +54,7 @@ const TranscriptPlaceholder = ({
             <MessageRow mid="pending-first-turn" enter>
                 <AgentMessage
                     message={pendingFirstMessage}
+                    sessionId={sessionId}
                     isLastMessage
                     onRewind={onRewind}
                     onClientToolOutput={onClientToolOutput}

--- a/web/oss/src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts
@@ -1,0 +1,27 @@
+import type {UploadFile} from "antd"
+import {describe, expect, it, vi} from "vitest"
+
+import {isUploadRetryReady, removeUploadFile} from "./useAttachmentUploads"
+
+describe("attachment upload controls", () => {
+    it("aborts an in-flight upload before removing its chip", () => {
+        const abort = vi.fn()
+        const files: UploadFile[] = [
+            {uid: "remove-me", name: "first.txt", status: "uploading"},
+            {uid: "keep-me", name: "second.txt", status: "done"},
+        ]
+        let nextFiles: UploadFile[] = []
+
+        removeUploadFile("remove-me", abort, (updater) => {
+            expect(abort).toHaveBeenCalledWith("remove-me")
+            nextFiles = updater(files)
+        })
+
+        expect(nextFiles).toEqual([files[1]])
+    })
+
+    it("holds retry until the Retry-After deadline", () => {
+        expect(isUploadRetryReady(7_000, 6_999)).toBe(false)
+        expect(isUploadRetryReady(7_000, 7_000)).toBe(true)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/hooks/useAttachmentUploads.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAttachmentUploads.ts
@@ -2,40 +2,63 @@ import {useCallback, useEffect, useRef} from "react"
 
 import type {UploadFile} from "antd"
 
-/**
- * Owns the per-attachment upload lifecycle, expressed on antd's `UploadFile` fields so the tray
- * renders straight off them: `status` (`uploading` | `done` | `error`), `percent`, and `error`
- * (a message). Everything is driven through here so the transport is the ONLY thing left to wire.
- *
- * `upload` is the seam. Until an upload transport exists it is left undefined: `enqueue` is then a
- * no-op and files stay `done` (ready to send), exactly as today. Provide an `upload` and the whole
- * progress / success / failure / retry flow runs with no other change — the tray already renders
- * every state.
- */
-export type AttachmentUploader = (
+/** Owns upload progress, retry, cancellation, and the validated response on each tray entry. */
+export type AttachmentUploader<TResponse = unknown> = (
     file: File,
-    ctx: {onProgress: (percent: number) => void; signal: AbortSignal},
-) => Promise<void>
+    ctx: {uid: string; onProgress: (percent: number) => void; signal: AbortSignal},
+) => Promise<TResponse>
+
+type SetAttachmentFiles<TResponse> = (
+    updater: (prev: UploadFile<TResponse>[]) => UploadFile<TResponse>[],
+) => void
 
 export interface AttachmentUploads {
     /** Start (or restart) upload for these uids. No-op without an `upload` transport. */
     enqueue: (uids: string[]) => void
-    /** Retry one failed upload. */
+    /** Retry one failed upload when its server-provided delay has elapsed. */
     retry: (uid: string) => void
+    /** Whether the failed upload should expose a retry action. */
+    canRetry: (uid: string) => boolean
+    /** Abort and release one in-flight upload. */
+    abort: (uid: string) => void
 }
 
-export function useAttachmentUploads(
-    files: UploadFile[],
-    setFiles: (updater: (prev: UploadFile[]) => UploadFile[]) => void,
-    upload?: AttachmentUploader,
+interface UploadFailureDetails {
+    retryable?: boolean
+    retryAfterSeconds?: number
+}
+
+const failureDetails = (error: unknown): UploadFailureDetails =>
+    error && typeof error === "object" ? (error as UploadFailureDetails) : {}
+
+export const isUploadRetryReady = (retryAt: number | undefined, now = Date.now()): boolean =>
+    retryAt === undefined || now >= retryAt
+
+export const removeUploadFile = <TResponse>(
+    uid: string,
+    abort: (uid: string) => void,
+    setFiles: SetAttachmentFiles<TResponse>,
+): void => {
+    abort(uid)
+    setFiles((prev) => prev.filter((file) => file.uid !== uid))
+}
+
+export function useAttachmentUploads<TResponse>(
+    files: UploadFile<TResponse>[],
+    setFiles: SetAttachmentFiles<TResponse>,
+    upload?: AttachmentUploader<TResponse>,
 ): AttachmentUploads {
     // Read the latest files (for the File blob) without making `run` depend on every list change.
     const filesRef = useRef(files)
     filesRef.current = files
     const controllers = useRef(new Map<string, AbortController>())
+    const queued = useRef(new Set<string>())
+    const retryAt = useRef(new Map<string, number>())
+    const retryable = useRef(new Map<string, boolean>())
+    const retryTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
 
     const patch = useCallback(
-        (uid: string, next: Partial<UploadFile>) => {
+        (uid: string, next: Partial<UploadFile<TResponse>>) => {
             setFiles((prev) => prev.map((f) => (f.uid === uid ? {...f, ...next} : f)))
         },
         [setFiles],
@@ -52,39 +75,110 @@ export function useAttachmentUploads(
             controllers.current.get(uid)?.abort()
             const controller = new AbortController()
             controllers.current.set(uid, controller)
+            retryAt.current.delete(uid)
+            retryable.current.delete(uid)
+
+            clearTimeout(retryTimers.current.get(uid))
+            retryTimers.current.delete(uid)
+
+            const release = () => {
+                if (controllers.current.get(uid) === controller) controllers.current.delete(uid)
+            }
 
             patch(uid, {status: "uploading", percent: 0, error: undefined})
             upload(file, {
+                uid,
                 onProgress: (percent) => patch(uid, {status: "uploading", percent}),
                 signal: controller.signal,
             })
-                .then(() => {
+                .then((response) => {
                     if (controller.signal.aborted) return
-                    controllers.current.delete(uid)
-                    patch(uid, {status: "done", percent: 100})
+                    release()
+                    patch(uid, {status: "done", percent: 100, response})
                 })
-                .catch((e: unknown) => {
+                .catch((error: unknown) => {
                     if (controller.signal.aborted) return
-                    controllers.current.delete(uid)
+                    release()
+                    const details = failureDetails(error)
+                    retryable.current.set(uid, details.retryable !== false)
+                    if (details.retryAfterSeconds !== undefined) {
+                        retryAt.current.set(uid, Date.now() + details.retryAfterSeconds * 1000)
+                    }
                     patch(uid, {
                         status: "error",
-                        error: e instanceof Error ? e.message : "Upload failed",
+                        error: error instanceof Error ? error.message : "Upload failed",
                     })
                 })
         },
         [upload, patch],
     )
 
-    const enqueue = useCallback((uids: string[]) => uids.forEach(run), [run])
-    const retry = useCallback((uid: string) => run(uid), [run])
+    const abort = useCallback((uid: string) => {
+        queued.current.delete(uid)
+        retryAt.current.delete(uid)
+        retryable.current.delete(uid)
+        clearTimeout(retryTimers.current.get(uid))
+        retryTimers.current.delete(uid)
+        const controller = controllers.current.get(uid)
+        controllers.current.delete(uid)
+        controller?.abort()
+    }, [])
+    const enqueue = useCallback((uids: string[]) => {
+        uids.forEach((uid) => queued.current.add(uid))
+    }, [])
+    useEffect(() => {
+        // A remounted tray resumes in-flight entries with the same uid/idempotency key.
+        for (const file of files) {
+            if (
+                file.status === "uploading" &&
+                file.originFileObj &&
+                !controllers.current.has(file.uid)
+            ) {
+                queued.current.add(file.uid)
+            }
+        }
+        for (const uid of queued.current) {
+            if (!files.some((file) => file.uid === uid)) continue
+            queued.current.delete(uid)
+            run(uid)
+        }
+    }, [files, run])
+    const retry = useCallback(
+        (uid: string) => {
+            if (retryable.current.get(uid) === false) return
+            const allowedAt = retryAt.current.get(uid)
+            if (!isUploadRetryReady(allowedAt)) {
+                clearTimeout(retryTimers.current.get(uid))
+                retryTimers.current.set(
+                    uid,
+                    setTimeout(
+                        () => {
+                            retryTimers.current.delete(uid)
+                            run(uid)
+                        },
+                        Math.max(0, (allowedAt ?? Date.now()) - Date.now()),
+                    ),
+                )
+                return
+            }
+            run(uid)
+        },
+        [run],
+    )
+    const canRetry = useCallback((uid: string) => retryable.current.get(uid) !== false, [])
 
     // Abort in-flight uploads on unmount (session switch / pane close).
     useEffect(() => {
         const map = controllers.current
-        return () => map.forEach((c) => c.abort())
+        return () => {
+            map.forEach((controller) => controller.abort())
+            map.clear()
+            retryTimers.current.forEach((timer) => clearTimeout(timer))
+            retryTimers.current.clear()
+        }
     }, [])
 
-    return {enqueue, retry}
+    return {enqueue, retry, canRetry, abort}
 }
 
 /** Aggregate upload state for composer-level messaging and send-gating. */

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
@@ -203,9 +203,10 @@ export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
         return {onDragEnter, onDragOver, onDragLeave, onDrop}
     }
 
-    /** Everything the composer just sent has left — drop the pending set and any rejection notice. */
-    const clearAttachments = () => {
-        setFiles([])
+    /** Drop the attachments a send just carried, plus any rejection notice. */
+    const clearAttachments = (consumedUids: string[]) => {
+        // Only what this send carried: anything staged while it was in flight belongs to the next message.
+        setFiles((prev) => prev.filter((file) => !consumedUids.includes(file.uid)))
         setRejections([])
         setAttachmentsOpen(false)
     }

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
@@ -4,8 +4,8 @@ import {generateId} from "@agenta/shared/utils"
 import type {UploadFile} from "antd"
 
 import {
-    type AttachmentLimits,
     type AttachmentRejection,
+    DEFAULT_ATTACHMENT_LIMITS,
     validateIncoming,
 } from "../assets/attachments"
 import {uploadAttachment, type SessionAttachmentResponse} from "../assets/attachmentTransport"
@@ -33,14 +33,7 @@ const toUploadFile = (file: File, uploadsEnabled: boolean): StagedFile => ({
  * the preview target, and the whole-panel drag-and-drop that feeds them. Files survive a remount
  * (route re-entry, tab close/reopen) alongside the composer draft; rejections stay transient.
  */
-export const useComposerAttachments = ({
-    sessionId,
-    limits,
-}: {
-    sessionId: string
-    /** Model-derived guardrails; perception rides along on the same object. */
-    limits: AttachmentLimits
-}) => {
+export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
     // Gate every attachment path on NEXT_PUBLIC_AGENT_FILE_UPLOADS until file parts are supported.
     const uploadsEnabled = isAgentFileUploadsEnabled()
     // Restored from the per-session store on remount (route re-entry, tab close/reopen) —
@@ -57,6 +50,8 @@ export const useComposerAttachments = ({
     // The attachment currently open in the Files-drawer preview (its uid), or null when closed.
     const [viewingUid, setViewingUid] = useState<string | null>(null)
     const [attachmentsOpen, setAttachmentsOpen] = useState(false)
+    // Single limits object so it can later be swapped for capability-derived limits.
+    const limits = DEFAULT_ATTACHMENT_LIMITS
     const atMax = files.length >= limits.maxCount
     // Drag-over state for the whole-panel drop overlay (depth counter avoids child flicker).
     const dragDepthRef = useRef(0)

--- a/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useComposerAttachments.ts
@@ -1,25 +1,30 @@
-import {useEffect, useRef, useState} from "react"
+import {useCallback, useEffect, useRef, useState} from "react"
 
 import {generateId} from "@agenta/shared/utils"
 import type {UploadFile} from "antd"
 
 import {
+    type AttachmentLimits,
     type AttachmentRejection,
-    DEFAULT_ATTACHMENT_LIMITS,
     validateIncoming,
 } from "../assets/attachments"
+import {uploadAttachment, type SessionAttachmentResponse} from "../assets/attachmentTransport"
 import {isAgentFileUploadsEnabled} from "../assets/constants"
 import {attachmentsBySession} from "../state/sessionEphemera"
 
-import {useAttachmentUploads} from "./useAttachmentUploads"
+import {removeUploadFile, useAttachmentUploads} from "./useAttachmentUploads"
 
-// `uid` is the tray's React key, its preview-URL key, and the remove / view / retry handle, so it
-// has to be unique per TRAY ROW. Deriving it from name+mtime+size collided whenever the same file
-// was attached twice (paste then drop) — one remove then wiped both rows and their previews.
-const toUploadFile = (file: File): UploadFile => ({
+type StagedFile = UploadFile<SessionAttachmentResponse>
+
+// `uid` is the tray's React key, its preview-URL key, the remove / view / retry handle, and the
+// upload's idempotency key, so it has to be unique per TRAY ROW. Deriving it from name+mtime+size
+// collided whenever the same file was attached twice (paste then drop) — one remove then wiped
+// both rows and their previews.
+const toUploadFile = (file: File, uploadsEnabled: boolean): StagedFile => ({
     uid: `att-${generateId()}`,
     name: file.name,
-    status: "done",
+    status: uploadsEnabled ? "uploading" : "done",
+    percent: uploadsEnabled ? 0 : 100,
     originFileObj: file as UploadFile["originFileObj"],
 })
 
@@ -28,12 +33,19 @@ const toUploadFile = (file: File): UploadFile => ({
  * the preview target, and the whole-panel drag-and-drop that feeds them. Files survive a remount
  * (route re-entry, tab close/reopen) alongside the composer draft; rejections stay transient.
  */
-export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
+export const useComposerAttachments = ({
+    sessionId,
+    limits,
+}: {
+    sessionId: string
+    /** Model-derived guardrails; perception rides along on the same object. */
+    limits: AttachmentLimits
+}) => {
     // Gate every attachment path on NEXT_PUBLIC_AGENT_FILE_UPLOADS until file parts are supported.
     const uploadsEnabled = isAgentFileUploadsEnabled()
     // Restored from the per-session store on remount (route re-entry, tab close/reopen) —
     // pending attachments survive alongside the composer draft. Rejections stay transient.
-    const [files, setFiles] = useState<UploadFile[]>(
+    const [files, setFiles] = useState<StagedFile[]>(
         () => attachmentsBySession.get(sessionId) ?? [],
     )
     useEffect(() => {
@@ -45,20 +57,38 @@ export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
     // The attachment currently open in the Files-drawer preview (its uid), or null when closed.
     const [viewingUid, setViewingUid] = useState<string | null>(null)
     const [attachmentsOpen, setAttachmentsOpen] = useState(false)
-    // Single limits object so it can later be swapped for capability-derived limits.
-    const limits = DEFAULT_ATTACHMENT_LIMITS
     const atMax = files.length >= limits.maxCount
     // Drag-over state for the whole-panel drop overlay (depth counter avoids child flicker).
     const dragDepthRef = useRef(0)
     const [isDragging, setIsDragging] = useState(false)
 
-    // Upload lifecycle for the tray (progress / error / retry). The transport is not wired yet, so
-    // no uploader is passed — files stay "done" and enqueue is a no-op. When upload lands, provide
-    // an uploader here and the whole flow runs; the tray already renders every state.
-    const uploads = useAttachmentUploads(files, setFiles, undefined)
-    // A staged attachment blocks send only once uploads exist: while any is uploading or has failed,
-    // the message isn't ready. All-"done" today, so this is inert until the transport is wired.
-    const attachmentsSettled = !files.some((f) => f.status === "uploading" || f.status === "error")
+    // One multipart upload per staged file; the tray uid doubles as the idempotency key, so a
+    // retry reuses the original identity instead of minting a second attachment.
+    const attachmentUploader = useCallback(
+        (
+            file: File,
+            {
+                uid,
+                onProgress,
+                signal,
+            }: {uid: string; onProgress: (percent: number) => void; signal: AbortSignal},
+        ) => uploadAttachment({file, sessionId, idempotencyKey: uid, onProgress, signal}),
+        [sessionId],
+    )
+    // Upload lifecycle for the tray (progress / error / retry).
+    const uploads = useAttachmentUploads(files, setFiles, attachmentUploader)
+    // A staged attachment blocks send until its reference exists; without uploads the inline path
+    // only needs every entry to be settled.
+    const attachmentsSettled = uploadsEnabled
+        ? files.every((file) => file.status === "done" && Boolean(file.response?.attachment))
+        : files.every((file) => file.status === "done")
+
+    /** Why send is held, for the send button's tooltip. */
+    const uploadBlockReason = files.some((file) => file.status === "error")
+        ? "an upload failed"
+        : files.some((file) => file.status === "uploading")
+          ? "waiting for uploads"
+          : undefined
 
     /** Add files from paste / programmatic sources through the guardrails. */
     const addFiles = (incoming: File[], extraRejections: AttachmentRejection[] = []) => {
@@ -67,9 +97,9 @@ export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
         if (accepted.length) {
             // Stage once and enqueue the MINTED uids — re-deriving them here is what let the tray
             // row and its upload disagree about which entry they addressed.
-            const staged = accepted.map(toUploadFile)
+            const staged = accepted.map((file) => toUploadFile(file, uploadsEnabled))
             setFiles((prev) => [...prev, ...staged])
-            uploads.enqueue(staged.map((f) => f.uid))
+            if (uploadsEnabled) uploads.enqueue(staged.map((f) => f.uid))
         }
         setRejections(allRejections)
         // Open for rejections too. Otherwise dropping something unsupported writes a message into
@@ -77,7 +107,43 @@ export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
         if (accepted.length || allRejections.length) setAttachmentsOpen(true)
     }
 
-    const removeFile = (uid: string) => setFiles((prev) => prev.filter((f) => f.uid !== uid))
+    // Removing a chip also aborts its in-flight request.
+    const removeFile = (uid: string) => removeUploadFile(uid, uploads.abort, setFiles)
+
+    /**
+     * Upload files that never entered the tray (a voice take sent outright) and return their staged
+     * entries. A failure adopts them into the tray so the error is visible and retryable, and
+     * returns null so the caller holds the send.
+     */
+    const uploadExtraFiles = async (extraFiles: File[]): Promise<StagedFile[] | null> => {
+        const staged = extraFiles.map((file) => toUploadFile(file, uploadsEnabled))
+        const results = await Promise.allSettled(
+            staged.map(async (entry) => {
+                const response = await attachmentUploader(entry.originFileObj as File, {
+                    uid: entry.uid,
+                    onProgress: () => undefined,
+                    signal: new AbortController().signal,
+                })
+                return {...entry, status: "done" as const, percent: 100, response}
+            }),
+        )
+        if (results.every((result) => result.status === "fulfilled")) {
+            return results.map((result) => (result as PromiseFulfilledResult<StagedFile>).value)
+        }
+        const settledEntries = results.map((result, index) =>
+            result.status === "fulfilled"
+                ? result.value
+                : {
+                      ...staged[index],
+                      status: "error" as const,
+                      error:
+                          result.reason instanceof Error ? result.reason.message : "Upload failed",
+                  },
+        )
+        setFiles((prev) => [...prev, ...settledEntries])
+        setAttachmentsOpen(true)
+        return null
+    }
 
     // Native drag-and-drop onto the whole panel. A depth counter ignores dragenter/leave from
     // nested children so the overlay doesn't flicker; only file drags (not text) are handled.
@@ -161,9 +227,11 @@ export const useComposerAttachments = ({sessionId}: {sessionId: string}) => {
         limits,
         atMax,
         attachmentsSettled,
+        uploadBlockReason,
         isDragging,
         addFiles,
         removeFile,
+        uploadExtraFiles,
         uploads,
         clearAttachments,
         bindDropTarget,

--- a/web/oss/test-results/junit.xml
+++ b/web/oss/test-results/junit.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="30" failures="0" errors="0" time="0.032288188">
+    <testsuite name="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" timestamp="2026-08-01T11:09:33.230Z" hostname="hetznerdev" tests="11" failures="0" errors="0" skipped="0" time="0.010121087">
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; posts the multipart fields and returns a validated response" time="0.003471653">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; reports upload progress" time="0.000814108">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; forwards the abort signal and preserves cancellation" time="0.000653035">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; turns a network failure into a retryable user-safe error" time="0.000686211">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 413 to a short non-retryable error" time="0.000424088">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 422 to a short non-retryable error" time="0.000196312">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 429 to a short non-retryable error" time="0.000154228">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 404 to a short non-retryable error" time="0.000152516">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; honours Retry-After for an upload already in flight" time="0.000302608">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; logs schema drift and throws a controlled retryable error" time="0.001929139">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; rejects uppercase attachment ids emitted outside the canonical server contract" time="0.000383141">
+        </testcase>
+    </testsuite>
+    <testsuite name="src/components/AgentChatSlice/assets/attachments.test.ts" timestamp="2026-08-01T11:09:33.231Z" hostname="hetznerdev" tests="3" failures="0" errors="0" skipped="0" time="0.00468596">
+        <testcase classname="src/components/AgentChatSlice/assets/attachments.test.ts" name="attachment validation &gt; accepts an unrecognized media type through the other bucket" time="0.00267367">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachments.test.ts" name="attachment validation &gt; enforces the 10 MB cap for the other bucket" time="0.000485362">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/attachments.test.ts" name="attachment validation &gt; enforces the per-message count cap" time="0.000246304">
+        </testcase>
+    </testsuite>
+    <testsuite name="src/components/AgentChatSlice/assets/files.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="2" failures="0" errors="0" skipped="0" time="0.002946947">
+        <testcase classname="src/components/AgentChatSlice/assets/files.test.ts" name="attachment file parts &gt; stores size under providerMetadata.agenta" time="0.001929868">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/files.test.ts" name="attachment file parts &gt; uses attachment when a replayed part has no filename" time="0.000179434">
+        </testcase>
+    </testsuite>
+    <testsuite name="src/components/AgentChatSlice/assets/inFlightSubmit.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="1" failures="0" errors="0" skipped="0" time="0.004511831">
+        <testcase classname="src/components/AgentChatSlice/assets/inFlightSubmit.test.ts" name="in-flight submit guard &gt; drops a second submit while the first await is unresolved" time="0.003093821">
+        </testcase>
+    </testsuite>
+    <testsuite name="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="11" failures="0" errors="0" skipped="0" time="0.005936531">
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; overlays a persisted approval response with the live response shape" time="0.001695614">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; keeps an unanswered request pending" time="0.000248943">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; lets an executed tool result supersede a later approval response" time="0.00020205">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; falls back to the interaction id when the response omits the tool-call id" time="0.00017115">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; reopens deferred call b when its turn-2 approval request arrives" time="0.00078471">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; keeps a real tool error closed when a late approval request arrives" time="0.000160332">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; merges a paused turn with its resume into one message and settles the re-emitted call once" time="0.000819154">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages paused end-marker &gt; flags the message whose turn ended paused (done.stopReason)" time="0.000186444">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages paused end-marker &gt; does not flag a normally completed turn" time="0.00014934">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages attachments &gt; rebuilds user attachment references as file parts with filenames" time="0.000353669">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages attachments &gt; ignores an attachment delivery record instead of rendering a part" time="0.000128959">
+        </testcase>
+    </testsuite>
+    <testsuite name="src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="2" failures="0" errors="0" skipped="0" time="0.004085832">
+        <testcase classname="src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts" name="attachment upload controls &gt; aborts an in-flight upload before removing its chip" time="0.002586717">
+        </testcase>
+        <testcase classname="src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts" name="attachment upload controls &gt; holds retry until the Retry-After deadline" time="0.000224426">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
+++ b/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
@@ -1,0 +1,96 @@
+import {
+    TestCostType,
+    TestCoverage,
+    TestLensType,
+    TestLicenseType,
+    TestPath,
+    TestRoleType,
+    TestScope,
+    TestSpeedType,
+    TestcaseType,
+} from "@agenta/web-tests/playwright/config/testTags"
+import {expect} from "@agenta/web-tests/utils"
+
+import {expectAuthenticatedSession} from "../utils/auth"
+import {buildAcceptanceTags} from "../utils/tags"
+
+import {resumeTextTurn, sseFulfill} from "./assets/elicitationStream"
+import {test} from "./tests"
+
+const tags = buildAcceptanceTags({
+    scope: [TestScope.PLAYGROUND],
+    coverage: [TestCoverage.SMOKE, TestCoverage.LIGHT, TestCoverage.FULL],
+    path: TestPath.HAPPY,
+    lens: TestLensType.FUNCTIONAL,
+    cost: TestCostType.Free,
+    license: TestLicenseType.OSS,
+    role: TestRoleType.Owner,
+    caseType: TestcaseType.TYPICAL,
+    speed: TestSpeedType.SLOW,
+})
+
+const IMAGE_NAME = "attachment-round-trip.png"
+const IMAGE = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zc1sAAAAASUVORK5CYII=",
+    "base64",
+)
+
+test(
+    "an uploaded attachment renders after send and after reload",
+    {tag: tags},
+    async ({page, seedAgentChatApp, navigateToAgentPlayground}) => {
+        await expectAuthenticatedSession(page)
+        const appId = await seedAgentChatApp()
+        await navigateToAgentPlayground(appId)
+
+        let run = 0
+        await page.route("**/invoke*", async (route) => {
+            run += 1
+            await route.fulfill(
+                sseFulfill(resumeTextTurn({messageId: `attachment-run-${run}`, text: "Done."})),
+            )
+        })
+
+        let contentReads = 0
+        page.on("request", (request) => {
+            if (new URL(request.url()).pathname.match(/\/sessions\/attachments\/[^/]+\/content$/)) {
+                contentReads += 1
+            }
+        })
+
+        const composer = page.getByRole("textbox").last()
+        await page.getByRole("button", {name: "Attach files"}).click()
+
+        const uploadResponsePromise = page.waitForResponse((response) => {
+            const url = new URL(response.url())
+            return (
+                response.request().method() === "POST" &&
+                url.pathname.endsWith("/sessions/attachments") &&
+                url.searchParams.has("session_id")
+            )
+        })
+        await page.locator('input[type="file"][multiple]').last().setInputFiles({
+            name: IMAGE_NAME,
+            mimeType: "image/png",
+            buffer: IMAGE,
+        })
+        expect((await uploadResponsePromise).ok()).toBe(true)
+        await expect(page.getByAltText(IMAGE_NAME)).toBeVisible()
+
+        const runRequestPromise = page.waitForRequest(
+            (request) => request.method() === "POST" && request.url().includes("/invoke"),
+        )
+        await composer.fill("Describe the attached image.")
+        await composer.press("Enter")
+
+        const runRequest = await runRequestPromise
+        expect(runRequest.postData() ?? "").not.toContain("data:")
+        await expect(page.getByText(IMAGE_NAME, {exact: true}).last()).toBeVisible()
+        await expect.poll(() => contentReads).toBeGreaterThanOrEqual(1)
+
+        await page.reload({waitUntil: "domcontentloaded"})
+
+        await expect(page.getByText(IMAGE_NAME, {exact: true}).last()).toBeVisible()
+        await expect.poll(() => contentReads).toBeGreaterThanOrEqual(2)
+    },
+)

--- a/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
@@ -67,6 +67,10 @@ export interface RichChatInputProps {
     onPasteFile?: (files: FileList) => void
     /** Keep the send button enabled with empty text (e.g. attachments pending) — sends "". */
     sendForceEnabled?: boolean
+    /** Disable submit without locking the editor (e.g. an attachment upload failed). */
+    sendDisabled?: boolean
+    /** Explain why submit is disabled without locking the editor. */
+    sendDisabledReason?: ReactNode
     /** Hide the built-in send button (keyboard-only). */
     hideSendButton?: boolean
     /** A stream is in flight — the send button becomes a Stop button. */
@@ -126,6 +130,7 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
             trailing,
             onPasteFile,
             sendForceEnabled,
+            sendDisabled,
             hideSendButton,
             streaming,
             onStop,
@@ -133,6 +138,7 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
             size = "compact",
             textSizeClassName = "text-xs",
             hideShortcutHints = false,
+            sendDisabledReason,
             submitOnEnter = true,
             onChange,
             initialMarkdown,
@@ -281,7 +287,8 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                                 <SendButton
                                     onSubmit={onSubmit}
                                     forceEnabled={sendForceEnabled}
-                                    disabled={disabled}
+                                    disabled={disabled || sendDisabled}
+                                    disabledReason={sendDisabledReason}
                                     streaming={streaming}
                                     onStop={onStop}
                                 />
@@ -307,7 +314,9 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                     <MarkdownShortcutPlugin transformers={CHAT_TRANSFORMERS} />
                     {/* Enter on a lone ``` fence opener → code block (runs before SubmitPlugin). */}
                     <CodeFencePlugin />
-                    {submitOnEnter ? <SubmitPlugin onSubmit={onSubmit} /> : null}
+                    {submitOnEnter ? (
+                        <SubmitPlugin onSubmit={onSubmit} disabled={sendDisabled} />
+                    ) : null}
                     <FocusStatePlugin onFocusChange={setFocused} />
                     {onChange ? <CharacterCountPlugin onTextChange={onChange} /> : null}
                 </div>

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/SendButton.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/SendButton.tsx
@@ -1,8 +1,8 @@
-import {useEffect, useState} from "react"
+import {useEffect, useState, type ReactNode} from "react"
 
 import {useLexicalComposerContext} from "@lexical/react/LexicalComposerContext"
 import {Stop} from "@phosphor-icons/react"
-import {Button} from "antd"
+import {Button, Tooltip} from "antd"
 
 import {$isBlankMessage, submitEditorAsMarkdown} from "../assets/submit"
 import {ComposerSendButton} from "../ComposerSendButton"
@@ -12,6 +12,8 @@ interface SendButtonProps {
     /** Keep enabled even with empty text (e.g. attachments are queued) — sends an empty message. */
     forceEnabled?: boolean
     disabled?: boolean
+    /** Tooltip shown when a caller blocks submit. */
+    disabledReason?: ReactNode
     /** When true, the button becomes a Stop button that aborts the in-flight stream. */
     streaming?: boolean
     /** Abort the in-flight stream — required for the `streaming` state. */
@@ -21,7 +23,14 @@ interface SendButtonProps {
 /** Circular send button. Mirrors the Cmd/Ctrl+Enter path via the shared submit helper.
  * While a stream is in flight it morphs into a Stop button (single affordance, no extra
  * stop control alongside it). */
-export function SendButton({onSubmit, forceEnabled, disabled, streaming, onStop}: SendButtonProps) {
+export function SendButton({
+    onSubmit,
+    forceEnabled,
+    disabled,
+    disabledReason,
+    streaming,
+    onStop,
+}: SendButtonProps) {
     const [editor] = useLexicalComposerContext()
     const [empty, setEmpty] = useState(true)
 
@@ -76,5 +85,12 @@ export function SendButton({onSubmit, forceEnabled, disabled, streaming, onStop}
     }
 
     const sendDisabled = disabled || (empty && !forceEnabled)
-    return <ComposerSendButton onClick={handleClick} disabled={sendDisabled} />
+    const button = <ComposerSendButton onClick={handleClick} disabled={sendDisabled} />
+    if (!sendDisabled || !disabledReason) return button
+
+    return (
+        <Tooltip title={disabledReason}>
+            <span className="inline-flex">{button}</span>
+        </Tooltip>
+    )
 }

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/SubmitPlugin.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/SubmitPlugin.tsx
@@ -7,6 +7,7 @@ import {submitEditorAsMarkdown} from "../assets/submit"
 
 interface SubmitPluginProps {
     onSubmit: (markdown: string) => void
+    disabled?: boolean
 }
 
 /**
@@ -16,7 +17,7 @@ interface SubmitPluginProps {
  * an exit-to-paragraph from an empty list item, a new line in code, a new paragraph in
  * text — and the caret lands at a block start so markdown shortcuts fire on it.
  */
-export function SubmitPlugin({onSubmit}: SubmitPluginProps) {
+export function SubmitPlugin({onSubmit, disabled}: SubmitPluginProps) {
     const [editor] = useLexicalComposerContext()
 
     useEffect(() => {
@@ -35,6 +36,11 @@ export function SubmitPlugin({onSubmit}: SubmitPluginProps) {
                     return true
                 }
 
+                if (disabled) {
+                    event.preventDefault()
+                    return true
+                }
+
                 // Plain Enter → always send.
                 event.preventDefault()
                 submitEditorAsMarkdown(editor, onSubmit)
@@ -42,7 +48,7 @@ export function SubmitPlugin({onSubmit}: SubmitPluginProps) {
             },
             COMMAND_PRIORITY_HIGH,
         )
-    }, [editor, onSubmit])
+    }, [disabled, editor, onSubmit])
 
     return null
 }


### PR DESCRIPTION
The composer collects files but has no transport: every attachment inlines as a base64 data URL, bloats browser storage and the wire, disappears from reloaded sessions, and the person never learns whether the model actually saw it. This is work package 4 of 4 of the Stage 1 plan, the producer the reader-first rollout saved for last, stacked on the SDK package #5617.

**Before:** attach inlines base64; a reloaded session loses user attachments; no upload progress, no retry, no honest errors; nothing tells the user a file went workspace-only.
**After:** attaching uploads once through `POST /sessions/attachments` (progress, abort on chip removal, retry reusing the same idempotency key, send blocked with a tooltip until every upload settles) and the message carries a reference: the content URL in the part plus `{attachmentId, size}` in `providerMetadata.agenta`, never base64. Upload errors are told apart (cap, invalid file, session quota, in-flight with Retry-After, old-backend 404). Sent and reloaded conversations render through the content route with an authenticated blob fallback and no eager downloads; durable records rebuild user file parts with filenames; `attachment_delivery` events are parsed and persisted but render nothing (the product owner removed both notice surfaces; a future surface can render the persisted events without wire changes). The per-turn attachment count is 100 (raised from the dark-shipped 5 at the product owner's direction; the per-session quotas are the real bound). Voice recordings use references only when the uploads flag is on and keep their inline path otherwise, so the two flags stay independent.

Adversarially reviewed before opening: fourteen findings, four merge blockers, all fixed. The blockers were exactly the quiet kind: the acceptance Playwright spec sat one directory outside the collected test root (it now lives with its siblings, tagged, no silent skip); voice messages would have broken whenever uploads were off; `size` sat top-level where the AI SDK's validation strips it; and a hardcoded perception map contradicted the capability data computed ten lines away. Full trail in `protocols/stage-1.md`.

## Implicit decisions and their tradeoffs

- **The shared composer package changed** (`RichChatInput`, `SubmitPlugin`, `SendButton` gain send-only disabling). The review enumerated all three consumers; the new props default to today's behavior, so the other two surfaces are untouched.
- **The tray uid doubles as the idempotency key** (one comment states it): that identity is what makes retry safe, and `generateId()` is used over `crypto.randomUUID` because dev boxes are reached over plain HTTP where the latter is undefined.
- **Static limits stay** (`DEFAULT_ATTACHMENT_LIMITS`): capability-derived limits are a Stage 2 item.
- **web/oss joins the unit-test loop** with an explicit include list (the 13 pre-existing orphaned test files stay excluded, tracked in #5618). The junit reporter is wired; the one-line CI glob addition for its report is left uncommitted because the push credential lacks the workflow scope; it is a follow-up line for a push with that scope.

## Forced routes to double-check

- **Axios, not Fern, for upload and blob read**: the documented exception (Fern's fetch cannot report upload progress; Fern JSON-parses binary), with zod at the boundary. The OpenAPI/Fern regeneration for typed accessors elsewhere in the domain is a stated follow-up.
- **Legacy base64 history keeps its old render path**: only newly sent files use references; old conversations change nothing.

## QA

lint clean, typecheck clean, 34 unit tests green with junit output. The full end-to-end live QA ran on the dev stack with all four packages deployed (full record in `protocols/stage-1.md`):

- **Reference upload + perception**: the upload POST returns 200 with a real multipart body, the run request carries the reference (`providerMetadata.agenta.attachmentId`, zero base64 in 2.3 KB of body), and the model reads the image's text verbatim.
- **ZIP workspace-only**: the run completes and the agent reads the archive's marker from its workspace. (Both notice surfaces that existed at QA time, the in-message line and the chip hint, were removed afterward at the product owner's direction; the first release ships no notice UI, and the persisted delivery events await a future surface.)
- **Reload from records**: real filenames, reference URLs, no data: nodes in the DOM, follow-up questions answered from the re-delivered content.
- **Errors**: the over-cap message names the file, its size, and the limit, with no retry offer; chip removal aborts the request.
- The first E2E round caught one blocker this suite had missed: the shared axios instance JSON-serializes FormData unless the multipart header is explicit (the file collapsed to `{}` and every upload 422'd). Fixed in this diff with a comment stating the trap.

https://claude.ai/code/session_01A1XQVjHPYJgVBHWSNUphtx
