### PR TITLE
[feat] Make browser tabs describe the active page

### DIFF
--- a/docs/design/browser-page-titles/README.md
+++ b/docs/design/browser-page-titles/README.md
@@ -1,0 +1,19 @@
+# Browser page titles
+
+This workspace plans a frontend-only change that makes the browser tab describe the page or chat session a user is viewing.
+
+## Reading order
+
+1. [context.md](context.md) explains the user-visible behavior and scope.
+2. [research.md](research.md) records the relevant frontend ownership and routing facts.
+3. [plan.md](plan.md) defines the implementation slice and its acceptance checks.
+4. [status.md](status.md) is the current source of truth for progress and blockers.
+
+## Terms
+
+- **Page title**: the text shown in the browser tab and written through `next/head`.
+- **Project page**: a page scoped to a project but not to one agent.
+- **Agent page**: a page scoped to one workflow artifact. The artifact provides the agent's display name.
+- **Empty session**: an agent chat session before the user sends its first message.
+- **Session title**: the persisted title derived from the first user message, capped at 60 characters by the existing chat state.
+

--- a/docs/design/browser-page-titles/context.md
+++ b/docs/design/browser-page-titles/context.md
@@ -1,0 +1,50 @@
+# Context
+
+## Current user experience
+
+Agenta currently presents a static marketing title in the browser tab. The title does not tell users which product page, agent, or chat session they are viewing. This makes multiple open Agenta tabs difficult to distinguish.
+
+## Required behavior
+
+The browser title follows these rules:
+
+| Context | Title |
+| --- | --- |
+| Home | `Home | Agenta` |
+| Empty agent chat | `<Agent name> | Agenta` |
+| Agent chat after the session starts | `<Session title, at most 60 characters> | Agenta` |
+| Project observability | `Observability | Agenta` |
+| Agent observability | `Observability | <Agent name>` |
+| Settings | `Settings | Agenta` |
+
+For example, an empty chat uses `Marketing Coworker | Agenta`. After the first message creates a session title, the same tab uses that persisted title and truncates it to 60 characters when needed.
+
+## Reviewed follow-up inventory
+
+The route inventory also found secondary page families that should eventually receive semantic titles:
+
+- Archive and detail pages: use the visible page concept, such as `Archived Agents | Agenta` or `Evaluation results | Agenta`.
+- Authentication and workspace pages: use the visible action or page, such as `Sign in | Agenta`, `Workspaces | Agenta`, or `Accept invitation | Agenta`.
+
+Those secondary routes are not part of this minor slice. They retain the safe global fallback and should be handled in a follow-up that can define and test their route-specific semantics. This slice covers the requested states plus primary navigation:
+
+- Project pages: `Home`, `Prompts`, `Agents`, `Test sets`, `Evaluators`, `Evaluation runs`, `Annotation Queues`, `Observability`, and `Settings`, each followed by `| Agenta`.
+- Agent pages: `Overview`, `Registry`, `Evaluations`, and `Observability`, each followed by `| <Agent name>`.
+- Agent chat and non-agent workflow playground titles.
+
+Drawers, inspectors, filters, settings tabs, and other query-parameter-only states keep the title of their containing page.
+
+## Goals
+
+- Make open browser tabs distinguishable without adding data requests or new state.
+- Keep semantic title ownership with the page or feature that owns the displayed state.
+- Update the agent chat title when the active session changes, receives its first message, or is renamed.
+- Preserve a safe `Agenta` fallback during loading and on unknown routes.
+
+## Non-goals
+
+- Changing route structure, navigation labels, agent naming, or session naming.
+- Adding titles for drawers or temporary overlays.
+- Adding titles for authentication, workspace selection, archives, or deep detail pages.
+- Changing backend APIs, stored data, or analytics.
+

--- a/docs/design/browser-page-titles/plan.md
+++ b/docs/design/browser-page-titles/plan.md
@@ -1,0 +1,41 @@
+# Implementation plan
+
+## Shippable slice: semantic browser titles
+
+Implement the complete frontend title policy as one reviewable slice. This is one coherent behavior and does not change an API or stored contract.
+
+### Implementation
+
+1. Add a shared `PageTitle` component and pure formatter that use `next/head`, normalize title parts, truncate session titles to 60 characters, and fall back to `Agenta`.
+2. Keep one synchronous global title as the loading and unknown-route fallback; asynchronous cloud scripts must not write a competing title.
+3. Add page-owned titles for Home, Settings, and the primary project navigation pages.
+4. Add primary agent-feature titles that use the current workflow artifact display name.
+5. In the agent playground, use the artifact name for an empty session and the active persisted session title after chat starts.
+6. In observability, render `Observability | Agenta` for project scope and `Observability | <Agent name>` for agent scope.
+7. Do not attach title changes to drawers, inspectors, filters, or settings tab query parameters.
+8. Leave authentication, workspace, archive, and deep-detail routes on the safe fallback for a separately reviewed follow-up.
+
+### Automated acceptance checks
+
+- Unit tests cover formatting, missing values, whitespace, the separator, exact 60-character input, and truncation beyond 60 characters.
+- Unit tests cover agent-chat title precedence for an empty session, durable session title, first-user-message fallback, active-session input changes, and long titles.
+- A targeted live browser check covers Home, Settings, project observability, an empty agent chat, the first user message, and agent observability.
+- Existing frontend tests, type checks, and lint pass.
+
+### Live acceptance checks
+
+Against the local EE development deployment, confirm:
+
+1. Home shows `Home | Agenta`, including first-run onboarding.
+2. A new empty agent chat shows `<Agent name> | Agenta`.
+3. Sending the first message changes the title to the persisted session title followed by `| Agenta` and limits the session part to 60 characters.
+4. Switching or renaming a session updates the title without a reload.
+5. Project observability shows `Observability | Agenta`.
+6. Agent observability shows `Observability | <Agent name>`.
+7. Settings shows `Settings | Agenta`, and changing its tab does not change the title.
+8. Opening and closing an observability inspector or drawer does not change the containing page title.
+
+### Loop limit
+
+Run at most three implementation, test, or live-debug rounds. Each round must make measurable progress. If the same blocker remains after three rounds, record the exact reproduction in `status.md` and ask for direction.
+

