### PR TITLE
feat(runner): change a warm environment instead of rebuilding it

### DIFF
--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -697,7 +697,10 @@ export async function acquireEnvironment(
       log: logger,
     };
     try {
-      environment.workspace = await materializeWorkspace(workspaceInput, deps);
+      const materialized = await materializeWorkspace(workspaceInput, deps);
+      environment.workspace = materialized;
+      // The record a later in-place refresh needs to know what to DELETE.
+      environment.workspaceInventory = materialized.inventory;
     } catch (err) {
       if (
         !plan.isDaytona &&
@@ -708,10 +711,9 @@ export async function acquireEnvironment(
         logger(
           `retrying workspace preparation after local durable cwd remount`,
         );
-        environment.workspace = await materializeWorkspace(
-          workspaceInput,
-          deps,
-        );
+        const retried = await materializeWorkspace(workspaceInput, deps);
+        environment.workspace = retried;
+        environment.workspaceInventory = retried.inventory;
       } else {
         throw err;
       }

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -228,6 +228,14 @@ export interface SessionEnvironment {
    * `applied-state.ts`.
    */
   readonly appliedState: AppliedEnvironmentState;
+  /**
+   * What the workspace write left behind, so a later in-place refresh knows what to DELETE.
+   *
+   * Undefined until a workspace is materialized. A refresh with no inventory refuses rather than
+   * writing without deleting: a stale skill left readable is the failure that route exists to
+   * prevent. See `environment/workspace-manager.ts`.
+   */
+  workspaceInventory?: import("../../environment/workspace-manager.ts").WorkspaceInventory;
   /** Record a lifecycle action that already succeeded. The only writer of `appliedState`. */
   commitApplied: (result: {
     configFingerprint: string;

--- a/services/runner/src/environment/apply-plan.ts
+++ b/services/runner/src/environment/apply-plan.ts
@@ -1,0 +1,138 @@
+/**
+ * Applying a `ReconcilePlan` to a LIVE environment.
+ *
+ * LIFECYCLE MIGRATION, STEP 6. This is the first code in the project that changes a running
+ * environment instead of rebuilding it, so it is written to be paranoid.
+ *
+ * ============================================================================================
+ * THE ONE RULE
+ * ============================================================================================
+ *
+ * APPLIED STATE ADVANCES ONLY AFTER EVERY ACTION SUCCEEDED.
+ *
+ * An environment that applied half a plan but reports the whole new configuration is the
+ * stale-config bug in a new costume — the exact class step 2 made structurally impossible for
+ * request-derived fingerprints. Reintroducing it here through a premature `commitApplied` would
+ * undo that work, so the commit is the LAST statement and it is unreachable from any failure
+ * path.
+ *
+ * A partial application therefore leaves the environment reporting its OLD configuration, which
+ * is the truth. The caller sees `false` and rebuilds. Rebuilding after a partial change is
+ * wasteful but always sound; continuing is neither.
+ *
+ * ============================================================================================
+ * ORDER
+ * ============================================================================================
+ *
+ * Actions run in `FACETS` order, which is a real dependency order: a workspace refresh must land
+ * before anything that reads those files. `planReconcile` already emits them sorted, so this
+ * function iterates rather than re-sorts — but it asserts the property rather than trusting it,
+ * because a reordering upstream would be silent here.
+ */
+import type { AgentRunRequest } from "../protocol.ts";
+import { applyModel } from "../engines/sandbox_agent/model.ts";
+import type { SessionEnvironment } from "../engines/sandbox_agent/runtime-contracts.ts";
+import { normalizeDesiredState } from "../lifecycle/desired-state.ts";
+import { configFingerprint } from "../engines/sandbox_agent/session-identity.ts";
+import type { ReconcilePlan } from "../lifecycle/reconcile-plan.ts";
+import { refresh, type WorkspaceInventory } from "./workspace-manager.ts";
+import type { Log } from "./timing.ts";
+
+export interface ApplyPlanDeps {
+  applyModel?: typeof applyModel;
+  refresh?: typeof refresh;
+}
+
+/**
+ * Apply every action in `plan` to `env`. Returns whether the WHOLE plan applied.
+ *
+ * `false` means nothing may be assumed about what landed, except that applied state was not
+ * advanced. The caller rebuilds.
+ */
+export async function applyReconcilePlan(
+  env: SessionEnvironment,
+  request: AgentRunRequest,
+  plan: ReconcilePlan,
+  log: Log,
+  deps: ApplyPlanDeps = {},
+): Promise<boolean> {
+  if (plan.actions.length === 0) return false;
+
+  for (const action of plan.actions) {
+    switch (action.kind) {
+      case "no-op":
+        break;
+
+      case "refresh-workspace": {
+        // The runner-owned instructions and skills, rewritten in place. Deletion of a skill that
+        // left the request is decided from the inventory this environment recorded when it last
+        // wrote the workspace — never from a directory listing, because a durable cwd holds the
+        // user's own project.
+        const previous = env.workspaceInventory;
+        if (!previous) {
+          // No inventory means this environment never recorded what it wrote, so a refresh
+          // cannot know what to delete. Refuse rather than write-without-deleting: a stale skill
+          // left readable is the failure this route exists to prevent.
+          log("live-route: no workspace inventory recorded; cannot refresh safely");
+          return false;
+        }
+        const result = await (deps.refresh ?? refresh)(
+          {
+            sandbox: env.sandbox,
+            plan: env.plan as never,
+            log,
+          },
+          {
+            instructions: env.plan.prompt.agentsMd,
+            skills: env.plan.workspace.skillDirs,
+          },
+          previous,
+        );
+        env.workspaceInventory = result.inventory;
+        if (result.removedSkills.length) {
+          log(
+            `live-route: refreshed workspace, removed ${result.removedSkills.length} skill(s)`,
+          );
+        }
+        break;
+      }
+
+      case "apply-live": {
+        // The only live session-level operation: `setModel` on the running session. Strict, so a
+        // model the harness will not accept throws here and the whole plan fails rather than
+        // silently leaving the session on its previous model while we report the new one.
+        const applied = await (deps.applyModel ?? applyModel)(
+          env.session,
+          request.model,
+          log,
+          { strict: true },
+        );
+        if (request.model && applied !== request.model) {
+          log(
+            `live-route: setModel did not install '${request.model}' (got '${applied ?? "default"}')`,
+          );
+          return false;
+        }
+        env.model = applied;
+        break;
+      }
+
+      default:
+        // A plan carrying an action outside the live set should never reach here: the caller
+        // gates on `isLivelyApplicable`. Refuse rather than attempt it.
+        log(`live-route: refusing unsupported action '${action.kind}'`);
+        return false;
+    }
+  }
+
+  // EVERY action succeeded. Only now may the environment claim the new configuration, and this
+  // is the single call that lets it. See "THE ONE RULE" above.
+  const fingerprint = configFingerprint(request);
+  env.commitApplied({
+    configFingerprint: fingerprint,
+    facets: normalizeDesiredState(request, fingerprint).digests,
+  });
+  return true;
+}
+
+export type { WorkspaceInventory };

--- a/services/runner/src/environment/workspace-manager.ts
+++ b/services/runner/src/environment/workspace-manager.ts
@@ -1,24 +1,32 @@
 /**
  * `WorkspaceManager` — the run directory's managed files.
  *
- * LIFECYCLE MIGRATION, STEP 5. This unit owns one acquire stage (`prepare_workspace`) and one
- * teardown step (the workspace cleanup). It is the first unit to split out because it is the one
- * step 6 needs: an in-place workspace refresh is the cheapest live route in the whole design.
+ * LIFECYCLE MIGRATION, STEPS 5 AND 6. Step 5 split this unit out. Step 6 implements `refresh`:
+ * the cheapest live route in the whole design, rewriting instructions and skills in place on a
+ * running sandbox instead of rebuilding it.
  *
  * WHAT "MANAGED" MEANS. The runner owns `AGENTS.md` / `CLAUDE.md`, the rendered harness files, and
  * the skill directories. It does NOT own anything else in the run directory: an agent's own
  * working files are the user's, and a refresh must never touch them. That boundary is why
  * `refresh` takes an explicit manifest rather than reconciling the whole tree.
  *
- * THE `refresh` ENTRY IS DELIBERATELY UNWIRED. Step 5 is a structural split with zero behavior
- * change, so nothing calls `refresh` yet. It exists now, sharing its write path with
- * `materialize`, so step 6 is a routing change rather than a new implementation. See the note on
- * `refresh` for what it still owes.
+ * WHY DELETION NEEDS AN INVENTORY. A refresh can never reconcile the tree: it cannot ask "what is
+ * here that should not be?", because almost everything in a durable cwd is the user's. It can only
+ * ask "what did I write last time that I am not writing now?" — and that needs a record of what it
+ * wrote. That record is `WorkspaceInventory`, and it is why `materialize` returns one.
+ *
+ * THE FAILURE THIS PREVENTS: a skill removed from the request stays readable by the model. For an
+ * ordinary skill that is a correctness bug. For a skill removed BECAUSE it was unsafe, the removal
+ * silently does nothing.
  */
+import { cpSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
 import {
   prepareWorkspace,
   type Workspace,
 } from "../engines/sandbox_agent/workspace.ts";
+import { uploadDirToSandbox } from "../engines/sandbox_agent/pi-assets.ts";
 import type { PiSkillSnapshot } from "../engines/sandbox_agent/pi-assets.ts";
 import type { RunPlan } from "../engines/sandbox_agent/run-plan.ts";
 import type { Log } from "./timing.ts";
@@ -37,69 +45,212 @@ export interface WorkspaceDeps {
 }
 
 /**
+ * What the runner wrote, so it can tell later what to remove.
+ *
+ * DELIBERATELY NOT A CONTENT RECORD. It holds identities only, because a refresh compares what
+ * SHOULD exist against what DID, never old bytes against new ones.
+ */
+export interface WorkspaceInventory {
+  /** `CLAUDE.md` or `AGENTS.md`, relative to the cwd. Undefined when none was written. */
+  readonly instructionsFile: string | undefined;
+  /** Skill directory names under `skillRoot`. Empty for a harness with no project skill root. */
+  readonly skillNames: readonly string[];
+  /** Where skill directories live relative to the cwd, e.g. `.claude/skills`. */
+  readonly skillRoot: string | undefined;
+}
+
+/** The workspace handle plus the record of what produced it. */
+export interface ManagedWorkspace extends Workspace {
+  readonly inventory: WorkspaceInventory;
+}
+
+/** Claude's memory loader reads `CLAUDE.md` and never `AGENTS.md`; everything else reads the latter. */
+function instructionsFileFor(acpAgent: string): string {
+  return acpAgent === "claude" ? "CLAUDE.md" : "AGENTS.md";
+}
+
+/** Pi loads one content-addressed snapshot instead of project-local skill directories. */
+function skillRootFor(plan: { isPi: boolean; acpAgent: string }): string | undefined {
+  return plan.isPi ? undefined : `.${plan.acpAgent}/skills`;
+}
+
+/** The inventory a plan implies: what a write of this plan leaves behind. */
+export function inventoryOf(plan: WorkspaceInput["plan"]): WorkspaceInventory {
+  const p = plan as unknown as {
+    isPi?: boolean;
+    acpAgent?: string;
+    prompt?: { agentsMd?: string };
+    workspace?: { skillDirs?: Array<{ name: string }> };
+  };
+  // Absence reads as "wrote nothing", never as a throw. `materialize` calls this, so a throw here
+  // would fail an acquisition; and an EMPTY inventory is the safe direction, because a later
+  // refresh then deletes nothing rather than deleting something it never wrote.
+  const skillRoot = skillRootFor({
+    isPi: !!p.isPi,
+    acpAgent: p.acpAgent ?? "",
+  });
+  return {
+    instructionsFile: p.prompt?.agentsMd
+      ? instructionsFileFor(p.acpAgent ?? "")
+      : undefined,
+    skillNames: skillRoot ? (p.workspace?.skillDirs ?? []).map((s) => s.name) : [],
+    skillRoot,
+  };
+}
+
+/**
  * Write every managed file for a fresh run directory.
  *
- * This is byte-for-byte what the `prepare_workspace` stage did inline. The caller still owns the
- * timing mark and the local-remount retry, because both are acquire-path concerns rather than
- * workspace concerns: the retry re-signs a MOUNT, which belongs to the mount unit.
+ * Byte-for-byte what the `prepare_workspace` stage did inline, plus the inventory. The caller
+ * still owns the timing mark and the local-remount retry, because the retry re-signs a MOUNT,
+ * which belongs to the mount unit.
  */
 export async function materialize(
   input: WorkspaceInput,
   deps: WorkspaceDeps = {},
-): Promise<Workspace> {
-  return (deps.prepareWorkspace ?? prepareWorkspace)({
+): Promise<ManagedWorkspace> {
+  const workspace = await (deps.prepareWorkspace ?? prepareWorkspace)({
     sandbox: input.sandbox,
     plan: input.plan,
     piSkillSnapshot: input.piSkillSnapshot,
     log: input.log,
   });
+  return { ...workspace, inventory: inventoryOf(input.plan) };
 }
 
 /**
- * The set of managed files a refresh should end with.
+ * What a refresh should leave behind. A COMPLETE statement, never a delta.
  *
- * A manifest is a complete statement, not a delta. That is what lets a refresh delete a skill
- * directory that disappeared from the request: the manager compares what it wrote last against
- * what the manifest asks for, and removes the difference. A delta could never express a removal
- * safely, because it cannot distinguish "unchanged" from "gone".
+ * A delta could not express a removal: it cannot distinguish "unchanged" from "gone". The
+ * manifest plus the previous inventory is what makes deletion decidable.
  */
 export interface WorkspaceManifest {
-  /** Relative path to content, for every file the runner owns in this run directory. */
-  readonly files: ReadonlyMap<string, string>;
-  /** Skill directory names the runner owns. Anything else under the skills root is removed. */
-  readonly skillDirs: readonly string[];
+  /** The instructions text, or undefined to remove the file. */
+  readonly instructions: string | undefined;
+  /** The skill directories that should exist, by name and materialized source dir. */
+  readonly skills: ReadonlyArray<{ name: string; dir: string }>;
+}
+
+export interface RefreshResult {
+  readonly inventory: WorkspaceInventory;
+  /** Skill names removed, so the caller can log what the refresh actually did. */
+  readonly removedSkills: readonly string[];
 }
 
 /**
- * STEP 6 ENTRY. Bring an EXISTING run directory to the state a manifest describes.
+ * Bring an EXISTING run directory to the state a manifest describes.
  *
- * NOT WIRED, AND NOT YET COMPLETE. Step 5 changes no behavior, so nothing calls this. It is
- * declared now so step 6 is a routing change rather than a new implementation, and so the shape
- * of the manifest is settled while the split is fresh.
+ * SCOPE: INSTRUCTIONS AND SKILLS ONLY. Those are exactly what the `workspaceFiles` facet
+ * carries, and that facet is the narrowest of the four the old coarse `workspace` facet held.
+ * Prompts and harness files are NOT refreshed here — they escalate to a session reopen, because
+ * prompt observation is not guaranteed and a harness file may be a permission file. Widening this
+ * function without widening that facet would route a security-relevant change through an in-place
+ * write, which is the failure the facet split exists to prevent.
  *
- * WHAT IT STILL OWES, and none of it may be skipped when step 6 wires it:
- *  - DELETION. `prepareWorkspace` writes desired files and does not remove files that vanished
- *    from the request. A refresh that only writes leaves a removed skill readable by the model,
- *    which is a correctness bug and, for a removed skill, a policy one.
- *  - A RUNNER-OWNED INVENTORY. Deletion is only safe against a record of what the runner itself
- *    wrote. Never recursively clean the run directory: it holds the agent's own files.
- *  - ATOMIC REPLACEMENT where the platform allows it, so a half-written instructions file is
- *    never visible to a running harness.
- *  - THE OBSERVATION QUESTION. Writing a file does not prove a running harness reads it. The
- *    adapter matrix records instructions and skills as `not-guaranteed` for an active session,
- *    so step 6 must decide per harness whether a refresh alone is honest or whether it must be
- *    followed by a session reopen.
+ * ORDER: delete first, then write. A skill removed and another added in one refresh must not be
+ * able to collide on a directory name mid-operation.
+ *
+ * ATOMICITY, STATED HONESTLY:
+ *  - A LOCAL FILE is atomic. Content goes to a temp name in the SAME directory and is renamed
+ *    over the target, so a reader sees either the whole old file or the whole new one.
+ *  - A LOCAL SKILL DIRECTORY is not atomic as a unit: it is removed and re-copied, so a reader
+ *    inside that window can see a partial skill. Accepted, because the alternative is swapping in
+ *    a staged sibling directory and neither the Pi nor the Claude loader expects that.
+ *  - A DAYTONA WRITE is not atomic at all. The daemon FS API exposes no rename-over to lean on,
+ *    so a remote instructions write has a one-call window. Recorded rather than hidden.
+ *
+ * A FAILED DELETE THROWS. Leaving a removed skill readable is the exact outcome this route exists
+ * to prevent, so the caller must fall back to a rebuild rather than continue.
  */
 export async function refresh(
-  _input: WorkspaceInput,
-  _manifest: WorkspaceManifest,
-  _deps: WorkspaceDeps = {},
-): Promise<Workspace> {
-  throw new Error(
-    "WorkspaceManager.refresh is not implemented: step 5 is a structural split with no " +
-      "behavior change. Step 6 wires it, and must first add manifest-based deletion against a " +
-      "runner-owned inventory. See the doc comment.",
-  );
+  input: WorkspaceInput,
+  manifest: WorkspaceManifest,
+  previous: WorkspaceInventory,
+): Promise<RefreshResult> {
+  const p = input.plan as unknown as {
+    isPi: boolean;
+    isDaytona: boolean;
+    acpAgent: string;
+    workspace: { cwd: string };
+  };
+  const sandbox = input.sandbox as {
+    writeFsFile?: (q: { path: string }, body: string) => Promise<unknown>;
+    deleteFsEntry?: (q: { path: string }) => Promise<unknown>;
+  };
+  const cwd = p.workspace.cwd;
+  const skillRoot = skillRootFor(p);
+  const instructionsFile = instructionsFileFor(p.acpAgent);
+
+  // ---- 1. Deletions, decided from the INVENTORY and never from a directory listing. ----
+  // Listing the tree would put the agent's own files in scope, and almost nothing there is the
+  // runner's to remove.
+  const wanted = new Set(manifest.skills.map((s) => s.name));
+  const removedSkills = previous.skillNames.filter((n) => !wanted.has(n));
+  if (previous.skillRoot) {
+    for (const name of removedSkills) {
+      const target = `${cwd}/${previous.skillRoot}/${name}`;
+      try {
+        if (p.isDaytona) await sandbox.deleteFsEntry?.({ path: target });
+        else rmSync(target, { recursive: true, force: true });
+        input.log(`workspace refresh removed skill=${name}`);
+      } catch (err) {
+        throw new Error(
+          `workspace refresh could not remove skill '${name}': ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+  if (previous.instructionsFile && manifest.instructions === undefined) {
+    const target = `${cwd}/${previous.instructionsFile}`;
+    if (p.isDaytona) await sandbox.deleteFsEntry?.({ path: target }).catch(() => {});
+    else rmSync(target, { force: true });
+  }
+
+  // ---- 2. Writes. ----------------------------------------------------------------------
+  if (manifest.instructions !== undefined) {
+    if (p.isDaytona) {
+      await sandbox.writeFsFile?.(
+        { path: `${cwd}/${instructionsFile}` },
+        manifest.instructions,
+      );
+    } else {
+      writeFileAtomic(join(cwd, instructionsFile), manifest.instructions);
+    }
+  }
+
+  if (skillRoot) {
+    for (const skill of manifest.skills) {
+      const target = `${cwd}/${skillRoot}/${skill.name}`;
+      if (p.isDaytona) {
+        await sandbox.deleteFsEntry?.({ path: target }).catch(() => {});
+        await uploadDirToSandbox(input.sandbox, skill.dir, target);
+      } else {
+        rmSync(target, { recursive: true, force: true });
+        mkdirSync(dirname(target), { recursive: true });
+        cpSync(skill.dir, target, { recursive: true });
+      }
+    }
+  }
+
+  return { inventory: inventoryOf(input.plan), removedSkills };
+}
+
+/**
+ * Write a file so a concurrent reader never sees it half-written.
+ *
+ * The temp name MUST be in the same directory as the target: `rename` is only atomic within one
+ * filesystem, and a temp file elsewhere could cross a mount boundary and degrade to a copy.
+ */
+function writeFileAtomic(target: string, content: string): void {
+  mkdirSync(dirname(target), { recursive: true });
+  const staging = `${target}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(staging, content, "utf-8");
+  try {
+    renameSync(staging, target);
+  } catch (err) {
+    rmSync(staging, { force: true });
+    throw err;
+  }
 }
 
 /**

--- a/services/runner/src/lifecycle/desired-state.ts
+++ b/services/runner/src/lifecycle/desired-state.ts
@@ -33,11 +33,22 @@ import type { AgentRunRequest } from "../protocol.ts";
  * The order is a real dependency order, not a naming convention. Changed harness files may need
  * both a workspace refresh AND a session reopen, and the refresh must land first or the reopened
  * session reads the old bytes.
+ *
+ * GRANULARITY IS A SAFETY PROPERTY, NOT A STYLE CHOICE. A facet is the unit the router routes, so
+ * a facet that mixes two concerns forces the cheaper route onto both. The first three facets here
+ * were split out of one coarse `workspace` facet and one coarse `harnessSession` facet precisely
+ * because making those live would have routed harness permission files through an in-place
+ * refresh, and a permissions change through `setModel` — both of which `adapter-matrix.md`
+ * forbids by name. When in doubt, split: an over-fine facet costs an unnecessary rebuild, while
+ * an over-coarse one silently downgrades a security-relevant change.
  */
 export const FACETS = [
   "sandbox",
   "runtime",
-  "workspace",
+  "workspaceFiles",
+  "prompts",
+  "harnessFiles",
+  "model",
   "harnessSession",
   "toolCatalog",
 ] as const;
@@ -112,21 +123,51 @@ export function normalizeDesiredState(
       : null,
   });
 
-  // WORKSPACE: the managed files the runner writes into the run directory. These can be
-  // rewritten in place on a live sandbox, which is why they are their own facet.
-  const workspace = canonical({
+  // WORKSPACE FILES: the managed files the runner writes and OWNS. Instructions and skills only.
+  // This is the one workspace facet that may be refreshed in place on a live sandbox, so it is
+  // deliberately the narrowest of the four the old `workspace` facet used to contain.
+  const workspaceFiles = canonical({
     agentsMd: request.agentsMd ?? null,
+    skills: request.skills ?? null,
+  });
+
+  // PROMPTS: the system and append prompts.
+  //
+  // SEPARATE FROM `workspaceFiles`, and not live. For Pi these land as files under the agent
+  // directory, and the adapter matrix records active-session observation as NOT GUARANTEED: a
+  // running process may have captured their location or content already. Refreshing them and
+  // claiming the model saw the change would be a lie, so a prompt change escalates.
+  const prompts = canonical({
     systemPrompt: request.systemPrompt ?? null,
     appendSystemPrompt: request.appendSystemPrompt ?? null,
-    skills: request.skills ?? null,
+  });
+
+  // HARNESS FILES: opaque, harness-rendered configuration files.
+  //
+  // SEPARATE FROM `workspaceFiles`, and never live. `adapter-matrix.md` section 4.3.2 rule 3 is
+  // explicit: harness PERMISSION files join permission tightening and credential revocation on
+  // the list of changes that must never take the apply-live route. The runner cannot tell a
+  // permission file from any other harness file — they are opaque by construction — so the whole
+  // facet escalates. Folding these in with instructions would silently route a security-relevant
+  // change through an in-place refresh.
+  const harnessFiles = canonical({
     harnessFiles: request.harnessFiles ?? null,
   });
 
-  // HARNESS SESSION: what is fixed when the ACP session opens. The model and the harness mode
-  // are here because a live `setModel` is a session-level operation, not a daemon restart.
-  // User MCP servers are here because the server LIST is only read at session initialization.
+  // MODEL: the requested model id, ALONE.
+  //
+  // Its own facet because it is the one session-level change with a real live path: `setModel`
+  // on the running session. Everything else that is fixed at session open stays in
+  // `harnessSession` below and escalates.
+  const model = canonical({ model: request.model ?? null });
+
+  // HARNESS SESSION: everything else fixed when the ACP session opens. None of it is live.
+  //
+  // `permissions` is here rather than beside `model` for the same reason `harnessFiles` is its
+  // own facet: section 1.4 exempts permission TIGHTENING from apply-live entirely, and it must
+  // take effect or fail closed before execution continues. `mcpServers` is here because the
+  // server LIST is only read at session initialization and no live API exists on any harness.
   const harnessSession = canonical({
-    model: request.model ?? null,
     harnessMode: request.harnessMode ?? null,
     modelCapabilities: request.modelCapabilities ?? null,
     permissions: request.permissions ?? null,
@@ -152,7 +193,10 @@ export function normalizeDesiredState(
     digests: {
       sandbox: sha256(sandbox),
       runtime: sha256(runtime),
-      workspace: sha256(workspace),
+      workspaceFiles: sha256(workspaceFiles),
+      prompts: sha256(prompts),
+      harnessFiles: sha256(harnessFiles),
+      model: sha256(model),
       harnessSession: sha256(harnessSession),
       toolCatalog: sha256(toolCatalog),
     },

--- a/services/runner/src/lifecycle/reconciliation-router.ts
+++ b/services/runner/src/lifecycle/reconciliation-router.ts
@@ -44,39 +44,57 @@ export type HarnessKind = "pi" | "claude" | "codex" | "unknown";
  *  - the MCP shim `tools.listChanged` capability plus its notification.
  */
 export interface HarnessLifecycleCapabilities {
+  /** `setModel` on the running session. LIVE in v1. */
   readonly model: ActionKind;
+  /** Instructions and skills, rewritten in place. LIVE in v1. */
+  readonly workspaceFiles: ActionKind;
+  /** System and append prompts. Never live: observation is not guaranteed. */
+  readonly prompts: ActionKind;
+  /** Opaque harness-rendered files. Never live: they may be permission files. */
+  readonly harnessFiles: ActionKind;
+  /** Mode, capabilities, permissions, MCP server list. Never live. */
+  readonly harnessSession: ActionKind;
+  /** The model-visible tool catalog. Uniformly reopen in v1. */
   readonly toolCatalog: ActionKind;
-  readonly mcpServers: ActionKind;
-  readonly workspace: ActionKind;
 }
 
 const V1_CAPABILITIES: Readonly<
   Record<HarnessKind, HarnessLifecycleCapabilities>
 > = {
+  // The two LIVE routes are `model` and `workspaceFiles`, uniformly across harnesses. Everything
+  // else escalates. See the module comment for why the tool catalog is uniform rather than split.
   pi: {
-    model: "reopen-session",
+    model: "apply-live",
+    workspaceFiles: "refresh-workspace",
+    prompts: "reopen-session",
+    harnessFiles: "reopen-session",
+    harnessSession: "reopen-session",
     toolCatalog: "reopen-session",
-    mcpServers: "reopen-session",
-    workspace: "refresh-workspace",
   },
   claude: {
-    model: "reopen-session",
+    model: "apply-live",
+    workspaceFiles: "refresh-workspace",
+    prompts: "reopen-session",
+    harnessFiles: "reopen-session",
+    harnessSession: "reopen-session",
     toolCatalog: "reopen-session",
-    mcpServers: "reopen-session",
-    workspace: "refresh-workspace",
   },
   codex: {
-    model: "reopen-session",
+    model: "apply-live",
+    workspaceFiles: "refresh-workspace",
+    prompts: "reopen-session",
+    harnessFiles: "reopen-session",
+    harnessSession: "reopen-session",
     toolCatalog: "reopen-session",
-    mcpServers: "reopen-session",
-    workspace: "refresh-workspace",
   },
   // An unrecognized harness gets the safest answer available. Fail closed, never fail open.
   unknown: {
     model: "rebuild-sandbox",
+    workspaceFiles: "rebuild-sandbox",
+    prompts: "rebuild-sandbox",
+    harnessFiles: "rebuild-sandbox",
+    harnessSession: "rebuild-sandbox",
     toolCatalog: "rebuild-sandbox",
-    mcpServers: "rebuild-sandbox",
-    workspace: "rebuild-sandbox",
   },
 };
 
@@ -115,17 +133,47 @@ function actionForFacet(
         kind: "restart-runtime",
         reason: "daemon environment or credential shape changed",
       };
-    case "workspace":
+    case "workspaceFiles":
+      // Instructions and skills. The one workspace facet the runner may rewrite in place.
       return {
         facet,
-        kind: capabilities.workspace,
-        reason: "managed workspace files changed",
+        kind: capabilities.workspaceFiles,
+        reason: "instructions or skills changed",
       };
-    case "harnessSession":
+    case "prompts":
+      // Pi keeps these as files under its agent directory and a running process may already have
+      // captured them, so the adapter matrix records active-session observation as NOT
+      // GUARANTEED. Refreshing them and claiming the model saw it would be dishonest.
+      return {
+        facet,
+        kind: capabilities.prompts,
+        reason: "system or append prompt changed",
+      };
+    case "harnessFiles":
+      // Opaque by construction, and they may BE permission files. `adapter-matrix.md` section
+      // 4.3.2 rule 3 puts harness permission files alongside permission tightening and credential
+      // revocation on the never-apply-live list, and the runner cannot tell one harness file from
+      // another. So the whole facet escalates.
+      return {
+        facet,
+        kind: capabilities.harnessFiles,
+        reason: "harness-rendered configuration files changed",
+      };
+    case "model":
+      // The one session-level change with a real live path: `setModel` on the running session.
       return {
         facet,
         kind: capabilities.model,
-        reason: "model, mode, permissions, or MCP servers changed",
+        reason: "requested model changed",
+      };
+    case "harnessSession":
+      // Mode, capabilities, permissions, and the MCP server list. None is live: permission
+      // tightening is exempt from apply-live by section 1.4, and no harness exposes a live API
+      // for the MCP server list.
+      return {
+        facet,
+        kind: capabilities.harnessSession,
+        reason: "mode, permissions, or MCP servers changed",
       };
     case "toolCatalog":
       return {
@@ -158,6 +206,25 @@ export function planReconcile(
 /** What the coordinator actually decided, in the plan's own vocabulary. */
 export type CoordinatorDecision = "reuse" | "rebuild";
 
+/**
+ * What KIND of question the coordinator was answering.
+ *
+ * This distinction is what makes the disagreement counter mean anything. The router only ever
+ * answers one question: "does this ENVIRONMENT need rebuilding?" The coordinator answers a
+ * broader one, and some of its reasons are not about the environment at all.
+ *
+ *  - `environment`: the decision was about the environment's configuration. The router's plan is
+ *    directly comparable, so agreement and disagreement are both meaningful.
+ *  - `continuity`: the decision was about the CONVERSATION — an edited transcript, a tail the
+ *    runner did not write. The environment is untouched and the router correctly plans a no-op,
+ *    so counting that as a disagreement would be a permanent false positive that no amount of
+ *    router work could ever drive to zero.
+ *
+ * A continuity-scoped decision is still LOGGED, because seeing it is useful. It is simply not
+ * counted.
+ */
+export type DecisionScope = "environment" | "continuity";
+
 export interface ShadowLogInput {
   key: string;
   request: AgentRunRequest;
@@ -171,7 +238,57 @@ export interface ShadowLogInput {
   decision: CoordinatorDecision;
   /** The coordinator's own label for why, e.g. `mismatch:config` or `hit-continue`. */
   decisionReason: string;
+  /** Which question the decision answered. Defaults to `environment`. */
+  scope?: DecisionScope;
+  /**
+   * The plan the caller ACTED ON, when it already has one.
+   *
+   * The live route needs this. It builds a plan, applies it, and commits the new applied state —
+   * so by the time the shadow runs, recomputing from the environment yields an EMPTY plan and the
+   * counter would record `no-op` instead of the route that was actually taken. A counter that
+   * cannot name the route it is counting is useless for the rollout it exists to inform.
+   */
+  plan?: ReconcilePlan;
   log?: (message: string) => void;
+}
+
+/**
+ * Agreement counters, per action kind.
+ *
+ * The rollout signal. A route is ready to go authoritative when its disagreement count sits at
+ * zero across real traffic; a route that keeps disagreeing has a facet-ownership problem the
+ * shadow is telling you about.
+ *
+ * Keyed by the plan's `maxAction`, so a counter names the ROUTE rather than the facet: several
+ * facets can share one action kind, and it is the action that either works or does not.
+ */
+export interface ReconcileCounters {
+  readonly agree: Readonly<Record<string, number>>;
+  readonly disagree: Readonly<Record<string, number>>;
+  /** Decisions excluded from the comparison because they were not about the environment. */
+  readonly skippedByScope: number;
+}
+
+const counters = {
+  agree: {} as Record<string, number>,
+  disagree: {} as Record<string, number>,
+  skippedByScope: 0,
+};
+
+/** Read the counters. Returns a copy, so a caller cannot mutate the live tallies. */
+export function reconcileCounters(): ReconcileCounters {
+  return {
+    agree: { ...counters.agree },
+    disagree: { ...counters.disagree },
+    skippedByScope: counters.skippedByScope,
+  };
+}
+
+/** Test seam: forget every tally. */
+export function resetReconcileCounters(): void {
+  counters.agree = {};
+  counters.disagree = {};
+  counters.skippedByScope = 0;
 }
 
 function defaultLog(message: string): void {
@@ -207,11 +324,23 @@ export function logReconcileShadow(input: ShadowLogInput): ReconcilePlan | undef
       input.request,
       input.configFingerprint,
     );
-    const plan = planReconcile(input.request, desired, input.appliedDigests);
+    const plan =
+      input.plan ?? planReconcile(input.request, desired, input.appliedDigests);
+    const scope = input.scope ?? "environment";
     const agree = plan.outcome === input.decision;
+    // Count only what is comparable. A continuity decision is about the CONVERSATION, so the
+    // router's environment plan is not an answer to the same question and counting it would
+    // create a false positive that can never reach zero.
+    if (scope === "continuity") {
+      counters.skippedByScope += 1;
+    } else {
+      const bucket = agree ? counters.agree : counters.disagree;
+      bucket[plan.maxAction] = (bucket[plan.maxAction] ?? 0) + 1;
+    }
     // The marker is the point of the whole exercise: it is greppable, and a burst of DISAGREE
     // lines is the signal that the router's naming or ownership is still wrong.
-    const marker = agree ? "agree" : "DISAGREE";
+    const marker =
+      scope === "continuity" ? "n/a(continuity)" : agree ? "agree" : "DISAGREE";
     log(
       `shadow key=${input.key} harness=${harnessKind(input.request)} ` +
         `decision=${input.decision}(${input.decisionReason}) ` +
@@ -232,12 +361,15 @@ export function logReconcileShadow(input: ShadowLogInput): ReconcilePlan | undef
  * KNOWN DISAGREEMENTS. Both were found by running the shadow, which is what it is for. Neither
  * may be treated as noise, and neither may be silenced by widening a facet.
  *
- * 1. `mismatch:history` and `mismatch:tail`. The coordinator rebuilds; the router plans a no-op.
- *    THE ROUTER IS RIGHT. A wrong transcript says nothing about the environment, which is exactly
- *    why step 1 gave it the `continuity-invalid` teardown reason that parks the sandbox rather
- *    than deleting it. Closing this gap means teaching the coordinator that a continuity failure
- *    needs a fresh CONVERSATION, not a fresh environment. That is a behavior change, so it waits
- *    for step 6.
+ * 1. `mismatch:history` and `mismatch:tail`. RESOLVED, by classification rather than by code.
+ *    The coordinator rebuilds the conversation; the router plans a no-op for the environment.
+ *    Both are correct, because they answer DIFFERENT questions — which is the whole reason
+ *    `DecisionScope` exists. These decisions are now marked `continuity`, logged for visibility,
+ *    and excluded from the counters. Counting them would have left a permanent false positive
+ *    that no router work could ever drive to zero.
+ *
+ *    The environment side of it was already right: step 1 gave a transcript mismatch the
+ *    `continuity-invalid` teardown reason, which PARKS the sandbox instead of deleting it.
  *
  * 2. `mismatch:credentials-*`. The coordinator rebuilds; the router plans a no-op.
  *    THE ROUTER IS WRONG, and this one is security-relevant. Credential VALUES are deliberately
@@ -267,4 +399,30 @@ export function appliedDigestsFrom(
 ): FacetDigests | undefined {
   if (!acquiringRequest || !appliedFingerprint) return undefined;
   return normalizeDesiredState(acquiringRequest, appliedFingerprint).digests;
+}
+
+/**
+ * The action kinds the runner may perform on a LIVE environment, as of step 6.
+ *
+ * EXACTLY TWO, and this constant is the single place that says so. `no-op` is here because an
+ * empty plan is trivially satisfiable without touching anything.
+ *
+ * Adding a third entry is the whole decision to make another route live. It must not happen by
+ * accident, so a test counts this set and the capability table is checked against it.
+ */
+export const LIVE_ACTION_KINDS: ReadonlySet<ActionKind> = new Set<ActionKind>([
+  "no-op",
+  "apply-live",
+  "refresh-workspace",
+]);
+
+/**
+ * Whether a plan can be satisfied ON THE RUNNING ENVIRONMENT.
+ *
+ * FAIL CLOSED: an empty action list is applicable (nothing to do), but a single action outside
+ * the live set makes the whole plan inapplicable. A plan is all-or-nothing — applying the live
+ * half of a mixed plan would leave the environment in a state no request described.
+ */
+export function isLivelyApplicable(plan: ReconcilePlan): boolean {
+  return plan.actions.every((action) => LIVE_ACTION_KINDS.has(action.kind));
 }

--- a/services/runner/src/lifecycle/session-coordinator.ts
+++ b/services/runner/src/lifecycle/session-coordinator.ts
@@ -76,7 +76,14 @@ import {
   resolveRunLimits,
   TOTAL_DEADLINE_ENV,
 } from "../engines/sandbox_agent/run-limits.ts";
-import { logReconcileShadow } from "./reconciliation-router.ts";
+import {
+  isLivelyApplicable,
+  logReconcileShadow,
+  planReconcile,
+  type DecisionScope,
+} from "./reconciliation-router.ts";
+import { normalizeDesiredState } from "./desired-state.ts";
+import { formatPlan, type ReconcilePlan } from "./reconcile-plan.ts";
 
 export function klog(message: string): void {
   process.stderr.write(`[keepalive] ${message}\n`);
@@ -112,6 +119,22 @@ export interface KeepaliveEngine {
   ): Promise<AgentRunResult>;
   /** Best-effort provider activity refresh after a live park succeeds. */
   onParkedLive?(env: SessionEnvironment): Promise<void>;
+  /**
+   * Apply a reconciliation plan to a LIVE environment (lifecycle migration, step 6).
+   *
+   * Returns whether the WHOLE plan applied. The implementation must commit applied state only
+   * after every action succeeded, and must leave applied state untouched otherwise — a partially
+   * applied environment that claims the new configuration is the stale-config bug wearing a
+   * different hat.
+   *
+   * Optional: an engine that does not implement it simply never takes a live route, and every
+   * config change keeps rebuilding exactly as before.
+   */
+  applyReconcilePlan?(
+    env: SessionEnvironment,
+    request: AgentRunRequest,
+    plan: ReconcilePlan,
+  ): Promise<boolean>;
   /**
    * Today's cold path (acquire -> runTurn -> teardown). Used when a request must not park.
    * `presignedMount` threads an already-signed mount in (null = signed, no mount — do not sign
@@ -266,10 +289,64 @@ export async function runWithKeepalive(
    * fail the turn; the only product is a log line, and a `DISAGREE` marker is the signal that the
    * router's facet ownership still needs work before step 5 lets it decide anything.
    */
+  /**
+   * LIFECYCLE MIGRATION, STEP 6. Try to satisfy a configuration change on the RUNNING
+   * environment instead of rebuilding it.
+   *
+   * This is the first genuine behavior change in the lifecycle work, so every guard matters:
+   *
+   *  - It runs ONLY for `mismatch:config`. The credential and continuity mismatches are decided
+   *    before this point by their own checks and are untouched — credential facets keep
+   *    delegating to the epoch comparison until step 8 teaches the router to read it.
+   *  - The plan must be ENTIRELY live-applicable. A mixed plan rebuilds, because applying half
+   *    of it would leave the environment in a state no request ever described.
+   *  - The engine commits applied state only after every action succeeded. A `false` return
+   *    leaves the environment exactly as it was.
+   *  - Any throw is caught and treated as "did not apply". FAIL CLOSED: an unexpected failure
+   *    must cost a rebuild, never a silently half-reconfigured environment.
+   */
+  const tryLiveRoutes = async (
+    existing: LiveSession<SessionEnvironment>,
+  ): Promise<ReconcilePlan | undefined> => {
+    if (!engine.applyReconcilePlan) return undefined;
+    const desired = normalizeDesiredState(request, cfgFp);
+    const plan = planReconcile(
+      request,
+      desired,
+      existing.environment.appliedState.facets,
+    );
+    if (plan.actions.length === 0) return undefined;
+    if (!isLivelyApplicable(plan)) return undefined;
+    try {
+      const applied = await engine.applyReconcilePlan(
+        existing.environment,
+        request,
+        plan,
+      );
+      if (applied) {
+        klog(
+          `live-route key=${key} applied=[${formatPlan(plan)}] ` +
+            `generation=${existing.environment.appliedState.generation}`,
+        );
+        return plan;
+      }
+      klog(`live-route key=${key} refused=[${formatPlan(plan)}]; rebuilding`);
+      return undefined;
+    } catch (err) {
+      klog(
+        `live-route key=${key} threw, rebuilding: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  };
+
   const shadowRoute = (
     existing: LiveSession<SessionEnvironment> | undefined,
     decision: "reuse" | "rebuild",
     decisionReason: string,
+    scope: DecisionScope = "environment",
+    plan?: ReconcilePlan,
   ): void => {
     logReconcileShadow({
       key,
@@ -279,6 +356,8 @@ export async function runWithKeepalive(
       appliedDigests: existing?.environment.appliedState.facets,
       decision,
       decisionReason,
+      scope,
+      ...(plan ? { plan } : {}),
     });
   };
 
@@ -559,9 +638,31 @@ export async function runWithKeepalive(
       mismatch = "credentials-expiring";
     else if (!tailIsFreshUserMessage(request)) mismatch = "tail";
 
+    // STEP 6. A pure configuration mismatch gets one chance to be satisfied on the live
+    // environment. Everything else — credentials, continuity, an expiring lease — is decided
+    // above and never reaches this door.
+    if (mismatch === "config") {
+      // Pass the plan we ACTED ON: the apply has already committed the new applied state, so
+      // recomputing here would yield an empty plan and the counter could not name the route.
+      const appliedPlan = await tryLiveRoutes(existing);
+      if (appliedPlan) {
+        shadowRoute(existing, "reuse", "live-route", "environment", appliedPlan);
+        mismatch = undefined;
+      }
+    }
+
     if (mismatch) {
       klog(`mismatch (${mismatch}) key=${key}; evict + cold`);
-      shadowRoute(existing, "rebuild", `mismatch:${mismatch}`);
+      // A transcript mismatch is a decision about the CONVERSATION, not the environment, so it
+      // is logged but never counted against the router. See `DecisionScope`.
+      shadowRoute(
+        existing,
+        "rebuild",
+        `mismatch:${mismatch}`,
+        mismatch === "history" || mismatch === "tail"
+          ? "continuity"
+          : "environment",
+      );
       // Await: the old teardown unmounts the same durable cwd the cold acquire is about to
       // mount — they must never overlap.
       await pool.evict(

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -204,6 +204,7 @@ function apiBaseFromRequest(request: AgentRunRequest): string | undefined {
  * The seams are re-exported below so every existing import path and test keeps working
  * unchanged. That is what makes the extraction reviewable: the diff is a move, not a rewrite.
  */
+import { applyReconcilePlan } from "./environment/apply-plan.ts";
 import {
   klog,
   runWithKeepalive,
@@ -226,6 +227,10 @@ const realKeepaliveEngine: KeepaliveEngine = {
     acquireEnvironment(request, {}, signal, presignedMount),
   runTurn: (env, request, emit, signal, opts) =>
     runTurn(env, request, emit, signal, opts),
+  // LIFECYCLE MIGRATION, STEP 6. The live-route applier. The coordinator gates on the plan being
+  // entirely live-applicable; this performs it and commits applied state only if all of it landed.
+  applyReconcilePlan: (env, request, plan) =>
+    applyReconcilePlan(env, request, plan, klog),
   onParkedLive: async (env) => {
     if (!env.plan.isDaytona) return;
     await env.sandbox?.sandbox?.refreshActivity?.(env.sandbox.sandboxId);

--- a/services/runner/tests/unit/environment-units.test.ts
+++ b/services/runner/tests/unit/environment-units.test.ts
@@ -149,7 +149,13 @@ describe("workspace manager: the public surface", () => {
     const result = await workspaceManager.materialize(
       {
         sandbox: { id: "sbx" },
-        plan: { marker: "the-plan" } as never,
+        plan: {
+          marker: "the-plan",
+          isPi: false,
+          acpAgent: "claude",
+          prompt: { agentsMd: "body" },
+          workspace: { cwd: "/run/cwd", skillDirs: [] },
+        } as never,
         piSkillSnapshot: { marker: "snapshot" } as never,
         log: () => {},
       },
@@ -160,35 +166,29 @@ describe("workspace manager: the public surface", () => {
         }) as never,
       },
     );
-    assert.equal(result, fake);
+    // Step 6: materialize now returns a ManagedWorkspace — the writer's handle PLUS the
+    // inventory of what it wrote — so it is no longer reference-equal to the raw result.
+    assert.equal(result.cleanup, fake.cleanup, "the writer's handle is carried through");
+    assert.equal(result.inventory.instructionsFile, "CLAUDE.md");
     assert.equal(seen.length, 1);
     const input = seen[0] as Record<string, unknown>;
-    assert.deepEqual(input.plan, { marker: "the-plan" });
+    assert.equal((input.plan as { marker: string }).marker, "the-plan");
     assert.deepEqual(input.sandbox, { id: "sbx" });
   });
 
-  it("refresh is DECLARED but not implemented, and says so", async () => {
-    // Step 5 is a structural split with zero behavior change. The entry exists so step 6 is a
-    // routing change; throwing is what keeps it from being wired by accident.
-    await assert.rejects(
-      () =>
-        workspaceManager.refresh(
-          { sandbox: {}, plan: {} as never, log: () => {} },
-          { files: new Map(), skillDirs: [] },
-        ),
-      (err: Error) => /not implemented/.test(err.message),
-    );
-  });
-
   it("refresh takes a complete manifest, because deletion needs one", () => {
-    // A delta cannot express a removal: it cannot tell "unchanged" from "gone". The manifest
-    // shape is what lets step 6 delete a skill directory that left the request.
+    // DELIBERATE EDIT. Step 5 asserted `refresh` threw "not implemented"; step 6 implements it.
+    // A delta cannot express a removal — it cannot tell "unchanged" from "gone" — so the manifest
+    // is a complete statement and the previous inventory is what makes deletion decidable.
     const manifest: workspaceManager.WorkspaceManifest = {
-      files: new Map([["AGENTS.md", "body"]]),
-      skillDirs: ["pdf-tools"],
+      instructions: "body",
+      skills: [{ name: "pdf-tools", dir: "/tmp/pdf-tools" }],
     };
-    assert.equal(manifest.files.get("AGENTS.md"), "body");
-    assert.deepEqual([...manifest.skillDirs], ["pdf-tools"]);
+    assert.equal(manifest.instructions, "body");
+    assert.deepEqual(
+      manifest.skills.map((s) => s.name),
+      ["pdf-tools"],
+    );
   });
 
   it("cleanup swallows a failing cleanup and tolerates no workspace", async () => {

--- a/services/runner/tests/unit/environment-units.test.ts
+++ b/services/runner/tests/unit/environment-units.test.ts
@@ -26,6 +26,13 @@ const SRC = (rel: string) =>
  * Every file that may emit an acquire stage. The split moves stages OUT of `environment.ts` and
  * into the units, so the stage guard has to follow them. A unit added later must be listed here,
  * or its stages become invisible to the guard.
+ *
+ * `environment/timing.ts` MUST NOT be listed, and this is not a detail. That file DECLARES the
+ * stage names as quoted string literals, so searching it for `"sandbox_start"` finds the
+ * declaration rather than an emission. With it in the list the guard below matched its own
+ * source, passed for a stage nothing emitted any more, and reported a healthy dashboard contract
+ * while the dashboards broke. A guard that cannot fail is worse than no guard, because it is what
+ * the next reviewer checks against.
  */
 const STAGE_EMITTERS = [
   "engines/sandbox_agent/environment.ts",
@@ -35,7 +42,6 @@ const STAGE_EMITTERS = [
   "environment/mount-lifecycle.ts",
   "environment/harness-session-lifecycle.ts",
   "environment/runtime-lifecycle.ts",
-  "environment/timing.ts",
 ];
 
 const ALL_STAGE_SOURCE = () => STAGE_EMITTERS.map(SRC).join("\n");
@@ -94,10 +100,15 @@ describe("timing: the stage names are a public interface", () => {
   it("declares every stage the acquire path emits", () => {
     // The guard that keeps dashboards working. If a stage is renamed or dropped during the split,
     // the source no longer emits it and this fails.
-    const source = ALL_STAGE_SOURCE();
+    //
+    // The match is on the CALL, `timingLog("<stage>"`, not on the bare quoted name. A quoted name
+    // occurs in plenty of places that emit nothing, the declaration in `timing.ts` first among
+    // them, and matching those is how this guard used to pass for a stage that had gone.
+    const source = CODE_ONLY(ALL_STAGE_SOURCE());
     for (const stage of ACQUIRE_STAGES) {
-      assert.ok(
-        source.includes(`"${stage}"`),
+      assert.match(
+        source,
+        new RegExp(`timingLog\\(\\s*"${stage}"`),
         `stage '${stage}' is declared but no longer emitted; dashboards match on this name`,
       );
     }
@@ -121,15 +132,20 @@ describe("timing: the stage names are a public interface", () => {
   it("keeps the two-mode stages as ONE stage name with a mode suffix", () => {
     // A dashboard groups by stage and splits by mode. Turning `sandbox_start` into
     // `sandbox_start_create` would silently break every existing query.
-    const source = ALL_STAGE_SOURCE();
+    //
+    // Stage and mode are matched in ONE expression, over a single call. Checked apart, they were
+    // satisfied by any two emissions anywhere in the source, so `mode=create` on `create_session`
+    // stood in for `mode=create` on `sandbox_start` and a mode moved to the wrong stage passed.
+    const source = CODE_ONLY(ALL_STAGE_SOURCE());
     for (const [stage, modes] of [
       ["sandbox_start", ["reconnect", "create"]],
       ["create_session", ["load", "create"]],
     ] as Array<[AcquireStage, string[]]>) {
       for (const mode of modes) {
-        assert.ok(
-          source.includes(`"${stage}", `) && source.includes(`mode=${mode}`),
-          `${stage} must still carry mode=${mode} as a field, not in its name`,
+        assert.match(
+          source,
+          new RegExp(`timingLog\\(\\s*"${stage}"\\s*,[^;]*mode=${mode}\\b`),
+          `${stage} must still carry mode=${mode} as a field of its OWN call, not in its name`,
         );
       }
     }

--- a/services/runner/tests/unit/lifecycle-desired-state.test.ts
+++ b/services/runner/tests/unit/lifecycle-desired-state.test.ts
@@ -64,21 +64,25 @@ describe("facet ownership: one field moves exactly one facet", () => {
       },
       facet: "runtime",
     },
-    { what: "the instructions", overrides: { agentsMd: "new instructions" }, facet: "workspace" },
-    { what: "the system prompt", overrides: { systemPrompt: "sp" }, facet: "workspace" },
+    {
+      what: "the instructions",
+      overrides: { agentsMd: "new instructions" },
+      facet: "workspaceFiles",
+    },
+    { what: "the system prompt", overrides: { systemPrompt: "sp" }, facet: "prompts" },
     {
       what: "the skills",
       overrides: {
         skills: [{ name: "s", description: "d", body: "b" }] as never,
       },
-      facet: "workspace",
+      facet: "workspaceFiles",
     },
     {
       what: "the harness files",
       overrides: { harnessFiles: [{ path: "a", content: "b" }] as never },
-      facet: "workspace",
+      facet: "harnessFiles",
     },
-    { what: "the model", overrides: { model: "m2" }, facet: "harnessSession" },
+    { what: "the model", overrides: { model: "m2" }, facet: "model" },
     {
       what: "the permissions",
       overrides: { permissions: { default: "deny" } as never },
@@ -212,6 +216,28 @@ describe("facet normalization: stability and coverage", () => {
       digestsOf({ ...BASE, sandbox: "daytona", agentsMd: "x", model: "m2" }),
       digestsOf(BASE),
     );
-    assert.deepEqual(moved, ["sandbox", "workspace", "harnessSession"]);
+    assert.deepEqual(moved, ["sandbox", "workspaceFiles", "model"]);
+  });
+
+  it("SECURITY: harness files never share a facet with instructions or skills", () => {
+    // The blocker that forced the facet split. `adapter-matrix.md` section 4.3.2 rule 3 puts
+    // harness PERMISSION files on the never-apply-live list, and the runner cannot tell one
+    // harness file from another. If they shared `workspaceFiles`, making that facet live would
+    // silently route a permission change through an in-place refresh.
+    assert.deepEqual(movedBy({ agentsMd: "x" }), ["workspaceFiles"]);
+    assert.deepEqual(
+      movedBy({ harnessFiles: [{ path: "a", content: "b" }] as never }),
+      ["harnessFiles"],
+    );
+  });
+
+  it("SECURITY: permissions never share a facet with the model", () => {
+    // Same reasoning on the session side. Section 1.4 exempts permission TIGHTENING from
+    // apply-live entirely, so a permissions change must not ride the `setModel` route.
+    assert.deepEqual(movedBy({ model: "m2" }), ["model"]);
+    assert.deepEqual(
+      movedBy({ permissions: { default: "deny" } as never }),
+      ["harnessSession"],
+    );
   });
 });

--- a/services/runner/tests/unit/lifecycle-live-routes.test.ts
+++ b/services/runner/tests/unit/lifecycle-live-routes.test.ts
@@ -1,0 +1,538 @@
+/**
+ * The two LIVE routes, end to end through the dispatch (lifecycle migration, step 6).
+ *
+ * This is the first genuine behavior change in the lifecycle work: a configuration change that
+ * used to throw away a warm sandbox now mutates it in place. These tests exist to prove the
+ * guards, not the happy path — the happy path is one assertion and the guards are the reason it
+ * is safe.
+ *
+ * WHAT MUST HOLD:
+ *  - Only a plan that is ENTIRELY live-applicable takes the route. A mixed plan rebuilds.
+ *  - Applied state advances ONLY when the whole plan applied.
+ *  - Any refusal or throw falls back to a rebuild. Fail closed.
+ *  - Credentials and continuity never reach the route at all.
+ *
+ * Run: pnpm exec vitest run tests/unit/lifecycle-live-routes.test.ts
+ */
+import { beforeEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import type {
+  AgentRunRequest,
+  AgentRunResult,
+} from "../../src/protocol.ts";
+import {
+  runWithKeepalive,
+  type KeepaliveContext,
+  type KeepaliveEngine,
+} from "../../src/server.ts";
+import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
+import {
+  appliedStateForRequest,
+  type AppliedEnvironmentState,
+} from "../../src/engines/sandbox_agent/applied-state.ts";
+import {
+  configFingerprint,
+  type KeepaliveConfig,
+} from "../../src/engines/sandbox_agent/session-identity.ts";
+import {
+  isLivelyApplicable,
+  LIVE_ACTION_KINDS,
+  planReconcile,
+  reconcileCounters,
+  resetReconcileCounters,
+} from "../../src/lifecycle/reconciliation-router.ts";
+import { normalizeDesiredState } from "../../src/lifecycle/desired-state.ts";
+import { buildPlan } from "../../src/lifecycle/reconcile-plan.ts";
+import type { SessionEnvironment } from "../../src/engines/sandbox_agent.ts";
+import type { MountCredentials } from "../../src/engines/sandbox_agent/mount.ts";
+
+type AppliedCommit = Parameters<
+  ReturnType<typeof appliedStateForRequest>["commitApplied"]
+>[0];
+
+beforeEach(() => {
+  resetReconcileCounters();
+});
+
+interface FakeEnv {
+  id: number;
+  readonly appliedState: AppliedEnvironmentState;
+  commitApplied: (result: AppliedCommit) => void;
+  destroyed: number;
+  destroyReasons: string[];
+  turnsCleared: number;
+  lastTurnToolCallIds: string[];
+  parkedApprovals: Map<string, unknown>;
+  approvalGateCount: number;
+  nonParkablePauseCount: number;
+  installedMountExpiries: Record<string, number>;
+  clearTurn: () => void;
+  destroy: (opts?: { reason?: string }) => Promise<void>;
+}
+
+interface EngineOptions {
+  /** How the applier behaves: apply everything, refuse, or throw. */
+  apply?: "ok" | "refuse" | "throw";
+  /** Omit `applyReconcilePlan` entirely, modelling an engine with no live support. */
+  noApplier?: boolean;
+}
+
+function makeEngine(options: EngineOptions = {}) {
+  const calls = {
+    acquire: 0,
+    turns: [] as FakeEnv[],
+    applied: [] as Array<{ actions: string[] }>,
+    acquiredEnvs: [] as FakeEnv[],
+  };
+  let nextId = 1;
+
+  const engine: KeepaliveEngine = {
+    async resolveKeepaliveMount(): Promise<MountCredentials | null> {
+      return {
+        region: "us-east-1",
+        bucket: "b",
+        prefix: "p",
+        accessKey: "AK",
+        secretKey: "SK",
+        projectId: "proj-1",
+      } as MountCredentials;
+    },
+    async acquireEnvironment(request) {
+      calls.acquire += 1;
+      const applied = appliedStateForRequest(request);
+      const env: FakeEnv = {
+        id: nextId++,
+        get appliedState() {
+          return applied.appliedState;
+        },
+        commitApplied: (r) => applied.commitApplied(r),
+        destroyed: 0,
+        destroyReasons: [],
+        turnsCleared: 0,
+        lastTurnToolCallIds: [],
+        parkedApprovals: new Map(),
+        approvalGateCount: 0,
+        nonParkablePauseCount: 0,
+        installedMountExpiries: {},
+        clearTurn: () => {
+          env.turnsCleared += 1;
+        },
+        destroy: async (opts) => {
+          env.destroyed += 1;
+          if (opts?.reason) env.destroyReasons.push(opts.reason);
+        },
+      };
+      calls.acquiredEnvs.push(env);
+      return { ok: true, env: env as unknown as SessionEnvironment };
+    },
+    async runTurn(env): Promise<AgentRunResult> {
+      calls.turns.push(env as unknown as FakeEnv);
+      return { ok: true, output: "ok", stopReason: "complete" };
+    },
+    async runCold(): Promise<AgentRunResult> {
+      return { ok: true, output: "cold", stopReason: "complete" };
+    },
+    ...(options.noApplier
+      ? {}
+      : {
+          async applyReconcilePlan(env, request, plan) {
+            calls.applied.push({ actions: plan.actions.map((a) => a.kind) });
+            if (options.apply === "throw") throw new Error("apply blew up");
+            if (options.apply === "refuse") return false;
+            // The real applier commits only after every action succeeded. Model that exactly.
+            const fp = configFingerprint(request);
+            (env as unknown as FakeEnv).commitApplied({
+              configFingerprint: fp,
+              facets: normalizeDesiredState(request, fp).digests,
+            });
+            return true;
+          },
+        }),
+  };
+  return { engine, calls };
+}
+
+function makeCtx(engine: KeepaliveEngine): KeepaliveContext {
+  const config: KeepaliveConfig = {
+    enabled: true,
+    ttlMs: 60_000,
+    approvalTtlMs: 600_000,
+    poolMax: 8,
+  };
+  return {
+    engine,
+    pool: new SessionPool<SessionEnvironment>({ poolMax: 8 }, () => {}),
+    config,
+  };
+}
+
+const POOL_KEY = "proj-1:s1";
+
+const turn1: AgentRunRequest = {
+  harness: "claude",
+  model: "m1",
+  sessionId: "s1",
+  agentsMd: "original instructions",
+  runContext: { project: { id: "proj-1" } },
+  messages: [{ role: "user", content: "hello" }],
+};
+
+/** A continuation carrying the same conversation plus a fresh user turn. */
+function turn2(overrides: Partial<AgentRunRequest> = {}): AgentRunRequest {
+  return {
+    ...turn1,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "more" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("the live-route gate", () => {
+  it("declares EXACTLY the authorized kinds, plus the trivial no-op", () => {
+    // The single place that says how many routes are live. A fourth entry is the whole decision
+    // to make another route live, and it must not happen by accident.
+    assert.deepEqual(
+      [...LIVE_ACTION_KINDS].sort(),
+      ["apply-live", "no-op", "refresh-workspace"],
+    );
+  });
+
+  it("refuses a plan containing ANY non-live action", () => {
+    // All or nothing. Applying the live half of a mixed plan would leave the environment in a
+    // state no request ever described.
+    assert.equal(
+      isLivelyApplicable(
+        buildPlan(
+          [
+            { facet: "workspaceFiles", kind: "refresh-workspace", reason: "r" },
+            { facet: "harnessFiles", kind: "reopen-session", reason: "r" },
+          ],
+          ["workspaceFiles", "harnessFiles"],
+        ),
+      ),
+      false,
+    );
+  });
+
+  it("accepts a plan made only of live actions", () => {
+    assert.equal(
+      isLivelyApplicable(
+        buildPlan(
+          [
+            { facet: "workspaceFiles", kind: "refresh-workspace", reason: "r" },
+            { facet: "model", kind: "apply-live", reason: "r" },
+          ],
+          ["workspaceFiles", "model"],
+        ),
+      ),
+      true,
+    );
+  });
+});
+
+describe("LIVE ROUTE: an instructions change reuses the warm environment", () => {
+  it("does not rebuild, and runs the turn on the SAME environment", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+
+    await runWithKeepalive(
+      turn2({ agentsMd: "REWRITTEN instructions" }),
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    assert.equal(calls.acquire, 1, "the warm sandbox survives an instructions change");
+    assert.equal(env1.destroyed, 0);
+    assert.equal(calls.turns.length, 2);
+    assert.equal(calls.turns[1].id, env1.id);
+    assert.deepEqual(calls.applied[0].actions, ["refresh-workspace"]);
+  });
+
+  it("advances applied state to the NEW configuration", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    const before = env1.appliedState.generation;
+
+    const next = turn2({ agentsMd: "REWRITTEN instructions" });
+    await runWithKeepalive(next, undefined, undefined, ctx);
+
+    assert.equal(
+      env1.appliedState.configFingerprint,
+      configFingerprint(next),
+      "the environment now reports what it actually applied",
+    );
+    assert.ok(env1.appliedState.generation > before, "the generation advanced");
+  });
+});
+
+describe("LIVE ROUTE: a model change applies to the running session", () => {
+  it("does not rebuild", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(turn2({ model: "m2" }), undefined, undefined, ctx);
+    assert.equal(calls.acquire, 1);
+    assert.deepEqual(calls.applied[0].actions, ["apply-live"]);
+  });
+
+  it("both live routes in one plan still reuse", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(
+      turn2({ model: "m2", agentsMd: "REWRITTEN" }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.acquire, 1);
+    assert.deepEqual(calls.applied[0].actions, ["refresh-workspace", "apply-live"]);
+  });
+});
+
+describe("FAIL CLOSED: everything that must still rebuild", () => {
+  it("a MIXED plan rebuilds, and never applies the live half", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    // Instructions (live) plus harness files (must escalate).
+    await runWithKeepalive(
+      turn2({
+        agentsMd: "REWRITTEN",
+        harnessFiles: [{ path: "a", content: "b" }] as never,
+      }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.acquire, 2, "a mixed plan rebuilds");
+    assert.equal(
+      calls.applied.length,
+      0,
+      "and the applier is never called, so the live half never lands",
+    );
+  });
+
+  it("a REFUSED apply rebuilds", async () => {
+    const { engine, calls } = makeEngine({ apply: "refuse" });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    const env1 = calls.acquiredEnvs[0];
+    const before = env1.appliedState.configFingerprint;
+
+    await runWithKeepalive(turn2({ agentsMd: "REWRITTEN" }), undefined, undefined, ctx);
+
+    assert.equal(calls.acquire, 2);
+    assert.equal(
+      env1.appliedState.configFingerprint,
+      before,
+      "a refusal must leave applied state exactly where it was",
+    );
+  });
+
+  it("a THROWING apply rebuilds rather than failing the turn", async () => {
+    const { engine, calls } = makeEngine({ apply: "throw" });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    const result = await runWithKeepalive(
+      turn2({ agentsMd: "REWRITTEN" }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(result.ok, true, "a live-route failure must never fail the turn");
+    assert.equal(calls.acquire, 2);
+  });
+
+  it("an engine with NO applier keeps the old rebuild behavior exactly", async () => {
+    const { engine, calls } = makeEngine({ noApplier: true });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(turn2({ agentsMd: "REWRITTEN" }), undefined, undefined, ctx);
+    assert.equal(calls.acquire, 2, "the optional seam degrades to today's behavior");
+  });
+
+  it("a CREDENTIAL change never reaches the live route", async () => {
+    // Credential facets keep delegating to the epoch comparison until step 8. The route must not
+    // see them at all, because the router still cannot read the epoch.
+    const withSecret = (value: string, req: AgentRunRequest): AgentRunRequest => ({
+      ...req,
+      modelConnection: {
+        provider: "openai",
+        deployment: "direct",
+        endpoint: { baseUrl: "https://api.openai.com/v1" },
+        credentialMode: "env",
+        credentials: [
+          {
+            binding: { kind: "environment", name: "OPENAI_API_KEY" },
+            value,
+            usage: "opaque_http",
+          },
+        ],
+      } as never,
+    });
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(withSecret("sk-a", turn1), undefined, undefined, ctx);
+    await runWithKeepalive(withSecret("sk-b", turn2()), undefined, undefined, ctx);
+    assert.equal(calls.acquire, 2, "a rotated credential still rebuilds");
+    assert.equal(calls.applied.length, 0, "and never reaches the applier");
+  });
+
+  it("a TRANSCRIPT mismatch never reaches the live route", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(
+      turn2({
+        messages: [
+          { role: "user", content: "EDITED" },
+          { role: "assistant", content: "hi" },
+          { role: "user", content: "more" },
+        ],
+      }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.acquire, 2);
+    assert.equal(calls.applied.length, 0);
+  });
+});
+
+describe("the disagreement counters go quiet for the two live routes", () => {
+  it("an instructions change records an AGREEMENT, not a disagreement", async () => {
+    const { engine } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(turn2({ agentsMd: "REWRITTEN" }), undefined, undefined, ctx);
+
+    const counters = reconcileCounters();
+    assert.equal(
+      counters.disagree["refresh-workspace"] ?? 0,
+      0,
+      "the workspace route must be silent",
+    );
+    assert.ok((counters.agree["refresh-workspace"] ?? 0) > 0);
+  });
+
+  it("a model change records an AGREEMENT", async () => {
+    const { engine } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(turn2({ model: "m2" }), undefined, undefined, ctx);
+
+    const counters = reconcileCounters();
+    assert.equal(counters.disagree["apply-live"] ?? 0, 0);
+    assert.ok((counters.agree["apply-live"] ?? 0) > 0);
+  });
+
+  it("a TRANSCRIPT mismatch is excluded by scope, not counted as a disagreement", async () => {
+    // The improvement the shadow surfaced. The coordinator rebuilds the CONVERSATION while the
+    // router plans a no-op for the ENVIRONMENT: both correct, different questions. Counting it
+    // would have left a permanent false positive no router work could ever drive to zero.
+    const { engine } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(
+      turn2({
+        messages: [
+          { role: "user", content: "EDITED" },
+          { role: "assistant", content: "hi" },
+          { role: "user", content: "more" },
+        ],
+      }),
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    const counters = reconcileCounters();
+    assert.ok(counters.skippedByScope > 0, "the continuity decision was excluded");
+    assert.equal(
+      Object.values(counters.disagree).reduce((a, b) => a + b, 0),
+      0,
+      "and it did NOT land in the disagreement tally",
+    );
+  });
+
+  it("KNOWN GAP, still counted: a rotated credential remains a disagreement", async () => {
+    // Deliberately NOT excluded by scope. The router genuinely cannot see a credential rotation
+    // (values are kept out of every facet digest because digests are logged), so this is a real
+    // gap and the counter must keep saying so until step 8 feeds the epoch into the plan.
+    const withSecret = (value: string, req: AgentRunRequest): AgentRunRequest => ({
+      ...req,
+      modelConnection: {
+        provider: "openai",
+        deployment: "direct",
+        endpoint: { baseUrl: "https://api.openai.com/v1" },
+        credentialMode: "env",
+        credentials: [
+          {
+            binding: { kind: "environment", name: "OPENAI_API_KEY" },
+            value,
+            usage: "opaque_http",
+          },
+        ],
+      } as never,
+    });
+    const { engine } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(withSecret("sk-a", turn1), undefined, undefined, ctx);
+    await runWithKeepalive(withSecret("sk-b", turn2()), undefined, undefined, ctx);
+
+    const counters = reconcileCounters();
+    assert.ok(
+      Object.values(counters.disagree).reduce((a, b) => a + b, 0) > 0,
+      "the credential gap must stay visible in the counters",
+    );
+  });
+});
+
+describe("route selection matches the facet diff", () => {
+  const digestsOf = (r: AgentRunRequest) =>
+    normalizeDesiredState(r, configFingerprint(r)).digests;
+
+  const routeFor = (overrides: Partial<AgentRunRequest>) => {
+    const next = { ...turn1, ...overrides };
+    const plan = planReconcile(
+      next,
+      normalizeDesiredState(next, configFingerprint(next)),
+      digestsOf(turn1),
+    );
+    return { kinds: plan.actions.map((a) => a.kind), live: isLivelyApplicable(plan) };
+  };
+
+  it("routes each facet to its authorized action", () => {
+    assert.deepEqual(routeFor({ agentsMd: "x" }), {
+      kinds: ["refresh-workspace"],
+      live: true,
+    });
+    assert.deepEqual(routeFor({ model: "m2" }), { kinds: ["apply-live"], live: true });
+    assert.deepEqual(routeFor({ systemPrompt: "sp" }), {
+      kinds: ["reopen-session"],
+      live: false,
+    });
+    assert.deepEqual(routeFor({ harnessFiles: [{ path: "a", content: "b" }] as never }), {
+      kinds: ["reopen-session"],
+      live: false,
+    });
+    assert.deepEqual(routeFor({ permissions: { default: "deny" } as never }), {
+      kinds: ["reopen-session"],
+      live: false,
+    });
+    assert.deepEqual(routeFor({ sandbox: "daytona" }), {
+      kinds: ["rebuild-sandbox"],
+      live: false,
+    });
+  });
+});

--- a/services/runner/tests/unit/workspace-refresh.test.ts
+++ b/services/runner/tests/unit/workspace-refresh.test.ts
@@ -1,0 +1,331 @@
+/**
+ * `WorkspaceManager.refresh` correctness (lifecycle migration, step 6).
+ *
+ * The in-place workspace refresh is the cheapest live route in the design, and the one whose
+ * failure is quietest: a skill that was REMOVED from the request but stays on disk is still
+ * readable by the model. For an ordinary skill that is a correctness bug; for a skill removed
+ * because it was unsafe, the removal silently does nothing.
+ *
+ * So these tests run against a REAL temp directory, not a mock. Deletion either happens on a
+ * filesystem or it does not.
+ *
+ * Run: pnpm exec vitest run tests/unit/workspace-refresh.test.ts
+ */
+import { afterEach, beforeEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  inventoryOf,
+  refresh,
+  type WorkspaceInventory,
+} from "../../src/environment/workspace-manager.ts";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), "agenta-ws-refresh-"));
+});
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+/** A local Claude plan: instructions land in CLAUDE.md, skills under `.claude/skills`. */
+function planFor(skills: Array<{ name: string; dir: string }>, agentsMd = "instructions") {
+  return {
+    isPi: false,
+    isDaytona: false,
+    acpAgent: "claude",
+    prompt: { agentsMd },
+    workspace: { cwd, skillDirs: skills },
+  } as never;
+}
+
+function input(plan: unknown) {
+  return { sandbox: {}, plan: plan as never, log: () => {} };
+}
+
+/** Materialize a skill source directory the refresh can copy from. */
+function skillSource(name: string, body: string): { name: string; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), `agenta-skill-${name}-`));
+  writeFileSync(join(dir, "SKILL.md"), body);
+  return { name, dir };
+}
+
+const skillPath = (name: string) => join(cwd, ".claude", "skills", name);
+
+describe("the inventory records what a write leaves behind", () => {
+  it("names the instructions file per harness", () => {
+    assert.equal(inventoryOf(planFor([])).instructionsFile, "CLAUDE.md");
+    const piPlan = {
+      isPi: true,
+      acpAgent: "pi",
+      prompt: { agentsMd: "x" },
+      workspace: { cwd, skillDirs: [] },
+    } as never;
+    assert.equal(inventoryOf(piPlan).instructionsFile, "AGENTS.md");
+  });
+
+  it("records no instructions file when the plan writes none", () => {
+    // Built inline: `planFor`'s default parameter applies when the argument IS `undefined`, so it
+    // cannot express "no instructions" at all.
+    const plan = {
+      isPi: false,
+      acpAgent: "claude",
+      prompt: {},
+      workspace: { cwd, skillDirs: [] },
+    } as never;
+    assert.equal(inventoryOf(plan).instructionsFile, undefined);
+  });
+
+  it("records no skills for Pi, which uses a content-addressed snapshot instead", () => {
+    const piPlan = {
+      isPi: true,
+      acpAgent: "pi",
+      prompt: { agentsMd: "x" },
+      workspace: { cwd, skillDirs: [{ name: "a" }] },
+    } as never;
+    const inventory = inventoryOf(piPlan);
+    assert.equal(inventory.skillRoot, undefined);
+    assert.deepEqual([...inventory.skillNames], []);
+  });
+});
+
+describe("refresh: writes", () => {
+  it("writes the instructions file", async () => {
+    await refresh(input(planFor([])), { instructions: "hello", skills: [] }, {
+      instructionsFile: undefined,
+      skillNames: [],
+      skillRoot: ".claude/skills",
+    });
+    assert.equal(readFileSync(join(cwd, "CLAUDE.md"), "utf-8"), "hello");
+  });
+
+  it("replaces existing instructions rather than appending", async () => {
+    writeFileSync(join(cwd, "CLAUDE.md"), "OLD");
+    await refresh(input(planFor([])), { instructions: "NEW", skills: [] }, {
+      instructionsFile: "CLAUDE.md",
+      skillNames: [],
+      skillRoot: ".claude/skills",
+    });
+    assert.equal(readFileSync(join(cwd, "CLAUDE.md"), "utf-8"), "NEW");
+  });
+
+  it("leaves no temp file behind, so the atomic write is invisible afterwards", async () => {
+    await refresh(input(planFor([])), { instructions: "hello", skills: [] }, {
+      instructionsFile: undefined,
+      skillNames: [],
+      skillRoot: ".claude/skills",
+    });
+    assert.deepEqual(
+      readdirSync(cwd).filter((n) => n.includes(".tmp")),
+      [],
+      "the staging file must be renamed over the target, never left in place",
+    );
+  });
+
+  it("writes a skill directory from its materialized source", async () => {
+    const pdf = skillSource("pdf-tools", "PDF BODY");
+    await refresh(
+      input(planFor([pdf])),
+      { instructions: "x", skills: [pdf] },
+      { instructionsFile: undefined, skillNames: [], skillRoot: ".claude/skills" },
+    );
+    assert.equal(
+      readFileSync(join(skillPath("pdf-tools"), "SKILL.md"), "utf-8"),
+      "PDF BODY",
+    );
+  });
+
+  it("replaces a skill's contents rather than merging them", async () => {
+    const before = skillSource("pdf-tools", "V1");
+    mkdirSync(skillPath("pdf-tools"), { recursive: true });
+    writeFileSync(join(skillPath("pdf-tools"), "STALE.md"), "leftover");
+
+    const after = skillSource("pdf-tools", "V2");
+    await refresh(
+      input(planFor([after])),
+      { instructions: "x", skills: [after] },
+      {
+        instructionsFile: undefined,
+        skillNames: ["pdf-tools"],
+        skillRoot: ".claude/skills",
+      },
+    );
+    assert.equal(
+      readFileSync(join(skillPath("pdf-tools"), "SKILL.md"), "utf-8"),
+      "V2",
+    );
+    assert.ok(
+      !existsSync(join(skillPath("pdf-tools"), "STALE.md")),
+      "a file that left the skill must not survive the refresh",
+    );
+    void before;
+  });
+});
+
+describe("refresh: DELETION, the reason this route needs an inventory", () => {
+  it("removes a skill that left the request", async () => {
+    const keep = skillSource("keep", "KEEP");
+    const drop = skillSource("drop", "DROP");
+    mkdirSync(skillPath("drop"), { recursive: true });
+    writeFileSync(join(skillPath("drop"), "SKILL.md"), "DROP");
+    mkdirSync(skillPath("keep"), { recursive: true });
+
+    const result = await refresh(
+      input(planFor([keep])),
+      { instructions: "x", skills: [keep] },
+      {
+        instructionsFile: undefined,
+        skillNames: ["keep", "drop"],
+        skillRoot: ".claude/skills",
+      },
+    );
+
+    assert.ok(
+      !existsSync(skillPath("drop")),
+      "a removed skill must not stay readable by the model",
+    );
+    assert.ok(existsSync(skillPath("keep")));
+    assert.deepEqual([...result.removedSkills], ["drop"]);
+  });
+
+  it("decides deletion from the INVENTORY, never from a directory listing", async () => {
+    // The load-bearing property. A durable cwd holds the agent's own files, and almost none of
+    // them are the runner's to remove. A skill-shaped directory the runner never wrote must
+    // survive, because it is not in the inventory.
+    const keep = skillSource("keep", "KEEP");
+    mkdirSync(skillPath("not-ours"), { recursive: true });
+    writeFileSync(join(skillPath("not-ours"), "SKILL.md"), "USER FILE");
+
+    await refresh(
+      input(planFor([keep])),
+      { instructions: "x", skills: [keep] },
+      {
+        instructionsFile: undefined,
+        skillNames: ["keep"], // `not-ours` is absent: the runner never wrote it
+        skillRoot: ".claude/skills",
+      },
+    );
+
+    assert.ok(
+      existsSync(join(skillPath("not-ours"), "SKILL.md")),
+      "a directory the runner never wrote is not its to delete",
+    );
+  });
+
+  it("removes the instructions file when the manifest drops it", async () => {
+    writeFileSync(join(cwd, "CLAUDE.md"), "OLD");
+    await refresh(
+      input({
+        isPi: false,
+        isDaytona: false,
+        acpAgent: "claude",
+        prompt: {},
+        workspace: { cwd, skillDirs: [] },
+      } as never),
+      { instructions: undefined, skills: [] },
+      { instructionsFile: "CLAUDE.md", skillNames: [], skillRoot: ".claude/skills" },
+    );
+    assert.ok(!existsSync(join(cwd, "CLAUDE.md")));
+  });
+
+  it("THROWS on a failed delete, so the caller falls back to a rebuild", async () => {
+    // Continuing after a failed delete would leave the removed skill readable, which is the exact
+    // outcome this route exists to prevent. Silence here would be worse than a rebuild.
+    const failing = {
+      ...input(planFor([])),
+      plan: {
+        isPi: false,
+        isDaytona: true,
+        acpAgent: "claude",
+        prompt: { agentsMd: "x" },
+        workspace: { cwd, skillDirs: [] },
+      } as never,
+      sandbox: {
+        deleteFsEntry: async () => {
+          throw new Error("daemon refused");
+        },
+      },
+    };
+    await assert.rejects(
+      () =>
+        refresh(
+          failing,
+          { instructions: "x", skills: [] },
+          {
+            instructionsFile: undefined,
+            skillNames: ["gone"],
+            skillRoot: ".claude/skills",
+          },
+        ),
+      (err: Error) => /could not remove skill 'gone'/.test(err.message),
+    );
+  });
+
+  it("reports an accurate new inventory", async () => {
+    const keep = skillSource("keep", "KEEP");
+    const result = await refresh(
+      input(planFor([keep])),
+      { instructions: "x", skills: [keep] },
+      {
+        instructionsFile: undefined,
+        skillNames: ["keep", "drop"],
+        skillRoot: ".claude/skills",
+      },
+    );
+    const next: WorkspaceInventory = result.inventory;
+    assert.equal(next.instructionsFile, "CLAUDE.md");
+    assert.deepEqual([...next.skillNames], ["keep"]);
+  });
+});
+
+describe("refresh: SCOPE, the facet boundary", () => {
+  it("never touches harness files, because they may be permission files", async () => {
+    // adapter-matrix.md 4.3.2 rule 3. `harnessFiles` is its own facet that escalates to a session
+    // reopen; a refresh that wrote them would route a security-relevant change through an
+    // in-place write.
+    const harnessFile = join(cwd, ".claude", "settings.json");
+    mkdirSync(join(cwd, ".claude"), { recursive: true });
+    writeFileSync(harnessFile, '{"permissions":"strict"}');
+
+    await refresh(input(planFor([])), { instructions: "x", skills: [] }, {
+      instructionsFile: undefined,
+      skillNames: [],
+      skillRoot: ".claude/skills",
+    });
+
+    assert.equal(
+      readFileSync(harnessFile, "utf-8"),
+      '{"permissions":"strict"}',
+      "a harness file must survive a workspace refresh untouched",
+    );
+  });
+
+  it("never touches the agent's own working files", async () => {
+    const userFile = join(cwd, "my-project.py");
+    writeFileSync(userFile, "print('mine')");
+    mkdirSync(join(cwd, "src"), { recursive: true });
+    writeFileSync(join(cwd, "src", "app.ts"), "export {}");
+
+    await refresh(input(planFor([])), { instructions: "x", skills: [] }, {
+      instructionsFile: undefined,
+      skillNames: [],
+      skillRoot: ".claude/skills",
+    });
+
+    assert.equal(readFileSync(userFile, "utf-8"), "print('mine')");
+    assert.ok(existsSync(join(cwd, "src", "app.ts")));
+  });
+});


### PR DESCRIPTION
## Context

Part of the agent-config-editing stack. Targets `agent-config-editing-s3a`. Read the stack bottom up.

Editing an agent's instructions in the playground threw away a warm sandbox and built a new one. Every configuration change did, because the runner compared one whole-request fingerprint and had exactly two answers: reuse it unchanged, or rebuild it. A one-word edit to the instructions document cost the same as switching providers.

s6 built the plan and logged it. This lane lets a plan act.

## Changes

The request now normalizes into eight facets rather than one hash: `sandbox`, `runtime`, `workspaceFiles`, `prompts`, `harnessFiles`, `model`, `harnessSession`, and `toolCatalog`. Each has its own digest, so the router can say which part moved.

The split follows one rule: when in doubt, split. An over-fine facet costs an unnecessary rebuild. An over-coarse one silently downgrades a security-relevant change, which is why `harnessFiles` is its own facet and why `permissions` sits with the harness session rather than beside the model. Coarser facets would have routed a harness permission file through an in-place write, and a permissions change through `setModel`.

`apply-plan.ts` applies a plan to a live environment, and it is written to be paranoid because it is the first code here that changes a running environment instead of replacing it. One rule governs the file: applied state advances only after every action succeeded. `commitApplied` is the last statement and it is unreachable from any failure path. A partial application therefore leaves the environment reporting its old configuration, which is the truth, and the caller rebuilds. Rebuilding after a partial change is wasteful and always sound; continuing is neither.

The workspace refresh is a complete statement of what should exist, never a delta. A delta cannot express a removal, because it cannot distinguish "unchanged" from "gone". Deletions are decided from the inventory this environment recorded when it last wrote the workspace, never from a directory listing, since a durable cwd holds the user's own project. A failed delete throws rather than continuing, because a removed skill left readable is the exact outcome this route exists to prevent. Atomicity is stated honestly in the module: a local file write is atomic, a local skill directory is not atomic as a unit, and a Daytona write is not atomic at all.

The gate is all-or-nothing. A plan mixing a live action with a rebuild action rebuilds the whole thing, because applying the live half would leave the environment in a state no request ever described. Any refusal or throw falls back to a rebuild. Credential and continuity mismatches are decided before this point and never reach the applier.

## Tests / notes

- 35 new tests: the live routes end to end through the dispatch, the workspace refresh with its deletion and inventory rules, and the facet split.
- The tests are mostly guards rather than happy paths. The happy path is one assertion, and the guards are the reason it is safe.
- Worth poking at: the facet boundaries. If you think a field is in the wrong facet, that is the review comment to leave, because the cost of a wrong boundary is either a needless rebuild or a security-relevant change applied in place.

## What to QA

- Edit an agent's instructions in the playground and send another message. The reply comes back on the same warm sandbox, and the agent follows the new instructions.
- Change the model and send a message. Same sandbox, new model.
- Regression: change the provider or the harness. That still rebuilds, and it should.

## Added by the E2E campaign and review fix rounds (5 Aug, evening)
- Two test guards CodeRabbit caught as unable to fail now can: the stage-name guard no longer matches its own declaration, and stage+mode are asserted as one expression per pair. Both were bite-verified against real breaks, with the old guards shown passing on them.

## Post-approval correction (6 Aug, evening)
Live verification proved the workspace-files half of the in-place promise did not hold: the runner rewrote the instructions file, but no harness re-reads it mid-session, so the agent kept obeying old instructions while the config claimed applied. Instruction and skills edits therefore route to REBUILD again (the Option A fix in #5760, live-verified by gate cell L5 with a cold control). What remains live-applied from this PR is the model facet, which the harness genuinely observes. The fast-and-correct follow-up (refresh the file, reopen only the session, keep the sandbox) is recorded in docs/design/agent-config-editing/open-issues.md.
