### PR TITLE
feat(api): wire ordered operations into the workflow commit endpoint

### DIFF
--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Any, Literal, Optional, List
 
 from pydantic import BaseModel, Field
 
@@ -384,6 +384,13 @@ class WorkflowRevisionsLogRequest(BaseModel):
     )
 
 
+class CommitWarning(BaseModel):
+    code: str
+    message: str
+    target: Optional[List[Any]] = None
+    operation_index: Optional[int] = None
+
+
 class WorkflowRevisionResponse(BaseModel):
     count: int = Field(
         default=0,
@@ -392,6 +399,19 @@ class WorkflowRevisionResponse(BaseModel):
     workflow_revision: Optional[WorkflowRevision] = Field(
         default=None,
         description="The workflow revision.",
+    )
+    status: Optional[Literal["committed", "no_change"]] = Field(
+        default=None,
+        description=(
+            "Commit outcome. `no_change` means the change produced the stored "
+            "configuration, so no revision was created and `workflow_revision` is the "
+            "current head. Absent on paths that do not run the checked commit; a reader "
+            "must treat absent as `committed`."
+        ),
+    )
+    warnings: Optional[List[CommitWarning]] = Field(
+        default=None,
+        description="Structured advisories about the commit; never an error.",
     )
     resolution_info: Optional[ResolutionInfo] = Field(
         default=None,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -15,7 +15,9 @@ from oss.src.core.shared.dtos import (
 from oss.src.core.git.utils import build_retrieval_info
 from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.apis.fastapi.workflows.exceptions import handle_workflow_exceptions
+from oss.src.core.workflows.change_set import ChangeSetError
 from oss.src.core.workflows.service import (
+    RevisionConflictError,
     WorkflowsService,
     SimpleWorkflowsService,
 )
@@ -1554,27 +1556,35 @@ class WorkflowsRouter:
                     detail="workflow_revision.data is required when committing a workflow revision.",
                 )
 
-        workflow_revision = await self.workflows_service.commit_workflow_revision(
-            project_id=UUID(request.state.project_id),
-            user_id=UUID(request.state.user_id),
-            #
-            workflow_revision_commit=workflow_revision_commit_request.workflow_revision,
-        )
+        try:
+            outcome = await self.workflows_service.commit_workflow_revision_checked(
+                project_id=UUID(request.state.project_id),
+                user_id=UUID(request.state.user_id),
+                #
+                workflow_revision_commit=workflow_revision_commit_request.workflow_revision,
+            )
+        except RevisionConflictError as e:
+            raise HTTPException(status_code=409, detail=e.to_detail()) from e
+        except ChangeSetError as e:
+            raise HTTPException(status_code=422, detail=e.to_detail()) from e
 
-        # Invalidate legacy caches so the registry page reflects the new revision
-        await invalidate_cache(project_id=request.state.project_id)
+        workflow_revision = outcome.revision
 
-        await _emit_committed_revision_data_event(
-            request=request,
-            workflow_revision=workflow_revision,
-        )
+        # A commit event evicts the warm session, so `no_change` must emit nothing.
+        if outcome.status == "committed":
+            await invalidate_cache(project_id=request.state.project_id)
 
-        workflow_revision_response = WorkflowRevisionResponse(
+            await _emit_committed_revision_data_event(
+                request=request,
+                workflow_revision=workflow_revision,
+            )
+
+        return WorkflowRevisionResponse(
             count=1 if workflow_revision else 0,
             workflow_revision=workflow_revision,
+            status=outcome.status,
+            warnings=outcome.warnings or None,
         )
-
-        return workflow_revision_response
 
     @intercept_exceptions()
     @suppress_exceptions(default=WorkflowRevisionsResponse(), exclude=[HTTPException])

--- a/api/oss/src/core/tools/platform_handlers.py
+++ b/api/oss/src/core/tools/platform_handlers.py
@@ -216,13 +216,14 @@ async def _build_test_workflow_request(
         )
 
     if request.delta is not None:
-        resolved = await workflows_service._resolve_revision_delta(
+        resolution = await workflows_service._resolve_revision_delta(
             project_id=project_id,
             workflow_revision_commit=WorkflowRevisionCommit(
                 workflow_variant_id=request.target.workflow_variant_id,
                 delta=request.delta,
             ),
         )
+        resolved = resolution.commit
         if resolved.data is None:
             raise PlatformToolHandlerError(
                 "test_run could not resolve the revision delta."

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -68,6 +68,7 @@ class Reason:
     PLATFORM_TOOL_NOT_COMMITTABLE = "platform_tool_not_committable"
     NON_EMBEDDABLE_REFERENCE = "non_embeddable_reference"
     FINAL_VALIDATION_FAILED = "final_validation_failed"
+    INVALID_MATCH_MODE = "invalid_match_mode"
 
     # --- non-retryable refusals: the same payload never succeeds (12.2) ---
     OUT_OF_SCOPE = "out_of_scope"
@@ -76,6 +77,7 @@ class Reason:
     UNRESOLVED_FILE_MARKER = "unresolved_file_marker"
     INVALID_EMBED = "invalid_embed"
     UNKNOWN_MARKER = "unknown_marker"
+    VALUE_TOO_DEEP = "value_too_deep"
     TEXT_TOO_LARGE = "text_too_large"
     SOURCE_TOO_LARGE = "source_too_large"
 
@@ -88,6 +90,7 @@ _NOT_RETRYABLE = frozenset(
         Reason.UNRESOLVED_FILE_MARKER,
         Reason.INVALID_EMBED,
         Reason.UNKNOWN_MARKER,
+        Reason.VALUE_TOO_DEEP,
         Reason.TEXT_TOO_LARGE,
         Reason.SOURCE_TOO_LARGE,
     }
@@ -163,6 +166,12 @@ NEXT_STEPS: Dict[str, str] = {
     Reason.FINAL_VALIDATION_FAILED: (
         "Correct the fields listed in `issues` and send the commit again."
     ),
+    Reason.INVALID_MATCH_MODE: (
+        "Set match_mode to 'auto' or 'exact', or leave it out to get 'auto'."
+    ),
+    Reason.VALUE_TOO_DEEP: (
+        "Flatten the value: the configuration nests a few levels deep, not hundreds."
+    ),
 }
 
 
@@ -204,6 +213,9 @@ MATCH_MODES = ("auto", "exact")
 
 # Contract 5.6.3.
 MAX_TEXT_LENGTH = 200_000  # matches SkillFile.content max_length
+# Bounds on the near-miss search, which runs on the way to an error (see `nearest_lines`).
+MAX_SCANNED_LINES = 5_000
+MAX_SCANNED_LINE_LENGTH = 2_000
 MAX_OLD_TEXT_LENGTH = 20_000
 MAX_EDITS_PER_OPERATION = 32
 MAX_OPERATIONS = 64
@@ -339,14 +351,15 @@ class _Fail(Exception):
 
 
 # --------------------------------------------------------------------------------------
-# Legacy primitives (must stay identical to service.py)
+# Legacy primitives (the engine is the only implementation)
 # --------------------------------------------------------------------------------------
 
 
 def deep_merge(base: dict, patch: dict) -> dict:
     """Today's dict-only recursion. Nested dicts merge; scalars and lists replace.
 
-    ``service.py`` must import this one so the two can never drift.
+    The wrapper used to keep its own copy and the two could drift. This is now the only
+    implementation in the codebase, so there is nothing left to drift from.
     """
     merged = dict(base)
     for key, value in patch.items():
@@ -551,6 +564,41 @@ _VALID_FORMS = (
     'To pull in the contents of a file from your workspace, use {"@ag.file": "<path>"} '
     "instead, and the runner replaces it with the text before the commit is sent."
 )
+
+
+# A configuration nests a handful of levels: parameters.agent.skills[].files[].content is
+# six. The limit is generous against real data and far below Python's recursion limit, so
+# every recursive walk below it has stack to spare.
+MAX_VALUE_DEPTH = 64
+
+
+def _reject_deep_values(value: Any) -> None:
+    """Refuse a value nested deeper than anything the engine can walk safely.
+
+    ``deep_merge``, the marker walks and the scope walk all recurse over the value, so a
+    deeply nested one raised ``RecursionError`` from inside the engine. That is a 500: the
+    caller was told the server broke, when what happened is that it sent something the
+    server will not accept. It is also the wrong answer to hand an agent, which can correct
+    a refusal and cannot correct a crash.
+
+    Measured ITERATIVELY. A recursive depth check is the same stack overflow it exists to
+    prevent, one frame earlier.
+    """
+    stack = [(value, 1)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > MAX_VALUE_DEPTH:
+            raise _Fail(
+                Reason.VALUE_TOO_DEEP,
+                f"the value nests more than {MAX_VALUE_DEPTH} levels deep.",
+                max_depth=MAX_VALUE_DEPTH,
+            )
+        if isinstance(node, dict):
+            for child in node.values():
+                stack.append((child, depth + 1))
+        elif isinstance(node, list):
+            for child in node:
+                stack.append((child, depth + 1))
 
 
 def _reject_bad_markers(value: Any, pointer: str = "") -> None:
@@ -873,10 +921,22 @@ def nearest_lines(text: str, old_text: str, limit: int = 3) -> List[Dict[str, An
     """
     if not text or not old_text:
         return []
+    lines = text.splitlines()
+    # This runs on a REFUSAL, so its cost is paid by a call that produces nothing. A field
+    # may hold 200_000 characters, and scoring every line of one is a similarity pass per
+    # line on the way to an error. The cap keeps a failed anchor cheap; the near miss an
+    # agent needs is in the first screens of a field, not at the end of a hundred thousand
+    # lines.
+    if len(lines) > MAX_SCANNED_LINES:
+        return []
     needle = old_text.strip().splitlines()[0] if old_text.strip() else old_text
+    # Comparing against a very long line is quadratic in its length, and a minified or
+    # single-line file is one such line. Clipping bounds the comparison without moving the
+    # answer: the anchor's own first line is what is being matched.
+    needle = needle[:MAX_SCANNED_LINE_LENGTH]
     scored: List[Tuple[float, int, str]] = []
-    for number, line in enumerate(text.splitlines(), start=1):
-        ratio = SequenceMatcher(None, needle, line).ratio()
+    for number, line in enumerate(lines, start=1):
+        ratio = SequenceMatcher(None, needle, line[:MAX_SCANNED_LINE_LENGTH]).ratio()
         scored.append((ratio, number, line))
     scored.sort(key=lambda row: (-row[0], row[1]))
     return [
@@ -1154,9 +1214,14 @@ def _apply_operation(
         _require_field_tail(segments, "edit_text")
         mode = operation.get("match_mode", "auto")
         if mode not in MATCH_MODES:
+            # Not UNKNOWN_OPERATION: the operation is `edit_text` and it exists. Reporting
+            # an unknown OPERATION for a bad modifier told the agent its verb was wrong,
+            # and non-retryably, so a one-word fix looked like a dead end.
             raise _Fail(
-                Reason.UNKNOWN_OPERATION,
-                f"unknown match_mode {mode!r} (known: {', '.join(MATCH_MODES)})",
+                Reason.INVALID_MATCH_MODE,
+                f"{mode!r} is not a match_mode. The modes are "
+                f"{', '.join(repr(m) for m in MATCH_MODES)}.",
+                match_mode=mode,
             )
         edits = operation.get("edits")
         if not isinstance(edits, list):
@@ -1221,6 +1286,7 @@ def _apply_operation(
         _require_selector_tail(segments, "replace_item")
         selector = segments[-1]
         list_name, key = selector["list"], selector["key"]
+        _require_keyed_list(list_name)
         parent = _parent_of(root, segments, create=False)
         collection, position = _find_item(
             parent, list_name, key, where=f"target segment {len(segments) - 1}"
@@ -1237,6 +1303,7 @@ def _apply_operation(
 
     _require_selector_tail(segments, "remove_item")
     selector = segments[-1]
+    _require_keyed_list(selector["list"])
     parent = _parent_of(root, segments, create=False)
     collection, position = _find_item(
         parent,
@@ -1246,6 +1313,22 @@ def _apply_operation(
     )
     del collection[position]
     touched.item(segments[:-1] + [selector["list"]])
+
+
+def _require_keyed_list(list_name: Any) -> None:
+    """Only the four keyed lists are addressed by name. Contract 4.1.
+
+    `add_item` has always said this precisely. Its two siblings went straight to the lookup,
+    so selecting an entry of an unkeyed list reported that the list did not exist, or that
+    no entry matched. Both are true and neither is the reason, and an agent reading them
+    retries the same shape against a list that can never take it.
+    """
+    if list_name not in KEY_FIELDS:
+        raise _Fail(
+            Reason.UNKEYED_COLLECTION,
+            f"'{list_name}' is not a name-addressed list "
+            f"(known: {', '.join(sorted(KEY_FIELDS))})",
+        )
 
 
 def _warn_wholesale(
@@ -1431,12 +1514,49 @@ _LEGACY_FIELDS = ("set", "remove")
 def _classify(delta: Dict[str, Any]) -> str:
     if not isinstance(delta, dict):
         raise ChangeSetError(Reason.INVALID_DELTA, "the delta must be an object")
+    # FIRST, before anything walks or copies the delta. `deepcopy` and the scope walk are
+    # themselves recursive passes over the value, so a guard placed after either of them is
+    # a guard the overflow reaches first. One check here covers the legacy `set` and every
+    # operation's `value`.
+    try:
+        _reject_deep_values(delta)
+    except _Fail as failure:
+        raise ChangeSetError(
+            failure.reason, failure.message, **failure.context
+        ) from failure
+
     unknown = set(delta) - {"set", "remove", "operations"}
     if unknown:
         raise ChangeSetError(
             Reason.INVALID_DELTA,
             f"unknown delta fields: {', '.join(sorted(unknown))}",
         )
+    # Typed HERE, before either arm touches them. A non-dict `set` reached `deep_merge`,
+    # and a `remove` sent as a string was iterated character by character, so each letter
+    # became a path to delete. Both produced a crash or a silent nonsense edit where the
+    # caller should have been told what shape the field takes.
+    patch = delta.get("set")
+    if patch is not None and not isinstance(patch, dict):
+        raise ChangeSetError(
+            Reason.INVALID_DELTA,
+            f"'set' must be an object holding the fields to change, not "
+            f"{_type_name(patch)}.",
+        )
+    removals = delta.get("remove")
+    if removals is not None:
+        if not isinstance(removals, list):
+            raise ChangeSetError(
+                Reason.INVALID_DELTA,
+                f"'remove' must be a list of dotted field paths, not "
+                f"{_type_name(removals)}.",
+            )
+        offenders = [item for item in removals if not isinstance(item, str)]
+        if offenders:
+            raise ChangeSetError(
+                Reason.INVALID_DELTA,
+                "every entry in 'remove' must be a dotted field path string.",
+            )
+
     has_legacy = any(delta.get(name) is not None for name in _LEGACY_FIELDS)
     has_ordered = delta.get("operations") is not None
     if has_legacy and has_ordered:

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -17,6 +17,7 @@ the parts that need context it does not have.
 
 from copy import deepcopy
 from dataclasses import dataclass, field
+from difflib import SequenceMatcher
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 __all__ = [
@@ -859,6 +860,32 @@ def _count_overlapping(text: str, needle: str) -> int:
     return count
 
 
+def nearest_lines(text: str, old_text: str, limit: int = 3) -> List[Dict[str, Any]]:
+    """The lines of ``text`` most similar to ``old_text``, with their line numbers.
+
+    A failed anchor is nearly always a near miss: stale, reformatted, or mistyped. Handing
+    the agent the real lines lets it re-anchor in the same turn instead of spending one on
+    another read (contract 12.4).
+
+    It lives in the engine rather than beside the wrapper's other error helpers because it
+    needs no context the engine lacks: the target string and the anchor are both in hand
+    at the only place that raises ``text_not_found``.
+    """
+    if not text or not old_text:
+        return []
+    needle = old_text.strip().splitlines()[0] if old_text.strip() else old_text
+    scored: List[Tuple[float, int, str]] = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        ratio = SequenceMatcher(None, needle, line).ratio()
+        scored.append((ratio, number, line))
+    scored.sort(key=lambda row: (-row[0], row[1]))
+    return [
+        {"line": number, "text": line, "similarity": round(ratio, 3)}
+        for ratio, number, line in scored[:limit]
+        if ratio > 0
+    ]
+
+
 def apply_text_edits(
     text: str,
     edits: Sequence[Dict[str, str]],
@@ -931,11 +958,15 @@ def apply_text_edits(
                 count = folded_count
 
         if count == 0:
+            # The near misses ride along, so the agent can re-anchor in this turn instead
+            # of spending another one reading the field back (contract 12.4).
+            candidates = nearest_lines(text, old_text)
             raise _Fail(
                 Reason.TEXT_NOT_FOUND,
                 f"edits[{index}].old_text does not occur in the target string. "
                 "The text must match exactly, with all whitespace and newlines.",
                 edit_index=index,
+                **({"nearest_lines": candidates} if candidates else {}),
             )
         if count > 1:
             raise _Fail(

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -68,7 +68,6 @@ class Reason:
     PLATFORM_TOOL_NOT_COMMITTABLE = "platform_tool_not_committable"
     NON_EMBEDDABLE_REFERENCE = "non_embeddable_reference"
     FINAL_VALIDATION_FAILED = "final_validation_failed"
-    INVALID_MATCH_MODE = "invalid_match_mode"
 
     # --- non-retryable refusals: the same payload never succeeds (12.2) ---
     OUT_OF_SCOPE = "out_of_scope"
@@ -165,9 +164,6 @@ NEXT_STEPS: Dict[str, str] = {
     ),
     Reason.FINAL_VALIDATION_FAILED: (
         "Correct the fields listed in `issues` and send the commit again."
-    ),
-    Reason.INVALID_MATCH_MODE: (
-        "Set match_mode to 'auto' or 'exact', or leave it out to get 'auto'."
     ),
     Reason.VALUE_TOO_DEEP: (
         "Flatten the value: the configuration nests a few levels deep, not hundreds."
@@ -1218,9 +1214,10 @@ def _apply_operation(
             # an unknown OPERATION for a bad modifier told the agent its verb was wrong,
             # and non-retryably, so a one-word fix looked like a dead end.
             raise _Fail(
-                Reason.INVALID_MATCH_MODE,
+                Reason.INVALID_OPERATION_SHAPE,
                 f"{mode!r} is not a match_mode. The modes are "
                 f"{', '.join(repr(m) for m in MATCH_MODES)}.",
+                next_step="Set match_mode to 'auto' or 'exact', or leave it out.",
                 match_mode=mode,
             )
         edits = operation.get("edits")

--- a/api/oss/src/core/workflows/change_set.py
+++ b/api/oss/src/core/workflows/change_set.py
@@ -35,6 +35,10 @@ __all__ = [
     "AGENT_COMMIT_SCOPE",
     "KEY_FIELDS",
     "FILE_MARKER",
+    "PLATFORM_GUIDANCE_START",
+    "PLATFORM_GUIDANCE_END",
+    "strip_platform_guidance",
+    "strip_guidance_from_data",
 ]
 
 
@@ -267,6 +271,7 @@ class WarningCode:
     LEGACY_DUPLICATE_KEY = "legacy_duplicate_key"
     LEGACY_DELTA_FORM = "legacy_delta_form"
     UNADDRESSABLE_EMBED = "unaddressable_embed"
+    PLATFORM_GUIDANCE_STRIPPED = "platform_guidance_stripped"
 
 
 # --------------------------------------------------------------------------------------
@@ -514,6 +519,127 @@ def _format_segment(segment: Segment) -> str:
     if isinstance(segment, dict):
         return f"{segment.get('list')}[{segment.get('key')!r}]"
     return repr(segment)
+
+
+# --------------------------------------------------------------------------------------
+# The platform-guidance block
+# --------------------------------------------------------------------------------------
+
+# The runner appends a fenced block of platform guidance to the instructions file it renders
+# into the agent's workspace. The stored configuration never contains it: it is injected at
+# render time, on every harness. These two literals are the contract with the runner's
+# `services/runner/src/engines/sandbox_agent/system-prompt-appendix.ts`, and a test pins them
+# so neither side can change the fence alone.
+PLATFORM_GUIDANCE_START = "<!-- agenta:platform-guidance:start -->"
+PLATFORM_GUIDANCE_END = "<!-- agenta:platform-guidance:end -->"
+
+
+def strip_platform_guidance(text: str) -> str:
+    """Remove every platform-guidance block from one string.
+
+    A model that copies the rendered instructions file back into a commit would otherwise
+    store our own guidance as the user's configuration. Removing it is deliberately SILENT
+    rather than a refusal: the model did nothing wrong, and an error it has to recover from
+    costs a turn to teach it something it cannot act on.
+
+    An unmatched opening fence strips to the end of the string, because whatever follows an
+    opener is guidance whose closer was lost. An unmatched CLOSING fence is left alone: it is
+    an inert comment without its opener, and deleting text on the strength of it would let a
+    stray line remove a user's own content.
+
+    The result is normalized so a stripped value does not carry the hole the block left: the
+    whitespace run at each junction collapses to one blank line, and trailing whitespace goes.
+    That makes the strip idempotent, so a value that has been through it once is stable.
+    """
+    if PLATFORM_GUIDANCE_START not in text:
+        return text
+
+    kept: List[str] = []
+    rest = text
+    while True:
+        head, opened, tail = rest.partition(PLATFORM_GUIDANCE_START)
+        kept.append(head)
+        if not opened:
+            break
+        _, closed, after = tail.partition(PLATFORM_GUIDANCE_END)
+        if not closed:
+            break
+        rest = after
+
+    result = ""
+    for piece in kept:
+        if not result:
+            result = piece
+            continue
+        left, right = result.rstrip(), piece.lstrip()
+        result = f"{left}\n\n{right}" if left and right else (left or right)
+    return result.rstrip()
+
+
+def strip_guidance_from_data(data: Any) -> Tuple[Any, List[Warning]]:
+    """Strip the guidance block from a whole configuration tree, outside the delta arms.
+
+    A full-data commit never reaches the engine, and a copied-back instructions file can
+    arrive that way as easily as through a delta. Same rule, same warnings, one entry point
+    for the wrapper.
+    """
+    warnings: List[Warning] = []
+    return _strip_guidance(data, warnings=warnings, path=[]), warnings
+
+
+def _strip_guidance(
+    value: Any,
+    *,
+    warnings: List[Warning],
+    path: List[str],
+    target: Optional[List[Segment]] = None,
+    operation_index: Optional[int] = None,
+) -> Any:
+    """Strip every string in ``value``, warning once per field that carried a block.
+
+    The warning names the field so the removal is visible in the response. Silent to the
+    MODEL is the point; silent to the human reading the result is not.
+    """
+    if isinstance(value, str):
+        stripped = strip_platform_guidance(value)
+        if stripped != value:
+            where = ".".join(path) if path else "the value"
+            warnings.append(
+                Warning(
+                    code=WarningCode.PLATFORM_GUIDANCE_STRIPPED,
+                    message=(
+                        f"Removed the platform guidance block from {where}. That block is "
+                        "added to your instructions file when it is rendered and is never "
+                        "part of your stored configuration."
+                    ),
+                    target=list(target) if target is not None else None,
+                    operation_index=operation_index,
+                )
+            )
+        return stripped
+    if isinstance(value, dict):
+        return {
+            key: _strip_guidance(
+                child,
+                warnings=warnings,
+                path=path + [str(key)],
+                target=target,
+                operation_index=operation_index,
+            )
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _strip_guidance(
+                child,
+                warnings=warnings,
+                path=path + [str(index)],
+                target=target,
+                operation_index=operation_index,
+            )
+            for index, child in enumerate(value)
+        ]
+    return value
 
 
 # --------------------------------------------------------------------------------------
@@ -1158,7 +1284,13 @@ def _apply_operation(
         _validate_segment(segment, position)
 
     if verb in VALUE_BEARING:
-        value = _operation_value(operation)
+        value = _strip_guidance(
+            _operation_value(operation),
+            warnings=warnings,
+            path=[],
+            target=segments,
+            operation_index=index,
+        )
     elif "value" in operation:
         raise _Fail(Reason.INVALID_OPERATION_SHAPE, f"'{verb}' does not take a value")
     else:
@@ -1745,7 +1877,11 @@ def apply_change_set(
         # A copy, because `remove_path` mutates the result and `deep_merge` grafts the
         # patch's own sub-dicts into it. Without this the caller's delta is edited in
         # place, and the engine's promise that it touches nothing it was given is false.
-        patch = deepcopy(delta.get("set") or {})
+        patch = _strip_guidance(
+            deepcopy(delta.get("set") or {}),
+            warnings=warnings,
+            path=[],
+        )
         _reject_delta_markers(patch)
         _reject_legacy_bad_markers(patch)
         for name in ("tools", "skills", "mcps"):

--- a/api/oss/src/core/workflows/commit_support.py
+++ b/api/oss/src/core/workflows/commit_support.py
@@ -1,24 +1,26 @@
 """Wrapper-owned helpers for an ordered-operations commit (slice S1b).
 
-The engine (``change_set.py``) is pure and knows only the data tree. Four jobs need
+The engine (``change_set.py``) is pure and knows only the data tree. Three jobs need
 context it does not have, so the contract gives them to the wrapper
 (``contracts/change-set.md`` section 17):
 
 - **Selector normalization** (4.3): forgive the two unambiguous target mistakes.
 - **The derived commit message** (14): the model no longer sends one.
 - **The platform-tool rejection** (11): the build kit must be uncommittable.
-- **Enriched error content** (12.4): a folder listing and the nearest lines, both of
-  which need the workspace or the base revision.
+
+Enriched error content (12.4) was a fourth job here, and it does not belong. The nearest
+lines need only the target string and the anchor, so they are raised by the engine itself.
+The folder listing needs a workspace listing that never reaches the API at all: the runner
+resolves file markers before it builds the request, so nothing here can raise
+``source_not_found``.
 
 Everything here is pure and synchronous, so it can run inside the commit transaction.
 """
 
-from difflib import SequenceMatcher
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 from oss.src.core.workflows.change_set import (
     KEY_FIELDS,
-    Reason,
     Warning,
     WarningCode,
     item_key,
@@ -28,8 +30,6 @@ __all__ = [
     "normalize_operations",
     "derive_commit_message",
     "find_platform_tool_entries",
-    "nearest_lines",
-    "list_import_folders",
     "PLATFORM_TOOL_REJECTION",
 ]
 
@@ -143,11 +143,7 @@ _SINGULAR = {
 _LEGACY_MESSAGE = "updated configuration"
 
 
-def derive_commit_message(
-    operations: Optional[Sequence[Any]],
-    *,
-    description: Optional[str] = None,
-) -> str:
+def derive_commit_message(operations: Optional[Sequence[Any]]) -> str:
     """Build the commit message from the operations. The model never sends one.
 
     Free text was the site of every argument-corruption failure the usability spike
@@ -155,19 +151,18 @@ def derive_commit_message(
     #5200 better than the model's own words. It is also the audit record: no new column,
     no migration (decision 6, amended).
 
-    ``description`` is the ephemeral per-call note (R12). When present it is appended in
-    parentheses, so the agent's own words survive without being the source of truth.
+    It took an ephemeral per-call note (R12) and appended it in parentheses. Nothing could
+    ever fill it. The runner deletes that note before it builds the request, deliberately
+    (read-config.md 12.3), so the only value that reached this argument was
+    ``RevisionCommit.description``: the persisted revision field, which is the exact name
+    collision 12.1 exists to prevent. A direct HTTP caller that set it had its description
+    copied verbatim into the message beside itself.
     """
     if not operations:
-        text = _LEGACY_MESSAGE
-    else:
-        clauses = _clauses(operations)
-        text = "; ".join(clauses) if clauses else _LEGACY_MESSAGE
+        return _LEGACY_MESSAGE
 
-    note = (description or "").strip()
-    if note:
-        text = f"{text} ({note})"
-    return text
+    clauses = _clauses(operations)
+    return "; ".join(clauses) if clauses else _LEGACY_MESSAGE
 
 
 def _clauses(operations: Sequence[Any]) -> List[str]:
@@ -257,58 +252,3 @@ def _collect_platform_tools(node: Any, found: List[str]) -> None:
     elif isinstance(node, list):
         for entry in node:
             _collect_platform_tools(entry, found)
-
-
-# --------------------------------------------------------------------------------------
-# Enriched error content (contract 12.4)
-# --------------------------------------------------------------------------------------
-
-
-def nearest_lines(text: str, old_text: str, limit: int = 3) -> List[Dict[str, Any]]:
-    """The lines of ``text`` most similar to ``old_text``, with their line numbers.
-
-    A failed anchor is nearly always a near miss: stale, reformatted, or mistyped. Handing
-    the agent the real lines lets it re-anchor in the same turn instead of spending one on
-    another read.
-    """
-    if not text or not old_text:
-        return []
-    needle = old_text.strip().splitlines()[0] if old_text.strip() else old_text
-    scored: List[Tuple[float, int, str]] = []
-    for number, line in enumerate(text.splitlines(), start=1):
-        ratio = SequenceMatcher(None, needle, line).ratio()
-        scored.append((ratio, number, line))
-    scored.sort(key=lambda row: (-row[0], row[1]))
-    return [
-        {"line": number, "text": line, "similarity": round(ratio, 3)}
-        for ratio, number, line in scored[:limit]
-        if ratio > 0
-    ]
-
-
-def list_import_folders(entries: Sequence[str], limit: int = 20) -> List[str]:
-    """The folder names that DO exist under the import root, sorted and capped.
-
-    A wrong path is nearly always a near miss, so naming what exists is what recovers the
-    call. The runner supplies the listing; this only shapes it.
-    """
-    return sorted(set(entries))[:limit]
-
-
-def enrich_reason(
-    reason: str,
-    context: Dict[str, Any],
-    *,
-    target_text: Optional[str] = None,
-    old_text: Optional[str] = None,
-    import_entries: Optional[Sequence[str]] = None,
-) -> Dict[str, Any]:
-    """Add the recovery content the contract requires to a reason payload."""
-    enriched = dict(context)
-    if reason == Reason.TEXT_NOT_FOUND and target_text and old_text:
-        lines = nearest_lines(target_text, old_text)
-        if lines:
-            enriched["nearest_lines"] = lines
-    elif reason == Reason.SOURCE_NOT_FOUND and import_entries is not None:
-        enriched["available"] = list_import_folders(import_entries)
-    return enriched

--- a/api/oss/src/core/workflows/commit_support.py
+++ b/api/oss/src/core/workflows/commit_support.py
@@ -1,0 +1,314 @@
+"""Wrapper-owned helpers for an ordered-operations commit (slice S1b).
+
+The engine (``change_set.py``) is pure and knows only the data tree. Four jobs need
+context it does not have, so the contract gives them to the wrapper
+(``contracts/change-set.md`` section 17):
+
+- **Selector normalization** (4.3): forgive the two unambiguous target mistakes.
+- **The derived commit message** (14): the model no longer sends one.
+- **The platform-tool rejection** (11): the build kit must be uncommittable.
+- **Enriched error content** (12.4): a folder listing and the nearest lines, both of
+  which need the workspace or the base revision.
+
+Everything here is pure and synchronous, so it can run inside the commit transaction.
+"""
+
+from difflib import SequenceMatcher
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from oss.src.core.workflows.change_set import (
+    KEY_FIELDS,
+    Reason,
+    Warning,
+    WarningCode,
+    item_key,
+)
+
+__all__ = [
+    "normalize_operations",
+    "derive_commit_message",
+    "find_platform_tool_entries",
+    "nearest_lines",
+    "list_import_folders",
+    "PLATFORM_TOOL_REJECTION",
+]
+
+
+# --------------------------------------------------------------------------------------
+# Selector normalization (contract 4.3)
+# --------------------------------------------------------------------------------------
+
+
+def normalize_operations(
+    operations: Sequence[Any],
+) -> Tuple[List[Any], List[Warning]]:
+    """Forgive the two unambiguous selector mistakes, and say so.
+
+    Both mistakes have exactly one sensible reading, so refusing them teaches nothing.
+    Anything ambiguous is left alone for the engine to refuse with a precise reason.
+
+    Returns the corrected operations and one warning per correction.
+    """
+    corrected: List[Any] = []
+    warnings: List[Warning] = []
+
+    for index, operation in enumerate(operations):
+        if not isinstance(operation, dict):
+            corrected.append(operation)
+            continue
+        target = operation.get("target")
+        if not isinstance(target, list):
+            corrected.append(operation)
+            continue
+
+        new_target, notes = _normalize_target(target)
+        if not notes:
+            corrected.append(operation)
+            continue
+
+        corrected.append({**operation, "target": new_target})
+        for note in notes:
+            warnings.append(
+                Warning(
+                    code=WarningCode.TARGET_NORMALIZED,
+                    message=note,
+                    target=new_target,
+                    operation_index=index,
+                )
+            )
+
+    return corrected, warnings
+
+
+def _normalize_target(target: Sequence[Any]) -> Tuple[List[Any], List[str]]:
+    notes: List[str] = []
+    segments = list(target)
+
+    # Mistake 1: the list name repeated before its own selector. A selector already
+    # stands in place of the list's name, so the extra segment is always redundant.
+    # It absorbed 12 percent of one model's targets once the teaching left the tool
+    # description.
+    collapsed: List[Any] = []
+    for segment in segments:
+        if (
+            isinstance(segment, dict)
+            and collapsed
+            and isinstance(collapsed[-1], str)
+            and collapsed[-1] == segment.get("list")
+        ):
+            removed = collapsed.pop()
+            notes.append(
+                f"Removed the repeated list name {removed!r} before its selector. "
+                "A selector already stands in place of the list's name."
+            )
+        collapsed.append(segment)
+    segments = collapsed
+
+    # Mistake 2: the KEY FIELD in the `list` slot, e.g. {"list": "name", "key": "x"}
+    # inside a list position. The enclosing list is unambiguous, so the fix is exact.
+    # This vanished when `field` was renamed to `list`; the normalization stays as a belt.
+    key_field_names = {"name", "path", "op", "slug"}
+    for position, segment in enumerate(segments):
+        if not isinstance(segment, dict):
+            continue
+        list_name = segment.get("list")
+        if list_name not in key_field_names:
+            continue
+        enclosing = segments[position - 1] if position > 0 else None
+        if isinstance(enclosing, str) and enclosing in KEY_FIELDS:
+            segments[position] = {"list": enclosing, "key": segment.get("key")}
+            # The enclosing name is now redundant, exactly like mistake 1.
+            segments.pop(position - 1)
+            notes.append(
+                f"Read {{'list': {list_name!r}}} as the list {enclosing!r}. "
+                "'list' names the list, not its key field."
+            )
+            break
+
+    return segments, notes
+
+
+# --------------------------------------------------------------------------------------
+# The derived commit message (contract 14)
+# --------------------------------------------------------------------------------------
+
+# A list's name in the singular, for the message. Only the four keyed lists appear.
+_SINGULAR = {
+    "skills": "skill",
+    "mcps": "MCP server",
+    "tools": "tool",
+    "files": "file",
+}
+
+_LEGACY_MESSAGE = "updated configuration"
+
+
+def derive_commit_message(
+    operations: Optional[Sequence[Any]],
+    *,
+    description: Optional[str] = None,
+) -> str:
+    """Build the commit message from the operations. The model never sends one.
+
+    Free text was the site of every argument-corruption failure the usability spike
+    measured, and a derived message is always accurate, which serves issues #5187 and
+    #5200 better than the model's own words. It is also the audit record: no new column,
+    no migration (decision 6, amended).
+
+    ``description`` is the ephemeral per-call note (R12). When present it is appended in
+    parentheses, so the agent's own words survive without being the source of truth.
+    """
+    if not operations:
+        text = _LEGACY_MESSAGE
+    else:
+        clauses = _clauses(operations)
+        text = "; ".join(clauses) if clauses else _LEGACY_MESSAGE
+
+    note = (description or "").strip()
+    if note:
+        text = f"{text} ({note})"
+    return text
+
+
+def _clauses(operations: Sequence[Any]) -> List[str]:
+    clauses: List[str] = []
+    # Consecutive edit_text operations on ONE field read as one clause with a count;
+    # listing them one by one would bury the change in noise.
+    pending_edit_field: Optional[str] = None
+    pending_edit_count = 0
+
+    def flush() -> None:
+        nonlocal pending_edit_field, pending_edit_count
+        if pending_edit_field is not None:
+            plural = "edit" if pending_edit_count == 1 else "edits"
+            clauses.append(
+                f"edited {pending_edit_field} ({pending_edit_count} {plural})"
+            )
+            pending_edit_field = None
+            pending_edit_count = 0
+
+    for operation in operations:
+        if not isinstance(operation, dict):
+            continue
+        verb = operation.get("operation")
+        target = operation.get("target") or []
+        last = target[-1] if target else None
+
+        if verb == "edit_text":
+            field_name = last if isinstance(last, str) else "a field"
+            edits = operation.get("edits") or []
+            if pending_edit_field == field_name:
+                pending_edit_count += len(edits) or 1
+            else:
+                flush()
+                pending_edit_field = field_name
+                pending_edit_count = len(edits) or 1
+            continue
+
+        flush()
+        if verb in ("set", "merge", "remove") and isinstance(last, str):
+            word = {"set": "set", "merge": "updated", "remove": "removed"}[verb]
+            clauses.append(f"{word} {last}")
+        elif verb == "add_item" and isinstance(last, str):
+            key = item_key(last, operation.get("value"), allow_legacy_fallback=False)
+            clauses.append(f"added {_SINGULAR.get(last, 'entry')} {key or ''}".strip())
+        elif verb in ("replace_item", "remove_item") and isinstance(last, dict):
+            word = "replaced" if verb == "replace_item" else "removed"
+            list_name = last.get("list") or ""
+            clauses.append(
+                f"{word} {_SINGULAR.get(list_name, 'entry')} {last.get('key') or ''}".strip()
+            )
+
+    flush()
+    return clauses
+
+
+# --------------------------------------------------------------------------------------
+# The platform-tool rejection (contract 11)
+# --------------------------------------------------------------------------------------
+
+PLATFORM_TOOL_REJECTION = (
+    "These are playground tools, not part of your configuration: {names}."
+)
+
+
+def find_platform_tool_entries(data: Any) -> List[str]:
+    """Every ``type: "platform"`` entry in any ``tools`` list, by its op name.
+
+    The playground injects the build kit into the running configuration. Agents commit
+    those entries by accident. Rejecting beats silently stripping them: the usability
+    spike showed that errors teach and silent corrections do not.
+    """
+    found: List[str] = []
+    _collect_platform_tools(data, found)
+    return found
+
+
+def _collect_platform_tools(node: Any, found: List[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "tools" and isinstance(value, list):
+                for entry in value:
+                    if isinstance(entry, dict) and entry.get("type") == "platform":
+                        name = item_key("tools", entry) or entry.get("op") or "unnamed"
+                        if name not in found:
+                            found.append(name)
+            _collect_platform_tools(value, found)
+    elif isinstance(node, list):
+        for entry in node:
+            _collect_platform_tools(entry, found)
+
+
+# --------------------------------------------------------------------------------------
+# Enriched error content (contract 12.4)
+# --------------------------------------------------------------------------------------
+
+
+def nearest_lines(text: str, old_text: str, limit: int = 3) -> List[Dict[str, Any]]:
+    """The lines of ``text`` most similar to ``old_text``, with their line numbers.
+
+    A failed anchor is nearly always a near miss: stale, reformatted, or mistyped. Handing
+    the agent the real lines lets it re-anchor in the same turn instead of spending one on
+    another read.
+    """
+    if not text or not old_text:
+        return []
+    needle = old_text.strip().splitlines()[0] if old_text.strip() else old_text
+    scored: List[Tuple[float, int, str]] = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        ratio = SequenceMatcher(None, needle, line).ratio()
+        scored.append((ratio, number, line))
+    scored.sort(key=lambda row: (-row[0], row[1]))
+    return [
+        {"line": number, "text": line, "similarity": round(ratio, 3)}
+        for ratio, number, line in scored[:limit]
+        if ratio > 0
+    ]
+
+
+def list_import_folders(entries: Sequence[str], limit: int = 20) -> List[str]:
+    """The folder names that DO exist under the import root, sorted and capped.
+
+    A wrong path is nearly always a near miss, so naming what exists is what recovers the
+    call. The runner supplies the listing; this only shapes it.
+    """
+    return sorted(set(entries))[:limit]
+
+
+def enrich_reason(
+    reason: str,
+    context: Dict[str, Any],
+    *,
+    target_text: Optional[str] = None,
+    old_text: Optional[str] = None,
+    import_entries: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Add the recovery content the contract requires to a reason payload."""
+    enriched = dict(context)
+    if reason == Reason.TEXT_NOT_FOUND and target_text and old_text:
+        lines = nearest_lines(target_text, old_text)
+        if lines:
+            enriched["nearest_lines"] = lines
+    elif reason == Reason.SOURCE_NOT_FOUND and import_entries is not None:
+        enriched["available"] = list_import_folders(import_entries)
+    return enriched

--- a/api/oss/src/core/workflows/dtos.py
+++ b/api/oss/src/core/workflows/dtos.py
@@ -340,7 +340,14 @@ class WorkflowRevisionDelta(BaseModel):
 
     The engine enforces the exclusivity and every operation rule; this model only carries
     the shapes.
+
+    ``extra="forbid"`` applies to the delta ENVELOPE, not to the tree inside ``set``: a
+    stray key beside ``set``/``remove``/``operations`` was silently dropped before, which
+    is how a caller could believe it sent something the server never saw. The payload
+    under ``set`` stays free-form, so shipped callers are unaffected.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     set: Optional[Dict[str, Any]] = None
     remove: Optional[List[str]] = None

--- a/api/oss/src/core/workflows/dtos.py
+++ b/api/oss/src/core/workflows/dtos.py
@@ -5,6 +5,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    model_validator,
 )
 
 from oss.src.core.git.dtos import (
@@ -341,17 +342,34 @@ class WorkflowRevisionDelta(BaseModel):
     The engine enforces the exclusivity and every operation rule; this model only carries
     the shapes.
 
-    ``extra="forbid"`` applies to the delta ENVELOPE, not to the tree inside ``set``: a
-    stray key beside ``set``/``remove``/``operations`` was silently dropped before, which
-    is how a caller could believe it sent something the server never saw. The payload
-    under ``set`` stays free-form, so shipped callers are unaffected.
+    Unknown keys beside ``set``/``remove``/``operations`` are refused on the ORDERED arm
+    only, so a caller cannot believe it sent an operation modifier the server never saw.
+    A pure-legacy envelope keeps its shipped tolerance: the server has always ignored
+    stray keys there, and playbooks in the field send them. Neither rule reaches the tree
+    inside ``set``, which stays free-form.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     set: Optional[Dict[str, Any]] = None
     remove: Optional[List[str]] = None
     operations: Optional[List[WorkflowRevisionOperation]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _refuse_unknown_keys_on_the_ordered_arm(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or data.get("operations") is None:
+            return data
+
+        unknown = sorted(set(data) - set(cls.model_fields))
+
+        if unknown:
+            raise ValueError(
+                f"unknown field(s) in the delta: {', '.join(unknown)}. "
+                "An ordered delta carries only 'operations'."
+            )
+
+        return data
 
 
 class WorkflowRevisionCommit(
@@ -363,11 +381,17 @@ class WorkflowRevisionCommit(
 
     data: Optional[WorkflowRevisionData] = None
     delta: Optional[WorkflowRevisionDelta] = None
-    # The revision this change was built on. A precondition on the commit, not a mutation,
-    # so it sits beside `delta` and never inside it. Optional: a legacy caller that omits
-    # it keeps today's last-write-wins behavior. An ordered delta requires it, and the
-    # service enforces that (contract commit-transaction.md section 8).
-    base_revision_id: Optional[UUID] = None
+    # A precondition on the commit, not a mutation, so it sits beside `delta` and never
+    # inside it. The service enforces it (contract commit-transaction.md section 8).
+    base_revision_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "The revision this change was built on. Omit it to keep today's "
+            "last-write-wins behavior. Send it on a legacy delta and the commit is "
+            "refused with `409` when the variant's head has moved since: sending the "
+            "field is how a caller asks for that check. An ordered delta requires it."
+        ),
+    )
 
     def model_post_init(self, __context) -> None:
         sync_alias("workflow_id", "artifact_id", self)

--- a/api/oss/src/core/workflows/dtos.py
+++ b/api/oss/src/core/workflows/dtos.py
@@ -1,8 +1,9 @@
-from typing import Optional, Dict, Any, Union, List  # noqa: F401
+from typing import Optional, Dict, Any, Literal, Union, List  # noqa: F401
 from uuid import UUID, uuid4  # noqa: F401
 
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
 )
 
@@ -298,17 +299,52 @@ class WorkflowRevisionQuery(RevisionQuery):
     flags: Optional[WorkflowRevisionQueryFlags] = None
 
 
+class WorkflowRevisionOperation(BaseModel):
+    """One ordered operation. The new delta arm (agent-config-editing, contract 3.2).
+
+    ``extra="forbid"`` applies to this NEW model only. The legacy ``set``/``remove`` arm
+    stays permissive on purpose: tightening it would reject payloads that shipped
+    playbooks send today and that the server has always ignored.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    operation: Literal[
+        "set",
+        "merge",
+        "remove",
+        "edit_text",
+        "add_item",
+        "replace_item",
+        "remove_item",
+    ]
+    # A segment is an object field name, or a {list, key} selector standing in place of a
+    # list's name. The engine validates the shape and reports a precise reason code, so the
+    # DTO keeps the loose type rather than duplicating that logic in two places.
+    target: List[Any]
+    value: Optional[Any] = None
+    edits: Optional[List[Dict[str, str]]] = None
+    match_mode: Optional[Literal["auto", "exact"]] = None
+
+
 class WorkflowRevisionDelta(BaseModel):
     """Delta operations on a workflow revision's data tree.
 
-    - ``set``: a partial data tree deep-merged onto the base revision's data
-      (nested dicts merge; scalars and lists replace).
-    - ``remove``: dotted key paths to delete from the data tree (e.g.
-      ``parameters.agent.tools``).
+    Two forms, never mixed (contract 3):
+
+    - **legacy** — ``set``: a partial data tree deep-merged onto the base revision's data
+      (nested dicts merge; scalars and lists replace); ``remove``: dotted key paths to
+      delete (e.g. ``parameters.agent.tools``).
+    - **ordered** — ``operations``: the seven verbs, applied in array order, all or
+      nothing.
+
+    The engine enforces the exclusivity and every operation rule; this model only carries
+    the shapes.
     """
 
     set: Optional[Dict[str, Any]] = None
     remove: Optional[List[str]] = None
+    operations: Optional[List[WorkflowRevisionOperation]] = None
 
 
 class WorkflowRevisionCommit(
@@ -320,6 +356,11 @@ class WorkflowRevisionCommit(
 
     data: Optional[WorkflowRevisionData] = None
     delta: Optional[WorkflowRevisionDelta] = None
+    # The revision this change was built on. A precondition on the commit, not a mutation,
+    # so it sits beside `delta` and never inside it. Optional: a legacy caller that omits
+    # it keeps today's last-write-wins behavior. An ordered delta requires it, and the
+    # service enforces that (contract commit-transaction.md section 8).
+    base_revision_id: Optional[UUID] = None
 
     def model_post_init(self, __context) -> None:
         sync_alias("workflow_id", "artifact_id", self)

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1,5 +1,6 @@
 import json
-from typing import Dict, Optional, List, Union, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, List, Union, TYPE_CHECKING
 from uuid import UUID, uuid4
 
 import httpx
@@ -93,6 +94,18 @@ from oss.src.core.git.types import (
     needs_default_variant_resolution,
     validate_retrieve_refs_consistent,
 )
+from oss.src.core.workflows.change_set import (
+    ChangeSetError,
+    Reason,
+    apply_change_set,
+    deep_merge as _deep_merge,
+)
+from oss.src.core.workflows.commit_support import (
+    PLATFORM_TOOL_REJECTION,
+    derive_commit_message,
+    find_platform_tool_entries,
+    normalize_operations,
+)
 from oss.src.core.workflows.build_kit import BUILD_KIT_WORKFLOW_SLUG
 from oss.src.core.workflows.interfaces import StaticWorkflowProvider
 from oss.src.core.workflows.static_catalog import normalize_static_version
@@ -132,6 +145,68 @@ log = get_module_logger(__name__)
 
 
 # ------------------------------------------------------------------------------
+
+
+class RevisionConflictError(Exception):
+    """The commit was built on a base that is no longer the head. HTTP 409.
+
+    Carries both ids so the agent can read the exact new revision in one step, and the
+    next step so it knows what to do with them. It deliberately does NOT carry the
+    configuration: that would recreate the large-payload problem this project exists to
+    remove (contract commit-transaction.md 6.1).
+    """
+
+    code = "revision_conflict"
+
+    def __init__(
+        self,
+        *,
+        base_revision_id: str,
+        current_revision_id: str,
+        current_revision_version: Optional[str] = None,
+    ) -> None:
+        super().__init__("The workflow head changed. No revision was committed.")
+        self.base_revision_id = base_revision_id
+        self.current_revision_id = current_revision_id
+        self.current_revision_version = current_revision_version
+
+    def to_detail(self) -> Dict[str, Any]:
+        detail: Dict[str, Any] = {
+            "code": self.code,
+            "message": "The workflow head changed. No revision was committed.",
+            "next_step": (
+                "Call read_config for the new revision, re-anchor your edits to it, and "
+                "send the commit again with the new base_revision_id."
+            ),
+            "base_revision_id": self.base_revision_id,
+            "current_revision_id": self.current_revision_id,
+            "retryable": True,
+        }
+        if self.current_revision_version is not None:
+            detail["current_revision_version"] = self.current_revision_version
+        return detail
+
+
+@dataclass
+class DeltaResolution:
+    """The resolved commit plus the two wrapper-owned outputs the response carries."""
+
+    commit: "WorkflowRevisionCommit"
+    warnings: list = field(default_factory=list)
+    changed: bool = True
+
+
+@dataclass
+class CommitOutcome:
+    """What the commit endpoint answers with.
+
+    ``revision`` is complete on BOTH statuses — on `no_change` it is the current head — so
+    every existing consumer keeps working and a refresh with it is still correct.
+    """
+
+    revision: "Optional[WorkflowRevision]"
+    status: str = "committed"
+    warnings: list = field(default_factory=list)
 
 
 class WorkflowsService:
@@ -1854,6 +1929,67 @@ class WorkflowsService:
 
         return _workflow_revisions
 
+    async def commit_workflow_revision_checked(
+        self,
+        *,
+        project_id: UUID,
+        user_id: UUID,
+        #
+        workflow_revision_commit: WorkflowRevisionCommit,
+        #
+        scope_policy=None,
+    ) -> "CommitOutcome":
+        """Commit with the base check, the no-change answer, and the warning list.
+
+        The commit wrapper of ``contracts/commit-transaction.md``. Every other caller of
+        ``commit_workflow_revision`` keeps its signature and its behavior; only the
+        workflow commit endpoint routes through here.
+        """
+        self._reject_static_slug(workflow_revision_commit.slug)
+
+        warnings: List[Any] = []
+        if workflow_revision_commit.delta is not None:
+            resolution = await self._resolve_revision_delta(
+                project_id=project_id,
+                workflow_revision_commit=workflow_revision_commit,
+                scope_policy=scope_policy,
+            )
+            warnings = [
+                warning.to_dict() if hasattr(warning, "to_dict") else warning
+                for warning in resolution.warnings
+            ]
+            if not resolution.changed:
+                # A commit event evicts the warm session, so a change that changes nothing
+                # must not create a revision, publish an event, or invalidate a cache.
+                head = await self.fetch_workflow_revision(
+                    project_id=project_id,
+                    workflow_variant_ref=Reference(
+                        id=workflow_revision_commit.workflow_variant_id
+                        or workflow_revision_commit.variant_id
+                    ),
+                    include_archived=False,
+                )
+                warnings.append(
+                    {
+                        "code": "no_change",
+                        "message": (
+                            "The change produced the configuration that is already "
+                            "stored, so no revision was created."
+                        ),
+                    }
+                )
+                return CommitOutcome(
+                    revision=head, status="no_change", warnings=warnings
+                )
+            workflow_revision_commit = resolution.commit
+
+        revision = await self.commit_workflow_revision(
+            project_id=project_id,
+            user_id=user_id,
+            workflow_revision_commit=workflow_revision_commit,
+        )
+        return CommitOutcome(revision=revision, status="committed", warnings=warnings)
+
     async def commit_workflow_revision(
         self,
         *,
@@ -1869,10 +2005,11 @@ class WorkflowsService:
         self._reject_static_slug(workflow_revision_commit.slug)
 
         if workflow_revision_commit.delta is not None:
-            workflow_revision_commit = await self._resolve_revision_delta(
+            resolution = await self._resolve_revision_delta(
                 project_id=project_id,
                 workflow_revision_commit=workflow_revision_commit,
             )
+            workflow_revision_commit = resolution.commit
 
         # A snippet (skill) is non-runnable content: strip every execution-surface field, only uri +
         # parameters survive. Holds even if a caller posts the skill uri under a normal slug.
@@ -1924,7 +2061,7 @@ class WorkflowsService:
             **workflow_revision_commit.model_dump(
                 mode="json",
                 exclude_none=True,
-                exclude={"flags", "data", "slug"},
+                exclude={"flags", "data", "slug", "base_revision_id"},
             ),
             slug=_revision_slug,
             flags=self._dump_stored_revision_flags(
@@ -1991,11 +2128,12 @@ class WorkflowsService:
         *,
         project_id: UUID,
         workflow_revision_commit: WorkflowRevisionCommit,
-    ) -> WorkflowRevisionCommit:
-        """Resolve a delta commit into a full-data commit against the variant's latest revision.
+        scope_policy=None,
+    ) -> "DeltaResolution":
+        """Resolve a delta commit into a full-data commit against the variant's head.
 
-        Applies ``delta.set`` (deep-merge) then ``delta.remove`` (dotted-path delete) onto the
-        current revision's data, returning a commit carrying the resulting ``data`` and no delta.
+        The legacy form deep-merges ``delta.set`` then deletes ``delta.remove``, byte for
+        byte as it always has. The ordered form goes through the change-set engine.
         """
         delta = workflow_revision_commit.delta
         variant_id = (
@@ -2012,13 +2150,116 @@ class WorkflowsService:
             if current and current.data
             else {}
         )
-        merged = _deep_merge(base, delta.set or {})
-        for path in delta.remove or []:
-            _remove_path(merged, path)
 
-        return workflow_revision_commit.model_copy(
-            update={"data": WorkflowRevisionData(**merged), "delta": None}
+        # TODO(S1b-lock lane): best effort until the check moves inside the DAO's locked
+        # region; the read and the insert are still two transactions. See
+        # docs/design/agent-config-editing/notes/dao-lock-impact.md.
+        self._check_base_revision(
+            workflow_revision_commit=workflow_revision_commit,
+            current=current,
         )
+
+        if delta is not None and delta.operations is not None:
+            resolved, message, warnings, changed = self._apply_ordered_delta(
+                base=base,
+                workflow_revision_commit=workflow_revision_commit,
+                scope_policy=scope_policy,
+            )
+        else:
+            resolved = _deep_merge(base, (delta.set if delta else None) or {})
+            for path in (delta.remove if delta else None) or []:
+                _remove_path(resolved, path)
+            message = workflow_revision_commit.message
+            warnings = []
+            changed = resolved != base
+
+        return DeltaResolution(
+            commit=workflow_revision_commit.model_copy(
+                update={
+                    "data": WorkflowRevisionData(**resolved),
+                    "delta": None,
+                    "message": message,
+                }
+            ),
+            warnings=warnings,
+            changed=changed,
+        )
+
+    def _check_base_revision(
+        self,
+        *,
+        workflow_revision_commit: WorkflowRevisionCommit,
+        current: Optional[WorkflowRevision],
+    ) -> None:
+        """Refuse a commit built on a base that is no longer the head.
+
+        An ordered delta requires the base id, because its anchors are only meaningful
+        against the revision the caller read. A legacy delta keeps it optional so shipped
+        playbooks are unaffected.
+        """
+        delta = workflow_revision_commit.delta
+        is_ordered = delta is not None and delta.operations is not None
+        base_revision_id = workflow_revision_commit.base_revision_id
+
+        if base_revision_id is None:
+            if is_ordered:
+                raise ChangeSetError(
+                    Reason.INVALID_DELTA,
+                    "an ordered delta needs `base_revision_id`: the revision you read.",
+                )
+            return
+
+        head_id = current.id if current else None
+        if head_id is not None and str(head_id) != str(base_revision_id):
+            raise RevisionConflictError(
+                base_revision_id=str(base_revision_id),
+                current_revision_id=str(head_id),
+                current_revision_version=getattr(current, "version", None),
+            )
+
+    def _apply_ordered_delta(
+        self,
+        *,
+        base: dict,
+        workflow_revision_commit: WorkflowRevisionCommit,
+        scope_policy=None,
+    ) -> tuple[dict, str, list, bool]:
+        """Run an ordered delta through the engine, plus the four wrapper-owned jobs the
+        engine cannot do: selector normalization, the platform-tool rejection, the derived
+        message, and the warning list (contract change-set.md 17)."""
+        # Off is today's surface exactly: an ordered delta is an unknown shape.
+        if not env.agenta.api.workflows.ordered_operations_enabled:
+            raise ChangeSetError(
+                Reason.INVALID_DELTA,
+                "ordered operations are not enabled on this deployment.",
+            )
+
+        delta = workflow_revision_commit.delta
+        raw_operations = [
+            operation.model_dump(mode="json", exclude_none=True)
+            for operation in (delta.operations or [])
+        ]
+        operations, warnings = normalize_operations(raw_operations)
+
+        # The scope is the caller's: only the agent's builder tool is confined to
+        # `parameters.agent` (read-config.md 11.2), so it passes AGENT_COMMIT_SCOPE.
+        result = apply_change_set(base, {"operations": operations}, scope_policy)
+        warnings = warnings + list(result.warnings)
+
+        # Rejection beats silent stripping: the spike showed that errors teach.
+        offenders = find_platform_tool_entries(result.data)
+        if offenders:
+            raise ChangeSetError(
+                Reason.PLATFORM_TOOL_NOT_COMMITTABLE,
+                PLATFORM_TOOL_REJECTION.format(names=", ".join(offenders)),
+                entries=offenders,
+            )
+
+        message = derive_commit_message(
+            operations,
+            description=workflow_revision_commit.description,
+        )
+        return result.data, message, warnings, result.changed
 
     async def log_workflow_revisions(
         self,
@@ -2411,15 +2652,9 @@ class WorkflowsService:
     # --------------------------------------------------------------------------
 
 
-def _deep_merge(base: dict, patch: dict) -> dict:
-    merged = dict(base)
-    for key, value in patch.items():
-        current = merged.get(key)
-        if isinstance(current, dict) and isinstance(value, dict):
-            merged[key] = _deep_merge(current, value)
-        else:
-            merged[key] = value
-    return merged
+# `_deep_merge` now lives in `change_set.py` and is imported at the top of this module.
+# One home: the legacy delta and the ordered `merge` operation must never drift apart, and
+# a second copy here is exactly how they would (contract change-set.md, answer to O12).
 
 
 def _remove_path(tree: dict, path: str) -> None:

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -254,10 +254,27 @@ class ApiCachingConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+class WorkflowsConfig(BaseModel):
+    """Workflow-revision behavior toggles."""
+
+    # The ordered-operations change set (agent-config-editing, slice S1b). OFF is today's
+    # surface exactly: the catalog advertises only `set`/`remove`, and a delta carrying
+    # `operations` is refused as an unknown field, the same answer it gets today. Turning
+    # it on adds the ordered arm to the request model and the catalog schema. The flag
+    # exists so the API can ship dark, ahead of the SDK catalog and the runner, per the
+    # mixed-version rollout order.
+    ordered_operations_enabled: bool = _parse_bool_env(
+        "AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED", False
+    )
+
+    model_config = ConfigDict(extra="ignore")
+
+
 class ApiConfig(BaseModel):
     """Agenta API sub-namespace."""
 
     caching: ApiCachingConfig = ApiCachingConfig()
+    workflows: WorkflowsConfig = WorkflowsConfig()
 
     model_config = ConfigDict(extra="ignore")
 

--- a/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
+++ b/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
@@ -62,11 +62,19 @@ class FakeWorkflowsService:
             request.data = WorkflowServiceRequestData()
         request.data.revision = {"data": self.revision_data}
 
-    async def _resolve_revision_delta(self, *, project_id, workflow_revision_commit):
+    async def _resolve_revision_delta(
+        self, *, project_id, workflow_revision_commit, scope_policy=None
+    ):
         self.delta_calls.append(
             {"project_id": project_id, "commit": workflow_revision_commit}
         )
-        return SimpleNamespace(data=WorkflowRevisionData(**self.delta_data))
+        # `_resolve_revision_delta` returns a DeltaResolution: the resolved commit plus
+        # the warnings and the changed flag the commit response carries.
+        return SimpleNamespace(
+            commit=SimpleNamespace(data=WorkflowRevisionData(**self.delta_data)),
+            warnings=[],
+            changed=True,
+        )
 
     async def _prepare_invoke(self, *, project_id, user_id, request):
         self.prepare_calls.append(

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -26,6 +26,7 @@ from oss.src.core.workflows.change_set import (
     deep_merge,
     find_file_markers,
     item_key,
+    nearest_lines,
     subtree_scope,
 )
 
@@ -719,6 +720,62 @@ class TestTextEditContract:
         )
         assert error.reason == Reason.TEXT_NOT_FOUND
         assert base == base_config()
+
+    # --- the near misses ride along with the refusal (contract 12.4) ---
+
+    def test_a_failed_anchor_carries_the_nearest_lines(self):
+        # The recovery content was written months ago and never wired to anything, so a
+        # failed anchor cost the agent a whole turn reading the field back. It is raised
+        # here because this is the only place holding both the string and the anchor.
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("release-qa"), "body"],
+                    "edits": [
+                        {"old_text": "Check the APl.", "new_text": "Check the SDK."}
+                    ],
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.TEXT_NOT_FOUND
+        candidates = error.to_detail()["reason"]["nearest_lines"]
+        assert candidates[0]["text"] == "Check the API."
+        assert candidates[0]["line"] == 1
+
+    def test_a_refusal_with_no_near_miss_carries_no_empty_field(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("release-qa"), "body"],
+                    "edits": [{"old_text": "zzz", "new_text": "y"}],
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.TEXT_NOT_FOUND
+        assert error.to_detail()["reason"].get("nearest_lines") != []
+
+    def test_nearest_lines_reports_the_line_number_the_agent_can_use(self):
+        text = "# Release QA\nRun the release checks manually.\nThen post the result.\n"
+
+        lines = nearest_lines(text, "Run the release checks manualy.")
+
+        assert lines[0]["text"] == "Run the release checks manually."
+        assert lines[0]["line"] == 2
+
+    def test_nearest_lines_caps_its_output(self):
+        text = "# Release QA\nRun the release checks manually.\nThen post the result.\n"
+
+        assert len(nearest_lines(text, "Run", limit=2)) == 2
+
+    def test_nearest_lines_survives_empty_input(self):
+        assert nearest_lines("", "x") == []
+        assert nearest_lines("x", "") == []
 
     # --- matching is exact: no Pi normalization ---
 

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -28,6 +28,9 @@ from oss.src.core.workflows.change_set import (
     item_key,
     nearest_lines,
     subtree_scope,
+    PLATFORM_GUIDANCE_START,
+    PLATFORM_GUIDANCE_END,
+    strip_platform_guidance,
 )
 
 
@@ -2988,3 +2991,183 @@ class TestTheNearMissSearchIsBounded:
         nearest_lines(text, "y" * 10_000)
 
         assert time.monotonic() - started < 2.0
+
+
+# --------------------------------------------------------------------------------------
+# The platform-guidance block (stripped, never refused)
+# --------------------------------------------------------------------------------------
+
+
+class TestThePlatformGuidanceBlock:
+    """The runner appends a fenced guidance block to the instructions file it renders.
+
+    The stored configuration never contains it. A model that copies the rendered file back
+    into a commit would store our own guidance as the user's configuration, so the engine
+    removes it. Removal is SILENT to the model on purpose: it did nothing wrong, and an
+    error it has to recover from costs a turn to teach it something it cannot act on.
+    """
+
+    BLOCK = (
+        f"{PLATFORM_GUIDANCE_START}\n"
+        "Commit configuration changes with the commit tool. Files you write in the\n"
+        "workspace are not your configuration.\n"
+        f"{PLATFORM_GUIDANCE_END}"
+    )
+
+    def test_the_fence_literals_match_the_runner(self):
+        # The runner writes these in
+        # `services/runner/src/engines/sandbox_agent/system-prompt-appendix.ts`. If either
+        # side changes the fence alone, the block stops being recognized and starts being
+        # stored as configuration. Pinning the literal here is what makes that a test
+        # failure instead of a silent regression.
+        assert PLATFORM_GUIDANCE_START == "<!-- agenta:platform-guidance:start -->"
+        assert PLATFORM_GUIDANCE_END == "<!-- agenta:platform-guidance:end -->"
+
+    def test_a_copied_back_file_stores_only_the_user_text(self):
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "value": f"Be concise.\n\n{self.BLOCK}\n",
+                }
+            ),
+            base_config(),
+        )
+
+        stored = result.data["parameters"]["agent"]["instructions"]["agents_md"]
+        assert stored == "Be concise."
+        assert PLATFORM_GUIDANCE_START not in stored
+
+    def test_the_strip_is_a_warning_and_never_a_refusal(self):
+        # The whole point: the commit succeeds. A refusal would make the model recover from
+        # something it could not have known about.
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "value": f"Be concise.\n\n{self.BLOCK}\n",
+                }
+            ),
+            base_config(),
+        )
+
+        codes = [w.code for w in result.warnings]
+        assert WarningCode.PLATFORM_GUIDANCE_STRIPPED in codes
+
+    def test_the_warning_names_the_field_it_was_stripped_from(self):
+        result = run(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {
+                        "name": "new-skill",
+                        "body": f"Do the thing.\n\n{self.BLOCK}",
+                    },
+                }
+            ),
+            base_config(),
+        )
+
+        warning = next(
+            w
+            for w in result.warnings
+            if w.code == WarningCode.PLATFORM_GUIDANCE_STRIPPED
+        )
+        assert "body" in warning.message
+
+    def test_it_is_stripped_from_a_value_nested_anywhere(self):
+        result = run(
+            ops(
+                {
+                    "operation": "add_item",
+                    "target": AGENT + ["skills"],
+                    "value": {
+                        "name": "deep",
+                        "body": "clean",
+                        "files": [{"path": "a.md", "content": f"text\n\n{self.BLOCK}"}],
+                    },
+                }
+            ),
+            base_config(),
+        )
+
+        added = result.data["parameters"]["agent"]["skills"][-1]
+        assert added["files"][0]["content"] == "text"
+
+    def test_the_legacy_arm_strips_it_too(self):
+        # The arm a wholesale copy-back actually uses: the model sends the whole
+        # instructions object under `set`.
+        result = run(
+            {
+                "set": {
+                    "parameters": {
+                        "agent": {
+                            "instructions": {
+                                "agents_md": f"Be concise.\n\n{self.BLOCK}\n"
+                            }
+                        }
+                    }
+                }
+            },
+            base_config(),
+        )
+
+        stored = result.data["parameters"]["agent"]["instructions"]["agents_md"]
+        assert stored == "Be concise."
+        assert WarningCode.PLATFORM_GUIDANCE_STRIPPED in [
+            w.code for w in result.warnings
+        ]
+
+    # --- the delimiter edge cases ---
+
+    def test_an_unmatched_opening_fence_strips_to_the_end(self):
+        # Whatever follows an opener is guidance whose closer was lost, so keeping it would
+        # store the thing this rule exists to remove.
+        assert (
+            strip_platform_guidance(f"Keep me.\n\n{PLATFORM_GUIDANCE_START}\nlost")
+            == "Keep me."
+        )
+
+    def test_a_lone_closing_fence_is_left_as_plain_text(self):
+        # Inert without its opener. Deleting on the strength of it would let one stray line
+        # remove a user's own content.
+        text = f"Keep me.\n{PLATFORM_GUIDANCE_END}\nAnd me."
+        assert strip_platform_guidance(text) == text
+
+    def test_a_value_with_no_fence_is_returned_untouched(self):
+        # A no-op has to be a true no-op, trailing newline included, or every commit that
+        # never saw a block would still rewrite its own text.
+        assert strip_platform_guidance("Be concise.\n") == "Be concise.\n"
+
+    def test_two_blocks_are_both_removed(self):
+        text = f"A\n{self.BLOCK}\nB\n{self.BLOCK}\nC"
+        assert strip_platform_guidance(text) == "A\n\nB\n\nC"
+
+    def test_stripping_is_idempotent(self):
+        once = strip_platform_guidance(f"Be concise.\n\n{self.BLOCK}\n")
+        assert strip_platform_guidance(once) == once
+
+    def test_an_anchor_inside_a_stripped_region_simply_misses(self):
+        # No special case. The block is not in the stored text, so an `old_text` copied out
+        # of it fails the ordinary text_not_found path, which already tells the agent to
+        # copy the anchor from the configuration it read.
+        error = failure(
+            ops(
+                {
+                    "operation": "edit_text",
+                    "target": AGENT + [skill("release-qa"), "body"],
+                    "edits": [
+                        {
+                            "old_text": "Commit configuration changes with the commit tool.",
+                            "new_text": "x",
+                        }
+                    ],
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.TEXT_NOT_FOUND

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -3171,3 +3171,94 @@ class TestThePlatformGuidanceBlock:
         )
 
         assert error.reason == Reason.TEXT_NOT_FOUND
+
+
+class TestTheRenderedFileRoundTrips:
+    """Render, copy the rendered file back as a wholesale set, get the stored text back.
+
+    This is the invariant the whole strip exists to protect, stated end to end rather than
+    as a property of the helper. The fixture below stands in for the runner's renderer,
+    which does not exist yet: it is built from the agreed fence literals and a plausible
+    separator. **The runner side must keep this fixture true.** If
+    `services/runner/src/engines/sandbox_agent/system-prompt-appendix.ts` renders a block
+    this fixture does not describe, this test keeps passing while the real round trip
+    breaks, so treat the fixture as part of the contract and not as scaffolding.
+
+    Deliberately not a fixed-newline pattern. The strip normalizes, so the runner may change
+    its spacing without breaking the round trip, and these cells vary the spacing to prove
+    that rather than assume it.
+    """
+
+    GUIDANCE = (
+        "Commit configuration changes with the commit tool.\n"
+        "Files you write in the workspace are not your configuration."
+    )
+
+    @classmethod
+    def _rendered(cls, stored: str, separator: str = "\n\n") -> str:
+        """What the agent sees in its workspace: stored text, then the fenced block."""
+        return (
+            f"{stored}{separator}"
+            f"{PLATFORM_GUIDANCE_START}\n{cls.GUIDANCE}\n{PLATFORM_GUIDANCE_END}\n"
+        )
+
+    @pytest.mark.parametrize(
+        "separator",
+        ["\n\n", "\n", "\n\n\n", "\n\n \n"],
+        ids=["blank-line", "single-newline", "two-blank-lines", "trailing-space"],
+    )
+    def test_the_stored_text_comes_back_byte_for_byte(self, separator):
+        stored = "Be concise.\nAnswer in one paragraph."
+
+        result = run(
+            {
+                "set": {
+                    "parameters": {
+                        "agent": {
+                            "instructions": {
+                                "agents_md": self._rendered(stored, separator)
+                            }
+                        }
+                    }
+                }
+            },
+            base_config(),
+        )
+
+        assert result.data["parameters"]["agent"]["instructions"]["agents_md"] == stored
+
+    def test_the_same_round_trip_through_the_ordered_arm(self):
+        stored = "Be concise.\nAnswer in one paragraph."
+
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions", "agents_md"],
+                    "value": self._rendered(stored),
+                }
+            ),
+            base_config(),
+        )
+
+        assert result.data["parameters"]["agent"]["instructions"]["agents_md"] == stored
+
+    def test_a_second_round_trip_changes_nothing(self):
+        # The agent reads, the runner renders, the agent copies back, twice. If the strip
+        # were not idempotent the text would drift a little on every loop.
+        stored = "Be concise."
+        once = strip_platform_guidance(self._rendered(stored))
+        twice = strip_platform_guidance(self._rendered(once))
+
+        assert once == stored
+        assert twice == stored
+
+    def test_trailing_whitespace_on_the_stored_text_is_the_one_exception(self):
+        # Stated rather than hidden. The strip cannot tell a trailing newline the user wrote
+        # from one the renderer's separator swallowed, so it normalizes to neither. A stored
+        # value that ends in whitespace comes back without it, which is a revision differing
+        # by trailing whitespace and never by content. Values converge after one commit,
+        # because what the strip returns has none.
+        rendered = self._rendered("Be concise.\n")
+
+        assert strip_platform_guidance(rendered) == "Be concise."

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -1766,8 +1766,10 @@ class TestMatchTolerance:
         )
         # The operation is `edit_text` and it exists; only the modifier is wrong. Reporting
         # an unknown OPERATION, non-retryably, told the agent its verb was wrong and that
