### PR TITLE
[feat] Hide Daytona credentials by default

### DIFF
--- a/docs/docs/self-host/concepts/02-how-agents-run.mdx
+++ b/docs/docs/self-host/concepts/02-how-agents-run.mdx
@@ -57,18 +57,21 @@ subscription. See [Use your own subscription](/self-host/use-your-own-subscripti
 
 ### What the sandbox can see
 
-A model key normally arrives in the sandbox as an environment variable, and an MCP server's key as
-a request header. Both are readable by the agent running there, which matters because an agent
-writes and runs its own code: a prompt injection that convinces it to print its environment prints
-your keys.
+A model key would normally arrive in the sandbox as an environment variable, and an MCP server's
+key as a request header. Both would be readable by the agent running there, which matters because
+an agent writes and runs its own code: a prompt injection that convinces it to print its
+environment would print your keys.
 
-On Daytona you can close that gap. Set
-[`AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local`](/self-host/configuration#hiding-api-keys-from-the-sandbox)
-and the runner stores each key as a Daytona Secret restricted to the single hostname that key
-authenticates against, then puts a placeholder in the sandbox. Daytona swaps the placeholder for
-the real value on requests to that host, so the model call and the MCP call still work while the
-agent itself only ever holds a useless string. A request to any other host carries the placeholder,
-which is what makes exfiltration fail.
+On Daytona the runner closes that gap, and it does so by default. It stores each key as a Daytona
+Secret restricted to the single hostname that key authenticates against, then puts a placeholder in
+the sandbox. Daytona swaps the placeholder for the real value on requests to that host, so the
+model call and the MCP call still work while the agent itself only ever holds a useless string. A
+request to any other host carries the placeholder, which is what makes exfiltration fail.
+
+This needs a Daytona API key that is allowed to manage Secrets, which is a different permission
+from creating sandboxes. See
+[Hiding API keys from the sandbox](/self-host/configuration#hiding-api-keys-from-the-sandbox) for
+the upgrade note and for how to switch it off if you would rather not grant that permission.
 
 This works for a key the remote service reads over HTTPS, which covers the provider keys and the
 MCP keys. It does not work for a key a provider SDK signs with locally, which today means the AWS

--- a/docs/docs/self-host/reference/01-configuration.mdx
+++ b/docs/docs/self-host/reference/01-configuration.mdx
@@ -293,7 +293,7 @@ Read by the `runner` service. Required only when `daytona` is enabled.
 | `AGENTA_RUNNER_DAYTONA_IMAGE` | Image to start from | Unset | no | `...daytona.image` |
 | `AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES` | Idle minutes before stop | `15` | no | `...daytona.autostopMinutes` |
 | `AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES` | Idle minutes before delete | `30` | no | `...daytona.autodeleteMinutes` |
-| `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS` | Hide API keys from the sandbox | Unset (off) | no | `...daytona.opaqueSecrets` |
+| `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS` | Set to `off` to stop hiding API keys from the sandbox | Unset (hiding is on) | no | `...daytona.opaqueSecrets` |
 
 When neither `AGENTA_RUNNER_DAYTONA_SNAPSHOT` nor `AGENTA_RUNNER_DAYTONA_IMAGE` is set, the runner
 starts from its pinned default snapshot `agenta-agent-sandbox-v1`. The two variables are mutually
@@ -304,34 +304,47 @@ CPU, memory, and disk each sandbox gets.
 
 #### Hiding API keys from the sandbox
 
-By default, a Daytona run receives its model and MCP API keys as ordinary environment variables, so
-an agent that reads its own environment can read the keys. Set
-`AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local` to change that: the runner stores each key as a
-Daytona Secret, restricted to the one hostname that key authenticates against, and puts a
-placeholder in the sandbox instead. Daytona substitutes the real value into outbound requests to
-that host; requests anywhere else carry only the placeholder.
+A Daytona run hides its model and MCP API keys from the sandbox, and this is on by default. The
+runner stores each key as a Daytona Secret restricted to the one hostname that key authenticates
+against, and puts a placeholder in the sandbox instead. Daytona substitutes the real value into
+outbound requests to that host, so the model call and the MCP call still work. Requests to any
+other host carry only the placeholder.
 
-`process_local` is the only accepted value, and it names the guarantee it can make. The runner
-tracks the Secret records it created in its own memory and deletes them when the sandbox goes away.
-Restart the runner while sandboxes are live and those records are orphaned in your Daytona account
-until you remove them; a future value will add durable tracking.
+This matters because an agent writes and runs its own code. Without it, a prompt injection that
+persuades the agent to print its own environment prints your keys.
 
-:::warning Check the API key's permissions first
+:::warning Upgrading from a version before v0.108.1 requires a key change
+The permission this needs is new, and enabling it is not optional.
+
 A Daytona API key is minted with a set of permissions, and a key that can create sandboxes does
-not automatically have the separate permission to manage Secrets. Grant that permission to the key
-in `AGENTA_RUNNER_DAYTONA_API_KEY` before you set this variable.
+**not** automatically have the separate permission to manage Secrets. If your key lacks it, every
+Daytona run that carries a model or MCP key fails at sandbox creation as soon as you upgrade.
 
-If you skip it, **every Daytona run that carries a model or MCP key fails at sandbox creation.**
-The runner does not fall back to sending the key as plaintext, because silently doing the
-unprotected thing is worse than stopping. The error names this variable and the permission, so the
-failure is recognizable, but the runs still fail until the key is fixed. Unsetting the variable
-restores the previous behavior immediately.
+Grant the key in `AGENTA_RUNNER_DAYTONA_API_KEY` permission to manage Secrets, or reissue it with
+that permission, before upgrading. The failure names this variable and the permission, so it is
+recognizable, but the runs still fail until the key is fixed.
+
+The runner never falls back to sending keys as plaintext on its own, because silently doing the
+unprotected thing is worse than stopping. If you would rather not grant the permission, set
+`AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off` and keys go to the sandbox as plain environment
+variables, exactly as they did before v0.108.1.
 :::
 
-One more thing to know: keys that a provider SDK signs with locally instead of sending, which
-today means the AWS access keys used for Bedrock, cannot be hidden this way and still reach the
-sandbox in full. Nothing Daytona substitutes on the way out can help there, because the secret
-never leaves the sandbox in the first place.
+**Turning it off.** Set `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off`. The values `false`, `0`, `no`,
+`disabled`, and `plaintext` work too. Anything the runner does not recognize leaves hiding on, so a
+typo in this variable cannot silently remove the protection.
+
+**What `process_local` means.** Setting the variable to `process_local` is the same as leaving it
+unset, and the name states the cleanup guarantee: the runner tracks the Secret records it created
+in its own memory and deletes them when the sandbox goes away. Restart the runner while sandboxes
+are live and those records are orphaned in your Daytona account until you remove them. A future
+mode will add durable tracking, which is why the setting takes a mode name rather than a plain
+`on`.
+
+**What cannot be hidden.** Keys that a provider SDK signs with locally instead of sending, which
+today means the AWS access keys used for Bedrock, still reach the sandbox in full. Nothing Daytona
+substitutes on the way out can help there, because the secret never leaves the sandbox in the first
+place. Those runs work normally; they just do not get this protection.
 
 Leaving the variable unset keeps the previous behavior exactly.
 

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -89,11 +89,12 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES=15
 # AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES=30
 
-# Hide model and MCP API keys from the sandbox. When set to process_local, the runner stores each
-# key as a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees
-# only a placeholder. Needs a Daytona API key with permission to manage Secrets. Leave unset to
-# keep passing keys as plain environment variables.
-# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local
+# Hiding model and MCP API keys from the sandbox is ON by default: the runner stores each key as
+# a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees only
+# a placeholder. This needs a Daytona API key with permission to manage Secrets, which is separate
+# from the permission to create sandboxes. Uncomment the line below only if you would rather send
+# keys to the sandbox as plain environment variables, where the agent can read them.
+# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off
 
 # --- Warm sessions ---
 # Milliseconds. Must stay below AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES, or Daytona stops a sandbox

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -91,11 +91,12 @@ AGENTA_RUNNER_TOKEN=replace-me
 # AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES=15
 # AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES=30
 
-# Hide model and MCP API keys from the sandbox. When set to process_local, the runner stores each
-# key as a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees
-# only a placeholder. Needs a Daytona API key with permission to manage Secrets. Leave unset to
-# keep passing keys as plain environment variables.
-# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local
+# Hiding model and MCP API keys from the sandbox is ON by default: the runner stores each key as
+# a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees only
+# a placeholder. This needs a Daytona API key with permission to manage Secrets, which is separate
+# from the permission to create sandboxes. Uncomment the line below only if you would rather send
+# keys to the sandbox as plain environment variables, where the agent can read them.
+# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off
 
 # --- Warm sessions ---
 # Milliseconds. Must stay below AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES, or Daytona stops a sandbox

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -89,11 +89,12 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES=15
 # AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES=30
 
-# Hide model and MCP API keys from the sandbox. When set to process_local, the runner stores each
-# key as a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees
-# only a placeholder. Needs a Daytona API key with permission to manage Secrets. Leave unset to
-# keep passing keys as plain environment variables.
-# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local
+# Hiding model and MCP API keys from the sandbox is ON by default: the runner stores each key as
+# a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees only
+# a placeholder. This needs a Daytona API key with permission to manage Secrets, which is separate
+# from the permission to create sandboxes. Uncomment the line below only if you would rather send
+# keys to the sandbox as plain environment variables, where the agent can read them.
+# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off
 
 # --- Warm sessions ---
 # Milliseconds. Must stay below AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES, or Daytona stops a sandbox

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -91,11 +91,12 @@ AGENTA_RUNNER_TOKEN=replace-me
 # AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES=15
 # AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES=30
 
-# Hide model and MCP API keys from the sandbox. When set to process_local, the runner stores each
-# key as a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees
-# only a placeholder. Needs a Daytona API key with permission to manage Secrets. Leave unset to
-# keep passing keys as plain environment variables.
-# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local
+# Hiding model and MCP API keys from the sandbox is ON by default: the runner stores each key as
+# a Daytona Secret restricted to the one host it authenticates against, and the sandbox sees only
+# a placeholder. This needs a Daytona API key with permission to manage Secrets, which is separate
+# from the permission to create sandboxes. Uncomment the line below only if you would rather send
+# keys to the sandbox as plain environment variables, where the agent can read them.
+# AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off
 
 # --- Warm sessions ---
 # Milliseconds. Must stay below AGENTA_RUNNER_DAYTONA_AUTOSTOP_MINUTES, or Daytona stops a sandbox

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -340,7 +340,7 @@
                 "autodeleteMinutes": { "type": ["integer", "string"], "description": "AGENTA_RUNNER_DAYTONA_AUTODELETE_MINUTES." },
                 "sessionIdleTtlMs":  { "type": ["integer", "string"], "description": "AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS." },
                 "sessionMaxWarm":    { "type": ["integer", "string"], "description": "AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM." },
-                "opaqueSecrets":     { "type": "string", "enum": ["process_local"], "description": "AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS; hide model and MCP keys from the sandbox behind Daytona Secrets. Omit to keep passing them as plain environment variables." }
+                "opaqueSecrets":     { "type": "string", "enum": ["process_local", "off"], "description": "AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS; hiding model and MCP keys from the sandbox behind Daytona Secrets is ON by default. Set to 'off' to send them as plain environment variables instead, where the agent can read them. Needs a Daytona API key allowed to manage Secrets." }
               }
             }
           }

