### PR TITLE
[5620] fix(api): classify plain ZIP attachments correctly

### DIFF
--- a/api/oss/src/core/sessions/attachments/media.py
+++ b/api/oss/src/core/sessions/attachments/media.py
@@ -1,11 +1,11 @@
-from typing import Optional
+from io import BytesIO
+from zipfile import BadZipFile, ZipFile
 
 import puremagic
 from puremagic.main import PureError
 
 from oss.src.core.sessions.attachments.dtos import AttachmentKind, AttachmentMedia
 from oss.src.core.sessions.attachments.types import AttachmentInvalid
-
 
 _NATIVE_IMAGE_TYPES = {
     "image/gif",
@@ -43,9 +43,13 @@ _WEBM_VIDEO_CODECS = (
     b"V_VP9",
 )
 _CONTAINER_SCAN_BYTES = 1024 * 1024
+_ZIP_MEDIA_TYPE = "application/zip"
+_DOCX_MEDIA_TYPE = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
 
 
-def _sniff(data: bytes) -> Optional[str]:
+def _sniff(data: bytes) -> str | None:
     """The only puremagic call; classification is policy, not a security boundary."""
     try:
         media_type = puremagic.from_string(data, mime=True)
@@ -71,13 +75,38 @@ def _is_m4a(*, data: bytes) -> bool:
     return any(brand in _M4A_BRANDS for brand in brands)
 
 
+def _canonical_zip_media_type(
+    *,
+    data: bytes,
+    inspected_media_type: str | None,
+) -> str | None:
+    if inspected_media_type not in {_ZIP_MEDIA_TYPE, _DOCX_MEDIA_TYPE}:
+        return inspected_media_type
+
+    try:
+        with ZipFile(BytesIO(data)) as archive:
+            names = set(archive.namelist())
+    except (BadZipFile, ValueError):
+        return inspected_media_type
+
+    if "[Content_Types].xml" in names and "word/document.xml" in names:
+        return _DOCX_MEDIA_TYPE
+
+    return _ZIP_MEDIA_TYPE
+
+
 def _canonical_container_media_type(
     *,
     data: bytes,
-    inspected_media_type: Optional[str],
-) -> Optional[str]:
+    inspected_media_type: str | None,
+) -> str | None:
     if _is_m4a(data=data):
         return "audio/mp4"
+
+    inspected_media_type = _canonical_zip_media_type(
+        data=data,
+        inspected_media_type=inspected_media_type,
+    )
 
     scan = data[:_CONTAINER_SCAN_BYTES]
     if scan.startswith(b"OggS"):
@@ -109,9 +138,7 @@ def _kind_for(*, media_type: str) -> AttachmentKind:
     return AttachmentKind.OTHER
 
 
-def classify(
-    *, data: bytes, declared_media_type: Optional[str] = None
-) -> AttachmentMedia:
+def classify(*, data: bytes, declared_media_type: str | None = None) -> AttachmentMedia:
     if not data:
         raise AttachmentInvalid()
 

--- a/api/oss/tests/pytest/unit/sessions/test_attachment_media.py
+++ b/api/oss/tests/pytest/unit/sessions/test_attachment_media.py
@@ -2,7 +2,6 @@ from io import BytesIO
 from zipfile import ZipFile
 
 import pytest
-
 from oss.src.core.sessions.attachments.dtos import AttachmentKind
 from oss.src.core.sessions.attachments.media import classify
 from oss.src.core.sessions.attachments.types import AttachmentInvalid
@@ -45,19 +44,76 @@ def test_empty_or_unrecognizable_non_utf8_bytes_are_invalid(data):
         classify(data=data, declared_media_type="application/octet-stream")
 
 
-def test_recognized_zip_is_accepted_as_other():
+def _zip_bytes(*, files):
     buffer = BytesIO()
     with ZipFile(buffer, "w") as archive:
