### PR TITLE
feat(api): add the change-set engine for ordered config edits

### DIFF
--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -406,7 +406,13 @@ def item_key(
     if _EMBED_KEY in entry:
         return None
     if collection == "tools":
-        return _tool_name(entry, allow_legacy_fallback=allow_legacy_fallback)
+        name = _tool_name(entry, allow_legacy_fallback=allow_legacy_fallback)
+        # The same guard the keyed branch below applies. A tool entry carries its name in
+        # one of four fields, and any of them can hold a number or a null in a tree the
+        # caller sent. A non-string key reaches the duplicate report's `join` and raises
+        # TypeError, which leaves the caller with a 500 for a payload the engine should
+        # refuse. An entry with no usable key is simply not addressable by name.
+        return name if isinstance(name, str) and name else None
     key_field = KEY_FIELDS.get(collection)
     if key_field is None:
         return None
@@ -859,6 +865,17 @@ def apply_text_edits(
     result = text
     for start, length, new_text, _ in reversed(matches):
         result = result[:start] + new_text + result[start + length :]
+
+    # The input is bounded and each anchor is bounded, but the RESULT is not: 32 edits can
+    # each grow the field. A field that passes the limit can never be edited again through
+    # this operation, because the next call refuses its own input. Refusing the growth here
+    # keeps the field editable.
+    if len(result) > MAX_TEXT_LENGTH:
+        raise _Fail(
+            Reason.TEXT_TOO_LARGE,
+            f"the edits would leave a string of {len(result)} characters; the limit is "
+            f"{MAX_TEXT_LENGTH}",
+        )
 
     if result == text:
         raise _Fail(
@@ -1478,7 +1495,10 @@ def apply_change_set(
                 ),
             )
         )
-        patch = delta.get("set") or {}
+        # A copy, because `remove_path` mutates the result and `deep_merge` grafts the
+        # patch's own sub-dicts into it. Without this the caller's delta is edited in
+        # place, and the engine's promise that it touches nothing it was given is false.
+        patch = deepcopy(delta.get("set") or {})
         _reject_delta_markers(patch)
         for name in ("tools", "skills", "mcps"):
             nested = _legacy_list_write(patch, name)

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -274,6 +274,7 @@ class ChangeSetError(Exception):
         operation_index: Optional[int] = None,
         operation: Optional[str] = None,
         target: Optional[Target] = None,
+        next_step: Optional[str] = None,
         **context: Any,
     ) -> None:
         super().__init__(message)
@@ -282,6 +283,9 @@ class ChangeSetError(Exception):
         self.operation_index = operation_index
         self.operation = operation
         self.target = list(target) if target is not None else None
+        # A reason whose next action depends on the policy that refused it cannot come
+        # from the table, so a raise site may carry its own sentence.
+        self.explicit_next_step = next_step
         self.context = context
 
     @property
@@ -290,7 +294,7 @@ class ChangeSetError(Exception):
 
     @property
     def next_step(self) -> Optional[str]:
-        return NEXT_STEPS.get(self.reason)
+        return self.explicit_next_step or NEXT_STEPS.get(self.reason)
 
     def to_detail(self) -> Dict[str, Any]:
         """The HTTP 422 ``detail`` body. Contract section 12."""
@@ -452,7 +456,12 @@ def subtree_scope(
                 )
         return None
 
-    policy._prefix_depth = len(wanted)  # type: ignore[attr-defined]
+    policy._prefix = tuple(wanted)  # type: ignore[attr-defined]
+    # The legacy arm walks the `set` tree only this deep before it asks the policy, so a
+    # refused sub-path deeper than the prefix would never be reached and never refused.
+    policy._prefix_depth = max(  # type: ignore[attr-defined]
+        [len(wanted)] + [len(path) for path in blocked]
+    )
     return policy
 
 
@@ -1115,40 +1124,94 @@ def _warn_wholesale(
 # --------------------------------------------------------------------------------------
 
 
+# A path element is a field name, or one selected list entry as (list name, item key).
+# The pair is what keeps two skills' `files` lists apart; without it every nested list in
+# a keyed collection collapses onto one path and the siblings overwrite each other.
+PathElement = Union[str, Tuple[str, str]]
+
+
 class _Touched:
     """Which keyed lists an operation could have changed. Contract section 9."""
 
     def __init__(self) -> None:
-        self.item_paths: List[Tuple[str, ...]] = []
-        self.branch_paths: List[Tuple[str, ...]] = []
+        self.item_paths: List[Tuple[PathElement, ...]] = []
+        self.branch_paths: List[Tuple[PathElement, ...]] = []
 
     @staticmethod
-    def _plain(segments: Sequence[Segment]) -> Tuple[str, ...]:
-        # A selector stands in place of its list's name, so it flattens to that name.
-        return tuple(s["list"] if isinstance(s, dict) else s for s in segments)
+    def _plain(segments: Sequence[Segment]) -> Tuple[PathElement, ...]:
+        # A selector names ONE entry, so it keeps its key. Dropping the key here is what
+        # made an edit to one skill answer for every other skill's nested collections.
+        return tuple(
+            (s["list"], s["key"]) if isinstance(s, dict) else s for s in segments
+        )
 
     def item(self, segments: Sequence[Segment]) -> None:
         self.item_paths.append(self._plain(segments))
 
     def branch(self, segments: Sequence[Segment]) -> None:
-        self.branch_paths.append(self._plain(segments))
+        path = self._plain(segments)
+        self.branch_paths.append(path)
+        # Writing INSIDE a selected entry touches the list that entry belongs to: the
+        # write can change the entry's own key and collide with a sibling.
+        for index, element in enumerate(path):
+            if isinstance(element, tuple):
+                self.branch_paths.append(path[:index] + (element[0],))
+
+
+def _entry_identity(list_name: str, entry: Any, index: int) -> str:
+    """How one entry of a keyed list is named inside a path.
+
+    An entry with no derivable key (an `@ag.embed`) falls back to its position, so two
+    unaddressable siblings still hold separate collections.
+    """
+    return item_key(list_name, entry) or f"#{index}"
 
 
 def _collections(
-    tree: Any, path: Tuple[str, ...] = ()
-) -> Dict[Tuple[str, ...], List[Any]]:
-    """Every keyed list in a tree, by its path."""
-    found: Dict[Tuple[str, ...], List[Any]] = {}
+    tree: Any, path: Tuple[PathElement, ...] = ()
+) -> Dict[Tuple[PathElement, ...], List[Any]]:
+    """Every keyed list in a tree, by its path.
+
+    Entries of a KEYED list carry their key into the path, so a nested list belongs to the
+    entry that holds it. Entries of an unkeyed list share their parent's path: no selector
+    can address them, so nothing can touch a collection beneath one on its own.
+    """
+    found: Dict[Tuple[PathElement, ...], List[Any]] = {}
     if isinstance(tree, dict):
         for key, value in tree.items():
             child = path + (key,)
             if key in KEY_FIELDS and isinstance(value, list):
                 found[child] = value
-            found.update(_collections(value, child))
+                for index, entry in enumerate(value):
+                    found.update(
+                        _collections(
+                            entry,
+                            path + ((key, _entry_identity(key, entry, index)),),
+                        )
+                    )
+            else:
+                found.update(_collections(value, child))
     elif isinstance(tree, list):
         for entry in tree:
             found.update(_collections(entry, path))
     return found
+
+
+def _path_text(path: Sequence[PathElement]) -> str:
+    return ".".join(
+        f"{element[0]}[{element[1]}]" if isinstance(element, tuple) else element
+        for element in path
+    )
+
+
+def _path_target(path: Sequence[PathElement]) -> List[Segment]:
+    """The path as contract-shaped target segments, so a warning stays addressable."""
+    return [
+        {"list": element[0], "key": element[1]}
+        if isinstance(element, tuple)
+        else element
+        for element in path
+    ]
 
 
 def _duplicates(list_name: str, entries: Sequence[Any]) -> Dict[str, int]:
