### PR TITLE
feat(api): add read_config and harden the commit endpoint

### DIFF
--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -9,6 +9,8 @@ from oss.src.core.shared.dtos import (
 from oss.src.core.git.dtos import RetrievalInfo
 from oss.src.core.workflows.dtos import (
     #
+    CommitWarning,
+    #
     WorkflowCatalogType,
     WorkflowCatalogHarness,
     WorkflowCatalogTemplate,
@@ -413,13 +415,6 @@ class ReadConfigResponse(BaseModel):
     value: Any = None
     bytes: int = 0
     warnings: Optional[List[Dict[str, Any]]] = None
-
-
-class CommitWarning(BaseModel):
-    code: str
-    message: str
-    target: Optional[List[Any]] = None
-    operation_index: Optional[int] = None
 
 
 class WorkflowRevisionResponse(BaseModel):

--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, Optional, List
+from typing import Any, Literal, Optional, List
 
 from pydantic import BaseModel, Field
 
@@ -414,7 +414,7 @@ class ReadConfigResponse(BaseModel):
     path: List[Any] = Field(default_factory=list)
     value: Any = None
     bytes: int = 0
-    warnings: Optional[List[Dict[str, Any]]] = None
+    warnings: Optional[List[CommitWarning]] = None
 
 
 class WorkflowRevisionResponse(BaseModel):

--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, List
+from typing import Any, Dict, Literal, Optional, List
 
 from pydantic import BaseModel, Field
 
@@ -382,6 +382,37 @@ class WorkflowRevisionsLogRequest(BaseModel):
             "`workflow_revision_id` to scope the log, and an optional `depth`."
         ),
     )
+
+
+class ReadConfigTarget(BaseModel):
+    workflow_variant_id: Optional[str] = None
+    # Server-bound from $ctx.workflow.is_draft; stripped from the model-visible schema.
+    run_is_draft: Optional[bool] = None
+    path: Optional[List[Any]] = None
+
+
+class ReadConfigRequest(BaseModel):
+    target: ReadConfigTarget
+    max_bytes: Optional[int] = None
+
+
+class ReadConfigRevision(BaseModel):
+    id: str
+    version: Optional[str] = None
+    workflow_variant_id: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class ReadConfigResponse(BaseModel):
+    revision: ReadConfigRevision
+    base_revision_id: str = Field(
+        description="Copy this into your next commit's `base_revision_id`.",
+    )
+    is_draft: bool = False
+    path: List[Any] = Field(default_factory=list)
+    value: Any = None
+    bytes: int = 0
+    warnings: Optional[List[Dict[str, Any]]] = None
 
 
 class CommitWarning(BaseModel):

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1689,6 +1689,24 @@ class WorkflowsRouter:
                     "retryable": False,
                 },
             )
+        # `description` on a scoped commit is dropped, never stored. The model never sets the
+        # persisted revision description (read-config.md 12.2); the field it does write is the
+        # ephemeral per-call note, which shares this name and must not reach the audit trail
+        # (12.3). The runner strips that note before dispatch, so one arriving here means the
+        # runner did not, and storing it would persist exactly what the contract forbids.
+        if (
+            scope_policy is not None
+            and workflow_revision_commit.description is not None
+        ):
+            workflow_revision_commit = workflow_revision_commit.model_copy(
+                update={"description": None}
+            )
+            workflow_revision_commit_request = (
+                workflow_revision_commit_request.model_copy(
+                    update={"workflow_revision": workflow_revision_commit}
+                )
+            )
+
         if not has_data and not has_delta:
             current_revision = await self.workflows_service.fetch_workflow_revision(
                 project_id=UUID(request.state.project_id),

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1583,6 +1583,7 @@ class WorkflowsRouter:
 
     @intercept_exceptions()
     @handle_workflow_exceptions()
+    @handle_git_exceptions()
     async def commit_workflow_revision(
         self,
         request: Request,
@@ -1601,6 +1602,7 @@ class WorkflowsRouter:
 
     @intercept_exceptions()
     @handle_workflow_exceptions()
+    @handle_git_exceptions()
     async def commit_agent_workflow_revision(
         self,
         request: Request,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -16,6 +16,7 @@ from oss.src.core.git.utils import build_retrieval_info
 from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.apis.fastapi.workflows.exceptions import handle_workflow_exceptions
 from oss.src.core.workflows.change_set import ChangeSetError
+from oss.src.core.workflows.read_config import ReadConfigError
 from oss.src.core.workflows.service import (
     RevisionConflictError,
     WorkflowsService,
@@ -54,6 +55,10 @@ from oss.src.apis.fastapi.workflows.models import (
     WorkflowRevisionsLogRequest,
     WorkflowRevisionResponse,
     WorkflowRevisionsResponse,
+    #
+    ReadConfigRequest,
+    ReadConfigResponse,
+    ReadConfigRevision,
     #
     WorkflowRevisionResolveRequest,
     WorkflowRevisionResolveResponse,
@@ -427,6 +432,16 @@ class WorkflowsRouter:
             operation_id="commit_workflow_revision",
             status_code=status.HTTP_200_OK,
             response_model=WorkflowRevisionResponse,
+            response_model_exclude_none=True,
+        )
+
+        self.router.add_api_route(
+            "/revisions/read-config",
+            self.read_workflow_revision_config,
+            methods=["POST"],
+            operation_id="read_workflow_revision_config",
+            status_code=status.HTTP_200_OK,
+            response_model=ReadConfigResponse,
             response_model_exclude_none=True,
         )
 
@@ -1499,6 +1514,57 @@ class WorkflowsRouter:
 
     @intercept_exceptions()
     @handle_workflow_exceptions()
+    @intercept_exceptions()
+    async def read_workflow_revision_config(
+        self,
+        request: Request,
+        *,
+        read_config_request: ReadConfigRequest,
+    ) -> ReadConfigResponse:
+        if not await check_action_access(  # type: ignore
+            user_uid=request.state.user_id,
+            project_id=request.state.project_id,
+            permission=Permission.VIEW_WORKFLOWS,  # type: ignore
+        ):
+            raise FORBIDDEN_EXCEPTION  # type: ignore
+
+        variant_id = read_config_request.target.workflow_variant_id
+        if not variant_id:
+            raise HTTPException(
+                status_code=400,
+                detail="target.workflow_variant_id is required.",
+            )
+
+        try:
+            outcome = await self.workflows_service.read_workflow_revision_config(
+                project_id=UUID(request.state.project_id),
+                workflow_variant_id=UUID(variant_id),
+                path=read_config_request.target.path,
+                max_bytes=read_config_request.max_bytes,
+                run_is_draft=read_config_request.target.run_is_draft,
+            )
+        except ReadConfigError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.to_detail()) from e
+
+        revision = outcome.revision
+        return ReadConfigResponse(
+            revision=ReadConfigRevision(
+                id=str(revision.id),
+                version=getattr(revision, "version", None),
+                workflow_variant_id=str(getattr(revision, "variant_id", "") or "")
+                or None,
+                created_at=str(getattr(revision, "created_at", "") or "") or None,
+            ),
+            # The value the agent must copy into its next commit; the commit answers 409
+            # when the head moved, which is what makes read-then-edit safe.
+            base_revision_id=str(revision.id),
+            is_draft=outcome.is_draft,
+            path=outcome.path,
+            value=outcome.value,
+            bytes=outcome.bytes,
+            warnings=outcome.warnings or None,
+        )
+
     async def commit_workflow_revision(
         self,
         request: Request,

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -13,9 +13,11 @@ from oss.src.core.shared.dtos import (
     Reference,
 )
 from oss.src.core.git.utils import build_retrieval_info
+from oss.src.core.git.types import CommitLockTimeout
+from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
 from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.apis.fastapi.workflows.exceptions import handle_workflow_exceptions
-from oss.src.core.workflows.change_set import ChangeSetError
+from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE, ChangeSetError
 from oss.src.core.workflows.read_config import ReadConfigError
 from oss.src.core.workflows.service import (
     RevisionConflictError,
@@ -430,6 +432,20 @@ class WorkflowsRouter:
             self.commit_workflow_revision,
             methods=["POST"],
             operation_id="commit_workflow_revision",
+            status_code=status.HTTP_200_OK,
+            response_model=WorkflowRevisionResponse,
+            response_model_exclude_none=True,
+        )
+
+        # The agent's own commit surface. Same flow, same response, one difference: every
+        # write is confined to `parameters.agent`. It is a separate route because that is
+        # what makes the confinement unforgeable — the model cannot ask for the unscoped
+        # one, since the URL comes from the server-side catalog and it holds no credential.
+        self.router.add_api_route(
+            "/revisions/commit/agent",
+            self.commit_agent_workflow_revision,
+            methods=["POST"],
+            operation_id="commit_agent_workflow_revision",
             status_code=status.HTTP_200_OK,
             response_model=WorkflowRevisionResponse,
             response_model_exclude_none=True,
@@ -1565,6 +1581,8 @@ class WorkflowsRouter:
             warnings=outcome.warnings or None,
         )
 
+    @intercept_exceptions()
+    @handle_workflow_exceptions()
     async def commit_workflow_revision(
         self,
         request: Request,
@@ -1572,6 +1590,46 @@ class WorkflowsRouter:
         workflow_variant_id: Optional[UUID] = None,
         #
         workflow_revision_commit_request: WorkflowRevisionCommitRequest,
+    ) -> WorkflowRevisionResponse:
+        """The human and SDK route: no write scope, the caller owns the whole revision."""
+        return await self._commit_workflow_revision(
+            request=request,
+            workflow_variant_id=workflow_variant_id,
+            workflow_revision_commit_request=workflow_revision_commit_request,
+            scope_policy=None,
+        )
+
+    @intercept_exceptions()
+    @handle_workflow_exceptions()
+    async def commit_agent_workflow_revision(
+        self,
+        request: Request,
+        *,
+        workflow_variant_id: Optional[UUID] = None,
+        #
+        workflow_revision_commit_request: WorkflowRevisionCommitRequest,
+    ) -> WorkflowRevisionResponse:
+        """The agent's own route: every write is confined to `parameters.agent`.
+
+        The confinement is a property of the ROUTE, not of anything in the request, which
+        is what makes it unforgeable: the model never holds the credential, and the URL it
+        reaches comes from the server-side op catalog, so an agent cannot express an
+        unscoped commit (read-config.md 11.2).
+        """
+        return await self._commit_workflow_revision(
+            request=request,
+            workflow_variant_id=workflow_variant_id,
+            workflow_revision_commit_request=workflow_revision_commit_request,
+            scope_policy=AGENT_COMMIT_SCOPE,
+        )
+
+    async def _commit_workflow_revision(
+        self,
+        *,
+        request: Request,
+        workflow_variant_id: Optional[UUID],
+        workflow_revision_commit_request: WorkflowRevisionCommitRequest,
+        scope_policy,
     ) -> WorkflowRevisionResponse:
         if not await check_action_access(  # type: ignore
             user_uid=request.state.user_id,
@@ -1610,6 +1668,25 @@ class WorkflowsRouter:
                 status_code=400,
                 detail="Provide either data or delta for a commit, not both.",
             )
+        # A scoped caller states changes, never a whole configuration: a full replacement
+        # carries every field the scope exists to protect, so it is refused rather than
+        # filtered. The agent's tool only ever sends a delta.
+        if scope_policy is not None and not has_delta:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "full_data_not_committable",
+                    "message": (
+                        "This route commits a change to the configuration, not a whole "
+                        "configuration."
+                    ),
+                    "next_step": (
+                        "Send the change as `delta`, targeting the fields you want to "
+                        "alter."
+                    ),
+                    "retryable": False,
+                },
+            )
         if not has_data and not has_delta:
             current_revision = await self.workflows_service.fetch_workflow_revision(
                 project_id=UUID(request.state.project_id),
@@ -1628,13 +1705,49 @@ class WorkflowsRouter:
                 user_id=UUID(request.state.user_id),
                 #
                 workflow_revision_commit=workflow_revision_commit_request.workflow_revision,
+                #
+                scope_policy=scope_policy,
             )
         except RevisionConflictError as e:
             raise HTTPException(status_code=409, detail=e.to_detail()) from e
         except ChangeSetError as e:
             raise HTTPException(status_code=422, detail=e.to_detail()) from e
+        except NonEmbeddableWorkflowReferenceError as e:
+            # A change-set refusal like any other on this endpoint, so it answers 422 with
+            # a reason code rather than the shared 400 the other workflow routes give
+            # (contract commit-transaction.md 4.1).
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "non_embeddable_reference",
+                    "message": str(e),
+                    "retryable": False,
+                },
+            ) from e
+        except CommitLockTimeout as e:
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "code": "commit_lock_timeout",
+                    "message": e.message,
+                    "next_step": "Wait for the commit in flight to finish, then send this commit again.",
+                    "retryable": True,
+                },
+            ) from e
 
         workflow_revision = outcome.revision
+
+        # A commit that reports success with nothing to show for it is a failure the DAO
+        # swallowed. Answering 200 here would tell the caller its change landed.
+        if outcome.status == "committed" and not workflow_revision:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "code": "commit_failed",
+                    "message": "The commit did not produce a revision.",
+                    "retryable": True,
+                },
+            )
 
         # A commit event evicts the warm session, so `no_change` must emit nothing.
         if outcome.status == "committed":

--- a/api/oss/src/core/tools/platform_handlers.py
+++ b/api/oss/src/core/tools/platform_handlers.py
@@ -222,6 +222,10 @@ async def _build_test_workflow_request(
                 workflow_variant_id=request.target.workflow_variant_id,
                 delta=request.delta,
             ),
+            # A test run applies the delta in memory and stores nothing, so it carries no
+            # base revision id. Without this an ordered delta could never be previewed:
+            # the commit path requires that id, and it exists to protect a write.
+            preview=True,
         )
         resolved = resolution.commit
         if resolved.data is None:

--- a/api/oss/src/core/workflows/dtos.py
+++ b/api/oss/src/core/workflows/dtos.py
@@ -572,3 +572,53 @@ class WorkflowServiceDetachedResponse(BaseModel):
     accepted: bool = True
     trace_id: Optional[str] = None
     span_id: Optional[str] = None
+
+
+class CommitWarning(BaseModel):
+    """One thing the caller should know about a commit that still succeeded.
+
+    The codes are the engine's (change-set.md 7.1) plus `no_change`, which the commit
+    wrapper owns. `target` carries contract-shaped segments, so a caller can act on the
+    warning without parsing its prose.
+    """
+
+    code: str
+    message: str
+    target: Optional[List[Any]] = None
+    operation_index: Optional[int] = None
+
+
+class DeltaResolution(BaseModel):
+    """The resolved commit, the head it was built on, and the response's warnings.
+
+    The head travels with the resolution because the no-change comparison runs on the
+    ENRICHED result (contract commit-transaction.md 5.1), which the caller only holds
+    after this returns.
+    """
+
+    commit: WorkflowRevisionCommit
+    head: Optional[WorkflowRevision] = None
+    warnings: List[CommitWarning] = Field(default_factory=list)
+
+
+class ConfigReadOutcome(BaseModel):
+    """One `read_config` answer: the value plus which revision produced it."""
+
+    revision: WorkflowRevision
+    path: List[Any] = Field(default_factory=list)
+    value: Any = None
+    bytes: int = 0
+    is_draft: bool = False
+    warnings: List[CommitWarning] = Field(default_factory=list)
+
+
+class CommitOutcome(BaseModel):
+    """What the commit endpoint answers with.
+
+    ``revision`` is complete on BOTH statuses. On `no_change` it is the current head, so
+    every existing consumer keeps working and a refresh with it is still correct.
+    """
+
+    revision: Optional[WorkflowRevision] = None
+    status: Literal["committed", "no_change"] = "committed"
+    warnings: List[CommitWarning] = Field(default_factory=list)

