### PR TITLE
[5641] fix(sdk): return 422 for invalid self-managed connections

### DIFF
--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -145,6 +145,16 @@ class AgentTemplateShapeError(ErrorStatus):
         super().__init__(code=self.code, type=self.type, message=message)
 
 
+class AgentTemplateValidationError(ErrorStatus):
+    """A run request contains an invalid value in its agent template."""
+
+    code: int = 422
+    type: str = f"{ERRORS_BASE_URL}#v0:agent:invalid-template"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(code=self.code, type=self.type, message=message)
+
+
 # ---------------------------------------------------------------------------
 # Sandbox permission (Layer 2: the sandbox security boundary)
 # ---------------------------------------------------------------------------

--- a/sdks/python/agenta/sdk/agents/handler.py
+++ b/sdks/python/agenta/sdk/agents/handler.py
@@ -234,10 +234,9 @@ def make_agent_handler(composition: Optional[AgentComposition] = None):
         session_id = request.session_id
 
         params = parameters or {}
+        defaults = comp.default_template()
         try:
-            agent_template = AgentTemplate.from_params(
-                params, defaults=comp.default_template()
-            )
+            agent_template = AgentTemplate.from_params(params, defaults=defaults)
         except ValidationError as exc:
             raise AgentTemplateValidationError(str(exc)) from exc
 

--- a/sdks/python/agenta/sdk/agents/handler.py
+++ b/sdks/python/agenta/sdk/agents/handler.py
@@ -13,7 +13,14 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-from agenta.sdk.agents.dtos import AgentTemplate, SessionConfig, to_messages
+from pydantic import ValidationError
+
+from agenta.sdk.agents.dtos import (
+    AgentTemplate,
+    AgentTemplateValidationError,
+    SessionConfig,
+    to_messages,
+)
 from agenta.sdk.agents.interfaces import Backend, Environment
 from agenta.sdk.agents.capabilities import (
     harness_allows_deployment,
@@ -227,9 +234,12 @@ def make_agent_handler(composition: Optional[AgentComposition] = None):
         session_id = request.session_id
 
         params = parameters or {}
-        agent_template = AgentTemplate.from_params(
-            params, defaults=comp.default_template()
-        )
+        try:
+            agent_template = AgentTemplate.from_params(
+                params, defaults=comp.default_template()
+            )
+        except ValidationError as exc:
+            raise AgentTemplateValidationError(str(exc)) from exc
 
         # SVC-1: select the backend BEFORE resolving. select_backend carries the sandbox gate
         # (a `local` run on a shared deployment is refused), and it reads only agent_template,

--- a/sdks/python/oss/tests/pytest/unit/test_invoke_real_handlers_negotiation_routing.py
+++ b/sdks/python/oss/tests/pytest/unit/test_invoke_real_handlers_negotiation_routing.py
@@ -28,14 +28,14 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from types import SimpleNamespace
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agenta.sdk.agents import AgentResult, HarnessKind
+from agenta.sdk.agents import AgentResult, AgentTemplate, HarnessKind
 from agenta.sdk.agents.dtos import Event
 from agenta.sdk.agents.handler import AgentComposition, make_agent_handler
 from agenta.sdk.agents.interfaces import Backend, Sandbox, Session
@@ -152,7 +152,12 @@ class _FakeBackend(Backend):
         )
 
 
-def _agent_client(*, text: str = "hello world") -> TestClient:
+def _agent_client(
+    *,
+    text: str = "hello world",
+    default_template: Optional[Callable[[], AgentTemplate]] = None,
+    raise_server_exceptions: bool = True,
+) -> TestClient:
     backend = _FakeBackend(events=_events_for(text), output=text)
 
     async def _no_connection(*, model, context) -> ResolvedConnection:
@@ -164,6 +169,8 @@ def _agent_client(*, text: str = "hello world") -> TestClient:
         select_backend=lambda template: backend,
         resolve_connection=_no_connection,
     )
+    if default_template is not None:
+        composition.default_template = default_template
     handler = make_agent_handler(composition)
     handler.__name__ = "agent_v0_under_test"
 
@@ -175,7 +182,7 @@ def _agent_client(*, text: str = "hello world") -> TestClient:
         return await call_next(request)
 
     route("/", app=app)(handler)
-    return TestClient(app)
+    return TestClient(app, raise_server_exceptions=raise_server_exceptions)
 
 
 def _post_agent(client, *, headers=None, flags=None, parameters=None):