--- a/hosting/kubernetes/helm/values.yaml
+++ b/hosting/kubernetes/helm/values.yaml
@@ -151,8 +151,11 @@ redisDurable:
 #       autodeleteMinutes: 30
 #       sessionIdleTtlMs: ""
 #       sessionMaxWarm: ""
-#       opaqueSecrets: process_local   # hide model/MCP keys from the sandbox; needs a Daytona
-#                                      # API key that may manage Secrets
+#       opaqueSecrets: "off"           # QUOTE IT: bare off is a YAML boolean, and the template
+#                                      # would then skip the variable and leave hiding ON.
+#                                      # Hiding model/MCP keys from the sandbox is the DEFAULT
+#                                      # and needs a Daytona API key that may manage Secrets.
+#                                      # Set "off" only to send them as plain env vars instead.
 #   auth:
 #     tokenSecretRef:          # AGENTA_RUNNER_TOKEN; Services sends it, the runner verifies it
 #       name: agenta-runner

--- a/services/runner/README.md
+++ b/services/runner/README.md
@@ -118,26 +118,32 @@ reads `CODEX_HOME`. Set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` to override local
 
 ### Hiding keys from the sandbox
 
-By default a key reaches the sandbox as an ordinary environment variable or HTTP header, so the
-agent running there can read it. That matters because an agent writes and runs its own code: a
+A key would otherwise reach the sandbox as an ordinary environment variable or HTTP header, where
+the agent running there can read it. That matters because an agent writes and runs its own code: a
 prompt injection that convinces it to print its environment prints the key.
 
-Set `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local` and, on Daytona, the runner instead
-stores each key as a Daytona Secret restricted to the one hostname that key authenticates
-against, and puts a placeholder in the sandbox. Daytona substitutes the real value into outbound
-requests to that host, so the model call and the MCP call still work while the agent only ever
-holds a placeholder. A request to any other host carries the placeholder, which is what makes
-exfiltration fail.
+So on Daytona the runner hides them, by default. It stores each key as a Daytona Secret restricted
+to the one hostname that key authenticates against, and puts a placeholder in the sandbox. Daytona
+substitutes the real value into outbound requests to that host, so the model call and the MCP call
+still work while the agent only ever holds a placeholder. A request to any other host carries the
+placeholder, which is what makes exfiltration fail.
+
+Set `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off` to turn it off and go back to plain environment
+variables. Anything the runner does not recognize as an off value leaves hiding on, so a typo
+cannot silently remove the protection.
 
 Three things to know:
 
 - The runner's Daytona API key needs permission to manage Secrets. A key that can create
-  sandboxes does not automatically have it. Without it, every run carrying a model or MCP key
-  fails at sandbox creation; the runner never quietly falls back to plaintext. The error names
-  the variable and the permission (`DAYTONA_SECRETS_PERMISSION_MESSAGE` in `daytona-secrets.ts`).
-- `process_local` names the guarantee: the runner tracks the Secret records it created in its own
-  memory and deletes them when the sandbox goes away. Restart the runner while sandboxes are live
-  and those records are orphaned until someone removes them.
+  sandboxes does not automatically have it. Because hiding is on by default, a key without that
+  permission fails every run carrying a model or MCP key, at sandbox creation. The runner never
+  quietly falls back to plaintext. The error names the variable and the permission
+  (`DAYTONA_SECRETS_PERMISSION_MESSAGE` in `daytona-secrets.ts`).
+- `process_local` names the guarantee, and setting it is the same as leaving the variable unset:
+  the runner tracks the Secret records it created in its own memory and deletes them when the
+  sandbox goes away. Restart the runner while sandboxes are live and those records are orphaned
+  until someone removes them. A future mode will add durable tracking, which is why the setting
+  takes a mode name rather than a plain `on`.
 - Keys a provider SDK signs with locally instead of sending, which today means the AWS keys behind
   Bedrock, cannot be hidden this way. There is no outbound request to substitute them into, so the
   sandbox holds the real value. They are marked `usage: "local_use"` and the set of names allowed

--- a/services/runner/src/engines/sandbox_agent/daytona-secret-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona-secret-plan.ts
@@ -12,7 +12,7 @@ import type { McpServerConfig, ModelConnection } from "../../protocol.ts";
  * list. The provider then takes each candidate and actually creates the Daytona Secret record,
  * which can fail, needs cleanup, and turns the candidate into a real `dtn_secret_<id>`
  * placeholder. Keeping the two apart is what makes the decision unit-testable without a Daytona
- * account, and what lets the flag-off path build the same plan and simply not act on it.
+ * account, and what would let a caller build the same plan and simply not act on it.
  */
 export interface DaytonaSecretCandidate {
   /**
@@ -303,10 +303,41 @@ export function buildDaytonaSecretPlan(input: {
   return { candidates, environment };
 }
 
+/** The values that turn credential hiding OFF. Everything else leaves it on. */
+const OPAQUE_SECRETS_OFF_VALUES = new Set([
+  "off",
+  "false",
+  "0",
+  "no",
+  "disabled",
+  "plaintext",
+]);
+
+/**
+ * Whether a Daytona run hides its model and MCP keys behind Daytona Secrets.
+ *
+ * **On by default.** An operator who does nothing gets the protected behavior, and the variable
+ * exists only to turn it off. The reasoning is that the unprotected path is the one that needs a
+ * deliberate choice: leaving keys readable inside a sandbox that runs model-written code is the
+ * surprising option, so it should be the one someone has to ask for in writing.
+ *
+ * Unrecognized values leave hiding ON rather than off. A typo in this variable then fails safe:
+ * the operator keeps the protection they would have had by doing nothing, instead of silently
+ * losing it. `process_local` is still accepted and still names the cleanup guarantee (the runner
+ * tracks the Secret records it created in its own memory), so it stays meaningful as more modes
+ * arrive.
+ *
+ * Note the operational consequence of the default: the runner's Daytona API key now needs
+ * permission to manage Secrets on every deployment that uses Daytona, not only on ones that
+ * opted in. See `DAYTONA_SECRETS_PERMISSION_MESSAGE` in `daytona-secrets.ts` for what an
+ * under-permissioned key looks like, and the upgrade note in the configuration reference.
+ */
 export function daytonaOpaqueSecretsEnabled(
   value: string | undefined = process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS,
 ): boolean {
-  return value === "process_local";
+  const normalized = (value ?? "").trim().toLowerCase();
+  if (!normalized) return true;
+  return !OPAQUE_SECRETS_OFF_VALUES.has(normalized);
 }
 
 export function assertDaytonaOpaqueSecretsEnabled(
@@ -315,9 +346,9 @@ export function assertDaytonaOpaqueSecretsEnabled(
 ): void {
   if (plan.candidates.length > 0 && !daytonaOpaqueSecretsEnabled(value)) {
     throw new Error(
-      "Daytona opaque credentials are disabled. Set " +
-        "AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local to enable process-local Secret cleanup; " +
-        "plaintext fallback is not allowed.",
+      "Daytona credential hiding is switched off, but this run has credentials that would " +
+        "have been hidden. Unset AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS to restore the default " +
+        "(hide them behind Daytona Secrets); there is no plaintext fallback.",
     );
   }
 }

--- a/services/runner/src/engines/sandbox_agent/daytona-secrets.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona-secrets.ts
@@ -67,11 +67,11 @@ export function isDaytonaPermissionDenied(error: unknown): boolean {
 /** The message an operator can act on, instead of a bare provider status code. */
 export const DAYTONA_SECRETS_PERMISSION_MESSAGE =
   "Daytona refused to manage Secrets with this API key. " +
-  "AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local stores each model and MCP key as a " +
-  "Daytona Secret, which needs an API key that is allowed to manage Secrets, not only to " +
-  "create sandboxes. Grant that permission to the key in AGENTA_RUNNER_DAYTONA_API_KEY, or " +
-  "unset AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS to pass credentials as plain environment " +
-  "variables again.";
+  "This runner hides each model and MCP key by storing it as a Daytona Secret, which is the " +
+  "default, and that needs an API key allowed to manage Secrets, not only to create " +
+  "sandboxes. Grant that permission to the key in AGENTA_RUNNER_DAYTONA_API_KEY. If you " +
+  "would rather send credentials to the sandbox as plain environment variables, which lets " +
+  "the agent read them, set AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off.";
 
 async function deleteIdempotently(
   api: DaytonaSecretApi,

--- a/services/runner/src/engines/sandbox_agent/provider.ts
+++ b/services/runner/src/engines/sandbox_agent/provider.ts
@@ -172,15 +172,15 @@ export function buildSandboxProvider(
         { client: buildDaytonaClient(config.daytona) },
       );
     // The process-local Secret wrapper applies to EVERY plan-bearing Daytona run
-    // (`buildRunPlan` builds a plan only when AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local is
-    // enabled), INCLUDING a zero-candidate plan: the wrapper then allocates no Secrets and
+    // (`buildRunPlan` builds a plan unless AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS switched hiding
+    // off), INCLUDING a zero-candidate plan: the wrapper then allocates no Secrets and
     // attaches nothing, but its create-fingerprint check still governs reconnects, so a parked
     // sandbox holding plaintext local_use credentials (AWS/GCP) is rebuilt — never reconnected
-    // with stale values — after those credentials rotate. Every flag-off run carries no plan and
-    // takes the plain plaintext-env provider below, unchanged from the pre-feature behavior.
-    // The assert is defense-in-depth against a direct caller handing a candidate-bearing plan
-    // while the flag is off: that plan's environment already dropped the opaque values, so
-    // proceeding unwrapped would silently run without credentials.
+    // with stale values — after those credentials rotate. A run with hiding switched off carries
+    // no plan and takes the plain plaintext-env provider below, unchanged from the pre-feature
+    // behavior. The assert is defense-in-depth against a direct caller handing a
+    // candidate-bearing plan while hiding is off: that plan's environment already dropped the
+    // opaque values, so proceeding unwrapped would silently run without credentials.
     //
     // Accepted design limit: Secret ownership is PROCESS-LOCAL. The wrapper's registry dies
     // with the runner process, so a hard crash can orphan a Daytona Secret until Daytona's own

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -106,11 +106,11 @@ export interface RunPlanCredentials {
   /** Final plaintext model environment, after validating modelConnection. */
   modelEnvironment: Record<string, string>;
   /**
-   * Process-local opaque credential plan. Present for every Daytona run when
-   * AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local is enabled — even with zero candidates, so the
-   * Secret provider wrapper (and its create-fingerprint rotation check) governs every flag-on
-   * reconnect. Absent when the flag is off, so that path is the plain plaintext-env provider
-   * with no wrapper, unchanged from the pre-feature runner.
+   * Process-local opaque credential plan. Present for every Daytona run unless credential
+   * hiding was switched off with AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS, and present even with
+   * zero candidates, so the Secret provider wrapper (and its create-fingerprint rotation
+   * check) governs every reconnect. Absent only when hiding is off, and that path is the plain
+   * plaintext-env provider with no wrapper, unchanged from the pre-feature runner.
    */
   daytonaSecretPlan?: DaytonaSecretPlan;
   /**
@@ -519,13 +519,14 @@ export function buildRunPlan(
 
   const materializedModel = materializeModelEnvironment(request);
   if (!materializedModel.ok) return materializedModel;
-  // Daytona opaque-credential delivery is FLAG-GATED (AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=
-  // process_local). Flag OFF: no secret plan is built at all, so behavior is identical to the
-  // pre-feature runner — the full materialized environment reaches sandbox create as plaintext
-  // env, no provider wrapper is applied, and the plan's strict endpoint/binding validation
-  // cannot introduce a new failure mode. Flag ON: the plan splits every opaque_http value out
-  // of the plaintext env and is ALWAYS kept, even with zero candidates, so the provider wrapper
-  // (and its create fingerprint) governs every flag-on Daytona reconnect. A zero-candidate plan
+  // Daytona opaque-credential delivery is ON by default and switched off only by
+  // AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS. Switched OFF: no secret plan is built at all, so
+  // behavior is identical to the pre-feature runner — the full materialized environment reaches
+  // sandbox create as plaintext env, no provider wrapper is applied, and the plan's strict
+  // endpoint/binding validation cannot introduce a new failure mode. ON (the default): the plan
+  // splits every opaque_http value out of the plaintext env and is ALWAYS kept, even with zero
+  // candidates, so the provider wrapper (and its create fingerprint) governs every Daytona
+  // reconnect that hides credentials. A zero-candidate plan
   // allocates no Secrets, but a parked sandbox created with plaintext local_use credentials must
   // be rebuilt — never reconnected — after those credentials rotate, and only the wrapper's
   // fingerprint check enforces that (the plain reconnect path converges network policy only).
@@ -543,7 +544,7 @@ export function buildRunPlan(
       };
     }
   }
-  // Local keeps its existing direct environment. A flag-on Daytona run with opaque credentials
+  // Local keeps its existing direct environment. A Daytona run that hides opaque credentials
   // removes every opaque_http value and passes only non-secret config plus explicitly local_use
   // credentials to sandbox create. With zero candidates the plan's environment equals the
   // materialized one, so keeping the empty plan changes nothing here.

--- a/services/runner/tests/unit/daytona-secret-plan.test.ts
+++ b/services/runner/tests/unit/daytona-secret-plan.test.ts
@@ -268,19 +268,37 @@ describe("Daytona Secret planning", () => {
     );
   });
 
-  it("keeps the feature default-off and accepts only the explicit process_local mode", () => {
+  it("hides credentials by default, and only an explicit off value stops it", () => {
     const plan = buildDaytonaSecretPlan({ modelConnection });
-    assert.throws(
-      () => assertDaytonaOpaqueSecretsEnabled(plan),
-      /AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local/,
-    );
+
+    // Doing nothing gets you the protected behavior.
+    assert.doesNotThrow(() => assertDaytonaOpaqueSecretsEnabled(plan));
+    assert.doesNotThrow(() => assertDaytonaOpaqueSecretsEnabled(plan, ""));
     assert.doesNotThrow(() =>
       assertDaytonaOpaqueSecretsEnabled(plan, "process_local"),
     );
-    assert.throws(() => assertDaytonaOpaqueSecretsEnabled(plan, "true"));
+
+    // Only a recognized off value switches it off, in any case and with stray whitespace.
+    for (const off of ["off", "false", "0", "no", "disabled", "plaintext"]) {
+      assert.throws(
+        () => assertDaytonaOpaqueSecretsEnabled(plan, off),
+        /no plaintext fallback/,
+        `'${off}' should switch hiding off`,
+      );
+    }
+    assert.throws(() => assertDaytonaOpaqueSecretsEnabled(plan, "  OFF  "));
+
+    // A typo must fail SAFE. Someone who meant to switch hiding off and mistyped keeps the
+    // protection they would have had by doing nothing, rather than silently losing it.
+    for (const typo of ["of", "flase", "disable", "true", "process-local"]) {
+      assert.doesNotThrow(
+        () => assertDaytonaOpaqueSecretsEnabled(plan, typo),
+        `'${typo}' is not a recognized off value and must leave hiding on`,
+      );
+    }
   });
 
-  it("keeps flag-off Daytona runs on today's plaintext delivery and secretizes only when on", () => {
+  it("hides credentials on a default Daytona run, and only when switched off does not", () => {
     const request = {
       harness: "claude",
       sandbox: "daytona",
@@ -288,8 +306,9 @@ describe("Daytona Secret planning", () => {
       modelConnection,
     } satisfies AgentRunRequest;
 
-    // Flag OFF (the hermetic default): behavior-identical to main — the run proceeds and the
-    // opaque key rides the plaintext model environment; no secret plan, no fail-closed.
+    // Switched OFF explicitly: behavior-identical to the pre-feature runner — the run proceeds
+    // and the opaque key rides the plaintext model environment; no secret plan, no fail-closed.
+    process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS = "off";
     const disabled = buildRunPlan(request, {
       createDaytonaCwd: () => "/sandbox/cwd",
     });
@@ -302,8 +321,10 @@ describe("Daytona Secret planning", () => {
     assert.equal(disabled.plan.credentials.daytonaSecretPlan, undefined);
     assert.equal(disabled.plan.credentials.hasApiKey, true);
 
-    // Flag ON: the opaque value leaves the plaintext environment for the secret plan.
-    process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS = "process_local";
+    // ON, which is the default: the opaque value leaves the plaintext environment for the
+    // secret plan. Unset rather than set, so this asserts the DEFAULT and not just the
+    // explicit mode.
+    delete process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS;
     const enabled = buildRunPlan(request, {
       createDaytonaCwd: () => "/sandbox/cwd",
     });

--- a/services/runner/tests/unit/daytona-secret-provider.test.ts
+++ b/services/runner/tests/unit/daytona-secret-provider.test.ts
@@ -416,11 +416,11 @@ describe("process-local Daytona Secret provider", () => {
   });
 
   // Zero-candidate plans ARE a production state: buildRunPlan keeps the (empty) plan on every
-  // flag-on Daytona run and provider.ts wraps unconditionally on plan presence, so a run whose
+  // Daytona run that hides credentials, and provider.ts wraps on plan presence, so a run whose
   // credentials are all local_use/direct still flows through this wrapper — creating no Secrets
   // but subjecting every reconnect to the create-fingerprint check. These tests pin exactly the
   // fingerprints production computes (`daytonaCreateFingerprint` over `buildDaytonaCreate`).
-  describe("zero-candidate plan (flag-on run with no opaque credentials)", () => {
+  describe("zero-candidate plan (hiding on, but no opaque credentials)", () => {
     const emptyPlan: DaytonaSecretPlan = { environment: {}, candidates: [] };
     const daytonaConfig = parseRunnerConfig({
       AGENTA_RUNNER_DAYTONA_API_KEY: "test-key",

--- a/services/runner/tests/unit/sandbox-agent-provider.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-provider.test.ts
@@ -323,36 +323,36 @@ describe("buildSandboxProvider (enabled-provider gate + unknown-id refusal)", ()
         runnerConfig("local,daytona"),
       ) as { materializeMcpServers?: unknown };
 
-    // Flag OFF (hermetic default): a flag-off run never carries a plan (buildRunPlan builds one
-    // only when the flag is on), and the plain provider is unchanged from main.
+    // A run with hiding switched off never carries a plan (buildRunPlan builds one only while
+    // hiding is on), and the plain provider is unchanged from the pre-feature runner.
     assert.equal(
       typeof build(undefined).materializeMcpServers,
       "undefined",
-      "flag off (no plan) stays on the plain provider",
+      "no plan stays on the plain provider",
     );
-    // Defense-in-depth: a direct caller handing a candidate-bearing plan while the flag is off
-    // is refused — that plan's environment already dropped the opaque values, so proceeding
-    // unwrapped would silently run without credentials.
-    assert.throws(
-      () => build(plan),
-      /AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local/,
+
+    // Hiding is ON by default, so a plan-bearing run wraps without any variable being set.
+    assert.equal(
+      typeof build(plan).materializeMcpServers,
+      "function",
+      "the default attaches the Secret wrapper",
+    );
+    // Zero candidates must ALSO wrap: buildRunPlan keeps the empty plan on every Daytona run
+    // that hides credentials, precisely so the wrapper's create-fingerprint check governs
+    // reconnects (a rotated local_use credential forces a rebuild, never a stale plaintext
+    // reconnect).
+    assert.equal(
+      typeof build(buildDaytonaSecretPlan({})).materializeMcpServers,
+      "function",
+      "zero candidates still attaches the Secret wrapper",
     );
 
     try {
-      process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS = "process_local";
-      assert.equal(
-        typeof build(plan).materializeMcpServers,
-        "function",
-        "flag on + candidates attaches the Secret wrapper",
-      );
-      // Zero candidates must ALSO wrap: buildRunPlan keeps the empty plan on every flag-on
-      // Daytona run precisely so the wrapper's create-fingerprint check governs reconnects
-      // (a rotated local_use credential forces a rebuild, never a stale plaintext reconnect).
-      assert.equal(
-        typeof build(buildDaytonaSecretPlan({})).materializeMcpServers,
-        "function",
-        "flag on + zero candidates still attaches the Secret wrapper",
-      );
+      // Defense-in-depth: a direct caller handing a candidate-bearing plan while hiding is
+      // switched off is refused. That plan's environment already dropped the opaque values, so
+      // proceeding unwrapped would silently run without credentials.
+      process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS = "off";
+      assert.throws(() => build(plan), /no plaintext fallback/);
     } finally {
       delete process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS;
     }

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -1191,9 +1191,9 @@ describe("buildRunPlan", () => {
     assert.deepEqual(result.plan.workspace.skillDirs, []);
   });
 
-  it("keeps a zero-candidate secret plan when the flag is on, and none when it is off", () => {
+  it("keeps a zero-candidate secret plan by default, and none when switched off", () => {
     // A run with only local_use credentials produces ZERO opaque candidates. The plan must
-    // still ride the run plan when the flag is on: provider.ts applies the Secret wrapper off
+    // still ride the run plan while hiding is on: provider.ts applies the Secret wrapper off
     // plan PRESENCE, and only the wrapper's create-fingerprint check forces a rebuild (instead
     // of a stale plaintext reconnect) after the local_use credentials rotate.
     const localUseRequest = {
@@ -1236,8 +1236,8 @@ describe("buildRunPlan", () => {
       "aws-secret-local-use",
     );
 
-    // Flag OFF stays exactly the pre-feature behavior: no plan, so no wrapper is applied.
-    delete process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS;
+    // Switched OFF stays exactly the pre-feature behavior: no plan, so no wrapper is applied.
+    process.env.AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS = "off";
     const flagOff = buildRunPlan(localUseRequest, deps);
     assert.equal(flagOff.ok, true);
     if (!flagOff.ok) return;


### PR DESCRIPTION
## Context

Hiding Daytona credentials shipped in #5670 behind `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=process_local`, off unless an operator opted in. This inverts that: hiding is on by default and the variable now switches it **off**.

The reasoning is about which choice should need a deliberate decision. Leaving provider keys readable inside a sandbox that runs model-written code is the surprising option, so it should be the one someone has to ask for in writing, not the one they get by never learning the variable exists.

## Changes

**The default.** With the variable unset, a Daytona run stores each model and MCP key as a Daytona Secret restricted to the one host it authenticates against, and the sandbox gets a placeholder.

**Turning it off** takes `off`, `false`, `0`, `no`, `disabled`, or `plaintext`, case-insensitively and with whitespace trimmed.

**Anything unrecognized leaves hiding ON.** This is the part worth reviewing closely. A typo now fails safe: someone who meant to switch hiding off and wrote `of` keeps the protection they would have had by doing nothing, instead of silently losing it. The opposite default would turn a one-character mistake into an unprotected deployment that looks configured.

`process_local` still works and is identical to leaving the variable unset. It stays because it names the cleanup guarantee (the runner tracks the Secret records it created in its own memory), which will matter when a durable mode arrives. That is also why the setting takes a mode name rather than a plain `on`.

Before:
```
unset            -> keys sent as plaintext environment variables
process_local    -> keys hidden
anything else    -> keys sent as plaintext
```

After:
```
unset            -> keys hidden
process_local    -> keys hidden
off / false / 0 / no / disabled / plaintext  -> keys sent as plaintext
anything else    -> keys hidden (a typo cannot remove the protection)
```

## The operational cost, which is the real content of this PR

**The runner's Daytona API key now needs permission to manage Secrets on every deployment that uses Daytona, not only on ones that opted in.** That is a different permission from creating sandboxes. A key without it fails every run carrying a model or MCP key, at sandbox creation, with the named error added in #5670. There is still no silent plaintext fallback, because quietly doing the unprotected thing is worse than stopping.

The configuration reference now carries an upgrade warning saying exactly this, and gives `=off` as the way out for anyone who would rather not grant the permission. Our own keys across all environments were updated before this PR.

## Tests / notes

- Four tests encoded the old default and now encode the new one. Added coverage for every off spelling, for case and whitespace, and for typos leaving hiding on.
- Runner `tsc --noEmit` clean, 99 files / 1538 tests.
- One trap worth knowing about, now commented in `values.yaml`: a bare `off` in YAML parses as boolean `false`, the Helm template's `if` then skips the variable, and hiding stays **on**, the opposite of the intent. The value must be quoted. The schema types it as a string so an unquoted one fails validation rather than passing silently.
- Config surfaces updated to match: the four env examples now show how to turn it off rather than on, and the Helm schema accepts `process_local` or `off`.

## What to QA

- With nothing set, run Claude on Daytona with a managed Anthropic connection, allow bash, and ask the agent to print `ANTHROPIC_API_KEY`. It shows a `dtn_secret_` placeholder, not the key. This is the whole point and the release gate does not check it.
- Repeat on a Pi Daytona run with `OPENAI_API_KEY`.
- Set `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off`, restart the runner, run again. The real key is present, matching pre-v0.108.1 behavior.
- Set it to `of` (a deliberate typo), restart, run again. The placeholder is back, because an unrecognized value leaves hiding on.
- Regression: local sandbox runs are unaffected either way.