--- a/api/oss/src/core/workflows/read_config.py
+++ b/api/oss/src/core/workflows/read_config.py
@@ -1,0 +1,351 @@
+"""Reading one part of a workflow revision's configuration (slice S2).
+
+Implements the projection half of ``contracts/read-config.md``: resolve a target against a
+revision's data, refuse what the agent may not read, and answer fully or not at all.
+
+Pure and synchronous. The service fetches the revision; this module shapes the answer.
+
+The target grammar is the change set's, unchanged, and so is the reason-code vocabulary.
+One grammar for read and write is the point: what the agent reads, it can then name in an
+operation.
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+from oss.src.core.workflows.change_set import (
+    KEY_FIELDS,
+    Reason,
+    Segment,
+    Target,
+    item_key,
+)
+
+__all__ = [
+    "ReadConfigError",
+    "ReadConfigResult",
+    "DEFAULT_MAX_BYTES",
+    "MAX_MAX_BYTES",
+    "MIN_MAX_BYTES",
+    "READABLE_ROOTS",
+    "project_config",
+]
+
+
+DEFAULT_MAX_BYTES = 65_536
+MIN_MAX_BYTES = 1_024
+MAX_MAX_BYTES = 262_144
+
+# Contract 8. The read scope is wider than the write scope: reading `uri` helps the agent
+# understand itself, and writing it would break it. `url` and `schemas` are server-derived
+# and large, and they tell the model nothing it can act on.
+READABLE_ROOTS = ("parameters", "uri", "flags")
+_UNREADABLE_ROOTS = ("url", "schemas")
+
+_NEXT_STEPS = {
+    Reason.TARGET_NOT_FOUND: (
+        "Read the parent path to see which fields exist, then retry."
+    ),
+    Reason.TARGET_TYPE_MISMATCH: (
+        "That segment is a scalar, so it has no fields. Read its parent instead."
+    ),
+    Reason.ITEM_NOT_FOUND: (
+        "Read the list itself to see the keys it holds, then retry with one of them."
+    ),
+    Reason.DUPLICATE_ITEM_KEY: (
+        "Two entries share that key, so it does not address one entry. Read the whole "
+        "list instead."
+    ),
+    Reason.UNKEYED_COLLECTION: (
+        "That list is not addressed by name. Read the whole list instead."
+    ),
+    Reason.INVALID_TARGET_SHAPE: (
+        "A segment is a field name, or {'list': ..., 'key': ...} for one list entry."
+    ),
+    Reason.OUT_OF_SCOPE: ("Read `parameters` for the configuration you can change."),
+    "output_too_large": (
+        "Read one of the paths in `children` instead of the whole value."
+    ),
+}
+
+
+class ReadConfigError(Exception):
+    """A read the agent must correct. HTTP 422 unless stated otherwise."""
+
+    code = "read_config_rejected"
+
+    def __init__(
+        self,
+        reason: str,
+        message: str,
+        *,
+        path: Optional[Target] = None,
+        children: Optional[Sequence[str]] = None,
+        status_code: int = 422,
+        **context: Any,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+        self.path = list(path) if path is not None else None
+        self.children = list(children) if children is not None else None
+        self.status_code = status_code
+        self.context = context
+
+    def to_detail(self) -> Dict[str, Any]:
+        reason: Dict[str, Any] = {"code": self.reason, "message": self.message}
+        next_step = _NEXT_STEPS.get(self.reason)
+        if next_step:
+            reason["next_step"] = next_step
+        reason.update(self.context)
+        detail: Dict[str, Any] = {
+            "code": self.code,
+            "reason": reason,
+            "retryable": True,
+        }
+        if self.path is not None:
+            detail["path"] = self.path
+        if self.children is not None:
+            detail["children"] = self.children
+        return detail
+
+
+@dataclass(frozen=True)
+class ReadConfigResult:
+    path: List[Segment]
+    value: Any
+    bytes: int
+    warnings: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def _encoded_size(value: Any) -> int:
+    return len(json.dumps(value, ensure_ascii=False, default=str).encode("utf-8"))
+
+
+def children_of(value: Any) -> List[str]:
+    """The names one level under a value: object fields, or a list's item keys.
+
+    For a list this returns the selector keys the agent may use, so a refusal hands it the
+    exact vocabulary for the narrower read.
+    """
+    if isinstance(value, dict):
+        return [key for key in value if key not in _UNREADABLE_ROOTS]
+    if isinstance(value, list):
+        return []
+    return []
+
+
+def _list_children(list_name: str, entries: Sequence[Any]) -> List[str]:
+    keys = [item_key(list_name, entry) for entry in entries]
+    return [key for key in keys if key]
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    return {
+        dict: "an object",
+        list: "a list",
+        str: "a string",
+        bool: "a boolean",
+        int: "a number",
+        float: "a number",
+    }.get(type(value), type(value).__name__)
+
+
+def _check_scope(path: Sequence[Segment]) -> None:
+    if not path:
+        return
+    root = path[0]
+    if not isinstance(root, str):
+        raise ReadConfigError(
+            Reason.INVALID_TARGET_SHAPE,
+            "the first segment names a top-level field",
+            path=list(path),
+        )
+    if root in _UNREADABLE_ROOTS:
+        raise ReadConfigError(
+            Reason.OUT_OF_SCOPE,
+            f"'{root}' is server-derived and cannot be read.",
+            path=list(path),
+        )
+    if root not in READABLE_ROOTS:
+        raise ReadConfigError(
+            Reason.OUT_OF_SCOPE,
+            f"'{root}' is not readable (readable: {', '.join(READABLE_ROOTS)}).",
+            path=list(path),
+        )
+
+
+def _validate_segment(segment: Any, position: int, path: Sequence[Segment]) -> None:
+    if isinstance(segment, str):
+        if segment:
+            return
+        raise ReadConfigError(
+            Reason.INVALID_TARGET_SHAPE,
+            f"path segment {position} is empty",
+            path=list(path),
+        )
+    if isinstance(segment, dict):
+        if set(segment) != {"list", "key"}:
+            raise ReadConfigError(
+                Reason.INVALID_TARGET_SHAPE,
+                f"path segment {position} must have exactly 'list' and 'key'",
+                path=list(path),
+            )
+        if not isinstance(segment["list"], str) or not segment["list"]:
+            raise ReadConfigError(
+                Reason.INVALID_TARGET_SHAPE,
+                f"path segment {position} has an empty 'list'",
+                path=list(path),
+            )
+        if not isinstance(segment["key"], str) or not segment["key"]:
+            raise ReadConfigError(
+                Reason.INVALID_TARGET_SHAPE,
+                f"path segment {position} has an empty 'key'",
+                path=list(path),
+            )
+        return
+    raise ReadConfigError(
+        Reason.INVALID_TARGET_SHAPE,
+        f"path segment {position} must be a string or a {{list, key}} object",
+        path=list(path),
+    )
+
+
+def _resolve(data: Dict[str, Any], path: Sequence[Segment]) -> Any:
+    node: Any = data
+    for position, segment in enumerate(path):
+        _validate_segment(segment, position, path)
+        walked = list(path[: position + 1])
+        if isinstance(segment, str):
+            if not isinstance(node, dict):
+                raise ReadConfigError(
+                    Reason.TARGET_TYPE_MISMATCH,
+                    f"segment {position} ({segment!r}): the parent is "
+                    f"{_type_name(node)}, not an object",
+                    path=walked,
+                )
+            if segment not in node:
+                raise ReadConfigError(
+                    Reason.TARGET_NOT_FOUND,
+                    f"{segment!r} does not exist",
+                    path=walked,
+                    children=children_of(node),
+                )
+            node = node[segment]
+        else:
+            list_name, key = segment["list"], segment["key"]
+            if not isinstance(node, dict) or list_name not in node:
+                raise ReadConfigError(
+                    Reason.TARGET_NOT_FOUND,
+                    f"'{list_name}' does not exist",
+                    path=walked,
+                    children=children_of(node),
+                )
+            entries = node[list_name]
+            if not isinstance(entries, list):
+                raise ReadConfigError(
+                    Reason.TARGET_TYPE_MISMATCH,
+                    f"'{list_name}' is {_type_name(entries)}, not a list",
+                    path=walked,
+                )
+            if list_name not in KEY_FIELDS:
+                raise ReadConfigError(
+                    Reason.UNKEYED_COLLECTION,
+                    f"'{list_name}' is not addressed by name",
+                    path=walked,
+                )
+            matches = [entry for entry in entries if item_key(list_name, entry) == key]
+            if len(matches) > 1:
+                raise ReadConfigError(
+                    Reason.DUPLICATE_ITEM_KEY,
+                    f"'{list_name}' holds {len(matches)} entries named {key!r}",
+                    path=walked,
+                    match_count=len(matches),
+                )
+            if not matches:
+                raise ReadConfigError(
+                    Reason.ITEM_NOT_FOUND,
+                    f"'{list_name}' has no entry named {key!r}",
+                    path=walked,
+                    children=_list_children(list_name, entries),
+                )
+            node = matches[0]
+    return node
+
+
+def _readable_root_view(data: Dict[str, Any]) -> Dict[str, Any]:
+    """The whole-configuration answer, with the server-derived fields dropped.
+
+    The model never gets the raw revision dump: `url` and `schemas` are large and
+    unactionable, and shipping them would spend the agent's context on nothing.
+    """
+    return {key: value for key, value in data.items() if key in READABLE_ROOTS}
+
+
+def project_config(
+    data: Optional[Dict[str, Any]],
+    path: Optional[Sequence[Segment]] = None,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> ReadConfigResult:
+    """Resolve ``path`` against ``data`` and answer fully, or refuse.
+
+    An absent path means the whole readable configuration.
+    """
+    if data is None:
+        raise ReadConfigError(
+            "revision_not_found",
+            "The variant has no revision to read.",
+            status_code=404,
+        )
+
+    segments = list(path or [])
+    _check_scope(segments)
+
+    value = _resolve(data, segments) if segments else _readable_root_view(data)
+
+    size = _encoded_size(value)
+    if size > max_bytes:
+        # Refuse, never truncate: an anchor built from a cut string can match text the
+        # agent never saw, and that commits the wrong change.
+        raise ReadConfigError(
+            "output_too_large",
+            f"The value at that path is {size} bytes; the limit is {max_bytes}. "
+            "Read a narrower path.",
+            path=segments,
+            children=_children_for_refusal(value, segments),
+            bytes=size,
+            limit=max_bytes,
+        )
+
+    return ReadConfigResult(path=segments, value=value, bytes=size)
+
+
+def _children_for_refusal(value: Any, path: Sequence[Segment]) -> List[str]:
+    if isinstance(value, list) and path:
+        last = path[-1]
+        if isinstance(last, str):
+            return _list_children(last, value)
+    return children_of(value)
+
+
+def clamp_max_bytes(requested: Optional[int]) -> int:
+    if requested is None:
+        return DEFAULT_MAX_BYTES
+    return max(MIN_MAX_BYTES, min(MAX_MAX_BYTES, requested))
+
+
+def draft_warning(revision_version: Optional[str]) -> Dict[str, Any]:
+    """Contract 10. A draft run reads the committed head, not what it is running."""
+    version = f", revision {revision_version}" if revision_version else ""
+    return {
+        "code": "draft_run",
+        "message": (
+            "This run executes unsaved playground changes. The values below come from "
+            f"the committed head{version}. Your commit will also apply to the committed "
+            "head."
+        ),
+    }

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -2050,6 +2050,14 @@ class WorkflowsService:
                 ),
                 include_archived=False,
             )
+            # A stale base beats a no-change answer (commit-transaction.md 6, rule 2 over
+            # rule 6). A stale caller can send data that equals the NEW head; telling it
+            # `no_change` would confirm a base that had already moved. The delta arm runs
+            # this check inside `_resolve_revision_delta`, before it applies anything.
+            self._check_base_revision(
+                workflow_revision_commit=workflow_revision_commit,
+                current=head,
+            )
 
         # Built before the comparison, because the comparison runs on what would be
         # STORED: enrichment fills `url` and `schemas`, and the flags are inferred from the

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -105,6 +105,7 @@ from oss.src.core.workflows.change_set import (
     ChangeSetError,
     Reason,
     apply_change_set,
+    strip_guidance_from_data,
 )
 from oss.src.core.workflows.read_config import (
     ReadConfigError,
@@ -2027,6 +2028,23 @@ class WorkflowsService:
                 workflow_revision_commit=workflow_revision_commit,
                 current=head,
             )
+
+            # A full-data commit never reaches the engine, so the guidance block would be
+            # stored verbatim. A copied-back instructions file arrives this way as easily as
+            # through a delta, and the playground's own save path is full-data.
+            if workflow_revision_commit.data is not None:
+                stripped, guidance_warnings = strip_guidance_from_data(
+                    workflow_revision_commit.data.model_dump(
+                        mode="json", exclude_none=True
+                    )
+                )
+                if guidance_warnings:
+                    warnings.extend(
+                        CommitWarning(**w.to_dict()) for w in guidance_warnings
+                    )
+                    workflow_revision_commit = workflow_revision_commit.model_copy(
+                        update={"data": WorkflowRevisionData(**stripped)}
+                    )
 
         # Built before the comparison, because the comparison runs on what would be
         # STORED: enrichment fills `url` and `schemas`, and the flags are inferred from the

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -99,7 +99,6 @@ from oss.src.core.workflows.change_set import (
     ChangeSetError,
     Reason,
     apply_change_set,
-    deep_merge as _deep_merge,
 )
 from oss.src.core.workflows.read_config import (
     ReadConfigError,
@@ -196,11 +195,16 @@ class RevisionConflictError(Exception):
 
 @dataclass
 class DeltaResolution:
-    """The resolved commit plus the two wrapper-owned outputs the response carries."""
+    """The resolved commit, the head it was built on, and the response's warnings.
+
+    The head travels with the resolution because the no-change comparison runs on the
+    ENRICHED result (contract commit-transaction.md 5.1), which the caller only holds
+    after this returns.
+    """
 
     commit: "WorkflowRevisionCommit"
+    head: Optional["WorkflowRevision"] = None
     warnings: list = field(default_factory=list)
-    changed: bool = True
 
 
 @dataclass
@@ -226,6 +230,16 @@ class CommitOutcome:
     revision: "Optional[WorkflowRevision]"
     status: str = "committed"
     warnings: list = field(default_factory=list)
+
+
+def _validate_persisted_shape(data: dict) -> None:
+    """The engine's final gate: the finished tree must be storable as it stands.
+
+    The revision DTO is the only closed shape the server owns here, so this asserts that
+    and nothing more. Without it the same failure surfaces later as an uncaught pydantic
+    error rather than a 422 naming the field (contract commit-transaction.md 3, step 5).
+    """
+    WorkflowRevisionData(**data)
 
 
 class WorkflowsService:
@@ -2012,6 +2026,7 @@ class WorkflowsService:
         self._reject_static_slug(workflow_revision_commit.slug)
 
         warnings: List[Any] = []
+        head: Optional[WorkflowRevision] = None
         if workflow_revision_commit.delta is not None:
             resolution = await self._resolve_revision_delta(
                 project_id=project_id,
@@ -2022,34 +2037,49 @@ class WorkflowsService:
                 warning.to_dict() if hasattr(warning, "to_dict") else warning
                 for warning in resolution.warnings
             ]
-            if not resolution.changed:
-                # A commit event evicts the warm session, so a change that changes nothing
-                # must not create a revision, publish an event, or invalidate a cache.
-                head = await self.fetch_workflow_revision(
-                    project_id=project_id,
-                    workflow_variant_ref=Reference(
-                        id=workflow_revision_commit.workflow_variant_id
-                        or workflow_revision_commit.variant_id
-                    ),
-                    include_archived=False,
-                )
-                warnings.append(
-                    {
-                        "code": "no_change",
-                        "message": (
-                            "The change produced the configuration that is already "
-                            "stored, so no revision was created."
-                        ),
-                    }
-                )
-                return CommitOutcome(
-                    revision=head, status="no_change", warnings=warnings
-                )
+            head = resolution.head
             workflow_revision_commit = resolution.commit
+        else:
+            # A full-data commit answers `no_change` on the same terms as a delta: the
+            # comparison is a property of the result, not of how the caller expressed it.
+            head = await self.fetch_workflow_revision(
+                project_id=project_id,
+                workflow_variant_ref=Reference(
+                    id=workflow_revision_commit.workflow_variant_id
+                    or workflow_revision_commit.variant_id
+                ),
+                include_archived=False,
+            )
+
+        # Built before the comparison, because the comparison runs on what would be
+        # STORED: enrichment fills `url` and `schemas`, and the flags are inferred from the
+        # finished data (contract commit-transaction.md 5.1).
+        candidate = self._build_revision_commit(
+            workflow_revision_commit=workflow_revision_commit,
+        )
+
+        if await self._is_no_change(
+            project_id=project_id,
+            head=head,
+            candidate=candidate,
+        ):
+            # A commit event evicts the warm session, so a change that changes nothing
+            # must not create a revision, publish an event, or invalidate a cache.
+            warnings.append(
+                {
+                    "code": "no_change",
+                    "message": (
+                        "The change produced the configuration that is already "
+                        "stored, so no revision was created."
+                    ),
+                }
+            )
+            return CommitOutcome(revision=head, status="no_change", warnings=warnings)
 
         # The pre-check above is an early-out, not the guarantee: it reads the head in its
         # own transaction, so two writers can both pass it. Passing the expectation down
         # is what makes the DAO re-read under the variant lock and refuse the loser.
+        # `CommitLockTimeout` from that lock travels on unchanged: it is the router's 503.
         try:
             revision = await self.commit_workflow_revision(
                 project_id=project_id,
@@ -2063,6 +2093,54 @@ class WorkflowsService:
                 current_revision_id=e.current_head_revision_id,
             ) from e
         return CommitOutcome(revision=revision, status="committed", warnings=warnings)
+
+    async def _is_no_change(
+        self,
+        *,
+        project_id: UUID,
+        head: Optional[WorkflowRevision],
+        candidate: RevisionCommit,
+    ) -> bool:
+        """Whether committing ``candidate`` would store what the head already holds.
+
+        The head side reads the STORED row, never the read view: the read path merges the
+        artifact's flags in and infers `url` on top of what was written, so comparing
+        against it would answer "changed" forever (contract commit-transaction.md 5.1).
+        """
+        if head is None or head.id is None:
+            return False
+
+        stored_head = await self.workflows_dao.fetch_revision(
+            project_id=project_id,
+            #
+            revision_ref=Reference(id=head.id),
+        )
+        if stored_head is None:
+            return False
+
+        return self._canonical_revision_record(
+            data=candidate.data,
+            flags=candidate.flags,
+        ) == self._canonical_revision_record(
+            data=stored_head.data,
+            flags=stored_head.flags,
+        )
+
+    @staticmethod
+    def _canonical_revision_record(
+        *,
+        data: Optional[dict],
+        flags: Optional[dict],
+    ) -> dict:
+        """The persisted pair that decides equality (contract commit-transaction.md 5.1).
+
+        `flags` belongs in it because two revisions can hold equal data and different
+        inferred flags; comparing data alone would answer `no_change` for a commit that
+        does change behavior, and the new flags would never reach the database. The
+        contract's recursive key sort needs no step here: python compares dicts by content,
+        not by key order.
+        """
+        return {"data": data or None, "flags": flags or None}
 
     async def commit_workflow_revision(
         self,
@@ -2087,70 +2165,8 @@ class WorkflowsService:
             )
             workflow_revision_commit = resolution.commit
 
-        # A snippet (skill) is non-runnable content: strip every execution-surface field, only uri +
-        # parameters survive. Holds even if a caller posts the skill uri under a normal slug.
-        data = normalize_snippet_data(workflow_revision_commit.data)
-        if data and data.uri and not data.url:
-            _, kind, _, _ = parse_uri(data.uri)
-            if kind != "builtin":
-                path = infer_url_from_uri(data.uri)
-                if path:
-                    data = data.model_copy(
-                        update={"url": env.agenta.services_url.rstrip("/") + path}
-                    )
-
-        self._reject_non_embeddable_workflow_embeds(data)
-
-        if data and data.uri:
-            interface = retrieve_interface(data.uri)
-            current_schemas = data.schemas or {}
-            schemas_dict = (
-                current_schemas
-                if isinstance(current_schemas, dict)
-                else current_schemas.model_dump(mode="json", exclude_none=True)
-            )
-
-            if interface and interface.schemas:
-                iface_schemas = (
-                    interface.schemas
-                    if isinstance(interface.schemas, dict)
-                    else interface.schemas.model_dump(mode="json", exclude_none=True)
-                )
-                if "parameters" not in schemas_dict and "parameters" in iface_schemas:
-                    schemas_dict["parameters"] = iface_schemas["parameters"]
-                if "outputs" not in schemas_dict and "outputs" in iface_schemas:
-                    schemas_dict["outputs"] = iface_schemas["outputs"]
-
-            if data.parameters is not None:
-                inferred_outputs = infer_outputs_schema(
-                    uri=data.uri,
-                    parameters=data.parameters,
-                )
-                if inferred_outputs is not None:
-                    schemas_dict["outputs"] = inferred_outputs
-
-            if schemas_dict:
-                data = data.model_copy(update={"schemas": JsonSchemas(**schemas_dict)})
-
-        _revision_slug = workflow_revision_commit.slug or uuid4().hex[-12:]
-        _revision_commit = RevisionCommit(
-            **workflow_revision_commit.model_dump(
-                mode="json",
-                exclude_none=True,
-                exclude={"flags", "data", "slug", "base_revision_id"},
-            ),
-            slug=_revision_slug,
-            flags=self._dump_stored_revision_flags(
-                self._revision_flags_from_any(
-                    infer_flags_from_data(
-                        flags=workflow_revision_commit.flags,
-                        data=data,
-                        slug=_revision_slug,
-                    )
-                )
-            )
-            or None,
-            data=data.model_dump(mode="json", exclude_none=True) if data else None,
+        _revision_commit = self._build_revision_commit(
+            workflow_revision_commit=workflow_revision_commit,
         )
 
         if not _revision_commit.artifact_id:
@@ -2201,6 +2217,83 @@ class WorkflowsService:
             revision=_workflow_revision,
         )
 
+    def _build_revision_commit(
+        self,
+        *,
+        workflow_revision_commit: WorkflowRevisionCommit,
+    ) -> RevisionCommit:
+        """Enrich the commit's data and derive the flags that would be stored with it.
+
+        Pure and free of I/O, so the no-change comparison can build the candidate and the
+        insert can build it again without either owning a private copy of the enrichment
+        (contract commit-transaction.md 4).
+        """
+        # A snippet (skill) is non-runnable content: strip every execution-surface field, only uri +
+        # parameters survive. Holds even if a caller posts the skill uri under a normal slug.
+        data = normalize_snippet_data(workflow_revision_commit.data)
+        if data and data.uri and not data.url:
+            _, kind, _, _ = parse_uri(data.uri)
+            if kind != "builtin":
+                path = infer_url_from_uri(data.uri)
+                if path:
+                    data = data.model_copy(
+                        update={"url": env.agenta.services_url.rstrip("/") + path}
+                    )
+
+        self._reject_non_embeddable_workflow_embeds(data)
+
+        if data and data.uri:
+            interface = retrieve_interface(data.uri)
+            current_schemas = data.schemas or {}
+            schemas_dict = (
+                current_schemas
+                if isinstance(current_schemas, dict)
+                else current_schemas.model_dump(mode="json", exclude_none=True)
+            )
+
+            if interface and interface.schemas:
+                iface_schemas = (
+                    interface.schemas
+                    if isinstance(interface.schemas, dict)
+                    else interface.schemas.model_dump(mode="json", exclude_none=True)
+                )
+                if "parameters" not in schemas_dict and "parameters" in iface_schemas:
+                    schemas_dict["parameters"] = iface_schemas["parameters"]
+                if "outputs" not in schemas_dict and "outputs" in iface_schemas:
+                    schemas_dict["outputs"] = iface_schemas["outputs"]
+
+            if data.parameters is not None:
+                inferred_outputs = infer_outputs_schema(
+                    uri=data.uri,
+                    parameters=data.parameters,
+                )
+                if inferred_outputs is not None:
+                    schemas_dict["outputs"] = inferred_outputs
+
+            if schemas_dict:
+                data = data.model_copy(update={"schemas": JsonSchemas(**schemas_dict)})
+
+        _revision_slug = workflow_revision_commit.slug or uuid4().hex[-12:]
+        return RevisionCommit(
+            **workflow_revision_commit.model_dump(
+                mode="json",
+                exclude_none=True,
+                exclude={"flags", "data", "slug", "base_revision_id"},
+            ),
+            slug=_revision_slug,
+            flags=self._dump_stored_revision_flags(
+                self._revision_flags_from_any(
+                    infer_flags_from_data(
+                        flags=workflow_revision_commit.flags,
+                        data=data,
+                        slug=_revision_slug,
+                    )
+                )
+            )
+            or None,
+            data=data.model_dump(mode="json", exclude_none=True) if data else None,
+        )
+
     async def _resolve_revision_delta(
         self,
         *,
@@ -2210,10 +2303,9 @@ class WorkflowsService:
     ) -> "DeltaResolution":
         """Resolve a delta commit into a full-data commit against the variant's head.
 
