### PR TITLE
[5650] feat(ci): clone-based Railway previews behind a mode switch (WP3)

### DIFF
--- a/.github/workflows/14-check-pr-preview.yml
+++ b/.github/workflows/14-check-pr-preview.yml
@@ -34,6 +34,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Resolve the preview mode ONCE per run so setup and deploy always agree,
+  # even if the RAILWAY_PREVIEW_MODE repo variable is flipped mid-run.
+  # 'legacy' = one Railway project per PR (the original path);
+  # 'clone'  = one environment per PR, cloned from the template project
+  #            (issue #5650; see hosting/railway/oss/README.md).
+  mode:
+    if: github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.resolve.outputs.mode }}
+    steps:
+      - name: Resolve RAILWAY_PREVIEW_MODE
+        id: resolve
+        env:
+          MODE: ${{ vars.RAILWAY_PREVIEW_MODE || 'legacy' }}
+        run: echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+
   build:
     if: github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft
     uses: ./.github/workflows/42-railway-build.yml
@@ -41,16 +58,17 @@ jobs:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
 
   setup:
-    needs: [build]
-    if: needs.build.result == 'success'
+    needs: [build, mode]
+    if: needs.build.result == 'success' && needs.mode.result == 'success'
     uses: ./.github/workflows/41-railway-setup.yml
     with:
       pr_number: ${{ needs.build.outputs.pr_number }}
       image_tag: ${{ needs.build.outputs.image_tag }}
+      mode: ${{ needs.mode.outputs.mode }}
     secrets: inherit
 
   deploy:
-    needs: [build, setup]
+    needs: [build, setup, mode]
     if: |
       needs.build.result == 'success' &&
       needs.setup.result == 'success'
@@ -58,6 +76,7 @@ jobs:
     with:
       pr_number: ${{ needs.build.outputs.pr_number }}
       image_tag: ${{ needs.build.outputs.image_tag }}
+      mode: ${{ needs.mode.outputs.mode }}
     secrets: inherit
 
   tests:

--- a/.github/workflows/41-railway-setup.yml
+++ b/.github/workflows/41-railway-setup.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: ""
+      mode:
+        description: "Preview mode: 'legacy' (project per PR) or 'clone' (environment cloned from the template project; issue #5650)"
+        required: false
+        type: string
+        default: "legacy"
     secrets:
       RAILWAY_TOKEN:
         required: true
@@ -33,6 +38,11 @@ on:
         required: false
         type: string
         default: ""
+      mode:
+        description: "Preview mode: 'legacy' (project per PR) or 'clone' (environment cloned from the template project; issue #5650)"
+        required: false
+        type: string
+        default: "legacy"
 
 permissions:
   contents: read