@@ -1182,14 +1245,15 @@ def _check_unique_names(
         if item_touched:
             raise _Fail(
                 Reason.DUPLICATE_ITEM_KEY,
-                f"'{'.'.join(path)}' holds duplicate keys: {', '.join(sorted(after))}.",
+                f"'{_path_text(path)}' holds duplicate keys: "
+                f"{', '.join(sorted(after))}.",
                 duplicates=sorted(after),
             )
         grew = [key for key, count in after.items() if count > was.get(key, 0)]
         if branch_touched and grew:
             raise _Fail(
                 Reason.DUPLICATE_ITEM_KEY,
-                f"the change adds a duplicate key to '{'.'.join(path)}': "
+                f"the change adds a duplicate key to '{_path_text(path)}': "
                 f"{', '.join(sorted(grew))}.",
                 duplicates=sorted(grew),
             )
@@ -1197,11 +1261,11 @@ def _check_unique_names(
             Warning(
                 code=WarningCode.LEGACY_DUPLICATE_KEY,
                 message=(
-                    f"'{'.'.join(path)}' already held duplicate keys before this change: "
-                    f"{', '.join(sorted(after))}. Entries with a duplicate key cannot be "
-                    "addressed by name."
+                    f"'{_path_text(path)}' already held duplicate keys before this "
+                    f"change: {', '.join(sorted(after))}. Entries with a duplicate key "
+                    "cannot be addressed by name."
                 ),
-                target=list(path),
+                target=_path_target(path),
             )
         )
 
@@ -1262,6 +1326,21 @@ def _policy_depth(scope_policy: ScopePolicy) -> int:
     return depth if isinstance(depth, int) else 1
 
 
+def _scope_next_step(scope_policy: ScopePolicy) -> str:
+    """What to do about a scope refusal, naming the subtree the caller may write.
+
+    The refusal message names the path that was refused; this names the boundary, so the
+    two together tell an agent what to send instead.
+    """
+    prefix = ".".join(getattr(scope_policy, "_prefix", ()) or ())
+    if not prefix:
+        return "Remove the operation on that path and send the commit again."
+    return (
+        f"Write only under `{prefix}`. Remove the operation on the path this refusal "
+        "names, then send the commit again."
+    )
+
+
 # --------------------------------------------------------------------------------------
 # The engine
 # --------------------------------------------------------------------------------------
@@ -1289,7 +1368,12 @@ def apply_change_set(
         for target in _legacy_scope_targets(delta, _policy_depth(policy)):
             refusal = policy(target)
             if refusal:
-                raise ChangeSetError(Reason.OUT_OF_SCOPE, refusal, target=list(target))
+                raise ChangeSetError(
+                    Reason.OUT_OF_SCOPE,
+                    refusal,
+                    target=list(target),
+                    next_step=_scope_next_step(policy),
+                )
         warnings.append(
             Warning(
                 code=WarningCode.LEGACY_DELTA_FORM,
@@ -1342,6 +1426,7 @@ def apply_change_set(
                     operation_index=index,
                     operation=operation.get("operation"),
                     target=target,
+                    next_step=_scope_next_step(policy),
                 )
 
     for index, operation in enumerate(operations):

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -15,26 +15,25 @@ revision. The engine produces the machine-readable half of every error; the wrap
 the parts that need context it does not have.
 """
 
-from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 __all__ = [
-    "AGENT_COMMIT_SCOPE",
-    "FILE_MARKER",
-    "KEY_FIELDS",
-    "PARAMETERS_ONLY",
     "ChangeSetError",
     "ChangeSetResult",
     "Reason",
     "Warning",
-    "allow_all",
     "apply_change_set",
     "apply_text_edits",
     "deep_merge",
     "item_key",
+    "allow_all",
     "subtree_scope",
+    "PARAMETERS_ONLY",
+    "AGENT_COMMIT_SCOPE",
+    "KEY_FIELDS",
+    "FILE_MARKER",
 ]
 
 
@@ -92,7 +91,7 @@ _NOT_RETRYABLE = frozenset(
 
 # Contract 12.3: every retryable error names the next action in one imperative sentence.
 # An agent that reads only this line must still know what to do.
-NEXT_STEPS: dict[str, str] = {
+NEXT_STEPS: Dict[str, str] = {
     Reason.TARGET_NOT_FOUND: (
         "Call read_config for that part of the configuration and correct the target."
     ),
@@ -175,7 +174,7 @@ OPERATIONS = (
 VALUE_BEARING = frozenset({"set", "merge", "add_item", "replace_item"})
 
 # Contract 4.1. Only these four lists take a selector and item operations.
-KEY_FIELDS: dict[str, str] = {
+KEY_FIELDS: Dict[str, str] = {
     "skills": "name",
     "mcps": "name",
     "files": "path",
@@ -206,9 +205,9 @@ MAX_OPERATIONS = 64
 MAX_TARGET_SEGMENTS = 12
 
 
-Segment = str | dict[str, str]
+Segment = Union[str, Dict[str, str]]
 Target = Sequence[Segment]
-ScopePolicy = Callable[[Target], str | None]
+ScopePolicy = Callable[[Target], Optional[str]]
 
 
 # --------------------------------------------------------------------------------------
@@ -222,11 +221,11 @@ class Warning:
 
     code: str
     message: str
-    target: list[Segment] | None = None
-    operation_index: int | None = None
+    target: Optional[List[Segment]] = None
+    operation_index: Optional[int] = None
 
-    def to_dict(self) -> dict[str, Any]:
-        out: dict[str, Any] = {"code": self.code, "message": self.message}
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"code": self.code, "message": self.message}
         if self.target is not None:
             out["target"] = self.target
         if self.operation_index is not None:
@@ -243,9 +242,9 @@ class ChangeSetResult:
     canonical persisted record); this one only says whether the tree moved.
     """
 
-    data: dict[str, Any]
+    data: Dict[str, Any]
     changed: bool
-    warnings: list[Warning] = field(default_factory=list)
+    warnings: List[Warning] = field(default_factory=list)
 
 
 class WarningCode:
@@ -272,9 +271,9 @@ class ChangeSetError(Exception):
         reason: str,
         message: str,
         *,
-        operation_index: int | None = None,
-        operation: str | None = None,
-        target: Target | None = None,
+        operation_index: Optional[int] = None,
+        operation: Optional[str] = None,
+        target: Optional[Target] = None,
         **context: Any,
     ) -> None:
         super().__init__(message)
@@ -290,16 +289,16 @@ class ChangeSetError(Exception):
         return self.reason not in _NOT_RETRYABLE
 
     @property
-    def next_step(self) -> str | None:
+    def next_step(self) -> Optional[str]:
         return NEXT_STEPS.get(self.reason)
 
-    def to_detail(self) -> dict[str, Any]:
+    def to_detail(self) -> Dict[str, Any]:
         """The HTTP 422 ``detail`` body. Contract section 12."""
-        reason: dict[str, Any] = {"code": self.reason, "message": self.message}
+        reason: Dict[str, Any] = {"code": self.reason, "message": self.message}
         if self.next_step:
             reason["next_step"] = self.next_step
         reason.update(self.context)
-        detail: dict[str, Any] = {
+        detail: Dict[str, Any] = {
             "code": self.code,
             "message": "No revision was committed.",
             "reason": reason,
@@ -366,7 +365,7 @@ def remove_path(tree: dict, path: str) -> None:
 # --------------------------------------------------------------------------------------
 
 
-def _tool_name(entry: dict[str, Any], *, allow_legacy_fallback: bool) -> str | None:
+def _tool_name(entry: Dict[str, Any], *, allow_legacy_fallback: bool) -> Optional[str]:
     """The canonical effective tool name. Contract 4.2."""
     kind = entry.get("type")
     if kind == "gateway":
@@ -392,7 +391,7 @@ def item_key(
     entry: Any,
     *,
     allow_legacy_fallback: bool = True,
-) -> str | None:
+) -> Optional[str]:
     """The addressable key of one list entry, or ``None`` when it has none.
 
     ``None`` means "not addressable by name". An ``@ag.embed`` entry is the main case: its
@@ -416,7 +415,7 @@ def item_key(
 # --------------------------------------------------------------------------------------
 
 
-def allow_all(target: Target) -> str | None:
+def allow_all(target: Target) -> Optional[str]:
     """The human/SDK caller's policy: any target is in scope."""
     return None
 
@@ -434,7 +433,7 @@ def subtree_scope(
     wanted = list(prefix)
     blocked = [list(path) for path in refused]
 
-    def policy(target: Target) -> str | None:
+    def policy(target: Target) -> Optional[str]:
         segments = list(target)
         if len(segments) < len(wanted):
             got = ".".join(str(s) for s in segments) or "<empty>"
@@ -490,13 +489,13 @@ def _format_segment(segment: Segment) -> str:
 # --------------------------------------------------------------------------------------
 
 
-def find_file_markers(value: Any, pointer: str = "") -> list[str]:
+def find_file_markers(value: Any, pointer: str = "") -> List[str]:
     """Every ``@ag.file`` marker inside a value, as JSON Pointers.
 
     The runner keys one execution-authorization record per marker, so the pointer is the
     identity the engine reports when it finds one that survived.
     """
-    found: list[str] = []
+    found: List[str] = []
     if isinstance(value, dict):
         if FILE_MARKER in value:
             found.append(pointer or "/")
@@ -574,7 +573,7 @@ def _type_name(value: Any) -> str:
 
 def _find_item(
     node: Any, list_name: str, key: str, *, where: str
-) -> tuple[list[Any], int]:
+) -> Tuple[List[Any], int]:
     """Find the single entry named ``key`` in the list at ``node[list_name]``."""
     if not isinstance(node, dict):
         raise _Fail(
@@ -607,7 +606,7 @@ def _find_item(
     return collection, matches[0]
 
 
-def _walk(root: dict[str, Any], segments: Sequence[Segment]) -> Any:
+def _walk(root: Dict[str, Any], segments: Sequence[Segment]) -> Any:
     """Resolve every segment and return the node it addresses. No auto-creation."""
     node: Any = root
     for position, segment in enumerate(segments):
@@ -632,7 +631,7 @@ def _walk(root: dict[str, Any], segments: Sequence[Segment]) -> Any:
     return node
 
 
-def _walk_creating(root: dict[str, Any], segments: Sequence[Segment]) -> Any:
+def _walk_creating(root: Dict[str, Any], segments: Sequence[Segment]) -> Any:
     """Like ``_walk``, but a missing plain-string segment is created as ``{}``.
 
     Contract 5.3. Only `set` uses this, and only for its parents. It never creates through
@@ -746,10 +745,10 @@ def _count_overlapping(text: str, needle: str) -> int:
 
 def apply_text_edits(
     text: str,
-    edits: Sequence[dict[str, str]],
+    edits: Sequence[Dict[str, str]],
     *,
     tolerance: str = "code",
-) -> tuple[str, bool]:
+) -> Tuple[str, bool]:
     """Apply anchored edits to one string. All or nothing.
 
     Returns the new text and whether any anchor needed the normalized retry.
@@ -778,7 +777,7 @@ def apply_text_edits(
 
     folded_text = _fold(text) if tolerance == "prose" else None
     used_normalized = False
-    matches: list[tuple[int, int, str, int]] = []
+    matches: List[Tuple[int, int, str, int]] = []
 
     for index, edit in enumerate(edits):
         if not isinstance(edit, dict) or set(edit) - {"old_text", "new_text"}:
@@ -862,7 +861,7 @@ def apply_text_edits(
 # --------------------------------------------------------------------------------------
 
 
-def _operation_value(operation: dict[str, Any]) -> Any:
+def _operation_value(operation: Dict[str, Any]) -> Any:
     if "value" not in operation:
         raise _Fail(Reason.MISSING_OPERATION_VALUE, "the operation needs a 'value'")
     value = operation["value"]
@@ -899,7 +898,7 @@ def _derived_key(list_name: str, value: Any, verb: str) -> str:
 
 
 def _parent_of(
-    root: dict[str, Any], segments: Sequence[Segment], *, create: bool
+    root: Dict[str, Any], segments: Sequence[Segment], *, create: bool
 ) -> Any:
     if len(segments) == 1:
         return root
@@ -907,7 +906,7 @@ def _parent_of(
     return walker(root, segments[:-1])
 
 
-def _require_object_parent(parent: Any, field_name: Any) -> dict[str, Any]:
+def _require_object_parent(parent: Any, field_name: Any) -> Dict[str, Any]:
     if not isinstance(parent, dict):
         raise _Fail(
             Reason.TARGET_TYPE_MISMATCH,
@@ -917,9 +916,9 @@ def _require_object_parent(parent: Any, field_name: Any) -> dict[str, Any]:
 
 
 def _apply_operation(
-    root: dict[str, Any],
-    operation: dict[str, Any],
-    warnings: list[Warning],
+    root: Dict[str, Any],
+    operation: Dict[str, Any],
+    warnings: List[Warning],
     index: int,
     touched: "_Touched",
 ) -> None:
@@ -1093,7 +1092,7 @@ def _apply_operation(
 def _warn_wholesale(
     name: Any,
     value: Any,
-    warnings: list[Warning],
+    warnings: List[Warning],
     index: int,
     segments: Sequence[Segment],
 ) -> None:
@@ -1120,11 +1119,11 @@ class _Touched:
     """Which keyed lists an operation could have changed. Contract section 9."""
 
     def __init__(self) -> None:
-        self.item_paths: list[tuple[str, ...]] = []
-        self.branch_paths: list[tuple[str, ...]] = []
+        self.item_paths: List[Tuple[str, ...]] = []
+        self.branch_paths: List[Tuple[str, ...]] = []
 
     @staticmethod
-    def _plain(segments: Sequence[Segment]) -> tuple[str, ...]:
+    def _plain(segments: Sequence[Segment]) -> Tuple[str, ...]:
         # A selector stands in place of its list's name, so it flattens to that name.
         return tuple(s["list"] if isinstance(s, dict) else s for s in segments)
 
@@ -1136,10 +1135,10 @@ class _Touched:
 
 
 def _collections(
-    tree: Any, path: tuple[str, ...] = ()
-) -> dict[tuple[str, ...], list[Any]]:
+    tree: Any, path: Tuple[str, ...] = ()
+) -> Dict[Tuple[str, ...], List[Any]]:
     """Every keyed list in a tree, by its path."""
-    found: dict[tuple[str, ...], list[Any]] = {}
+    found: Dict[Tuple[str, ...], List[Any]] = {}
     if isinstance(tree, dict):
         for key, value in tree.items():
             child = path + (key,)
@@ -1152,8 +1151,8 @@ def _collections(
     return found
 
 
-def _duplicates(list_name: str, entries: Sequence[Any]) -> dict[str, int]:
-    counts: dict[str, int] = {}
+def _duplicates(list_name: str, entries: Sequence[Any]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
     for entry in entries:
         key = item_key(list_name, entry)
         if key is not None:
@@ -1162,10 +1161,10 @@ def _duplicates(list_name: str, entries: Sequence[Any]) -> dict[str, int]:
 
 
 def _check_unique_names(
-    base: dict[str, Any],
-    result: dict[str, Any],
+    base: Dict[str, Any],
+    result: Dict[str, Any],
     touched: _Touched,
-    warnings: list[Warning],
+    warnings: List[Warning],
 ) -> None:
     before = {
         path: _duplicates(path[-1], entries)
@@ -1215,7 +1214,7 @@ def _check_unique_names(
 _LEGACY_FIELDS = ("set", "remove")
 
 
-def _classify(delta: dict[str, Any]) -> str:
+def _classify(delta: Dict[str, Any]) -> str:
     if not isinstance(delta, dict):
         raise ChangeSetError(Reason.INVALID_DELTA, "the delta must be an object")
     unknown = set(delta) - {"set", "remove", "operations"}
@@ -1241,10 +1240,10 @@ def _classify(delta: dict[str, Any]) -> str:
     )
 
 
-def _legacy_scope_targets(delta: dict[str, Any], depth: int) -> list[Target]:
-    targets: list[Target] = []
+def _legacy_scope_targets(delta: Dict[str, Any], depth: int) -> List[Target]:
+    targets: List[Target] = []
 
-    def walk(node: Any, path: list[str]) -> None:
+    def walk(node: Any, path: List[str]) -> None:
         if len(path) >= depth or not isinstance(node, dict) or not node:
             targets.append(list(path))
             return
@@ -1269,11 +1268,11 @@ def _policy_depth(scope_policy: ScopePolicy) -> int:
 
 
 def apply_change_set(
-    base: dict[str, Any],
-    delta: dict[str, Any],
-    scope_policy: ScopePolicy | None = None,
+    base: Dict[str, Any],
+    delta: Dict[str, Any],
+    scope_policy: Optional[ScopePolicy] = None,
     *,
-    validate: Callable[[dict[str, Any]], Any] | None = None,
+    validate: Optional[Callable[[Dict[str, Any]], Any]] = None,
 ) -> ChangeSetResult:
     """Apply ``delta`` to ``base``. Contract sections 7 and 8.
 
@@ -1283,7 +1282,7 @@ def apply_change_set(
     policy = scope_policy or allow_all
     form = _classify(delta)
     result = deepcopy(base) if base else {}
-    warnings: list[Warning] = []
+    warnings: List[Warning] = []
     touched = _Touched()
 
     if form == "legacy":
@@ -1361,7 +1360,7 @@ def apply_change_set(
     return _finish(base, result, warnings, touched, validate)
 
 
-def _legacy_list_write(patch: Any, name: str) -> list[Any] | None:
+def _legacy_list_write(patch: Any, name: str) -> Optional[List[Any]]:
     """The value a legacy `set` writes at any depth for one keyed list name."""
     if isinstance(patch, dict):
         for key, value in patch.items():
@@ -1385,11 +1384,11 @@ def _reject_delta_markers(patch: Any) -> None:
 
 
 def _finish(
-    base: dict[str, Any],
-    result: dict[str, Any],
-    warnings: list[Warning],
+    base: Dict[str, Any],
+    result: Dict[str, Any],
+    warnings: List[Warning],
     touched: _Touched,
-    validate: Callable[[dict[str, Any]], Any] | None,
+    validate: Optional[Callable[[Dict[str, Any]], Any]],
 ) -> ChangeSetResult:
     try:
         _check_unique_names(base or {}, result, touched, warnings)
@@ -1403,7 +1402,7 @@ def _finish(
             issues = validate(result)
         except ChangeSetError:
             raise
-        except Exception as error:
+        except Exception as error:  # noqa: BLE001 - any failure is one reason code
             raise ChangeSetError(
                 Reason.FINAL_VALIDATION_FAILED,
                 "The finished configuration is not valid.",

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -15,25 +15,26 @@ revision. The engine produces the machine-readable half of every error; the wrap
 the parts that need context it does not have.
 """
 
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any
 
 __all__ = [
+    "AGENT_COMMIT_SCOPE",
+    "FILE_MARKER",
+    "KEY_FIELDS",
+    "PARAMETERS_ONLY",
     "ChangeSetError",
     "ChangeSetResult",
     "Reason",
     "Warning",
+    "allow_all",
     "apply_change_set",
     "apply_text_edits",
     "deep_merge",
     "item_key",
-    "allow_all",
     "subtree_scope",
-    "PARAMETERS_ONLY",
-    "AGENT_COMMIT_SCOPE",
-    "KEY_FIELDS",
-    "FILE_MARKER",
 ]
 
 
@@ -91,7 +92,7 @@ _NOT_RETRYABLE = frozenset(
 
 # Contract 12.3: every retryable error names the next action in one imperative sentence.
 # An agent that reads only this line must still know what to do.
-NEXT_STEPS: Dict[str, str] = {
+NEXT_STEPS: dict[str, str] = {
     Reason.TARGET_NOT_FOUND: (
         "Call read_config for that part of the configuration and correct the target."
     ),
@@ -174,7 +175,7 @@ OPERATIONS = (
 VALUE_BEARING = frozenset({"set", "merge", "add_item", "replace_item"})
 
 # Contract 4.1. Only these four lists take a selector and item operations.
-KEY_FIELDS: Dict[str, str] = {
+KEY_FIELDS: dict[str, str] = {
     "skills": "name",
     "mcps": "name",
     "files": "path",
@@ -205,9 +206,9 @@ MAX_OPERATIONS = 64
 MAX_TARGET_SEGMENTS = 12
 
 
-Segment = Union[str, Dict[str, str]]
+Segment = str | dict[str, str]
 Target = Sequence[Segment]
-ScopePolicy = Callable[[Target], Optional[str]]
+ScopePolicy = Callable[[Target], str | None]
 
 
 # --------------------------------------------------------------------------------------
@@ -221,11 +222,11 @@ class Warning:
 
     code: str
     message: str
-    target: Optional[List[Segment]] = None
-    operation_index: Optional[int] = None
+    target: list[Segment] | None = None
+    operation_index: int | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
-        out: Dict[str, Any] = {"code": self.code, "message": self.message}
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"code": self.code, "message": self.message}
         if self.target is not None:
             out["target"] = self.target
         if self.operation_index is not None:
@@ -242,9 +243,9 @@ class ChangeSetResult:
     canonical persisted record); this one only says whether the tree moved.
     """
 
-    data: Dict[str, Any]
+    data: dict[str, Any]
     changed: bool
-    warnings: List[Warning] = field(default_factory=list)
+    warnings: list[Warning] = field(default_factory=list)
 
 
 class WarningCode:
@@ -271,9 +272,9 @@ class ChangeSetError(Exception):
         reason: str,
         message: str,
         *,
-        operation_index: Optional[int] = None,
-        operation: Optional[str] = None,
-        target: Optional[Target] = None,
+        operation_index: int | None = None,
+        operation: str | None = None,
+        target: Target | None = None,
         **context: Any,
     ) -> None:
         super().__init__(message)
@@ -289,16 +290,16 @@ class ChangeSetError(Exception):
         return self.reason not in _NOT_RETRYABLE
 
     @property
-    def next_step(self) -> Optional[str]:
+    def next_step(self) -> str | None:
         return NEXT_STEPS.get(self.reason)
 
-    def to_detail(self) -> Dict[str, Any]:
+    def to_detail(self) -> dict[str, Any]:
         """The HTTP 422 ``detail`` body. Contract section 12."""
-        reason: Dict[str, Any] = {"code": self.reason, "message": self.message}
+        reason: dict[str, Any] = {"code": self.reason, "message": self.message}
         if self.next_step:
             reason["next_step"] = self.next_step
         reason.update(self.context)
-        detail: Dict[str, Any] = {
+        detail: dict[str, Any] = {
             "code": self.code,
             "message": "No revision was committed.",
             "reason": reason,
@@ -365,7 +366,7 @@ def remove_path(tree: dict, path: str) -> None:
 # --------------------------------------------------------------------------------------
 
 
-def _tool_name(entry: Dict[str, Any], *, allow_legacy_fallback: bool) -> Optional[str]:
+def _tool_name(entry: dict[str, Any], *, allow_legacy_fallback: bool) -> str | None:
     """The canonical effective tool name. Contract 4.2."""
     kind = entry.get("type")
     if kind == "gateway":
@@ -391,7 +392,7 @@ def item_key(
     entry: Any,
     *,
     allow_legacy_fallback: bool = True,
-) -> Optional[str]:
+) -> str | None:
     """The addressable key of one list entry, or ``None`` when it has none.
 
     ``None`` means "not addressable by name". An ``@ag.embed`` entry is the main case: its
@@ -415,7 +416,7 @@ def item_key(
 # --------------------------------------------------------------------------------------
 
 
-def allow_all(target: Target) -> Optional[str]:
+def allow_all(target: Target) -> str | None:
     """The human/SDK caller's policy: any target is in scope."""
     return None
 
@@ -433,7 +434,7 @@ def subtree_scope(
     wanted = list(prefix)
     blocked = [list(path) for path in refused]
 
-    def policy(target: Target) -> Optional[str]:
+    def policy(target: Target) -> str | None:
         segments = list(target)
         if len(segments) < len(wanted):
             got = ".".join(str(s) for s in segments) or "<empty>"
@@ -489,13 +490,13 @@ def _format_segment(segment: Segment) -> str:
 # --------------------------------------------------------------------------------------
 
 
-def find_file_markers(value: Any, pointer: str = "") -> List[str]:
+def find_file_markers(value: Any, pointer: str = "") -> list[str]:
     """Every ``@ag.file`` marker inside a value, as JSON Pointers.
 
     The runner keys one execution-authorization record per marker, so the pointer is the
     identity the engine reports when it finds one that survived.
     """
-    found: List[str] = []
+    found: list[str] = []
     if isinstance(value, dict):
         if FILE_MARKER in value:
             found.append(pointer or "/")
@@ -573,7 +574,7 @@ def _type_name(value: Any) -> str:
 
 def _find_item(
     node: Any, list_name: str, key: str, *, where: str
-) -> Tuple[List[Any], int]:
+) -> tuple[list[Any], int]:
     """Find the single entry named ``key`` in the list at ``node[list_name]``."""
     if not isinstance(node, dict):
         raise _Fail(
@@ -606,7 +607,7 @@ def _find_item(
     return collection, matches[0]
 
 
-def _walk(root: Dict[str, Any], segments: Sequence[Segment]) -> Any:
+def _walk(root: dict[str, Any], segments: Sequence[Segment]) -> Any:
     """Resolve every segment and return the node it addresses. No auto-creation."""
     node: Any = root
     for position, segment in enumerate(segments):
@@ -631,7 +632,7 @@ def _walk(root: Dict[str, Any], segments: Sequence[Segment]) -> Any:
     return node
 
 
-def _walk_creating(root: Dict[str, Any], segments: Sequence[Segment]) -> Any:
+def _walk_creating(root: dict[str, Any], segments: Sequence[Segment]) -> Any:
     """Like ``_walk``, but a missing plain-string segment is created as ``{}``.
 
     Contract 5.3. Only `set` uses this, and only for its parents. It never creates through
@@ -745,10 +746,10 @@ def _count_overlapping(text: str, needle: str) -> int:
 
 def apply_text_edits(
     text: str,
-    edits: Sequence[Dict[str, str]],
+    edits: Sequence[dict[str, str]],
     *,
     tolerance: str = "code",
-) -> Tuple[str, bool]:
+) -> tuple[str, bool]:
     """Apply anchored edits to one string. All or nothing.
 
     Returns the new text and whether any anchor needed the normalized retry.
@@ -777,7 +778,7 @@ def apply_text_edits(
 
     folded_text = _fold(text) if tolerance == "prose" else None
     used_normalized = False
-    matches: List[Tuple[int, int, str, int]] = []
+    matches: list[tuple[int, int, str, int]] = []
 
     for index, edit in enumerate(edits):
         if not isinstance(edit, dict) or set(edit) - {"old_text", "new_text"}:
@@ -861,7 +862,7 @@ def apply_text_edits(
 # --------------------------------------------------------------------------------------
 
 
-def _operation_value(operation: Dict[str, Any]) -> Any:
+def _operation_value(operation: dict[str, Any]) -> Any:
     if "value" not in operation:
         raise _Fail(Reason.MISSING_OPERATION_VALUE, "the operation needs a 'value'")
     value = operation["value"]
@@ -898,7 +899,7 @@ def _derived_key(list_name: str, value: Any, verb: str) -> str:
 
 
 def _parent_of(
-    root: Dict[str, Any], segments: Sequence[Segment], *, create: bool
+    root: dict[str, Any], segments: Sequence[Segment], *, create: bool
 ) -> Any:
     if len(segments) == 1:
         return root
@@ -906,7 +907,7 @@ def _parent_of(
     return walker(root, segments[:-1])
 
 
-def _require_object_parent(parent: Any, field_name: Any) -> Dict[str, Any]:
+def _require_object_parent(parent: Any, field_name: Any) -> dict[str, Any]:
     if not isinstance(parent, dict):
         raise _Fail(
             Reason.TARGET_TYPE_MISMATCH,
@@ -916,9 +917,9 @@ def _require_object_parent(parent: Any, field_name: Any) -> Dict[str, Any]:
 
 
 def _apply_operation(
-    root: Dict[str, Any],
-    operation: Dict[str, Any],
-    warnings: List[Warning],
+    root: dict[str, Any],
+    operation: dict[str, Any],
+    warnings: list[Warning],
     index: int,
     touched: "_Touched",
 ) -> None:
@@ -1092,7 +1093,7 @@ def _apply_operation(
 def _warn_wholesale(
     name: Any,
     value: Any,
-    warnings: List[Warning],
+    warnings: list[Warning],
     index: int,
     segments: Sequence[Segment],
 ) -> None:
@@ -1119,11 +1120,11 @@ class _Touched:
     """Which keyed lists an operation could have changed. Contract section 9."""
 
     def __init__(self) -> None:
-        self.item_paths: List[Tuple[str, ...]] = []
-        self.branch_paths: List[Tuple[str, ...]] = []
+        self.item_paths: list[tuple[str, ...]] = []
+        self.branch_paths: list[tuple[str, ...]] = []
 
     @staticmethod
-    def _plain(segments: Sequence[Segment]) -> Tuple[str, ...]:
+    def _plain(segments: Sequence[Segment]) -> tuple[str, ...]:
         # A selector stands in place of its list's name, so it flattens to that name.
         return tuple(s["list"] if isinstance(s, dict) else s for s in segments)
 
@@ -1135,10 +1136,10 @@ class _Touched:
 
 
 def _collections(
-    tree: Any, path: Tuple[str, ...] = ()
-) -> Dict[Tuple[str, ...], List[Any]]:
+    tree: Any, path: tuple[str, ...] = ()
+) -> dict[tuple[str, ...], list[Any]]:
     """Every keyed list in a tree, by its path."""
-    found: Dict[Tuple[str, ...], List[Any]] = {}
+    found: dict[tuple[str, ...], list[Any]] = {}
     if isinstance(tree, dict):
         for key, value in tree.items():
             child = path + (key,)
@@ -1151,8 +1152,8 @@ def _collections(
     return found
 
 
-def _duplicates(list_name: str, entries: Sequence[Any]) -> Dict[str, int]:
-    counts: Dict[str, int] = {}
+def _duplicates(list_name: str, entries: Sequence[Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
     for entry in entries:
         key = item_key(list_name, entry)
         if key is not None:
@@ -1161,10 +1162,10 @@ def _duplicates(list_name: str, entries: Sequence[Any]) -> Dict[str, int]:
 
 
 def _check_unique_names(
-    base: Dict[str, Any],
-    result: Dict[str, Any],
+    base: dict[str, Any],
+    result: dict[str, Any],
     touched: _Touched,
-    warnings: List[Warning],
+    warnings: list[Warning],
 ) -> None:
     before = {
         path: _duplicates(path[-1], entries)
@@ -1214,7 +1215,7 @@ def _check_unique_names(
 _LEGACY_FIELDS = ("set", "remove")
 
 
-def _classify(delta: Dict[str, Any]) -> str:
+def _classify(delta: dict[str, Any]) -> str:
     if not isinstance(delta, dict):
         raise ChangeSetError(Reason.INVALID_DELTA, "the delta must be an object")
     unknown = set(delta) - {"set", "remove", "operations"}
@@ -1240,10 +1241,10 @@ def _classify(delta: Dict[str, Any]) -> str:
     )
 
 
-def _legacy_scope_targets(delta: Dict[str, Any], depth: int) -> List[Target]:
-    targets: List[Target] = []
+def _legacy_scope_targets(delta: dict[str, Any], depth: int) -> list[Target]:
+    targets: list[Target] = []
 
-    def walk(node: Any, path: List[str]) -> None:
+    def walk(node: Any, path: list[str]) -> None:
         if len(path) >= depth or not isinstance(node, dict) or not node:
             targets.append(list(path))
             return
@@ -1268,11 +1269,11 @@ def _policy_depth(scope_policy: ScopePolicy) -> int:
 
 
 def apply_change_set(
-    base: Dict[str, Any],
-    delta: Dict[str, Any],
-    scope_policy: Optional[ScopePolicy] = None,
+    base: dict[str, Any],
+    delta: dict[str, Any],
+    scope_policy: ScopePolicy | None = None,
     *,
-    validate: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    validate: Callable[[dict[str, Any]], Any] | None = None,
 ) -> ChangeSetResult:
     """Apply ``delta`` to ``base``. Contract sections 7 and 8.
 
@@ -1282,7 +1283,7 @@ def apply_change_set(
     policy = scope_policy or allow_all
     form = _classify(delta)
     result = deepcopy(base) if base else {}
-    warnings: List[Warning] = []
+    warnings: list[Warning] = []
     touched = _Touched()
 
     if form == "legacy":
@@ -1360,7 +1361,7 @@ def apply_change_set(
     return _finish(base, result, warnings, touched, validate)
 
 
-def _legacy_list_write(patch: Any, name: str) -> Optional[List[Any]]:
+def _legacy_list_write(patch: Any, name: str) -> list[Any] | None:
     """The value a legacy `set` writes at any depth for one keyed list name."""
     if isinstance(patch, dict):
         for key, value in patch.items():
@@ -1384,11 +1385,11 @@ def _reject_delta_markers(patch: Any) -> None:
 
 
 def _finish(
-    base: Dict[str, Any],
-    result: Dict[str, Any],
-    warnings: List[Warning],
+    base: dict[str, Any],
+    result: dict[str, Any],
+    warnings: list[Warning],
     touched: _Touched,
-    validate: Optional[Callable[[Dict[str, Any]], Any]],
+    validate: Callable[[dict[str, Any]], Any] | None,
 ) -> ChangeSetResult:
     try:
         _check_unique_names(base or {}, result, touched, warnings)
@@ -1402,7 +1403,7 @@ def _finish(
             issues = validate(result)
         except ChangeSetError:
             raise
-        except Exception as error:  # noqa: BLE001 - any failure is one reason code
+        except Exception as error:
             raise ChangeSetError(
                 Reason.FINAL_VALIDATION_FAILED,
                 "The finished configuration is not valid.",

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -73,6 +73,8 @@ class Reason:
     INVALID_DELTA = "invalid_delta"
     UNKNOWN_OPERATION = "unknown_operation"
     UNRESOLVED_FILE_MARKER = "unresolved_file_marker"
+    INVALID_EMBED = "invalid_embed"
+    UNKNOWN_MARKER = "unknown_marker"
     TEXT_TOO_LARGE = "text_too_large"
     SOURCE_TOO_LARGE = "source_too_large"
 
@@ -83,6 +85,8 @@ _NOT_RETRYABLE = frozenset(
         Reason.INVALID_DELTA,
         Reason.UNKNOWN_OPERATION,
         Reason.UNRESOLVED_FILE_MARKER,
+        Reason.INVALID_EMBED,
+        Reason.UNKNOWN_MARKER,
         Reason.TEXT_TOO_LARGE,
         Reason.SOURCE_TOO_LARGE,
     }
@@ -529,6 +533,100 @@ def _escape(token: str) -> str:
     return token.replace("~", "~0").replace("/", "~1")
 
 
+# Contract 6. Every marker the platform defines. `@ag.references` and `@ag.selector` are
+# only meaningful INSIDE an embed, and are checked there.
+_REFERENCES_KEY = "@ag.references"
+_SELECTOR_KEY = "@ag.selector"
+_MARKER_PREFIX = "@ag."
+_EMBED_KEYS = frozenset({_REFERENCES_KEY, _SELECTOR_KEY})
+_KNOWN_MARKERS = frozenset({_EMBED_KEY, FILE_MARKER, _REFERENCES_KEY, _SELECTOR_KEY})
+
+# Named in every refusal below, because a model that invents a marker has to be shown the
+# two real ones rather than told that its guess was wrong.
+_VALID_FORMS = (
+    "An embed points at another stored artifact: "
+    '{"@ag.embed": {"@ag.references": {"workflow_revision": {"id": "..."}}}}, '
+    'with an optional {"@ag.selector": {"path": "..."}}. '
+    'To pull in the contents of a file from your workspace, use {"@ag.file": "<path>"} '
+    "instead, and the runner replaces it with the text before the commit is sent."
+)
+
+
+def _reject_bad_markers(value: Any, pointer: str = "") -> None:
+    """Refuse a marker the platform does not define, or an embed that is not one.
+
+    A live session invented ``{"@ag.embed": {"@ag.references": {"file": "/abs/path"}}}`` to
+    import a file. Nothing rejected it: the embed resolver skips a reference whose value is
+    not an object, so the invented marker resolved to nothing and the literal dict was
+    STORED as the configuration value. The agent was told the commit succeeded, and the
+    field held a marker instead of the file's text from then on.
+
+    Refusing it here is a storage-integrity rule, not a courtesy: the engine is the last
+    place that sees the value before it is written, and a marker it does not understand is
+    a value nobody can read back.
+    """
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_bad_markers(child, f"{pointer}/{index}")
+        return
+    if not isinstance(value, dict):
+        return
+
+    for key, child in value.items():
+        if isinstance(key, str) and key.startswith(_MARKER_PREFIX):
+            if key not in _KNOWN_MARKERS:
+                raise _Fail(
+                    Reason.UNKNOWN_MARKER,
+                    f"'{key}' at {pointer or '/'} is not a marker this platform defines. "
+                    + _VALID_FORMS,
+                    pointer=pointer or "/",
+                    marker=key,
+                )
+            if key == _EMBED_KEY:
+                _check_embed(child, f"{pointer}/{_escape(key)}")
+        _reject_bad_markers(child, f"{pointer}/{_escape(str(key))}")
+
+
+def _check_embed(embed: Any, pointer: str) -> None:
+    """The canonical embed shape, as the resolver in ``core/embeds`` reads it."""
+    if not isinstance(embed, dict) or not embed:
+        raise _Fail(
+            Reason.INVALID_EMBED,
+            f"the embed at {pointer} is not an embed. " + _VALID_FORMS,
+            pointer=pointer,
+        )
+
+    unknown = sorted(key for key in embed if key not in _EMBED_KEYS)
+    if unknown:
+        raise _Fail(
+            Reason.INVALID_EMBED,
+            f"the embed at {pointer} carries {', '.join(unknown)}, which an embed does "
+            "not hold. " + _VALID_FORMS,
+            pointer=pointer,
+        )
+
+    references = embed.get(_REFERENCES_KEY)
+    if not isinstance(references, dict) or not references:
+        raise _Fail(
+            Reason.INVALID_EMBED,
+            f"the embed at {pointer} has no '{_REFERENCES_KEY}' naming what it points at. "
+            + _VALID_FORMS,
+            pointer=pointer,
+        )
+
+    # A reference is an object identifying a stored artifact. A bare string here is the
+    # shape a model reaches for when it means a file path, and it resolves to nothing.
+    for kind, reference in references.items():
+        if not isinstance(reference, dict) or not reference:
+            raise _Fail(
+                Reason.INVALID_EMBED,
+                f"the reference '{kind}' at {pointer} is not an object identifying a "
+                "stored artifact. " + _VALID_FORMS,
+                pointer=pointer,
+                reference=kind,
+            )
+
+
 def _reject_file_markers(value: Any) -> None:
     markers = find_file_markers(value)
     if not markers:
@@ -895,6 +993,7 @@ def _operation_value(operation: Dict[str, Any]) -> Any:
         raise _Fail(Reason.MISSING_OPERATION_VALUE, "the operation needs a 'value'")
     value = operation["value"]
     _reject_file_markers(value)
+    _reject_bad_markers(value)
     return value
 
 
@@ -1500,6 +1599,7 @@ def apply_change_set(
         # place, and the engine's promise that it touches nothing it was given is false.
         patch = deepcopy(delta.get("set") or {})
         _reject_delta_markers(patch)
+        _reject_legacy_bad_markers(patch)
         for name in ("tools", "skills", "mcps"):
             nested = _legacy_list_write(patch, name)
             if nested is not None:
@@ -1583,6 +1683,20 @@ def _legacy_list_write(patch: Any, name: str) -> Optional[List[Any]]:
             if found is not None:
                 return found
     return None
+
+
+def _reject_legacy_bad_markers(patch: Any) -> None:
+    """The same marker rules on the legacy arm, which merges its patch in whole.
+
+    The legacy arm has always been the one that stores a value verbatim, so it is the arm
+    an invented marker actually reaches.
+    """
+    try:
+        _reject_bad_markers(patch)
+    except _Fail as failure:
+        raise ChangeSetError(
+            failure.reason, failure.message, **failure.context
+        ) from failure
 
 
 def _reject_delta_markers(patch: Any) -> None:

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -1,0 +1,1422 @@
+"""The change-set engine: one pure function that applies a delta to a base data tree.
+
+Implements ``docs/design/agent-config-editing/contracts/change-set.md`` (slice S1a). The
+contract is authoritative; this module is its executable half.
+
+The engine is dependency-free: plain dicts in, a plain result out, no pydantic, no I/O, no
+database. Two wrappers call it. The commit wrapper checks ``base_revision_id`` against the
+head and persists; the invoke-override wrapper resolves an immutable revision, applies with
+the ``parameters``-only scope policy, and persists nothing.
+
+Three things belong to the wrapper, not here, and the contract says so: the selector
+normalization (contract 4.3), the platform-tool rejection (11), the derived commit message
+(14), and the enriched error content (12.4), which needs the workspace and the base
+revision. The engine produces the machine-readable half of every error; the wrapper adds
+the parts that need context it does not have.
+"""
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+__all__ = [
+    "ChangeSetError",
+    "ChangeSetResult",
+    "Reason",
+    "Warning",
+    "apply_change_set",
+    "apply_text_edits",
+    "deep_merge",
+    "item_key",
+    "allow_all",
+    "subtree_scope",
+    "PARAMETERS_ONLY",
+    "AGENT_COMMIT_SCOPE",
+    "KEY_FIELDS",
+    "FILE_MARKER",
+]
+
+
+# --------------------------------------------------------------------------------------
+# Vocabulary
+# --------------------------------------------------------------------------------------
+
+
+class Reason:
+    """Stable machine-readable reason codes. Contract section 12."""
+
+    # --- retryable: the agent can correct these and send again (12.1) ---
+    TARGET_NOT_FOUND = "target_not_found"
+    TARGET_TYPE_MISMATCH = "target_type_mismatch"
+    INVALID_TARGET_SHAPE = "invalid_target_shape"
+    ITEM_ALREADY_EXISTS = "item_already_exists"
+    ITEM_NOT_FOUND = "item_not_found"
+    ITEM_RENAME_NOT_ALLOWED = "item_rename_not_allowed"
+    DUPLICATE_ITEM_KEY = "duplicate_item_key"
+    ITEM_KEY_UNDEFINED = "item_key_undefined"
+    UNKEYED_COLLECTION = "unkeyed_collection"
+    MISSING_OPERATION_VALUE = "missing_operation_value"
+    INVALID_OPERATION_SHAPE = "invalid_operation_shape"
+    TEXT_NOT_FOUND = "text_not_found"
+    TEXT_NOT_UNIQUE = "text_not_unique"
+    TEXT_EDITS_OVERLAP = "text_edits_overlap"
+    EMPTY_OLD_TEXT = "empty_old_text"
+    NO_CHANGE = "no_change"
+    SOURCE_NOT_FOUND = "source_not_found"
+    SOURCE_UNSUPPORTED = "source_unsupported"
+    PLATFORM_TOOL_NOT_COMMITTABLE = "platform_tool_not_committable"
+    NON_EMBEDDABLE_REFERENCE = "non_embeddable_reference"
+    FINAL_VALIDATION_FAILED = "final_validation_failed"
+
+    # --- non-retryable refusals: the same payload never succeeds (12.2) ---
+    OUT_OF_SCOPE = "out_of_scope"
+    INVALID_DELTA = "invalid_delta"
+    UNKNOWN_OPERATION = "unknown_operation"
+    UNRESOLVED_FILE_MARKER = "unresolved_file_marker"
+    TEXT_TOO_LARGE = "text_too_large"
+    SOURCE_TOO_LARGE = "source_too_large"
+
+
+_NOT_RETRYABLE = frozenset(
+    {
+        Reason.OUT_OF_SCOPE,
+        Reason.INVALID_DELTA,
+        Reason.UNKNOWN_OPERATION,
+        Reason.UNRESOLVED_FILE_MARKER,
+        Reason.TEXT_TOO_LARGE,
+        Reason.SOURCE_TOO_LARGE,
+    }
+)
+
+
+# Contract 12.3: every retryable error names the next action in one imperative sentence.
+# An agent that reads only this line must still know what to do.
+NEXT_STEPS: Dict[str, str] = {
+    Reason.TARGET_NOT_FOUND: (
+        "Call read_config for that part of the configuration and correct the target."
+    ),
+    Reason.TARGET_TYPE_MISMATCH: (
+        "Call read_config for that path to see what type it holds, then use the matching "
+        "operation."
+    ),
+    Reason.INVALID_TARGET_SHAPE: (
+        "Fix the last target segment: set / merge / remove / edit_text end with a field "
+        "name, add_item ends with a list name, replace_item / remove_item end with "
+        "{'list': ..., 'key': ...}."
+    ),
+    Reason.ITEM_ALREADY_EXISTS: (
+        "Use replace_item to overwrite that entry, or add_item with a different key."
+    ),
+    Reason.ITEM_NOT_FOUND: (
+        "Call read_config for that list to see the keys it holds, then retry with a key "
+        "from it."
+    ),
+    Reason.ITEM_RENAME_NOT_ALLOWED: (
+        "Send remove_item for the old key, then add_item with the new value."
+    ),
+    Reason.DUPLICATE_ITEM_KEY: (
+        "Remove the duplicate entries with remove_item first, then send this change again."
+    ),
+    Reason.ITEM_KEY_UNDEFINED: (
+        "Give the new entry its key field: name for a skill, an MCP server, or a tool; "
+        "path for a file. A gateway tool needs an explicit name."
+    ),
+    Reason.UNKEYED_COLLECTION: (
+        "That list is not addressed by name. Use set to replace the whole list."
+    ),
+    Reason.MISSING_OPERATION_VALUE: "Add a `value` to the operation and send it again.",
+    Reason.INVALID_OPERATION_SHAPE: (
+        "Correct the operation to the shape in the tool description and send it again."
+    ),
+    Reason.TEXT_NOT_FOUND: (
+        "Copy old_text from the configuration you read, character for character."
+    ),
+    Reason.TEXT_NOT_UNIQUE: (
+        "Add more surrounding lines to old_text until it appears once, then send the "
+        "commit again."
+    ),
+    Reason.TEXT_EDITS_OVERLAP: (
+        "Merge the overlapping edits into one edit, or target separate regions."
+    ),
+    Reason.EMPTY_OLD_TEXT: "Put the exact text you want to replace in old_text.",
+    Reason.NO_CHANGE: (
+        "The new text equals the old text. Send the change you actually want, or send "
+        "nothing."
+    ),
+    Reason.SOURCE_NOT_FOUND: (
+        "Write the file under .agenta-imports/ first, then send the commit again."
+    ),
+    Reason.SOURCE_UNSUPPORTED: (
+        "That file is not readable as text. Reference a UTF-8 text file."
+    ),
+    Reason.PLATFORM_TOOL_NOT_COMMITTABLE: (
+        "Remove those entries from `tools` and send the commit again."
+    ),
+    Reason.NON_EMBEDDABLE_REFERENCE: (
+        "Remove the embedded reference to that workflow and send the commit again."
+    ),
+    Reason.FINAL_VALIDATION_FAILED: (
+        "Correct the fields listed in `issues` and send the commit again."
+    ),
+}
+
+
+OPERATIONS = (
+    "set",
+    "merge",
+    "remove",
+    "edit_text",
+    "add_item",
+    "replace_item",
+    "remove_item",
+)
+
+VALUE_BEARING = frozenset({"set", "merge", "add_item", "replace_item"})
+
+# Contract 4.1. Only these four lists take a selector and item operations.
+KEY_FIELDS: Dict[str, str] = {
+    "skills": "name",
+    "mcps": "name",
+    "files": "path",
+    "tools": "__tool_name__",  # computed, see `item_key`
+}
+
+_EMBED_KEY = "@ag.embed"
+
+# Contract 6. The runner replaces this marker with the file's text before the API sees the
+# call. The engine is pure, so a marker that reaches it means the runner did not run.
+FILE_MARKER = "@ag.file"
+
+# Contract 5.6.1. Match tolerance follows what the text IS, by its field name.
+# Prose is written by humans and models, so a smart quote from another editor must not
+# block an edit. A script's bytes are its meaning, so a normalized match there could
+# rewrite a string literal into something that no longer runs. An unknown field is exact:
+# fail safe.
+_PROSE_FIELDS = frozenset({"agents_md", "body", "description"})
+_CODE_FIELDS = frozenset({"content", "script"})
+
+MATCH_MODES = ("auto", "exact")
+
+# Contract 5.6.3.
+MAX_TEXT_LENGTH = 200_000  # matches SkillFile.content max_length
+MAX_OLD_TEXT_LENGTH = 20_000
+MAX_EDITS_PER_OPERATION = 32
+MAX_OPERATIONS = 64
+MAX_TARGET_SEGMENTS = 12
+
+
+Segment = Union[str, Dict[str, str]]
+Target = Sequence[Segment]
+ScopePolicy = Callable[[Target], Optional[str]]
+
+
+# --------------------------------------------------------------------------------------
+# Result
+# --------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Warning:
+    """One structured warning. Never a bare sentence: the wrapper renders it."""
+
+    code: str
+    message: str
+    target: Optional[List[Segment]] = None
+    operation_index: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.target is not None:
+            out["target"] = self.target
+        if self.operation_index is not None:
+            out["operation_index"] = self.operation_index
+        return out
+
+
+@dataclass(frozen=True)
+class ChangeSetResult:
+    """What the engine returns. Contract section 8.
+
+    ``changed`` is mandatory before ship, not a convenience: a cornered model commits a
+    no-op to manufacture success. The wrapper's own comparison is larger (it covers the
+    canonical persisted record); this one only says whether the tree moved.
+    """
+
+    data: Dict[str, Any]
+    changed: bool
+    warnings: List[Warning] = field(default_factory=list)
+
+
+class WarningCode:
+    TEXT_MATCHED_NORMALIZED = "text_matched_normalized"
+    TARGET_NORMALIZED = "target_normalized"
+    WHOLESALE_LIST_REPLACE = "wholesale_list_replace"
+    LEGACY_DUPLICATE_KEY = "legacy_duplicate_key"
+    LEGACY_DELTA_FORM = "legacy_delta_form"
+    UNADDRESSABLE_EMBED = "unaddressable_embed"
+
+
+# --------------------------------------------------------------------------------------
+# Errors
+# --------------------------------------------------------------------------------------
+
+
+class ChangeSetError(Exception):
+    """One failed operation. It aborts the whole change set; nothing is committed."""
+
+    code = "change_set_rejected"
+
+    def __init__(
+        self,
+        reason: str,
+        message: str,
+        *,
+        operation_index: Optional[int] = None,
+        operation: Optional[str] = None,
+        target: Optional[Target] = None,
+        **context: Any,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+        self.operation_index = operation_index
+        self.operation = operation
+        self.target = list(target) if target is not None else None
+        self.context = context
+
+    @property
+    def retryable(self) -> bool:
+        return self.reason not in _NOT_RETRYABLE
+
+    @property
+    def next_step(self) -> Optional[str]:
+        return NEXT_STEPS.get(self.reason)
+
+    def to_detail(self) -> Dict[str, Any]:
+        """The HTTP 422 ``detail`` body. Contract section 12."""
+        reason: Dict[str, Any] = {"code": self.reason, "message": self.message}
+        if self.next_step:
+            reason["next_step"] = self.next_step
+        reason.update(self.context)
+        detail: Dict[str, Any] = {
+            "code": self.code,
+            "message": "No revision was committed.",
+            "reason": reason,
+            "retryable": self.retryable,
+        }
+        if self.operation_index is not None:
+            detail["operation_index"] = self.operation_index
+        if self.operation is not None:
+            detail["operation"] = self.operation
+        if self.target is not None:
+            detail["target"] = self.target
+        return detail
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"ChangeSetError(reason={self.reason!r}, "
+            f"operation_index={self.operation_index!r}, message={self.message!r})"
+        )
+
+
+class _Fail(Exception):
+    """Internal carrier so helpers can report without knowing the operation index."""
+
+    def __init__(self, reason: str, message: str, **context: Any) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+        self.context = context
+
+
+# --------------------------------------------------------------------------------------
+# Legacy primitives (must stay identical to service.py)
+# --------------------------------------------------------------------------------------
+
+
+def deep_merge(base: dict, patch: dict) -> dict:
+    """Today's dict-only recursion. Nested dicts merge; scalars and lists replace.
+
+    ``service.py`` must import this one so the two can never drift.
+    """
+    merged = dict(base)
+    for key, value in patch.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = deep_merge(current, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def remove_path(tree: dict, path: str) -> None:
+    """Today's dotted-path delete. A missing path is a silent no-op."""
+    keys = path.split(".")
+    node = tree
+    for key in keys[:-1]:
+        node = node.get(key) if isinstance(node, dict) else None
+        if not isinstance(node, dict):
+            return
+    node.pop(keys[-1], None)
+
+
+# --------------------------------------------------------------------------------------
+# Item identity
+# --------------------------------------------------------------------------------------
+
+
+def _tool_name(entry: Dict[str, Any], *, allow_legacy_fallback: bool) -> Optional[str]:
+    """The canonical effective tool name. Contract 4.2."""
+    kind = entry.get("type")
+    if kind == "gateway":
+        name = entry.get("name")
+        if name:
+            return name
+        if not allow_legacy_fallback:
+            return None
+        integration = entry.get("integration")
+        action = entry.get("action")
+        if integration and action:
+            return f"{integration}__{action}"
+        return None
+    if kind == "reference":
+        return entry.get("name") or entry.get("slug")
+    if kind == "platform":
+        return entry.get("op")
+    return entry.get("name")
+
+
+def item_key(
+    collection: str,
+    entry: Any,
+    *,
+    allow_legacy_fallback: bool = True,
+) -> Optional[str]:
+    """The addressable key of one list entry, or ``None`` when it has none.
+
+    ``None`` means "not addressable by name". An ``@ag.embed`` entry is the main case: its
+    identity lives behind a server-side reference, so it gets no key here.
+    """
+    if not isinstance(entry, dict):
+        return None
+    if _EMBED_KEY in entry:
+        return None
+    if collection == "tools":
+        return _tool_name(entry, allow_legacy_fallback=allow_legacy_fallback)
+    key_field = KEY_FIELDS.get(collection)
+    if key_field is None:
+        return None
+    value = entry.get(key_field)
+    return value if isinstance(value, str) and value else None
+
+
+# --------------------------------------------------------------------------------------
+# Scope policies
+# --------------------------------------------------------------------------------------
+
+
+def allow_all(target: Target) -> Optional[str]:
+    """The human/SDK caller's policy: any target is in scope."""
+    return None
+
+
+def subtree_scope(
+    prefix: Sequence[str],
+    *,
+    refused: Sequence[Sequence[str]] = (),
+) -> ScopePolicy:
+    """Restrict every target to one subtree, minus any refused sub-paths.
+
+    A target shorter than the prefix is refused: writing it would rewrite the subtree's
+    parent.
+    """
+    wanted = list(prefix)
+    blocked = [list(path) for path in refused]
+
+    def policy(target: Target) -> Optional[str]:
+        segments = list(target)
+        if len(segments) < len(wanted):
+            got = ".".join(str(s) for s in segments) or "<empty>"
+            return f"the target must sit under '{'.'.join(wanted)}' (got: {got})"
+        for depth, expected in enumerate(wanted):
+            if segments[depth] != expected:
+                return (
+                    f"the target must sit under '{'.'.join(wanted)}' "
+                    f"(segment {depth} is {_format_segment(segments[depth])})"
+                )
+        for path in blocked:
+            if _plain_prefix(path, segments):
+                return (
+                    f"'{'.'.join(path)}' is owned by the platform and cannot be changed "
+                    "by the agent"
+                )
+        return None
+
+    policy._prefix_depth = len(wanted)  # type: ignore[attr-defined]
+    return policy
+
+
+def _plain_prefix(prefix: Sequence[str], segments: Sequence[Segment]) -> bool:
+    if len(segments) < len(prefix):
+        return False
+    return all(segments[i] == part for i, part in enumerate(prefix))
+
+
+PARAMETERS_ONLY: ScopePolicy = subtree_scope(["parameters"])
+
+# Contract via read-config.md 11.1: the agent writes its own agent subtree, minus the
+# subtrees that decide what it may run. Widening this later is additive; narrowing is not.
+AGENT_COMMIT_SCOPE: ScopePolicy = subtree_scope(
+    ["parameters", "agent"],
+    refused=(
+        ["parameters", "agent", "harness", "kind"],
+        ["parameters", "agent", "harness", "permissions"],
+        ["parameters", "agent", "runner", "permissions"],
+        ["parameters", "agent", "sandbox", "kind"],
+        ["parameters", "agent", "sandbox", "permissions"],
+    ),
+)
+
+
+def _format_segment(segment: Segment) -> str:
+    if isinstance(segment, dict):
+        return f"{segment.get('list')}[{segment.get('key')!r}]"
+    return repr(segment)
+
+
+# --------------------------------------------------------------------------------------
+# The @ag.file marker
+# --------------------------------------------------------------------------------------
+
+
+def find_file_markers(value: Any, pointer: str = "") -> List[str]:
+    """Every ``@ag.file`` marker inside a value, as JSON Pointers.
+
+    The runner keys one execution-authorization record per marker, so the pointer is the
+    identity the engine reports when it finds one that survived.
+    """
+    found: List[str] = []
+    if isinstance(value, dict):
+        if FILE_MARKER in value:
+            found.append(pointer or "/")
+        for key, child in value.items():
+            found.extend(find_file_markers(child, f"{pointer}/{_escape(key)}"))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found.extend(find_file_markers(child, f"{pointer}/{index}"))
+    return found
+
+
+def _escape(token: str) -> str:
+    return token.replace("~", "~0").replace("/", "~1")
+
+
+def _reject_file_markers(value: Any) -> None:
+    markers = find_file_markers(value)
+    if not markers:
+        return
+    raise _Fail(
+        Reason.UNRESOLVED_FILE_MARKER,
+        f"an '{FILE_MARKER}' marker reached the engine at {', '.join(markers)}. "
+        "The runner resolves every marker into text before the API sees the call.",
+        pointers=markers,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Target resolution
+# --------------------------------------------------------------------------------------
+
+
+def _validate_segment(segment: Any, position: int) -> None:
+    if isinstance(segment, str):
+        if not segment:
+            raise _Fail(
+                Reason.INVALID_TARGET_SHAPE, f"target segment {position} is empty"
+            )
+        return
+    if isinstance(segment, dict):
+        if set(segment) != {"list", "key"}:
+            raise _Fail(
+                Reason.INVALID_TARGET_SHAPE,
+                f"target segment {position} must have exactly 'list' and 'key'",
+            )
+        if not isinstance(segment["list"], str) or not segment["list"]:
+            raise _Fail(
+                Reason.INVALID_TARGET_SHAPE,
+                f"target segment {position} has an empty 'list'",
+            )
+        if not isinstance(segment["key"], str) or not segment["key"]:
+            raise _Fail(
+                Reason.INVALID_TARGET_SHAPE,
+                f"target segment {position} has an empty 'key'",
+            )
+        return
+    raise _Fail(
+        Reason.INVALID_TARGET_SHAPE,
+        f"target segment {position} must be a string or a {{list, key}} object",
+    )
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    return {
+        dict: "an object",
+        list: "a list",
+        str: "a string",
+        bool: "a boolean",
+        int: "a number",
+        float: "a number",
+    }.get(type(value), type(value).__name__)
+
+
+def _find_item(
+    node: Any, list_name: str, key: str, *, where: str
+) -> Tuple[List[Any], int]:
+    """Find the single entry named ``key`` in the list at ``node[list_name]``."""
+    if not isinstance(node, dict):
+        raise _Fail(
+            Reason.TARGET_TYPE_MISMATCH,
+            f"{where}: expected an object, found {_type_name(node)}",
+        )
+    if list_name not in node:
+        raise _Fail(Reason.TARGET_NOT_FOUND, f"{where}: '{list_name}' does not exist")
+    collection = node[list_name]
+    if not isinstance(collection, list):
+        raise _Fail(
+            Reason.TARGET_TYPE_MISMATCH,
+            f"{where}: '{list_name}' is {_type_name(collection)}, not a list",
+        )
+    matches = [
+        index
+        for index, entry in enumerate(collection)
+        if item_key(list_name, entry) == key
+    ]
+    if len(matches) > 1:
+        raise _Fail(
+            Reason.DUPLICATE_ITEM_KEY,
+            f"{where}: '{list_name}' holds {len(matches)} entries named {key!r}",
+            match_count=len(matches),
+        )
+    if not matches:
+        raise _Fail(
+            Reason.ITEM_NOT_FOUND, f"{where}: '{list_name}' has no entry named {key!r}"
+        )
+    return collection, matches[0]
+
+
+def _walk(root: Dict[str, Any], segments: Sequence[Segment]) -> Any:
+    """Resolve every segment and return the node it addresses. No auto-creation."""
+    node: Any = root
+    for position, segment in enumerate(segments):
+        where = f"target segment {position}"
+        if isinstance(segment, str):
+            if not isinstance(node, dict):
+                raise _Fail(
+                    Reason.TARGET_TYPE_MISMATCH,
+                    f"{where} ({segment!r}): the parent is {_type_name(node)}, "
+                    "not an object",
+                )
+            if segment not in node:
+                raise _Fail(
+                    Reason.TARGET_NOT_FOUND, f"{where}: {segment!r} does not exist"
+                )
+            node = node[segment]
+        else:
+            collection, index = _find_item(
+                node, segment["list"], segment["key"], where=where
+            )
+            node = collection[index]
+    return node
+
+
+def _walk_creating(root: Dict[str, Any], segments: Sequence[Segment]) -> Any:
+    """Like ``_walk``, but a missing plain-string segment is created as ``{}``.
+
+    Contract 5.3. Only `set` uses this, and only for its parents. It never creates through
+    a selector: a missing entry is still an error, because inventing a list entry would
+    invent an identity. An existing scalar / list / null parent is a type mismatch, never
+    an overwrite.
+    """
+    node: Any = root
+    for position, segment in enumerate(segments):
+        where = f"target segment {position}"
+        if isinstance(segment, str):
+            if not isinstance(node, dict):
+                raise _Fail(
+                    Reason.TARGET_TYPE_MISMATCH,
+                    f"{where} ({segment!r}): the parent is {_type_name(node)}, "
+                    "not an object",
+                )
+            if segment not in node:
+                node[segment] = {}
+            elif not isinstance(node[segment], dict):
+                raise _Fail(
+                    Reason.TARGET_TYPE_MISMATCH,
+                    f"{where}: {segment!r} is {_type_name(node[segment])}, so it cannot "
+                    "hold the field you are setting",
+                )
+            node = node[segment]
+        else:
+            collection, index = _find_item(
+                node, segment["list"], segment["key"], where=where
+            )
+            node = collection[index]
+    return node
+
+
+# --------------------------------------------------------------------------------------
+# edit_text
+# --------------------------------------------------------------------------------------
+
+# Contract 5.6.1: every fold is ONE code point to ONE code point. That is what makes the
+# byte-exact write true. A length-changing fold (trailing trim, run collapsing, CRLF, NFC)
+# would put the match at an offset that does not exist in the original string, and
+# recovering the real offsets needs the line-overlay machinery whose corruption risk is
+# the reason this design rejected Pi's approach.
+_FOLD_MAP = {
+    # smart single quotes
+    0x2018: "'",
+    0x2019: "'",
+    0x201A: "'",
+    0x201B: "'",
+    # smart double quotes
+    0x201C: '"',
+    0x201D: '"',
+    0x201E: '"',
+    0x201F: '"',
+    # dashes and minus
+    0x2010: "-",
+    0x2011: "-",
+    0x2012: "-",
+    0x2013: "-",
+    0x2014: "-",
+    0x2015: "-",
+    0x2212: "-",
+    # spaces
+    0x00A0: " ",
+    0x2002: " ",
+    0x2003: " ",
+    0x2004: " ",
+    0x2005: " ",
+    0x2006: " ",
+    0x2007: " ",
+    0x2008: " ",
+    0x2009: " ",
+    0x200A: " ",
+    0x202F: " ",
+    0x205F: " ",
+    0x3000: " ",
+}
+
+
+def _fold(text: str) -> str:
+    """Length-preserving fold of quotes, dashes, and spaces to their ASCII forms."""
+    return text.translate(_FOLD_MAP)
+
+
+def content_class(field_name: str) -> str:
+    """``prose`` or ``code``, from the field's name. Contract 5.6.1.
+
+    An unknown field is ``code``, which means exact matching. Fail safe: a new field that
+    nobody classified must not silently gain tolerance.
+    """
+    if field_name in _PROSE_FIELDS:
+        return "prose"
+    if field_name in _CODE_FIELDS:
+        return "code"
+    return "code"
+
+
+def _count_overlapping(text: str, needle: str) -> int:
+    """Every start position, not every non-overlapping occurrence. Contract 5.6.2.
+
+    ``str.count`` reports one occurrence of ``"aa"`` in ``"aaa"``. Two start positions
+    exist, so the anchor is ambiguous and must be refused.
+    """
+    count = 0
+    index = text.find(needle)
+    while index >= 0:
+        count += 1
+        index = text.find(needle, index + 1)
+    return count
+
+
+def apply_text_edits(
+    text: str,
+    edits: Sequence[Dict[str, str]],
+    *,
+    tolerance: str = "code",
+) -> Tuple[str, bool]:
+    """Apply anchored edits to one string. All or nothing.
+
+    Returns the new text and whether any anchor needed the normalized retry.
+
+    The contract, in order: a non-empty anchor; exactly one occurrence counted WITH
+    overlap; every anchor matched against the pre-operation string; no overlapping
+    matches; a batch that changes nothing is refused.
+
+    ``tolerance`` is ``prose`` (exact first, then one normalized retry) or ``code``
+    (exact only). The write is byte-exact either way: a normalized match still replaces
+    the span of the ORIGINAL string, and no byte outside the span is touched.
+    """
+    if not edits:
+        raise _Fail(Reason.INVALID_OPERATION_SHAPE, "edits must hold at least one edit")
+    if len(edits) > MAX_EDITS_PER_OPERATION:
+        raise _Fail(
+            Reason.INVALID_OPERATION_SHAPE,
+            f"an edit_text operation takes at most {MAX_EDITS_PER_OPERATION} edits",
+        )
+    if len(text) > MAX_TEXT_LENGTH:
+        raise _Fail(
+            Reason.TEXT_TOO_LARGE,
+            f"the target string is {len(text)} characters; the limit is "
+            f"{MAX_TEXT_LENGTH}",
+        )
+
+    folded_text = _fold(text) if tolerance == "prose" else None
+    used_normalized = False
+    matches: List[Tuple[int, int, str, int]] = []
+
+    for index, edit in enumerate(edits):
+        if not isinstance(edit, dict) or set(edit) - {"old_text", "new_text"}:
+            raise _Fail(
+                Reason.INVALID_OPERATION_SHAPE,
+                f"edits[{index}] must hold exactly 'old_text' and 'new_text'",
+            )
+        old_text = edit.get("old_text")
+        new_text = edit.get("new_text")
+        if not isinstance(old_text, str) or not isinstance(new_text, str):
+            raise _Fail(
+                Reason.INVALID_OPERATION_SHAPE,
+                f"edits[{index}]: 'old_text' and 'new_text' must be strings",
+            )
+        if old_text == "":
+            raise _Fail(
+                Reason.EMPTY_OLD_TEXT,
+                f"edits[{index}].old_text must not be empty",
+                edit_index=index,
+            )
+        if len(old_text) > MAX_OLD_TEXT_LENGTH:
+            raise _Fail(
+                Reason.INVALID_OPERATION_SHAPE,
+                f"edits[{index}].old_text is {len(old_text)} characters; the limit is "
+                f"{MAX_OLD_TEXT_LENGTH}",
+            )
+
+        count = _count_overlapping(text, old_text)
+        haystack, needle, normalized = text, old_text, False
+        if count == 0 and folded_text is not None:
+            folded_old = _fold(old_text)
+            folded_count = _count_overlapping(folded_text, folded_old)
+            if folded_count:
+                haystack, needle, normalized = folded_text, folded_old, True
+                count = folded_count
+
+        if count == 0:
+            raise _Fail(
+                Reason.TEXT_NOT_FOUND,
+                f"edits[{index}].old_text does not occur in the target string. "
+                "The text must match exactly, with all whitespace and newlines.",
+                edit_index=index,
+            )
+        if count > 1:
+            raise _Fail(
+                Reason.TEXT_NOT_UNIQUE,
+                f"edits[{index}].old_text matched {count} times.",
+                edit_index=index,
+                match_count=count,
+            )
+
+        # The fold is length-preserving, so a folded offset is the original offset.
+        start = haystack.find(needle)
+        matches.append((start, len(needle), new_text, index))
+        used_normalized = used_normalized or normalized
+
+    matches.sort(key=lambda match: match[0])
+    for position in range(1, len(matches)):
+        previous, current = matches[position - 1], matches[position]
+        if previous[0] + previous[1] > current[0]:
+            raise _Fail(
+                Reason.TEXT_EDITS_OVERLAP,
+                f"edits[{previous[3]}] and edits[{current[3]}] overlap.",
+                edit_indexes=[previous[3], current[3]],
+            )
+
+    result = text
+    for start, length, new_text, _ in reversed(matches):
+        result = result[:start] + new_text + result[start + length :]
+
+    if result == text:
+        raise _Fail(
+            Reason.NO_CHANGE,
+            "The edits produced identical content. Nothing would change.",
+        )
+    return result, used_normalized
+
+
+# --------------------------------------------------------------------------------------
+# Operations
+# --------------------------------------------------------------------------------------
+
+
+def _operation_value(operation: Dict[str, Any]) -> Any:
+    if "value" not in operation:
+        raise _Fail(Reason.MISSING_OPERATION_VALUE, "the operation needs a 'value'")
+    value = operation["value"]
+    _reject_file_markers(value)
+    return value
+
+
+def _require_field_tail(segments: Sequence[Segment], verb: str) -> None:
+    if isinstance(segments[-1], dict):
+        raise _Fail(
+            Reason.INVALID_TARGET_SHAPE,
+            f"'{verb}' addresses an object field, so the last target segment must be a "
+            "plain string. Use add_item / replace_item / remove_item for list entries.",
+        )
+
+
+def _require_selector_tail(segments: Sequence[Segment], verb: str) -> None:
+    if not isinstance(segments[-1], dict):
+        raise _Fail(
+            Reason.INVALID_TARGET_SHAPE,
+            f"'{verb}' addresses one named list entry, so the last target segment must "
+            "be a {list, key} object.",
+        )
+
+
+def _derived_key(list_name: str, value: Any, verb: str) -> str:
+    key = item_key(list_name, value, allow_legacy_fallback=False)
+    if key is None:
+        raise _Fail(
+            Reason.ITEM_KEY_UNDEFINED,
+            f"'{verb}' cannot derive a key for the new '{list_name}' entry.",
+        )
+    return key
+
+
+def _parent_of(
+    root: Dict[str, Any], segments: Sequence[Segment], *, create: bool
+) -> Any:
+    if len(segments) == 1:
+        return root
+    walker = _walk_creating if create else _walk
+    return walker(root, segments[:-1])
+
+
+def _require_object_parent(parent: Any, field_name: Any) -> Dict[str, Any]:
+    if not isinstance(parent, dict):
+        raise _Fail(
+            Reason.TARGET_TYPE_MISMATCH,
+            f"the parent of {field_name!r} is {_type_name(parent)}, not an object",
+        )
+    return parent
+
+
+def _apply_operation(
+    root: Dict[str, Any],
+    operation: Dict[str, Any],
+    warnings: List[Warning],
+    index: int,
+    touched: "_Touched",
+) -> None:
+    verb = operation.get("operation")
+    if verb not in OPERATIONS:
+        raise _Fail(
+            Reason.UNKNOWN_OPERATION,
+            f"unknown operation {verb!r} (known: {', '.join(OPERATIONS)})",
+        )
+
+    segments = operation.get("target")
+    if not isinstance(segments, list) or not segments:
+        raise _Fail(
+            Reason.INVALID_TARGET_SHAPE, "the operation needs a non-empty 'target'"
+        )
+    if len(segments) > MAX_TARGET_SEGMENTS:
+        raise _Fail(
+            Reason.INVALID_TARGET_SHAPE,
+            f"a target takes at most {MAX_TARGET_SEGMENTS} segments",
+        )
+    for position, segment in enumerate(segments):
+        _validate_segment(segment, position)
+
+    if verb in VALUE_BEARING:
+        value = _operation_value(operation)
+    elif "value" in operation:
+        raise _Fail(Reason.INVALID_OPERATION_SHAPE, f"'{verb}' does not take a value")
+    else:
+        value = None
+
+    if verb == "set":
+        _require_field_tail(segments, "set")
+        parent = _require_object_parent(
+            _parent_of(root, segments, create=True), segments[-1]
+        )
+        _warn_wholesale(segments[-1], value, warnings, index, segments)
+        parent[segments[-1]] = deepcopy(value)
+        touched.branch(segments)
+        return
+
+    if verb == "merge":
+        _require_field_tail(segments, "merge")
+        if not isinstance(value, dict):
+            raise _Fail(Reason.INVALID_OPERATION_SHAPE, "'merge' takes an object value")
+        parent = _require_object_parent(
+            _parent_of(root, segments, create=False), segments[-1]
+        )
+        name = segments[-1]
+        if name not in parent:
+            raise _Fail(Reason.TARGET_NOT_FOUND, f"{name!r} does not exist")
+        current = parent[name]
+        if not isinstance(current, dict):
+            raise _Fail(
+                Reason.TARGET_TYPE_MISMATCH,
+                f"'merge' needs an object target; {name!r} is {_type_name(current)}",
+            )
+        parent[name] = deep_merge(current, deepcopy(value))
+        touched.branch(segments)
+        return
+
+    if verb == "remove":
+        _require_field_tail(segments, "remove")
+        parent = _require_object_parent(
+            _parent_of(root, segments, create=False), segments[-1]
+        )
+        name = segments[-1]
+        if name not in parent:
+            raise _Fail(Reason.TARGET_NOT_FOUND, f"{name!r} does not exist")
+        del parent[name]
+        touched.branch(segments)
+        return
+
+    if verb == "edit_text":
+        _require_field_tail(segments, "edit_text")
+        mode = operation.get("match_mode", "auto")
+        if mode not in MATCH_MODES:
+            raise _Fail(
+                Reason.UNKNOWN_OPERATION,
+                f"unknown match_mode {mode!r} (known: {', '.join(MATCH_MODES)})",
+            )
+        edits = operation.get("edits")
+        if not isinstance(edits, list):
+            raise _Fail(
+                Reason.INVALID_OPERATION_SHAPE, "'edit_text' needs an 'edits' list"
+            )
+        parent = _require_object_parent(
+            _parent_of(root, segments, create=False), segments[-1]
+        )
+        name = segments[-1]
+        if name not in parent:
+            raise _Fail(Reason.TARGET_NOT_FOUND, f"{name!r} does not exist")
+        current = parent[name]
+        if not isinstance(current, str):
+            raise _Fail(
+                Reason.TARGET_TYPE_MISMATCH,
+                f"'edit_text' needs a string target; {name!r} is {_type_name(current)}",
+            )
+        tolerance = "code" if mode == "exact" else content_class(name)
+        new_text, normalized = apply_text_edits(current, edits, tolerance=tolerance)
+        parent[name] = new_text
+        if normalized:
+            warnings.append(
+                Warning(
+                    code=WarningCode.TEXT_MATCHED_NORMALIZED,
+                    message=(
+                        "An anchor matched only after normalizing quotes, dashes, and "
+                        "spaces. The stored text is unchanged outside the replaced span."
+                    ),
+                    target=list(segments),
+                    operation_index=index,
+                )
+            )
+        return
+
+    if verb == "add_item":
+        _require_field_tail(segments, "add_item")
+        list_name = segments[-1]
+        if list_name not in KEY_FIELDS:
+            raise _Fail(
+                Reason.UNKEYED_COLLECTION,
+                f"'{list_name}' is not a name-addressed list "
+                f"(known: {', '.join(sorted(KEY_FIELDS))})",
+            )
+        collection = _walk(root, segments)
+        if not isinstance(collection, list):
+            raise _Fail(
+                Reason.TARGET_TYPE_MISMATCH,
+                f"the target is {_type_name(collection)}, not a list",
+            )
+        key = _derived_key(list_name, value, "add_item")
+        if any(item_key(list_name, entry) == key for entry in collection):
+            raise _Fail(
+                Reason.ITEM_ALREADY_EXISTS,
+                f"'{list_name}' already holds an entry named {key!r}.",
+            )
+        collection.append(deepcopy(value))
+        touched.item(segments)
+        return
+
+    if verb == "replace_item":
+        _require_selector_tail(segments, "replace_item")
+        selector = segments[-1]
+        list_name, key = selector["list"], selector["key"]
+        parent = _parent_of(root, segments, create=False)
+        collection, position = _find_item(
+            parent, list_name, key, where=f"target segment {len(segments) - 1}"
+        )
+        new_key = _derived_key(list_name, value, "replace_item")
+        if new_key != key:
+            raise _Fail(
+                Reason.ITEM_RENAME_NOT_ALLOWED,
+                f"the target names {key!r} but the value is named {new_key!r}.",
+            )
+        collection[position] = deepcopy(value)
+        touched.item(segments[:-1] + [list_name])
+        return
+
+    _require_selector_tail(segments, "remove_item")
+    selector = segments[-1]
+    parent = _parent_of(root, segments, create=False)
+    collection, position = _find_item(
+        parent,
+        selector["list"],
+        selector["key"],
+        where=f"target segment {len(segments) - 1}",
+    )
+    del collection[position]
+    touched.item(segments[:-1] + [selector["list"]])
+
+
+def _warn_wholesale(
+    name: Any,
+    value: Any,
+    warnings: List[Warning],
+    index: int,
+    segments: Sequence[Segment],
+) -> None:
+    if name in ("tools", "skills", "mcps") and isinstance(value, list):
+        warnings.append(
+            Warning(
+                code=WarningCode.WHOLESALE_LIST_REPLACE,
+                message=(
+                    f"The change replaced the whole '{name}' list. Use add_item, "
+                    "replace_item, or remove_item to change one entry."
+                ),
+                target=list(segments),
+                operation_index=index,
+            )
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Unique names
+# --------------------------------------------------------------------------------------
+
+
+class _Touched:
+    """Which keyed lists an operation could have changed. Contract section 9."""
+
+    def __init__(self) -> None:
+        self.item_paths: List[Tuple[str, ...]] = []
+        self.branch_paths: List[Tuple[str, ...]] = []
+
+    @staticmethod
+    def _plain(segments: Sequence[Segment]) -> Tuple[str, ...]:
+        # A selector stands in place of its list's name, so it flattens to that name.
+        return tuple(s["list"] if isinstance(s, dict) else s for s in segments)
+
+    def item(self, segments: Sequence[Segment]) -> None:
+        self.item_paths.append(self._plain(segments))
+
+    def branch(self, segments: Sequence[Segment]) -> None:
+        self.branch_paths.append(self._plain(segments))
+
+
+def _collections(
+    tree: Any, path: Tuple[str, ...] = ()
+) -> Dict[Tuple[str, ...], List[Any]]:
+    """Every keyed list in a tree, by its path."""
+    found: Dict[Tuple[str, ...], List[Any]] = {}
+    if isinstance(tree, dict):
+        for key, value in tree.items():
+            child = path + (key,)
+            if key in KEY_FIELDS and isinstance(value, list):
+                found[child] = value
+            found.update(_collections(value, child))
+    elif isinstance(tree, list):
+        for entry in tree:
+            found.update(_collections(entry, path))
+    return found
+
+
+def _duplicates(list_name: str, entries: Sequence[Any]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for entry in entries:
+        key = item_key(list_name, entry)
+        if key is not None:
+            counts[key] = counts.get(key, 0) + 1
+    return {key: count for key, count in counts.items() if count > 1}
+
+
+def _check_unique_names(
+    base: Dict[str, Any],
+    result: Dict[str, Any],
+    touched: _Touched,
+    warnings: List[Warning],
+) -> None:
+    before = {
+        path: _duplicates(path[-1], entries)
+        for path, entries in _collections(base).items()
+    }
+    for path, entries in _collections(result).items():
+        after = _duplicates(path[-1], entries)
+        if not after:
+            continue
+        was = before.get(path, {})
+        item_touched = any(p == path for p in touched.item_paths)
+        branch_touched = any(
+            len(p) <= len(path) and path[: len(p)] == p for p in touched.branch_paths
+        )
+        if item_touched:
+            raise _Fail(
+                Reason.DUPLICATE_ITEM_KEY,
+                f"'{'.'.join(path)}' holds duplicate keys: {', '.join(sorted(after))}.",
+                duplicates=sorted(after),
+            )
+        grew = [key for key, count in after.items() if count > was.get(key, 0)]
+        if branch_touched and grew:
+            raise _Fail(
+                Reason.DUPLICATE_ITEM_KEY,
+                f"the change adds a duplicate key to '{'.'.join(path)}': "
+                f"{', '.join(sorted(grew))}.",
+                duplicates=sorted(grew),
+            )
+        warnings.append(
+            Warning(
+                code=WarningCode.LEGACY_DUPLICATE_KEY,
+                message=(
+                    f"'{'.'.join(path)}' already held duplicate keys before this change: "
+                    f"{', '.join(sorted(after))}. Entries with a duplicate key cannot be "
+                    "addressed by name."
+                ),
+                target=list(path),
+            )
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Delta form
+# --------------------------------------------------------------------------------------
+
+
+_LEGACY_FIELDS = ("set", "remove")
+
+
+def _classify(delta: Dict[str, Any]) -> str:
+    if not isinstance(delta, dict):
+        raise ChangeSetError(Reason.INVALID_DELTA, "the delta must be an object")
+    unknown = set(delta) - {"set", "remove", "operations"}
+    if unknown:
+        raise ChangeSetError(
+            Reason.INVALID_DELTA,
+            f"unknown delta fields: {', '.join(sorted(unknown))}",
+        )
+    has_legacy = any(delta.get(name) is not None for name in _LEGACY_FIELDS)
+    has_ordered = delta.get("operations") is not None
+    if has_legacy and has_ordered:
+        raise ChangeSetError(
+            Reason.INVALID_DELTA,
+            "a delta uses either 'set'/'remove' or 'operations', never both.",
+        )
+    if has_ordered:
+        return "ordered"
+    if has_legacy:
+        return "legacy"
+    raise ChangeSetError(
+        Reason.INVALID_DELTA,
+        "the delta is empty: give 'set'/'remove', or 'operations'.",
+    )
+
+
+def _legacy_scope_targets(delta: Dict[str, Any], depth: int) -> List[Target]:
+    targets: List[Target] = []
+
+    def walk(node: Any, path: List[str]) -> None:
+        if len(path) >= depth or not isinstance(node, dict) or not node:
+            targets.append(list(path))
+            return
+        for key, value in node.items():
+            walk(value, path + [key])
+
+    for key, value in (delta.get("set") or {}).items():
+        walk(value, [key])
+    for path in delta.get("remove") or []:
+        targets.append(path.split("."))
+    return targets
+
+
+def _policy_depth(scope_policy: ScopePolicy) -> int:
+    depth = getattr(scope_policy, "_prefix_depth", None)
+    return depth if isinstance(depth, int) else 1
+
+
+# --------------------------------------------------------------------------------------
+# The engine
+# --------------------------------------------------------------------------------------
+
+
+def apply_change_set(
+    base: Dict[str, Any],
+    delta: Dict[str, Any],
+    scope_policy: Optional[ScopePolicy] = None,
+    *,
+    validate: Optional[Callable[[Dict[str, Any]], Any]] = None,
+) -> ChangeSetResult:
+    """Apply ``delta`` to ``base``. Contract sections 7 and 8.
+
+    Pure: ``base`` is never modified. On any failure it raises :class:`ChangeSetError` and
+    no partial result escapes.
+    """
+    policy = scope_policy or allow_all
+    form = _classify(delta)
+    result = deepcopy(base) if base else {}
+    warnings: List[Warning] = []
+    touched = _Touched()
+
+    if form == "legacy":
+        for target in _legacy_scope_targets(delta, _policy_depth(policy)):
+            refusal = policy(target)
+            if refusal:
+                raise ChangeSetError(Reason.OUT_OF_SCOPE, refusal, target=list(target))
+        warnings.append(
+            Warning(
+                code=WarningCode.LEGACY_DELTA_FORM,
+                message=(
+                    "This change used the legacy set/remove form. Ordered operations "
+                    "change one field or one list entry at a time."
+                ),
+            )
+        )
+        patch = delta.get("set") or {}
+        _reject_delta_markers(patch)
+        for name in ("tools", "skills", "mcps"):
+            nested = _legacy_list_write(patch, name)
+            if nested is not None:
+                _warn_wholesale(name, nested, warnings, 0, [name])
+        result = deep_merge(result, patch)
+        for path in delta.get("remove") or []:
+            remove_path(result, path)
+        for key in patch:
+            touched.branch([key])
+        return _finish(base, result, warnings, touched, validate)
+
+    operations = delta["operations"]
+    if not isinstance(operations, list) or not operations:
+        raise ChangeSetError(
+            Reason.INVALID_DELTA, "'operations' must hold at least one operation"
+        )
+    if len(operations) > MAX_OPERATIONS:
+        raise ChangeSetError(
+            Reason.INVALID_DELTA,
+            f"a delta takes at most {MAX_OPERATIONS} operations",
+        )
+
+    # The scope guard runs before anything is applied: a refusal is a policy answer, and it
+    # must not depend on how far the change set already got.
+    for index, operation in enumerate(operations):
+        if not isinstance(operation, dict):
+            raise ChangeSetError(
+                Reason.INVALID_OPERATION_SHAPE,
+                "each operation must be an object",
+                operation_index=index,
+            )
+        target = operation.get("target")
+        if isinstance(target, list):
+            refusal = policy(target)
+            if refusal:
+                raise ChangeSetError(
+                    Reason.OUT_OF_SCOPE,
+                    refusal,
+                    operation_index=index,
+                    operation=operation.get("operation"),
+                    target=target,
+                )
+
+    for index, operation in enumerate(operations):
+        try:
+            _apply_operation(result, operation, warnings, index, touched)
+        except _Fail as failure:
+            raise ChangeSetError(
+                failure.reason,
+                failure.message,
+                operation_index=index,
+                operation=operation.get("operation"),
+                target=operation.get("target"),
+                **failure.context,
+            ) from None
+
+    return _finish(base, result, warnings, touched, validate)
+
+
+def _legacy_list_write(patch: Any, name: str) -> Optional[List[Any]]:
+    """The value a legacy `set` writes at any depth for one keyed list name."""
+    if isinstance(patch, dict):
+        for key, value in patch.items():
+            if key == name and isinstance(value, list):
+                return value
+            found = _legacy_list_write(value, name)
+            if found is not None:
+                return found
+    return None
+
+
+def _reject_delta_markers(patch: Any) -> None:
+    markers = find_file_markers(patch)
+    if markers:
+        raise ChangeSetError(
+            Reason.UNRESOLVED_FILE_MARKER,
+            f"an '{FILE_MARKER}' marker appeared in a legacy delta at "
+            f"{', '.join(markers)}. The legacy form does not carry file references.",
+            pointers=markers,
+        )
+
+
+def _finish(
+    base: Dict[str, Any],
+    result: Dict[str, Any],
+    warnings: List[Warning],
+    touched: _Touched,
+    validate: Optional[Callable[[Dict[str, Any]], Any]],
+) -> ChangeSetResult:
+    try:
+        _check_unique_names(base or {}, result, touched, warnings)
+    except _Fail as failure:
+        raise ChangeSetError(
+            failure.reason, failure.message, **failure.context
+        ) from None
+
+    if validate is not None:
+        try:
+            issues = validate(result)
+        except ChangeSetError:
+            raise
+        except Exception as error:  # noqa: BLE001 - any failure is one reason code
+            raise ChangeSetError(
+                Reason.FINAL_VALIDATION_FAILED,
+                "The finished configuration is not valid.",
+                issues=[str(error)],
+            ) from error
+        if issues:
+            raise ChangeSetError(
+                Reason.FINAL_VALIDATION_FAILED,
+                "The finished configuration is not valid.",
+                issues=list(issues),
+            )
+
+    return ChangeSetResult(
+        data=result,
+        changed=result != (base or {}),
+        warnings=warnings,
+    )

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -457,6 +457,9 @@ def subtree_scope(
         return None
 
     policy._prefix = tuple(wanted)  # type: ignore[attr-defined]
+    # The refused paths travel with the policy, because a target that sits ABOVE one of
+    # them writes it through its value, and only the caller of the policy holds that value.
+    policy._refused = tuple(tuple(path) for path in blocked)  # type: ignore[attr-defined]
     # The legacy arm walks the `set` tree only this deep before it asks the policy, so a
     # refused sub-path deeper than the prefix would never be reached and never refused.
     policy._prefix_depth = max(  # type: ignore[attr-defined]
@@ -1326,6 +1329,81 @@ def _policy_depth(scope_policy: ScopePolicy) -> int:
     return depth if isinstance(depth, int) else 1
 
 
+_MISSING = object()
+
+
+def _value_at(tree: Any, path: Sequence[str]) -> Any:
+    """What ``tree`` holds at ``path``, or ``_MISSING`` when the path is not there."""
+    node = tree
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return _MISSING
+        node = node[key]
+    return node
+
+
+def _refused_paths_under(
+    scope_policy: ScopePolicy, target: Target
+) -> List[Tuple[str, ...]]:
+    """Refused paths that lie strictly BELOW this target.
+
+    A selector segment never matches, because no refused path lives inside a list entry.
+    """
+    segments = list(target)
+    found = []
+    for path in getattr(scope_policy, "_refused", ()) or ():
+        if len(path) <= len(segments):
+            continue
+        if all(segments[i] == path[i] for i in range(len(segments))):
+            found.append(path)
+    return found
+
+
+def _check_scope_value(
+    scope_policy: ScopePolicy,
+    *,
+    target: Target,
+    verb: str,
+    value: Any,
+    base: Dict[str, Any],
+    operation_index: Optional[int] = None,
+) -> None:
+    """Refuse an operation that writes a refused path THROUGH an ancestor target.
+
+    The target check alone asks whether the caller named a refused path. It does not ask
+    what the caller writes, so `set` on `parameters.agent.harness` with
+    `{"kind": "codex"}` passed while `set` on `parameters.agent.harness.kind` was refused.
+    Both change the same stored field.
+
+    The rule is one sentence: whatever the operation would leave at a refused path must
+    equal what is stored there now. That keeps the neighbours of a refused key writable,
+    which matters because `harness.extras` and `runner.kind` are not refused and sit beside
+    keys that are. An outright refusal of the parents would take those away with no gain.
+
+    An omission is a write for `set`, which replaces its target wholesale, and for
+    `remove`, which deletes it. It is not a write for `merge`, which leaves absent keys
+    alone.
+    """
+    for path in _refused_paths_under(scope_policy, target):
+        stored = _value_at(base or {}, path)
+        if verb == "remove":
+            written: Any = _MISSING
+        else:
+            written = _value_at(value, path[len(list(target)) :])
+            if verb == "merge" and written is _MISSING:
+                written = stored
+        if written == stored:
+            continue
+        raise ChangeSetError(
+            Reason.OUT_OF_SCOPE,
+            f"this changes '{'.'.join(path)}', which is owned by the platform and "
+            "cannot be changed by the agent",
+            target=list(target),
+            operation_index=operation_index,
+            next_step=_scope_next_step(scope_policy),
+        )
+
+
 def _scope_next_step(scope_policy: ScopePolicy) -> str:
     """What to do about a scope refusal, naming the subtree the caller may write.
 
@@ -1374,6 +1452,23 @@ def apply_change_set(
                     target=list(target),
                     next_step=_scope_next_step(policy),
                 )
+        # The legacy `set` is one deep merge at the root, so one check over the whole patch
+        # covers every refused path it would write, at any depth.
+        _check_scope_value(
+            policy,
+            target=[],
+            verb="merge",
+            value=delta.get("set") or {},
+            base=base,
+        )
+        for path in delta.get("remove") or []:
+            _check_scope_value(
+                policy,
+                target=path.split("."),
+                verb="remove",
+                value=None,
+                base=base,
+            )
         warnings.append(
             Warning(
                 code=WarningCode.LEGACY_DELTA_FORM,
@@ -1427,6 +1522,19 @@ def apply_change_set(
                     operation=operation.get("operation"),
                     target=target,
                     next_step=_scope_next_step(policy),
+                )
+            # These four verbs carry or delete a whole subtree, so each can reach a refused
+            # path that its target only sits above. `add_item` and `remove_item` change a
+            # list entry and `edit_text` changes a string; no refused path lives in either.
+            verb = operation.get("operation")
+            if verb in ("set", "merge", "remove", "replace_item"):
+                _check_scope_value(
+                    policy,
+                    target=target,
+                    verb=verb,
+                    value=operation.get("value"),
+                    base=base,
+                    operation_index=index,
                 )
 
     for index, operation in enumerate(operations):

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -11,13 +11,13 @@ true), and every retryable reason code carries a next-step sentence.
 """
 
 import copy
+import typing
 
 import pytest
-
 from oss.src.core.workflows.change_set import (
     AGENT_COMMIT_SCOPE,
-    ChangeSetError,
     PARAMETERS_ONLY,
+    ChangeSetError,
     Reason,
     WarningCode,
     apply_change_set,
@@ -28,7 +28,6 @@ from oss.src.core.workflows.change_set import (
     item_key,
     subtree_scope,
 )
-
 
 # --------------------------------------------------------------------------------------
 # Fixtures
@@ -1379,7 +1378,6 @@ class TestFinalValidation:
 
         def validate(data):
             seen["model"] = data["parameters"]["agent"]["llm"]["model"]
-            return None
 
         apply(
             ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
@@ -1922,7 +1920,7 @@ class TestUniqueNames:
 
 
 class TestErrorSplit:
-    RETRYABLE = [
+    RETRYABLE: typing.ClassVar = [
         (
             Reason.TARGET_NOT_FOUND,
             ops({"operation": "remove", "target": AGENT + ["x"]}),
@@ -1994,7 +1992,7 @@ class TestErrorSplit:
     def test_every_retryable_code_has_a_next_step_sentence(self):
         # Contract 12.3 makes this mandatory, so a missing entry is a contract violation,
         # not a cosmetic gap.
-        from oss.src.core.workflows.change_set import NEXT_STEPS, _NOT_RETRYABLE
+        from oss.src.core.workflows.change_set import _NOT_RETRYABLE, NEXT_STEPS
 
         codes = {
             value

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -189,16 +189,44 @@ LEGACY_CASES = [
 ]
 
 
-class TestLegacyMatchesService:
+def reference_legacy_apply(base, delta):
+    """The legacy fold, written out independently of the engine.
+
+    It is a transcription of what `service.py` did before the legacy arm moved into the
+    engine: deep-merge `set`, then delete each `remove` path, in that order. Keeping an
+    independent copy HERE is the point — it is what makes the parametrized table below a
+    check on the engine rather than a restatement of it.
+    """
+
+    def merge(into, patch):
+        for key, value in patch.items():
+            if (
+                isinstance(value, dict)
+                and isinstance(into.get(key), dict)
+                and into.get(key) is not None
+            ):
+                merge(into[key], value)
+            else:
+                into[key] = copy.deepcopy(value)
+        return into
+
+    result = merge(copy.deepcopy(base), delta.get("set") or {})
+    for path in delta.get("remove") or []:
+        keys = path.split(".")
+        node = result
+        for key in keys[:-1]:
+            node = node.get(key) if isinstance(node, dict) else None
+            if not isinstance(node, dict):
+                break
+        else:
+            node.pop(keys[-1], None)
+    return result
+
+
+class TestLegacyMatchesTheOriginalFold:
     @pytest.mark.parametrize("delta,_unused", LEGACY_CASES)
-    def test_same_result_as_service_helpers(self, delta, _unused):
-        from oss.src.core.workflows.service import _deep_merge, _remove_path
-
-        reference = _deep_merge(base_config(), delta.get("set") or {})
-        for path in delta.get("remove") or []:
-            _remove_path(reference, path)
-
-        assert apply(delta) == reference
+    def test_same_result_as_the_original_fold(self, delta, _unused):
+        assert apply(delta) == reference_legacy_apply(base_config(), delta)
 
     def test_lists_replace_whole(self):
         result = apply({"set": {"parameters": {"agent": {"skills": []}}}})
@@ -220,28 +248,16 @@ class TestLegacyMatchesService:
         assert result == base_config()
 
     def test_the_base_is_never_modified(self):
-        # service.py's `_remove_path` mutates through the shallow `_deep_merge` copy.
-        # The engine deep-copies first, so a caller's base survives.
+        # The original fold merged shallowly and then removed through the copy, so a
+        # remove reached back into the caller's base. The engine deep-copies first.
         base = base_config()
         snapshot = copy.deepcopy(base)
         apply({"remove": ["parameters.agent.tools"]}, base)
         assert base == snapshot
 
-    def test_service_helpers_do_mutate_the_base(self):
-        # This documents the aliasing defect the engine fixes. If it ever fails,
-        # service.py changed and the note in the spike report is stale.
-        from oss.src.core.workflows.service import _deep_merge, _remove_path
-
-        base = base_config()
-        merged = _deep_merge(base, {"uri": "/other"})
-        _remove_path(merged, "parameters.agent.tools")
-        assert "tools" not in base["parameters"]["agent"]
-
 
 class TestDeepMergeParity:
-    def test_engine_deep_merge_matches_service_deep_merge(self):
-        from oss.src.core.workflows.service import _deep_merge
-
+    def test_engine_deep_merge_matches_the_original_fold(self):
         cases = [
             ({}, {"a": 1}),
             ({"a": {"b": 1}}, {"a": {"c": 2}}),
@@ -251,7 +267,9 @@ class TestDeepMergeParity:
             ({"a": None}, {"a": {"b": 2}}),
         ]
         for base, patch in cases:
-            assert deep_merge(base, patch) == _deep_merge(base, patch)
+            assert deep_merge(base, patch) == reference_legacy_apply(
+                base, {"set": patch}
+            )
 
 
 # --------------------------------------------------------------------------------------
@@ -1914,6 +1932,91 @@ class TestUniqueNames:
             ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"})
         )
         assert WarningCode.LEGACY_DUPLICATE_KEY not in codes
+
+
+class TestNestedCollectionIdentity:
+    """A nested list belongs to the entry that holds it (contract 9).
+
+    Every case here has TWO skills, because that is what it takes to see the bug: the
+    paths carried only the list name, so all the skills' `files` lists collapsed onto one
+    key and the last one silently answered for every other. Which skill held the
+    duplicates then decided the outcome, and both possible outcomes were wrong.
+    """
+
+    def _skills(self, alpha_files, beta_files, alpha_first=True):
+        base = base_config()
+        alpha = {"name": "alpha", "description": "d", "files": alpha_files}
+        beta = {"name": "beta", "description": "d", "files": beta_files}
+        base["parameters"]["agent"]["skills"] = (
+            [alpha, beta] if alpha_first else [beta, alpha]
+        )
+        return base
+
+    def _files(self, *paths):
+        return [{"path": path, "content": "x"} for path in paths]
+
+    def test_a_sibling_duplicate_does_not_block_a_clean_edit(self):
+        # `beta` was never touched. Its duplicates are its own, and rule 2 keeps every
+        # existing configuration editable.
+        result = run(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + [{"list": "skills", "key": "alpha"}, "files"],
+                    "value": {"path": "new.md", "content": "n"},
+                }
+            ),
+            self._skills(self._files("a.md"), self._files("d.md", "d.md")),
+        )
+        assert WarningCode.LEGACY_DUPLICATE_KEY in [w.code for w in result.warnings]
+
+    @pytest.mark.parametrize("alpha_first", [True, False])
+    def test_a_new_duplicate_is_refused_wherever_the_skill_sits(self, alpha_first):
+        # The order of the skills decided this before: writing the duplicate into the
+        # LAST skill was refused and writing it into any other was accepted in silence.
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + [{"list": "skills", "key": "alpha"}, "files"],
+                    "value": self._files("d.md", "d.md"),
+                }
+            ),
+            self._skills(self._files("a.md"), self._files("b.md"), alpha_first),
+        )
+        assert error.reason == Reason.DUPLICATE_ITEM_KEY
+        assert "skills[alpha].files" in error.message
+
+    def test_renaming_a_file_onto_a_sibling_is_refused(self):
+        # The collision is inside the touched skill, and the write that causes it is a
+        # `set` on the key field of one entry.
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT
+                    + [
+                        {"list": "skills", "key": "alpha"},
+                        {"list": "files", "key": "b.md"},
+                        "path",
+                    ],
+                    "value": "a.md",
+                }
+            ),
+            self._skills(self._files("a.md", "b.md"), self._files("c.md")),
+        )
+        assert error.reason == Reason.DUPLICATE_ITEM_KEY
+
+    def test_a_duplicate_warning_names_the_skill_that_holds_it(self):
+        result = run(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
+            self._skills(self._files("d.md", "d.md"), self._files("c.md")),
+        )
+        warning = next(
+            w for w in result.warnings if w.code == WarningCode.LEGACY_DUPLICATE_KEY
+        )
+        # The target stays addressable, so a caller can act on it without parsing prose.
+        assert {"list": "skills", "key": "alpha"} in warning.target
 
 
 # --------------------------------------------------------------------------------------

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -2176,6 +2176,92 @@ class TestAgentCommitScope:
         assert error.retryable is False
 
 
+class TestMalformedEntriesAndBounds:
+    """Three ways a payload used to leave the engine's own error vocabulary."""
+
+    def test_a_non_string_tool_name_is_not_addressable(self):
+        # `item_key` fed the raw value to the duplicate report, which joins keys into a
+        # sentence. A number there raised TypeError, so a malformed payload became a 500
+        # instead of a change-set refusal. An entry with no usable key is simply not
+        # addressable, which is what the keyed lists already did.
+        base = {"parameters": {"agent": {"tools": [{"type": "platform", "op": 7}]}}}
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": "z",
+                }
+            ),
+            base,
+        )
+        assert result["parameters"]["agent"]["tools"][0]["op"] == 7
+
+    def test_two_unaddressable_tools_do_not_collide(self):
+        # Neither entry has a key, so neither is a duplicate of the other.
+        base = {
+            "parameters": {
+                "agent": {
+                    "tools": [
+                        {"type": "platform", "op": None},
+                        {"type": "platform", "op": 7},
+                    ]
+                }
+            }
+        }
+        assert apply(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
+            base,
+        )
+
+    def test_edits_that_would_grow_past_the_limit_are_refused(self):
+        # The input and each anchor are bounded; the RESULT was not. A field pushed past
+        # the limit can never be edited again, because the next call refuses its own input.
+        text = "a" * 100
+        base = {"parameters": {"agent": {"instructions": {"agents_md": text}}}}
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": "a" * 100, "new_text": "b" * 200_001}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_TOO_LARGE
+
+    def test_an_edit_that_lands_exactly_on_the_limit_is_allowed(self):
+        text = "a" * 100
+        base = {"parameters": {"agent": {"instructions": {"agents_md": text}}}}
+        result = apply(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": "a" * 100, "new_text": "b" * 200_000}],
+                }
+            ),
+            base,
+        )
+        assert (
+            len(result["parameters"]["agent"]["instructions"]["agents_md"]) == 200_000
+        )
+
+    def test_the_caller_delta_is_not_modified(self):
+        # `remove_path` mutates the result, and the result held the caller's own sub-dicts.
+        # A caller that reused its delta got a tree the engine had already edited.
+        delta = {
+            "set": {
+                "parameters": {"agent": {"llm": {"model": "z", "extras": {"a": 1}}}}
+            },
+            "remove": ["parameters.agent.llm.extras"],
+        }
+        snapshot = copy.deepcopy(delta)
+        apply(delta)
+        assert delta == snapshot
+
+
 class TestAgentCommitScopeThroughAnAncestor:
     """A write to a parent of a refused path is a write to the refused path.
 

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -11,13 +11,13 @@ true), and every retryable reason code carries a next-step sentence.
 """
 
 import copy
-import typing
 
 import pytest
+
 from oss.src.core.workflows.change_set import (
     AGENT_COMMIT_SCOPE,
-    PARAMETERS_ONLY,
     ChangeSetError,
+    PARAMETERS_ONLY,
     Reason,
     WarningCode,
     apply_change_set,
@@ -28,6 +28,7 @@ from oss.src.core.workflows.change_set import (
     item_key,
     subtree_scope,
 )
+
 
 # --------------------------------------------------------------------------------------
 # Fixtures
@@ -1378,6 +1379,7 @@ class TestFinalValidation:
 
         def validate(data):
             seen["model"] = data["parameters"]["agent"]["llm"]["model"]
+            return None
 
         apply(
             ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
@@ -1920,7 +1922,7 @@ class TestUniqueNames:
 
 
 class TestErrorSplit:
-    RETRYABLE: typing.ClassVar = [
+    RETRYABLE = [
         (
             Reason.TARGET_NOT_FOUND,
             ops({"operation": "remove", "target": AGENT + ["x"]}),
@@ -1992,7 +1994,7 @@ class TestErrorSplit:
     def test_every_retryable_code_has_a_next_step_sentence(self):
         # Contract 12.3 makes this mandatory, so a missing entry is a contract violation,
         # not a cosmetic gap.
-        from oss.src.core.workflows.change_set import _NOT_RETRYABLE, NEXT_STEPS
+        from oss.src.core.workflows.change_set import NEXT_STEPS, _NOT_RETRYABLE
 
         codes = {
             value

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -2174,3 +2174,178 @@ class TestAgentCommitScope:
         )
         assert error.reason == Reason.OUT_OF_SCOPE
         assert error.retryable is False
+
+
+class TestAgentCommitScopeThroughAnAncestor:
+    """A write to a parent of a refused path is a write to the refused path.
+
+    This is how the scope was defeated on a live stack: the target check asks which path
+    the caller NAMED, and `set` on `parameters.agent.harness` names none of the refused
+    paths. Its value changed `harness.kind` all the same, the human approved it, and the
+    commit landed.
+
+    The rule now is that whatever an operation would leave at a refused path must equal
+    what is stored there. That keeps the writable neighbours writable: `harness.extras` and
+    `runner.kind` are not refused, and they sit beside keys that are.
+    """
+
+    SELECTORS = {
+        "harness": {"kind": "pi_core"},
+        "sandbox": {"kind": "local"},
+        "runner": {"kind": "sidecar", "permissions": {"default": "allow_reads"}},
+    }
+
+    def base(self):
+        config = base_config()
+        config["parameters"]["agent"].update(copy.deepcopy(self.SELECTORS))
+        return config
+
+    def refuse(self, delta):
+        error = failure(delta, self.base(), scope_policy=AGENT_COMMIT_SCOPE)
+        assert error.reason == Reason.OUT_OF_SCOPE
+        assert error.next_step
+        return error
+
+    def test_the_live_bypass_payload_is_refused(self):
+        # The exact operation the agent sent on the stack, verbatim.
+        error = self.refuse(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness"],
+                    "value": {"kind": "codex"},
+                }
+            )
+        )
+        assert "parameters.agent.harness.kind" in error.message
+
+    def test_a_merge_at_the_agent_root_cannot_smuggle_a_refused_key(self):
+        error = self.refuse(
+            ops(
+                {
+                    "operation": "merge",
+                    "target": AGENT,
+                    "value": {"harness": {"kind": "codex"}},
+                }
+            )
+        )
+        assert "parameters.agent.harness.kind" in error.message
+
+    @pytest.mark.parametrize(
+        "target,value,expected",
+        [
+            (["sandbox"], {"kind": "daytona"}, "parameters.agent.sandbox.kind"),
+            (
+                ["sandbox"],
+                {"permissions": {"network": "all"}},
+                "parameters.agent.sandbox.kind",
+            ),
+            (
+                ["runner"],
+                {"permissions": {"default": "allow"}},
+                "parameters.agent.runner.permissions",
+            ),
+            (
+                ["harness"],
+                {"permissions": {"allow": ["*"]}},
+                "parameters.agent.harness.kind",
+            ),
+        ],
+    )
+    def test_every_selector_is_covered(self, target, value, expected):
+        error = self.refuse(
+            ops({"operation": "set", "target": AGENT + target, "value": value})
+        )
+        assert expected in error.message
+
+    def test_removing_a_parent_deletes_a_refused_path(self):
+        # A delete is a write. Nothing in the operation names `kind`, and the stored value
+        # is gone all the same.
+        error = self.refuse(ops({"operation": "remove", "target": AGENT + ["harness"]}))
+        assert "parameters.agent.harness.kind" in error.message
+
+    def test_replacing_the_whole_agent_subtree_is_refused(self):
+        # `set` replaces wholesale, so an omitted refused key is a deletion.
+        self.refuse(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT,
+                    "value": {"llm": {"model": "openai/gpt-5"}},
+                }
+            )
+        )
+
+    def test_the_legacy_arm_is_covered_too(self):
+        error = self.refuse(
+            {"set": {"parameters": {"agent": {"harness": {"kind": "codex"}}}}}
+        )
+        assert "parameters.agent.harness.kind" in error.message
+
+    def test_a_legacy_remove_of_a_parent_is_covered(self):
+        error = self.refuse({"set": {}, "remove": ["parameters.agent.harness"]})
+        assert "parameters.agent.harness.kind" in error.message
+
+    def test_a_set_that_preserves_the_refused_values_is_allowed(self):
+        # `harness.extras` is the agent's to write. Taking it away would cost a real
+        # capability to close this hole, and the preserving rule does not.
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness"],
+                    "value": {"kind": "pi_core", "extras": {"verbose": True}},
+                }
+            ),
+            self.base(),
+            scope_policy=AGENT_COMMIT_SCOPE,
+        )
+        harness = result["parameters"]["agent"]["harness"]
+        assert harness == {"kind": "pi_core", "extras": {"verbose": True}}
+
+    def test_a_merge_that_touches_no_refused_key_is_allowed(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "merge",
+                    "target": AGENT + ["harness"],
+                    "value": {"extras": {"verbose": True}},
+                }
+            ),
+            self.base(),
+            scope_policy=AGENT_COMMIT_SCOPE,
+        )
+        assert result["parameters"]["agent"]["harness"]["kind"] == "pi_core"
+
+    def test_a_writable_sibling_of_a_refused_key_stays_writable(self):
+        # `runner.kind` is not refused. A set at `runner` may change it while it preserves
+        # `runner.permissions`.
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["runner"],
+                    "value": {
+                        "kind": "local",
+                        "permissions": {"default": "allow_reads"},
+                    },
+                }
+            ),
+            self.base(),
+            scope_policy=AGENT_COMMIT_SCOPE,
+        )
+        assert result["parameters"]["agent"]["runner"]["kind"] == "local"
+
+    def test_an_unscoped_caller_is_unaffected(self):
+        # The human and SDK route owns the whole revision, including the selectors.
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness"],
+                    "value": {"kind": "codex"},
+                }
+            ),
+            self.base(),
+        )
+        assert result["parameters"]["agent"]["harness"]["kind"] == "codex"

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -892,12 +892,18 @@ class TestAddItem:
         assert error.reason == Reason.ITEM_KEY_UNDEFINED
 
     def test_an_embed_entry_has_no_key(self):
+        # A REAL embed: this cell is about an entry whose key cannot be derived, so the
+        # embed itself has to be well formed or it earns the marker refusal first.
         error = failure(
             ops(
                 {
                     "operation": "add_item",
                     "target": AGENT + ["skills"],
-                    "value": {"@ag.embed": {"@ag.references": {"skill": "x"}}},
+                    "value": {
+                        "@ag.embed": {
+                            "@ag.references": {"workflow_revision": {"id": "abc"}}
+                        }
+                    },
                 }
             )
         )
@@ -2435,3 +2441,236 @@ class TestAgentCommitScopeThroughAnAncestor:
             self.base(),
         )
         assert result["parameters"]["agent"]["harness"]["kind"] == "codex"
+
+
+# --------------------------------------------------------------------------------------
+# Markers the platform does not define (storage integrity)
+# --------------------------------------------------------------------------------------
+
+
+class TestInventedMarkers:
+    """A marker the engine does not understand must never be stored as a value.
+
+    The engine is the last thing that sees a value before it is written. An `@ag.embed`
+    whose references are not references resolves to nothing, so the literal marker dict was
+    stored as the configuration and the agent was told the commit succeeded. Every read
+    after that returned a marker where the text should have been.
+    """
+
+    # Exactly what a live session sent, trying to import a file it had written.
+    HAIKU_PAYLOAD = {
+        "@ag.embed": {
+            "@ag.references": {"file": "/tmp/agenta-workspace/skills/qa/body.md"}
+        }
+    }
+
+    def test_the_invented_embed_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": self.HAIKU_PAYLOAD,
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.INVALID_EMBED
+
+    def test_the_refusal_names_the_file_marker_as_the_way_to_import_a_file(self):
+        # The model was reaching for a file import. Telling it the shape is wrong teaches
+        # nothing; naming the marker that does the job is what recovers the turn.
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": self.HAIKU_PAYLOAD,
+                }
+            ),
+            base_config(),
+        )
+
+        assert "@ag.file" in error.message
+        assert "@ag.embed" in error.message
+
+    def test_the_invented_embed_is_refused_on_the_legacy_arm_too(self):
+        # The arm that merges its patch in whole is the one an invented marker reaches.
+        error = failure(
+            {"set": {"parameters": {"agent": {"instructions": self.HAIKU_PAYLOAD}}}},
+            base_config(),
+        )
+
+        assert error.reason == Reason.INVALID_EMBED
+
+    def test_an_unknown_marker_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": {"@ag.include": "some/path.md"},
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.UNKNOWN_MARKER
+        assert "@ag.include" in error.message
+
+    def test_an_unknown_marker_nested_deep_is_still_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {
+                        "name": "new-skill",
+                        "body": {"nested": [{"@ag.import": "x"}]},
+                    },
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.UNKNOWN_MARKER
+
+    def test_a_reference_that_is_a_bare_string_is_refused(self):
+        # The shape a model reaches for when it means a path. The resolver skips it, so it
+        # resolved to nothing and stored the marker.
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": {
+                        "@ag.embed": {"@ag.references": {"workflow_revision": "v1"}}
+                    },
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.INVALID_EMBED
+
+    def test_an_embed_with_no_references_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": {"@ag.embed": {"@ag.selector": {"path": "params.prompt"}}},
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.INVALID_EMBED
+
+    def test_an_embed_carrying_an_unknown_key_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": {
+                        "@ag.embed": {
+                            "@ag.references": {"workflow_revision": {"id": "abc"}},
+                            "@ag.path": "/tmp/x",
+                        }
+                    },
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.INVALID_EMBED
+
+    def test_every_marker_refusal_is_non_retryable(self):
+        # The same bytes never succeed, so telling the agent to retry would burn its turns.
+        for value in (
+            {"@ag.include": "x"},
+            {"@ag.embed": {"@ag.references": {"file": "/tmp/x"}}},
+        ):
+            error = failure(
+                ops(
+                    {
+                        "operation": "set",
+                        "target": AGENT + ["instructions"],
+                        "value": value,
+                    }
+                ),
+                base_config(),
+            )
+            assert error.retryable is False
+
+    # --- what must keep working ---
+
+    def test_a_real_embed_still_commits(self):
+        value = {
+            "@ag.embed": {
+                "@ag.references": {"workflow_revision": {"id": "019c-abc"}},
+                "@ag.selector": {"path": "parameters.agent.instructions"},
+            }
+        }
+
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": value,
+                }
+            ),
+            base_config(),
+        ).data
+
+        assert result["parameters"]["agent"]["instructions"] == value
+
+    def test_a_real_embed_with_references_only_still_commits(self):
+        value = {"@ag.embed": {"@ag.references": {"workflow_revision": {"slug": "s"}}}}
+
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": value,
+                }
+            ),
+            base_config(),
+        ).data
+
+        assert result["parameters"]["agent"]["instructions"] == value
+
+    def test_the_file_marker_still_earns_its_own_refusal(self):
+        # `@ag.file` is a known marker with its own rule: the runner resolves it before the
+        # API sees the call, so one that arrives means the runner did not run. The new
+        # check must not swallow that more specific answer.
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": {"@ag.file": "notes.md"},
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.UNRESOLVED_FILE_MARKER
+
+    def test_an_ordinary_value_is_untouched(self):
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": {"agents_md": "plain text", "at": "an @ in prose"},
+                }
+            ),
+            base_config(),
+        ).data
+
+        assert result["parameters"]["agent"]["instructions"]["at"] == "an @ in prose"

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -1,0 +1,2034 @@
+"""Unit tests for the change-set engine (slice S1a).
+
+The suite is written against
+``docs/design/agent-config-editing/contracts/change-set.md``, which is authoritative.
+Each class names the contract section it pins.
+
+It also pins the legacy form against the real ``service.py`` helpers, so the two can never
+drift apart silently, and it pins the two properties that a reader would otherwise have to
+take on trust: the fold is length-preserving (which is what makes the byte-exact write
+true), and every retryable reason code carries a next-step sentence.
+"""
+
+import copy
+
+import pytest
+
+from oss.src.core.workflows.change_set import (
+    AGENT_COMMIT_SCOPE,
+    ChangeSetError,
+    PARAMETERS_ONLY,
+    Reason,
+    WarningCode,
+    apply_change_set,
+    apply_text_edits,
+    content_class,
+    deep_merge,
+    find_file_markers,
+    item_key,
+    subtree_scope,
+)
+
+
+# --------------------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------------------
+
+
+def base_config():
+    """A small but realistic ``parameters.agent`` tree."""
+    return {
+        "uri": "/services/agent",
+        "parameters": {
+            "agent": {
+                "instructions": {
+                    "agents_md": (
+                        "# Release agent\n"
+                        "Run the release checks manually.\n"
+                        "Then post the result.\n"
+                    )
+                },
+                "llm": {
+                    "model": "openai/gpt-5",
+                    "extras": {"reasoning_effort": "high"},
+                },
+                "tools": [
+                    {
+                        "type": "gateway",
+                        "provider": "composio",
+                        "integration": "slack",
+                        "action": "send_message",
+                        "connection": "default",
+                        "name": "send-slack-message",
+                    },
+                    {"type": "platform", "op": "discover_tools"},
+                    {
+                        "type": "reference",
+                        "ref_by": "variant",
+                        "slug": "summarizer",
+                    },
+                ],
+                "mcps": [{"name": "github", "url": "https://mcp.example/github"}],
+                "skills": [
+                    {
+                        "name": "release-qa",
+                        "description": "Run the release QA gate.",
+                        "body": "Check the API.\nCheck the UI.\n",
+                        "files": [
+                            {
+                                "path": "scripts/check.py",
+                                "content": "timeout = 30\nretries = 2\n",
+                                "executable": False,
+                            }
+                        ],
+                    },
+                    {
+                        "name": "write-docs",
+                        "description": "Write documentation.",
+                        "body": "Use short sentences.\n",
+                        "files": [],
+                    },
+                ],
+                "harness": {"kind": "pi_agenta"},
+            }
+        },
+    }
+
+
+AGENT = ["parameters", "agent"]
+
+
+def skill(key):
+    return {"list": "skills", "key": key}
+
+
+def run(delta, base=None, **kwargs):
+    """The full `ChangeSetResult`."""
+    return apply_change_set(
+        base if base is not None else base_config(), delta, **kwargs
+    )
+
+
+def apply(delta, base=None, **kwargs):
+    """Just the new tree — most assertions only care about that."""
+    return run(delta, base, **kwargs).data
+
+
+def warning_codes(delta, base=None, **kwargs):
+    return [w.code for w in run(delta, base, **kwargs).warnings]
+
+
+def failure(delta, base=None, **kwargs):
+    with pytest.raises(ChangeSetError) as caught:
+        apply(delta, base, **kwargs)
+    return caught.value
+
+
+def ops(*operations):
+    return {"operations": list(operations)}
+
+
+def edit_text(text, edits, **kwargs):
+    """Just the new text — `apply_text_edits` also reports whether it normalized."""
+    return apply_text_edits(text, edits, **kwargs)[0]
+
+
+# --------------------------------------------------------------------------------------
+# Delta form
+# --------------------------------------------------------------------------------------
+
+
+class TestDeltaForm:
+    def test_the_two_forms_are_mutually_exclusive(self):
+        error = failure({"set": {"a": 1}, "operations": [{"operation": "remove"}]})
+        assert error.reason == Reason.INVALID_DELTA
+
+    def test_an_empty_delta_is_refused(self):
+        assert failure({}).reason == Reason.INVALID_DELTA
+
+    def test_explicit_nulls_do_not_count_as_a_form(self):
+        # A pydantic model dump carries `set=None, remove=None, operations=None`.
+        assert failure({"set": None, "remove": None}).reason == Reason.INVALID_DELTA
+
+    def test_a_null_operations_field_beside_a_legacy_set_is_legacy(self):
+        result = apply({"set": {"uri": "/new"}, "operations": None})
+        assert result["uri"] == "/new"
+
+    def test_unknown_delta_fields_are_refused(self):
+        assert failure({"edit": []}).reason == Reason.INVALID_DELTA
+
+    def test_an_empty_operations_list_is_refused(self):
+        assert failure({"operations": []}).reason == Reason.INVALID_DELTA
+
+
+# --------------------------------------------------------------------------------------
+# Legacy form: it must match service.py exactly
+# --------------------------------------------------------------------------------------
+
+
+LEGACY_CASES = [
+    ({"set": {"parameters": {"agent": {"llm": {"model": "anthropic/opus"}}}}}, None),
+    ({"set": {"parameters": {"agent": {"tools": []}}}}, None),
+    ({"set": {"new_root": {"deep": {"deeper": 1}}}}, None),
+    ({"set": {"uri": None}}, None),
+    ({"remove": ["parameters.agent.tools"]}, None),
+    ({"remove": ["parameters.agent.does_not_exist"]}, None),
+    ({"remove": ["does.not.exist.at.all"]}, None),
+    ({"remove": ["uri"]}, None),
+    (
+        {
+            "set": {"parameters": {"agent": {"harness": {"kind": "claude"}}}},
+            "remove": ["parameters.agent.mcps"],
+        },
+        None,
+    ),
+    # `set` writes a key, then `remove` deletes it: set-then-remove order matters.
+    ({"set": {"marker": 1}, "remove": ["marker"]}, None),
+    # A scalar in the middle of a remove path stops the walk.
+    ({"remove": ["uri.deeper"]}, None),
+]
+
+
+class TestLegacyMatchesService:
+    @pytest.mark.parametrize("delta,_unused", LEGACY_CASES)
+    def test_same_result_as_service_helpers(self, delta, _unused):
+        from oss.src.core.workflows.service import _deep_merge, _remove_path
+
+        reference = _deep_merge(base_config(), delta.get("set") or {})
+        for path in delta.get("remove") or []:
+            _remove_path(reference, path)
+
+        assert apply(delta) == reference
+
+    def test_lists_replace_whole(self):
+        result = apply({"set": {"parameters": {"agent": {"skills": []}}}})
+        assert result["parameters"]["agent"]["skills"] == []
+
+    def test_scalars_replace_dicts(self):
+        result = apply({"set": {"parameters": {"agent": {"llm": "gpt"}}}})
+        assert result["parameters"]["agent"]["llm"] == "gpt"
+
+    def test_deep_merge_keeps_untouched_siblings(self):
+        result = apply({"set": {"parameters": {"agent": {"llm": {"model": "x"}}}}})
+        assert result["parameters"]["agent"]["llm"]["extras"] == {
+            "reasoning_effort": "high"
+        }
+        assert result["parameters"]["agent"]["harness"] == {"kind": "pi_agenta"}
+
+    def test_a_missing_remove_path_stays_a_no_op(self):
+        result = apply({"remove": ["parameters.agent.nope"]})
+        assert result == base_config()
+
+    def test_the_base_is_never_modified(self):
+        # service.py's `_remove_path` mutates through the shallow `_deep_merge` copy.
+        # The engine deep-copies first, so a caller's base survives.
+        base = base_config()
+        snapshot = copy.deepcopy(base)
+        apply({"remove": ["parameters.agent.tools"]}, base)
+        assert base == snapshot
+
+    def test_service_helpers_do_mutate_the_base(self):
+        # This documents the aliasing defect the engine fixes. If it ever fails,
+        # service.py changed and the note in the spike report is stale.
+        from oss.src.core.workflows.service import _deep_merge, _remove_path
+
+        base = base_config()
+        merged = _deep_merge(base, {"uri": "/other"})
+        _remove_path(merged, "parameters.agent.tools")
+        assert "tools" not in base["parameters"]["agent"]
+
+
+class TestDeepMergeParity:
+    def test_engine_deep_merge_matches_service_deep_merge(self):
+        from oss.src.core.workflows.service import _deep_merge
+
+        cases = [
+            ({}, {"a": 1}),
+            ({"a": {"b": 1}}, {"a": {"c": 2}}),
+            ({"a": {"b": 1}}, {"a": 2}),
+            ({"a": [1, 2]}, {"a": [3]}),
+            ({"a": 1}, {"a": {"b": 2}}),
+            ({"a": None}, {"a": {"b": 2}}),
+        ]
+        for base, patch in cases:
+            assert deep_merge(base, patch) == _deep_merge(base, patch)
+
+
+# --------------------------------------------------------------------------------------
+# set / merge / remove
+# --------------------------------------------------------------------------------------
+
+
+class TestSet:
+    def test_replaces_a_scalar(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": "anthropic/opus",
+                }
+            )
+        )
+        assert result["parameters"]["agent"]["llm"]["model"] == "anthropic/opus"
+
+    def test_replaces_an_object_whole(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm"],
+                    "value": {"model": "x"},
+                }
+            )
+        )
+        assert result["parameters"]["agent"]["llm"] == {"model": "x"}
+
+    def test_creates_the_final_field(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness", "extras"],
+                    "value": {"system": "be brief"},
+                }
+            )
+        )
+        assert result["parameters"]["agent"]["harness"]["extras"] == {
+            "system": "be brief"
+        }
+
+    def test_creates_missing_object_parents(self):
+        # Contract 5.3. Without this, setting a field inside an absent `extras` bag needs
+        # two operations, and the second is a `set` of an empty object.
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness", "extras", "system"],
+                    "value": "be brief",
+                }
+            )
+        )
+        assert result["parameters"]["agent"]["harness"]["extras"] == {
+            "system": "be brief"
+        }
+
+    def test_created_parents_still_face_final_validation(self):
+        # Parent creation is a convenience, not a licence to invent fields. The closed
+        # agent template is what refuses an invented path.
+        error = failure(
+            ops({"operation": "set", "target": AGENT + ["nope", "deeper"], "value": 1}),
+            validate=lambda data: ["parameters.agent.nope is not a known field"],
+        )
+        assert error.reason == Reason.FINAL_VALIDATION_FAILED
+
+    def test_it_never_creates_through_a_selector(self):
+        # A missing list ENTRY is still an error: inventing one would invent an identity.
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + [skill("nope"), "body"],
+                    "value": "x",
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_NOT_FOUND
+
+    def test_it_never_overwrites_a_scalar_parent(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model", "deeper"],
+                    "value": 1,
+                }
+            )
+        )
+        assert error.reason == Reason.TARGET_TYPE_MISMATCH
+
+    def test_a_scalar_parent_is_a_type_mismatch(self):
+        error = failure(
+            ops({"operation": "set", "target": ["uri", "deeper"], "value": 1})
+        )
+        assert error.reason == Reason.TARGET_TYPE_MISMATCH
+
+    def test_reaches_through_a_named_list_entry(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + [skill("release-qa"), "description"],
+                    "value": "New description.",
+                }
+            )
+        )
+        skills = result["parameters"]["agent"]["skills"]
+        assert skills[0]["description"] == "New description."
+        assert skills[1]["description"] == "Write documentation."
+
+    def test_reaches_a_nested_skill_file(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT
+                    + [
+                        skill("release-qa"),
+                        {"list": "files", "key": "scripts/check.py"},
+                        "executable",
+                    ],
+                    "value": True,
+                }
+            )
+        )
+        file = result["parameters"]["agent"]["skills"][0]["files"][0]
+        assert file["executable"] is True
+
+    def test_a_selector_tail_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + [skill("release-qa")],
+                    "value": {"name": "release-qa"},
+                }
+            )
+        )
+        assert error.reason == Reason.INVALID_TARGET_SHAPE
+
+    def test_the_value_is_copied_not_aliased(self):
+        shared = {"model": "x"}
+        result = apply(
+            ops({"operation": "set", "target": AGENT + ["llm"], "value": shared})
+        )
+        shared["model"] = "mutated"
+        assert result["parameters"]["agent"]["llm"]["model"] == "x"
+
+    def test_a_null_value_is_a_real_value(self):
+        result = apply(
+            ops({"operation": "set", "target": AGENT + ["harness"], "value": None})
+        )
+        assert result["parameters"]["agent"]["harness"] is None
+
+    def test_a_missing_value_is_refused(self):
+        error = failure(ops({"operation": "set", "target": AGENT + ["llm"]}))
+        assert error.reason == Reason.MISSING_OPERATION_VALUE
+
+
+class TestMerge:
+    def test_merges_nested_dicts(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "merge",
+                    "target": AGENT + ["llm"],
+                    "value": {"extras": {"verbosity": "low"}},
+                }
+            )
+        )
+        assert result["parameters"]["agent"]["llm"] == {
+            "model": "openai/gpt-5",
+            "extras": {"reasoning_effort": "high", "verbosity": "low"},
+        }
+
+    def test_uses_todays_rules_so_lists_replace(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "merge",
+                    "target": AGENT,
+                    "value": {"mcps": []},
+                }
+            )
+        )
+        assert result["parameters"]["agent"]["mcps"] == []
+
+    def test_a_missing_target_is_an_error(self):
+        error = failure(
+            ops({"operation": "merge", "target": AGENT + ["nope"], "value": {"a": 1}})
+        )
+        assert error.reason == Reason.TARGET_NOT_FOUND
+
+    def test_a_non_object_target_is_a_type_mismatch(self):
+        error = failure(
+            ops({"operation": "merge", "target": AGENT + ["tools"], "value": {"a": 1}})
+        )
+        assert error.reason == Reason.TARGET_TYPE_MISMATCH
+
+    def test_a_non_object_value_is_refused(self):
+        error = failure(
+            ops({"operation": "merge", "target": AGENT + ["llm"], "value": 3})
+        )
+        assert error.reason == Reason.INVALID_OPERATION_SHAPE
+
+
+class TestRemove:
+    def test_removes_an_object_field(self):
+        result = apply(
+            ops({"operation": "remove", "target": AGENT + ["llm", "extras"]})
+        )
+        assert "extras" not in result["parameters"]["agent"]["llm"]
+
+    def test_a_missing_field_is_an_error_unlike_the_legacy_form(self):
+        error = failure(ops({"operation": "remove", "target": AGENT + ["nope"]}))
+        assert error.reason == Reason.TARGET_NOT_FOUND
+
+    def test_a_selector_tail_is_refused(self):
+        error = failure(
+            ops({"operation": "remove", "target": AGENT + [skill("release-qa")]})
+        )
+        assert error.reason == Reason.INVALID_TARGET_SHAPE
+
+    def test_a_value_is_refused(self):
+        error = failure(
+            ops({"operation": "remove", "target": AGENT + ["llm"], "value": 1})
+        )
+        assert error.reason == Reason.INVALID_OPERATION_SHAPE
+
+
+# --------------------------------------------------------------------------------------
+# edit_text
+# --------------------------------------------------------------------------------------
+
+
+class TestEditText:
+    def test_replaces_one_anchor(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [
+                        {
+                            "old_text": "Run the release checks manually.",
+                            "new_text": "Run the release checks with the release-qa skill.",
+                        }
+                    ],
+                }
+            )
+        )
+        text = result["parameters"]["agent"]["instructions"]["agents_md"]
+        assert "with the release-qa skill" in text
+        assert "manually" not in text
+
+    def test_edits_a_named_skill_body(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("release-qa"), "body"],
+                    "edits": [
+                        {
+                            "old_text": "Check the API.",
+                            "new_text": "Check the API and the runner.",
+                        }
+                    ],
+                }
+            )
+        )
+        skills = result["parameters"]["agent"]["skills"]
+        assert skills[0]["body"] == "Check the API and the runner.\nCheck the UI.\n"
+        assert skills[1]["body"] == "Use short sentences.\n"
+
+    def test_edits_a_nested_skill_file(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT
+                    + [
+                        skill("release-qa"),
+                        {"list": "files", "key": "scripts/check.py"},
+                        "content",
+                    ],
+                    "edits": [{"old_text": "timeout = 30", "new_text": "timeout = 60"}],
+                }
+            )
+        )
+        file = result["parameters"]["agent"]["skills"][0]["files"][0]
+        assert file["content"] == "timeout = 60\nretries = 2\n"
+
+    def test_a_non_string_target_is_a_type_mismatch(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["llm"],
+                    "edits": [{"old_text": "a", "new_text": "b"}],
+                }
+            )
+        )
+        assert error.reason == Reason.TARGET_TYPE_MISMATCH
+
+    def test_the_reason_carries_the_match_count(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("release-qa"), "body"],
+                    "edits": [{"old_text": "Check the", "new_text": "Verify the"}],
+                }
+            )
+        )
+        assert error.reason == Reason.TEXT_NOT_UNIQUE
+        assert error.to_detail()["reason"]["match_count"] == 2
+
+
+class TestTextEditContract:
+    def test_two_disjoint_edits_apply_together(self):
+        assert (
+            edit_text(
+                "alpha beta gamma",
+                [
+                    {"old_text": "alpha", "new_text": "ALPHA"},
+                    {"old_text": "gamma", "new_text": "GAMMA"},
+                ],
+            )
+            == "ALPHA beta GAMMA"
+        )
+
+    def test_edits_may_arrive_out_of_order(self):
+        assert (
+            edit_text(
+                "alpha beta gamma",
+                [
+                    {"old_text": "gamma", "new_text": "GAMMA"},
+                    {"old_text": "alpha", "new_text": "ALPHA"},
+                ],
+            )
+            == "ALPHA beta GAMMA"
+        )
+
+    def test_every_anchor_matches_the_pre_operation_string(self):
+        # The first edit writes the text the second edit's anchor names. The second
+        # anchor must still fail, because it is matched against the original string.
+        with pytest.raises(Exception) as caught:
+            edit_text(
+                "one two",
+                [
+                    {"old_text": "one", "new_text": "three"},
+                    {"old_text": "three", "new_text": "four"},
+                ],
+            )
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_an_empty_anchor_is_refused(self):
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("abc", [{"old_text": "", "new_text": "x"}])
+        assert caught.value.reason == Reason.EMPTY_OLD_TEXT
+
+    def test_a_missing_anchor_is_refused(self):
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("abc", [{"old_text": "zzz", "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_a_repeated_anchor_is_refused(self):
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("abc abc", [{"old_text": "abc", "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_UNIQUE
+
+    def test_overlapping_edits_are_refused(self):
+        with pytest.raises(Exception) as caught:
+            edit_text(
+                "abcdef",
+                [
+                    {"old_text": "abcd", "new_text": "X"},
+                    {"old_text": "cdef", "new_text": "Y"},
+                ],
+            )
+        assert caught.value.reason == Reason.TEXT_EDITS_OVERLAP
+
+    def test_two_identical_anchors_overlap(self):
+        with pytest.raises(Exception) as caught:
+            edit_text(
+                "abc",
+                [
+                    {"old_text": "abc", "new_text": "x"},
+                    {"old_text": "abc", "new_text": "y"},
+                ],
+            )
+        assert caught.value.reason == Reason.TEXT_EDITS_OVERLAP
+
+    def test_adjacent_edits_are_allowed(self):
+        assert (
+            edit_text(
+                "abcdef",
+                [
+                    {"old_text": "abc", "new_text": "X"},
+                    {"old_text": "def", "new_text": "Y"},
+                ],
+            )
+            == "XY"
+        )
+
+    def test_a_no_change_batch_is_refused(self):
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("abc", [{"old_text": "abc", "new_text": "abc"}])
+        assert caught.value.reason == Reason.NO_CHANGE
+
+    def test_one_real_change_saves_a_mixed_batch(self):
+        assert (
+            edit_text(
+                "abc def",
+                [
+                    {"old_text": "abc", "new_text": "abc"},
+                    {"old_text": "def", "new_text": "xyz"},
+                ],
+            )
+            == "abc xyz"
+        )
+
+    def test_an_edit_may_delete_text(self):
+        assert edit_text("abc def", [{"old_text": " def", "new_text": ""}]) == "abc"
+
+    def test_the_batch_is_atomic(self):
+        # The first edit is valid, the second is not. Nothing is applied.
+        base = base_config()
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("release-qa"), "body"],
+                    "edits": [
+                        {"old_text": "Check the API.", "new_text": "Check nothing."},
+                        {"old_text": "absent", "new_text": "present"},
+                    ],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_FOUND
+        assert base == base_config()
+
+    # --- matching is exact: no Pi normalization ---
+
+    def test_smart_quotes_do_not_match_ascii_quotes(self):
+        with pytest.raises(Exception) as caught:
+            edit_text("say “hello”", [{"old_text": 'say "hello"', "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_an_em_dash_does_not_match_a_hyphen(self):
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("a — b", [{"old_text": "a - b", "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_a_non_breaking_space_does_not_match_a_space(self):
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("a b", [{"old_text": "a b", "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_trailing_whitespace_is_significant(self):
+        with pytest.raises(Exception) as caught:
+            edit_text("line   \nnext", [{"old_text": "line\nnext", "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_crlf_is_not_folded_to_lf(self):
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("a\r\nb", [{"old_text": "a\nb", "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_a_bom_is_not_stripped(self):
+        assert edit_text("﻿abc", [{"old_text": "﻿abc", "new_text": "x"}]) == "x"
+
+    def test_composed_and_decomposed_unicode_do_not_match(self):
+        # "é" as one code point vs. "e" + combining acute.
+        with pytest.raises(Exception) as caught:
+            apply_text_edits("café", [{"old_text": "café", "new_text": "x"}])
+        assert caught.value.reason == Reason.TEXT_NOT_FOUND
+
+    def test_overlapping_occurrences_are_ambiguous(self):
+        # Contract 5.6.2. `str.count` is non-overlapping and would report one occurrence
+        # of "aa" in "aaa". Two START positions exist, so the anchor is ambiguous and the
+        # engine must refuse it rather than silently pick the first.
+        with pytest.raises(Exception) as caught:
+            edit_text("aaa", [{"old_text": "aa", "new_text": "b"}])
+        assert caught.value.reason == Reason.TEXT_NOT_UNIQUE
+        assert caught.value.context["match_count"] == 2
+
+    def test_a_single_occurrence_still_applies(self):
+        assert edit_text("aab", [{"old_text": "aa", "new_text": "c"}]) == "cb"
+
+
+# --------------------------------------------------------------------------------------
+# add_item / replace_item / remove_item
+# --------------------------------------------------------------------------------------
+
+
+class TestAddItem:
+    def test_appends_a_new_skill(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {
+                        "name": "pdf-tools",
+                        "description": "Make PDFs.",
+                        "body": "Use the pdf CLI.",
+                    },
+                }
+            )
+        )
+        names = [entry["name"] for entry in result["parameters"]["agent"]["skills"]]
+        assert names == ["release-qa", "write-docs", "pdf-tools"]
+
+    def test_a_collision_is_an_error(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {"name": "release-qa", "description": "d", "body": "b"},
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_ALREADY_EXISTS
+
+    def test_adds_a_file_inside_a_skill(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + [skill("release-qa"), "files"],
+                    "value": {
+                        "path": "README.md",
+                        "content": "hi",
+                        "executable": False,
+                    },
+                }
+            )
+        )
+        paths = [
+            file["path"] for file in result["parameters"]["agent"]["skills"][0]["files"]
+        ]
+        assert paths == ["scripts/check.py", "README.md"]
+
+    def test_an_unkeyed_collection_is_refused(self):
+        base = base_config()
+        base["parameters"]["agent"]["harness"]["permissions"] = {"allow": ["Read"]}
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": [
+                        "parameters",
+                        "agent",
+                        "harness",
+                        "permissions",
+                        "allow",
+                    ],
+                    "value": "Bash",
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.UNKEYED_COLLECTION
+
+    def test_a_missing_collection_is_target_not_found(self):
+        base = base_config()
+        del base["parameters"]["agent"]["mcps"]
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["mcps"],
+                    "value": {"name": "github", "url": "https://x"},
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TARGET_NOT_FOUND
+
+    def test_a_non_list_collection_is_a_type_mismatch(self):
+        base = base_config()
+        base["parameters"]["agent"]["mcps"] = {"github": {}}
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["mcps"],
+                    "value": {"name": "github", "url": "https://x"},
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TARGET_TYPE_MISMATCH
+
+    def test_a_gateway_tool_without_a_name_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["tools"],
+                    "value": {
+                        "type": "gateway",
+                        "integration": "slack",
+                        "action": "list_channels",
+                        "connection": "default",
+                    },
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_KEY_UNDEFINED
+
+    def test_an_embed_entry_has_no_key(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {"@ag.embed": {"@ag.references": {"skill": "x"}}},
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_KEY_UNDEFINED
+
+    def test_an_unresolved_file_marker_is_refused(self):
+        # Contract 6.5. The runner resolves every marker before the API sees the call. A
+        # marker that reaches the engine means the runner did not run, and storing it
+        # verbatim would ship a broken agent.
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {
+                        "name": "pdf-tools",
+                        "description": "Make PDFs.",
+                        "body": {"@ag.file": ".agenta-imports/pdf-tools/SKILL.md"},
+                    },
+                }
+            )
+        )
+        assert error.reason == Reason.UNRESOLVED_FILE_MARKER
+        assert error.retryable is False
+        assert error.context["pointers"] == ["/body"]
+
+    def test_adding_to_an_empty_list_works(self):
+        base = base_config()
+        base["parameters"]["agent"]["mcps"] = []
+        result = apply(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["mcps"],
+                    "value": {"name": "github", "url": "https://x"},
+                }
+            ),
+            base,
+        )
+        assert len(result["parameters"]["agent"]["mcps"]) == 1
+
+
+class TestReplaceItem:
+    def test_replaces_in_place(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "replace_item",
+                    "target": AGENT + [skill("release-qa")],
+                    "value": {
+                        "name": "release-qa",
+                        "description": "New.",
+                        "body": "New body.",
+                    },
+                }
+            )
+        )
+        skills = result["parameters"]["agent"]["skills"]
+        assert skills[0] == {
+            "name": "release-qa",
+            "description": "New.",
+            "body": "New body.",
+        }
+        assert skills[1]["name"] == "write-docs"
+
+    def test_a_missing_entry_is_an_error(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "replace_item",
+                    "target": AGENT + [skill("nope")],
+                    "value": {"name": "nope", "description": "d", "body": "b"},
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_NOT_FOUND
+
+    def test_a_rename_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "replace_item",
+                    "target": AGENT + [skill("release-qa")],
+                    "value": {"name": "renamed", "description": "d", "body": "b"},
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_RENAME_NOT_ALLOWED
+
+    def test_a_field_tail_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "replace_item",
+                    "target": AGENT + ["skills"],
+                    "value": {"name": "x", "description": "d", "body": "b"},
+                }
+            )
+        )
+        assert error.reason == Reason.INVALID_TARGET_SHAPE
+
+
+class TestRemoveItem:
+    def test_removes_a_named_tool(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "tools", "key": "send-slack-message"}],
+                }
+            )
+        )
+        tools = result["parameters"]["agent"]["tools"]
+        assert len(tools) == 2
+        assert all(tool.get("name") != "send-slack-message" for tool in tools)
+
+    def test_a_missing_entry_is_an_error(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "tools", "key": "nope"}],
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_NOT_FOUND
+
+    def test_a_duplicate_key_is_an_error(self):
+        base = base_config()
+        base["parameters"]["agent"]["skills"].append(
+            {"name": "release-qa", "description": "dupe", "body": "b"}
+        )
+        error = failure(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [skill("release-qa")],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.DUPLICATE_ITEM_KEY
+        assert error.to_detail()["reason"]["match_count"] == 2
+
+    def test_a_missing_collection_is_target_not_found(self):
+        base = base_config()
+        del base["parameters"]["agent"]["mcps"]
+        error = failure(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "mcps", "key": "github"}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TARGET_NOT_FOUND
+
+    def test_a_non_list_collection_is_a_type_mismatch(self):
+        base = base_config()
+        base["parameters"]["agent"]["mcps"] = {"github": {}}
+        error = failure(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "mcps", "key": "github"}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TARGET_TYPE_MISMATCH
+
+
+# --------------------------------------------------------------------------------------
+# Tool identity
+# --------------------------------------------------------------------------------------
+
+
+class TestToolIdentity:
+    def test_a_platform_tool_is_keyed_by_op(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "tools", "key": "discover_tools"}],
+                }
+            )
+        )
+        assert all(
+            tool.get("op") != "discover_tools"
+            for tool in result["parameters"]["agent"]["tools"]
+        )
+
+    def test_a_reference_tool_falls_back_to_its_slug(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT
+                    + [{"list": "tools", "key": "summarizer"}, "description"],
+                    "value": "Summarize text.",
+                }
+            )
+        )
+        assert result["parameters"]["agent"]["tools"][2]["description"] == (
+            "Summarize text."
+        )
+
+    def test_an_unnamed_gateway_is_addressable_by_the_legacy_fallback(self):
+        base = base_config()
+        base["parameters"]["agent"]["tools"].append(
+            {
+                "type": "gateway",
+                "integration": "notion",
+                "action": "create_page",
+                "connection": "default",
+            }
+        )
+        result = apply(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "tools", "key": "notion__create_page"}],
+                }
+            ),
+            base,
+        )
+        assert len(result["parameters"]["agent"]["tools"]) == 3
+
+    def test_item_key_helper(self):
+        assert item_key("tools", {"type": "platform", "op": "test_run"}) == "test_run"
+        assert item_key("tools", {"type": "reference", "slug": "s", "name": "n"}) == "n"
+        assert item_key("skills", {"@ag.embed": {}}) is None
+        assert item_key("files", {"path": "a/b.py"}) == "a/b.py"
+        assert item_key("unknown", {"name": "x"}) is None
+        assert item_key("skills", "not-a-dict") is None
+        assert (
+            item_key(
+                "tools",
+                {"type": "gateway", "integration": "i", "action": "a"},
+                allow_legacy_fallback=False,
+            )
+            is None
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Ordering, atomicity, and errors
+# --------------------------------------------------------------------------------------
+
+
+class TestOrdering:
+    def test_operations_see_the_result_of_earlier_operations(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {"name": "new", "description": "d", "body": "hello world"},
+                },
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("new"), "body"],
+                    "edits": [{"old_text": "world", "new_text": "there"}],
+                },
+            )
+        )
+        assert result["parameters"]["agent"]["skills"][2]["body"] == "hello there"
+
+    def test_remove_then_add_is_a_rename(self):
+        result = apply(
+            ops(
+                {"operation": "remove_item", "target": AGENT + [skill("write-docs")]},
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {
+                        "name": "write-prose",
+                        "description": "Write documentation.",
+                        "body": "Use short sentences.\n",
+                    },
+                },
+            )
+        )
+        names = [entry["name"] for entry in result["parameters"]["agent"]["skills"]]
+        assert names == ["release-qa", "write-prose"]
+
+    def test_merge_sees_an_earlier_set(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm"],
+                    "value": {"model": "a"},
+                },
+                {
+                    "operation": "merge",
+                    "target": AGENT + ["llm"],
+                    "value": {"extras": {"k": 1}},
+                },
+            )
+        )
+        assert result["parameters"]["agent"]["llm"] == {
+            "model": "a",
+            "extras": {"k": 1},
+        }
+
+    def test_the_first_failure_aborts_everything(self):
+        base = base_config()
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": "changed",
+                },
+                {"operation": "remove", "target": AGENT + ["nope"]},
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness", "kind"],
+                    "value": "claude",
+                },
+            ),
+            base,
+        )
+        assert error.operation_index == 1
+        assert error.operation == "remove"
+        assert base == base_config()
+
+
+class TestErrorModel:
+    def test_the_detail_body_matches_the_spec_shape(self):
+        error = failure(
+            ops(
+                {"operation": "set", "target": AGENT + ["llm", "model"], "value": "a"},
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("release-qa"), "body"],
+                    "edits": [{"old_text": "Check the", "new_text": "Verify the"}],
+                },
+            )
+        )
+        detail = error.to_detail()
+        assert detail["code"] == "change_set_rejected"
+        assert detail["message"] == "No revision was committed."
+        assert detail["operation_index"] == 1
+        assert detail["operation"] == "edit_text"
+        assert detail["target"] == AGENT + [skill("release-qa"), "body"]
+        assert detail["reason"]["code"] == "text_not_unique"
+        assert detail["reason"]["match_count"] == 2
+        assert detail["retryable"] is True
+
+    def test_a_scope_refusal_is_not_retryable(self):
+        error = failure(
+            ops({"operation": "set", "target": ["uri"], "value": "/x"}),
+            scope_policy=PARAMETERS_ONLY,
+        )
+        assert error.to_detail()["retryable"] is False
+
+    def test_an_unknown_verb_is_refused(self):
+        error = failure(ops({"operation": "upsert", "target": AGENT, "value": {}}))
+        assert error.reason == Reason.UNKNOWN_OPERATION
+
+    def test_an_empty_target_is_refused(self):
+        error = failure(ops({"operation": "set", "target": [], "value": 1}))
+        assert error.reason == Reason.INVALID_TARGET_SHAPE
+
+    def test_a_malformed_selector_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "skills"}],
+                }
+            )
+        )
+        assert error.reason == Reason.INVALID_TARGET_SHAPE
+
+    def test_a_selector_with_extra_keys_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "skills", "key": "a", "index": 0}],
+                }
+            )
+        )
+        assert error.reason == Reason.INVALID_TARGET_SHAPE
+
+
+# --------------------------------------------------------------------------------------
+# Scope policy
+# --------------------------------------------------------------------------------------
+
+
+class TestScopePolicy:
+    def test_parameters_only_allows_a_parameters_target(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": "anthropic/opus",
+                }
+            ),
+            scope_policy=PARAMETERS_ONLY,
+        )
+        assert result["parameters"]["agent"]["llm"]["model"] == "anthropic/opus"
+
+    def test_parameters_only_refuses_another_root(self):
+        error = failure(
+            ops({"operation": "set", "target": ["uri"], "value": "/x"}),
+            scope_policy=PARAMETERS_ONLY,
+        )
+        assert error.reason == Reason.OUT_OF_SCOPE
+        assert error.operation_index == 0
+
+    def test_the_guard_runs_before_any_operation_applies(self):
+        base = base_config()
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": "ok",
+                },
+                {"operation": "set", "target": ["uri"], "value": "/x"},
+            ),
+            base,
+            scope_policy=PARAMETERS_ONLY,
+        )
+        assert error.operation_index == 1
+        assert base == base_config()
+
+    def test_it_inspects_nested_selectors_too(self):
+        # The current invoke guard only reads top-level `set` keys, so a structured
+        # target would slip past it. The engine reads the whole target.
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": [
+                        "secrets",
+                        {"list": "files", "key": "a"},
+                        "content",
+                    ],
+                    "edits": [{"old_text": "a", "new_text": "b"}],
+                }
+            ),
+            scope_policy=PARAMETERS_ONLY,
+        )
+        assert error.reason == Reason.OUT_OF_SCOPE
+
+    def test_it_guards_the_legacy_form_the_same_way(self):
+        error = failure({"set": {"uri": "/x"}}, scope_policy=PARAMETERS_ONLY)
+        assert error.reason == Reason.OUT_OF_SCOPE
+
+    def test_it_guards_legacy_remove_paths(self):
+        error = failure({"remove": ["uri"]}, scope_policy=PARAMETERS_ONLY)
+        assert error.reason == Reason.OUT_OF_SCOPE
+
+    def test_legacy_remove_of_the_root_itself_stays_allowed(self):
+        # Today's guard accepts `remove: ["parameters"]`. Behavior is preserved.
+        result = apply({"remove": ["parameters"]}, scope_policy=PARAMETERS_ONLY)
+        assert "parameters" not in result
+
+    def test_a_deeper_prefix_walks_the_legacy_set_tree(self):
+        policy = subtree_scope(["parameters", "agent"])
+        result = apply(
+            {"set": {"parameters": {"agent": {"harness": {"kind": "claude"}}}}},
+            scope_policy=policy,
+        )
+        assert result["parameters"]["agent"]["harness"]["kind"] == "claude"
+
+        error = failure(
+            {"set": {"parameters": {"other": 1}}},
+            scope_policy=policy,
+        )
+        assert error.reason == Reason.OUT_OF_SCOPE
+
+    def test_a_short_target_is_refused(self):
+        error = failure(
+            ops({"operation": "set", "target": ["parameters"], "value": {}}),
+            scope_policy=subtree_scope(["parameters", "agent"]),
+        )
+        assert error.reason == Reason.OUT_OF_SCOPE
+
+
+# --------------------------------------------------------------------------------------
+# Final validation hook
+# --------------------------------------------------------------------------------------
+
+
+class TestFinalValidation:
+    def test_it_runs_on_the_finished_tree(self):
+        seen = {}
+
+        def validate(data):
+            seen["model"] = data["parameters"]["agent"]["llm"]["model"]
+            return None
+
+        apply(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
+            validate=validate,
+        )
+        assert seen["model"] == "z"
+
+    def test_returned_issues_become_one_error(self):
+        error = failure(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
+            validate=lambda data: ["llm.model is unknown", "tools[0] is invalid"],
+        )
+        assert error.reason == Reason.FINAL_VALIDATION_FAILED
+        assert len(error.to_detail()["reason"]["issues"]) == 2
+
+    def test_a_raised_validator_error_becomes_the_same_reason(self):
+        def validate(data):
+            raise ValueError("extra_forbidden: parameters.agent.nope")
+
+        error = failure(
+            ops({"operation": "set", "target": AGENT + ["nope"], "value": 1}),
+            validate=validate,
+        )
+        assert error.reason == Reason.FINAL_VALIDATION_FAILED
+
+    def test_it_also_runs_on_the_legacy_form(self):
+        error = failure({"set": {"uri": "/x"}}, validate=lambda data: ["bad"])
+        assert error.reason == Reason.FINAL_VALIDATION_FAILED
+
+
+# --------------------------------------------------------------------------------------
+# Purity
+# --------------------------------------------------------------------------------------
+
+
+class TestPurity:
+    def test_the_result_shares_nothing_with_the_base(self):
+        base = base_config()
+        result = apply(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
+            base,
+        )
+        result["parameters"]["agent"]["skills"][0]["body"] = "mutated"
+        assert base["parameters"]["agent"]["skills"][0]["body"] != "mutated"
+
+    def test_an_empty_base_still_works(self):
+        result = apply_change_set({}, {"set": {"a": 1}}).data
+        assert result == {"a": 1}
+
+    def test_an_empty_base_refuses_an_ordered_target(self):
+        error = failure(ops({"operation": "remove", "target": ["a"]}), {})
+        assert error.reason == Reason.TARGET_NOT_FOUND
+
+
+# --------------------------------------------------------------------------------------
+# The result envelope (contract 8)
+# --------------------------------------------------------------------------------------
+
+
+class TestChangeSetResult:
+    def test_a_real_change_reports_changed(self):
+        result = run(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"})
+        )
+        assert result.changed is True
+
+    def test_a_no_effect_change_set_reports_unchanged(self):
+        # Mandatory before ship: a cornered model commits a no-op to manufacture success.
+        # The wrapper turns `changed=False` into a no_change answer and creates no revision.
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": "openai/gpt-5",
+                }
+            )
+        )
+        assert result.changed is False
+        assert result.data == base_config()
+
+    def test_a_remove_then_add_of_the_same_entry_moves_it_and_counts_as_changed(self):
+        # add_item appends, so the round trip reorders the list. Order is data.
+        result = run(
+            ops(
+                {"operation": "remove_item", "target": AGENT + [skill("release-qa")]},
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": base_config()["parameters"]["agent"]["skills"][0],
+                },
+            )
+        )
+        assert result.changed is True
+
+    def test_warnings_are_structured(self):
+        result = run({"set": {"uri": "/x"}})
+        assert all(isinstance(w.to_dict()["code"], str) for w in result.warnings)
+
+    def test_the_legacy_form_warns_that_it_is_legacy(self):
+        assert WarningCode.LEGACY_DELTA_FORM in warning_codes({"set": {"uri": "/x"}})
+
+    def test_a_wholesale_list_replace_warns(self):
+        codes = warning_codes(
+            ops({"operation": "set", "target": AGENT + ["tools"], "value": []})
+        )
+        assert WarningCode.WHOLESALE_LIST_REPLACE in codes
+
+    def test_a_legacy_wholesale_list_replace_warns_too(self):
+        codes = warning_codes({"set": {"parameters": {"agent": {"skills": []}}}})
+        assert WarningCode.WHOLESALE_LIST_REPLACE in codes
+
+    def test_an_ordinary_field_set_does_not_warn_about_lists(self):
+        codes = warning_codes(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"})
+        )
+        assert WarningCode.WHOLESALE_LIST_REPLACE not in codes
+
+
+# --------------------------------------------------------------------------------------
+# Match tolerance by content class (contract 5.6.1)
+# --------------------------------------------------------------------------------------
+
+
+SMART = "Run the “release” checks — manually.\n"
+ASCII_ANCHOR = 'Run the "release" checks - manually.'
+
+
+class TestMatchTolerance:
+    def test_the_classifier_follows_the_field_name(self):
+        assert content_class("agents_md") == "prose"
+        assert content_class("body") == "prose"
+        assert content_class("description") == "prose"
+        assert content_class("content") == "code"
+        assert content_class("script") == "code"
+
+    def test_an_unknown_field_is_treated_as_code(self):
+        # Fail safe: a new field nobody classified must not silently gain tolerance.
+        assert content_class("some_new_field") == "code"
+
+    def test_prose_matches_after_normalizing_quotes_and_dashes(self):
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = SMART
+        result = run(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": ASCII_ANCHOR, "new_text": "Run the gate."}],
+                }
+            ),
+            base,
+        )
+        assert (
+            result.data["parameters"]["agent"]["instructions"]["agents_md"]
+            == "Run the gate.\n"
+        )
+
+    def test_a_normalized_match_is_reported(self):
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = SMART
+        result = run(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": ASCII_ANCHOR, "new_text": "Run the gate."}],
+                }
+            ),
+            base,
+        )
+        assert WarningCode.TEXT_MATCHED_NORMALIZED in [w.code for w in result.warnings]
+
+    def test_the_write_stays_byte_exact_outside_the_span(self):
+        # The fold is for MATCHING only. Bytes the edit did not replace keep their
+        # original code points, smart quotes included.
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = (
+            SMART + "Keep this “quoted” line.\n"
+        )
+        result = apply(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": ASCII_ANCHOR, "new_text": "Run the gate."}],
+                }
+            ),
+            base,
+        )
+        text = result["parameters"]["agent"]["instructions"]["agents_md"]
+        assert text == "Run the gate.\nKeep this “quoted” line.\n"
+        assert "“" in text
+
+    def test_an_exact_prose_match_reports_no_normalization(self):
+        result = run(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [
+                        {
+                            "old_text": "Run the release checks manually.",
+                            "new_text": "Run the gate.",
+                        }
+                    ],
+                }
+            )
+        )
+        assert WarningCode.TEXT_MATCHED_NORMALIZED not in [
+            w.code for w in result.warnings
+        ]
+
+    def test_a_script_does_not_get_the_tolerance(self):
+        base = base_config()
+        base["parameters"]["agent"]["tools"].append(
+            {
+                "type": "code",
+                "name": "runner",
+                "script": "print(“hello”)\n",
+            }
+        )
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [{"list": "tools", "key": "runner"}, "script"],
+                    "edits": [
+                        {"old_text": 'print("hello")', "new_text": "print('hi')"}
+                    ],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_FOUND
+
+    def test_a_skill_file_content_does_not_get_the_tolerance(self):
+        base = base_config()
+        base["parameters"]["agent"]["skills"][0]["files"][0]["content"] = (
+            "TIMEOUT = “30”\n"
+        )
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT
+                    + [
+                        skill("release-qa"),
+                        {"list": "files", "key": "scripts/check.py"},
+                        "content",
+                    ],
+                    "edits": [
+                        {"old_text": 'TIMEOUT = "30"', "new_text": 'TIMEOUT = "60"'}
+                    ],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_FOUND
+
+    def test_match_mode_exact_switches_the_tolerance_off_for_prose(self):
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = SMART
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "match_mode": "exact",
+                    "edits": [{"old_text": ASCII_ANCHOR, "new_text": "Run the gate."}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_FOUND
+
+    def test_match_mode_auto_is_the_default(self):
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = SMART
+        # No match_mode field at all behaves like "auto".
+        assert apply(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": ASCII_ANCHOR, "new_text": "Run the gate."}],
+                }
+            ),
+            base,
+        )
+
+    def test_an_unknown_match_mode_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "match_mode": "fuzzy",
+                    "edits": [{"old_text": "a", "new_text": "b"}],
+                }
+            )
+        )
+        assert error.reason == Reason.UNKNOWN_OPERATION
+        assert error.retryable is False
+
+    def test_a_normalized_match_must_still_be_unique(self):
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = SMART + SMART
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": ASCII_ANCHOR, "new_text": "Run the gate."}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_UNIQUE
+
+    def test_the_fold_is_length_preserving(self):
+        # This is what makes the byte-exact write true: a folded offset IS the original
+        # offset. A length-changing fold would need Pi's line-overlay machinery.
+        from oss.src.core.workflows.change_set import _fold
+
+        for text in (SMART, "a—b", "x y", "‘q’"):
+            assert len(_fold(text)) == len(text)
+
+    def test_trailing_whitespace_is_still_significant(self):
+        # Deliberately NOT folded: it changes length. Contract 18.1.
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = "line   \nnext\n"
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": "line\nnext", "new_text": "x"}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_FOUND
+
+    def test_crlf_is_still_significant(self):
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = "a\r\nb"
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": "a\nb", "new_text": "x"}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_FOUND
+
+
+# --------------------------------------------------------------------------------------
+# The @ag.file marker (contract 6)
+# --------------------------------------------------------------------------------------
+
+
+class TestFileMarker:
+    def test_it_is_found_at_any_depth(self):
+        value = {
+            "name": "pdf-tools",
+            "body": {"@ag.file": "a.md"},
+            "files": [
+                {"path": "x.py", "content": {"@ag.file": "b.py"}},
+                {"path": "y.py", "content": "inline"},
+            ],
+        }
+        assert find_file_markers(value) == ["/body", "/files/0/content"]
+
+    def test_a_value_with_no_marker_is_clean(self):
+        assert find_file_markers({"body": "inline", "files": []}) == []
+
+    def test_a_marker_deep_in_a_list_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {
+                        "name": "pdf-tools",
+                        "description": "Make PDFs.",
+                        "body": "inline",
+                        "files": [
+                            {"path": "x.py", "content": {"@ag.file": "x.py"}},
+                        ],
+                    },
+                }
+            )
+        )
+        assert error.reason == Reason.UNRESOLVED_FILE_MARKER
+        assert error.context["pointers"] == ["/files/0/content"]
+
+    def test_a_marker_in_a_set_value_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "value": {"@ag.file": ".agenta-imports/AGENTS.md"},
+                }
+            )
+        )
+        assert error.reason == Reason.UNRESOLVED_FILE_MARKER
+
+    def test_a_marker_in_a_legacy_set_is_refused(self):
+        error = failure(
+            {
+                "set": {
+                    "parameters": {
+                        "agent": {"instructions": {"agents_md": {"@ag.file": "a.md"}}}
+                    }
+                }
+            }
+        )
+        assert error.reason == Reason.UNRESOLVED_FILE_MARKER
+
+    def test_an_embed_marker_is_not_a_file_marker(self):
+        # `@ag.embed` persists and re-resolves; `@ag.file` is consumed at commit. Same
+        # family, different lifetime. The engine must not confuse them.
+        assert find_file_markers({"@ag.embed": {"x": 1}}) == []
+
+
+# --------------------------------------------------------------------------------------
+# Unique names (contract 9)
+# --------------------------------------------------------------------------------------
+
+
+class TestUniqueNames:
+    def _with_duplicate(self):
+        base = base_config()
+        base["parameters"]["agent"]["skills"].append(
+            {"name": "release-qa", "description": "dupe", "body": "b"}
+        )
+        return base
+
+    def test_an_item_operation_cannot_leave_a_duplicate(self):
+        base = self._with_duplicate()
+        error = failure(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {"name": "new", "description": "d", "body": "b"},
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.DUPLICATE_ITEM_KEY
+
+    def test_a_branch_write_that_adds_a_duplicate_is_refused(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["skills"],
+                    "value": [
+                        {"name": "a", "description": "d", "body": "b"},
+                        {"name": "a", "description": "d", "body": "b"},
+                    ],
+                }
+            )
+        )
+        assert error.reason == Reason.DUPLICATE_ITEM_KEY
+
+    def test_an_untouched_legacy_duplicate_only_warns(self):
+        base = self._with_duplicate()
+        result = run(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
+            base,
+        )
+        assert WarningCode.LEGACY_DUPLICATE_KEY in [w.code for w in result.warnings]
+
+    def test_a_pre_existing_duplicate_does_not_block_an_unrelated_commit(self):
+        # Rule 2 keeps every existing configuration committable. Without it, one bad
+        # legacy config could never be edited again.
+        base = self._with_duplicate()
+        result = run(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"}),
+            base,
+        )
+        assert result.data["parameters"]["agent"]["llm"]["model"] == "z"
+
+    def test_a_clean_configuration_produces_no_duplicate_warning(self):
+        codes = warning_codes(
+            ops({"operation": "set", "target": AGENT + ["llm", "model"], "value": "z"})
+        )
+        assert WarningCode.LEGACY_DUPLICATE_KEY not in codes
+
+
+# --------------------------------------------------------------------------------------
+# The error model (contract 12)
+# --------------------------------------------------------------------------------------
+
+
+class TestErrorSplit:
+    RETRYABLE = [
+        (
+            Reason.TARGET_NOT_FOUND,
+            ops({"operation": "remove", "target": AGENT + ["x"]}),
+        ),
+        (
+            Reason.ITEM_NOT_FOUND,
+            ops({"operation": "remove_item", "target": AGENT + [skill("nope")]}),
+        ),
+        (
+            Reason.MISSING_OPERATION_VALUE,
+            ops({"operation": "set", "target": AGENT + ["llm"]}),
+        ),
+        (
+            Reason.INVALID_TARGET_SHAPE,
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + [skill("release-qa")],
+                    "value": 1,
+                }
+            ),
+        ),
+    ]
+
+    @pytest.mark.parametrize("reason,delta", RETRYABLE)
+    def test_shape_errors_are_retryable(self, reason, delta):
+        # An agent honoring `retryable: false` would otherwise dead-end on a mistake it
+        # could fix in one turn.
+        error = failure(delta)
+        assert error.reason == reason
+        assert error.retryable is True
+
+    @pytest.mark.parametrize("reason,delta", RETRYABLE)
+    def test_every_retryable_error_names_a_next_step(self, reason, delta):
+        error = failure(delta)
+        assert error.next_step
+        assert error.to_detail()["reason"]["next_step"] == error.next_step
+
+    def test_a_rename_has_its_own_retryable_code(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "replace_item",
+                    "target": AGENT + [skill("release-qa")],
+                    "value": {"name": "renamed", "description": "d", "body": "b"},
+                }
+            )
+        )
+        assert error.reason == Reason.ITEM_RENAME_NOT_ALLOWED
+        assert error.retryable is True
+        assert "remove_item" in error.next_step
+        assert "add_item" in error.next_step
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            Reason.OUT_OF_SCOPE,
+            Reason.INVALID_DELTA,
+            Reason.UNKNOWN_OPERATION,
+            Reason.UNRESOLVED_FILE_MARKER,
+            Reason.TEXT_TOO_LARGE,
+            Reason.SOURCE_TOO_LARGE,
+        ],
+    )
+    def test_refusals_are_not_retryable(self, reason):
+        error = ChangeSetError(reason, "x")
+        assert error.retryable is False
+
+    def test_every_retryable_code_has_a_next_step_sentence(self):
+        # Contract 12.3 makes this mandatory, so a missing entry is a contract violation,
+        # not a cosmetic gap.
+        from oss.src.core.workflows.change_set import NEXT_STEPS, _NOT_RETRYABLE
+
+        codes = {
+            value
+            for name, value in vars(Reason).items()
+            if not name.startswith("_") and isinstance(value, str)
+        }
+        for code in codes - _NOT_RETRYABLE:
+            assert code in NEXT_STEPS, f"{code} has no next_step sentence"
+
+    def test_a_text_too_large_target_is_refused(self):
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = "a" * 200_001
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [{"old_text": "a", "new_text": "b"}],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_TOO_LARGE
+
+    def test_too_many_operations_are_refused(self):
+        delta = ops(
+            *[
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": str(i),
+                }
+                for i in range(65)
+            ]
+        )
+        assert failure(delta).reason == Reason.INVALID_DELTA
+
+
+# --------------------------------------------------------------------------------------
+# The agent commit scope (read-config.md 11.1)
+# --------------------------------------------------------------------------------------
+
+
+class TestAgentCommitScope:
+    def test_the_agent_may_write_its_own_subtree(self):
+        result = apply(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["llm", "model"],
+                    "value": "anthropic/opus",
+                }
+            ),
+            scope_policy=AGENT_COMMIT_SCOPE,
+        )
+        assert result["parameters"]["agent"]["llm"]["model"] == "anthropic/opus"
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            ["uri"],
+            ["parameters", "prompt", "messages"],
+            ["parameters", "agent", "harness", "kind"],
+            ["parameters", "agent", "harness", "permissions", "allow"],
+            ["parameters", "agent", "runner", "permissions", "default"],
+            ["parameters", "agent", "sandbox", "kind"],
+            ["parameters", "agent", "sandbox", "permissions"],
+        ],
+    )
+    def test_platform_owned_targets_are_refused(self, target):
+        error = failure(
+            ops({"operation": "set", "target": target, "value": "x"}),
+            scope_policy=AGENT_COMMIT_SCOPE,
+        )
+        assert error.reason == Reason.OUT_OF_SCOPE
+        assert error.retryable is False

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -1739,6 +1739,45 @@ class TestMatchTolerance:
         )
         assert error.reason == Reason.TEXT_NOT_FOUND
 
