### PR TITLE
fix(runner): let an environment own the configuration it installed

### DIFF
--- a/services/runner/src/engines/sandbox_agent/applied-state.ts
+++ b/services/runner/src/engines/sandbox_agent/applied-state.ts
@@ -1,0 +1,88 @@
+/**
+ * `AppliedEnvironmentState` — what an environment ACTUALLY has installed.
+ *
+ * LIFECYCLE MIGRATION, STEP 2. This is the smallest change that kills the stale-config bug class.
+ *
+ * The bug. Until now the pool stored a `configFingerprint` its CALLER supplied, and the caller
+ * supplied the INCOMING request's fingerprint. On the ordinary path that is harmless, because the
+ * dispatch already proved the incoming and parked configurations equal. On the approval-resume
+ * path it is not: that branch never compares configurations, so the re-park stamped a
+ * configuration the environment had never applied. The next turn then read that stamp, found a
+ * match, and continued warm on an environment running something else.
+ *
+ * The fix is structural, not a patch. A request says what somebody WANTED. Only the environment
+ * knows what it GOT. So the environment owns its applied state, and the pool reads it. There is
+ * no fingerprint parameter left for a caller to stamp, which makes the bug unrepresentable rather
+ * than merely fixed.
+ *
+ * Scope note. This slice carries one facet, `configFingerprint`, because that is the facet the
+ * pool compares today. The richer shape in the lifecycle design (sandbox, runtime, mounts,
+ * workspace, and harness-session facets, each with its own generation) arrives with the
+ * reconciliation router. `generation` is here from the start so a later facet split has a counter
+ * to build on.
+ */
+
+/**
+ * The state an environment has successfully installed. Read-only to everyone except
+ * `commitApplied`.
+ */
+export interface AppliedEnvironmentState {
+  /**
+   * Increments on every successful commit. It is a monotonic counter for logs and for tests, and
+   * it never re-enters environment identity. A test asserts that two commits of the same
+   * fingerprint still advance it, so "nothing changed" and "we re-applied" stay distinguishable.
+   */
+  readonly generation: number;
+  /**
+   * The canonical hash of the configuration this environment actually runs. It is stamped from a
+   * SUCCESSFUL acquire, never from an incoming request.
+   */
+  readonly configFingerprint: string;
+}
+
+/**
+ * The structural contract the pool needs. It is deliberately minimal: the pool must stay
+ * engine-agnostic, so it constrains its environment type to this shape rather than importing the
+ * engine.
+ */
+export interface AppliedStateOwner {
+  readonly appliedState: AppliedEnvironmentState;
+}
+
+/**
+ * A mutable holder for one environment's applied state.
+ *
+ * `commitApplied` is the ONLY way to advance it. Every caller must be a lifecycle action that
+ * already succeeded. Committing before the action succeeds recreates the bug this module exists
+ * to remove.
+ */
+export class AppliedState implements AppliedStateOwner {
+  #generation: number;
+  #configFingerprint: string;
+
+  constructor(configFingerprint: string) {
+    this.#generation = 1;
+    this.#configFingerprint = configFingerprint;
+  }
+
+  get appliedState(): AppliedEnvironmentState {
+    // A fresh object each read, so a caller cannot hold a reference and mutate it later.
+    return {
+      generation: this.#generation,
+      configFingerprint: this.#configFingerprint,
+    };
+  }
+
+  /**
+   * Record a lifecycle action that ALREADY SUCCEEDED.
+   *
+   * Call this after the action, never before and never instead of it. A `setModel` that threw, a
+   * workspace refresh that failed halfway, or a session reopen that lost its native history must
+   * leave applied state exactly where it was. That is the partial-reconciliation rule from the
+   * lifecycle design, and it is why this method takes a result rather than a desired value.
+   */
+  commitApplied(result: { configFingerprint: string }): void {
+    this.#generation += 1;
+    this.#configFingerprint = result.configFingerprint;
+  }
+}

--- a/services/runner/src/engines/sandbox_agent/environment-setup.ts
+++ b/services/runner/src/engines/sandbox_agent/environment-setup.ts
@@ -1,6 +1,7 @@
 import { rmSync } from "node:fs";
 
 import { apiBase } from "../../apiBase.ts";
+import { AppliedState } from "./applied-state.ts";
 
 import { resolveRunSessionId, type AgentRunRequest } from "../../protocol.ts";
 import { type ClientToolOutcome } from "../../responder.ts";
@@ -32,6 +33,7 @@ import {
   type PiModelConfigPlan,
 } from "./pi-model-config.ts";
 import { buildRunPlan } from "./run-plan.ts";