--- a/docs/design/browser-page-titles/research.md
+++ b/docs/design/browser-page-titles/research.md
@@ -1,0 +1,36 @@
+# Research
+
+## Existing title ownership
+
+- The OSS application writes a static marketing title in `web/oss/src/components/Scripts/GlobalScripts.tsx`.
+- EE reuses the same synchronous `GlobalScripts` fallback; the asynchronous `CloudScripts` component must not write a competing title.
+- The implementation must keep one safe fallback while allowing page-level `next/head` titles to override it.
+
+## Routing and rendering facts
+
+- Home normally uses the `/apps` route.
+- First-run onboarding can render Home through `/playground`, so pathname alone cannot identify Home correctly.
+- Project observability and agent traces reuse the observability feature. The feature must choose project or agent context from the state already available to it.
+- Settings uses one route with a tab query parameter. Changing tabs must not change the browser title.
+
+## Dynamic chat facts
+
+- Agent chat sessions are scoped and expose an active session.
+- `web/oss/src/components/AgentChatSlice/state/sessions.ts` persists a session title from the first user message and caps it at 60 characters.
+- The agent display name belongs to the workflow artifact, not to a revision.
+- The playground already has the artifact and active session state needed for the title. No additional fetch is required.
+
+## Design decision
+
+Use a small declarative `PageTitle` component and formatter built on `next/head`. Each page-level feature supplies its semantic title. The agent playground owns the choice between the artifact name for an empty session and the active session title after chat starts. The observability feature owns the choice between project and agent context.
+
+This avoids a global pathname switch that would duplicate route knowledge and miss render-state exceptions such as onboarding. The formatter owns whitespace normalization, the `|` separator, the `Agenta` fallback, and the 60-character limit. Feature code owns meaning.
+
+## Risks and safeguards
+
+- Multiple `<title>` elements could compete. Use the existing Next.js head mechanism consistently and retain only one global fallback.
+- Loading state could expose an ID. Keep `Agenta` until a semantic name is available.
+- A stale chat title could survive a session switch. Derive it reactively from the active scoped session.
+- Agent rename could leave the title stale. Read the artifact name from reactive workflow state.
+- Route-only logic could label onboarding as Playground. Let the rendered Home feature supply `Home`.
+

--- a/docs/design/browser-page-titles/status.md
+++ b/docs/design/browser-page-titles/status.md
@@ -1,0 +1,30 @@
+# Status
+
+## Current state
+
+- Date: 2026-08-03
+- State: validated and ready for PR
+- Shippable slice: requested browser titles plus primary navigation
+- Blockers: none
+
+## Completed
+
+- Added a shared formatter and declarative `PageTitle` component with a synchronous global fallback.
+- Added page-owned titles for Home, Settings, primary project navigation, primary agent navigation, playground, and both observability scopes.
+- Added reactive agent-chat titles for empty sessions, first messages, active-session switches, and renames.
+- Kept agent names on the current workflow artifact and added no new backend request.
+- Completed an independent review and resolved its title-precedence, scope, slug-fallback, Unicode, and reactivity-test findings.
+- Passed 12 focused unit tests, OSS and EE TypeScript checks, repository lint-fix, and `git diff --check`.
+- Verified six requested states against the live EE development deployment: Home, project Observability, Settings, empty agent chat, first-message transition, and agent Observability.
+
+## Next action
+
+Create the isolated GitButler lane, commit the reviewed files, push, and open the PR.
+
+## Decisions
+
+- Use 60 Unicode code points as the session-title limit and reserve the last position for an ellipsis.
+- Use the workflow artifact name, then slug, and never expose an ID in the title.
+- Add no new fetches or backend changes.
+- Keep drawers and query-parameter-only UI under the containing page title.
+- Leave authentication, workspace, archive, and deep-detail titles for a separately reviewed follow-up.

--- a/web/ee/src/components/Scripts/assets/CloudScripts.tsx
+++ b/web/ee/src/components/Scripts/assets/CloudScripts.tsx
@@ -1,7 +1,6 @@
 import {useEffect} from "react"
 
 import {ChatboxColors, Crisp} from "crisp-sdk-web"
-import Head from "next/head"
 import Script from "next/script"
 
 import {ThemeMode, useAppTheme} from "@/oss/components/Layout/ThemeContextProvider"
@@ -43,16 +42,10 @@ const CloudScripts = () => {
     }, [appTheme])
 
     return (
-        <>
-            <Head>
-                <title>Agenta – the open-source workspace for building and running agents</title>
-                <link rel="shortcut icon" href="/assets/favicon.ico" />
-            </Head>
-            <Script
-                src="https://app.termly.io/embed.min.js/8e05e2f3-b396-45dd-bb76-4dfa5ce28e10?autoBlock=on"
-                strategy="afterInteractive"
-            />
-        </>
+        <Script
+            src="https://app.termly.io/embed.min.js/8e05e2f3-b396-45dd-bb76-4dfa5ce28e10?autoBlock=on"
+            strategy="afterInteractive"
+        />
     )
 }
 

