### PR TITLE
refactor(runner): finish the lifecycle split with a typed context

### DIFF
--- a/services/runner/src/engines/sandbox_agent/environment-setup.ts
+++ b/services/runner/src/engines/sandbox_agent/environment-setup.ts
@@ -50,6 +50,7 @@ import {
   resolvesToLocalProvider,
 } from "./session-identity.ts";
 import { loadRunnerConfig } from "../../config/runner-config.ts";
+import { buildRuntimeEnvironment } from "../../environment/runtime-lifecycle.ts";
 import { createTimingLog } from "../../environment/timing.ts";
 
 function defaultLog(message: string): void {
@@ -173,59 +174,21 @@ export async function prepareEnvironmentSetup(
   // provider cannot leak.
   // "none" asserts NO credential (connections/models.py), so it clears too — otherwise the
   // daemon would inherit the declared provider's keys (e.g. OPENAI_API_KEY) from the sidecar.
-  // Only runtime_provided keeps the inherited keys: the harness uses its own login there.
-  const clearProviderEnv =
-    plan.credentials.credentialMode === "env" ||
-    plan.credentials.credentialMode === "none";
-  const env = (deps.buildDaemonEnv ?? buildDaemonEnv)(plan.acpAgent, {
-    clearProviderEnv,
-    provider: request.modelConnection?.provider,
-    deployment: request.modelConnection?.deployment,
+  // RuntimeLifecycle BUILDS the daemon world: both env maps plus the 0600 OTLP bearer file.
+  // That was never planning, which is why it moved out of this file (lifecycle migration,
+  // step 5). See `environment/runtime-lifecycle.ts` for the ordering rule inside it.
+  const runtimeEnvironment = buildRuntimeEnvironment({
+    plan: plan as never,
+    request: request as never,
+    piSkillSnapshot,
+    log: logger,
+    deps: { ...(deps.buildDaemonEnv ? { buildDaemonEnv: deps.buildDaemonEnv } : {}) },
   });
-  // apply only the resolved provider keys
-  Object.assign(env, plan.credentials.modelEnvironment);
-  applyClaudeConnectionEnv(env, request, plan.acpAgent, logger);
-  const piSessionDir = configurePiSessionWorkspace(plan, env);
-  configurePiSkillSnapshot(piSkillSnapshot, env);
+  const env = runtimeEnvironment.env;
+  const piExtEnv = runtimeEnvironment.piExtEnv;
+  const piSessionDir = runtimeEnvironment.piSessionDir;
+  const otlpAuthFilePath = runtimeEnvironment.otlpAuthFilePath;
   const strictModel = modelResolutionStrict();
-  // Pi self-instruments locally: propagate the trace context + public tool metadata into Pi
-  // via the Agenta extension. Tool execution always relays back to this runner, which keeps
-  // private specs, scoped env, callback endpoints, and callback auth in memory.
-  // local Pi's OTLP bearer rides a runner-written 0600 file, never a plain env var —
-  // Daytona never receives telemetry env here at all (`!plan.isDaytona` gates it off above).
-  const otlpAuthFilePath =
-    plan.isPi && !plan.isDaytona
-      ? `${plan.workspace.relayDir}.otlp-auth`
-      : undefined;
-  const otlpAuthorization =
-    request.telemetry?.exporters?.otlp?.headers?.authorization;
-  if (otlpAuthFilePath && otlpAuthorization) {
-    writeOtlpAuthFile(otlpAuthFilePath, otlpAuthorization, logger);
-  }
-  const piExtEnv = plan.isPi
-    ? buildPiExtensionEnv(request, !plan.isDaytona, {
-        relayDir: plan.workspace.relayDir,
-        usageOutPath: plan.workspace.usageOutPath,
-        otlpAuthFilePath,
-        builtinGatingActive: plan.tools.builtinGatingActive,
-        // The materialized skill names (author + forced `_agenta.*`) so Pi's own agent span
-        // records which skills loaded; local Pi self-instruments, so the runner's sandbox-agent
-        // otel has no span to stamp here.
-        skills: plan.workspace.skillDirs.map((s) => s.name),
-      })
-    : {};
-  // Daytona's provider is built from `piExtEnv` rather than the local daemon env. Keep the
-  // transcript location in both environment slices so Pi and pi-acp see the same durable path
-  // regardless of provider.
-  if (piSessionDir) piExtEnv.PI_CODING_AGENT_SESSION_DIR = piSessionDir;
-  configurePiSkillSnapshot(piSkillSnapshot, piExtEnv);
-  // Managed Daytona Codex: CODEX_HOME stays on the durable cwd (native resume rides its sessions/
-  // rollouts) while CODEX_SQLITE_HOME points in-VM, off the mount (D-002 final ruling). Set here
-  // because the Daytona daemon env is fixed at sandbox creation and is built from piExtEnv. Managed
-  // auth is file-free (env_key provider; no auth.json anywhere). Non-Daytona / non-codex runs are
-  // no-ops; local Codex uses configureCodexHome below instead.
-  configureDaytonaCodexEnv(plan, piExtEnv);
-  Object.assign(env, piExtEnv); // local daemon inherits it; daytona gets it via envVars
   logger(
     `tools=${plan.tools.toolSpecs.length} executableTools=${plan.tools.executableToolSpecs.length} ` +
       `piPublicTools=${piExtEnv.AGENTA_AGENT_TOOLS_PUBLIC_SPECS ? "yes" : "no"}`,

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -137,6 +137,24 @@ import {
   acquire as acquireSandbox,
   teardown as teardownSandbox,
 } from "../../environment/sandbox-lifecycle.ts";
+import { createAcquireContext } from "../../environment/acquire-context-impl.ts";
+import {
+  removeRuntimeFiles,
+  teardownInFlight as teardownRuntimeInFlight,
+} from "../../environment/runtime-lifecycle.ts";
+import {
+  openSession as openHarnessSession,
+  probe as probeHarness,
+  teardown as teardownHarnessSession,
+} from "../../environment/harness-session-lifecycle.ts";
+import {
+  activateAgentMountGuidance as activateAgentMountGuidanceUnit,
+  mountLocalAgentCwd as mountLocalAgentCwdUnit,
+  mountLocalDurableCwd as mountLocalDurableCwdUnit,
+  reSignAndRemountLocalCwd as reSignAndRemountLocalCwdUnit,
+  remountLocalCwdAfterRuntimeEnotconn as remountLocalCwdAfterRuntimeEnotconnUnit,
+  type MountDeps,
+} from "../../environment/mount-lifecycle.ts";
 import { uploadToolMcpAssets, type ToolMcpAssets } from "./tool-mcp-assets.ts";
 import { prepareWorkspace } from "./workspace.ts";
 import { prepareEnvironmentSetup } from "./environment-setup.ts";
@@ -303,18 +321,22 @@ export async function acquireEnvironment(
   environment.destroy = async (opts?: { reason?: TeardownReason }) => {
     if (environment.destroyed) return;
     environment.destroyed = true;
-    await environment.runtimeRemount?.catch(() => {});
+    // RuntimeLifecycle quiesces everything that could still be running. This must come FIRST:
+    // an in-flight remount or a live `tools/call` would otherwise land against freed state.
+    await teardownRuntimeInFlight({
+      runtimeRemount: environment.runtimeRemount,
+      toolRelay: environment.currentTurn?.toolRelay,
+      mcpAbort: environment.mcpAbort,
+      closeToolMcp: environment.closeToolMcp,
+    });
     inFlightSandboxes.delete(environment);
-    await environment.currentTurn?.toolRelay?.stop().catch(() => {});
-    // Teardown backstop: destroy any in-flight loopback `tools/call` before closing the server.
-    environment.mcpAbort.abort();
-    await environment.closeToolMcp?.().catch(() => {});
     // Graceful `session/cancel` BEFORE tearing down the daemon, or the ACP adapter subprocess
     // reparents to PID 1 and never exits. Skip if the pause path already sent it.
-    if (environment.session && !environment.sessionDestroyRequested)
-      await environment.sandbox
-        ?.destroySession?.(environment.session.id)
-        .catch(() => {});
+    await teardownHarnessSession({
+      sandbox: environment.sandbox,
+      session: environment.session,
+      alreadyRequested: !!environment.sessionDestroyRequested,
+    });
     // SandboxLifecycle owns park-versus-delete. It returns `parked` because the mount teardown
     // below is gated on it: a parked Daytona sandbox keeps its agent mount.
     const { parked } = await teardownSandbox({
@@ -329,9 +351,14 @@ export async function acquireEnvironment(
     // mountpoint is torn down. If unmount is not CONFIRMED gone, skip the delete: rmSync must
     // never run against a possibly-live FUSE mount into the durable store.
     if (environment.mountedCwd) {
-      environment.durableCwdSafeToDelete = await (
-        environment.deps.unmountStorage ?? unmountStorage
-      )(environment.mountedCwd, { log }).catch(() => false);
+      // One of `durableCwdSafeToDelete`'s three named transitions. A wrong `true` here runs a
+      // recursive delete against a possibly-live FUSE mount into the durable store.
+      ctx.recordCwdUnmountResult(
+        await (environment.deps.unmountStorage ?? unmountStorage)(
+          environment.mountedCwd,
+          { log },
+        ).catch(() => false),
+      );
     }
     if (!parked && !plan.isDaytona && environment.agentMountedPath) {
       const agentMountSafeToDelete = await (
@@ -357,243 +384,53 @@ export async function acquireEnvironment(
     } else {
       await cleanupWorkspace(environment.workspace);
     }
-    // The per-run Agenta agent dir (skills isolation) is throwaway; remove it too. This is only
-    // ever a temp dir: a subscription run leaves `runAgentDir` undefined precisely so that the
-    // operator's mounted login (which the harness runs out of directly) is never deleted here.
-    if (environment.runAgentDir)
-      rmSync(environment.runAgentDir, { recursive: true, force: true });
-    // Backstop: the extension deletes this on read; remove it here too in case the harness never
-    // started (or crashed before reading it), so the bearer never lingers.
-    if (environment.otlpAuthFilePath)
-      rmSync(environment.otlpAuthFilePath, { force: true });
-    // No Codex auth.json backstop: managed auth is file-free (no file exists), and the subscription
-    // symlink is intentionally left in the runner-owned home (a symlink to the operator's mount, not
-    // a secret; correct for the next resume). The old managed-file backstop was also ordering-buggy
-    // (it ran AFTER unmountStorage, so on a local durable session it deleted nothing and stranded the
-    // key in the store — the bug the file-free design removes entirely; D-002 research Q2a).
-    // Best-effort: remove the local off-mount CODEX_SQLITE_HOME dir. The SQLite state is
-    // disposable (native resume rides the sessions/ rollouts on CODEX_HOME), so a failure here is
-    // harmless.
-    if (environment.codexSqliteHome)
-      rmSync(environment.codexSqliteHome, { recursive: true, force: true });
+    // RuntimeLifecycle owns the runner-written files. The reasoning for each — and for the
+    // Codex auth.json backstop that deliberately does NOT exist — lives with the unit.
+    removeRuntimeFiles({
+      runAgentDir: environment.runAgentDir,
+      otlpAuthFilePath: environment.otlpAuthFilePath,
+      codexSqliteHome: environment.codexSqliteHome,
+    });
     // Remove the per-run skills temp root the materializer created (success or error).
     plan.workspace.skillsCleanup();
   };
 
-  let agentMountGuidanceActive = false;
-  const activateAgentMountGuidance = async (): Promise<void> => {
-    const mountedPath = environment.agentMountedPath;
-    if (!mountedPath || agentMountGuidanceActive) return;
-    agentMountGuidanceActive = true;
-
-    // Only advertise durable storage after the mount is confirmed active. Local daemon env is
-    // still mutable here because local mounts run before SandboxAgent.start below. Daytona cannot
-    // change daemon env after sandbox creation, so its harness discovers the mount through the
-    // post-mount system-prompt channel and the cwd-local agent-files symlink instead.
-    if (!plan.isDaytona) {
-      env[AGENT_MOUNT_ENV_VAR] = mountedPath;
-      piExtEnv[AGENT_MOUNT_ENV_VAR] = mountedPath;
-    }
-    if (!plan.isPi) return;
-
-    plan.prompt.appendSystemPrompt = combineAppendSystemPrompt(
-      plan.prompt.appendSystemPrompt,
-      AGENT_MOUNT_SYSTEM_PROMPT_SEGMENT,
-    );
-    plan.prompt.hasSystemPrompt = true;
-    if (plan.isDaytona) {
-      await uploadSystemPromptToSandbox(
-        environment.sandbox,
-        DAYTONA_PI_DIR,
-        plan.prompt.systemPrompt,
-        plan.prompt.appendSystemPrompt,
-        logger,
-      );
-      return;
-    }
-    if (environment.runAgentDir) {
-      writeSystemPromptLocal(
-        environment.runAgentDir,
-        plan.prompt.systemPrompt,
-        plan.prompt.appendSystemPrompt,
-        logger,
-      );
-      return;
-    }
-    // Discarding `.extensionInstalled` here is safe, and a fail-closed throw here would be
-    // unsound anyway (both callers wrap this in a mount try/catch that logs and continues, so a
-    // throw could not stop the run). Reachability: managed/none local Pi runs always created a
-    // throwaway dir in the first prepareLocalPiAssets call, so `environment.runAgentDir` is set
-    // for them and they returned above — only the subscription (runtime_provided) path reaches
-    // this re-prep. That path installs into the SAME operator mount the first call already
-    // installed into, and the fail-closed gating check right after that first call stopped the
-    // run when the install was required but failed. So by the time this runs, either enforcement
-    // is not needed (policy allows everything) or the extension file is already on disk from the
-    // verified first install; a transient failure here cannot remove it.
-    runAgentDir = prepareLocalPiAssets({ plan, env, log: logger }).dir;
-    environment.runAgentDir = runAgentDir;
+  // ---- MountLifecycle ------------------------------------------------------------------ //
+  // The six mount helpers moved to `environment/mount-lifecycle.ts`. They used to be mutually
+  // recursive closures over this scope; they now take `ctx` and capture nothing. `ctx` is the
+  // only thing that carries the shared state, and it exposes the environment as a read-only
+  // projection so a unit cannot reach a field it does not own. See `environment/acquire-context.ts`.
+  const { context: ctx } = createAcquireContext({
+    environment,
+    plan,
+    env,
+    piExtEnv,
+    sessionForMount,
+    artifactId,
+    runCred,
+    log: logger,
+    timingLog,
+    remountLimit: LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT,
+    combineAppendSystemPrompt,
+    // Needs the raw daemon env map, which units must not see, so it is injected here.
+    reprepareLocalPiAssets: () =>
+      prepareLocalPiAssets({ plan, env, log: logger }).dir,
+  });
+  const mountDeps: MountDeps = {
+    ...(deps.mountStorage ? { mountStorage: deps.mountStorage } : {}),
+    signMount,
+    signAgentMount,
+    daytonaPiDir: DAYTONA_PI_DIR,
   };
-
-  // --- local durable cwd mount helpers (session-scoped, close over environment) ------ //
-  const mountLocalDurableCwd = async (reason: string): Promise<boolean> => {
-    if (!environment.mountCreds || plan.isDaytona) return false;
-    logger(
-      `local durable cwd mount (${reason}) session=${sessionForMount} cwd=${plan.workspace.cwd}`,
-    );
-    environment.durableCwdSafeToDelete = false;
-    const mounted = await (deps.mountStorage ?? mountStorage)(
-      plan.workspace.cwd,
-      environment.mountCreds,
-      {
-        log: logger,
-      },
-    );
-    if (mounted) {
-      environment.mountedCwd = plan.workspace.cwd;
-      environment.installedMountExpiries.cwd = mountExpiryMs(
-        environment.mountCreds.expiresAt,
-      );
-      // Session-local links belong to the mount's lifecycle, not to first acquire: this mount is
-      // object storage, which has no symlinks, so a remount hands back a 0-byte file where the
-      // link was. Re-materialize the subscription Codex login link here, AFTER the mount is live
-      // (linking before it would be shadowed) — the same reason `mountLocalAgentCwd` re-runs
-      // `linkAgentFiles` on every mount. Idempotent, and a no-op for every other kind of run.
-      if (isSubscriptionCodexRun(plan)) {
-        await symlinkCodexSubscriptionAuthFile(plan, logger).catch((err) => {
-          logger(
-            `codex subscription auth.json link failed after mount: ${conciseError(err, plan.harness)}`,
-          );
-        });
-      }
-      return true;
-    }
-    // A false result means mountStorage stopped the attempt and confirmed the path detached.
-    environment.durableCwdSafeToDelete = true;
-    return false;
-  };
-  const mountLocalAgentCwd = async (): Promise<boolean> => {
-    if (!environment.agentMountCreds || plan.isDaytona) return false;
-    const mountPath = agentMountPath(plan.workspace.cwd);
-    if (environment.agentMountedPath === mountPath) return true;
-    try {
-      mkdirSync(mountPath, { recursive: true });
-      if (
-        !(await (deps.mountStorage ?? mountStorage)(
-          mountPath,
-          environment.agentMountCreds,
-          { log: logger },
-        ))
-      ) {
-        // false means mountStorage confirmed detach is safe. This path is a sibling of the
-        // session cwd, so workspace cleanup cannot remove the failed mountpoint stub.
-        rmSync(mountPath, { recursive: true, force: true });
-        return false;
-      }
-      environment.agentMountedPath = mountPath;
-      environment.installedMountExpiries.agent = mountExpiryMs(
-        environment.agentMountCreds.expiresAt,
-      );
-      await seedAgentReadme(mountPath, { log: logger });
-      await linkAgentFiles(plan.workspace.cwd, mountPath, { log: logger });
-      await activateAgentMountGuidance();
-      return true;
-    } catch (err) {
-      logger(
-        `local agent mount failed artifact=${artifactId}: ${conciseError(err, plan.harness)}`,
-      );
-      return false;
-    }
-  };
-  let localAgentMountEnotconnRemounts = 0;
-  const reSignAndRemountLocalAgentMount = async (): Promise<boolean> => {
-    if (!artifactId || !runCred || plan.isDaytona) return false;
-    if (
-      localAgentMountEnotconnRemounts >=
-      LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT
-    ) {
-      logger(
-        `local agent mount ENOTCONN remount limit reached artifact=${artifactId} path=${agentMountPath(plan.workspace.cwd)}`,
-      );
-      return false;
-    }
-    localAgentMountEnotconnRemounts += 1;
-    logger(
-      `local agent mount ENOTCONN artifact=${artifactId}; re-signing and remounting`,
-    );
-    const fresh = await signAgentMount(artifactId, {
-      apiBase: apiBase(),
-      authorization: runCred,
-      log: logger,
-    });
-    if (!fresh) {
-      logger(
-        `local agent mount re-sign returned no credentials artifact=${artifactId}`,
-      );
-      return false;
-    }
-    environment.agentMountCreds = fresh;
-    // Clear the marker so mountLocalAgentCwd remounts instead of short-circuiting.
-    environment.agentMountedPath = undefined;
-    return mountLocalAgentCwd();
-  };
-  let localDurableCwdEnotconnRemounts = 0;
-  const reSignAndRemountLocalCwd = async (): Promise<boolean> => {
-    if (!sessionForMount || !runCred || plan.isDaytona) return false;
-    if (
-      localDurableCwdEnotconnRemounts >=
-      LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT
-    ) {
-      logger(
-        `local durable cwd ENOTCONN remount limit reached session=${sessionForMount} cwd=${plan.workspace.cwd}`,
-      );
-      return false;
-    }
-    localDurableCwdEnotconnRemounts += 1;
-    logger(
-      `local durable cwd ENOTCONN session=${sessionForMount} cwd=${plan.workspace.cwd}; re-signing and remounting`,
-    );
-    const fresh = await signMount(sessionForMount, {
-      apiBase: apiBase(),
-      authorization: runCred,
-      log: logger,
-    });
-    if (!fresh) {
-      logger(
-        `local durable cwd re-sign returned no credentials session=${sessionForMount}`,
-      );
-      return false;
-    }
-    environment.mountCreds = fresh;
-    return mountLocalDurableCwd("enotconn-retry");
-  };
-  const remountLocalCwdAfterRuntimeEnotconn = (event: unknown): void => {
-    if (plan.isDaytona) return;
-    // The event cannot say which mount broke; remount every eligible one (alive mounts no-op).
-    const cwdEligible = !!environment.mountCreds && !!environment.mountedCwd;
-    const agentEligible =
-      !!environment.agentMountCreds && !!environment.agentMountedPath;
-    if (!cwdEligible && !agentEligible) return;
-    if (
-      environment.runtimeRemount ||
-      !containsTransportEndpointDisconnected(event)
-    )
-      return;
-    logger(
-      `local durable mount ENOTCONN observed in ACP event session=${sessionForMount} cwd=${plan.workspace.cwd}; re-signing and remounting`,
-    );
-    environment.runtimeRemount = (async () => {
-      const cwdOk = cwdEligible ? await reSignAndRemountLocalCwd() : true;
-      const agentOk = agentEligible
-        ? await reSignAndRemountLocalAgentMount()
-        : true;
-      return cwdOk && agentOk;
-    })().catch((err) => {
-      logger(
-        `local durable mount runtime remount failed session=${sessionForMount}: ${conciseError(err, plan.harness)}`,
-      );
-      return false;
-    });
-  };
+  const mountLocalDurableCwd = (reason: string) =>
+    mountLocalDurableCwdUnit(ctx, mountDeps, reason);
+  const mountLocalAgentCwd = () => mountLocalAgentCwdUnit(ctx, mountDeps);
+  const reSignAndRemountLocalCwd = () =>
+    reSignAndRemountLocalCwdUnit(ctx, mountDeps);
+  const activateAgentMountGuidance = () =>
+    activateAgentMountGuidanceUnit(ctx, mountDeps);
+  const remountLocalCwdAfterRuntimeEnotconn = (event: unknown) =>
+    remountLocalCwdAfterRuntimeEnotconnUnit(ctx, mountDeps, event);
 
   try {
     // Fail loud before any sandbox/mount infra spins up: an applicable-but-incomplete
@@ -636,6 +473,10 @@ export async function acquireEnvironment(
     if (environment.agentMountCreds && !plan.isDaytona) {
       await mountLocalAgentCwd();
     }
+    // INVARIANT 1: the provider takes `env` and `piExtEnv` BY REFERENCE and hands them to the
+    // daemon, after which the daemon environment is fixed. Every local mount had to land above
+    // this line. From here a `writeDaemonEnv` is a programming-order bug and throws.
+    ctx.freezeDaemonEnv();
     const sandboxProvider = (deps.buildSandboxProvider ?? buildSandboxProvider)(
       plan.sandboxId,
       env,
@@ -907,16 +748,15 @@ export async function acquireEnvironment(
     );
 
     // Probe what this harness supports and branch on capabilities, not on the harness name.
-    const probeCapabilitiesStartedAt = Date.now();
-    let probed;
-    try {
-      probed = await (deps.probeCapabilities ?? probeCapabilities)(
-        environment.sandbox,
-        plan.acpAgent,
-      );
-    } finally {
-      timingLog("probe_capabilities", probeCapabilitiesStartedAt);
-    }
+    // HarnessSessionLifecycle owns the stage and its timing mark.
+    const probed = await probeHarness(
+      {
+        sandbox: environment.sandbox,
+        acpAgent: plan.acpAgent,
+        timingLog,
+      },
+      { ...(deps.probeCapabilities ? { probeCapabilities: deps.probeCapabilities } : {}) },
+    );
     const capabilities = probed.capabilities;
     environment.capabilities = capabilities;
 
@@ -1019,49 +859,22 @@ export async function acquireEnvironment(
     // The live sandbox id rides forward as a field on the turn-append row written at turn end
     // (see `appendSessionTurn` call in `runTurn`), not a separate pre-turn pointer PUT: the
     // turns table is append-only, so there is nothing to overwrite mid-conversation.
-    let loadedFromContinuity = false;
-    if (priorAgentSessionId && localSessionId) {
-      await persist.updateSession({
-        id: localSessionId,
-        agent: plan.acpAgent,
-        agentSessionId: priorAgentSessionId,
-        lastConnectionId: "",
-        createdAt: Date.now(),
-        sessionInit,
-      });
-      const createSessionStartedAt = Date.now();
-      try {
-        environment.session =
-          await environment.sandbox.resumeSession(localSessionId);
-        loadedFromContinuity =
-          environment.session.agentSessionId === priorAgentSessionId;
-        logger(
-          `[continuity] session/load attempted session=${continuitySessionKey} ` +
-            `harness=${plan.harness} loaded=${loadedFromContinuity}`,
-        );
-      } catch (err) {
-        logger(
-          `[continuity] resumeSession failed, falling back to cold createSession: ` +
-            `${conciseError(err, plan.harness)}`,
-        );
-      } finally {
-        timingLog("create_session", createSessionStartedAt, " mode=load");
-      }
-    }
-    environment.loadedFromContinuity = loadedFromContinuity;
-    if (!environment.session) {
-      const createSessionStartedAt = Date.now();
-      try {
-        environment.session = await environment.sandbox.createSession({
-          ...(localSessionId ? { id: localSessionId } : {}),
-          agent: plan.acpAgent,
-          cwd: plan.workspace.cwd,
-          sessionInit,
-        });
-      } finally {
-        timingLog("create_session", createSessionStartedAt, " mode=create");
-      }
-    }
+    // HarnessSessionLifecycle owns both open modes and both `create_session` timing marks.
+    const opened = await openHarnessSession({
+      sandbox: environment.sandbox,
+      persist,
+      acpAgent: plan.acpAgent,
+      harness: plan.harness,
+      cwd: plan.workspace.cwd,
+      sessionInit,
+      priorAgentSessionId,
+      localSessionId,
+      continuitySessionKey,
+      log: logger,
+      timingLog,
+    });
+    environment.session = opened.session;
+    environment.loadedFromContinuity = opened.loadedFromContinuity;
     environment.sessionId = resolveRunSessionId(
       request,
       environment.session.id,

--- a/services/runner/src/environment/acquire-context-impl.ts
+++ b/services/runner/src/environment/acquire-context-impl.ts
@@ -1,0 +1,214 @@
+/**
+ * `createAcquireContext` — the one function allowed to hold both halves.
+ *
+ * LIFECYCLE MIGRATION, STEP 5 (S7b). The contract, its invariants, and the review record live in
+ * `acquire-context.ts`. This file is the implementation, and it is deliberately separate so the
+ * reviewed artifact stays readable.
+ *
+ * THE WHOLE POINT OF THIS MODULE is that the mutable `SessionEnvironment` enters here and does not
+ * leave. Units get `context`, which exposes reads through `EnvironmentView` and writes through
+ * named committers. The composer gets `mutableEnvironment` for the fields no unit owns.
+ */
+import { mountExpiryMs } from "../engines/sandbox_agent/session-identity.ts";
+import type { MountCredentials } from "../engines/sandbox_agent/mount.ts";
+import type { RunPlan } from "../engines/sandbox_agent/run-plan.ts";
+import type { SessionEnvironment } from "../engines/sandbox_agent/runtime-contracts.ts";
+import {
+  AcquireInvariantError,
+  type AcquireContext,
+  type AcquireContextHandle,
+  type EnvironmentView,
+  type MountKind,
+} from "./acquire-context.ts";
+import type { Log, TimingLog } from "./timing.ts";
+
+export interface CreateAcquireContextInput {
+  environment: SessionEnvironment;
+  plan: RunPlan;
+  /** The daemon environment map. Taken by reference by `buildSandboxProvider`. */
+  env: Record<string, string>;
+  /** The Pi extension environment map. Also taken by reference. */
+  piExtEnv: Record<string, string>;
+  sessionForMount: string | undefined;
+  artifactId: string | undefined;
+  runCred: string | undefined;
+  log: Log;
+  timingLog: TimingLog;
+  /** Shared cap for both ENOTCONN remount budgets. */
+  remountLimit: number;
+  /** Appends the guidance segment to an existing prompt. Injected to avoid a cycle. */
+  combineAppendSystemPrompt: (
+    existing: string | undefined,
+    segment: string,
+  ) => string;
+  /**
+   * Re-prepares the local Pi assets and returns their directory. Injected because it needs the
+   * raw daemon env map, which units must not see.
+   */
+  reprepareLocalPiAssets: () => string | undefined;
+}
+
+export function createAcquireContext(
+  input: CreateAcquireContextInput,
+): AcquireContextHandle {
+  const { environment, plan, env, piExtEnv } = input;
+
+  let envFrozen = false;
+  let guidanceActive = false;
+  const remountsTaken: Record<MountKind, number> = { cwd: 0, agent: 0 };
+
+  // The read-only projection. Getters, not a snapshot: a unit that reads `mountedCwd` after
+  // another unit committed a mount must see the new value, exactly as the closure did.
+  const view: EnvironmentView = {
+    get sandbox() {
+      return environment.sandbox;
+    },
+    get session() {
+      return environment.session;
+    },
+    get sessionId() {
+      return environment.sessionId;
+    },
+    get mountCreds() {
+      return environment.mountCreds;
+    },
+    get agentMountCreds() {
+      return environment.agentMountCreds;
+    },
+    get mountedCwd() {
+      return environment.mountedCwd;
+    },
+    get agentMountedPath() {
+      return environment.agentMountedPath;
+    },
+    get runAgentDir() {
+      return environment.runAgentDir;
+    },
+    get durableCwdSafeToDelete() {
+      return environment.durableCwdSafeToDelete;
+    },
+    get runtimeRemount() {
+      return environment.runtimeRemount;
+    },
+  };
+
+  const context: AcquireContext = {
+    plan,
+    env: view,
+    sessionForMount: input.sessionForMount,
+    artifactId: input.artifactId,
+    runCred: input.runCred,
+    log: input.log,
+    timingLog: input.timingLog,
+
+    // --- daemon env, INVARIANT 1 ------------------------------------------------------ //
+    get envFrozen() {
+      return envFrozen;
+    },
+    writeDaemonEnv(name, value) {
+      if (envFrozen) {
+        // A PROGRAMMING-ORDER violation, not an operational failure. It must fail the
+        // acquisition rather than be swallowed by a mount unit's broad catch, which is why this
+        // is `AcquireInvariantError` and why every such catch calls `rethrowIfInvariant` first.
+        throw new AcquireInvariantError(
+          "local-mounts-before-provider-freeze",
+          `cannot set daemon env '${name}': the provider already took the env maps by ` +
+            `reference, so the daemon environment is fixed. A local mount must complete ` +
+            `BEFORE buildSandboxProvider.`,
+        );
+      }
+      env[name] = value;
+      piExtEnv[name] = value;
+    },
+    freezeDaemonEnv() {
+      envFrozen = true;
+    },
+
+    // --- the plan's system prompt ----------------------------------------------------- //
+    reprepareLocalPiAssets() {
+      return input.reprepareLocalPiAssets();
+    },
+    appendAgentMountGuidance(segment) {
+      plan.prompt.appendSystemPrompt = input.combineAppendSystemPrompt(
+        plan.prompt.appendSystemPrompt,
+        segment,
+      );
+      plan.prompt.hasSystemPrompt = true;
+    },
+
+    // --- mount state, INVARIANTS 2 and 3 ---------------------------------------------- //
+    recordResignedCredential(kind, credential) {
+      if (kind === "cwd") environment.mountCreds = credential;
+      else environment.agentMountCreds = credential;
+    },
+    commitLocalMount(kind, path, credential) {
+      // Path and expiry together, from ONE credential, so the recorded lease provably belongs to
+      // the mount the daemon received.
+      if (kind === "cwd") {
+        environment.mountedCwd = path;
+        environment.installedMountExpiries.cwd = mountExpiryMs(
+          credential.expiresAt,
+        );
+      } else {
+        environment.agentMountedPath = path;
+        environment.installedMountExpiries.agent = mountExpiryMs(
+          credential.expiresAt,
+        );
+      }
+    },
+    commitRemoteMountExpiry(kind, credential) {
+      // Expiry with NO path. A Daytona mount lives inside the sandbox and dies with it, so there
+      // is no host mountpoint for teardown to unmount.
+      const expiry = mountExpiryMs(credential.expiresAt);
+      if (kind === "cwd") environment.installedMountExpiries.cwd = expiry;
+      else environment.installedMountExpiries.agent = expiry;
+    },
+    clearMountPath(kind) {
+      if (kind === "cwd") environment.mountedCwd = undefined;
+      else environment.agentMountedPath = undefined;
+    },
+
+    // --- durableCwdSafeToDelete: three named transitions ------------------------------ //
+    beginCwdMount() {
+      environment.durableCwdSafeToDelete = false;
+    },
+    markCwdDetachConfirmed() {
+      environment.durableCwdSafeToDelete = true;
+    },
+    recordCwdUnmountResult(unmounted) {
+      environment.durableCwdSafeToDelete = unmounted;
+    },
+
+    // --- runtime-owned handles -------------------------------------------------------- //
+    setRuntimeRemount(remount) {
+      environment.runtimeRemount = remount;
+    },
+    setRunAgentDir(dir) {
+      environment.runAgentDir = dir;
+    },
+    setOtlpAuthFilePath(path) {
+      environment.otlpAuthFilePath = path;
+    },
+    setCodexSqliteHome(dir) {
+      environment.codexSqliteHome = dir;
+    },
+    setCloseToolMcp(close) {
+      environment.closeToolMcp = close;
+    },
+
+    // --- retry budgets and one-shot flags --------------------------------------------- //
+    takeRemountBudget(kind) {
+      if (remountsTaken[kind] >= input.remountLimit) return false;
+      remountsTaken[kind] += 1;
+      return true;
+    },
+    get guidanceActive() {
+      return guidanceActive;
+    },
+    markGuidanceActive() {
+      guidanceActive = true;
+    },
+  };
+
+  return { context, mutableEnvironment: environment };
+}

--- a/services/runner/src/environment/acquire-context.ts
+++ b/services/runner/src/environment/acquire-context.ts
@@ -1,0 +1,413 @@
+/**
+ * `AcquireContext` — the shared state the lifecycle units read and write.
+ *
+ * LIFECYCLE MIGRATION, STEP 5 (S7b). REVISION 2, after an external security review REJECTED
+ * revision 1. That review's findings are recorded at the bottom of this file, because each one
+ * describes a way the type could have looked correct and enforced nothing.
+ *
+ * ============================================================================================
+ * WHY A CONTEXT OBJECT AT ALL
+ * ============================================================================================
+ *
+ * The three remaining units (mount, runtime, harness session) are not separable the way sandbox
+ * and workspace were. They share ONE closure containing six mutually recursive helpers:
+ *
+ *   activateAgentMountGuidance          mountLocalAgentCwd
+ *   mountLocalDurableCwd                reSignAndRemountLocalAgentMount
+ *   reSignAndRemountLocalCwd            remountLocalCwdAfterRuntimeEnotconn
+ *
+ * `mountLocalAgentCwd` calls `activateAgentMountGuidance`, which writes the DAEMON ENV and the
+ * PLAN's system prompt. `reSignAndRemountLocalCwd` re-signs a credential and then calls
+ * `mountLocalDurableCwd`. `remountLocalCwdAfterRuntimeEnotconn` calls both re-signers.
+ *
+ * A context object is the smallest change that lets those helpers live in separate modules
+ * without any of them importing another. Every helper takes `ctx`; nothing captures.
+ *
+ * ============================================================================================
+ * THE ENFORCEMENT RULE THIS REVISION IS BUILT ON
+ * ============================================================================================
+ *
+ * Revision 1 stated its invariants in comments and exposed the mutable environment anyway. The
+ * reviewer's summary was exact: "The type compiles, but it does not enforce what its comments
+ * promise." So this revision follows one rule:
+ *
+ *   IF A COMMENT SAYS A UNIT MAY NOT DO SOMETHING, THE TYPE MUST MAKE IT IMPOSSIBLE.
+ *
+ * Concretely: units receive `EnvironmentView`, a read-only PROJECTION. The mutable
+ * `SessionEnvironment` never leaves this module. Every write goes through a named committer, so
+ * the set of writers is the set of methods below and a reviewer can enumerate them.
+ *
+ * ============================================================================================
+ * THE THREE ORDERING INVARIANTS
+ * ============================================================================================
+ *
+ * ---- INVARIANT 1: LOCAL MOUNTS RUN BEFORE THE PROVIDER FREEZES THE DAEMON ENV ----
+ *
+ * On a LOCAL run the daemon has not started when the mounts run, so the env maps are still
+ * mutable and a successful mount can advertise itself through `AGENT_MOUNT_ENV_VAR`.
+ * `buildSandboxProvider` takes them BY REFERENCE (environment.ts:641-647) and hands them to
+ * `SandboxAgent.start`; after that the daemon environment is fixed for the life of the sandbox.
+ *
+ * Today the ordering is guaranteed by POSITION: the two `mountLocal*` calls sit immediately above
+ * the `buildSandboxProvider` call. Once they live in different modules, position guarantees
+ * nothing, and the failure is silent — a harness that cannot see its own durable storage.
+ *
+ * On DAYTONA the ordering is reversed and the env channel is unavailable: the sandbox is created
+ * first, its env can never change, and the harness learns about the mount through the post-mount
+ * system-prompt upload and a cwd-local symlink instead.
+ *
+ * ENFORCEMENT, CORRECTED. Revision 1 threw a plain `Error`, which `mountLocalAgentCwd`'s broad
+ * catch (environment.ts:478) would have swallowed — the guidance call sits INSIDE that try. So
+ * the throw is now `AcquireInvariantError`, and every operational catch in the mount unit must
+ * rethrow it. The distinction the reviewer drew is the right one and is now expressible:
+ *
+ *   a PROGRAMMING-ORDER violation  -> AcquireInvariantError -> fails the acquisition, loudly
+ *   an OPERATIONAL mount failure   -> any other error       -> logged, and the run continues
+ *
+ * ---- INVARIANT 2: A RE-SIGN COMMITS THROUGH ONE COMMITTER ----
+ *
+ * Exactly two credential re-sign paths exist:
+ *
+ *   reSignAndRemountLocalCwd        signMount(session)   -> mountCreds      -> mountLocalDurableCwd
+ *   reSignAndRemountLocalAgentMount signAgentMount(art)  -> agentMountCreds -> mountLocalAgentCwd
+ *
+ * Each writes the fresh credential and THEN remounts. PRESERVED FOR THIS SPLIT, per the
+ * reviewer's ruling: it is current behavior, and changing it does not belong in a zero-change
+ * refactor.
+ *
+ * CORRECTION TO REVISION 1's NOTE. Revision 1 claimed a failed remount leaves nothing pointing at
+ * a mount, "so nothing reads a credential it did not mount with". That was WRONG, and the
+ * reviewer caught it: `mountLocalDurableCwd` sets `durableCwdSafeToDelete = false` and then, on a
+ * failed mount, returns without clearing `mountedCwd`. A cwd remount that fails can therefore
+ * leave `mountedCwd` STILL SET from the previous successful mount, while `mountCreds` holds the
+ * new credential. The two disagree until the next successful remount. That is the real current
+ * behavior; it is preserved, and it is written down here so it is not rediscovered as a surprise.
+ *
+ * ---- INVARIANT 3: THE EXPIRY IS STAMPED FROM THE CREDENTIAL THAT WAS ACTUALLY MOUNTED ----
+ *
+ * `installedMountExpiries` is what the keep-alive pool compares to decide whether a parked
+ * session's mount can still cover a turn. It must record the expiry of the credential the daemon
+ * RECEIVED, never one that was merely signed.
+ *
+ * CORRECTION TO REVISION 1's SHAPE. A single `commitMount(kind, path, credential)` could not
+ * express what Daytona actually does. On Daytona the cwd mount records an expiry and does NOT set
+ * `mountedCwd` (environment.ts:768-772), because `mountedCwd` exists to gate the HOST unmount at
+ * teardown and a Daytona mount lives inside the sandbox, dying with it. Forcing a path in would
+ * have made teardown try to unmount a host path that never existed. So there are now two
+ * committers, and the difference is explicit rather than accidental.
+ */
+import type { MountCredentials } from "../engines/sandbox_agent/mount.ts";
+import type { RunPlan } from "../engines/sandbox_agent/run-plan.ts";
+import type { SessionEnvironment } from "../engines/sandbox_agent/runtime-contracts.ts";
+import type { Log, TimingLog } from "./timing.ts";
+
+/** Which of the two durable mounts a call is about. */
+export type MountKind = "cwd" | "agent";
+
+/**
+ * A violation of an acquire ORDERING rule. It means the code called things in the wrong order,
+ * which is a bug in the runner, not a condition of the environment.
+ *
+ * It must escape every operational catch. A mount unit that catches broadly has to rethrow this
+ * class specifically; `rethrowIfInvariant` below is the one-liner for that, so no call site has
+ * to remember the instanceof check.
+ */
+export class AcquireInvariantError extends Error {
+  readonly invariant: string;
+  constructor(invariant: string, message: string) {
+    super(message);
+    this.name = "AcquireInvariantError";
+    this.invariant = invariant;
+  }
+}
+
+/**
+ * Rethrow `err` when it is an invariant violation; otherwise return it for ordinary handling.
+ *
+ * Every broad `catch` in the mount and runtime units starts with this call. That is what keeps
+ * invariant 1's throw from being swallowed by the catch at environment.ts:478.
+ */
+export function rethrowIfInvariant(err: unknown): unknown {
+  if (err instanceof AcquireInvariantError) throw err;
+  return err;
+}
+
+/**
+ * The READ-ONLY projection of the environment that units receive.
+ *
+ * This is the reviewer's first required change. `readonly environment: SessionEnvironment` was an
+ * illusion: `readonly` freezes the reference, not the object, so every unit could still assign
+ * every writable field and the ownership table was documentation rather than structure.
+ *
+ * Only the fields units legitimately READ are here. A unit that needs a new one adds it here,
+ * which is a visible, reviewable act rather than a silent reach into a shared object.
+ */
+export interface EnvironmentView {
+  readonly sandbox: unknown;
+  readonly session: unknown;
+  readonly sessionId: string;
+  readonly mountCreds: MountCredentials | null;
+  readonly agentMountCreds: MountCredentials | null | undefined;
+  readonly mountedCwd: string | undefined;
+  readonly agentMountedPath: string | undefined;
+  readonly runAgentDir: string | undefined;
+  readonly durableCwdSafeToDelete: boolean;
+  readonly runtimeRemount: Promise<boolean> | undefined;
+}
+
+/**
+ * The state shared across the mount, runtime, and harness-session units.
+ *
+ * Read the method list as the complete set of writers. There is no other way to change the
+ * environment from a unit, because the mutable object is not reachable from this interface.
+ */
+export interface AcquireContext {
+  // ---------------------------------------------------------------------------------------
+  // IDENTITY AND PLAN
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * The run plan, read-only.
+   *
+   * NOTE, per the reviewer: `readonly plan: RunPlan` does NOT prevent nested mutation, so this
+   * annotation is not the protection. `appendAgentMountGuidance` below is. The plan is exposed
+   * for reads; the one legitimate write goes through that method.
+   */
+  readonly plan: RunPlan;
+
+  /** What units may read of the environment. The mutable object stays private to this module. */
+  readonly env: EnvironmentView;
+
+  /** The session id whose mount is being signed. Undefined disables the durable cwd mount. */
+  readonly sessionForMount: string | undefined;
+  /** The artifact id whose agent mount is being signed. Undefined disables the agent mount. */
+  readonly artifactId: string | undefined;
+  /** The caller credential every re-sign presents. Undefined disables BOTH re-sign paths. */
+  readonly runCred: string | undefined;
+
+  readonly log: Log;
+  readonly timingLog: TimingLog;
+
+  // ---------------------------------------------------------------------------------------
+  // DAEMON ENVIRONMENT. Writer: the mount unit's guidance path. Frozen by: the sandbox unit.
+  // INVARIANT 1.
+  // ---------------------------------------------------------------------------------------
+
+  /** True once `buildSandboxProvider` has taken the env maps by reference. */
+  readonly envFrozen: boolean;
+
+  /**
+   * Set a daemon environment variable on both the daemon env and the Pi extension env.
+   *
+   * THROWS `AcquireInvariantError` when `envFrozen`. Both maps are written together because they
+   * are always written together today; splitting them would let the extension and the daemon
+   * disagree about where the agent mount is.
+   */
+  writeDaemonEnv(name: string, value: string): void;
+
+  /** Called by the sandbox unit immediately before `buildSandboxProvider`. Idempotent. */
+  freezeDaemonEnv(): void;
+
+  // ---------------------------------------------------------------------------------------
+  // THE PLAN'S SYSTEM PROMPT. Writer: the mount unit's guidance path.
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * Append the durable-storage paragraph to the plan's system prompt and mark the plan as
+   * carrying one.
+   *
+   * A narrow method rather than a raw mutable plan, per the reviewer's answer 4. Writing into the
+   * plan from a lifecycle unit remains ugly; it is PRESERVED for this slice because S7b is a
+   * zero-behavior-change split. Moving prompt composition behind a proper seam is follow-up work.
+   */
+  appendAgentMountGuidance(segment: string): void;
+
+  /**
+   * Re-prepare the local Pi assets and return the directory they landed in.
+   *
+   * A narrow injected callback, for the same reason `appendAgentMountGuidance` is one: the call
+   * needs the raw daemon env map, and exposing that map to units would reopen the exact hole the
+   * `EnvironmentView` projection closes. The composer wires this with the map it already owns.
+   *
+   * Only the guidance path calls it, and only on the subscription branch that has no agent dir
+   * yet. The caller is still responsible for committing the result through `setRunAgentDir`.
+   */
+  reprepareLocalPiAssets(): string | undefined;
+
+  // ---------------------------------------------------------------------------------------
+  // MOUNT STATE. Writer: the mount unit ONLY, through the committers below.
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * Record a credential that was just re-signed. INVARIANT 2.
+   *
+   * The ONLY writer of `mountCreds` and `agentMountCreds`. Takes a NON-NULL credential, per the
+   * reviewer's answer 2: keeping the committer total forces each signer to handle and log its own
+   * null result, which is what both signers already do.
+   */
+  recordResignedCredential(kind: MountKind, credential: MountCredentials): void;
+
+  /**
+   * Record a LOCAL mount that is now live: its host path and the expiry of the credential the
+   * daemon actually received, written together. INVARIANT 3.
+   *
+   * Local only. The path matters because teardown must unmount that host mountpoint before
+   * deleting anything under it.
+   */
+  commitLocalMount(
+    kind: MountKind,
+    path: string,
+    credential: MountCredentials,
+  ): void;
+
+  /**
+   * Record a DAYTONA cwd mount: the expiry ONLY, with no path.
+   *
+   * This is not a shortcut, it is the real behavior (environment.ts:768-772). A Daytona mount
+   * lives inside the sandbox and dies with it, so there is no host mountpoint to unmount and
+   * `mountedCwd` must stay unset. Setting it would make teardown attempt to unmount a path that
+   * never existed on this host.
+   */
+  commitRemoteMountExpiry(kind: MountKind, credential: MountCredentials): void;
+
+  /**
+   * Clear a mount's path so a later attempt does not short-circuit.
+   *
+   * Used by the agent re-sign path, which clears `agentMountedPath` precisely so
+   * `mountLocalAgentCwd` remounts instead of returning early on its identity check.
+   */
+  clearMountPath(kind: MountKind): void;
+
+  // ---------------------------------------------------------------------------------------
+  // `durableCwdSafeToDelete`. Writer: the mount unit and teardown.
+  //
+  // Revision 1's table hid this field's transitions behind `commitMount`. It has THREE, and they
+  // are not all mount-success transitions, so they are modeled explicitly here.
+  //
+  //   beginCwdMount()               -> false   a mount is starting; the path may be live
+  //                                            (environment.ts:443)
+  //   markCwdDetachConfirmed()      -> true    mountStorage confirmed the path is detached
+  //                                            (environment.ts:470)
+  //   recordCwdUnmountResult(ok)    -> ok      teardown's unmount result (environment.ts:331)
+  //
+  // The field gates whether teardown may `rmSync` the workspace. A wrong `true` runs a recursive
+  // delete against a possibly-live FUSE mount into the durable store, so every transition is
+  // named rather than inferred.
+  // ---------------------------------------------------------------------------------------
+
+  beginCwdMount(): void;
+  markCwdDetachConfirmed(): void;
+  recordCwdUnmountResult(unmounted: boolean): void;
+
+  // ---------------------------------------------------------------------------------------
+  // RUNTIME-OWNED HANDLES. Writer: the runtime unit.
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * The in-flight remount promise. Teardown awaits it FIRST, so a remount cannot land against a
+   * half-torn-down environment.
+   */
+  setRuntimeRemount(remount: Promise<boolean> | undefined): void;
+
+  /**
+   * The per-run agent directory.
+   *
+   * SINGLE SOURCE OF TRUTH, mandated by the reviewer's answer 5. Today this is written twice: an
+   * outer `let runAgentDir` in `acquireEnvironment` and `environment.runAgentDir`, both assigned
+   * in `activateAgentMountGuidance` (environment.ts:433-434). The outer `let` has no reader left
+   * in `acquireEnvironment`, so deleting it is not a behavior change — revision 1 was wrong to
+   * call that "the one place S7b is not a pure move", and the reviewer corrected it.
+   *
+   * WRITER: the mount unit's GUIDANCE path, not the runtime unit. Revision 1's table assigned
+   * this to runtime, which was simply wrong.
+   */
+  setRunAgentDir(dir: string | undefined): void;
+
+  setOtlpAuthFilePath(path: string | undefined): void;
+  setCodexSqliteHome(dir: string | undefined): void;
+  setCloseToolMcp(close: (() => Promise<void>) | undefined): void;
+
+  // ---------------------------------------------------------------------------------------
+  // RETRY BUDGETS AND ONE-SHOT FLAGS. Writer: the mount unit.
+  //
+  // Three `let`s from the closure: two ENOTCONN remount counters (one per mount kind, both
+  // bounded by the same `LOCAL_DURABLE_CWD_ENOTCONN_REMOUNT_LIMIT`) and one guidance flag.
+  //
+  // A budget is PER ACQUIRE, not per call site. An ENOTCONN storm must not be able to re-sign
+  // forever, so every retry path for a given mount draws from the same counter — including the
+  // runtime-event remount, which is why that path cannot become its own budget later without
+  // reopening the loop this bound closes.
+  // ---------------------------------------------------------------------------------------
+
+  /** Consume one retry for `kind`. False when the budget is spent; the caller then gives up. */
+  takeRemountBudget(kind: MountKind): boolean;
+
+  /**
+   * True once the agent-mount guidance has run. The guidance is idempotent by this flag rather
+   * than by its effects, because it APPENDS to a system prompt and appending twice is visible.
+   */
+  readonly guidanceActive: boolean;
+  markGuidanceActive(): void;
+}
+
+/**
+ * The internal handle the composer builds. It holds the mutable environment; units never see it.
+ *
+ * The type is declared here so the boundary is visible in the reviewed artifact: exactly one
+ * function may hold both halves.
+ */
+export interface AcquireContextHandle {
+  readonly context: AcquireContext;
+  /** The composer's own escape hatch, for the fields no unit owns. */
+  readonly mutableEnvironment: SessionEnvironment;
+}
+
+/**
+ * ============================================================================================
+ * THE ENVIRONMENT FIELD MAP, CORRECTED
+ * ============================================================================================
+ *
+ * | # | environment field        | owner unit          | written via                  |
+ * |---|--------------------------|---------------------|------------------------------|
+ * | 1 | `mountCreds`             | mount               | recordResignedCredential     |
+ * | 2 | `agentMountCreds`        | mount               | recordResignedCredential     |
+ * | 3 | `mountedCwd`             | mount (LOCAL only)  | commitLocalMount             |
+ * | 4 | `agentMountedPath`       | mount               | commitLocalMount / clearMountPath |
+ * | 5 | `installedMountExpiries` | mount               | commitLocalMount / commitRemoteMountExpiry |
+ * | 6 | `durableCwdSafeToDelete` | mount + teardown    | beginCwdMount / markCwdDetachConfirmed / recordCwdUnmountResult |
+ * | 7 | `runtimeRemount`         | runtime             | setRuntimeRemount            |
+ * | 8 | `runAgentDir`            | mount (GUIDANCE)    | setRunAgentDir               |
+ * | 9 | `otlpAuthFilePath`       | runtime             | setOtlpAuthFilePath          |
+ * |10 | `codexSqliteHome`        | runtime             | setCodexSqliteHome           |
+ * |11 | `closeToolMcp`           | runtime             | setCloseToolMcp              |
+ *
+ * Corrections against revision 1, all from the review:
+ *   - #3 is LOCAL ONLY. Daytona records an expiry with no path (#5's second committer).
+ *   - #6 has three named transitions, not one hidden inside a mount commit.
+ *   - #8 is owned by the mount unit's guidance path. Revision 1 said runtime.
+ *
+ * Already split in S7a: `sandbox`, `resumable` (sandbox unit); `workspace` (workspace unit).
+ * Owned by the harness-session unit: `session`, `sessionId`, `capabilities`, `model`,
+ * `loadedFromContinuity`. None has an ordering hazard that warrants a committer.
+ *
+ * ============================================================================================
+ * REVIEW RECORD
+ * ============================================================================================
+ *
+ * Revision 1 was rejected. Every finding is addressed above; none was argued away.
+ *
+ * | Finding | Where it is fixed |
+ * |---|---|
+ * | `readonly environment` is only a readonly REFERENCE; units could mutate every field | `EnvironmentView`; the mutable object never leaves this module |
+ * | The freeze throw would be swallowed by the broad catch at environment.ts:478 | `AcquireInvariantError` + `rethrowIfInvariant` |
+ * | `commitMount` cannot represent Daytona's expiry-without-path | `commitLocalMount` vs `commitRemoteMountExpiry` |
+ * | The table hid `durableCwdSafeToDelete`'s mount-start, detach, and teardown writes | three named transitions |
+ * | `runAgentDir` is written by the guidance path, not runtime | field map #8 |
+ * | The note wrongly claimed a failed remount leaves nothing pointing at a mount | invariant 2's correction paragraph |
+ *
+ * Rulings adopted as given: credential-before-remount PRESERVED for this split;
+ * `recordResignedCredential` takes a non-null credential; the `plan.prompt` mutation is preserved
+ * behind `appendAgentMountGuidance`; `environment.runAgentDir` is the single source of truth and
+ * the outer `let` is deleted.
+ */
+export type AcquireContextReviewRecord = never;

--- a/services/runner/src/environment/harness-session-lifecycle.ts
+++ b/services/runner/src/environment/harness-session-lifecycle.ts
@@ -163,5 +163,13 @@ export async function teardown(input: {
   alreadyRequested: boolean;
 }): Promise<void> {
   if (!input.session || input.alreadyRequested) return;
-  await input.sandbox?.destroySession?.(input.session.id).catch(() => {});
+  // try/catch rather than `.catch()`: a `destroySession` that throws SYNCHRONOUSLY never returns
+  // a promise, so there is nothing to attach a rejection handler to and the throw escapes into
+  // `destroy`, which must never throw. Teardown is best effort by design; a session the harness
+  // has already lost is not a reason to fail the caller.
+  try {
+    await input.sandbox?.destroySession?.(input.session.id);
+  } catch {
+    // best-effort session teardown
+  }
 }

--- a/services/runner/src/environment/harness-session-lifecycle.ts
+++ b/services/runner/src/environment/harness-session-lifecycle.ts
@@ -1,0 +1,167 @@
+/**
+ * `HarnessSessionLifecycle` — probing the harness and opening its ACP session.
+ *
+ * LIFECYCLE MIGRATION, STEP 5 (S7b). This unit owns two acquire stages, `probe_capabilities` and
+ * `create_session`, plus the session teardown.
+ *
+ * IT TAKES AN EXPLICIT INPUT, NOT `AcquireContext`. The mount unit needed the context because its
+ * six helpers shared mutable state and called each other. Nothing here does: probing and opening
+ * are straight-line, their inputs are read-only, and their outputs are returned rather than
+ * assigned. Threading the context through anyway would suggest a coupling that does not exist.
+ *
+ * TWO MODES, ONE STAGE NAME. `openSession` either LOADS a native conversation by id or CREATES a
+ * fresh one. Both emit `create_session`, with the mode in the ` mode=...` field, so a dashboard
+ * grouping by stage keeps one series with a mode dimension.
+ *
+ * CONTINUITY IS BEST EFFORT, AND THAT IS DELIBERATE. A resume that throws is caught, logged, and
+ * falls through to a cold `createSession`. The worst outcome is a conversation that replays
+ * instead of resuming, which costs latency and never correctness. What the caller must NOT do is
+ * treat a successful `resumeSession` as proof that history loaded — see `loadedFromContinuity`.
+ */
+import { conciseError } from "../engines/sandbox_agent/errors.ts";
+import { probeCapabilities } from "../engines/sandbox_agent/capabilities.ts";
+import type { Log, TimingLog } from "./timing.ts";
+
+export interface ProbeInput {
+  sandbox: { createSession?: unknown };
+  acpAgent: string;
+  timingLog: TimingLog;
+}
+
+export interface ProbeDeps {
+  probeCapabilities?: typeof probeCapabilities;
+}
+
+/**
+ * Ask the harness what it supports.
+ *
+ * The caller branches on CAPABILITIES, never on the harness name. That is what lets a new harness
+ * work without touching the acquire path.
+ */
+export async function probe(
+  input: ProbeInput,
+  deps: ProbeDeps = {},
+): Promise<Awaited<ReturnType<typeof probeCapabilities>>> {
+  const probeCapabilitiesStartedAt = Date.now();
+  try {
+    return await (deps.probeCapabilities ?? probeCapabilities)(
+      input.sandbox as never,
+      input.acpAgent as never,
+    );
+  } finally {
+    input.timingLog("probe_capabilities", probeCapabilitiesStartedAt);
+  }
+}
+
+export interface OpenSessionInput {
+  sandbox: {
+    resumeSession: (localSessionId: string) => Promise<{ id: string; agentSessionId?: string }>;
+    createSession: (request: unknown) => Promise<{ id: string }>;
+  };
+  /** The session persist driver. Typed loosely so this unit does not restate the SDK's record. */
+  persist: { updateSession: (record: never) => Promise<unknown> };
+  acpAgent: string;
+  harness: string;
+  cwd: string;
+  /** The shared init payload both modes send. */
+  sessionInit: Record<string, unknown>;
+  /** The native session id to resume, when the store says one is eligible. */
+  priorAgentSessionId: string | undefined;
+  /** The runner-local key both modes use for the persist record. */
+  localSessionId: string | undefined;
+  /** For the continuity log line only. */
+  continuitySessionKey: string | undefined;
+  log: Log;
+  timingLog: TimingLog;
+}
+
+export interface OpenSessionResult {
+  session: { id: string; agentSessionId?: string };
+  /**
+   * Whether the native conversation was loaded.
+   *
+   * READ THE CAVEAT. This compares the returned `agentSessionId` to the one we asked for, which
+   * proves the ADAPTER ACCEPTED THE ID. It does NOT prove the adapter replayed the turns. A
+   * `session/load` that succeeds at the transport layer and loads nothing would still set this
+   * true. The adapter matrix records the gap and requires a positive history check before a
+   * reopen may claim continuity; this unit reports what it can observe and no more.
+   */
+  loadedFromContinuity: boolean;
+  mode: "load" | "create";
+}
+
+/**
+ * Open the harness session: load the native conversation when one is eligible, otherwise create
+ * a fresh one.
+ *
+ * A load that throws degrades to a create. The `finally` still emits the ` mode=load` mark, so
+ * the failed attempt is visible in timing rather than hidden behind the create that follows it.
+ */
+export async function openSession(
+  input: OpenSessionInput,
+): Promise<OpenSessionResult> {
+  let session: { id: string; agentSessionId?: string } | undefined;
+  let loadedFromContinuity = false;
+
+  if (input.priorAgentSessionId && input.localSessionId) {
+    await input.persist.updateSession({
+      id: input.localSessionId,
+      agent: input.acpAgent,
+      agentSessionId: input.priorAgentSessionId,
+      lastConnectionId: "",
+      createdAt: Date.now(),
+      sessionInit: input.sessionInit,
+    } as never);
+    const createSessionStartedAt = Date.now();
+    try {
+      session = await input.sandbox.resumeSession(input.localSessionId);
+      loadedFromContinuity =
+        session.agentSessionId === input.priorAgentSessionId;
+      input.log(
+        `[continuity] session/load attempted session=${input.continuitySessionKey} ` +
+          `harness=${input.harness} loaded=${loadedFromContinuity}`,
+      );
+    } catch (err) {
+      input.log(
+        `[continuity] resumeSession failed, falling back to cold createSession: ` +
+          `${conciseError(err, input.harness)}`,
+      );
+    } finally {
+      input.timingLog("create_session", createSessionStartedAt, " mode=load");
+    }
+  }
+
+  if (!session) {
+    const createSessionStartedAt = Date.now();
+    try {
+      session = await input.sandbox.createSession({
+        ...(input.localSessionId ? { id: input.localSessionId } : {}),
+        agent: input.acpAgent,
+        cwd: input.cwd,
+        sessionInit: input.sessionInit,
+      });
+    } finally {
+      input.timingLog("create_session", createSessionStartedAt, " mode=create");
+    }
+    return { session, loadedFromContinuity, mode: "create" };
+  }
+
+  return { session, loadedFromContinuity, mode: "load" };
+}
+
+/**
+ * Close the harness session gracefully.
+ *
+ * ORDERING IS LOAD-BEARING: this must run BEFORE the daemon is torn down, or the ACP adapter
+ * subprocess reparents to PID 1 and never exits. The composer sequences it; the unit only refuses
+ * to throw.
+ */
+export async function teardown(input: {
+  sandbox: { destroySession?: (id: string) => Promise<unknown> } | undefined;
+  session: { id: string } | undefined;
+  /** True when the pause path already sent its own cancel. */
+  alreadyRequested: boolean;
+}): Promise<void> {
+  if (!input.session || input.alreadyRequested) return;
+  await input.sandbox?.destroySession?.(input.session.id).catch(() => {});
+}

--- a/services/runner/src/environment/mount-lifecycle.ts
+++ b/services/runner/src/environment/mount-lifecycle.ts
@@ -1,0 +1,337 @@
+/**
+ * `MountLifecycle` — the two durable mounts and everything that keeps them alive.
+ *
+ * LIFECYCLE MIGRATION, STEP 5 (S7b). This unit is the reason `AcquireContext` exists. The six
+ * helpers below were mutually recursive closures sharing one scope in `acquireEnvironment`; they
+ * are now ordinary functions that take `ctx` and capture nothing.
+ *
+ * ZERO BEHAVIOR CHANGE. Every guard, every log string, every early return and every ordering is
+ * preserved. The only differences are mechanical: reads go through `ctx.env`, writes go through a
+ * named committer, and the two broad catches now start with `rethrowIfInvariant`.
+ *
+ * ============================================================================================
+ * THE TWO MOUNTS, AND WHY THEY ARE NOT SYMMETRIC
+ * ============================================================================================
+ *
+ *  - The DURABLE CWD is the run directory. It is keyed by SESSION, signed with `signMount`, and
+ *    its path is the plan's cwd. Teardown must unmount it before deleting anything under it.
+ *  - The AGENT MOUNT is the harness's own home (logins, agent files). It is keyed by ARTIFACT,
+ *    signed with `signAgentMount`, and lives at a SIBLING path of the cwd. It carries guidance:
+ *    a successful agent mount tells the model that durable storage exists.
+ *
+ * Only the agent mount runs the guidance path, and only the cwd mount participates in the
+ * `durableCwdSafeToDelete` handshake. That asymmetry is why the helpers are separate functions
+ * rather than one parameterized by `MountKind`.
+ *
+ * ============================================================================================
+ * THE INVARIANT THIS UNIT MUST RESPECT
+ * ============================================================================================
+ *
+ * INVARIANT 1 (see `acquire-context.ts`): a LOCAL mount must complete before the sandbox provider
+ * takes the daemon env maps by reference. The guidance path writes `AGENT_MOUNT_ENV_VAR`, so a
+ * local mount landing after the freeze would write into maps nobody reads again and the harness
+ * would never learn about its own durable storage.
+ *
+ * `ctx.writeDaemonEnv` throws `AcquireInvariantError` in that case. Both broad catches in this
+ * file therefore call `rethrowIfInvariant(err)` FIRST. Without it, `mountLocalAgentCwd`'s catch
+ * would swallow the violation and log it as an ordinary mount failure — which is exactly what the
+ * external review caught in revision 1 of the contract.
+ */
+import { mkdirSync, rmSync } from "node:fs";
+
+import { apiBase } from "../apiBase.ts";
+import {
+  AGENT_MOUNT_ENV_VAR,
+  agentMountPath,
+  linkAgentFiles,
+  seedAgentReadme,
+} from "../engines/sandbox_agent/agent-mount.ts";
+import {
+  AGENT_MOUNT_SYSTEM_PROMPT_SEGMENT,
+} from "../engines/sandbox_agent/agent-mount-guidance.ts";
+import {
+  isSubscriptionCodexRun,
+  symlinkCodexSubscriptionAuthFile,
+} from "../engines/sandbox_agent/codex-assets.ts";
+import { conciseError } from "../engines/sandbox_agent/errors.ts";
+import { mountStorage } from "../engines/sandbox_agent/mount.ts";
+import {
+  uploadSystemPromptToSandbox,
+  writeSystemPromptLocal,
+} from "../engines/sandbox_agent/pi-assets.ts";
+import { containsTransportEndpointDisconnected } from "../engines/sandbox_agent/runtime-policy.ts";
+import { rethrowIfInvariant, type AcquireContext } from "./acquire-context.ts";
+
+/** The Pi agent directory inside a Daytona sandbox. Injected so this unit stays import-light. */
+export interface MountDeps {
+  mountStorage?: typeof mountStorage;
+  signMount: (
+    sessionId: string,
+    opts: { apiBase: string; authorization: string; log: (m: string) => void },
+  ) => Promise<import("../engines/sandbox_agent/mount.ts").MountCredentials | null>;
+  signAgentMount: (
+    artifactId: string,
+    opts: { apiBase: string; authorization: string; log: (m: string) => void },
+  ) => Promise<import("../engines/sandbox_agent/mount.ts").MountCredentials | null>;
+  /** The remote Pi directory constant, passed in rather than imported. */
+  daytonaPiDir: string;
+}
+
+/**
+ * Tell the model that durable storage exists, once.
+ *
+ * Runs only after an agent mount is CONFIRMED live. It has four outcomes, in priority order, and
+ * every one is preserved from the original:
+ *   1. Not local -> no daemon env write (Daytona's env is already frozen by construction).
+ *   2. Not Pi    -> stop after the env write; only Pi takes the prompt segment.
+ *   3. Daytona   -> upload the composed prompt into the sandbox.
+ *   4. Local     -> write it beside the agent dir, re-preparing the dir if this is the
+ *                   subscription path that has none yet.
+ */
+export async function activateAgentMountGuidance(
+  ctx: AcquireContext,
+  deps: MountDeps,
+): Promise<void> {
+  const mountedPath = ctx.env.agentMountedPath;
+  if (!mountedPath || ctx.guidanceActive) return;
+  ctx.markGuidanceActive();
+
+  const plan = ctx.plan;
+  // Only advertise durable storage after the mount is confirmed active. Local daemon env is
+  // still mutable here because local mounts run before SandboxAgent.start. Daytona cannot change
+  // daemon env after sandbox creation, so its harness discovers the mount through the post-mount
+  // system-prompt channel and the cwd-local agent-files symlink instead.
+  if (!plan.isDaytona) {
+    // INVARIANT 1. Throws `AcquireInvariantError` if the provider already froze the env.
+    ctx.writeDaemonEnv(AGENT_MOUNT_ENV_VAR, mountedPath);
+  }
+  if (!plan.isPi) return;
+
+  ctx.appendAgentMountGuidance(AGENT_MOUNT_SYSTEM_PROMPT_SEGMENT);
+
+  if (plan.isDaytona) {
+    await uploadSystemPromptToSandbox(
+      ctx.env.sandbox,
+      deps.daytonaPiDir,
+      plan.prompt.systemPrompt,
+      plan.prompt.appendSystemPrompt,
+      ctx.log,
+    );
+    return;
+  }
+  if (ctx.env.runAgentDir) {
+    writeSystemPromptLocal(
+      ctx.env.runAgentDir,
+      plan.prompt.systemPrompt,
+      plan.prompt.appendSystemPrompt,
+      ctx.log,
+    );
+    return;
+  }
+  // Discarding `.extensionInstalled` here is safe, and a fail-closed throw would be unsound
+  // anyway: both callers wrap this in a mount try/catch that logs and continues, so a throw could
+  // not stop the run. Reachability: managed/none local Pi runs always created a throwaway dir in
+  // the first `prepareLocalPiAssets` call and returned above, so only the subscription
+  // (runtime_provided) path reaches this re-prep. That path installs into the SAME operator mount
+  // the first call installed into, and the fail-closed gating check after that first call stopped
+  // the run when the install was required but failed.
+  ctx.setRunAgentDir(ctx.reprepareLocalPiAssets());
+}
+
+/** Mount the durable cwd on the local host. Returns whether it is live. */
+export async function mountLocalDurableCwd(
+  ctx: AcquireContext,
+  deps: MountDeps,
+  reason: string,
+): Promise<boolean> {
+  const plan = ctx.plan;
+  const creds = ctx.env.mountCreds;
+  if (!creds || plan.isDaytona) return false;
+  ctx.log(
+    `local durable cwd mount (${reason}) session=${ctx.sessionForMount} cwd=${plan.workspace.cwd}`,
+  );
+  // A mount is starting, so the path may become live: the workspace must not be deleted.
+  ctx.beginCwdMount();
+  const mounted = await (deps.mountStorage ?? mountStorage)(
+    plan.workspace.cwd,
+    creds,
+    { log: ctx.log },
+  );
+  if (mounted) {
+    ctx.commitLocalMount("cwd", plan.workspace.cwd, creds);
+    // Session-local links belong to the mount's lifecycle, not to first acquire: this mount is
+    // object storage, which has no symlinks, so a remount hands back a 0-byte file where the link
+    // was. Re-materialize the subscription Codex login link here, AFTER the mount is live
+    // (linking before it would be shadowed). Idempotent, and a no-op for every other run.
+    if (isSubscriptionCodexRun(plan)) {
+      await symlinkCodexSubscriptionAuthFile(plan, ctx.log).catch((err) => {
+        ctx.log(
+          `codex subscription auth.json link failed after mount: ${conciseError(err, plan.harness)}`,
+        );
+      });
+    }
+    return true;
+  }
+  // A false result means mountStorage stopped the attempt and CONFIRMED the path detached.
+  ctx.markCwdDetachConfirmed();
+  return false;
+}
+
+/** Mount the agent home on the local host, then run the guidance. Returns whether it is live. */
+export async function mountLocalAgentCwd(
+  ctx: AcquireContext,
+  deps: MountDeps,
+): Promise<boolean> {
+  const plan = ctx.plan;
+  const creds = ctx.env.agentMountCreds;
+  if (!creds || plan.isDaytona) return false;
+  const mountPath = agentMountPath(plan.workspace.cwd);
+  if (ctx.env.agentMountedPath === mountPath) return true;
+  try {
+    mkdirSync(mountPath, { recursive: true });
+    if (
+      !(await (deps.mountStorage ?? mountStorage)(mountPath, creds, {
+        log: ctx.log,
+      }))
+    ) {
+      // false means mountStorage confirmed detach is safe. This path is a sibling of the session
+      // cwd, so workspace cleanup cannot remove the failed mountpoint stub.
+      rmSync(mountPath, { recursive: true, force: true });
+      return false;
+    }
+    ctx.commitLocalMount("agent", mountPath, creds);
+    await seedAgentReadme(mountPath, { log: ctx.log });
+    await linkAgentFiles(plan.workspace.cwd, mountPath, { log: ctx.log });
+    await activateAgentMountGuidance(ctx, deps);
+    return true;
+  } catch (err) {
+    // INVARIANT 1's escape hatch. `activateAgentMountGuidance` runs INSIDE this try, so without
+    // this line an ordering violation would be logged as an ordinary mount failure and the run
+    // would continue with a harness that cannot see its durable storage. This is the exact defect
+    // the external review found in revision 1 of the contract.
+    rethrowIfInvariant(err);
+    ctx.log(
+      `local agent mount failed artifact=${ctx.artifactId}: ${conciseError(err, plan.harness)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Re-sign the agent mount credential and remount.
+ *
+ * INVARIANT 2: the fresh credential is committed BEFORE the remount is known to have succeeded.
+ * That is current behavior, preserved deliberately for this split.
+ */
+export async function reSignAndRemountLocalAgentMount(
+  ctx: AcquireContext,
+  deps: MountDeps,
+): Promise<boolean> {
+  const plan = ctx.plan;
+  if (!ctx.artifactId || !ctx.runCred || plan.isDaytona) return false;
+  if (!ctx.takeRemountBudget("agent")) {
+    ctx.log(
+      `local agent mount ENOTCONN remount limit reached artifact=${ctx.artifactId} path=${agentMountPath(plan.workspace.cwd)}`,
+    );
+    return false;
+  }
+  ctx.log(
+    `local agent mount ENOTCONN artifact=${ctx.artifactId}; re-signing and remounting`,
+  );
+  const fresh = await deps.signAgentMount(ctx.artifactId, {
+    apiBase: apiBase(),
+    authorization: ctx.runCred,
+    log: ctx.log,
+  });
+  if (!fresh) {
+    // The signer handles its own null, which is why `recordResignedCredential` stays total.
+    ctx.log(
+      `local agent mount re-sign returned no credentials artifact=${ctx.artifactId}`,
+    );
+    return false;
+  }
+  ctx.recordResignedCredential("agent", fresh);
+  // Clear the marker so `mountLocalAgentCwd` remounts instead of short-circuiting on its
+  // path-identity check.
+  ctx.clearMountPath("agent");
+  return mountLocalAgentCwd(ctx, deps);
+}
+
+/**
+ * Re-sign the durable cwd credential and remount.
+ *
+ * INVARIANT 2 again, with the caveat the review corrected: if the remount below FAILS, the
+ * environment keeps the fresh credential while `mountedCwd` stays pointed at the previous
+ * successful mount. The two disagree until the next successful remount. Preserved as-is.
+ */
+export async function reSignAndRemountLocalCwd(
+  ctx: AcquireContext,
+  deps: MountDeps,
+): Promise<boolean> {
+  const plan = ctx.plan;
+  if (!ctx.sessionForMount || !ctx.runCred || plan.isDaytona) return false;
+  if (!ctx.takeRemountBudget("cwd")) {
+    ctx.log(
+      `local durable cwd ENOTCONN remount limit reached session=${ctx.sessionForMount} cwd=${plan.workspace.cwd}`,
+    );
+    return false;
+  }
+  ctx.log(
+    `local durable cwd ENOTCONN session=${ctx.sessionForMount} cwd=${plan.workspace.cwd}; re-signing and remounting`,
+  );
+  const fresh = await deps.signMount(ctx.sessionForMount, {
+    apiBase: apiBase(),
+    authorization: ctx.runCred,
+    log: ctx.log,
+  });
+  if (!fresh) {
+    ctx.log(
+      `local durable cwd re-sign returned no credentials session=${ctx.sessionForMount}`,
+    );
+    return false;
+  }
+  ctx.recordResignedCredential("cwd", fresh);
+  return mountLocalDurableCwd(ctx, deps, "enotconn-retry");
+}
+
+/**
+ * React to an ENOTCONN seen in an ACP event by remounting every eligible local mount.
+ *
+ * Synchronous by design: it starts the remount and stores the promise, so the event handler is
+ * never blocked. Teardown awaits `runtimeRemount` FIRST, which is what stops a remount from
+ * landing against a half-torn-down environment.
+ */
+export function remountLocalCwdAfterRuntimeEnotconn(
+  ctx: AcquireContext,
+  deps: MountDeps,
+  event: unknown,
+): void {
+  const plan = ctx.plan;
+  if (plan.isDaytona) return;
+  // The event cannot say which mount broke; remount every eligible one (alive mounts no-op).
+  const cwdEligible = !!ctx.env.mountCreds && !!ctx.env.mountedCwd;
+  const agentEligible = !!ctx.env.agentMountCreds && !!ctx.env.agentMountedPath;
+  if (!cwdEligible && !agentEligible) return;
+  if (ctx.env.runtimeRemount || !containsTransportEndpointDisconnected(event))
+    return;
+  ctx.log(
+    `local durable mount ENOTCONN observed in ACP event session=${ctx.sessionForMount} cwd=${plan.workspace.cwd}; re-signing and remounting`,
+  );
+  ctx.setRuntimeRemount(
+    (async () => {
+      const cwdOk = cwdEligible ? await reSignAndRemountLocalCwd(ctx, deps) : true;
+      const agentOk = agentEligible
+        ? await reSignAndRemountLocalAgentMount(ctx, deps)
+        : true;
+      return cwdOk && agentOk;
+    })().catch((err) => {
+      // No `rethrowIfInvariant` here: this is a detached promise, so a rethrow would become an
+      // unhandled rejection rather than failing the acquisition. An ordering violation cannot
+      // reach this path anyway — the daemon env is long frozen by the time an ACP event arrives.
+      ctx.log(
+        `local durable mount runtime remount failed session=${ctx.sessionForMount}: ${conciseError(err, plan.harness)}`,
+      );
+      return false;
+    }),
+  );
+}

--- a/services/runner/src/environment/runtime-lifecycle.ts
+++ b/services/runner/src/environment/runtime-lifecycle.ts
@@ -1,0 +1,235 @@
+/**
+ * `RuntimeLifecycle` — the agent daemon and the runner-owned files that live beside it.
+ *
+ * LIFECYCLE MIGRATION, STEP 5 (S7b). This unit owns the four handles nothing else owns:
+ * the loopback tool-MCP server, the OTLP bearer file, the Codex SQLite home, and the per-run
+ * agent directory. It also owns the two teardown steps that must run FIRST.
+ *
+ * ============================================================================================
+ * WHY THIS UNIT IS SMALL, AND WHY THAT IS THE HONEST ANSWER
+ * ============================================================================================
+ *
+ * The lifecycle design gives the runtime a large role: `bootstrap`, `reconfigure`, `restart`. It
+ * has none of that here, because the runner cannot do any of it yet. The daemon environment is
+ * built ONCE, before the sandbox starts, and is immutable afterwards (see `AcquireContext`'s
+ * invariant 1). There is no restart path and no credential refresh.
+ *
+ * So this unit is the runtime's TEARDOWN and its file handles, and nothing more. Inventing a
+ * `restart()` that throws would suggest the seam exists; leaving it out says plainly that it does
+ * not. Step 8 of the migration is where a real runtime reconfigure gets designed.
+ *
+ * ============================================================================================
+ * TEARDOWN ORDERING IS LOAD-BEARING
+ * ============================================================================================
+ *
+ * `teardownInFlight` must run BEFORE anything else in destroy, for two independent reasons:
+ *
+ *  1. `runtimeRemount` may be an in-flight mount operation. Tearing the environment down under it
+ *     would let a remount land against half-freed state.
+ *  2. The tool relay and the loopback MCP server can both have a `tools/call` in flight. Aborting
+ *     them before the server closes is what stops a handler writing a result after the turn ended.
+ *
+ * The composer sequences this. The unit only guarantees it never throws.
+ */
+import { rmSync } from "node:fs";
+
+import { configureDaytonaCodexEnv } from "../engines/sandbox_agent/codex-assets.ts";
+import { buildDaemonEnv } from "../engines/sandbox_agent/daemon.ts";
+import {
+  buildPiExtensionEnv,
+  configurePiSessionWorkspace,
+  configurePiSkillSnapshot,
+  writeOtlpAuthFile,
+} from "../engines/sandbox_agent/pi-assets.ts";
+import { applyClaudeConnectionEnv } from "../engines/sandbox_agent/runtime-policy.ts";
+import type { Log } from "./timing.ts";
+
+/** The handles this unit tears down. All optional: a partial acquire leaves most unset. */
+export interface RuntimeTeardownInput {
+  /** An in-flight remount promise. Awaited first, and its failure is ignored. */
+  runtimeRemount: Promise<unknown> | undefined;
+  /** The current turn's tool relay, if a turn is running. */
+  toolRelay: { stop: () => Promise<unknown> } | undefined;
+  /** Aborts any in-flight loopback `tools/call`. */
+  mcpAbort: { abort: () => void };
+  /** Closes the internal gateway-tool MCP server, when one started. */
+  closeToolMcp: (() => Promise<unknown>) | undefined;
+}
+
+/**
+ * Quiesce everything that could still be running, in order.
+ *
+ * Every step swallows its own failure. Teardown must always reach the end: a throw here would
+ * strand a sandbox, a mount, or both.
+ */
+export async function teardownInFlight(
+  input: RuntimeTeardownInput,
+): Promise<void> {
+  await input.runtimeRemount?.catch(() => {});
+  await input.toolRelay?.stop().catch(() => {});
+  // Backstop: destroy any in-flight loopback `tools/call` before closing the server, so a
+  // handler cannot write a result after the turn has ended.
+  input.mcpAbort.abort();
+  await input.closeToolMcp?.().catch(() => {});
+}
+
+/** The runner-owned paths this unit removes at teardown. */
+export interface RuntimeFilesInput {
+  /**
+   * The per-run Agenta agent dir (skills isolation). Throwaway by construction.
+   *
+   * It is ALWAYS a temp dir when set: a subscription run leaves it undefined precisely so that
+   * the operator's mounted login — which the harness runs out of directly — is never deleted
+   * here. Deleting an operator mount would destroy a real credential.
+   */
+  runAgentDir: string | undefined;
+  /**
+   * The OTLP bearer file. The Pi extension deletes it on read; this is the backstop for a
+   * harness that never started or crashed before reading it, so the bearer never lingers.
+   */
+  otlpAuthFilePath: string | undefined;
+  /**
+   * The local off-mount Codex SQLite home. Disposable: native resume rides the `sessions/`
+   * rollout files on CODEX_HOME, not the SQLite, so losing it costs nothing.
+   */
+  codexSqliteHome: string | undefined;
+}
+
+/**
+ * Remove the runner-owned files.
+ *
+ * NO CODEX `auth.json` BACKSTOP, deliberately. Managed auth is file-free, so no file exists. The
+ * subscription symlink is left in the runner-owned home on purpose: it points at the operator's
+ * mount, it is not a secret, and it is correct for the next resume. The old managed-file backstop
+ * was also ordering-buggy — it ran AFTER `unmountStorage`, so on a local durable session it
+ * deleted nothing and stranded the key in the store.
+ */
+export function removeRuntimeFiles(input: RuntimeFilesInput): void {
+  if (input.runAgentDir)
+    rmSync(input.runAgentDir, { recursive: true, force: true });
+  if (input.otlpAuthFilePath) rmSync(input.otlpAuthFilePath, { force: true });
+  if (input.codexSqliteHome)
+    rmSync(input.codexSqliteHome, { recursive: true, force: true });
+}
+
+/**
+ * ============================================================================================
+ * BOOTSTRAP: building the daemon environment
+ * ============================================================================================
+ *
+ * This is the part of `prepareEnvironmentSetup` that was never planning. It BUILDS two
+ * environment maps and WRITES one file, so it belongs to the runtime rather than to the planner.
+ * Moving it here is what lets `environment-setup.ts` become what its name claims.
+ *
+ * THE OUTPUT IS THE DAEMON'S WHOLE WORLD, and it is immutable once the provider takes it. See
+ * `AcquireContext`'s invariant 1: after `buildSandboxProvider` the maps are frozen, so everything
+ * the daemon will ever know has to be in place before that call.
+ */
+export interface BuildRuntimeEnvironmentInput {
+  plan: never;
+  request: never;
+  piSkillSnapshot: unknown;
+  log: Log;
+  deps: { buildDaemonEnv?: typeof buildDaemonEnv };
+}
+
+export interface RuntimeEnvironment {
+  /** The daemon process environment. Taken BY REFERENCE by the sandbox provider. */
+  env: Record<string, string>;
+  /** The Pi extension environment. Also taken by reference; Daytona builds its provider from it. */
+  piExtEnv: Record<string, string>;
+  /** Where Pi writes native transcripts, or undefined for a non-Pi run. */
+  piSessionDir: string | undefined;
+  /** The 0600 file holding the OTLP bearer, or undefined when there is none to write. */
+  otlpAuthFilePath: string | undefined;
+}
+
+/**
+ * Build the daemon and extension environments, and write the OTLP bearer file.
+ *
+ * ONE ORDERING RULE INSIDE: `Object.assign(env, piExtEnv)` comes LAST. The local daemon inherits
+ * the extension env that way, while Daytona receives the same values through its own `envVars`.
+ * Assigning earlier would drop every key the Pi and Codex configuration adds after it.
+ *
+ * THE OTLP BEARER RIDES A FILE, NEVER AN ENV VAR. The daemon environment is inherited by the
+ * harness process, so a prompt-injected sandbox could read and echo a plain env var holding the
+ * caller's reusable bearer. Only the PATH goes into the env; the extension reads the file once
+ * and deletes it, and `removeRuntimeFiles` above is the backstop for a harness that never ran.
+ */
+export function buildRuntimeEnvironment(
+  input: BuildRuntimeEnvironmentInput,
+): RuntimeEnvironment {
+  const plan = input.plan as never as Record<string, never>;
+  const request = input.request as never as Record<string, never>;
+  const p = plan as unknown as {
+    acpAgent: string;
+    isPi: boolean;
+    isDaytona: boolean;
+    credentials: { credentialMode: string; modelEnvironment: Record<string, string> };
+    workspace: {
+      relayDir: string;
+      usageOutPath: string;
+      skillDirs: Array<{ name: string }>;
+    };
+    tools: { builtinGatingActive: boolean };
+  };
+  const r = request as unknown as {
+    modelConnection?: { provider?: string; deployment?: string };
+    telemetry?: {
+      exporters?: { otlp?: { headers?: { authorization?: string } } };
+    };
+  };
+
+  // Only runtime_provided keeps the inherited keys: the harness uses its own login there.
+  const clearProviderEnv =
+    p.credentials.credentialMode === "env" ||
+    p.credentials.credentialMode === "none";
+  const env = (input.deps.buildDaemonEnv ?? buildDaemonEnv)(
+    p.acpAgent as never,
+    {
+      clearProviderEnv,
+      provider: r.modelConnection?.provider,
+      deployment: r.modelConnection?.deployment,
+    },
+  );
+  // Apply only the resolved provider keys.
+  Object.assign(env, p.credentials.modelEnvironment);
+  applyClaudeConnectionEnv(env, input.request, p.acpAgent as never, input.log);
+  const piSessionDir = configurePiSessionWorkspace(input.plan, env);
+  configurePiSkillSnapshot(input.piSkillSnapshot as never, env);
+
+  // Pi self-instruments locally: the trace context and public tool metadata reach Pi through the
+  // Agenta extension. Tool execution always relays back to this runner, which keeps private
+  // specs, scoped env, callback endpoints, and callback auth in runner memory.
+  const otlpAuthFilePath =
+    p.isPi && !p.isDaytona ? `${p.workspace.relayDir}.otlp-auth` : undefined;
+  const otlpAuthorization = r.telemetry?.exporters?.otlp?.headers?.authorization;
+  if (otlpAuthFilePath && otlpAuthorization) {
+    writeOtlpAuthFile(otlpAuthFilePath, otlpAuthorization, input.log);
+  }
+
+  const piExtEnv: Record<string, string> = p.isPi
+    ? buildPiExtensionEnv(input.request, !p.isDaytona, {
+        relayDir: p.workspace.relayDir,
+        usageOutPath: p.workspace.usageOutPath,
+        otlpAuthFilePath,
+        builtinGatingActive: p.tools.builtinGatingActive,
+        // The materialized skill names (author plus forced `_agenta.*`) so Pi's own agent span
+        // records which skills loaded.
+        skills: p.workspace.skillDirs.map((s) => s.name),
+      })
+    : {};
+  // Daytona builds its provider from `piExtEnv` rather than the local daemon env, so the
+  // transcript location has to sit in BOTH slices or Pi and pi-acp disagree about the path.
+  if (piSessionDir) piExtEnv.PI_CODING_AGENT_SESSION_DIR = piSessionDir;
+  configurePiSkillSnapshot(input.piSkillSnapshot as never, piExtEnv);
+  // Managed Daytona Codex: CODEX_HOME stays on the durable cwd (native resume rides its
+  // `sessions/` rollouts) while CODEX_SQLITE_HOME points in-VM, off the mount. Set here because
+  // the Daytona daemon env is fixed at sandbox creation and is built from `piExtEnv`.
+  configureDaytonaCodexEnv(input.plan, piExtEnv);
+  // LAST, deliberately: the local daemon inherits the extension env, and Daytona gets the same
+  // values through `envVars`. Assigning earlier would drop every key added above.
+  Object.assign(env, piExtEnv);
+
+  return { env, piExtEnv, piSessionDir, otlpAuthFilePath };
+}

--- a/services/runner/src/environment/runtime-lifecycle.ts
+++ b/services/runner/src/environment/runtime-lifecycle.ts
@@ -42,6 +42,8 @@ import {
   writeOtlpAuthFile,
 } from "../engines/sandbox_agent/pi-assets.ts";
 import { applyClaudeConnectionEnv } from "../engines/sandbox_agent/runtime-policy.ts";
+import type { AgentRunRequest } from "../protocol.ts";
+import type { RunPlan } from "../engines/sandbox_agent/run-plan.ts";
 import type { Log } from "./timing.ts";
 
 /** The handles this unit tears down. All optional: a partial acquire leaves most unset. */
@@ -105,11 +107,22 @@ export interface RuntimeFilesInput {
  * deleted nothing and stranded the key in the store.
  */
 export function removeRuntimeFiles(input: RuntimeFilesInput): void {
-  if (input.runAgentDir)
-    rmSync(input.runAgentDir, { recursive: true, force: true });
-  if (input.otlpAuthFilePath) rmSync(input.otlpAuthFilePath, { force: true });
-  if (input.codexSqliteHome)
-    rmSync(input.codexSqliteHome, { recursive: true, force: true });
+  // `force: true` suppresses ENOENT and nothing else. A per-run dir under a stale FUSE node can
+  // still fail with EACCES, EBUSY or ENOTCONN, and `destroy` runs this BEFORE the skills cleanup,
+  // so one unlucky unlink used to leak the skills temp root and reject a teardown that promises
+  // never to throw. Each removal is independent, so one failure must not skip the next.
+  for (const [path, recursive] of [
+    [input.runAgentDir, true],
+    [input.otlpAuthFilePath, false],
+    [input.codexSqliteHome, true],
+  ] as const) {
+    if (!path) continue;
+    try {
+      rmSync(path, { recursive, force: true });
+    } catch {
+      // best-effort cleanup of a runner-owned file
+    }
+  }
 }
 
 /**
@@ -126,8 +139,17 @@ export function removeRuntimeFiles(input: RuntimeFilesInput): void {
  * the daemon will ever know has to be in place before that call.
  */
 export interface BuildRuntimeEnvironmentInput {
-  plan: never;
-  request: never;
+  /**
+   * The real types, not `never`.
+   *
+   * These were `never` with `as never` casts at the call site, which meant `tsc --strict` checked
+   * nothing across this module boundary: a renamed field in `RunPlan` or `AgentRunRequest` would
+   * compile on both sides and fail at run time. The structural aliases inside the function were
+   * the same hole in a second place, describing a shape the compiler never compared to the source
+   * of truth.
+   */
+  plan: RunPlan;
+  request: AgentRunRequest;
   piSkillSnapshot: unknown;
   log: Log;
   deps: { buildDaemonEnv?: typeof buildDaemonEnv };
@@ -159,26 +181,8 @@ export interface RuntimeEnvironment {
 export function buildRuntimeEnvironment(
   input: BuildRuntimeEnvironmentInput,
 ): RuntimeEnvironment {
-  const plan = input.plan as never as Record<string, never>;
-  const request = input.request as never as Record<string, never>;
-  const p = plan as unknown as {
-    acpAgent: string;
-    isPi: boolean;
-    isDaytona: boolean;
-    credentials: { credentialMode: string; modelEnvironment: Record<string, string> };
-    workspace: {
-      relayDir: string;
-      usageOutPath: string;
-      skillDirs: Array<{ name: string }>;
-    };
-    tools: { builtinGatingActive: boolean };
-  };
-  const r = request as unknown as {
-    modelConnection?: { provider?: string; deployment?: string };
-    telemetry?: {
-      exporters?: { otlp?: { headers?: { authorization?: string } } };
-    };
-  };
+  const p = input.plan;
+  const r = input.request;
 
   // Only runtime_provided keeps the inherited keys: the harness uses its own login there.
   const clearProviderEnv =
@@ -216,7 +220,7 @@ export function buildRuntimeEnvironment(
         builtinGatingActive: p.tools.builtinGatingActive,
         // The materialized skill names (author plus forced `_agenta.*`) so Pi's own agent span
         // records which skills loaded.
-        skills: p.workspace.skillDirs.map((s) => s.name),
+        skills: p.workspace.skillDirs.map((skill) => skill.name),
       })
     : {};
   // Daytona builds its provider from `piExtEnv` rather than the local daemon env, so the

--- a/services/runner/tests/unit/acquire-context.test.ts
+++ b/services/runner/tests/unit/acquire-context.test.ts
@@ -1,0 +1,324 @@
+/**
+ * `AcquireContext` seam tests (lifecycle migration, step 5 / S7b).
+ *
+ * An external security review REJECTED revision 1 of the type with the summary "it does not
+ * enforce what its comments promise". These tests are the proof that revision 2 does. Each
+ * `describe` block below maps to one review finding, and every one of them FAILS against
+ * revision 1's shape.
+ *
+ * Run: pnpm exec vitest run tests/unit/acquire-context.test.ts
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  AcquireInvariantError,
+  rethrowIfInvariant,
+} from "../../src/environment/acquire-context.ts";
+import { createAcquireContext } from "../../src/environment/acquire-context-impl.ts";
+import type { SessionEnvironment } from "../../src/engines/sandbox_agent/runtime-contracts.ts";
+import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
+
+const CREDS = (expiresAt: string | undefined): MountCredentials =>
+  ({
+    region: "us-east-1",
+    bucket: "b",
+    prefix: "p",
+    accessKey: "AK",
+    secretKey: "SK",
+    expiresAt,
+  }) as MountCredentials;
+
+function makeContext() {
+  const environment = {
+    sandbox: undefined,
+    session: undefined,
+    sessionId: "sess-1",
+    mountCreds: null,
+    agentMountCreds: undefined,
+    mountedCwd: undefined,
+    agentMountedPath: undefined,
+    runAgentDir: undefined,
+    durableCwdSafeToDelete: false,
+    runtimeRemount: undefined,
+    otlpAuthFilePath: undefined,
+    codexSqliteHome: undefined,
+    closeToolMcp: undefined,
+    installedMountExpiries: {} as Record<string, number | undefined>,
+  } as unknown as SessionEnvironment;
+
+  const env: Record<string, string> = {};
+  const piExtEnv: Record<string, string> = {};
+  const plan = {
+    prompt: { appendSystemPrompt: undefined, hasSystemPrompt: false },
+  } as never;
+
+  const handle = createAcquireContext({
+    environment,
+    plan,
+    env,
+    piExtEnv,
+    sessionForMount: "sess-1",
+    artifactId: "art-1",
+    runCred: "ApiKey k",
+    log: () => {},
+    timingLog: () => {},
+    remountLimit: 2,
+    combineAppendSystemPrompt: (existing, segment) =>
+      existing ? `${existing}\n${segment}` : segment,
+    reprepareLocalPiAssets: () => "/tmp/re-prepared-agent-dir",
+  });
+
+  return { ...handle, environment, env, piExtEnv, plan };
+}
+
+describe("FINDING 1: the environment is a read-only projection, not a readonly reference", () => {
+  it("exposes only reads, and the mutable environment never leaves the module", () => {
+    const { context, mutableEnvironment } = makeContext();
+    // The view is a distinct object. Revision 1 handed out `environment` itself, so a unit could
+    // assign any writable field and the whole ownership table was documentation.
+    assert.notStrictEqual(
+      context.env as unknown,
+      mutableEnvironment as unknown,
+      "the context must not expose the mutable environment",
+    );
+  });
+
+  it("the view has no writer for any owned field", () => {
+    const { context } = makeContext();
+    // Structural proof: assigning through the view cannot compile, and at runtime the getter-only
+    // property refuses the write. Both directions matter; a silent no-op would be worse.
+    assert.throws(
+      () => {
+        "use strict";
+        (context.env as unknown as Record<string, unknown>).mountedCwd = "/hack";
+      },
+      /only a getter|Cannot set/,
+    );
+  });
+
+  it("reads through, so a committed change is visible at once", () => {
+    // Getters, not a snapshot. The closure this replaces shared one object, so a unit that reads
+    // after another unit committed must see the new value.
+    const { context } = makeContext();
+    assert.equal(context.env.mountedCwd, undefined);
+    context.commitLocalMount("cwd", "/run/cwd", CREDS(undefined));
+    assert.equal(context.env.mountedCwd, "/run/cwd");
+  });
+});
+
+describe("FINDING 2: the freeze throw escapes an operational catch", () => {
+  it("writes to both env maps before the freeze", () => {
+    const { context, env, piExtEnv } = makeContext();
+    context.writeDaemonEnv("AGENT_MOUNT", "/mnt/agent");
+    assert.equal(env.AGENT_MOUNT, "/mnt/agent");
+    assert.equal(
+      piExtEnv.AGENT_MOUNT,
+      "/mnt/agent",
+      "both maps are written together or the extension and the daemon disagree",
+    );
+  });
+
+  it("throws AcquireInvariantError after the freeze, not a plain Error", () => {
+    const { context } = makeContext();
+    context.freezeDaemonEnv();
+    assert.throws(
+      () => context.writeDaemonEnv("AGENT_MOUNT", "/mnt/agent"),
+      (err: unknown) =>
+        err instanceof AcquireInvariantError &&
+        err.invariant === "local-mounts-before-provider-freeze",
+    );
+  });
+
+  it("survives the broad catch that would have swallowed revision 1's plain Error", () => {
+    // This is the exact shape of `mountLocalAgentCwd` at environment.ts:478: a wide try/catch
+    // that logs and returns false. Revision 1's plain Error died here silently.
+    const { context } = makeContext();
+    context.freezeDaemonEnv();
+
+    const mountLikeHelper = (): boolean => {
+      try {
+        context.writeDaemonEnv("AGENT_MOUNT", "/mnt/agent");
+        return true;
+      } catch (err) {
+        rethrowIfInvariant(err); // the one line every operational catch must start with
+        return false; // ordinary operational failure: log and continue
+      }
+    };
+
+    assert.throws(mountLikeHelper, AcquireInvariantError);
+  });
+
+  it("still lets an ORDINARY failure be swallowed, which is the whole distinction", () => {
+    const operationalHelper = (): boolean => {
+      try {
+        throw new Error("geesefs mount failed");
+      } catch (err) {
+        rethrowIfInvariant(err);
+        return false;
+      }
+    };
+    assert.equal(
+      operationalHelper(),
+      false,
+      "a mount failure is operational and must stay logged-and-continue",
+    );
+  });
+
+  it("freezing is idempotent", () => {
+    const { context } = makeContext();
+    context.freezeDaemonEnv();
+    context.freezeDaemonEnv();
+    assert.equal(context.envFrozen, true);
+  });
+});
+
+describe("FINDING 3: Daytona records an expiry WITHOUT a path", () => {
+  it("commitLocalMount writes path and expiry together", () => {
+    const { context, environment } = makeContext();
+    context.commitLocalMount("cwd", "/run/cwd", CREDS("2026-01-01T00:00:00Z"));
+    assert.equal(context.env.mountedCwd, "/run/cwd");
+    assert.ok(environment.installedMountExpiries.cwd);
+  });
+
+  it("commitRemoteMountExpiry records the expiry and leaves mountedCwd UNSET", () => {
+    // The real Daytona behavior (environment.ts:768-772). Setting a path here would make
+    // teardown try to unmount a host path that never existed.
+    const { context, environment } = makeContext();
+    context.commitRemoteMountExpiry("cwd", CREDS("2026-01-01T00:00:00Z"));
+    assert.ok(environment.installedMountExpiries.cwd);
+    assert.equal(
+      context.env.mountedCwd,
+      undefined,
+      "a Daytona mount has no host mountpoint to unmount",
+    );
+  });
+
+  it("the expiry comes from the credential PASSED, not from the environment", () => {
+    // INVARIANT 3. Passing the credential explicitly is what proves the recorded lease belongs
+    // to the mount that actually happened, rather than to one that was merely signed.
+    const { context, environment } = makeContext();
+    context.recordResignedCredential("cwd", CREDS("2030-01-01T00:00:00Z"));
+    context.commitLocalMount("cwd", "/run/cwd", CREDS("2026-01-01T00:00:00Z"));
+    const mounted = Date.parse("2026-01-01T00:00:00Z");
+    assert.equal(environment.installedMountExpiries.cwd, mounted);
+  });
+});
+
+describe("FINDING 4: durableCwdSafeToDelete has three named transitions", () => {
+  it("begin -> false, detach-confirmed -> true, unmount-result -> the result", () => {
+    const { context } = makeContext();
+    context.markCwdDetachConfirmed();
+    assert.equal(context.env.durableCwdSafeToDelete, true);
+
+    context.beginCwdMount();
+    assert.equal(
+      context.env.durableCwdSafeToDelete,
+      false,
+      "a mount is starting, so the path may be live and must not be deleted",
+    );
+
+    context.markCwdDetachConfirmed();
+    assert.equal(context.env.durableCwdSafeToDelete, true);
+
+    context.recordCwdUnmountResult(false);
+    assert.equal(
+      context.env.durableCwdSafeToDelete,
+      false,
+      "teardown's unmount was not confirmed, so the recursive delete must be skipped",
+    );
+    context.recordCwdUnmountResult(true);
+    assert.equal(context.env.durableCwdSafeToDelete, true);
+  });
+});
+
+describe("FINDING 5 and INVARIANT 2: credentials and the re-sign path", () => {
+  it("recordResignedCredential is the only writer of both credential fields", () => {
+    const { context, environment } = makeContext();
+    const fresh = CREDS("2030-01-01T00:00:00Z");
+    context.recordResignedCredential("cwd", fresh);
+    assert.strictEqual(environment.mountCreds, fresh);
+    context.recordResignedCredential("agent", fresh);
+    assert.strictEqual(environment.agentMountCreds, fresh);
+  });
+
+  it("PRESERVED: a failed cwd remount can leave mountedCwd set while the credential is new", () => {
+    // The behavior revision 1 described WRONGLY and the reviewer corrected. It is preserved for
+    // this split, and pinned here so it is not rediscovered as a surprise later.
+    const { context, environment } = makeContext();
+    context.commitLocalMount("cwd", "/run/cwd", CREDS("2026-01-01T00:00:00Z"));
+
+    // A re-sign lands, then the remount fails: the mount helper returns without clearing the path.
+    const fresh = CREDS("2030-01-01T00:00:00Z");
+    context.recordResignedCredential("cwd", fresh);
+    context.beginCwdMount();
+
+    assert.strictEqual(environment.mountCreds, fresh, "the new credential is committed");
+    assert.equal(
+      context.env.mountedCwd,
+      "/run/cwd",
+      "and the OLD path is still set: the two disagree until the next successful remount",
+    );
+  });
+
+  it("the agent re-sign clears its path so the remount does not short-circuit", () => {
+    const { context } = makeContext();
+    context.commitLocalMount("agent", "/mnt/agent", CREDS(undefined));
+    context.clearMountPath("agent");
+    assert.equal(context.env.agentMountedPath, undefined);
+  });
+});
+
+describe("the plan mutation is narrow, and the budgets are per acquire", () => {
+  it("appendAgentMountGuidance is the only plan writer, and it appends", () => {
+    const { context, plan } = makeContext();
+    context.appendAgentMountGuidance("DURABLE STORAGE");
+    assert.equal(
+      (plan as { prompt: { appendSystemPrompt?: string } }).prompt.appendSystemPrompt,
+      "DURABLE STORAGE",
+    );
+    assert.equal(
+      (plan as { prompt: { hasSystemPrompt: boolean } }).prompt.hasSystemPrompt,
+      true,
+    );
+    context.appendAgentMountGuidance("SECOND");
+    assert.match(
+      (plan as { prompt: { appendSystemPrompt?: string } }).prompt
+        .appendSystemPrompt as string,
+      /DURABLE STORAGE\nSECOND/,
+      "it appends, which is exactly why the guidance is guarded by a one-shot flag",
+    );
+  });
+
+  it("the guidance flag is one-shot", () => {
+    const { context } = makeContext();
+    assert.equal(context.guidanceActive, false);
+    context.markGuidanceActive();
+    assert.equal(context.guidanceActive, true);
+  });
+
+  it("each mount kind has its own budget, and both are bounded", () => {
+    const { context } = makeContext(); // remountLimit: 2
+    assert.equal(context.takeRemountBudget("cwd"), true);
+    assert.equal(context.takeRemountBudget("cwd"), true);
+    assert.equal(
+      context.takeRemountBudget("cwd"),
+      false,
+      "an ENOTCONN storm must not be able to re-sign forever",
+    );
+    assert.equal(
+      context.takeRemountBudget("agent"),
+      true,
+      "the agent budget is independent of the cwd budget",
+    );
+  });
+
+  it("the budget is shared across every retry path for one kind", () => {
+    // Including the runtime-event remount. That is why that path cannot later grow its own
+    // budget without reopening the loop this bound closes.
+    const { context } = makeContext();
+    context.takeRemountBudget("cwd");
+    context.takeRemountBudget("cwd");
+    assert.equal(context.takeRemountBudget("cwd"), false);
+  });
+});

--- a/services/runner/tests/unit/environment-units.test.ts
+++ b/services/runner/tests/unit/environment-units.test.ts
@@ -32,10 +32,23 @@ const STAGE_EMITTERS = [
   "engines/sandbox_agent/environment-setup.ts",
   "environment/sandbox-lifecycle.ts",
   "environment/workspace-manager.ts",
+  "environment/mount-lifecycle.ts",
+  "environment/harness-session-lifecycle.ts",
+  "environment/runtime-lifecycle.ts",
   "environment/timing.ts",
 ];
 
 const ALL_STAGE_SOURCE = () => STAGE_EMITTERS.map(SRC).join("\n");
+
+/**
+ * Strip block and line comments, so a source assertion checks CODE and not prose.
+ *
+ * These units are heavily commented on purpose, and the prose legitimately uses the same words
+ * the assertions forbid in code. A check that cannot tell the two apart would either fail on a
+ * comment or be loosened until it proves nothing.
+ */
+const CODE_ONLY = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
 
 describe("timing: the stage names are a public interface", () => {
   it("emits the documented line shape", () => {
@@ -227,5 +240,195 @@ describe("the composer delegates instead of inlining", () => {
       !source.includes("`[timing] stage="),
       "the line shape must live in one place",
     );
+  });
+});
+
+describe("mount unit: the seam (lifecycle migration, step 5 / S7b)", () => {
+  it("the six helpers left environment.ts", () => {
+    // They were mutually recursive closures over `acquireEnvironment`'s scope. The composer now
+    // holds thin adapters that pass `ctx`; the bodies live in the unit.
+    const source = SRC("engines/sandbox_agent/environment.ts");
+    for (const marker of [
+      "let agentMountGuidanceActive",
+      "let localAgentMountEnotconnRemounts",
+      "let localDurableCwdEnotconnRemounts",
+    ]) {
+      assert.ok(
+        !source.includes(marker),
+        `environment.ts still declares '${marker}'; that state belongs on the context`,
+      );
+    }
+  });
+
+  it("the unit captures nothing: every helper takes ctx as its first parameter", () => {
+    const source = SRC("environment/mount-lifecycle.ts");
+    for (const fn of [
+      "activateAgentMountGuidance",
+      "mountLocalDurableCwd",
+      "mountLocalAgentCwd",
+      "reSignAndRemountLocalAgentMount",
+      "reSignAndRemountLocalCwd",
+      "remountLocalCwdAfterRuntimeEnotconn",
+    ]) {
+      assert.ok(
+        source.includes(`function ${fn}(`),
+        `${fn} must be a top-level function in the unit`,
+      );
+    }
+    assert.equal(
+      source.split("ctx: AcquireContext").length - 1,
+      6,
+      "all six helpers take ctx; a captured variable would defeat the split",
+    );
+  });
+
+  it("the unit never touches the mutable environment or the raw env maps", () => {
+    // The structural half of the external review's first finding. A unit that could reach
+    // `environment.x = ...` would make the ownership table documentation again.
+    const source = CODE_ONLY(SRC("environment/mount-lifecycle.ts"));
+    assert.ok(!source.includes("environment."), "no direct environment access");
+    assert.ok(
+      !source.includes("piExtEnv"),
+      "the daemon env maps stay private to the context",
+    );
+  });
+
+  it("every operational catch rethrows an invariant violation first", () => {
+    // Without this the freeze throw dies in mountLocalAgentCwd's catch and the run continues
+    // with a harness that cannot see its durable storage.
+    const source = SRC("environment/mount-lifecycle.ts");
+    assert.ok(source.includes("catch (err)"), "the unit still has an operational catch");
+    assert.ok(
+      source.includes("rethrowIfInvariant(err)"),
+      "an operational catch must start with rethrowIfInvariant",
+    );
+  });
+
+  it("the composer freezes the daemon env BEFORE building the provider", () => {
+    // INVARIANT 1's enforcement point. `buildSandboxProvider` takes the env maps by reference.
+    const source = SRC("engines/sandbox_agent/environment.ts");
+    const freeze = source.indexOf("ctx.freezeDaemonEnv()");
+    const provider = source.indexOf("buildSandboxProvider)(");
+    assert.ok(freeze > 0, "the composer must freeze the daemon env");
+    assert.ok(provider > 0);
+    assert.ok(
+      freeze < provider,
+      "the freeze must come BEFORE the provider takes the env maps by reference",
+    );
+  });
+
+  it("the composer kept every call site it had before", () => {
+    // `reSignAndRemountLocalAgentMount` is absent on purpose: it was only ever reached from the
+    // ENOTCONN handler, so it is now internal to the unit.
+    const source = SRC("engines/sandbox_agent/environment.ts");
+    for (const call of [
+      'mountLocalDurableCwd("initial")',
+      "mountLocalAgentCwd()",
+      "activateAgentMountGuidance()",
+      "reSignAndRemountLocalCwd()",
+      "remountLocalCwdAfterRuntimeEnotconn",
+    ]) {
+      assert.ok(source.includes(call), `the composer lost its '${call}' call site`);
+    }
+  });
+
+  it("teardown records the cwd unmount through its named transition", () => {
+    const source = SRC("engines/sandbox_agent/environment.ts");
+    assert.ok(source.includes("ctx.recordCwdUnmountResult("));
+    assert.ok(
+      !source.includes("durableCwdSafeToDelete ="),
+      "durableCwdSafeToDelete must no longer be assigned directly",
+    );
+  });
+});
+
+describe("harness-session unit: the seam", () => {
+  it("owns both acquire stages and the session teardown", () => {
+    const source = SRC("environment/harness-session-lifecycle.ts");
+    assert.ok(source.includes('"probe_capabilities"'));
+    assert.ok(source.includes('"create_session"'));
+    assert.ok(source.includes("export async function teardown("));
+  });
+
+  it("keeps create_session as ONE stage with a mode field", () => {
+    const source = CODE_ONLY(SRC("environment/harness-session-lifecycle.ts"));
+    assert.ok(source.includes('" mode=load"'));
+    assert.ok(source.includes('" mode=create"'));
+  });
+
+  it("takes an explicit input rather than AcquireContext", () => {
+    // Deliberate: nothing here shares mutable state or calls a sibling, so threading the context
+    // through would imply a coupling that does not exist.
+    const source = CODE_ONLY(SRC("environment/harness-session-lifecycle.ts"));
+    assert.ok(!source.includes("AcquireContext"));
+  });
+
+  it("reports loadedFromContinuity WITHOUT claiming history replayed", () => {
+    // The comparison proves the adapter accepted the id, not that it replayed the turns. The
+    // caveat is in the type's doc comment so a reader cannot mistake one for the other.
+    const source = SRC("environment/harness-session-lifecycle.ts");
+    assert.ok(source.includes("It does NOT prove the adapter replayed the turns"));
+  });
+
+  it("the composer delegates both stages", () => {
+    const source = SRC("engines/sandbox_agent/environment.ts");
+    assert.ok(source.includes("await probeHarness("));
+    assert.ok(source.includes("await openHarnessSession("));
+    assert.ok(source.includes("await teardownHarnessSession("));
+  });
+});
+
+describe("runtime unit: the seam", () => {
+  it("owns the in-flight quiesce and the runner-owned files", () => {
+    const source = SRC("environment/runtime-lifecycle.ts");
+    assert.ok(source.includes("export async function teardownInFlight("));
+    assert.ok(source.includes("export function removeRuntimeFiles("));
+    assert.ok(source.includes("export function buildRuntimeEnvironment("));
+  });
+
+  it("declares NO restart or reconfigure, because neither exists yet", () => {
+    // The honest answer. Inventing a `restart()` that throws would suggest the seam is there.
+    const source = CODE_ONLY(SRC("environment/runtime-lifecycle.ts"));
+    assert.ok(!source.includes("export function restart"));
+    assert.ok(!source.includes("export async function restart"));
+    assert.ok(!source.includes("export function reconfigure"));
+  });
+
+  it("the composer quiesces BEFORE it removes the sandbox from the registry", () => {
+    // Ordering is load-bearing: an in-flight remount or `tools/call` must be stopped before
+    // anything else in destroy frees state under it.
+    const source = SRC("engines/sandbox_agent/environment.ts");
+    const quiesce = source.indexOf("teardownRuntimeInFlight(");
+    const registry = source.indexOf("inFlightSandboxes.delete(");
+    assert.ok(quiesce > 0 && registry > 0);
+    assert.ok(quiesce < registry, "the quiesce must come first");
+  });
+
+  it("the composer removes runner files through the unit", () => {
+    const source = SRC("engines/sandbox_agent/environment.ts");
+    assert.ok(source.includes("removeRuntimeFiles({"));
+  });
+});
+
+describe("environment-setup is a planner again", () => {
+  it("no longer builds the daemon environment or writes the OTLP bearer", () => {
+    // The purification. These were never planning: they build two env maps and write a file.
+    const source = CODE_ONLY(SRC("engines/sandbox_agent/environment-setup.ts"));
+    for (const marker of [
+      "buildDaemonEnv)(",
+      "writeOtlpAuthFile(",
+      "buildPiExtensionEnv(",
+      "configureDaytonaCodexEnv(",
+    ]) {
+      assert.ok(
+        !source.includes(marker),
+        `environment-setup still performs '${marker}'; it belongs to the runtime unit`,
+      );
+    }
+  });
+
+  it("delegates to the runtime unit instead", () => {
+    const source = SRC("engines/sandbox_agent/environment-setup.ts");
+    assert.ok(source.includes("buildRuntimeEnvironment({"));
   });
 });


### PR DESCRIPTION
## Context

Part of the agent-config-editing stack. Targets `agent-config-editing-s2`. Read the stack bottom up.

Expect no behavior change. Every guard, every log string, every early return, and every ordering is preserved. The differences are mechanical: reads go through `ctx.env`, writes go through a named committer, and the two broad catches now rethrow invariant violations first. The characterization and keep-alive suites pin the behavior across the move.

s7a extracted the three separable units. The last three are not separable the same way. Mount, runtime, and harness session shared one closure holding six mutually recursive helpers. `mountLocalAgentCwd` calls `activateAgentMountGuidance`, which writes the daemon environment and the plan's system prompt. `reSignAndRemountLocalCwd` re-signs a credential and then calls `mountLocalDurableCwd`. Splitting them into modules meant either importing each other or sharing state through something.

## Changes

`AcquireContext` is that something. Every helper takes `ctx` and captures nothing, so the six helpers become ordinary functions in three modules with no module importing another.

This is revision 2 of the context. An external security review rejected revision 1 because it stated its invariants in comments and exposed the mutable environment anyway. The reviewer's summary was exact: the type compiled but did not enforce what its comments promised. Revision 2 follows one rule, and the review's findings are recorded at the bottom of the file so the next reader sees what was tried and why it failed. If a comment says a unit may not do something, the type makes it impossible.

The three units:

- `mount-lifecycle.ts` owns the durable cwd and the agent mount. They are not symmetric and the module says why: the cwd mount is keyed by session and participates in the safe-to-delete handshake, while the agent mount is keyed by artifact, lives at a sibling path, and carries the guidance that tells the model durable storage exists. One invariant is load-bearing. A local mount must complete before the sandbox provider takes the daemon environment maps by reference, or the guidance writes into maps nobody reads again.
- `runtime-lifecycle.ts` owns the four handles nothing else owns: the loopback tool-MCP server, the OTLP bearer file, the Codex SQLite home, and the per-run agent directory. It is small, and the file says plainly why. The daemon environment is built once and is immutable afterwards, so there is no restart and no credential refresh to own yet. Inventing a `restart()` that throws would suggest a seam that does not exist.
- `harness-session-lifecycle.ts` owns `probe_capabilities` and `create_session` plus session teardown. It takes an explicit input rather than the context, because nothing here shares mutable state or calls a sibling. Threading the context through anyway would imply a coupling that is not there.

Continuity stays best effort. A resume that throws is caught and falls through to a cold `createSession`. The worst outcome is a replay instead of a resume, which costs latency and never correctness. What a caller must not do is read a successful `resumeSession` as proof that history loaded, and `loadedFromContinuity` is what carries that distinction.

## Tests / notes

- 37 new tests: 324 lines covering the context's enforcement itself, plus unit coverage for each lifecycle unit.
- Worth reading first: the rejected-revision notes at the bottom of `acquire-context.ts`. They are the argument for why the type looks the way it does, and a reviewer who skips them will want to simplify it back.