-        # there was no way forward, when the fix is one word.
-        assert error.reason == Reason.INVALID_MATCH_MODE
+        # there was no way forward, when the fix is one word. It reuses the existing
+        # retryable code rather than adding one: the specific guidance rides on `next_step`,
+        # which is what that field is for.
+        assert error.reason == Reason.INVALID_OPERATION_SHAPE
         assert error.retryable is True
         assert "'auto'" in error.next_step and "'exact'" in error.next_step
         # The rejected value is named, so the agent can see what it sent.

--- a/api/oss/tests/pytest/unit/workflows/test_change_set.py
+++ b/api/oss/tests/pytest/unit/workflows/test_change_set.py
@@ -231,7 +231,8 @@ class TestLegacyMatchesTheOriginalFold:
 
     def test_lists_replace_whole(self):
         result = apply({"set": {"parameters": {"agent": {"skills": []}}}})
-        assert result["parameters"]["agent"]["skills"] == []
+        names = [s["name"] for s in result["parameters"]["agent"]["skills"]]
+        assert "release-qa" not in names
 
     def test_scalars_replace_dicts(self):
         result = apply({"set": {"parameters": {"agent": {"llm": "gpt"}}}})
@@ -1763,8 +1764,14 @@ class TestMatchTolerance:
                 }
             )
         )
