### PR TITLE
[5662] test(sdk): fix two builtin-tool tests that don't exercise what they claim

### DIFF
--- a/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
@@ -181,7 +181,9 @@ def test_no_json_example_writes_a_builtin_tool_entry():
     # examples verbatim, so an example that still writes one would keep producing configs the
     # resolver has to ignore.
     content = _file("references/config-schema.md").content
-    for block in re.findall(r"```json\n(.*?)```", content, flags=re.DOTALL):
+    blocks = re.findall(r"```json\n(.*?)```", content, flags=re.DOTALL)
+    assert blocks, "config-schema.md must contain at least one JSON example"
+    for block in blocks:
         try:
             parsed = json.loads(block)
         except json.JSONDecodeError as exc:

--- a/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
@@ -10,6 +10,7 @@ is not mirrored in the doc fails CI instead of shipping a stale reference to the
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import get_args
@@ -165,13 +166,29 @@ def test_config_schema_names_every_tool_type_discriminator():
     assert not missing, f"config-schema.md does not document tool type(s): {missing}"
 
 
+def _contains_builtin_tool_entry(value: object) -> bool:
+    if isinstance(value, dict):
+        if value.get("type") == "builtin":
+            return True
+        return any(_contains_builtin_tool_entry(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_builtin_tool_entry(item) for item in value)
+    return False
+
+
 def test_no_json_example_writes_a_builtin_tool_entry():
     # The `builtin` arm survives only as legacy dual-read. The authoring agent copies these
     # examples verbatim, so an example that still writes one would keep producing configs the
     # resolver has to ignore.
     content = _file("references/config-schema.md").content
     for block in re.findall(r"```json\n(.*?)```", content, flags=re.DOTALL):
-        assert '"type": "builtin"' not in block, (
+        try:
+            parsed = json.loads(block)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(
+                f"config-schema.md has a json fence that is not valid JSON: {exc}"
+            ) from exc
+        assert not _contains_builtin_tool_entry(parsed), (
             "a JSON example in config-schema.md still writes a builtin tool entry"
         )
 

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_resolver.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_resolver.py
@@ -295,7 +295,7 @@ async def test_reserved_gateway_name_fails_before_adapter_call():
 
 
 async def test_a_bare_tool_name_string_is_ignored_too():
-    # `coerce_tool_config` turns a bare string into a BuiltinToolConfig.
+    # `coerce_tool_configs` turns a bare string into a BuiltinToolConfig.
     parsed = coerce_tool_configs(["read"])
     assert parsed.tool_configs == [BuiltinToolConfig(name="read")]
 

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_resolver.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_resolver.py
@@ -296,7 +296,10 @@ async def test_reserved_gateway_name_fails_before_adapter_call():
 
 async def test_a_bare_tool_name_string_is_ignored_too():
     # `coerce_tool_config` turns a bare string into a BuiltinToolConfig.
-    resolved = await ToolResolver().resolve(coerce_tool_configs(["read"]))
+    parsed = coerce_tool_configs(["read"])
+    assert parsed.tool_configs == [BuiltinToolConfig(name="read")]
+
+    resolved = await ToolResolver().resolve(parsed.tool_configs)
 
     assert resolved.tool_specs == []
 


### PR DESCRIPTION
Closes #5662

## Summary

Two unit tests in the SDK tests from the built-ins directory pass but don't actually test what they are supposed to be testing.

**test_a_bare_tool_name_string_is_ignored_too** (`test_resolver.py`) invoked
`ToolResolver().resolve(coerce_tool_configs(["read"]))`. `coerce_tool_configs`
returns a `ToolConfigParseResult` pydantic model rather than a list of
configs, thus iterating over it inside `resolve()` will yield pairs
`(field, value)` rather than the actual `BuiltinToolConfig` objects.
`resolve()` will quietly accept this wrong input and return
`tool_specs == []` which is indeed correct, but this doesn't mean that the
coercion path was actually taken. It now first asserts
`coerce_tool_configs(["read"]).tool_configs == [BuiltinToolConfig(name="read")]`,
and only then resolves that list.

**test_no_json_example_writes_a_builtin_tool_entry**
(`test_agenta_builtins_reference_files.py`) was checking that
`'"type": "builtin"' not in block` as an unprocessed string. However, any
variant with whitespace, like `"type":"builtin"`, would pass silently.
It now `json.loads`s each block and recursively walks dicts and lists
for any object with `type == "builtin"`, and fails loudly if a block
isn't even valid JSON.

## Testing

### Verified locally

- Targeted files (2): 48 tests passed.
- Full SDK suite (`run-tests.py`): 2382 passed, 4 skipped, 10 xfailed.
The single unit test failure (`test_cli_stream_terminal_only_on_empty_request`)
and the 97 acceptance test errors are pre-existing and totally
unrelated – confirmed by stashing this change and re-running against
an unmodified `main`, yielding the same results. The acceptance errors
require a live `AGENTA_API_URL`.
- Sanity checked that both rewrites can indeed fail as requested in the
issue: corrupted the expected value in the resolver assertion and
verified pytest fails with a proper diff, then reverted it. For the
JSON example check, verified that the new algorithm correctly catches
the no-space `"type":"builtin"` case where the old substring check
would silently miss it.
- `ruff format` and `ruff check`: clean.

### Added or updated tests

N/A — this PR only strengthens two existing tests, no new tests added.

### QA follow-up

N/A — test-only change, no user-visible behavior.

## Demo

N/A — not a UI change.

## AI assistance disclosure

Written with Claude Sonnet 5 via Claude Code (CLI), standard interactive
reasoning (no extended/deep-thinking budget configured for this session).
Session: read the actual source (`ToolConfigParseResult`, `BuiltinToolConfig`,
the reference-file regex extraction) to verify both bugs independently rather
than trust the issue text alone, found and reused an existing idiomatic
assertion pattern already in the codebase (`test_parsing.py`) for the first
fix, implemented both rewrites, ran the targeted files and the full SDK suite,
then did the sanity checks described above before handing off for commit/push.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
