### PR TITLE
feat(runner): declare that our input token count excludes cached tokens

### DIFF
--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -561,6 +561,21 @@ function lastAssistantText(messages: any): string {
 }
 
 /**
+ * Declares which token contract a span's `gen_ai.usage.input_tokens` follows.
+ *
+ * The runner writes `false`: its input count is EXCLUSIVE — uncached input only, with
+ * `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens`
+ * reported beside it rather than inside it. The OpenTelemetry GenAI contract means the
+ * opposite (input already includes cached tokens), and pricing derives ordinary input by
+ * subtracting the cache details from the count it is given. Agenta ingests OTLP from
+ * third-party instrumentation as well as from this runner, so without this marker the two
+ * contracts are indistinguishable and one of them is mispriced. An ABSENT marker means
+ * inclusive, the OpenTelemetry meaning; every span this runner gives an input token count
+ * carries the marker.
+ */
+const INPUT_TOKENS_INCLUDES_CACHE = "agenta.usage.input_tokens_includes_cache";
+
+/**
  * Stamp a run's cost, and only its cost, on a PARENT span (`invoke_agent`).
  *
  * A parent must not repeat its children's `gen_ai.usage.*_tokens`: ingest maps those to the
@@ -594,6 +609,7 @@ function applyAssistant(
   const u = msg.usage;
   if (u) {
     // Current GenAI names (mapped by Agenta's logfire adapter) ...
+    span.setAttribute(INPUT_TOKENS_INCLUDES_CACHE, false);
     span.setAttribute("gen_ai.usage.input_tokens", u.input ?? 0);
     span.setAttribute("gen_ai.usage.output_tokens", u.output ?? 0);
     // ... and legacy names (mapped by Agenta's semconv.py). Emit both so token
@@ -1193,6 +1209,7 @@ export function createSandboxAgentOtel(
     // stamping zeros would assert a run cost nothing and spent nothing. An ABSENT cost counts
     // as no cost here, exactly like a reported 0, so it cannot carry a token-less record.
     if (!u || (u.total <= 0 && !(u.cost != null && u.cost > 0))) return;
+    span.setAttribute(INPUT_TOKENS_INCLUDES_CACHE, false);
     span.setAttribute("gen_ai.usage.input_tokens", u.input);
     span.setAttribute("gen_ai.usage.output_tokens", u.output);
     span.setAttribute("gen_ai.usage.prompt_tokens", u.input);

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -561,6 +561,21 @@ function lastAssistantText(messages: any): string {
 }
 
 /**
+ * Declares which token contract a span's `gen_ai.usage.input_tokens` follows.
+ *
+ * The runner writes `false`: its input count is EXCLUSIVE — uncached input only, with
+ * `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens`
+ * reported beside it rather than inside it. The OpenTelemetry GenAI contract means the
+ * opposite (input already includes cached tokens), and pricing derives ordinary input by
+ * subtracting the cache details from the count it is given. Agenta ingests OTLP from
+ * third-party instrumentation as well as from this runner, so without this marker the two
+ * contracts are indistinguishable and one of them is mispriced. An ABSENT marker means
+ * inclusive, the OpenTelemetry meaning; every span this runner gives an input token count
+ * carries the marker.
+ */
+const INPUT_TOKENS_INCLUDES_CACHE = "agenta.usage.input_tokens_includes_cache";
+
+/**
  * Stamp a run's cost, and only its cost, on a PARENT span (`invoke_agent`).
  *
  * A parent must not repeat its children's `gen_ai.usage.*_tokens`: ingest maps those to the
@@ -594,6 +609,7 @@ function applyAssistant(
   const u = msg.usage;
   if (u) {
     // Current GenAI names (mapped by Agenta's logfire adapter) ...
+    span.setAttribute(INPUT_TOKENS_INCLUDES_CACHE, false);
     span.setAttribute("gen_ai.usage.input_tokens", u.input ?? 0);
     span.setAttribute("gen_ai.usage.output_tokens", u.output ?? 0);
     // ... and legacy names (mapped by Agenta's semconv.py). Emit both so token
@@ -1234,6 +1250,7 @@ export function createSandboxAgentOtel(
     // stamping zeros would assert a run cost nothing and spent nothing. An ABSENT cost counts
     // as no cost here, exactly like a reported 0, so it cannot carry a token-less record.
     if (!u || (u.total <= 0 && !(u.cost != null && u.cost > 0))) return;
+    span.setAttribute(INPUT_TOKENS_INCLUDES_CACHE, false);
     span.setAttribute("gen_ai.usage.input_tokens", u.input);
     span.setAttribute("gen_ai.usage.output_tokens", u.output);
     span.setAttribute("gen_ai.usage.prompt_tokens", u.input);

--- a/services/runner/tests/unit/otel-input-token-semantics.test.ts
+++ b/services/runner/tests/unit/otel-input-token-semantics.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The runner declares the token contract its spans follow.
+ *
+ * `gen_ai.usage.input_tokens` is EXCLUSIVE here — uncached input only, with the cache read and
+ * cache creation counts reported beside it. The OpenTelemetry GenAI contract means the opposite,
+ * and Agenta ingests OTLP from third-party instrumentation too, so a consumer that assumes either
+ * contract misprices the other. `agenta.usage.input_tokens_includes_cache = false` says which one
+ * this span follows; an absent marker means the OpenTelemetry (inclusive) meaning.
+ *
+ * INVARIANT these tests pin, for both tracers: every span that carries an input token count also
+ * carries the marker, as a boolean `false`.
+ *
+ * Run: pnpm exec vitest run tests/unit/otel-input-token-semantics.test.ts
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { trace, type Span } from "@opentelemetry/api";
+
+import {
+  createAgentaOtel,
+  createSandboxAgentOtel,
+} from "../../src/tracing/otel.ts";
+
+const MARKER = "agenta.usage.input_tokens_includes_cache";
+const INPUT_TOKENS = "gen_ai.usage.input_tokens";
+
+interface FakeSpan {
+  name: string;
+  attributes: Record<string, unknown>;
+}
+
+/** Replace the OTel tracer so every span built records into a captured array. */
+function spyTracer(): FakeSpan[] {
+  const spans: FakeSpan[] = [];
+  const makeSpan = (name: string): Span => {
+    const span: FakeSpan = { name, attributes: {} };
+    spans.push(span);
+    const api = {
+      setAttribute(key: string, value: unknown) {
+        span.attributes[key] = value;
+        return api;
+      },
+      setAttributes(attrs: Record<string, unknown>) {
+        Object.assign(span.attributes, attrs);
+        return api;
+      },
+      recordException() {},
+      setStatus() {
+        return api;
+      },
+      end() {},
+      spanContext() {
+        return {
+          traceId: "0".repeat(32),
+          spanId: "0".repeat(16),
+          traceFlags: 1,
+        };
+      },
+      isRecording: () => true,
+      addEvent: () => api,
+      updateName: () => api,
+    };
+    return api as unknown as Span;
+  };
+  vi.spyOn(trace, "getTracer").mockReturnValue({
+    startSpan: (name: string) => makeSpan(name),
+    startActiveSpan: ((name: string, fn: (s: Span) => unknown) =>
+      fn(makeSpan(name))) as any,
+  } as any);
+  return spans;
+}
+
+/**
+ * The declaration invariant: a span carries the marker if and only if it carries an input token
+ * count, and the marker is the boolean `false` (not the string "false", which would land as a
+ * different attribute type on the wire). Returns how many spans declared it, so a caller can
+ * assert the run produced any at all.
+ */
+function assertEveryTokenSpanDeclaresExclusiveInput(spans: FakeSpan[]): number {
+  let declared = 0;
+  for (const span of spans) {
+    const hasTokens = span.attributes[INPUT_TOKENS] !== undefined;
+    if (!hasTokens) {
+      expect(
+        span.attributes[MARKER],
+        `${span.name} reports no input tokens, so it must not declare their contract`,
+      ).toBeUndefined();
+      continue;
+    }
+    expect(
+      span.attributes[MARKER],
+      `${span.name} reports input tokens and must declare they exclude cache`,
+    ).toBe(false);
+    expect(typeof span.attributes[MARKER]).toBe("boolean");
+    declared += 1;
+  }
+  return declared;
+}
+
+/** Drive the Pi extension lifecycle by capturing the handlers it registers. */
+function piHandlers(otel: ReturnType<typeof createAgentaOtel>) {
+  const handlers: Record<string, (e: any, ctx?: any) => Promise<void>> = {};
+  otel.register({
+    on: (name: string, fn: (e: any, ctx?: any) => Promise<void>) => {
+      handlers[name] = fn;
+    },
+  } as any);
+  return handlers;
+}
+
+const assistantMessage = (usage: Record<string, unknown>) => ({
+  role: "assistant",
+  model: "claude-haiku-9",
+  provider: "anthropic",
+  content: "ok",
+  usage,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the ACP tracer declares its input token contract", () => {
+  it("marks the chat leaf that carries the token split", () => {
+    const spans = spyTracer();
+    const otel = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+    });
+    otel.start({ prompt: "hi" });
+    otel.setUsage({ input: 3595, output: 248, total: 3843, cost: 0.0219 });
+    otel.finish();
+
+    const chatSpan = spans.find((s) => s.name.startsWith("chat"));
+    expect(chatSpan?.attributes[INPUT_TOKENS]).toBe(3595);
+    expect(chatSpan?.attributes[MARKER]).toBe(false);
+    expect(assertEveryTokenSpanDeclaresExclusiveInput(spans)).toBe(1);
+  });
+
+  it("leaves the parent spans undeclared, since they report no input tokens", () => {
+    const spans = spyTracer();
+    const otel = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+    });
+    otel.start({ prompt: "hi" });
+    otel.setUsage({ input: 100, output: 20, total: 120, cost: 0.01 });
+    otel.finish();
+
+    const agentSpan = spans.find((s) => s.name === "invoke_agent");
+    expect(agentSpan?.attributes["gen_ai.usage.cost"]).toBe(0.01);
+    expect(agentSpan?.attributes[MARKER]).toBeUndefined();
+    assertEveryTokenSpanDeclaresExclusiveInput(spans);
+  });
+
+  it("declares the contract even when the run reported cost without a token split", () => {
+    const spans = spyTracer();
+    const otel = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+    });
+    otel.start({ prompt: "hi" });
+    otel.setUsage({ input: 0, output: 0, total: 0, cost: 0.04 });
+    otel.finish();
+
+    const chatSpan = spans.find((s) => s.name.startsWith("chat"));
+    expect(chatSpan?.attributes[INPUT_TOKENS]).toBe(0);
+    expect(assertEveryTokenSpanDeclaresExclusiveInput(spans)).toBe(1);
+  });
+});
+
+describe("the Pi tracer declares its input token contract", () => {
+  it("marks every turn's chat span, alongside the cache counts it reports separately", async () => {
+    const spans = spyTracer();
+    const otel = createAgentaOtel({
+      captureContent: false,
+      requestModel: "claude-haiku-9",
+    });
+    const handlers = piHandlers(otel);
+
+    await handlers["before_agent_start"]?.({ prompt: "hi" });
+    await handlers["agent_start"]?.({});
+    for (const index of [0, 1]) {
+      await handlers["turn_start"]?.({ turnIndex: index });
+      await handlers["before_provider_request"]?.({}, {});
+      await handlers["message_end"]?.({
+        message: assistantMessage({
+          input: 120,
+          output: 30,
+          totalTokens: 150,
+          cacheRead: 900,
+          cacheWrite: 40,
+          cost: { total: 0.002 },
+        }),
+      });
+      await handlers["turn_end"]?.({});
+    }
+    await handlers["agent_end"]?.({ messages: [] });
+
+    const chatSpans = spans.filter((s) => s.name.startsWith("chat"));
+    expect(chatSpans).toHaveLength(2);
+    for (const span of chatSpans) {
+      // The cache counts sit BESIDE the input count: that is what the marker declares.
+      expect(span.attributes[INPUT_TOKENS]).toBe(120);
+      expect(span.attributes["gen_ai.usage.cache_read.input_tokens"]).toBe(900);
+      expect(span.attributes["gen_ai.usage.cache_creation.input_tokens"]).toBe(
+        40,
+      );
+      expect(span.attributes[MARKER]).toBe(false);
+    }
+    expect(assertEveryTokenSpanDeclaresExclusiveInput(spans)).toBe(2);
+  });
+
+  it("marks a turn that reported no cache counts at all", async () => {
+    const spans = spyTracer();
+    const otel = createAgentaOtel({
+      captureContent: false,
+      requestModel: "gpt-5.6-luna",
+    });
+    const handlers = piHandlers(otel);
+
+    await handlers["before_agent_start"]?.({ prompt: "hi" });
+    await handlers["agent_start"]?.({});
+    await handlers["turn_start"]?.({ turnIndex: 0 });
+    await handlers["before_provider_request"]?.({}, {});
+    await handlers["message_end"]?.({
+      message: assistantMessage({ input: 10, output: 5, totalTokens: 15 }),
+    });
+    await handlers["turn_end"]?.({});
+    await handlers["agent_end"]?.({ messages: [] });
+
+    const chatSpan = spans.find((s) => s.name.startsWith("chat"));
+    expect(chatSpan?.attributes[INPUT_TOKENS]).toBe(10);
+    expect(
+      chatSpan?.attributes["gen_ai.usage.cache_read.input_tokens"],
+    ).toBeUndefined();
+    expect(assertEveryTokenSpanDeclaresExclusiveInput(spans)).toBe(1);
+  });
+});