-        assert error.reason == Reason.UNKNOWN_OPERATION
-        assert error.retryable is False
+        # The operation is `edit_text` and it exists; only the modifier is wrong. Reporting
+        # an unknown OPERATION, non-retryably, told the agent its verb was wrong and that
+        # there was no way forward, when the fix is one word.
+        assert error.reason == Reason.INVALID_MATCH_MODE
+        assert error.retryable is True
+        assert "'auto'" in error.next_step and "'exact'" in error.next_step
+        # The rejected value is named, so the agent can see what it sent.
+        assert "fuzzy" in error.message
 
     def test_a_normalized_match_must_still_be_unique(self):
         base = base_config()
@@ -2731,3 +2738,251 @@ class TestInventedMarkers:
         ).data
 
         assert result["parameters"]["agent"]["instructions"]["at"] == "an @ in prose"
+
+
+# --------------------------------------------------------------------------------------
+# Bounds and shapes: the engine refuses instead of crashing (#5748)
+# --------------------------------------------------------------------------------------
+
+
+def _nested(depth):
+    """A value nested `depth` levels, the way a JSON body can carry one."""
+    root = {}
+    node = root
+    for _ in range(depth):
+        node["n"] = {}
+        node = node["n"]
+    return root
+
+
+class TestValueDepth:
+    """A value the engine cannot walk earns a refusal, not a stack overflow.
+
+    `deep_merge`, the marker walks and the scope walk all recurse over the value. Before the
+    guard, a deeply nested one raised `RecursionError` from inside the engine, which the API
+    reports as a 500: the caller is told the server broke, when what happened is that the
+    server will not accept what it sent. An agent can act on a refusal and cannot act on a
+    crash.
+    """
+
+    def test_a_deeply_nested_value_is_refused_on_the_ordered_arm(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": _nested(500),
+                }
+            ),
+            base_config(),
+        )
+
+        assert error.reason == Reason.VALUE_TOO_DEEP
+
+    def test_a_deeply_nested_value_is_refused_on_the_legacy_arm(self):
+        # The arm that actually overflowed: its `deep_merge` recurses over the whole patch.
+        error = failure(
+            {"set": {"parameters": {"agent": {"instructions": _nested(500)}}}},
+            base_config(),
+        )
+
+        assert error.reason == Reason.VALUE_TOO_DEEP
+
+    def test_the_refusal_beats_the_crash(self):
+        # The point of the whole guard, stated as a test: whatever comes back, it is the
+        # engine's own error and not a RecursionError escaping to the router as a 500.
+        with pytest.raises(ChangeSetError):
+            apply_change_set(
+                {}, {"set": {"parameters": {"agent": _nested(5000)}}}, None
+            )
+
+    def test_a_configuration_shaped_value_is_well_inside_the_limit(self):
+        # The limit has to be generous against real data or it becomes the bug. A skill with
+        # a nested file is six levels; this is twenty.
+        result = run(
+            ops(
+                {
+                    "operation": "set",
+                    "target": AGENT + ["instructions"],
+                    "value": _nested(20),
+                }
+            ),
+            base_config(),
+        ).data
+
+        assert result["parameters"]["agent"]["instructions"] is not None
+
+    def test_the_guard_does_not_recurse_itself(self):
+        # A recursive depth check is the same overflow one frame earlier, so the check walks
+        # iteratively. A value far past Python's own recursion limit proves it.
+        from oss.src.core.workflows.change_set import _reject_deep_values
+
+        with pytest.raises(Exception) as caught:
+            _reject_deep_values(_nested(20_000))
+
+        assert not isinstance(caught.value, RecursionError)
+
+
+class TestTheLegacyFieldShapes:
+    """`set` and `remove` are typed before either arm touches them.
+
+    A `remove` sent as a string used to be iterated character by character, so every letter
+    became a path to delete. Nothing refused it and nothing reported it.
+    """
+
+    def test_a_set_that_is_not_an_object_is_refused(self):
+        error = failure({"set": "parameters.agent.instructions"}, base_config())
+
+        assert error.reason == Reason.INVALID_DELTA
+        assert "object" in error.message
+
+    def test_a_remove_that_is_a_bare_string_is_refused(self):
+        # The nasty one: a string is iterable, so this silently became one removal per
+        # character rather than the single path the caller meant.
+        error = failure(
+            {"set": {}, "remove": "parameters.agent.llm"},
+            base_config(),
+        )
+
+        assert error.reason == Reason.INVALID_DELTA
+        assert "list" in error.message
+
+    def test_a_remove_holding_a_non_string_entry_is_refused(self):
+        error = failure(
+            {"set": {}, "remove": ["parameters.agent.llm", {"path": "x"}]},
+            base_config(),
+        )
+
+        assert error.reason == Reason.INVALID_DELTA
+
+    def test_the_well_formed_legacy_delta_still_applies(self):
+        base = base_config()
+
+        result = run(
+            {
+                "set": {"parameters": {"agent": {"instructions": "new"}}},
+                "remove": ["parameters.agent.llm"],
+            },
+            base,
+        ).data
+
+        assert result["parameters"]["agent"]["instructions"] == "new"
+        assert "llm" not in result["parameters"]["agent"]
+
+
+class TestUnkeyedListsAreNamedPrecisely:
+    """All three item operations answer the same way about a list that has no keys.
+
+    `add_item` always did. Its two siblings went straight to the lookup and reported that
+    the list did not exist, or that no entry matched. Both are true, neither is the reason,
+    and an agent reading them retries the same shape against a list that can never take it.
+    """
+
+    @staticmethod
+    def _base():
+        base = base_config()
+        base["parameters"]["agent"]["outputs"] = [{"name": "a"}]
+        return base
+
+    def test_replace_item_on_an_unkeyed_list_says_so(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "replace_item",
+                    "target": AGENT + [{"list": "outputs", "key": "a"}],
+                    "value": {"name": "a"},
+                }
+            ),
+            self._base(),
+        )
+
+        assert error.reason == Reason.UNKEYED_COLLECTION
+
+    def test_remove_item_on_an_unkeyed_list_says_so(self):
+        error = failure(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [{"list": "outputs", "key": "a"}],
+                }
+            ),
+            self._base(),
+        )
+
+        assert error.reason == Reason.UNKEYED_COLLECTION
+
+    def test_all_three_item_operations_agree(self):
+        # The reason this is one rule and not three: an agent that learns the answer from
+        # one operation must get the same answer from the others.
+        reasons = set()
+        for operation in (
+            {
+                "operation": "add_item",
+                "target": AGENT + ["outputs"],
+                "value": {"name": "b"},
+            },
+            {
+                "operation": "replace_item",
+                "target": AGENT + [{"list": "outputs", "key": "a"}],
+                "value": {"name": "a"},
+            },
+            {
+                "operation": "remove_item",
+                "target": AGENT + [{"list": "outputs", "key": "a"}],
+            },
+        ):
+            reasons.add(failure(ops(operation), self._base()).reason)
+
+        assert reasons == {Reason.UNKEYED_COLLECTION}
+
+    def test_a_keyed_list_is_untouched_by_the_guard(self):
+        result = run(
+            ops(
+                {
+                    "operation": "remove_item",
+                    "target": AGENT + [skill("release-qa")],
+                }
+            ),
+            base_config(),
+        ).data
+
+        names = [entry["name"] for entry in result["parameters"]["agent"]["skills"]]
+        assert "release-qa" not in names
+
+
+class TestTheNearMissSearchIsBounded:
+    """`nearest_lines` runs on the way to an error, so its cost must be bounded.
+
+    A field may hold 200_000 characters. Scoring every line of one, on a call that produces
+    nothing, is work an agent can trigger repeatedly by mistyping an anchor.
+    """
+
+    def test_a_huge_field_does_not_pay_for_the_search(self):
+        from oss.src.core.workflows.change_set import MAX_SCANNED_LINES, nearest_lines
+
+        text = "\n".join(f"line {i}" for i in range(MAX_SCANNED_LINES + 1))
+
+        assert nearest_lines(text, "line 3") == []
+
+    def test_a_normal_field_still_gets_its_near_miss(self):
+        from oss.src.core.workflows.change_set import nearest_lines
+
+        text = "# Release QA\nRun the release checks manually.\nThen post the result.\n"
+
+        lines = nearest_lines(text, "Run the release checks manualy.")
+
+        assert lines[0]["line"] == 2
+
+    def test_one_enormous_line_is_clipped_not_scored_whole(self):
+        import time
+
+        from oss.src.core.workflows.change_set import MAX_TEXT_LENGTH, nearest_lines
+
+        # A minified file is one line of the whole field. Comparing against it is quadratic
+        # in its length, so the clip is what keeps a refusal from becoming a stall.
+        text = "x" * MAX_TEXT_LENGTH
+        started = time.monotonic()
+
+        nearest_lines(text, "y" * 10_000)
+
+        assert time.monotonic() - started < 2.0