+    def test_a_soft_wrap_newline_is_still_significant(self):
+        # Spike failure F.3.6: the stored text is soft-wrapped and the model sends the
+        # sentence on one line. A bare LF to space fold WOULD fix this, and it is
+        # length-preserving, so it passes the test that excludes CRLF.
+        #
+        # It stays excluded anyway, for a stronger reason. Every other fold is a glyph
+        # variant, so the anchor and the stored span hold the same characters. LF against
+        # space is STRUCTURAL: the model believes the span is one line, writes new_text for
+        # that belief, and the write then deletes a line break it never saw. Prose-class
+        # fields are Markdown, and they embed lists, headings, and fenced code where a line
+        # break is meaning. Measured: a two-item list silently becomes one item, and
+        # `x = 1\ny = 2` inside a fence silently becomes `x = 3 y = 2`, a syntax error.
+        #
+        # The enriched text_not_found (contract 12.4) returns the nearest lines, so the
+        # model sees the real break and re-anchors. One extra turn, no corruption.
+        # Contract 18.2.
+        base = base_config()
+        base["parameters"]["agent"]["instructions"]["agents_md"] = (
+            "Use the gate when the suite is\nunavailable.\n"
+        )
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "edits": [
+                        {
+                            "old_text": "when the suite is unavailable.",
+                            "new_text": "when the suite is down.",
+                        }
+                    ],
+                }
+            ),
+            base,
+        )
+        assert error.reason == Reason.TEXT_NOT_FOUND
+        # The next step is what recovers it: copy the text as it is actually stored.
+        assert "character for character" in error.next_step
+
 
 # --------------------------------------------------------------------------------------
 # The @ag.file marker (contract 6)

