### PR TITLE
[refactor] Group RunPlan by concern instead of one flat bag

### DIFF
--- a/services/runner/src/engines/sandbox_agent/attachments.ts
+++ b/services/runner/src/engines/sandbox_agent/attachments.ts
@@ -23,7 +23,7 @@ import {
   type FetchedAttachment,
 } from "../../sessions/attachments.ts";
 import { attachmentDeliveryUnsupportedMessage } from "./capabilities.ts";
-import type { RunPlan } from "./run-plan.ts";
+import type { RunPlan, RunPlanWorkspace } from "./run-plan.ts";
 import { COLD_FRAME_USER_LABEL } from "./transcript.ts";
 
 export type AttachmentDeliveryOutcome =
@@ -83,8 +83,10 @@ export interface AttachmentSandbox {
   }) => Promise<{ exitCode?: number } | undefined>;
 }
 
-type MaterializePlan = Pick<RunPlan, "cwd" | "isDaytona">;
-type DeliveryPlan = Pick<RunPlan, "cwd" | "isDaytona" | "acpAgent" | "harness">;
+type MaterializePlan = Pick<RunPlan, "isDaytona"> & {
+  workspace: Pick<RunPlanWorkspace, "cwd">;
+};
+type DeliveryPlan = MaterializePlan & Pick<RunPlan, "acpAgent" | "harness">;
 type Auth = () => string;
 type Log = (message: string) => void;
 