@@ -276,6 +283,20 @@ def test_agent_v0_invalid_self_managed_connection_returns_422():
     status = resp.json()["status"]
     assert status["type"].endswith("#v0:agent:invalid-template")
     assert "self_managed' must not carry a 'slug'" in status["message"]
+
+
+def test_agent_v0_invalid_composition_default_remains_500():
+    def _invalid_default_template() -> AgentTemplate:
+        return AgentTemplate.model_validate({"permission_default": "invalid"})
+
+    resp = _post_agent(
+        _agent_client(
+            default_template=_invalid_default_template,
+            raise_server_exceptions=False,
+        )
+    )
+
+    assert resp.status_code == 500
 
 
 # llm_v0: batch-only. json/absent Accept OK; stream Accept -> 406 (symmetry).

--- a/sdks/python/oss/tests/pytest/unit/test_invoke_real_handlers_negotiation_routing.py
+++ b/sdks/python/oss/tests/pytest/unit/test_invoke_real_handlers_negotiation_routing.py
@@ -178,8 +178,10 @@ def _agent_client(*, text: str = "hello world") -> TestClient:
     return TestClient(app)
 
 
-def _post_agent(client, *, headers=None, flags=None):
+def _post_agent(client, *, headers=None, flags=None, parameters=None):
     body: dict = {"data": {"inputs": {"messages": [{"role": "user", "content": "hi"}]}}}
+    if parameters is not None:
+        body["data"]["parameters"] = parameters
     if flags is not None:
         body["flags"] = flags
     with _offline_tracing():
@@ -254,6 +256,26 @@ def test_agent_v0_body_trim_flag_wins_over_transcript_header():
     )
     assert resp.status_code == 200
     assert resp.json()["data"]["outputs"]["messages"][0]["content"] == "hi"
+
+
+def test_agent_v0_invalid_self_managed_connection_returns_422():
+    resp = _post_agent(
+        _agent_client(),
+        parameters={
+            "agent": {
+                "llm": {
+                    "provider": "openai",
+                    "model": "gpt-5.5",
+                    "connection": {"mode": "self_managed", "slug": "unused"},
+                }
+            }
+        },
+    )
+
+    assert resp.status_code == 422
+    status = resp.json()["status"]
+    assert status["type"].endswith("#v0:agent:invalid-template")
+    assert "self_managed' must not carry a 'slug'" in status["message"]
 
 
 # llm_v0: batch-only. json/absent Accept OK; stream Accept -> 406 (symmetry).

--- a/sdks/python/oss/tests/pytest/unit/test_invoke_real_handlers_negotiation_routing.py
+++ b/sdks/python/oss/tests/pytest/unit/test_invoke_real_handlers_negotiation_routing.py
@@ -297,6 +297,9 @@ def test_agent_v0_invalid_composition_default_remains_500():
     )
 
     assert resp.status_code == 500
+    status = resp.json()["status"]
+    assert status["code"] == 500
+    assert status["type"].endswith("#v1:sdk:unknown-workflow-invoke-error")
 
 
 # llm_v0: batch-only. json/absent Accept OK; stream Accept -> 406 (symmetry).


### PR DESCRIPTION
## Summary

Closes #5641.

Invalid agent connection values are parsed inside the agent handler, after FastAPI request-model validation. The resulting Pydantic `ValidationError` therefore reached the workflow normalizer without a client-error status and was returned as HTTP 500.

This change catches validation only around `AgentTemplate.from_params()` and converts it to a typed `AgentTemplateValidationError` with status 422. The narrow boundary keeps downstream/internal Pydantic failures visible as server errors while preserving the original field-level validation message for callers.

## Testing
### Verified locally

- `24 passed`: `oss/tests/pytest/unit/test_invoke_real_handlers_negotiation_routing.py`
- `14 passed`: `oss/tests/pytest/unit/agents/test_agent_composition_seam.py`
- `ruff format --check` with the CI-pinned Ruff 0.15.12
- `ruff check` with the CI-pinned Ruff 0.15.12

### Added or updated tests

Added a regression through the real FastAPI `/invoke` route. It submits `connection: {mode: self_managed, slug: unused}`, asserts HTTP 422 and the typed error URI, and verifies the original validation message is preserved.

### QA follow-up

Confirm the same request returns 422 in a deployed staging workflow service after the next build.

## Demo

![Before and after HTTP behavior](https://raw.githubusercontent.com/Linxiushen/agenta/assets/issue-5641-demo/.github/pr-assets/5641-invalid-connection.svg)

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me