### PR TITLE
fix: treat absent harness.kind as pi_core to match runner default

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -171,7 +171,7 @@ export function useModelHarness({
     // carries through extra keys (e.g. `extras`) so a form edit never silently drops them. The picker
     // is harness-filtered: selecting a model sets BOTH the model id and its provider, fed by the
     // `/inspect` capability map below.
-    const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : null
+    const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : "pi_core"
     const isPiHarness = harnessValue === "pi_core" || harnessValue === "pi_agenta"
     const llm = config.llm
     const modelId = useMemo(() => modelIdFromConfig(llm), [llm])


### PR DESCRIPTION
## Description

When an agent config omits `harness.kind`, the runner treats the harness as `pi_core` — all seven Pi built-ins are active and the `harness.permissions` allow/ask/deny rules are enforced at runtime. However, the UI kept `harnessValue` as `null` when `harness.kind` was absent, making `isPiHarness` and `hasPiPermissions` evaluate to `false`, which hid the Pi permissions controls.

## Fix

Changed the default value of `harnessValue` from `null` to `pi_core` when `harness.kind` is not a string, matching the runner's default behavior. This covers both:

- **Absent `harness.kind`**: `{harness: {}}` — the kind field is undefined
- **Missing harness block entirely**: the hook receives an empty default

## Changes

```diff
- const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : null
+ const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : "pi_core"
```

Fixes #5661