### PR TITLE
feat(runner): read workspace files into a commit, under one root

### DIFF
--- a/services/runner/src/tools/file-markers.ts
+++ b/services/runner/src/tools/file-markers.ts
@@ -1,0 +1,301 @@
+/**
+ * Resolving `@ag.file` markers in a commit's operations (agent-config-editing, slice S3a).
+ *
+ * Contract: change-set.md sections 6.1, 6.5, and 6.6. The agent writes
+ * `{"@ag.file": "<path>"}` wherever a string would go; the runner replaces each marker with
+ * the file's text before the API sees the call. The engine refuses any marker that survives,
+ * so resolution is not optional and a partial substitution is not a valid outcome.
+ *
+ * This module does the walk and the substitution, and returns the manifest the approval card
+ * will render. It deliberately does NOT gate, freeze, or authorize: that is S3b, and it
+ * lands after runner-spike's route work to avoid colliding in acp-interactions.
+ */
+import {
+  ImportError,
+  type ImportedFile,
+  type WorkspaceReader,
+} from "./workspace-reader.ts";
+import { MAX_TOTAL_BYTES } from "./import-paths.ts";
+
+export const FILE_MARKER = "@ag.file";
+
+export interface MarkerLocation {
+  /** Index in `delta.operations`. */
+  operationIndex: number;
+  /** JSON Pointer of the marker inside that operation's `value`. */
+  valuePointer: string;
+  path: string;
+}
+
+export interface ResolvedMarker extends MarkerLocation {
+  file: ImportedFile;
+}
+
+export interface ImportManifest {
+  entries: Array<{
+    operationIndex: number;
+    valuePointer: string;
+    /** The path the agent wrote, for the card. */
+    requestedPath: string;
+    /** The path below the import root, after normalization. */
+    relativePath: string;
+    bytes: number;
+    digest: string;
+    /** Observed only. The stored `executable` field is the agent's to author. */
+    executableBit: boolean;
+  }>;
+  totalBytes: number;
+}
+
+export interface ResolveMarkersResult {
+  /** The arguments with every marker replaced by its text. */
+  args: unknown;
+  manifest: ImportManifest;
+}
+
+export class MarkerResolutionError extends Error {
+  readonly code: string;
+  readonly operationIndex?: number;
+  readonly valuePointer?: string;
+  readonly available?: string[];
+  readonly nextStep: string;
+
+  constructor(
+    code: string,
+    message: string,
+    options: {
+      operationIndex?: number;
+      valuePointer?: string;
+      available?: string[];
+      nextStep?: string;
+    } = {},
+  ) {
+    super(message);
+    this.name = "MarkerResolutionError";
+    this.code = code;
+    this.operationIndex = options.operationIndex;
+    this.valuePointer = options.valuePointer;
+    this.available = options.available;
+    this.nextStep =
+      options.nextStep ??
+      "Write the file under .agenta-imports/ first, then send the commit again.";
+  }
+
+  toDetail(): Record<string, unknown> {
+    const detail: Record<string, unknown> = {
+      code: this.code,
+      message: this.message,
+      next_step: this.nextStep,
+      retryable: this.code !== "source_too_large",
+    };
+    if (this.operationIndex !== undefined) {
+      detail.operation_index = this.operationIndex;
+    }
+    if (this.valuePointer !== undefined)
+      detail.value_pointer = this.valuePointer;
+    if (this.available !== undefined) detail.available = this.available;
+    return detail;
+  }
+}
+
+function escapeToken(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function isMarker(node: unknown): node is Record<string, unknown> {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    !Array.isArray(node) &&
+    FILE_MARKER in (node as Record<string, unknown>)
+  );
+}
+
+/** Every marker in one operation's value, with its JSON Pointer. */
+export function findMarkers(
+  value: unknown,
+  operationIndex: number,
+  pointer = "",
+): MarkerLocation[] {
+  const found: MarkerLocation[] = [];
+  if (isMarker(value)) {
+    const raw = (value as Record<string, unknown>)[FILE_MARKER];
+    found.push({
+      operationIndex,
+      valuePointer: pointer === "" ? "/" : pointer,
+      path: typeof raw === "string" ? raw : "",
+    });
+    return found;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((child, index) => {
+      found.push(...findMarkers(child, operationIndex, `${pointer}/${index}`));
+    });
+    return found;
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const [key, child] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      found.push(
+        ...findMarkers(child, operationIndex, `${pointer}/${escapeToken(key)}`),
+      );
+    }
+  }
+  return found;
+}
+
+/** Every marker across a whole operations delta, in operation then pointer order. */
+export function findAllMarkers(args: unknown): MarkerLocation[] {
+  const operations = operationsOf(args);
+  if (!operations) return [];
+  const found: MarkerLocation[] = [];
+  operations.forEach((operation, index) => {
+    if (typeof operation !== "object" || operation === null) return;
+    const value = (operation as Record<string, unknown>).value;
+    if (value === undefined) return;
+    found.push(...findMarkers(value, index));
+  });
+  return found;
+}
+
+function operationsOf(args: unknown): unknown[] | null {
+  const revision = (args as Record<string, unknown> | undefined)
+    ?.workflow_revision;
+  const delta = (revision as Record<string, unknown> | undefined)?.delta;
+  const operations = (delta as Record<string, unknown> | undefined)?.operations;
+  return Array.isArray(operations) ? operations : null;
+}
+
+function setAtPointer(root: unknown, pointer: string, next: unknown): void {
+  if (pointer === "/" || pointer === "") {
+    throw new MarkerResolutionError(
+      "source_invalid",
+      "a marker cannot replace the whole operation value",
+    );
+  }
+  const tokens = pointer
+    .split("/")
+    .slice(1)
+    .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let node: Record<string, unknown> | unknown[] = root as Record<
+    string,
+    unknown
+  >;
+  for (const token of tokens.slice(0, -1)) {
+    node = (node as Record<string, unknown>)[token] as Record<string, unknown>;
+  }
+  const last = tokens[tokens.length - 1];
+  if (Array.isArray(node)) {
+    node[Number.parseInt(last, 10)] = next;
+  } else {
+    (node as Record<string, unknown>)[last] = next;
+  }
+}
+
+/**
+ * Resolve every marker in one commit and substitute the text.
+ *
+ * All or nothing: a commit is one atomic change, so a partially resolvable one has no
+ * useful meaning. The first failure throws and nothing is substituted.
+ */
+export async function resolveFileMarkers(
+  args: unknown,
+  reader: WorkspaceReader,
+): Promise<ResolveMarkersResult> {
+  const markers = findAllMarkers(args);
+  if (markers.length === 0) {
+    return { args, manifest: { entries: [], totalBytes: 0 } };
+  }
+
+  const resolved: ResolvedMarker[] = [];
+  let totalBytes = 0;
+
+  for (const marker of markers) {
+    if (marker.path === "") {
+      throw new MarkerResolutionError(
+        "source_invalid",
+        `${FILE_MARKER} needs a path string.`,
+        {
+          operationIndex: marker.operationIndex,
+          valuePointer: marker.valuePointer,
+          nextStep: `Give ${FILE_MARKER} the path of a file under .agenta-imports/.`,
+        },
+      );
+    }
+    let file: ImportedFile;
+    try {
+      file = await reader.readImportFile(marker.path);
+    } catch (error) {
+      throw toResolutionError(error, marker);
+    }
+    totalBytes += file.bytes;
+    if (totalBytes > MAX_TOTAL_BYTES) {
+      throw new MarkerResolutionError(
+        "source_too_large",
+        `the commit's files total more than ${MAX_TOTAL_BYTES} bytes.`,
+        {
+          operationIndex: marker.operationIndex,
+          valuePointer: marker.valuePointer,
+          nextStep: "Commit fewer or smaller files.",
+        },
+      );
+    }
+    resolved.push({ ...marker, file });
+  }
+
+  // Substitution happens only after EVERY marker resolved, so a later failure cannot leave
+  // half-substituted arguments behind.
+  const next = structuredClone(args) as Record<string, unknown>;
+  const operations = operationsOf(next);
+  for (const marker of resolved) {
+    const operation = operations?.[marker.operationIndex] as Record<
+      string,
+      unknown
+    >;
+    setAtPointer(operation.value, marker.valuePointer, marker.file.content);
+  }
+
+  return {
+    args: next,
+    manifest: {
+      entries: resolved.map((marker) => ({
+        operationIndex: marker.operationIndex,
+        valuePointer: marker.valuePointer,
+        requestedPath: marker.path,
+        relativePath: marker.file.relativePath,
+        bytes: marker.file.bytes,
+        digest: marker.file.digest,
+        executableBit: marker.file.executableBit,
+      })),
+      totalBytes,
+    },
+  };
+}
+
+function toResolutionError(
+  error: unknown,
+  marker: MarkerLocation,
+): MarkerResolutionError {
+  if (error instanceof ImportError) {
+    return new MarkerResolutionError(error.code, error.message, {
+      operationIndex: marker.operationIndex,
+      valuePointer: marker.valuePointer,
+      available: error.available,
+      nextStep:
+        error.code === "source_not_found"
+          ? "Write the file under .agenta-imports/ first, then send the commit again."
+          : error.code === "source_too_large"
+            ? "Reference a smaller file."
+            : "Reference a UTF-8 text file under .agenta-imports/.",
+    });
+  }
+  return new MarkerResolutionError(
+    "source_invalid",
+    error instanceof Error ? error.message : String(error),
+    {
+      operationIndex: marker.operationIndex,
+      valuePointer: marker.valuePointer,
+    },
+  );
+}

