### PR TITLE
[#5540] fix(api): price cached input tokens, and stop losing costs to a missing model

### DIFF
--- a/api/oss/src/core/tracing/utils/trees.py
+++ b/api/oss/src/core/tracing/utils/trees.py
@@ -248,6 +248,19 @@ def _connect_tree_dfs(
             parent_span.spans = None
 
 
+def _has_reported_cumulative(span: OTelFlatSpan) -> bool:
+    if not isinstance(span.attributes, dict):
+        return False
+
+    node = span.attributes
+    for key in ("ag", "metrics", "costs", "cumulative"):
+        if not isinstance(node, dict):
+            return False
+        node = node.get(key)
+
+    return isinstance(node, dict) and "total" in node
+
+
 def cumulate_costs(
     spans_id_tree: OrderedDict,
     spans_idx: Dict[str, OTelFlatSpan],
@@ -340,7 +353,9 @@ def cumulate_costs(
         # aggregate for this subtree. Child costs recomputed from token counts
         # re-estimate the same spend, so overwriting here would swap a billed figure
         # for a lossier one. The roll-up only fills spans that report nothing.
-        if _get_cumulative(span).get("total", 0.0) != 0.0:
+        # Test presence, not truthiness: a reported 0.0 (a fully cached turn, a free
+        # model) is a measurement, not a missing value.
+        if _has_reported_cumulative(span):
             return
 
         if (
@@ -604,6 +619,13 @@ TYPES_WITH_COSTS = [
 ]
 
 
+def _token_count(value) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def calculate_costs(span_idx: Dict[str, OTelFlatSpan]):
     for span in span_idx.values():
         if (
@@ -612,31 +634,49 @@ def calculate_costs(span_idx: Dict[str, OTelFlatSpan]):
             and span.attributes
         ):
             attr: dict = span.attributes
-            model = attr.get("ag", {}).get("meta", {}).get("response", {}).get(
-                "model"
-            ) or attr.get("ag", {}).get("data", {}).get("parameters", {}).get("model")
+            ag_attr: dict = attr.get("ag", {})
+            ag_meta: dict = ag_attr.get("meta", {})
+            ag_data: dict = ag_attr.get("data", {})
 
-            prompt_tokens = (
-                attr.get("ag", {})
-                .get("metrics", {})
-                .get("tokens", {})
-                .get("incremental", {})
-                .get("prompt", 0.0)
+            # The agent runner sets the response model only for codex; every other
+            # harness sets only the request model, so without that fallback those
+            # spans are never priced at all.
+            model = (
+                ag_meta.get("response", {}).get("model")
+                or ag_meta.get("request", {}).get("model")
+                or ag_data.get("parameters", {}).get("model")
             )
 
-            completion_tokens = (
-                attr.get("ag", {})
-                .get("metrics", {})
-                .get("tokens", {})
-                .get("incremental", {})
-                .get("completion", 0.0)
+            token_metrics: dict = (
+                ag_attr.get("metrics", {}).get("tokens", {}).get("incremental", {})
+            )
+
+            uncached_input_tokens = _token_count(token_metrics.get("prompt"))
+            cache_read_input_tokens = _token_count(token_metrics.get("cache_read"))
+            cache_creation_input_tokens = _token_count(
+                token_metrics.get("cache_creation")
+            )
+            completion_tokens = _token_count(token_metrics.get("completion"))
+
+            # INVARIANT: the `prompt` bucket carries *exclusive* input (gen_ai.usage.
+            # input_tokens is raw uncached input), while litellm's generic calculator
+            # derives ordinary input by subtracting the cache details from the prompt
+            # count it is given, so it expects an *inclusive* count. If the canonical
+            # `prompt` bucket ever becomes inclusive at ingest, this sum double counts
+            # and must be dropped; it is kept in one place so that is a one-line change.
+            inclusive_prompt_tokens = (
+                uncached_input_tokens
+                + cache_read_input_tokens
+                + cache_creation_input_tokens
             )
 
             try:
                 costs = cost_calculator.cost_per_token(
                     model=model,
-                    prompt_tokens=prompt_tokens,
+                    prompt_tokens=inclusive_prompt_tokens,
                     completion_tokens=completion_tokens,
+                    cache_read_input_tokens=cache_read_input_tokens,
+                    cache_creation_input_tokens=cache_creation_input_tokens,
                 )
 
                 if not costs:
@@ -668,12 +708,17 @@ def calculate_costs(span_idx: Dict[str, OTelFlatSpan]):
                     "total": total_cost,
                 }
 
+            # Model aliases litellm cannot price (e.g. the bare "sonnet" the model
+            # picker sends) raise here rather than returning nothing; swallowing keeps
+            # an unpriceable span cost-less instead of failing the whole ingest.
             except Exception:  # pylint: disable=bare-except
                 log.warn(
                     "Failed to calculate costs",
                     model=model,
-                    prompt_tokens=prompt_tokens,
+                    prompt_tokens=inclusive_prompt_tokens,
                     completion_tokens=completion_tokens,
+                    cache_read_input_tokens=cache_read_input_tokens,
+                    cache_creation_input_tokens=cache_creation_input_tokens,
                 )
 
 

--- a/api/oss/tests/pytest/unit/otlp/test_reported_cost_ingest.py
+++ b/api/oss/tests/pytest/unit/otlp/test_reported_cost_ingest.py
@@ -95,15 +95,13 @@ def _agent_span(**overrides) -> OTelSpanDTO:
 
 
 def _unpriceable_model_span(**overrides) -> OTelSpanDTO:
-    # The agent runner reports the request model but not the response model, which is
-    # the key the litellm recompute needs. This is what every agent chat span looks
-    # like today, and why the recompute produces nothing.
+    # No model name at all, so the litellm recompute has nothing to price against.
+    # Spans that carry only a request model ARE priceable (see calculate_costs).
     return _otel_span(
         span_id=MODEL_SPAN_ID,
         span_name="chat",
         attributes={
             "gen_ai.operation.name": "chat",
-            "gen_ai.request.model": "gpt-4o-mini",
             "gen_ai.usage.input_tokens": 1000,
             "gen_ai.usage.output_tokens": 100,
         },

--- a/api/oss/tests/pytest/unit/tracing/test_cost_calculation.py
+++ b/api/oss/tests/pytest/unit/tracing/test_cost_calculation.py
@@ -1,0 +1,291 @@
+from typing import Optional
+
+import pytest
+from litellm import cost_calculator
+
+from oss.src.core.tracing.dtos import OTelFlatSpan, SpanType
+from oss.src.core.tracing.utils.trees import (
+    KNOWN_PRICING_PROVIDERS,
+    TRUSTED_PRICING_PROVIDERS,
+    calculate_and_propagate_metrics,
+    calculate_costs,
+)
+
+
+OPENAI_MODEL = "gpt-5.3-codex"
+ANTHROPIC_MODEL = "claude-sonnet-4-6"
+
+
+def _span(
+    *,
+    span_id: str = "s1",
+    parent_id: Optional[str] = None,
+    span_type: SpanType = SpanType.CHAT,
+    response_model: Optional[str] = None,
+    request_model: Optional[str] = None,
+    parameters_model: Optional[str] = None,
+    prompt: Optional[int] = None,
+    completion: Optional[int] = None,
+    cache_read: Optional[int] = None,
+    cache_creation: Optional[int] = None,
+    reported_cost: Optional[float] = None,
+) -> OTelFlatSpan:
+    meta: dict = {}
+    if response_model is not None:
+        meta["response"] = {"model": response_model}
+    if request_model is not None:
+        meta["request"] = {"model": request_model}
+
+    data: dict = {}
+    if parameters_model is not None:
+        data["parameters"] = {"model": parameters_model}
+
+    tokens: dict = {}
+    for key, value in (
+        ("prompt", prompt),
+        ("completion", completion),
+        ("cache_read", cache_read),
+        ("cache_creation", cache_creation),
+    ):
+        if value is not None:
+            tokens[key] = value
+
+    metrics: dict = {}
+    if tokens:
+        metrics["tokens"] = {"incremental": tokens}
+    if reported_cost is not None:
+        metrics["costs"] = {"cumulative": {"total": reported_cost}}
+
+    ag: dict = {}
+    if meta:
+        ag["meta"] = meta
+    if data:
+        ag["data"] = data
+    if metrics:
+        ag["metrics"] = metrics
+
+    return OTelFlatSpan(
+        trace_id="t1",
+        span_id=span_id,
+        parent_id=parent_id,
+        span_type=span_type,
+        attributes={"ag": ag},
+    )
+
+
+def _incremental_costs(span: OTelFlatSpan) -> dict:
+    return (
+        (span.attributes or {})
+        .get("ag", {})
+        .get("metrics", {})
+        .get("costs", {})
+        .get("incremental", {})
+    )
+
+
+def _cumulative_costs(span: OTelFlatSpan) -> dict:
+    return (
+        (span.attributes or {})
+        .get("ag", {})
+        .get("metrics", {})
+        .get("costs", {})
+        .get("cumulative", {})
+    )
+
+
+def _expected(model: str, *, prompt: int, completion: int, read: int, creation: int):
+    """Oracle: what litellm charges for the inclusive-prompt shape we mean to send."""
+    prompt_cost, completion_cost = cost_calculator.cost_per_token(
+        model=model,
+        prompt_tokens=prompt + read + creation,
+        completion_tokens=completion,
+        cache_read_input_tokens=read,
+        cache_creation_input_tokens=creation,
+    )
+    return prompt_cost, completion_cost
+
+
+@pytest.mark.parametrize("model", [OPENAI_MODEL, ANTHROPIC_MODEL])
+@pytest.mark.parametrize(
+    "read,creation",
+    [
+        (0, 0),  # no cache
+        (25_182, 0),  # cache read only
+        (0, 4_096),  # cache creation only
+        (25_182, 4_096),  # both cache buckets
+    ],
+    ids=["no-cache", "cache-read", "cache-creation", "both-buckets"],
+)
+def test_calculate_costs_prices_cache_buckets(model, read, creation):
+    span = _span(
+        response_model=model,
+        prompt=1,
+        completion=20,
+        cache_read=read or None,
+        cache_creation=creation or None,
+    )
+
+    calculate_costs({span.span_id: span})
+
+    prompt_cost, completion_cost = _expected(
+        model, prompt=1, completion=20, read=read, creation=creation
+    )
+    costs = _incremental_costs(span)
+
+    assert costs["prompt"] == pytest.approx(prompt_cost)
+    assert costs["completion"] == pytest.approx(completion_cost)
+    assert costs["total"] == pytest.approx(prompt_cost + completion_cost)
+
+
+@pytest.mark.parametrize("model", [OPENAI_MODEL, ANTHROPIC_MODEL])
+def test_cached_input_is_not_dropped_from_the_estimate(model):
+    """Regression for #5540: cache-read tokens used to be priced as if absent."""
+    span = _span(response_model=model, prompt=1, completion=20, cache_read=25_182)
+
+    calculate_costs({span.span_id: span})
+
+    ignoring_cache, _ = cost_calculator.cost_per_token(
+        model=model, prompt_tokens=1, completion_tokens=20
+    )
+
+    assert _incremental_costs(span)["prompt"] > 10 * ignoring_cache
+
+
+@pytest.mark.parametrize("model", [OPENAI_MODEL, ANTHROPIC_MODEL])
+def test_ordinary_input_survives_alongside_cache_reads(model):
+    """The prompt bucket is exclusive, so it must be added to, not replaced by, cache."""
+    with_ordinary = _span(response_model=model, prompt=93, cache_read=13_463)
+    without_ordinary = _span(response_model=model, prompt=0, cache_read=13_463)
+
+    calculate_costs({"a": with_ordinary, "b": without_ordinary})
+
+    assert (
+        _incremental_costs(with_ordinary)["prompt"]
+        > _incremental_costs(without_ordinary)["prompt"]
+    )
+
+
+def test_request_model_is_used_when_response_model_is_absent():
+    span = _span(request_model=OPENAI_MODEL, prompt=1_000, completion=100)
+
+    calculate_costs({span.span_id: span})
+
+    prompt_cost, completion_cost = _expected(
+        OPENAI_MODEL, prompt=1_000, completion=100, read=0, creation=0
+    )
+
+    assert _incremental_costs(span)["total"] == pytest.approx(
+        prompt_cost + completion_cost
+    )
+
+
+def test_response_model_wins_over_request_model():
+    span = _span(
+        response_model=OPENAI_MODEL,
+        request_model=ANTHROPIC_MODEL,
+        prompt=1_000,
+        completion=100,
+    )
+
+    calculate_costs({span.span_id: span})
+
+    prompt_cost, completion_cost = _expected(
+        OPENAI_MODEL, prompt=1_000, completion=100, read=0, creation=0
+    )
+
+    assert _incremental_costs(span)["total"] == pytest.approx(
+        prompt_cost + completion_cost
+    )
+
+
+def test_legacy_parameters_model_still_works():
+    span = _span(parameters_model=OPENAI_MODEL, prompt=1_000, completion=100)
+
+    calculate_costs({span.span_id: span})
+
+    assert _incremental_costs(span)["total"] > 0
+
+
+@pytest.mark.parametrize("model", ["sonnet", "not-a-real-model", ""])
+def test_unpriceable_model_is_contained(model):
+    """An alias litellm cannot price must yield no cost, never break the batch."""
+    span = _span(request_model=model, prompt=1_000, completion=100, cache_read=500)
+
+    calculate_costs({span.span_id: span})
+
+    assert _incremental_costs(span) == {}
+
+
+def test_missing_model_is_contained():
+    span = _span(prompt=1_000, completion=100)
+
+    calculate_costs({span.span_id: span})
+
+    assert _incremental_costs(span) == {}
+
+
+def test_non_llm_span_types_are_skipped():
+    span = _span(span_type=SpanType.TOOL, response_model=OPENAI_MODEL, prompt=1_000)
+
+    calculate_costs({span.span_id: span})
+
+    assert _incremental_costs(span) == {}
+
+
+def test_reported_zero_cost_is_not_overwritten_by_an_estimate():
+    """Missing and measured-zero are different facts: a free/fully-cached turn is 0."""
+    parent = _span(
+        span_id="parent",
+        span_type=SpanType.AGENT,
+        reported_cost=0.0,
+    )
+    child = _span(
+        span_id="child",
+        parent_id="parent",
+        response_model=OPENAI_MODEL,
+        prompt=1_000,
+        completion=100,
+    )
+
+    spans = {s.span_id: s for s in calculate_and_propagate_metrics([parent, child])}
+
+    assert _cumulative_costs(spans["parent"])["total"] == 0.0
+    assert _cumulative_costs(spans["child"])["total"] > 0.0
+
+
+def test_reported_nonzero_cost_is_not_replaced_by_an_estimate():
+    parent = _span(
+        span_id="parent",
+        span_type=SpanType.AGENT,
+        reported_cost=1.25,
+    )
+    child = _span(
+        span_id="child",
+        parent_id="parent",
+        response_model=OPENAI_MODEL,
+        prompt=1_000,
+        completion=100,
+    )
+
+    spans = {s.span_id: s for s in calculate_and_propagate_metrics([parent, child])}
+
+    assert _cumulative_costs(spans["parent"])["total"] == 1.25
+
+
+def test_missing_cost_is_filled_by_the_rollup():
+    parent = _span(span_id="parent", span_type=SpanType.AGENT)
+    child = _span(
+        span_id="child",
+        parent_id="parent",
+        response_model=OPENAI_MODEL,
+        prompt=1_000,
+        completion=100,
+    )
+
+    spans = {s.span_id: s for s in calculate_and_propagate_metrics([parent, child])}
+
+    assert (
+        _cumulative_costs(spans["parent"])["total"]
+        == _cumulative_costs(spans["child"])["total"]
+        > 0.0
+    )

--- a/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
+++ b/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
@@ -434,7 +434,7 @@ def test_calculate_and_propagate_metrics_runs_full_pipeline(monkeypatch):
 
     monkeypatch.setattr(
         "oss.src.core.tracing.utils.trees.cost_calculator.cost_per_token",
-        lambda model, prompt_tokens, completion_tokens: (
+        lambda model, prompt_tokens, completion_tokens, **_kwargs: (
             prompt_tokens * 0.01,
             completion_tokens * 0.02,
         ),


### PR DESCRIPTION
Closes #5540.

Stacked on #5709. Set the base to that branch, so this diff shows only its own change.

## The symptom

Three separate defects in how Agenta estimates the cost of a model call.

**Cached input is charged at the full uncached rate.** One measured span with 1 uncached prompt token, 25,182 cache-read tokens and 20 completion tokens was priced at **$0.000303** against a harness-reported **$0.0082**. That is a 27x undercount, and it grows with every warm turn.

**Estimation is dead for most agent spans.** The model lookup checks the response model and a legacy parameters path. The agent runner sets the response model **only for codex**. Measured: **0 of 8,365** chat spans without a response model were priced, and **858 of 858** with one were. A perfect discriminator.

**A reported cost of zero is treated as missing.** The guard that stops the roll-up overwriting a producer-reported cost tested for a non-zero value, and the reader it used defaults every field to `0.0`. So a genuine measured zero, such as a fully cached turn or a free model, was indistinguishable from an absent attribute and got replaced by an estimate.

## The fix, and why the token math looks the way it does

Litellm derives ordinary input by **subtracting** the cache details from whatever prompt count you hand it. So it wants the **inclusive** figure, not the uncached remainder. Passing the uncached count plus the cache arguments silently drops the ordinary tokens.

Reproduced against the pinned litellm 1.92.0, with 93 uncached and 13,463 cache-read tokens:

| Shape passed to litellm | `gpt-5.3-codex` | `claude-sonnet-4-6` |
|---|---:|---:|
| 93, no cache arguments | $0.00016275 | $0.000279 |
| 93, plus cache arguments | $0.002356025 | $0.0040389 |
| 13,556 inclusive, plus cache arguments | $0.002518775 | $0.0043179 |

The middle row loses the 93 ordinary tokens. Only the last row prices both kinds of input, and it holds on both the OpenAI and the Anthropic pricing routes.

**One assumption, written into the code.** Today's `prompt` bucket holds raw **exclusive** input, which is why summing the cache buckets into it is correct. A planned canonical change would make input inclusive at the boundary, at which point the same sum would double count. The comment at the summation names that condition, and the arithmetic sits in one place so the future migration has one thing to change. No heuristic tries to detect which convention is in force.

**Model lookup** now tries the response model, then `ag.meta.request.model`, then the legacy parameters path.

**The guard** now tests whether the cumulative total attribute is **present**, not whether it is non-zero.

## Verification

- **1,631 passing** in OSS unit tests, **1,890** in EE.
- 23 new tests: the pricing oracle parametrized over four cache shapes and two providers, the #5540 regression itself, the case that guards the middle row of the table above, model lookup precedence, containment of an unpriceable alias and a missing model, and the reported-zero guard driven through the real ingest pipeline.
- **Mutation checked.** The new tests were run against the previous version of the module, loaded from `HEAD` under the production module name: **9 fail**. They pin the fix rather than the framework. The one cache-creation case that passes on the old code does so legitimately, because OpenAI has no separate cache-write price and both shapes agree there.

## Notes for the reviewer

- **New noise, by design.** Falling back to the request model starts feeding unpriceable aliases into litellm, such as the bare string `"sonnet"` that the model picker sends. Verified that the failure stays contained: `litellm.BadRequestError` is caught by the existing handler, one warning is logged, no cost is written, no exception escapes into ingest. Litellm also prints its own provider banner to stderr on each such failure, which is new noise at comparable volume.
- **The estimate is still an estimate.** Anthropic prices five-minute and one-hour cache writes differently. Litellm maps `cache_creation_input_tokens` to a single write rate and the runner emits a single cache-write number, so long-lived cache writes are still undercounted.
- **Two pre-existing tests needed fixture updates**, not behavior changes. One helper was unpriceable only because of the model-lookup defect, so its premise disappeared. Another monkeypatched `cost_per_token` with a fixed three-argument signature that rejected the new cache keywords.

## Follow-ups this does not do

- The roll-up has the same missing-versus-zero conflation on its own **write** path: a parent whose children genuinely cost zero still gets no cumulative attribute rather than an explicit zero. The same shape exists for tokens and errors.
- `calculate_costs` assumes several attribute containers are dictionaries. A scalar there raises outside the `try` and would fail the whole ingest batch. Pre-existing.