### PR TITLE
docs(design): Propose moving the theme switch into Preferences

### DIFF
--- a/docs/design/preferences-tab/proposal.md
+++ b/docs/design/preferences-tab/proposal.md
@@ -1,0 +1,19 @@
+# Move the theme switch into Preferences
+
+The breadcrumb bar carries a three-way theme switcher next to the version label —
+permanent chrome for a control people set once, rendered as three unlabelled icons in
+the row that truncates first on narrow screens. It belongs in settings.
+
+| | Before | After |
+|---|---|---|
+| Theme switcher | Breadcrumb bar, right | Settings › Personal › Preferences |
+| Tab name | Feature flags | Preferences |
+| Tab layout | One flat list | Appearance, then Experiments |
+
+The tab is renamed because a theme is not a flag, and a separate Appearance tab would
+leave two Personal tabs holding two controls each. One tab, one place to look.
+
+Preferences is visible in OSS and EE, so neither edition loses the control, and
+`?tab=featureFlags` still resolves.
+
+**The cost:** switching theme goes from one click to three.


### PR DESCRIPTION
## Context

The breadcrumb bar carries a three-way theme switcher next to the version label. It is permanent chrome for a control people set once, rendered as three unlabelled icons, sitting in the row that truncates first on narrow screens.

Deisgn: https://claude.ai/code/artifact/0a9f69ac-1de6-4cfb-b6d8-18108a063374

## Changes

Adds `docs/design/preferences-tab/proposal.md`. The proposal covers three changes:

| | Before | After |
|---|---|---|
| Theme switcher | Breadcrumb bar, right | Settings › Personal › Preferences |
| Tab name | Feature flags | Preferences |
| Tab layout | One flat list | Appearance, then Experiments |

The tab is renamed because a theme is not a flag, and a separate Appearance tab would leave two Personal tabs holding two controls each.

Preferences is visible in OSS and EE, so neither edition loses the control, and `?tab=featureFlags` still resolves. The one cost: switching theme goes from one click to three.

## Notes

Docs only. No code changes, nothing to QA. The design is prototyped and reviewed against `navigation.ts`, `FeatureFlags.tsx`, and `palette.ts`; implementation lands separately.

## Design before/after

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/bfdd63b7-70b0-4c5d-aaac-532a80d7f978" />

After

<img width="500" alt="image" src="https://github.com/user-attachments/assets/38ef584d-7224-4cd0-bc61-a27acd10f9b7" />