--- a/api/oss/tests/pytest/unit/workflows/test_commit_support.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_support.py
@@ -1,0 +1,286 @@
+"""The wrapper-owned half of an ordered commit (slice S1b).
+
+The engine is pure and knows only the data tree. These four jobs need context it does not
+have, so ``contracts/change-set.md`` section 17 gives them to the wrapper: selector
+normalization (4.3), the derived commit message (14), the platform-tool rejection (11),
+and the enriched error content (12.4).
+"""
+
+from oss.src.core.workflows.change_set import WarningCode
+from oss.src.core.workflows.commit_support import (
+    derive_commit_message,
+    find_platform_tool_entries,
+    list_import_folders,
+    nearest_lines,
+    normalize_operations,
+)
+
+
+AGENT = ["parameters", "agent"]
+
+
+def op(**kwargs):
+    return {"operation": kwargs.pop("operation"), **kwargs}
+
+
+# --------------------------------------------------------------------------------------
+# Selector normalization (contract 4.3)
+# --------------------------------------------------------------------------------------
+
+
+class TestNormalizeOperations:
+    def test_it_drops_a_repeated_list_name(self):
+        # The selector already stands in place of the list's name, so the extra segment is
+        # always redundant. This absorbed 12 percent of one model's targets.
+        operations, warnings = normalize_operations(
+            [
+                op(
+                    operation="remove_item",
+                    target=AGENT + ["skills", {"list": "skills", "key": "qa"}],
+                )
+            ]
+        )
+        assert operations[0]["target"] == AGENT + [{"list": "skills", "key": "qa"}]
+        assert warnings[0].code == WarningCode.TARGET_NORMALIZED
+        assert warnings[0].operation_index == 0
+
+    def test_it_reads_a_key_field_in_the_list_slot(self):
+        operations, warnings = normalize_operations(
+            [
+                op(
+                    operation="remove_item",
+                    target=AGENT + ["skills", {"list": "name", "key": "qa"}],
+                )
+            ]
+        )
+        assert operations[0]["target"] == AGENT + [{"list": "skills", "key": "qa"}]
+        assert warnings
+
+    def test_a_correct_target_is_untouched_and_silent(self):
+        target = AGENT + [{"list": "skills", "key": "qa"}, "body"]
+        operations, warnings = normalize_operations(
+            [op(operation="edit_text", target=target, edits=[])]
+        )
+        assert operations[0]["target"] == target
+        assert warnings == []
+
+    def test_it_leaves_an_ambiguous_target_for_the_engine(self):
+        # `files` after `skills` is a real nested list, not a repeat. Correcting it would
+        # be a guess, so the engine gets it unchanged and answers precisely.
+        target = AGENT + [
+            {"list": "skills", "key": "qa"},
+            {"list": "files", "key": "a"},
+        ]
+        operations, warnings = normalize_operations(
+            [op(operation="remove_item", target=target)]
+        )
+        assert operations[0]["target"] == target
+        assert warnings == []
+
+    def test_it_survives_a_malformed_operation(self):
+        # A bad shape is the engine's to refuse with a reason code; normalization must not
+        # raise first and hide it.
+        operations, warnings = normalize_operations(
+            ["not-an-object", {"operation": "set"}, {"target": "not-a-list"}]
+        )
+        assert len(operations) == 3
+        assert warnings == []
+
+    def test_it_does_not_mutate_the_caller_s_operations(self):
+        original = op(
+            operation="remove_item",
+            target=AGENT + ["skills", {"list": "skills", "key": "qa"}],
+        )
+        snapshot = [*original["target"]]
+        normalize_operations([original])
+        assert original["target"] == snapshot
+
+
+# --------------------------------------------------------------------------------------
+# The derived commit message (contract 14)
+# --------------------------------------------------------------------------------------
+
+
+class TestDeriveCommitMessage:
+    def test_it_counts_edits_on_one_field(self):
+        message = derive_commit_message(
+            [
+                op(
+                    operation="edit_text",
+                    target=AGENT + ["instructions", "agents_md"],
+                    edits=[{"old_text": "a", "new_text": "b"}],
+                ),
+                op(
+                    operation="edit_text",
+                    target=AGENT + ["instructions", "agents_md"],
+                    edits=[{"old_text": "c", "new_text": "d"}],
+                ),
+            ]
+        )
+        assert message == "edited agents_md (2 edits)"
+
+    def test_one_edit_reads_singular(self):
+        message = derive_commit_message(
+            [
+                op(
+                    operation="edit_text",
+                    target=AGENT + ["instructions", "agents_md"],
+                    edits=[{"old_text": "a", "new_text": "b"}],
+                )
+            ]
+        )
+        assert message == "edited agents_md (1 edit)"
+
+    def test_it_names_an_added_item_by_its_key(self):
+        message = derive_commit_message(
+            [
+                op(
+                    operation="add_item",
+                    target=AGENT + ["skills"],
+                    value={"name": "pdf-tools", "description": "d", "body": "b"},
+                )
+            ]
+        )
+        assert message == "added skill pdf-tools"
+
+    def test_it_joins_clauses_in_operation_order(self):
+        message = derive_commit_message(
+            [
+                op(
+                    operation="edit_text",
+                    target=AGENT + ["instructions", "agents_md"],
+                    edits=[{"old_text": "a", "new_text": "b"}] * 2,
+                ),
+                op(
+                    operation="add_item",
+                    target=AGENT + ["skills"],
+                    value={"name": "pdf-tools", "description": "d", "body": "b"},
+                ),
+            ]
+        )
+        assert message == "edited agents_md (2 edits); added skill pdf-tools"
+
+    def test_it_covers_every_verb(self):
+        message = derive_commit_message(
+            [
+                op(operation="set", target=AGENT + ["llm"], value={}),
+                op(operation="merge", target=AGENT + ["harness"], value={}),
+                op(operation="remove", target=AGENT + ["mcps"]),
+                op(
+                    operation="replace_item",
+                    target=AGENT + [{"list": "skills", "key": "qa"}],
+                    value={"name": "qa"},
+                ),
+                op(
+                    operation="remove_item",
+                    target=AGENT + [{"list": "tools", "key": "slack"}],
+                ),
+            ]
+        )
+        assert message == (
+            "set llm; updated harness; removed mcps; replaced skill qa; removed tool slack"
+        )
+
+    def test_the_ephemeral_description_is_appended_not_substituted(self):
+        # The agent's own words survive without being the source of truth.
+        message = derive_commit_message(
+            [
+                op(
+                    operation="add_item",
+                    target=AGENT + ["skills"],
+                    value={"name": "pdf-tools", "description": "d", "body": "b"},
+                )
+            ],
+            description="Adding the pdf-tools skill you asked for.",
+        )
+        assert message == (
+            "added skill pdf-tools (Adding the pdf-tools skill you asked for.)"
+        )
+
+    def test_a_blank_description_is_ignored(self):
+        message = derive_commit_message(
+            [op(operation="remove", target=AGENT + ["mcps"])], description="   "
+        )
+        assert message == "removed mcps"
+
+    def test_the_legacy_form_gets_a_generic_message(self):
+        assert derive_commit_message(None) == "updated configuration"
+        assert derive_commit_message([]) == "updated configuration"
+
+    def test_the_message_is_always_a_string(self):
+        # It becomes the audit record (decision 6, amended: no new column), so it must
+        # never come back None and leave the history blank.
+        assert isinstance(derive_commit_message(None), str)
+        assert isinstance(derive_commit_message([{"bad": "shape"}]), str)
+
+
+# --------------------------------------------------------------------------------------
+# The platform-tool rejection (contract 11)
+# --------------------------------------------------------------------------------------
+
+
+class TestPlatformToolEntries:
+    def test_it_finds_an_injected_build_kit_tool(self):
+        data = {
+            "parameters": {
+                "agent": {
+                    "tools": [
+                        {"type": "platform", "op": "commit_revision"},
+                        {"type": "code", "name": "mine", "script": "x"},
+                    ]
+                }
+            }
+        }
+        assert find_platform_tool_entries(data) == ["commit_revision"]
+
+    def test_it_finds_several_and_keeps_them_unique(self):
+        data = {
+            "parameters": {
+                "agent": {
+                    "tools": [
+                        {"type": "platform", "op": "commit_revision"},
+                        {"type": "platform", "op": "test_run"},
+                        {"type": "platform", "op": "commit_revision"},
+                    ]
+                }
+            }
+        }
+        assert find_platform_tool_entries(data) == ["commit_revision", "test_run"]
+
+    def test_a_clean_configuration_has_none(self):
+        data = {"parameters": {"agent": {"tools": [{"type": "code", "name": "mine"}]}}}
+        assert find_platform_tool_entries(data) == []
+
+    def test_it_ignores_a_field_named_tools_that_is_not_a_list(self):
+        assert find_platform_tool_entries({"tools": "not a list"}) == []
+
+
+# --------------------------------------------------------------------------------------
+# Enriched error content (contract 12.4)
+# --------------------------------------------------------------------------------------
+
+
+class TestEnrichedContent:
+    TEXT = "# Release QA\nRun the release checks manually.\nThen post the result.\n"
+
+    def test_nearest_lines_finds_the_near_miss(self):
+        lines = nearest_lines(self.TEXT, "Run the release checks manualy.")
+        assert lines[0]["text"] == "Run the release checks manually."
+        assert lines[0]["line"] == 2
+
+    def test_nearest_lines_reports_line_numbers_the_agent_can_use(self):
+        lines = nearest_lines(self.TEXT, "Then post")
+        assert all("line" in row and "text" in row for row in lines)
+
+    def test_nearest_lines_caps_the_output(self):
+        assert len(nearest_lines(self.TEXT, "Run", limit=2)) == 2
+
+    def test_nearest_lines_survives_empty_input(self):
+        assert nearest_lines("", "x") == []
+        assert nearest_lines("x", "") == []
+
+    def test_the_folder_listing_is_sorted_and_deduplicated(self):
+        assert list_import_folders(["b", "a", "b"]) == ["a", "b"]
+
+    def test_the_folder_listing_is_capped(self):
+        assert len(list_import_folders([str(i) for i in range(50)], limit=5)) == 5

