### PR TITLE
fix(entity-ui): treat absent harness.kind as pi_core for Pi permissions visibility

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -45,6 +45,7 @@ import {
     connectionFromConfig,
     harnessAllowsModel,
     harnessSupportsUserMcp,
+    isPiHarnessValue,
     modelIdFromConfig,
     modelLabel,
     providerForModel,
@@ -172,7 +173,7 @@ export function useModelHarness({
     // is harness-filtered: selecting a model sets BOTH the model id and its provider, fed by the
     // `/inspect` capability map below.
     const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : null
-    const isPiHarness = harnessValue === "pi_core" || harnessValue === "pi_agenta"
+    const isPiHarness = isPiHarnessValue(harnessValue)
     const llm = config.llm
     const modelId = useMemo(() => modelIdFromConfig(llm), [llm])
     const connection = useMemo(() => connectionFromConfig(llm), [llm])

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/connectionUtils.ts
@@ -163,6 +163,16 @@ function capsFor(
     return capabilities[harness] ?? null
 }
 
+/**
+ * Whether a harness value is one of the Pi harnesses. An absent `harness.kind` (`null`/`undefined`)
+ * runs as `pi_core` at runtime (see `agents/dtos.py`'s `harness: str = "pi_core"` default), so it
+ * counts as Pi here too — otherwise the Pi permissions controls stay hidden for a run that is
+ * actually enforcing them (#5661).
+ */
+export function isPiHarnessValue(harness: string | null | undefined): boolean {
+    return harness == null || harness === "pi_core" || harness === "pi_agenta"
+}
+
 /** External MCP authoring is available only when the selected harness publishes it. */
 export function harnessSupportsUserMcp(
     capabilities: HarnessCapabilitiesMap | null | undefined,

--- a/web/packages/agenta-entity-ui/tests/unit/connectionUtils.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/connectionUtils.test.ts
@@ -20,6 +20,7 @@ import {
     harnessAllowsProvider,
     harnessSupportsUserMcp,
     isDeploymentProviderKind,
+    isPiHarnessValue,
     modelIdFromConfig,
     modelSelectionMode,
     providerForModel,
@@ -193,6 +194,14 @@ describe("connectionUtils: capability gating (inspect-fed)", () => {
     it("exposes the per-harness model selection mode", () => {
         expect(modelSelectionMode(CAPABILITIES, "pi_core")).toBe("provider/id")
         expect(modelSelectionMode(CAPABILITIES, "claude")).toBe("alias")
+    })
+
+    it("treats an absent harness.kind as pi_core, matching the runner default (#5661)", () => {
+        expect(isPiHarnessValue(undefined)).toBe(true)
+        expect(isPiHarnessValue(null)).toBe(true)
+        expect(isPiHarnessValue("pi_core")).toBe(true)
+        expect(isPiHarnessValue("pi_agenta")).toBe(true)
+        expect(isPiHarnessValue("claude")).toBe(false)
     })
 
     it("is permissive when the map or harness is missing", () => {


### PR DESCRIPTION
## Summary
- When an agent config omits `harness.kind`, the runner treats the harness as `pi_core` (`agents/dtos.py`'s `harness: str = "pi_core"` default) and enforces the Pi `harness.permissions` allow/ask/deny rules at runtime.
- The Model & harness panel didn't apply the same default: `harnessValue` stayed `null` for such a config, so `isPiHarness` was `false` and `PiPermissionsControl` was hidden — even though the run enforces Pi permission gating. The author couldn't see or edit the rules that apply to their own runs.
- This is a visibility gap only; the runtime permission gate (including `allow_reads`) was never affected.

## Changes
- Extracted the check into `isPiHarnessValue()` in `connectionUtils.ts`, alongside the other pure harness-capability helpers (`harnessSupportsUserMcp`, `harnessAllowsModel`, ...). An absent/null harness now counts as Pi.
- `useModelHarness.tsx`'s `isPiHarness` now uses this helper instead of the inline `=== "pi_core" || === "pi_agenta"` check.

Fixes #5661

## Test plan
- [x] Added `isPiHarnessValue` unit test in `connectionUtils.test.ts` covering `undefined`, `null` (the `{harness: {}}` case), `"pi_core"`, `"pi_agenta"`, and `"claude"`.
- [x] `pnpm vitest run` in `agenta-entity-ui`: 302/302 tests pass.
- [x] `tsc --noEmit` in `agenta-entity-ui`: no errors.