### PR TITLE
fix(frontend): denied and cold-resumed approvals render and resolve correctly

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -285,6 +285,109 @@ describe("transcriptToMessages approval hydration", () => {
     })
 })
 
+/**
+ * Cold approval resume: the harness re-raises the approved call under a NEW toolCallId, so the
+ * response's `toolCallId` no longer matches the gated part. Only the interaction id still does.
+ */
+describe("transcriptToMessages cold approval resume (re-raised tool call id)", () => {
+    const pausedTurn = (): SessionRecord[] => [
+        record("r-user", {type: "message", text: "delete the file"}, "user"),
+        record("r-call-old", {
+            type: "tool_call",
+            id: "tool-old",
+            name: "bash",
+            input: {command: "rm x"},
+        }),
+        record("r-req", {
+            type: "interaction_request",
+            id: "approval-1",
+            kind: "user_approval",
+            payload: {toolCallId: "tool-old"},
+        }),
+        record("r-done-paused", {type: "done", stopReason: "paused"}),
+        record("r-call-new", {
+            type: "tool_call",
+            id: "tool-new",
+            name: "bash",
+            input: {command: "rm x"},
+        }),
+    ]
+
+    const response = (approved: boolean): SessionRecord =>
+        record("r-resp", {
+            type: "interaction_response",
+            id: "approval-1",
+            kind: "user_approval",
+            payload: {toolCallId: "tool-new", approved},
+        })
+
+    const errorResult = (): SessionRecord =>
+        record("r-result", {
+            type: "tool_result",
+            id: "tool-new",
+            output: "boom",
+            isError: true,
+        })
+
+    const toolParts = (records: SessionRecord[]): Record<string, unknown>[] => {
+        const messages = transcriptToMessages(records)
+        expect(messages).not.toBeNull()
+        return (messages ?? [])
+            .flatMap((message) => message.parts as unknown as Record<string, unknown>[])
+            .filter((part) => "toolCallId" in part)
+    }
+
+    it("settles the gated part when the response arrives before the re-raised result", () => {
+        const parts = toolParts([
+            ...pausedTurn(),
+            response(true),
+            errorResult(),
+            record("r-done", {type: "done"}),
+        ])
+
+        expect(parts).toHaveLength(1)
+        expect(parts[0]).toMatchObject({
+            state: "output-error",
+            errorText: "boom",
+            approval: {id: "approval-1", approved: true},
+        })
+        expect(parts.filter((part) => part.state === "approval-requested")).toEqual([])
+    })
+
+    it("settles the gated part when the re-raised result arrives before the response", () => {
+        const parts = toolParts([
+            ...pausedTurn(),
+            errorResult(),
+            response(true),
+            record("r-done", {type: "done"}),
+        ])
+
+        expect(parts).toHaveLength(1)
+        expect(parts[0]).toMatchObject({
+            state: "output-error",
+            errorText: "boom",
+            approval: {id: "approval-1", approved: true},
+        })
+        expect(parts.filter((part) => part.state === "approval-requested")).toEqual([])
+    })
+
+    it("resolves a denied re-raised call to output-denied", () => {
+        const parts = toolParts([
+            ...pausedTurn(),
+            response(false),
+            record("r-result", {type: "tool_result", id: "tool-new", denied: true}),
+            record("r-done", {type: "done"}),
+        ])
+
+        expect(parts).toHaveLength(1)
+        expect(parts[0]).toMatchObject({
+            state: "output-denied",
+            approval: {id: "approval-1", approved: false},
+        })
+        expect(parts.filter((part) => part.state === "approval-requested")).toEqual([])
+    })
+})
+
 describe("transcriptToMessages paused end-marker", () => {
     it("flags the message whose turn ended paused (done.stopReason)", () => {
         const messages = transcriptToMessages([

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -239,18 +239,30 @@ function applyEvent(
             const responsePayload = (payload.payload ?? {}) as Record<string, unknown>
             const responseId = str(payload.id)
             const toolCallId = str(responsePayload.toolCallId)
+            // A cold resume re-raises the approved call under a NEW toolCallId, so the interaction
+            // id (identical on request and response by contract) is the reliable key to the gate.
             const part =
-                (toolCallId ? index.tools.get(toolCallId) : undefined) ??
-                index.approvals.get(responseId)
-            if (
-                !part ||
-                part.state !== "approval-requested" ||
-                typeof responsePayload.approved !== "boolean"
-            ) {
-                return
+                index.approvals.get(responseId) ??
+                (toolCallId ? index.tools.get(toolCallId) : undefined)
+            if (!part || typeof responsePayload.approved !== "boolean") return
+            if (part.state === "approval-requested") {
+                part.state = "approval-responded"
+                part.approval = {id: responseId, approved: responsePayload.approved}
             }
-            part.state = "approval-responded"
-            part.approval = {id: responseId, approved: responsePayload.approved}
+            if (!toolCallId || toolCallId === str(part.toolCallId)) return
+            // Re-raised under a new id: point that id at the gated part and fold in the duplicate
+            // it created — an executed result supersedes the approval-responded state.
+            const duplicate = index.tools.get(toolCallId)
+            index.tools.set(toolCallId, part)
+            if (!duplicate || duplicate === part) return
+            const at = draft.parts.indexOf(duplicate)
+            if (at >= 0) draft.parts.splice(at, 1)
+            if (duplicate.input !== undefined) part.input = duplicate.input
+            if (typeof duplicate.state === "string" && duplicate.state.startsWith("output-")) {
+                part.state = duplicate.state
+                if (duplicate.output !== undefined) part.output = duplicate.output
+                if (duplicate.errorText !== undefined) part.errorText = duplicate.errorText
+            }
             return
         }
         case "file": {

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -370,7 +370,7 @@ const ApprovalDock = ({
                             leave the yellow Approve competing, so the redirect panel below becomes the
                             entire action surface. Mirrors the panel's expand (open={!steerOpen} vs
                             open={steerOpen}) for one smooth swap. */}
-                        <HeightCollapse open={!steerOpen} fade>
+                        <HeightCollapse open={!steerOpen} fade inert>
                             <div className="flex items-center gap-2">
                                 {onViewTrace && !chatMode ? (
                                     <button
@@ -480,46 +480,50 @@ const ApprovalDock = ({
                             It and the always-allow row below share this bottom slot and animate as a
                             complementary pair (open={steerOpen} vs open={!steerOpen}, same primitive,
                             same fade) so one expands exactly as the other collapses — no pop-vs-slide. */}
-                        <HeightCollapse open={steerOpen} fade>
-                            <div className="flex flex-col gap-2 border-0 border-t border-solid border-colorBorderSecondary pt-2.5">
-                                <Text type="secondary" className="!text-[11px]">
-                                    Deny this step and tell the agent what to do instead — your note
-                                    runs as the next message.
-                                </Text>
-                                {/* Filled + borderless-at-rest so the redirect reads as a nested field
+                        {/* Unmounted (not merely collapsed) while the flag is off: a collapsed
+                            HeightCollapse still leaves its controls in the DOM and tab order. */}
+                        {steerEnabled ? (
+                            <HeightCollapse open={steerOpen} fade inert>
+                                <div className="flex flex-col gap-2 border-0 border-t border-solid border-colorBorderSecondary pt-2.5">
+                                    <Text type="secondary" className="!text-[11px]">
+                                        Deny this step and tell the agent what to do instead — your
+                                        note runs as the next message.
+                                    </Text>
+                                    {/* Filled + borderless-at-rest so the redirect reads as a nested field
                                     of the approval card, subordinate to the main composer below — not a
                                     second, louder input competing with it. The filled variant lights its
                                     border with the full primary on focus (louder than the composer), so
                                     we pin hover/focus to a neutral border and drop the focus glow. */}
-                                <Input.TextArea
-                                    ref={steerInputRef}
-                                    variant="filled"
-                                    autoSize={{minRows: 2, maxRows: 6}}
-                                    value={steerMessage}
-                                    onChange={(e) => setSteerMessage(e.target.value)}
-                                    placeholder="e.g. write to staging, not prod — or ask for something else entirely"
-                                    disabled={responding}
-                                    className="!text-xs hover:!border-colorBorder focus:!border-colorBorder focus:!shadow-none"
-                                />
-                                <div className="flex items-center justify-end gap-1.5">
-                                    <Button
-                                        type="text"
+                                    <Input.TextArea
+                                        ref={steerInputRef}
+                                        variant="filled"
+                                        autoSize={{minRows: 2, maxRows: 6}}
+                                        value={steerMessage}
+                                        onChange={(e) => setSteerMessage(e.target.value)}
+                                        placeholder="e.g. write to staging, not prod — or ask for something else entirely"
                                         disabled={responding}
-                                        onClick={() => setSteerOpen(false)}
-                                    >
-                                        Cancel
-                                    </Button>
-                                    {/* Default, not primary: Approve is the card's single primary. This
+                                        className="!text-xs hover:!border-colorBorder focus:!border-colorBorder focus:!shadow-none"
+                                    />
+                                    <div className="flex items-center justify-end gap-1.5">
+                                        <Button
+                                            type="text"
+                                            disabled={responding}
+                                            onClick={() => setSteerOpen(false)}
+                                        >
+                                            Cancel
+                                        </Button>
+                                        {/* Default, not primary: Approve is the card's single primary. This
                                         is the confirm for the redirect sub-action, so it stays quiet. */}
-                                    <Button
-                                        disabled={responding || !steerMessage.trim()}
-                                        onClick={() => respond(false, steerMessage)}
-                                    >
-                                        Deny &amp; send
-                                    </Button>
+                                        <Button
+                                            disabled={responding || !steerMessage.trim()}
+                                            onClick={() => respond(false, steerMessage)}
+                                        >
+                                            Deny &amp; send
+                                        </Button>
+                                    </div>
                                 </div>
-                            </div>
-                        </HeightCollapse>
+                            </HeightCollapse>
+                        ) : null}
 
                         {/* Always-allow: arms a config write-through so this tool stops asking. The
                             switch only ARMS the intent (it must not progress the flow); the grant is
@@ -528,7 +532,7 @@ const ApprovalDock = ({
                             steering (open={!steerOpen}) — "applies when you approve" contradicts a
                             deny+redirect — as the mirror of the steer panel's expand, for one smooth swap. */}
                         {canAlwaysAllow ? (
-                            <HeightCollapse open={!steerOpen} fade>
+                            <HeightCollapse open={!steerOpen} fade inert>
                                 <div className="flex items-center gap-2 border-0 border-t border-solid border-colorBorderSecondary pt-2.5">
                                     <Switch
                                         checked={alwaysAllowArmed}

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -173,7 +173,9 @@ const ToolRow = ({
         state === "approval-requested"
             ? "Awaiting approval"
             : state === "approval-responded"
-              ? "approved"
+              ? (part as {approval?: {approved?: boolean}}).approval?.approved === false
+                  ? "denied"
+                  : "approved"
               : live && running
                 ? "running…"
                 : detailed

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for `isClientToolPart` — the predicate that routes a tool part to the client-tool
+ * dispatcher (and, for an unknown tool, to the auto-settling "not handled" fallback).
+ *
+ * The load-bearing case is DENY: a denied approval part lands in `output-denied` carrying its
+ * `{approved: false}` envelope. Reading it as a parked client tool made the fallback overwrite that
+ * envelope with `{status: "not_handled"}`, so the model saw a failed tool and retried the same call.
+ */
+import type {ToolUIPart} from "ai"
+import {describe, expect, it} from "vitest"
+
+import {isClientToolPart} from "./meta"
+
+const settledCtx = {isStreaming: false, isLastMessage: true}
+
+const toolPart = (part: Record<string, unknown>): ToolUIPart =>
+    ({
+        type: "tool-deleteFile",
+        toolCallId: "call_1",
+        input: {path: "/x"},
+        ...part,
+    }) as unknown as ToolUIPart
+
+describe("isClientToolPart", () => {
+    it("does NOT claim a denied approval part (output-denied)", () => {
+        const part = toolPart({
+            state: "output-denied",
+            approval: {id: "perm_1", approved: false},
+        })
+        expect(isClientToolPart(part, settledCtx)).toBe(false)
+    })
+
+    it("does NOT claim any part carrying approval metadata, whatever its state", () => {
+        for (const state of ["input-available", "output-denied", "output-available"]) {
+            const part = toolPart({state, approval: {id: "perm_1"}})
+            expect(isClientToolPart(part, settledCtx)).toBe(false)
+        }
+    })
+
+    it("still claims a parked unknown client tool so the fallback settles it", () => {
+        const part = toolPart({type: "tool-mysteryTool", state: "input-available"})
+        expect(isClientToolPart(part, settledCtx)).toBe(true)
+    })
+
+    it("does NOT claim an unsettled tool while the turn is still streaming", () => {
+        const part = toolPart({type: "tool-mysteryTool", state: "input-available"})
+        expect(isClientToolPart(part, {isStreaming: true, isLastMessage: true})).toBe(false)
+    })
+
+    it("claims a known client tool in every state", () => {
+        const part = toolPart({
+            type: "tool-request_connection",
+            state: "output-available",
+            output: {connected: true},
+        })
+        expect(isClientToolPart(part, settledCtx)).toBe(true)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
@@ -9,7 +9,7 @@ import type {ToolUIPart} from "ai"
 import {hasClientToolHandler} from "./registry"
 import type {ClientToolMeta} from "./types"
 
-const SETTLED = new Set(["output-available", "output-error"])
+const SETTLED = new Set(["output-available", "output-error", "output-denied"])
 const APPROVAL = new Set(["approval-requested", "approval-responded"])
 
 /** Friendly tool name: `tool-<name>` carries it in the type; `dynamic-tool` on `toolName`. */
@@ -59,6 +59,8 @@ export const isClientToolPart = (
 ): boolean => {
     const state = part.state as string
     if (APPROVAL.has(state)) return false
+    // An approval-gated part is `ToolActivity`'s: auto-settling it would erase the user's decision.
+    if ((part as {approval?: unknown}).approval != null) return false
     if ((part as {providerExecuted?: boolean}).providerExecuted === true) return false
 
     const meta = clientToolMeta(part, renderMap)

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -135,9 +135,11 @@ const activeByAppAtom = atomWithStorage<Record<string, string>>(
 )
 
 /** Persisted messages per session id. Written when a conversation's stream settles. Session ids
- * are globally unique, so this store has no scope dimension. */
+ * are globally unique, so this store has no scope dimension.
+ * v2: caches written by the pre-fix mapper hold duplicated approval parts; the key bump forces
+ * one re-sync from records (the watermark otherwise keeps the stale copy authoritative). */
 export const sessionMessagesAtom = atomWithStorage<Record<string, UIMessage[]>>(
-    "agenta:agent-chat:messages",
+    "agenta:agent-chat:messages:v2",
     {},
     tabLocalStorage(),
     STORAGE_OPTS,
@@ -152,7 +154,7 @@ export const sessionMessagesAtom = atomWithStorage<Record<string, UIMessage[]>>(
  * goes through `persistSessionMessagesAtom` and every delete through `dropSessionMessages`.
  */
 const sessionRecordCountsAtom = atomWithStorage<Record<string, number>>(
-    "agenta:agent-chat:record-counts",
+    "agenta:agent-chat:record-counts:v2",
     {},
     tabLocalStorage(),
     STORAGE_OPTS,

--- a/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
@@ -121,6 +121,7 @@ const isSettledToolPart = (part: ToolPartLike): boolean =>
     isToolPart(part) &&
     (part.state === "output-available" ||
         part.state === "output-error" ||
+        part.state === "output-denied" ||
         part.state === "approval-responded")
 
 /**

--- a/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
@@ -273,6 +273,36 @@ describe("agentShouldResumeAfterApproval", () => {
         expect(agentShouldResumeAfterApproval({messages})).toBe(true)
     })
 
+    it("counts a DENIED tool part as settled (output-denied)", () => {
+        // A denied gate settles to `output-denied` carrying its `{approved: false}` envelope; if it
+        // did not count as settled, a sibling-resolved turn would never resume.
+        const messages = [
+            user("do two"),
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [
+                    {type: "step-start"},
+                    {
+                        type: "tool-deleteFile",
+                        toolCallId: "call_1",
+                        state: "output-denied",
+                        input: {path: "/x"},
+                        approval: {id: "perm_1", approved: false},
+                    },
+                    {
+                        type: "tool-readFile",
+                        toolCallId: "call_2",
+                        state: "approval-responded",
+                        input: {path: "/y"},
+                        approval: {id: "perm_2", approved: true},
+                    },
+                ],
+            },
+        ]
+        expect(agentShouldResumeAfterApproval({messages})).toBe(true)
+    })
+
     it("does NOT resume when there are no messages", () => {
         expect(agentShouldResumeAfterApproval({messages: []})).toBe(false)
     })

--- a/web/packages/agenta-playground/tests/unit/agentMessageQueue.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentMessageQueue.test.ts
@@ -58,6 +58,29 @@ const assistantWithOrphanApproval = () => ({
     ],
 })
 
+/**
+ * Cold approval resume, as the record→message mapper now rebuilds it: the harness re-raised the
+ * approved call under a new toolCallId, and the mapper folds that duplicate back into the gated
+ * part instead of leaving an orphan stuck `approval-requested` (which would freeze the queue and
+ * show a live dock for a call that already ran).
+ */
+const assistantAfterColdResume = () => ({
+    id: "a1",
+    role: "assistant",
+    parts: [
+        {type: "step-start"},
+        {
+            type: "tool-deleteFile",
+            toolCallId: "call_old",
+            state: "output-error",
+            input: {path: "/x"},
+            errorText: "boom",
+            approval: {id: "perm_1", approved: true},
+        },
+        {type: "text", text: "That failed."},
+    ],
+})
+
 describe("isHitlPending", () => {
     it("is true while awaiting the user's decision (approval-requested)", () => {
         expect(isHitlPending([user("do it"), assistantWithTool("approval-requested")])).toBe(true)
@@ -71,6 +94,10 @@ describe("isHitlPending", () => {
 
     it("is false for an orphaned approval-responded turn (no approval-requested → nothing to act on)", () => {
         expect(isHitlPending([user("do it"), assistantWithOrphanApproval()])).toBe(false)
+    })
+
+    it("is false for a cold-resume turn whose re-raised call was folded back into the gated part", () => {
+        expect(isHitlPending([user("do it"), assistantAfterColdResume()])).toBe(false)
     })
 
     it("is false once the tool has run (output-available)", () => {


### PR DESCRIPTION
## What was broken

Three defects in the approval flow, all found during multi-modality QA, all in code that predates the train:

1. **A denial was erased before the model saw it.** Answering a gate with Deny came back to the model as `{"status":"not_handled"}`, so it kept retrying the same command (reported on #5598).
2. **After a page reload, a resolved approval came back as a live card**, locked the composer, and answering the stale card fired a bogus new run.
3. **A hidden, permanently disabled "Deny & send" button sat in the DOM** whenever an approval was pending, confusing tooling and tab order, because the flag-gated steer panel was collapsed instead of unmounted.

## Causes and fixes

1. A denied part lands in state `output-denied`, which was missing from the client-tool dispatcher's settled set, so `UnhandledClientTool` auto-settled it and the AI SDK rewrote the part, erasing the `{approved: false}` envelope. Fix: `output-denied` joins `SETTLED`, and any part carrying approval metadata is never a client-tool fallback candidate (`clientTools/meta.ts`); `isSettledToolPart` learns the state too.
2. A cold approval resume re-raises the approved call under a **new** tool-call id. Reconstruction resolved the answer by tool-call id first, found the re-raised part, bailed, and left the original part `approval-requested` forever. Fix: settle by the **interaction id** first (the wire contract guarantees it matches), re-point the tool index at the gate part, and splice the duplicate re-raised part, carrying its executed result. Both arrival orders covered (`transcriptToMessages.ts`).
3. The steer panel now unmounts entirely while `NEXT_PUBLIC_AGENT_CHAT_STEER` is off, and the sibling collapses gained `inert` (`ApprovalDock.tsx`).

## Tests

The dispatch decision, both cold-resume arrival orders plus a deny variant, the composer-unlock predicate, and the resume seam are all pinned (`meta.test.ts`, `transcriptToMessages.test.ts`, `agentMessageQueue.test.ts`). Verified live on the dev stack: the denial envelope reaches the runner and the model changes course; reload renders each resolved call exactly once.

## Notes for review

- All three are base bugs, not train regressions; they ride this train because its QA exposed them and the release should not ship approvals in this state.
- No user-facing strings added or removed.
- A future "deny with feedback" seam exists (the AI SDK approval response supports `reason`); the steer feature remains behind its flag, untouched.

https://claude.ai/code/session_01McMogkcDRV7UpSAjfd8VKG