-        archive.writestr("file.txt", "hello")
+        for path, content in files:
+            archive.writestr(path, content)
+    return buffer.getvalue()
+
+
+def test_plain_zip_is_classified_as_zip():
+    data = _zip_bytes(files=[("file.txt", "hello")])
 
     result = classify(
-        data=buffer.getvalue(),
+        data=data,
         declared_media_type="application/zip",
     )
 
-    assert result.media_type.startswith("application/")
+    assert result.media_type == "application/zip"
     assert result.kind == AttachmentKind.OTHER
     assert result.native_image is False
+
+
+def test_plain_zip_structure_overrides_declared_docx_type():
+    result = classify(
+        data=_zip_bytes(files=[("notes.txt", "hello")]),
+        declared_media_type=(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+    )
+
+    assert result.media_type == "application/zip"
+    assert result.kind == AttachmentKind.OTHER
+
+
+@pytest.mark.parametrize(
+    "declared_media_type",
+    [
+        "application/zip",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ],
+)
+def test_docx_structure_is_classified_as_docx(declared_media_type):
+    result = classify(
+        data=_zip_bytes(
+            files=[
+                ("[Content_Types].xml", "<Types />"),
+                ("word/document.xml", "<document />"),
+            ]
+        ),
+        declared_media_type=declared_media_type,
+    )
+
+    assert result.media_type == (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    assert result.kind == AttachmentKind.OTHER
+
+
+def test_malformed_zip_signature_keeps_inspected_type(monkeypatch):
+    monkeypatch.setattr(
+        "oss.src.core.sessions.attachments.media.puremagic.from_string",
+        lambda *_args, **_kwargs: "application/zip",
+    )
+
+    result = classify(
+        data=b"PK\x03\x04not-a-valid-archive",
+        declared_media_type="application/zip",
+    )
+
+    assert result.media_type == "application/zip"
+    assert result.kind == AttachmentKind.OTHER
 
 
 def test_svg_is_a_workspace_document_not_a_native_image():


### PR DESCRIPTION
## Summary

Uploading a plain ZIP through `/sessions/attachments` stored it with the DOCX media type. ZIP and DOCX share the same container signature, and PureMagic selected the more specific Word type without checking whether the archive contained Word structures.

Before:

```text
notes.zip -> application/vnd.openxmlformats-officedocument.wordprocessingml.document
```

After:

```text
notes.zip -> application/zip
document.docx -> application/vnd.openxmlformats-officedocument.wordprocessingml.document
```

## Demo
<img width="687" height="356" alt="Screenshot 2026-08-04 153019" src="https://github.com/user-attachments/assets/8ecfbc31-a8c2-4480-b08e-47c6ec4845e6" />

## Changes

The attachment classifier now inspects ZIP entry names before accepting the DOCX classification. Archives containing the required Word OOXML structure remain DOCX; other valid ZIP containers use `application/zip`.

The classifier reads only archive metadata. It does not extract archive contents, and inspected bytes remain authoritative over the client-declared media type.

## Tests / notes

- `ruff format` passed.
- `ruff check --fix` passed.
- `git diff --check` passed.
- Direct Python 3.13 assertions using the pinned PureMagic 1.30 passed for plain ZIP, DOCX, declared-type mismatches, and malformed ZIP metadata.
- The targeted pytest suite could not run on this Windows host because the locked LiteLLM 1.92.0 dependency requires the MSVC linker (`link.exe`). CI should run the targeted test under its Linux environment.

## AI assistance

Model used: OpenAI GPT-5 through Codex.

Session summary: Codex inspected issue #5620, the attachment classifier, existing unit coverage, and repository contribution conventions. We reproduced that the repository-pinned PureMagic 1.30 classifies both a plain ZIP and a DOCX-shaped archive as DOCX. Codex then helped implement a focused policy that distinguishes DOCX by its internal Word OOXML entries, falls back to `application/zip` for ordinary ZIP archives, and adds regression coverage for both formats, incorrect client declarations, and malformed archive metadata. I reviewed the resulting diff and validation results before submitting it.

Closes #5620.