-        The legacy form deep-merges ``delta.set`` then deletes ``delta.remove``, byte for
-        byte as it always has. The ordered form goes through the change-set engine.
+        Both delta forms go through the change-set engine, which owns the exclusivity rule
+        (contract change-set.md 3.3) and every refusal either form can earn.
         """
-        delta = workflow_revision_commit.delta
         variant_id = (
             workflow_revision_commit.workflow_variant_id
             or workflow_revision_commit.variant_id
@@ -2237,19 +2329,11 @@ class WorkflowsService:
             current=current,
         )
 
-        if delta is not None and delta.operations is not None:
-            resolved, message, warnings, changed = self._apply_ordered_delta(
-                base=base,
-                workflow_revision_commit=workflow_revision_commit,
-                scope_policy=scope_policy,
-            )
-        else:
-            resolved = _deep_merge(base, (delta.set if delta else None) or {})
-            for path in (delta.remove if delta else None) or []:
-                _remove_path(resolved, path)
-            message = workflow_revision_commit.message
-            warnings = []
-            changed = resolved != base
+        resolved, message, warnings = self._apply_delta(
+            base=base,
+            workflow_revision_commit=workflow_revision_commit,
+            scope_policy=scope_policy,
+        )
 
         return DeltaResolution(
             commit=workflow_revision_commit.model_copy(
@@ -2259,8 +2343,8 @@ class WorkflowsService:
                     "message": message,
                 }
             ),
+            head=current,
             warnings=warnings,
-            changed=changed,
         )
 
     def _check_base_revision(
@@ -2295,33 +2379,51 @@ class WorkflowsService:
                 current_revision_version=getattr(current, "version", None),
             )
 
-    def _apply_ordered_delta(
+    def _apply_delta(
         self,
         *,
         base: dict,
         workflow_revision_commit: WorkflowRevisionCommit,
         scope_policy=None,
-    ) -> tuple[dict, str, list, bool]:
-        """Run an ordered delta through the engine, plus the four wrapper-owned jobs the
-        engine cannot do: selector normalization, the platform-tool rejection, the derived
-        message, and the warning list (contract change-set.md 17)."""
+    ) -> tuple[dict, Optional[str], list]:
+        """Run either delta form through the engine, plus the wrapper-owned jobs the engine
+        cannot do: selector normalization, the platform-tool rejection, the derived
+        message, and the warning list (contract change-set.md 17).
+
+        The engine classifies the form, so a delta carrying both arms is refused rather
+        than silently losing one of them, and the legacy arm earns the same marker,
+        scope, and unique-name refusals the ordered arm does.
+        """
+        # `exclude_unset` and not `exclude_none`: an explicit `"value": null` is a value
+        # the contract writes, and dropping it would report a missing value instead.
+        delta = (
+            workflow_revision_commit.delta.model_dump(mode="json", exclude_unset=True)
+            if workflow_revision_commit.delta is not None
+            else {}
+        )
+        is_ordered = delta.get("operations") is not None
+
         # Off is today's surface exactly: an ordered delta is an unknown shape.
-        if not env.agenta.api.workflows.ordered_operations_enabled:
+        if is_ordered and not env.agenta.api.workflows.ordered_operations_enabled:
             raise ChangeSetError(
                 Reason.INVALID_DELTA,
                 "ordered operations are not enabled on this deployment.",
             )
 
-        delta = workflow_revision_commit.delta
-        raw_operations = [
-            operation.model_dump(mode="json", exclude_none=True)
-            for operation in (delta.operations or [])
-        ]
-        operations, warnings = normalize_operations(raw_operations)
+        operations: list = []
+        warnings: list = []
+        if is_ordered:
+            operations, warnings = normalize_operations(delta["operations"])
+            delta = {**delta, "operations": operations}
 
         # The scope is the caller's: only the agent's builder tool is confined to
         # `parameters.agent` (read-config.md 11.2), so it passes AGENT_COMMIT_SCOPE.
-        result = apply_change_set(base, {"operations": operations}, scope_policy)
+        result = apply_change_set(
+            base,
+            delta,
+            scope_policy,
+            validate=_validate_persisted_shape,
+        )
         warnings = warnings + list(result.warnings)
 
         # Rejection beats silent stripping: the spike showed that errors teach.
@@ -2333,11 +2435,15 @@ class WorkflowsService:
                 entries=offenders,
             )
 
-        message = derive_commit_message(
-            operations,
-            description=workflow_revision_commit.description,
+        message = (
+            derive_commit_message(
+                operations,
+                description=workflow_revision_commit.description,
+            )
+            if is_ordered
+            else workflow_revision_commit.message
         )
-        return result.data, message, warnings, result.changed
+        return result.data, message, warnings
 
     async def log_workflow_revisions(
         self,
@@ -2730,19 +2836,9 @@ class WorkflowsService:
     # --------------------------------------------------------------------------
 
 
-# `_deep_merge` now lives in `change_set.py` and is imported at the top of this module.
-# One home: the legacy delta and the ordered `merge` operation must never drift apart, and
-# a second copy here is exactly how they would (contract change-set.md, answer to O12).
-
-
-def _remove_path(tree: dict, path: str) -> None:
-    keys = path.split(".")
-    node = tree
-    for key in keys[:-1]:
-        node = node.get(key) if isinstance(node, dict) else None
-        if not isinstance(node, dict):
-            return
-    node.pop(keys[-1], None)
+# The legacy delta's merge and remove now run inside the engine, which is the only copy of
+# either. One home: the legacy delta and the ordered `merge` operation must never drift
+# apart, and a second copy here is exactly how they would (contract change-set.md, O12).
 
 
 def _build_simple_workflow_data(

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, List, Union, TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -73,6 +72,11 @@ from oss.src.core.workflows.dtos import (
     WorkflowRevisionQuery,
     WorkflowRevisionCommit,
     WorkflowRevisionData,
+    #
+    CommitWarning,
+    CommitOutcome,
+    ConfigReadOutcome,
+    DeltaResolution,
     #
     SimpleWorkflow,
     SimpleWorkflowFlags,
@@ -191,45 +195,6 @@ class RevisionConflictError(Exception):
         if self.current_revision_version is not None:
             detail["current_revision_version"] = self.current_revision_version
         return detail
-
-
-@dataclass
-class DeltaResolution:
-    """The resolved commit, the head it was built on, and the response's warnings.
-
-    The head travels with the resolution because the no-change comparison runs on the
-    ENRICHED result (contract commit-transaction.md 5.1), which the caller only holds
-    after this returns.
-    """
-
-    commit: "WorkflowRevisionCommit"
-    head: Optional["WorkflowRevision"] = None
-    warnings: list = field(default_factory=list)
-
-
-@dataclass
-class ConfigReadOutcome:
-    """One `read_config` answer: the value plus which revision produced it."""
-
-    revision: "WorkflowRevision"
-    path: list
-    value: Any
-    bytes: int
-    is_draft: bool = False
-    warnings: list = field(default_factory=list)
-
-
-@dataclass
-class CommitOutcome:
-    """What the commit endpoint answers with.
-
-    ``revision`` is complete on BOTH statuses — on `no_change` it is the current head — so
-    every existing consumer keeps working and a refresh with it is still correct.
-    """
-
-    revision: "Optional[WorkflowRevision]"
-    status: str = "committed"
-    warnings: list = field(default_factory=list)
 
 
 def _validate_persisted_shape(data: dict) -> None:
@@ -2025,7 +1990,7 @@ class WorkflowsService:
         """
         self._reject_static_slug(workflow_revision_commit.slug)
 
-        warnings: List[Any] = []
+        warnings: List[CommitWarning] = []
         head: Optional[WorkflowRevision] = None
         if workflow_revision_commit.delta is not None:
             resolution = await self._resolve_revision_delta(
@@ -2033,10 +1998,7 @@ class WorkflowsService:
                 workflow_revision_commit=workflow_revision_commit,
                 scope_policy=scope_policy,
             )
-            warnings = [
-                warning.to_dict() if hasattr(warning, "to_dict") else warning
-                for warning in resolution.warnings
-            ]
+            warnings = list(resolution.warnings)
             head = resolution.head
             workflow_revision_commit = resolution.commit
         else:
@@ -2074,13 +2036,13 @@ class WorkflowsService:
             # A commit event evicts the warm session, so a change that changes nothing
             # must not create a revision, publish an event, or invalidate a cache.
             warnings.append(
-                {
-                    "code": "no_change",
-                    "message": (
+                CommitWarning(
+                    code="no_change",
+                    message=(
                         "The change produced the configuration that is already "
                         "stored, so no revision was created."
                     ),
-                }
+                )
             )
             return CommitOutcome(revision=head, status="no_change", warnings=warnings)
 
@@ -2308,11 +2270,18 @@ class WorkflowsService:
         project_id: UUID,
         workflow_revision_commit: WorkflowRevisionCommit,
         scope_policy=None,
+        preview: bool = False,
     ) -> "DeltaResolution":
         """Resolve a delta commit into a full-data commit against the variant's head.
 
         Both delta forms go through the change-set engine, which owns the exclusivity rule
         (contract change-set.md 3.3) and every refusal either form can earn.
+
+        ``preview`` is for a caller that resolves a delta to RUN it and never to store it,
+        which today is `test_run`. It drops the requirement that an ordered delta carry a
+        base revision id. That id is a precondition on a write, and a preview performs
+        none. A base id the caller does supply is still checked, because a preview built on
+        a head that moved is not the preview the caller asked for.
         """
         variant_id = (
             workflow_revision_commit.workflow_variant_id
@@ -2335,6 +2304,7 @@ class WorkflowsService:
         self._check_base_revision(
             workflow_revision_commit=workflow_revision_commit,
             current=current,
+            require_base=not preview,
         )
 
         resolved, message, warnings = self._apply_delta(
@@ -2360,19 +2330,21 @@ class WorkflowsService:
         *,
         workflow_revision_commit: WorkflowRevisionCommit,
         current: Optional[WorkflowRevision],
+        require_base: bool = True,
     ) -> None:
         """Refuse a commit built on a base that is no longer the head.
 
         An ordered delta requires the base id, because its anchors are only meaningful
         against the revision the caller read. A legacy delta keeps it optional so shipped
-        playbooks are unaffected.
+        playbooks are unaffected. ``require_base`` is false only for a preview, which
+        stores nothing and so has no write for the id to protect.
         """
         delta = workflow_revision_commit.delta
         is_ordered = delta is not None and delta.operations is not None
         base_revision_id = workflow_revision_commit.base_revision_id
 
         if base_revision_id is None:
-            if is_ordered:
+            if is_ordered and require_base:
                 raise ChangeSetError(
                     Reason.INVALID_DELTA,
                     "an ordered delta needs `base_revision_id`: the revision you read.",
@@ -2393,7 +2365,7 @@ class WorkflowsService:
         base: dict,
         workflow_revision_commit: WorkflowRevisionCommit,
         scope_policy=None,
-    ) -> tuple[dict, Optional[str], list]:
+    ) -> tuple[dict, Optional[str], List[CommitWarning]]:
         """Run either delta form through the engine, plus the wrapper-owned jobs the engine
         cannot do: selector normalization, the platform-tool rejection, the derived
         message, and the warning list (contract change-set.md 17).
@@ -2419,7 +2391,7 @@ class WorkflowsService:
             )
 
         operations: list = []
-        warnings: list = []
+        warnings: list = []  # engine warnings; typed at the return
         if is_ordered:
             operations, warnings = normalize_operations(delta["operations"])
             delta = {**delta, "operations": operations}
@@ -2451,7 +2423,8 @@ class WorkflowsService:
             if is_ordered
             else workflow_revision_commit.message
         )
-        return result.data, message, warnings
+        # The engine speaks its own dataclass. The typed model is what leaves the service.
+        return result.data, message, [CommitWarning(**w.to_dict()) for w in warnings]
 
     async def log_workflow_revisions(
         self,

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -88,6 +88,7 @@ from oss.src.core.workflows.dtos import (
 )
 from oss.src.core.git.types import (
     InlineResolveInvalid,
+    RevisionConflict,
     VariantForkError,
     validate_revision_refs_sufficient,
     validate_variant_refs_sufficient,
@@ -99,6 +100,12 @@ from oss.src.core.workflows.change_set import (
     Reason,
     apply_change_set,
     deep_merge as _deep_merge,
+)
+from oss.src.core.workflows.read_config import (
+    ReadConfigError,
+    clamp_max_bytes,
+    draft_warning,
+    project_config,
 )
 from oss.src.core.workflows.commit_support import (
     PLATFORM_TOOL_REJECTION,
@@ -194,6 +201,18 @@ class DeltaResolution:
     commit: "WorkflowRevisionCommit"
     warnings: list = field(default_factory=list)
     changed: bool = True
+
+
+@dataclass
+class ConfigReadOutcome:
+    """One `read_config` answer: the value plus which revision produced it."""
+
+    revision: "WorkflowRevision"
+    path: list
+    value: Any
+    bytes: int
+    is_draft: bool = False
+    warnings: list = field(default_factory=list)
 
 
 @dataclass
@@ -1929,6 +1948,51 @@ class WorkflowsService:
 
         return _workflow_revisions
 
+    async def read_workflow_revision_config(
+        self,
+        *,
+        project_id: UUID,
+        workflow_variant_id: UUID,
+        path: Optional[list] = None,
+        max_bytes: Optional[int] = None,
+        run_is_draft: Optional[bool] = None,
+    ) -> "ConfigReadOutcome":
+        """Read one part of the variant's committed configuration.
+
+        The answer always comes from the stored head, on every kind of run. On a draft run
+        that is not what is executing, and the response says so: the read and the commit
+        then still agree, because the commit applies to the head too.
+        """
+        head = await self.fetch_workflow_revision(
+            project_id=project_id,
+            workflow_variant_ref=Reference(id=workflow_variant_id),
+            include_archived=False,
+        )
+        if head is None:
+            raise ReadConfigError(
+                "revision_not_found",
+                "That variant has no revision to read.",
+                status_code=404,
+            )
+
+        data = (
+            head.data.model_dump(mode="json", exclude_none=True) if head.data else None
+        )
+        result = project_config(data, path, max_bytes=clamp_max_bytes(max_bytes))
+
+        warnings = list(result.warnings)
+        if run_is_draft:
+            warnings.append(draft_warning(getattr(head, "version", None)))
+
+        return ConfigReadOutcome(
+            revision=head,
+            path=result.path,
+            value=result.value,
+            bytes=result.bytes,
+            is_draft=bool(run_is_draft),
+            warnings=warnings,
+        )
+
     async def commit_workflow_revision_checked(
         self,
         *,
@@ -1983,11 +2047,21 @@ class WorkflowsService:
                 )
             workflow_revision_commit = resolution.commit
 
-        revision = await self.commit_workflow_revision(
-            project_id=project_id,
-            user_id=user_id,
-            workflow_revision_commit=workflow_revision_commit,
-        )
+        # The pre-check above is an early-out, not the guarantee: it reads the head in its
+        # own transaction, so two writers can both pass it. Passing the expectation down
+        # is what makes the DAO re-read under the variant lock and refuse the loser.
+        try:
+            revision = await self.commit_workflow_revision(
+                project_id=project_id,
+                user_id=user_id,
+                workflow_revision_commit=workflow_revision_commit,
+                expected_head_revision_id=workflow_revision_commit.base_revision_id,
+            )
+        except RevisionConflict as e:
+            raise RevisionConflictError(
+                base_revision_id=e.expected_head_revision_id,
+                current_revision_id=e.current_head_revision_id,
+            ) from e
         return CommitOutcome(revision=revision, status="committed", warnings=warnings)
 
     async def commit_workflow_revision(
@@ -2001,6 +2075,8 @@ class WorkflowsService:
         initial: bool = False,
         #
         emit: bool = True,
+        #
+        expected_head_revision_id: Optional[UUID] = None,
     ) -> Optional[WorkflowRevision]:
         self._reject_static_slug(workflow_revision_commit.slug)
 
@@ -2099,6 +2175,8 @@ class WorkflowsService:
             revision_commit=_revision_commit,
             #
             initial=initial,
+            #
+            expected_head_revision_id=expected_head_revision_id,
         )
 
         if not revision:

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -2178,8 +2178,50 @@ class WorkflowsService:
         does change behavior, and the new flags would never reach the database. The
         contract's recursive key sort needs no step here: python compares dicts by content,
         not by key order.
+
+        A field that is absent, null, or an empty string is the same field: not set. The
+        distinction has no meaning anywhere in a configuration, and keeping it produced a
+        pointless revision. An agent with no stored instructions gets a workspace file
+        holding only the platform-guidance block; copying it back strips to `""`, which
+        differed from absent and wrote a revision that changed nothing a reader can see.
+
+        Only the EQUALITY question changes. Nothing rewrites the stored tree, because a
+        commit that quietly normalized what it was given would be the worse bug: a caller
+        that sets a field to empty on purpose must still see exactly that stored.
         """