@@ -398,7 +400,7 @@ export async function materializeWorkingCopy(
   ref: AttachmentRef,
   bytes: Uint8Array,
 ): Promise<"written" | "exists"> {
-  const path = attachmentWorkingPath(plan.cwd, ref);
+  const path = attachmentWorkingPath(plan.workspace.cwd, ref);
   return plan.isDaytona
     ? daytonaMaterialize(sandbox, path, bytes)
     : localMaterialize(path, bytes);
@@ -637,7 +639,7 @@ async function workingCopyExists(
   plan: MaterializePlan,
   ref: AttachmentRef,
 ): Promise<boolean> {
-  const path = attachmentWorkingPath(plan.cwd, ref);
+  const path = attachmentWorkingPath(plan.workspace.cwd, ref);
   if (plan.isDaytona) {
     if (typeof sandbox.statFs !== "function") return false;
     await rejectDaytonaSymlinks(sandbox, [
@@ -839,7 +841,7 @@ export async function resolveCurrentTurnAttachments(input: {
     const authoritative = verifiedRef(ref, fetched);
     let path: AttachmentPath;
     try {
-      path = attachmentWorkingPath(input.plan.cwd, authoritative);
+      path = attachmentWorkingPath(input.plan.workspace.cwd, authoritative);
       await materializeWorkingCopy(
         input.sandbox,
         input.plan,

--- a/services/runner/src/engines/sandbox_agent/codex-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/codex-assets.ts
@@ -24,7 +24,11 @@ import { existsSync, mkdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
-import type { RunPlan } from "./run-plan.ts";
+import type {
+  RunPlan,
+  RunPlanCredentials,
+  RunPlanWorkspace,
+} from "./run-plan.ts";
 
 type Log = (message: string) => void;
 
@@ -44,6 +48,17 @@ export function codexHomeDir(cwd: string): string {
  * constant across a session's turns and is NOT a config-fingerprint input, preserving warm daemon
  * reuse.
  */
+/** The slice that decides which Codex auth mode a run is in. */
+type CodexModePlan = Pick<RunPlan, "acpAgent"> & {
+  credentials: Pick<RunPlanCredentials, "credentialMode">;
+};
+
+/** The mode slice plus where the run's Codex home is rooted. */
+type CodexHomePlan = CodexModePlan &
+  Pick<RunPlan, "isDaytona"> & {
+    workspace: Pick<RunPlanWorkspace, "cwd">;
+  };
+
 export function codexSqliteHomeDir(cwd: string): string {
   return join(tmpdir(), "agenta", "codex-sqlite", basename(cwd));
 }
@@ -54,18 +69,20 @@ export function codexSqliteHomeDir(cwd: string): string {
  * own mounted OAuth login instead, so it is excluded here.
  */
 export function isManagedCodexRun(
-  plan: Pick<RunPlan, "acpAgent" | "credentialMode">,
+  plan: CodexModePlan,
 ): boolean {
   return (
-    plan.acpAgent === "codex" && plan.credentialMode !== "runtime_provided"
+    plan.acpAgent === "codex" &&
+    plan.credentials.credentialMode !== "runtime_provided"
   );
 }
 
 export function isSubscriptionCodexRun(
-  plan: Pick<RunPlan, "acpAgent" | "credentialMode">,
+  plan: CodexModePlan,
 ): boolean {
   return (
-    plan.acpAgent === "codex" && plan.credentialMode === "runtime_provided"
+    plan.acpAgent === "codex" &&
+    plan.credentials.credentialMode === "runtime_provided"
   );
 }
 
@@ -86,7 +103,7 @@ function codexSubscriptionMountDir(): string | undefined {
  * for best-effort teardown cleanup. Subscription additionally pins the credential store to `file`.
  */
 export function configureCodexHome(
-  plan: Pick<RunPlan, "acpAgent" | "credentialMode" | "isDaytona" | "cwd">,
+  plan: CodexHomePlan,
   env: Record<string, string>,
 ): string | undefined {
   // Local codex only (managed or subscription). Daytona and non-codex runs are no-ops.
@@ -94,10 +111,10 @@ export function configureCodexHome(
   // Runner-owned per-session home in both modes. For subscription this overrides the operator's
   // mount path that buildDaemonEnv inherited into env.CODEX_HOME, so only the auth.json we symlink
   // in (see symlinkCodexSubscriptionAuthFile) is visible — not the operator's config/plugins/apps.
-  env.CODEX_HOME = codexHomeDir(plan.cwd);
+  env.CODEX_HOME = codexHomeDir(plan.workspace.cwd);
   // Both modes redirect SQLite off the home so neither the geesefs cwd nor the operator mount
   // accumulates per-run WAL SQLite.
-  const sqliteHome = codexSqliteHomeDir(plan.cwd);
+  const sqliteHome = codexSqliteHomeDir(plan.workspace.cwd);
   mkdirSync(sqliteHome, { recursive: true });
   env.CODEX_SQLITE_HOME = sqliteHome;
   // Subscription: pin the credential store to `file` so a keyring/auto mode (from any config layer)
@@ -133,12 +150,12 @@ export function codexDaytonaSqliteHomeDir(cwd: string): string {
  * (run-plan.ts); local runs and non-codex runs are no-ops.
  */
 export function configureDaytonaCodexEnv(
-  plan: Pick<RunPlan, "acpAgent" | "credentialMode" | "isDaytona" | "cwd">,
+  plan: CodexHomePlan,
   daytonaEnv: Record<string, string>,
 ): void {
   if (!plan.isDaytona || !isManagedCodexRun(plan)) return;
-  daytonaEnv.CODEX_HOME = codexHomeDir(plan.cwd);
-  daytonaEnv.CODEX_SQLITE_HOME = codexDaytonaSqliteHomeDir(plan.cwd);
+  daytonaEnv.CODEX_HOME = codexHomeDir(plan.workspace.cwd);
+  daytonaEnv.CODEX_SQLITE_HOME = codexDaytonaSqliteHomeDir(plan.workspace.cwd);
 }
 
 /**
@@ -151,7 +168,7 @@ export function configureDaytonaCodexEnv(
  * file-free and never reach here.
  */
 export function symlinkCodexSubscriptionAuthFile(
-  plan: Pick<RunPlan, "acpAgent" | "credentialMode" | "isDaytona" | "cwd">,
+  plan: CodexHomePlan,
   log: Log = () => {},
 ): void {
   if (!isSubscriptionCodexRun(plan) || plan.isDaytona) return;
@@ -162,7 +179,7 @@ export function symlinkCodexSubscriptionAuthFile(
     return;
   }
 
-  const home = codexHomeDir(plan.cwd);
+  const home = codexHomeDir(plan.workspace.cwd);
   mkdirSync(home, { recursive: true, mode: 0o700 });
   const linkPath = join(home, "auth.json");
   if (existsSync(linkPath)) return;

--- a/services/runner/src/engines/sandbox_agent/daytona.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona.ts
@@ -11,7 +11,11 @@ import {
   serializePiModelsJson,
   type PiModelConfigPlan,
 } from "./pi-model-config.ts";
-import { type RunPlan } from "./run-plan.ts";
+import {
+  type RunPlan,
+  type RunPlanPrompt,
+  type RunPlanWorkspace,
+} from "./run-plan.ts";
 
 type Log = (message: string) => void;
 
@@ -190,14 +194,13 @@ export async function removePiModelsConfigFromSandbox(
 
 export interface PrepareDaytonaPiAssetsInput {
   sandbox: any;
-  plan: Pick<
-    RunPlan,
-    | "isPi"
-    | "skillDirs"
-    | "hasSystemPrompt"
-    | "systemPrompt"
-    | "appendSystemPrompt"
-  >;
+  plan: Pick<RunPlan, "isPi"> & {
+    workspace: Pick<RunPlanWorkspace, "skillDirs">;
+    prompt: Pick<
+      RunPlanPrompt,
+      "hasSystemPrompt" | "systemPrompt" | "appendSystemPrompt"
+    >;
+  };
   /**
    * A managed OpenAI-compatible custom run's Pi provider config. When set, its `models.json` is
    * uploaded before the ACP session starts; when absent, any stale `models.json` on a reused
@@ -243,15 +246,20 @@ export async function prepareDaytonaPiAssets({
   } else {
     await removePiModelsConfigFromSandbox(sandbox, DAYTONA_PI_DIR, log);
   }
-  if (plan.skillDirs.length > 0) {
-    await uploadSkillsToSandbox(sandbox, DAYTONA_PI_DIR, plan.skillDirs, log);
+  if (plan.workspace.skillDirs.length > 0) {
+    await uploadSkillsToSandbox(
+      sandbox,
+      DAYTONA_PI_DIR,
+      plan.workspace.skillDirs,
+      log,
+    );
   }
-  if (plan.hasSystemPrompt) {
+  if (plan.prompt.hasSystemPrompt) {
     await uploadSystemPromptToSandbox(
       sandbox,
       DAYTONA_PI_DIR,
-      plan.systemPrompt,
-      plan.appendSystemPrompt,
+      plan.prompt.systemPrompt,
+      plan.prompt.appendSystemPrompt,
       log,
     );
   }

--- a/services/runner/src/engines/sandbox_agent/environment-setup.ts
+++ b/services/runner/src/engines/sandbox_agent/environment-setup.ts
@@ -161,22 +161,26 @@ export async function prepareEnvironmentSetup(
   if (!planResult.ok) return { ok: false as const, error: planResult.error };
   const plan = planResult.plan;
   const piSkillSnapshot = resolvePiSkillSnapshot(plan);
-  const agentMountDir = agentMountCreds ? agentMountPath(plan.cwd) : undefined;
+  const agentMountDir = agentMountCreds
+    ? agentMountPath(plan.workspace.cwd)
+    : undefined;
 
   // Clear-then-apply (Security rule 5): on a managed run (credentialMode "env") the daemon
   // inherits NONE of the sidecar's own provider keys, so only the resolved
-  // `plan.modelEnvironment` is present and an inherited key for another provider cannot leak.
+  // `plan.credentials.modelEnvironment` is present and an inherited key for another provider cannot leak.
   // "none" asserts NO credential (connections/models.py), so it clears too — otherwise the
   // daemon would inherit the declared provider's keys (e.g. OPENAI_API_KEY) from the sidecar.
   // Only runtime_provided keeps the inherited keys: the harness uses its own login there.
   const clearProviderEnv =
-    plan.credentialMode === "env" || plan.credentialMode === "none";
+    plan.credentials.credentialMode === "env" ||
+    plan.credentials.credentialMode === "none";
   const env = (deps.buildDaemonEnv ?? buildDaemonEnv)(plan.acpAgent, {
     clearProviderEnv,
     provider: request.modelConnection?.provider,
     deployment: request.modelConnection?.deployment,
   });
-  Object.assign(env, plan.modelEnvironment); // apply only the resolved provider keys
+  // apply only the resolved provider keys
+  Object.assign(env, plan.credentials.modelEnvironment);
   applyClaudeConnectionEnv(env, request, plan.acpAgent, logger);
   const piSessionDir = configurePiSessionWorkspace(plan, env);
   configurePiSkillSnapshot(piSkillSnapshot, env);
@@ -187,7 +191,7 @@ export async function prepareEnvironmentSetup(
   // local Pi's OTLP bearer rides a runner-written 0600 file, never a plain env var —
   // Daytona never receives telemetry env here at all (`!plan.isDaytona` gates it off above).
   const otlpAuthFilePath =
-    plan.isPi && !plan.isDaytona ? `${plan.relayDir}.otlp-auth` : undefined;
+    plan.isPi && !plan.isDaytona ? `${plan.workspace.relayDir}.otlp-auth` : undefined;
   const otlpAuthorization =
     request.telemetry?.exporters?.otlp?.headers?.authorization;
   if (otlpAuthFilePath && otlpAuthorization) {
@@ -195,14 +199,14 @@ export async function prepareEnvironmentSetup(
   }
   const piExtEnv = plan.isPi
     ? buildPiExtensionEnv(request, !plan.isDaytona, {
-        relayDir: plan.relayDir,
-        usageOutPath: plan.usageOutPath,
+        relayDir: plan.workspace.relayDir,
+        usageOutPath: plan.workspace.usageOutPath,
         otlpAuthFilePath,
-        builtinGatingActive: plan.builtinGatingActive,
+        builtinGatingActive: plan.tools.builtinGatingActive,
         // The materialized skill names (author + forced `_agenta.*`) so Pi's own agent span
         // records which skills loaded; local Pi self-instruments, so the runner's sandbox-agent
         // otel has no span to stamp here.
-        skills: plan.skillDirs.map((s) => s.name),
+        skills: plan.workspace.skillDirs.map((s) => s.name),
       })
     : {};
   // Daytona's provider is built from `piExtEnv` rather than the local daemon env. Keep the
@@ -218,11 +222,11 @@ export async function prepareEnvironmentSetup(
   configureDaytonaCodexEnv(plan, piExtEnv);
   Object.assign(env, piExtEnv); // local daemon inherits it; daytona gets it via envVars
   logger(
-    `tools=${plan.toolSpecs.length} executableTools=${plan.executableToolSpecs.length} ` +
+    `tools=${plan.tools.toolSpecs.length} executableTools=${plan.tools.executableToolSpecs.length} ` +
       `piPublicTools=${piExtEnv.AGENTA_AGENT_TOOLS_PUBLIC_SPECS ? "yes" : "no"}`,
   );
   if (!plan.isPi && plan.isDaytona) {
-    const clientTools = plan.toolSpecs
+    const clientTools = plan.tools.toolSpecs
       .filter((spec) => spec.kind === "client")
       .map((spec) => spec.name);
     if (clientTools.length > 0) {
@@ -243,12 +247,14 @@ export async function prepareEnvironmentSetup(
   if (plan.isPi) {
     try {
       // The presence check consults the FULL materialized model environment: on a Daytona
-      // Secrets run the opaque key left `plan.modelEnvironment` for the secret plan, but the
-      // sandbox still receives its binding (as a Daytona Secret attachment).
+      // Secrets run the opaque key left `plan.credentials.modelEnvironment` for the
+      // secret plan, but the sandbox still receives its binding (as a Daytona Secret
+      // attachment).
       const fullModelEnvironment: Record<string, string> = {
-        ...plan.modelEnvironment,
+        ...plan.credentials.modelEnvironment,
       };
-      for (const candidate of plan.daytonaSecretPlan?.candidates ?? []) {
+      const secretCandidates = plan.credentials.daytonaSecretPlan?.candidates;
+      for (const candidate of secretCandidates ?? []) {
         if (candidate.consumer.kind === "model") {
           fullModelEnvironment[candidate.binding.name] = candidate.value;
         }
@@ -295,7 +301,7 @@ export async function prepareEnvironmentSetup(
   const localBuiltinGatingUnenforceable =
     plan.isPi &&
     !plan.isDaytona &&
-    plan.builtinGatingActive &&
+    plan.tools.builtinGatingActive &&
     !localPiAssets.extensionInstalled;
   // Fail closed: a Pi run whose provider routing rides the extension's model endpoint override
   // (`model-provider-override.ts`, set in `buildPiExtensionEnv`) cannot run without the
@@ -315,7 +321,7 @@ export async function prepareEnvironmentSetup(
   // lifecycle, exactly like a normal local install (interface.md section 6). buildRunPlan already
   // rejected a runtime_provided Claude run with no configured CLAUDE_CONFIG_DIR.
 
-  logger(`harness=${plan.harness} sandbox=${plan.sandboxId} cwd=${plan.cwd}`);
+  logger(`harness=${plan.harness} sandbox=${plan.sandboxId} cwd=${plan.workspace.cwd}`);
 
   // The resolved model ref as it reaches the runner (key NAMES only, never values) — the one
   // line that answers "what model/provider/deployment/credential did this run actually use".
@@ -391,7 +397,7 @@ export async function prepareEnvironmentSetup(
       ? undefined
       : {
           cleanup: async () =>
-            rmSync(plan.cwd, { recursive: true, force: true }),
+            rmSync(plan.workspace.cwd, { recursive: true, force: true }),
         },
     runtimeRemount: undefined,
     closeToolMcp: undefined,

--- a/services/runner/src/engines/sandbox_agent/environment-setup.ts
+++ b/services/runner/src/engines/sandbox_agent/environment-setup.ts
@@ -167,7 +167,8 @@ export async function prepareEnvironmentSetup(
 
   // Clear-then-apply (Security rule 5): on a managed run (credentialMode "env") the daemon
   // inherits NONE of the sidecar's own provider keys, so only the resolved
-  // `plan.credentials.modelEnvironment` is present and an inherited key for another provider cannot leak.
+  // `plan.credentials.modelEnvironment` is present and an inherited key for another
+  // provider cannot leak.
   // "none" asserts NO credential (connections/models.py), so it clears too — otherwise the
   // daemon would inherit the declared provider's keys (e.g. OPENAI_API_KEY) from the sidecar.
   // Only runtime_provided keeps the inherited keys: the harness uses its own login there.
@@ -191,7 +192,9 @@ export async function prepareEnvironmentSetup(
   // local Pi's OTLP bearer rides a runner-written 0600 file, never a plain env var —
   // Daytona never receives telemetry env here at all (`!plan.isDaytona` gates it off above).
   const otlpAuthFilePath =
-    plan.isPi && !plan.isDaytona ? `${plan.workspace.relayDir}.otlp-auth` : undefined;
+    plan.isPi && !plan.isDaytona
+      ? `${plan.workspace.relayDir}.otlp-auth`
+      : undefined;
   const otlpAuthorization =
     request.telemetry?.exporters?.otlp?.headers?.authorization;
   if (otlpAuthFilePath && otlpAuthorization) {
@@ -321,7 +324,9 @@ export async function prepareEnvironmentSetup(
   // lifecycle, exactly like a normal local install (interface.md section 6). buildRunPlan already
   // rejected a runtime_provided Claude run with no configured CLAUDE_CONFIG_DIR.
 
-  logger(`harness=${plan.harness} sandbox=${plan.sandboxId} cwd=${plan.workspace.cwd}`);
+  logger(
+    `harness=${plan.harness} sandbox=${plan.sandboxId} cwd=${plan.workspace.cwd}`,
+  );
 
   // The resolved model ref as it reaches the runner (key NAMES only, never values) — the one
   // line that answers "what model/provider/deployment/credential did this run actually use".

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -350,7 +350,7 @@ export async function acquireEnvironment(
     }
     if (!environment.durableCwdSafeToDelete) {
       logger(
-        `durable cwd unmount not confirmed, skipping workspace cleanup cwd=${plan.cwd}`,
+        `durable cwd unmount not confirmed, skipping workspace cleanup cwd=${plan.workspace.cwd}`,
       );
     } else {
       await environment.workspace?.cleanup().catch(() => {});
@@ -375,7 +375,7 @@ export async function acquireEnvironment(
     if (environment.codexSqliteHome)
       rmSync(environment.codexSqliteHome, { recursive: true, force: true });
     // Remove the per-run skills temp root the materializer created (success or error).
-    plan.skillsCleanup();
+    plan.workspace.skillsCleanup();
   };
 
   let agentMountGuidanceActive = false;
@@ -394,17 +394,17 @@ export async function acquireEnvironment(
     }
     if (!plan.isPi) return;
 
-    plan.appendSystemPrompt = combineAppendSystemPrompt(
-      plan.appendSystemPrompt,
+    plan.prompt.appendSystemPrompt = combineAppendSystemPrompt(
+      plan.prompt.appendSystemPrompt,
       AGENT_MOUNT_SYSTEM_PROMPT_SEGMENT,
     );
-    plan.hasSystemPrompt = true;
+    plan.prompt.hasSystemPrompt = true;
     if (plan.isDaytona) {
       await uploadSystemPromptToSandbox(
         environment.sandbox,
         DAYTONA_PI_DIR,
-        plan.systemPrompt,
-        plan.appendSystemPrompt,
+        plan.prompt.systemPrompt,
+        plan.prompt.appendSystemPrompt,
         logger,
       );
       return;
@@ -412,8 +412,8 @@ export async function acquireEnvironment(
     if (environment.runAgentDir) {
       writeSystemPromptLocal(
         environment.runAgentDir,
-        plan.systemPrompt,
-        plan.appendSystemPrompt,
+        plan.prompt.systemPrompt,
+        plan.prompt.appendSystemPrompt,
         logger,
       );
       return;
@@ -436,18 +436,18 @@ export async function acquireEnvironment(
   const mountLocalDurableCwd = async (reason: string): Promise<boolean> => {
     if (!environment.mountCreds || plan.isDaytona) return false;
     logger(
-      `local durable cwd mount (${reason}) session=${sessionForMount} cwd=${plan.cwd}`,
+      `local durable cwd mount (${reason}) session=${sessionForMount} cwd=${plan.workspace.cwd}`,
     );
     environment.durableCwdSafeToDelete = false;
     const mounted = await (deps.mountStorage ?? mountStorage)(
-      plan.cwd,
+      plan.workspace.cwd,
       environment.mountCreds,
       {
         log: logger,
       },
     );
     if (mounted) {
-      environment.mountedCwd = plan.cwd;
+      environment.mountedCwd = plan.workspace.cwd;
       environment.installedMountExpiries.cwd = mountExpiryMs(
         environment.mountCreds.expiresAt,
       );
@@ -459,7 +459,7 @@ export async function acquireEnvironment(
   };
   const mountLocalAgentCwd = async (): Promise<boolean> => {
     if (!environment.agentMountCreds || plan.isDaytona) return false;
-    const mountPath = agentMountPath(plan.cwd);
+    const mountPath = agentMountPath(plan.workspace.cwd);
     if (environment.agentMountedPath === mountPath) return true;
     try {
       mkdirSync(mountPath, { recursive: true });
@@ -480,7 +480,7 @@ export async function acquireEnvironment(
         environment.agentMountCreds.expiresAt,
       );
       await seedAgentReadme(mountPath, { log: logger });
-      await linkAgentFiles(plan.cwd, mountPath, { log: logger });
+      await linkAgentFiles(plan.workspace.cwd, mountPath, { log: logger });
       await activateAgentMountGuidance();
       return true;
     } catch (err) {
@@ -498,7 +498,7 @@ export async function acquireEnvironment(
       LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT
     ) {
       logger(
-        `local agent mount ENOTCONN remount limit reached artifact=${artifactId} path=${agentMountPath(plan.cwd)}`,
+        `local agent mount ENOTCONN remount limit reached artifact=${artifactId} path=${agentMountPath(plan.workspace.cwd)}`,
       );
       return false;
     }
@@ -530,13 +530,13 @@ export async function acquireEnvironment(
       LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT
     ) {
       logger(
-        `local durable cwd ENOTCONN remount limit reached session=${sessionForMount} cwd=${plan.cwd}`,
+        `local durable cwd ENOTCONN remount limit reached session=${sessionForMount} cwd=${plan.workspace.cwd}`,
       );
       return false;
     }
     localDurableCwdEnotconnRemounts += 1;
     logger(
-      `local durable cwd ENOTCONN session=${sessionForMount} cwd=${plan.cwd}; re-signing and remounting`,
+      `local durable cwd ENOTCONN session=${sessionForMount} cwd=${plan.workspace.cwd}; re-signing and remounting`,
     );
     const fresh = await signMount(sessionForMount, {
       apiBase: apiBase(),
@@ -565,7 +565,7 @@ export async function acquireEnvironment(
     )
       return;
     logger(
-      `local durable mount ENOTCONN observed in ACP event session=${sessionForMount} cwd=${plan.cwd}; re-signing and remounting`,
+      `local durable mount ENOTCONN observed in ACP event session=${sessionForMount} cwd=${plan.workspace.cwd}; re-signing and remounting`,
     );
     environment.runtimeRemount = (async () => {
       const cwdOk = cwdEligible ? await reSignAndRemountLocalCwd() : true;
@@ -627,9 +627,9 @@ export async function acquireEnvironment(
       env,
       binaryPath,
       piExtEnv,
-      plan.modelEnvironment,
+      plan.credentials.modelEnvironment,
       plan.sandboxPermission,
-      plan.daytonaSecretPlan,
+      plan.credentials.daytonaSecretPlan,
     );
     const startOptions = {
       sandbox: sandboxProvider,
@@ -708,13 +708,17 @@ export async function acquireEnvironment(
         deps.prepareDaytonaPiAssets ?? prepareDaytonaPiAssets
       )({
         sandbox: environment.sandbox,
-        plan: { ...plan, skillDirs: [] },
+        plan: { ...plan, workspace: { ...plan.workspace, skillDirs: [] } },
         piModelConfig,
         log: logger,
       });
       // Fail closed (Decision 2): same guarantee as the local path. A genuine upload failure on the
       // Daytona sandbox stops the run rather than running Pi's built-in tools unprotected.
-      if (plan.isPi && plan.builtinGatingActive && !daytonaExtensionInstalled) {
+      if (
+        plan.isPi &&
+        plan.tools.builtinGatingActive &&
+        !daytonaExtensionInstalled
+      ) {
         throw new Error(PI_PERMISSION_EXTENSION_UNAVAILABLE_MESSAGE);
       }
       // Fail closed: the Pi model endpoint override rides the extension; without it the model
@@ -726,15 +730,15 @@ export async function acquireEnvironment(
       ) {
         throw new Error(PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE);
       }
-      if (!plan.isPi && plan.toolSpecs.length > 0) {
+      if (!plan.isPi && plan.tools.toolSpecs.length > 0) {
         // Advertise the FULL tool set to the shim, client tools included: a parked client tool
         // resolves through the relay's paused answer (see startToolRelay / tool-mcp-stdio.ts).
         internalToolMcp = await (
           deps.uploadToolMcpAssets ?? uploadToolMcpAssets
         )(
           environment.sandbox,
-          plan.toolMcpDir,
-          advertisedToolSpecs(plan.toolSpecs),
+          plan.workspace.toolMcpDir,
+          advertisedToolSpecs(plan.tools.toolSpecs),
           logger,
         );
       }
@@ -762,7 +766,7 @@ export async function acquireEnvironment(
           canMount &&
           (await (deps.mountStorageRemote ?? mountStorageRemote)(
             environment.sandbox,
-            plan.cwd,
+            plan.workspace.cwd,
             environment.mountCreds,
             {
               endpoint,
@@ -833,9 +837,12 @@ export async function acquireEnvironment(
           await seedAgentReadmeRemote(environment.sandbox, mountPath, {
             log: logger,
           });
-          await linkAgentFilesRemote(environment.sandbox, plan.cwd, mountPath, {
-            log: logger,
-          });
+          await linkAgentFilesRemote(
+            environment.sandbox,
+            plan.workspace.cwd,
+            mountPath,
+            { log: logger },
+          );
           await activateAgentMountGuidance();
           logger(`remote agent mount active for artifact=${artifactId}`);
         }
@@ -929,7 +936,7 @@ export async function acquireEnvironment(
       harness: plan.harness,
       isPi: plan.isPi,
       probed,
-      toolSpecs: plan.toolSpecs,
+      toolSpecs: plan.tools.toolSpecs,
       log: logger,
     });
 
@@ -938,14 +945,14 @@ export async function acquireEnvironment(
       capabilities,
       harness: plan.harness,
       isDaytona: plan.isDaytona,
-      toolSpecs: plan.toolSpecs,
+      toolSpecs: plan.tools.toolSpecs,
       // On a Daytona Secrets run the provider swaps each MCP credential value for its Daytona
       // Secret placeholder, so no plaintext secret rides the sandbox-bound session config.
       userMcpServers: materializeDaytonaMcpServers(
         sandboxProvider,
         request.mcpServers,
       ),
-      relayDir: plan.relayDir,
+      relayDir: plan.workspace.relayDir,
       clientToolRelay: deferredClientToolRelay,
       executableToolGate:
         !plan.isPi && !plan.isDaytona ? deferredExecutableToolGate : undefined,
@@ -982,7 +989,7 @@ export async function acquireEnvironment(
         ? { ...(claudeSystemPromptMeta ?? {}), ...(claudeThinking ?? {}) }
         : undefined;
     const sessionInit = {
-      cwd: plan.cwd,
+      cwd: plan.workspace.cwd,
       mcpServers: sessionMcp.servers,
       ...(claudeMeta ? { _meta: claudeMeta } : {}),
     };
@@ -1058,7 +1065,7 @@ export async function acquireEnvironment(
         environment.session = await environment.sandbox.createSession({
           ...(localSessionId ? { id: localSessionId } : {}),
           agent: plan.acpAgent,
-          cwd: plan.cwd,
+          cwd: plan.workspace.cwd,
           sessionInit,
         });
       } finally {

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -29,7 +29,12 @@ import {
   serializePiModelsJson,
   type PiModelConfigPlan,
 } from "./pi-model-config.ts";
-import type { RunPlan } from "./run-plan.ts";
+import type {
+  RunPlan,
+  RunPlanCredentials,
+  RunPlanPrompt,
+  RunPlanWorkspace,
+} from "./run-plan.ts";
 
 type Log = (message: string) => void;
 
@@ -45,11 +50,13 @@ export function piSessionWorkspaceDir(cwd: string): string {
 
 /** Point Pi at the durable conversation-scoped transcript directory. */
 export function configurePiSessionWorkspace(
-  plan: Pick<RunPlan, "isPi" | "cwd">,
+  plan: Pick<RunPlan, "isPi"> & {
+    workspace: Pick<RunPlanWorkspace, "cwd">;
+  },
   env: Record<string, string>,
 ): string | undefined {
   if (!plan.isPi) return undefined;
-  const sessionDir = piSessionWorkspaceDir(plan.cwd);
+  const sessionDir = piSessionWorkspaceDir(plan.workspace.cwd);
   env.PI_CODING_AGENT_SESSION_DIR = sessionDir;
   return sessionDir;
 }
@@ -105,11 +112,13 @@ function hashPart(
 
 /** Resolve the immutable project-local snapshot selected for this Pi run. */
 export function resolvePiSkillSnapshot(
-  plan: Pick<RunPlan, "isPi" | "cwd" | "skillDirs">,
+  plan: Pick<RunPlan, "isPi"> & {
+    workspace: Pick<RunPlanWorkspace, "cwd" | "skillDirs">;
+  },
 ): PiSkillSnapshot | undefined {
-  if (!plan.isPi || plan.skillDirs.length === 0) return undefined;
+  if (!plan.isPi || plan.workspace.skillDirs.length === 0) return undefined;
 
-  const skills = [...plan.skillDirs].sort((a, b) =>
+  const skills = [...plan.workspace.skillDirs].sort((a, b) =>
     a.name.localeCompare(b.name),
   );
   const hash = createHash("sha256");
@@ -130,7 +139,7 @@ export function resolvePiSkillSnapshot(
   })}\n`;
   return {
     digest,
-    dir: join(plan.cwd, "agents", "skills", digest),
+    dir: join(plan.workspace.cwd, "agents", "skills", digest),
     marker,
     skills,
   };
@@ -571,17 +580,14 @@ export function prepareLocalAgentDir(
 }
 
 export interface PrepareLocalPiAssetsInput {
-  plan: Pick<
-    RunPlan,
-    | "isPi"
-    | "isDaytona"
-    | "credentialMode"
-    | "skillDirs"
-    | "hasSystemPrompt"
-    | "systemPrompt"
-    | "appendSystemPrompt"
-    | "sourcePiAgentDir"
-  >;
+  plan: Pick<RunPlan, "isPi" | "isDaytona"> & {
+    credentials: Pick<RunPlanCredentials, "credentialMode">;
+    workspace: Pick<RunPlanWorkspace, "skillDirs" | "sourcePiAgentDir">;
+    prompt: Pick<
+      RunPlanPrompt,
+      "hasSystemPrompt" | "systemPrompt" | "appendSystemPrompt"
+    >;
+  };
   env: Record<string, string>;
   /**
    * A managed OpenAI-compatible custom run's Pi provider config. When set, the isolated per-run
@@ -650,14 +656,14 @@ export function prepareLocalPiAssets({
   // buildRunPlan already rejected a local runtime_provided run with no configured
   // PI_CODING_AGENT_DIR, so `sourcePiAgentDir` here IS the operator's mount. A model-config plan
   // never reaches here (it requires credentialMode "env"), so there is no models.json to write.
-  if (plan.credentialMode === "runtime_provided") {
-    const agentDir = plan.sourcePiAgentDir;
+  if (plan.credentials.credentialMode === "runtime_provided") {
+    const agentDir = plan.workspace.sourcePiAgentDir;
     const extensionInstalled = installPiExtensionLocal(agentDir, log);
-    if (plan.hasSystemPrompt) {
+    if (plan.prompt.hasSystemPrompt) {
       writeSystemPromptLocal(
         agentDir,
-        plan.systemPrompt,
-        plan.appendSystemPrompt,
+        plan.prompt.systemPrompt,
+        plan.prompt.appendSystemPrompt,
         log,
       );
     }
@@ -671,15 +677,15 @@ export function prepareLocalPiAssets({
   // managed OpenAI-compatible custom run (a model-config plan is present) additionally gets a
   // models.json and does NOT receive the operator's personal auth.json.
   const { dir: runAgentDir, extensionInstalled } = prepareLocalAgentDir(
-    plan.sourcePiAgentDir,
+    plan.workspace.sourcePiAgentDir,
     log,
     { seedCredentials: !piModelConfig },
   );
-  if (plan.hasSystemPrompt) {
+  if (plan.prompt.hasSystemPrompt) {
     writeSystemPromptLocal(
       runAgentDir,
-      plan.systemPrompt,
-      plan.appendSystemPrompt,
+      plan.prompt.systemPrompt,
+      plan.prompt.appendSystemPrompt,
       log,
     );
   }

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -98,15 +98,11 @@ export const LOCAL_SUBSCRIPTION_MOUNT_MISSING_MESSAGE =
   "runtime_provided local run requires a mounted subscription: set PI_CODING_AGENT_DIR " +
   "(Pi), CLAUDE_CONFIG_DIR (Claude), or CODEX_HOME (Codex) to a read-write mount of your harness login.";
 
-export interface RunPlan {
-  harness: string;
-  acpAgent: string;
-  sandboxId: string;
-  isPi: boolean;
-  isDaytona: boolean;
-  prompt: string;
-  turnText: string;
-  agentsMd?: string;
+/**
+ * How the run authenticates with the model provider. Everything here describes the credential
+ * itself and how it is delivered, not where the run executes or what it asks the model to do.
+ */
+export interface RunPlanCredentials {
   /** Final plaintext model environment, after validating modelConnection. */
   modelEnvironment: Record<string, string>;
   /**
@@ -132,6 +128,13 @@ export interface RunPlan {
    * that request may still use the harness login. Drives clear-then-apply env (Security rule 5).
    */
   credentialMode?: string;
+}
+
+/**
+ * Where the run's files live and what gets materialized into them. These are the directories the
+ * engine creates, mounts, writes into, and cleans up.
+ */
+export interface RunPlanWorkspace {
   cwd: string;
   relayDir: string;
   /**
@@ -144,6 +147,24 @@ export interface RunPlan {
    */
   toolMcpDir: string;
   usageOutPath?: string;
+  skillDirs: MaterializedSkill[];
+  /** Removes the per-run skills temp root. The engine runs it in its `finally` so it never leaks. */
+  skillsCleanup: () => void;
+  sourcePiAgentDir: string;
+  /**
+   * Generic harness-rendered files to materialize in the cwd before the session starts. Each
+   * `{ path (relative to cwd), content }` was produced by the Python harness adapter (e.g. the
+   * claude adapter renders `.claude/settings.json` from its permissions slice). `prepareWorkspace`
+   * writes each entry blind — no harness knowledge on the runner.
+   */
+  harnessFiles?: Array<{ path: string; content: string }>;
+}
+
+/**
+ * The tools this run offers the model and how they are delivered. It covers both the resolved
+ * specs and the delivery switches the engine reads when it wires the relay and the gates.
+ */
+export interface RunPlanTools {
   toolSpecs: ResolvedToolSpec[];
   executableToolSpecs: ResolvedToolSpec[];
   /** True when the permission policy needs the extension to intercept Pi builtin calls. */
@@ -156,13 +177,31 @@ export interface RunPlan {
    * "pi-native", the non-Pi shim (Claude on Daytona) → "cold-acknowledge".
    */
   clientToolPauseDisposition: ClientToolPauseDisposition;
+}
+
+/**
+ * Everything the model is told for this turn. It holds the user text alongside the rendered
+ * transcript and the system instructions layered on top of it.
+ */
+export interface RunPlanPrompt {
+  text: string;
+  turnText: string;
+  agentsMd?: string;
   systemPrompt?: string;
   appendSystemPrompt?: string;
   hasSystemPrompt: boolean;
-  skillDirs: MaterializedSkill[];
-  /** Removes the per-run skills temp root. The engine runs it in its `finally` so it never leaks. */
-  skillsCleanup: () => void;
-  sourcePiAgentDir: string;
+}
+
+export interface RunPlan {
+  harness: string;
+  acpAgent: string;
+  sandboxId: string;
+  isPi: boolean;
+  isDaytona: boolean;
+  credentials: RunPlanCredentials;
+  workspace: RunPlanWorkspace;
+  tools: RunPlanTools;
+  prompt: RunPlanPrompt;
   /**
    * The declared sandbox security boundary (Layer 2). `buildSandboxProvider` enforces the
    * network policy on Daytona (S1b); `buildRunPlan` rejects restricted-network runs the
@@ -170,13 +209,6 @@ export interface RunPlan {
    * MCP) when `enforcement === "strict"`.
    */
   sandboxPermission?: SandboxPermission;
-  /**
-   * Generic harness-rendered files to materialize in the cwd before the session starts. Each
-   * `{ path (relative to cwd), content }` was produced by the Python harness adapter (e.g. the
-   * claude adapter renders `.claude/settings.json` from its permissions slice). `prepareWorkspace`
-   * writes each entry blind — no harness knowledge on the runner.
-   */
-  harnessFiles?: Array<{ path: string; content: string }>;
 }
 
 export type BuildRunPlanResult =
@@ -670,42 +702,51 @@ export function buildRunPlan(
       sandboxId,
       isPi,
       isDaytona,
-      prompt,
-      turnText: buildTurnText(request, log),
-      agentsMd: request.agentsMd?.trim() || undefined,
-      modelEnvironment,
-      daytonaSecretPlan,
-      harnessApiKeyVar,
-      // Consult the FULL materialized environment: on a Daytona Secrets run the opaque key is
-      // delivered as a Secret attachment rather than plaintext env, but the harness still has it.
-      hasApiKey: !!materializedModel.environment[harnessApiKeyVar],
-      credentialMode: materializedModel.credentialMode,
-      cwd,
-      relayDir,
-      toolMcpDir,
-      // Usage capture is ephemeral runner output, not durable session data — keep it off the
-      // geesefs mount alongside the relay dir (a mount write would risk ENOTCONN).
-      usageOutPath: isPi ? join(relayDir, ".agenta-usage.json") : undefined,
-      toolSpecs,
-      executableToolSpecs: executableToolSpecsForRun,
-      builtinGatingActive,
-      // The relay carries tool EXECUTION only (permission gates ride the extension's
-      // `ctx.ui.confirm` dialog onto the ACP plane), so a builtin-gating-only run needs no relay.
-      useToolRelay: toolSpecs.length > 0,
-      // Pi parks through its own extension (no answer file); the non-Pi shim blocks on an answer
-      // file, so a parked client tool is acknowledged with a benign paused answer.
-      clientToolPauseDisposition: isPi ? "pi-native" : "cold-acknowledge",
-      systemPrompt,
-      appendSystemPrompt,
-      hasSystemPrompt: !!(systemPrompt || appendSystemPrompt),
-      skillDirs,
-      skillsCleanup,
-      sourcePiAgentDir:
-        process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent"),
+      credentials: {
+        modelEnvironment,
+        daytonaSecretPlan,
+        harnessApiKeyVar,
+        // Consult the FULL materialized environment: on a Daytona Secrets run the opaque key is
+        // delivered as a Secret attachment rather than plaintext env, but the harness still has it.
+        hasApiKey: !!materializedModel.environment[harnessApiKeyVar],
+        credentialMode: materializedModel.credentialMode,
+      },
+      workspace: {
+        cwd,
+        relayDir,
+        toolMcpDir,
+        // Usage capture is ephemeral runner output, not durable session data — keep it off the
+        // geesefs mount alongside the relay dir (a mount write would risk ENOTCONN).
+        usageOutPath: isPi ? join(relayDir, ".agenta-usage.json") : undefined,
+        skillDirs,
+        skillsCleanup,
+        sourcePiAgentDir:
+          process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent"),
+        // Generic: the Python harness adapter already rendered any harness config files; the
+        // runner just carries them onto the plan and writes them into the cwd in
+        // `prepareWorkspace`.
+        harnessFiles: request.harnessFiles,
+      },
+      tools: {
+        toolSpecs,
+        executableToolSpecs: executableToolSpecsForRun,
+        builtinGatingActive,
+        // The relay carries tool EXECUTION only (permission gates ride the extension's
+        // `ctx.ui.confirm` dialog onto the ACP plane), so a builtin-gating-only run needs no relay.
+        useToolRelay: toolSpecs.length > 0,
+        // Pi parks through its own extension (no answer file); the non-Pi shim blocks on an answer
+        // file, so a parked client tool is acknowledged with a benign paused answer.
+        clientToolPauseDisposition: isPi ? "pi-native" : "cold-acknowledge",
+      },
+      prompt: {
+        text: prompt,
+        turnText: buildTurnText(request, log),
+        agentsMd: request.agentsMd?.trim() || undefined,
+        systemPrompt,
+        appendSystemPrompt,
+        hasSystemPrompt: !!(systemPrompt || appendSystemPrompt),
+      },
       sandboxPermission: request.sandboxPermission,
-      // Generic: the Python harness adapter already rendered any harness config files; the runner
-      // just carries them onto the plan and writes them into the cwd in `prepareWorkspace`.
-      harnessFiles: request.harnessFiles,
     },
   };
 }

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -86,7 +86,8 @@ import { resolveRunUsage } from "./usage.ts";
  * controller / decisions / responder into `env.currentTurn`, restart the tool relay,
  * send the prompt, resolve usage, and finish + flush the trace. It does NOT tear down the
  * environment (the caller owns `env.destroy`). On a continuation the prompt is only the new user
- * text (`buildTurnText` does not run); on a cold turn it is `plan.prompt.turnText`, exactly as before.
+ * text (`buildTurnText` does not run); on a cold turn it is `plan.prompt.turnText`,
+ * exactly as before.
  */
 export async function runTurn(
   env: SessionEnvironment,
@@ -227,10 +228,10 @@ export async function runTurn(
       : currentUserTurn(request).text;
     // Cold: replay the full transcript. Continuation or loaded: send only new text. When history
     // was rebuilt from records, recompute the transcript from it — the prebuilt
-    // plan.prompt.turnText
-    // predates the reconstruction. An approval reply has no new text either way, so it sends the
-    // approval-resume frame `buildTurnText` renders (the harness already holds the prior turns
-    // when the session was loaded natively; otherwise the rebuilt transcript comes with it).
+    // plan.prompt.turnText predates the reconstruction. An approval reply has no new text
+    // either way, so it sends the approval-resume frame `buildTurnText` renders (the
+    // harness already holds the prior turns when the session was loaded natively;
+    // otherwise the rebuilt transcript comes with it).
     const turnText = sendLastMessageOnly(opts)
       ? approvalReplyOnly
         ? buildTurnText(inboundRequest, logger)
@@ -1044,8 +1045,9 @@ export async function runTurn(
       !plan.isDaytona &&
       !run.output().trim() &&
       !run.events().some((e) => e.type === "tool_call")
-        ? // The helper derives the transcript location from `piSessionWorkspaceDir(plan.workspace.cwd)`,
-          // the same shared helper `configurePiSessionWorkspace` used to point Pi at it.
+        ? // The helper derives the transcript location from
+          // `piSessionWorkspaceDir(plan.workspace.cwd)`, the same shared helper
+          // `configurePiSessionWorkspace` used to point Pi at it.
           findSwallowedPiError(plan.workspace.cwd)
         : undefined;
     let swallowedError: string | undefined;

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -86,7 +86,7 @@ import { resolveRunUsage } from "./usage.ts";
  * controller / decisions / responder into `env.currentTurn`, restart the tool relay,
  * send the prompt, resolve usage, and finish + flush the trace. It does NOT tear down the
  * environment (the caller owns `env.destroy`). On a continuation the prompt is only the new user
- * text (`buildTurnText` does not run); on a cold turn it is `plan.turnText`, exactly as before.
+ * text (`buildTurnText` does not run); on a cold turn it is `plan.prompt.turnText`, exactly as before.
  */
 export async function runTurn(
   env: SessionEnvironment,
@@ -226,7 +226,8 @@ export async function runTurn(
       ? resolvePromptText(request)
       : currentUserTurn(request).text;
     // Cold: replay the full transcript. Continuation or loaded: send only new text. When history
-    // was rebuilt from records, recompute the transcript from it — the prebuilt plan.turnText
+    // was rebuilt from records, recompute the transcript from it — the prebuilt
+    // plan.prompt.turnText
     // predates the reconstruction. An approval reply has no new text either way, so it sends the
     // approval-resume frame `buildTurnText` renders (the harness already holds the prior turns
     // when the session was loaded natively; otherwise the rebuilt transcript comes with it).
@@ -236,12 +237,12 @@ export async function runTurn(
         : promptText
       : reconstructed || historicalAttachmentsPresent
         ? buildTurnText(request, logger)
-        : plan.turnText;
+        : plan.prompt.turnText;
 
     const run = (deps.createOtel ?? createSandboxAgentOtel)({
       harness: plan.harness,
       model: env.model,
-      skills: plan.skillDirs.map((s) => s.name),
+      skills: plan.workspace.skillDirs.map((s) => s.name),
       traceparent: request.context?.propagation?.traceparent,
       baggage: request.context?.propagation?.baggage,
       endpoint: request.telemetry?.exporters?.otlp?.endpoint,
@@ -640,7 +641,7 @@ export async function runTurn(
     const serverPermissions = serverPermissionsFromRequest(request);
     // The SAME name->spec index the relay execute loop hands to the relay execution guard, so
     // the approval card and the guard cannot disagree about a tool's permission/readOnly.
-    const specsByName = toolSpecsByName(plan.toolSpecs);
+    const specsByName = toolSpecsByName(plan.tools.toolSpecs);
     const settleBufferedPausedCompletions = (): void => {
       for (const [toolCallId, update] of [
         ...bufferedPausedCompletedFrames.entries(),
@@ -733,7 +734,7 @@ export async function runTurn(
       // policy). Absent for Claude, so a title collision there keeps the base path.
       piToolSpecsByName: plan.isPi
         ? new Map(
-            plan.toolSpecs.map((spec) => [
+            plan.tools.toolSpecs.map((spec) => [
               spec.name,
               {
                 permission: spec.permission,
@@ -816,15 +817,15 @@ export async function runTurn(
       executionGrants,
     });
 
-    if (plan.useToolRelay) {
+    if (plan.tools.useToolRelay) {
       turn.toolRelay = (deps.startToolRelay ?? startToolRelay)(
         plan.isDaytona
           ? (deps.sandboxRelayHost ?? sandboxRelayHost)(env.sandbox, {
               log: logger,
             })
           : (deps.localRelayHost ?? localRelayHost)(),
-        plan.relayDir,
-        plan.toolSpecs,
+        plan.workspace.relayDir,
+        plan.tools.toolSpecs,
         request.toolCallback as ToolCallbackContext | undefined,
         request.runContext,
         env.clientToolRelayRef.current,
@@ -834,7 +835,7 @@ export async function runTurn(
           // Derived from the run plan's client-tool pause disposition (the closed set lives at
           // the client-tool boundary; the relay only needs the boolean).
           writePausedAnswer: relayWritesPausedAnswer(
-            plan.clientToolPauseDisposition,
+            plan.tools.clientToolPauseDisposition,
           ),
         },
       );
@@ -1031,7 +1032,7 @@ export async function runTurn(
 
     const usage = await resolveRunUsage({
       sandbox: env.sandbox,
-      usageOutPath: plan.usageOutPath,
+      usageOutPath: plan.workspace.usageOutPath,
       isDaytona: plan.isDaytona,
       promptResult: result,
       streamUsage: run.usage(),
@@ -1043,9 +1044,9 @@ export async function runTurn(
       !plan.isDaytona &&
       !run.output().trim() &&
       !run.events().some((e) => e.type === "tool_call")
-        ? // The helper derives the transcript location from `piSessionWorkspaceDir(plan.cwd)`,
+        ? // The helper derives the transcript location from `piSessionWorkspaceDir(plan.workspace.cwd)`,
           // the same shared helper `configurePiSessionWorkspace` used to point Pi at it.
-          findSwallowedPiError(plan.cwd)
+          findSwallowedPiError(plan.workspace.cwd)
         : undefined;
     let swallowedError: string | undefined;
     if (swallowedPiError) {

--- a/services/runner/src/engines/sandbox_agent/workspace.ts
+++ b/services/runner/src/engines/sandbox_agent/workspace.ts
@@ -1,7 +1,12 @@
 import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import type { RunPlan } from "./run-plan.ts";
+import type {
+  RunPlan,
+  RunPlanPrompt,
+  RunPlanTools,
+  RunPlanWorkspace,
+} from "./run-plan.ts";
 import {
   materializeDaytonaPiSkillSnapshot,
   materializeLocalPiSkillSnapshot,
@@ -18,18 +23,14 @@ export interface Workspace {
 export interface PrepareWorkspaceInput {
   sandbox: any;
   piSkillSnapshot?: PiSkillSnapshot;
-  plan: Pick<
-    RunPlan,
-    | "isDaytona"
-    | "isPi"
-    | "cwd"
-    | "relayDir"
-    | "useToolRelay"
-    | "agentsMd"
-    | "acpAgent"
-    | "harnessFiles"
-    | "skillDirs"
-  >;
+  plan: Pick<RunPlan, "isDaytona" | "isPi" | "acpAgent"> & {
+    workspace: Pick<
+      RunPlanWorkspace,
+      "cwd" | "relayDir" | "harnessFiles" | "skillDirs"
+    >;
+    tools: Pick<RunPlanTools, "useToolRelay">;
+    prompt: Pick<RunPlanPrompt, "agentsMd">;
+  };
   log?: Log;
 }
 
@@ -52,7 +53,7 @@ export async function prepareWorkspace({
   piSkillSnapshot,
   log = () => {},
 }: PrepareWorkspaceInput): Promise<Workspace> {
-  const harnessFiles = plan.harnessFiles ?? [];
+  const harnessFiles = plan.workspace.harnessFiles ?? [];
   const projectSkillRoot = plan.isPi ? undefined : `.${plan.acpAgent}/skills`;
   // Claude's memory loader reads CLAUDE.md, never AGENTS.md; Pi (and any other harness) reads
   // AGENTS.md. See the doc comment above and docs/design/agent-workflows/projects/
@@ -61,32 +62,37 @@ export async function prepareWorkspace({
     plan.acpAgent === "claude" ? "CLAUDE.md" : "AGENTS.md";
 
   if (plan.isDaytona) {
-    await sandbox.mkdirFs({ path: plan.cwd }).catch((err: Error) => {
+    await sandbox.mkdirFs({ path: plan.workspace.cwd }).catch((err: Error) => {
       log(`workspace mkdir skipped: ${err.message}`);
     });
-    if (plan.useToolRelay) {
+    if (plan.tools.useToolRelay) {
       // Clear stale .req.json/.res.json from a prior turn before recreating: the relay
       // dir is keyed on the durable cwd and a fresh per-turn `seen` set would otherwise re-execute it.
       if (typeof sandbox.runProcess === "function") {
         // Direct argv, no shell, so an arbitrary path can't break or inject.
         await sandbox
-          .runProcess({ command: "rm", args: ["-rf", "--", plan.relayDir] })
+          .runProcess({
+            command: "rm",
+            args: ["-rf", "--", plan.workspace.relayDir],
+          })
           .catch((err: Error) => {
             log(`tool relay dir clear skipped: ${err.message}`);
           });
       }
-      await sandbox.mkdirFs({ path: plan.relayDir }).catch((err: Error) => {
-        log(`tool relay dir mkdir skipped: ${err.message}`);
-      });
+      await sandbox
+        .mkdirFs({ path: plan.workspace.relayDir })
+        .catch((err: Error) => {
+          log(`tool relay dir mkdir skipped: ${err.message}`);
+        });
     }
-    if (plan.agentsMd) {
+    if (plan.prompt.agentsMd) {
       await sandbox.writeFsFile(
-        { path: `${plan.cwd}/${instructionsFile}` },
-        plan.agentsMd,
+        { path: `${plan.workspace.cwd}/${instructionsFile}` },
+        plan.prompt.agentsMd,
       );
     }
     for (const file of harnessFiles) {
-      const path = `${plan.cwd}/${file.path}`;
+      const path = `${plan.workspace.cwd}/${file.path}`;
       const parent = dirname(path);
       await sandbox.mkdirFs({ path: parent }).catch((err: Error) => {
         log(`harness file dir mkdir skipped: ${err.message}`);
@@ -97,11 +103,11 @@ export async function prepareWorkspace({
       await materializeDaytonaPiSkillSnapshot(sandbox, piSkillSnapshot);
     }
     if (projectSkillRoot) {
-      for (const skill of plan.skillDirs) {
+      for (const skill of plan.workspace.skillDirs) {
         await uploadDirToSandbox(
           sandbox,
           skill.dir,
-          `${plan.cwd}/${projectSkillRoot}/${skill.name}`,
+          `${plan.workspace.cwd}/${projectSkillRoot}/${skill.name}`,
         ).catch((err: Error) => {
           log(
             `skill workspace upload skipped for ${skill.name}: ${err.message}`,
@@ -115,25 +121,29 @@ export async function prepareWorkspace({
   // A durable local cwd mount is best-effort. When geesefs cannot mount (for example, the
   // runner has no /dev/fuse), acquisition deliberately falls back to an ephemeral cwd. Ensure
   // that fallback exists before writing CLAUDE.md/AGENTS.md or any harness files into it.
-  mkdirSync(plan.cwd, { recursive: true });
+  mkdirSync(plan.workspace.cwd, { recursive: true });
 
-  if (plan.useToolRelay) {
+  if (plan.tools.useToolRelay) {
     // Clear stale .req.json from a prior turn: relayDir is keyed on the durable cwd and
     // is never otherwise cleared, so an old request would be re-picked-up by the fresh `seen` set.
-    rmSync(plan.relayDir, { recursive: true, force: true });
-    mkdirSync(plan.relayDir, { recursive: true });
+    rmSync(plan.workspace.relayDir, { recursive: true, force: true });
+    mkdirSync(plan.workspace.relayDir, { recursive: true });
   }
-  if (plan.agentsMd)
-    writeFileSync(join(plan.cwd, instructionsFile), plan.agentsMd, "utf-8");
+  if (plan.prompt.agentsMd)
+    writeFileSync(
+      join(plan.workspace.cwd, instructionsFile),
+      plan.prompt.agentsMd,
+      "utf-8",
+    );
   for (const file of harnessFiles) {
-    const path = join(plan.cwd, file.path);
+    const path = join(plan.workspace.cwd, file.path);
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, file.content, "utf-8");
   }
   if (piSkillSnapshot) materializeLocalPiSkillSnapshot(piSkillSnapshot);
   if (projectSkillRoot) {
-    for (const skill of plan.skillDirs) {
-      const dest = join(plan.cwd, projectSkillRoot, skill.name);
+    for (const skill of plan.workspace.skillDirs) {
+      const dest = join(plan.workspace.cwd, projectSkillRoot, skill.name);
       mkdirSync(dirname(dest), { recursive: true });
       cpSync(skill.dir, dest, { recursive: true, dereference: true });
     }
@@ -141,7 +151,7 @@ export async function prepareWorkspace({
 
   return {
     cleanup: async () => {
-      rmSync(plan.cwd, { recursive: true, force: true });
+      rmSync(plan.workspace.cwd, { recursive: true, force: true });
     },
   };
 }

--- a/services/runner/tests/unit/attachment-delivery-events.test.ts
+++ b/services/runner/tests/unit/attachment-delivery-events.test.ts
@@ -71,7 +71,7 @@ describe("attachment delivery events", () => {
       auth: () => "ApiKey test",
       sandbox: {},
       plan: {
-        cwd,
+        workspace: { cwd },
         isDaytona: false,
         acpAgent: "pi",
         harness: "pi_core",
@@ -151,7 +151,7 @@ describe("attachment delivery events", () => {
       auth: () => "ApiKey test",
       sandbox: {},
       plan: {
-        cwd,
+        workspace: { cwd },
         isDaytona: false,
         acpAgent: "pi",
         harness: "pi_core",
@@ -207,7 +207,7 @@ describe("attachment delivery events", () => {
       auth: () => "ApiKey test",
       sandbox: {},
       plan: {
-        cwd,
+        workspace: { cwd },
         isDaytona: false,
         acpAgent: "pi",
         harness: "pi_core",

--- a/services/runner/tests/unit/attachment-materialize.test.ts
+++ b/services/runner/tests/unit/attachment-materialize.test.ts
@@ -39,7 +39,7 @@ describe("attachment materialization", () => {
     assert.equal(
       await materializeWorkingCopy(
         {},
-        { cwd, isDaytona: false },
+        { workspace: { cwd }, isDaytona: false },
         ref,
         new Uint8Array([1, 2, 3]),
       ),
@@ -56,7 +56,7 @@ describe("attachment materialization", () => {
     const ref = { attachmentId: ID_ONE, filename: "photo.png" };
     await materializeWorkingCopy(
       {},
-      { cwd, isDaytona: false },
+      { workspace: { cwd }, isDaytona: false },
       ref,
       new Uint8Array([1]),
     );
@@ -66,7 +66,7 @@ describe("attachment materialization", () => {
     assert.equal(
       await materializeWorkingCopy(
         {},
-        { cwd, isDaytona: false },
+        { workspace: { cwd }, isDaytona: false },
         ref,
         new Uint8Array([2]),
       ),
@@ -81,13 +81,13 @@ describe("attachment materialization", () => {
     const second = { attachmentId: ID_TWO, filename: "same.txt" };
     await materializeWorkingCopy(
       {},
-      { cwd, isDaytona: false },
+      { workspace: { cwd }, isDaytona: false },
       first,
       new Uint8Array([1]),
     );
     await materializeWorkingCopy(
       {},
-      { cwd, isDaytona: false },
+      { workspace: { cwd }, isDaytona: false },
       second,
       new Uint8Array([2]),
     );
@@ -125,7 +125,7 @@ describe("attachment materialization", () => {
     assert.equal(
       await materializeWorkingCopy(
         sandbox,
-        { cwd, isDaytona: true },
+        { workspace: { cwd }, isDaytona: true },
         ref,
         bytes,
       ),
@@ -159,7 +159,7 @@ describe("attachment materialization", () => {
     await assert.rejects(
       materializeWorkingCopy(
         sandbox,
-        { cwd: "/home/sandbox/cwd", isDaytona: true },
+        { workspace: { cwd: "/home/sandbox/cwd" }, isDaytona: true },
         { attachmentId: ID_ONE, filename: "photo.png" },
         new Uint8Array([1]),
       ),
@@ -180,7 +180,7 @@ describe("attachment materialization", () => {
     const existing = { attachmentId: ids[0], filename: `.png` };
     await materializeWorkingCopy(
       {},
-      { cwd, isDaytona: false },
+      { workspace: { cwd }, isDaytona: false },
       existing,
       new Uint8Array([9]),
     );
@@ -215,7 +215,7 @@ describe("attachment materialization", () => {
 
     const restored = await restoreReferencedWorkingCopies(
       {},
-      { cwd, isDaytona: false },
+      { workspace: { cwd }, isDaytona: false },
       messages,
       "session-1",
       () => "ApiKey test",
@@ -272,7 +272,7 @@ describe("attachment materialization", () => {
 
     const restored = await restoreReferencedWorkingCopies(
       {},
-      { cwd, isDaytona: false },
+      { workspace: { cwd }, isDaytona: false },
       messages,
       "session-1",
       () => "ApiKey test",

--- a/services/runner/tests/unit/attachment-path-safety.test.ts
+++ b/services/runner/tests/unit/attachment-path-safety.test.ts
@@ -77,7 +77,7 @@ describe("attachment path safety", () => {
       () =>
         materializeWorkingCopy(
           {},
-          { cwd, isDaytona: false },
+          { workspace: { cwd }, isDaytona: false },
           { attachmentId: ATTACHMENT_ID, filename: "safe.txt" },
           new Uint8Array([1]),
         ),

--- a/services/runner/tests/unit/daytona-secret-plan.test.ts
+++ b/services/runner/tests/unit/daytona-secret-plan.test.ts
@@ -296,11 +296,11 @@ describe("Daytona Secret planning", () => {
     assert.equal(disabled.ok, true);
     if (!disabled.ok) return;
     assert.equal(
-      disabled.plan.modelEnvironment.ANTHROPIC_API_KEY,
+      disabled.plan.credentials.modelEnvironment.ANTHROPIC_API_KEY,
       "opaque-model-value",
     );
-    assert.equal(disabled.plan.daytonaSecretPlan, undefined);
-    assert.equal(disabled.plan.hasApiKey, true);
+    assert.equal(disabled.plan.credentials.daytonaSecretPlan, undefined);
+    assert.equal(disabled.plan.credentials.hasApiKey, true);
 
     // Flag ON: the opaque value leaves the plaintext environment for the secret plan.
     process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS = "process_local";
@@ -309,12 +309,12 @@ describe("Daytona Secret planning", () => {
     });
     assert.equal(enabled.ok, true);
     if (!enabled.ok) return;
-    assert.deepEqual(enabled.plan.modelEnvironment, {
+    assert.deepEqual(enabled.plan.credentials.modelEnvironment, {
       AWS_REGION: "us-east-1",
     });
     // hasApiKey consults the FULL materialized environment: the opaque key left the plaintext
     // env for the secret plan, but the harness still receives it as a Secret attachment.
-    assert.equal(enabled.plan.hasApiKey, true);
-    assert.equal(enabled.plan.daytonaSecretPlan?.candidates.length, 1);
+    assert.equal(enabled.plan.credentials.hasApiKey, true);
+    assert.equal(enabled.plan.credentials.daytonaSecretPlan?.candidates.length, 1);
   });
 });

--- a/services/runner/tests/unit/pi-builtin-activation.test.ts
+++ b/services/runner/tests/unit/pi-builtin-activation.test.ts
@@ -49,8 +49,8 @@ describe("the deprecated `tools` field does not influence the plan", () => {
   ]) {
     it(`produces the same gating decision for tools=${JSON.stringify(tools)}`, () => {
       const plan = planFor({ permissions, tools } as Partial<AgentRunRequest>);
-      assert.equal(plan.builtinGatingActive, false);
-      assert.equal(plan.useToolRelay, false);
+      assert.equal(plan.tools.builtinGatingActive, false);
+      assert.equal(plan.tools.useToolRelay, false);
     });
   }
 });
@@ -58,7 +58,7 @@ describe("the deprecated `tools` field does not influence the plan", () => {
 describe("builtin gating follows the permission policy alone", () => {
   it("stays off under a blanket allow with no builtin rules", () => {
     assert.equal(
-      planFor({ permissions: { default: "allow", rules: [] } })
+      planFor({ permissions: { default: "allow", rules: [] } }).tools
         .builtinGatingActive,
       false,
     );
@@ -66,7 +66,7 @@ describe("builtin gating follows the permission policy alone", () => {
 
   it("turns on under allow_reads", () => {
     assert.equal(
-      planFor({ permissions: { default: "allow_reads", rules: [] } })
+      planFor({ permissions: { default: "allow_reads", rules: [] } }).tools
         .builtinGatingActive,
       true,
     );
@@ -79,7 +79,7 @@ describe("builtin gating follows the permission policy alone", () => {
           default: "allow",
           rules: [{ pattern: "bash(npm:*)", permission: "deny" }],
         },
-      }).builtinGatingActive,
+      }).tools.builtinGatingActive,
       true,
     );
   });

--- a/services/runner/tests/unit/sandbox-agent-codex-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-codex-assets.test.ts
@@ -43,9 +43,9 @@ describe("Codex managed-credential assets", () => {
     const env: Record<string, string> = {};
     const plan = {
       acpAgent: "codex",
-      credentialMode: "env",
+      credentials: { credentialMode: "env" },
       isDaytona: false,
-      cwd,
+      workspace: { cwd },
       secrets: { OPENAI_API_KEY: "sk-live" },
       legacyHarnessApiKeyVar: "OPENAI_API_KEY",
     } as any;
@@ -75,9 +75,9 @@ describe("Codex managed-credential assets", () => {
     const env: Record<string, string> = {};
     const plan = {
       acpAgent: "claude",
-      credentialMode: "env",
+      credentials: { credentialMode: "env" },
       isDaytona: false,
-      cwd,
+      workspace: { cwd },
       secrets: { OPENAI_API_KEY: "sk-live" },
       legacyHarnessApiKeyVar: "OPENAI_API_KEY",
     } as any;
@@ -95,9 +95,9 @@ describe("Codex managed-credential assets", () => {
     };
     const plan = {
       acpAgent: "codex",
-      credentialMode: "runtime_provided",
+      credentials: { credentialMode: "runtime_provided" },
       isDaytona: false,
-      cwd,
+      workspace: { cwd },
       secrets: { OPENAI_API_KEY: "sk-live" },
       legacyHarnessApiKeyVar: "OPENAI_API_KEY",
     } as any;
@@ -119,9 +119,9 @@ describe("Codex managed-credential assets", () => {
     const env: Record<string, string> = {};
     const plan = {
       acpAgent: "codex",
-      credentialMode: "env",
+      credentials: { credentialMode: "env" },
       isDaytona: false,
-      cwd,
+      workspace: { cwd },
       secrets: { OPENAI_API_KEY: "sk-live" },
       legacyHarnessApiKeyVar: "OPENAI_API_KEY",
     } as any;
@@ -135,9 +135,9 @@ describe("Codex managed-credential assets", () => {
     const env: Record<string, string> = {};
     const plan = {
       acpAgent: "codex",
-      credentialMode: "env",
+      credentials: { credentialMode: "env" },
       isDaytona: true,
-      cwd,
+      workspace: { cwd },
       secrets: { OPENAI_API_KEY: "sk-live" },
       legacyHarnessApiKeyVar: "OPENAI_API_KEY",
     } as any;
@@ -154,9 +154,9 @@ describe("Codex managed-credential assets", () => {
     const env: Record<string, string> = {};
     const plan = {
       acpAgent: "codex",
-      credentialMode: "env",
+      credentials: { credentialMode: "env" },
       isDaytona: false,
-      cwd,
+      workspace: { cwd },
       secrets: { OPENAI_API_KEY: "sk-live" },
       legacyHarnessApiKeyVar: "OPENAI_API_KEY",
     } as any;
@@ -171,35 +171,35 @@ describe("Codex managed-credential assets", () => {
     assert.equal(
       isManagedCodexRun({
         acpAgent: "codex",
-        credentialMode: "env",
+        credentials: { credentialMode: "env" },
       } as any),
       true,
     );
     assert.equal(
       isManagedCodexRun({
         acpAgent: "codex",
-        credentialMode: "none",
+        credentials: { credentialMode: "none" },
       } as any),
       true,
     );
     assert.equal(
       isManagedCodexRun({
         acpAgent: "codex",
-        credentialMode: undefined,
+        credentials: { credentialMode: undefined },
       } as any),
       true,
     );
     assert.equal(
       isManagedCodexRun({
         acpAgent: "codex",
-        credentialMode: "runtime_provided",
+        credentials: { credentialMode: "runtime_provided" },
       } as any),
       false,
     );
     assert.equal(
       isManagedCodexRun({
         acpAgent: "claude",
-        credentialMode: "env",
+        credentials: { credentialMode: "env" },
       } as any),
       false,
     );
@@ -209,21 +209,21 @@ describe("Codex managed-credential assets", () => {
     assert.equal(
       isSubscriptionCodexRun({
         acpAgent: "codex",
-        credentialMode: "runtime_provided",
+        credentials: { credentialMode: "runtime_provided" },
       } as any),
       true,
     );
     assert.equal(
       isSubscriptionCodexRun({
         acpAgent: "codex",
-        credentialMode: "env",
+        credentials: { credentialMode: "env" },
       } as any),
       false,
     );
     assert.equal(
       isSubscriptionCodexRun({
         acpAgent: "claude",
-        credentialMode: "runtime_provided",
+        credentials: { credentialMode: "runtime_provided" },
       } as any),
       false,
     );
@@ -251,9 +251,9 @@ describe("Codex managed-credential assets", () => {
     const subPlan = () =>
       ({
         acpAgent: "codex",
-        credentialMode: "runtime_provided",
+        credentials: { credentialMode: "runtime_provided" },
         isDaytona: false,
-        cwd,
+        workspace: { cwd },
       }) as any;
 
     it("symlinks <cwd>/.codex/auth.json to the mount's auth.json and links nothing else", () => {
@@ -288,18 +288,23 @@ describe("Codex managed-credential assets", () => {
 
     it("is a no-op for a managed run, a Daytona subscription run, and a non-codex run", () => {
       const plans = [
-        { acpAgent: "codex", credentialMode: "env", isDaytona: false, cwd },
         {
           acpAgent: "codex",
-          credentialMode: "runtime_provided",
+          credentials: { credentialMode: "env" },
+          isDaytona: false,
+          workspace: { cwd },
+        },
+        {
+          acpAgent: "codex",
+          credentials: { credentialMode: "runtime_provided" },
           isDaytona: true,
-          cwd,
+          workspace: { cwd },
         },
         {
           acpAgent: "claude",
-          credentialMode: "runtime_provided",
+          credentials: { credentialMode: "runtime_provided" },
           isDaytona: false,
-          cwd,
+          workspace: { cwd },
         },
       ] as any[];
       for (const plan of plans) {
@@ -314,9 +319,9 @@ describe("Codex managed-credential assets", () => {
       const env: Record<string, string> = {};
       const plan = {
         acpAgent: "codex",
-        credentialMode: "env",
+        credentials: { credentialMode: "env" },
         isDaytona: true,
-        cwd,
+        workspace: { cwd },
       } as any;
 
       configureDaytonaCodexEnv(plan, env);
@@ -332,15 +337,30 @@ describe("Codex managed-credential assets", () => {
 
     it("configureDaytonaCodexEnv is a no-op for local, subscription, and non-codex Daytona runs", () => {
       const plans = [
-        { acpAgent: "codex", credentialMode: "env", isDaytona: false, cwd },
         {
           acpAgent: "codex",
-          credentialMode: "runtime_provided",
-          isDaytona: true,
-          cwd,
+          credentials: { credentialMode: "env" },
+          isDaytona: false,
+          workspace: { cwd },
         },
-        { acpAgent: "claude", credentialMode: "env", isDaytona: true, cwd },
-        { acpAgent: "pi", credentialMode: "env", isDaytona: true, cwd },
+        {
+          acpAgent: "codex",
+          credentials: { credentialMode: "runtime_provided" },
+          isDaytona: true,
+          workspace: { cwd },
+        },
+        {
+          acpAgent: "claude",
+          credentials: { credentialMode: "env" },
+          isDaytona: true,
+          workspace: { cwd },
+        },
+        {
+          acpAgent: "pi",
+          credentials: { credentialMode: "env" },
+          isDaytona: true,
+          workspace: { cwd },
+        },
       ] as any[];
       for (const plan of plans) {
         const env: Record<string, string> = {};
@@ -357,9 +377,9 @@ describe("Codex managed-credential assets", () => {
       configureDaytonaCodexEnv(
         {
           acpAgent: "codex",
-          credentialMode: "env",
+          credentials: { credentialMode: "env" },
           isDaytona: true,
-          cwd,
+          workspace: { cwd },
         } as any,
         env,
       );

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -836,7 +836,7 @@ describe("runSandboxAgent orchestration", () => {
     });
     let agentDirSkillCount = -1;
     deps.prepareDaytonaPiAssets = (async ({ plan }: any) => {
-      agentDirSkillCount = plan.skillDirs.length;
+      agentDirSkillCount = plan.workspace.skillDirs.length;
       return true;
     }) as any;
 
@@ -940,7 +940,7 @@ describe("runSandboxAgent orchestration", () => {
       (calls.providerArgs[1] as Record<string, string>).AGENTA_AGENT_MOUNT_DIR,
       undefined,
     );
-    assert.equal(calls.workspacePlan.appendSystemPrompt, undefined);
+    assert.equal(calls.workspacePlan.prompt.appendSystemPrompt, undefined);
     assert.equal(existsSync(`${cwd}-agent`), false);
     rmSync(cwd, { recursive: true, force: true });
   });

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -56,7 +56,7 @@ describe("Pi session workspace", () => {
 
     const env: Record<string, string> = {};
     const sessionDir = configurePiSessionWorkspace(
-      { isPi: true, cwd: "/work/session-1" },
+      { isPi: true, workspace: { cwd: "/work/session-1" } },
       env,
     );
 
@@ -71,7 +71,10 @@ describe("Pi session workspace", () => {
     const env: Record<string, string> = {};
 
     assert.equal(
-      configurePiSessionWorkspace({ isPi: false, cwd: "/work/session-1" }, env),
+      configurePiSessionWorkspace(
+        { isPi: false, workspace: { cwd: "/work/session-1" } },
+        env,
+      ),
       undefined,
     );
     assert.equal(env.PI_CODING_AGENT_SESSION_DIR, undefined);
@@ -543,11 +546,16 @@ describe("prepareLocalPiAssets (managed/none routes through a throwaway dir)", (
   const plainPiPlan = {
     isPi: true,
     isDaytona: false,
-    skillDirs: [],
-    hasSystemPrompt: false,
-    systemPrompt: undefined,
-    appendSystemPrompt: undefined,
-    sourcePiAgentDir: "/unused",
+    credentials: {},
+    workspace: {
+      skillDirs: [],
+      sourcePiAgentDir: "/unused",
+    },
+    prompt: {
+      hasSystemPrompt: false,
+      systemPrompt: undefined,
+      appendSystemPrompt: undefined,
+    },
   };
 
   it("installs the extension into a per-run temp dir it owns, independent of PI_CODING_AGENT_DIR", () => {
@@ -604,7 +612,10 @@ describe("prepareLocalPiAssets (managed/none routes through a throwaway dir)", (
     writeFileSync(join(source, "auth.json"), '{"token":"managed"}', "utf-8");
 
     const { dir: runDir } = prepareLocalPiAssets({
-      plan: { ...plainPiPlan, sourcePiAgentDir: source },
+      plan: {
+        ...plainPiPlan,
+        workspace: { ...plainPiPlan.workspace, sourcePiAgentDir: source },
+      },
       env: {},
     });
     assert.ok(runDir);
@@ -622,7 +633,10 @@ describe("prepareLocalPiAssets (managed/none routes through a throwaway dir)", (
     const env: Record<string, string> = {};
 
     const { dir: runDir, modelConfigWritten } = prepareLocalPiAssets({
-      plan: { ...plainPiPlan, sourcePiAgentDir: source },
+      plan: {
+        ...plainPiPlan,
+        workspace: { ...plainPiPlan.workspace, sourcePiAgentDir: source },
+      },
       env,
       piModelConfig: MODEL_CONFIG_PLAN,
     });
@@ -660,8 +674,10 @@ describe("Pi skill snapshots", () => {
 
     const first = resolvePiSkillSnapshot({
       isPi: true,
-      cwd,
-      skillDirs: [{ name: "release-notes", dir: skill }],
+      workspace: {
+        cwd,
+        skillDirs: [{ name: "release-notes", dir: skill }],
+      },
     });
     assert.ok(first);
     assert.match(first.dir, new RegExp(`${cwd}/agents/skills/[a-f0-9]{64}$`));
@@ -686,8 +702,10 @@ describe("Pi skill snapshots", () => {
     writeFileSync(join(skill, "SKILL.md"), "second", "utf-8");
     const second = resolvePiSkillSnapshot({
       isPi: true,
-      cwd,
-      skillDirs: [{ name: "release-notes", dir: skill }],
+      workspace: {
+        cwd,
+        skillDirs: [{ name: "release-notes", dir: skill }],
+      },
     });
     assert.ok(second);
     assert.notEqual(second.dir, first.dir);
@@ -705,8 +723,10 @@ describe("Pi skill snapshots", () => {
     writeFileSync(join(skill, "SKILL.md"), "skill", "utf-8");
     const snapshot = resolvePiSkillSnapshot({
       isPi: true,
-      cwd,
-      skillDirs: [{ name: "release-notes", dir: skill }],
+      workspace: {
+        cwd,
+        skillDirs: [{ name: "release-notes", dir: skill }],
+      },
     });
     assert.ok(snapshot);
     mkdirSync(snapshot.dir, { recursive: true });
@@ -724,11 +744,17 @@ describe("Pi skill snapshots", () => {
 
   it("does not configure snapshots for non-Pi or empty-skill runs", () => {
     assert.equal(
-      resolvePiSkillSnapshot({ isPi: false, cwd: "/work", skillDirs: [] }),
+      resolvePiSkillSnapshot({
+        isPi: false,
+        workspace: { cwd: "/work", skillDirs: [] },
+      }),
       undefined,
     );
     assert.equal(
-      resolvePiSkillSnapshot({ isPi: true, cwd: "/work", skillDirs: [] }),
+      resolvePiSkillSnapshot({
+        isPi: true,
+        workspace: { cwd: "/work", skillDirs: [] },
+      }),
       undefined,
     );
     const env: Record<string, string> = {};
@@ -746,17 +772,29 @@ describe("Pi skill snapshots", () => {
 describe("prepareLocalPiAssets (runtime_provided runs out of the mount, read-write)", () => {
   const subscriptionPlan = (
     mount: string,
-    over: Record<string, unknown> = {},
+    over: {
+      credentials?: Record<string, unknown>;
+      workspace?: Record<string, unknown>;
+      prompt?: Record<string, unknown>;
+    } = {},
   ) => ({
     isPi: true,
     isDaytona: false,
-    credentialMode: "runtime_provided",
-    skillDirs: [],
-    hasSystemPrompt: false,
-    systemPrompt: undefined,
-    appendSystemPrompt: undefined,
-    sourcePiAgentDir: mount,
-    ...over,
+    credentials: {
+      credentialMode: "runtime_provided",
+      ...over.credentials,
+    },
+    workspace: {
+      skillDirs: [],
+      sourcePiAgentDir: mount,
+      ...over.workspace,
+    },
+    prompt: {
+      hasSystemPrompt: false,
+      systemPrompt: undefined,
+      appendSystemPrompt: undefined,
+      ...over.prompt,
+    },
   });
 
   it("points PI_CODING_AGENT_DIR at the mount itself, not at a per-run copy", () => {
@@ -783,9 +821,8 @@ describe("prepareLocalPiAssets (runtime_provided runs out of the mount, read-wri
 
     const { dir: runDir } = prepareLocalPiAssets({
       plan: subscriptionPlan(mount, {
-        skillDirs: [],
-        hasSystemPrompt: true,
-        appendSystemPrompt: "extra",
+        workspace: { skillDirs: [] },
+        prompt: { hasSystemPrompt: true, appendSystemPrompt: "extra" },
       }) as never,
       env: {},
     });
@@ -802,9 +839,8 @@ describe("prepareLocalPiAssets (runtime_provided runs out of the mount, read-wri
 
     const { dir: runDir } = prepareLocalPiAssets({
       plan: subscriptionPlan(source, {
-        credentialMode: "env",
-        hasSystemPrompt: true,
-        appendSystemPrompt: "extra",
+        credentials: { credentialMode: "env" },
+        prompt: { hasSystemPrompt: true, appendSystemPrompt: "extra" },
       }) as never,
       env,
     });
@@ -854,8 +890,10 @@ describe("sandbox uploads", () => {
     writeFileSync(join(skill, "SKILL.md"), "skill", "utf-8");
     const snapshot = resolvePiSkillSnapshot({
       isPi: true,
-      cwd: "/workspace",
-      skillDirs: [{ name: "release-notes", dir: skill }],
+      workspace: {
+        cwd: "/workspace",
+        skillDirs: [{ name: "release-notes", dir: skill }],
+      },
     });
     assert.ok(snapshot);
 

--- a/services/runner/tests/unit/sandbox-agent-qa-transcript-replay.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-qa-transcript-replay.test.ts
@@ -156,15 +156,15 @@ describe("runSandboxAgent replays real captured QA transcripts", () => {
     // The plan is where F-001 actually broke (`pi-assets.ts` never received the override): assert
     // directly on it, not on a downstream side effect that a fake session cannot reproduce.
     assert.equal(
-      calls.workspacePlan.appendSystemPrompt,
+      calls.workspacePlan.prompt.appendSystemPrompt,
       request.appendSystemPrompt,
       "buildRunPlan must carry the recorded append_system override through to the plan",
     );
-    assert.equal(calls.workspacePlan.hasSystemPrompt, true);
+    assert.equal(calls.workspacePlan.prompt.hasSystemPrompt, true);
     // The session receives the plan's turnText (the orchestration's framing of the request),
     // not necessarily just the last message -- assert against it so multi-message captures hold.
     assert.deepEqual(calls.promptBlocks, [
-      { type: "text", text: calls.workspacePlan.turnText },
+      { type: "text", text: calls.workspacePlan.prompt.turnText },
     ]);
   });
 
@@ -186,7 +186,7 @@ describe("runSandboxAgent replays real captured QA transcripts", () => {
       // `pi_agenta` drive the same "pi" ACP agent (see `run-plan.ts`'s `acpAgent` derivation).
       assert.equal(calls.createSessionOptions.agent, "pi");
       assert.deepEqual(calls.promptBlocks, [
-        { type: "text", text: calls.workspacePlan.turnText },
+        { type: "text", text: calls.workspacePlan.prompt.turnText },
       ]);
       // The recorded request's deprecated `tools` field is accepted and ignored: built-ins are
       // activated unconditionally, so replanning without it must reach the same gating decision.
@@ -197,8 +197,8 @@ describe("runSandboxAgent replays real captured QA transcripts", () => {
       assert.equal(withoutTools.ok, true);
       if (withoutTools.ok) {
         assert.equal(
-          withoutTools.plan.builtinGatingActive,
-          calls.workspacePlan.builtinGatingActive,
+          withoutTools.plan.tools.builtinGatingActive,
+          calls.workspacePlan.tools.builtinGatingActive,
         );
       }
     },

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -78,7 +78,7 @@ describe("buildRunPlan", () => {
     );
 
     assert.equal(result.ok, true);
-    assert.equal(result.ok && result.plan.prompt, "");
+    assert.equal(result.ok && result.plan.prompt.text, "");
   });
 
   it("accepts both legacy image-only current user turn shapes", () => {
@@ -94,7 +94,7 @@ describe("buildRunPlan", () => {
       );
 
       assert.equal(result.ok, true);
-      assert.equal(result.ok && result.plan.prompt, "");
+      assert.equal(result.ok && result.plan.prompt.text, "");
     }
   });
 
@@ -215,9 +215,9 @@ describe("buildRunPlan", () => {
     );
 
     assert.equal(result.ok, true);
-    assert.equal(result.ok && result.plan.prompt, "");
+    assert.equal(result.ok && result.plan.prompt.text, "");
     assert.ok(
-      result.ok && result.plan.turnText.includes("user APPROVED Write"),
+      result.ok && result.plan.prompt.turnText.includes("user APPROVED Write"),
       "the plan's turn text carries the approval-resume frame",
     );
   });
@@ -355,33 +355,33 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.harness, "pi_agenta");
     assert.equal(result.plan.acpAgent, "pi");
     assert.equal(result.plan.sandboxId, "local");
-    assert.equal(result.plan.cwd, "/tmp/local-cwd");
+    assert.equal(result.plan.workspace.cwd, "/tmp/local-cwd");
     // The relay dir + usage capture are ephemeral runner files kept OFF the (possibly geesefs)
     // cwd: an ephemeral sibling whose leaf is the cwd basename.
-    assert.ok(!result.plan.relayDir.startsWith(result.plan.cwd));
-    assert.ok(result.plan.relayDir.endsWith("/agenta/relay/local-cwd"));
+    assert.ok(!result.plan.workspace.relayDir.startsWith(result.plan.workspace.cwd));
+    assert.ok(result.plan.workspace.relayDir.endsWith("/agenta/relay/local-cwd"));
     assert.equal(
-      result.plan.usageOutPath,
-      `${result.plan.relayDir}/.agenta-usage.json`,
+      result.plan.workspace.usageOutPath,
+      `${result.plan.workspace.relayDir}/.agenta-usage.json`,
     );
-    assert.equal(result.plan.prompt, " ship it ");
-    assert.equal(result.plan.agentsMd, "instructions");
-    assert.equal(result.plan.systemPrompt, "system");
-    assert.equal(result.plan.appendSystemPrompt, "append");
-    assert.equal(result.plan.hasSystemPrompt, true);
-    assert.equal(result.plan.hasApiKey, true);
-    assert.deepEqual(result.plan.modelEnvironment, { OPENAI_API_KEY: "key" });
-    assert.equal(result.plan.sourcePiAgentDir, "/tmp/pi-agent");
+    assert.equal(result.plan.prompt.text, " ship it ");
+    assert.equal(result.plan.prompt.agentsMd, "instructions");
+    assert.equal(result.plan.prompt.systemPrompt, "system");
+    assert.equal(result.plan.prompt.appendSystemPrompt, "append");
+    assert.equal(result.plan.prompt.hasSystemPrompt, true);
+    assert.equal(result.plan.credentials.hasApiKey, true);
+    assert.deepEqual(result.plan.credentials.modelEnvironment, { OPENAI_API_KEY: "key" });
+    assert.equal(result.plan.workspace.sourcePiAgentDir, "/tmp/pi-agent");
     assert.deepEqual(
-      result.plan.executableToolSpecs.map((tool) => tool.name),
+      result.plan.tools.executableToolSpecs.map((tool) => tool.name),
       ["server_tool"],
     );
     assert.deepEqual(
-      result.plan.toolSpecs.map((tool) => tool.name),
+      result.plan.tools.toolSpecs.map((tool) => tool.name),
       ["server_tool", "client_tool"],
     );
-    assert.equal(result.plan.useToolRelay, true);
-    assert.deepEqual(result.plan.skillDirs, [
+    assert.equal(result.plan.tools.useToolRelay, true);
+    assert.deepEqual(result.plan.workspace.skillDirs, [
       { name: "alpha", dir: "/skills/alpha" },
     ]);
     assert.deepEqual(logs, ["resolved alpha", "skills: alpha"]);
@@ -396,8 +396,8 @@ describe("buildRunPlan", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.deepEqual(result.plan.executableToolSpecs, []);
-    assert.equal(result.plan.useToolRelay, true);
+    assert.deepEqual(result.plan.tools.executableToolSpecs, []);
+    assert.equal(result.plan.tools.useToolRelay, true);
   });
 
   it("leaves builtin gating off under a blanket allow with no builtin rules", () => {
@@ -412,9 +412,9 @@ describe("buildRunPlan", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.builtinGatingActive, false);
+    assert.equal(result.plan.tools.builtinGatingActive, false);
     // Builtin gating rides the ACP dialog plane, not the relay: no custom tools, no relay.
-    assert.equal(result.plan.useToolRelay, false);
+    assert.equal(result.plan.tools.useToolRelay, false);
   });
 
   it("turns builtin gating on under the default allow_reads mode", () => {
@@ -431,7 +431,7 @@ describe("buildRunPlan", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.builtinGatingActive, true);
+    assert.equal(result.plan.tools.builtinGatingActive, true);
   });
 
   it("turns builtin gating on when the permission kill switch is set", () => {
@@ -448,8 +448,8 @@ describe("buildRunPlan", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.builtinGatingActive, true);
-    assert.equal(result.plan.useToolRelay, false);
+    assert.equal(result.plan.tools.builtinGatingActive, true);
+    assert.equal(result.plan.tools.useToolRelay, false);
   });
 
   it("turns builtin gating on when an all-allow policy has a builtin rule", () => {
@@ -467,7 +467,7 @@ describe("buildRunPlan", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.builtinGatingActive, true);
+    assert.equal(result.plan.tools.builtinGatingActive, true);
   });
 
   it("carries the sandbox permission onto the plan and leaves an unrestricted run alone", () => {
@@ -757,16 +757,16 @@ describe("buildRunPlan", () => {
       assert.equal(result.ok, true);
       if (!result.ok) return;
       assert.equal(
-        result.plan.toolMcpDir,
+        result.plan.workspace.toolMcpDir,
         "/home/sandbox/agenta/tool-mcp/agenta-fixed",
       );
-      assert.notEqual(result.plan.toolMcpDir, result.plan.relayDir);
+      assert.notEqual(result.plan.workspace.toolMcpDir, result.plan.workspace.relayDir);
       assert.ok(
-        !result.plan.toolMcpDir.startsWith(`${result.plan.relayDir}/`),
+        !result.plan.workspace.toolMcpDir.startsWith(`${result.plan.workspace.relayDir}/`),
         "the shim dir is never nested inside the relay dir (the relay loop sweeps it)",
       );
       assert.equal(
-        result.plan.useToolRelay,
+        result.plan.tools.useToolRelay,
         true,
         "the relay loop still starts (it executes the shim's requests)",
       );
@@ -887,14 +887,14 @@ describe("buildRunPlan", () => {
       assert.equal(result.ok, true);
       if (!result.ok) return;
       assert.deepEqual(
-        result.plan.toolSpecs.map((tool) => tool.name),
+        result.plan.tools.toolSpecs.map((tool) => tool.name),
         ["server_tool", "request_connection"],
       );
       assert.deepEqual(
-        result.plan.executableToolSpecs.map((tool) => tool.name),
+        result.plan.tools.executableToolSpecs.map((tool) => tool.name),
         ["server_tool"],
       );
-      assert.equal(result.plan.clientToolPauseDisposition, "cold-acknowledge");
+      assert.equal(result.plan.tools.clientToolPauseDisposition, "cold-acknowledge");
     });
 
     it("allows claude x daytona x client-ONLY tools (the shim advertises them and the relay parks)", () => {
@@ -917,17 +917,17 @@ describe("buildRunPlan", () => {
       assert.equal(result.ok, true);
       if (!result.ok) return;
       assert.deepEqual(
-        result.plan.toolSpecs.map((tool) => tool.name),
+        result.plan.tools.toolSpecs.map((tool) => tool.name),
         ["request_connection"],
       );
       // No executable tool remains, but the run is no longer refused.
-      assert.deepEqual(result.plan.executableToolSpecs, []);
+      assert.deepEqual(result.plan.tools.executableToolSpecs, []);
       assert.equal(
-        result.plan.clientToolPauseDisposition,
+        result.plan.tools.clientToolPauseDisposition,
         "cold-acknowledge",
         "non-Pi shim path acknowledges a parked client tool with a paused answer",
       );
-      assert.equal(result.plan.useToolRelay, true);
+      assert.equal(result.plan.tools.useToolRelay, true);
     });
 
     it("allows pi x daytona x client-only tools (Pi's extension + file relay deliver them)", () => {
@@ -944,7 +944,7 @@ describe("buildRunPlan", () => {
       assert.equal(result.ok, true);
       if (!result.ok) return;
       // Pi parks through its own extension, so its disposition is "pi-native" (no paused answer).
-      assert.equal(result.plan.clientToolPauseDisposition, "pi-native");
+      assert.equal(result.plan.tools.clientToolPauseDisposition, "pi-native");
     });
 
     it("still refuses claude x daytona x executable tools under strict restricted network", () => {
@@ -1115,7 +1115,7 @@ describe("buildRunPlan", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.deepEqual(result.plan.skillDirs, [
+    assert.deepEqual(result.plan.workspace.skillDirs, [
       { name: "alpha", dir: "/skills/alpha" },
       { name: "beta", dir: "/skills/beta" },
     ]);
@@ -1176,19 +1176,19 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.acpAgent, "claude");
     assert.equal(result.plan.isPi, false);
     assert.equal(result.plan.isDaytona, true);
-    assert.equal(result.plan.cwd, "/home/sandbox/agenta-fixed");
-    assert.equal(result.plan.usageOutPath, undefined);
-    assert.equal(result.plan.harnessApiKeyVar, "ANTHROPIC_API_KEY");
+    assert.equal(result.plan.workspace.cwd, "/home/sandbox/agenta-fixed");
+    assert.equal(result.plan.workspace.usageOutPath, undefined);
+    assert.equal(result.plan.credentials.harnessApiKeyVar, "ANTHROPIC_API_KEY");
     // The FULL materialized environment sets hasApiKey: on a Daytona Secrets run the opaque key
     // leaves the plaintext env for the secret plan, but the harness still receives its binding.
-    assert.equal(result.plan.hasApiKey, true);
-    assert.equal(result.plan.modelEnvironment.ANTHROPIC_API_KEY, undefined);
-    assert.equal(result.plan.daytonaSecretPlan?.candidates.length, 1);
+    assert.equal(result.plan.credentials.hasApiKey, true);
+    assert.equal(result.plan.credentials.modelEnvironment.ANTHROPIC_API_KEY, undefined);
+    assert.equal(result.plan.credentials.daytonaSecretPlan?.candidates.length, 1);
     // The resolved credentialMode is carried onto the plan (drives clear-then-apply).
-    assert.equal(result.plan.credentialMode, "env");
-    assert.equal(result.plan.systemPrompt, undefined);
-    assert.equal(result.plan.hasSystemPrompt, false);
-    assert.deepEqual(result.plan.skillDirs, []);
+    assert.equal(result.plan.credentials.credentialMode, "env");
+    assert.equal(result.plan.prompt.systemPrompt, undefined);
+    assert.equal(result.plan.prompt.hasSystemPrompt, false);
+    assert.deepEqual(result.plan.workspace.skillDirs, []);
   });
 
   it("keeps a zero-candidate secret plan when the flag is on, and none when it is off", () => {
@@ -1224,15 +1224,15 @@ describe("buildRunPlan", () => {
     const flagOn = buildRunPlan(localUseRequest, deps);
     assert.equal(flagOn.ok, true);
     if (!flagOn.ok) return;
-    assert.ok(flagOn.plan.daytonaSecretPlan, "flag on keeps the empty plan");
-    assert.equal(flagOn.plan.daytonaSecretPlan.candidates.length, 0);
+    assert.ok(flagOn.plan.credentials.daytonaSecretPlan, "flag on keeps the empty plan");
+    assert.equal(flagOn.plan.credentials.daytonaSecretPlan.candidates.length, 0);
     // local_use values still reach sandbox create as plaintext env (by design).
     assert.equal(
-      flagOn.plan.modelEnvironment.AWS_ACCESS_KEY_ID,
+      flagOn.plan.credentials.modelEnvironment.AWS_ACCESS_KEY_ID,
       "AKIA-local-use",
     );
     assert.equal(
-      flagOn.plan.modelEnvironment.AWS_SECRET_ACCESS_KEY,
+      flagOn.plan.credentials.modelEnvironment.AWS_SECRET_ACCESS_KEY,
       "aws-secret-local-use",
     );
 
@@ -1241,9 +1241,9 @@ describe("buildRunPlan", () => {
     const flagOff = buildRunPlan(localUseRequest, deps);
     assert.equal(flagOff.ok, true);
     if (!flagOff.ok) return;
-    assert.equal(flagOff.plan.daytonaSecretPlan, undefined);
+    assert.equal(flagOff.plan.credentials.daytonaSecretPlan, undefined);
     assert.equal(
-      flagOff.plan.modelEnvironment.AWS_ACCESS_KEY_ID,
+      flagOff.plan.credentials.modelEnvironment.AWS_ACCESS_KEY_ID,
       "AKIA-local-use",
     );
   });
@@ -1278,9 +1278,9 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.acpAgent, "codex");
     assert.equal(result.plan.isPi, false);
     assert.equal(result.plan.isDaytona, false);
-    assert.equal(result.plan.harnessApiKeyVar, "OPENAI_API_KEY");
-    assert.equal(result.plan.hasApiKey, true);
-    assert.equal(result.plan.credentialMode, "env");
+    assert.equal(result.plan.credentials.harnessApiKeyVar, "OPENAI_API_KEY");
+    assert.equal(result.plan.credentials.hasApiKey, true);
+    assert.equal(result.plan.credentials.credentialMode, "env");
   });
 });
 
@@ -1305,10 +1305,10 @@ describe("buildRunPlan durableCwd (prefix-derived cwd)", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.cwd, "/tmp/agenta/mounts/proj-1/mount-abc");
+    assert.equal(result.plan.workspace.cwd, "/tmp/agenta/mounts/proj-1/mount-abc");
     // Relay dir is an ephemeral sibling (leaf = cwd basename), NOT inside the durable mount.
-    assert.ok(!result.plan.relayDir.startsWith(result.plan.cwd));
-    assert.ok(result.plan.relayDir.endsWith("/agenta/relay/mount-abc"));
+    assert.ok(!result.plan.workspace.relayDir.startsWith(result.plan.workspace.cwd));
+    assert.ok(result.plan.workspace.relayDir.endsWith("/agenta/relay/mount-abc"));
     // createLocalCwd received the durableCwd value.
     assert.deepEqual(localCwdCalls, ["/tmp/agenta/mounts/proj-1/mount-abc"]);
   });
@@ -1333,7 +1333,7 @@ describe("buildRunPlan durableCwd (prefix-derived cwd)", () => {
     assert.equal(result.ok, true);
     if (!result.ok) return;
     assert.equal(
-      result.plan.cwd,
+      result.plan.workspace.cwd,
       "/home/sandbox/agenta/mounts/proj-1/mount-abc",
     );
     assert.deepEqual(daytonaCwdCalls, [
@@ -1360,7 +1360,7 @@ describe("buildRunPlan durableCwd (prefix-derived cwd)", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.cwd, "/tmp/agenta-sandbox-agent-ephemeral");
+    assert.equal(result.plan.workspace.cwd, "/tmp/agenta-sandbox-agent-ephemeral");
     assert.deepEqual(localCwdCalls, [undefined]);
   });
 
@@ -1389,8 +1389,8 @@ describe("buildRunPlan durableCwd (prefix-derived cwd)", () => {
     assert.equal(r2.ok, true);
     if (!r1.ok || !r2.ok) return;
     // Same prefix -> same cwd across turns.
-    assert.equal(r1.plan.cwd, r2.plan.cwd);
-    assert.equal(r1.plan.cwd, localPath);
+    assert.equal(r1.plan.workspace.cwd, r2.plan.workspace.cwd);
+    assert.equal(r1.plan.workspace.cwd, localPath);
   });
 });
 
@@ -1478,7 +1478,7 @@ describe("buildRunPlan runtime_provided (subscription) gates", () => {
 
       assert.equal(result.ok, true);
       if (!result.ok) return;
-      assert.equal(result.plan.credentialMode, "runtime_provided");
+      assert.equal(result.plan.credentials.credentialMode, "runtime_provided");
       assert.equal(result.plan.acpAgent, "codex");
     });
   });
@@ -1564,8 +1564,8 @@ describe("buildRunPlan runtime_provided (subscription) gates", () => {
       });
       assert.equal(result.ok, true);
       if (!result.ok) return;
-      assert.equal(result.plan.credentialMode, "runtime_provided");
-      assert.equal(result.plan.sourcePiAgentDir, "/agenta/harness/pi");
+      assert.equal(result.plan.credentials.credentialMode, "runtime_provided");
+      assert.equal(result.plan.workspace.sourcePiAgentDir, "/agenta/harness/pi");
     });
   });
 
@@ -1704,7 +1704,7 @@ describe("modelConnection validation", () => {
     } as AgentRunRequest);
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.deepEqual(result.plan.modelEnvironment, {
+    assert.deepEqual(result.plan.credentials.modelEnvironment, {
       AWS_REGION: "us-east-1",
       AWS_ACCESS_KEY_ID: "AKIA",
     });
@@ -1732,7 +1732,7 @@ describe("modelConnection validation", () => {
     assert.equal(result.ok, true);
     if (!result.ok) return;
     assert.equal(
-      result.plan.modelEnvironment.GOOGLE_APPLICATION_CREDENTIALS,
+      result.plan.credentials.modelEnvironment.GOOGLE_APPLICATION_CREDENTIALS,
       "/tmp/adc.json",
     );
   });

--- a/services/runner/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-workspace.test.ts
@@ -42,13 +42,19 @@ describe("prepareWorkspace", () => {
       sandbox: {},
       plan: {
         isDaytona: false,
-        cwd,
-        relayDir: join(cwd, ".agenta-tools"),
-        useToolRelay: false,
-        agentsMd: "agent instructions",
         acpAgent: "claude",
         isPi: false,
-        skillDirs: [],
+        workspace: {
+          cwd,
+          relayDir: join(cwd, ".agenta-tools"),
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -68,13 +74,19 @@ describe("prepareWorkspace", () => {
       sandbox: {},
       plan: {
         isDaytona: false,
-        cwd,
-        relayDir: join(cwd, ".agenta-tools"),
-        useToolRelay: true,
-        agentsMd: "agent instructions",
         acpAgent: "pi",
         isPi: true,
-        skillDirs: [],
+        workspace: {
+          cwd,
+          relayDir: join(cwd, ".agenta-tools"),
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: true,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -102,13 +114,19 @@ describe("prepareWorkspace", () => {
       sandbox: {},
       plan: {
         isDaytona: false,
-        cwd,
-        relayDir,
-        useToolRelay: true,
-        agentsMd: "agent instructions",
         acpAgent: "pi",
         isPi: true,
-        skillDirs: [],
+        workspace: {
+          cwd,
+          relayDir,
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: true,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -138,13 +156,19 @@ describe("prepareWorkspace", () => {
       sandbox,
       plan: {
         isDaytona: true,
-        cwd: "/home/sandbox/agenta-fixed",
-        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
-        useToolRelay: true,
-        agentsMd: "agent instructions",
         acpAgent: "pi",
         isPi: true,
-        skillDirs: [],
+        workspace: {
+          cwd: "/home/sandbox/agenta-fixed",
+          relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: true,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -178,13 +202,19 @@ describe("prepareWorkspace", () => {
       sandbox: {},
       plan: {
         isDaytona: false,
-        cwd,
-        relayDir: join(cwd, ".agenta-tools"),
-        useToolRelay: false,
-        agentsMd: "agent instructions",
         acpAgent: "claude",
         isPi: false,
-        skillDirs: [],
+        workspace: {
+          cwd,
+          relayDir: join(cwd, ".agenta-tools"),
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -218,14 +248,20 @@ describe("prepareWorkspace", () => {
       sandbox: {},
       plan: {
         isDaytona: false,
-        cwd,
-        relayDir: join(cwd, ".agenta-tools"),
-        useToolRelay: false,
-        agentsMd: "agent instructions",
         acpAgent: "claude",
         isPi: false,
-        harnessFiles: [{ path: ".claude/settings.json", content }],
-        skillDirs: [],
+        workspace: {
+          cwd,
+          relayDir: join(cwd, ".agenta-tools"),
+          harnessFiles: [{ path: ".claude/settings.json", content }],
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -244,13 +280,19 @@ describe("prepareWorkspace", () => {
       sandbox: {},
       plan: {
         isDaytona: false,
-        cwd,
-        relayDir: join(cwd, ".agenta-tools"),
-        useToolRelay: false,
-        agentsMd: "agent instructions",
         acpAgent: "claude",
         isPi: false,
-        skillDirs: [],
+        workspace: {
+          cwd,
+          relayDir: join(cwd, ".agenta-tools"),
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -271,13 +313,19 @@ describe("prepareWorkspace", () => {
       sandbox,
       plan: {
         isDaytona: true,
-        cwd: "/home/sandbox/agenta-fixed",
-        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
-        useToolRelay: true,
-        agentsMd: "agent instructions",
         acpAgent: "pi",
         isPi: true,
-        skillDirs: [],
+        workspace: {
+          cwd: "/home/sandbox/agenta-fixed",
+          relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: true,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
     await workspace.cleanup();
@@ -307,13 +355,19 @@ describe("prepareWorkspace", () => {
       sandbox,
       plan: {
         isDaytona: true,
-        cwd: "/home/sandbox/agenta-fixed",
-        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
-        useToolRelay: false,
-        agentsMd: "agent instructions",
         acpAgent: "claude",
         isPi: false,
-        skillDirs: [],
+        workspace: {
+          cwd: "/home/sandbox/agenta-fixed",
+          relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -352,14 +406,20 @@ describe("prepareWorkspace", () => {
       sandbox,
       plan: {
         isDaytona: true,
-        cwd: "/home/sandbox/agenta-fixed",
-        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
-        useToolRelay: false,
-        agentsMd: "agent instructions",
         acpAgent: "claude",
         isPi: false,
-        harnessFiles: [{ path: ".claude/settings.json", content }],
-        skillDirs: [],
+        workspace: {
+          cwd: "/home/sandbox/agenta-fixed",
+          relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          harnessFiles: [{ path: ".claude/settings.json", content }],
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -393,13 +453,19 @@ describe("prepareWorkspace", () => {
       sandbox,
       plan: {
         isDaytona: true,
-        cwd: "/home/sandbox/agenta-fixed",
-        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
-        useToolRelay: false,
-        agentsMd: "agent instructions",
         acpAgent: "pi",
         isPi: true,
-        skillDirs: [],
+        workspace: {
+          cwd: "/home/sandbox/agenta-fixed",
+          relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {
+          agentsMd: "agent instructions",
+        },
       },
     });
 
@@ -419,12 +485,17 @@ describe("prepareWorkspace", () => {
       sandbox: {},
       plan: {
         isDaytona: false,
-        cwd,
-        relayDir: join(cwd, ".agenta-tools"),
-        useToolRelay: false,
         acpAgent: "claude",
         isPi: false,
-        skillDirs: [{ name: "release-notes", dir: skillDir }],
+        workspace: {
+          cwd,
+          relayDir: join(cwd, ".agenta-tools"),
+          skillDirs: [{ name: "release-notes", dir: skillDir }],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {},
       },
     });
 
@@ -453,12 +524,17 @@ describe("prepareWorkspace", () => {
       sandbox,
       plan: {
         isDaytona: true,
-        cwd: "/home/sandbox/agenta-fixed",
-        relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
-        useToolRelay: false,
         acpAgent: "claude",
         isPi: false,
-        skillDirs: [{ name: "release-notes", dir: skillDir }],
+        workspace: {
+          cwd: "/home/sandbox/agenta-fixed",
+          relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          skillDirs: [{ name: "release-notes", dir: skillDir }],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {},
       },
     });
 


### PR DESCRIPTION
## Context

`RunPlan` had grown to thirty fields on one flat interface, and every consumer took the whole thing regardless of how little of it they read. Raised in review of #5670: https://github.com/Agenta-AI/agenta/pull/5670#discussion_r3702960993

This PR is stacked on `feat/daytona-secrets-v2` (#5670) and its base is that branch, so the diff here is only the refactor.

## Changes

The fields are grouped by concern into `credentials`, `workspace`, `tools`, and `prompt`, each exported as its own interface. Five identity fields stay at the top level because almost every consumer branches on them, and `sandboxPermission` stays there too since the declared security boundary is its own concern.

```
RunPlan {
  harness, acpAgent, sandboxId, isPi, isDaytona
  credentials: { modelEnvironment, daytonaSecretPlan?, harnessApiKeyVar, hasApiKey, credentialMode? }
  workspace:   { cwd, relayDir, toolMcpDir, usageOutPath?, skillDirs, skillsCleanup,
                 sourcePiAgentDir, harnessFiles? }
  tools:       { toolSpecs, executableToolSpecs, builtinGatingActive, useToolRelay,
                 clientToolPauseDisposition }
  prompt:      { text, turnText, agentsMd?, systemPrompt?, appendSystemPrompt?, hasSystemPrompt }
  sandboxPermission?
}
```

The real payoff is that consumers can now say what they touch. `prepareWorkspace` used to declare a nine-key `Pick` of the flat plan:

Before:
```ts
plan: Pick<RunPlan, "isDaytona" | "isPi" | "cwd" | "relayDir" | "useToolRelay"
                  | "agentsMd" | "acpAgent" | "harnessFiles" | "skillDirs">
```

After:
```ts
plan: Pick<RunPlan, "isDaytona" | "isPi" | "acpAgent"> & {
  workspace: Pick<RunPlanWorkspace, "cwd" | "relayDir" | "harnessFiles" | "skillDirs">
  tools: Pick<RunPlanTools, "useToolRelay">
  prompt: Pick<RunPlanPrompt, "agentsMd">
}
```

The parameter type now reads as a description of the function rather than an alphabet soup of field names. `pi-assets.ts`, `codex-assets.ts`, `attachments.ts`, and `daytona.ts` narrowed the same way. That means a future change to credential delivery has a compiler-checked list of what depends on it, which is the thing the flat bag made impossible.

The one rename is `plan.prompt` to `plan.prompt.text`, forced by the group taking the name.

## Tests / notes

- Runner `tsc --noEmit` is clean and the unit suite reports 99 files / 1535 tests, the same counts as before the change.
- No logic, ordering, condition, or default changed. No `any` cast, `@ts-ignore`, or `@ts-expect-error` was added; verified by grepping the diff.
- Test updates are purely the same field moves. No test was weakened or deleted.
- Review suggestion: read `run-plan.ts` first for the new shape, then skim the rest as mechanical. The interesting files are the ones where a signature narrowed, since that is where the change earns its keep.

This is a pure refactor, so there is nothing to QA manually. If the runner suite is green and the type checker is clean, behavior is unchanged.