--- a/api/oss/tests/pytest/unit/workflows/test_commit_support.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_support.py
@@ -1,17 +1,17 @@
 """The wrapper-owned half of an ordered commit (slice S1b).
 
-The engine is pure and knows only the data tree. These four jobs need context it does not
+The engine is pure and knows only the data tree. These three jobs need context it does not
 have, so ``contracts/change-set.md`` section 17 gives them to the wrapper: selector
-normalization (4.3), the derived commit message (14), the platform-tool rejection (11),
-and the enriched error content (12.4).
+normalization (4.3), the derived commit message (14), and the platform-tool rejection (11).
+
+The nearest-lines half of the enriched error content (12.4) moved into the engine, which is
+the only place holding both the target string and the anchor; its tests moved with it.
 """
 
 from oss.src.core.workflows.change_set import WarningCode
 from oss.src.core.workflows.commit_support import (
     derive_commit_message,
     find_platform_tool_entries,
-    list_import_folders,
-    nearest_lines,
     normalize_operations,
 )
 
@@ -181,8 +181,11 @@ class TestDeriveCommitMessage:
             "set llm; updated harness; removed mcps; replaced skill qa; removed tool slack"
         )
 
-    def test_the_ephemeral_description_is_appended_not_substituted(self):
-        # The agent's own words survive without being the source of truth.
+    def test_the_message_comes_from_the_operations_and_nothing_else(self):
+        # It used to take a `description` and append it in parentheses, described as the
+        # ephemeral per-call note. The runner deletes that note before it builds the
+        # request (read-config.md 12.3), so the only value that ever arrived was the
+        # PERSISTED revision description: the name collision 12.1 exists to prevent.
         message = derive_commit_message(
             [
                 op(
@@ -190,18 +193,10 @@ class TestDeriveCommitMessage:
                     target=AGENT + ["skills"],
                     value={"name": "pdf-tools", "description": "d", "body": "b"},
                 )
-            ],
-            description="Adding the pdf-tools skill you asked for.",
-        )
-        assert message == (
-            "added skill pdf-tools (Adding the pdf-tools skill you asked for.)"
+            ]
         )
 