-        return {"data": data or None, "flags": flags or None}
+        return {
+            "data": WorkflowsService._without_unset_fields(data) or None,
+            "flags": flags or None,
+        }
+
+    @staticmethod
+    def _without_unset_fields(node: Any) -> Any:
+        """Drop object fields that are absent in every way a caller can express it.
+
+        An object left holding nothing is dropped too, and that is what the round trip
+        actually needs: a copied-back file sets `instructions.agents_md` to empty, so the
+        field goes and `instructions` is left as `{}` where the head had no `instructions`
+        at all.
+
+        Applied to dict KEYS only. A list keeps its elements and its length, because an
+        empty string inside a list is a positional value and dropping it would silently
+        renumber the entries around it.
+        """
+        if isinstance(node, dict):
+            cleaned = {}
+            for key, value in node.items():
+                if value is None:
+                    continue
+                if isinstance(value, str) and not value.strip():
+                    continue
+                value = WorkflowsService._without_unset_fields(value)
+                if isinstance(value, dict) and not value:
+                    continue
+                cleaned[key] = value
+            return cleaned
+        if isinstance(node, list):
+            return [WorkflowsService._without_unset_fields(entry) for entry in node]
+        return node
 
     async def commit_workflow_revision(
         self,

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -38,6 +38,7 @@ from oss.src.core.git.dtos import (
     VariantQuery,
     VariantFork,
     #
+    Revision,
     RevisionCreate,
     RevisionEdit,
     RevisionQuery,
@@ -93,6 +94,7 @@ from oss.src.core.workflows.dtos import (
 from oss.src.core.git.types import (
     InlineResolveInvalid,
     RevisionConflict,
+    RevisionUnchanged,
     VariantForkError,
     validate_revision_refs_sufficient,
     validate_variant_refs_sufficient,
@@ -2041,11 +2043,30 @@ class WorkflowsService:
             is_ordered or env.agenta.api.workflows.ordered_operations_enabled
         )
 
-        if answers_no_change and await self._is_no_change(
-            project_id=project_id,
-            head=head,
-            candidate=candidate,
-        ):
+        # There is ONE decision point, and it is inside the lock. Deciding here, before the
+        # call, reads a head another writer can move afterwards: the caller was then told
+        # `no_change` about a revision that was no longer the head, and the conflict the DAO
+        # would have raised never happened because the early return skipped it.
+        # Passing the expectation down is what makes the DAO re-read under the variant lock
+        # and refuse the loser. `CommitLockTimeout` travels on unchanged: it is the 503.
+        try:
+            revision = await self.commit_workflow_revision(
+                project_id=project_id,
+                user_id=user_id,
+                workflow_revision_commit=workflow_revision_commit,
+                expected_head_revision_id=workflow_revision_commit.base_revision_id,
+                no_change_check=(
+                    self._no_change_check(candidate=candidate)
+                    if answers_no_change
+                    else None
+                ),
+            )
+        except RevisionConflict as e:
+            raise RevisionConflictError(
+                base_revision_id=e.expected_head_revision_id,
+                current_revision_id=e.current_head_revision_id,
+            ) from e
+        except RevisionUnchanged as e:
             # A commit event evicts the warm session, so a change that changes nothing
             # must not create a revision, publish an event, or invalidate a cache.
             warnings.append(
@@ -2057,25 +2078,42 @@ class WorkflowsService:
                     ),
                 )
             )
-            return CommitOutcome(revision=head, status="no_change", warnings=warnings)
-
-        # The pre-check above is an early-out, not the guarantee: it reads the head in its
-        # own transaction, so two writers can both pass it. Passing the expectation down
-        # is what makes the DAO re-read under the variant lock and refuse the loser.
-        # `CommitLockTimeout` from that lock travels on unchanged: it is the router's 503.
-        try:
-            revision = await self.commit_workflow_revision(
-                project_id=project_id,
-                user_id=user_id,
-                workflow_revision_commit=workflow_revision_commit,
-                expected_head_revision_id=workflow_revision_commit.base_revision_id,
+            # Re-read rather than answering with the head fetched earlier: the decision was
+            # made against the head under the lock, and the answer has to describe that one.
+            unchanged_head = (
+                await self.fetch_workflow_revision(
+                    project_id=project_id,
+                    workflow_revision_ref=Reference(id=e.head_revision_id),
+                )
+                if e.head_revision_id is not None
+                else None
             )
-        except RevisionConflict as e:
-            raise RevisionConflictError(
-                base_revision_id=e.expected_head_revision_id,
-                current_revision_id=e.current_head_revision_id,
-            ) from e
+            return CommitOutcome(
+                revision=unchanged_head,
+                status="no_change",
+                warnings=warnings,
+            )
         return CommitOutcome(revision=revision, status="committed", warnings=warnings)
+
+    def _no_change_check(self, *, candidate: RevisionCommit):
+        """The comparison the DAO runs against the head it holds the lock on.
+
+        A closure rather than a value, because the row it compares against does not exist
+        yet at this point: it is whatever the head turns out to be once the lock is taken.
+        """
+
+        def unchanged(stored_head: Optional[Revision]) -> bool:
+            if stored_head is None:
+                return False
+            return self._canonical_revision_record(
+                data=candidate.data,
+                flags=candidate.flags,
+            ) == self._canonical_revision_record(
+                data=stored_head.data,
+                flags=stored_head.flags,
+            )
+
+        return unchanged
 
     async def _is_no_change(
         self,
@@ -2138,6 +2176,8 @@ class WorkflowsService:
         emit: bool = True,
         #
         expected_head_revision_id: Optional[UUID] = None,
+        #
+        no_change_check=None,
     ) -> Optional[WorkflowRevision]:
         self._reject_static_slug(workflow_revision_commit.slug)
 
@@ -2176,6 +2216,8 @@ class WorkflowsService:
             initial=initial,
             #
             expected_head_revision_id=expected_head_revision_id,
+            #
+            no_change_check=no_change_check,
         )
 
         if not revision:

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1992,6 +1992,11 @@ class WorkflowsService:
 
         warnings: List[CommitWarning] = []
         head: Optional[WorkflowRevision] = None
+        # Read before the delta arm rebinds the commit, which clears `delta`.
+        is_ordered = (
+            workflow_revision_commit.delta is not None
+            and workflow_revision_commit.delta.operations is not None
+        )
         if workflow_revision_commit.delta is not None:
             resolution = await self._resolve_revision_delta(
                 project_id=project_id,
@@ -2028,7 +2033,15 @@ class WorkflowsService:
             workflow_revision_commit=workflow_revision_commit,
         )
 
-        if await self._is_no_change(
+        # The no-change answer belongs to the ordered-operations surface. With the flag off
+        # the commit path stays exactly today's: a legacy delta or a full-data commit that
+        # produces the stored configuration still creates a revision, because callers in
+        # the field read that new revision back and count on it existing.
+        answers_no_change = (
+            is_ordered or env.agenta.api.workflows.ordered_operations_enabled
+        )
+
+        if answers_no_change and await self._is_no_change(
             project_id=project_id,
             head=head,
             candidate=candidate,
@@ -2416,10 +2429,7 @@ class WorkflowsService:
             )
 
         message = (
-            derive_commit_message(
-                operations,
-                description=workflow_revision_commit.description,
-            )
+            derive_commit_message(operations)
             if is_ordered
             else workflow_revision_commit.message
         )

--- a/api/oss/tests/pytest/unit/git/test_commit_stores_data.py
+++ b/api/oss/tests/pytest/unit/git/test_commit_stores_data.py
@@ -1,0 +1,261 @@
+"""What the commit path STORES, read back from the database and not from the response.
+
+This file exists because of a live data loss. A full-data commit on a fresh variant
+answered 200, and the stored row held NULL. `read_config` then reported that the variant
+had no revision at all, so the configuration a user had just saved was gone.
+
+Every existing commit test asserted on the response, and the response is built from the
+object the service assembled. That is why 1939 green tests did not see it. The only
+assertion that catches this class is a read of the row through a different connection.
+
+The cause was the version-0 rule in `commit_revision`: version 0 is the empty placeholder a
+variant is seeded with, and its fields are nulled so a reader can tell "not configured yet"
+from "configured empty". It fired for ANY first revision, including one carrying a real
+payload. Flows that commit twice never saw it, because the second commit is version 1.
+
+Runs where Postgres exists; skipped otherwise by the conftest probe beside this file.
+"""
+
+import json
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+
+from oss.src.core.shared.dtos import Reference
+from oss.src.dbs.postgres.shared.engine import TransactionsEngine
+
+pytestmark = pytest.mark.integration
+
+
+AGENT_DATA = {
+    "parameters": {
+        "agent": {
+            "instructions": {"agents_md": "# Release agent\n\nBe brief.\n"},
+            "llm": {"model": "anthropic/claude-sonnet-5", "max_tokens": 8192},
+        }
+    }
+}
+
+
+@pytest.fixture
+async def engine():
+    """One engine per test, on the loop the test runs on."""
+    instance = TransactionsEngine()
+    try:
+        yield instance
+    finally:
+        await instance.close()
+
+
+async def _exec(engine, sql, params=None):
+    async with engine.session() as session:
+        return await session.execute(text(sql), params or {})
+
+
+@pytest.fixture
+async def variant(engine):
+    """A fresh artifact and variant with NO revisions, borrowed onto a live project."""
+    result = await _exec(
+        engine,
+        "SELECT id FROM projects WHERE deleted_at IS NULL ORDER BY created_at LIMIT 1",
+    )
+    project_id = result.scalar_one_or_none()
+    if project_id is None:
+        pytest.skip("no project in the target database to attach the fixture to")
+
+    artifact_id, variant_id = uuid4(), uuid4()
+    await _exec(
+        engine,
+        "INSERT INTO workflow_artifacts (id, project_id, slug, created_at) "
+        "VALUES (:id, :project_id, :slug, now())",
+        {"id": artifact_id, "project_id": project_id, "slug": f"a-{artifact_id.hex}"},
+    )
+    await _exec(
+        engine,
+        "INSERT INTO workflow_variants (id, project_id, artifact_id, slug, created_at) "
+        "VALUES (:id, :project_id, :artifact_id, :slug, now())",
+        {
+            "id": variant_id,
+            "project_id": project_id,
+            "artifact_id": artifact_id,
+            "slug": f"v-{variant_id.hex}",
+        },
+    )
+    yield {"project_id": project_id, "artifact_id": artifact_id, "id": variant_id}
+    for table, column, target in (
+        ("workflow_revisions", "variant_id", variant_id),
+        ("workflow_variants", "id", variant_id),
+        ("workflow_artifacts", "id", artifact_id),
+    ):
+        await _exec(
+            engine, f"DELETE FROM {table} WHERE {column} = :target", {"target": target}
+        )
+
+
+def _service(engine):
+    import oss.src.models.db_models  # noqa: F401  (registers `projects` for the FKs)
+    from oss.src.core.workflows.service import WorkflowsService
+    from oss.src.dbs.postgres.git.dao import GitDAO
+    from oss.src.dbs.postgres.workflows.dbes import (
+        WorkflowArtifactDBE,
+        WorkflowRevisionDBE,
+        WorkflowVariantDBE,
+    )
+
+    return WorkflowsService(
+        workflows_dao=GitDAO(
+            ArtifactDBE=WorkflowArtifactDBE,
+            VariantDBE=WorkflowVariantDBE,
+            RevisionDBE=WorkflowRevisionDBE,
+            engine=engine,
+        )
+    )
+
+
+async def _commit(service, variant, **kwargs):
+    from oss.src.core.workflows.dtos import WorkflowRevisionCommit
+
+    return await service.commit_workflow_revision_checked(
+        project_id=variant["project_id"],
+        user_id=uuid4(),
+        workflow_revision_commit=WorkflowRevisionCommit(
+            workflow_variant_id=variant["id"], **kwargs
+        ),
+    )
+
+
+async def _stored_data(engine, revision_id: UUID):
+    """The row as the database holds it, read independently of the response."""
+    result = await _exec(
+        engine,
+        "SELECT data FROM workflow_revisions WHERE id = :id",
+        {"id": revision_id},
+    )
+    row = result.scalar_one_or_none()
+    return json.loads(row) if isinstance(row, str) else row
+
+
+class TestAFullDataCommitStoresItsData:
+    async def test_the_first_commit_on_a_fresh_variant_stores_its_data(
+        self, engine, variant
+    ):
+        from oss.src.core.workflows.dtos import WorkflowRevisionData
+
+        outcome = await _commit(
+            _service(engine),
+            variant,
+            data=WorkflowRevisionData(**AGENT_DATA),
+            message="seed",
+        )
+
+        assert outcome.status == "committed"
+        assert outcome.revision is not None
+        stored = await _stored_data(engine, outcome.revision.id)
+        assert stored is not None, "the stored row holds NULL: the commit lost its data"
+        assert stored["parameters"] == AGENT_DATA["parameters"]
+
+    async def test_the_response_and_the_stored_row_agree(self, engine, variant):
+        # The response is built from the object the service assembled. Asserting on it
+        # alone is what let the loss through, so this pins the two together.
+        from oss.src.core.workflows.dtos import WorkflowRevisionData
+
+        outcome = await _commit(
+            _service(engine), variant, data=WorkflowRevisionData(**AGENT_DATA)
+        )
+
+        echoed = outcome.revision.data.model_dump(mode="json", exclude_none=True)
+        stored = await _stored_data(engine, outcome.revision.id)
+        assert stored == echoed
+
+    async def test_an_empty_first_commit_is_still_the_seed(self, engine, variant):
+        # The placeholder convention survives: a first commit that carries nothing is
+        # still stored empty, so a reader can tell "not configured yet" from
+        # "configured empty".
+        outcome = await _commit(_service(engine), variant, message="Initial revision")
+
+        assert outcome.revision is not None
+        assert await _stored_data(engine, outcome.revision.id) is None
+
+    async def test_a_second_commit_stores_its_data_too(self, engine, variant):
+        from oss.src.core.workflows.dtos import WorkflowRevisionData
+
+        service = _service(engine)
+        await _commit(service, variant, message="Initial revision")
+        outcome = await _commit(
+            service, variant, data=WorkflowRevisionData(**AGENT_DATA)
+        )
+
+        stored = await _stored_data(engine, outcome.revision.id)
+        assert stored["parameters"] == AGENT_DATA["parameters"]
+
+
+class TestTheDeltaPathStoresItsData:
+    async def test_a_delta_commit_on_a_fresh_variant_stores_its_result(
+        self, engine, variant
+    ):
+        service = _service(engine)
+        outcome = await _commit(
+            service,
+            variant,
+            delta={"set": AGENT_DATA},
+            message="from a delta",
+        )
+
+        stored = await _stored_data(engine, outcome.revision.id)
+        assert stored is not None, "the delta path lost its data"
+        assert stored["parameters"] == AGENT_DATA["parameters"]
+
+    async def test_a_delta_on_top_of_a_stored_revision_keeps_the_rest(
+        self, engine, variant
+    ):
+        from oss.src.core.workflows.dtos import WorkflowRevisionData
+
+        service = _service(engine)
+        first = await _commit(service, variant, data=WorkflowRevisionData(**AGENT_DATA))
+        second = await _commit(
+            service,
+            variant,
+            base_revision_id=first.revision.id,
+            delta={"set": {"parameters": {"agent": {"llm": {"model": "opus"}}}}},
+        )
+
+        stored = await _stored_data(engine, second.revision.id)
+        agent = stored["parameters"]["agent"]
+        assert agent["llm"]["model"] == "opus"
+        assert agent["llm"]["max_tokens"] == 8192, "the delta dropped a sibling field"
+        assert agent["instructions"]["agents_md"].startswith("# Release agent")
+
+
+class TestReadConfigSeesWhatWasStored:
+    async def test_a_seeded_variant_can_be_read_back(self, engine, variant):
+        # The user-visible symptom: commit answered 200, then read_config reported that
+        # the variant had no revision to read.
+        from oss.src.core.workflows.dtos import WorkflowRevisionData
+
+        service = _service(engine)
+        await _commit(service, variant, data=WorkflowRevisionData(**AGENT_DATA))
+
+        outcome = await service.read_workflow_revision_config(
+            project_id=variant["project_id"],
+            workflow_variant_id=variant["id"],
+            path=None,
+        )
+
+        assert outcome.value["parameters"]["agent"]["llm"]["model"] == (
+            "anthropic/claude-sonnet-5"
+        )
+
+    async def test_the_head_the_reader_resolves_carries_the_data(self, engine, variant):
+        from oss.src.core.workflows.dtos import WorkflowRevisionData
+
+        service = _service(engine)
+        await _commit(service, variant, data=WorkflowRevisionData(**AGENT_DATA))
+
+        head = await service.fetch_workflow_revision(
+            project_id=variant["project_id"],
+            workflow_variant_ref=Reference(id=variant["id"]),
+            include_archived=False,
+        )
+
+        assert head is not None and head.data is not None

--- a/api/oss/tests/pytest/unit/git/test_commit_stores_data.py
+++ b/api/oss/tests/pytest/unit/git/test_commit_stores_data.py
@@ -259,3 +259,46 @@ class TestReadConfigSeesWhatWasStored:
         )
 
         assert head is not None and head.data is not None
+
+
+class TestThePlatformGuidanceNeverReachesTheDatabase:
+    """The stored row is the assertion, not the response.
+
+    The runner appends a fenced guidance block to the instructions file it renders into the
+    workspace. A model that copies that file back into a commit would store our own guidance
+    as the user's configuration. The engine strips it, and this cell proves the strip
+    reaches the DATABASE rather than only the object the endpoint echoes back.
+    """
+
+    async def test_a_copied_back_file_is_stored_without_the_block(
+        self, engine, variant
+    ):
+        from oss.src.core.workflows.change_set import (
+            PLATFORM_GUIDANCE_END,
+            PLATFORM_GUIDANCE_START,
+        )
+
+        service = _service(engine)
+        block = (
+            f"{PLATFORM_GUIDANCE_START}\n"
+            "Commit configuration changes with the commit tool.\n"
+            f"{PLATFORM_GUIDANCE_END}"
+        )
+
+        outcome = await _commit(
+            service,
+            variant,
+            data={
+                "parameters": {
+                    "agent": {
+                        "instructions": {"agents_md": f"Be concise.\n\n{block}\n"}
+                    }
+                }
+            },
+        )
+
+        stored = await _stored_data(engine, outcome.revision.id)
+        agents_md = stored["parameters"]["agent"]["instructions"]["agents_md"]
+        assert PLATFORM_GUIDANCE_START not in agents_md
+        assert PLATFORM_GUIDANCE_END not in agents_md
+        assert agents_md == "Be concise."

--- a/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
+++ b/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
@@ -68,12 +68,12 @@ class FakeWorkflowsService:
         self.delta_calls.append(
             {"project_id": project_id, "commit": workflow_revision_commit}
         )
-        # `_resolve_revision_delta` returns a DeltaResolution: the resolved commit plus
-        # the warnings and the changed flag the commit response carries.
+        # `_resolve_revision_delta` returns a DeltaResolution: the resolved commit, the
+        # head it was built on, and the warnings the commit response carries.
         return SimpleNamespace(
             commit=SimpleNamespace(data=WorkflowRevisionData(**self.delta_data)),
+            head=None,
             warnings=[],
-            changed=True,
         )
 
     async def _prepare_invoke(self, *, project_id, user_id, request):

--- a/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
+++ b/api/oss/tests/pytest/unit/tools/test_platform_handlers.py
@@ -63,10 +63,14 @@ class FakeWorkflowsService:
         request.data.revision = {"data": self.revision_data}
 
     async def _resolve_revision_delta(
-        self, *, project_id, workflow_revision_commit, scope_policy=None
+        self, *, project_id, workflow_revision_commit, scope_policy=None, preview=False
     ):
         self.delta_calls.append(
-            {"project_id": project_id, "commit": workflow_revision_commit}
+            {
+                "project_id": project_id,
+                "commit": workflow_revision_commit,
+                "preview": preview,
+            }
         )
         # `_resolve_revision_delta` returns a DeltaResolution: the resolved commit, the
         # head it was built on, and the warnings the commit response carries.
@@ -350,6 +354,11 @@ async def test_test_run_applies_delta_in_memory(monkeypatch):
     assert result.verdict == "unconfirmed"
     assert workflows.ensure_calls
     assert workflows.delta_calls
+    # A test run stores nothing, so it carries no base revision id. It has to resolve as a
+    # preview, or an ordered delta could never be previewed: the commit path requires that
+    # id, and it is the precondition on a write.
+    assert workflows.delta_calls[0]["preview"] is True
+    assert workflows.delta_calls[0]["commit"].base_revision_id is None
     revision = http.calls[0]["json"]["data"]["revision"]["data"]
     assert revision["parameters"]["agent"]["model"] == "changed"
 

--- a/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
@@ -15,7 +15,7 @@ import pytest
 from fastapi import HTTPException
 
 from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
-from oss.src.core.git.types import CommitLockTimeout
+from oss.src.core.git.types import CommitLockTimeout, VariantNotFound
 from oss.src.core.workflows.change_set import ChangeSetError, Reason
 from oss.src.core.workflows.service import CommitOutcome, RevisionConflictError
 from oss.src.core.workflows.types import StaticWorkflowSlug
@@ -134,6 +134,58 @@ class TestFailuresThatMustNotLookLikeSuccess:
         assert caught.value.status_code == 500
         assert caught.value.detail["code"] == "commit_failed"
         invalidate.assert_not_awaited()
+
+
+class TestVariantNotFound:
+    """A commit against a variant this project does not have answers 404.
+
+    The DAO raises `VariantNotFound` when the locking select matches no row. That covers a
+    variant id that does not exist and one that belongs to another project. The mapping to
+    404 lives in `handle_git_exceptions`, so both routes must install that decorator.
+    Without it the refusal reaches `intercept_exceptions` and becomes a generic 500.
+    """
+
+    @pytest.fixture(
+        params=["commit_workflow_revision", "commit_agent_workflow_revision"]
+    )
+    def route(self, request, router):
+        return getattr(router, request.param), request.param
+
+    async def test_a_missing_variant_answers_404(self, router, allow_access, route):
+        handler, name = route
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            VariantNotFound(variant_id=VARIANT_ID)
+        )
+        payload = (
+            _commit_request()
+            if name == "commit_workflow_revision"
+            else _delta_request(set={"parameters": {"agent": {"instructions": "hi"}}})
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await handler(_request(), workflow_revision_commit_request=payload)
+
+        assert caught.value.status_code == 404
+
+    async def test_a_cross_project_variant_answers_404(
+        self, router, allow_access, route
+    ):
+        # Same refusal, different cause: the row exists, but it belongs to another
+        # project, so the locking select scoped by project_id matches nothing.
+        handler, name = route
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            VariantNotFound(variant_id=uuid4())
+        )
+        payload = (
+            _commit_request()
+            if name == "commit_workflow_revision"
+            else _delta_request(set={"parameters": {"agent": {"instructions": "hi"}}})
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await handler(_request(), workflow_revision_commit_request=payload)
+
+        assert caught.value.status_code == 404
 
 
 class TestDomainRefusals:

--- a/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
@@ -1,0 +1,324 @@
+"""What the commit endpoint answers when the commit does not simply succeed.
+
+Every case here is a failure that used to reach the client as a 200, a 500, or a silent
+`count: 0`. The endpoint carries no `suppress_exceptions`, so each of these is decided in
+the handler or by the two decorators on it, and a missing decorator is a real regression:
+`StaticWorkflowSlug` and `NonEmbeddableWorkflowReferenceError` are raised by the service
+on the normal path.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
+from oss.src.core.git.types import CommitLockTimeout
+from oss.src.core.workflows.change_set import ChangeSetError, Reason
+from oss.src.core.workflows.service import CommitOutcome, RevisionConflictError
+from oss.src.core.workflows.types import StaticWorkflowSlug
+
+
+VARIANT_ID = uuid4()
+
+
+def _request():
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            project_id=str(uuid4()),
+            user_id=str(uuid4()),
+        )
+    )
+
+
+def _commit_request(**data):
+    from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
+
+    return WorkflowRevisionCommitRequest.model_validate(
+        {
+            "workflow_revision": {
+                "workflow_variant_id": str(VARIANT_ID),
+                "data": {"parameters": {"agent": {"instructions": "hi"}}},
+                **data,
+            }
+        }
+    )
+
+
+def _revision():
+    from oss.src.core.workflows.dtos import WorkflowRevision
+
+    return WorkflowRevision(
+        id=uuid4(),
+        workflow_variant_id=VARIANT_ID,
+        version="3",
+    )
+
+
+@pytest.fixture
+def router():
+    from oss.src.apis.fastapi.workflows.router import WorkflowsRouter
+
+    return WorkflowsRouter(
+        workflows_service=AsyncMock(),
+        environments_service=AsyncMock(),
+    )
+
+
+@pytest.fixture
+def allow_access():
+    with patch(
+        "oss.src.apis.fastapi.workflows.router.check_action_access",
+        AsyncMock(return_value=True),
+    ):
+        yield
+
+
+async def _commit(router, **kwargs):
+    return await router.commit_workflow_revision(
+        _request(),
+        workflow_revision_commit_request=_commit_request(),
+        **kwargs,
+    )
+
+
+def _delta_request(**delta):
+    from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
+
+    return WorkflowRevisionCommitRequest.model_validate(
+        {
+            "workflow_revision": {
+                "workflow_variant_id": str(VARIANT_ID),
+                "base_revision_id": str(uuid4()),
+                "delta": delta,
+            }
+        }
+    )
+
+
+class TestFailuresThatMustNotLookLikeSuccess:
+    async def test_a_lock_timeout_answers_503_and_says_it_is_retryable(
+        self, router, allow_access
+    ):
+        # Suppression in the DAO used to turn the timeout into `None`, which arrived as
+        # `status="committed", count: 0`: a successful empty commit for a commit that
+        # never happened.
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            CommitLockTimeout(variant_id=VARIANT_ID)
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await _commit(router)
+
+        assert caught.value.status_code == 503
+        assert caught.value.detail["code"] == "commit_lock_timeout"
+        assert caught.value.detail["retryable"] is True
+
+    async def test_a_committed_status_with_no_revision_is_a_failure(
+        self, router, allow_access
+    ):
+        # The backstop for every OTHER swallowed database error. Whatever the DAO lost, a
+        # commit with nothing to show for it must not answer 200.
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=None, status="committed")
+        )
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ) as invalidate:
+            with pytest.raises(HTTPException) as caught:
+                await _commit(router)
+
+        assert caught.value.status_code == 500
+        assert caught.value.detail["code"] == "commit_failed"
+        invalidate.assert_not_awaited()
+
+
+class TestDomainRefusals:
+    async def test_a_static_slug_is_a_client_error_not_a_crash(
+        self, router, allow_access
+    ):
+        # Raised by `_reject_static_slug`, the first statement of the checked commit. It
+        # only becomes a 4xx because `@handle_workflow_exceptions()` is on the route.
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            StaticWorkflowSlug("__ag__llm")
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await _commit(router)
+
+        assert 400 <= caught.value.status_code < 500
+
+    async def test_a_non_embeddable_reference_answers_422_with_its_reason(
+        self, router, allow_access
+    ):
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            NonEmbeddableWorkflowReferenceError("__ag__llm")
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await _commit(router)
+
+        assert caught.value.status_code == 422
+        assert caught.value.detail["code"] == "non_embeddable_reference"
+
+    async def test_a_moved_head_answers_409_with_the_current_head(
+        self, router, allow_access
+    ):
+        current = str(uuid4())
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            RevisionConflictError(
+                base_revision_id=str(uuid4()),
+                current_revision_id=current,
+            )
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await _commit(router)
+
+        assert caught.value.status_code == 409
+        assert caught.value.detail["current_revision_id"] == current
+
+    async def test_a_change_set_refusal_answers_422(self, router, allow_access):
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            ChangeSetError(Reason.INVALID_DELTA, "both forms")
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await _commit(router)
+
+        assert caught.value.status_code == 422
+        assert caught.value.detail["reason"]["code"] == Reason.INVALID_DELTA
+
+
+class TestTheScopedAgentRoute:
+    """The agent's write scope is a property of the ROUTE it is given.
+
+    The model never holds the run's credential and never chooses the URL: the path comes
+    from the server-side op catalog and the runner makes the call from outside the sandbox.
+    So an agent cannot reach the unscoped route, and it cannot express a commit outside
+    `parameters.agent`. The unscoped route keeps its behavior for humans and the SDK.
+    """
+
+    async def test_it_passes_the_agent_scope_to_the_service(self, router, allow_access):
+        from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE
+
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=_revision(), status="committed")
+        )
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ):
+            await router.commit_agent_workflow_revision(
+                _request(),
+                workflow_revision_commit_request=_delta_request(
+                    set={"parameters": {"agent": {"instructions": "hi"}}}
+                ),
+            )
+
+        call = router.workflows_service.commit_workflow_revision_checked.await_args
+        assert call.kwargs["scope_policy"] is AGENT_COMMIT_SCOPE
+
+    async def test_the_unscoped_route_passes_no_scope(self, router, allow_access):
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=_revision(), status="committed")
+        )
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ):
+            await _commit(router)
+
+        call = router.workflows_service.commit_workflow_revision_checked.await_args
+        assert call.kwargs["scope_policy"] is None
+
+    async def test_it_refuses_a_full_data_commit(self, router, allow_access):
+        # A whole configuration carries every field the scope exists to protect, so the
+        # scoped route refuses the shape instead of filtering it. The agent's tool only
+        # ever sends a delta.
+        with pytest.raises(HTTPException) as caught:
+            await router.commit_agent_workflow_revision(
+                _request(),
+                workflow_revision_commit_request=_commit_request(),
+            )
+
+        assert caught.value.status_code == 422
+        assert caught.value.detail["code"] == "full_data_not_committable"
+        assert caught.value.detail["next_step"]
+        router.workflows_service.commit_workflow_revision_checked.assert_not_awaited()
+
+    async def test_the_unscoped_route_still_accepts_a_full_data_commit(
+        self, router, allow_access
+    ):
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=_revision(), status="committed")
+        )
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ):
+            response = await _commit(router)
+
+        assert response.status == "committed"
+
+    async def test_the_scoped_route_keeps_the_committed_side_effects(
+        self, router, allow_access
+    ):
+        # Same flow as the open route: the agent's commit must still evict the warm
+        # session and refresh the playground, or the run would keep the stale config.
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=_revision(), status="committed")
+        )
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ) as invalidate:
+            response = await router.commit_agent_workflow_revision(
+                _request(),
+                workflow_revision_commit_request=_delta_request(
+                    set={"parameters": {"agent": {"instructions": "hi"}}}
+                ),
+            )
+
+        assert response.count == 1
+        invalidate.assert_awaited_once()
+
+
+class TestSideEffects:
+    async def test_no_change_evicts_nothing(self, router, allow_access):
+        # A commit event throws away the warm sandbox. A commit that wrote no revision
+        # must not pay that cost.
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(
+                revision=_revision(),
+                status="no_change",
+                warnings=[{"code": "no_change", "message": "nothing changed"}],
+            )
+        )
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ) as invalidate:
+            response = await _commit(router)
+
+        assert response.status == "no_change"
+        assert response.count == 1
+        assert response.warnings[0].code == "no_change"
+        invalidate.assert_not_awaited()
+
+    async def test_a_real_commit_invalidates_the_cache(self, router, allow_access):
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=_revision(), status="committed")
+        )
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ) as invalidate:
+            response = await _commit(router)
+
+        assert response.status == "committed"
+        assert response.count == 1
+        invalidate.assert_awaited_once()

--- a/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
@@ -274,6 +274,54 @@ class TestTheScopedAgentRoute:
         call = router.workflows_service.commit_workflow_revision_checked.await_args
         assert call.kwargs["scope_policy"] is AGENT_COMMIT_SCOPE
 
+    async def test_it_never_stores_a_description_the_agent_sent(
+        self, router, allow_access
+    ):
+        # `description` on this route is the ephemeral per-call note, which shares its name
+        # with the persisted revision field and must not reach the audit trail
+        # (read-config.md 12.3). The runner strips it before dispatch, so one arriving here
+        # means the runner did not, and the persisted field would silently take it.
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=_revision(), status="committed")
+        )
+        commit_request = _delta_request(
+            set={"parameters": {"agent": {"instructions": "hi"}}}
+        )
+        commit_request.workflow_revision.description = "I made it friendlier"
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ):
+            await router.commit_agent_workflow_revision(
+                _request(),
+                workflow_revision_commit_request=commit_request,
+            )
+
+        call = router.workflows_service.commit_workflow_revision_checked.await_args
+        assert call.kwargs["workflow_revision_commit"].description is None
+
+    async def test_the_unscoped_route_keeps_a_description(self, router, allow_access):
+        # A human or the SDK setting the revision description is using the real field for
+        # what it is for. Only the agent route drops it.
+        router.workflows_service.commit_workflow_revision_checked.return_value = (
+            CommitOutcome(revision=_revision(), status="committed")
+        )
+        commit_request = _commit_request()
+        commit_request.workflow_revision.description = "release candidate"
+
+        with patch(
+            "oss.src.apis.fastapi.workflows.router.invalidate_cache", AsyncMock()
+        ):
+            await router.commit_workflow_revision(
+                _request(),
+                workflow_revision_commit_request=commit_request,
+            )
+
+        call = router.workflows_service.commit_workflow_revision_checked.await_args
+        assert (
+            call.kwargs["workflow_revision_commit"].description == "release candidate"
+        )
+
     async def test_the_unscoped_route_passes_no_scope(self, router, allow_access):
         router.workflows_service.commit_workflow_revision_checked.return_value = (
             CommitOutcome(revision=_revision(), status="committed")

--- a/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
@@ -526,6 +526,66 @@ class TestNoChange:
                 workflow_revision_commit=commit,
             )
 
+    async def test_a_stale_base_beats_no_change_on_a_full_data_commit(self, service):
+        # The same precedence as the delta arm, on the arm that carries no delta. A stale
+        # caller can send a whole configuration that equals the NEW head. An answer of
+        # `no_change` would confirm a base that had already moved.
+        from oss.src.core.workflows.service import RevisionConflictError
+
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data=data,
+            base_revision_id=uuid4(),
+        )
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(uuid4(), data=data)
+        )
+        service.commit_workflow_revision = AsyncMock()
+
+        with pytest.raises(RevisionConflictError):
+            await service.commit_workflow_revision_checked(
+                project_id=uuid4(),
+                user_id=uuid4(),
+                workflow_revision_commit=commit,
+            )
+
+        service.commit_workflow_revision.assert_not_awaited()
+
+    async def test_a_current_base_on_a_full_data_commit_still_answers_no_change(
+        self, service
+    ):
+        # The check must not refuse a caller whose base IS the head. That caller is
+        # correct, and its commit changes nothing.
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        stored = _stored(
+            data=data,
+            flags=service._build_revision_commit(
+                workflow_revision_commit=WorkflowRevisionCommit(
+                    workflow_variant_id=VARIANT_ID,
+                    data=data,
+                )
+            ).flags,
+        )
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data=data,
+            base_revision_id=stored.id,
+        )
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(stored.id, data=data)
+        )
+        service.workflows_dao.fetch_revision.return_value = stored
+        service.commit_workflow_revision = AsyncMock()
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=commit,
+        )
+
+        assert outcome.status == "no_change"
+
     async def test_a_metadata_only_commit_writes_nothing(self, service):
         # `message` is commit metadata, not configuration: it stays out of the record, so
         # a new message over an identical tree creates no revision.

--- a/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
@@ -942,3 +942,142 @@ class TestTheFlagDecidesWhetherTheCommitTakesTheLock:
         self, service, ordered_on
     ):
         assert await self._comparison_handed_down(service) is not None
+
+
+class TestTheEmptyAuthorRoundTrip:
+    """An agent with no stored instructions must not commit a revision by reading its file.
+
+    The runner renders the platform-guidance block into the workspace even when the author
+    wrote nothing, so the file holds only the block. A model that copies it back sends a
+    value that strips to `""`, where the stored value was absent. That is not a change any
+    reader can see, and answering `committed` for it evicts the warm sandbox and grows the
+    revision list for nothing.
+
+    The fix is in the comparison, not in the write: absent, null and empty are the same
+    field, so the pair compares equal. Nothing normalizes the stored tree, which is why the
+    second class below still commits.
+    """
+
+    @staticmethod
+    def _canonical(service, data):
+        return service._canonical_revision_record(data=data, flags=None)
+
+    def test_an_empty_string_equals_an_absent_field(self, service):
+        assert self._canonical(
+            service, {"parameters": {"agent": {"instructions": {"agents_md": ""}}}}
+        ) == self._canonical(service, {"parameters": {"agent": {"instructions": {}}}})
+
+    def test_a_whitespace_only_string_equals_an_absent_field(self, service):
+        # What a stripped block leaves behind when the renderer's separator survives it.
+        assert self._canonical(
+            service, {"parameters": {"agent": {"instructions": {"agents_md": "\n\n"}}}}
+        ) == self._canonical(service, {"parameters": {"agent": {"instructions": {}}}})
+
+    def test_a_null_field_equals_an_absent_field(self, service):
+        assert self._canonical(service, {"parameters": {"agent": None}}) == (
+            self._canonical(service, {"parameters": {}})
+        )
+
+    def test_an_object_left_holding_nothing_equals_an_absent_object(self, service):
+        # The step the round trip actually needs. Emptying `agents_md` removes the field,
+        # which leaves `instructions` as `{}` where the head had no `instructions` at all.
+        assert self._canonical(
+            service, {"parameters": {"agent": {"instructions": {"agents_md": ""}}}}
+        ) == self._canonical(service, {"parameters": {"agent": {}}})
+
+    def test_an_empty_list_is_not_dropped(self, service):
+        # A list is positional and an explicitly empty one is a value a caller chose, so the
+        # rule stops at objects. This is the boundary, pinned so nobody widens it by feel.
+        assert self._canonical(service, {"parameters": {"agent": {"tools": []}}}) != (
+            self._canonical(service, {"parameters": {"agent": {}}})
+        )
+
+    async def test_the_empty_author_round_trip_writes_nothing(
+        self, service, ordered_on
+    ):
+        # End to end: the head has no instructions, the agent commits the stripped file.
+        from oss.src.core.workflows.change_set import (
+            PLATFORM_GUIDANCE_END,
+            PLATFORM_GUIDANCE_START,
+        )
+
+        data = {"parameters": {"agent": {"llm": {"model": "x"}}}}
+        stored = _stored(
+            data=data,
+            flags=service._build_revision_commit(
+                workflow_revision_commit=WorkflowRevisionCommit(
+                    workflow_variant_id=VARIANT_ID,
+                    data=data,
+                )
+            ).flags,
+        )
+        rendered = f"{PLATFORM_GUIDANCE_START}\nguidance\n{PLATFORM_GUIDANCE_END}\n"
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(stored.id, data=data)
+        )
+        service.workflows_dao.fetch_revision.return_value = stored
+        _locked_commit(service, stored=stored)
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=_commit_on(
+                stored.id,
+                set={
+                    "parameters": {"agent": {"instructions": {"agents_md": rendered}}}
+                },
+            ),
+        )
+
+        assert outcome.status == "no_change"
+
+
+class TestAnIntentionalEmptyStillCommits:
+    """Clearing a field on purpose is a real change and must be stored.
+
+    This is the line the comparison rule must not cross. Absent and empty compare equal, so
+    a commit that only ADDS an empty field writes nothing. Emptying a field that held text
+    is a different pair entirely, and it commits.
+    """
+
+    async def test_clearing_a_non_empty_field_commits(self, service, ordered_on):
+        stored_data = {
+            "parameters": {"agent": {"instructions": {"agents_md": "Be concise."}}}
+        }
+        stored = _stored(
+            data=stored_data,
+            flags=service._build_revision_commit(
+                workflow_revision_commit=WorkflowRevisionCommit(
+                    workflow_variant_id=VARIANT_ID,
+                    data=stored_data,
+                )
+            ).flags,
+        )
+        committed = _head(uuid4())
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(stored.id, data=stored_data)
+        )
+        service.workflows_dao.fetch_revision.return_value = stored
+        _locked_commit(service, stored=stored, committed=committed)
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=_commit_on(
+                stored.id,
+                set={"parameters": {"agent": {"instructions": {"agents_md": ""}}}},
+            ),
+        )
+
+        assert outcome.status == "committed"
+
+    def test_the_stored_tree_is_never_rewritten(self, service):
+        # The comparison sees through the distinction; the write does not. A caller that
+        # sets a field to empty on purpose gets exactly that stored.
+        resolved, _, _ = _apply(
+            service,
+            {"parameters": {"agent": {"instructions": {"agents_md": "Be concise."}}}},
+            _commit(set={"parameters": {"agent": {"instructions": {"agents_md": ""}}}}),
+        )
+
+        assert resolved["parameters"]["agent"]["instructions"]["agents_md"] == ""

--- a/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
@@ -49,6 +49,23 @@ def ordered_on():
         yield
 
 
+@pytest.fixture
+def ordered_off():
+    """The flag pinned off, whatever the suite is run with.
+
+    Both flag states are run in CI, so a test about flag-off behavior has to say so rather
+    than inherit whichever value the run happens to carry.
+    """
+    from oss.src.core.workflows import service as service_module
+
+    with patch.object(
+        service_module.env.agenta.api.workflows,
+        "ordered_operations_enabled",
+        False,
+    ):
+        yield
+
+
 def _commit(**delta):
     """A commit as the request model would hand it over, `delta` keys included as sent."""
     from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
@@ -58,6 +75,22 @@ def _commit(**delta):
             "workflow_revision": {
                 "workflow_variant_id": str(VARIANT_ID),
                 "base_revision_id": str(uuid4()),
+                "delta": delta,
+            }
+        }
+    )
+    return request.workflow_revision
+
+
+def _commit_on(base_revision_id, **delta):
+    """The same, with the base pinned to a known head so the base check passes."""
+    from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
+
+    request = WorkflowRevisionCommitRequest.model_validate(
+        {
+            "workflow_revision": {
+                "workflow_variant_id": str(VARIANT_ID),
+                "base_revision_id": str(base_revision_id),
                 "delta": delta,
             }
         }
@@ -100,13 +133,37 @@ class TestDeltaForms:
 
         assert caught.value.reason == Reason.INVALID_DELTA
 
-    def test_an_unknown_delta_field_never_reaches_the_engine(self):
-        # The envelope is closed at the boundary now: a stray key used to be dropped by
-        # pydantic, so the caller believed the server had seen it.
+    def test_an_unknown_field_beside_operations_never_reaches_the_engine(
+        self, ordered_on
+    ):
+        # The ordered envelope is closed: a stray key there is a modifier the caller
+        # believes it sent and the server would never see.
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
-            _commit(sett={"parameters": {}})
+            _commit(
+                operations=[
+                    {
+                        "operation": "set",
+                        "target": AGENT + ["instructions"],
+                        "value": "x",
+                    }
+                ],
+                match_mode="exact",
+            )
+
+    def test_a_legacy_delta_still_tolerates_an_unknown_field(self, service):
+        # Closing the envelope closed it for the legacy arm too, which rejected payloads
+        # that shipped playbooks send and that the server has always ignored. The stray key
+        # is dropped, and the `set` beside it applies exactly as before.
+        commit = _commit(
+            set={"parameters": {"agent": {"instructions": "new"}}},
+            sett={"parameters": {"agent": {"instructions": "typo"}}},
+        )
+
+        resolved, _, _ = _apply(service, {}, commit)
+
+        assert resolved["parameters"]["agent"]["instructions"] == "new"
 
     def test_the_legacy_form_still_deep_merges(self, service):
         base = {"parameters": {"agent": {"instructions": "old", "llm": {"model": "x"}}}}
@@ -130,6 +187,39 @@ class TestDeltaForms:
         )
 
         assert "llm" not in resolved["parameters"]["agent"]
+
+    def test_a_persisted_description_stays_out_of_the_derived_message(
+        self, service, ordered_on
+    ):
+        # `RevisionCommit.description` is a revision field a direct HTTP caller may set.
+        # The service used to feed it to the message derivation as if it were the agent's
+        # ephemeral per-call note, which copied the caller's description verbatim into the
+        # message beside itself. Live on the preview stack, that stored
+        # `set instructions (I renamed the tone to be friendlier)`.
+        from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
+
+        commit = WorkflowRevisionCommitRequest.model_validate(
+            {
+                "workflow_revision": {
+                    "workflow_variant_id": str(VARIANT_ID),
+                    "base_revision_id": str(uuid4()),
+                    "description": "I renamed the tone to be friendlier",
+                    "delta": {
+                        "operations": [
+                            {
+                                "operation": "set",
+                                "target": AGENT + ["instructions"],
+                                "value": "be friendly",
+                            }
+                        ]
+                    },
+                }
+            }
+        ).workflow_revision
+
+        _, message, _ = _apply(service, {}, commit)
+
+        assert message == "set instructions"
 
     def test_the_legacy_form_keeps_the_caller_message(self, service):
         from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
@@ -516,7 +606,7 @@ class TestNoChange:
             candidate=service._build_revision_commit(workflow_revision_commit=commit),
         )
 
-    async def test_a_full_data_commit_is_compared_too(self, service):
+    async def test_a_full_data_commit_is_compared_too(self, service, ordered_on):
         # It used to skip the comparison outright: the check was reached only through the
         # delta branch, so an identical full-data commit always created a revision.
         data = {"parameters": {"agent": {"instructions": "hi"}}}
@@ -560,7 +650,9 @@ class TestNoChange:
         assert outcome.status == "committed"
         assert outcome.revision is committed
 
-    async def test_a_delta_that_rewrites_the_same_value_writes_nothing(self, service):
+    async def test_a_delta_that_rewrites_the_same_value_writes_nothing(
+        self, service, ordered_on
+    ):
         # The end-to-end shape of the same rule: a `set` to the value already stored
         # produces the head's tree, so the commit is answered without a revision. This is
         # what a cornered model does to manufacture a success.
@@ -646,7 +738,7 @@ class TestNoChange:
         service.commit_workflow_revision.assert_not_awaited()
 
     async def test_a_current_base_on_a_full_data_commit_still_answers_no_change(
-        self, service
+        self, service, ordered_on
     ):
         # The check must not refuse a caller whose base IS the head. That caller is
         # correct, and its commit changes nothing.
@@ -695,3 +787,87 @@ class TestNoChange:
             stored=_stored(data=data, flags=flags),
             commit=commit,
         )
+
+
+class TestTheFlagOffCommitPath:
+    """With the flag off, a commit behaves exactly as it did before this project.
+
+    The no-change answer is part of the ordered-operations surface. Shipping it to every
+    caller would be a silent behavior change on the legacy arm: a caller that commits an
+    identical tree today gets a new revision back, reads its id, and points a deployment at
+    it. Answering `no_change` instead hands it the OLD revision, which is a different
+    revision than the one it just asked to create.
+    """
+
+    @staticmethod
+    def _identical(service, data):
+        stored = _stored(
+            data=data,
+            flags=service._build_revision_commit(
+                workflow_revision_commit=WorkflowRevisionCommit(
+                    workflow_variant_id=VARIANT_ID,
+                    data=data,
+                )
+            ).flags,
+        )
+        committed = _head(uuid4(), data=data)
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(stored.id, data=data)
+        )
+        service.workflows_dao.fetch_revision.return_value = stored
+        service.commit_workflow_revision = AsyncMock(return_value=committed)
+        return stored, committed
+
+    async def test_a_legacy_no_op_set_still_creates_a_revision(
+        self, service, ordered_off
+    ):
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        stored, committed = self._identical(service, data)
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=_commit_on(stored.id, set=data),
+        )
+
+        assert outcome.status == "committed"
+        assert outcome.revision is committed
+        assert "no_change" not in [w.code for w in outcome.warnings]
+        service.commit_workflow_revision.assert_awaited_once()
+
+    async def test_an_identical_full_data_commit_still_creates_a_revision(
+        self, service, ordered_off
+    ):
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        stored, committed = self._identical(service, data)
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=WorkflowRevisionCommit(
+                workflow_variant_id=VARIANT_ID,
+                data=data,
+                base_revision_id=stored.id,
+            ),
+        )
+
+        assert outcome.status == "committed"
+        assert outcome.revision is committed
+        service.commit_workflow_revision.assert_awaited_once()
+
+    async def test_the_same_legacy_no_op_writes_nothing_once_the_flag_is_on(
+        self, service, ordered_on
+    ):
+        # The other side of the gate, on the identical payload: the flag is the only
+        # difference between this test and the first one in this class.
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        stored, _ = self._identical(service, data)
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=_commit_on(stored.id, set=data),
+        )
+
+        assert outcome.status == "no_change"
+        service.commit_workflow_revision.assert_not_awaited()

--- a/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
@@ -1,0 +1,544 @@
+"""The commit wrapper: which delta forms it accepts, and when it writes nothing.
+
+Two rules are being pinned here, and both were wrong in ways no test could see:
+
+- the delta forms are exclusive (contract change-set.md 3.3), and BOTH of them go through
+  the engine, so neither arm can skip a refusal the other earns;
+- equality is decided on the record that would be STORED, after enrichment and flag
+  inference (contract commit-transaction.md 5.1), not on the engine's raw output.
+
+The payloads are built through the request model, so what these exercise is what an HTTP
+caller can actually send.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.git.dtos import Revision
+from oss.src.core.workflows.change_set import ChangeSetError, Reason
+from oss.src.core.workflows.dtos import WorkflowRevision, WorkflowRevisionCommit
+from oss.src.core.workflows.service import WorkflowsService
+
+
+AGENT = ["parameters", "agent"]
+VARIANT_ID = uuid4()
+
+
+@pytest.fixture
+def service():
+    return WorkflowsService(workflows_dao=AsyncMock())
+
+
+@pytest.fixture
+def ordered_on():
+    """The ordered arm ships behind a flag; the legacy arm is what runs with it off.
+
+    Patched through the service module's own `env` reference, not through a fresh import:
+    another test in the suite reloads the env module, which rebinds the name without
+    touching the object every already-imported module still holds.
+    """
+    from oss.src.core.workflows import service as service_module
+
+    with patch.object(
+        service_module.env.agenta.api.workflows,
+        "ordered_operations_enabled",
+        True,
+    ):
+        yield
+
+
+def _commit(**delta):
+    """A commit as the request model would hand it over, `delta` keys included as sent."""
+    from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
+
+    request = WorkflowRevisionCommitRequest.model_validate(
+        {
+            "workflow_revision": {
+                "workflow_variant_id": str(VARIANT_ID),
+                "base_revision_id": str(uuid4()),
+                "delta": delta,
+            }
+        }
+    )
+    return request.workflow_revision
+
+
+def _apply(service, base, commit, scope_policy=None):
+    return service._apply_delta(
+        base=base,
+        workflow_revision_commit=commit,
+        scope_policy=scope_policy,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# The delta forms (contract change-set.md 3.3)
+# --------------------------------------------------------------------------------------
+
+
+class TestDeltaForms:
+    def test_a_delta_carrying_both_forms_is_refused(self, service, ordered_on):
+        # It used to apply `operations` and drop `set` without a word, so a caller that
+        # sent both was told everything landed.
+        commit = _commit(
+            set={"parameters": {"agent": {"instructions": "from set"}}},
+            operations=[
+                {"operation": "set", "target": AGENT + ["instructions"], "value": "ops"}
+            ],
+        )
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, commit)
+
+        assert caught.value.reason == Reason.INVALID_DELTA
+
+    def test_an_empty_delta_is_refused(self, service, ordered_on):
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, _commit())
+
+        assert caught.value.reason == Reason.INVALID_DELTA
+
+    def test_an_unknown_delta_field_never_reaches_the_engine(self):
+        # The envelope is closed at the boundary now: a stray key used to be dropped by
+        # pydantic, so the caller believed the server had seen it.
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            _commit(sett={"parameters": {}})
+
+    def test_the_legacy_form_still_deep_merges(self, service):
+        base = {"parameters": {"agent": {"instructions": "old", "llm": {"model": "x"}}}}
+
+        resolved, _, _ = _apply(
+            service,
+            base,
+            _commit(set={"parameters": {"agent": {"instructions": "new"}}}),
+        )
+
+        assert resolved["parameters"]["agent"]["instructions"] == "new"
+        assert resolved["parameters"]["agent"]["llm"] == {"model": "x"}
+
+    def test_the_legacy_form_still_removes_paths(self, service):
+        base = {"parameters": {"agent": {"instructions": "old", "llm": {"model": "x"}}}}
+
+        resolved, _, _ = _apply(
+            service,
+            base,
+            _commit(set={}, remove=["parameters.agent.llm"]),
+        )
+
+        assert "llm" not in resolved["parameters"]["agent"]
+
+    def test_the_legacy_form_keeps_the_caller_message(self, service):
+        from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
+
+        commit = WorkflowRevisionCommitRequest.model_validate(
+            {
+                "workflow_revision": {
+                    "workflow_variant_id": str(VARIANT_ID),
+                    "message": "written by a human",
+                    "delta": {"set": {"parameters": {"agent": {"instructions": "hi"}}}},
+                }
+            }
+        ).workflow_revision
+
+        _, message, _ = _apply(service, {}, commit)
+
+        assert message == "written by a human"
+
+
+class TestTheLegacyArmEarnsTheSameRefusals:
+    def test_an_unresolved_file_marker_is_refused(self, service):
+        # The runner replaces `@ag.file` before the API sees the call, so one that arrives
+        # means the runner did not run. The legacy arm used to merge it straight in.
+        commit = _commit(
+            set={"parameters": {"agent": {"instructions": {"@ag.file": "notes.md"}}}}
+        )
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, commit)
+
+        assert caught.value.reason == Reason.UNRESOLVED_FILE_MARKER
+
+    def test_a_platform_tool_is_refused(self, service):
+        # The build kit is injected for the run and is not part of the configuration. An
+        # agent that commits it writes the playground's own tools into its stored config.
+        commit = _commit(
+            set={
+                "parameters": {
+                    "agent": {
+                        "tools": [{"type": "platform", "op": "commit_revision"}],
+                    }
+                }
+            }
+        )
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, commit)
+
+        assert caught.value.reason == Reason.PLATFORM_TOOL_NOT_COMMITTABLE
+
+    def test_a_new_duplicate_name_is_refused(self, service):
+        base = {"parameters": {"agent": {"skills": [{"name": "qa"}]}}}
+        commit = _commit(
+            set={"parameters": {"agent": {"skills": [{"name": "qa"}, {"name": "qa"}]}}}
+        )
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, base, commit)
+
+        assert caught.value.reason == Reason.DUPLICATE_ITEM_KEY
+
+    def test_an_unstorable_result_is_refused(self, service):
+        # The engine's final gate. Without it the same failure surfaces later as an
+        # uncaught pydantic error, which is a 500 for what is a client mistake.
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, _commit(set={"not_a_revision_field": 1}))
+
+        assert caught.value.reason == Reason.FINAL_VALIDATION_FAILED
+
+
+class TestTheAgentWriteScope:
+    """What the scoped route confines, on BOTH arms (read-config.md 11.1).
+
+    An agent that could widen its own permission lists could grant itself any tool, and one
+    that could switch its sandbox could leave the boundary a human chose. Both are silent
+    privilege escalation, so both are refused, and the refusal names the boundary.
+    """
+
+    def test_the_ordered_arm_refuses_a_harness_kind_write(self, service, ordered_on):
+        from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE
+
+        commit = _commit(
+            operations=[
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness", "kind"],
+                    "value": "codex",
+                }
+            ]
+        )
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, commit, scope_policy=AGENT_COMMIT_SCOPE)
+
+        assert caught.value.reason == Reason.OUT_OF_SCOPE
+        assert "harness.kind" in caught.value.message
+        # The refusal names the path; the next step names the boundary.
+        assert "parameters.agent" in caught.value.next_step
+
+    def test_the_legacy_arm_refuses_a_sandbox_permissions_write(self, service):
+        # The legacy walk used to stop at the scope's own depth, so a refused sub-path
+        # deeper than `parameters.agent` was never reached and never refused.
+        from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE
+
+        commit = _commit(
+            set={
+                "parameters": {
+                    "agent": {"sandbox": {"permissions": {"network": "all"}}}
+                }
+            }
+        )
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, commit, scope_policy=AGENT_COMMIT_SCOPE)
+
+        assert caught.value.reason == Reason.OUT_OF_SCOPE
+        assert "sandbox.permissions" in caught.value.message
+
+    def test_it_refuses_a_write_outside_the_agent_subtree(self, service):
+        from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(
+                service,
+                {},
+                _commit(set={"uri": "agenta:custom:evil"}),
+                scope_policy=AGENT_COMMIT_SCOPE,
+            )
+
+        assert caught.value.reason == Reason.OUT_OF_SCOPE
+
+    def test_it_allows_an_ordinary_write_inside_the_subtree(self, service):
+        from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE
+
+        resolved, _, _ = _apply(
+            service,
+            {},
+            _commit(set={"parameters": {"agent": {"instructions": "hi"}}}),
+            scope_policy=AGENT_COMMIT_SCOPE,
+        )
+
+        assert resolved["parameters"]["agent"]["instructions"] == "hi"
+
+    def test_the_unscoped_caller_may_still_write_both(self, service, ordered_on):
+        # The human and SDK route is unchanged: it owns the whole revision.
+        harness = _commit(
+            operations=[
+                {
+                    "operation": "set",
+                    "target": AGENT + ["harness", "kind"],
+                    "value": "codex",
+                }
+            ]
+        )
+        resolved, _, _ = _apply(service, {}, harness)
+        assert resolved["parameters"]["agent"]["harness"]["kind"] == "codex"
+
+        sandbox = _commit(
+            set={
+                "parameters": {
+                    "agent": {"sandbox": {"permissions": {"network": "all"}}}
+                }
+            }
+        )
+        resolved, _, _ = _apply(service, {}, sandbox)
+        assert resolved["parameters"]["agent"]["sandbox"]["permissions"] == {
+            "network": "all"
+        }
+
+
+class TestExplicitNull:
+    def test_an_explicit_null_value_writes_null(self, service, ordered_on):
+        # `value` is optional, so dumping with `exclude_none` deleted an explicit null and
+        # the engine then reported a missing value for an operation that had one.
+        commit = _commit(
+            operations=[
+                {"operation": "set", "target": AGENT + ["llm"], "value": None},
+            ]
+        )
+
+        resolved, _, _ = _apply(
+            service,
+            {"parameters": {"agent": {"llm": {"model": "x"}}}},
+            commit,
+        )
+
+        assert resolved["parameters"]["agent"]["llm"] is None
+
+    def test_an_omitted_value_is_still_missing(self, service, ordered_on):
+        # The other half of the same change: presence semantics must not invent a value
+        # for an operation that never carried one.
+        commit = _commit(operations=[{"operation": "set", "target": AGENT + ["llm"]}])
+
+        with pytest.raises(ChangeSetError) as caught:
+            _apply(service, {}, commit)
+
+        assert caught.value.reason == Reason.MISSING_OPERATION_VALUE
+
+    def test_an_operation_that_takes_no_value_is_unaffected(self, service, ordered_on):
+        commit = _commit(
+            operations=[{"operation": "remove", "target": AGENT + ["llm"]}]
+        )
+
+        resolved, _, _ = _apply(
+            service,
+            {"parameters": {"agent": {"llm": {"model": "x"}}}},
+            commit,
+        )
+
+        assert "llm" not in resolved["parameters"]["agent"]
+
+
+# --------------------------------------------------------------------------------------
+# No change (contract commit-transaction.md 5.1)
+# --------------------------------------------------------------------------------------
+
+
+def _stored(data=None, flags=None):
+    return Revision(id=uuid4(), data=data, flags=flags)
+
+
+def _head(revision_id, data=None):
+    return WorkflowRevision(
+        id=revision_id,
+        workflow_variant_id=VARIANT_ID,
+        data=data,
+    )
+
+
+async def _is_no_change(service, *, stored, commit):
+    service.workflows_dao.fetch_revision.return_value = stored
+    return await service._is_no_change(
+        project_id=uuid4(),
+        head=_head(stored.id),
+        candidate=service._build_revision_commit(workflow_revision_commit=commit),
+    )
+
+
+class TestNoChange:
+    async def test_an_identical_tree_writes_nothing(self, service):
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data=data,
+        )
+        flags = service._build_revision_commit(workflow_revision_commit=commit).flags
+
+        assert await _is_no_change(
+            service,
+            stored=_stored(data=data, flags=flags),
+            commit=commit,
+        )
+
+    async def test_a_different_tree_commits(self, service):
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data={"parameters": {"agent": {"instructions": "new"}}},
+        )
+        stored = _stored(
+            data={"parameters": {"agent": {"instructions": "old"}}},
+            flags=service._build_revision_commit(workflow_revision_commit=commit).flags,
+        )
+
+        assert not await _is_no_change(service, stored=stored, commit=commit)
+
+    async def test_equal_data_with_different_stored_flags_commits(self, service):
+        # The reason the comparison covers a record and not a tree: flag inference can
+        # change between deployments, and comparing data alone would answer `no_change`
+        # for a commit that does change behavior, leaving the new flags unwritten.
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data=data,
+        )
+
+        assert not await _is_no_change(
+            service,
+            stored=_stored(data=data, flags={"is_agent": True, "is_custom": True}),
+            commit=commit,
+        )
+
+    async def test_a_variant_with_no_head_always_commits(self, service):
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data={"parameters": {"agent": {}}},
+        )
+
+        assert not await service._is_no_change(
+            project_id=uuid4(),
+            head=None,
+            candidate=service._build_revision_commit(workflow_revision_commit=commit),
+        )
+
+    async def test_a_full_data_commit_is_compared_too(self, service):
+        # It used to skip the comparison outright: the check was reached only through the
+        # delta branch, so an identical full-data commit always created a revision.
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        commit = WorkflowRevisionCommit(workflow_variant_id=VARIANT_ID, data=data)
+        stored = _stored(
+            data=data,
+            flags=service._build_revision_commit(workflow_revision_commit=commit).flags,
+        )
+        service.fetch_workflow_revision = AsyncMock(return_value=_head(stored.id))
+        service.workflows_dao.fetch_revision.return_value = stored
+        service.commit_workflow_revision = AsyncMock()
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=commit,
+        )
+
+        assert outcome.status == "no_change"
+        assert outcome.revision.id == stored.id
+        assert [w["code"] for w in outcome.warnings] == ["no_change"]
+        service.commit_workflow_revision.assert_not_awaited()
+
+    async def test_a_real_change_still_commits(self, service):
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data={"parameters": {"agent": {"instructions": "new"}}},
+        )
+        stored = _stored(data={"parameters": {"agent": {"instructions": "old"}}})
+        committed = _head(uuid4())
+        service.fetch_workflow_revision = AsyncMock(return_value=_head(stored.id))
+        service.workflows_dao.fetch_revision.return_value = stored
+        service.commit_workflow_revision = AsyncMock(return_value=committed)
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=commit,
+        )
+
+        assert outcome.status == "committed"
+        assert outcome.revision is committed
+
+    async def test_a_delta_that_rewrites_the_same_value_writes_nothing(self, service):
+        # The end-to-end shape of the same rule: a `set` to the value already stored
+        # produces the head's tree, so the commit is answered without a revision. This is
+        # what a cornered model does to manufacture a success.
+        from oss.src.apis.fastapi.workflows.models import WorkflowRevisionCommitRequest
+
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        stored = _stored(
+            data=data,
+            flags=service._build_revision_commit(
+                workflow_revision_commit=WorkflowRevisionCommit(
+                    workflow_variant_id=VARIANT_ID,
+                    data=data,
+                )
+            ).flags,
+        )
+        commit = WorkflowRevisionCommitRequest.model_validate(
+            {
+                "workflow_revision": {
+                    "workflow_variant_id": str(VARIANT_ID),
+                    "base_revision_id": str(stored.id),
+                    "delta": {"set": data},
+                }
+            }
+        ).workflow_revision
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(stored.id, data=data)
+        )
+        service.workflows_dao.fetch_revision.return_value = stored
+        service.commit_workflow_revision = AsyncMock()
+
+        outcome = await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=commit,
+        )
+
+        assert outcome.status == "no_change"
+        service.commit_workflow_revision.assert_not_awaited()
+
+    async def test_a_stale_base_beats_no_change(self, service):
+        # Contract precedence (commit-transaction.md 6, rule 2 over rule 6): a stale caller
+        # can produce a result that happens to equal the new head. Answering `no_change`
+        # would tell it its base was current. It was not.
+        from oss.src.core.workflows.service import RevisionConflictError
+
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        commit = _commit(set=data)
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(uuid4(), data=data)
+        )
+
+        with pytest.raises(RevisionConflictError):
+            await service.commit_workflow_revision_checked(
+                project_id=uuid4(),
+                user_id=uuid4(),
+                workflow_revision_commit=commit,
+            )
+
+    async def test_a_metadata_only_commit_writes_nothing(self, service):
+        # `message` is commit metadata, not configuration: it stays out of the record, so
+        # a new message over an identical tree creates no revision.
+        data = {"parameters": {"agent": {"instructions": "hi"}}}
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            data=data,
+            message="just a note",
+        )
+        flags = service._build_revision_commit(workflow_revision_commit=commit).flags
+
+        assert await _is_no_change(
+            service,
+            stored=_stored(data=data, flags=flags),
+            commit=commit,
+        )