--- a/services/runner/src/tools/import-paths.ts
+++ b/services/runner/src/tools/import-paths.ts
@@ -1,0 +1,200 @@
+/**
+ * Path rules for the workspace import root (agent-config-editing, slice S3a).
+ *
+ * Contract: docs/design/agent-config-editing/contracts/workspace-import.md sections 2 and
+ * 3.1, with the path FORM taken from change-set.md section 6.3 (the consolidation row:
+ * "relative to the workspace root, or absolute inside the workspace; the runner normalizes
+ * both"). workspace-import.md 3.1 still says "rejects an absolute path"; that line predates
+ * the ruling and the banner at the top of that file supersedes it.
+ *
+ * Everything here is lexical and pure. It runs BEFORE any filesystem access, so a path that
+ * cannot possibly be legal never reaches the reader. The real-path and descriptor checks in
+ * workspace-reader.ts are the other half; neither is sufficient alone.
+ */
+import { posix as path } from "node:path";
+
+/** The designated import root, relative to the run's workspace cwd. */
+export const IMPORT_ROOT = ".agenta-imports";
+
+/** Contract 3.1. Long enough for any real tree, short enough to bound the walk. */
+export const MAX_PATH_BYTES = 1024;
+
+/** Contract 4.4. Matches `SkillFile.content` so a runner-side success cannot become a
+ *  server-side validation failure. */
+export const MAX_FILE_BYTES = 200_000;
+
+/** Contract 4.4, read per commit rather than per folder now that a marker is one file. */
+export const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
+
+/** Contract 4.4. The walk stops here, and stopping is reported, never silent. */
+export const MAX_DEPTH = 8;
+
+/** Contract 4.4. */
+export const MAX_RELATIVE_PATH_CHARS = 255;
+
+export type ImportPathRejection =
+  | "path_empty"
+  | "path_too_long"
+  | "path_traversal"
+  | "path_backslash"
+  | "path_nul"
+  | "path_outside_workspace"
+  | "path_outside_import_root"
+  | "path_is_root"
+  | "path_too_deep";
+
+export interface ImportPathOk {
+  ok: true;
+  /** Components below the import root, already checked. Walk these one at a time. */
+  segments: string[];
+  /** The same path as text, for manifests and errors. Never used to open anything. */
+  relativePath: string;
+}
+
+export interface ImportPathError {
+  ok: false;
+  reason: ImportPathRejection;
+  message: string;
+}
+
+export type ImportPathResult = ImportPathOk | ImportPathError;
+
+const reject = (
+  reason: ImportPathRejection,
+  message: string,
+): ImportPathError => ({ ok: false, reason, message });
+
+/**
+ * Normalize and confine one `@ag.file` path, lexically.
+ *
+ * Accepts either form the agent may write:
+ *   - relative to the workspace root:  `.agenta-imports/pdf-tools/SKILL.md`
+ *   - relative to the import root:     `pdf-tools/SKILL.md`
+ *   - absolute inside the workspace:   `/workspace/.agenta-imports/pdf-tools/SKILL.md`
+ *
+ * Rejecting absolute paths would fight the model, which writes them naturally; the ruling
+ * is to normalize instead and refuse only what leaves the workspace.
+ */
+export function resolveImportPath(
+  rawPath: string,
+  workspaceCwd: string,
+): ImportPathResult {
+  if (typeof rawPath !== "string" || rawPath.trim() === "") {
+    return reject("path_empty", "the path is empty");
+  }
+  // NUL first: it terminates a C string, so a check on the JS string can pass while the
+  // syscall sees a shorter path.
+  if (rawPath.includes("\0")) {
+    return reject("path_nul", "the path holds a NUL byte");
+  }
+  if (Buffer.byteLength(rawPath, "utf8") > MAX_PATH_BYTES) {
+    return reject(
+      "path_too_long",
+      `the path is longer than ${MAX_PATH_BYTES} bytes`,
+    );
+  }
+  // A backslash is a separator on some platforms and a literal on others; refusing it
+  // keeps one meaning everywhere.
+  if (rawPath.includes("\\")) {
+    return reject("path_backslash", "the path holds a backslash");
+  }
+
+  let candidate = rawPath;
+
+  // An absolute path is legal only inside the workspace, and it is normalized to a
+  // workspace-relative one before any other rule applies.
+  if (path.isAbsolute(candidate)) {
+    const root = ensureTrailingSlash(path.normalize(workspaceCwd));
+    const normalized = path.normalize(candidate);
+    if (
+      normalized !== path.normalize(workspaceCwd) &&
+      !normalized.startsWith(root)
+    ) {
+      return reject(
+        "path_outside_workspace",
+        "an absolute path must sit inside the workspace",
+      );
+    }
+    candidate = path.relative(path.normalize(workspaceCwd), normalized);
+  }
+
+  // `..` is checked on the RAW segments, not after normalization: normalizing first would
+  // silently collapse `a/../../b` into an escape that no longer looks like one.
+  if (candidate.split("/").some((segment) => segment === "..")) {
+    return reject("path_traversal", "the path holds a '..' segment");
+  }
+
+  // Both spellings reach the same place; the import root is implied when it is absent.
+  const withinRoot = stripImportRoot(candidate);
+  if (withinRoot === null) {
+    return reject(
+      "path_outside_import_root",
+      `the path must sit under ${IMPORT_ROOT}/`,
+    );
+  }
+
+  const segments = withinRoot.split("/").filter((s) => s !== "" && s !== ".");
+  if (segments.length === 0) {
+    return reject(
+      "path_is_root",
+      `${IMPORT_ROOT}/ is the root; name a file inside it`,
+    );
+  }
+  if (segments.length > MAX_DEPTH) {
+    return reject(
+      "path_too_deep",
+      `the path is deeper than ${MAX_DEPTH} levels`,
+    );
+  }
+
+  const relativePath = segments.join("/");
+  if ([...relativePath].length > MAX_RELATIVE_PATH_CHARS) {
+    return reject(
+      "path_too_long",
+      `the path below the root is longer than ${MAX_RELATIVE_PATH_CHARS} characters`,
+    );
+  }
+
+  return { ok: true, segments, relativePath };
+}
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+/**
+ * Drop a leading `.agenta-imports/` when the caller wrote one. Returns null when the path
+ * names a DIFFERENT top-level folder, which is the "outside the root" case.
+ */
+function stripImportRoot(candidate: string): string | null {
+  const normalized = candidate.replace(/^\.\//, "");
+  if (normalized === IMPORT_ROOT) return "";
+  if (normalized.startsWith(`${IMPORT_ROOT}/`)) {
+    return normalized.slice(IMPORT_ROOT.length + 1);
+  }
+  // No root prefix: the path is already relative to the root. A path that starts with a
+  // different dot-folder is still just a name inside the root, so it stays legal here and
+  // the real-path check decides.
+  return normalized;
+}
+
+/** The absolute import root for a workspace. Used to open the root descriptor once. */
+export function importRootFor(workspaceCwd: string): string {
+  return path.join(path.normalize(workspaceCwd), IMPORT_ROOT);
+}
+
+/**
+ * Contract 6.2: the descendant test, on RESOLVED paths only.
+ *
+ * `F` passes when it equals `R` or starts with `R` plus a separator. Comparing unresolved
+ * paths is exactly what the symbolic-link check exists to defeat, so callers must pass
+ * realpath output.
+ */
+export function isResolvedDescendant(
+  resolvedTarget: string,
+  resolvedRoot: string,
+): boolean {
+  const target = path.normalize(resolvedTarget);
+  const root = path.normalize(resolvedRoot);
+  return target === root || target.startsWith(ensureTrailingSlash(root));
+}

--- a/services/runner/src/tools/workspace-reader.ts
+++ b/services/runner/src/tools/workspace-reader.ts
@@ -1,0 +1,516 @@
+/**
+ * Reading one file out of the workspace import root (agent-config-editing, slice S3a).
+ *
+ * Contract: docs/design/agent-config-editing/contracts/workspace-import.md sections 3 and 6.
+ * Since the `@ag.file` consolidation each read is ONE FILE, not a folder tree, so the codec
+ * is gone; the confinement, the symbolic-link refusal, the caps, and the digests stay.
+ *
+ * Two implementations, because the two platforms give different guarantees:
+ *
+ * - `LocalWorkspaceReader` does the descriptor-relative walk section 3.4 REQUIRES. A
+ *   descriptor names an inode, not a path, so replacing a directory after the runner holds
+ *   its handle cannot redirect the read.
+ * - `DaytonaWorkspaceReader` cannot hold descriptors across the daemon interface, so it uses
+ *   the one-shot NUL-framed manifest of section 6.2 and accepts the residual window section
+ *   6.5 states plainly.
+ */
+import { createHash } from "node:crypto";
+import { constants as fsConstants, promises as fs } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { posix as path } from "node:path";
+
+import {
+  IMPORT_ROOT,
+  MAX_DEPTH,
+  MAX_FILE_BYTES,
+  importRootFor,
+  isResolvedDescendant,
+  resolveImportPath,
+} from "./import-paths.ts";
+
+export type ImportFailureCode =
+  | "source_not_found"
+  | "source_invalid"
+  | "source_too_large"
+  | "source_unsupported_content";
+
+export class ImportError extends Error {
+  readonly code: ImportFailureCode;
+  /** Folders that DO exist under the root; a wrong path is nearly always a near miss. */
+  readonly available?: string[];
+
+  constructor(
+    code: ImportFailureCode,
+    message: string,
+    options?: { available?: string[] },
+  ) {
+    super(message);
+    this.name = "ImportError";
+    this.code = code;
+    this.available = options?.available;
+  }
+}
+
+export interface ImportedFile {
+  /** The path below the import root, for the manifest and the card. */
+  relativePath: string;
+  content: string;
+  bytes: number;
+  /** SHA-256 over the exact bytes that will be committed. Contract 7.1. */
+  digest: string;
+  /** Observed, never a grant. Contract 5.3: the runner never derives policy from it. */
+  executableBit: boolean;
+}
+
+export interface WorkspaceReader {
+  /** Read one file, confined to the import root. */
+  readImportFile(rawPath: string): Promise<ImportedFile>;
+  /** Top-level names under the import root, for a `source_not_found` answer. */
+  listImportRoot(): Promise<string[]>;
+}
+
+export function digestOf(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function assertUtf8Text(buffer: Buffer, relativePath: string): string {
+  // A lone surrogate or an invalid sequence decodes to U+FFFD. The configuration stores
+  // text, so a binary file must fail its own marker rather than land as mojibake.
+  const text = buffer.toString("utf8");
+  if (text.includes("�") && !buffer.includes(0xef)) {
+    throw new ImportError(
+      "source_unsupported_content",
+      `${relativePath} is not valid UTF-8 text.`,
+    );
+  }
+  if (buffer.includes(0)) {
+    throw new ImportError(
+      "source_unsupported_content",
+      `${relativePath} holds a NUL byte, so it is not text.`,
+    );
+  }
+  return text;
+}
+
+function assertSize(bytes: number, relativePath: string): void {
+  if (bytes > MAX_FILE_BYTES) {
+    throw new ImportError(
+      "source_too_large",
+      `${relativePath} is ${bytes} bytes; the limit is ${MAX_FILE_BYTES}.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local: the descriptor-relative walk (contract 3.2, 3.4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Open `name` relative to an already-open directory handle.
+ *
+ * Node exposes no `openat`, but `/proc/self/fd/<fd>` names the directory the descriptor
+ * points at, so opening `<that>/<name>` resolves `name` against the INODE we hold rather
+ * than against a path that may have been replaced. Combined with `O_NOFOLLOW` on each
+ * component, this gives the property section 3.2 requires without a native helper.
+ *
+ * `name` is a single component, never a path: the caller walks one level at a time, so an
+ * attacker never gets a multi-component lookup to redirect.
+ */
+async function openAt(
+  parent: FileHandle,
+  name: string,
+  flags: number,
+): Promise<FileHandle> {
+  if (name.includes("/")) {
+    throw new ImportError(
+      "source_invalid",
+      "internal: openAt takes one component",
+    );
+  }
+  return fs.open(`/proc/self/fd/${parent.fd}/${name}`, flags);
+}
+
+export class LocalWorkspaceReader implements WorkspaceReader {
+  constructor(private readonly workspaceCwd: string) {}
+
+  private rootPath(): string {
+    return importRootFor(this.workspaceCwd);
+  }
+
+  async listImportRoot(): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(this.rootPath(), {
+        withFileTypes: true,
+      });
+      return entries
+        .map((entry) => (entry.isDirectory() ? `${entry.name}/` : entry.name))
+        .sort();
+    } catch {
+      return [];
+    }
+  }
+
+  async readImportFile(rawPath: string): Promise<ImportedFile> {
+    const resolved = resolveImportPath(rawPath, this.workspaceCwd);
+    if (!resolved.ok) {
+      throw new ImportError("source_invalid", resolved.message);
+    }
+
+    let dir: FileHandle | undefined;
+    let file: FileHandle | undefined;
+    try {
+      try {
+        dir = await fs.open(
+          this.rootPath(),
+          fsConstants.O_RDONLY | fsConstants.O_DIRECTORY,
+        );
+      } catch {
+        throw new ImportError(
+          "source_not_found",
+          `${IMPORT_ROOT}/ does not exist in this workspace.`,
+          { available: [] },
+        );
+      }
+
+      // Verify the root itself before trusting anything below it.
+      const rootStat = await dir.stat();
+      if (!rootStat.isDirectory()) {
+        throw new ImportError(
+          "source_invalid",
+          `${IMPORT_ROOT} is not a directory.`,
+        );
+      }
+
+      const segments = resolved.segments;
+      for (let index = 0; index < segments.length - 1; index += 1) {
+        if (index >= MAX_DEPTH) {
+          throw new ImportError(
+            "source_unsupported_content",
+            `the path is deeper than ${MAX_DEPTH} levels.`,
+          );
+        }
+        const next = await this.openDirAt(
+          dir,
+          segments[index],
+          resolved.relativePath,
+        );
+        await dir.close();
+        dir = next;
+      }
+
+      const name = segments[segments.length - 1];
+      try {
+        // O_NOFOLLOW on the final component: a symbolic link is refused, never followed
+        // (contract 3.5). The intermediate components are already safe because each was
+        // opened relative to the previous descriptor.
+        file = await openAt(
+          dir,
+          name,
+          fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+        );
+      } catch (error) {
+        throw await this.describeOpenFailure(error, resolved.relativePath);
+      }
+
+      // Type, size, and mode come from the HANDLE, never from a path.
+      const stat = await file.stat();
+      if (stat.isDirectory()) {
+        throw new ImportError(
+          "source_invalid",
+          `${resolved.relativePath} is a directory; name one file.`,
+        );
+      }
+      if (!stat.isFile()) {
+        throw new ImportError(
+          "source_unsupported_content",
+          `${resolved.relativePath} is not a regular file.`,
+        );
+      }
+      assertSize(stat.size, resolved.relativePath);
+
+      const buffer = await file.readFile();
+      assertSize(buffer.byteLength, resolved.relativePath);
+      const content = assertUtf8Text(buffer, resolved.relativePath);
+
+      return {
+        relativePath: resolved.relativePath,
+        content,
+        bytes: buffer.byteLength,
+        digest: digestOf(content),
+        executableBit: (stat.mode & 0o111) !== 0,
+      };
+    } finally {
+      await file?.close().catch(() => {});
+      await dir?.close().catch(() => {});
+    }
+  }
+
+  private async openDirAt(
+    parent: FileHandle,
+    name: string,
+    relativePath: string,
+  ): Promise<FileHandle> {
+    try {
+      return await openAt(
+        parent,
+        name,
+        fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+      );
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      // With O_DIRECTORY and O_NOFOLLOW together, Linux reports a symbolic link as
+      // ENOTDIR on some kernels and ELOOP on others. Both mean the component was
+      // refused, not followed, so the security property holds either way — but the
+      // message must be right. Re-open WITHOUT O_DIRECTORY, still relative to the same
+      // descriptor: ELOOP then means a link, success means an ordinary file. This costs
+      // one syscall on the error path and never performs a new path lookup.
+      if (code === "ENOTDIR" || code === "ELOOP") {
+        const kind = await this.classifyRefusedComponent(parent, name);
+        throw new ImportError(
+          "source_unsupported_content",
+          kind === "symlink"
+            ? `${name} is a symbolic link; links are not imported.`
+            : `${relativePath}: '${name}' is not a directory.`,
+        );
+      }
+      throw await this.describeOpenFailure(error, relativePath, name);
+    }
+  }
+
+  private async classifyRefusedComponent(
+    parent: FileHandle,
+    name: string,
+  ): Promise<"symlink" | "not-a-directory"> {
+    let handle: FileHandle | undefined;
+    try {
+      handle = await openAt(
+        parent,
+        name,
+        fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+      );
+      return "not-a-directory";
+    } catch (error) {
+      return (error as NodeJS.ErrnoException)?.code === "ELOOP"
+        ? "symlink"
+        : "not-a-directory";
+    } finally {
+      await handle?.close().catch(() => {});
+    }
+  }
+
+  private async describeOpenFailure(
+    error: unknown,
+    relativePath: string,
+    component?: string,
+  ): Promise<ImportError> {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ELOOP") {
+      // O_NOFOLLOW reports ELOOP for a symbolic link. Refused, not followed.
+      return new ImportError(
+        "source_unsupported_content",
+        `${component ?? relativePath} is a symbolic link; links are not imported.`,
+      );
+    }
+    if (code === "ENOTDIR") {
+      return new ImportError(
+        "source_invalid",
+        `${relativePath}: a parent segment is not a directory.`,
+      );
+    }
+    return new ImportError(
+      "source_not_found",
+      `${relativePath} does not exist under ${IMPORT_ROOT}/.`,
+      { available: await this.listImportRoot() },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Daytona: the one-shot NUL-framed manifest (contract 6.2)
+// ---------------------------------------------------------------------------
+
+export interface DaytonaExec {
+  /** Run one argv, never a shell. Returns stdout as raw bytes. */
+  (argv: string[]): Promise<{ stdout: Buffer; exitCode: number }>;
+}
+
+export interface ManifestEntry {
+  type: string;
+  mode: string;
+  size: number;
+  relativePath: string;
+}
+
+/**
+ * Parse `find -printf '%y\0%m\0%s\0%P\0'`.
+ *
+ * NUL is the only safe separator: a file name may hold a newline, a tab, a quote, or a
+ * backslash, but never a NUL. The prototype's tab-and-newline framing was not safe.
+ */
+export function parseManifest(stdout: Buffer): ManifestEntry[] {
+  const fields = stdout.toString("utf8").split("\0");
+  const entries: ManifestEntry[] = [];
+  // The trailing NUL yields one empty tail field, so stop before a short final record.
+  for (let index = 0; index + 3 < fields.length; index += 4) {
+    const [type, mode, size, relativePath] = fields.slice(index, index + 4);
+    if (type === "" && mode === "" && size === "" && relativePath === "")
+      continue;
+    entries.push({
+      type,
+      mode,
+      size: Number.parseInt(size, 10) || 0,
+      relativePath,
+    });
+  }
+  return entries;
+}
+
+export class DaytonaWorkspaceReader implements WorkspaceReader {
+  constructor(
+    private readonly workspaceCwd: string,
+    private readonly exec: DaytonaExec,
+  ) {}
+
+  private rootPath(): string {
+    return importRootFor(this.workspaceCwd);
+  }
+
+  async listImportRoot(): Promise<string[]> {
+    const result = await this.exec([
+      "find",
+      this.rootPath(),
+      "-mindepth",
+      "1",
+      "-maxdepth",
+      "1",
+      "-printf",
+      "%y\0%m\0%s\0%P\0",
+    ]);
+    if (result.exitCode !== 0) return [];
+    return parseManifest(result.stdout)
+      .map((entry) =>
+        entry.type === "d" ? `${entry.relativePath}/` : entry.relativePath,
+      )
+      .sort();
+  }
+
+  /** Contract 6.2: any output means the tree goes deeper than the walk. */
+  async hasDepthOverflow(): Promise<boolean> {
+    const result = await this.exec([
+      "find",
+      this.rootPath(),
+      "-mindepth",
+      String(MAX_DEPTH + 1),
+      "-printf",
+      "x",
+      "-quit",
+    ]);
+    return result.exitCode === 0 && result.stdout.length > 0;
+  }
+
+  async readImportFile(rawPath: string): Promise<ImportedFile> {
+    const resolved = resolveImportPath(rawPath, this.workspaceCwd);
+    if (!resolved.ok) {
+      throw new ImportError("source_invalid", resolved.message);
+    }
+
+    const absTarget = path.join(this.rootPath(), resolved.relativePath);
+
+    // The descendant test runs on RESOLVED paths: comparing unresolved ones is what the
+    // symbolic-link check exists to defeat.
+    const [resolvedRoot, resolvedTarget] = await Promise.all([
+      this.realpath(this.rootPath()),
+      this.realpath(absTarget),
+    ]);
+    if (resolvedTarget === null) {
+      throw new ImportError(
+        "source_not_found",
+        `${resolved.relativePath} does not exist under ${IMPORT_ROOT}/.`,
+        { available: await this.listImportRoot() },
+      );
+    }
+    if (resolvedRoot === null) {
+      throw new ImportError(
+        "source_not_found",
+        `${IMPORT_ROOT}/ does not exist in this workspace.`,
+        { available: [] },
+      );
+    }
+    if (!isResolvedDescendant(resolvedTarget, resolvedRoot)) {
+      throw new ImportError(
+        "source_invalid",
+        `${resolved.relativePath} resolves outside ${IMPORT_ROOT}/.`,
+      );
+    }
+
+    const stat = await this.statOne(absTarget);
+    if (stat === null) {
+      throw new ImportError(
+        "source_not_found",
+        `${resolved.relativePath} does not exist under ${IMPORT_ROOT}/.`,
+        { available: await this.listImportRoot() },
+      );
+    }
+    // `%y` reports the entry's OWN type, so a link reports `l` and is refused here rather
+    // than silently followed.
+    if (stat.type === "l") {
+      throw new ImportError(
+        "source_unsupported_content",
+        `${resolved.relativePath} is a symbolic link; links are not imported.`,
+      );
+    }
+    if (stat.type === "d") {
+      throw new ImportError(
+        "source_invalid",
+        `${resolved.relativePath} is a directory; name one file.`,
+      );
+    }
+    if (stat.type !== "f") {
+      throw new ImportError(
+        "source_unsupported_content",
+        `${resolved.relativePath} is not a regular file.`,
+      );
+    }
+    assertSize(stat.size, resolved.relativePath);
+
+    const result = await this.exec(["cat", "--", absTarget]);
+    if (result.exitCode !== 0) {
+      throw new ImportError(
+        "source_not_found",
+        `${resolved.relativePath} could not be read.`,
+        { available: await this.listImportRoot() },
+      );
+    }
+    assertSize(result.stdout.byteLength, resolved.relativePath);
+    const content = assertUtf8Text(result.stdout, resolved.relativePath);
+
+    return {
+      relativePath: resolved.relativePath,
+      content,
+      bytes: result.stdout.byteLength,
+      digest: digestOf(content),
+      executableBit: /[1357]/.test(stat.mode.slice(-3)),
+    };
+  }
+
+  private async realpath(target: string): Promise<string | null> {
+    const result = await this.exec(["realpath", "--", target]);
+    if (result.exitCode !== 0) return null;
+    const value = result.stdout.toString("utf8").trim();
+    return value === "" ? null : value;
+  }
+
+  private async statOne(absTarget: string): Promise<ManifestEntry | null> {
+    const result = await this.exec([
+      "find",
+      absTarget,
+      "-maxdepth",
+      "0",
+      "-printf",
+      "%y\0%m\0%s\0%P\0",
+    ]);
+    if (result.exitCode !== 0) return null;
+    const entries = parseManifest(result.stdout);
+    return entries[0] ?? null;
+  }
+}

--- a/services/runner/src/tools/workspace-reader.ts
+++ b/services/runner/src/tools/workspace-reader.ts
@@ -74,10 +74,18 @@ export function digestOf(content: string): string {
 }
 
 function assertUtf8Text(buffer: Buffer, relativePath: string): string {
-  // A lone surrogate or an invalid sequence decodes to U+FFFD. The configuration stores
-  // text, so a binary file must fail its own marker rather than land as mojibake.
-  const text = buffer.toString("utf8");
-  if (text.includes("�") && !buffer.includes(0xef)) {
+  // A fatal decoder refuses the malformed sequence itself. Testing the DECODED text for U+FFFD
+  // cannot: a file may legitimately contain that character, and exempting every buffer holding
+  // its first byte (0xEF) lets any invalid sequence carrying an 0xEF through as mojibake.
+  //
+  // `ignoreBOM` keeps a leading BOM as a character. The default strips it, which would make the
+  // committed content differ from the bytes on disk and desynchronize `bytes` from `digest`.
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+      buffer,
+    );
+  } catch {
     throw new ImportError(
       "source_unsupported_content",
       `${relativePath} is not valid UTF-8 text.`,
@@ -160,16 +168,18 @@ export class LocalWorkspaceReader implements WorkspaceReader {
     let file: FileHandle | undefined;
     try {
       try {
+        // O_NOFOLLOW on the ROOT, not only on the components below it. Without it a symbolic
+        // link in place of `.agenta-imports` is followed before the walk starts, and every
+        // descriptor-relative open below is then correctly confined to the link's target rather
+        // than to the workspace (contract 3.2 step 1).
         dir = await fs.open(
           this.rootPath(),
-          fsConstants.O_RDONLY | fsConstants.O_DIRECTORY,
+          fsConstants.O_RDONLY |
+            fsConstants.O_DIRECTORY |
+            fsConstants.O_NOFOLLOW,
         );
-      } catch {
-        throw new ImportError(
-          "source_not_found",
-          `${IMPORT_ROOT}/ does not exist in this workspace.`,
-          { available: [] },
-        );
+      } catch (error) {
+        throw await this.describeRootFailure(error);
       }
 
       // Verify the root itself before trusting anything below it.
@@ -275,6 +285,40 @@ export class LocalWorkspaceReader implements WorkspaceReader {
       }
       throw await this.describeOpenFailure(error, relativePath, name);
     }
+  }
+
+  /**
+   * Why the root open failed, as a code the caller can act on.
+   *
+   * With `O_DIRECTORY` and `O_NOFOLLOW` together Linux reports a symbolic link as `ENOTDIR` on
+   * some kernels and `ELOOP` on others, so the errno alone cannot tell a link from a plain file.
+   * `lstat` names the entry itself. It runs only on the error path and only to pick the answer;
+   * nothing is opened through it.
+   */
+  private async describeRootFailure(error: unknown): Promise<ImportError> {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ELOOP" || code === "ENOTDIR") {
+      let isLink = code === "ELOOP";
+      if (!isLink) {
+        try {
+          isLink = (await fs.lstat(this.rootPath())).isSymbolicLink();
+        } catch {
+          // The root went away between the open and the classification; the answer stays
+          // "not a directory", which is true either way.
+        }
+      }
+      return new ImportError(
+        "source_invalid",
+        isLink
+          ? `${IMPORT_ROOT} is a symbolic link; links are not imported.`
+          : `${IMPORT_ROOT} is not a directory.`,
+      );
+    }
+    return new ImportError(
+      "source_not_found",
+      `${IMPORT_ROOT}/ does not exist in this workspace.`,
+      { available: [] },
+    );
   }
 
   private async classifyRefusedComponent(
@@ -414,12 +458,16 @@ export class DaytonaWorkspaceReader implements WorkspaceReader {
       throw new ImportError("source_invalid", resolved.message);
     }
 
-    const absTarget = path.join(this.rootPath(), resolved.relativePath);
+    const root = this.rootPath();
+    const absTarget = path.join(root, resolved.relativePath);
 
     // The descendant test runs on RESOLVED paths: comparing unresolved ones is what the
-    // symbolic-link check exists to defeat.
-    const [resolvedRoot, resolvedTarget] = await Promise.all([
-      this.realpath(this.rootPath()),
+    // symbolic-link check exists to defeat. The ROOT is resolved against the workspace for the
+    // same reason: a root that is itself a link anchors every check below it to the link's
+    // target, so "under the root" would stop meaning "inside the workspace".
+    const [resolvedWorkspace, resolvedRoot, resolvedTarget] = await Promise.all([
+      this.realpath(this.workspaceCwd),
+      this.realpath(root),
       this.realpath(absTarget),
     ]);
     if (resolvedTarget === null) {
@@ -429,11 +477,17 @@ export class DaytonaWorkspaceReader implements WorkspaceReader {
         { available: await this.listImportRoot() },
       );
     }
-    if (resolvedRoot === null) {
+    if (resolvedRoot === null || resolvedWorkspace === null) {
       throw new ImportError(
         "source_not_found",
         `${IMPORT_ROOT}/ does not exist in this workspace.`,
         { available: [] },
+      );
+    }
+    if (!isResolvedDescendant(resolvedRoot, resolvedWorkspace)) {
+      throw new ImportError(
+        "source_invalid",
+        `${IMPORT_ROOT}/ resolves outside the workspace.`,
       );
     }
     if (!isResolvedDescendant(resolvedTarget, resolvedRoot)) {
@@ -443,16 +497,53 @@ export class DaytonaWorkspaceReader implements WorkspaceReader {
       );
     }
 
-    const stat = await this.statOne(absTarget);
-    if (stat === null) {
+    // ONE execution covers the whole path: the root, every intermediate directory, and the file.
+    // `%y` reports each entry's OWN type, so a link ANYWHERE on the path reports `l` and is
+    // refused rather than followed (contract 3.5, and 6.2 rule 2). Checking only the final entry
+    // would accept an intermediate link, which the local walk refuses; `realpath` alone catches
+    // only the links that leave the root.
+    const prefixes = resolved.segments.map((_, index) =>
+      path.join(root, ...resolved.segments.slice(0, index + 1)),
+    );
+    const walked = await this.statChain([root, ...prefixes]);
+    if (walked === null || walked.length !== prefixes.length + 1) {
       throw new ImportError(
         "source_not_found",
         `${resolved.relativePath} does not exist under ${IMPORT_ROOT}/.`,
         { available: await this.listImportRoot() },
       );
     }
-    // `%y` reports the entry's OWN type, so a link reports `l` and is refused here rather
-    // than silently followed.
+
+    const [rootEntry, ...entries] = walked;
+    if (rootEntry.type === "l") {
+      throw new ImportError(
+        "source_invalid",
+        `${IMPORT_ROOT} is a symbolic link; links are not imported.`,
+      );
+    }
+    if (rootEntry.type !== "d") {
+      throw new ImportError(
+        "source_invalid",
+        `${IMPORT_ROOT} is not a directory.`,
+      );
+    }
+    for (let index = 0; index < entries.length - 1; index += 1) {
+      const segment = resolved.segments[index];
+      if (entries[index].type === "l") {
+        throw new ImportError(
+          "source_unsupported_content",
+          `${segment} is a symbolic link; links are not imported.`,
+        );
+      }
+      if (entries[index].type !== "d") {
+        throw new ImportError(
+          "source_invalid",
+          `${resolved.relativePath}: '${segment}' is not a directory.`,
+        );
+      }
+    }
+
+    const stat = entries[entries.length - 1];
     if (stat.type === "l") {
       throw new ImportError(
         "source_unsupported_content",
@@ -500,17 +591,23 @@ export class DaytonaWorkspaceReader implements WorkspaceReader {
     return value === "" ? null : value;
   }
 
-  private async statOne(absTarget: string): Promise<ManifestEntry | null> {
+  /**
+   * The own-type of every path in `paths`, in one execution.
+   *
+   * `find` takes many starting points, reports them in argument order, and prints an empty `%P`
+   * for a starting point itself, so the records line up with the paths positionally. One call per
+   * component would cost one process per level of every import.
+   */
+  private async statChain(paths: string[]): Promise<ManifestEntry[] | null> {
     const result = await this.exec([
       "find",
-      absTarget,
+      ...paths,
       "-maxdepth",
       "0",
       "-printf",
       "%y\0%m\0%s\0%P\0",
     ]);
     if (result.exitCode !== 0) return null;
-    const entries = parseManifest(result.stdout);
-    return entries[0] ?? null;
+    return parseManifest(result.stdout);
   }
 }


### PR DESCRIPTION
## Context

Part of the agent-config-editing stack. Targets `agent-config-editing-s7b`. Read the stack bottom up.

An agent that writes a large instructions document or a skill file into its workspace has no way to commit it. The commit tool takes JSON, and a 200 KB document inside a tool call is not workable. The design's answer is a marker: the agent writes `{"@ag.file": ".agenta-imports/notes.md"}` inside the commit and the runner resolves it to the file's text before the API sees the call.

That makes the runner read files on the agent's instruction, so the whole feature is a confinement problem.

## Changes

Three modules, matching `contracts/workspace-import.md` sections 2, 3, and 6.

`import-paths.ts` is lexical and pure. It runs before any filesystem access, so a path that cannot possibly be legal never reaches the reader. It accepts the three forms an agent naturally writes (relative to the import root, relative to the workspace root, or absolute inside the workspace) and refuses traversal, backslashes, NUL bytes, over-long paths, and the root itself. `..` is checked on the raw segments, because normalizing first would collapse `a/../../b` into an escape that no longer looks like one.

`workspace-reader.ts` has two implementations, because the two platforms give different guarantees.

The local reader does a descriptor-relative walk. A path-based walk with `O_NOFOLLOW` is cheaper and does not work: the flag refuses a link at the final component only, so an attacker who swaps an intermediate directory for a link between the walk and the open redirects the read and the flag stays silent. A descriptor names an inode, not a path, so replacing a directory after the runner holds its handle cannot move it. Node exposes no `openat`, but `/proc/self/fd/<fd>` names the directory a descriptor points at, so opening `/proc/self/fd/<parentFd>/<name>` one component at a time gives the same property in plain Node.

The Daytona reader cannot hold descriptors across the daemon interface, so it uses one NUL-framed `find` manifest. NUL is the only safe separator, since a file name may hold a newline or a quote but never a NUL. `%y` is used rather than `%Y` because it reports the entry's own type, so a link reports `l` and is refused instead of followed. The residual race is stated in the contract rather than papered over: on Daytona this is not a TOCTOU defense.

`file-markers.ts` finds every marker in a call, resolves each one, and substitutes the text into a copy of the arguments. One marker failing fails the whole commit, because a commit is one atomic change.

This lane also carries two fixes from the final review round.

The local reader opened the import root without `O_NOFOLLOW`. A symlink in place of `.agenta-imports` was therefore followed before the walk began, and every confined open below it was then faithfully confined to the link's target. A probe read a file outside the workspace through exactly that. The root open now refuses a link for its own sake, whatever it points at. On Daytona the root is resolved against the workspace as well, and the whole path chain (root, every intermediate, and the file) is type-checked in one `find`, which is what catches an intermediate link that stays inside the root. `realpath` alone passes that case, and the local walk refuses it, so accepting it left the two readers disagreeing about one tree.

UTF-8 validation accepted malformed bytes. It rejected only when the decoded text contained U+FFFD and the buffer held no `0xEF`, and that exemption exists because the replacement character itself encodes as `EF BF BD`. So any invalid sequence carrying an `0xEF` passed, decoded to mojibake, and was digested after the change.

Before: `EF 28` on disk imported as content `EF BF BD 28`, with `bytes` reporting 2 and the digest taken over 4 different bytes.
After: `new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })` refuses it. `ignoreBOM` is load-bearing. The default strips a byte-order mark, which would make the committed content differ from the file on disk.

## Tests / notes

- 47 tests. Confinement, both readers, the depth-overflow probe, and marker resolution.
- The symlink and UTF-8 cases were also proven outside the suite, against real fixture directories and the real readers, before and after the fix.
- Recorded boundary: the Daytona path is weaker than the local descriptor walk by design. `workspace-import.md` section 6.5 states the attack it does not stop, and a test asserts the limitation so nobody mistakes it for a defense.
- Nothing is wired to a tool yet. The gate, the approval card, and the execution check land in the s3b lanes.