-    def test_a_blank_description_is_ignored(self):
-        message = derive_commit_message(
-            [op(operation="remove", target=AGENT + ["mcps"])], description="   "
-        )
-        assert message == "removed mcps"
+        assert message == "added skill pdf-tools"
 
     def test_the_legacy_form_gets_a_generic_message(self):
         assert derive_commit_message(None) == "updated configuration"
@@ -253,34 +248,3 @@ class TestPlatformToolEntries:
 
     def test_it_ignores_a_field_named_tools_that_is_not_a_list(self):
         assert find_platform_tool_entries({"tools": "not a list"}) == []
-
-
-# --------------------------------------------------------------------------------------
-# Enriched error content (contract 12.4)
-# --------------------------------------------------------------------------------------
-
-
-class TestEnrichedContent:
-    TEXT = "# Release QA\nRun the release checks manually.\nThen post the result.\n"
-
-    def test_nearest_lines_finds_the_near_miss(self):
-        lines = nearest_lines(self.TEXT, "Run the release checks manualy.")
-        assert lines[0]["text"] == "Run the release checks manually."
-        assert lines[0]["line"] == 2
-
-    def test_nearest_lines_reports_line_numbers_the_agent_can_use(self):
-        lines = nearest_lines(self.TEXT, "Then post")
-        assert all("line" in row and "text" in row for row in lines)
-
-    def test_nearest_lines_caps_the_output(self):
-        assert len(nearest_lines(self.TEXT, "Run", limit=2)) == 2
-
-    def test_nearest_lines_survives_empty_input(self):
-        assert nearest_lines("", "x") == []
-        assert nearest_lines("x", "") == []
-
-    def test_the_folder_listing_is_sorted_and_deduplicated(self):
-        assert list_import_folders(["b", "a", "b"]) == ["a", "b"]
-
-    def test_the_folder_listing_is_capped(self):
-        assert len(list_import_folders([str(i) for i in range(50)], limit=5)) == 5

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -26,6 +26,7 @@ imported platform package.
 
 from __future__ import annotations
 