--- a/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
@@ -899,3 +899,46 @@ class TestTheFlagOffCommitPath:
             service.commit_workflow_revision.await_args.kwargs["no_change_check"]
             is not None
         )
+
+
+class TestTheFlagDecidesWhetherTheCommitTakesTheLock:
+    """The flag decides whether the commit path takes the variant lock at all.
+
+    The no-change comparison is only meaningful against a head that cannot move under it,
+    so asking for one makes the DAO take the variant lock. With the flag off the wrapper
+    hands none down, and that is what keeps the flag-off path byte-for-byte today's: no
+    lock, no serialization, no behavior change for callers who never opted in.
+
+    The DAO half of the same claim, which commits take the lock given what they are passed,
+    is in `unit/git/test_commit_lock_scope.py` two lanes down.
+    """
+
+    @staticmethod
+    async def _comparison_handed_down(service):
+        head = _head(uuid4(), data={"parameters": {"agent": {"instructions": "old"}}})
+        service.fetch_workflow_revision = AsyncMock(return_value=head)
+        service.commit_workflow_revision = AsyncMock(return_value=head)
+
+        await service.commit_workflow_revision_checked(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            workflow_revision_commit=WorkflowRevisionCommit(
+                workflow_variant_id=VARIANT_ID,
+                data={"parameters": {"agent": {"instructions": "new"}}},
+            ),
+        )
+
+        return service.commit_workflow_revision.await_args.kwargs["no_change_check"]
+
+    async def test_the_flag_off_path_hands_down_no_comparison(
+        self, service, ordered_off
+    ):
+        assert await self._comparison_handed_down(service) is None, (
+            "the flag-off path asked for the no-change comparison, which takes the "
+            "variant lock and changes today's behavior"
+        )
+
+    async def test_the_flag_on_path_hands_down_the_comparison(
+        self, service, ordered_on
+    ):
+        assert await self._comparison_handed_down(service) is not None