--- a/docs/design/agent-config-editing/contracts/change-set.md
+++ b/docs/design/agent-config-editing/contracts/change-set.md
@@ -726,7 +726,7 @@ The agent can fix these and send again. Each one carries `next_step`.
 | `item_key_undefined` | The value has no derivable key. |
 | `unkeyed_collection` | The list has no key field. |
 | `missing_operation_value` | A value-bearing operation carried no `value`. |
-| `invalid_operation_shape` | Any other malformed operation the schema also rejects. |
+| `invalid_operation_shape` | Any other malformed operation the schema also rejects, including a `match_mode` that is not `auto` or `exact`. That case carries a `next_step` naming the modes. |
 | `text_not_found` | The anchor does not occur. |
 | `text_not_unique` | The anchor occurs more than once. |
 | `text_edits_overlap` | Two matches share a character. |
@@ -737,7 +737,6 @@ The agent can fix these and send again. Each one carries `next_step`.
 | `platform_tool_not_committable` | The `tools` list holds a platform-kind entry. Section 11. |
 | `non_embeddable_reference` | The result embeds a static workflow that may not be embedded. Wrapper-owned; `commit-transaction.md` section 4.1. |
 | `final_validation_failed` | The finished tree is not a valid configuration. Carries `issues`. |
-| `invalid_match_mode` | `edit_text` carried a `match_mode` that is not `auto` or `exact`. The operation itself is valid, so the fix is one word. |
 
 ### 12.2 Non-retryable refusals
 
