### PR TITLE
feat(sdk): let a builder tool call carry the agent's own note

### DIFF
--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -27,7 +27,7 @@ imported platform package.
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -56,6 +56,27 @@ _CTX_TOKEN_PREFIX = "$ctx."
 # server's registered handlers (``PLATFORM_TOOL_HANDLERS`` in the API's
 # ``core/tools/platform_handlers.py``); an op naming anything else fails at import.
 _HANDLER_CALL_REFS = frozenset({f"{PLATFORM_OP_NAMESPACE}test_run"})
+
+# The ephemeral per-call description (R12). The model writes it, the frontend shows it beside
+# the call, and the runner deletes it before it builds the request. It is NOT the commit message:
+# ``message`` describes the change in the revision history and is persisted; this describes the
+# call in the conversation and is never persisted. It is also NOT the persisted
+# ``RevisionCommit.description``, which the model never sets. See
+# ``docs/design/agent-config-editing/contracts/read-config.md`` section 12.
+EPHEMERAL_DESCRIPTION_ARG = "description"
+
+# Long enough for one or two sentences of intent, short enough that it can never become a payload
+# channel. The frontend truncates for display and shows that it truncated.
+EPHEMERAL_DESCRIPTION_MAX_LENGTH = 500
+
+_EPHEMERAL_DESCRIPTION_SCHEMA: Dict[str, Any] = {
+    "type": "string",
+    "maxLength": EPHEMERAL_DESCRIPTION_MAX_LENGTH,
+    "description": (
+        "Optional. One or two sentences saying what this call does and why. The user sees it "
+        "beside the call. It is not saved with the change; use the commit message for that."
+    ),
+}
 
 
 class PlatformOp(BaseModel):
@@ -95,6 +116,11 @@ class PlatformOp(BaseModel):
     read_only: bool = False
     # Per-op execution budget for long-running server-side handlers. Emitted as `timeoutMs`.
     timeout_ms: Optional[int] = Field(default=None, gt=0)
+    # Builder ops opt in to the ephemeral per-call ``description`` (R12). The model writes one
+    # sentence saying what this call does and why; the frontend shows it beside the call. The
+    # runner strips it before it builds the request, so no endpoint schema changes. Off by
+    # default: an op that does not show its calls to a human gains nothing from it.
+    accepts_description: bool = False
 
     @model_validator(mode="after")
     def _check(self) -> "PlatformOp":
@@ -153,12 +179,24 @@ class PlatformOp(BaseModel):
         """The stable reserved id, ``tools.agenta.<op>``."""
         return f"{PLATFORM_OP_NAMESPACE}{self.op}"
 
+    @property
+    def ephemeral_args(self) -> Optional[List[str]]:
+        """Top-level argument names the runner must delete before it builds the request.
+
+        These are model-authored fields that exist for the human, not for the endpoint. Returning
+        them on the spec keeps ONE list: the schema that offers the field and the strip that
+        removes it cannot drift apart.
+        """
+        return [EPHEMERAL_DESCRIPTION_ARG] if self.accepts_description else None
+
     def resolved_input_schema(self) -> Dict[str, Any]:
         """The concrete, model-visible input schema.
 
         Catalog schema with every ``x-ag-type-ref`` expanded to concrete JSON Schema, then with the
         server-bound ``context_bindings`` fields stripped (path-aware, including their ``required``
-        entries) so the model never sees a field the runner fills from run context.
+        entries) so the model never sees a field the runner fills from run context. A builder op
+        then gains the optional ephemeral ``description`` at the TOP level, beside the op's own
+        payload object, because it describes the call and not the payload.
         """
         if self.input_schema_ref is not None:
             schema = expand_type_refs({"x-ag-type-ref": self.input_schema_ref})
@@ -170,6 +208,15 @@ class PlatformOp(BaseModel):
             return schema
         for field in self.context_bindings:
             _strip_field(schema, field)
+        if self.accepts_description:
+            # The catalog schemas are closed (``additionalProperties: false``), so the field must
+            # be advertised or the model cannot send it at all. It is never required: an agent
+            # that says nothing is quieter, not broken.
+            properties = schema.setdefault("properties", {})
+            if isinstance(properties, dict):
+                properties[EPHEMERAL_DESCRIPTION_ARG] = deepcopy(
+                    _EPHEMERAL_DESCRIPTION_SCHEMA
+                )
         return schema
 
     def to_call(self) -> ToolCall:
@@ -1098,6 +1145,9 @@ PLATFORM_OPS: Dict[str, PlatformOp] = {
             context_bindings={"target.workflow_variant_id": "$ctx.workflow.variant.id"},
             read_only=False,
             timeout_ms=120000,
+            # A builder op: the playground shows every one of its calls to the human who is
+            # building the agent, so the agent's own account of the call is worth showing (R12).
+            accepts_description=True,
         ),
         PlatformOp(
             op="commit_revision",
@@ -1109,6 +1159,7 @@ PLATFORM_OPS: Dict[str, PlatformOp] = {
                 "workflow_revision.workflow_variant_id": "$ctx.workflow.variant.id"
             },
             read_only=False,
+            accepts_description=True,
         ),
         PlatformOp(
             op="annotate_trace",

--- a/sdks/python/agenta/sdk/agents/platform/platform_tools.py
+++ b/sdks/python/agenta/sdk/agents/platform/platform_tools.py
@@ -110,6 +110,10 @@ class AgentaPlatformToolResolver:
                     render=tool_config.render,
                     permission=tool_config.permission,
                     read_only=op.read_only,
+                    # Model-authored arguments the runner deletes before it builds the request
+                    # (today: the ephemeral per-call ``description``). Both dispatch modes carry
+                    # it, because both must strip before they send.
+                    ephemeral_args=op.ephemeral_args,
                     **target,
                 )
             )

