### PR TITLE
feat(frontend): enable agent file uploads by default

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/constants.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/constants.ts
@@ -35,8 +35,9 @@ export const isAgentVoiceInputEnabled = (): boolean =>
 /**
  * File uploads and attachments — the composer attach button + attachment preview, and every drive
  * upload entry point (upload button, drop-to-upload in the Files drawer, drop-to-stage on a recents
- * peek). Off by default: the composer→model delivery contract is still open on the backend. Enable
- * with `NEXT_PUBLIC_AGENT_FILE_UPLOADS=true`. The composer gates button, paste, and drag paths.
+ * peek). On by default since the attachment delivery chain shipped; set
+ * `NEXT_PUBLIC_AGENT_FILE_UPLOADS=false` to turn it off. The composer gates button, paste, and
+ * drag paths.
  */
 export const isAgentFileUploadsEnabled = (): boolean =>
-    (getEnv("NEXT_PUBLIC_AGENT_FILE_UPLOADS") || "").toLowerCase() === "true"
+    (getEnv("NEXT_PUBLIC_AGENT_FILE_UPLOADS") || "").toLowerCase() !== "false"


### PR DESCRIPTION
## What this is

The rollout flip for agent file attachments, isolated in one revertable PR at the top of the multi-modality train.

`isAgentFileUploadsEnabled` becomes opt-out: uploads are ON unless `NEXT_PUBLIC_AGENT_FILE_UPLOADS=false` is set. Voice input stays opt-in and is unaffected. One file, four lines.

Merge last: everything below it in the train delivers the attachment chain this flip exposes.

https://claude.ai/code/session_01McMogkcDRV7UpSAjfd8VKG