--- a/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
@@ -200,6 +200,99 @@ class TestTheLegacyArmEarnsTheSameRefusals:
         assert caught.value.reason == Reason.FINAL_VALIDATION_FAILED
 
 
+class TestPreviewResolution:
+    """`test_run` resolves a delta to RUN it, and stores nothing.
+
+    An ordered delta must carry `base_revision_id` on the commit path, because that id is
+    the precondition that protects the write. A preview performs no write, and the test_run
+    handler builds its delta without the id, so the requirement blocked previewing an
+    ordered delta at all.
+    """
+
+    async def test_an_ordered_delta_without_a_base_resolves_for_a_preview(
+        self, service, ordered_on
+    ):
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(uuid4(), data={"parameters": {"agent": {}}})
+        )
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            delta={
+                "operations": [
+                    {
+                        "operation": "set",
+                        "target": AGENT + ["instructions"],
+                        "value": "hi",
+                    }
+                ]
+            },
+        )
+
+        resolution = await service._resolve_revision_delta(
+            project_id=uuid4(),
+            workflow_revision_commit=commit,
+            preview=True,
+        )
+
+        assert resolution.commit.data.parameters["agent"]["instructions"] == "hi"
+
+    async def test_the_commit_path_still_requires_the_base(self, service, ordered_on):
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(uuid4(), data={"parameters": {"agent": {}}})
+        )
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            delta={
+                "operations": [
+                    {
+                        "operation": "set",
+                        "target": AGENT + ["instructions"],
+                        "value": "hi",
+                    }
+                ]
+            },
+        )
+
+        with pytest.raises(ChangeSetError) as caught:
+            await service._resolve_revision_delta(
+                project_id=uuid4(),
+                workflow_revision_commit=commit,
+            )
+
+        assert caught.value.reason == Reason.INVALID_DELTA
+
+    async def test_a_preview_that_supplies_a_stale_base_is_still_refused(
+        self, service, ordered_on
+    ):
+        # The id is optional for a preview, not ignored. A preview built on a head that
+        # moved is not the preview the caller asked for.
+        from oss.src.core.workflows.service import RevisionConflictError
+
+        service.fetch_workflow_revision = AsyncMock(
+            return_value=_head(uuid4(), data={"parameters": {"agent": {}}})
+        )
+        commit = WorkflowRevisionCommit(
+            workflow_variant_id=VARIANT_ID,
+            base_revision_id=uuid4(),
+            delta={
+                "operations": [
+                    {
+                        "operation": "set",
+                        "target": AGENT + ["instructions"],
+                        "value": "hi",
+                    }
+                ]
+            },
+        )
+
+        with pytest.raises(RevisionConflictError):
+            await service._resolve_revision_delta(
+                project_id=uuid4(),
+                workflow_revision_commit=commit,
+                preview=True,
+            )
+
+
 class TestTheAgentWriteScope:
     """What the scoped route confines, on BOTH arms (read-config.md 11.1).
 
@@ -444,7 +537,7 @@ class TestNoChange:
 
         assert outcome.status == "no_change"
         assert outcome.revision.id == stored.id
-        assert [w["code"] for w in outcome.warnings] == ["no_change"]
+        assert [w.code for w in outcome.warnings] == ["no_change"]
         service.commit_workflow_revision.assert_not_awaited()
 
     async def test_a_real_change_still_commits(self, service):

--- a/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_wrapper.py
@@ -551,6 +551,27 @@ async def _is_no_change(service, *, stored, commit):
     )
 
 
+def _locked_commit(service, *, stored, committed=None):
+    """Stand in for the DAO's locked region.
+
+    The no-change decision moved inside the variant lock, so the wrapper's contract with
+    the layer below is now: hand down a comparison, and get back either a revision or
+    `RevisionUnchanged`. A mock that just returns a revision would pass whatever the
+    wrapper did with the callback, including dropping it.
+    """
+    from oss.src.core.git.types import RevisionUnchanged
+
+    async def commit(*, no_change_check=None, **_):
+        if no_change_check is not None and no_change_check(stored):
+            raise RevisionUnchanged(
+                head_revision_id=stored.id if stored is not None else None
+            )
+        return committed
+
+    service.commit_workflow_revision = AsyncMock(side_effect=commit)
+    return service.commit_workflow_revision
+
+
 class TestNoChange:
     async def test_an_identical_tree_writes_nothing(self, service):
         data = {"parameters": {"agent": {"instructions": "hi"}}}
@@ -617,7 +638,7 @@ class TestNoChange:
         )
         service.fetch_workflow_revision = AsyncMock(return_value=_head(stored.id))
         service.workflows_dao.fetch_revision.return_value = stored
-        service.commit_workflow_revision = AsyncMock()
+        _locked_commit(service, stored=stored)
 
         outcome = await service.commit_workflow_revision_checked(
             project_id=uuid4(),
@@ -628,7 +649,12 @@ class TestNoChange:
         assert outcome.status == "no_change"
         assert outcome.revision.id == stored.id
         assert [w.code for w in outcome.warnings] == ["no_change"]
-        service.commit_workflow_revision.assert_not_awaited()
+        # The wrapper no longer decides this: it hands the comparison down and the locked
+        # region refuses. Asserting it never called down would pin the old, racy shape.
+        assert (
+            service.commit_workflow_revision.await_args.kwargs["no_change_check"]
+            is not None
+        )
 
     async def test_a_real_change_still_commits(self, service):
         commit = WorkflowRevisionCommit(
@@ -681,7 +707,7 @@ class TestNoChange:
             return_value=_head(stored.id, data=data)
         )
         service.workflows_dao.fetch_revision.return_value = stored
-        service.commit_workflow_revision = AsyncMock()
+        _locked_commit(service, stored=stored)
 
         outcome = await service.commit_workflow_revision_checked(
             project_id=uuid4(),
@@ -690,7 +716,6 @@ class TestNoChange:
         )
 
         assert outcome.status == "no_change"
-        service.commit_workflow_revision.assert_not_awaited()
 
     async def test_a_stale_base_beats_no_change(self, service):
         # Contract precedence (commit-transaction.md 6, rule 2 over rule 6): a stale caller
@@ -761,7 +786,7 @@ class TestNoChange:
             return_value=_head(stored.id, data=data)
         )
         service.workflows_dao.fetch_revision.return_value = stored
-        service.commit_workflow_revision = AsyncMock()
+        _locked_commit(service, stored=stored)
 
         outcome = await service.commit_workflow_revision_checked(
             project_id=uuid4(),
@@ -815,7 +840,7 @@ class TestTheFlagOffCommitPath:
             return_value=_head(stored.id, data=data)
         )
         service.workflows_dao.fetch_revision.return_value = stored
-        service.commit_workflow_revision = AsyncMock(return_value=committed)
+        _locked_commit(service, stored=stored, committed=committed)
         return stored, committed
 
     async def test_a_legacy_no_op_set_still_creates_a_revision(
@@ -870,4 +895,7 @@ class TestTheFlagOffCommitPath:
         )
 
         assert outcome.status == "no_change"
-        service.commit_workflow_revision.assert_not_awaited()
+        assert (
+            service.commit_workflow_revision.await_args.kwargs["no_change_check"]
+            is not None
+        )

--- a/api/oss/tests/pytest/unit/workflows/test_read_config.py
+++ b/api/oss/tests/pytest/unit/workflows/test_read_config.py
@@ -1,0 +1,304 @@
+"""The `read_config` projection (slice S2).
+
+Pins ``contracts/read-config.md``: partial reads at every depth with the change-set target
+grammar, the read scope, refuse-not-truncate with a `children` listing, and the draft echo.
+"""
+
+import pytest
+
+from oss.src.core.workflows.change_set import Reason
+from oss.src.core.workflows.read_config import (
+    DEFAULT_MAX_BYTES,
+    MAX_MAX_BYTES,
+    MIN_MAX_BYTES,
+    ReadConfigError,
+    children_of,
+    clamp_max_bytes,
+    draft_warning,
+    project_config,
+)
+
+
+def config():
+    return {
+        "uri": "/services/agent",
+        "url": "https://example/services/agent",
+        "schemas": {"parameters": {"type": "object"}},
+        "flags": {"is_custom": True},
+        "parameters": {
+            "agent": {
+                "instructions": {"agents_md": "# Release agent\nRun the gate.\n"},
+                "llm": {
+                    "model": "openai/gpt-5",
+                    "extras": {"reasoning_effort": "high"},
+                },
+                "tools": [
+                    {"type": "platform", "op": "discover_tools"},
+                    {"type": "code", "name": "checker", "script": "print(1)\n"},
+                ],
+                "skills": [
+                    {
+                        "name": "release-qa",
+                        "description": "Run the gate.",
+                        "body": "Check the API.\n",
+                        "files": [
+                            {"path": "scripts/check.py", "content": "timeout = 30\n"}
+                        ],
+                    }
+                ],
+                "harness": {"kind": "pi_agenta"},
+            }
+        },
+    }
+
+
+AGENT = ["parameters", "agent"]
+
+
+_UNSET = object()
+
+
+def read(path=None, data=_UNSET, **kwargs):
+    return project_config(config() if data is _UNSET else data, path, **kwargs)
+
+
+def refusal(path=None, data=_UNSET, **kwargs):
+    with pytest.raises(ReadConfigError) as caught:
+        read(path, data, **kwargs)
+    return caught.value
+
+
+# --------------------------------------------------------------------------------------
+# Partial reads at each depth (contract 3)
+# --------------------------------------------------------------------------------------
+
+
+class TestPartialReads:
+    def test_the_whole_readable_configuration(self):
+        result = read()
+        assert set(result.value) == {"uri", "flags", "parameters"}
+
+    def test_a_top_level_field(self):
+        assert read(["uri"]).value == "/services/agent"
+
+    def test_an_object_two_deep(self):
+        assert read(AGENT + ["llm"]).value["model"] == "openai/gpt-5"
+
+    def test_a_scalar_leaf(self):
+        assert read(AGENT + ["llm", "model"]).value == "openai/gpt-5"
+
+    def test_a_whole_list(self):
+        assert len(read(AGENT + ["tools"]).value) == 2
+
+    def test_one_list_entry_by_key(self):
+        value = read(AGENT + [{"list": "skills", "key": "release-qa"}]).value
+        assert value["name"] == "release-qa"
+
+    def test_a_field_inside_a_list_entry(self):
+        value = read(AGENT + [{"list": "skills", "key": "release-qa"}, "body"]).value
+        assert value == "Check the API.\n"
+
+    def test_a_nested_list_entry_two_selectors_deep(self):
+        value = read(
+            AGENT
+            + [
+                {"list": "skills", "key": "release-qa"},
+                {"list": "files", "key": "scripts/check.py"},
+                "content",
+            ]
+        ).value
+        assert value == "timeout = 30\n"
+
+    def test_a_tool_by_its_canonical_name(self):
+        # The same identity function the change set uses, so what is read can be named.
+        value = read(AGENT + [{"list": "tools", "key": "discover_tools"}]).value
+        assert value["op"] == "discover_tools"
+
+    def test_the_path_is_echoed_back(self):
+        path = AGENT + ["llm", "model"]
+        assert read(path).path == path
+
+    def test_the_byte_count_is_reported(self):
+        assert read(["uri"]).bytes > 0
+
+
+class TestExactBytes:
+    def test_text_comes_back_unchanged(self):
+        # An `old_text` copied from a read must match the stored bytes, or every anchored
+        # edit built from it fails.
+        data = config()
+        data["parameters"]["agent"]["instructions"]["agents_md"] = (
+            "Line with  spaces\r\nand a “smart” quote\n"
+        )
+        value = read(AGENT + ["instructions", "agents_md"], data).value
+        assert value == "Line with  spaces\r\nand a “smart” quote\n"
+
+
+# --------------------------------------------------------------------------------------
+# The read scope (contract 8)
+# --------------------------------------------------------------------------------------
+
+
+class TestReadScope:
+    @pytest.mark.parametrize("root", ["parameters", "uri", "flags"])
+    def test_readable_roots(self, root):
+        assert read([root]).value is not None
+
+    @pytest.mark.parametrize("root", ["url", "schemas"])
+    def test_server_derived_roots_are_refused(self, root):
+        error = refusal([root])
+        assert error.reason == Reason.OUT_OF_SCOPE
+
+    def test_a_path_into_a_server_derived_root_is_refused(self):
+        assert refusal(["schemas", "parameters"]).reason == Reason.OUT_OF_SCOPE
+
+    def test_an_unknown_root_is_refused(self):
+        assert refusal(["secrets"]).reason == Reason.OUT_OF_SCOPE
+
+    def test_the_whole_read_omits_server_derived_fields(self):
+        # The model never gets the raw revision dump: `url` and `schemas` are large and
+        # unactionable, so shipping them would spend the agent's context on nothing.
+        value = read().value
+        assert "url" not in value
+        assert "schemas" not in value
+
+
+# --------------------------------------------------------------------------------------
+# Refuse, never truncate (contract 6)
+# --------------------------------------------------------------------------------------
+
+
+class TestRefuseNotTruncate:
+    def test_an_oversized_value_is_refused(self):
+        error = refusal(AGENT, max_bytes=64)
+        assert error.reason == "output_too_large"
+
+    def test_the_refusal_reports_both_numbers(self):
+        error = refusal(AGENT, max_bytes=64)
+        assert error.context["bytes"] > error.context["limit"]
+        assert error.context["limit"] == 64
+
+    def test_the_refusal_lists_object_children(self):
+        error = refusal(AGENT, max_bytes=64)
+        assert "instructions" in error.children
+        assert "skills" in error.children
+
+    def test_the_refusal_lists_item_keys_for_a_list(self):
+        # For a list the children ARE the selector keys, so the narrower read needs no
+        # guessing.
+        error = refusal(AGENT + ["skills"], max_bytes=64)
+        assert error.children == ["release-qa"]
+
+    def test_no_value_is_returned_with_the_refusal(self):
+        error = refusal(AGENT, max_bytes=64)
+        detail = error.to_detail()
+        assert "value" not in detail
+
+    def test_the_refusal_names_the_next_step(self):
+        error = refusal(AGENT, max_bytes=64)
+        assert "children" in error.to_detail()["reason"]["next_step"]
+
+    def test_a_value_at_the_limit_still_answers(self):
+        result = read(["uri"], max_bytes=64)
+        assert result.value == "/services/agent"
+
+    def test_the_limit_is_clamped_to_its_range(self):
+        assert clamp_max_bytes(None) == DEFAULT_MAX_BYTES
+        assert clamp_max_bytes(1) == MIN_MAX_BYTES
+        assert clamp_max_bytes(10_000_000) == MAX_MAX_BYTES
+        assert clamp_max_bytes(50_000) == 50_000
+
+
+# --------------------------------------------------------------------------------------
+# Errors (contract 7)
+# --------------------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_a_missing_field_lists_what_exists(self):
+        error = refusal(AGENT + ["nope"])
+        assert error.reason == Reason.TARGET_NOT_FOUND
+        assert "llm" in error.children
+
+    def test_walking_into_a_scalar_is_a_type_mismatch(self):
+        assert (
+            refusal(AGENT + ["llm", "model", "deeper"]).reason
+            == Reason.TARGET_TYPE_MISMATCH
+        )
+
+    def test_a_missing_item_lists_the_keys_that_exist(self):
+        error = refusal(AGENT + [{"list": "skills", "key": "nope"}])
+        assert error.reason == Reason.ITEM_NOT_FOUND
+        assert error.children == ["release-qa"]
+
+    def test_a_duplicate_key_is_refused(self):
+        data = config()
+        data["parameters"]["agent"]["skills"].append(
+            {"name": "release-qa", "description": "d", "body": "b"}
+        )
+        error = refusal(AGENT + [{"list": "skills", "key": "release-qa"}], data)
+        assert error.reason == Reason.DUPLICATE_ITEM_KEY
+
+    def test_a_selector_on_an_unkeyed_list_is_refused(self):
+        data = config()
+        data["parameters"]["agent"]["notes"] = ["a", "b"]
+        error = refusal(AGENT + [{"list": "notes", "key": "a"}], data)
+        assert error.reason == Reason.UNKEYED_COLLECTION
+
+    def test_a_malformed_segment_is_refused(self):
+        assert (
+            refusal(AGENT + [{"list": "skills"}]).reason == Reason.INVALID_TARGET_SHAPE
+        )
+
+    def test_a_selector_first_is_refused(self):
+        assert (
+            refusal([{"list": "skills", "key": "x"}]).reason
+            == Reason.INVALID_TARGET_SHAPE
+        )
+
+    def test_a_revision_with_no_data_is_a_404(self):
+        error = refusal(None, data=None)
+        assert error.reason == "revision_not_found"
+        assert error.status_code == 404
+
+    def test_the_envelope_matches_the_commit_error_shape(self):
+        detail = refusal(AGENT + ["nope"]).to_detail()
+        assert detail["code"] == "read_config_rejected"
+        assert detail["reason"]["code"] == Reason.TARGET_NOT_FOUND
+        assert detail["retryable"] is True
+        assert "path" in detail
+
+    def test_every_error_names_a_next_step(self):
+        for path in (
+            AGENT + ["nope"],
+            AGENT + [{"list": "skills", "key": "nope"}],
+            ["schemas"],
+            AGENT + ["llm", "model", "deeper"],
+        ):
+            detail = refusal(path).to_detail()
+            assert detail["reason"].get("next_step"), path
+
+
+# --------------------------------------------------------------------------------------
+# Children and the draft echo (contracts 6 and 10)
+# --------------------------------------------------------------------------------------
+
+
+class TestChildrenAndDraft:
+    def test_children_of_an_object_are_its_fields(self):
+        assert children_of({"a": 1, "b": 2}) == ["a", "b"]
+
+    def test_children_hide_the_server_derived_roots(self):
+        assert children_of({"uri": "x", "url": "y", "schemas": {}}) == ["uri"]
+
+    def test_children_of_a_scalar_are_empty(self):
+        assert children_of("text") == []
+
+    def test_the_draft_warning_says_where_the_values_came_from(self):
+        warning = draft_warning("17")
+        assert warning["code"] == "draft_run"
+        assert "committed head" in warning["message"]
+        assert "17" in warning["message"]
+
+    def test_the_draft_warning_survives_an_unknown_version(self):
+        assert draft_warning(None)["code"] == "draft_run"

--- a/api/oss/tests/pytest/unit/workflows/test_read_config.py
+++ b/api/oss/tests/pytest/unit/workflows/test_read_config.py
@@ -4,6 +4,8 @@ Pins ``contracts/read-config.md``: partial reads at every depth with the change-
 grammar, the read scope, refuse-not-truncate with a `children` listing, and the draft echo.
 """
 