--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -359,6 +359,16 @@ class CallbackToolSpec(ToolSpecBase):
         validation_alias=AliasChoices("timeout_ms", "timeoutMs"),
         serialization_alias="timeoutMs",
     )
+    # Top-level argument names the model may write but the request must NOT carry. The runner
+    # deletes them from the model's arguments before it builds either request, so the field
+    # reaches the human (the recorded call keeps it) and never reaches the API. This is how the
+    # ephemeral per-call ``description`` rides a builder tool call without any endpoint schema
+    # change. Executor-private, like ``context_bindings``: the child harness never sees it.
+    ephemeral_args: Optional[List[str]] = Field(
+        default=None,
+        validation_alias=AliasChoices("ephemeral_args", "ephemeralArgs"),
+        serialization_alias="ephemeralArgs",
+    )
 
     @model_validator(mode="after")
     def _check_call_target(self) -> "CallbackToolSpec":

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
@@ -250,10 +250,13 @@ async def test_test_run_emits_handler_call_ref_with_bindings_and_timeout_by_defa
     assert spec.read_only is False
     assert spec.effective_permission() is None
     assert "target" not in spec.input_schema["properties"]
+    # `description` is the ephemeral per-call note every builder op offers (R12); the runner
+    # strips it before it builds the request. See test_op_catalog_description.py.
     assert set(spec.input_schema["properties"]) == {
         "inputs",
         "delta",
         "expectations",
+        "description",
     }
     assert spec.input_schema["required"] == ["inputs"]
     assert spec.input_schema["properties"]["inputs"]["required"] == ["messages"]

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog_description.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog_description.py
@@ -1,0 +1,166 @@
+"""The ephemeral per-call ``description`` on builder tool calls (R12).
+
+The agent may attach one or two sentences to a builder tool call, saying what the call does and
+why. The frontend shows it beside the call. It is NOT the commit message: ``message`` describes the
+change in the revision history and is persisted; this describes the call in the conversation and is
+never persisted.
+
+The field costs no endpoint schema change. The catalog advertises it, the resolver puts its name on
+the spec as an ephemeral argument, and the runner deletes it before it builds the request. These
+tests cover the two SDK-side halves: the schema the model sees, and the strip list the runner reads.
+The runner's own strip is covered in ``services/runner/tests/unit/tool-direct.test.ts``.
+
+Contract: ``docs/design/agent-config-editing/contracts/read-config.md`` section 12.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agenta.sdk.agents import PlatformToolConfig
+from agenta.sdk.agents.platform import (
+    PLATFORM_OPS,
+    AgentaPlatformToolResolver,
+    PlatformOp,
+)
+from agenta.sdk.agents.platform.op_catalog import (
+    EPHEMERAL_DESCRIPTION_ARG,
+    EPHEMERAL_DESCRIPTION_MAX_LENGTH,
+)
+
+
+def _resolver(connection):
+    return AgentaPlatformToolResolver(connection=connection)
+
+
+# The builder ops: the playground shows every one of their calls to the human building the agent.
+BUILDER_OPS = ["commit_revision", "test_run"]
+
+
+# --- the model-visible schema -------------------------------------------------
+
+
+@pytest.mark.parametrize("op_name", BUILDER_OPS)
+def test_builder_op_offers_the_description(op_name):
+    schema = PLATFORM_OPS[op_name].resolved_input_schema()
+    prop = schema["properties"][EPHEMERAL_DESCRIPTION_ARG]
+    assert prop["type"] == "string"
+    assert prop["maxLength"] == EPHEMERAL_DESCRIPTION_MAX_LENGTH
+
+
+@pytest.mark.parametrize("op_name", BUILDER_OPS)
+def test_the_description_is_never_required(op_name):
+    # An agent that says nothing is quieter, not broken.
+    schema = PLATFORM_OPS[op_name].resolved_input_schema()
+    assert EPHEMERAL_DESCRIPTION_ARG not in schema.get("required", [])
+
+
+@pytest.mark.parametrize("op_name", BUILDER_OPS)
+def test_the_description_sits_at_the_top_level(op_name):
+    # It describes the CALL, not the payload. A description nested inside `workflow_revision`
+    # would collide with the persisted `RevisionCommit.description`, which the model never sets.
+    schema = PLATFORM_OPS[op_name].resolved_input_schema()
+    payload_keys = set(schema["properties"]) - {EPHEMERAL_DESCRIPTION_ARG}
+    for key in payload_keys:
+        nested = schema["properties"][key]
+        if isinstance(nested, dict) and isinstance(nested.get("properties"), dict):
+            assert EPHEMERAL_DESCRIPTION_ARG not in nested["properties"]
+
+
+def test_a_non_builder_op_does_not_offer_it():
+    # Off by default: an op whose calls no human reads gains nothing from a note.
+    schema = PLATFORM_OPS["discover_tools"].resolved_input_schema()
+    assert EPHEMERAL_DESCRIPTION_ARG not in schema["properties"]
+    assert PLATFORM_OPS["discover_tools"].ephemeral_args is None
+
+
+def test_the_injection_does_not_leak_between_reads():
+    # `resolved_input_schema` must return a fresh tree each call; a shared sub-object would let
+    # one caller's edit reach the next one.
+    first = PLATFORM_OPS["commit_revision"].resolved_input_schema()
+    first["properties"][EPHEMERAL_DESCRIPTION_ARG]["maxLength"] = 1
+    second = PLATFORM_OPS["commit_revision"].resolved_input_schema()
+    assert (
+        second["properties"][EPHEMERAL_DESCRIPTION_ARG]["maxLength"]
+        == EPHEMERAL_DESCRIPTION_MAX_LENGTH
+    )
+
+
+def test_the_catalog_schema_stays_closed():
+    # The catalog schemas forbid unknown keys, so the field must be advertised or the model
+    # cannot send it at all. This pins the reason the injection exists.
+    schema = PLATFORM_OPS["commit_revision"].resolved_input_schema()
+    assert schema["additionalProperties"] is False
+
+
+# --- the strip list on the spec ----------------------------------------------
+
+
+@pytest.mark.parametrize("op_name", BUILDER_OPS)
+def test_the_op_declares_the_ephemeral_argument(op_name):
+    assert PLATFORM_OPS[op_name].ephemeral_args == [EPHEMERAL_DESCRIPTION_ARG]
+
+
+@pytest.mark.parametrize("op_name", BUILDER_OPS)
+async def test_the_resolver_puts_the_strip_list_on_the_spec(connection, op_name):
+    resolution = await _resolver(connection).resolve([PlatformToolConfig(op=op_name)])
+    spec = resolution.tool_specs[0]
+    assert spec.ephemeral_args == [EPHEMERAL_DESCRIPTION_ARG]
+
+
+async def test_both_dispatch_modes_carry_the_strip_list(connection):
+    # `commit_revision` is endpoint mode (a direct `call`); `test_run` is handler mode (a
+    # `call_ref`). Both must strip, so both must carry the list.
+    resolution = await _resolver(connection).resolve(
+        [PlatformToolConfig(op="commit_revision"), PlatformToolConfig(op="test_run")]
+    )
+    by_name = {spec.name: spec for spec in resolution.tool_specs}
+    assert by_name["commit_revision"].call is not None
+    assert by_name["commit_revision"].ephemeral_args == [EPHEMERAL_DESCRIPTION_ARG]
+    assert by_name["test_run"].call_ref == "tools.agenta.test_run"
+    assert by_name["test_run"].ephemeral_args == [EPHEMERAL_DESCRIPTION_ARG]
+
+
+async def test_a_non_builder_spec_carries_no_strip_list(connection):
+    resolution = await _resolver(connection).resolve(
+        [PlatformToolConfig(op="discover_tools")]
+    )
+    assert resolution.tool_specs[0].ephemeral_args is None
+
+
+# --- the wire ----------------------------------------------------------------
+
+
+async def test_the_strip_list_rides_the_wire_as_camel_case(connection):
+    resolution = await _resolver(connection).resolve(
+        [PlatformToolConfig(op="commit_revision")]
+    )
+    wire = resolution.tool_specs[0].to_wire()
+    assert wire["ephemeralArgs"] == [EPHEMERAL_DESCRIPTION_ARG]
+
+
+async def test_the_wire_omits_the_field_when_there_is_nothing_to_strip(connection):
+    resolution = await _resolver(connection).resolve(
+        [PlatformToolConfig(op="discover_tools")]
+    )
+    assert "ephemeralArgs" not in resolution.tool_specs[0].to_wire()
+
+
+# --- the flag itself ----------------------------------------------------------
+
+
+def test_the_flag_is_off_by_default():
+    op = PlatformOp(
+        op="x",
+        description="d",
+        method="POST",
+        path="/api/x",
+        input_schema={
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {},
+        },
+    )
+    assert op.accepts_description is False
+    assert op.ephemeral_args is None
+    assert EPHEMERAL_DESCRIPTION_ARG not in op.resolved_input_schema()["properties"]

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -153,6 +153,15 @@ export interface ResolvedToolSpec {
     context?: Record<string, string>;
     args_into?: string;
   };
+  /**
+   * Top-level argument names the model may write but the request must NOT carry. The runner
+   * deletes them from the model's arguments before it builds either request (direct or gateway),
+   * so the field reaches the human — the recorded call and the approval card keep it — and never
+   * reaches the API. Today the list holds one name, `description`: the ephemeral per-call note the
+   * agent writes to explain what it is doing (R12). Executor-private, like `contextBindings`: it
+   * never goes to a harness child process.
+   */
+  ephemeralArgs?: string[];
   kind?: "callback" | "code" | "client";
   render?: RenderHint;
   /** MCP behavioral hint: true (read-only), false (mutating), absent (unknown). */

--- a/services/runner/src/tools/direct.ts
+++ b/services/runner/src/tools/direct.ts
@@ -83,7 +83,10 @@ export function deepSet(
  * way `deepSet` does (no empty segments, no prototype-polluting keys), so this can never reach
  * through the prototype chain. A path whose parent is missing or not a plain object is a no-op.
  */
-export function deepDelete(target: Record<string, unknown>, path: string): void {
+export function deepDelete(
+  target: Record<string, unknown>,
+  path: string,
+): void {
   const parts = path.split(".");
   for (const part of parts) {
     if (!part) throw new Error(`invalid empty segment in path '${path}'`);
@@ -180,18 +183,26 @@ export function pathParamNames(path: unknown): string[] {
   return names;
 }
 
-function substitutePathParams(path: unknown, params: Record<string, unknown>): string {
+function substitutePathParams(
+  path: unknown,
+  params: Record<string, unknown>,
+): string {
   if (typeof path !== "string") return String(path);
-  return path.replace(/\{([A-Za-z_][A-Za-z0-9_.-]*)\}/g, (_match, name: string) => {
-    const value = readParam(params, name);
-    if (value === undefined || value === null) {
-      throw new Error(`direct-call path parameter '{${name}}' is missing`);
-    }
-    if (!["string", "number", "boolean"].includes(typeof value)) {
-      throw new Error(`direct-call path parameter '{${name}}' must be scalar`);
-    }
-    return encodeURIComponent(String(value));
-  });
+  return path.replace(
+    /\{([A-Za-z_][A-Za-z0-9_.-]*)\}/g,
+    (_match, name: string) => {
+      const value = readParam(params, name);
+      if (value === undefined || value === null) {
+        throw new Error(`direct-call path parameter '{${name}}' is missing`);
+      }
+      if (!["string", "number", "boolean"].includes(typeof value)) {
+        throw new Error(
+          `direct-call path parameter '{${name}}' must be scalar`,
+        );
+      }
+      return encodeURIComponent(String(value));
+    },
+  );
 }
 
 /**
@@ -206,9 +217,9 @@ function substitutePathParams(path: unknown, params: Record<string, unknown>): s
  *     retarget or override a fixed field.
  *  3. `call.context` — the run-context binding (`{ bodyPath: "$ctx.<key>" }`), filled LAST so a
  *     bound field always wins over both the model's args and the static `body`. Each token resolves
- *     against the run's `runContext` (delivered on `/run`); a token that does not resolve is left
- *     unset (the field is simply absent), and the model never sees or sets a bound field. This is
- *     how a self-targeting tool gets its own trace/variant server-side.
+ *     against the run's `runContext` (delivered on `/run`); a token that does not resolve THROWS
+ *     (fail closed; see applyContextBindings), and the model never sees or sets a bound field.
+ *     This is how a self-targeting tool gets its own trace/variant server-side.
  */
 export function assembleBody(
   call: DirectCall,
@@ -246,6 +257,40 @@ export function assembleBody(
   return body;
 }
 
+/**
+ * Remove the model-authored arguments that exist for the human, not for the endpoint.
+ *
+ * A builder tool call may carry an ephemeral `description`: one or two sentences saying what the
+ * call does and why (R12). The frontend shows it beside the call, so it must survive in the
+ * RECORDED call. It must never reach the API, because no endpoint has a field for it and an
+ * ephemeral note must not become part of the audit trail by accident.
+ *
+ * So the strip happens here, at dispatch, and not earlier. Both dispatch modes call this before
+ * they build a request: the direct call before `assembleBody`, and the gateway call before it
+ * posts to `/tools/call`. Stripping before `args_into` matters — with `args_into` set, every model
+ * argument is deep-set at that path, so a description left in place would land INSIDE the payload
+ * object (e.g. `schedule.description`) and silently overwrite a real field.
+ *
+ * Only TOP-LEVEL names are removed. The list is a closed catalog value, never model input, but
+ * keeping it top-level-only means a nested field with the same name is always safe.
+ *
+ * Returns `args` unchanged when there is nothing to strip, so the common path allocates nothing.
+ */
+export function stripEphemeralArgs(
+  args: unknown,
+  ephemeralArgs: string[] | undefined,
+): unknown {
+  if (!ephemeralArgs || ephemeralArgs.length === 0) return args;
+  if (!isPlainObject(args)) return args;
+  const present = ephemeralArgs.filter((name) =>
+    Object.prototype.hasOwnProperty.call(args, name),
+  );
+  if (present.length === 0) return args;
+  const stripped = { ...(args as Record<string, unknown>) };
+  for (const name of present) delete stripped[name];
+  return stripped;
+}
+
 export function applyContextBindings(
   args: unknown,
   bindings: Record<string, string>,
@@ -258,7 +303,9 @@ export function applyContextBindings(
     deepDelete(body, argPath);
     const value = resolveCtxToken(runContext, token);
     if (value === undefined) {
-      throw new Error(`missing run-context value for tool binding '${argPath}'`);
+      throw new Error(
+        `missing run-context value for tool binding '${argPath}'`,
+      );
     }
     deepSet(body, argPath, value);
   }

--- a/services/runner/src/tools/relay.ts
+++ b/services/runner/src/tools/relay.ts
@@ -41,6 +41,7 @@ import {
   deepDelete,
   directCallUrl,
   pathParamNames,
+  stripEphemeralArgs,
 } from "./direct.ts";
 import type {
   ResolvedToolSpec,
@@ -375,13 +376,18 @@ async function executeAllowedRelayedTool(
   if (!callback?.endpoint) {
     throw new Error(`missing toolCallback endpoint for '${spec.name}'`);
   }
+  // Drop the model-authored arguments that are for the human only (today: the ephemeral per-call
+  // `description`, R12). This runs BEFORE the dispatch fork so both modes strip identically, and
+  // before `assembleBody` so an `args_into` op cannot deep-set the note inside its payload. The
+  // recorded call and the approval card keep the full arguments; only the request loses them.
+  const dispatchArgs = stripEphemeralArgs(req.args, spec.ephemeralArgs);
   // Direct-call tools (reference / platform): the host makes the call directly so the sandbox
   // child still sends only name + args. The origin is bound to the run's own callback endpoint
   // and the run's authorization is reused (see tools/direct.ts). A spec carries `call` XOR
   // `callRef`, so this is checked before the gateway fallback. `runContext` fills the
   // `call.context` bindings server-side (direct-call tools, Phase 3a), hidden from the model.
   if (spec.call) {
-    const body = assembleBody(spec.call, req.args, runContext);
+    const body = assembleBody(spec.call, dispatchArgs, runContext);
     const url = directCallUrl(callback.endpoint, spec.call, body);
     // Path params were just substituted into the URL from this same body; strip them so a
     // POST handler whose request model expects the identifier only in the route (e.g.
@@ -393,10 +399,11 @@ async function executeAllowedRelayedTool(
       runKind: runContext?.run?.kind,
     });
   }
-  // Gateway (Composio): POST back through Agenta's /tools/call so the secret stays server-side.
+  // Gateway (Composio) and handler-mode platform ops: POST back through Agenta's /tools/call so
+  // the secret stays server-side.
   const args = spec.contextBindings
-    ? applyContextBindings(req.args, spec.contextBindings, runContext)
-    : req.args;
+    ? applyContextBindings(dispatchArgs, spec.contextBindings, runContext)
+    : dispatchArgs;
   return callAgentaTool(
     callback.endpoint,
     callback.authorization,

--- a/services/runner/tests/unit/tool-direct.test.ts
+++ b/services/runner/tests/unit/tool-direct.test.ts
@@ -35,6 +35,7 @@ import {
   directCallUrl,
   pathParamNames,
   resolveCtxToken,
+  stripEphemeralArgs,
   type DirectCall,
 } from "../../src/tools/direct.ts";
 import {
@@ -707,5 +708,187 @@ describe("startToolRelay direct branch (host makes the call for the sandbox)", (
     assert.equal(res.error, "direct tool call failed: HTTP 500");
     assert.doesNotMatch(res.error ?? "", /agenta\.example/);
     assert.doesNotMatch(res.error ?? "", /stack trace|secret detail/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ephemeral arguments (the per-call `description`, R12)
+//
+// A builder tool call may carry a model-authored `description`: one or two sentences saying what
+// the call does and why. The frontend shows it beside the call, so it must stay in the RECORDED
+// call, and it must never reach the API. The runner therefore strips it at dispatch, on both
+// branches, before either one builds a request.
+// ---------------------------------------------------------------------------
+
+describe("stripEphemeralArgs", () => {
+  it("removes only the declared top-level names", () => {
+    const args = { description: "why", workflow_revision: { message: "m" } };
+    assert.deepEqual(stripEphemeralArgs(args, ["description"]), {
+      workflow_revision: { message: "m" },
+    });
+  });
+
+  it("leaves a same-named NESTED field alone", () => {
+    // `create_schedule` and friends have a real `description` inside their payload object.
+    const args = { schedule: { description: "a real payload field" } };
+    assert.deepEqual(stripEphemeralArgs(args, ["description"]), args);
+  });
+
+  it("returns the same object when there is nothing to strip", () => {
+    const args = { a: 1 };
+    assert.equal(stripEphemeralArgs(args, ["description"]), args);
+    assert.equal(stripEphemeralArgs(args, []), args);
+    assert.equal(stripEphemeralArgs(args, undefined), args);
+  });
+
+  it("does not mutate the caller's arguments", () => {
+    const args = { description: "why", keep: 1 };
+    stripEphemeralArgs(args, ["description"]);
+    assert.deepEqual(args, { description: "why", keep: 1 });
+  });
+
+  it("passes a non-object through untouched", () => {
+    assert.equal(stripEphemeralArgs("plain", ["description"]), "plain");
+    assert.equal(stripEphemeralArgs(undefined, ["description"]), undefined);
+  });
+});
+
+describe("relay strips ephemeral args before it builds a request", () => {
+  /** A builder op: self-targeting, and it accepts the ephemeral description. */
+  const commitSpec: ResolvedToolSpec = {
+    name: "commit_revision",
+    kind: "callback",
+    call: {
+      method: "POST",
+      path: "/api/workflows/revisions/commit",
+      context: {
+        "workflow_revision.workflow_variant_id": "$ctx.workflow.variant.id",
+      },
+    },
+    ephemeralArgs: ["description"],
+  };
+
+  it("keeps the description out of the direct-call request body", async () => {
+    const calls = stubFetch("committed");
+    const res = await relayOnce(
+      commitSpec,
+      { endpoint: ENDPOINT, authorization: "ApiKey secret" },
+      {
+        description: "Adding the pdf-tools skill you asked for.",
+        workflow_revision: { message: "Add the pdf-tools skill." },
+      },
+      RUN_CONTEXT,
+    );
+
+    assert.equal(res.ok, true);
+    assert.equal(calls.length, 1);
+    const body = JSON.parse(calls[0].init.body as string);
+    assert.equal(
+      body.description,
+      undefined,
+      "the ephemeral note never reaches the API",
+    );
+    assert.deepEqual(body, {
+      workflow_revision: {
+        message: "Add the pdf-tools skill.",
+        workflow_variant_id: "own-variant",
+      },
+    });
+  });
+
+  it("sends the same body when the model writes no description", async () => {
+    const calls = stubFetch("committed");
+    const res = await relayOnce(
+      commitSpec,
+      { endpoint: ENDPOINT, authorization: "ApiKey secret" },
+      { workflow_revision: { message: "Add the pdf-tools skill." } },
+      RUN_CONTEXT,
+    );
+
+    assert.equal(res.ok, true);
+    const body = JSON.parse(calls[0].init.body as string);
+    // No empty key appears: absent and present-then-stripped produce one identical request.
+    assert.deepEqual(body, {
+      workflow_revision: {
+        message: "Add the pdf-tools skill.",
+        workflow_variant_id: "own-variant",
+      },
+    });
+    assert.ok(!("description" in body));
+  });
+
+  it("strips BEFORE args_into, so the note cannot land inside the payload", async () => {
+    // This is the failure the strip point prevents: with `args_into` every model argument is
+    // deep-set at that path, so a description left in place would become `data.inputs.description`.
+    const calls = stubFetch("ok");
+    const spec: ResolvedToolSpec = {
+      ...refSpec,
+      ephemeralArgs: ["description"],
+    };
+    const res = await relayOnce(
+      spec,
+      { endpoint: ENDPOINT, authorization: "ApiKey secret" },
+      { description: "Checking the weather first.", city: "Berlin" },
+    );
+
+    assert.equal(res.ok, true);
+    assert.deepEqual(JSON.parse(calls[0].init.body as string), {
+      data: { inputs: { city: "Berlin" } },
+      references: { workflow_revision: { id: "rev_abc123" } },
+    });
+  });
+
+  it("strips on the gateway branch too (handler-mode ops post through /tools/call)", async () => {
+    const calls = stubFetch(JSON.stringify({ ok: true }));
+    // `test_run` is handler-mode: it carries a callRef, not a `call` descriptor.
+    const testRunSpec: ResolvedToolSpec = {
+      name: "test_run",
+      kind: "callback",
+      callRef: "tools.agenta.test_run",
+      contextBindings: {
+        "target.workflow_variant_id": "$ctx.workflow.variant.id",
+      },
+      ephemeralArgs: ["description"],
+    };
+    const res = await relayOnce(
+      testRunSpec,
+      { endpoint: ENDPOINT, authorization: "ApiKey secret" },
+      {
+        description: "Trying the new instructions once.",
+        inputs: { messages: [] },
+      },
+      RUN_CONTEXT,
+    );
+
+    assert.equal(res.ok, true);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      (calls[0].init.body as string).includes(
+        "Trying the new instructions once.",
+      ),
+      false,
+      "the ephemeral note never reaches /tools/call",
+    );
+  });
+
+  it("leaves `description` alone for an op that did not declare it ephemeral", async () => {
+    // A payload field named `description` is normal (a schedule, a subscription). Only a spec
+    // that declares the name loses it, so the strip can never eat someone else's data.
+    const calls = stubFetch("ok");
+    const plainSpec: ResolvedToolSpec = {
+      name: "create_thing",
+      kind: "callback",
+      call: { method: "POST", path: "/api/things" },
+    };
+    const res = await relayOnce(
+      plainSpec,
+      { endpoint: ENDPOINT, authorization: "ApiKey secret" },
+      { description: "a real field" },
+    );
+
+    assert.equal(res.ok, true);
+    assert.deepEqual(JSON.parse(calls[0].init.body as string), {
+      description: "a real field",
+    });
   });
 });

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
@@ -54,6 +54,31 @@ describe("extractCallDescription", () => {
             truncated: false,
         })
     })
+
+    it("cuts on a code-point boundary when an emoji straddles the limit", () => {
+        // The emoji is one code point but two UTF-16 units, so a `slice` at the cap would keep a
+        // lone surrogate half and the card would render a replacement character.
+        const description = `${"a".repeat(CALL_DESCRIPTION_MAX_LENGTH - 1)}\u{1F600}tail`
+        const result = extractCallDescription({description})
+
+        expect(result?.truncated).toBe(true)
+        expect(result?.text.endsWith("\u{1F600}")).toBe(true)
+        expect(result?.text).not.toContain("\uFFFD")
+        // No unpaired surrogate survived the cut.
+        expect(/[\uD800-\uDFFF]/.test(result!.text.replace(/\p{Emoji_Presentation}/gu, ""))).toBe(
+            false,
+        )
+        expect(Array.from(result!.text)).toHaveLength(CALL_DESCRIPTION_MAX_LENGTH)
+    })
+
+    it("counts an all-emoji note in code points, matching the catalog cap", () => {
+        // 400 emoji are 800 UTF-16 units: measured in units this would look over the limit and be
+        // cut, when the model was well within what the catalog allowed it to send.
+        const description = "\u{1F600}".repeat(400)
+        const result = extractCallDescription({description})
+
+        expect(result).toEqual({text: description, truncated: false})
+    })
 })
 
 describe("partToolName", () => {

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it} from "vitest"
+
+import {CALL_DESCRIPTION_MAX_LENGTH, extractCallDescription, partToolName} from "./toolDisplay"
+
+// The agent's own note about a builder tool call (R12). It rides in the call's arguments, so the
+// tool card reads it straight off `input` on both the live and the replay path.
+describe("extractCallDescription", () => {
+    it("reads the agent's note off the call input", () => {
+        expect(
+            extractCallDescription({
+                description: "Adding the pdf-tools skill you asked for.",
+                workflow_revision: {message: "Add the pdf-tools skill."},
+            }),
+        ).toEqual({text: "Adding the pdf-tools skill you asked for.", truncated: false})
+    })
+
+    it("returns null when the agent wrote no note", () => {
+        expect(extractCallDescription({workflow_revision: {message: "m"}})).toBeNull()
+    })
+
+    it("treats a blank note as no note", () => {
+        expect(extractCallDescription({description: "   "})).toBeNull()
+        expect(extractCallDescription({description: ""})).toBeNull()
+    })
+
+    it("trims surrounding whitespace", () => {
+        expect(extractCallDescription({description: "  why  "})?.text).toBe("why")
+    })
+
+    it("ignores a non-string description", () => {
+        expect(extractCallDescription({description: 42})).toBeNull()
+        expect(extractCallDescription({description: {nested: "no"}})).toBeNull()
+        expect(extractCallDescription({description: null})).toBeNull()
+    })
+
+    it("survives inputs that are not objects", () => {
+        expect(extractCallDescription(undefined)).toBeNull()
+        expect(extractCallDescription(null)).toBeNull()
+        expect(extractCallDescription("plain")).toBeNull()
+        expect(extractCallDescription(["description"])).toBeNull()
+    })
+
+    it("cuts an over-long note and says it cut it", () => {
+        const long = "a".repeat(CALL_DESCRIPTION_MAX_LENGTH + 50)
+        const result = extractCallDescription({description: long})
+        expect(result?.truncated).toBe(true)
+        expect(result?.text).toHaveLength(CALL_DESCRIPTION_MAX_LENGTH)
+    })
+
+    it("does not mark a note at exactly the limit as cut", () => {
+        const exact = "a".repeat(CALL_DESCRIPTION_MAX_LENGTH)
+        expect(extractCallDescription({description: exact})).toEqual({
+            text: exact,
+            truncated: false,
+        })
+    })
+})
+
+describe("partToolName", () => {
+    it("strips the tool- prefix from a typed part", () => {
+        expect(partToolName({type: "tool-commit_revision"} as never)).toBe("commit_revision")
+    })
+
+    it("reads toolName off a dynamic part", () => {
+        expect(partToolName({type: "dynamic-tool", toolName: "test_run"} as never)).toBe("test_run")
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
@@ -1,6 +1,12 @@
 import {describe, expect, it} from "vitest"
 
-import {CALL_DESCRIPTION_MAX_LENGTH, extractCallDescription, partToolName} from "./toolDisplay"
+import {
+    CALL_DESCRIPTION_MAX_LENGTH,
+    canonicalToolName,
+    extractCallDescription,
+    partToolName,
+    resolveToolDisplay,
+} from "./toolDisplay"
 
 // The agent's own note about a builder tool call (R12). It rides in the call's arguments, so the
 // tool card reads it straight off `input` on both the live and the replay path.
@@ -88,5 +94,39 @@ describe("partToolName", () => {
 
     it("reads toolName off a dynamic part", () => {
         expect(partToolName({type: "dynamic-tool", toolName: "test_run"} as never)).toBe("test_run")
+    })
+})
+
+describe("canonicalToolName", () => {
+    it("unwraps our own MCP server so both harnesses key the same", () => {
+        expect(canonicalToolName("mcp__agenta-tools__commit_revision")).toBe("commit_revision")
+        expect(canonicalToolName("commit_revision")).toBe("commit_revision")
+    })
+
+    it("leaves another server's tool wrapped, so it cannot collide with a platform tool", () => {
+        expect(canonicalToolName("mcp__other__commit_revision")).toBe("mcp__other__commit_revision")
+        expect(canonicalToolName("mcp__other__x")).toBe("mcp__other__x")
+    })
+
+    it("never returns an empty name", () => {
+        expect(canonicalToolName("mcp__agenta-tools__")).toBe("mcp__agenta-tools__")
+        expect(canonicalToolName("")).toBe("")
+    })
+})
+
+describe("resolveToolDisplay under an MCP wrapper", () => {
+    it("applies the platform tool's override to the wrapped name", () => {
+        // The commit summary is keyed by tool name, so it went missing under Claude too.
+        const summary = resolveToolDisplay("mcp__agenta-tools__commit_revision").summary
+        expect(summary?.({workflow_revision: {message: "Add the skill."}}, null)).toBe(
+            "Add the skill.",
+        )
+    })
+
+    it("still presents it as an MCP tool, and keeps the raw name reachable", () => {
+        const display = resolveToolDisplay("mcp__agenta-tools__commit_revision")
+
+        expect(display.kind).toBe("mcp")
+        expect(display.raw).toBe("mcp__agenta-tools__commit_revision")
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
@@ -74,6 +74,31 @@ export const resolveToolDisplay = (raw: string): ToolDisplay => {
     }
 }
 
+/** Longest call description we render; the catalog caps the model at the same number. */
+export const CALL_DESCRIPTION_MAX_LENGTH = 500
+
+export interface CallDescription {
+    text: string
+    /** True when the text was cut — the caller must show that it was. */
+    truncated: boolean
+}
+
+/**
+ * The agent's own note about a builder tool call (R12), read from the call's arguments.
+ *
+ * It rides in `input.description` because the runner strips it only at dispatch, so the recorded
+ * call keeps it on both the live and the replay path. This is model text, never a fact.
+ */
+export const extractCallDescription = (input: unknown): CallDescription | null => {
+    if (!input || typeof input !== "object" || Array.isArray(input)) return null
+    const raw = (input as {description?: unknown}).description
+    if (typeof raw !== "string") return null
+    const text = raw.trim()
+    if (!text) return null
+    if (text.length <= CALL_DESCRIPTION_MAX_LENGTH) return {text, truncated: false}
+    return {text: text.slice(0, CALL_DESCRIPTION_MAX_LENGTH), truncated: true}
+}
+
 /** Wire name of a tool part. `dynamic-tool` carries it on `toolName`; typed parts encode it as
  * `tool-<name>`. */
 export const partToolName = (part: ToolUIPart): string => {

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
@@ -32,6 +32,23 @@ interface ToolDisplayOverride {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
     Boolean(value && typeof value === "object" && !Array.isArray(value))
 
+/** Our in-sandbox MCP server (runner: `INTERNAL_TOOL_MCP_SERVER_NAME`). */
+const INTERNAL_MCP_PREFIX = "mcp__agenta-tools__"
+
+/**
+ * The platform tool name behind a harness wrapper.
+ *
+ * Pi sends `commit_revision`; Claude exposes the same tool over MCP and sends
+ * `mcp__agenta-tools__commit_revision`. Anything keyed BY tool name must key on this, or one call
+ * renders two different ways depending on the harness.
+ *
+ * Only OUR server is unwrapped. A third-party MCP tool keeps its full name, so it can never
+ * collide with a platform tool of the same bare name. NOT for permission rules: those must match
+ * the wire name verbatim (see `useAlwaysAllowTool`).
+ */
+export const canonicalToolName = (raw: string): string =>
+    raw.startsWith(INTERNAL_MCP_PREFIX) ? raw.slice(INTERNAL_MCP_PREFIX.length) || raw : raw
+
 /** Special cases, keyed by wire name. */
 const BY_TOOL_NAME: Record<string, ToolDisplayOverride> = {
     commit_revision: {
@@ -63,7 +80,9 @@ const parseNameShape = (raw: string): {label: string; source?: string; kind: Too
 
 /** Resolve display info for a raw runtime tool name. Pure and total — never throws. */
 export const resolveToolDisplay = (raw: string): ToolDisplay => {
-    const override = BY_TOOL_NAME[raw]
+    // Canonical for the override lookup, raw for the shape: the same platform tool must get its
+    // summary under both harnesses, while an MCP-wrapped name still reads as an MCP tool.
+    const override = BY_TOOL_NAME[canonicalToolName(raw)]
     const parsed = parseNameShape(raw)
     return {
         raw,

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
@@ -74,7 +74,12 @@ export const resolveToolDisplay = (raw: string): ToolDisplay => {
     }
 }
 
-/** Longest call description we render; the catalog caps the model at the same number. */
+/**
+ * Longest call description we render, counted in CODE POINTS.
+ *
+ * The catalog caps the model at the same number, and JSON Schema `maxLength` counts code points
+ * too, so both ends measure the same string the same way.
+ */
 export const CALL_DESCRIPTION_MAX_LENGTH = 500
 
 export interface CallDescription {
@@ -95,8 +100,11 @@ export const extractCallDescription = (input: unknown): CallDescription | null =
     if (typeof raw !== "string") return null
     const text = raw.trim()
     if (!text) return null
-    if (text.length <= CALL_DESCRIPTION_MAX_LENGTH) return {text, truncated: false}
-    return {text: text.slice(0, CALL_DESCRIPTION_MAX_LENGTH), truncated: true}
+    // Cut on code points, not UTF-16 units: `slice` at the cap can land inside a surrogate pair and
+    // emit a lone half, which renders as a replacement character.
+    const points = Array.from(text)
+    if (points.length <= CALL_DESCRIPTION_MAX_LENGTH) return {text, truncated: false}
+    return {text: points.slice(0, CALL_DESCRIPTION_MAX_LENGTH).join(""), truncated: true}
 }
 
 /** Wire name of a tool part. `dynamic-tool` carries it on `toolName`; typed parts encode it as

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -18,7 +18,12 @@ import {useAtomValue, useSetAtom} from "jotai"
 
 import {DriveFileCard} from "@/oss/components/Drives/DriveFileCard"
 
-import {partToolName, resolveToolDisplay, type ToolDisplay} from "../assets/toolDisplay"
+import {
+    extractCallDescription,
+    partToolName,
+    resolveToolDisplay,
+    type ToolDisplay,
+} from "../assets/toolDisplay"
 import {formatToolValue, stripFence} from "../assets/toolFormat"
 import {
     APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
@@ -203,6 +208,8 @@ const ToolRow = ({
     const stored = useAtomValue(expandedValueAtomFamily(rowKey))
     const setExpanded = useSetAtom(setExpandedAtom)
     const open = stored ?? false
+    // The agent's own note about this call (R12). Always shown: explaining the call is its job.
+    const callDescription = extractCallDescription(input)
 
     const header = (
         <>
@@ -248,6 +255,17 @@ const ToolRow = ({
             ) : (
                 <div className="flex min-w-0 items-center gap-2">{header}</div>
             )}
+
+            {callDescription ? (
+                <Text
+                    type="secondary"
+                    className="!text-[11px] mt-0.5 pl-[21px] italic leading-snug"
+                    title={callDescription.text}
+                >
+                    {callDescription.text}
+                    {callDescription.truncated ? "… (shortened)" : ""}
+                </Text>
+            ) : null}
 
             {hasIO ? (
                 <HeightCollapse open={open}>


### PR DESCRIPTION
## Context

When a build-kit agent commits a change or runs a test, the playground shows the call and its arguments. It does not show why the agent made it. The user watching a tool call scroll past has to read a JSON payload and infer the intent.

This adds one optional field the model writes and the human reads: a sentence or two saying what this call does and why.

## Changes

Builder ops opt in with `accepts_description` on the catalog entry. `commit_revision` and `test_run` carry it. An op whose calls no human ever sees gains nothing from it, so it stays off by default.

The field rides at the top level of the arguments, beside the op's own payload object, because it describes the call and not the payload:

```json
{"description": "Adding the release checklist skill so I can run the checks myself.",
 "workflow_revision": {"delta": {"operations": [...]}}}
```

The endpoint never sees it. The runner deletes it from the model's arguments at dispatch, before it builds the request, so no endpoint schema changes and no persisted record grows a field. The strip runs at dispatch and not earlier for one reason: the recorded call keeps the full arguments, so the frontend shows the note on both the live path and the replay path.

The list of fields to strip lives on the resolved tool spec as `ephemeralArgs`, next to the schema that offers the field. One list means the schema and the strip cannot drift apart, and both dispatch modes call the same strip.

This is not the commit message and not the persisted `description`. The commit message describes the change in the revision history and is derived by the server from the operations. This describes the call in the conversation and is never saved. The catalog caps it at 500 characters, which is long enough for two sentences and short enough that it can never become a payload channel. The frontend truncates at the same number and shows that it truncated.

The playground renders it under the tool name in the activity list, in secondary text. It is model-authored text, so it is presented as the agent's own account of the call and never as a fact about what happened.

## Tests / notes

- `test_op_catalog_description.py` in the SDK, 13 tests: which ops carry the field, where it sits in the schema, and that `ephemeral_args` matches what the schema offers.
- `tool-direct.test.ts` in the runner, 55 tests, including the strip on both dispatch modes and the recorded call keeping the field.
- `toolDisplay.test.ts` in the web app covers extraction and truncation.
- Reviewers should confirm the strip cannot be skipped on a new dispatch path. That is the failure that would leak a model-authored field into a request body.

## What to QA

- In the playground, ask an agent to commit a change. The tool call shows the agent's note under the call name.
- Reload the conversation. The note is still there, which is the replay path.
- Check a long note. It cuts off at 500 characters and shows that it was cut.
- Regression: the commit itself still works, and the revision history shows the derived commit message rather than this note.

This targets `agent-config-editing-s5` and is part of the agent-config-editing stack. Read the stack bottom up.

## Added by the E2E campaign and review fix rounds (5 Aug, evening)
- Description truncation now counts code points, matching the catalog's maxLength; an emoji at the boundary is no longer split into a broken surrogate.