@@ -747,7 +746,7 @@ Sending the same payload again never helps.
 |---|---|
 | `out_of_scope` | The scope policy refuses the target. |
 | `invalid_delta` | Both forms, no form, or an unknown delta field. |
-| `unknown_operation` | An unknown verb. A bad `match_mode` is `invalid_match_mode` and retryable: the verb was right. |
+| `unknown_operation` | An unknown verb. A bad `match_mode` is NOT this: the verb was right, so it is a retryable `invalid_operation_shape`. |
 | `unresolved_file_marker` | An `@ag.file` reached the engine. Section 6.5. |
 | `invalid_embed` | An `@ag.embed` that is not one: no references, a reference that is not an object, or a key an embed does not hold. Section 6.7. |
 | `unknown_marker` | An `@ag.*` key the platform does not define. Section 6.7. |

--- a/docs/design/agent-config-editing/contracts/change-set.md
+++ b/docs/design/agent-config-editing/contracts/change-set.md
@@ -442,7 +442,10 @@ retryable and whose next step is "send `remove_item` then `add_item`".
 
 Removes one existing entry. A missing entry is `item_not_found`.
 
-## 6. The `@ag.file` marker
+## 6. Markers, and the shape of a committed value
+
+Sections 6.1 to 6.6 are the `@ag.file` marker. 6.7 and 6.8 are the rules that keep every
+other value committable: which markers exist at all, and how deep a value may nest.
 
 ### 6.1 The shape
 