+from uuid import uuid4
+
 import pytest
 
 from oss.src.core.workflows.change_set import Reason
@@ -302,3 +304,80 @@ class TestChildrenAndDraft:
 
     def test_the_draft_warning_survives_an_unknown_version(self):
         assert draft_warning(None)["code"] == "draft_run"
+
+
+# --------------------------------------------------------------------------------------
+# The response envelope
+# --------------------------------------------------------------------------------------
+
+
+class TestTheResponseCarriesTheWarnings:
+    """A read that earns a warning must still answer 200.
+
+    The service hands the route `ConfigReadOutcome.warnings`, which is typed
+    `List[CommitWarning]`. The response declared bare dicts, so every draft read raised a
+    validation error inside the route and the caller saw a 500 instead of its config.
+    """
+
+    def _outcome(self, **kwargs):
+        from oss.src.core.workflows.dtos import ConfigReadOutcome, WorkflowRevision
+
+        return ConfigReadOutcome(
+            revision=WorkflowRevision(id=uuid4(), slug="v", version="3"),
+            path=[],
+            value=config(),
+            bytes=12,
+            **kwargs,
+        )
+
+    def _response(self, outcome):
+        from oss.src.apis.fastapi.workflows.models import (
+            ReadConfigResponse,
+            ReadConfigRevision,
+        )
+
+        return ReadConfigResponse(
+            revision=ReadConfigRevision(id=str(outcome.revision.id)),
+            base_revision_id=str(outcome.revision.id),
+            is_draft=outcome.is_draft,
+            path=outcome.path,
+            value=outcome.value,
+            bytes=outcome.bytes,
+            warnings=outcome.warnings or None,
+        )
+
+    def test_a_draft_read_serializes_through_the_response(self):
+        outcome = self._outcome(
+            is_draft=True,
+            warnings=[draft_warning("3")],
+        )
+
+        payload = self._response(outcome).model_dump(mode="json", exclude_none=True)
+
+        assert payload["is_draft"] is True
+        assert payload["warnings"][0]["code"] == "draft_run"
+        assert "committed head" in payload["warnings"][0]["message"]
+
+    def test_a_read_without_warnings_omits_the_field(self):
+        payload = self._response(self._outcome()).model_dump(
+            mode="json", exclude_none=True
+        )
+
+        assert "warnings" not in payload
+
+    def test_a_targeted_warning_keeps_its_target(self):
+        from oss.src.core.workflows.dtos import CommitWarning
+
+        outcome = self._outcome(
+            warnings=[
+                CommitWarning(
+                    code="truncated",
+                    message="The value was too large to return whole.",
+                    target=AGENT + ["skills"],
+                )
+            ]
+        )
+
+        payload = self._response(outcome).model_dump(mode="json", exclude_none=True)
+
+        assert payload["warnings"][0]["target"] == AGENT + ["skills"]

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -811,6 +811,76 @@ _COMMIT_REVISION_DESCRIPTION = (
     else _COMMIT_REVISION_DESCRIPTION_LEGACY
 )
 