--- a/web/ee/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/evaluations/index.tsx
+++ b/web/ee/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/evaluations/index.tsx
@@ -1,11 +1,17 @@
 import {memo} from "react"
 
 import EvaluationsView from "@/oss/components/pages/evaluations/EvaluationsView"
+import WorkflowPageTitle from "@/oss/components/PageTitle/WorkflowPageTitle"
 import {useAppId} from "@/oss/hooks/useAppId"
 
 const AppEvaluationsPage = () => {
     const appId = useAppId()
-    return <EvaluationsView scope="app" appId={appId} />
+    return (
+        <>
+            <WorkflowPageTitle title="Evaluations" />
+            <EvaluationsView scope="app" appId={appId} />
+        </>
+    )
 }
 
 export default memo(AppEvaluationsPage)

--- a/web/ee/src/pages/w/[workspace_id]/p/[project_id]/evaluations/index.tsx
+++ b/web/ee/src/pages/w/[workspace_id]/p/[project_id]/evaluations/index.tsx
@@ -1,7 +1,13 @@
 import EvaluationsView from "@/oss/components/pages/evaluations/EvaluationsView"
+import PageTitle from "@/oss/components/PageTitle"
 
 const ProjectEvaluationsPage = () => {
-    return <EvaluationsView scope="project" />
+    return (
+        <>
+            <PageTitle title="Evaluation runs" />
+            <EvaluationsView scope="project" />
+        </>
+    )
 }
 
 export default ProjectEvaluationsPage