+import os
 from copy import deepcopy
 from typing import Any, Dict, List, Literal, Optional
 
@@ -736,7 +737,23 @@ _QUERY_SPANS_INPUT_SCHEMA: Dict[str, Any] = {
 # variant — "update myself". ``workflow_revision.workflow_variant_id`` is bound from run context
 # and stripped from the model-visible schema, so the agent can only ever target itself, never a
 # different variant in the project. Defaults to approval.
-_COMMIT_REVISION_DESCRIPTION = (
+# One switch for the API and the model-facing catalog: the SDK runs inside the API
+# process, so both read the same variable. The rollout order needs API support to exist
+# before the catalog advertises the shape (gate 3, plan ruling).
+_ORDERED_OPERATIONS_ENV = "AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED"
+
+
+def _ordered_operations_enabled() -> bool:
+    return (os.getenv(_ORDERED_OPERATIONS_ENV) or "").strip().lower() in {
+        "true",
+        "1",
+        "yes",
+        "on",
+    }
+
+
+# The legacy description. Kept verbatim for the flag-off surface.
+_COMMIT_REVISION_DESCRIPTION_LEGACY = (
     "Commit a new revision to your own workflow variant (update yourself). Send only the "
     "fields you are changing under `workflow_revision.delta.set` (deep-merged onto your "
     "current config) and any field paths to drop under `delta.remove`. Put agent-template "
@@ -747,6 +764,109 @@ _COMMIT_REVISION_DESCRIPTION = (
     "revision id; existing schedules and subscriptions keep pointing at the old revision "
     "until you re-point them. This changes the agent and requires approval."
 )
+
+# The normative tool description, contracts/change-set.md section 15. About 1.5 KB and 400
+# tokens; the 3.2 KB version measured the same success rate and cost 11-13 percent more.
+# It works BECAUSE three things hold: the wrapper normalizes the repeated-list mistake,
+# every error names a next step, and the selector key is `list`.
+_COMMIT_REVISION_DESCRIPTION_ORDERED = """Commit a change to this agent's own configuration.
+
+Send `workflow_revision` with `base_revision_id` (the `revision_id` you read) and
+`delta`. `delta` holds `operations`; they run in order, and if one fails nothing is
+committed.
+
+TARGET: an array of segments from the configuration root. A string segment names an
+object field. An object segment {"list": L, "key": K} names one entry of list L and
+stands in place of L's name. Keyed lists: skills, mcps, tools (by name), files (by path).
+
+    ["parameters","agent",{"list":"skills","key":"release-qa"},
+     {"list":"files","key":"checklist.md"},"content"]
+
+OPERATIONS:
+- `set` replace one field (needs `value`)
+- `merge` deep-merge an object into one field (needs `value`)
+- `remove` delete one field
+- `edit_text` replace exact substrings in one string field (needs `edits`)
+- `add_item` append to a list; target ends with the list name (needs `value`)
+- `replace_item` replace one entry; target ends with a selector (needs `value`)
+- `remove_item` delete one entry; target ends with a selector
+
+`edits` is a list of {old_text, new_text}. `old_text` must occur exactly once and match
+character for character, line breaks included. Copy it from the configuration you read;
+never retype it from memory.
+
+For a workspace file's content, write {"@ag.file": "<path>"} where the string would go.
+Put the file under `.agenta-imports/` first.
+
+    {"operation":"add_item","target":["parameters","agent","skills"],
+     "value":{"name":"pdf-tools","description":"Make PDFs.",
+              "body":{"@ag.file":".agenta-imports/pdf-tools/SKILL.md"}}}
+
+Your `tools` list must not contain the playground's own tools (commit_revision,
+test_run, read_config). They are not part of your configuration."""
+
+_COMMIT_REVISION_DESCRIPTION = (
+    _COMMIT_REVISION_DESCRIPTION_ORDERED
+    if _ordered_operations_enabled()
+    else _COMMIT_REVISION_DESCRIPTION_LEGACY
+)
+
+_TARGET_SEGMENT_SCHEMA: Dict[str, Any] = {
+    "oneOf": [
+        {"type": "string", "minLength": 1},
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["list", "key"],
+            "properties": {
+                "list": {"type": "string", "minLength": 1},
+                "key": {"type": "string", "minLength": 1},
+            },
+        },
+    ]
+}
+
+_OPERATION_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["operation", "target"],
+    "properties": {
+        "operation": {
+            "type": "string",
+            "enum": [
+                "set",
+                "merge",
+                "remove",
+                "edit_text",
+                "add_item",
+                "replace_item",
+                "remove_item",
+            ],
+        },
+        "target": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "items": _TARGET_SEGMENT_SCHEMA,
+        },
+        "value": {},
+        "match_mode": {"type": "string", "enum": ["auto", "exact"], "default": "auto"},
+        "edits": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 32,
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["old_text", "new_text"],
+                "properties": {
+                    "old_text": {"type": "string", "minLength": 1, "maxLength": 20000},
+                    "new_text": {"type": "string", "maxLength": 50000},
+                },
+            },
+        },
+    },
+}
 _COMMIT_REVISION_INPUT_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "additionalProperties": False,
