### PR TITLE
[5650] chore(ci): cap Railway preview lifetime at 6h and sweep hourly

### DIFF
--- a/.github/workflows/45-railway-cleanup.yml
+++ b/.github/workflows/45-railway-cleanup.yml
@@ -115,11 +115,15 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
-          echo "### Railway Preview Cleanup" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **PR:** #${{ github.event.pull_request.number || inputs.pr_number }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Action:** Destroyed preview environment" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Railway Preview Cleanup"
+            echo ""
+            echo "- **PR:** #${PR_NUMBER}"
+            echo "- **Action:** Destroyed preview environment"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   cleanup-stale:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.pr_number == '')
@@ -154,15 +158,27 @@ jobs:
       - name: Clean up stale clone preview environments
         env:
           RAILWAY_PREVIEW_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          # Dispatch inputs reach the shell as env values, never as ${{ }} inside
+          # `run:`: template expansion happens before the shell parses the script,
+          # so an interpolated input can inject commands onto the runner.
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '6' }}
         run: |
+          case "$MAX_AGE_HOURS" in
+            '' | *[!0-9]*) echo "max_age_hours must be a whole number of hours" >&2; exit 1 ;;
+          esac
           chmod +x hosting/railway/oss/scripts/preview-clone-destroy.sh
           hosting/railway/oss/scripts/preview-clone-destroy.sh \
-            --stale-hours "${{ inputs.max_age_hours || '6' }}"
+            --stale-hours "$MAX_AGE_HOURS"
 
       - name: Summary
         if: always()
+        env:
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '6' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
-          echo "### Railway Stale Preview Cleanup" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Max age:** ${{ inputs.max_age_hours || '6' }}h" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Dry run:** ${{ inputs.dry_run || 'false' }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Railway Stale Preview Cleanup"
+            echo ""
+            echo "- **Max age:** ${MAX_AGE_HOURS}h"
+            echo "- **Dry run:** ${DRY_RUN}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/45-railway-cleanup.yml
+++ b/.github/workflows/45-railway-cleanup.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     types: [closed, converted_to_draft]
   schedule:
-    # Run daily at 06:00 UTC to clean up stale previews
-    - cron: "0 6 * * *"
+    # Hourly. The sweep, not the age limit, sets the real ceiling on how long a
+    # preview can live: a daily sweep left a 6h-old preview running for up to 24h.
+    - cron: "0 * * * *"
   workflow_dispatch:
     inputs:
       pr_number:
@@ -13,10 +14,10 @@ on:
         required: false
         type: string
       max_age_hours:
-        description: "Max age in hours for stale cleanup (default: 24)"
+        description: "Max age in hours for stale cleanup (default: 6)"
         required: false
         type: string
-        default: "24"
+        default: "6"
       dry_run:
         description: "Dry run mode (true/false)"
         required: false
@@ -156,12 +157,12 @@ jobs:
         run: |
           chmod +x hosting/railway/oss/scripts/preview-clone-destroy.sh
           hosting/railway/oss/scripts/preview-clone-destroy.sh \
-            --stale-hours "${{ inputs.max_age_hours || '24' }}"
+            --stale-hours "${{ inputs.max_age_hours || '6' }}"
 
       - name: Summary
         if: always()
         run: |
           echo "### Railway Stale Preview Cleanup" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Max age:** ${{ inputs.max_age_hours || '24' }}h" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Max age:** ${{ inputs.max_age_hours || '6' }}h" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Dry run:** ${{ inputs.dry_run || 'false' }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Symptom

Preview environments were living far longer than the stale-cleanup setting suggested, and Railway spend ran past the workspace usage limit.

The cleanup sweep ran **once a day at 06:00 UTC** with a **24 hour** max age. The sweep frequency, not the age number, was the real ceiling: a preview created at 07:00 UTC survived until the next morning's sweep, about 23 hours, no matter what the age limit said.

## Change

| | Before | After |
|---|---|---|
| Sweep schedule | daily, 06:00 UTC | hourly |
| Max age | 24h | 6h |

Together these cap a preview's real life at roughly 6 to 7 hours.

## Side effect worth knowing

Age is measured from environment creation, not from last use. A preview on a long-lived pull request now disappears about 6 hours after it was created, even if someone is still reviewing on it. Getting it back means pushing a commit or re-running "14 - check PR preview". That is the trade we are making for lower spend.

## Scope

This only affects `pr-<number>` environments inside the template project. `production` and `pr-template` are protected by name and are never swept.

A sweep with nothing to delete costs about three Railway API calls, so running it hourly is cheap against the 1000 requests per hour account limit.

Related: #5650