+_READ_CONFIG_DESCRIPTION = """Read your own configuration, or one part of it.
+
+Send `target.path`: an array of segments from the configuration root, the same shape
+`commit_revision` takes. Omit it to read everything you can change.
+
+    ["parameters","agent","llm"]
+    ["parameters","agent",{"list":"skills","key":"release-qa"},"body"]
+
+The response carries `revision_id`. Copy it into your next commit's `base_revision_id`.
+If the head moved in between, the commit answers 409 and you read again.
+
+Text comes back exactly as stored, so an `old_text` you copy from it will match. A value
+larger than the limit is refused, never shortened: the answer then lists `children`, and
+you read one of those instead."""
+
+_READ_CONFIG_INPUT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["target"],
+    "properties": {
+        "target": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                # Bound from $ctx.workflow.variant.id and stripped before the model sees it.
+                "workflow_variant_id": {
+                    "type": "string",
+                    "description": "Server-bound to the running variant; do not set.",
+                },
+                # Bound from $ctx.workflow.is_draft. It always resolves, so the call never
+                # fails on an absent binding.
+                "run_is_draft": {
+                    "type": "boolean",
+                    "description": "Server-bound; do not set.",
+                },
+                "path": {
+                    "type": "array",
+                    "maxItems": 12,
+                    "items": {"$ref": "#/$defs/read_config_segment"},
+                    "description": (
+                        "Segments from the configuration root. Omit to read everything."
+                    ),
+                },
+            },
+        },
+        "max_bytes": {
+            "type": "integer",
+            "minimum": 1024,
+            "maximum": 262144,
+            "description": "Largest answer to return before refusing. Default 65536.",
+        },
+    },
+    "$defs": {
+        "read_config_segment": {
+            "oneOf": [
+                {"type": "string", "minLength": 1},
+                {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["list", "key"],
+                    "properties": {
+                        "list": {"type": "string", "minLength": 1},
+                        "key": {"type": "string", "minLength": 1},
+                    },
+                },
+            ]
+        }
+    },
+}
+
 _TARGET_SEGMENT_SCHEMA: Dict[str, Any] = {
     "oneOf": [
         {"type": "string", "minLength": 1},
@@ -1267,9 +1337,34 @@ _TRIGGER_ID_INPUT_SCHEMA: Dict[str, Any] = {
 }
 
 
+# `read_config` and ordered operations are one feature: the read-then-edit loop. The flag
+# gates both, so a deployment never advertises the read without the write it feeds.
+_READ_CONFIG_OPS: tuple = (
+    (
+        PlatformOp(
+            op="read_config",
+            description=_READ_CONFIG_DESCRIPTION,
+            method="POST",
+            path="/api/workflows/revisions/read-config",
+            input_schema=_READ_CONFIG_INPUT_SCHEMA,
+            context_bindings={
+                "target.workflow_variant_id": "$ctx.workflow.variant.id",
+                "target.run_is_draft": "$ctx.workflow.is_draft",
+            },
+            read_only=True,
+            timeout_ms=15000,
+            accepts_description=True,
+        ),
+    )
+    if _ordered_operations_enabled()
+    else ()
+)
+
+
 PLATFORM_OPS: Dict[str, PlatformOp] = {
     op.op: op
-    for op in (
+    for op in _READ_CONFIG_OPS
+    + (
         PlatformOp(
             op="discover_tools",
             description=_DISCOVER_TOOLS_DESCRIPTION,

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 import pytest
 from pydantic import ValidationError
@@ -30,6 +31,18 @@ from agenta.sdk.agents.platform import (
 from agenta.sdk.agents.tools import GatewayToolResolutionError, UnknownPlatformOpError
 
 
+def _ordered_operations_enabled() -> bool:
+    """Read the flag independently of the code under test.
+
+    Calling the catalog's own helper would derive the expectation from the thing being
+    asserted: a helper that always returned True would move both sides together and the
+    test would still pass.
+    """
+    return (
+        os.getenv("AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED") or ""
+    ).strip().lower() in {"true", "1", "yes", "on"}
+
+
 def _resolver(connection):
     return AgentaPlatformToolResolver(connection=connection)
 
@@ -38,7 +51,9 @@ def _resolver(connection):
 
 
 def test_catalog_ships_platform_builder_ops():
-    assert set(PLATFORM_OPS) == {
+    # `read_config` ships only with ordered operations, so it is not in the always-on set.
+    # Its own gating is pinned in test_read_config_op.py.
+    assert set(PLATFORM_OPS) - {"read_config"} == {
         "discover_tools",
         "query_workflows",
         "query_spans",
@@ -387,15 +402,30 @@ async def test_commit_revision_binds_self_and_strips_bound_field(connection):
     # the model SHOULD supply remain.
     workflow_revision = spec.input_schema["properties"]["workflow_revision"]
     assert "workflow_variant_id" not in workflow_revision["properties"]
-    assert set(workflow_revision["properties"]) == {"message", "delta"}
     assert workflow_revision["required"] == ["delta"]
     delta = workflow_revision["properties"]["delta"]
-    assert set(delta["properties"]) == {"set", "remove"}
+
+    # The rest of the surface depends on the ordered-operations flag: with it on, the
+    # server derives the message and the ordered arm appears. Both states are pinned, so
+    # this test is honest whichever way the suite runs.
+    if _ordered_operations_enabled():
+        assert set(workflow_revision["properties"]) == {"base_revision_id", "delta"}
+        assert set(delta["properties"]) == {"set", "remove", "operations"}
+    else:
+        assert set(workflow_revision["properties"]) == {"message", "delta"}
+        assert set(delta["properties"]) == {"set", "remove"}
     assert "parameters.agent" in delta["properties"]["set"]["description"]
-    # Lists (tools, skills, mcps) replace wholesale on deep-merge; the description must warn
-    # the model to resend the complete list or it wipes its own build-kit tools (B2).
-    assert "wholesale" in spec.description
-    assert "revision id" in spec.description
+
+    if _ordered_operations_enabled():
+        # Ordered operations change one entry at a time, so the wholesale-list warning is
+        # obsolete; the description teaches the read-then-commit loop instead.
+        assert "base_revision_id" in spec.description
+        assert "playground's own tools" in spec.description
+    else:
+        # Lists (tools, skills, mcps) replace wholesale on deep-merge; the description must
+        # warn the model to resend the complete list or it wipes its own build-kit tools (B2).
+        assert "wholesale" in spec.description
+        assert "revision id" in spec.description
 
 
 async def test_commit_revision_is_not_read_only(connection):

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_read_config_op.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_read_config_op.py
@@ -1,0 +1,124 @@
+"""The `read_config` catalog entry (slice S2).
+
+`read_config` and ordered operations are one feature, the read-then-edit loop, so one flag
+gates both. A deployment never advertises the read without the write it feeds.
+
+The flag is read at import time, so each state needs its own interpreter. These tests run
+the check in a subprocess rather than reloading the module graph in place, which would
+leave other tests looking at a half-rebuilt catalog.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+FLAG = "AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED"
+
+_PROBE = """
+import json
+from agenta.sdk.agents.platform.op_catalog import PLATFORM_OPS
+
+present = "read_config" in PLATFORM_OPS
+out = {"present": present}
+if present:
+    op = PLATFORM_OPS["read_config"]
+    schema = op.resolved_input_schema()
+    out.update(
+        read_only=op.read_only,
+        path=op.path,
+        method=op.method,
+        bindings=sorted(op.context_bindings),
+        top_keys=sorted(schema["properties"]),
+        target_keys=sorted(schema["properties"]["target"]["properties"]),
+        description=op.description,
+        timeout_ms=op.timeout_ms,
+    )
+print(json.dumps(out))
+"""
+
+
+def _catalog(flag_value):
+    env = dict(os.environ)
+    if flag_value is None:
+        env.pop(FLAG, None)
+    else:
+        env[FLAG] = flag_value
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+@pytest.fixture(scope="module")
+def catalog_on():
+    return _catalog("true")
+
+
+@pytest.fixture(scope="module")
+def catalog_off():
+    return _catalog(None)
+
+
+class TestFlagGating:
+    def test_the_op_is_absent_by_default(self, catalog_off):
+        assert catalog_off["present"] is False
+
+    def test_the_op_appears_with_the_flag(self, catalog_on):
+        assert catalog_on["present"] is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "", "no"])
+    def test_only_a_truthy_value_enables_it(self, value):
+        assert _catalog(value)["present"] is False
+
+
+class TestCatalogEntry:
+    def test_it_is_a_read(self, catalog_on):
+        assert catalog_on["read_only"] is True
+
+    def test_it_targets_the_read_config_endpoint(self, catalog_on):
+        assert catalog_on["method"] == "POST"
+        assert catalog_on["path"] == "/api/workflows/revisions/read-config"
+
+    def test_it_carries_a_timeout(self, catalog_on):
+        assert catalog_on["timeout_ms"] == 15000
+
+
+class TestBindings:
+    def test_it_binds_the_variant_and_the_draft_flag(self, catalog_on):
+        assert catalog_on["bindings"] == [
+            "target.run_is_draft",
+            "target.workflow_variant_id",
+        ]
+
+    def test_both_bindings_are_hidden_from_the_model(self, catalog_on):
+        # A bound field the model could set would let it retarget another variant, or
+        # claim it is not on a draft run.
+        assert catalog_on["target_keys"] == ["path"]
+
+    def test_it_binds_no_revision_id(self, catalog_on):
+        # `$ctx.workflow.revision.id` does not resolve on a draft run, and an unresolved
+        # binding is a hard failure, so binding it would break the exact run that needs
+        # the draft answer most (read-config.md 2.1).
+        assert "target.run_revision_id" not in catalog_on["bindings"]
+
+
+class TestModelSurface:
+    def test_the_model_sets_only_the_path_and_the_limit(self, catalog_on):
+        assert catalog_on["top_keys"] == ["description", "max_bytes", "target"]
+
+    def test_the_description_teaches_the_loop(self, catalog_on):
+        text = catalog_on["description"]
+        assert "base_revision_id" in text
+        assert "409" in text
+
+    def test_the_description_states_the_refusal(self, catalog_on):
+        text = catalog_on["description"]
+        assert "children" in text
+        assert "never shortened" in text


### PR DESCRIPTION
## Context

An agent can now write one field of its own configuration, but it still has to read the whole thing to know what to write. `read_config` closes that loop: it returns one part of the stored configuration, in the same target grammar the commit takes, so what the agent reads it can then name in an operation.

This lane also carries the hardening round from the external review. Four findings were real defects on the commit path. The worst: when the variant lock timed out, the endpoint answered **HTTP 200 with `status: "committed"`, `count: 0`, and a null revision**. The DAO's generic suppression turned the timeout into `None`, and the wrapper reported that as a successful commit. Every other swallowed database error did the same thing.

## Changes

**`read_config`.** `POST /api/workflows/revisions/read-config` returns the value at a path, plus the `base_revision_id` the agent copies into its next commit. Omit the path to read everything it may change. A value larger than the limit is refused, never truncated: the answer lists the `children` paths instead, and the agent reads one of those. Truncation would give the model text it cannot anchor an `edit_text` on, which is worse than a refusal. Text comes back exactly as stored, so an `old_text` copied from a read will match on the way back in. The read scope is wider than the write scope on purpose: reading `uri` helps the agent understand itself, while `url` and `schemas` are server-derived, large, and tell the model nothing it can act on.

**A lock timeout answers 503.** Postgres reports the expiry as SQLSTATE `55P03`, which the DAO translates into `CommitLockTimeout` instead of losing it to suppression.

Before: `200 {"status": "committed", "count": 0, "workflow_revision": null}`
After: `503 {"code": "commit_lock_timeout", "next_step": "Wait for the commit in flight to finish, then send this commit again.", "retryable": true}`

A backstop covers whatever else the DAO might swallow: a `committed` status with no revision is now a 500 with an explicit body, raised before the cache is invalidated. A commit with nothing to show for it must not answer 200.

**No-change is decided on what would be stored.** Equality used to be checked on the engine's raw output, before snippet normalization, schema enrichment, and flag inference. Two consequences followed. A commit whose data was identical but whose inferred flags differed answered `no_change`, so the new flags never reached the database, and flag inference does change between deployments. A commit that only removed a field the enrichment re-derives, such as `url` from `uri`, reported `committed` and wrote a byte-identical revision. The comparison now runs on the canonical persisted `{data, flags}` pair, and it runs for full-data commits too, which skipped it entirely before.

The head side of that comparison reads the stored row, not the read view. The read path merges the artifact's flags in and infers `url` for any uri, while the commit path skips `url` inference for builtin uris. Comparing against the read view would answer "changed" forever for exactly the builtin-uri agents this feature exists for.

**Both delta forms go through the engine.** The service used to branch on `delta.operations`, run the ordered arm through the engine, and deep-merge the legacy arm by hand. So a delta carrying both forms silently dropped `set` and `remove` and told the caller everything landed, and the legacy arm skipped every refusal the ordered arm earned. The engine already had the correct form check. It is now the only path, and the platform-tool rejection and the derived message run on both arms.

**The scoped agent route.** `POST /api/workflows/revisions/commit/agent` is a sibling of the commit endpoint with one difference: every write is confined to `parameters.agent`, minus `harness.kind`, `harness.permissions`, `runner.permissions`, `sandbox.kind`, and `sandbox.permissions`. An agent that could widen its own permission lists could grant itself any tool, and one that could switch its sandbox could leave the boundary a human chose.

The confinement is a property of the route, not of anything in the request, and that is what makes it unforgeable. The agent never picks the URL: the path comes from the server-side op catalog, the runner makes the call from outside the sandbox, and the sandbox holds no credential. So there is no field an agent could set or omit to widen its own scope, and no runner version that could forget to send one. The unscoped route keeps its behavior for humans and the SDK, who own the whole revision and already hold `EDIT_WORKFLOWS`. The scoped route refuses a full-data commit outright, because a whole configuration carries every field the scope exists to protect.

Scope enforcement needed one fix to be real on the legacy arm. That arm walked the `set` tree only to the policy's own prefix depth, so a write of `parameters.agent.sandbox.permissions` collapsed to the allowed target `["parameters", "agent"]` and passed. Every blocked sub-path is deeper than the allowed prefix. The walk now goes as deep as the deepest blocked path.

The scoped route also drops any `description` on the commit. That field is the persisted revision description, which the model never sets, and it shares its name with the ephemeral per-call note the runner strips before dispatch. One arriving here means the runner did not strip it, and storing it would put an ephemeral note into the audit trail.

**Two exception decorators came back.** `@intercept_exceptions()` and `@handle_workflow_exceptions()` had been dropped from the commit route. Without them, a commit to a reserved static slug and a commit holding a non-embeddable embed both escaped as unhandled exceptions and became 500s. The embed refusal now answers 422 with `code: non_embeddable_reference`. The other eight routes that share the decorator keep their 400.

**The engine's final gate is wired.** `apply_change_set` accepted a validator and never got one, so `final_validation_failed` could not fire. It now checks that the finished tree is storable as the revision DTO. That failure used to surface later as an uncaught pydantic error, which is a 500 for what is a client mistake.

## Behavior changes to know about

- A legacy `set` that includes the playground's own build-kit tools now answers 422. Rejection was chosen over silent stripping because errors teach.
- A legacy `set` that introduces a duplicate name now answers 422. Pre-existing duplicates still only warn, so existing configurations stay editable.
- A delta carrying both forms, or an empty delta, now answers 422. An unknown key beside `operations` is refused too. A pure legacy `set`/`remove` envelope keeps its previous tolerance of stray keys, because playbooks in the field send them and the server has always ignored them.
- An explicit `"value": null` now writes null. The operation dump excluded null values, so an explicit null disappeared and the engine reported a missing value for an operation that had one.
- An empty commit against a v0 seed now answers `no_change` and returns the seed, instead of creating a second empty revision.

Only the agent's commit tool sends workflow deltas. No internal caller constructs one, and the frontend posts deltas only for testsets, which use a different service.

## Tests / notes

- `test_read_config.py`, `test_commit_wrapper.py` and `test_commit_endpoint.py` cover the read grammar, the delta forms, the scope on both arms, explicit null, the no-change record, the status mapping and the scoped route. `test_read_config_op.py` covers the SDK catalog entry.
- `test_commit_stores_data.py` asserts against the STORED row through an independent connection, rather than against the object the endpoint echoes back. That distinction is the reason a first commit could answer 200 while writing NULL and no test noticed: the response carried the object the service had built, and the insert had lost it.
- Full API unit suite: 2068 passed in both flag states.
- Recorded scope boundary: the commit is still not the single atomic transaction the contract describes. The apply happens in one transaction and the insert in another. The DAO's locked re-read closes the window that matters for two concurrent writers, and closing the rest needs the build callback in `contracts/commit-transaction.md` section 3.1. `notes/dao-lock-impact.md` section 5 states this.

## What to QA

- In the playground, ask a build-kit agent to change one line of its instructions. The commit lands, and the history shows a derived message naming what changed.
- Ask it to make the same change twice. The second answers no change, the revision list does not grow, and the sandbox stays warm.
- Ask it to change its own sandbox permissions or its harness kind. It is refused, and the error names the boundary and tells it what to do instead.
- Create a variant and commit to it exactly once, with real configuration. Read it back: the data is there. This is the first-commit case that used to store NULL.
- Regression: save a variant from the playground UI by hand. The normal commit path still works and still creates a revision.

This targets `agent-config-editing-s7a` and is part of the agent-config-editing stack. Read the stack bottom up.


## The guidance strip on the full-data path, and what counts as unset

The lane below strips the platform-guidance block from the two delta arms. A full-data commit never reaches the engine at all, so it skipped every rule in them and stored the block verbatim. That is not a corner case: the playground's own save path is full-data, and a model copying the rendered instructions file back can send it either way. The wrapper now applies the same rule through `strip_guidance_from_data`, so there is still one implementation and one warning. The bypass was found by a test that asserts the STORED row rather than the response, which failed on its first run; the engine-layer tests could not have seen it, because the value never reached the engine.

The same round trip surfaced a second, smaller problem. An agent with no stored instructions still gets a workspace file, holding only the guidance block, so copying it back sends a value that strips to an empty string where the stored field was absent. That wrote a revision nobody can see the effect of, and a commit event throws away the warm sandbox. The no-change comparison now treats absent, null, an empty string, and an object left holding nothing as the same field, anywhere in the data tree. Only the equality question changes: nothing rewrites the stored tree, so a caller that sets a field to empty on purpose still gets exactly that stored, and clearing a field that held text still commits. Empty lists are deliberately excluded and pinned by a test, because a list is positional and an explicitly empty one is a value a caller chose, so treating it as absent would let a commit that clears a list answer `no_change`.
