### PR TITLE
fix(frontend): Pi permissions controls hidden when agent config omits harness.kind

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -85,6 +85,15 @@ function isPermissionPolicy(value: unknown): value is PermissionPolicy {
     return typeof value === "string" && PERMISSION_POLICY_VALUES.has(value)
 }
 
+/**
+ * Resolve the effective harness kind from the config, defaulting to `"pi_core"` when absent.
+ * The runner already treats a missing harness.kind as pi_core, so this aligns the UI with
+ * what actually runs. The default is read-path only — it never writes kind back into the config.
+ */
+export function resolveHarnessKind(harness: {kind?: string} | null | undefined): string {
+    return typeof harness?.kind === "string" ? harness.kind : "pi_core"
+}
+
 export function useModelHarness({
     schema,
     config,
@@ -171,7 +180,7 @@ export function useModelHarness({
     // carries through extra keys (e.g. `extras`) so a form edit never silently drops them. The picker
     // is harness-filtered: selecting a model sets BOTH the model id and its provider, fed by the
     // `/inspect` capability map below.
-    const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : null
+    const harnessValue = resolveHarnessKind(harness)
     const isPiHarness = harnessValue === "pi_core" || harnessValue === "pi_agenta"
     const llm = config.llm
     const modelId = useMemo(() => modelIdFromConfig(llm), [llm])

--- a/web/packages/agenta-entity-ui/tests/unit/resolveHarnessKind.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/resolveHarnessKind.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for resolveHarnessKind — the defaulting logic that aligns the UI with the runner's
+ * treatment of absent harness.kind as pi_core.
+ *
+ * The default is read-path only; resolveHarnessKind never writes kind back into the config.
+ * Runs under @agenta/entity-ui's own vitest runner.
+ */
+import {describe, expect, it} from "vitest"
+
+import {resolveHarnessKind} from "../../src/DrillInView/SchemaControls/agentTemplate/useModelHarness"
+
+describe("resolveHarnessKind", () => {
+    it("returns pi_core when harness is null", () => {
+        expect(resolveHarnessKind(null)).toBe("pi_core")
+    })
+
+    it("returns pi_core when harness is undefined", () => {
+        expect(resolveHarnessKind(undefined)).toBe("pi_core")
+    })
+
+    it("returns pi_core when harness.kind is absent", () => {
+        expect(resolveHarnessKind({})).toBe("pi_core")
+    })
+
+    it("returns pi_core when harness.kind is undefined", () => {
+        expect(resolveHarnessKind({kind: undefined})).toBe("pi_core")
+    })
+
+    it("returns pi_core when harness.kind is an empty object (edge case)", () => {
+        // This covers the {harness: {}} case from the issue — the runner treats it as pi_core
+        expect(resolveHarnessKind({} as {kind?: string})).toBe("pi_core")
+    })
+
+    it("does not override an explicit claude harness", () => {
+        expect(resolveHarnessKind({kind: "claude"})).toBe("claude")
+    })
+
+    it("does not override an explicit openai harness", () => {
+        expect(resolveHarnessKind({kind: "openai"})).toBe("openai")
+    })
+
+    it("does not override an explicit pi_agenta harness", () => {
+        expect(resolveHarnessKind({kind: "pi_agenta"})).toBe("pi_agenta")
+    })
+
+    it("does not override an explicit bedrock harness", () => {
+        expect(resolveHarnessKind({kind: "bedrock"})).toBe("bedrock")
+    })
+})


### PR DESCRIPTION
## Symptom

When an agent config omits `harness.kind`, the runner treats the harness as `pi_core` — all seven Pi built-ins are active and the `harness.permissions` allow/ask/deny rules are enforced at runtime. The web UI does not apply the same default, so for such a config the Pi permissions controls are hidden while the run enforces Pi permission gating. The author cannot see or edit the rules that apply to their runs.

## Before

![Before — PiPermissionsControl is hidden when harness.kind is absent](https://github.com/Agenta-AI/agenta/issues/5661)

## Root Cause

In `useModelHarness.tsx`, `harnessValue` stayed `null` when `harness.kind` was absent (line 174), so `isPiHarness` was `false` and `hasPiPermissions` hid `PiPermissionsControl`.

## Fix

Extracted a small exported helper `resolveHarnessKind` that defaults to `"pi_core"` when `harness.kind` is absent (matching the runner's default). The default is **read-path only** — it never writes `kind` back into the saved config.

### Coverage
- `null` / `undefined` harness → `"pi_core"`
- `{harness: {}}` → `"pi_core"`
- `{harness: {kind: "claude"}}` → `"claude"` (not overridden)
- All other explicit harness kinds preserved

## Validation

All 310 tests pass (20 test files, including 9 new tests for `resolveHarnessKind`):

```
 ✓ tests/unit/resolveHarnessKind.test.ts (9 tests) 12ms
 Test Files  20 passed (20)
      Tests  310 passed (310)
```

No lint errors.

## AI Model

This change was produced by DeepSeek V4 Flash (Hermes Agent) with web research and unit test verification. The implementation follows the step-by-step instructions left by @mmabrouk in the issue.

Closes #5661