### PR TITLE
test(api): skip database-adjacent acceptance tests when Postgres is unreachable

### DIFF
--- a/api/oss/tests/pytest/acceptance/conftest.py
+++ b/api/oss/tests/pytest/acceptance/conftest.py
@@ -1,0 +1,34 @@
+import socket
+from functools import lru_cache
+from urllib.parse import urlparse
+
+import pytest
+
+from oss.src.utils.env import env
+
+
+@lru_cache(maxsize=1)
+def _postgres_reachable() -> bool:
+    """TCP-probe the configured core Postgres once per session.
+
+    Most acceptance tests speak pure HTTP and run against any deployed stage. A few
+    verify server-side effects by reading the database directly, which only works when
+    the suite runs adjacent to the stack (compose network or a tunnel). Probe rather
+    than error so a remote-stage run skips those instead of failing on name resolution.
+    """
+    parsed = urlparse(env.postgres.uri_core)
+    host = parsed.hostname or "postgres"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _skip_db_adjacent_when_postgres_unreachable(request):
+    if request.node.get_closest_marker("integration") and not _postgres_reachable():
+        pytest.skip(
+            "Postgres not reachable — skipping database-adjacent acceptance tests"
+        )

--- a/api/oss/tests/pytest/acceptance/mounts/test_attachments_mount_hidden.py
+++ b/api/oss/tests/pytest/acceptance/mounts/test_attachments_mount_hidden.py
@@ -1,3 +1,4 @@
+import pytest
 import asyncio
 from uuid import UUID, uuid4
 
@@ -6,6 +7,9 @@ from sqlalchemy import select
 from oss.src.dbs.postgres.sessions.attachments.dbes import SessionAttachmentDBE
 from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.tests.pytest.utils.mounts import skip_if_mount_storage_unavailable
+
+# Reads the database directly, so it only runs adjacent to the stack (see conftest).
+pytestmark = pytest.mark.integration
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"hidden-mount"
 

--- a/api/oss/tests/pytest/acceptance/sessions/test_session_attachment_teardown.py
+++ b/api/oss/tests/pytest/acceptance/sessions/test_session_attachment_teardown.py
@@ -13,6 +13,9 @@ from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.src.utils.env import env
 from oss.tests.pytest.utils.mounts import skip_if_mount_storage_unavailable
 
+# Reads the database directly, so it only runs adjacent to the stack (see conftest).
+pytestmark = pytest.mark.integration
+
 _PNG = b"\x89PNG\r\n\x1a\n" + b"teardown"
 
 

--- a/api/oss/tests/pytest/acceptance/sessions/test_session_attachments.py
+++ b/api/oss/tests/pytest/acceptance/sessions/test_session_attachments.py
@@ -1,3 +1,4 @@
+import pytest
 import asyncio
 from uuid import UUID, uuid4
 
@@ -6,6 +7,9 @@ from sqlalchemy import select
 from oss.src.dbs.postgres.sessions.attachments.dbes import SessionAttachmentDBE
 from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.tests.pytest.utils.mounts import skip_if_mount_storage_unavailable
+
+# Reads the database directly, so it only runs adjacent to the stack (see conftest).
+pytestmark = pytest.mark.integration
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"attachment-content"
 _AUDIO_CAP_BYTES = 15 * 1024 * 1024


### PR DESCRIPTION
The staging test workflow failed 6 of the new attachment acceptance tests with `socket.gaierror`: they verify server-side effects by reading Postgres directly, which works beside a compose stack but cannot resolve the database host from a hosted runner testing a remote stage. All 777 wire-level acceptance tests passed.

Fix: the same probe-and-skip pattern the unit DAO tests use, lifted into an acceptance-level conftest, with the three database-adjacent modules marked `integration`. Verified both modes against the dev stack: stage-like (API reachable, DB host unresolvable) yields 9 clean skips; adjacent (DB reachable) runs them for real.

https://claude.ai/code/session_01McMogkcDRV7UpSAjfd8VKG