### PR TITLE
fix(frontend): upload a dropped folder's contents instead of a 0-byte pseudo-file

### DIFF
--- a/web/oss/src/components/Drives/ContextRail.tsx
+++ b/web/oss/src/components/Drives/ContextRail.tsx
@@ -25,6 +25,7 @@ import {listArrowKeyDown} from "./driveKeyboard"
 import {FILE_ITEM_VARIANTS, FILE_SPRING} from "./driveMotion"
 import {useDriveArtifactId} from "./driveSessionContext"
 import {relativeTime} from "./driveTree"
+import {type DroppedFile} from "./dropEntries"
 import {driveQuickLookAtomFamily} from "./quickLook"
 import {isRecentlyChanged, useRecentChangeClock} from "./recentChange"
 import {type FileDropProps, useStageDrop} from "./useDriveDrop"
@@ -65,7 +66,7 @@ export function ContextRail({
     onOpenFiles: () => void
     /** Files dropped on the rail → stage them and open the drawer to pick a destination. Omit to
      * disable drop-to-stage. */
-    onStageFiles?: (files: File[]) => void
+    onStageFiles?: (files: DroppedFile[]) => void
 }) {
     const [open, setOpen] = useAtom(contextRailOpenAtom)
     // Drop-to-stage: a file drag over the rail (strip or expanded) opens the drawer with the files

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -34,6 +34,7 @@ import {DriveTreeList} from "./DriveTreeList"
 import {DriveTreePane} from "./DriveTreePane"
 import {looksLikeFilePath} from "./driveTreeView"
 import {type DriveId, type DriveScope} from "./driveTypes"
+import {type DroppedFile} from "./dropEntries"
 import {FolderView} from "./FolderView"
 import {useDriveDownloadAll} from "./useDriveDownloadAll"
 import {useDriveFilters} from "./useDriveFilters"
@@ -83,8 +84,8 @@ export function DriveExplorer({
     onToggleExpand?: () => void
     /** Files dropped on a recents peek, staged (unwritten) until the user picks a destination folder
      * and clicks "Upload here" — shown as ghost tiles in the grid. The host owns the list. */
-    stagedFiles?: File[]
-    onStagedChange?: (files: File[]) => void
+    stagedFiles?: DroppedFile[]
+    onStagedChange?: (files: DroppedFile[]) => void
 }) {
     const rootLabel = driveRootLabel(drive.mount)
     const {
@@ -375,7 +376,14 @@ export function DriveExplorer({
                         className="hidden"
                         onChange={(e) => {
                             const picked = e.target.files
-                            if (picked?.length) uploadIntoFolder(Array.from(picked), currentFolder)
+                            if (picked?.length)
+                                uploadIntoFolder(
+                                    Array.from(picked).map((file) => ({
+                                        file,
+                                        relativePath: file.name,
+                                    })),
+                                    currentFolder,
+                                )
                             e.target.value = ""
                         }}
                     />

--- a/web/oss/src/components/Drives/FilesDrawer.tsx
+++ b/web/oss/src/components/Drives/FilesDrawer.tsx
@@ -17,6 +17,7 @@ import dynamic from "next/dynamic"
 
 import {type DriveId, type DriveScope} from "./DriveExplorer"
 import {DriveExplorerSkeleton} from "./DriveExplorerSkeleton"
+import {type DroppedFile} from "./dropEntries"
 import {type SessionDriveData} from "./useSessionDrive"
 
 // Normal vs. expanded drawer width — the header's expand toggle flips between them, mirroring the
@@ -68,8 +69,8 @@ export interface FilesDrawerProps {
     /** Preselect this path on open — and, while open, re-select when it changes (a chat link/tile). */
     initialPath?: string | null
     /** Files staged by a drop on a recents peek, awaiting a destination — the host owns the list. */
-    stagedFiles?: File[]
-    onStagedChange?: (files: File[]) => void
+    stagedFiles?: DroppedFile[]
+    onStagedChange?: (files: DroppedFile[]) => void
 }
 
 export function FilesDrawer({

--- a/web/oss/src/components/Drives/SessionFilesDrawer.tsx
+++ b/web/oss/src/components/Drives/SessionFilesDrawer.tsx
@@ -14,6 +14,7 @@ import {atomFamily} from "jotai/utils"
 
 import {type DriveId} from "./DriveExplorer"
 import {useDriveArtifactId} from "./driveSessionContext"
+import {type DroppedFile} from "./dropEntries"
 import {FilesDrawer} from "./FilesDrawer"
 import {driveQuickLookAtomFamily} from "./quickLook"
 import {useSessionDriveSummary} from "./useSessionDrive"
@@ -24,7 +25,9 @@ export const filesDrawerOpenAtomFamily = atomFamily((_sessionId: string) => atom
 
 // Files staged by a drop on the chat rail's Files peek, awaiting a destination in the drawer. Keyed
 // per session like the open flag; setting it (with the drawer opened) shows ghost tiles in the grid.
-export const filesDrawerStagedAtomFamily = atomFamily((_sessionId: string) => atom<File[]>([]))
+export const filesDrawerStagedAtomFamily = atomFamily((_sessionId: string) =>
+    atom<DroppedFile[]>([]),
+)
 
 // A requested path may be a tool-path tail; match it against a full drive path by suffix.
 const matchesTail = (filePath: string, requested: string): boolean =>

--- a/web/oss/src/components/Drives/configDrive.ts
+++ b/web/oss/src/components/Drives/configDrive.ts
@@ -16,6 +16,7 @@ import {
     sessionsListAtomFamily,
 } from "@/oss/components/AgentChatSlice/state/sessions"
 
+import {type DroppedFile} from "./dropEntries"
 import {useSessionDriveSummary, type SessionDriveData} from "./useSessionDrive"
 
 export interface ConfigFilesDrawerRequest {
@@ -23,7 +24,7 @@ export interface ConfigFilesDrawerRequest {
     /** Preselect this path in the tree/preview when opening; null opens at the root. */
     initialPath: string | null
     /** Files dropped on the Files peek, staged (unwritten) until a destination is chosen in the drawer. */
-    staged: File[]
+    staged: DroppedFile[]
 }
 
 /** One drawer-open request per config revision, shared by the Files header and body. */

--- a/web/oss/src/components/Drives/driveMedia.ts
+++ b/web/oss/src/components/Drives/driveMedia.ts
@@ -163,12 +163,13 @@ export function useMountFileObjectUrl(
 /**
  * Upload a file into a mount folder, reporting real progress via axios `onUploadProgress` (the
  * Fern client uses fetch, which can't stream upload progress). `destFolder` is the mount-relative
- * directory ("" = root); the filename is appended.
+ * directory ("" = root); `destName` is appended to it, defaulting to the filename.
  */
 export async function uploadMountFile({
     mountId,
     destFolder,
     file,
+    destName,
     projectId,
     onProgress,
     signal,
@@ -176,13 +177,17 @@ export async function uploadMountFile({
     mountId: string
     destFolder: string
     file: File
+    /** Destination path relative to `destFolder`. May be nested ("sub/a.txt") — a dropped folder
+     * keeps its structure, and the backend creates the intermediate directories. */
+    destName?: string
     projectId?: string | null
     onProgress?: (percent: number) => void
     signal?: AbortSignal
 }): Promise<void> {
     const form = new FormData()
     form.append("file", file, file.name)
-    const path = destFolder ? `${destFolder.replace(/\/$/, "")}/${file.name}` : file.name
+    const name = destName || file.name
+    const path = destFolder ? `${destFolder.replace(/\/$/, "")}/${name}` : name
     // The explicit header matters: the shared instance defaults to application/json, and
     // axios then JSON-serializes the FormData, collapsing the File to {}.
     await axios.post(`${getAgentaApiUrl()}/mounts/${mountId}/files/upload`, form, {

--- a/web/oss/src/components/Drives/dropEntries.test.ts
+++ b/web/oss/src/components/Drives/dropEntries.test.ts
@@ -1,0 +1,158 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+import axios from "@/oss/lib/api/assets/axiosConfig"
+
+import {uploadMountFile} from "./driveMedia"
+import {
+    collectDropEntry,
+    type DropEntry,
+    type DropEntryReader,
+    readDroppedFiles,
+} from "./dropEntries"
+
+vi.mock("@/oss/lib/api/assets/axiosConfig", () => ({
+    default: {post: vi.fn(), get: vi.fn()},
+}))
+
+vi.mock("@/oss/lib/helpers/api", () => ({
+    getAgentaApiUrl: vi.fn(() => "https://api.example.test"),
+}))
+
+const file = (name: string) => new File([name], name, {type: "text/plain"})
+
+/** A file entry whose `file()` resolves the given File. */
+const fileEntry = (f: File): DropEntry => ({
+    isFile: true,
+    isDirectory: false,
+    name: f.name,
+    file: (onSuccess) => onSuccess(f),
+})
+
+/** A directory entry whose reader hands back `batches` in order, then an empty batch (the API's
+ * end-of-list signal — a real reader returns at most ~100 entries per call). */
+const dirEntry = (name: string, batches: DropEntry[][]): DropEntry => ({
+    isFile: false,
+    isDirectory: true,
+    name,
+    createReader: (): DropEntryReader => {
+        let next = 0
+        return {
+            readEntries: (onSuccess) => onSuccess(next < batches.length ? batches[next++] : []),
+        }
+    },
+})
+
+describe("collectDropEntry", () => {
+    it("passes a plain file entry through with a bare relative path", async () => {
+        const notes = file("notes.txt")
+        await expect(collectDropEntry(fileEntry(notes))).resolves.toEqual([
+            {file: notes, relativePath: "notes.txt"},
+        ])
+    })
+
+    it("yields nothing for an empty directory", async () => {
+        await expect(collectDropEntry(dirEntry("empty", []))).resolves.toEqual([])
+    })
+
+    it("flattens a directory tree, reading every batch the reader returns", async () => {
+        const a = file("a.txt")
+        const b = file("b.txt")
+        const deep = file("deep.txt")
+        const other = file("other.txt")
+        const sub = dirEntry("sub", [[fileEntry(deep)]])
+        // Two chunks: a real readEntries caps each call, so a single read would drop `sub` + other.txt.
+        const root = dirEntry("myfolder", [
+            [fileEntry(a), fileEntry(b)],
+            [sub, fileEntry(other)],
+        ])
+
+        await expect(collectDropEntry(root)).resolves.toEqual([
+            {file: a, relativePath: "myfolder/a.txt"},
+            {file: b, relativePath: "myfolder/b.txt"},
+            {file: deep, relativePath: "myfolder/sub/deep.txt"},
+            {file: other, relativePath: "myfolder/other.txt"},
+        ])
+    })
+
+    it("skips a file entry the browser refuses to read", async () => {
+        const broken: DropEntry = {
+            isFile: true,
+            isDirectory: false,
+            name: "gone.txt",
+            file: (_onSuccess, onError) => onError?.(new Error("not found")),
+        }
+        await expect(collectDropEntry(dirEntry("d", [[broken]]))).resolves.toEqual([])
+    })
+})
+
+describe("readDroppedFiles", () => {
+    /** A DataTransfer stand-in: one item per (entry, file) pair, plus the flat `files` list. */
+    const transfer = (pairs: {entry: DropEntry | null; file: File | null}[]) =>
+        ({
+            items: pairs.map(({entry, file}) => ({
+                kind: "file",
+                webkitGetAsEntry: () => entry,
+                getAsFile: () => file,
+            })),
+            files: pairs.map((p) => p.file).filter(Boolean) as File[],
+        }) as unknown as DataTransfer
+
+    it("expands a dropped folder while passing a sibling file through", async () => {
+        const inner = file("inner.txt")
+        const loose = file("loose.txt")
+        const folder = dirEntry("myfolder", [[fileEntry(inner)]])
+
+        await expect(
+            readDroppedFiles(
+                transfer([
+                    {entry: folder, file: new File([], "myfolder")},
+                    {entry: fileEntry(loose), file: loose},
+                ]),
+            ),
+        ).resolves.toEqual([
+            {file: inner, relativePath: "myfolder/inner.txt"},
+            {file: loose, relativePath: "loose.txt"},
+        ])
+    })
+
+    it("falls back to the plain file when the item has no filesystem entry", async () => {
+        const loose = file("loose.txt")
+        await expect(readDroppedFiles(transfer([{entry: null, file: loose}]))).resolves.toEqual([
+            {file: loose, relativePath: "loose.txt"},
+        ])
+    })
+})
+
+describe("uploadMountFile path composition", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.mocked(axios.post).mockResolvedValue({data: {}})
+    })
+
+    const postedPath = () => vi.mocked(axios.post).mock.calls[0]?.[2]?.params?.path
+
+    it("nests a dropped folder's file under the destination folder", async () => {
+        await uploadMountFile({
+            mountId: "m1",
+            destFolder: "reports",
+            file: file("deep.txt"),
+            destName: "myfolder/sub/deep.txt",
+        })
+        expect(postedPath()).toBe("reports/myfolder/sub/deep.txt")
+    })
+
+    it("keeps the relative path at the drive root", async () => {
+        await uploadMountFile({
+            mountId: "m1",
+            destFolder: "",
+            file: file("deep.txt"),
+            destName: "myfolder/sub/deep.txt",
+        })
+        expect(postedPath()).toBe("myfolder/sub/deep.txt")
+    })
+
+    it("falls back to the filename when no destName is given", async () => {
+        await uploadMountFile({mountId: "m1", destFolder: "reports", file: file("notes.txt")})
+        expect(postedPath()).toBe("reports/notes.txt")
+    })
+})

--- a/web/oss/src/components/Drives/dropEntries.ts
+++ b/web/oss/src/components/Drives/dropEntries.ts
@@ -1,0 +1,108 @@
+/**
+ * Reading a file drop. A dropped DIRECTORY shows up on `dataTransfer.files` as a single 0-byte
+ * pseudo-file named after the folder, so its real contents have to come from the entries API
+ * (`DataTransferItem.webkitGetAsEntry`), walked recursively. Every drop handler in the drive goes
+ * through {@link readDroppedFiles}, which yields the flat list of files plus where each one lands
+ * relative to the drop destination.
+ */
+
+/** A file picked for upload plus its path relative to the destination folder. */
+export interface DroppedFile {
+    file: File
+    /** "notes.txt" for a plain file, "myfolder/sub/a.txt" for one inside a dropped folder. */
+    relativePath: string
+}
+
+/** The slice of the DOM's `FileSystemEntry` the walk needs — structural so tests can fake a tree. */
+export interface DropEntry {
+    isFile: boolean
+    isDirectory: boolean
+    name: string
+    file?: (onSuccess: (file: File) => void, onError?: (error: unknown) => void) => void
+    createReader?: () => DropEntryReader
+}
+
+/** The slice of the DOM's `FileSystemDirectoryReader` the walk needs. */
+export interface DropEntryReader {
+    readEntries: (
+        onSuccess: (entries: DropEntry[]) => void,
+        onError?: (error: unknown) => void,
+    ) => void
+}
+
+const join = (prefix: string, name: string): string => (prefix ? `${prefix}/${name}` : name)
+
+/** A file entry's File, or null if the browser refuses it (a deleted/unreadable file). */
+const entryFile = (entry: DropEntry): Promise<File | null> =>
+    new Promise((resolve) => {
+        if (!entry.file) return resolve(null)
+        entry.file(
+            (file) => resolve(file),
+            () => resolve(null),
+        )
+    })
+
+/** One directory's children. `readEntries` returns at most ~100 per call and signals the end with an
+ * empty batch, so it has to be called in a loop until then — a single call silently truncates. */
+const readAllEntries = async (reader: DropEntryReader): Promise<DropEntry[]> => {
+    const all: DropEntry[] = []
+    for (;;) {
+        const batch = await new Promise<DropEntry[]>((resolve) => {
+            reader.readEntries(
+                (entries) => resolve(entries ?? []),
+                () => resolve([]),
+            )
+        })
+        if (!batch.length) return all
+        all.push(...batch)
+    }
+}
+
+/**
+ * Flatten one dropped entry into its files, each tagged with its path relative to the drop target.
+ * A file entry yields itself; a directory entry yields its whole subtree under the directory's name.
+ * `prefix` is the path already walked (empty at the top level, so a plain file keeps a bare name).
+ */
+export async function collectDropEntry(entry: DropEntry, prefix = ""): Promise<DroppedFile[]> {
+    if (entry.isFile) {
+        const file = await entryFile(entry)
+        return file ? [{file, relativePath: join(prefix, file.name)}] : []
+    }
+    if (!entry.isDirectory || !entry.createReader) return []
+    const dirPrefix = join(prefix, entry.name)
+    const children = await readAllEntries(entry.createReader())
+    const collected: DroppedFile[] = []
+    for (const child of children) collected.push(...(await collectDropEntry(child, dirPrefix)))
+    return collected
+}
+
+/**
+ * Resolve a drop event to its files. MUST be called synchronously from the drop handler: the
+ * `dataTransfer` item list is only alive for the duration of the event, so the entries are taken
+ * up front and only the walk itself is async. Falls back to the flat `dataTransfer.files` list where
+ * the entries API is unavailable.
+ */
+export function readDroppedFiles(dataTransfer: DataTransfer | null): Promise<DroppedFile[]> {
+    const items = Array.from(dataTransfer?.items ?? []).filter((item) => item.kind === "file")
+    if (!items.length) {
+        return Promise.resolve(
+            Array.from(dataTransfer?.files ?? []).map((file) => ({file, relativePath: file.name})),
+        )
+    }
+    // Both the entry and the plain File are taken here, in the same synchronous pass: an item that
+    // has no filesystem entry (a file dragged from another page) still uploads as it always did.
+    const picked = items.map((item) => ({
+        entry:
+            typeof item.webkitGetAsEntry === "function"
+                ? (item.webkitGetAsEntry() as DropEntry | null)
+                : null,
+        file: item.getAsFile(),
+    }))
+    return Promise.all(
+        picked.map(({entry, file}) =>
+            entry
+                ? collectDropEntry(entry)
+                : Promise.resolve(file ? [{file, relativePath: file.name}] : []),
+        ),
+    ).then((lists) => lists.flat())
+}

--- a/web/oss/src/components/Drives/useDriveDrop.ts
+++ b/web/oss/src/components/Drives/useDriveDrop.ts
@@ -1,10 +1,15 @@
 import {useCallback, useEffect, useRef, useState} from "react"
 
+import {type DroppedFile, readDroppedFiles} from "./dropEntries"
+
 /**
  * Drag-and-drop upload behaviour shared by the drive's tree and grid: highlight the folder under
  * the cursor, spring-load into it after a short hover (drill to a nested destination without
  * dropping), and upload on drop — into the hovered folder, or the current folder for a background
  * drop. The views wire the returned handler props onto folder targets and their container.
+ *
+ * Every drop reads its files through {@link readDroppedFiles}, which walks dropped directories into
+ * their contents; each file carries the path it should keep under the destination folder.
  */
 
 const SPRING_MS = 700
@@ -38,7 +43,7 @@ export function useDriveDrop({
 }: {
     /** False leaves the hook mounted but inert — no window listeners, nothing to hover. */
     enabled?: boolean
-    onUpload: (files: File[], folder: string) => void
+    onUpload: (files: DroppedFile[], folder: string) => void
     onNavigate: (folder: string) => void
 }): DriveDrop {
     const [dragging, setDragging] = useState(false)
@@ -120,8 +125,9 @@ export function useDriveDrop({
                 if (!isFileDrag(e)) return
                 e.preventDefault()
                 e.stopPropagation()
-                const files = Array.from(e.dataTransfer.files)
-                if (files.length) onUpload(files, path)
+                void readDroppedFiles(e.dataTransfer).then((files) => {
+                    if (files.length) onUpload(files, path)
+                })
                 setHoverPath(null)
                 clearSpring()
             },
@@ -142,8 +148,9 @@ export function useDriveDrop({
             onDrop: (e: React.DragEvent) => {
                 if (!isFileDrag(e)) return
                 e.preventDefault()
-                const files = Array.from(e.dataTransfer.files)
-                if (files.length) onUpload(files, currentFolder)
+                void readDroppedFiles(e.dataTransfer).then((files) => {
+                    if (files.length) onUpload(files, currentFolder)
+                })
                 setHoverPath(null)
                 clearSpring()
             },
@@ -167,7 +174,9 @@ export type FileDropProps = Pick<
  * destination is chosen). Pass a falsy `onFiles` to disable (e.g. no writable mount) — then `dropProps`
  * is empty and nothing highlights.
  */
-export function useStageDrop(onFiles: ((files: File[]) => void) | false | null | undefined): {
+export function useStageDrop(
+    onFiles: ((files: DroppedFile[]) => void) | false | null | undefined,
+): {
     dropActive: boolean
     dropProps: FileDropProps
 } {
@@ -186,8 +195,9 @@ export function useStageDrop(onFiles: ((files: File[]) => void) | false | null |
                 if (!isFileDrag(e)) return
                 e.preventDefault()
                 setDropActive(false)
-                const files = Array.from(e.dataTransfer.files)
-                if (files.length) onFiles(files)
+                void readDroppedFiles(e.dataTransfer).then((files) => {
+                    if (files.length) onFiles(files)
+                })
             },
         },
     }

--- a/web/oss/src/components/Drives/useDriveUploads.ts
+++ b/web/oss/src/components/Drives/useDriveUploads.ts
@@ -16,12 +16,16 @@ import {type MountFile} from "@agenta/entities/session"
 import {isAgentFileUploadsEnabled} from "@/oss/components/AgentChatSlice/assets/constants"
 
 import {type StagedTileItem} from "./DrivePendingTiles"
+import {type DroppedFile} from "./dropEntries"
 import {useDriveDrop} from "./useDriveDrop"
 import {useImagePreviews} from "./useImagePreviews"
 import {fileKey, type MountUploadItem, useMountUpload} from "./useMountUpload"
 import {type SessionDriveData} from "./useSessionDrive"
 
-const NO_FILES: File[] = []
+const NO_FILES: DroppedFile[] = []
+
+/** The staged tile's id — stable per position + destination path, and the handle removeStaged uses. */
+const stagedId = (dropped: DroppedFile, index: number) => `${index}-${dropped.relativePath}`
 
 export function useDriveUploads({
     drive,
@@ -35,8 +39,8 @@ export function useDriveUploads({
     explicitFiles?: MountFile[]
     /** The explorer's selection callback — a drop springs-loads into the hovered folder. */
     select: (path: string | null) => void
-    stagedFiles?: File[]
-    onStagedChange?: (files: File[]) => void
+    stagedFiles?: DroppedFile[]
+    onStagedChange?: (files: DroppedFile[]) => void
 }) {
     // Upload state lives here (above the tree) so in-flight uploads can be injected as synthetic files —
     // buildDriveTree then nests each UNDER its destination folder, and the real tree row / file tile
@@ -44,7 +48,7 @@ export function useDriveUploads({
     const mountUpload = useMountUpload()
     const uploadPath = useCallback(
         (it: MountUploadItem) =>
-            it.presentedFolder ? `${it.presentedFolder}/${it.name}` : it.name,
+            it.presentedFolder ? `${it.presentedFolder}/${it.relativePath}` : it.relativePath,
         [],
     )
     const uploadFiles = useMemo<MountFile[]>(
@@ -62,7 +66,7 @@ export function useDriveUploads({
     const uploadInputRef = useRef<HTMLInputElement>(null)
     const canUpload = isAgentFileUploadsEnabled() && !explicitFiles && !!drive.mount
     const uploadIntoFolder = useCallback(
-        (picked: File[], folder: string) => {
+        (picked: DroppedFile[], folder: string) => {
             const resolved = drive.resolveMount(folder)
             if (!resolved) return
             mountUpload.upload(picked, {
@@ -92,21 +96,20 @@ export function useDriveUploads({
     // destination and clicks "Upload here" — ghost tiles in the grid meanwhile. Only for writable
     // mounts (never the local-file preview). Image previews come from the shared hook.
     const staged = canUpload ? (stagedFiles ?? NO_FILES) : NO_FILES
-    const stagedPreviews = useImagePreviews(staged)
+    const stagedPreviews = useImagePreviews(useMemo(() => staged.map((d) => d.file), [staged]))
     const stagedItems = useMemo<StagedTileItem[]>(
         () =>
-            staged.map((f, i) => ({
-                id: `${i}-${f.name}`,
-                name: f.name,
-                file: f,
-                previewUrl: stagedPreviews.get(f) ?? null,
+            staged.map((d, i) => ({
+                id: stagedId(d, i),
+                name: d.file.name,
+                file: d.file,
+                previewUrl: stagedPreviews.get(d.file) ?? null,
             })),
         [staged, stagedPreviews],
     )
     const removeStaged = useCallback(
-        (id: string) =>
-            onStagedChange?.(stagedItems.filter((it) => it.id !== id).map((it) => it.file)),
-        [stagedItems, onStagedChange],
+        (id: string) => onStagedChange?.(staged.filter((d, i) => stagedId(d, i) !== id)),
+        [staged, onStagedChange],
     )
     // Single source of truth: a file that is in-flight (uploading OR failed) must never ALSO remain
     // staged. Reconcile the staged inbox against in-flight keys on every change, so re-staging a file

--- a/web/oss/src/components/Drives/useMountUpload.ts
+++ b/web/oss/src/components/Drives/useMountUpload.ts
@@ -7,6 +7,7 @@ import {queryClientAtom} from "jotai-tanstack-query"
 import {projectIdAtom} from "@/oss/state/project"
 
 import {uploadMountFile} from "./driveMedia"
+import {type DroppedFile} from "./dropEntries"
 import {useImagePreviews} from "./useImagePreviews"
 
 /**
@@ -18,15 +19,22 @@ import {useImagePreviews} from "./useImagePreviews"
  * so it refreshes the open directory whether the host is a session or the config panel).
  */
 
-/** Stable identity for a picked File — so a re-drop, or staging then dropping the same file, is
- * recognised as the SAME upload and never duplicated. */
-export const fileKey = (f: File): string => `${f.name}::${f.size}::${f.lastModified}`
+/** How many files upload at once (a dropped folder can queue far more than that). */
+const MAX_CONCURRENT_UPLOADS = 4
+
+/** Stable identity for a picked file — so a re-drop, or staging then dropping the same file, is
+ * recognised as the SAME upload and never duplicated. Keyed on the relative path, not the bare name,
+ * so same-named files from two subfolders of a dropped directory stay distinct. */
+export const fileKey = (f: DroppedFile): string =>
+    `${f.relativePath}::${f.file.size}::${f.file.lastModified}`
 
 export interface MountUploadItem {
     id: string
     /** Stable file identity (see fileKey) — lets a host reconcile staged files against in-flight ones. */
     key: string
     name: string
+    /** Destination path relative to `destFolder` — nested for a file from a dropped folder. */
+    relativePath: string
     size: number
     /** The picked file — drives the image preview (via useImagePreviews). */
     file: File
@@ -52,7 +60,7 @@ export interface MountUploadTarget {
 
 export interface MountUpload {
     items: MountUploadItem[]
-    upload: (files: File[], target: MountUploadTarget) => void
+    upload: (files: DroppedFile[], target: MountUploadTarget) => void
     retry: (id: string) => void
     dismiss: (id: string) => void
 }
@@ -63,8 +71,12 @@ export function useMountUpload(): MountUpload {
     const [items, setItems] = useState<MountUploadItem[]>([])
 
     // Per-item inputs kept for retry, plus abort controllers for cleanup.
-    const sources = useRef(new Map<string, {file: File; target: MountUploadTarget}>())
+    const sources = useRef(new Map<string, {dropped: DroppedFile; target: MountUploadTarget}>())
     const controllers = useRef(new Map<string, AbortController>())
+    // A dropped folder can hold hundreds of files, so runs are gated: ids wait here until a slot frees.
+    const waiting = useRef<string[]>([])
+    const running = useRef(0)
+    const pumpRef = useRef<() => void>(() => undefined)
 
     const patch = useCallback((id: string, next: Partial<MountUploadItem>) => {
         setItems((prev) => prev.map((it) => (it.id === id ? {...it, ...next} : it)))
@@ -88,12 +100,15 @@ export function useMountUpload(): MountUpload {
             uploadMountFile({
                 mountId: src.target.mount.id ?? "",
                 destFolder: src.target.destFolder,
-                file: src.file,
+                file: src.dropped.file,
+                destName: src.dropped.relativePath,
                 projectId,
                 onProgress: (percent) => patch(id, {percent}),
                 signal: controller.signal,
             })
                 .then(() => {
+                    running.current = Math.max(0, running.current - 1)
+                    pumpRef.current()
                     if (controller.signal.aborted) return
                     controllers.current.delete(id)
                     // On success the real file arrives via the listing refetch, so drop the optimistic
@@ -103,6 +118,8 @@ export function useMountUpload(): MountUpload {
                     refreshListing()
                 })
                 .catch((e: unknown) => {
+                    running.current = Math.max(0, running.current - 1)
+                    pumpRef.current()
                     if (controller.signal.aborted) return
                     controllers.current.delete(id)
                     patch(id, {error: e instanceof Error ? e.message : "Upload failed"})
@@ -111,23 +128,47 @@ export function useMountUpload(): MountUpload {
         [projectId, patch, refreshListing],
     )
 
+    // Start queued uploads up to the concurrency limit; ids dismissed while waiting are skipped.
+    const pump = useCallback(() => {
+        while (running.current < MAX_CONCURRENT_UPLOADS && waiting.current.length) {
+            const id = waiting.current.shift() as string
+            if (!sources.current.has(id)) continue
+            running.current += 1
+            run(id)
+        }
+    }, [run])
+    // `run` settles asynchronously and pumps the queue again, so it reaches pump through a ref.
+    useEffect(() => {
+        pumpRef.current = pump
+    }, [pump])
+
+    const enqueue = useCallback(
+        (id: string) => {
+            waiting.current.push(id)
+            pump()
+        },
+        [pump],
+    )
+
     const upload = useCallback(
-        (files: File[], target: MountUploadTarget) => {
+        (files: DroppedFile[], target: MountUploadTarget) => {
             // Skip files already in flight (same key) so a re-drop, or a drop of a file that's also
             // staged, can't create a second upload item for the same file.
             const inFlight = new Set(
-                Array.from(sources.current.values()).map((s) => fileKey(s.file)),
+                Array.from(sources.current.values()).map((s) => fileKey(s.dropped)),
             )
             const fresh = files.filter((f) => !inFlight.has(fileKey(f)))
             if (!fresh.length) return
             const started: MountUploadItem[] = []
-            fresh.forEach((file, i) => {
-                const id = `${Date.now()}-${i}-${file.name}`
-                sources.current.set(id, {file, target})
+            fresh.forEach((dropped, i) => {
+                const {file, relativePath} = dropped
+                const id = `${Date.now()}-${i}-${relativePath}`
+                sources.current.set(id, {dropped, target})
                 started.push({
                     id,
-                    key: fileKey(file),
+                    key: fileKey(dropped),
                     name: file.name,
+                    relativePath,
                     size: file.size,
                     file,
                     percent: 0,
@@ -138,12 +179,12 @@ export function useMountUpload(): MountUpload {
                 })
             })
             setItems((prev) => [...prev, ...started])
-            started.forEach((it) => run(it.id))
+            started.forEach((it) => enqueue(it.id))
         },
-        [run],
+        [enqueue],
     )
 
-    const retry = useCallback((id: string) => run(id), [run])
+    const retry = useCallback((id: string) => enqueue(id), [enqueue])
     const dismiss = useCallback((id: string) => {
         controllers.current.get(id)?.abort()
         controllers.current.delete(id)


### PR DESCRIPTION
## What was broken

Dragging a folder into the Files drawer created a single 0-byte file named after the folder. The drop handlers read `dataTransfer.files`, and a directory arrives there as an empty pseudo-file. Closes #5626.

## Fix

- New `dropEntries.ts`: reads `dataTransfer.items` synchronously (the list is only alive during the event), takes `webkitGetAsEntry()` per item, and recursively walks directory entries. `readEntries` is called until it returns an empty batch, since it caps each batch. The walk is a pure helper with 9 unit tests.
- Files flow as `{file, relativePath}` pairs through the existing upload machinery, so a nested file posts to `${destFolder}/${relativePath}` and the progress UI renders it under its folder while in flight.
- All three drop affordances covered: folder-row drop, open-folder background drop, and drop-to-stage on a recents peek (staging now carries paths so the tree survives until a destination is picked).

## Implicit decisions and their tradeoffs

- Uploads now go through a small FIFO gate (4 concurrent). Before, a 500-file folder would fire 500 concurrent requests. Retry uses the same gate.
- The dedup key moved from `name::size::lastModified` to `relativePath::size::lastModified`, otherwise same-named files in two subfolders silently collapse. Identical behavior for top-level files.
- The file-picker button is unchanged: no `webkitdirectory`, since folder-picking via the button would be a new affordance, not a bug fix.
- No new user-facing strings; per-file failures surface through the existing upload error state.

Stacked on #5625 (the multipart transport fix); base is that branch so this diff shows only the walk.

https://claude.ai/code/session_01McMogkcDRV7UpSAjfd8VKG