### PR TITLE
fix(frontend): send drive uploads as multipart instead of JSON

### DIFF
--- a/web/oss/src/components/Drives/driveMedia.ts
+++ b/web/oss/src/components/Drives/driveMedia.ts
@@ -183,8 +183,11 @@ export async function uploadMountFile({
     const form = new FormData()
     form.append("file", file, file.name)
     const path = destFolder ? `${destFolder.replace(/\/$/, "")}/${file.name}` : file.name
+    // The explicit header matters: the shared instance defaults to application/json, and
+    // axios then JSON-serializes the FormData, collapsing the File to {}.
     await axios.post(`${getAgentaApiUrl()}/mounts/${mountId}/files/upload`, form, {
         params: {path, project_id: projectId},
+        headers: {"Content-Type": "multipart/form-data"},
         signal,
         onUploadProgress: (e) => {
             if (onProgress && e.total) onProgress(Math.round((e.loaded / e.total) * 100))


### PR DESCRIPTION
Dragging a file (or using the Upload button, or committing staged files) in the agent chat's Files drawer fails with 422 `{"detail":[{"type":"missing","loc":["body","file"],"msg":"Field required"}]}`. The request goes out as `Content-Type: application/json` with body `{"file":{}}`.

**Before:** `uploadMountFile` posts its FormData through the shared axios instance, whose default `application/json` content type makes axios 1.x JSON-serialize the FormData (`formDataToJSON`), collapsing the `File` to an empty object. Every upload affordance in the drawer funnels into this one helper, so all of them fail. The surface shipped dark behind `NEXT_PUBLIC_AGENT_FILE_UPLOADS`, which is why nobody hit it until the flag came on in dev.
**After:** the post carries an explicit `Content-Type: multipart/form-data`, the same fix and comment the composer's attachment transport uses for the identical trap.

Verified against v0.106.2/main: the reworked drawer still funnels into this unchanged helper, so the one-line fix applies cleanly.

Not fixed here, filed separately: dropping a **folder** additionally arrives as a single zero-byte pseudo-file because the drop handlers read `dataTransfer.files` with no directory enumeration; that fix needs authoring against the reworked drawer on main.

https://claude.ai/code/session_01A1XQVjHPYJgVBHWSNUphtx