### PR TITLE
[5580] fix(frontend): skip onboarding session query

### DIFF
--- a/web/oss/src/components/AgentChatSlice/state/projectSessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/projectSessions.ts
@@ -7,6 +7,7 @@ import {atomWithQuery} from "jotai-tanstack-query"
 
 import {projectIdAtom} from "@/oss/state/project"
 
+import {ONBOARDING_SCOPE_KEY} from "./scope"
 import {
     GLOBAL_APP_KEY,
     reconcileServerSessionsAtomFamily,
@@ -21,10 +22,14 @@ import {
  *
  * Mirrors `liveness.ts`: ONE low-priority query per agent backs the whole list, revalidated on tab
  * refocus and on a slow interval, so it stays out of the live conversation's way. Disabled for the
- * non-agent scopes (`__global__`, the revision drawer) where there is no artifact id to match.
+ * non-agent scopes (`__global__`, onboarding, the revision drawer) where there is no artifact id
+ * to match.
  */
-const isQueryableScope = (appId: string): boolean =>
-    Boolean(appId) && appId !== GLOBAL_APP_KEY && !appId.startsWith("drawer:")
+export const isQueryableScope = (appId: string): boolean =>
+    Boolean(appId) &&
+    appId !== GLOBAL_APP_KEY &&
+    appId !== ONBOARDING_SCOPE_KEY &&
+    !appId.startsWith("drawer:")
 
 export const projectSessionsQueryAtomFamily = atomFamily((appId: string) =>
     atomWithQuery<SessionStream[] | null>((get) => {


### PR DESCRIPTION
Fixes #5580

## Summary

The playground onboarding panel uses the synthetic `onboarding` scope before an agent exists. The durable session query treated that value as an artifact UUID and sent it to `/sessions/query`, producing a 422 on every onboarding landing.

This change classifies the onboarding scope alongside the existing global and drawer non-agent scopes, so the server-session query remains disabled until a real agent ID is available.

## Testing

### Verified locally

- `pnpm lint-fix` (passes; two existing React Compiler warnings in unrelated Drive components)
- `pnpm --filter @agenta/oss exec tsc --noEmit`
- Focused `tsx` assertions covering empty, global, onboarding, drawer, and UUID scopes
- `git diff --check`

### Added or updated tests

N/A — `web/oss` does not currently expose a unit-test script; the scope predicate was verified with focused assertions.

### QA follow-up

Verify that opening Playground without an existing agent no longer sends a `/sessions/query` request with `references[0].id=onboarding`.

## Demo

The focused guard verification below shows that the synthetic onboarding scope no longer enables a server session query, while a real agent UUID still does. The UI itself is unchanged.

![Focused verification of the onboarding session-query guard](https://gist.githubusercontent.com/nightcityblade/739db0e1f4cbcacc9d091a23471474bb/raw/860c4a1a891dd4f36a16b760b651422b0e51deba/agenta-5580-demo.svg)

## Checklist

- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
