### PR TITLE
[5693] fix(backend): report Codex in runner health

### DIFF
--- a/services/runner/src/version.ts
+++ b/services/runner/src/version.ts
@@ -12,7 +12,7 @@ import pkg from "../package.json";
 export const PROTOCOL_VERSION = 1;
 export const RUNNER_VERSION: string = pkg.version;
 export const ENGINES = ["sandbox-agent"] as const;
-export const HARNESS_KINDS = ["pi_core", "claude", "pi_agenta"] as const;
+export const HARNESS_KINDS = ["pi_core", "claude", "pi_agenta", "codex"] as const;
 
 export interface RunnerInfo {
   status: "ok";

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -76,7 +76,10 @@ describe("createAgentServer", () => {
         Array.isArray(body.engines) &&
           (body.engines as unknown[]).includes("sandbox-agent"),
       );
-      assert.ok(Array.isArray(body.harnesses));
+      assert.ok(
+        Array.isArray(body.harnesses) &&
+          (body.harnesses as unknown[]).includes("codex"),
+      );
     } finally {
       await s.close();
     }


### PR DESCRIPTION
## Context
The runner's `/health` endpoint omitted `codex` from the `harnesses` list, even though Codex runs are supported. The response therefore under-reported the runner capabilities.

## Changes
Add `codex` to `HARNESS_KINDS`, the source used to build the health response. Extend the `/health` unit test to assert that the returned harness list includes `codex`.

Fixes #5693

## Tests / notes
- `corepack pnpm exec vitest run --project unit tests/unit/server.test.ts`
- `corepack pnpm run typecheck`
- `git diff --check`

The focused test and typecheck pass. The full suite was also attempted, but this Windows sparse checkout reports unrelated failures involving POSIX permissions, path separators, and cross-tree fixtures.