### PR TITLE
[AGE-4027] fix(api): Stop session rename from bumping the activity timestamp

### DIFF
--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -206,7 +206,10 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
                 user_id=user_id,
                 header=header,
             )
-            dbe.updated_at = datetime.now(timezone.utc)
+            # `updated_at` is the heartbeat timestamp (see SessionStreamDBE docstring), read by the
+            # frontend as last-activity time for sorting -- a rename must not move it, or an
+            # unrelated/delayed header write (e.g. the fire-and-forget auto-title call) can reorder
+            # the session list ahead of a session with a genuinely more recent message.
             await session.commit()
             await session.refresh(dbe)
         return map_stream_dbe_to_dto(stream_dbe=dbe)

--- a/api/oss/tests/pytest/unit/sessions/test_stream_header_no_activity_bump.py
+++ b/api/oss/tests/pytest/unit/sessions/test_stream_header_no_activity_bump.py
@@ -1,0 +1,98 @@
+"""Unit test: SessionStreamsDAO.update_header must not touch `updated_at`.
+
+`updated_at` is the heartbeat timestamp the frontend reads as last-activity time when
+sorting the session list (see `activity()` in `projectSessions.ts`). A rename write
+(including the frontend's fire-and-forget auto-title call, fired unawaited on a
+session's first message) bumping the same column let a delayed, unrelated header write
+reorder the list ahead of a session with a genuinely more recent message (#5579).
+
+No live DB: a fake TransactionsEngine returns a pre-built dbe from `execute()`,
+mirroring the SELECT + mutate + commit shape `update_header` uses.
+"""
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.sessions.streams.dtos import SessionStreamHeaderEdit
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
+from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
+
+
+class _FakeResult:
+    def __init__(self, dbe):
+        self._dbe = dbe
+
+    def scalar_one_or_none(self):
+        return self._dbe
+
+
+class _FakeSession:
+    def __init__(self, dbe):
+        self._dbe = dbe
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._dbe)
+
+    async def commit(self):
+        pass
+
+    async def refresh(self, _dbe):
+        pass
+
+    async def rollback(self):
+        pass
+
+    async def close(self):
+        pass
+
+
+class _FakeEngine:
+    def __init__(self, dbe):
+        self._dbe = dbe
+
+    @asynccontextmanager
+    async def session(self):
+        fake = _FakeSession(self._dbe)
+        try:
+            yield fake
+            await fake.commit()
+        except Exception:
+            await fake.rollback()
+            raise
+        finally:
+            await fake.close()
+
+
+@pytest.mark.anyio
+async def test_update_header_does_not_bump_updated_at(anyio_backend):
+    assert anyio_backend == "asyncio"
+    stale_heartbeat = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    dbe = SessionStreamDBE(
+        id=uuid4(),
+        project_id=uuid4(),
+        session_id="sess-rename-1",
+        name="old name",
+        updated_at=stale_heartbeat,
+    )
+    dao = SessionStreamsDAO(engine=_FakeEngine(dbe))
+
+    result = await dao.update_header(
+        project_id=dbe.project_id,
+        user_id=uuid4(),
+        session_id=dbe.session_id,
+        header=SessionStreamHeaderEdit(name="new name"),
+    )
+
+    assert result is not None
+    assert result.name == "new name"
+    # The rename applied, but the heartbeat timestamp must stay put -- only the real
+    # heartbeat path (SessionStreamsDAO.update) may move it.
+    assert result.updated_at == stale_heartbeat
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
## Summary

Fixes Agenta-AI/agenta#5579. In the playground's Session history list, sending a message in session A then session B correctly shows B on top (most recent first) — but reloading the page can flip the order back, even though B still has the more recent message.

Root cause: the session list has one sort function on both the live and reload paths, keyed on `lastMessageAt`. Live updates stamp it precisely client-side when a turn settles. On reload, the value is folded in from the server's `SessionStream.updated_at` column — documented as "the heartbeat timestamp." But `update_header()` in the API also bumped that same column on every rename, **including the frontend's fire-and-forget auto-title call that fires on every session's first message**. That call is unawaited, so its write can land arbitrarily late — including after a different session's entire exchange has finished — silently reordering the list on the next reconcile (mount/reload/focus/60s poll).

## Changes

`update_header()` (`api/oss/src/dbs/postgres/sessions/streams/dao.py`) no longer touches `updated_at`. That's the real heartbeat path's job (`update()`, a separate method) — a rename/auto-title is not activity. Checked: on the frontend, `updated_at` has exactly one consumer (the session-list sort), and nothing else on the backend depends on rename bumping it.

## Testing

### Verified locally

* `ruff format` / `ruff check` clean.
* Reproduced the underlying issue manually (create two sessions, message both, rename the older one, reload — order flips) to confirm the diagnosis before writing the fix.

### Added or updated tests

* `api/oss/tests/pytest/unit/sessions/test_stream_header_no_activity_bump.py`: a fake-engine unit test (no live DB) asserting a rename leaves `updated_at` untouched. Verified it fails against the pre-fix code and passes against the fix.
* Full `api/oss/tests/pytest/unit/sessions/` suite (142 tests) passes.

### QA follow-up

* Create two chat sessions on the same agent, message the older one, message the newer one — history list shows newest on top. Rename the older session, reload — order should stay the same (newest still on top).
* Regression: the live/in-tab ordering (already correct before this fix) should be unaffected.

## Demo

<img src="https://github.com/user-attachments/assets/72811803-2b23-44ad-b4a2-d0cc547a12d1 " alt="Screenshot 2026-08-01 at 6 39 07 PM" width="1537" data-linear-height="416" />

## Checklist

- [X] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [X] Relevant tests pass locally
- [X] Relevant linting and formatting pass locally
- [X] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

* [Contributing guide](<https://agenta.ai/docs/contributing/overview>)
* [Creating your first PR](<https://agenta.ai/docs/contributing/first-pr>)
* [Development mode](<https://agenta.ai/docs/contributing/guides/development-mode>)
* [Testing](<https://agenta.ai/docs/contributing/guides/testing>)
* [Formatting and linting](<https://agenta.ai/docs/contributing/guides/formatting-and-linting>)
* [Slack support](<https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw>)