### PR TITLE
fix(runner): bake unzip, zip, and the python alias into both sandbox runtimes

### DIFF
--- a/docs/docs/self-host/agents/02-daytona.mdx
+++ b/docs/docs/self-host/agents/02-daytona.mdx
@@ -76,9 +76,14 @@ DAYTONA_API_KEY=<daytona-api-key> DAYTONA_TARGET=eu uv run build_snapshot.py --f
 ```
 
 The recipe starts from the sandbox base image, which already contains Claude Code, Codex, and
-OpenCode. It adds the Pi harness at the version the runner expects, plus the FUSE tooling that
-mounts durable working directories inside the sandbox. It builds a snapshot named
-`agenta-agent-sandbox-v1` and sets each sandbox to 2 vCPU, 4 GB of memory, and 5 GB of disk.
+OpenCode. It adds the Pi harness at the version the runner expects, the FUSE tooling that
+mounts durable working directories inside the sandbox, and the everyday shell tools agents reach
+for on their own: `python3` (also available as `python`), `unzip`, and `zip`. It builds a snapshot
+named `agenta-agent-sandbox-v1` and sets each sandbox to 2 vCPU, 4 GB of memory, and 5 GB of disk.
+
+If you already built `agenta-agent-sandbox-v1` from an earlier release, rebuild it with `--force`
+after upgrading. Daytona keeps the snapshot you built, so a snapshot built from an older recipe
+keeps its older toolset until you rebuild it.
 
 Point the runner at it:
 

--- a/docs/docs/self-host/agents/02-daytona.mdx
+++ b/docs/docs/self-host/agents/02-daytona.mdx
@@ -78,8 +78,9 @@ DAYTONA_API_KEY=<daytona-api-key> DAYTONA_TARGET=eu uv run build_snapshot.py --f
 The recipe starts from the sandbox base image, which already contains Claude Code, Codex, and
 OpenCode. It adds the Pi harness at the version the runner expects, the FUSE tooling that
 mounts durable working directories inside the sandbox, and the everyday shell tools agents reach
-for on their own: `python3` (also available as `python`), `unzip`, and `zip`. It builds a snapshot
-named `agenta-agent-sandbox-v1` and sets each sandbox to 2 vCPU, 4 GB of memory, and 5 GB of disk.
+for on their own: `python3` (also available as `python`), `unzip`, `zip`, `rg` (ripgrep), `fd`,
+`jq`, `ps`, `file`, and `tree`. It builds a snapshot named `agenta-agent-sandbox-v1` and sets each
+sandbox to 2 vCPU, 4 GB of memory, and 5 GB of disk.
 
 If you already built `agenta-agent-sandbox-v1` from an earlier release, rebuild it with `--force`
 after upgrading. Daytona keeps the snapshot you built, so a snapshot built from an older recipe

--- a/docs/docs/self-host/agents/04-customize-the-agent-runtime.mdx
+++ b/docs/docs/self-host/agents/04-customize-the-agent-runtime.mdx
@@ -10,6 +10,9 @@ Agents sometimes need tools that are not in the default runtime: a browser like 
 `gh` CLI, a custom certificate, or an extra system package. They sometimes need a folder from your
 infrastructure, such as a repository checkout, or more CPU, memory, and disk than the default.
 
+Both runtimes already ship Node, `git`, `curl`, `python3` (also available as `python`), `unzip`,
+and `zip`, so you do not need to add those.
+
 This page shows how to add each of those. The mechanism depends on where your agents run:
 
 - **Daytona runs** execute in a cloud sandbox. You customize the snapshot the sandbox starts from.

--- a/docs/docs/self-host/agents/04-customize-the-agent-runtime.mdx
+++ b/docs/docs/self-host/agents/04-customize-the-agent-runtime.mdx
@@ -11,7 +11,7 @@ Agents sometimes need tools that are not in the default runtime: a browser like 
 infrastructure, such as a repository checkout, or more CPU, memory, and disk than the default.
 
 Both runtimes already ship Node, `git`, `curl`, `python3` (also available as `python`), `unzip`,
-and `zip`, so you do not need to add those.
+`zip`, `rg` (ripgrep), `fd`, `jq`, `ps`, `file`, and `tree`, so you do not need to add those.
 
 This page shows how to add each of those. The mechanism depends on where your agents run:
 

--- a/services/runner/docker/Dockerfile.dev
+++ b/services/runner/docker/Dockerfile.dev
@@ -15,8 +15,12 @@ WORKDIR /app
 # spawns `python3` (src/tools/code.ts), so without it those tools fail `spawn python3 ENOENT`.
 # fuse + geesefs: the durable session cwd (mount.ts) is a geesefs FUSE mount of the store
 # prefix; `fuse` provides fusermount + /etc/fuse.conf (user_allow_other for -o allow_other).
+# unzip/zip + python-is-python3 (which symlinks /usr/bin/python -> python3): the local sandbox
+# IS this container, and an agent handed an archive reaches for `unzip` and plain `python`.
+# Without them every such task burns failed bash calls and extra approval round-trips.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git python3 fuse curl \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates git python3 python-is-python3 unzip zip fuse curl \
     && rm -rf /var/lib/apt/lists/* \
     && echo "user_allow_other" >> /etc/fuse.conf
 

--- a/services/runner/docker/Dockerfile.dev
+++ b/services/runner/docker/Dockerfile.dev
@@ -18,9 +18,14 @@ WORKDIR /app
 # unzip/zip + python-is-python3 (which symlinks /usr/bin/python -> python3): the local sandbox
 # IS this container, and an agent handed an archive reaches for `unzip` and plain `python`.
 # Without them every such task burns failed bash calls and extra approval round-trips.
+# ripgrep/fd-find/jq/procps/file/tree are the same bet on habit: `rg` and `fd` are the first
+# commands every harness reaches for when searching a tree, and Debian ships fd as `fdfind`,
+# so the symlink below is what makes the command agents actually type resolve.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates git python3 python-is-python3 unzip zip fuse curl \
+        ripgrep fd-find jq procps file tree \
+    && ln -s "$(which fdfind)" /usr/local/bin/fd \
     && rm -rf /var/lib/apt/lists/* \
     && echo "user_allow_other" >> /etc/fuse.conf
 

--- a/services/runner/docker/Dockerfile.gh
+++ b/services/runner/docker/Dockerfile.gh
@@ -28,9 +28,14 @@ WORKDIR /app
 # unzip/zip + python-is-python3 (which symlinks /usr/bin/python -> python3): the local sandbox
 # IS this container, and an agent handed an archive reaches for `unzip` and plain `python`.
 # Without them every such task burns failed bash calls and extra approval round-trips.
+# ripgrep/fd-find/jq/procps/file/tree are the same bet on habit: `rg` and `fd` are the first
+# commands every harness reaches for when searching a tree, and Debian ships fd as `fdfind`,
+# so the symlink below is what makes the command agents actually type resolve.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates git python3 python-is-python3 unzip zip fuse curl \
+        ripgrep fd-find jq procps file tree \
+    && ln -s "$(which fdfind)" /usr/local/bin/fd \
     && rm -rf /var/lib/apt/lists/* \
     && echo "user_allow_other" >> /etc/fuse.conf
 

--- a/services/runner/docker/Dockerfile.gh
+++ b/services/runner/docker/Dockerfile.gh
@@ -25,8 +25,12 @@ WORKDIR /app
 # `spawn python3 ENOENT`.
 # fuse + geesefs: the durable session cwd (mount.ts) is a geesefs FUSE mount of the store
 # prefix; `fuse` provides fusermount + /etc/fuse.conf (user_allow_other for -o allow_other).
+# unzip/zip + python-is-python3 (which symlinks /usr/bin/python -> python3): the local sandbox
+# IS this container, and an agent handed an archive reaches for `unzip` and plain `python`.
+# Without them every such task burns failed bash calls and extra approval round-trips.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git python3 fuse curl \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates git python3 python-is-python3 unzip zip fuse curl \
     && rm -rf /var/lib/apt/lists/* \
     && echo "user_allow_other" >> /etc/fuse.conf
 

--- a/services/runner/images/sandbox/daytona/README.md
+++ b/services/runner/images/sandbox/daytona/README.md
@@ -41,9 +41,11 @@ The snapshot recipe therefore:
 - verifies that the Claude, Codex, and OpenCode binaries are still present;
 - installs the FUSE and geesefs dependencies used for durable remote working directories;
 - installs `python3` and `typescript`/`ts-node` for the shared custom-code evaluator runtimes; and
-- installs `unzip`, `zip`, and `python-is-python3` (which puts a plain `python` on PATH), the
-  everyday tools an agent reaches for unprompted. Without them a task as ordinary as "read this
-  zip" costs the agent several failed shell calls and the operator several approval prompts.
+- installs the everyday command-line tools an agent reaches for unprompted: `unzip`, `zip`,
+  `python-is-python3` (which puts a plain `python` on PATH), `ripgrep`, `fd-find`, `jq`, `procps`,
+  `file`, and `tree`, and symlinks `fdfind` to `fd` because Debian ships the binary under the
+  other name. Without them a task as ordinary as "read this zip" or a first search of the working
+  directory costs the agent several failed shell calls and the operator several approval prompts.
 
 The Pi CLI and Pi ACP adapter are separate dependencies. Keep both pins explicit. The CLI
 runs the agent; the adapter translates Pi events and dialogs onto ACP. In particular, the

--- a/services/runner/images/sandbox/daytona/README.md
+++ b/services/runner/images/sandbox/daytona/README.md
@@ -39,13 +39,28 @@ The snapshot recipe therefore:
 - fails the build unless the private launcher exists and its installed package reports
   version `0.0.29`;
 - verifies that the Claude, Codex, and OpenCode binaries are still present;
-- installs the FUSE and geesefs dependencies used for durable remote working directories; and
-- installs `python3` and `typescript`/`ts-node` for the shared custom-code evaluator runtimes.
+- installs the FUSE and geesefs dependencies used for durable remote working directories;
+- installs `python3` and `typescript`/`ts-node` for the shared custom-code evaluator runtimes; and
+- installs `unzip`, `zip`, and `python-is-python3` (which puts a plain `python` on PATH), the
+  everyday tools an agent reaches for unprompted. Without them a task as ordinary as "read this
+  zip" costs the agent several failed shell calls and the operator several approval prompts.
 
 The Pi CLI and Pi ACP adapter are separate dependencies. Keep both pins explicit. The CLI
 runs the agent; the adapter translates Pi events and dialogs onto ACP. In particular, the
 adapter version must not be inherited implicitly from the base image because older versions
 do not forward Pi extension dialogs as ACP permission requests.
+
+## Refreshing an existing snapshot
+
+The snapshot name is pinned, so Daytona keeps serving whatever you built under it. When this recipe
+changes, rebuild it in each Daytona account that uses it:
+
+```bash
+DAYTONA_API_KEY=... DAYTONA_TARGET=eu uv run build_snapshot.py --force
+```
+
+`--force` is required: without it the script sees the existing snapshot and exits. Sandboxes already
+running keep the old contents; only sandboxes created after the rebuild pick up the change.
 
 ## Pi installation
 

--- a/services/runner/images/sandbox/daytona/build_snapshot.py
+++ b/services/runner/images/sandbox/daytona/build_snapshot.py
@@ -112,8 +112,12 @@ def main() -> None:
             # handed an archive reaches for `unzip` and plain `python`; without them every
             # such task burns failed bash calls and extra approval round-trips. The base is
             # Debian bookworm (node:22-bookworm), so python-is-python3 is the right package.
+            # ripgrep/fd-find/jq/procps/file/tree are the same bet on habit: `rg` and `fd` are
+            # the first commands every harness reaches for when searching a tree, and Debian
+            # ships fd as `fdfind`, so the symlink is what makes the typed command resolve.
             "RUN apt-get update && apt-get install -y --no-install-recommends fuse curl "
-            "python3 python-is-python3 unzip zip "
+            "python3 python-is-python3 unzip zip ripgrep fd-find jq procps file tree "
+            '&& ln -s "$(which fdfind)" /usr/local/bin/fd '
             "&& rm -rf /var/lib/apt/lists/* && echo user_allow_other >> /etc/fuse.conf",
             # Code-evaluator runtimes: this snapshot is shared with the SDK DaytonaRunner.
             # typescript@5: ts-node needs the JS compiler API; typescript 7+ is the Go

--- a/services/runner/images/sandbox/daytona/build_snapshot.py
+++ b/services/runner/images/sandbox/daytona/build_snapshot.py
@@ -19,6 +19,9 @@ recipe additionally installs python3 and typescript/ts-node.
 
 Run: DAYTONA_API_KEY=... DAYTONA_TARGET=eu uv run build_snapshot.py [--force]
 
+The snapshot name is pinned, so Daytona keeps serving whatever was built under it. Whenever this
+recipe changes, every Daytona account using it must rerun the build with --force; see README.md.
+
 Licensing (see services/runner/docker/README.md):
     This script is the build recipe we ship, NOT a snapshot we distribute. Whoever
     runs it builds the snapshot in their own Daytona account: Agenta Cloud builds
@@ -105,8 +108,12 @@ def main() -> None:
             "RUN test -x /home/sandbox/.local/share/sandbox-agent/bin/opencode "
             "&& echo opencode-baked-in-base-image",
             # Durable cwd: fuse + geesefs so the remote sandbox can mount its store prefix.
+            # unzip/zip + python-is-python3 (symlinks /usr/bin/python -> python3): an agent
+            # handed an archive reaches for `unzip` and plain `python`; without them every
+            # such task burns failed bash calls and extra approval round-trips. The base is
+            # Debian bookworm (node:22-bookworm), so python-is-python3 is the right package.
             "RUN apt-get update && apt-get install -y --no-install-recommends fuse curl "
-            "python3 "
+            "python3 python-is-python3 unzip zip "
             "&& rm -rf /var/lib/apt/lists/* && echo user_allow_other >> /etc/fuse.conf",
             # Code-evaluator runtimes: this snapshot is shared with the SDK DaytonaRunner.
             # typescript@5: ts-node needs the JS compiler API; typescript 7+ is the Go


### PR DESCRIPTION
## What was broken

Asking an agent to read a file inside a ZIP cost three approval round-trips: the sandbox has no `unzip` and no plain `python`, so the agent burned two failed bash calls (exit 127) before discovering `python3`. Closes #5637. More broadly, the sandboxes lacked the small set of shell tools every coding agent reaches for first, so ordinary tasks kept paying failed-call and approval overhead.

## Fix

Both sandbox runtimes get the same additions in their existing package layer:

`unzip`, `zip`, `python-is-python3` (the plain `python` name), `ripgrep` (`rg`), `fd-find` (with a symlink so `fd` works; Debian ships it as `fdfind`), `jq`, `procps` (`ps`), `file`, and `tree`.

- Local sandbox = the runner container: `docker/Dockerfile.dev` and `docker/Dockerfile.gh`. Railway and Helm inherit automatically (they wrap the published runner image).
- Daytona sandbox: the snapshot recipe `images/sandbox/daytona/build_snapshot.py`. The snapshot name is pinned, so every account that runs Daytona must rebuild once with `--force`; that operations step is documented in the recipe README and the self-host Daytona page.

## Verification

Both runner images were really built and probed from inside: every tool resolves and runs (`rg` 13.0.0, `jq` 1.6, `ps` 4.0.2, `file` 5.44, `tree` 2.1.0, `fd` 8.6.0 via the symlink chain, `python` 3.11.2, `unzip` 6.00, `zip` 3.0), plus functional smokes (`fd` finds a file, `rg` counts a match). The `gh` image was verified as its runtime non-root user. The Daytona recipe compiles; its package set was proven on the same Debian bookworm base, confirmed against the actual base image config.

## For reviewers

- The tool list is deliberately bounded to what agents demonstrably reach for; `python3-pip` and build tools were left out on purpose (image weight and dependency sprawl deserve their own decision).
- Operations reminder after merge: each Daytona account (Agenta Cloud included) reruns `build_snapshot.py --force` once, and stages want a runner-image redeploy.

https://claude.ai/code/session_01McMogkcDRV7UpSAjfd8VKG