@@ -542,6 +545,42 @@ every value, then dispatches. A failure on any one marker fails the whole call b
 anything is sent. `execution-authorization.md` section 3.4 owns the atomic
 verify-and-consume rules, which now cover the SET of markers in one commit rather than a
 set of operation-level sources.
+
+### 6.7 Every other `@ag.*` marker is refused
+
+`@ag.file` and `@ag.embed` are the only markers a committed value may carry, and
+`@ag.references` / `@ag.selector` are meaningful only inside an embed. Any other `@ag.*`
+key, at any depth, in either delta form, is `unknown_marker`.
+
+An `@ag.embed` must also BE one: a non-empty object holding only `@ag.references` and
+`@ag.selector`, carrying at least one reference, where every reference is an object
+identifying a stored artifact. Anything else is `invalid_embed`.
+
+This is a storage-integrity rule, not schema hygiene. The embed resolver skips a reference
+whose value is not an object, so an invented marker resolved to nothing and the literal
+marker dict was STORED as the configuration value. A live session sent
+`{"@ag.embed": {"@ag.references": {"file": "/abs/path"}}}` meaning "import this file",
+was told the commit succeeded, and every read of that field returned a marker afterwards.
+The engine is the last thing that sees a value before it is written, and a marker it does
+not understand is a value nobody can read back.
+
+Both refusals name the two valid forms in full, including `@ag.file` for pulling in file
+content. A model that invents a marker has to be shown the real one; telling it that its
+guess was wrong teaches it nothing.
+
+### 6.8 Values are bounded in depth
+
+A value nested deeper than 64 levels is refused with `value_too_deep`.
+
+The engine walks values recursively in several places, and `deepcopy` does too, so a deeply
+nested value raised `RecursionError` from inside the engine. That reaches the caller as a
+500: the server reporting that it broke, when what happened is that it will not accept what
+it was sent. An agent can act on a refusal and cannot act on a crash.
+
+The check runs before anything else touches the delta, because `deepcopy` and the scope
+walk are themselves recursive passes: a guard placed after either of them is a guard the
+overflow reaches first. It measures depth iteratively, since a recursive depth check is the
+same overflow one frame earlier.
 
 ## 7. Application and atomicity
 
