### PR TITLE
[docs] Announce Codex and Daytona credential hiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ When you self-host Agenta, you can run agents locally with your existing Claude 
 
 ### Choose your harness and model
 
-Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code and Pi as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+Switch harnesses and models without rebuilding your agent. Agenta already supports almost any model, whether self-hosted or accessed through an API. Agenta supports Claude Code, Pi, and Codex as harnesses today, with [more harnesses planned](https://agenta.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ### Build with open agent standards
 
@@ -163,7 +163,7 @@ For more details, read the [self-hosting documentation](https://agenta.ai/docs/s
 
 - [x] Claude Code
 - [x] Pi
-- [ ] Codex
+- [x] Codex
 - [ ] Gemini
 - [ ] OpenCode
 - [ ] [Create an issue to prioritize yours](https://github.com/Agenta-AI/agenta/issues)
@@ -225,7 +225,7 @@ Claude Cowork provides a workspace built around Claude. Agenta is open source an
 
 ### Claude Code, Codex, Pi, and OpenCode
 
-These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code and Pi today. Support for more harnesses is on the roadmap.
+These coding agents provide the execution layer that plans work and uses tools. Agenta adds the shared workspace around that execution layer: files, team access, triggers, versions, and traces. Agenta supports Claude Code, Pi, and Codex today. Support for more harnesses is on the roadmap.
 
 ## Community and contributing
 

--- a/docs/blog/entries/agenta-is-now-a-workspace-for-building-agents.mdx
+++ b/docs/blog/entries/agenta-is-now-a-workspace-for-building-agents.mdx
@@ -8,15 +8,17 @@ description: "Agenta is now a workspace for building and running agents: assista
 
 <Summary>
 
-<iframe
-  width="100%"
-  height="400"
-  src="https://www.youtube.com/embed/Y5l2BPRkKC8"
-  title="Agenta Is Now a Workspace for Building Agents"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
-></iframe>
+<div style={{display: 'flex', justifyContent: 'center', marginTop: "20px", marginBottom: "20px", flexDirection: 'column', alignItems: 'center'}}>
+  <iframe
+    width="100%"
+    height="400"
+    src="https://www.youtube.com/embed/Y5l2BPRkKC8"
+    title="Agenta Is Now a Workspace for Building Agents"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
 
 Agenta is now a workspace for building and running agents, not only a platform for managing prompts. You build an agent by chatting with it: describe the job, connect the apps it needs, and correct it through feedback until it works the way you want.
 
@@ -28,15 +30,17 @@ An agent is made of instructions, tools, skills, permissions, and files. You can
 
 Agenta started as a platform for managing and evaluating prompts. With this release, it becomes a workspace where you build agents: assistants that plan their own steps, call tools, and get work done, rather than answer a single prompt.
 
-<iframe
-  width="100%"
-  height="400"
-  src="https://www.youtube.com/embed/Y5l2BPRkKC8"
-  title="Agenta Is Now a Workspace for Building Agents"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
-></iframe>
+<div style={{display: 'flex', justifyContent: 'center', marginTop: "20px", marginBottom: "20px", flexDirection: 'column', alignItems: 'center'}}>
+  <iframe
+    width="100%"
+    height="400"
+    src="https://www.youtube.com/embed/Y5l2BPRkKC8"
+    title="Agenta Is Now a Workspace for Building Agents"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
 
 ## What an agent is made of
 

--- a/docs/blog/entries/api-keys-hidden-from-agent-sandboxes.mdx
+++ b/docs/blog/entries/api-keys-hidden-from-agent-sandboxes.mdx
@@ -1,0 +1,68 @@
+---
+title: "API Keys Are Hidden from Agent Sandboxes"
+slug: api-keys-hidden-from-agent-sandboxes
+date: 2026-08-04
+tags: [v0.108.1]
+description: "Agents running in a cloud sandbox no longer see your provider API keys. Each key becomes a Daytona Secret scoped to a single host, and the sandbox holds only a placeholder."
+---
+
+<Summary>
+
+We improved security in Agenta. An agent can no longer see your API keys when it runs in a cloud sandbox. This covers both your model provider keys and the credentials on your MCP servers.
+
+Ask an agent to print its own environment variables now, and you get a useless placeholder instead of a key.
+
+This is on by default in Agenta Cloud, and there is nothing for you to do.
+
+If you self-host, it applies to agents running in a Daytona sandbox, and your Daytona API key now needs permission to manage Secrets. Read the upgrade note below before you upgrade.
+
+</Summary>
+
+{/* truncate */}
+
+An agent is not ordinary application code. It writes code and runs it, it installs packages, and it downloads things you did not choose. Until now, the API key it used to call the model was an ordinary environment variable in the same sandbox, readable by all of that. A prompt injection that persuaded an agent to print its environment printed your key.
+
+That is no longer the case on [Daytona](/self-host/agent-execution/daytona) sandboxes.
+
+## How it works
+
+The runner no longer puts the real key in the sandbox. For each key a run carries, it does three things:
+
+1. Stores the key as a Daytona Secret record, restricted to the one hostname that key authenticates against.
+2. Puts an opaque placeholder in the sandbox in place of the real value.
+3. Lets Daytona substitute the real value back in on outbound requests to that host.
+
+The model call and the MCP call still work, because the substitution happens after the request leaves the sandbox. Everything inside the sandbox, including anything the agent installs or downloads, only ever holds the placeholder. A request to any other host carries the placeholder as well, which is what makes exfiltration fail.
+
+## What it covers
+
+Model provider API keys, and the credentials and headers you set on an HTTP MCP server. Each one is scoped separately, to its own host, so an MCP credential cannot be used against your model provider and the other way round. The host comes from the credential's own endpoint, and it has to be a plain HTTPS hostname: no wildcards, no IP addresses, no `localhost`.
+
+One class of credential is not covered. Some keys are signed locally by the provider's own SDK rather than sent, which today means the AWS keys behind Bedrock and the Google service account credentials behind Vertex AI. Those still reach the sandbox in full, because there is no outbound header to substitute them into. Those runs work normally, they just do not get this protection yet. We are working on covering them.
+
+Local sandbox runs are unaffected. The harness runs inside the runner container there, so its keys never leave your deployment in the first place.
+
+## Self-hosting: your Daytona API key needs a new permission
+
+:::warning Grant the Secrets permission before you upgrade
+A Daytona API key is minted with a set of permissions, and a key that can create sandboxes does **not** automatically have the separate permission to manage Secrets.
+
+Because hiding is on by default, a key without that permission fails every Daytona run that carries a model or MCP key, at sandbox creation. Grant the key in `AGENTA_RUNNER_DAYTONA_API_KEY` permission to manage Secrets, or reissue it with that permission, before you upgrade. The error names the variable and the permission, so it is recognizable, but runs keep failing until the key is fixed.
+
+The runner never quietly falls back to sending keys as plaintext. Silently doing the unprotected thing is worse than stopping.
+:::
+
+## Bugs and improvements
+
+- Agent replies no longer end with an error after the turn finished successfully.
+- Codex sessions on your own subscription no longer fail after the first turn when you self-host.
+- Browser tabs now name the page you are on.
+- Voice input, for dictating in the agent chat, is available as an experimental setting.
+
+## Getting started
+
+There is nothing to turn on. If you use Agenta Cloud, it is already in effect.
+
+- [Configuration reference](/self-host/configuration#hiding-api-keys-from-the-sandbox) has the full setting, the cleanup guarantee behind the `process_local` mode, and the upgrade note.
+- [Run agents in a cloud sandbox (Daytona)](/self-host/agent-execution/daytona) covers the Daytona setup.
+- [Sandbox isolation and security](/self-host/agent-execution/sandbox-isolation-and-security) covers what each sandbox type isolates.

--- a/docs/blog/entries/codex-harness.mdx
+++ b/docs/blog/entries/codex-harness.mdx
@@ -1,0 +1,93 @@
+---
+title: "Run Your Agents on Codex"
+slug: codex-harness
+date: 2026-08-03
+tags: [v0.108.0]
+description: "Codex is now a harness you can pick for an agent, alongside Claude Code and Pi. Five OpenAI models, local or cloud sandbox, tool approvals, and your own ChatGPT subscription when you self-host."
+---
+
+<Summary>
+
+<div style={{display: 'flex', justifyContent: 'center', marginTop: "20px", marginBottom: "20px", flexDirection: 'column', alignItems: 'center'}}>
+  <iframe
+    width="100%"
+    height="500"
+    src="https://customer-8r37tdgzpxskd9f1.cloudflarestream.com/8eb653a1dc978ffd4bc6f566141bad17/iframe?muted=true&loop=true&autoplay=true"
+    title="Running an agent on the Codex harness"
+    frameBorder="0"
+    allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+    allowFullScreen
+  ></iframe>
+</div>
+
+You can now run an agent on Codex, OpenAI's coding agent. Switching an agent over is a configuration change, and you can do it from either of the other two harnesses in the middle of a session.
+
+Pay with an API key, or use your own ChatGPT subscription when you self-host.
+
+Codex has the following capabilities:
+
+- Five OpenAI models, from GPT-5.6 Sol down to the cheaper Luna, most with a context window of about a million tokens.
+- Runs on the local sandbox or in a Daytona cloud sandbox.
+- Follows the same tool approvals as your other agents, and answering an approval resumes the session instead of restarting it.
+- Connects to your own HTTP MCP servers.
+- Reads image attachments.
+- Keeps every tool you already configured, with tracing and cost reporting attached as usual.
+
+</Summary>
+
+{/* truncate */}
+
+Agenta now ships three harnesses: Claude Code, Pi, and Codex. A harness is the program that drives the model, runs the tools it asks for, and manages context. You pick one per agent, and the rest of the agent does not move with it.
+
+## Picking Codex
+
+Go to `Sidebar > Agents > <agent name>`, set `Playground mode` to `Build`, and open the `Model & harness` section at the top of the `Configuration` column. Click `Detailed configuration`, open the `Harness` section, and choose `Codex`. Then pick a model in the `Model` section below.
+
+## The models
+
+| Model | Picker label | Context window |
+|---|---|---|
+| GPT-5.6 Sol | `Sol (default)` | 1,050,000 |
+| GPT-5.6 Terra | `Terra` | 1,050,000 |
+| GPT-5.6 Luna | `Luna (cheapest)` | 1,050,000 |
+| GPT-5.5 | `GPT-5.5` | 1,050,000 |
+| GPT-5.2 | `GPT-5.2` | 272,000 |
+
+Sol is the strongest of the three 5.6 tiers, Luna is the fastest and cheapest, and Terra sits between them. The picker shows each model's price and its cost, intelligence, and speed ratings so you can compare before you switch.
+
+Codex reaches OpenAI directly. Unlike Claude Code, it does not route through Bedrock, Vertex AI, or a custom gateway.
+
+## Tool approvals
+
+Codex uses the same permission rules as your other agents. A tool set to `allow` runs, a tool set to `deny` is refused, and a tool set to `ask` stops the run and puts the question in front of you.
+
+An `ask` parks the session warm. Answering resumes the session that was already running, keeping the original tool call, instead of paying for a cold start. Denying a tool ends the turn cleanly and reports the tool as denied rather than as an error.
+
+This works on both the local sandbox and Daytona.
+
+## Tools, MCP, and attachments
+
+Every tool you have configured on the agent works: Agenta's own tools, code tools, and connected integrations all reach Codex, with tracing and cost reporting attached as usual.
+
+You can also point Codex at your own HTTP MCP servers, the same way you can with Claude Code. The `MCP servers` section appears in the agent configuration when you select Codex.
+
+Codex reads image attachments natively. Paste or drag an image into the chat and the model sees it. Audio and document attachments are not supported on Codex today.
+
+## Paying for the model
+
+Two options, the same two the other harnesses have:
+
+- **An API key.** Add an OpenAI key to the agent and Agenta uses it for the run. This works on Agenta Cloud and on self-hosted deployments, on both sandbox types.
+- **Your ChatGPT subscription.** When you self-host, an agent can authenticate from a ChatGPT/Codex login you already pay for, instead of metered API billing. This works on local runs only. A Daytona run cannot use a subscription, and the option is not available on Agenta Cloud.
+
+## Notes for self-hosters
+
+If you run agents on Daytona, rebuild your sandbox snapshot before you use Codex there. Run the snapshot recipe with `--force` so `agenta-agent-sandbox-v1` picks up the Codex build from this release. See [Run agents in a cloud sandbox (Daytona)](/self-host/agent-execution/daytona).
+
+To use a ChatGPT subscription, mount your `~/.codex` login into the runner and set `CODEX_HOME`. See [Use your own subscription](/self-host/use-your-own-subscription).
+
+## Getting started
+
+- [Use your own subscription](/self-host/use-your-own-subscription) has the Codex login setup.
+- [Run agents in a cloud sandbox (Daytona)](/self-host/agent-execution/daytona) covers the snapshot rebuild.
+- [Permissions](/concepts/permissions) covers the approval rules Codex follows.

--- a/docs/blog/entries/file-attachments-in-agent-chat.mdx
+++ b/docs/blog/entries/file-attachments-in-agent-chat.mdx
@@ -1,18 +1,32 @@
 ---
-title: "File Attachments in Agent Chat"
+title: "Shared Workspace Files"
 slug: file-attachments-in-agent-chat
 date: 2026-08-02
 tags: [v0.107.0]
-description: "Attach files and images to agent chat by pasting, dragging and dropping, or uploading a whole folder. Plus simpler built-in tool permissions for Pi agents and better-equipped sandboxes."
+description: "One cloud folder for you, your team, and your agents. Upload images, PDFs, and whole folders, and the agent works from the same files you do."
 ---
 
 <Summary>
 
-{/* TODO(Mahmoud): add a short screenshot or video showing a file being attached to an agent chat message (paste, drag and drop, or the attach button) */}
+<div style={{display: 'flex', justifyContent: 'center', marginTop: "20px", marginBottom: "20px", flexDirection: 'column', alignItems: 'center'}}>
+  <iframe
+    width="100%"
+    height="500"
+    src="https://customer-8r37tdgzpxskd9f1.cloudflarestream.com/04df507b65359344e047e23a59b09b1e/iframe?muted=true&loop=true&autoplay=true"
+    title="Shared workspace files in Agenta"
+    frameBorder="0"
+    allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+    allowFullScreen
+  ></iframe>
+</div>
 
-You can now attach files and images directly to an agent chat message. Paste from your clipboard, drag and drop, click the attach button, or drop a whole folder and Agenta uploads its contents one file at a time.
+Your agents now work from a shared folder in the cloud, not from files sitting on one person's laptop.
 
-Attachments belong to the session. Open the Files drawer to see everything that has been added, and the agent can read the same files inside its sandbox.
+Upload images, PDFs, spreadsheets, or a whole folder. Paste from your clipboard, drag files in, or use the attach button. Your team sees the same files, and so do your agents.
+
+Each agent keeps its own folder that survives between conversations. Save the reference material, the approved examples, and the notes it should follow, and the agent starts every session already knowing them instead of being told again. Files you attach to a single conversation stay with that conversation.
+
+This works on Agenta Cloud and on a self-hosted deployment.
 
 **Also in this release:**
 
@@ -30,17 +44,21 @@ Attachments belong to the session. Open the Files drawer to see everything that 
 
 {/* truncate */}
 
-{/* TODO(Mahmoud): add a short screenshot or video showing a file being attached to an agent chat message (paste, drag and drop, or the attach button) */}
+An agent is only as useful as the material it can reach. Until now that material lived wherever you kept it, which usually meant a folder on one machine that nobody else could see. Agenta now gives you and your agents one folder in the cloud, and your team works from the same copy.
 
-Agent chat now takes files and images as attachments, not just text. Give the agent a spreadsheet, a screenshot, or a whole folder of reference material, and it can read them while it works.
+## Getting files in
 
-## How it works
+You can add a file four ways: paste it from your clipboard, drag it in, click the attach button, or drop a whole folder. When you drop a folder, Agenta uploads its contents one file at a time.
 
-You can attach a file four ways: paste it from your clipboard, drag it in, click the attach button, or drop a whole folder. When you drop a folder, Agenta uploads its contents one file at a time.
+Images, PDFs, spreadsheets, and plain documents all work. Large files upload in chunks, so a slow connection does not sink the whole upload, and a file that is too big gives you a clear message instead of a failed request.
 
-Attachments belong to the session that created them. Open the session's Files drawer to see everything you and the agent have added, and the agent can read those same files from inside its sandbox.
+## Two folders, and the difference matters
 
-Large files upload in chunks, so a slow connection does not sink the whole upload. If a file is too big, you get a clear message instead of a failed request.
+Files you attach to a conversation belong to that conversation. They are the desk for today's work: the spreadsheet you are asking about, the drafts you are shaping, the results you want to take away.
+
+Each agent also has its own folder that persists across every conversation with it. That is where the reference material goes: the brand guide, the examples your team approved, the notes the agent should follow. Point at those files from the agent's instructions and it starts every session already knowing them, instead of you explaining the same context again.
+
+Both are visible to your team, and the agent reads them from inside its sandbox exactly as you see them.
 
 See [Files and knowledge](/concepts/files-and-knowledge) for how session files and agent files differ.
 

--- a/docs/docs/concepts/08-harnesses-and-models.mdx
+++ b/docs/docs/concepts/08-harnesses-and-models.mdx
@@ -27,13 +27,21 @@ The harness also manages what surrounds the loop. It loads your instructions at 
 
 The harness handles compaction, which is what happens when a conversation grows past what the model can hold. The harness summarizes the earlier part of the conversation so the session can keep going.
 
-Agenta ships two harnesses, Claude Code and Pi. Both run the loop above. They differ in how they compact a long conversation, how they load instructions, and which models they accept.
+Agenta ships three harnesses: Claude Code, Pi, and Codex. All three run the loop above. They differ in how they compact a long conversation, how they load instructions, and which models they accept.
+
+| Harness | Models it accepts |
+|---|---|
+| Claude Code | Anthropic's Claude models, from Anthropic directly, from AWS Bedrock or Google Vertex AI, or through a gateway of your own. |
+| Pi | Models from several providers, including OpenAI, Anthropic, Google Gemini, Mistral, Groq, MiniMax, Together AI, and OpenRouter, plus any OpenAI-compatible endpoint. |
+| Codex | Five OpenAI models: GPT-5.6 Sol, Terra, and Luna, plus GPT-5.5 and GPT-5.2. Codex reaches OpenAI directly, not through Bedrock, Vertex AI, or a gateway. |
+
+Claude Code and Codex also accept HTTP [MCP servers](/guides/add-an-mcp-server) you configure on the agent. Pi does not.
 
 ## You choose the harness, the model, and the credential separately
 
 Setting up an agent's runtime means three separate decisions:
 
-- **The harness.** Claude Code or Pi.
+- **The harness.** Claude Code, Pi, or Codex.
 - **The model.** The model the harness sends the conversation to.
 - **The credential.** Where that model runs. The same model can come from the provider directly, from a proxy you run, or from a cloud such as AWS Bedrock.
 

--- a/docs/docs/guides/04-add-an-mcp-server.mdx
+++ b/docs/docs/guides/04-add-an-mcp-server.mdx
@@ -16,7 +16,7 @@ Have these ready:
 
 - **The server's HTTP URL**, such as `https://example.com/mcp`. Agenta supports HTTP connections, but not local processes over stdio.
 - **The authentication header and key**, if the server requires them. Check the server's documentation for the header name, such as `x-api-key`.
-- **An agent on the Claude Code harness.** MCP servers are available on Claude Code. If the agent runs on Pi, the **MCP servers** section does not appear in its configuration. See [Choose a harness and model](/guides/choose-a-harness-and-model).
+- **An agent on the Claude Code or Codex harness.** MCP servers are available on both. If the agent runs on Pi, the **MCP servers** section does not appear in its configuration, and a run that declares one is refused. See [Choose a harness and model](/guides/choose-a-harness-and-model).
 
 ## Store the key as a project secret first
 
@@ -68,4 +68,4 @@ The agent's `Policy` in the **Advanced** dialog governs MCP tools. They do not s
 ## Next
 
 - [Control what an agent can do](/guides/control-what-an-agent-can-do) covers the policy that decides when an MCP call waits for you.
-- [Choose a harness and model](/guides/choose-a-harness-and-model) covers switching an agent to Claude Code.
+- [Choose a harness and model](/guides/choose-a-harness-and-model) covers switching an agent to Claude Code or Codex.

--- a/docs/docs/guides/09-choose-a-harness-and-model.mdx
+++ b/docs/docs/guides/09-choose-a-harness-and-model.mdx
@@ -25,7 +25,7 @@ Use the inline panel to change the model or add a provider key. To change the ha
 
 ## Choose the harness
 
-In the `Model & harness` dialog, open the `Harness` section. It offers `Pi` and `Claude Code`. The one in use carries a `Current` pill.
+In the `Model & harness` dialog, open the `Harness` section. It offers `Pi`, `Claude Code`, and `Codex`. The one in use carries a `Current` pill.
 
 <Image
   style={{ display: "block", margin: "24px 0" }}

--- a/docs/docs/guides/10-use-your-own-subscription.mdx
+++ b/docs/docs/guides/10-use-your-own-subscription.mdx
@@ -24,6 +24,7 @@ Which login you need depends on the harness the agent uses:
 |---|---|
 | `Claude Code` | Your Claude Code login |
 | `Pi` | Your Pi login, which also covers signing in with ChatGPT |
+| `Codex` | Your ChatGPT/Codex login. The runner reads it from `CODEX_HOME`, pointed at a read-write mount of your `~/.codex` |
 
 ## 2. Match the harness on the agent
 

--- a/docs/docs/reference/agents/01-agent-configuration.mdx
+++ b/docs/docs/reference/agents/01-agent-configuration.mdx
@@ -195,7 +195,7 @@ Each entry is an inline skill package. See [Skills](/concepts/skills).
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `kind` | `"pi_core"` \| `"pi_agenta"` \| `"claude"` | No | `"pi_core"` | Which coding agent to drive. |
+| `kind` | `"pi_core"` \| `"pi_agenta"` \| `"claude"` \| `"codex"` | No | `"pi_core"` | Which coding agent to drive. |
 | `permissions` | object | No | see [harness.permissions](#harnesspermissions) | Tool-use gating posture, applied by harnesses that gate. |
 | `extras` | object | No | `{}` | Per-harness knobs passed through unchanged. For Pi, `system` replaces the base system prompt and `append_system` adds to it. Both are independent of `instructions.agents_md`. |
 
@@ -204,12 +204,13 @@ Each entry is an inline skill package. See [Skills](/concepts/skills).
 | `pi_core` | Pi | `agenta:harness:pi_core:v0` |
 | `pi_agenta` | Pi (Agenta) | `agenta:harness:pi_agenta:v0` |
 | `claude` | Claude Code | `agenta:harness:claude:v0` |
+| `codex` | Codex | `agenta:harness:codex:v0` |
 
 `pi_agenta` runs the same engine as `pi_core` with Agenta's own skills, tools, and base instructions forced on.
 
 ### harness.permissions
 
-Applied by harnesses that gate tool use. Claude Code renders it into `.claude/settings.json` in the session working directory. Pi does not gate and leaves it empty.
+Applied by harnesses that gate tool use. Claude Code renders it into `.claude/settings.json` in the session working directory. Pi does not gate and leaves it empty. Codex renders no per-tool rules of its own; its tool gating comes from [runner.permissions](#runnerpermissions) and the `permission` on each tool entry.
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|

--- a/docs/docs/self-host/agents/02-daytona.mdx
+++ b/docs/docs/self-host/agents/02-daytona.mdx
@@ -15,7 +15,7 @@ the [runner reference](/self-host/configuration#agent-runner).
 
 ## Before you start
 
-- A Daytona account and an API key.
+- A Daytona account and an API key that may create sandboxes **and** manage organization Secrets.
 - A running deployment. See the [Quick start](/self-host/quick-start).
 
 ## 1. Enable the provider
@@ -45,6 +45,17 @@ AGENTA_RUNNER_DAYTONA_TARGET=eu
 ```
 
 The API key is required whenever `daytona` is enabled. The URL and the target are optional.
+
+:::warning The API key needs the Secrets permission
+A Daytona run hides its model and MCP API keys from the sandbox by storing each one as a Daytona
+Secret, and that is on by default. Managing Secrets is a separate permission from creating
+sandboxes, so a key minted only for sandboxes fails every run that carries a model or MCP key.
+
+Grant the key in `AGENTA_RUNNER_DAYTONA_API_KEY` permission to manage Secrets, or reissue it with
+that permission. The runner never falls back to sending keys as plaintext on its own. To send them
+as plain environment variables instead, set `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off`. See
+[Hiding API keys from the sandbox](/self-host/configuration#hiding-api-keys-from-the-sandbox).
+:::
 
 For Helm:
 
@@ -221,6 +232,19 @@ model API key instead. See [Use your own subscription](/self-host/use-your-own-s
 
 **Solution:** Check `AGENTA_RUNNER_DAYTONA_API_KEY` and `AGENTA_RUNNER_DAYTONA_TARGET` against your
 Daytona account.
+
+### A run fails with `Daytona refused to manage Secrets with this API key`
+
+**Cause:** The key in `AGENTA_RUNNER_DAYTONA_API_KEY` can create sandboxes but cannot manage
+Secrets. Hiding model and MCP keys from the sandbox is on by default, and it stores each key as a
+Daytona Secret. The failure happens at sandbox creation, so the run produces no output, and it hits
+every run that carries a model or MCP key.
+
+**Solution:** Grant that key permission to manage Secrets in your Daytona account, or reissue it
+with that permission. The runner never falls back to sending keys as plaintext. If you would rather
+not grant the permission, set `AGENTA_RUNNER_DAYTONA_OPAQUE_SECRETS=off` on the runner and recreate
+it; keys then reach the sandbox as plain environment variables, where the agent can read them. See
+[Hiding API keys from the sandbox](/self-host/configuration#hiding-api-keys-from-the-sandbox).
 
 ### Working directories do not persist across turns
 

--- a/docs/docs/self-host/agents/03-run-agents-locally.mdx
+++ b/docs/docs/self-host/agents/03-run-agents-locally.mdx
@@ -71,8 +71,8 @@ runner.
 
 ### A self-managed run fails because the harness has no login
 
-**Cause:** The subscription mount is missing, or `PI_CODING_AGENT_DIR` / `CLAUDE_CONFIG_DIR` does
-not point at it.
+**Cause:** The subscription mount is missing, or `PI_CODING_AGENT_DIR` / `CLAUDE_CONFIG_DIR` /
+`CODEX_HOME` does not point at it.
 
 **Solution:** See [Use your own subscription](/self-host/use-your-own-subscription).
 

--- a/docs/docs/self-host/concepts/01-architecture.mdx
+++ b/docs/docs/self-host/concepts/01-architecture.mdx
@@ -129,7 +129,7 @@ selector (for example, `AGENTA_WORKER_STREAMS=spans` on its own).
 - **Port**: 8765 (internal)
 - **Purpose**: Executes agent workflows on behalf of the Services API
 
-The runner receives `/run` requests from the Services API (routed via `AGENTA_RUNNER_INTERNAL_URL`) and starts harness processes (Pi, Claude Code, or other supported adapters) in local or remote sandboxes. It mounts durable working directories from the store into each sandbox and relays server-side tools back to the Services API without exposing the full stack environment to the harness.
+The runner receives `/run` requests from the Services API (routed via `AGENTA_RUNNER_INTERNAL_URL`) and starts harness processes (Pi, Claude Code, Codex, or other supported adapters) in local or remote sandboxes. It mounts durable working directories from the store into each sandbox and relays server-side tools back to the Services API without exposing the full stack environment to the harness.
 
 The runner runs each harness in a sandbox: the local runner container (`local`, the default) or a
 Daytona cloud sandbox (`daytona`, enabled by adding `daytona` to

--- a/docs/docs/self-host/concepts/02-how-agents-run.mdx
+++ b/docs/docs/self-host/concepts/02-how-agents-run.mdx
@@ -26,7 +26,7 @@ Its replicas all share the same provider configuration.
 
 Two separate choices shape a run:
 
-- **The harness** is the agent program that runs: Pi, or Claude Code.
+- **The harness** is the agent program that runs: Pi, Claude Code, or Codex.
 - **The sandbox provider** is where that program runs: the local runner container, or a Daytona
   cloud sandbox.
 
@@ -75,8 +75,9 @@ the upgrade note and for how to switch it off if you would rather not grant that
 
 This works for a key the remote service reads over HTTPS, which covers the provider keys and the
 MCP keys. It does not work for a key a provider SDK signs with locally, which today means the AWS
-access keys behind Bedrock: that secret never leaves the sandbox, so there is no outbound request
-to substitute it into, and the sandbox holds the real value.
+access keys behind Bedrock and the Google service account credentials behind Vertex AI: those
+secrets never leave the sandbox, so there is no outbound request to substitute them into, and the
+sandbox holds the real values.
 
 The local sandbox is unaffected. The harness runs inside the runner container there, so its keys are
 already inside your own deployment rather than a third party's.

--- a/docs/docs/self-host/concepts/03-sandbox-isolation-and-security.mdx
+++ b/docs/docs/self-host/concepts/03-sandbox-isolation-and-security.mdx
@@ -29,11 +29,19 @@ process environment, or the working directory of another run.
 
 | Value | Crosses in |
 |---|---|
-| The model key for the run | Yes. The harness needs it to call the model. |
+| The model key for the run | No, by default. The sandbox holds a placeholder. |
+| An HTTP MCP server's credential or header | No, by default. The sandbox holds a placeholder. |
+| A model credential a provider SDK signs with locally | Yes. Today that means the AWS access keys behind Bedrock and the Google service account credentials behind Vertex AI. |
 | The run's own working directory | Yes, mounted from the durable store. |
 | The runner's Daytona API key | No. It stays on the runner. |
 | The runner's other environment variables | No. |
 | A mounted personal subscription login | No. It never leaves the runner container. |
+
+The runner stores each hidden key as a Daytona Secret restricted to the one hostname that key
+authenticates against, and Daytona substitutes the real value into outbound requests to that host.
+The model call and the MCP call still work, and a request to any other host carries only the
+placeholder. This needs a Daytona API key that may manage Secrets, and it can be switched off. See
+[Hiding API keys from the sandbox](/self-host/configuration#hiding-api-keys-from-the-sandbox).
 
 ### What Daytona runs share with each other
 
@@ -60,10 +68,14 @@ worktree, a subscription login) puts it inside that boundary and inside reach of
 | Value | Crosses in |
 |---|---|
 | The model key for the run | Yes. The harness needs it to call the model. |
+| An HTTP MCP server's credential or header | Yes. |
 | The run's own working directory | Yes. |
 | The runner container's environment | Yes, including `AGENTA_RUNNER_TOKEN` and, when it is set, `AGENTA_RUNNER_DAYTONA_API_KEY`. |
 | Anything you mounted into the runner container | Yes, including a personal subscription login. |
 | Anything on the host you did not mount | No. |
+
+Hiding keys behind Daytona Secrets does not apply here. The harness runs inside the runner
+container, so its keys stay inside your own deployment instead of travelling to a third party.
 
 ### What local runs share with each other
 

--- a/docs/docs/self-host/reference/01-configuration.mdx
+++ b/docs/docs/self-host/reference/01-configuration.mdx
@@ -334,6 +334,17 @@ variables, exactly as they did before v0.108.1.
 `disabled`, and `plaintext` work too. Anything the runner does not recognize leaves hiding on, so a
 typo in this variable cannot silently remove the protection.
 
+In Helm, quote the value. YAML reads a bare `off` as the boolean `false`, and the chart's
+`values.schema.json` types `opaqueSecrets` as a string, so an unquoted value fails the install with
+`agentRunner.providers.daytona.opaqueSecrets: Invalid type. Expected: string, given: boolean`.
+
+```yaml
+agentRunner:
+  providers:
+    daytona:
+      opaqueSecrets: "off" # quote it: a bare off is a YAML boolean
+```
+
 **What `process_local` means.** Setting the variable to `process_local` is the same as leaving it
 unset, and the name states the cleanup guarantee: the runner tracks the Secret records it created
 in its own memory and deletes them when the sandbox goes away. Restart the runner while sandboxes
@@ -342,11 +353,10 @@ mode will add durable tracking, which is why the setting takes a mode name rathe
 `on`.
 
 **What cannot be hidden.** Keys that a provider SDK signs with locally instead of sending, which
-today means the AWS access keys used for Bedrock, still reach the sandbox in full. Nothing Daytona
-substitutes on the way out can help there, because the secret never leaves the sandbox in the first
-place. Those runs work normally; they just do not get this protection.
-
-Leaving the variable unset keeps the previous behavior exactly.
+today means the AWS access keys used for Bedrock and the Google service account credentials used
+for Vertex AI, still reach the sandbox in full. Nothing Daytona substitutes on the way out can help
+there, because the secret never leaves the sandbox in the first place. Those runs work normally;
+they just do not get this protection.
 
 :::warning The bare `DAYTONA_*` variables configure a different sandbox
 `DAYTONA_API_KEY`, `DAYTONA_API_URL`, `DAYTONA_TARGET`, `DAYTONA_SNAPSHOT`, and

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -33,6 +33,76 @@ export const shippedFeatures: ShippedFeature[] = [
   // Channels: 2DD4BF
   // Mobile: F472B6
   {
+    id: "durable-sessions",
+    title: "Durable Agent Sessions",
+    description:
+      "An agent keeps its conversation and its work folder when the process running it restarts. The runner rebuilds the session from stored records, so the agent picks up where it left off instead of losing earlier turns.",
+    changelogPath: "/docs/changelog/api-keys-hidden-from-agent-sandboxes",
+    shippedAt: "2026-08-04",
+    labels: [
+      {
+        name: "Reliability",
+        color: "FF6B6B",
+      },
+    ],
+  },
+  {
+    id: "sandbox-credential-hiding",
+    title: "API Keys Hidden from Agent Sandboxes",
+    description:
+      "An agent running in a cloud sandbox no longer sees its own provider API keys. Each model or MCP key becomes a Daytona Secret restricted to the one host it authenticates against, and the sandbox holds only a placeholder. On by default.",
+    changelogPath: "/docs/changelog/api-keys-hidden-from-agent-sandboxes",
+    shippedAt: "2026-08-04",
+    labels: [
+      {
+        name: "Security",
+        color: "000000",
+      },
+    ],
+  },
+  {
+    id: "codex-harness",
+    title: "Codex as an Agent Harness",
+    description:
+      "Run an agent on Codex, next to Claude Code and Pi. Five OpenAI models, the local or Daytona sandbox, image attachments, your own HTTP MCP servers, and the same tool approvals as the other harnesses.",
+    changelogPath: "/docs/changelog/codex-harness",
+    shippedAt: "2026-08-03",
+    labels: [
+      {
+        name: "Agent Builder",
+        color: "BCFF78",
+      },
+    ],
+  },
+  {
+    id: "work-folder",
+    title: "The Agent Work Folder",
+    description:
+      "Attach files and images to an agent chat by pasting, dragging and dropping, or uploading a whole folder. Everything you add lives in the session's work folder, which the agent reads from inside its sandbox.",
+    changelogPath: "/docs/changelog/file-attachments-in-agent-chat",
+    shippedAt: "2026-08-02",
+    labels: [
+      {
+        name: "Multimodality",
+        color: "5CC8FF",
+      },
+    ],
+  },
+  {
+    id: "batch-tool-approvals",
+    title: "Batch Tool Approvals",
+    description:
+      "Approve or deny several tool calls together in one step, including a deny-all option, instead of answering one approval card at a time.",
+    changelogPath: "/docs/changelog/file-attachments-in-agent-chat",
+    shippedAt: "2026-07-30",
+    labels: [
+      {
+        name: "Approvals",
+        color: "FFC53D",
+      },
+    ],
+  },
+  {
     id: "agents-from-ui",
     title: "Creating Agents from the UI",
     description:
@@ -77,61 +147,6 @@ export const shippedFeatures: ShippedFeature[] = [
 ];
 export const inProgressFeatures: PlannedFeature[] = [
   {
-    id: "durable-sessions",
-    title: "Durable Agent Sessions",
-    description:
-      "Keep the full conversation when the process running an agent restarts. The runner rebuilds session history from stored records on a cold start, so an agent resumes exactly where it left off instead of losing or replaying earlier turns.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/issues/5443",
-    labels: [
-      {
-        name: "Reliability",
-        color: "FF6B6B",
-      },
-    ],
-  },
-  {
-    id: "voice-and-attachments",
-    title: "Voice and Attachments",
-    description:
-      "Talk to an agent with voice input, and attach files or drive uploads to a message. Adds input beyond text so agents can work with what the user says and shares, not just typed prompts.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/pull/5439",
-    labels: [
-      {
-        name: "Multimodality",
-        color: "5CC8FF",
-      },
-    ],
-  },
-  {
-    id: "batch-tool-approvals",
-    title: "Batch Tool Approvals",
-    description:
-      "Approve or deny several tool calls together in one step, including a deny-all option, instead of handling one approval card at a time. Makes the human-in-the-loop approval flow faster when an agent requests many tools at once.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/issues/5391",
-    labels: [
-      {
-        name: "Approvals",
-        color: "FFC53D",
-      },
-    ],
-  },
-  {
-    id: "build-kit-context",
-    title: "A Build Kit That Manages Its Own Context",
-    description:
-      "Give agents with many tools and large tool results a reliable context. Tools are revealed to the model in stages as the toolset grows, and oversized tool outputs are capped so a single large result does not break a long conversation.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/issues/5341",
-    labels: [
-      {
-        name: "Build Kit",
-        color: "FFA500",
-      },
-    ],
-  },
-];
-
-export const plannedFeatures: PlannedFeature[] = [
-  {
     id: "channels",
     title: "Channels: Slack, Telegram, and More",
     description:
@@ -157,6 +172,22 @@ export const plannedFeatures: PlannedFeature[] = [
       },
     ],
   },
+  {
+    id: "build-kit-context",
+    title: "A Build Kit That Manages Its Own Context",
+    description:
+      "Give agents with many tools and large tool results a reliable context. Tools are revealed to the model in stages as the toolset grows, and oversized tool outputs are capped so a single large result does not break a long conversation.",
+    githubUrl: "https://github.com/Agenta-AI/agenta/issues/5341",
+    labels: [
+      {
+        name: "Build Kit",
+        color: "FFA500",
+      },
+    ],
+  },
+];
+
+export const plannedFeatures: PlannedFeature[] = [
   {
     id: "skill-registry",
     title: "Skill Registry",

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -76,9 +76,9 @@ export const shippedFeatures: ShippedFeature[] = [
   },
   {
     id: "work-folder",
-    title: "The Agent Work Folder",
+    title: "Shared Workspace Files",
     description:
-      "Attach files and images to an agent chat by pasting, dragging and dropping, or uploading a whole folder. Everything you add lives in the session's work folder, which the agent reads from inside its sandbox.",
+      "One cloud folder for you, your team, and your agents. Upload images, PDFs, or a whole folder, and each agent keeps its own folder that survives between conversations, so it starts every session already knowing your material.",
     changelogPath: "/docs/changelog/file-attachments-in-agent-chat",
     shippedAt: "2026-08-02",
     labels: [

--- a/docs/static/images/agents/harness-loop.svg
+++ b/docs/static/images/agents/harness-loop.svg
@@ -21,7 +21,7 @@
   <!-- Harness -->
   <rect class="accent" x="228" y="140" width="200" height="80" rx="8"/>
   <text class="title" x="328" y="176" text-anchor="middle">Harness</text>
-  <text class="label" x="328" y="198" text-anchor="middle">Claude Code or Pi</text>
+  <text class="label" x="328" y="198" text-anchor="middle">Claude Code, Pi, or Codex</text>
 
   <!-- Model -->
   <rect class="box" x="628" y="140" width="200" height="80" rx="8"/>

--- a/services/runner/src/tools/mcp-bridge.ts
+++ b/services/runner/src/tools/mcp-bridge.ts
@@ -32,12 +32,13 @@ export type { ResolvedToolSpec, ToolCallbackContext } from "../protocol.ts";
  * `[]` for Pi), so a user MCP server attached to a Pi run would be DROPPED — silently, with no
  * log and an HTTP 200. That is exactly the silent-drop F-032 forbids. The `run-plan.ts` gate
  * refuses it up front (the way the stdio-MCP and code-tool gates do) so the failure is loud
- * instead of a "successful" empty run. HTTP MCP is a Claude-only capability for now; pick a
- * non-Pi harness to use one.
+ * instead of a "successful" empty run. Both non-Pi harnesses accept HTTP MCP: Claude Code and,
+ * since v0.108.0, codex. Naming only Claude here sent codex users looking for a harness they
+ * were already allowed to use.
  */
 export const PI_USER_MCP_UNSUPPORTED_MESSAGE =
   "User MCPs are not supported on the Pi harness (Pi delivers tools through its bundled " +
-  "extension, not MCP). Use a non-Pi harness (e.g. claude) for a user MCP server, or remove " +
+  "extension, not MCP). Use the claude or codex harness for a user MCP server, or remove " +
   "mcpServers.";
 
 // The ACP `McpServerStdio` shape lives in `engines/sandbox_agent/mcp.ts` (ACP entry

--- a/web/oss/src/components/SidebarBanners/data/changelog.json
+++ b/web/oss/src/components/SidebarBanners/data/changelog.json
@@ -1,5 +1,17 @@
 [
     {
+        "id": "changelog-2026-08-04-api-keys-hidden-from-agent-sandboxes",
+        "title": "API Keys Hidden from Sandboxes",
+        "description": "Agents in a cloud sandbox now see a placeholder instead of your provider API keys.",
+        "link": "https://agenta.ai/docs/changelog/api-keys-hidden-from-agent-sandboxes"
+    },
+    {
+        "id": "changelog-2026-08-03-codex-harness",
+        "title": "Codex Harness",
+        "description": "Run your agents on Codex, alongside Claude Code and Pi. Five OpenAI models, local or cloud sandbox.",
+        "link": "https://agenta.ai/docs/changelog/codex-harness"
+    },
+    {
         "id": "changelog-2026-06-05-dark-mode",
         "title": "Dark Mode",
         "description": "Agenta now has a dark theme. Switch between light, dark, and system from the top bar.",


### PR DESCRIPTION
## Context

Two releases shipped without an announcement. Codex became a third agent harness in v0.108.0, and v0.108.1 stops putting provider API keys into Daytona sandboxes as plaintext.

While writing them up, seven documentation pages turned out to say things those releases made untrue. Two still said Agenta ships two harnesses. One said MCP servers were Claude Code only. One still answered "Yes" to whether the model key crosses into a Daytona sandbox, which is exactly what this release stopped. Publishing a changelog that its own documentation contradicts is worse than publishing nothing, so the corrections are here too.

## Changes

**Two changelog entries.**

"Run Your Agents on Codex" opens with a demo video and covers the five OpenAI models, both sandbox types, tool approvals, MCP servers, image attachments, and the two ways to pay for the model.

"API Keys Are Hidden from Agent Sandboxes" covers what credential hiding does, what it covers, what it deliberately does not cover, and a warning telling self-hosters to grant their Daytona key permission to manage Secrets before upgrading. There is no fallback to plaintext by design, so a key without that permission fails every credential-carrying Daytona run at sandbox creation.

**Twelve documentation corrections.** The most important is the sandbox isolation page:

Before:

    | The model key for the run | Yes. The harness needs it to call the model. |

After:

    | The model key for the run | No, by default. The sandbox holds a placeholder. |

plus a matching row for MCP credentials and a new row for the credentials a provider SDK signs locally, which genuinely are still sent.

The Daytona self-hosting page gains the Secrets permission in its prerequisites, a warning after the setup step, and a troubleshooting entry whose heading matches the runner's actual error. The configuration reference loses a line saying the variable's old behaviour is preserved when unset, which contradicted the paragraph above it.

**Roadmap.** Durable sessions, the agent work folder, and batch tool approvals moved to shipped. Channels and mobile moved from planned to in progress. The two new features were added.

**One runner fix.** An error message told users to pick "a non-Pi harness (e.g. claude)" for an MCP server. Codex accepts them too, so it now names both harnesses.

## Tests / notes

- `npm run build` in `docs/` passes, both new pages render, no broken links.
- `pnpm exec vitest run tests/unit/sandbox-agent-run-plan.test.ts` in `services/runner`: 70 passed. No test asserted the old error wording.
- `pnpm run typecheck` in `services/runner` passes.
- The demo video is hosted on Cloudflare Stream, public, with no signed-URL requirement.

Left for a follow-up on purpose: the four screenshots on the harness guide still show a two-harness picker and need re-capturing, and Kubernetes has no supported way to mount a Codex subscription login, which is a product gap rather than a docs gap.

## What to QA

- Open the two new entries under `/changelog/`. The Codex video plays and loops.
- Open the roadmap page. Durable sessions, the work folder, and batch approvals appear under shipped; channels and mobile appear under in progress.
- Regression: the sidebar announcement banner still renders, now with the two new cards on top.