### PR TITLE
fix(frontend): select the session cwd mount by name, order mount listings deterministically

### DIFF
--- a/api/oss/src/dbs/postgres/mounts/dao.py
+++ b/api/oss/src/dbs/postgres/mounts/dao.py
@@ -308,6 +308,10 @@ class MountsDAO(MountsDAOInterface):
                     order="descending",
                     windowing=windowing,
                 )
+            else:
+                # Consumers index into this list (the web drive picks a mount out of it), so an
+                # unordered query made their pick depend on whatever row order Postgres returned.
+                stmt = stmt.order_by(MountDBE.created_at.asc(), MountDBE.id.asc())
 
             result = await session.execute(stmt)
 

--- a/api/oss/tests/pytest/unit/sessions/test_wp5_dao_fanout.py
+++ b/api/oss/tests/pytest/unit/sessions/test_wp5_dao_fanout.py
@@ -16,6 +16,7 @@ delete/archive/unarchive fan-out is built on, and were "new plumbing" per the br
 """
 
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
@@ -29,7 +30,7 @@ from oss.src.core.sessions.interactions.dtos import (
     SessionInteractionStatus,
     SessionInteractionTransition,
 )
-from oss.src.core.mounts.dtos import MountCreate
+from oss.src.core.mounts.dtos import MountCreate, MountQuery
 import oss.src.models.db_models  # noqa: F401
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE  # noqa: F401
 from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
@@ -492,3 +493,56 @@ async def test_mounts_delete_by_session_id_no_mounts_returns_empty(mounts_dao, p
         project_id=project_id, session_id=session_id
     )
     assert deleted_mounts == []
+
+
+# ---------------------------------------------------------------------------
+# MountsDAO.query_mounts — default ordering when no windowing is passed
+# ---------------------------------------------------------------------------
+
+
+async def test_query_mounts_without_windowing_orders_oldest_first(mounts_dao, project):
+    """Consumers index into the returned list (the web drive picks a mount out of it),
+    so the unwindowed query must be deterministic: oldest created_at first."""
+    project_id = project["project_id"]
+    user_id = project["user_id"]
+    session_id = f"wp5-mounts-order-{uuid.uuid4().hex[:8]}"
+
+    mounts = []
+    for label in ("cwd", "pi-sessions", "notes"):
+        mounts.append(
+            await mounts_dao.create_mount(
+                project_id=project_id,
+                user_id=user_id,
+                mount_create=MountCreate(
+                    slug=f"wp5-order-{label}-{uuid.uuid4().hex[:8]}",
+                    name=label,
+                    session_id=session_id,
+                ),
+            )
+        )
+
+    # Stamp created_at out of insertion order so the assertion pins the ORDER BY, not the
+    # order the rows were written in.
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    stamps = [base + timedelta(minutes=offset) for offset in (2, 0, 1)]
+    async with get_transactions_engine().session() as session:
+        for mount, created_at in zip(mounts, stamps):
+            await session.execute(
+                text(
+                    "UPDATE mounts SET created_at = :created_at "
+                    "WHERE project_id = :project_id AND id = :id"
+                ),
+                {
+                    "created_at": created_at,
+                    "project_id": project_id,
+                    "id": mount.id,
+                },
+            )
+        await session.commit()
+
+    queried = await mounts_dao.query_mounts(
+        project_id=project_id,
+        mount_query=MountQuery(session_id=session_id),
+    )
+
+    assert [m.id for m in queried] == [mounts[1].id, mounts[2].id, mounts[0].id]

--- a/web/oss/src/components/Drives/chatFileRefs.tsx
+++ b/web/oss/src/components/Drives/chatFileRefs.tsx
@@ -17,6 +17,7 @@ import {type ReactNode, useCallback, useEffect, useRef, useState} from "react"
 import {
     mountFileContentQueryFamily,
     mountPathMatchesToolPath,
+    pickCwdMount,
     sessionMountsQueryFamily,
     sessionRecordFileRecencyAtomFamily,
     type Mount,
@@ -67,7 +68,7 @@ const knownFromRecords = (byBasename: Map<string, string[]>, candidate: string):
  * its mount + mount-relative path, the same rule the full drive uses. */
 function useMountResolver(sessionId: string, artifactId?: string | null) {
     const cwdMounts = useAtomValue(sessionMountsQueryFamily(sessionId)).data ?? []
-    const cwdMount = cwdMounts.find((m) => m.slug === "cwd") ?? cwdMounts[0] ?? null
+    const cwdMount = pickCwdMount(cwdMounts)
     const agentMount = useAtomValue(agentMountQueryFamily(artifactId ?? "")).data ?? null
     return useCallback(
         (path: string): {mount: Mount; path: string} | null => {

--- a/web/oss/src/components/Drives/useSessionDrive.ts
+++ b/web/oss/src/components/Drives/useSessionDrive.ts
@@ -4,6 +4,7 @@ import {
     latestMountFilesQueryFamily,
     mountFilesQueryFamily,
     mountRootQueryFamily,
+    pickCwdMount,
     sessionFileActivityAtomFamily,
     sessionMountsQueryFamily,
     sessionRecordFileRecencyAtomFamily,
@@ -134,7 +135,7 @@ export function useSessionDrive(
 ): SessionDriveData {
     const mountsQuery = useAtomValue(sessionMountsQueryFamily(sessionId))
     const mounts = mountsQuery.data ?? []
-    const mount = mounts.find((m) => m.slug === "cwd") ?? mounts[0] ?? null
+    const mount = pickCwdMount(mounts)
 
     const filesQuery = useAtomValue(
         mountFilesQueryFamily({mountId: mount?.id ?? "", includeGitignored}),
@@ -333,7 +334,7 @@ const SUMMARY_LATEST_LIMIT = 5
 export function useSessionDriveSummary(sessionId: string, artifactId?: string): SessionDriveData {
     const mountsQuery = useAtomValue(sessionMountsQueryFamily(sessionId))
     const mounts = mountsQuery.data ?? []
-    const mount = mounts.find((m) => m.slug === "cwd") ?? mounts[0] ?? null
+    const mount = pickCwdMount(mounts)
 
     const agentMountQuery = useAtomValue(agentMountQueryFamily(artifactId ?? ""))
     const agentMount = artifactId ? (agentMountQuery.data ?? null) : null

--- a/web/packages/agenta-entities/src/session/core/mountSelection.ts
+++ b/web/packages/agenta-entities/src/session/core/mountSelection.ts
@@ -1,0 +1,22 @@
+/**
+ * Picking the session's working-directory ("cwd") mount out of a session's mount list.
+ */
+import type {Mount} from "./schema"
+
+/** The canonical mount name the backend stores for the session working directory. */
+const CWD_MOUNT_NAME = "cwd"
+
+/**
+ * The session's working-directory mount, else the first mount.
+ *
+ * Matched on `name`: the wire `slug` is a minted reserved slug (`__ag__session__<uuid5>__cwd`), so
+ * it never equals `"cwd"`. The slug-suffix pass is only a fallback for responses without a name.
+ */
+export function pickCwdMount(mounts: Mount[]): Mount | null {
+    return (
+        mounts.find((mount) => mount.name === CWD_MOUNT_NAME) ??
+        mounts.find((mount) => Boolean(mount.slug?.endsWith(`__${CWD_MOUNT_NAME}`))) ??
+        mounts[0] ??
+        null
+    )
+}

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -69,6 +69,7 @@ export {
 } from "./core/liveness"
 export {shouldAdoptServerTranscript, type TranscriptAdoptionInput} from "./core/transcriptAdoption"
 export {deriveMountRows, mountBreadcrumbs, type MountRow} from "./core/mountBrowser"
+export {pickCwdMount} from "./core/mountSelection"
 export {
     sessionRecordsQueryFamily,
     sessionRecordFileRecencyAtomFamily,

--- a/web/packages/agenta-entities/tests/unit/session-pick-cwd-mount.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-pick-cwd-mount.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Pins how the session's working-directory mount is picked. The wire `slug` is a minted reserved
+ * slug (`__ag__session__<uuid5>__cwd`), so selecting on `slug === "cwd"` never matched and the
+ * drive silently ran on whichever mount the backend happened to return first.
+ */
+import {describe, expect, it} from "vitest"
+
+import {pickCwdMount} from "../../src/session/core/mountSelection"
+import type {Mount} from "../../src/session/core/schema"
+
+const mount = (id: string, slug: string, name?: string | null): Mount => ({
+    id,
+    slug,
+    name: name ?? null,
+    session_id: "sess-1",
+})
+
+describe("pickCwdMount", () => {
+    it("matches the canonical name regardless of position in the list", () => {
+        const mounts = [
+            mount("1", "__ag__session__abc__pi-sessions", "pi-sessions"),
+            mount("2", "__ag__session__abc__cwd", "cwd"),
+        ]
+        expect(pickCwdMount(mounts)?.id).toBe("2")
+    })
+
+    it("falls back to the `__cwd` slug suffix when the name is missing", () => {
+        const mounts = [
+            mount("1", "__ag__session__abc__pi-sessions"),
+            mount("2", "__ag__session__abc__cwd"),
+        ]
+        expect(pickCwdMount(mounts)?.id).toBe("2")
+    })
+
+    it("falls back to the first mount when neither name nor slug identifies a cwd", () => {
+        const mounts = [
+            mount("1", "__ag__session__abc__pi-sessions", "pi-sessions"),
+            mount("2", "__ag__session__abc__notes", "notes"),
+        ]
+        expect(pickCwdMount(mounts)?.id).toBe("1")
+    })
+
+    it("returns null for an empty list", () => {
+        expect(pickCwdMount([])).toBeNull()
+    })
+})


### PR DESCRIPTION
## What was broken

On staging, the Files drawer sometimes showed an empty tree with no session-files option even though the agent had written files into the session workspace (reported by Mahmoud during release QA, reproduced live).

## Cause

The drawer picked the working-directory mount with `mounts.find((m) => m.slug === "cwd")`, but the wire slug has been the minted reserved slug (`__ag__session__<uuid5>__cwd`) since before that line was written, so the selector never matched once and every drawer ran on `mounts[0]`: an UNORDERED SQL result. When a sibling mount (pi-sessions) happened to come back first, the drawer pointed at the wrong mount: empty tree, and the All/Agent/Session control never rendered. Pre-existing since the drive surfaces landed (byte-identical in v0.106.2); plausibly surfaced now because the release's new query predicates can flip the arbitrary row order.

## Fix

- New `pickCwdMount` helper in `@agenta/entities/session`: match by `name === "cwd"` first (the API returns it on every response), then a `__cwd` slug-suffix fallback, then the old first-mount fallback. Used at all three call sites so they cannot drift again.
- The mounts DAO applies a stable `ORDER BY created_at, id` when no windowing is passed, so no consumer depends on undefined row order.

## Tests

Helper unit tests (name beats position, suffix fallback, empty list) and a DB-backed ordering test that stamps `created_at` out of insertion order and fails with the ORDER BY removed (verified by mutation).

https://claude.ai/code/session_01McMogkcDRV7UpSAjfd8VKG