+import { configFingerprint } from "./session-identity.ts";
 import type {
   SandboxAgentDeps,
   SessionEnvironment,
@@ -368,7 +370,16 @@ export async function prepareEnvironmentSetup(
   // so its handler is torn down deterministically and cannot write a result after the turn ends.
   const mcpAbort = new AbortController();
 
+  // LIFECYCLE MIGRATION, STEP 2. The environment owns what it applied. It is seeded from the
+  // request that is building it, because that request IS what this environment installs. Every
+  // later change must go through `commitApplied`, and only after the change succeeds.
+  const applied = new AppliedState(configFingerprint(request));
+
   const environment: SessionEnvironment = {
+    get appliedState() {
+      return applied.appliedState;
+    },
+    commitApplied: (result) => applied.commitApplied(result),
     plan,
     logger,
     deps,

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -108,7 +108,10 @@ import {
   routeSessionEventToActiveTurn,
 } from "./session-events.ts";
 import { buildSandboxProvider } from "./provider.ts";
-import { readStoredSandboxPointer } from "./sandbox-reconnect.ts";
+import {
+  markSandboxDestroyed,
+  readStoredSandboxPointer,
+} from "./sandbox-reconnect.ts";
 import type {
   AcquireEnvironmentResult,
   SandboxAgentDeps,
@@ -322,7 +325,15 @@ export async function acquireEnvironment(
         );
       }
     }
-    if (!parked) await environment.sandbox?.destroySandbox().catch(() => {});
+    if (!parked) {
+      // Record the id BEFORE the delete call, and record it even when the call throws. A delete
+      // that failed may still have removed the sandbox, so reconnecting to it is a wasted round
+      // trip either way. See `markSandboxDestroyed`.
+      markSandboxDestroyed(
+        environment.sandbox?.sandboxId ?? plan.sandboxId ?? undefined,
+      );
+      await environment.sandbox?.destroySandbox().catch(() => {});
+    }
     await environment.sandbox?.dispose().catch(() => {});
     // Unmount the durable cwd BEFORE removing the dir: data lives in the store, only the host
     // mountpoint is torn down. If unmount is not CONFIRMED gone, skip the delete: rmSync must

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -42,6 +42,7 @@ import {
 } from "./session-continuity-durable.ts";
 import { type SessionContinuityStore } from "./session-continuity.ts";
 import { type InstalledMountExpiries } from "./session-identity.ts";
+import type { AppliedEnvironmentState } from "./applied-state.ts";
 import { type TeardownReason } from "./teardown.ts";
 import { uploadToolMcpAssets } from "./tool-mcp-assets.ts";
 import { prepareWorkspace } from "./workspace.ts";
@@ -217,6 +218,17 @@ export function sendLastMessageOnly(opts: RunTurnOptions): boolean {
  * call. Per-turn state rides `currentTurn`, swapped in by `runTurn`.
  */
 export interface SessionEnvironment {
+  /**
+   * What this environment ACTUALLY has installed.
+   *
+   * LIFECYCLE MIGRATION, STEP 2. The pool reads this instead of a fingerprint its caller supplies,
+   * so a request can no longer stamp a configuration the environment never applied. Only
+   * `commitApplied` advances it, and only after a lifecycle action succeeds. See
+   * `applied-state.ts`.
+   */
+  readonly appliedState: AppliedEnvironmentState;
+  /** Record a lifecycle action that already succeeded. The only writer of `appliedState`. */
+  commitApplied: (result: { configFingerprint: string }) => void;
   plan: RunPlan;
   logger: Log;
   deps: SandboxAgentDeps;

--- a/services/runner/src/engines/sandbox_agent/sandbox-reconnect.ts
+++ b/services/runner/src/engines/sandbox_agent/sandbox-reconnect.ts
@@ -12,6 +12,44 @@
  */
 import { fetchLatestSessionTurn } from "./session-continuity-durable.ts";
 
+/**
+ * Sandbox ids this runner process has DELETED.
+ *
+ * LIFECYCLE MIGRATION, STEP 1. The stored pointer is the latest turn's `sandbox_id`, and the turns
+ * table is append-only, so there is no pointer row to clear when a destroy deletes the sandbox.
+ * The dead id therefore stays readable until the next turn appends its own row. Reconnecting to it
+ * fails and falls through to a fresh create, which is safe but spends a provider round trip on a
+ * sandbox we ourselves deleted moments earlier.
+ *
+ * This set closes that window inside one runner process: `markSandboxDestroyed` records the id at
+ * the moment of deletion, and `readStoredSandboxPointer` refuses to hand it back.
+ *
+ * What it deliberately does NOT do: it is per-process and in-memory, so another replica, or this
+ * replica after a restart, still reads the stale id and still falls through to a fresh create.
+ * That path was always correct and stays correct. This is a latency fix with a correctness-shaped
+ * name, and treating it as a durable guarantee would be wrong.
+ */
+const destroyedSandboxIds = new Set<string>();
+
+/** Cap the set so a long-lived replica cannot grow it without bound. */
+const DESTROYED_SANDBOX_ID_MAX = 512;
+
+/** Record that this process deleted `sandboxId`, so it never reconnects to it. */
+export function markSandboxDestroyed(sandboxId: string | undefined): void {
+  if (!sandboxId) return;
+  if (destroyedSandboxIds.size >= DESTROYED_SANDBOX_ID_MAX) {
+    // Drop the oldest entry. Losing one only costs the failed-reconnect round trip it saved.
+    const oldest = destroyedSandboxIds.values().next().value;
+    if (oldest !== undefined) destroyedSandboxIds.delete(oldest);
+  }
+  destroyedSandboxIds.add(sandboxId);
+}
+
+/** Test seam: forget every recorded id. */
+export function resetDestroyedSandboxIds(): void {
+  destroyedSandboxIds.clear();
+}
+
 export interface SandboxPointerDeps {
   apiBase?: string;
   authorization: string;
@@ -35,5 +73,11 @@ export async function readStoredSandboxPointer(
   const latest = await fetchLatestSessionTurn(sessionId, undefined, deps);
   const id = latest?.sandbox_id;
   if (typeof id !== "string" || id.length === 0) return undefined;
+  if (destroyedSandboxIds.has(id)) {
+    // This process deleted that sandbox. Reconnecting would fail, so skip straight to a fresh
+    // create. See `destroyedSandboxIds`.
+    deps.log?.(`ignoring pointer to sandbox=${id} destroyed by this runner`);
+    return undefined;
+  }
   return { sandboxId: id };
 }

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -195,9 +195,16 @@ function canonicalJson(value: unknown): string {
  * every hash, the credential epoch included — each turn's relay uses the INCOMING request's
  * `toolCallback` (see `CredentialEpoch` and `run-turn.ts`), so the parked copy never executes
  * anything.
+ *
+ * LIFECYCLE MIGRATION, STEP 1. The workflow REVISION id, the revision version, and the draft flag
+ * were in this hash and are now out. They are turn METADATA, not environment identity: nothing in
+ * the sandbox, the daemon, the workspace, or the harness session changes when a revision id
+ * changes. Keeping them here meant that committing a revision mid-conversation threw away a warm
+ * sandbox that was still perfectly usable, which is the exact cost this project exists to remove.
+ * They stay in `runContext` for tool binding and observability; they simply no longer decide
+ * whether an environment may be reused.
  */
 export function configFingerprint(request: AgentRunRequest): string {
-  const workflow = request.runContext?.workflow;
   const shape = {
     harness: request.harness ?? null,
     sandbox: request.sandbox ?? null,
@@ -247,13 +254,7 @@ export function configFingerprint(request: AgentRunRequest): string {
     permissions: request.permissions ?? null,
     sandboxPermission: request.sandboxPermission ?? null,
     harnessFiles: request.harnessFiles ?? null,
-    workflowRevision: workflow?.revision
-      ? {
-          id: workflow.revision.id ?? null,
-          version: workflow.revision.version ?? null,
-        }
-      : null,
-    isDraft: workflow?.is_draft ?? null,
+    // No `workflowRevision` and no `isDraft`. See the doc comment above.
   };
   return sha256(canonicalJson(shape));
 }

--- a/services/runner/src/engines/sandbox_agent/session-pool.ts
+++ b/services/runner/src/engines/sandbox_agent/session-pool.ts
@@ -12,6 +12,7 @@
  * never imports the engine, so it stays a pure map + timer + policy unit. Operators can disable
  * it explicitly with `AGENTA_RUNNER_SESSION_KEEPALIVE=off`.
  */
+import type { AppliedStateOwner } from "./applied-state.ts";
 import type { CredentialEpoch, KeepaliveConfig } from "./session-identity.ts";
 import type { TeardownReason } from "./teardown.ts";
 
@@ -27,10 +28,19 @@ export type SessionState = "busy" | "idle" | "awaiting_approval" | "destroyed";
  * One parked live session. `environment` is opaque to the pool (the engine reads it on a
  * continuation). `teardown` is the engine's complete, idempotent teardown closure.
  */
-export interface LiveSession<E = unknown> {
+export interface LiveSession<E extends AppliedStateOwner = AppliedStateOwner> {
   key: string;
   environment: E;
-  configFingerprint: string;
+  /**
+   * The configuration this session's environment ACTUALLY runs.
+   *
+   * LIFECYCLE MIGRATION, STEP 2. This is a READ-ONLY view of `environment.appliedState`, not a
+   * stored copy. It used to be a field the caller wrote at park time, and the approval-resume
+   * path wrote the INCOMING request's value into it — a configuration the environment had never
+   * applied. Reading through to the environment removes the field a caller could stamp, so that
+   * bug can no longer be written.
+   */
+  readonly configFingerprint: string;
   historyFingerprint: string;
   /**
    * Whether the request this session parked from asserted a transcript beyond its own turn. A
@@ -49,11 +59,15 @@ export interface LiveSession<E = unknown> {
   teardownPromise?: Promise<void>;
 }
 
-/** Fields the caller supplies to park a session (the pool arms the timer and state itself). */
-export interface ParkInput<E> {
+/**
+ * Fields the caller supplies to park a session (the pool arms the timer and state itself).
+ *
+ * There is deliberately NO `configFingerprint` here. The environment owns that, and the pool
+ * reads it. See `LiveSession.configFingerprint`.
+ */
+export interface ParkInput<E extends AppliedStateOwner> {
   key: string;
   environment: E;
-  configFingerprint: string;
   historyFingerprint: string;
   /** See `LiveSession.historyAsserted`. Omitted defaults to the strictest resume check. */
   historyAsserted?: boolean;
@@ -66,7 +80,7 @@ export interface ParkInput<E> {
  * (Node), so check-and-set on a key needs no lock. All teardown routes through the session's
  * one idempotent `teardown`.
  */
-export class SessionPool<E = unknown> {
+export class SessionPool<E extends AppliedStateOwner = AppliedStateOwner> {
   private readonly sessions = new Map<string, LiveSession<E>>();
 
   constructor(
@@ -156,7 +170,6 @@ export class SessionPool<E = unknown> {
   async repark(
     session: LiveSession<E>,
     update: {
-      configFingerprint: string;
       historyFingerprint: string;
       /** See `LiveSession.historyAsserted`. Omitted defaults to the strictest resume check. */
       historyAsserted?: boolean;
@@ -182,7 +195,8 @@ export class SessionPool<E = unknown> {
       this.sessions.set(session.key, session);
     }
     this.clearTimer(session);
-    session.configFingerprint = update.configFingerprint;
+    // No `configFingerprint` assignment. It reads through to the environment, which is the only
+    // thing that knows what it actually applied.
     session.historyFingerprint = update.historyFingerprint;
     session.historyAsserted = update.historyAsserted ?? true;
     session.credentialEpoch = update.credentialEpoch;
@@ -225,10 +239,14 @@ export class SessionPool<E = unknown> {
       return false;
     }
 
+    const environment = input.environment;
     const session: LiveSession<E> = {
       key: input.key,
-      environment: input.environment,
-      configFingerprint: input.configFingerprint,
+      environment,
+      // A getter, not a copy: the pool always reports what the environment currently has applied.
+      get configFingerprint() {
+        return environment.appliedState.configFingerprint;
+      },
       historyFingerprint: input.historyFingerprint,
       historyAsserted: input.historyAsserted ?? true,
       credentialEpoch: input.credentialEpoch,

--- a/services/runner/src/engines/sandbox_agent/teardown.ts
+++ b/services/runner/src/engines/sandbox_agent/teardown.ts
@@ -1,13 +1,42 @@
 /**
  * Map why an environment is torn down to whether its sandbox is stopped or deleted.
  * The destroy path escalates a failed stop to delete.
+ *
+ * LIFECYCLE MIGRATION, STEP 1. The old single `compatibility-mismatch` reason could not say WHAT
+ * was incompatible, so every incompatibility deleted the sandbox. That is right for some causes
+ * and wasteful for others. The reason set now names the LAYER that failed, and only the layers
+ * whose sandbox is still sound may park.
+ *
+ * One rule drives the split: a sandbox may park only when nothing inside its DAEMON is stale.
+ *
+ *  - `session-incompatible`  The harness SESSION is wrong. An example is a parked approval gate
+ *                            the runner can no longer answer. The sandbox, the daemon, and the
+ *                            installed credentials are all sound, so park it.
+ *  - `continuity-invalid`    The CONVERSATION is wrong. An example is an edited transcript. This
+ *                            says nothing about the environment, so park it.
+ *  - `runtime-incompatible`  Something baked into the DAEMON is stale. Examples are model or MCP
+ *                            credentials, the process environment, and Pi's runtime assets. A
+ *                            parked sandbox would resume with that stale material installed.
+ *                            Delete it.
+ *  - `sandbox-incompatible`  The sandbox itself is wrong. Examples are the provider, the image,
+ *                            the snapshot, and the network policy. There is nothing worth
+ *                            parking. Delete it.
+ *
+ * `compatibility-mismatch` stays in the union as a DEPRECATED alias that still deletes. It keeps
+ * an unclassified call site safe, because delete is always sound and only costs a rebuild. Name
+ * one of the four reasons above instead.
  */
 
 export type TeardownReason =
   | "kill"
   | "failed-turn"
   | "aborted"
+  /** @deprecated Name the failing layer instead. Kept so an unclassified call site fails safe. */
   | "compatibility-mismatch"
+  | "session-incompatible"
+  | "runtime-incompatible"
+  | "sandbox-incompatible"
+  | "continuity-invalid"
   | "clean-resumable"
   | "idle-expiry"
   | "capacity-eviction"
@@ -20,17 +49,28 @@ export type TeardownDisposition = "delete" | "stop";
 // Slice 5's E3 live verification gates this default in the merged feature.
 export const PARK_CLEAN_RESUMABLE_TURNS = true;
 
+/**
+ * The reasons that may park the sandbox. Every other reason deletes.
+ *
+ * This is an allowlist, and it must stay one. A new reason therefore deletes until somebody
+ * proves its sandbox is safe to reuse. A denylist would make a new reason park by accident, and
+ * that is the failure mode that leaves stale credentials inside a resumed daemon.
+ */
+const PARKABLE_REASONS: ReadonlySet<TeardownReason> = new Set<TeardownReason>([
+  "clean-resumable",
+  "idle-expiry",
+  "capacity-eviction",
+  "shutdown-idle",
+  // The two incompatibilities whose daemon is still sound. See the module comment.
+  "session-incompatible",
+  "continuity-invalid",
+]);
+
 export function teardownDisposition(
   reason: TeardownReason,
   parkCleanResumableTurns = PARK_CLEAN_RESUMABLE_TURNS,
 ): TeardownDisposition {
-  if (
-    parkCleanResumableTurns &&
-    (reason === "clean-resumable" ||
-      reason === "idle-expiry" ||
-      reason === "capacity-eviction" ||
-      reason === "shutdown-idle")
-  ) {
+  if (parkCleanResumableTurns && PARKABLE_REASONS.has(reason)) {
     return "stop";
   }
   return "delete";

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -461,6 +461,35 @@ export async function runWithKeepalive(
         ? "aborted"
         : "failed-turn";
 
+  /**
+   * Turn a dispatch mismatch label into the teardown reason that names the FAILING LAYER.
+   *
+   * LIFECYCLE MIGRATION, STEP 1. Every mismatch used to tear down with one
+   * `compatibility-mismatch` reason, so every mismatch deleted the sandbox. The mapping below
+   * says which layer is actually wrong, and `teardownDisposition` then parks only the layers
+   * whose daemon is still sound.
+   *
+   * The mapping is conservative on purpose. Anything that might have baked material into the
+   * DAEMON maps to `runtime-incompatible`, which deletes. Only a wrong CONVERSATION or a wrong
+   * harness SESSION parks, because neither says anything is stale inside the sandbox.
+   */
+  const mismatchTeardownReason = (mismatch: string): TeardownReason => {
+    // A conversation problem. The environment is fine; the transcript is not.
+    if (mismatch === "history" || mismatch === "tail") return "continuity-invalid";
+    // Credentials live in the daemon's environment on Daytona, and Pi's runtime assets are
+    // installed at start. A parked sandbox would resume with the stale material still in place,
+    // so these must delete. This is the case the lifecycle design warns about by name.
+    if (mismatch.startsWith("credentials")) return "runtime-incompatible";
+    // A parked approval gate the runner can no longer answer. Nothing inside the sandbox is
+    // stale, so the sandbox may park.
+    if (mismatch === "no-parked-gate" || mismatch === "unrecognized-gate-type")
+      return "session-incompatible";
+    // `config` covers every remaining configuration change, including a changed model connection
+    // or MCP credential shape. Until the reconciliation router can say which facet moved, treat
+    // it as runtime-level and delete. Delete is always sound; it only costs a rebuild.
+    return "runtime-incompatible";
+  };
+
   const notifyParkedLive = async (env: SessionEnvironment): Promise<void> => {
     if (resolveKeepaliveProvider(request) !== "daytona") return;
     // Best-effort: the session is already parked, so an activity-refresh failure must not turn
@@ -560,7 +589,7 @@ export async function runWithKeepalive(
     const input = {
       key,
       environment: env,
-      configFingerprint: cfgFp,
+      // No `configFingerprint`. The environment owns it (lifecycle migration, step 2).
       historyFingerprint: nextHistoryFp(env),
       historyAsserted,
       credentialEpoch: parkedEpoch(env, incomingEpoch.secrets),
@@ -600,7 +629,9 @@ export async function runWithKeepalive(
     const env = live.environment;
     env.clearTurn();
     const update = {
-      configFingerprint: cfgFp,
+      // No `configFingerprint`. THIS is where the stale-config bug lived: the approval-resume
+      // path reached here with the INCOMING request's fingerprint and stamped it onto an
+      // environment that had never applied it. The field is gone, so the bug cannot be written.
       historyFingerprint: nextHistoryFp(env),
       historyAsserted,
       credentialEpoch: parkedEpoch(env, live.credentialEpoch.secrets),
@@ -704,7 +735,11 @@ export async function runWithKeepalive(
       klog(`mismatch (${mismatch}) key=${key}; evict + cold`);
       // Await: the old teardown unmounts the same durable cwd the cold acquire is about to
       // mount — they must never overlap.
-      await pool.evict(key, `mismatch:${mismatch}`, "compatibility-mismatch");
+      await pool.evict(
+        key,
+        `mismatch:${mismatch}`,
+        mismatchTeardownReason(mismatch),
+      );
       return coldAndPark();
     }
 
@@ -860,7 +895,9 @@ export async function runWithKeepalive(
       await pool.evict(
         key,
         `approval-mismatch:${mismatch ?? "unknown"}`,
-        "compatibility-mismatch",
+        // An unanswered approval with no recorded mismatch is a session-level problem: the
+        // request carried no decision this parked gate could consume.
+        mismatchTeardownReason(mismatch ?? "no-parked-gate"),
       );
       return coldAndPark();
     }

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -28,10 +28,15 @@ import {
 import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
 import {
   computeCredentialEpoch,
+  configFingerprint,
   mountExpiryMs,
   type InstalledMountExpiries,
   type KeepaliveConfig,
 } from "../../src/engines/sandbox_agent/session-identity.ts";
+import {
+  AppliedState,
+  type AppliedEnvironmentState,
+} from "../../src/engines/sandbox_agent/applied-state.ts";
 import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
 import {
   acquireEnvironment,
@@ -97,6 +102,9 @@ interface TurnScript {
 
 interface DispatchFakeEnv {
   id: number;
+  /** The environment owns what it applied (lifecycle migration, step 2). The pool reads it. */
+  readonly appliedState: AppliedEnvironmentState;
+  commitApplied: (result: { configFingerprint: string }) => void;
   destroyed: number;
   turnsCleared: number;
   lastTurnToolCallIds: string[];
@@ -135,9 +143,16 @@ function makeApprovalEngine(
   const holds = new Map<number, () => void>();
 
   let nextEnvId = 1;
-  const makeEnv = (): DispatchFakeEnv => {
+  // Seeded from the acquiring request, exactly as `prepareEnvironmentSetup` does. The approval
+  // tests care about this most: a resume must NOT be able to move it.
+  const makeEnv = (configFp: string): DispatchFakeEnv => {
+    const applied = new AppliedState(configFp);
     const env: DispatchFakeEnv = {
       id: nextEnvId++,
+      get appliedState() {
+        return applied.appliedState;
+      },
+      commitApplied: (result) => applied.commitApplied(result),
       destroyed: 0,
       turnsCleared: 0,
       lastTurnToolCallIds: [],
@@ -248,9 +263,9 @@ function makeApprovalEngine(
       calls.resolveMount += 1;
       return signedMount();
     },
-    async acquireEnvironment(_request, _signal, _presigned) {
+    async acquireEnvironment(request, _signal, _presigned) {
       calls.acquire += 1;
-      const env = makeEnv();
+      const env = makeEnv(configFingerprint(request));
       const expiry = mountExpiryMs(mountOpts.expiresAt);
       if (expiry !== undefined) env.installedMountExpiries.cwd = expiry;
       calls.acquiredEnvs.push(env);

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -25,11 +25,16 @@ import {
 } from "../../src/server.ts";
 import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
 import {
+  configFingerprint,
   mountExpiryMs,
   MOUNT_LEASE_SKEW_MS,
   type InstalledMountExpiries,
   type KeepaliveConfig,
 } from "../../src/engines/sandbox_agent/session-identity.ts";
+import {
+  AppliedState,
+  type AppliedEnvironmentState,
+} from "../../src/engines/sandbox_agent/applied-state.ts";
 import { TOTAL_DEADLINE_ENV } from "../../src/engines/sandbox_agent/run-limits.ts";
 import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
 import type { SessionEnvironment } from "../../src/engines/sandbox_agent.ts";
@@ -60,6 +65,9 @@ interface EngineOptions {
 
 interface FakeEnv {
   id: number;
+  /** The environment owns what it applied (lifecycle migration, step 2). The pool reads it. */
+  readonly appliedState: AppliedEnvironmentState;
+  commitApplied: (result: { configFingerprint: string }) => void;
   destroyed: number;
   turnsCleared: number;
   lastTurnToolCallIds: string[];
@@ -89,9 +97,16 @@ function makeEngine(options: EngineOptions = {}) {
   };
 
   let nextEnvId = 1;
-  const makeEnv = (): FakeEnv => {
+  // The fake acquire seeds applied state from the acquiring request, exactly as the real
+  // `prepareEnvironmentSetup` does. Without it the pool would have nothing to read.
+  const makeEnv = (configFp: string): FakeEnv => {
+    const applied = new AppliedState(configFp);
     const env: FakeEnv = {
       id: nextEnvId++,
+      get appliedState() {
+        return applied.appliedState;
+      },
+      commitApplied: (result) => applied.commitApplied(result),
       destroyed: 0,
       turnsCleared: 0,
       lastTurnToolCallIds: [],
@@ -155,9 +170,9 @@ function makeEngine(options: EngineOptions = {}) {
         options.mountExpiresAtSequence?.[idx] ?? options.mountExpiresAt,
       );
     },
-    async acquireEnvironment(_request, _signal, presigned) {
+    async acquireEnvironment(request, _signal, presigned) {
       calls.acquire += 1;
-      const env = makeEnv();
+      const env = makeEnv(configFingerprint(request));
       // The real mount helpers stamp the expiry of the credentials the daemon received; a
       // mount-less acquire leaves the entry unset (no lease at all).
       const cwd = mountExpiryMs(presigned?.expiresAt);

--- a/services/runner/tests/unit/session-lifecycle-characterization.test.ts
+++ b/services/runner/tests/unit/session-lifecycle-characterization.test.ts
@@ -1,0 +1,729 @@
+/**
+ * LIFECYCLE MIGRATION, STEPS 1 AND 2 — the behavior record.
+ *
+ * This file began as CHARACTERIZATION tests. It pinned three defects so the refactor could see
+ * itself, and it was written so that fixing a defect BREAKS the test. That is what happened. This
+ * revision is the deliberate edit, and it is the record of what changed and why.
+ *
+ * Design: docs/design/agent-config-editing/research/runner-lifecycle-codex.md, "5. Migration
+ * path", steps 1 and 2.
+ *
+ * | Block | Was pinned as | Is now |
+ * |---|---|---|
+ * | (a) revision metadata | A revision-id change evicted the warm session | Revision id, version, and draft flag are out of the fingerprint. The session survives. |
+ * | (b) teardown reasons | Every incompatibility mapped to delete | Four named reasons. Only the two whose daemon is sound may park. |
+ * | (c) approval stale config | The re-park stamped the INCOMING fingerprint | The pool has no fingerprint parameter. Applied state is owned by the environment. |
+ *
+ * Each block keeps a WAS note beside its assertions. A future reader must be able to see the old
+ * behavior without reading git history, because the old behavior is why the code looks like this.
+ *
+ * Run: pnpm exec vitest run tests/unit/session-lifecycle-characterization.test.ts
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentRunRequest, AgentRunResult } from "../../src/protocol.ts";
+import {
+  runWithKeepalive,
+  type KeepaliveContext,
+  type KeepaliveEngine,
+} from "../../src/server.ts";
+import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
+import {
+  configFingerprint,
+  type KeepaliveConfig,
+} from "../../src/engines/sandbox_agent/session-identity.ts";
+import {
+  AppliedState,
+  type AppliedEnvironmentState,
+} from "../../src/engines/sandbox_agent/applied-state.ts";
+import {
+  teardownDisposition,
+  type TeardownReason,
+} from "../../src/engines/sandbox_agent/teardown.ts";
+import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
+import type {
+  ParkedApproval,
+  SessionEnvironment,
+} from "../../src/engines/sandbox_agent.ts";
+
+const auth = {
+  telemetry: {
+    exporters: { otlp: { headers: { authorization: "ApiKey run" } } },
+  },
+};
+
+const POOL_KEY = "proj-1:s1";
+
+// --------------------------------------------------------------------------- //
+// A fake engine, modelled on tests/unit/session-keepalive-approval.test.ts.     //
+// It records which teardown REASON each destroy carried, which the existing     //
+// helpers do not, because (b) is about the reason -> disposition mapping.       //
+// --------------------------------------------------------------------------- //
+
+interface FakeEnv {
+  id: number;
+  /** The environment owns what it applied. The pool reads through to it. */
+  readonly appliedState: AppliedEnvironmentState;
+  commitApplied: (result: { configFingerprint: string }) => void;
+  destroyed: number;
+  destroyReasons: TeardownReason[];
+  turnsCleared: number;
+  lastTurnToolCallIds: string[];
+  parkedApprovals: Map<string, ParkedApproval>;
+  parkedApproval?: ParkedApproval;
+  approvalGateCount: number;
+  nonParkablePauseCount: number;
+  installedMountExpiries: Record<string, number>;
+  clearTurn: () => void;
+  destroy: (opts?: { reason?: TeardownReason }) => Promise<void>;
+}
+
+interface TurnScript {
+  approvalPause?: { permissionId: string; toolCallId: string; toolName?: string };
+  result?: AgentRunResult;
+  toolCallIds?: string[];
+}
+
+function makeEngine(scripts: TurnScript[] = []) {
+  const calls = {
+    acquire: 0,
+    turns: [] as Array<{ env: FakeEnv; opts: any }>,
+    resumes: [] as Array<{ toolCallId: string; reply: string }>,
+    acquiredEnvs: [] as FakeEnv[],
+  };
+  let nextEnvId = 1;
+
+  // Seeded from the acquiring request, exactly as `prepareEnvironmentSetup` does.
+  const makeEnv = (configFp: string): FakeEnv => {
+    const applied = new AppliedState(configFp);
+    const env: FakeEnv = {
+      id: nextEnvId++,
+      get appliedState() {
+        return applied.appliedState;
+      },
+      commitApplied: (result) => applied.commitApplied(result),
+      destroyed: 0,
+      destroyReasons: [],
+      turnsCleared: 0,
+      lastTurnToolCallIds: [],
+      parkedApprovals: new Map(),
+      parkedApproval: undefined,
+      approvalGateCount: 0,
+      nonParkablePauseCount: 0,
+      installedMountExpiries: {},
+      clearTurn: () => {
+        env.turnsCleared += 1;
+      },
+      destroy: async (opts) => {
+        env.destroyed += 1;
+        if (opts?.reason) env.destroyReasons.push(opts.reason);
+      },
+    };
+    return env;
+  };
+
+  const signedMount = (): MountCredentials => ({
+    region: "us-east-1",
+    bucket: "b",
+    prefix: "mounts/proj/mount",
+    accessKey: "AK",
+    secretKey: "SK",
+    projectId: "proj-1",
+  });
+
+  const engine: KeepaliveEngine = {
+    async resolveKeepaliveMount() {
+      return signedMount();
+    },
+    async acquireEnvironment(request) {
+      calls.acquire += 1;
+      const env = makeEnv(configFingerprint(request));
+      calls.acquiredEnvs.push(env);
+      return { ok: true, env: env as unknown as SessionEnvironment };
+    },
+    async runTurn(rawEnv, _request, _emit, _signal, opts) {
+      const env = rawEnv as unknown as FakeEnv;
+      const idx = calls.turns.length;
+      const script = scripts[idx] ?? {};
+      env.parkedApprovals = new Map();
+      env.parkedApproval = undefined;
+      env.approvalGateCount = 0;
+      env.nonParkablePauseCount = 0;
+      for (const gate of (opts as any)?.resume?.carriedForward ?? []) {
+        env.parkedApprovals.set(gate.toolCallId, gate);
+        env.parkedApproval ??= gate;
+      }
+      env.approvalGateCount = env.parkedApprovals.size;
+      env.lastTurnToolCallIds = script.toolCallIds ?? [];
+      calls.turns.push({ env, opts });
+      for (const decision of (opts as any)?.resume?.decisions ?? []) {
+        calls.resumes.push({
+          toolCallId: decision.toolCallId,
+          reply: decision.reply,
+        });
+      }
+      if (script.approvalPause) {
+        const promptPromise = new Promise(() => {});
+        promptPromise.catch(() => {});
+        const record: ParkedApproval = {
+          gateType: "claude-acp-permission",
+          permissionId: script.approvalPause.permissionId,
+          toolCallId: script.approvalPause.toolCallId,
+          toolName: script.approvalPause.toolName,
+          args: {},
+          interactionToken: script.approvalPause.toolCallId,
+          promptPromise,
+        };
+        env.parkedApprovals.set(record.toolCallId, record);
+        env.parkedApproval = record;
+        env.approvalGateCount = 1;
+        return { ok: true, stopReason: "paused" };
+      }
+      return script.result ?? { ok: true, output: "ok", stopReason: "complete" };
+    },
+    async runCold() {
+      return { ok: true, output: "cold", stopReason: "complete" };
+    },
+  };
+
+  return { engine, calls };
+}
+
+function makeCtx(engine: KeepaliveEngine): KeepaliveContext {
+  const config: KeepaliveConfig = {
+    enabled: true,
+    ttlMs: 60_000,
+    approvalTtlMs: 600_000,
+    poolMax: 8,
+  };
+  const pool = new SessionPool<SessionEnvironment>(
+    { poolMax: config.poolMax },
+    () => {},
+  );
+  return { engine, pool, config };
+}
+
+/** A request carrying a workflow revision id + draft flag in its run context. */
+function requestWithRevision(
+  revisionId: string,
+  overrides: {
+    version?: string;
+    isDraft?: boolean;
+    messages?: AgentRunRequest["messages"];
+  } = {},
+): AgentRunRequest {
+  return {
+    harness: "claude",
+    model: "m1",
+    sessionId: "s1",
+    ...auth,
+    messages: overrides.messages ?? [{ role: "user", content: "hello" }],
+    runContext: {
+      project: { id: "proj-1" },
+      workflow: {
+        revision: { id: revisionId, version: overrides.version ?? "1" },
+        is_draft: overrides.isDraft ?? false,
+      },
+    },
+  };
+}
+
+// =========================================================================== //
+// (a) Revision metadata is OUT of environment identity.                        //
+// =========================================================================== //
+
+describe("(a) revision metadata is turn metadata, not environment identity", () => {
+  // WAS: `configFingerprint` folded in `workflowRevision.id`, `workflowRevision.version`, and
+  // `isDraft`. So committing a revision mid-conversation changed the fingerprint, the dispatch
+  // read a mismatch, and it destroyed a warm sandbox that was still perfectly usable. These four
+  // tests asserted `notEqual` and now assert `equal`.
+
+  it("a revision-ID-only change does NOT change the configFingerprint", () => {
+    assert.equal(
+      configFingerprint(requestWithRevision("rev-1")),
+      configFingerprint(requestWithRevision("rev-2")),
+      "nothing in the sandbox, the daemon, the workspace, or the harness session depends on " +
+        "a revision id, so it must not decide whether the environment can be reused",
+    );
+  });
+
+  it("a revision-VERSION-only change does NOT change the configFingerprint", () => {
+    assert.equal(
+      configFingerprint(requestWithRevision("rev-1", { version: "1" })),
+      configFingerprint(requestWithRevision("rev-1", { version: "2" })),
+    );
+  });
+
+  it("a draft-flag-only change does NOT change the configFingerprint", () => {
+    assert.equal(
+      configFingerprint(requestWithRevision("rev-1", { isDraft: false })),
+      configFingerprint(requestWithRevision("rev-1", { isDraft: true })),
+    );
+  });
+
+  it("a real config change still DOES change the configFingerprint", () => {
+    // The guard against over-removal. Dropping the revision fields must not make the fingerprint
+    // blind to a change that genuinely does invalidate the environment.
+    const base = requestWithRevision("rev-1");
+    assert.notEqual(
+      configFingerprint(base),
+      configFingerprint({ ...base, model: "m2" }),
+    );
+  });
+
+  it("END TO END: committing a revision keeps the warm session", () => {
+    // WAS: `acquire` went 1 -> 2 and the warm environment was destroyed with
+    // `compatibility-mismatch`. This is the product cost the whole project exists to remove.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+
+    return (async () => {
+      await runWithKeepalive(
+        requestWithRevision("rev-1"),
+        undefined,
+        undefined,
+        ctx,
+      );
+      assert.equal(calls.acquire, 1);
+      const env1 = calls.acquiredEnvs[0];
+
+      // The agent committed a revision mid-conversation, so the service sends the NEW revision id.
+      // Model, harness, skills, tools, and instructions are all identical.
+      await runWithKeepalive(
+        requestWithRevision("rev-2", {
+          messages: [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi" },
+            { role: "user", content: "more" },
+          ],
+        }),
+        undefined,
+        undefined,
+        ctx,
+      );
+
+      assert.equal(
+        calls.acquire,
+        1,
+        "the committed revision reuses the warm sandbox instead of rebuilding it",
+      );
+      assert.equal(env1.destroyed, 0, "the warm environment survives");
+      assert.equal(calls.turns.length, 2);
+      assert.equal(
+        calls.turns[1].env.id,
+        env1.id,
+        "the second turn ran on the SAME environment",
+      );
+    })();
+  });
+});
+
+// =========================================================================== //
+// (b) Teardown names the failing LAYER, and only a sound daemon may park.      //
+// =========================================================================== //
+
+describe("(b) teardown reasons name the failing layer", () => {
+  // WAS: one `compatibility-mismatch` reason for every incompatibility, always mapping to
+  // `delete`. It could not say WHAT was incompatible, so a wrong transcript cost the same
+  // rebuild as a rotated credential.
+
+  it("the two incompatibilities whose daemon is sound PARK", () => {
+    // A wrong harness session and a wrong conversation both leave the sandbox, the daemon, and
+    // the installed credentials untouched. There is nothing stale to carry forward.
+    assert.equal(teardownDisposition("session-incompatible"), "stop");
+    assert.equal(teardownDisposition("continuity-invalid"), "stop");
+  });
+
+  it("the two incompatibilities that could leave stale material DELETE", () => {
+    // This is the case the lifecycle design warns about by name: credentials and Pi runtime
+    // assets are installed into the daemon, so a parked sandbox would resume with the stale
+    // material still in place.
+    assert.equal(teardownDisposition("runtime-incompatible"), "delete");
+    assert.equal(teardownDisposition("sandbox-incompatible"), "delete");
+  });
+
+  it("the deprecated alias still deletes, so an unclassified call site fails safe", () => {
+    assert.equal(
+      teardownDisposition("compatibility-mismatch"),
+      "delete",
+      "delete is always sound; it only ever costs a rebuild",
+    );
+  });
+
+  it("the ordinary park reasons are unchanged", () => {
+    for (const reason of [
+      "clean-resumable",
+      "idle-expiry",
+      "capacity-eviction",
+      "shutdown-idle",
+    ] as const) {
+      assert.equal(teardownDisposition(reason), "stop", `${reason} parks the sandbox`);
+    }
+  });
+
+  it("the ordinary delete reasons are unchanged", () => {
+    for (const reason of ["kill", "failed-turn", "aborted", "shutdown-in-flight"] as const) {
+      assert.equal(teardownDisposition(reason), "delete", `${reason} deletes the sandbox`);
+    }
+  });
+
+  it("the parkable set is an ALLOWLIST, so a new reason deletes by default", () => {
+    // The invariant that keeps this safe as the union grows. A denylist would make a newly added
+    // reason park by accident, which is how stale credentials survive into a resumed daemon.
+    const parkable: TeardownReason[] = [
+      "clean-resumable",
+      "idle-expiry",
+      "capacity-eviction",
+      "shutdown-idle",
+      "session-incompatible",
+      "continuity-invalid",
+    ];
+    const everyReason: TeardownReason[] = [
+      "kill",
+      "failed-turn",
+      "aborted",
+      "compatibility-mismatch",
+      "session-incompatible",
+      "runtime-incompatible",
+      "sandbox-incompatible",
+      "continuity-invalid",
+      "clean-resumable",
+      "idle-expiry",
+      "capacity-eviction",
+      "shutdown-in-flight",
+      "shutdown-idle",
+    ];
+    assert.equal(everyReason.length, 13, "the TeardownReason union has 13 members");
+    for (const reason of everyReason) {
+      assert.equal(
+        teardownDisposition(reason),
+        parkable.includes(reason) ? "stop" : "delete",
+        `${reason} must follow the allowlist`,
+      );
+    }
+  });
+
+  it("the park default is on, so this is a real disposition and not a disabled flag", () => {
+    assert.equal(
+      teardownDisposition("session-incompatible", false),
+      "delete",
+      "with parking off everything deletes; the default (true) is what this block records",
+    );
+  });
+
+  it("END TO END: an edited transcript now PARKS the sandbox instead of deleting it", async () => {
+    // WAS: `mismatch:history` tore down with `compatibility-mismatch`, which deleted. But an
+    // edited transcript says nothing about the environment. The sandbox, the daemon, and the
+    // credentials are all sound, so the only correct answer is to park it.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(requestWithRevision("rev-1"), undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+
+    // Turn 2 rewrites the first user message, so the history fingerprint cannot match.
+    await runWithKeepalive(
+      requestWithRevision("rev-1", {
+        messages: [
+          { role: "user", content: "EDITED" },
+          { role: "assistant", content: "hi" },
+          { role: "user", content: "more" },
+        ],
+      }),
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    assert.equal(calls.acquire, 2, "the conversation is wrong, so the turn still runs cold");
+    assert.deepEqual(
+      env1.destroyReasons,
+      ["continuity-invalid"],
+      "the reason names the CONVERSATION, not the environment",
+    );
+    assert.equal(
+      teardownDisposition(env1.destroyReasons[0]),
+      "stop",
+      "so the sandbox parks and the next turn can reconnect to it",
+    );
+  });
+
+  it("END TO END: a rotated credential still DELETES the sandbox", async () => {
+    // The other half of the split, and the one the lifecycle design warns about by name. A
+    // rotated model credential is baked into the daemon, so a parked sandbox would resume with
+    // the stale material still installed.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    const withCredential = (secret: string, messages: AgentRunRequest["messages"]) => ({
+      ...requestWithRevision("rev-1", { messages }),
+      modelConnection: {
+        provider: "openai",
+        deployment: "direct",
+        endpoint: { baseUrl: "https://api.openai.com/v1" },
+        credentialMode: "env",
+        credentials: [
+          {
+            binding: { kind: "environment", name: "OPENAI_API_KEY" },
+            value: secret,
+            usage: "opaque_http",
+          },
+        ],
+      } satisfies NonNullable<AgentRunRequest["modelConnection"]>,
+    });
+
+    await runWithKeepalive(
+      withCredential("sk-a", [{ role: "user", content: "hello" }]),
+      undefined,
+      undefined,
+      ctx,
+    );
+    const env1 = calls.acquiredEnvs[0];
+
+    await runWithKeepalive(
+      withCredential("sk-b", [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        { role: "user", content: "more" },
+      ]),
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    assert.equal(calls.acquire, 2);
+    assert.deepEqual(env1.destroyReasons, ["runtime-incompatible"]);
+    assert.equal(
+      teardownDisposition(env1.destroyReasons[0]),
+      "delete",
+      "a stale credential must never survive inside a parked daemon",
+    );
+  });
+});
+
+// =========================================================================== //
+// (c) The approval-resume path can no longer stamp a configuration.            //
+// =========================================================================== //
+
+describe("(c) applied state is owned by the environment, never stamped by a request", () => {
+  /** Turn 1 pauses on a gate; the resume answers it. */
+  function pauseRequest(revisionId: string): AgentRunRequest {
+    return requestWithRevision(revisionId, {
+      messages: [{ role: "user", content: "do X" }],
+    });
+  }
+
+  function approveResume(
+    revisionId: string,
+    overrides: Partial<AgentRunRequest> = {},
+  ): AgentRunRequest {
+    return {
+      ...requestWithRevision(revisionId, {
+        messages: [
+          { role: "user", content: "do X" },
+          {
+            role: "assistant",
+            content: [
+              { type: "tool_call", toolCallId: "tc-gate", toolName: "commit" },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                toolCallId: "tc-gate",
+                output: { approved: true },
+              },
+            ],
+          },
+        ],
+      }),
+      ...overrides,
+    };
+  }
+
+  async function parkThenResume(resume: AgentRunRequest, parkRevision = "rev-1") {
+    const { engine, calls } = makeEngine([
+      {
+        approvalPause: {
+          permissionId: "perm-1",
+          toolCallId: "tc-gate",
+          toolName: "commit",
+        },
+        toolCallIds: ["tc-gate"],
+      },
+      { result: { ok: true, output: "resumed", stopReason: "complete" } },
+    ]);
+    const ctx = makeCtx(engine);
+    const parked = pauseRequest(parkRevision);
+    const r1 = await runWithKeepalive(parked, undefined, undefined, ctx);
+    assert.equal(r1.stopReason, "paused");
+    assert.equal(ctx.pool.get(POOL_KEY)!.state, "awaiting_approval");
+    const parkedFp = ctx.pool.get(POOL_KEY)!.configFingerprint;
+    const r2 = await runWithKeepalive(resume, undefined, undefined, ctx);
+    return { calls, ctx, r2, parked, parkedFp };
+  }
+
+  it("the approval branch still does not compare the incoming config fingerprint", () => {
+    // UNCHANGED, and deliberately so. The commit the agent asked approval FOR is what changes the
+    // revision id, so an approval reply routinely arrives with a different config than the park.
+    // Evicting there would throw away the very session that can answer the gate. What changes in
+    // step 2 is not whether the branch compares, but what it RECORDS afterwards.
+    return (async () => {
+      const resume = approveResume("rev-2");
+      const { calls, r2 } = await parkThenResume(resume, "rev-1");
+      assert.equal(r2.ok, true);
+      assert.equal(
+        calls.acquire,
+        1,
+        "the resume runs on the parked environment",
+      );
+      assert.equal(calls.resumes.length, 1, "the parked gate is answered live");
+    })();
+  });
+
+  it("THE FIX: the re-park reports the APPLIED configuration, not the incoming one", async () => {
+    // WAS: `reparkOrEvict` passed `configFingerprint: cfgFp` from the INCOMING request, so the
+    // pool recorded a configuration the environment had never applied.
+    // NOW: `ParkInput` and the repark update have no `configFingerprint` field at all. The pool
+    // reads `environment.appliedState`, so the stamp cannot be written.
+    const resume = approveResume("rev-2", { model: "m2" });
+    const { ctx, parked, parkedFp } = await parkThenResume(resume, "rev-1");
+
+    const reparked = ctx.pool.get(POOL_KEY)!;
+    assert.equal(reparked.state, "idle", "the resumed turn completed and re-parked");
+
+    assert.equal(
+      reparked.configFingerprint,
+      parkedFp,
+      "the environment still reports what it was built with",
+    );
+    assert.equal(
+      reparked.configFingerprint,
+      configFingerprint(parked),
+      "and that is the configuration of the request that actually built it",
+    );
+    assert.notEqual(
+      reparked.configFingerprint,
+      configFingerprint(resume),
+      "the incoming request's configuration was never applied, so it is never recorded",
+    );
+  });
+
+  it("THE REGRESSION: park m1, resume m2, no setModel success, applied stays m1", async () => {
+    // The exact regression the migration's step 2 asks for. It is the inverse of the bug this
+    // file used to pin, and it is the reason `commitApplied` takes a RESULT rather than a
+    // desired value.
+    const resume = approveResume("rev-1", { model: "m2" });
+    const { calls, ctx, parked } = await parkThenResume(resume, "rev-1");
+    assert.equal(calls.acquire, 1, "the model change does not evict on the approval branch");
+
+    const env = calls.acquiredEnvs[0];
+    assert.equal(
+      env.appliedState.configFingerprint,
+      configFingerprint(parked),
+      "no successful setModel(m2) happened, so the environment is still applied as m1",
+    );
+    assert.equal(
+      ctx.pool.get(POOL_KEY)!.configFingerprint,
+      configFingerprint(parked),
+      "and the pool reports m1, because it reads the environment",
+    );
+  });
+
+  it("THE PAYOFF: the next checkout sees the m1 -> m2 delta and rebuilds", async () => {
+    // WAS: the third turn matched the stamped m2 fingerprint and continued warm on an
+    // environment running m1. Now the stamp is m1, the incoming request is m2, and the mismatch
+    // is real, so the dispatch rebuilds. The delta is finally VISIBLE.
+    const resume = approveResume("rev-1", { model: "m2" });
+    const { calls, ctx } = await parkThenResume(resume, "rev-1");
+    assert.equal(calls.acquire, 1);
+    const env1 = calls.acquiredEnvs[0];
+
+    const third: AgentRunRequest = {
+      ...requestWithRevision("rev-1", {
+        messages: [
+          { role: "user", content: "do X" },
+          {
+            role: "assistant",
+            content: [{ type: "tool_call", toolCallId: "tc-gate", toolName: "commit" }],
+          },
+          {
+            role: "user",
+            content: [
+              { type: "tool_result", toolCallId: "tc-gate", output: { approved: true } },
+            ],
+          },
+          { role: "assistant", content: "resumed" },
+          { role: "user", content: "next" },
+        ],
+      }),
+      model: "m2",
+    };
+    await runWithKeepalive(third, undefined, undefined, ctx);
+
+    assert.equal(
+      calls.acquire,
+      2,
+      "the m1 -> m2 delta is seen and the environment is rebuilt on m2",
+    );
+    assert.equal(
+      env1.destroyed,
+      1,
+      "the m1 environment is torn down rather than silently reused as m2",
+    );
+    assert.deepEqual(
+      env1.destroyReasons,
+      ["runtime-incompatible"],
+      "a model change may have changed baked credentials, so it deletes rather than parks",
+    );
+  });
+
+  it("applied state advances ONLY through commitApplied, and only on a real result", () => {
+    // The unit-level guard behind the three tests above. `AppliedState` has no setter, and the
+    // generation moves only when a caller reports a lifecycle action that already succeeded.
+    const applied = new AppliedState("fp-m1");
+    assert.equal(applied.appliedState.configFingerprint, "fp-m1");
+    assert.equal(applied.appliedState.generation, 1);
+
+    // A snapshot is a copy: mutating it cannot reach the real state.
+    const snapshot = applied.appliedState as { configFingerprint: string };
+    snapshot.configFingerprint = "fp-forged";
+    assert.equal(applied.appliedState.configFingerprint, "fp-m1");
+
+    applied.commitApplied({ configFingerprint: "fp-m2" });
+    assert.equal(applied.appliedState.configFingerprint, "fp-m2");
+    assert.equal(applied.appliedState.generation, 2);
+
+    // Re-applying the same configuration still advances the generation, so "nothing changed" and
+    // "we re-applied" stay distinguishable.
+    applied.commitApplied({ configFingerprint: "fp-m2" });
+    assert.equal(applied.appliedState.generation, 3);
+  });
+
+  it("for contrast: the IDLE branch does compare the fingerprint and evicts", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(requestWithRevision("rev-1"), undefined, undefined, ctx);
+    await runWithKeepalive(
+      {
+        ...requestWithRevision("rev-1", {
+          messages: [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi" },
+            { role: "user", content: "more" },
+          ],
+        }),
+        model: "m2",
+      },
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(
+      calls.acquire,
+      2,
+      "the idle branch evicts on a model change; only the approval branch skips the check",
+    );
+  });
+});

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import { inspect } from "node:util";
 
 import type { AgentRunRequest } from "../../src/protocol.ts";
+import { AppliedState } from "../../src/engines/sandbox_agent/applied-state.ts";
 import {
   approvalDecisionForToolCall,
   computeCredentialEpoch,
@@ -48,13 +49,24 @@ describe("resolvesToLocalProvider (local/remote gate)", () => {
   });
 });
 
-// A fake environment: only `destroy` matters to the pool; we count destroys. Idempotent like
-// the real engine `destroy()` closure (the pool's contract): a second call is a no-op.
-function fakeEnv() {
+// A fake environment: `destroy` and `appliedState` are what the pool touches. Destroys are
+// counted. `teardown` is idempotent like the real engine `destroy()` closure (the pool's
+// contract): a second call is a no-op.
+//
+// The environment now OWNS its applied configuration (lifecycle migration, step 2), so the fake
+// carries a real `AppliedState`. The pool reads `configFingerprint` through it and no test can
+// hand the pool a fingerprint of its own.
+function fakeEnv(configFp = "cfg") {
   const state = { destroyed: 0, reasons: [] as string[] };
+  const applied = new AppliedState(configFp);
   let done = false;
   return {
     state,
+    get appliedState() {
+      return applied.appliedState;
+    },
+    commitApplied: (result: { configFingerprint: string }) =>
+      applied.commitApplied(result),
     teardown: async (reason: string) => {
       if (done) return;
       done = true;
@@ -71,7 +83,6 @@ function parkInput(key: string, env = fakeEnv()) {
     input: {
       key,
       environment: env,
-      configFingerprint: "cfg",
       historyFingerprint: "hist",
       credentialEpoch: epoch,
       teardown: env.teardown,
@@ -970,8 +981,14 @@ describe("SessionPool", () => {
   it("strict capacity keeps a stopping seat and awaits teardown before inserting", async () => {
     let releaseTeardown: (() => void) | undefined;
     let teardownCompleted = false;
+    const stoppingApplied = new AppliedState("cfg");
     const stoppingEnv = {
       state: { destroyed: 0, reasons: [] as string[] },
+      get appliedState() {
+        return stoppingApplied.appliedState;
+      },
+      commitApplied: (r: { configFingerprint: string }) =>
+        stoppingApplied.commitApplied(r),
       teardown: async (reason: string) => {
         await new Promise<void>((resolve) => {
           releaseTeardown = resolve;
@@ -1039,8 +1056,14 @@ describe("SessionPool", () => {
 
   it("a strict stopping entry cannot be checked out or reparked over", async () => {
     let releaseTeardown: (() => void) | undefined;
+    const envApplied = new AppliedState("cfg");
     const environment = {
       state: { destroyed: 0, reasons: [] as string[] },
+      get appliedState() {
+        return envApplied.appliedState;
+      },
+      commitApplied: (r: { configFingerprint: string }) =>
+        envApplied.commitApplied(r),
       teardown: async (_reason: string) =>
         new Promise<void>((resolve) => {
           releaseTeardown = resolve;
@@ -1061,7 +1084,6 @@ describe("SessionPool", () => {
       await pool.repark(
         stopping,
         {
-          configFingerprint: "new",
           historyFingerprint: "new",
           credentialEpoch: epoch,
         },
@@ -1082,8 +1104,14 @@ describe("SessionPool", () => {
   it("non-strict capacity still frees the seat before teardown completes", async () => {
     let releaseTeardown: (() => void) | undefined;
     let teardownCompleted = false;
+    const nonStrictApplied = new AppliedState("cfg");
     const environment = {
       state: { destroyed: 0, reasons: [] as string[] },
+      get appliedState() {
+        return nonStrictApplied.appliedState;
+      },
+      commitApplied: (r: { configFingerprint: string }) =>
+        nonStrictApplied.commitApplied(r),
       teardown: async (reason: string) => {
         await new Promise<void>((resolve) => {
           releaseTeardown = resolve;
@@ -1133,7 +1161,6 @@ describe("SessionPool", () => {
     const ok = await pool.repark(
       live,
       {
-        configFingerprint: "cfg2",
         historyFingerprint: "hist2",
         credentialEpoch: epoch,
       },
@@ -1160,7 +1187,6 @@ describe("SessionPool", () => {
     const ok = await pool.repark(
       live,
       {
-        configFingerprint: "cfg2",
         historyFingerprint: "hist2",
         credentialEpoch: epoch,
       },
@@ -1187,7 +1213,6 @@ describe("SessionPool", () => {
     const ok = await pool.repark(
       live,
       {
-        configFingerprint: "cfg2",
         historyFingerprint: "hist2",
         credentialEpoch: epoch,
       },
@@ -1267,7 +1292,6 @@ describe("SessionPool", () => {
       await pool.repark(
         live,
         {
-          configFingerprint: "c2",
           historyFingerprint: "h2",
           credentialEpoch: epoch,
         },
@@ -1285,7 +1309,6 @@ describe("SessionPool", () => {
       await pool.repark(
         live2,
         {
-          configFingerprint: "c",
           historyFingerprint: "h",
           credentialEpoch: epoch,
         },
@@ -1362,8 +1385,14 @@ describe("SessionPool", () => {
     // A's destroy is gated: it does not resolve until we release it, standing in for a slow unmount.
     let releaseADestroy: (() => void) | undefined;
     const aState = { destroyed: 0, reasons: [] as string[] };
+    const aApplied = new AppliedState("cfg");
     const aEnv = {
       state: aState,
+      get appliedState() {
+        return aApplied.appliedState;
+      },
+      commitApplied: (r: { configFingerprint: string }) =>
+        aApplied.commitApplied(r),
       teardown: async (reason: string) => {
         await new Promise<void>((resolve) => {
           releaseADestroy = resolve;

--- a/services/runner/tests/unit/teardown.test.ts
+++ b/services/runner/tests/unit/teardown.test.ts
@@ -14,6 +14,12 @@ describe("sandbox teardown disposition", () => {
       ["failed-turn", "delete"],
       ["aborted", "delete"],
       ["compatibility-mismatch", "delete"],
+      // Lifecycle migration, step 1: the four named layers. Only the two whose daemon is sound
+      // may park. See `teardown.ts`.
+      ["session-incompatible", "stop"],
+      ["continuity-invalid", "stop"],
+      ["runtime-incompatible", "delete"],
+      ["sandbox-incompatible", "delete"],
       ["clean-resumable", "stop"],
       ["idle-expiry", "stop"],
       ["capacity-eviction", "stop"],


### PR DESCRIPTION
## Context

Part of the agent-config-editing stack. Targets `agent-config-editing-plan`. Read the stack bottom up.

A warm session could serve a turn while running a different configuration than the one the request asked for. The session pool stored a `configFingerprint` that its caller passed in, and the caller passed the incoming request's fingerprint. On the ordinary path that is harmless, because the dispatch has already proved the incoming and parked configurations equal. On the approval-resume path it is not. That branch never compares configurations, so re-parking stamped the environment with a configuration it had never applied. The next turn read that stamp, found a match, and continued warm on an environment running something else.

Two smaller costs sat next to it. Committing a revision mid-conversation threw away a warm sandbox, because the workflow revision id was part of environment identity. And every configuration mismatch deleted the sandbox, even when the sandbox itself was fine.

## Changes

The environment now owns its applied state and the pool reads it. `ParkInput` has no `configFingerprint` field for a caller to fill in, and `LiveSession.configFingerprint` is a read-only view of `environment.appliedState`. The bug is not patched, it is unrepresentable: there is no longer a place to write a configuration the environment never installed. `commitApplied` is the only writer, and it runs after a successful acquire.

Before: `pool.park({ key, environment, configFingerprint: configFingerprint(request), ... })`
After: `pool.park({ key, environment, ... })`, and the pool reads `environment.appliedState.configFingerprint`.

`configFingerprint` no longer hashes the workflow revision id, the revision version, or the draft flag. Those are turn metadata, not environment identity. Nothing in the sandbox, the daemon, the workspace, or the harness session changes when a revision id changes, so committing a revision now keeps the warm session instead of rebuilding it. They stay in `runContext` for tool binding and observability.

Teardown reasons now name the layer that failed instead of collapsing into one `compatibility-mismatch`. A wrong harness session or an invalid conversation parks the sandbox, because the daemon and its installed credentials are sound. Stale daemon material or a wrong sandbox still deletes. The parkable set is an allowlist, so a new reason deletes until somebody proves its sandbox is safe to reuse. `compatibility-mismatch` stays as a deprecated alias that deletes.

The runner also remembers the sandbox ids it deleted, so a stale pointer to one of them skips the failed reconnect and goes straight to a fresh create. This is per-process and in-memory. Another replica still reads the stale id and still falls through correctly. It saves a round trip; it is not a durable guarantee.

## Tests / notes

- 20 new tests, including a 729-line characterization suite that pins today's session lifecycle behavior before the later lanes move any of it. The rest of the stack is reviewable because this suite exists.
- Worth poking at: the teardown allowlist. If you think a reason belongs on the parkable side, say so here rather than later, because a wrong entry leaves stale credentials inside a resumed daemon.

## What to QA

- Run a turn in the playground, commit a revision, then send another message. The session stays warm. Before this change the commit rebuilt the sandbox.
- Approve a gated tool call, let the turn resume, then send a follow-up message that changes nothing. The follow-up still reuses the warm session and does not silently run an older configuration.