### PR DESCRIPTION
Stacked on #5717. Set the base to that branch, so this diff shows only its own change.

This is one half of a contract. The API half maps the attribute and decides what to do with it. **This half should merge first**, so that by the time the API starts trusting the marker, the runner is already sending it.

## The problem

The API prices a model call by handing token counts to litellm. Litellm expects an **inclusive** prompt count and derives ordinary input by subtracting the cache details from it.

This runner emits the opposite. `gen_ai.usage.input_tokens` holds uncached tokens only, with cache-read and cache-creation counts beside it. The pinned Pi implementation confirms it: it reconstructs a prompt count as input plus cache read plus cache write.

The OpenTelemetry GenAI contract says `input_tokens` **already includes** cached tokens.

Agenta ingests OTLP from third-party instrumentation as well as from this runner, and ingest maps both into the same bucket. So the API cannot tell the two contracts apart, and whichever it assumes is wrong for the other. Measured against the pinned litellm, the wrong assumption misprices by roughly tenfold, in one direction or the other.

## The change

Say which contract this is. Every span that carries an input token count now also carries `agenta.usage.input_tokens_includes_cache = false`. One shared constant, stamped on both tracer paths at the same place they stamp the token counts.

## Why this is safe under version skew

The API half treats an **absent** marker as inclusive, which is the OpenTelemetry meaning. The runner and the services deploy as independently versioned artifacts, so an old runner will reach a new API. Under that default, the skew reproduces the pre-existing undercount, which is the bug we already have, rather than producing a new tenfold overcharge. A fix should never introduce an error worse than the one it repairs.

## Verification

The full runner suite passes, **1,495 tests across 99 files**, and `tsc --noEmit` is clean.

Five new tests cover both tracers, a parent that carries no input token count and therefore needs no marker, a cost-only run, and a turn with no cache counts.

The tests assert the two facts as a **biconditional**: a span carries the marker exactly when it carries an input token count. A future stamping site that forgets the marker fails the suite rather than shipping a span the API cannot price.

## Notes for the reviewer

- The search for stamping sites was exhaustive rather than sampled. Only one file in `src/` calls `setAttribute` at all, and only two places write an input token count.
- `stampRunCost` writes cost onto parent spans and never carries an input token count, so the invariant holds there without a marker.
- The workflow root span in the Python SDK does not carry the marker. It carries no cache attributes, and its span type is not priced from tokens, so a declaration there would assert a contract about a number the API never reads that way.