@@ -698,6 +737,7 @@ The agent can fix these and send again. Each one carries `next_step`.
 | `platform_tool_not_committable` | The `tools` list holds a platform-kind entry. Section 11. |
 | `non_embeddable_reference` | The result embeds a static workflow that may not be embedded. Wrapper-owned; `commit-transaction.md` section 4.1. |
 | `final_validation_failed` | The finished tree is not a valid configuration. Carries `issues`. |
+| `invalid_match_mode` | `edit_text` carried a `match_mode` that is not `auto` or `exact`. The operation itself is valid, so the fix is one word. |
 
 ### 12.2 Non-retryable refusals
 
@@ -707,8 +747,11 @@ Sending the same payload again never helps.
 |---|---|
 | `out_of_scope` | The scope policy refuses the target. |
 | `invalid_delta` | Both forms, no form, or an unknown delta field. |
-| `unknown_operation` | An unknown verb or an unknown `match_mode`. |
+| `unknown_operation` | An unknown verb. A bad `match_mode` is `invalid_match_mode` and retryable: the verb was right. |
 | `unresolved_file_marker` | An `@ag.file` reached the engine. Section 6.5. |
+| `invalid_embed` | An `@ag.embed` that is not one: no references, a reference that is not an object, or a key an embed does not hold. Section 6.7. |
+| `unknown_marker` | An `@ag.*` key the platform does not define. Section 6.7. |
+| `value_too_deep` | The value nests past the depth the engine walks. Section 6.8. |
 | `text_too_large` | The target string is above the work limit. |
 | `source_too_large` | The file a marker names is above the byte limit. |
 