--- a/web/oss/src/components/AgentChatSlice/assets/pageTitle.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/pageTitle.test.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it} from "vitest"
+
+import {selectAgentChatTitlePart} from "./pageTitle"
+
+describe("selectAgentChatTitlePart", () => {
+    it("uses the agent name for an empty session", () => {
+        expect(selectAgentChatTitlePart({agentName: "Marketing Coworker"})).toBe(
+            "Marketing Coworker",
+        )
+    })
+
+    it("uses the durable session title after chat starts", () => {
+        expect(
+            selectAgentChatTitlePart({
+                agentName: "Marketing Coworker",
+                sessionTitle: "Draft the launch plan",
+                firstUserMessage: "Ignored fallback",
+            }),
+        ).toBe("Draft the launch plan")
+    })
+
+    it("falls back to the first user message before the title persists", () => {
+        expect(
+            selectAgentChatTitlePart({
+                agentName: "Marketing Coworker",
+                firstUserMessage: "Draft the launch plan",
+            }),
+        ).toBe("Draft the launch plan")
+    })
+
+    it("caps a long session title", () => {
+        expect(selectAgentChatTitlePart({sessionTitle: "a".repeat(61)})).toBe(`${"a".repeat(59)}…`)
+    })
+
+    it("reflects the currently selected session input", () => {
+        expect(selectAgentChatTitlePart({sessionTitle: "Second session"})).toBe("Second session")
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/pageTitle.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/pageTitle.ts
@@ -1,0 +1,21 @@
+import {
+    SESSION_TITLE_MAX_LENGTH,
+    normalizeTitlePart,
+    truncateTitlePart,
+} from "@/oss/components/PageTitle/utils"
+
+interface AgentChatTitleInput {
+    agentName?: string | null
+    sessionTitle?: string | null
+    firstUserMessage?: string | null
+}
+
+export const selectAgentChatTitlePart = ({
+    agentName,
+    sessionTitle,
+    firstUserMessage,
+}: AgentChatTitleInput): string => {
+    const startedTitle = normalizeTitlePart(sessionTitle) || normalizeTitlePart(firstUserMessage)
+    if (startedTitle) return truncateTitlePart(startedTitle, SESSION_TITLE_MAX_LENGTH)
+    return normalizeTitlePart(agentName)
+}

--- a/web/oss/src/components/AgentChatSlice/state/sessions.pageTitle.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.pageTitle.test.ts
@@ -1,0 +1,27 @@
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {
+    activeSessionTitleAtomFamily,
+    adoptSessionAtomFamily,
+    renameSessionAtomFamily,
+    setActiveSessionAtomFamily,
+} from "./sessions"
+
+describe("activeSessionTitleAtomFamily", () => {
+    it("reacts to active-session switches and renames", () => {
+        const scope = `page-title-${Date.now()}`
+        const store = createStore()
+
+        store.set(adoptSessionAtomFamily(scope), {id: "one", title: "First"})
+        store.set(adoptSessionAtomFamily(scope), {id: "two", title: "Second"})
+
+        expect(store.get(activeSessionTitleAtomFamily(scope)).title).toBe("Second")
+
+        store.set(setActiveSessionAtomFamily(scope), "one")
+        expect(store.get(activeSessionTitleAtomFamily(scope)).title).toBe("First")
+
+        store.set(renameSessionAtomFamily(scope), {id: "one", title: "Renamed"})
+        expect(store.get(activeSessionTitleAtomFamily(scope)).title).toBe("Renamed")
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -613,7 +613,8 @@ export const autoTitleSessionAtomFamily = atomFamily((key: string) =>
         const all = get(sessionsByAppAtom)
         const session = (all[key] ?? []).find((s) => s.id === id)
         if (!session || session.title?.trim()) return
-        const title = trimmed.slice(0, AUTO_TITLE_MAX_CHARS)
+        // Cut on code points, not UTF-16 units, so an emoji straddling the cap isn't halved.
+        const title = Array.from(trimmed).slice(0, AUTO_TITLE_MAX_CHARS).join("")
         set(sessionsByAppAtom, {
             ...all,
             [key]: (all[key] ?? []).map((s) => (s.id === id ? {...s, title} : s)),

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -829,6 +829,22 @@ export const sessionFirstUserTextAtomFamily = atomFamily((id: string) =>
     selectAtom(sessionMessagesAtom, (all) => firstUserText(all[id])),
 )
 
+/** Active tab title without subscribing to streamed assistant content. */
+export const activeSessionTitleAtomFamily = atomFamily((key: string) =>
+    atom((get) => {
+        const sessions = get(sessionsListAtomFamily(key))
+        const rawActiveId = get(activeSessionIdAtomFamily(key))
+        const activeSession =
+            sessions.find((session) => session.id === rawActiveId) ?? sessions[0] ?? null
+        if (!activeSession) return {title: "", firstUserMessage: ""}
+
+        return {
+            title: activeSession.title?.trim() ?? "",
+            firstUserMessage: get(sessionFirstUserTextAtomFamily(activeSession.id)),
+        }
+    }),
+)
+
 /**
  * Run state of a session's live conversation — the single source of truth for "what is this
  * session doing right now", surfaced as the tab bar's status dot AND the session inspector's

--- a/web/oss/src/components/PageTitle/WorkflowPageTitle.tsx
+++ b/web/oss/src/components/PageTitle/WorkflowPageTitle.tsx
@@ -1,0 +1,14 @@
+import {useAtomValue} from "jotai"
+
+import {currentWorkflowContextAtom} from "@/oss/state/workflow"
+
+import PageTitle from "."
+
+const WorkflowPageTitle = ({title}: {title: string}) => {
+    const workflow = useAtomValue(currentWorkflowContextAtom).workflow
+    const workflowName = workflow?.name || workflow?.slug
+
+    return <PageTitle title={title} context={workflowName} />
+}
+
+export default WorkflowPageTitle

--- a/web/oss/src/components/PageTitle/index.tsx
+++ b/web/oss/src/components/PageTitle/index.tsx
@@ -1,0 +1,16 @@
+import Head from "next/head"
+
+import {formatPageTitle} from "./utils"
+
+interface PageTitleProps {
+    title?: string | null
+    context?: string | null
+}
+
+const PageTitle = ({title, context}: PageTitleProps) => (
+    <Head>
+        <title>{formatPageTitle(title, context)}</title>
+    </Head>
+)
+
+export default PageTitle

--- a/web/oss/src/components/PageTitle/utils.test.ts
+++ b/web/oss/src/components/PageTitle/utils.test.ts
@@ -36,8 +36,13 @@ describe("truncateTitlePart", () => {
         expect(title).toHaveLength(SESSION_TITLE_MAX_LENGTH)
     })
 
-    it("does not split an emoji at the truncation boundary", () => {
+    it("does not split a surrogate pair at the truncation boundary", () => {
         const title = truncateTitlePart(`${"a".repeat(59)}🙂b`, SESSION_TITLE_MAX_LENGTH)
         expect(title).toBe(`${"a".repeat(59)}…`)
+    })
+
+    it("drops a trailing lone surrogate left by an upstream UTF-16 cut", () => {
+        const halvedUpstream = `${"a".repeat(59)}🙂 hello`.slice(0, SESSION_TITLE_MAX_LENGTH)
+        expect(truncateTitlePart(halvedUpstream, SESSION_TITLE_MAX_LENGTH)).toBe("a".repeat(59))
     })
 })

--- a/web/oss/src/components/PageTitle/utils.test.ts
+++ b/web/oss/src/components/PageTitle/utils.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from "vitest"
+
+import {
+    DEFAULT_PAGE_TITLE,
+    SESSION_TITLE_MAX_LENGTH,
+    formatPageTitle,
+    truncateTitlePart,
+} from "./utils"
+
+describe("formatPageTitle", () => {
+    it("falls back when no semantic title is available", () => {
+        expect(formatPageTitle()).toBe(DEFAULT_PAGE_TITLE)
+        expect(formatPageTitle("   ")).toBe(DEFAULT_PAGE_TITLE)
+    })
+
+    it("normalizes parts and adds one separator", () => {
+        expect(formatPageTitle("  Evaluation   runs ", " Marketing   Coworker ")).toBe(
+            "Evaluation runs | Marketing Coworker",
+        )
+    })
+
+    it("uses Agenta when the context is missing", () => {
+        expect(formatPageTitle("Settings")).toBe("Settings | Agenta")
+    })
+})
+
+describe("truncateTitlePart", () => {
+    it("keeps an exact 60-character title", () => {
+        const title = "a".repeat(SESSION_TITLE_MAX_LENGTH)
+        expect(truncateTitlePart(title, SESSION_TITLE_MAX_LENGTH)).toBe(title)
+    })
+
+    it("caps a longer title at 60 characters with an ellipsis", () => {
+        const title = truncateTitlePart("a".repeat(61), SESSION_TITLE_MAX_LENGTH)
+        expect(title).toBe(`${"a".repeat(59)}…`)
+        expect(title).toHaveLength(SESSION_TITLE_MAX_LENGTH)
+    })
+
+    it("does not split an emoji at the truncation boundary", () => {
+        const title = truncateTitlePart(`${"a".repeat(59)}🙂b`, SESSION_TITLE_MAX_LENGTH)
+        expect(title).toBe(`${"a".repeat(59)}…`)
+    })
+})

--- a/web/oss/src/components/PageTitle/utils.ts
+++ b/web/oss/src/components/PageTitle/utils.ts
@@ -1,0 +1,22 @@
+export const DEFAULT_PAGE_TITLE = "Agenta"
+export const SESSION_TITLE_MAX_LENGTH = 60
+
+export const normalizeTitlePart = (value?: string | null): string =>
+    value?.replace(/\s+/g, " ").trim() ?? ""
+
+export const truncateTitlePart = (value: string, maxLength: number): string => {
+    const normalized = normalizeTitlePart(value)
+    const characters = Array.from(normalized)
+    if (characters.length <= maxLength) return normalized
+    return `${characters
+        .slice(0, Math.max(0, maxLength - 1))
+        .join("")
+        .trimEnd()}…`
+}
+
+export const formatPageTitle = (title?: string | null, context?: string | null): string => {
+    const normalizedTitle = normalizeTitlePart(title)
+    if (!normalizedTitle) return DEFAULT_PAGE_TITLE
+
+    return `${normalizedTitle} | ${normalizeTitlePart(context) || DEFAULT_PAGE_TITLE}`
+}

--- a/web/oss/src/components/PageTitle/utils.ts
+++ b/web/oss/src/components/PageTitle/utils.ts
@@ -5,7 +5,9 @@ export const normalizeTitlePart = (value?: string | null): string =>
     value?.replace(/\s+/g, " ").trim() ?? ""
 
 export const truncateTitlePart = (value: string, maxLength: number): string => {
-    const normalized = normalizeTitlePart(value)
+    // Server-persisted titles may arrive cut on a UTF-16 boundary; a trailing high surrogate
+    // has no pair left and renders as a replacement character.
+    const normalized = normalizeTitlePart(value).replace(/[\uD800-\uDBFF]$/, "")
     const characters = Array.from(normalized)
     if (characters.length <= maxLength) return normalized
     return `${characters

--- a/web/oss/src/components/Playground/Playground.tsx
+++ b/web/oss/src/components/Playground/Playground.tsx
@@ -30,6 +30,7 @@ import PlaygroundMainView from "./Components/MainLayout"
 import PlaygroundHeader from "./Components/PlaygroundHeader"
 import {OSSPlaygroundShell} from "./OSSPlaygroundShell"
 import PlaygroundOnboarding from "./PlaygroundOnboarding"
+import PlaygroundPageTitle from "./PlaygroundPageTitle"
 
 // Agent-chat surface (third generation arm). The host is a LIGHT static import that lazy-loads
 // the AI-SDK panel internally and crossfades it in through a persistent skeleton overlay —
@@ -132,6 +133,7 @@ const Playground: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
 
     const content = (
         <OSSPlaygroundShell providers={providers}>
+            <PlaygroundPageTitle onboarding={onboarding} />
             <div className="flex flex-col w-full h-[calc(100dvh-46px)] overflow-hidden">
                 {prefetchAgentCatalogs ? <AgentCatalogPrefetcher /> : null}
                 <PlaygroundOnboarding />

--- a/web/oss/src/components/Playground/PlaygroundPageTitle.tsx
+++ b/web/oss/src/components/Playground/PlaygroundPageTitle.tsx
@@ -1,0 +1,38 @@
+import {useMemo} from "react"
+
+import {useAtomValue} from "jotai"
+
+import {selectAgentChatTitlePart} from "@/oss/components/AgentChatSlice/assets/pageTitle"
+import {useChatScopeKey} from "@/oss/components/AgentChatSlice/state/scope"
+import {activeSessionTitleAtomFamily} from "@/oss/components/AgentChatSlice/state/sessions"
+import PageTitle from "@/oss/components/PageTitle"
+import {currentWorkflowContextAtom, playgroundEarlyAgentStateAtom} from "@/oss/state/workflow"
+
+const PlaygroundPageTitle = ({onboarding}: {onboarding: boolean}) => {
+    const scope = useChatScopeKey()
+    const workflowContext = useAtomValue(currentWorkflowContextAtom)
+    const workflowName = workflowContext.workflow?.name || workflowContext.workflow?.slug
+    const earlyAgentState = useAtomValue(playgroundEarlyAgentStateAtom)
+    const activeSessionTitle = useAtomValue(
+        useMemo(() => activeSessionTitleAtomFamily(scope), [scope]),
+    )
+
+    if (onboarding) return <PageTitle title="Home" />
+    if (!workflowName) return <PageTitle />
+
+    if (earlyAgentState === "agent") {
+        return (
+            <PageTitle
+                title={selectAgentChatTitlePart({
+                    agentName: workflowName,
+                    sessionTitle: activeSessionTitle.title,
+                    firstUserMessage: activeSessionTitle.firstUserMessage,
+                })}
+            />
+        )
+    }
+
+    return <PageTitle title="Playground" context={workflowName} />
+}
+
+export default PlaygroundPageTitle

--- a/web/oss/src/components/PlaygroundRouter/index.tsx
+++ b/web/oss/src/components/PlaygroundRouter/index.tsx
@@ -6,6 +6,7 @@ import {useRouter} from "next/router"
 
 import {PLAYGROUND_NATIVE_ONBOARDING} from "@/oss/components/pages/agent-home/assets/constants"
 import OnboardingLoader from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingLoader"
+import PageTitle from "@/oss/components/PageTitle"
 import {currentWorkflowContextAtom} from "@/oss/state/workflow"
 import {prewarmCurrentWorkflowQueries} from "@/oss/state/workflow/prewarmCurrentWorkflow"
 
@@ -63,10 +64,13 @@ const PlaygroundRouter = () => {
         // (mint-once `startedRef` + `realEntityId`) and never re-mints, falling through to the generic
         // empty playground instead of a fresh onboarding for the new project.
         return (
-            <OnboardingPlayground
-                key={`onboarding-${String(router.query.project_id ?? "")}`}
-                onboarding
-            />
+            <>
+                <PageTitle title="Home" />
+                <OnboardingPlayground
+                    key={`onboarding-${String(router.query.project_id ?? "")}`}
+                    onboarding
+                />
+            </>
         )
     }
 

--- a/web/oss/src/components/Scripts/GlobalScripts.tsx
+++ b/web/oss/src/components/Scripts/GlobalScripts.tsx
@@ -8,15 +8,14 @@ const CloudScripts = dynamic(() => import("@/oss/components/Scripts/assets/Cloud
 })
 
 const GlobalScripts = () => {
-    if (isDemo()) {
-        return <CloudScripts />
-    }
-
     return (
-        <Head>
-            <title>Agenta – the open-source workspace for building and running agents</title>
-            <link rel="shortcut icon" href="/assets/favicon.ico" />
-        </Head>
+        <>
+            <Head>
+                <title>Agenta – the open-source workspace for building and running agents</title>
+                <link rel="shortcut icon" href="/assets/favicon.ico" />
+            </Head>
+            {isDemo() ? <CloudScripts /> : null}
+        </>
     )
 }
 

--- a/web/oss/src/components/pages/observability/index.tsx
+++ b/web/oss/src/components/pages/observability/index.tsx
@@ -5,6 +5,8 @@ import {Chats, TreeStructure} from "@phosphor-icons/react"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
+import PageTitle from "@/oss/components/PageTitle"
+import WorkflowPageTitle from "@/oss/components/PageTitle/WorkflowPageTitle"
 import {
     onboardingWidgetActivationAtom,
     recordWidgetEventAtom,
@@ -88,23 +90,30 @@ const ObservabilityTabs = () => {
     }, [isCurrentWorkflowEvaluator])
 
     return (
-        <PageLayout
-            title={"Observability"}
-            className="h-full overflow-hidden"
-            headerTabsProps={{
-                items: tabItems,
-                activeKey: activeTab,
-                onChange: (key) => setTabParam(key),
-            }}
-        >
-            <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-                {activeTab === "traces" ? <ObservabilityTable /> : <SessionsTable />}
-            </div>
-            <SetupTracingModal
-                open={isSetupTracingModalOpen}
-                onCancel={() => setIsSetupTracingModalOpen(false)}
-            />
-        </PageLayout>
+        <>
+            {workflowCtx.workflowId ? (
+                <WorkflowPageTitle title="Observability" />
+            ) : (
+                <PageTitle title="Observability" />
+            )}
+            <PageLayout
+                title={"Observability"}
+                className="h-full overflow-hidden"
+                headerTabsProps={{
+                    items: tabItems,
+                    activeKey: activeTab,
+                    onChange: (key) => setTabParam(key),
+                }}
+            >
+                <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+                    {activeTab === "traces" ? <ObservabilityTable /> : <SessionsTable />}
+                </div>
+                <SetupTracingModal
+                    open={isSetupTracingModalOpen}
+                    onCancel={() => setIsSetupTracingModalOpen(false)}
+                />
+            </PageLayout>
+        </>
     )
 }
 

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/agents/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/agents/index.tsx
@@ -1,1 +1,11 @@
-export {default} from "@/oss/components/pages/agents/AgentsPage"
+import AgentsPage from "@/oss/components/pages/agents/AgentsPage"
+import PageTitle from "@/oss/components/PageTitle"
+
+const Agents = () => (
+    <>
+        <PageTitle title="Agents" />
+        <AgentsPage />
+    </>
+)
+
+export default Agents

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/annotations/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/annotations/index.tsx
@@ -7,6 +7,7 @@ import {useSetAtom} from "jotai"
 import {useRouter} from "next/router"
 
 import {openHumanEvaluatorDrawerAtom} from "@/oss/components/Evaluators/Drawers/HumanEvaluatorDrawer/store"
+import PageTitle from "@/oss/components/PageTitle"
 import {useProjectPermissions} from "@/oss/hooks/useProjectPermissions"
 import useURL from "@/oss/hooks/useURL"
 
@@ -30,18 +31,21 @@ const AnnotationQueuesPage = () => {
     )
 
     return (
-        <AnnotationUIProvider navigation={navigation}>
-            <PageLayout
-                title={<span className="inline-flex items-center gap-2">Queues</span>}
-                className="h-full min-h-0"
-            >
-                <AnnotationQueuesView
-                    canExportData={canExportData}
-                    feedbackOnCreate={() => openHumanEvaluatorDrawer({mode: "create"})}
-                    feedbackCreateLabel="Create evaluator"
-                />
-            </PageLayout>
-        </AnnotationUIProvider>
+        <>
+            <PageTitle title="Annotation Queues" />
+            <AnnotationUIProvider navigation={navigation}>
+                <PageLayout
+                    title={<span className="inline-flex items-center gap-2">Queues</span>}
+                    className="h-full min-h-0"
+                >
+                    <AnnotationQueuesView
+                        canExportData={canExportData}
+                        feedbackOnCreate={() => openHumanEvaluatorDrawer({mode: "create"})}
+                        feedbackCreateLabel="Create evaluator"
+                    />
+                </PageLayout>
+            </AnnotationUIProvider>
+        </>
     )
 }
 

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/evaluations/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/evaluations/index.tsx
@@ -1,13 +1,17 @@
 import EvaluationsView from "@/oss/components/pages/evaluations/EvaluationsView"
+import WorkflowPageTitle from "@/oss/components/PageTitle/WorkflowPageTitle"
 import RequireWorkflowKind from "@/oss/components/RequireWorkflowKind"
 import {useAppId} from "@/oss/hooks/useAppId"
 
 const AppEvaluationsPage = () => {
     const appId = useAppId()
     return (
-        <RequireWorkflowKind allowed={["app", "evaluator"]} currentRoute="evaluations">
-            <EvaluationsView scope="app" appId={appId} />
-        </RequireWorkflowKind>
+        <>
+            <WorkflowPageTitle title="Evaluations" />
+            <RequireWorkflowKind allowed={["app", "evaluator"]} currentRoute="evaluations">
+                <EvaluationsView scope="app" appId={appId} />
+            </RequireWorkflowKind>
+        </>
     )
 }
 

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
@@ -12,6 +12,7 @@ import {openDeleteAppModalAtom} from "@/oss/components/pages/app-management/moda
 import {openEditAppModalAtom} from "@/oss/components/pages/app-management/modals/EditAppModal/store/editAppModalStore"
 import DeploymentOverview from "@/oss/components/pages/overview/deployments/DeploymentOverview"
 import VariantsOverview from "@/oss/components/pages/overview/variants/VariantsOverview"
+import WorkflowPageTitle from "@/oss/components/PageTitle/WorkflowPageTitle"
 import RequireWorkflowKind from "@/oss/components/RequireWorkflowKind"
 import {useAppId} from "@/oss/hooks/useAppId"
 import {copyToClipboard} from "@/oss/lib/helpers/copyToClipboard"
@@ -147,6 +148,7 @@ const OverviewContent = () => {
 
     return (
         <>
+            <WorkflowPageTitle title="Overview" />
             <PageLayout className="gap-8">
                 <AppDetailsSection />
                 <ObservabilityOverview />

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/variants/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/variants/index.tsx
@@ -1,7 +1,13 @@
+import WorkflowPageTitle from "@/oss/components/PageTitle/WorkflowPageTitle"
 import VariantsDashboard from "@/oss/components/VariantsComponents"
 
 const VariantsPage = () => {
-    return <VariantsDashboard />
+    return (
+        <>
+            <WorkflowPageTitle title="Registry" />
+            <VariantsDashboard />
+        </>
+    )
 }
 
 export default VariantsPage

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/index.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic"
 import {PLAYGROUND_NATIVE_ONBOARDING} from "@/oss/components/pages/agent-home/assets/constants"
 import {useConsumePendingTemplate} from "@/oss/components/pages/agent-home/hooks/useConsumePendingTemplate"
 import OnboardingLoader from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingLoader"
+import PageTitle from "@/oss/components/PageTitle"
 
 const AgentHome = dynamic(() => import("@/oss/components/pages/agent-home"))
 
@@ -19,7 +20,17 @@ export default function Apps() {
     // happens wherever the user lands. While a valid template is being consumed, hold the loader
     // instead of rendering a surface that would fire its own redirect and race the create.
     const consumingTemplate = useConsumePendingTemplate()
-    if (consumingTemplate) return <OnboardingLoader />
 
-    return PLAYGROUND_NATIVE_ONBOARDING ? <OnboardingEntry /> : <AgentHome />
+    return (
+        <>
+            <PageTitle title="Home" />
+            {consumingTemplate ? (
+                <OnboardingLoader />
+            ) : PLAYGROUND_NATIVE_ONBOARDING ? (
+                <OnboardingEntry />
+            ) : (
+                <AgentHome />
+            )}
+        </>
+    )
 }

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/evaluations/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/evaluations/index.tsx
@@ -1,7 +1,13 @@
 import EvaluationsView from "@/oss/components/pages/evaluations/EvaluationsView"
+import PageTitle from "@/oss/components/PageTitle"
 
 const ProjectEvaluationsPage = () => {
-    return <EvaluationsView scope="project" />
+    return (
+        <>
+            <PageTitle title="Evaluation runs" />
+            <EvaluationsView scope="project" />
+        </>
+    )
 }
 
 export default ProjectEvaluationsPage

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/evaluators/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/evaluators/index.tsx
@@ -1,7 +1,13 @@
 import EvaluatorsRegistry from "@/oss/components/Evaluators"
+import PageTitle from "@/oss/components/PageTitle"
 
 const ProjectEvaluatorsPage = () => {
-    return <EvaluatorsRegistry scope="project" />
+    return (
+        <>
+            <PageTitle title="Evaluators" />
+            <EvaluatorsRegistry scope="project" />
+        </>
+    )
 }
 
 export default ProjectEvaluatorsPage

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/prompts/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/prompts/index.tsx
@@ -1,7 +1,13 @@
 import PromptsPage from "@/oss/components/pages/prompts/PromptsPage"
+import PageTitle from "@/oss/components/PageTitle"
 
 const Prompts = () => {
-    return <PromptsPage />
+    return (
+        <>
+            <PageTitle title="Prompts" />
+            <PromptsPage />
+        </>
+    )
 }
 
 export default Prompts

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/settings/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/settings/index.tsx
@@ -12,6 +12,7 @@ import {
     resolveSettingsTab,
 } from "@/oss/components/pages/settings/assets/navigation"
 import {useSettingsAccess} from "@/oss/components/pages/settings/hooks/useSettingsAccess"
+import PageTitle from "@/oss/components/PageTitle"
 import {useQueryParam} from "@/oss/hooks/useQuery"
 import useURL from "@/oss/hooks/useURL"
 import {copyToClipboard} from "@/oss/lib/helpers/copyToClipboard"
@@ -205,16 +206,19 @@ export const Settings: React.FC<SettingsProps> = ({AuditLogComponent}) => {
     }, [resolvedTab, buildOrganizationTitle, settingsAccess, AuditLogComponent])
 
     return (
-        <PageLayout
-            key={settingsKey}
-            title={title}
-            // The Audit Log tab hosts a full-height InfiniteVirtualTable, which
-            // needs a bounded parent so it scrolls internally instead of growing
-            // the page. Other tabs keep PageLayout's default `min-h-full` flow.
-            className={resolvedTab === "auditLog" ? "h-full min-h-0" : undefined}
-        >
-            {content}
-        </PageLayout>
+        <>
+            <PageTitle title="Settings" />
+            <PageLayout
+                key={settingsKey}
+                title={title}
+                // The Audit Log tab hosts a full-height InfiniteVirtualTable, which
+                // needs a bounded parent so it scrolls internally instead of growing
+                // the page. Other tabs keep PageLayout's default `min-h-full` flow.
+                className={resolvedTab === "auditLog" ? "h-full min-h-0" : undefined}
+            >
+                {content}
+            </PageLayout>
+        </>
     )
 }
 

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/testsets/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/testsets/index.tsx
@@ -1,5 +1,6 @@
 import {PageLayout} from "@agenta/ui"
 
+import PageTitle from "@/oss/components/PageTitle"
 import TestsetsTable from "@/oss/components/TestsetsTable/TestsetsTable"
 import {useBreadcrumbsEffect} from "@/oss/lib/hooks/useBreadcrumbs"
 
@@ -7,9 +8,12 @@ const Testset = () => {
     useBreadcrumbsEffect({breadcrumbs: {testsets: {label: "testsets"}}}, [])
 
     return (
-        <PageLayout title="Testsets" className="grow min-h-0">
-            <TestsetsTable />
-        </PageLayout>
+        <>
+            <PageTitle title="Test sets" />
+            <PageLayout title="Testsets" className="grow min-h-0">
+                <TestsetsTable />
+            </PageLayout>
+        </>
     )
 }
 


### PR DESCRIPTION
## Context
Agenta showed the same marketing title across product pages, agents, and chats. Multiple open tabs were hard to distinguish because the title did not follow the active page or session.

## Changes
Pages now own semantic titles through a small shared `PageTitle` formatter.

Before: `Agenta – the open-source workspace for building and running agents`

After examples:
- `Home | Agenta`
- `Marketing Coworker | Agenta` for an empty agent chat
- `Draft the launch plan | Agenta` after the first message
- `Observability | Marketing Coworker` inside an agent

The active chat title follows the selected session and reacts to its first message or rename. Session titles are normalized and capped at 60 Unicode code points with an ellipsis. Primary project and agent navigation pages also receive stable titles.

The global marketing title remains a synchronous loading and unknown-route fallback. The asynchronous cloud scripts no longer write a competing title, so they cannot overwrite page-owned titles after mount.

## Scope and risk
This is frontend-only. It adds no API, backend, storage, analytics, or data-fetching changes. Agent names come from the already-loaded current workflow artifact.

Authentication, workspace selection, archive, and deep-detail routes remain on the safe fallback. They are documented as a separate follow-up so this PR stays reviewable.

The main regression risk is title precedence between the global fallback and page heads. The fallback now mounts synchronously before page content, and live EE verification covered both project and agent contexts.

## How to review
1. Start with `web/oss/src/components/PageTitle/` for formatting and fallback behavior.
2. Review `PlaygroundPageTitle.tsx` and `activeSessionTitleAtomFamily` for empty-session, active-session, and rename behavior.
3. Check the observability and primary route wrappers for semantic ownership.
4. Confirm `GlobalScripts` owns the only fallback title and `CloudScripts` no longer competes.

## Tests / notes
- `pnpm --filter @agenta/oss exec vitest run --reporter=default src/components/PageTitle/utils.test.ts src/components/AgentChatSlice/assets/pageTitle.test.ts src/components/AgentChatSlice/state/sessions.pageTitle.test.ts` (12 passed)
- `pnpm lint-fix` (passed; two existing TanStack Virtual compiler warnings)
- `pnpm type-check` (OSS and EE passed)
- `git diff --check` (passed)
- Live EE dev verification: Home, project Observability, Settings, empty agent chat, first-message transition, and agent Observability all showed the expected title.
- Independent review completed. Follow-up review found no remaining code or test blockers.

## What to QA
- Open Home, Prompts, Agents, Test sets, Evaluators, Evaluation runs, Annotation Queues, Observability, and Settings. Each tab should show the page name followed by `| Agenta`.
- Open a new empty agent chat. The tab should show the agent name followed by `| Agenta`.
- Send the first message. The tab should switch to the session title followed by `| Agenta`; a long title should end with an ellipsis and stay within 60 characters before the separator.
- Switch sessions or rename the active session. The tab should update without a reload.
- Open Overview, Registry, Evaluations, and Observability inside an agent. The tab should show the page name followed by the agent name.
- Change Settings or Observability tabs and open a drawer or inspector. The containing page title should stay unchanged.