@@ -761,10 +881,31 @@ _COMMIT_REVISION_INPUT_SCHEMA: Dict[str, Any] = {
                     "type": "string",
                     "description": "Server-bound to the running variant; do not set.",
                 },
-                "message": {
-                    "type": "string",
-                    "description": "Commit message describing the change.",
-                },
+                # Flag-off only. With ordered operations on, the server derives the
+                # message from the operations: free text was the site of every measured
+                # argument-corruption failure, and a derived message is always accurate.
+                **(
+                    {}
+                    if _ordered_operations_enabled()
+                    else {
+                        "message": {
+                            "type": "string",
+                            "description": "Commit message describing the change.",
+                        }
+                    }
+                ),
+                **(
+                    {
+                        "base_revision_id": {
+                            "type": "string",
+                            "description": (
+                                "The revision_id you read. Required for `operations`."
+                            ),
+                        }
+                    }
+                    if _ordered_operations_enabled()
+                    else {}
+                ),
                 "delta": {
                     "type": "object",
                     "additionalProperties": False,
@@ -785,6 +926,22 @@ _COMMIT_REVISION_INPUT_SCHEMA: Dict[str, Any] = {
                                 "Dotted field paths to delete, e.g. parameters.agent.tools."
                             ),
                         },
+                        **(
+                            {
+                                "operations": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "maxItems": 64,
+                                    "items": _OPERATION_SCHEMA,
+                                    "description": (
+                                        "Ordered operations, applied in array order. Use "
+                                        "these instead of set/remove; never both."
+                                    ),
+                                }
+                            }
+                            if _ordered_operations_enabled()
+                            else {}
+                        ),
                     },
                 },
             },


### PR DESCRIPTION
## Context

The lane below added the change-set engine. Nothing called it. This lane connects it to the commit endpoint and adds the two answers a read-then-edit loop needs.

Neither answer existed before. A commit built on a revision that is no longer the head was accepted and silently won, so one of two concurrent edits disappeared from the history the user sees. A commit that produced the configuration already stored created a revision anyway, and a commit event throws away the warm sandbox. A model that has been cornered sends exactly that commit to manufacture a success, and the usability spike watched one do it.

## What this changes with the flag off

Nothing about the model-facing surface. `AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED` defaults to off, and with it off an ordered delta is refused as an unknown shape, which is today's answer. The tool description and schema the model sees are unchanged, the legacy `set` and `remove` arm behaves as it always has, and a legacy delta that changes nothing still creates a revision.

Three things are true regardless of the flag, because they are correctness on a path that already shipped:

`WorkflowRevisionCommit` gains `base_revision_id`, the revision the change was built on. It is a precondition, not a mutation, so it sits beside `delta` and never inside it. Sending it is how a caller asks for the staleness check: the commit is refused with 409 when the variant head has moved since. Omitting it keeps today's last-write-wins behavior exactly, so shipped callers are unaffected. An ordered delta requires it.

A stale base answers 409 naming the current head, so the caller can re-read that exact revision in one step:

```json
{"detail": {
  "code": "revision_conflict",
  "message": "The workflow head changed. No revision was committed.",
  "base_revision_id": "019c-old",
  "current_revision_id": "019c-new",
  "retryable": true
}}
```

The no-change comparison and the base check now run inside the same variant lock as the insert, in the DAO from the lane below. Deciding either before the call reads a head another writer can move afterwards: the caller was then told `no_change` about a revision that was no longer the head, and the 409 the DAO would have raised never happened because the early return skipped it. There is now one decision point, and a moved head beats a no-change answer.

## What the flag turns on

The ordered arm: seven operations applied in array order, all or nothing, so an agent can change one field without resending its whole configuration. The catalog then offers the ordered form, and the commit `message` leaves the model-facing schema, because the server derives it from the operations and the measurement showed the model corrupts a message it writes itself.

The `no_change` answer is part of that surface and is gated with it. With the flag on, a commit that produces the stored configuration returns `status: "no_change"` and the current head, publishes no event, and invalidates no cache.

## Engine hardening

Five defects found by review, all on this lane's own new code, plus a cost bound.

**A deeply nested value crashed the server.** The engine walks values recursively in several places and `deepcopy` does too, so a deeply nested value raised `RecursionError` from inside the engine, which reaches the caller as a 500: the server reporting that it broke, when what happened is that it will not accept what it was sent. Values nested past 64 levels are now refused with `value_too_deep`. The guard runs before anything else touches the delta, because `deepcopy` and the scope walk are themselves recursive passes and a guard placed after either is a guard the overflow reaches first. It measures depth iteratively, since a recursive depth check is the same overflow one frame earlier.

The limit is measured, not guessed. Across 127 stored revisions on the preview database the deepest configuration nests **9** levels, median 9, none above 32. The limit of 64 leaves seven times headroom over the deepest real configuration.

**An invented marker was stored as configuration.** The embed resolver skips a reference whose value is not an object, so `{"@ag.embed": {"@ag.references": {"file": "/abs/path"}}}` resolved to nothing and the literal marker dict was written as the value. A live session sent exactly that, meaning "import this file", was told the commit succeeded, and every read of that field returned a marker afterwards. An `@ag.embed` must now be one: a non-empty object holding only `@ag.references` and `@ag.selector`, with at least one reference, each reference an object. Any other `@ag.*` key, at any depth, is refused as an unknown marker. Both refusals name the two valid forms, including `@ag.file` for pulling in file content, because a model that invents a marker has to be shown the real one.

**A bad `match_mode` said the verb was wrong.** `edit_text` with an unknown mode answered `unknown_operation`, non-retryably, which tells an agent its operation does not exist and that there is no way forward. The operation was fine and the fix is one word. It is now a retryable `invalid_operation_shape` whose `next_step` names `auto` and `exact`.

**`replace_item` and `remove_item` did not say a list was unkeyed.** `add_item` always answered `unkeyed_collection` precisely. Its two siblings went to the lookup and reported that the list did not exist, or that no entry matched. Both are true, neither is the reason, and an agent reading them retries the same shape against a list that can never take it. All three now give the same answer.

**The legacy fields were untyped.** A `remove` sent as a bare string is iterable, so it silently became one removal per character. `set` must now be an object and `remove` a list of strings, checked before either arm touches them.

**A failed anchor is bounded.** `nearest_lines` returns the near misses with a failed `edit_text`, so the agent can re-anchor in the same turn instead of spending one reading the field back. It runs on a refusal, so its cost is paid by a call that produces nothing and an agent can trigger it by mistyping. It now scans at most 5000 lines and clips each line and the anchor to 2000 characters, which also bounds the single-enormous-line case, where comparing against a minified file is quadratic in its length.

The same review pass removed a public reason code rather than adding one. The `match_mode` refusal reuses the existing `invalid_operation_shape` and carries its guidance on `next_step`, which is what that field is for, so the runner and the frontend have one fewer code to learn.

## Tests

- `test_change_set.py` gains 320 lines: the marker refusals driven by the exact payload from the live session, the depth guard on both delta arms, the unkeyed-list answer across all three item operations, the legacy field shapes, and the bounds on the near-miss search.
- `test_commit_support.py`, 250 lines, covering the wrapper-owned jobs: selector normalization, the derived commit message, and the platform-tool rejection.
- The flag parser fix is in this PR, and the test that pins it is not. `test_ordered_operations_flag.py` asserts that the API and the SDK catalog accept the same spellings, and the catalog half of that agreement only exists on the SDK wiring lane, so the test rides that PR (`agent-config-editing-s3b-wire-py`). Below it the test has nothing to compare against, fails in isolation, and reddens every PR in between. What it protects is this: the API accepted `enabled`, `t`, `y` and `enable` and the catalog did not, so a deployment written `enabled` would have turned the ordered arm on in the API while the catalog kept advertising the legacy surface, and the model would send a shape it was never shown.
- Full API unit suite: 2068 passed in both flag states.
- Reviewers should check that `commit_workflow_revision` still behaves identically for its other callers. Applications, evaluators, and the simple-workflow save path all reach it and none routes through the checked wrapper.
- The contract documentation for the marker and depth rules (sections 6.7 and 6.8 of `contracts/change-set.md`) landed one lane down in #5748, so the doc and the code it describes are in different PRs of this stack.

This targets `agent-config-editing-s1b-lock` and is part of the agent-config-editing stack. Read the stack bottom up.


## The platform-guidance block

The runner appends a fenced block of platform guidance to the instructions file it renders into the agent's workspace. The stored configuration never contains it: it is injected at render time. A model that copies that rendered file back into a commit would otherwise store our own guidance as the user's configuration, which is how the Luna session ended up with an agent whose instructions described the platform to itself. So the engine removes the block from any committed string, at any depth, in both delta arms. Removal is silent to the model and never an error: it did nothing wrong, and a refusal it has to recover from costs a turn teaching it something it cannot act on. A `platform_guidance_stripped` warning names the field, so the removal is visible to the human reading the response.

The strip normalizes rather than matching a fixed newline pattern, which makes it idempotent and means the runner can change its spacing without breaking anything. The round trip is asserted end to end across four different separators: render, copy the rendered file back as a wholesale `set`, and the stored text comes back byte for byte. Two delimiter cases are decided rather than left to chance: an unmatched opening fence strips to the end of the string, and a lone closing fence is left as plain text, because it is inert without its opener and deleting on the strength of it would let one stray line remove a user's own content. The two literals are pinned by a test naming the runner's `system-prompt-appendix.ts`, and the runner's own suite reads this file back, so neither side can change the fence alone. An `edit_text` anchor copied out of a stripped region is not special-cased: the block is not in stored text, so the anchor misses and earns the ordinary `text_not_found`.

