### PR TITLE
[AGE-4063] test(qa): make continuity a real dimension of the agent release gate

### DIFF
--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -31,18 +31,27 @@ export AGENTA_BASE=https://your-stack.example.com   # deployment origin
 export AGENTA_PROJECT_ID=...                         # target project
 export AGENTA_API_KEY=...                            # project API key
 
-uv run resources/qa_product.py --all --custom-slug <vault-slug>  # every cell, every journey
+uv run resources/qa_product.py --all --custom-slug <vault-slug> --require-store  # everything
 uv run resources/qa_product.py --cell P1                         # one cell
 uv run resources/qa_product.py --cell C1 --only chat              # one journey
+uv run resources/qa_product.py --cell S2 --only warm --only cold1 --require-store  # continuity
 ```
 
 Paths are relative to this skill's directory. The deployment's vault must hold the provider keys
 the cells use (Anthropic / OpenAI / OpenRouter). If the three env vars are unset the driver stops
 immediately and names exactly what is missing; a legacy `--env-file <path>` fallback also exists.
 `--all` includes cell P2 (a custom OpenAI-compatible provider), which needs a vault slug passed
-via `--custom-slug`; the driver fails fast if it's missing. Cell S1 (the Codex subscription path)
-additionally needs the subscription sidecar logged in on the target deployment — see
-`resources/coverage.md` for what each cell requires.
+via `--custom-slug`; the driver fails fast if it's missing. Cells S1, S2 and C1 additionally need
+the subscription sidecar logged in on the target deployment — see `resources/coverage.md` for what
+each cell requires.
+
+**The one flag a release conductor must not skip past.** The continuity journeys
+(`warm`, `cold1`, `cold2`) only mean anything on a **store-backed** deployment: with no object
+store the runner degrades silently to an ephemeral working directory, so those journeys SKIP by
+default and FAIL with `--require-store`. Run the gate against a deployment with `AGENTA_STORE_*`
+configured and pass `--require-store`, or the greenest possible run still says nothing about
+durability. `cold2` additionally needs an operator hook that SIGKILLs the runner replica
+(`--cold2-replace-cmd`) and SKIPs without it.
 
 **Reading the result.** Each journey prints `PASS`, `FAIL`, or `SKIP` with a one-line reason, and
 a per-cell markdown table lands with the full JSON in `./qa-gate-runs/<timestamp>/` (override the
@@ -54,14 +63,17 @@ cell — user MCP is Claude-only). Any `FAIL` blocks the release until triaged.
 
 The runtime **fails open**: a component can break, get logged, and the turn still succeeds with a
 normal-looking answer. A green turn is therefore not proof on its own. Before trusting a pass,
-read `resources/LESSONS.md` — every trap there produced a green test that proved nothing. The two
+read `resources/LESSONS.md` — every trap there produced a green test that proved nothing. The three
 that bite hardest: replay conversation history byte-faithfully (tool parts included) or every turn
-silently goes cold, and re-run any prior blocker-level finding after a redeploy before believing it.
+silently goes cold; re-run any prior blocker-level finding after a redeploy before believing it;
+and a multi-turn check that never leaves the warm daemon, on a deployment with no object store,
+proves nothing about the durable working directory (LESSONS #16).
 
 ## Resources (read on demand)
 
-- `resources/coverage.md` — the cells (harness × sandbox × auth) and journeys (chat, mount, tool,
-  approve, deny, commit, warm, mcp) with a one-line meaning for each.
+- `resources/coverage.md` — the cells (harness × sandbox × auth), the journeys (chat, mount, tool,
+  approve, deny, commit, warm, cold1, cold2, mcp) with a one-line meaning for each, the continuity
+  tiers and their method, and a table of what each cell needs beyond the three env vars.
 - `resources/LESSONS.md` — the traps. Read before writing or trusting any agent QA test.
 - `resources/qa_product.py` — the gate driver (cells × journeys).
 - `resources/qa_probe.py` — a one-turn wire probe: `uv run resources/qa_probe.py` confirms the

--- a/.agents/skills/agent-release-gate/resources/LESSONS.md
+++ b/.agents/skills/agent-release-gate/resources/LESSONS.md
@@ -200,6 +200,34 @@ The config entry is a full object, not a URL string:
 `{"name","connection":{"type":"http","url":...},"policy":{"tools":{"mode":"all"}}}`. Assert on the
 wire: a `tool-output-available` frame for a tool named `mcp__<server>__<tool>`.
 
+## 16. A warm multi-turn test cannot see anything the object store cannot represent
+
+The agent's working directory is durable because it is a geesefs mount over S3. It only makes the
+round trip through the store when something **unmounts and remounts** it — an eviction, a rebuild,
+a new replica. A test that stays on the live daemon never takes that trip, so any entry the store
+cannot represent survives in the FUSE cache and the test goes green.
+
+That is how #5692 shipped: the Codex subscription path symlinks `auth.json` into the durable cwd,
+S3 has no symlinks, and the entry came back as a **0-byte object**; an `existsSync` guard read the
+0-byte file as "already linked" and never rebuilt it. Turn 1 worked, every later turn failed. The
+pre-merge QA that covered that configuration was four **single-turn** checks, and the gate's
+multi-turn journey was warm-only. Known siblings of the same class: SQLite WAL (already designed
+around — `CODEX_SQLITE_HOME` is split onto container-local disk) and hard links.
+
+**Two rules.**
+
+- Any claim about durability needs a turn that reads the directory back **from the store**, not
+  from the live mount. `cold1` forces it from the client (change the agent's instructions → the
+  config fingerprint changes → `evict + cold` → unmount + remount); `cold2` needs the replica
+  replaced.
+- **Confirm the store was in play.** With no store configured the runner degrades silently to an
+  ephemeral directory (`mount degraded kind=session_cwd`) and every turn still looks fine, so a
+  continuity pass on such a deployment means nothing. Resolve the session's mount over the API
+  (`GET /api/sessions/mounts/?session_id=…`) and refuse to report green without it — that is what
+  `--require-store` enforces. Read the durable file back with `GET /api/mounts/{id}/files?read=…`:
+  the API reads S3 directly, so a hit is store-side proof, and the same listing shows any 0-byte
+  objects — the fingerprint of this whole bug class.
+
 ## The checklist for the next QA run
 
 1. `docker ps` — is anything restarting? If yes, wait.
@@ -211,3 +239,5 @@ wire: a `tool-output-available` frame for a tool named `mcp__<server>__<tool>`.
 7. Re-run anything that failed once before reporting it.
 8. Before trusting an existing blocker-level finding, check whether the stack has been redeployed
    since it was observed — if so, re-run the decisive experiment.
+9. Is the deployment store-backed? If yes, run the continuity journeys with `--require-store`; if
+   no, do not read their result as durability coverage.

--- a/.agents/skills/agent-release-gate/resources/coverage.md
+++ b/.agents/skills/agent-release-gate/resources/coverage.md
@@ -5,9 +5,12 @@ The gate is the product of two lists: **cells** (the configurations under test) 
 
 ## Cells (harness × sandbox × auth)
 
-The core axis is harness × sandbox. Provider and auth mode are a sub-matrix run inside the Pi cells
-only, because that is an authentication question, not a sandbox one — re-running it in all four core
-cells would test the same code twice.
+The core axis is harness × sandbox. Provider is a sub-matrix run inside the Pi cells only, because
+that is an authentication question, not a sandbox one — re-running it in all four core cells would
+test the same code twice. **Auth mode is not** delegated that way: each harness assembles
+subscription credentials differently (Claude reads a config dir, Pi reads its own login, Codex
+assembles a `.codex` home inside the durable working directory), so every harness that supports a
+subscription has its own cell — C1, S1, S2.
 
 | Cell | Harness | Sandbox | Model | Auth mode | Why this cell exists |
 |---|---|---|---|---|---|
@@ -16,12 +19,14 @@ cells would test the same code twice.
 | C3 | `pi_core` | `local` | `gpt-5.6-luna` | vault key (OpenAI) | Pi on the local sandbox with a managed OpenAI key. |
 | C4 | `pi_core` | `daytona` | `gpt-5.6-luna` | vault key (OpenAI) | Pi in a cloud sandbox; the remote-mount path that surfaced the silent file-loss finding (F-7). |
 | P1 | `pi_core` | `local` | `openrouter/deepseek/deepseek-v4-flash` | vault key (OpenRouter) | OpenRouter as a first-class native provider. |
-| S1 | `pi_core` | `local` | `gpt-5.6-luna` | subscription (Codex OAuth) | The ChatGPT/Codex subscription path via the sidecar, independent of any vault key. |
+| S1 | `pi_core` | `local` | `gpt-5.6-luna` | subscription (Pi, `openai-codex` provider) | **Pi** authenticating from a ChatGPT/Codex subscription through the sidecar, independent of any vault key. Not the Codex harness — see S2. |
 | X1 | `codex` | `local` | `gpt-5.6-luna` | vault key (OpenAI) | The native Codex harness with a managed key. Since the D-008 amendment (2026-07-31, patched bridge), Agenta-tool calls raise codex-native approval gates that park warm, and the `approve`/`deny` journeys RUN for codex with an MCP-shaped probe (the `list_connections` platform tool, per-tool `ask`) instead of the builtin-shell probe. Only `mcp` (Claude-only) and `mount` still SKIP (see below). |
-| P2 | `pi_core` | `local` | `deepseek/deepseek-v4-flash` | custom OpenAI-compatible provider | OpenRouter reached as a custom OpenAI-compatible endpoint — the path every self-hoster with a proxy or local vLLM uses, and the least-travelled one. Needs a `custom_provider` vault slug; pass `--custom-slug`. |
+| X2 | `codex` | `daytona` | `gpt-5.6-luna` | vault key (OpenAI) | Codex in a cloud sandbox. Exists for the continuity tiers: a `cold2` resume can only COMPLETE on a remote sandbox (on local it correctly refuses), so without this cell the gate can never observe a finished codex cold 2. Verified out of band during the v0.108.0 release run; promoted into the gate. |
+| S2 | `codex` | `local` | `gpt-5.6-luna` | subscription (Codex OAuth, `runtime_provided`) | **The genuine Codex-subscription cell**: the codex harness with the operator's mounted ChatGPT/Codex login. The only cell that exercises the subscription file assembly — `CODEX_HOME` pointed at `<cwd>/.codex` and `auth.json` symlinked into the **durable** working directory. That link is the one credential path an object-store round trip can destroy (#5692). Local-only (Daytona rejects `runtime_provided`), and needs the subscription sidecar. |
+| P2 | `pi_core` | `local` | `<slug>/custom/deepseek/deepseek-v4-flash` | custom OpenAI-compatible provider | OpenRouter reached as a custom OpenAI-compatible endpoint — the path every self-hoster with a proxy or local vLLM uses, and the least-travelled one. Needs a `custom_provider` vault slug; pass `--custom-slug` (the driver then sends the full `<slug>/custom/<model>` key and connection mode `agenta`, which is what v0.107.x resolver semantics require). |
 
-The Codex cell (`X1`) runs `chat`, `tool`, `commit`, `warm`, `approve`, and `deny`; `mcp` SKIPs
-(Claude-only) and `mount` SKIPs with a codex-specific reason:
+The Codex cells (`X1`, `X2`, `S2`) run `chat`, `tool`, `commit`, `warm`, `cold1`, `cold2`,
+`approve`, and `deny`; `mcp` SKIPs (Claude-only) and `mount` SKIPs with a codex-specific reason:
 
 - `approve` / `deny` RUN for codex with an MCP-shaped probe. The shared shell probe cannot park a
   codex run — codex only raises exec (shell) approval when its filesystem sandbox is restricted,
@@ -51,7 +56,9 @@ cell — keep them in sync if a cell changes.
 | `approve` | Raise an approval, then approve it. | The approved tool call continues via the in-band approval protocol the browser uses. |
 | `deny` | Raise an approval, then deny it. | The denied path is handled cleanly (no phantom failure, no re-parking forever). |
 | `commit` | Save an agent config as a new workflow revision, then fetch it back. | The changed parameter survives the round trip and the version bumps (v0 seed → v1; see LESSONS #14). Harness-agnostic — it drives the config REST API, not a turn. |
-| `warm` | Run three turns, watch latency and the runner log. | Turns 2-3 are faster and the log confirms the session was genuinely **loaded**, not silently cold. |
+| `warm` | Continuity tier 1: three turns on one live daemon, over a store-backed cwd. | The durable token written in turn 1 comes back in the last turn, and the turn ledger shows one harness session and one sandbox (a second id means the turn was not warm). |
+| `cold1` | Continuity tier 2: the pooled session is **evicted** (the client changes the agent's instructions, which changes the config fingerprint) and the runner rebuilds it — unmounting and remounting the durable cwd. | The token survives the store round trip AND the agent can read a file the client wrote directly into the object store. |
+| `cold2` | Continuity tier 3: the runner **replica is replaced** (operator hook: SIGKILL, then wait out the owner TTL). | On a **local** sandbox the resume must REFUSE (`local sandbox requires a single runner`); on a remote sandbox it must complete with both files intact. SKIPs without `--cold2-replace-cmd`. |
 | `mcp` | Deliver an MCP server in the agent config and call one of its tools. | A `tool-output-available` frame fires for an `mcp__*` tool. **Claude only** — Pi rejects user MCP, so this `SKIP`s on every Pi cell. Uses the public DeepWiki server by default; override with `--mcp-url`. |
 | `rule_deny` | Policy `allow`, plus a `deny` rule for `Bash`. Ask for a bash command. | The model still attempts the call (the tool is not hidden), the call never executes, no approval card appears, and no real shell token reaches the reply. **Pi only.** |
 | `rule_allow` | Policy `ask`, plus an `allow` rule for `Bash`. Ask for the same command. | No approval card fires and the call executes — the rule overrode the policy. **Pi only.** |
@@ -63,6 +70,73 @@ active and are never listed in `tools`, so those three lists are the only lever 
 stop being honored, nothing else in the gate notices.
 
 Triggers are deliberately **out of scope** for this gate.
+
+## Continuity: the third dimension (warm / cold 1 / cold 2)
+
+The tier names are the ones the codex approvals QA already uses
+([`docs/design/codex-harness/reports/warm-approvals-qa.md`](../../../../docs/design/codex-harness/reports/warm-approvals-qa.md)):
+**warm** = same daemon, same live mount; **cold 1** = session evicted, runner alive; **cold 2** =
+runner replica replaced. `warm`, `cold1` and `cold2` run in EVERY cell — every harness, every
+credential mode — because the tier is a property of the runtime, not of a harness.
+
+**The object store is a precondition, not a detail.** The session working directory is a geesefs
+mount over S3, and it only makes the round trip through the store when something unmounts and
+remounts it. That round trip is what a continuity cell exists to exercise: anything the store
+cannot represent (a symlink — #5692; SQLite WAL, already designed around via `CODEX_SQLITE_HOME`;
+hard links) comes back wrong on the far side. On a deployment with no store configured, the
+runner degrades **silently** to an ephemeral directory (`mount.ts`: "running without this mount"
+→ `mount degraded kind=session_cwd`) and every turn still looks fine. So the journeys resolve the
+session's durable mount through `GET /api/sessions/mounts/?session_id=…` first and refuse to
+report a pass without one: **SKIP** by default, **FAIL** with `--require-store`. Pass
+`--require-store` on any deployment that is supposed to have a store — it is what stops "the
+store was not in play" from reading as green.
+
+**What proves the tier.** Nothing about warm-vs-cold reaches the SSE stream, so the journeys
+layer four kinds of evidence and the results carry all of them:
+
+1. The client reads `qa-cwd.txt` (written by the agent, content generated by the sandbox's own
+   shell) straight out of the store via `GET /api/mounts/{id}/files?read=…` — proof the cwd is
+   durable, and how the client learns a token the transcript never carried.
+2. The agent reads that same token back after the transition — proof the directory survived it.
+3. The client writes `qa-store.txt` into the store; on the cold tiers the agent must be able to
+   `cat` it — content that only ever existed as an object cannot reach the agent unless that
+   turn's cwd resolves to that store prefix.
+4. The turn ledger (`POST /api/sessions/turns/query`) reports `agent_session_id` and `sandbox_id`
+   per turn. `warm` asserts they did not change; the cold tiers report them as corroboration.
+
+Every result also carries the runner-log grep that settles the tier definitively —
+`[keepalive] hit-continue` (warm), `[keepalive] mismatch (config) …; evict + cold` (cold 1), a
+fresh `[keepalive] miss …; cold` from a replica id you have not seen before (cold 2) — and any
+**0-byte objects** found in the durable cwd, which is the store-side fingerprint of an entry S3
+cannot represent.
+
+**The cold-2 method, stated (the wrong method measures the wrong thing).** `--cold2-replace-cmd`
+must SIGKILL the runner replica (`docker kill -s KILL <runner>`), never `docker stop`/`restart`:
+on SIGTERM the runner runs its shutdown handler and destroys every sandbox it owns, including the
+session under test. The driver then waits `--owner-ttl` seconds (default 120,
+`AGENTA_SESSIONS_REDIS_OWNER_TTL_SECONDS`) because the killed replica never released
+`owner:session:<id>` and `claim_owner` never steals from an owner that still looks live; resuming
+inside that window fails for an unrelated, misleading reason (#5611). Expected results differ per
+sandbox: a **local** sandbox lives inside the runner process, so a replacement replica genuinely
+cannot adopt it and the correct outcome is a loud refusal; a **remote** sandbox resumes cold. If
+the deployment pins `AGENTA_RUNNER_REPLICA_ID`, the replacement replica is not a *different*
+replica as far as the owner key is concerned and the local cell will resume instead of refusing —
+unset it for a genuine cold 2.
+
+## What each cell needs beyond the three env vars
+
+| Requirement | Cells |
+|---|---|
+| Store-backed deployment (`AGENTA_STORE_*` set) for `warm` / `cold1` / `cold2` | all — the journeys SKIP without it, FAIL with `--require-store` |
+| Daytona configured | C2, C4, X2 |
+| Funded Anthropic vault key | C2 |
+| OpenAI vault key | C3, C4, X1, X2 |
+| OpenRouter vault key | P1 |
+| `custom_provider` vault slug (`--custom-slug`) | P2 |
+| Subscription sidecar — Claude login mounted (`CLAUDE_CONFIG_DIR`) | C1 |
+| Subscription sidecar — ChatGPT/Codex login mounted (Pi's `~/.pi/agent/auth.json`) | S1 |
+| Subscription sidecar — ChatGPT/Codex login mounted read-write with `CODEX_HOME` naming it | S2 |
+| Operator hook that SIGKILLs the runner (`--cold2-replace-cmd`) | `cold2` in every cell |
 
 ## Optional probes (`qa_longctx.py`)
 

--- a/.agents/skills/agent-release-gate/resources/coverage.md
+++ b/.agents/skills/agent-release-gate/resources/coverage.md
@@ -58,7 +58,7 @@ cell — keep them in sync if a cell changes.
 | `commit` | Save an agent config as a new workflow revision, then fetch it back. | The changed parameter survives the round trip and the version bumps (v0 seed → v1; see LESSONS #14). Harness-agnostic — it drives the config REST API, not a turn. |
 | `warm` | Continuity tier 1: three turns on one live daemon, over a store-backed cwd. | The durable token written in turn 1 comes back in the last turn, and the turn ledger shows one harness session and one sandbox (a second id means the turn was not warm). |
 | `cold1` | Continuity tier 2: the pooled session is **evicted** (the client changes the agent's instructions, which changes the config fingerprint) and the runner rebuilds it — unmounting and remounting the durable cwd. | The token survives the store round trip AND the agent can read a file the client wrote directly into the object store. |
-| `cold2` | Continuity tier 3: the runner **replica is replaced** (operator hook: SIGKILL, then wait out the owner TTL). | On a **local** sandbox the resume must REFUSE (`local sandbox requires a single runner`); on a remote sandbox it must complete with both files intact. SKIPs without `--cold2-replace-cmd`. |
+| `cold2` | Continuity tier 3: the runner **replica is replaced** (operator hook: SIGKILL, then wait out the owner TTL plus a margin). | On a **local** sandbox the resume must REFUSE (the runner's `… is not the owner of session …`, the substring the driver asserts); on a remote sandbox it must complete with both files intact. SKIPs without `--cold2-replace-cmd`. |
 | `mcp` | Deliver an MCP server in the agent config and call one of its tools. | A `tool-output-available` frame fires for an `mcp__*` tool. **Claude only** — Pi rejects user MCP, so this `SKIP`s on every Pi cell. Uses the public DeepWiki server by default; override with `--mcp-url`. |
 | `rule_deny` | Policy `allow`, plus a `deny` rule for `Bash`. Ask for a bash command. | The model still attempts the call (the tool is not hidden), the call never executes, no approval card appears, and no real shell token reaches the reply. **Pi only.** |
 | `rule_allow` | Policy `ask`, plus an `allow` rule for `Bash`. Ask for the same command. | No approval card fires and the call executes — the rule overrode the policy. **Pi only.** |
@@ -116,7 +116,10 @@ on SIGTERM the runner runs its shutdown handler and destroys every sandbox it ow
 session under test. The driver then waits `--owner-ttl` seconds (default 120,
 `AGENTA_SESSIONS_REDIS_OWNER_TTL_SECONDS`) because the killed replica never released
 `owner:session:<id>` and `claim_owner` never steals from an owner that still looks live; resuming
-inside that window fails for an unrelated, misleading reason (#5611). Expected results differ per
+inside that window fails for an unrelated, misleading reason (#5611). The driver waits the TTL
+**plus a 20s margin**, because the key lapses at the boundary and the replacement replica may
+still be starting; the hook itself is bounded (3 minutes) and must return once the replacement is
+serving. Expected results differ per
 sandbox: a **local** sandbox lives inside the runner process, so a replacement replica genuinely
 cannot adopt it and the correct outcome is a loud refusal; a **remote** sandbox resumes cold. If
 the deployment pins `AGENTA_RUNNER_REPLICA_ID`, the replacement replica is not a *different*

--- a/.agents/skills/agent-release-gate/resources/qa_product.py
+++ b/.agents/skills/agent-release-gate/resources/qa_product.py
@@ -25,6 +25,7 @@ import json
 import os
 import pathlib
 import re
+import subprocess
 import time
 import uuid
 
@@ -102,14 +103,21 @@ DEFAULT_MCP_URL = "https://mcp.deepwiki.com/mcp"
 MCP_URL = DEFAULT_MCP_URL
 
 
-def api_call(method: str, path: str, timeout: float = 60.0, **kwargs) -> httpx.Response:
+def api_call(
+    method: str,
+    path: str,
+    timeout: float = 60.0,
+    params: dict | None = None,
+    **kwargs,
+) -> httpx.Response:
     """One REST call to the /api surface (the routes the playground UI drives for config/commits),
     NOT the SSE /services/agent/v0/invoke turn endpoint. Auth is the same ApiKey header, and
-    project_id rides the query string (never the body), exactly like the browser."""
+    project_id rides the query string (never the body), exactly like the browser. `params` merges
+    extra query args on top of project_id (the mounts and turns routes take their filters there)."""
     return httpx.request(
         method,
         f"{BASE}/api{path}",
-        params={"project_id": PROJECT},
+        params={"project_id": PROJECT, **(params or {})},
         headers={"Authorization": f"ApiKey {KEY}", "Content-Type": "application/json"},
         timeout=timeout,
         **kwargs,
@@ -160,11 +168,18 @@ CELLS = {
         "model": "openrouter/deepseek/deepseek-v4-flash",
         "provider": "openrouter",
     },
-    # S1: the Codex SUBSCRIPTION path — Pi with provider `openai-codex` (a first-class
-    # subscription provider slug, distinct from the vault-key `openai` provider; see
-    # sdks/python/agenta/sdk/agents/capabilities.py PI_SUBSCRIPTION_PROVIDERS). Auth comes from
-    # the subscription sidecar's ChatGPT/Codex OAuth login (~/.pi/agent/auth.json), never a
-    # vault key, so `self_managed` + slug None is the whole connection.
+    # S1: PI on a ChatGPT/Codex SUBSCRIPTION provider — the `pi_core` harness with provider
+    # `openai-codex` (a first-class subscription provider slug, distinct from the vault-key
+    # `openai` provider; see sdks/python/agenta/sdk/agents/capabilities.py
+    # PI_SUBSCRIPTION_PROVIDERS). Auth comes from the subscription sidecar's ChatGPT/Codex OAuth
+    # login (~/.pi/agent/auth.json), never a vault key, so `self_managed` + slug None is the whole
+    # connection.
+    #
+    # NOT the codex-harness subscription path: this cell never loads codex-acp, never assembles a
+    # <cwd>/.codex home, and never touches `symlinkCodexSubscriptionAuthFile`. "Codex harness +
+    # your own login" is cell S2. The old label on this cell read "the Codex subscription path",
+    # which is how a supported product configuration ended up with zero gate coverage until
+    # #5692 (see docs/design/codex-harness/reports/durable-cwd-entries-lesson.md).
     "S1": {
         "harness": "pi_core",
         "sandbox": "local",
@@ -189,15 +204,55 @@ CELLS = {
         "model": "gpt-5.6-luna",
         "provider": "openai",
     },
+    # X2: the CODEX harness on DAYTONA with a managed vault key. Daytona rejects subscription
+    # auth by design, so managed is the only codex cell a cloud sandbox can have. It exists
+    # because the continuity tiers mean DIFFERENT things per sandbox: a cold-2 resume (runner
+    # replica replaced) can only COMPLETE on a remote sandbox — on local it correctly refuses,
+    # since a local sandbox lives inside the runner process. Without a codex-on-daytona cell the
+    # gate can never observe a completed codex cold 2. Verified out of band during the v0.108.0
+    # release run (a one-off staging probe); promoted into the gate here.
+    "X2": {
+        "harness": "codex",
+        "sandbox": "daytona",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+    },
+    # S2: the genuine CODEX SUBSCRIPTION cell — the codex harness with `self_managed`
+    # (-> credentialMode=runtime_provided), authenticating from the operator's mounted
+    # ChatGPT/Codex login. Local-only: Daytona rejects runtime_provided auth
+    # (DAYTONA_SUBSCRIPTION_UNSUPPORTED_MESSAGE), and the login is a host mount.
+    #
+    # This is the ONLY cell that exercises the subscription-specific file assembly:
+    # `configureCodexHome` points CODEX_HOME at the runner-owned <cwd>/.codex and
+    # `symlinkCodexSubscriptionAuthFile` links <cwd>/.codex/auth.json -> the mounted login. That
+    # link lives INSIDE the durable working directory, so it is the one credential path an
+    # object-store round trip can destroy — the #5692 failure. Needs the subscription sidecar:
+    # the runner must have the login bind-mounted read-write with CODEX_HOME naming it, or every
+    # journey fails with `runtime_provided local run requires a mounted subscription`.
+    "S2": {
+        "harness": "codex",
+        "sandbox": "local",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "self_managed", "slug": None},
+    },
     # P2 (OpenRouter as a CUSTOM OpenAI-compatible provider) needs a `custom_provider` secret in
     # the vault; `connection.slug` points at it. Set --custom-slug to run it.
     "P2": {
         "harness": "pi_core",
         "sandbox": "local",
         "model": "deepseek/deepseek-v4-flash",
-        "provider": "custom",
+        # Provider MUST be None for a named custom connection since v0.107.x: an explicit
+        # request provider always wins in the resolver, and only a provider-LESS custom
+        # normalizes to the `openai` family that the harness pair check accepts
+        # (sdks/python/agenta/sdk/agents/platform/connections.py, resolved-provider rule).
+        # The old placeholder "custom" now fails the post-resolve pair check outright.
+        "provider": None,
+        # Mode MUST be `agenta`, not `self_managed`: the slug names a vault connection, and
+        # `self_managed` injects nothing, so the API rejects the pair outright (Connection
+        # validator, sdks/python/agenta/sdk/agents/connections/models.py).
         "connection": {
-            "mode": "self_managed",
+            "mode": "agenta",
             "slug": None,
         },  # slug filled from --custom-slug
     },
@@ -640,33 +695,408 @@ def j4_deny(cell: dict) -> dict:
     return _approval_flow(cell, approved=False)
 
 
-def j6_warm(cell: dict) -> dict:
-    """J6 (latency half): three turns in one session; turns 2/3 should be faster than turn 1.
-    The cold/warm TRUTH lives in the runner log — this only measures. See STATUS.md F-2."""
+# --------------------------------------------------------------------------------------------
+# Continuity: warm / cold 1 / cold 2, over a store-backed durable working directory.
+#
+# The tier vocabulary is NOT invented here — it is the one the codex approvals QA already uses
+# (docs/design/codex-harness/reports/warm-approvals-qa.md):
+#
+#   warm    same daemon, same live mount. The keep-alive pool serves the turn in place
+#           (`[keepalive] hit-continue`).
+#   cold 1  the session was EVICTED, the runner process is alive. The pool entry is torn down —
+#           which unmounts the durable cwd — and the next turn rebuilds and REMOUNTS it.
+#   cold 2  the runner REPLICA was replaced. A different process serves the session.
+#
+# Why the tiers are a release-gate dimension at all: the session working directory is a geesefs
+# mount over S3, and a cwd only makes the round trip through the object store when something
+# unmounts and remounts it. A single-turn check, or a multi-turn check that stays warm, never
+# takes that trip — which is exactly how #5692 shipped (a symlink inside the durable cwd came
+# back from S3 as a 0-byte object; the second turn read it and failed). Same class as the two
+# durable-cwd limitations already designed around: SQLite WAL (CODEX_SQLITE_HOME is split onto
+# container-local disk) and hard links.
+#
+# The store dimension is therefore a PRECONDITION, not a nice-to-have. `mount.ts` degrades
+# silently to an ephemeral directory when the sign call 503s ("running without this mount" ->
+# `mount degraded kind=session_cwd cause=sign_returned_no_mount`), and every turn still looks
+# fine. A continuity journey that ran on an ephemeral cwd would go green while proving nothing,
+# so these journeys resolve the session's durable mount through the API FIRST and refuse to
+# report a pass without it (SKIP by default, FAIL with --require-store).
+# --------------------------------------------------------------------------------------------
+
+# Set from the CLI in main(); see the flags for what each one means.
+REQUIRE_STORE = False
+STORE_SETTLE_SECONDS = 45.0
+COLD2_REPLACE_CMD: str | None = None
+OWNER_TTL_SECONDS = 120.0
+
+CWD_PROBE_FILE = "qa-cwd.txt"
+STORE_PROBE_FILE = "qa-store.txt"
+
+# Turn 1 plants a token that is unguessable AND absent from the transcript: the value is produced
+# by the shell inside the sandbox (`$(hostname)`/`$(date +%s)`), the command only carries the
+# expression, and the redirect means the tool output is empty. So when a later turn replies with
+# that exact string, the model cannot have recited it from history — it read the durable file.
+# (LESSONS #2: never assert on prose the model could have computed. This one it cannot.)
+CWD_WRITE_PROMPT = (
+    "Use the bash tool to run exactly: "
+    f"echo QA-CWD-$(hostname)-$(date +%s) > {CWD_PROBE_FILE} "
+    "and then reply with only: WROTE"
+)
+CWD_TOKEN_RE = re.compile(r"QA-CWD-\S+")
+
+
+def _cwd_mount_id(session_id: str) -> tuple[str | None, str]:
+    """The session's durable `cwd` mount id, or None with the reason.
+
+    `GET /api/sessions/mounts/?session_id=...` is the read side of the same row the runner signs
+    on every turn (`POST /sessions/mounts/sign?session_id=...&name=cwd`, mount.ts). A mount row
+    means the store handed out credentials for this session; no row means the run degraded to an
+    ephemeral cwd and nothing that follows can be trusted as continuity evidence.
+    """
+    try:
+        r = api_call("GET", "/sessions/mounts/", params={"session_id": session_id})
+    except Exception as e:  # a transport failure is a reason, not a crash
+        return None, f"sessions/mounts query failed: {type(e).__name__}: {e}"
+    if r.status_code == 503:
+        return None, "the deployment has no object store configured (mounts 503)"
+    if r.status_code != 200:
+        return None, f"sessions/mounts HTTP {r.status_code}: {r.text[:160]}"
+    # The stored `name` IS the slugified mount name (mounts/service.py
+    # get_or_create_session_mount), so the cwd mount is exactly `name == "cwd"`; the other
+    # session-scoped mounts are the per-harness transcript dirs (`claude-projects`,
+    # `pi-sessions`) and must not stand in for it.
+    mounts = r.json().get("mounts") or []
+    cwd = next((m for m in mounts if m.get("name") == "cwd"), None)
+    if not cwd:
+        return None, (
+            "no durable cwd mount exists for this session — the runner ran on an EPHEMERAL "
+            "directory (grep the runner log for `mount degraded kind=session_cwd`), so a green "
+            "continuity result here would prove nothing about the object store"
+        )
+    return str(cwd.get("id")), f"durable cwd mount {cwd.get('id')}"
+
+
+def _store_read(
+    mount_id: str, path: str, settle: float = 0.0
+) -> tuple[str | None, str]:
+    """Read a file straight out of the OBJECT STORE, server-side, bypassing the runner entirely.
+
+    `GET /api/mounts/{id}/files?read=<path>` goes to S3, not to the FUSE mount, so a hit proves
+    the bytes really landed in the store. `settle` polls, because geesefs uploads on close and a
+    just-written file can take a moment to appear as an object.
+    """
+    deadline = time.time() + max(settle, 0.0)
+    last = ""
+    while True:
+        r = api_call("GET", f"/mounts/{mount_id}/files", params={"read": path})
+        if r.status_code == 200:
+            return r.json().get("content"), "read from the object store"
+        if r.status_code == 503:
+            return None, "the deployment has no object store configured (mounts 503)"
+        last = f"HTTP {r.status_code}: {r.text[:120]}"
+        if time.time() >= deadline:
+            return None, f"{path} is not in the object store ({last})"
+        time.sleep(3)
+
+
+def _store_write(mount_id: str, path: str, content: str) -> tuple[bool, str]:
+    """Write a file into the object store from the CLIENT side (`PUT .../files?path=`, raw body).
+
+    The agent never saw this content. If a later turn can `cat` it, that turn's cwd is provably
+    resolving to this store prefix.
+    """
+    r = api_call(
+        "PUT", f"/mounts/{mount_id}/files", params={"path": path}, content=content
+    )
+    if r.status_code == 200:
+        return True, "wrote a store-only file"
+    return False, f"store write HTTP {r.status_code}: {r.text[:120]}"
+
+
+def _zero_byte_entries(mount_id: str) -> list:
+    """Paths in the durable cwd whose stored object is 0 bytes.
+
+    Informational, never a verdict: a 0-byte object is the store-side fingerprint of an entry S3
+    cannot represent (a symlink lands exactly this way — #5692), so it is worth surfacing next to
+    every continuity result even when the run is green.
+    """
+    r = api_call("GET", f"/mounts/{mount_id}/files", params={"limit": 200})
+    if r.status_code != 200:
+        return []
+    return [
+        f.get("path")
+        for f in (r.json().get("files") or [])
+        if not f.get("is_folder") and f.get("size") == 0
+    ]
+
+
+def _turn_ledger(session_id: str, limit: int = 20) -> list:
+    """The session's turn rows, newest first — the only continuity signal a pure HTTP client can
+    see. The runner writes `agent_session_id` and `sandbox_id` per turn
+    (`session-continuity-durable.ts` -> `POST /sessions/turns/`); nothing about warm-vs-cold ever
+    reaches the SSE stream. Empty list when the ledger is unavailable."""
+    r = api_call(
+        "POST",
+        "/sessions/turns/query",
+        json={
+            "query": {"session_id": session_id},
+            "windowing": {"limit": limit, "order": "descending"},
+        },
+    )
+    if r.status_code != 200:
+        return []
+    return r.json().get("turns") or []
+
+
+def _ledger_ids(session_id: str) -> tuple[list, list]:
+    """(agent_session_ids, sandbox_ids) seen across the session's ledger rows, order-insensitive
+    and de-duplicated. Two distinct agent session ids means the harness session was rebuilt; two
+    distinct sandbox ids means the sandbox itself was replaced."""
+    rows = _turn_ledger(session_id)
+    agents = list(
+        {r.get("agent_session_id") for r in rows if r.get("agent_session_id")}
+    )
+    sandboxes = list({r.get("sandbox_id") for r in rows if r.get("sandbox_id")})
+    return agents, sandboxes
+
+
+def _continuity(cell: dict, tier: str) -> dict:
+    """The shared body of `warm` / `cold1` / `cold2`: multi-turn, over a store-backed cwd.
+
+    Shape, identical in all three tiers except the transition in the middle:
+
+      1. turn 1 — the agent writes an unguessable, shell-generated token into `qa-cwd.txt` in its
+         working directory.
+      2. the CLIENT reads that file back through the mounts API. This is the store precondition:
+         it proves the cwd is object-store backed, and it teaches the client the true token.
+      3. the CLIENT writes `qa-store.txt` into the same store prefix — content the agent has
+         never seen and that exists ONLY as an object.
+      4. the transition: nothing (warm), a forced eviction (cold 1), or a replica replacement
+         (cold 2).
+      5. the final turn reads both files back.
+
+    What each piece of evidence actually proves — the point being that "turn 2 replied" proves
+    nothing, and on a warm daemon a broken durable cwd still answers:
+
+      - `qa-cwd.txt` visible in the STORE  -> the working directory is durable, not ephemeral.
+      - `qa-cwd.txt` returned by the AGENT after the transition -> the directory survived the
+        transition with its content intact. On the cold tiers this is the exact shape of #5692:
+        the cwd went to S3 and came back, and anything the store cannot represent comes back
+        wrong.
+      - `qa-store.txt` returned by the AGENT -> that turn's cwd resolves to the same store prefix
+        the client wrote to (store-only content cannot reach the agent any other way).
+      - the turn ledger's `agent_session_id` / `sandbox_id` -> tier corroboration (warm asserts
+        they did not change; the cold tiers report them).
+
+    The runner log remains the definitive tier witness, so every result carries the exact grep:
+    `[keepalive] hit-continue` for warm, `[keepalive] mismatch (config) ...; evict + cold` for
+    cold 1, and a fresh `[keepalive] miss ...; cold` from a new replica for cold 2.
+    """
     s = str(uuid.uuid4())
-    params = template(cell)
-    msgs: list = []
-    times = []
-    for i, q in enumerate(
-        [
-            "Reply with exactly: ONE",
-            "Reply with exactly: TWO",
-            "Reply with exactly: THREE",
-        ]
-    ):
-        msgs = msgs + [user_msg(q)]
-        t = invoke(s, msgs, params)
-        times.append(t.ms)
-        msgs = msgs + [t.assistant_message()]
-        if t.errors:
-            return {"pass": False, "why": f"turn {i + 1} errored", "turn": t.summary()}
-    warm_gain = times[0] - min(times[1], times[2])
-    return {
-        "pass": warm_gain > 0,
-        "why": f"turn1={times[0]}ms, turn2={times[1]}ms, turn3={times[2]}ms (warm gain {warm_gain}ms)",
-        "session_id": s,
-        "times_ms": times,
+    params = template(
+        cell,
+        instructions="Use the bash tool when asked to run a command. Report only its stdout.",
+        permission_default="allow",
+    )
+    msgs = [user_msg(CWD_WRITE_PROMPT)]
+    t1 = invoke(s, msgs, params)
+    if t1.errors:
+        return {
+            "pass": False,
+            "why": f"turn 1 (the durable write) errored: {t1.errors[:1]}",
+            "turn_write": t1.summary(),
+        }
+    msgs = msgs + [t1.assistant_message()]
+
+    mount_id, mount_why = _cwd_mount_id(s)
+    if not mount_id:
+        # Never a PASS: without a store-backed cwd this cell cannot say anything about
+        # continuity, and a silent green here is precisely how the class of bug escapes.
+        verdict = {"pass": False} if REQUIRE_STORE else {"skip": True}
+        return {
+            **verdict,
+            "why": f"{tier}: {mount_why}. Run the gate against a store-backed deployment.",
+            "turn_write": t1.summary(),
+        }
+
+    token, read_why = _store_read(mount_id, CWD_PROBE_FILE, settle=STORE_SETTLE_SECONDS)
+    token = (token or "").strip()
+    if not CWD_TOKEN_RE.fullmatch(token):
+        return {
+            "pass": False,
+            "why": (
+                f"{tier}: the durable cwd holds no usable {CWD_PROBE_FILE} object ({read_why}); "
+                "either the agent never wrote it or geesefs never flushed it to the store"
+            ),
+            "mount_id": mount_id,
+            "turn_write": t1.summary(),
+        }
+
+    store_token = f"QA-STORE-{uuid.uuid4().hex[:12]}"
+    wrote, write_why = _store_write(mount_id, STORE_PROBE_FILE, store_token)
+    if not wrote:
+        return {"pass": False, "why": f"{tier}: {write_why}", "mount_id": mount_id}
+
+    transition = ""
+    if tier == "warm":
+        # Stay on the live daemon: one filler turn, so the read-back is genuinely turn 3 of one
+        # session rather than a two-turn special case.
+        msgs = msgs + [user_msg("Reply with exactly: TWO")]
+        t_mid = invoke(s, msgs, params)
+        if t_mid.errors:
+            return {
+                "pass": False,
+                "why": f"warm: turn 2 errored: {t_mid.errors[:1]}",
+                "turn": t_mid.summary(),
+            }
+        msgs = msgs + [t_mid.assistant_message()]
+        transition = "none (same daemon, same live mount)"
+    elif tier == "cold1":
+        # Force the eviction from the CLIENT, with byte-faithful history: `agentsMd` is a
+        # configFingerprint input (session-identity.ts), so changing the instructions makes the
+        # next turn mismatch on `config` -> `evict + cold`. The teardown unmounts the durable cwd
+        # and the cold acquire remounts it — a real store round trip, driven by a real product
+        # action (editing an agent's instructions mid-session). Editing the TRANSCRIPT instead
+        # would trip the history guard, which is a different (and deliberately hostile) path.
+        params = json.loads(json.dumps(params))
+        params["instructions"]["agents_md"] += (
+            f" (qa-continuity {uuid.uuid4().hex[:8]})"
+        )
+        transition = "config-fingerprint change -> the runner evicts the pooled session and rebuilds cold"
+    elif tier == "cold2":
+        if not COLD2_REPLACE_CMD:
+            return {
+                "skip": True,
+                "why": (
+                    "cold 2 needs the runner replica REPLACED, which no HTTP client can do. Pass "
+                    "--cold2-replace-cmd (or set AGENTA_QA_RUNNER_REPLACE_CMD) to a command that "
+                    "SIGKILLs the runner replica — e.g. `docker kill -s KILL <runner>`. It must "
+                    "be SIGKILL: on SIGTERM the runner runs its shutdown handler and destroys "
+                    "every sandbox it owns, including the session this cell wants to resume "
+                    "(warm-approvals-qa.md)."
+                ),
+            }
+        proc = subprocess.run(
+            COLD2_REPLACE_CMD, shell=True, capture_output=True, text=True
+        )
+        if proc.returncode != 0:
+            return {
+                "pass": False,
+                "why": f"cold 2: the replica-replacement command failed ({proc.returncode}): {proc.stderr[:200]}",
+            }
+        # Wait out the session-owner key. The killed replica never released `owner:session:<id>`
+        # and `claim_owner` never steals from an owner that still looks live, so a resume inside
+        # the window fails for the wrong reason (issue #5611's misleading MCP-shim error).
+        time.sleep(OWNER_TTL_SECONDS)
+        transition = f"replica replaced via the operator hook, then {int(OWNER_TTL_SECONDS)}s of owner-TTL wait"
+    else:  # pragma: no cover - guarded by the JOURNEYS table
+        raise ValueError(f"unknown continuity tier {tier}")
+
+    read_prompt = (
+        f"Use the bash tool to run exactly: cat {CWD_PROBE_FILE} {STORE_PROBE_FILE} "
+        "and reply with only its stdout."
+        if tier != "warm"
+        # A warm turn keeps the SAME live geesefs mount, so a file the client wrote straight into
+        # S3 behind that mount is not guaranteed to be visible; asking for it would make the warm
+        # cell fail for a reason that has nothing to do with continuity.
+        else f"Use the bash tool to run exactly: cat {CWD_PROBE_FILE} and reply with only its stdout."
+    )
+    msgs = msgs + [user_msg(read_prompt)]
+    t_last = invoke(s, msgs, params)
+
+    zero_byte = _zero_byte_entries(mount_id)
+    agents, sandboxes = _ledger_ids(s)
+    evidence = {
+        "tier": tier,
+        "transition": transition,
+        "mount_id": mount_id,
+        "cwd_token_in_store": True,
+        # Kept as corroboration only (the old warm journey's single signal): a cold turn pays for
+        # a rebuilt session and a remount, a warm one does not. Never a verdict on its own — see
+        # STATUS.md F-2.
+        "times_ms": {"first": t1.ms, "last": t_last.ms},
+        "agent_session_ids": agents,
+        "sandbox_ids": sandboxes,
+        "zero_byte_objects_in_cwd": zero_byte,
+        "runner_log_grep": {
+            "warm": "[keepalive] hit-continue",
+            "cold1": "[keepalive] mismatch (config) ...; evict + cold",
+            "cold2": "[keepalive] miss ...; cold  (from a replica id you have not seen before)",
+        }[tier],
     }
+
+    if tier == "cold2" and cell["sandbox"] == "local":
+        # A local sandbox lives INSIDE the runner process, so a replacement replica genuinely
+        # cannot adopt it. The correct outcome is the ownership guard refusing, loudly — not a
+        # completed resume (`assertLocalRunnerOwnership` -> LocalSandboxNotOwnerError). This
+        # per-sandbox expectation is the one warm-approvals-qa.md already worked out.
+        refused = any("is not the owner of session" in e for e in t_last.errors)
+        return {
+            "pass": refused,
+            "why": (
+                "cold 2 on a local sandbox must REFUSE: the replacement replica is not the "
+                f"session owner (observed refusal={refused}). A completed resume here would mean "
+                "a wrong-host cold start, which is the failure the guard exists to prevent."
+            ),
+            "evidence": evidence,
+            "turn_resumed": t_last.summary(),
+        }
+
+    reply = t_last.reply
+    cwd_back = token in reply
+    store_back = store_token in reply if tier != "warm" else None
+    ok = cwd_back and not t_last.errors and (store_back is not False)
+
+    if tier == "warm":
+        # A warm continuation cannot have rebuilt the harness session or the sandbox. More than
+        # one distinct id across the ledger means the turn was NOT served warm, so the cell did
+        # not test the tier it claims (the runner log grep says which mismatch evicted it).
+        warm_ids_stable = len(agents) <= 1 and len(sandboxes) <= 1
+        evidence["warm_ids_stable"] = warm_ids_stable
+        ok = ok and warm_ids_stable
+
+    why = {
+        "warm": (
+            f"warm: 3 turns on one live daemon; the durable cwd token survived (in reply={cwd_back}), "
+            f"and the turn ledger shows a single harness session + sandbox (stable={evidence.get('warm_ids_stable')})"
+        ),
+        "cold1": (
+            f"cold 1: the pooled session was evicted and rebuilt on the same runner; the cwd token "
+            f"came back from the store (in reply={cwd_back}) and the agent read a file that only "
+            f"ever existed as an object (store-only file readable={store_back})"
+        ),
+        "cold2": (
+            f"cold 2: the replica was replaced; the cwd token came back (in reply={cwd_back}) and "
+            f"the store-only file was readable ({store_back}) — the resume remounted the cwd from "
+            "the object store on a different process"
+        ),
+    }[tier]
+    return {
+        "pass": bool(ok),
+        "why": why,
+        "session_id": s,
+        "cwd_token": token,
+        "evidence": evidence,
+        "turn_write": t1.summary(),
+        "turn_resumed": t_last.summary(),
+    }
+
+
+def j6_warm(cell: dict) -> dict:
+    """Warm resume: same daemon, same live mount, three turns, durable cwd intact."""
+    return _continuity(cell, "warm")
+
+
+def j6_cold1(cell: dict) -> dict:
+    """Cold 1: session evicted, runner alive. The durable cwd is unmounted and remounted from the
+    object store between turns — the round trip that #5692 needed to surface."""
+    return _continuity(cell, "cold1")
+
+
+def j6_cold2(cell: dict) -> dict:
+    """Cold 2: the runner replica is replaced. Needs an operator hook (SIGKILL), and the expected
+    result differs per sandbox: a local sandbox correctly REFUSES, a remote one resumes cold."""
+    return _continuity(cell, "cold2")
 
 
 def j2_mount(cell: dict) -> dict:
@@ -1141,6 +1571,8 @@ JOURNEYS = {
     "deny": j4_deny,
     "commit": j5_commit,
     "warm": j6_warm,
+    "cold1": j6_cold1,
+    "cold2": j6_cold2,
     "mcp": j7_mcp,
     "rule_deny": j_rule_deny,
     "rule_allow": j_rule_allow,
@@ -1176,12 +1608,51 @@ def main() -> int:
         help="override the cell's model (e.g. `haiku` on a Claude cell; aliases only on Claude — F-007)",
     )
     p.add_argument(
+        "--require-store",
+        action="store_true",
+        help=(
+            "treat a missing durable cwd mount as a FAILURE in the continuity journeys instead "
+            "of a SKIP. Pass this on any deployment that is supposed to have an object store — "
+            "it is what stops 'the store was not in play' from reading as green."
+        ),
+    )
+    p.add_argument(
+        "--store-settle",
+        type=float,
+        default=45.0,
+        help="seconds to wait for a just-written file to appear as an object (default 45)",
+    )
+    p.add_argument(
+        "--cold2-replace-cmd",
+        default=os.environ.get("AGENTA_QA_RUNNER_REPLACE_CMD"),
+        help=(
+            "shell command that replaces the runner replica, for the cold2 journey. MUST SIGKILL "
+            "(e.g. `docker kill -s KILL <runner>`): on SIGTERM the runner destroys every sandbox "
+            "it owns, including the session under test. Without it, cold2 SKIPs."
+        ),
+    )
+    p.add_argument(
+        "--owner-ttl",
+        type=float,
+        default=120.0,
+        help=(
+            "seconds to wait after replacing the replica, so the dead replica's session-owner key "
+            "lapses (AGENTA_SESSIONS_REDIS_OWNER_TTL_SECONDS, default 120)"
+        ),
+    )
+    p.add_argument(
         "--env-file",
         help=f"credentials file (fallback when the env vars are unset; default {DEFAULT_ENV_FILE})",
     )
     args = p.parse_args()
 
     resolve_credentials(args.env_file)
+
+    global REQUIRE_STORE, STORE_SETTLE_SECONDS, COLD2_REPLACE_CMD, OWNER_TTL_SECONDS
+    REQUIRE_STORE = args.require_store
+    STORE_SETTLE_SECONDS = args.store_settle
+    COLD2_REPLACE_CMD = args.cold2_replace_cmd
+    OWNER_TTL_SECONDS = args.owner_ttl
 
     cells = list(CELLS) if args.all else (args.cell or ["C3"])
     journeys = args.only or list(JOURNEYS)
@@ -1195,6 +1666,14 @@ def main() -> int:
         )
     if args.custom_slug:
         CELLS["P2"]["connection"]["slug"] = args.custom_slug
+        # Send the FULL custom model key, not the bare model id: a bare id that also exists
+        # in the shared catalog gets its provider inferred (F-017) before the named custom
+        # connection can normalize, and the (inferred-provider, custom) pair check then
+        # rejects the run. The `<slug>/custom/<model>` key is opaque to the catalog, matches
+        # the secret's model_keys, and resolves to the `openai` family as designed.
+        p2_model = CELLS["P2"]["model"]
+        if not p2_model.startswith(f"{args.custom_slug}/"):
+            CELLS["P2"]["model"] = f"{args.custom_slug}/custom/{p2_model}"
     if args.mcp_url:
         global MCP_URL
         MCP_URL = args.mcp_url

--- a/.agents/skills/agent-release-gate/resources/qa_product.py
+++ b/.agents/skills/agent-release-gate/resources/qa_product.py
@@ -728,6 +728,20 @@ REQUIRE_STORE = False
 STORE_SETTLE_SECONDS = 45.0
 COLD2_REPLACE_CMD: str | None = None
 OWNER_TTL_SECONDS = 120.0
+# A hung operator hook must not hang the whole gate run.
+COLD2_REPLACE_TIMEOUT_SECONDS = 180.0
+# The owner key lapses AT the TTL, and the replacement replica may still be coming up, so a
+# resume timed exactly on the boundary races both and fails for an unrelated, misleading reason.
+# The approval-matrix driver waits for container health plus the same margin
+# (docs/design/codex-harness/spike/scripts/codex-approval-matrix-qa.py).
+OWNER_TTL_MARGIN_SECONDS = 20.0
+
+# The runner's refusal when a replacement replica tries to adopt a local-sandbox session
+# (`LocalSandboxNotOwnerError`, session-continuity.ts). Asserted by the cold2 journey and quoted
+# in coverage.md — one spelling, one source, so the doc and the assertion cannot drift apart.
+# Full text: "local sandbox requires a single runner: replica '<a>' is not the owner of session
+# '<b>' (owned by '<c>'). Refusing to cold-start on the wrong host."
+LOCAL_NOT_OWNER_MARKER = "is not the owner of session"
 
 CWD_PROBE_FILE = "qa-cwd.txt"
 STORE_PROBE_FILE = "qa-store.txt"
@@ -976,9 +990,26 @@ def _continuity(cell: dict, tier: str) -> dict:
                     "(warm-approvals-qa.md)."
                 ),
             }
-        proc = subprocess.run(
-            COLD2_REPLACE_CMD, shell=True, capture_output=True, text=True
-        )
+        try:
+            # `shell=True` on an operator-supplied hook (a flag or an env var set by whoever
+            # runs the gate), never on anything that came off the wire. Bounded, because a hook
+            # that hangs would otherwise hang the entire gate run with no output.
+            proc = subprocess.run(
+                COLD2_REPLACE_CMD,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=COLD2_REPLACE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "pass": False,
+                "why": (
+                    "cold 2: the replica-replacement command did not finish within "
+                    f"{COLD2_REPLACE_TIMEOUT_SECONDS:.0f}s. The hook must return once the "
+                    "replacement replica is serving, not block on it."
+                ),
+            }
         if proc.returncode != 0:
             return {
                 "pass": False,
@@ -986,9 +1017,12 @@ def _continuity(cell: dict, tier: str) -> dict:
             }
         # Wait out the session-owner key. The killed replica never released `owner:session:<id>`
         # and `claim_owner` never steals from an owner that still looks live, so a resume inside
-        # the window fails for the wrong reason (issue #5611's misleading MCP-shim error).
-        time.sleep(OWNER_TTL_SECONDS)
-        transition = f"replica replaced via the operator hook, then {int(OWNER_TTL_SECONDS)}s of owner-TTL wait"
+        # the window fails for the wrong reason (issue #5611's misleading MCP-shim error). The
+        # margin matters as much as the TTL: the key lapses AT the boundary, so a resume timed
+        # exactly on it races the lapse and the replacement replica's own startup.
+        wait = OWNER_TTL_SECONDS + OWNER_TTL_MARGIN_SECONDS
+        time.sleep(wait)
+        transition = f"replica replaced via the operator hook, then {int(wait)}s of owner-TTL wait"
     else:  # pragma: no cover - guarded by the JOURNEYS table
         raise ValueError(f"unknown continuity tier {tier}")
 
@@ -1030,13 +1064,14 @@ def _continuity(cell: dict, tier: str) -> dict:
         # cannot adopt it. The correct outcome is the ownership guard refusing, loudly — not a
         # completed resume (`assertLocalRunnerOwnership` -> LocalSandboxNotOwnerError). This
         # per-sandbox expectation is the one warm-approvals-qa.md already worked out.
-        refused = any("is not the owner of session" in e for e in t_last.errors)
+        refused = any(LOCAL_NOT_OWNER_MARKER in str(e) for e in t_last.errors)
         return {
             "pass": refused,
             "why": (
-                "cold 2 on a local sandbox must REFUSE: the replacement replica is not the "
-                f"session owner (observed refusal={refused}). A completed resume here would mean "
-                "a wrong-host cold start, which is the failure the guard exists to prevent."
+                "cold 2 on a local sandbox must REFUSE with "
+                f'"{LOCAL_NOT_OWNER_MARKER}" (observed refusal={refused}). A completed resume '
+                "here would mean a wrong-host cold start, which is the failure the guard exists "
+                "to prevent."
             ),
             "evidence": evidence,
             "turn_resumed": t_last.summary(),
@@ -1051,14 +1086,27 @@ def _continuity(cell: dict, tier: str) -> dict:
         # A warm continuation cannot have rebuilt the harness session or the sandbox. More than
         # one distinct id across the ledger means the turn was NOT served warm, so the cell did
         # not test the tier it claims (the runner log grep says which mismatch evicted it).
-        warm_ids_stable = len(agents) <= 1 and len(sandboxes) <= 1
+        #
+        # Exactly one, not "at most one": an EMPTY ledger is missing evidence, not evidence of
+        # stability (`_turn_ledger` returns [] on any non-200), and letting it pass would be the
+        # same false green this whole journey exists to remove.
+        ledger_available = bool(agents or sandboxes)
+        warm_ids_stable = len(agents) == 1 and len(sandboxes) == 1
+        evidence["ledger_available"] = ledger_available
         evidence["warm_ids_stable"] = warm_ids_stable
         ok = ok and warm_ids_stable
 
     why = {
         "warm": (
             f"warm: 3 turns on one live daemon; the durable cwd token survived (in reply={cwd_back}), "
-            f"and the turn ledger shows a single harness session + sandbox (stable={evidence.get('warm_ids_stable')})"
+            f"and the turn ledger shows a single harness session + sandbox (stable={evidence.get('warm_ids_stable')}"
+            + (
+                ""
+                if evidence.get("ledger_available", True)
+                else "; the turn ledger returned NO rows, so there is no warm corroboration to "
+                "read — check that the deployment records session turns"
+            )
+            + ")"
         ),
         "cold1": (
             f"cold 1: the pooled session was evicted and rebuilt on the same runner; the cwd token "

--- a/.agents/skills/agent-release-gate/resources/seeds/README.md
+++ b/.agents/skills/agent-release-gate/resources/seeds/README.md
@@ -11,5 +11,6 @@ shape a healthy run produces, and a baseline to diff a future run against.
 These are captured evidence, not fixtures a test loads. Live runs write to `./qa-gate-runs/`.
 
 The canary tokens the probes plant and read back (the `QA-MEM-*`, `QA-CONC*`, `QA-MOUNT-*`,
-`QA-BASH-*` values) are replaced here with the fixed placeholder `QA-TOKEN-SANITIZED`. The JSON
+`QA-BASH-*`, `QA-CWD-*`, `QA-STORE-*` values) are replaced here with the fixed placeholder
+`QA-TOKEN-SANITIZED`. The JSON
 structure is untouched — only those per-run random token values were scrubbed.

--- a/docs/design/codex-harness/reports/durable-cwd-entries-lesson.md
+++ b/docs/design/codex-harness/reports/durable-cwd-entries-lesson.md
@@ -1,0 +1,85 @@
+# Lesson: entries the durable cwd cannot represent, and why QA could not see one
+
+Date: 2026-08-03. Occasion: issue #5692 (AGE-4063), found in real use after v0.108.0 shipped —
+a Codex agent running on a personal ChatGPT subscription worked for exactly one turn per session
+and failed on every turn after that. The product fix ships separately; this note is about the
+shape of the bug and the shape of the QA that missed it.
+
+## The class of bug
+
+The agent's working directory is durable because it is a geesefs mount over S3. Object storage is
+not a filesystem: some entries have no representation in it. When one is written into the durable
+cwd, it survives only as long as the live mount does. On the next unmount/remount it comes back
+as something else — for a symlink, a **0-byte object**.
+
+We already knew this and had designed around it twice:
+
+- **SQLite write-ahead logging** is unsupported on geesefs, so `CODEX_SQLITE_HOME` is redirected
+  onto container-local disk, in both managed and subscription modes.
+- **Hard links** are unsupported for the same reason and were pre-empted the same way.
+
+The third instance was a **symlink**: the Codex subscription path points the run's Codex home at
+the operator's mounted login by symlinking `<cwd>/.codex/auth.json` into the durable cwd. The
+symlink persisted to the store as a 0-byte object, and the "create only when absent" guard read
+that 0-byte file as "the link is already there" — so it was never rebuilt. Every later turn read
+an empty credential file and reported it as an authentication failure.
+
+The generalisation worth keeping: **the durable cwd is object storage wearing a filesystem's
+clothes.** Anything placed in it that is not plain file bytes is a candidate for this failure, and
+the failure is invisible for as long as the mount stays up.
+
+## Why our QA shape could not see it
+
+Two independent blind spots, both structural rather than accidental.
+
+**Single-turn coverage.** The pre-merge QA for the subscription path was four checks, all green,
+all one request each. The failure only exists on turn two — after the working directory has made a
+round trip through the object store. No number of single-turn checks reaches it.
+
+**Warm-only resumes.** The release gate did have a multi-turn journey, but it ran three quick turns
+against a live daemon on a live mount, where geesefs serves the symlink correctly. The gate could
+not distinguish "the directory is durable" from "the directory is still mounted".
+
+A third, smaller gap made the first two invisible: the gate had a cell **labelled** as the Codex
+subscription path that actually ran the **Pi** harness with an OpenAI-compatible subscription
+provider. Pi never loads codex-acp and never assembles a `.codex` home, so the code that broke had
+no coverage at all — while the matrix read as if it did. A supported, documented configuration can
+be missing from a matrix that appears to contain it.
+
+## What changed in the gate
+
+Continuity is now a real dimension rather than a single journey, using the tier vocabulary the
+approvals QA already established in `warm-approvals-qa.md`:
+
+- **`warm`** — same daemon, same live mount.
+- **`cold1`** — the pooled session is evicted and rebuilt while the runner stays alive. The client
+  forces this the way a user would: changing the agent's instructions changes the config
+  fingerprint, the runner evicts, and the rebuild unmounts and remounts the durable cwd. That is
+  the store round trip.
+- **`cold2`** — the runner replica is replaced (an operator hook that SIGKILLs it, then waits out
+  the session-owner TTL). Expected results differ per sandbox: a local sandbox correctly refuses,
+  a remote one resumes cold.
+
+All three run in every cell — Codex, Claude and Pi, across the credential modes — and the matrix
+gained a genuine Codex-subscription cell (the codex harness with `runtime_provided` credentials),
+plus a codex-on-Daytona cell so a completed cold 2 is observable at all. The mislabelled cell now
+says what it actually is.
+
+Two things make a green result mean something:
+
+- **The store must be in play.** With no object store configured the runner degrades silently to
+  an ephemeral directory and every turn still looks fine, so the journeys resolve the session's
+  durable mount through the API first and refuse to pass without one (`--require-store` turns that
+  refusal into a failure).
+- **The evidence is store-side.** The client reads the token the agent wrote straight out of the
+  store, and writes a file into the store that the agent must then read back — content that cannot
+  reach the agent unless that turn's working directory really resolves to the store. Results also
+  list any 0-byte objects found in the durable cwd, which is exactly the fingerprint this bug left
+  behind.
+
+The general rule is recorded as lesson #16 in the release gate's `LESSONS.md`: a warm multi-turn
+test cannot see anything the object store cannot represent, and a continuity result from a
+storeless deployment is not durability coverage.
+
+**Status:** the new journeys have not yet been executed against a live stack. The next release run
+is their first exercise.

--- a/docs/design/codex-harness/status.md
+++ b/docs/design/codex-harness/status.md
@@ -1,7 +1,18 @@
 # Status
 
-Last updated: 2026-08-02 (PR OPEN on `main`; rebased onto v0.107.0 with codex multimodality
-enabled and live-QA'ed 8/8; awaiting Mahmoud review)
+Last updated: 2026-08-03 (shipped in v0.108.0; one post-release lesson recorded below)
+
+## 2026-08-03 — Post-release lesson: durable-cwd entries the object store cannot represent
+
+Issue #5692 (AGE-4063): the Codex subscription path symlinks `auth.json` into the durable working
+directory, which is a geesefs mount over S3 — the symlink persisted as a 0-byte object and the
+"create only when absent" guard never rebuilt it, so a subscription session worked for one turn
+and failed on every turn after. Same class as the two durable-cwd limitations already designed
+around (SQLite WAL → `CODEX_SQLITE_HOME` on container-local disk; hard links).
+
+Why QA missed it and what changed in the release gate (continuity is now a warm / cold 1 / cold 2
+dimension over a store-backed cwd, and there is a genuine Codex-subscription cell):
+`reports/durable-cwd-entries-lesson.md`. The product fix ships separately.
 
 ## 2026-08-02 — Rebased onto v0.107.0; codex multimodality enabled
 

--- a/docs/designs/testing/README.md
+++ b/docs/designs/testing/README.md
@@ -125,9 +125,11 @@ drives and asserts on the SSE frame stream and real side effects, never on model
 against any deployment (cloud or self-hosted) from three env vars (`AGENTA_BASE`,
 `AGENTA_PROJECT_ID`, `AGENTA_API_KEY`) that connect the driver to the deployment. Some individual
 cells need more than that — a vault provider key, a custom-provider slug, or a subscription
-sidecar login — documented per cell in `resources/coverage.md`. Run the gate before an
-agent-workflows release, or after changing the runner, the SDK agent adapters, or the runner
-images. The skill's `SKILL.md` has the run procedure; `resources/coverage.md` has the cells ×
+sidecar login — documented per cell in `resources/coverage.md`. The continuity journeys (`warm`,
+`cold1`, `cold2`) additionally need a **store-backed** deployment: with no object store the runner
+falls back to an ephemeral working directory, so they SKIP by default and FAIL with
+`--require-store`. Run the gate before an agent-workflows release, or after changing the runner,
+the SDK agent adapters, or the runner images. The skill's `SKILL.md` has the run procedure; `resources/coverage.md` has the cells ×
 journeys matrix.
 
 ## Related In-Tree Documentation


### PR DESCRIPTION
## Context

The Codex subscription bug in #5692 reached a release through a gate that could not have caught it. Three things lined up.

The gate cell labelled "the Codex subscription path" (S1) runs the **Pi** harness with the `openai-codex` provider. Pi never loads codex-acp and never assembles a `.codex` home, so the code that broke had no coverage. The cell that does run the Codex harness (X1) uses a managed vault key, and managed mode is deliberately file-free with no `auth.json` at all. "Codex harness plus your own login" was a supported, documented configuration with zero gate coverage, in a matrix that read as though it had some.

The pre-merge QA that did cover that configuration was four single-turn checks (`docs/design/codex-harness/reports/m4-implementation-notes.md`). The failure only appears on turn two.

And the gate's one multi-turn journey (`warm`) fired three quick turns against a live daemon on a live mount. The working directory is a geesefs mount over S3, and it only makes the round trip through the object store when something unmounts and remounts it. geesefs serves a symlink correctly while the mount is up, so a warm-only journey never takes the trip where the symlink turns into a 0-byte object.

The bug class is bigger than one symlink: an entry inside the durable working directory that the object store cannot represent. It has now bitten symlinks, and it was pre-empted twice before (SQLite write-ahead logging, which is why `CODEX_SQLITE_HOME` is split onto container-local disk, and hard links).

## Changes

Continuity is now a dimension of the gate rather than a single journey, using the tier names the approvals QA already established in `reports/warm-approvals-qa.md`: **warm** (same daemon, same live mount), **cold 1** (session evicted, runner alive), **cold 2** (runner replica replaced). All three run in every cell, so Codex, Claude and Pi are covered across the credential modes that matter.

Each journey is multi-turn over a store-backed working directory, and the transition in the middle is the only difference.

`cold1` forces the eviction from the client. Changing the agent's instructions changes the config fingerprint, the runner evicts the pooled session (`mismatch (config) ...; evict + cold`), and the rebuild unmounts and remounts the durable cwd. That is a real store round trip driven by a real product action (editing an agent mid-session), and it leaves the transcript untouched, so the history guard stays out of it.

`cold2` needs the runner replica replaced, which no HTTP client can do, so it takes an operator hook. `--cold2-replace-cmd` must SIGKILL the replica, never `docker stop` (on SIGTERM the runner destroys every sandbox it owns, including the session under test), and the driver then waits out the session-owner TTL. The expected result differs per sandbox, exactly as `warm-approvals-qa.md` worked out: a local sandbox must REFUSE (`local sandbox requires a single runner`), a remote one resumes cold. It SKIPs loudly without the hook.

The store is a precondition, not a detail. `mount.ts` degrades silently to an ephemeral directory when the sign call 503s, and every turn still looks fine, so a continuity pass on a storeless deployment would be green and meaningless. The journeys resolve the session's durable mount through `GET /api/sessions/mounts/?session_id=...` before asserting anything, and SKIP without one, or FAIL with `--require-store`.

The assertions are store-side, not "turn two replied":

- Turn 1 writes a token generated by the sandbox's own shell, so it is unguessable and never appears in the transcript. The client then reads it straight out of the object store (`GET /api/mounts/{id}/files?read=...`, which goes to S3, not to the mount). That proves the cwd is durable and teaches the client the true token.
- The client writes a second file directly into the store. On the cold tiers the agent must be able to `cat` it. Content that only ever existed as an object cannot reach the agent unless that turn's cwd really resolves to that store prefix.
- Results carry the turn ledger's `agent_session_id` and `sandbox_id` (`POST /api/sessions/turns/query`, the only continuity signal a client can see). `warm` fails if either changed, since a rebuilt session means the turn was not warm.
- Results also list any 0-byte objects in the durable cwd. That is the store-side fingerprint of this whole bug class, and it is what #5692 left behind.

Every result prints the runner-log grep that settles the tier definitively, because nothing about warm versus cold reaches the SSE stream.

Cells changed:

- **S2** added: the codex harness with `runtime_provided` credentials. The genuine Codex subscription cell, and the only one that exercises `CODEX_HOME` pointed at `<cwd>/.codex` with `auth.json` symlinked into the durable cwd.
- **X2** added: codex on Daytona. A cold-2 resume can only complete on a remote sandbox (on local it correctly refuses), so without it the gate can never observe a finished codex cold 2. This was verified out of band during the v0.108.0 release run with a one-off probe. It belongs in the gate.
- **S1** relabelled as what it is, Pi on a ChatGPT/Codex subscription provider, with a pointer to S2.

Docs: `coverage.md` gains the continuity section, the stated cold-2 method, and a table of what each cell needs beyond the three env vars (which cells need a store-backed deployment, which need the subscription sidecar). `SKILL.md` tells a release conductor about `--require-store` and the cold-2 hook. The lesson is recorded as #16 in `LESSONS.md` and as a one-page retrospective in `docs/design/codex-harness/reports/durable-cwd-entries-lesson.md`.

## Folded in from the release run

Cell P2 was corrected during the v0.108.0 release and the fix was never committed. It touches the same file, so splitting it would only create a conflict. Under v0.107.x resolver semantics a named custom connection needs connection mode `agenta` and a provider-less config, and `--custom-slug` must send the full `<slug>/custom/<model>` key (a bare id that also exists in the shared catalog gets its provider inferred first, and the pair check then rejects the run).

Two other corrections described as pending from that release, `CLAUDE_CONFIG_DIR` with a writable login copy for C1 and the shared runner token for the sidecar, are not present as uncommitted changes in the release worktree. Only the P2 fix and two one-off probe scripts are there, so only P2 is included. The probe scripts are release-night one-offs with a hardcoded vault slug. The X2 cell above is the durable version of one of them.

## Tests / notes

- `ruff format` and `ruff check` are clean, and `uv run qa_product.py --help` works with the cell and journey lists updated.
- The journey control flow was exercised offline with `invoke` and `api_call` stubbed: warm passes on a store-backed deployment and fails when the ledger shows a rebuilt session, both cold tiers pass on a healthy store round trip and fail when the durable file never reaches the store, the storeless case SKIPs and becomes a FAIL under `--require-store`, and cold 2 SKIPs without the hook, passes on a local refusal, and fails if a local sandbox resumes instead. That stub harness is scratch and is not committed.
- **Nothing here has run against a live stack.** That needs a running deployment, provider keys and a subscription sidecar. The next release run is the first real exercise of these journeys. Two numbers to watch there: the store settle window (`--store-settle`, default 45s, since geesefs uploads on close), and whether the deployment pins `AGENTA_RUNNER_REPLICA_ID`, which would make a local cold 2 resume instead of refusing.
- No product code changes. The fix for #5692 ships separately, which is why this references the issue rather than closing it.

Refs #5692