@@ -48,12 +58,14 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      project_name: ${{ steps.setup.outputs.project_name }}
-      environment_name: ${{ steps.setup.outputs.environment_name }}
+      # Exactly one of the two steps runs, selected by inputs.mode.
+      project_name: ${{ steps.setup.outputs.project_name || steps.clone.outputs.project_name }}
+      environment_name: ${{ steps.setup.outputs.environment_name || steps.clone.outputs.environment_name }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Install Railway CLI
+        if: inputs.mode != 'clone'
         run: |
           npm install -g @railway/cli@latest
           railway --version
@@ -65,6 +77,7 @@ jobs:
           fi
 
       - name: Setup preview environment
+        if: inputs.mode != 'clone'
         id: setup
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -100,6 +113,43 @@ jobs:
             exit "$setup_status"
           fi
 
+      # Clone mode (issue #5650): create-or-update the per-PR environment in
+      # the template project, patch the app images to this run's tag, wait for
+      # green, and smoke it — all in one script, pure GraphQL (no Railway
+      # CLI). The deploy workflow (43) then only re-verifies and posts the
+      # preview URL.
+      - name: Create or update clone preview environment
+        if: inputs.mode == 'clone'
+        id: clone
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          chmod +x hosting/railway/oss/scripts/*.sh
+
+          # Same artifact contract as the legacy step: persist the full log so
+          # "Upload setup log" publishes it regardless of live-log truncation.
+          log_file="${GITHUB_WORKSPACE:-$PWD}/railway-setup-${PR_NUMBER:-unknown}.log"
+
+          set +e
+          hosting/railway/oss/scripts/preview-clone-create.sh 2>&1 | tee "$log_file"
+          setup_status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$setup_status" -ne 0 ]; then
+            {
+              echo "### Railway Preview Setup (clone mode) — Failed"
+              echo
+              echo "<details><summary>Setup log (last 100 lines)</summary>"
+              echo
+              echo '```'
+              tail -n 100 "$log_file" 2>/dev/null
+              echo '```'
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit "$setup_status"
+          fi
+
       - name: Upload setup log
         if: always()
         # Diagnostics only: a failed/duplicate upload must never fail the job.
@@ -120,6 +170,7 @@ jobs:
             echo "| Item | Value |"
             echo "| --- | --- |"
             echo "| PR | \`${{ inputs.pr_number }}\` |"
-            echo "| Project | \`${{ steps.setup.outputs.project_name }}\` |"
-            echo "| Environment | \`${{ steps.setup.outputs.environment_name }}\` |"
+            echo "| Mode | \`${{ inputs.mode || 'legacy' }}\` |"
+            echo "| Project | \`${{ steps.setup.outputs.project_name || steps.clone.outputs.project_name }}\` |"
+            echo "| Environment | \`${{ steps.setup.outputs.environment_name || steps.clone.outputs.environment_name }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/43-railway-deploy.yml
+++ b/.github/workflows/43-railway-deploy.yml
@@ -11,6 +11,11 @@ on:
         description: "PR number"
         required: true
         type: string
+      mode:
+        description: "Preview mode: 'legacy' (project per PR) or 'clone' (environment cloned from the template project; issue #5650)"
+        required: false
+        type: string
+        default: "legacy"
     secrets:
       RAILWAY_TOKEN:
         required: true
@@ -48,6 +53,11 @@ on:
         description: "PR number"
         required: true
         type: string
+      mode:
+        description: "Preview mode: 'legacy' (project per PR) or 'clone' (environment cloned from the template project; issue #5650)"
+        required: false
+        type: string
+        default: "legacy"
 
 permissions:
   contents: read
@@ -64,14 +74,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     outputs:
-      preview_url: ${{ steps.deploy.outputs.preview_url }}
-      project_name: ${{ steps.deploy.outputs.project_name }}
-      environment_name: ${{ steps.deploy.outputs.environment_name }}
-      railway_logs_url: ${{ steps.deploy.outputs.railway_logs_url }}
+      # Exactly one of the two steps runs, selected by inputs.mode.
+      preview_url: ${{ steps.deploy.outputs.preview_url || steps.verify.outputs.preview_url }}
+      project_name: ${{ steps.deploy.outputs.project_name || steps.verify.outputs.project_name }}
+      environment_name: ${{ steps.deploy.outputs.environment_name || steps.verify.outputs.environment_name }}
+      railway_logs_url: ${{ steps.deploy.outputs.railway_logs_url || steps.verify.outputs.railway_logs_url }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Install Railway CLI
+        if: inputs.mode != 'clone'
         run: |
           npm install -g @railway/cli@latest
           railway --version
@@ -83,6 +95,7 @@ jobs:
           fi
 
       - name: Deploy preview environment
+        if: inputs.mode != 'clone'
         id: deploy
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -216,6 +229,51 @@ jobs:
             exit 1
           fi
 
+      # Clone mode (issue #5650): setup (41) already created the environment,
+      # patched the images and smoked it, so the legacy deploy is redundant.
+      # This step re-verifies the smoke endpoints (mutation-free) and emits
+      # the same outputs the legacy step would, keeping the 14-chain's job
+      # graph (tests + PR comment) intact.
+      - name: Verify clone preview environment
+        if: inputs.mode == 'clone'
+        id: verify
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          chmod +x hosting/railway/oss/scripts/*.sh
+
+          # Same artifact contract as the legacy step: persist the full log so
+          # "Upload deploy log" publishes it regardless of live-log truncation.
+          log_file="${GITHUB_WORKSPACE:-$PWD}/railway-deploy-${PR_NUMBER:-unknown}.log"
+
+          set +e
+          hosting/railway/oss/scripts/preview-clone-create.sh --verify-only 2>&1 | tee "$log_file"
+          verify_status=${PIPESTATUS[0]}
+          set -e
+
+          status_label="Deployed"
+          [ "$verify_status" -ne 0 ] && status_label="Failed"
+          {
+            echo "### Railway Preview Deploy (clone mode)"
+            echo
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| PR | \`${PR_NUMBER}\` |"
+            echo "| Image tag | \`${IMAGE_TAG}\` |"
+            echo "| Status | ${status_label} |"
+            if [ "$verify_status" -ne 0 ]; then
+              echo
+              echo "<details><summary>Verify log (last 100 lines)</summary>"
+              echo
+              echo '```'
+              tail -n 100 "$log_file" 2>/dev/null
+              echo '```'
+              echo "</details>"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$verify_status"
+
       - name: Upload deploy log
         if: always()
         # Diagnostics only: a failed/duplicate upload must never fail the job.
@@ -229,17 +287,17 @@ jobs:
           retention-days: 7
 
       - name: Post preview URL as PR comment
-        if: inputs.pr_number != '' && steps.deploy.outputs.preview_url != ''
+        if: inputs.pr_number != '' && (steps.deploy.outputs.preview_url != '' || steps.verify.outputs.preview_url != '')
         uses: actions/github-script@v7
         with:
           script: |
             const prNumber = parseInt('${{ inputs.pr_number }}');
-            const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
-            const projectName = '${{ steps.deploy.outputs.project_name }}';
+            const previewUrl = '${{ steps.deploy.outputs.preview_url || steps.verify.outputs.preview_url }}';
+            const projectName = '${{ steps.deploy.outputs.project_name || steps.verify.outputs.project_name }}';
             const imageTag = '${{ inputs.image_tag }}';
             const marker = '<!-- railway-preview-bot -->';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const railwayLogsUrl = '${{ steps.deploy.outputs.railway_logs_url }}';
+            const railwayLogsUrl = '${{ steps.deploy.outputs.railway_logs_url || steps.verify.outputs.railway_logs_url }}';
 
             const body = [
               marker,
@@ -290,8 +348,8 @@ jobs:
             const imageTag = '${{ inputs.image_tag }}';
             const marker = '<!-- railway-preview-bot -->';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
-            const railwayLogsUrl = '${{ steps.deploy.outputs.railway_logs_url }}';
+            const previewUrl = '${{ steps.deploy.outputs.preview_url || steps.verify.outputs.preview_url }}';
+            const railwayLogsUrl = '${{ steps.deploy.outputs.railway_logs_url || steps.verify.outputs.railway_logs_url }}';
 
             const body = [
               marker,

--- a/.github/workflows/45-railway-cleanup.yml
+++ b/.github/workflows/45-railway-cleanup.yml
@@ -29,6 +29,11 @@ permissions:
 
 env:
   RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+  # This workflow triggers directly (PR close / cron / dispatch), so it cannot
+  # receive the mode resolved by workflow 14; it reads the repo variable at
+  # its own run time. 'legacy' = project per PR; 'clone' = environment per PR
+  # in the template project (issue #5650).
+  RAILWAY_PREVIEW_MODE: ${{ vars.RAILWAY_PREVIEW_MODE || 'legacy' }}
 
 jobs:
   destroy-pr-preview:
@@ -49,11 +54,23 @@ jobs:
           fi
 
       - name: Destroy preview environment
+        if: env.RAILWAY_PREVIEW_MODE != 'clone'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           chmod +x hosting/railway/oss/scripts/preview-destroy.sh
           hosting/railway/oss/scripts/preview-destroy.sh
+
+      # Clone mode (issue #5650): the preview is an environment in the
+      # template project, not a project — delete just that environment
+      # (idempotent: absent = success).
+      - name: Destroy clone preview environment
+        if: env.RAILWAY_PREVIEW_MODE == 'clone'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          chmod +x hosting/railway/oss/scripts/preview-clone-destroy.sh
+          hosting/railway/oss/scripts/preview-clone-destroy.sh
 
       - name: Update preview comment on PR
         if: github.event_name == 'pull_request'
@@ -127,6 +144,19 @@ jobs:
         run: |
           chmod +x hosting/railway/oss/scripts/preview-cleanup-stale.sh
           hosting/railway/oss/scripts/preview-cleanup-stale.sh
+
+      # Clone-mode equivalent of the stale sweep (issue #5650): delete pr-*
+      # preview environments older than the max age in the template project.
+      # Runs in BOTH modes on purpose — after a rollback to legacy, clone
+      # environments created before the flip would otherwise linger forever.
+      # A sweep with nothing to delete costs ~3 API calls.
+      - name: Clean up stale clone preview environments
+        env:
+          RAILWAY_PREVIEW_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          chmod +x hosting/railway/oss/scripts/preview-clone-destroy.sh
+          hosting/railway/oss/scripts/preview-clone-destroy.sh \
+            --stale-hours "${{ inputs.max_age_hours || '24' }}"
 
       - name: Summary
         if: always()

--- a/.github/workflows/48-railway-clone-preview-test.yml
+++ b/.github/workflows/48-railway-clone-preview-test.yml
@@ -1,0 +1,111 @@
+# Acceptance-evidence workflow for clone-mode previews (issue #5650, WP3).
+#
+# Runs N consecutive FULL preview cycles — create/clone + image patch + deploy
+# + smoke, then destroy — against the template project, using the PRODUCTION
+# scripts (hosting/railway/oss/scripts/preview-clone-{create,destroy}.sh),
+# not spike copies. Any cycle failure fails the run. Per-cycle wall time and
+# Railway API call counts land in the step summary; issue #5650's criterion
+# is 3 consecutive green cycles from a real Actions run.
+#
+# Test environments are named pr-clone-ci-<run-id>-c<n> and are destroyed in
+# the same iteration, pass or fail. If the job dies mid-cycle (cancel or
+# timeout), the daily stale sweep in workflow 45 removes the leftover
+# (pr-clone-* names are in its match set).
+#
+# Auth traps (same as workflows 46/47): the secret must be exported as
+# RAILWAY_API_TOKEN (never RAILWAY_TOKEN — the Railway CLI treats that name as
+# project-scoped and account-level calls fail Unauthorized), and it must be an
+# ACCOUNT token.
+#
+# The patch tag must be a PINNED tag that differs from the template's app tag:
+# environmentPatchCommit silently no-ops on an unchanged config, and 'latest'
+# is refused by the script.
+
+name: "48 - railway clone preview test"
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/48-railway-clone-preview-test.yml'
+      - 'hosting/railway/oss/scripts/preview-clone-create.sh'
+      - 'hosting/railway/oss/scripts/preview-clone-destroy.sh'
+      - 'hosting/railway/oss/template/lib-graphql.sh'
+  workflow_dispatch:
+    inputs:
+      cycles:
+        description: "Number of consecutive full cycles"
+        required: false
+        type: string
+        default: "3"
+      patch_tag:
+        description: "Pinned app-image tag to patch to (never 'latest'; must differ from the template's app tag)"
+        required: false
+        type: string
+        default: "pr-5651-a46168f"
+
+permissions:
+  contents: read
+
+# Serialize runs: parallel cycles would contend for the template project and
+# for the token's hourly API budget.
+concurrency:
+  group: railway-clone-preview-test
+  cancel-in-progress: false
+
+env:
+  RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+jobs:
+  clone-cycles:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run consecutive clone cycles with the production scripts
+        env:
+          CYCLES: ${{ inputs.cycles || '3' }}
+          IMAGE_TAG: ${{ inputs.patch_tag || 'pr-5651-a46168f' }}
+          # One shared call-counter file so per-cycle API call deltas can be
+          # computed here (every request in lib-graphql.sh appends a line).
+          RW_CALLS_FILE: /tmp/rw-calls-48
+        run: |
+          set -euo pipefail
+          chmod +x hosting/railway/oss/scripts/*.sh
+          touch "$RW_CALLS_FILE"
+
+          {
+            echo "### Railway clone preview cycles"
+            echo
+            echo "Tag: \`${IMAGE_TAG}\` — ${CYCLES} consecutive cycle(s) with the production scripts."
+            echo
+            echo "| Cycle | Environment | Result | Create+deploy+smoke (s) | Destroy (s) | API calls |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for i in $(seq 1 "$CYCLES"); do
+            env_name="pr-clone-ci-${GITHUB_RUN_ID}-c${i}"
+            export RAILWAY_PREVIEW_ENV_NAME="$env_name"
+            calls_before=$(wc -l < "$RW_CALLS_FILE")
+            result=pass
+            t0=$(date +%s)
+            hosting/railway/oss/scripts/preview-clone-create.sh || result=fail
+            t1=$(date +%s)
+            # Destroy ALWAYS runs, pass or fail: test environments never
+            # outlive their cycle.
+            hosting/railway/oss/scripts/preview-clone-destroy.sh || result=fail
+            t2=$(date +%s)
+            calls=$(( $(wc -l < "$RW_CALLS_FILE") - calls_before ))
+            echo "| ${i} | \`${env_name}\` | ${result} | $((t1 - t0)) | $((t2 - t1)) | ${calls} |" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$result" = "fail" ]; then
+              failed=$((failed + 1))
+              echo "::error::Cycle ${i} (${env_name}) failed."
+            fi
+          done
+
+          {
+            echo
+            echo "Failed cycles: ${failed}/${CYCLES}. Total API calls: $(wc -l < "$RW_CALLS_FILE")."
+          } >> "$GITHUB_STEP_SUMMARY"
+          [ "$failed" -eq 0 ]

--- a/hosting/railway/oss/README.md
+++ b/hosting/railway/oss/README.md
@@ -39,6 +39,9 @@ baseline.
 - `scripts/deploy-from-images.sh` - deploy Railway services from explicit image tags
 - `scripts/preview-create-or-update.sh` - create or update a PR-scoped preview project
 - `scripts/preview-destroy.sh` - delete a PR-scoped preview project
+- `scripts/preview-clone-create.sh` - create or update a clone-mode preview environment (issue #5650)
+- `scripts/preview-clone-destroy.sh` - delete a clone-mode preview environment (plus `--stale-hours` sweep)
+- `template/` - the preview template environment as code (definition, converge tool, GraphQL client)
 
 ## Prerequisites
 
@@ -149,6 +152,82 @@ Defaults:
 
 - Project naming uses `RAILWAY_PREVIEW_PROJECT_PREFIX` (default `agenta-oss-pr`) and a normalized preview key.
 - Preview key resolution order is `RAILWAY_PREVIEW_KEY`, `PR_NUMBER`, `GITHUB_PR_NUMBER`, then GitHub branch refs.
+
+## Clone-Based Previews (Experimental)
+
+Issue #5650 adds a second, faster preview path: instead of bootstrapping one
+Railway **project** per PR (~58 API calls, minutes of setup), a PR preview is
+one **environment** cloned from a pre-built template environment inside a
+single shared project (~15 API calls, under a minute). The template itself is
+code: `template/template.json`, converged by `template/apply.sh` and guarded
+by the drift workflow (47).
+
+### The mode switch
+
+The GitHub repo variable `RAILWAY_PREVIEW_MODE` selects the path:
+
+- unset or `legacy` (default) — the original project-per-PR flow. The legacy
+  steps run exactly as before.
+- `clone` — the clone flow described below.
+
+Workflow 14 resolves the variable ONCE per run and passes it down to setup
+(41) and deploy (43), so a mid-run flip cannot split a run across modes.
+Cleanup (45) triggers on its own events and reads the variable at its own run
+time.
+
+**Rollback = flip the variable back to `legacy`** (or delete it). Nothing
+else to undo: the next push on any PR bootstraps a legacy project again.
+Clone environments created before the flip are removed by the daily stale
+sweep in workflow 45 (which sweeps `pr-*` environments in the template
+project in both modes for exactly this reason), or immediately via
+`scripts/preview-clone-destroy.sh`.
+
+### How clone mode works
+
+1. **Setup (41)** runs `scripts/preview-clone-create.sh`: ensure environment
+   `pr-<PR_NUMBER>` exists (`environmentCreate` from the template with
+   `skipInitialDeploys`; an ambiguous create failure is reconciled by polling
+   the name, never by re-creating), then ONE `environmentPatchCommit` that
+   points the eight app services at the run's image tag (Railway auto-deploys
+   every service whose config changed), then deploy the rest in the proven
+   order (infra, then alembic, then everything else; supertokens must wait
+   for alembic), then smoke `/w`, `/api/health`, `/services/health` through
+   the clone's own gateway domain. On a later push to the same PR the
+   environment is patched in place, not re-created.
+2. **Deploy (43)** is redundant in clone mode (setup already deployed and
+   smoked); it runs `preview-clone-create.sh --verify-only`, a mutation-free
+   re-check that emits the preview URL for the tests job and the PR comment.
+3. **Cleanup (45)** runs `scripts/preview-clone-destroy.sh`: one
+   `environmentDelete` (idempotent — an absent environment is a success),
+   plus the daily stale sweep (`--stale-hours 24`).
+
+Two traps the scripts are built around (proven live in
+`docs/design/railway-preview-clone-spike/findings.md`): the template's app
+tags must stay disjoint from PR tags because `environmentPatchCommit`
+silently no-ops on an unchanged config (services whose image already matches
+are deployed explicitly instead, and `latest` is refused outright), and a
+single Postgres first-deploy timeout in a fresh clone is transient (the
+script retries that deploy exactly once).
+
+### Configuration
+
+- `RAILWAY_TEMPLATE_PROJECT` — template project name.
+  TODO(cutover): the script default is the proven test bed
+  `agenta-oss-clone-spike` until rollout re-points it (and
+  `template/template.json`'s `project`) at the production preview project.
+- `RAILWAY_TEMPLATE_ENV` — template environment name (default `pr-template`).
+- `RAILWAY_PREVIEW_ENV_NAME` — override the per-PR environment name (test
+  cycles use `pr-clone-*` names).
+- Auth is the same account token as the legacy path, exported as
+  `RAILWAY_API_TOKEN` (never `RAILWAY_TOKEN`).
+
+### Evidence
+
+Workflow 48 (`48-railway-clone-preview-test.yml`) is the acceptance harness:
+it runs N consecutive full cycles (create + patch + deploy + smoke, then
+destroy) with the production scripts against the template project and prints
+per-cycle timing and API call counts to the step summary. Issue #5650's bar
+is 3 consecutive green cycles from a real Actions run.
 
 ## Prebuilt Wrapper Images (Clone-Based Previews)
 

--- a/hosting/railway/oss/scripts/preview-clone-create.sh
+++ b/hosting/railway/oss/scripts/preview-clone-create.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+
+# preview-clone-create.sh — create or update a clone-mode PR preview
+# environment (issue #5650, WP3).
+#
+# Clone mode replaces the legacy one-project-per-PR bootstrap: per-PR previews
+# are ENVIRONMENTS cloned from a template environment inside one shared
+# project. The template is defined in git (../template/template.json,
+# converged by ../template/apply.sh). This script drives Railway's GraphQL API
+# through the template tooling's client (../template/lib-graphql.sh) and:
+#
+#   1. Ensures environment $ENV_NAME exists: environmentCreate from the
+#      template with skipInitialDeploys. environmentCreate can 504 while the
+#      environment is still created in the background, so an ambiguous failure
+#      is reconciled by polling environments-by-name, never by re-creating.
+#   2. Patches the eight app-service images to the run's pinned tag with ONE
+#      environmentPatchCommit; Railway auto-deploys every service whose config
+#      actually CHANGED. Services whose image already equals the target are
+#      deployed explicitly instead, because environmentPatchCommit silently
+#      NO-OPS on an unchanged config — the trap that strands clones on
+#      template images (spike findings, deploy-mode section).
+#   3. Deploys the remaining services in the proven order: infra first, then
+#      alembic (creates the databases and runs migrations), then everything
+#      else — supertokens MUST NOT deploy before alembic. Polling is bounded.
+#      A single Postgres first-deploy timeout is retried once (proven
+#      transient for volume-backed services in a fresh clone); a second
+#      timeout is fatal.
+#   4. Smoke-checks /w, /api/health and /services/health through the clone's
+#      own gateway domain (same endpoints as scripts/smoke.sh, without the
+#      Railway CLI dependency).
+#
+# Idempotent: re-running for the same PR converges. An existing environment is
+# patched, not re-created, and already-successful services are left alone.
+#
+# Usage:
+#   preview-clone-create.sh [--verify-only]
+#
+#   --verify-only  Mutation-free: resolve the existing environment, read the
+#                  gateway domain, smoke-check it, and emit the same outputs.
+#                  Fails if the environment does not exist. Used by workflow
+#                  43's clone-mode verify step.
+#
+# Environment variables:
+#   PR_NUMBER                 PR number; default environment name is
+#                             pr-<PR_NUMBER>.
+#   RAILWAY_PREVIEW_ENV_NAME  Override the environment name (test cycles use
+#                             pr-clone-* names). One of PR_NUMBER or this
+#                             variable is required.
+#   IMAGE_TAG                 Pinned app-image tag (pr-<n>-<sha>). Required
+#                             unless --verify-only. 'latest' is refused.
+#   RAILWAY_TEMPLATE_PROJECT  Template project name.
+#                             TODO(cutover): default becomes the production
+#                             preview project at rollout; until then it is the
+#                             proven test bed.
+#   RAILWAY_TEMPLATE_ENV      Template environment name (default pr-template).
+#   RAILWAY_TEMPLATE_PROJECT_ID / RAILWAY_TEMPLATE_ENV_ID
+#                             Skip name resolution entirely (saves reads).
+#   RAILWAY_API_TOKEN         Account token (auto-sourced from
+#                             ~/.agenta-railway.env locally; in CI exported
+#                             from secrets.RAILWAY_TOKEN — never named
+#                             RAILWAY_TOKEN, the CLI treats that name as
+#                             project-scoped).
+#   AGENTA_API_IMAGE_REPO / AGENTA_WEB_IMAGE_REPO /
+#   AGENTA_SERVICES_IMAGE_REPO / AGENTA_RUNNER_IMAGE_REPO
+#                             Image repository overrides.
+#   RW_INFRA_WAIT_SECONDS     Postgres wait per attempt (default 420).
+#   RW_ALEMBIC_WAIT_SECONDS   Alembic wait (default 420).
+#   RW_DEPLOY_WAIT_SECONDS    Late-services wait (default 900).
+#   RW_POLL_INTERVAL          Status poll interval (default 15).
+#   SMOKE_MAX_WAIT_SECONDS / SMOKE_SLEEP_SECONDS
+#                             Smoke bounds (defaults 300 / 5; same knobs as
+#                             scripts/smoke.sh).
+
+# GraphQL documents use $var for GraphQL variables, not shell expansion.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Single shared GraphQL client (WP2); do not fork another copy.
+# shellcheck source=../template/lib-graphql.sh
+source "$SCRIPT_DIR/../template/lib-graphql.sh"
+
+VERIFY_ONLY=false
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --verify-only) VERIFY_ONLY=true; shift ;;
+        *) printf 'preview-clone-create.sh: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+done
+
+# TODO(cutover): default becomes the production preview template project at
+# rollout (also re-point ../template/template.json's "project").
+PROJECT_NAME="${RAILWAY_TEMPLATE_PROJECT:-agenta-oss-clone-spike}"
+TEMPLATE_ENV_NAME="${RAILWAY_TEMPLATE_ENV:-pr-template}"
+PR_NUMBER="${PR_NUMBER:-}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+ENV_NAME="${RAILWAY_PREVIEW_ENV_NAME:-${PR_NUMBER:+pr-${PR_NUMBER}}}"
+
+die() {
+    printf 'preview-clone-create.sh: %s\n' "$*" >&2
+    exit 1
+}
+
+[ -n "$ENV_NAME" ] || die "set PR_NUMBER or RAILWAY_PREVIEW_ENV_NAME"
+[ "$ENV_NAME" != "$TEMPLATE_ENV_NAME" ] || die "refusing to target the template environment '$TEMPLATE_ENV_NAME'"
+[ "$ENV_NAME" != "production" ] || die "refusing to target the 'production' environment"
+case "$PROJECT_NAME" in
+    agenta-oss-pr-*) die "refusing to target legacy per-PR project '$PROJECT_NAME'" ;;
+esac
+if [ "$VERIFY_ONLY" = false ]; then
+    [ -n "$IMAGE_TAG" ] || die "IMAGE_TAG is required"
+    [ "$IMAGE_TAG" != "latest" ] || die "IMAGE_TAG must be a pinned tag, never 'latest'"
+fi
+
+API_REPO="${AGENTA_API_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-api}"
+WEB_REPO="${AGENTA_WEB_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-web}"
+SERVICES_REPO="${AGENTA_SERVICES_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-services}"
+RUNNER_REPO="${AGENTA_RUNNER_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-runner}"
+
+# The eight image-patched app services; the api image backs five of them.
+APP_SERVICES=(api worker-streams worker-queues cron alembic web services runner)
+# supertokens must deploy AFTER alembic: it needs the agenta_oss_supertokens
+# database that alembic's startCommand creates (spike finding Q12).
+INFRA_SERVICES=(Postgres redis seaweedfs)
+LATE_SERVICES=(supertokens api worker-streams worker-queues runner services cron web gateway)
+ALL_SERVICES=("${INFRA_SERVICES[@]}" alembic "${LATE_SERVICES[@]}")
+
+Q_ENV_SERVICES='query($id: String!) { environment(id: $id) { serviceInstances { edges { node { serviceId serviceName source { image } latestDeployment { status } domains { serviceDomains { domain } } } } } } }'
+Q_ENVS='query($p: String!) { environments(projectId: $p, first: 100) { edges { node { id name } } } }'
+M_ENV_CREATE='mutation($in: EnvironmentCreateInput!) { environmentCreate(input: $in) { id name } }'
+M_DEPLOY='mutation($e: String!, $s: String!) { serviceInstanceDeployV2(environmentId: $e, serviceId: $s) }'
+M_PATCH_COMMIT='mutation($e: String!, $p: EnvironmentConfig) { environmentPatchCommit(environmentId: $e, patch: $p, commitMessage: "preview image patch") }'
+M_DOMAIN_CREATE='mutation($in: ServiceDomainCreateInput!) { serviceDomainCreate(input: $in) { domain } }'
+
+now() { date +%s; }
+
+emit_output() {
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
+    fi
+}
+
+image_for() {
+    case "$1" in
+        api | worker-streams | worker-queues | cron | alembic) printf '%s:%s' "$API_REPO" "$IMAGE_TAG" ;;
+        web) printf '%s:%s' "$WEB_REPO" "$IMAGE_TAG" ;;
+        services) printf '%s:%s' "$SERVICES_REPO" "$IMAGE_TAG" ;;
+        runner) printf '%s:%s' "$RUNNER_REPO" "$IMAGE_TAG" ;;
+        *) return 1 ;;
+    esac
+}
+
+PROJECT_ID="${RAILWAY_TEMPLATE_PROJECT_ID:-}"
+TEMPLATE_ENV_ID="${RAILWAY_TEMPLATE_ENV_ID:-}"
+CLONE_ENV_ID=""
+CLONE_SERVICES_JSON=""
+GATEWAY_DOMAIN=""
+
+resolve_template_ids() {
+    if [ -z "$PROJECT_ID" ]; then
+        PROJECT_ID="$(rw_find_project_id "$PROJECT_NAME" || true)"
+    fi
+    [ -n "$PROJECT_ID" ] || die "project '$PROJECT_NAME' not found for this token"
+    if [ -z "$TEMPLATE_ENV_ID" ]; then
+        TEMPLATE_ENV_ID="$(rw_graphql "$Q_ENVS" "$(jq -nc --arg p "$PROJECT_ID" '{p: $p}')" \
+            | jq -r --arg n "$TEMPLATE_ENV_NAME" '.data.environments.edges[].node | select(.name == $n) | .id' | head -n1)"
+    fi
+    [ -n "$TEMPLATE_ENV_ID" ] || die "template environment '$TEMPLATE_ENV_NAME' not found in project '$PROJECT_NAME'"
+}
+
+find_env_id_by_name() {
+    rw_graphql "$Q_ENVS" "$(jq -nc --arg p "$PROJECT_ID" '{p: $p}')" \
+        | jq -r --arg n "$1" '.data.environments.edges[].node | select(.name == $n) | .id' | head -n1
+}
+
+clone_environment() {
+    local resp rc
+    RW_NO_TRANSIENT_RETRY=1
+    resp="$(rw_graphql "$M_ENV_CREATE" \
+        "$(jq -nc --arg p "$PROJECT_ID" --arg n "$ENV_NAME" --arg src "$TEMPLATE_ENV_ID" \
+            '{in: {projectId: $p, name: $n, sourceEnvironmentId: $src, skipInitialDeploys: true}}')")" && rc=0 || rc=$?
+    RW_NO_TRANSIENT_RETRY=0
+    if [ "$rc" -eq 0 ]; then
+        CLONE_ENV_ID="$(jq -r '.data.environmentCreate.id // empty' <<<"$resp")"
+        [ -n "$CLONE_ENV_ID" ] && return 0
+    fi
+
+    # environmentCreate can 504 while the environment is still created in the
+    # background; reconcile by polling for the name instead of re-creating.
+    printf "environmentCreate did not return cleanly; polling for env '%s' by name.\n" "$ENV_NAME" >&2
+    local waited=0 interval="${RW_ENV_CREATE_POLL_INTERVAL:-10}" max="${RW_ENV_CREATE_POLL_SECONDS:-180}"
+    while [ "$waited" -lt "$max" ]; do
+        sleep "$interval"
+        waited=$((waited + interval))
+        CLONE_ENV_ID="$(find_env_id_by_name "$ENV_NAME" || true)"
+        [ -n "$CLONE_ENV_ID" ] && return 0
+    done
+    printf "Environment '%s' never appeared within %ss.\n" "$ENV_NAME" "$max" >&2
+    return 1
+}
+
+refresh_clone_services() {
+    CLONE_SERVICES_JSON="$(rw_graphql "$Q_ENV_SERVICES" "$(jq -nc --arg id "$CLONE_ENV_ID" '{id: $id}')")"
+}
+
+clone_service_id() {
+    jq -r --arg n "$1" \
+        '.data.environment.serviceInstances.edges[].node | select(.serviceName == $n) | .serviceId' \
+        <<<"$CLONE_SERVICES_JSON" | head -n1
+}
+
+clone_service_status() {
+    jq -r --arg n "$1" \
+        '.data.environment.serviceInstances.edges[].node | select(.serviceName == $n) | .latestDeployment.status // "NONE"' \
+        <<<"$CLONE_SERVICES_JSON" | head -n1
+}
+
+clone_service_image() {
+    jq -r --arg n "$1" \
+        '.data.environment.serviceInstances.edges[].node | select(.serviceName == $n) | .source.image // ""' \
+        <<<"$CLONE_SERVICES_JSON" | head -n1
+}
+
+# Wait until the clone's serviceInstances are fully materialized (reads can
+# lag writes right after environmentCreate).
+wait_clone_populated() {
+    local waited=0 interval=5 max="${RW_CLONE_POPULATE_SECONDS:-120}" count
+    while :; do
+        refresh_clone_services || return 1
+        count="$(jq -r '[.data.environment.serviceInstances.edges[].node] | length' <<<"$CLONE_SERVICES_JSON")"
+        [ "$count" -ge "${#ALL_SERVICES[@]}" ] && return 0
+        waited=$((waited + interval))
+        if [ "$waited" -ge "$max" ]; then
+            printf 'Environment has %s/%s service instances after %ss.\n' "$count" "${#ALL_SERVICES[@]}" "$max" >&2
+            return 1
+        fi
+        sleep "$interval"
+    done
+}
+
+deploy_service() {
+    local svc="$1" svc_id
+    svc_id="$(clone_service_id "$svc")"
+    [ -n "$svc_id" ] || { printf "No serviceId for '%s'.\n" "$svc" >&2; return 1; }
+    rw_graphql "$M_DEPLOY" "$(jq -nc --arg e "$CLONE_ENV_ID" --arg s "$svc_id" '{e: $e, s: $s}')" >/dev/null
+}
+
+# dump_failed_service_logs <service>: best-effort diagnostics (redacted) so a
+# failed run leaves evidence in the workflow log.
+dump_failed_service_logs() {
+    local svc="$1" svc_id dep_id
+    svc_id="$(clone_service_id "$svc")"
+    [ -n "$svc_id" ] || return 0
+    dep_id="$(rw_graphql \
+        'query($in: DeploymentListInput!) { deployments(input: $in, first: 1) { edges { node { id } } } }' \
+        "$(jq -nc --arg e "$CLONE_ENV_ID" --arg s "$svc_id" '{in: {environmentId: $e, serviceId: $s}}')" \
+        | jq -r '.data.deployments.edges[0].node.id // empty' || true)"
+    [ -n "$dep_id" ] || return 0
+    printf -- '--- %s build logs (last 20, redacted) ---\n' "$svc" >&2
+    rw_graphql 'query($id: String!) { buildLogs(deploymentId: $id, limit: 20) { message } }' \
+        "$(jq -nc --arg id "$dep_id" '{id: $id}')" \
+        | jq -r '(.data.buildLogs // [])[].message' | rw_redact >&2 || true
+    printf -- '--- %s deploy logs (last 20, redacted) ---\n' "$svc" >&2
+    rw_graphql 'query($id: String!) { deploymentLogs(deploymentId: $id, limit: 20) { message } }' \
+        "$(jq -nc --arg id "$dep_id" '{id: $id}')" \
+        | jq -r '(.data.deploymentLogs // [])[].message' | rw_redact >&2 || true
+    return 0
+}
+
+# wait_services_success <timeout-seconds> <service...>
+# Returns 0 when every service is SUCCESS, 2 when a service ends FAILED or
+# CRASHED (terminal — retrying the wait is pointless), 1 on timeout. alembic
+# is a one-shot: an exited container may report SLEEPING/REMOVED, accepted for
+# alembic only.
+wait_services_success() {
+    local timeout="$1"; shift
+    local waited=0 interval="${RW_POLL_INTERVAL:-15}" svc st all_ok
+    while :; do
+        refresh_clone_services || return 1
+        all_ok=1
+        for svc in "$@"; do
+            st="$(clone_service_status "$svc")"
+            case "$st" in
+                SUCCESS) : ;;
+                SLEEPING | REMOVED) [ "$svc" = "alembic" ] || all_ok=0 ;;
+                FAILED | CRASHED)
+                    printf "Service '%s' deployment ended %s.\n" "$svc" "$st" >&2
+                    dump_failed_service_logs "$svc"
+                    return 2 ;;
+                *) all_ok=0 ;;
+            esac
+        done
+        [ "$all_ok" -eq 1 ] && return 0
+        waited=$((waited + interval))
+        if [ "$waited" -ge "$timeout" ]; then
+            printf 'Timed out (%ss) waiting for: %s\n' "$timeout" "$*" >&2
+            return 1
+        fi
+        sleep "$interval"
+    done
+}
+
+# Clone fidelity: Railway usually regenerates a gateway service domain inside
+# the clone; create one only when absent (gateway nginx listens on PORT=8080).
+ensure_gateway_domain() {
+    refresh_clone_services || return 1
+    GATEWAY_DOMAIN="$(jq -r \
+        '.data.environment.serviceInstances.edges[].node | select(.serviceName == "gateway") | .domains.serviceDomains[0].domain // empty' \
+        <<<"$CLONE_SERVICES_JSON" | head -n1)"
+    [ -n "$GATEWAY_DOMAIN" ] && return 0
+    [ "$VERIFY_ONLY" = false ] || { printf 'No gateway domain found (verify-only never creates one).\n' >&2; return 1; }
+
+    local gw_id resp
+    gw_id="$(clone_service_id gateway)"
+    [ -n "$gw_id" ] || return 1
+    resp="$(rw_graphql "$M_DOMAIN_CREATE" \
+        "$(jq -nc --arg e "$CLONE_ENV_ID" --arg s "$gw_id" '{in: {environmentId: $e, serviceId: $s, targetPort: 8080}}')")" \
+        || return 1
+    GATEWAY_DOMAIN="$(jq -r '.data.serviceDomainCreate.domain // empty' <<<"$resp")"
+    [ -n "$GATEWAY_DOMAIN" ]
+}
+
+# ONE environmentPatchCommit for every app service whose live image differs
+# from the target; Railway deploys each patched service immediately. Services
+# already on the target image are recorded in UNCHANGED_SERVICES: patchCommit
+# would silently no-op for them, so the deploy phase issues explicit deploys
+# for any of them that is not already green.
+PATCHED_SERVICES=""
+UNCHANGED_SERVICES=""
+
+patch_commit_images() {
+    local svc svc_id img live services_patch='{}' patched=0
+    PATCHED_SERVICES=""
+    UNCHANGED_SERVICES=""
+    for svc in "${APP_SERVICES[@]}"; do
+        svc_id="$(clone_service_id "$svc")"
+        [ -n "$svc_id" ] || { printf "No serviceId for '%s'.\n" "$svc" >&2; return 1; }
+        img="$(image_for "$svc")"
+        live="$(clone_service_image "$svc")"
+        if [ "$live" = "$img" ]; then
+            UNCHANGED_SERVICES="$UNCHANGED_SERVICES $svc"
+            continue
+        fi
+        services_patch="$(jq -c --arg s "$svc_id" --arg img "$img" \
+            '. + {($s): {source: {image: $img}}}' <<<"$services_patch")"
+        PATCHED_SERVICES="$PATCHED_SERVICES $svc"
+        patched=$((patched + 1))
+    done
+    if [ "$patched" -eq 0 ]; then
+        printf 'All app images already at %s; nothing to patch (explicit deploys cover the no-op trap).\n' "$IMAGE_TAG"
+        return 0
+    fi
+    printf 'environmentPatchCommit: %d service(s) ->%s\n' "$patched" "$PATCHED_SERVICES"
+    rw_graphql "$M_PATCH_COMMIT" \
+        "$(jq -nc --arg e "$CLONE_ENV_ID" --argjson sp "$services_patch" '{e: $e, p: {services: $sp}}')" \
+        >/dev/null
+}
+
+contains_word() {
+    case " $1 " in *" $2 "*) return 0 ;; esac
+    return 1
+}
+
+# needs_explicit_deploy <service>: a service needs an explicit
+# serviceInstanceDeployV2 when the patchCommit did not cover it AND it is not
+# already green (fresh clones start with no deployments at all).
+needs_explicit_deploy() {
+    local svc="$1" st
+    contains_word "$PATCHED_SERVICES" "$svc" && return 1
+    st="$(clone_service_status "$svc")"
+    case "$st" in
+        SUCCESS) return 1 ;;
+        SLEEPING | REMOVED) [ "$svc" = "alembic" ] && return 1 || return 0 ;;
+        *) return 0 ;;
+    esac
+}
+
+deploy_all() {
+    local svc rc
+
+    # Infra first. In an existing environment green services are left alone.
+    refresh_clone_services || return 1
+    for svc in "${INFRA_SERVICES[@]}"; do
+        if needs_explicit_deploy "$svc"; then
+            deploy_service "$svc" || return 1
+        fi
+    done
+    # A single Postgres first-deploy timeout in a fresh clone is transient
+    # (volume provisioning); retry the deploy once. Terminal FAILED/CRASHED
+    # (rc=2) is not retried.
+    wait_services_success "${RW_INFRA_WAIT_SECONDS:-420}" Postgres && rc=0 || rc=$?
+    if [ "$rc" -eq 1 ]; then
+        printf 'Postgres first deploy timed out once; retrying the deploy (single retry).\n' >&2
+        deploy_service Postgres || return 1
+        wait_services_success "${RW_INFRA_WAIT_SECONDS:-420}" Postgres || return 1
+    elif [ "$rc" -ne 0 ]; then
+        return 1
+    fi
+
+    # One patchCommit for every changed app image (deploys them, alembic
+    # included, in parallel — alembic's startCommand waits for Postgres and
+    # the other apps ride their restart policy until migrations land).
+    patch_commit_images || return 1
+
+    # alembic must be green before supertokens deploys.
+    refresh_clone_services || return 1
+    if needs_explicit_deploy alembic; then
+        deploy_service alembic || return 1
+    fi
+    if contains_word "$PATCHED_SERVICES" alembic || [ "$(clone_service_status alembic)" != "SUCCESS" ]; then
+        wait_services_success "${RW_ALEMBIC_WAIT_SECONDS:-420}" alembic || return 1
+    fi
+
+    # Everything else: services covered by the patchCommit are already
+    # deploying; deploy the rest that are not green (supertokens, gateway, and
+    # any app service the patch skipped because its image was unchanged).
+    refresh_clone_services || return 1
+    for svc in "${LATE_SERVICES[@]}"; do
+        if needs_explicit_deploy "$svc"; then
+            deploy_service "$svc" || return 1
+        fi
+    done
+    wait_services_success "${RW_DEPLOY_WAIT_SECONDS:-900}" "${LATE_SERVICES[@]}"
+}
+
+check_endpoint() {
+    local base="$1" path="$2"
+    local waited=0 interval="${SMOKE_SLEEP_SECONDS:-5}" max="${SMOKE_MAX_WAIT_SECONDS:-300}"
+    while :; do
+        if curl -fsS --connect-timeout 5 --max-time 10 "${base}${path}" >/dev/null 2>&1; then
+            printf 'OK: %s\n' "$path"
+            return 0
+        fi
+        waited=$((waited + interval))
+        if [ "$waited" -ge "$max" ]; then
+            printf 'FAILED: %s after %ss\n' "$path" "$waited" >&2
+            return 1
+        fi
+        sleep "$interval"
+    done
+}
+
+smoke_check() {
+    local base="https://${GATEWAY_DOMAIN}" path
+    printf 'Smoke-checking %s\n' "$base"
+    for path in /w /api/health /services/health; do
+        check_endpoint "$base" "$path" || return 1
+    done
+}
+
+main() {
+    command -v jq >/dev/null 2>&1 || die "missing required command: jq"
+    command -v curl >/dev/null 2>&1 || die "missing required command: curl"
+    rw_require_token
+
+    local t0 t_created=- t_deployed=- t_smoked=- clone_mode
+    t0="$(now)"
+    local calls_before
+    calls_before="$(rw_call_count)"
+
+    resolve_template_ids
+    CLONE_ENV_ID="$(find_env_id_by_name "$ENV_NAME" || true)"
+
+    if [ "$VERIFY_ONLY" = true ]; then
+        [ -n "$CLONE_ENV_ID" ] || die "environment '$ENV_NAME' does not exist in project '$PROJECT_NAME' (setup must run first)"
+        clone_mode="verify"
+        ensure_gateway_domain || die "gateway domain not found in environment '$ENV_NAME'"
+        smoke_check || die "smoke checks failed for environment '$ENV_NAME'"
+    else
+        if [ -n "$CLONE_ENV_ID" ]; then
+            clone_mode="update"
+            printf "Environment '%s' already exists; converging it to tag %s.\n" "$ENV_NAME" "$IMAGE_TAG"
+        else
+            clone_mode="create"
+            printf "Cloning template '%s' into environment '%s'.\n" "$TEMPLATE_ENV_NAME" "$ENV_NAME"
+            clone_environment || die "could not create environment '$ENV_NAME'"
+        fi
+        wait_clone_populated || die "environment '$ENV_NAME' never fully materialized"
+        t_created=$(( $(now) - t0 ))
+
+        # Domain BEFORE app deploys: web/api render
+        # ${{gateway.RAILWAY_PUBLIC_DOMAIN}} into their env at container start.
+        ensure_gateway_domain || die "could not ensure a gateway domain"
+        deploy_all || die "deploy did not reach green"
+        t_deployed=$(( $(now) - t0 ))
+
+        smoke_check || die "smoke checks failed"
+        t_smoked=$(( $(now) - t0 ))
+    fi
+
+    local total_s calls
+    total_s=$(( $(now) - t0 ))
+    calls=$(( $(rw_call_count) - calls_before ))
+
+    local preview_url="https://${GATEWAY_DOMAIN}/w"
+    local logs_url="https://railway.com/project/${PROJECT_ID}/logs?environmentId=${CLONE_ENV_ID}"
+    printf 'Preview ready (%s): %s\n' "$clone_mode" "$preview_url"
+    printf 'Timings: created=%ss deployed=%ss smoked=%ss total=%ss api_calls=%s\n' \
+        "$t_created" "$t_deployed" "$t_smoked" "$total_s" "$calls"
+    rw_report_calls "preview-clone-create ($clone_mode)"
+
+    emit_output project_name "$PROJECT_NAME"
+    emit_output environment_name "$ENV_NAME"
+    emit_output preview_url "$preview_url"
+    emit_output railway_logs_url "$logs_url"
+    emit_output clone_mode "$clone_mode"
+    emit_output total_seconds "$total_s"
+    emit_output api_calls "$calls"
+}
+
+main

--- a/hosting/railway/oss/scripts/preview-clone-destroy.sh
+++ b/hosting/railway/oss/scripts/preview-clone-destroy.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+
+# preview-clone-destroy.sh — delete a clone-mode PR preview environment
+# (issue #5650, WP3), or sweep stale ones.
+#
+# Clone-mode previews are ENVIRONMENTS inside the shared template project
+# (created by preview-clone-create.sh), so destroying one is a single
+# environmentDelete — never a project delete. Idempotent: an absent
+# environment is a success.
+#
+# Usage:
+#   preview-clone-destroy.sh                 # delete pr-<PR_NUMBER> (or
+#                                            # $RAILWAY_PREVIEW_ENV_NAME)
+#   preview-clone-destroy.sh --stale-hours N # delete preview environments in
+#                                            # the template project older than
+#                                            # N hours (cron equivalent of
+#                                            # scripts/preview-cleanup-stale.sh
+#                                            # for clone mode)
+#
+# The stale sweep matches only preview-shaped names: pr-<digits>, pr-clone-*,
+# and wp3-* (the test-cycle prefixes). The template environment and
+# 'production' are always excluded, twice over: they do not match the
+# patterns, and they are rejected by name before any delete.
+#
+# Environment variables:
+#   PR_NUMBER                 PR number; default environment name pr-<PR_NUMBER>.
+#   RAILWAY_PREVIEW_ENV_NAME  Override the environment name.
+#   RAILWAY_TEMPLATE_PROJECT  Template project name.
+#                             TODO(cutover): default becomes the production
+#                             preview project at rollout; until then it is the
+#                             proven test bed.
+#   RAILWAY_TEMPLATE_ENV      Template environment name (default pr-template).
+#   RAILWAY_PREVIEW_DRY_RUN   'true' with --stale-hours: report, delete nothing.
+#   RAILWAY_API_TOKEN         Account token (auto-sourced from
+#                             ~/.agenta-railway.env locally; in CI exported
+#                             from secrets.RAILWAY_TOKEN — never named
+#                             RAILWAY_TOKEN).
+
+# GraphQL documents use $var for GraphQL variables, not shell expansion.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Single shared GraphQL client (WP2); do not fork another copy.
+# shellcheck source=../template/lib-graphql.sh
+source "$SCRIPT_DIR/../template/lib-graphql.sh"
+
+die() {
+    printf 'preview-clone-destroy.sh: %s\n' "$*" >&2
+    exit 1
+}
+
+STALE_HOURS=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --stale-hours) [ "$#" -ge 2 ] || die "--stale-hours needs a value"; STALE_HOURS="$2"; shift 2 ;;
+        --stale-hours=*) STALE_HOURS="${1#*=}"; shift ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+if [ -n "$STALE_HOURS" ]; then
+    printf '%s' "$STALE_HOURS" | grep -qE '^[0-9]+$' || die "--stale-hours must be a whole number of hours"
+fi
+
+# TODO(cutover): default becomes the production preview template project at
+# rollout (also re-point ../template/template.json's "project").
+PROJECT_NAME="${RAILWAY_TEMPLATE_PROJECT:-agenta-oss-clone-spike}"
+TEMPLATE_ENV_NAME="${RAILWAY_TEMPLATE_ENV:-pr-template}"
+DRY_RUN="${RAILWAY_PREVIEW_DRY_RUN:-false}"
+
+case "$PROJECT_NAME" in
+    agenta-oss-pr-*) die "refusing to target legacy per-PR project '$PROJECT_NAME'" ;;
+esac
+
+Q_ENVS='query($p: String!) { environments(projectId: $p, first: 100) { edges { node { id name createdAt } } } }'
+M_ENV_DELETE='mutation($id: String!) { environmentDelete(id: $id) }'
+
+# is_protected_env <name>: the template environment and production must never
+# be deleted, whatever the caller or the name patterns say.
+is_protected_env() {
+    [ "$1" = "$TEMPLATE_ENV_NAME" ] || [ "$1" = "production" ]
+}
+
+delete_env() {
+    local env_id="$1" env_name="$2"
+    is_protected_env "$env_name" && die "refusing to delete protected environment '$env_name'"
+    rw_graphql "$M_ENV_DELETE" "$(jq -nc --arg id "$env_id" '{id: $id}')" >/dev/null
+    printf "Deleted preview environment '%s'\n" "$env_name"
+}
+
+destroy_one() {
+    local env_name="${RAILWAY_PREVIEW_ENV_NAME:-${PR_NUMBER:+pr-${PR_NUMBER}}}"
+    [ -n "$env_name" ] || die "set PR_NUMBER or RAILWAY_PREVIEW_ENV_NAME"
+    is_protected_env "$env_name" && die "refusing to delete protected environment '$env_name'"
+
+    local env_id
+    env_id="$(rw_graphql "$Q_ENVS" "$(jq -nc --arg p "$PROJECT_ID" '{p: $p}')" \
+        | jq -r --arg n "$env_name" '.data.environments.edges[].node | select(.name == $n) | .id' | head -n1)"
+    if [ -z "$env_id" ]; then
+        printf "Environment '%s' does not exist in project '%s'. Nothing to delete.\n" "$env_name" "$PROJECT_NAME"
+        return 0
+    fi
+    delete_env "$env_id" "$env_name"
+}
+
+destroy_stale() {
+    local now_epoch max_age_seconds deleted=0 kept=0
+    now_epoch="$(date +%s)"
+    max_age_seconds=$((STALE_HOURS * 3600))
+
+    local envs_json
+    envs_json="$(rw_graphql "$Q_ENVS" "$(jq -nc --arg p "$PROJECT_ID" '{p: $p}')")"
+
+    local env_id env_name created_at created_epoch age_seconds age_hours
+    while IFS=$'\t' read -r env_id env_name created_at; do
+        # Preview-shaped names only; everything else (production, pr-template,
+        # operator scratch envs) is left alone.
+        case "$env_name" in
+            pr-clone-* | wp3-*) : ;;
+            pr-*)
+                printf '%s' "${env_name#pr-}" | grep -qE '^[0-9]+$' || continue ;;
+            *) continue ;;
+        esac
+        is_protected_env "$env_name" && continue
+
+        created_epoch="$(date -d "$created_at" +%s 2>/dev/null || echo 0)"
+        if [ "$created_epoch" -eq 0 ]; then
+            printf "SKIP: %s (could not parse createdAt: %s)\n" "$env_name" "$created_at"
+            kept=$((kept + 1))
+            continue
+        fi
+        age_seconds=$((now_epoch - created_epoch))
+        age_hours=$((age_seconds / 3600))
+        if [ "$age_seconds" -gt "$max_age_seconds" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+                printf "DRY-RUN: would delete '%s' (age: %dh)\n" "$env_name" "$age_hours"
+            else
+                printf "DELETE: '%s' (age: %dh)\n" "$env_name" "$age_hours"
+                delete_env "$env_id" "$env_name"
+            fi
+            deleted=$((deleted + 1))
+        else
+            printf "KEEP: '%s' (age: %dh, max: %dh)\n" "$env_name" "$age_hours" "$STALE_HOURS"
+            kept=$((kept + 1))
+        fi
+    done < <(jq -r '.data.environments.edges[].node | [.id, .name, .createdAt] | @tsv' <<<"$envs_json")
+
+    if [ "$DRY_RUN" = "true" ]; then
+        printf 'Stale sweep complete (dry-run). Would delete: %d, kept: %d (max age: %sh)\n' \
+            "$deleted" "$kept" "$STALE_HOURS"
+    else
+        printf 'Stale sweep complete. Deleted: %d, kept: %d (max age: %sh)\n' \
+            "$deleted" "$kept" "$STALE_HOURS"
+    fi
+}
+
+main() {
+    command -v jq >/dev/null 2>&1 || die "missing required command: jq"
+    command -v curl >/dev/null 2>&1 || die "missing required command: curl"
+    rw_require_token
+
+    PROJECT_ID="${RAILWAY_TEMPLATE_PROJECT_ID:-}"
+    if [ -z "$PROJECT_ID" ]; then
+        PROJECT_ID="$(rw_find_project_id "$PROJECT_NAME" || true)"
+    fi
+    [ -n "$PROJECT_ID" ] || die "project '$PROJECT_NAME' not found for this token"
+
+    if [ -n "$STALE_HOURS" ]; then
+        destroy_stale
+    else
+        destroy_one
+    fi
+    rw_report_calls "preview-clone-destroy"
+}
+
+main


### PR DESCRIPTION
Part of the clone-based Railway preview redesign (#5650, WP3 of 3, final). **Do not merge before #5665; merge order is bottom-up through the stack.**

Today every preview is constructed imperatively (~75 Railway mutations per run), which is why previews keep failing in new ways. The spike (#5658) proved the replacement: clone a prepared template environment, patch the image tags in one batched mutation, deploy, delete on close. This PR wires that flow into the real preview workflows behind a switch, with the legacy path untouched.

## What changes

- **One switch**: the `mode` job in workflow 14 resolves `vars.RAILWAY_PREVIEW_MODE || 'legacy'` once per run and passes it down, so a single repo variable flips previews between modes, and rollback is flipping it back. The variable does not exist yet; everything defaults to legacy.
- `preview-clone-create.sh`: create-or-update of the per-PR clone environment. Fresh PR: clone the template (`skipInitialDeploys`, poll-by-name on ambiguous create), one `environmentPatchCommit` for all app images, ordered deploys (infra → migrations → rest, supertokens after alembic), one retry for a slow first Postgres deploy, then smoke checks. Subsequent push: just patch and redeploy. `--verify-only` gives workflow 43 a mutation-free re-check that emits the same outputs the legacy deploy step did, so the tests job and PR comment work unchanged.
- `preview-clone-destroy.sh`: idempotent environment deletion plus a stale-clone sweep (`--stale-hours`) for the cleanup cron, with `pr-template` and `production` double-protected.
- Workflows 41/43/45: legacy steps gated `mode != 'clone'` with their command lines byte-identical; clone steps added alongside. 45 also gains the stale-clone sweep in its daily cron (runs in both modes deliberately, so a rollback to legacy cannot strand clone environments).
- Workflow 48: the evidence harness. Dispatchable and PR-triggered; runs N consecutive create→smoke→destroy cycles with the production scripts and fails on any cycle failure.

## Verification

- **Live, against the test bed**: fresh create+patch+deploy+smoke green in 89s / 24 API calls (7 mutations); idempotent re-run 3s (empty patch-set handled, nothing redeployed); verify-only 2s; destroy and absent-destroy both green. Full redacted transcript in the PR comment below.
- **Legacy equivalence**: with the variable unset, every legacy step's `run`/`env`/`with` block is byte-identical; the only expressions that changed are output fallbacks (`steps.deploy.X || steps.verify.X`) that render identical values in legacy mode. Stated precisely in the equivalence note in the comment.
- shellcheck, bash -n, and actionlint clean.
- This PR's own CI run of workflow 48 provides the "consecutive green clone cycles from a real Actions run" acceptance evidence.

Refs #5650

https://claude.ai/code/session_011zdniFW44QDqcs4Nz8n3hr