--- a/docs/design/agent-config-editing/contracts/change-set.md
+++ b/docs/design/agent-config-editing/contracts/change-set.md
@@ -444,8 +444,9 @@ Removes one existing entry. A missing entry is `item_not_found`.
 
 ## 6. Markers, and the shape of a committed value
 
-Sections 6.1 to 6.6 are the `@ag.file` marker. 6.7 and 6.8 are the rules that keep every
-other value committable: which markers exist at all, and how deep a value may nest.
+Sections 6.1 to 6.6 are the `@ag.file` marker. 6.7 to 6.9 are the rules that keep every
+other value committable: which markers exist at all, how deep a value may nest, and the
+platform-guidance block that must never be stored.
 
 ### 6.1 The shape
 
@@ -581,6 +582,43 @@ The check runs before anything else touches the delta, because `deepcopy` and th
 walk are themselves recursive passes: a guard placed after either of them is a guard the
 overflow reaches first. It measures depth iteratively, since a recursive depth check is the
 same overflow one frame earlier.
+
+### 6.9 The platform-guidance block is stripped, never stored
+
+The runner appends a fenced block of platform guidance to the instructions file it renders
+into the agent's workspace, on every harness. The stored configuration never contains it:
+it is injected at render time and belongs to the platform, not to the user.
+
+```
+<!-- agenta:platform-guidance:start -->
+...guidance the runner wrote...
+<!-- agenta:platform-guidance:end -->
+```
+
+A model that copies the rendered file back into a commit would store that guidance as the
+user's configuration. So every committed STRING, at any depth, in either delta form and in a
+full-data commit, has the block removed before the value is stored. The whitespace at each
+junction collapses to one blank line and trailing whitespace goes, which makes the strip
+idempotent: a value that has been through it once is stable.
+
+The removal is silent to the model and visible to the human. There is no refusal and no
+reason code, because the model did nothing wrong and an error it has to recover from would
+cost a turn teaching it something it cannot act on. A `platform_guidance_stripped` warning
+names the field, so the removal appears in the response.
+
+Two delimiter cases are decided rather than left to chance. An unmatched OPENING fence strips
+to the end of the string, because whatever follows an opener is guidance whose closer was
+lost. An unmatched CLOSING fence is left as plain text: it is inert without its opener, and
+deleting on the strength of it would let one stray line remove a user's own content.
+
+An `edit_text` anchor copied out of a stripped region is not special-cased. The block is not
+in the stored text, so the anchor misses and earns the ordinary `text_not_found`, which
+already tells the agent to copy its anchor from the configuration it read.
+
+The two literals are the contract with the runner's
+`services/runner/src/engines/sandbox_agent/system-prompt-appendix.ts`. A test pins them on
+this side so neither side can change the fence alone: a fence that no longer matches is not a
+parse error, it is guidance stored as configuration.
 
 ## 7. Application and atomicity
 


### PR DESCRIPTION
## Context

An agent that wants to change one line of its own instructions has to send its whole configuration back. That is how the commit endpoint works today: `delta.set` is deep-merged, and any list it names is replaced wholesale. So changing one skill means resending every skill, and the model reliably drops something on the way. It also means every edit carries the full tree through the context window.

This PR adds the engine that makes a small edit expressible. It is pure: plain dicts in, a plain result out, no database, no pydantic, no I/O. Nothing calls it yet. The wrapper that does arrives in the next lane.

## Changes

Seven operations, applied in array order, all or nothing: `set`, `merge`, `remove`, `edit_text`, `add_item`, `replace_item`, `remove_item`. A target is an array of segments from the configuration root. A string segment names an object field. An object segment names one entry of a list and stands in place of that list's name.

Before, changing one skill's body:

```json
{"delta": {"set": {"parameters": {"agent": {"skills": [
  {"name": "release-qa", "body": "the new text"},
  {"name": "triage", "body": "...resend this whole entry or lose it..."}
]}}}}}
```

After:

```json
{"delta": {"operations": [{
  "operation": "set",
  "target": ["parameters", "agent", {"list": "skills", "key": "release-qa"}, "body"],
  "value": "the new text"
}]}}
```

`edit_text` goes further and replaces an exact substring, so a long instruction document can be edited without resending it. An anchor must appear exactly once, counted with overlap, or the operation fails rather than guessing.

Match tolerance follows what the text is. Prose fields (`agents_md`, `body`, `description`) match exact first, then retry with normalized quotes, dashes, and whitespace, and the response reports that normalization was used. Script and file contents (`content`, `script`) match exact only, because bytes are meaning there.

The engine also owns the refusals. Every operation's target is checked against a scope policy before anything is applied, and the check is on the RESULT rather than the named target: an operation that writes an ancestor object whose value would change a platform-owned path is refused too. That closed a live bypass found in UI testing, where an agent switched its own harness by writing the object above it. A result that would hold an unresolved `@ag.file` marker is rejected, since the runner replaces every marker before the API sees the call and one that survives means the runner did not run.

Duplicate names are enforced in three tiers. An item operation must leave its collection clean, a branch write must not add a duplicate, and an untouched collection only warns. That last tier is what keeps existing configurations editable.

Nested collections carry their parent's key in their identity, so `skills[alpha].files` and `skills[beta].files` are two collections. Without that they collapse onto one path and the last skill in the list answers for every other one, which makes the outcome depend on sibling order in both directions: a clean edit gets rejected because an untouched sibling holds duplicates, and a real duplicate written into a non-last skill is accepted in silence.

Every reason code is stable and machine readable, and every retryable one carries a sentence naming the next action. The usability spike measured this as the difference between a model that recovers and one that dead-ends.

## Tests / notes

- `api/oss/tests/pytest/unit/workflows/test_change_set.py`, 188 tests. It is written against `contracts/change-set.md`, and each class names the contract section it pins.
- The legacy `set` and `remove` fold is pinned against an independent reference implementation written out in the test file, so the engine's legacy arm cannot drift from what the service did before.
- The nested-identity tests all use two skills on purpose. Every earlier test used one, which is exactly why the aliasing survived.
- Reviewers should look hardest at `_check_unique_names` and the touched-path bookkeeping around it. It is the part with the most cases and the least obvious failure mode.
- The contract update in this PR documents two rules the engine does not yet enforce here: the marker refusals (section 6.7) and the value depth bound (6.8). Both are enforced by code that landed one lane up, in #5751, after the stack's hunk attribution split the doc from the code. Do not look for them in this diff.

This targets `agent-config-editing-s4` and is part of the agent-config-editing stack. Read the stack bottom up.
