### PR TITLE
feat(runner): reopen a harness session without losing the sandbox

### DIFF
--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -145,6 +145,7 @@ import {
 import {
   openSession as openHarnessSession,
   probe as probeHarness,
+  reopen as reopenHarnessSession,
   teardown as teardownHarnessSession,
 } from "../../environment/harness-session-lifecycle.ts";
 import {
@@ -877,6 +878,31 @@ export async function acquireEnvironment(
     });
     environment.session = opened.session;
     environment.loadedFromContinuity = opened.loadedFromContinuity;
+    // The reopen capability, captured here because this is the only scope holding the persist
+    // driver, the session-init payload and the local session key together. Same pattern as
+    // `destroy`: the environment carries a closure rather than the ingredients.
+    environment.reopenSession = async ({ transcriptReplayable }) => {
+      const result = await reopenHarnessSession({
+        sandbox: environment.sandbox,
+        persist,
+        acpAgent: plan.acpAgent,
+        harness: plan.harness,
+        cwd: plan.workspace.cwd,
+        sessionInit,
+        priorAgentSessionId: environment.session?.agentSessionId,
+        localSessionId,
+        continuitySessionKey,
+        log: logger,
+        timingLog,
+        current: environment.session,
+        transcriptReplayable,
+      });
+      if (result.ok) {
+        environment.session = result.session;
+        environment.loadedFromContinuity = result.loadedFromContinuity;
+      }
+      return result;
+    };
     environment.sessionId = resolveRunSessionId(
       request,
       environment.session.id,

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -236,6 +236,20 @@ export interface SessionEnvironment {
    * prevent. See `environment/workspace-manager.ts`.
    */
   workspaceInventory?: import("../../environment/workspace-manager.ts").WorkspaceInventory;
+  /**
+   * Close and reopen this environment's harness session on the SAME sandbox.
+   *
+   * A CLOSURE built at acquire, exactly like `destroy`, because a reopen needs the persist
+   * driver, the session-init payload and the local session key — all of which live in the acquire
+   * scope and none of which belong on this interface individually.
+   *
+   * Undefined when the environment never opened a session. The caller then rebuilds.
+   */
+  reopenSession?: (opts: {
+    transcriptReplayable: boolean;
+  }) => Promise<
+    import("../../environment/harness-session-lifecycle.ts").ReopenResult
+  >;
   /** Record a lifecycle action that already succeeded. The only writer of `appliedState`. */
   commitApplied: (result: {
     configFingerprint: string;

--- a/services/runner/src/environment/apply-plan.ts
+++ b/services/runner/src/environment/apply-plan.ts
@@ -31,6 +31,7 @@
  */
 import type { AgentRunRequest } from "../protocol.ts";
 import { applyModel } from "../engines/sandbox_agent/model.ts";
+import { resolveSkillDirs } from "../engines/skills.ts";
 import type { SessionEnvironment } from "../engines/sandbox_agent/runtime-contracts.ts";
 import { normalizeDesiredState } from "../lifecycle/desired-state.ts";
 import { configFingerprint } from "../engines/sandbox_agent/session-identity.ts";
@@ -42,6 +43,7 @@ import type { Log } from "./timing.ts";
 export interface ApplyPlanDeps {
   applyModel?: typeof applyModel;
   refresh?: typeof refresh;
+  resolveSkillDirs?: typeof resolveSkillDirs;
 }
 
 /**
@@ -90,18 +92,56 @@ export async function applyReconcilePlan(
           log("live-route: no workspace inventory recorded; cannot refresh safely");
           return false;
         }
-        const result = await (deps.refresh ?? refresh)(
-          {
-            sandbox: env.sandbox,
-            plan: env.plan as never,
-            log,
-          },
-          {
-            instructions: env.plan.prompt.agentsMd,
-            skills: env.plan.workspace.skillDirs,
-          },
-          previous,
+        // The desired content comes from the INCOMING request. Reading it from `env.plan` would
+        // rewrite the configuration this environment was BUILT with and then commit the incoming
+        // one as applied: the stale-config bug this file's header warns about, in that costume.
+        const instructions = request.agentsMd?.trim() || undefined;
+        const desiredSkills = (deps.resolveSkillDirs ?? resolveSkillDirs)(
+          request.skills,
+          log,
         );
+        if (env.plan.isPi && desiredSkills.skills.length > 0) {
+          // Pi loads one content-addressed snapshot instead of project-local skill directories,
+          // so `refresh` writes no skills there at all (see `skillRootFor`). Reporting the new
+          // configuration as applied after writing none of it is the exact failure above.
+          desiredSkills.cleanup();
+          log("live-route: pi skills cannot be refreshed in place; rebuilding");
+          return false;
+        }
+        // The plan the refresh writes from, and records its inventory from. It replaces the
+        // environment's plan only after the write succeeded, so a failure leaves the environment
+        // describing what is really on disk.
+        const priorSkillsCleanup = env.plan.workspace.skillsCleanup;
+        const nextPlan = {
+          ...env.plan,
+          prompt: { ...env.plan.prompt, agentsMd: instructions },
+          workspace: {
+            ...env.plan.workspace,
+            skillDirs: desiredSkills.skills,
+            // Both temp roots go at teardown. The old one is not removed here: files this
+            // session already reads may still be backed by it.
+            skillsCleanup: () => {
+              priorSkillsCleanup();
+              desiredSkills.cleanup();
+            },
+          },
+        };
+        let result;
+        try {
+          result = await (deps.refresh ?? refresh)(
+            {
+              sandbox: env.sandbox,
+              plan: nextPlan as never,
+              log,
+            },
+            { instructions, skills: desiredSkills.skills },
+            previous,
+          );
+        } catch (error) {
+          desiredSkills.cleanup();
+          throw error;
+        }
+        env.plan = nextPlan;
         env.workspaceInventory = result.inventory;
         if (result.removedSkills.length) {
           log(
@@ -112,6 +152,12 @@ export async function applyReconcilePlan(
       }
 
       case "reopen-session": {
+        // NOT REACHED while `LIVE_ACTION_KINDS` excludes this kind, and the exclusion is the
+        // point: `env.reopenSession` closes over the session init this environment was BUILT
+        // with, so reopening reinstalls the OLD MCP list, prompts and harness files while the
+        // commit below would report the incoming ones. The machinery stays because it is what
+        // the desired-plan installer will drive; only the routing is off.
+        //
         // Close and reopen on the SAME sandbox. `reopen` refuses before touching anything when
         // the conversation could not survive, so a refusal leaves the live session running and
         // the caller rebuilds from a clean state.

--- a/services/runner/src/environment/apply-plan.ts
+++ b/services/runner/src/environment/apply-plan.ts
@@ -36,6 +36,7 @@ import { normalizeDesiredState } from "../lifecycle/desired-state.ts";
 import { configFingerprint } from "../engines/sandbox_agent/session-identity.ts";
 import type { ReconcilePlan } from "../lifecycle/reconcile-plan.ts";
 import { refresh, type WorkspaceInventory } from "./workspace-manager.ts";
+import { carriesMinimalHistory } from "../engines/sandbox_agent/session-identity.ts";
 import type { Log } from "./timing.ts";
 
 export interface ApplyPlanDeps {
@@ -106,6 +107,26 @@ export async function applyReconcilePlan(
           log(
             `live-route: refreshed workspace, removed ${result.removedSkills.length} skill(s)`,
           );
+        }
+        break;
+      }
+
+      case "reopen-session": {
+        // Close and reopen on the SAME sandbox. `reopen` refuses before touching anything when
+        // the conversation could not survive, so a refusal leaves the live session running and
+        // the caller rebuilds from a clean state.
+        if (!env.reopenSession) {
+          log("live-route: this environment cannot reopen its session; rebuilding");
+          return false;
+        }
+        const result = await env.reopenSession({
+          // Native history cannot be positively verified, so a reopen is only safe when the
+          // request carries a transcript the turn will replay. See `reopen`.
+          transcriptReplayable: !carriesMinimalHistory(request),
+        });
+        if (!result.ok) {
+          log(`live-route: reopen refused (${result.reason}); rebuilding`);
+          return false;
         }
         break;
       }

--- a/services/runner/src/environment/harness-session-lifecycle.ts
+++ b/services/runner/src/environment/harness-session-lifecycle.ts
@@ -173,3 +173,87 @@ export async function teardown(input: {
     // best-effort session teardown
   }
 }
+
+/**
+ * ============================================================================================
+ * REOPEN: closing and reopening the session on the SAME sandbox
+ * ============================================================================================
+ *
+ * LIFECYCLE MIGRATION, STEP 6 (continued). A reopen is what makes the uniform tool, MCP, prompt
+ * and harness-file routes cheaper than a rebuild: the sandbox, the daemon, the mounts and the
+ * workspace all survive; only the ACP session is recreated.
+ *
+ * THE HARD PART IS NOT REOPENING. It is knowing whether the CONVERSATION survived.
+ *
+ * `adapter-matrix.md` section 6.2 is explicit that a matching `agentSessionId` proves the adapter
+ * ACCEPTED the id, not that it replayed the turns. A `session/load` that succeeds at the transport
+ * layer and loads nothing would look identical. So a reopen may not claim continuity on that
+ * evidence, and the matrix gives two options: read back a positive signal, or treat the reopen as
+ * a continuity loss and replay.
+ *
+ * WHAT WE CAN ACTUALLY OBSERVE: nothing. The ACP surface exposes no conversation length and no
+ * last-message identifier, so the first option is unavailable today. Inventing a check that does
+ * not check anything would be worse than having none.
+ *
+ * SO THE CONDITION IS REPLAYABILITY, NOT VERIFICATION. The runner does not always NEED native
+ * history. When the request carries the full transcript, the turn replays it and a reopened
+ * session that lost its memory is indistinguishable from one that kept it. When the request
+ * carries only the last message, the harness's native memory IS the conversation, and losing it
+ * silently truncates the user's context.
+ *
+ *   full transcript in the request -> reopen is safe. Replay covers the loss.
+ *   last-message-only request      -> reopen needs proof we cannot obtain. FAIL CLOSED.
+ *
+ * That is the honest reading of the matrix's second option, and it keeps the route useful for the
+ * common case instead of making it permanently inert.
+ */
+export interface ReopenInput extends OpenSessionInput {
+  /** The live session to close before reopening. */
+  current: { id: string } | undefined;
+  /**
+   * True when the incoming request carries the whole prior conversation, so the turn replays it
+   * and native memory is not load-bearing. Computed by the caller from `carriesMinimalHistory`.
+   */
+  transcriptReplayable: boolean;
+}
+
+export type ReopenResult =
+  | {
+      ok: true;
+      session: { id: string; agentSessionId?: string };
+      loadedFromContinuity: boolean;
+    }
+  | { ok: false; reason: "history-unverifiable" | "reopen-failed" };
+
+/**
+ * Close and reopen the harness session on the same sandbox.
+ *
+ * Returns `ok: false` rather than throwing: a refusal is an ordinary outcome the caller answers
+ * with a rebuild. `history-unverifiable` is a REFUSAL BEFORE ANY CHANGE — nothing is closed and
+ * the live session keeps running, so the caller's rebuild starts from a clean state rather than
+ * from a session we already tore down.
+ */
+export async function reopen(input: ReopenInput): Promise<ReopenResult> {
+  if (!input.transcriptReplayable) {
+    input.log(
+      "reopen refused: the request carries no transcript to replay, and native history cannot be verified",
+    );
+    return { ok: false, reason: "history-unverifiable" };
+  }
+  try {
+    await teardown({
+      sandbox: input.sandbox as never,
+      session: input.current,
+      alreadyRequested: false,
+    });
+    const opened = await openSession(input);
+    return {
+      ok: true,
+      session: opened.session,
+      loadedFromContinuity: opened.loadedFromContinuity,
+    };
+  } catch (err) {
+    input.log(`reopen failed: ${conciseError(err, input.harness)}`);
+    return { ok: false, reason: "reopen-failed" };
+  }
+}

--- a/services/runner/src/lifecycle/reconciliation-router.ts
+++ b/services/runner/src/lifecycle/reconciliation-router.ts
@@ -414,6 +414,14 @@ export const LIVE_ACTION_KINDS: ReadonlySet<ActionKind> = new Set<ActionKind>([
   "no-op",
   "apply-live",
   "refresh-workspace",
+  // Step 6 (continued). A reopen keeps the sandbox, the daemon, the mounts and the workspace;
+  // only the ACP session is recreated. It is what makes the uniform tool, MCP, prompt and
+  // harness-file routes cheaper than a rebuild.
+  //
+  // It carries its own refusal: a session may only be reopened when the request carries a
+  // transcript to replay, because native history cannot be positively verified. See
+  // `harness-session-lifecycle.ts` `reopen`.
+  "reopen-session",
 ]);
 
 /**

--- a/services/runner/tests/unit/lifecycle-apply-plan.test.ts
+++ b/services/runner/tests/unit/lifecycle-apply-plan.test.ts
@@ -1,0 +1,220 @@
+/**
+ * What a live route actually INSTALLS (lifecycle migration, step 6).
+ *
+ * The route tests one directory over assert on the plan the coordinator chose and on the applied
+ * state it advanced to. Both stayed green while the refresh rewrote the configuration the
+ * environment was BUILT with, because an action name and a digest cannot tell you which bytes
+ * landed. These tests read the files back.
+ *
+ * The refresh runs for real against a temp directory, because "the new instructions are on disk"
+ * is a filesystem property and a fake refresh would prove only that a fake was called.
+ *
+ * Run: pnpm exec vitest run tests/unit/lifecycle-apply-plan.test.ts
+ */
+import { afterEach, beforeEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { applyReconcilePlan } from "../../src/environment/apply-plan.ts";
+import { buildPlan } from "../../src/lifecycle/reconcile-plan.ts";
+import { inventoryOf } from "../../src/environment/workspace-manager.ts";
+import type { AgentRunRequest } from "../../src/protocol.ts";
+import type { SessionEnvironment } from "../../src/engines/sandbox_agent/runtime-contracts.ts";
+
+const SKILL_ROOT = ".claude/skills";
+
+function wireSkill(name: string, body: string) {
+  return { name, description: `${name} description`, body };
+}
+
+const REFRESH_PLAN = buildPlan(
+  [{ facet: "workspaceFiles", kind: "refresh-workspace", reason: "r" }],
+  ["workspaceFiles"],
+);
+
+describe("applyReconcilePlan: refresh-workspace installs the INCOMING configuration", () => {
+  let cwd: string;
+  let committed: Array<{ configFingerprint: string }>;
+  let cleanups: string[];
+
+  /** The environment a first turn would have left behind: old instructions, one old skill. */
+  function makeEnv(overrides: { isPi?: boolean } = {}) {
+    const plan = {
+      isPi: overrides.isPi ?? false,
+      isDaytona: false,
+      acpAgent: overrides.isPi ? "pi" : "claude",
+      prompt: { agentsMd: "OLD instructions" },
+      workspace: {
+        cwd,
+        skillDirs: [{ name: "departed", dir: join(cwd, "source-departed") }],
+        skillsCleanup: () => cleanups.push("original"),
+      },
+    };
+    const env = {
+      plan,
+      sandbox: {},
+      workspaceInventory: inventoryOf(plan as never),
+      commitApplied: (input: { configFingerprint: string }) =>
+        committed.push(input),
+    };
+    return env as unknown as SessionEnvironment;
+  }
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "agenta-apply-plan-"));
+    committed = [];
+    cleanups = [];
+    // What the first turn wrote: the old instructions file and the old skill directory.
+    writeFileSync(join(cwd, "CLAUDE.md"), "OLD instructions");
+    mkdirSync(join(cwd, SKILL_ROOT, "departed"), { recursive: true });
+    writeFileSync(
+      join(cwd, SKILL_ROOT, "departed", "SKILL.md"),
+      "the skill that leaves",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("writes the instructions the REQUEST carries, never the plan's", async () => {
+    const env = makeEnv();
+    const request: AgentRunRequest = {
+      harness: "claude",
+      agentsMd: "NEW instructions",
+      messages: [],
+    } as never;
+
+    const applied = await applyReconcilePlan(
+      env,
+      request,
+      REFRESH_PLAN,
+      () => {},
+    );
+
+    assert.equal(applied, true);
+    assert.equal(
+      readFileSync(join(cwd, "CLAUDE.md"), "utf-8"),
+      "NEW instructions",
+      "the agent must read the instructions this request carries",
+    );
+    assert.equal(
+      committed.length,
+      1,
+      "applied state advances once, after the write",
+    );
+  });
+
+  it("replaces the plan, so the next refresh deletes the right tree", async () => {
+    const env = makeEnv();
+    const request: AgentRunRequest = {
+      harness: "claude",
+      agentsMd: "NEW instructions",
+      skills: [wireSkill("arrived", "# arrived")],
+      messages: [],
+    } as never;
+
+    await applyReconcilePlan(env, request, REFRESH_PLAN, () => {});
+
+    assert.equal(env.plan.prompt.agentsMd, "NEW instructions");
+    assert.deepEqual(
+      env.plan.workspace.skillDirs.map((skill) => skill.name),
+      ["arrived"],
+    );
+    assert.deepEqual(
+      env.workspaceInventory?.skillNames,
+      ["arrived"],
+      "the inventory records what was WRITTEN; a stale one deletes the wrong tree next time",
+    );
+    // Both skill roots are removed at teardown. The old one is not removed during the turn:
+    // files this session already reads may still be backed by it.
+    env.plan.workspace.skillsCleanup();
+    assert.deepEqual(cleanups, ["original"]);
+  });
+
+  it("installs an arriving skill and removes a departed one", async () => {
+    const env = makeEnv();
+    const request: AgentRunRequest = {
+      harness: "claude",
+      agentsMd: "NEW instructions",
+      skills: [wireSkill("arrived", "# arrived")],
+      messages: [],
+    } as never;
+
+    const applied = await applyReconcilePlan(
+      env,
+      request,
+      REFRESH_PLAN,
+      () => {},
+    );
+
+    assert.equal(applied, true);
+    assert.equal(
+      existsSync(join(cwd, SKILL_ROOT, "departed")),
+      false,
+      "a skill that left the request must not stay readable",
+    );
+    assert.match(
+      readFileSync(join(cwd, SKILL_ROOT, "arrived", "SKILL.md"), "utf-8"),
+      /# arrived/,
+    );
+  });
+
+  it("refuses a Pi skills change instead of reporting one it cannot write", async () => {
+    // Pi loads one content-addressed snapshot, so `refresh` writes no skill directories there at
+    // all. Committing the new configuration after writing none of it is the failure this whole
+    // route is guarded against.
+    const env = makeEnv({ isPi: true });
+    const request: AgentRunRequest = {
+      harness: "pi",
+      agentsMd: "NEW instructions",
+      skills: [wireSkill("arrived", "# arrived")],
+      messages: [],
+    } as never;
+
+    const applied = await applyReconcilePlan(
+      env,
+      request,
+      REFRESH_PLAN,
+      () => {},
+    );
+
+    assert.equal(applied, false, "the caller must rebuild");
+    assert.equal(committed.length, 0, "and applied state must not advance");
+  });
+
+  it("commits nothing when a later action in the same plan fails", async () => {
+    // THE ONE RULE, through the real refresh: the workspace write lands, the model action fails,
+    // and applied state stays where it was. The caller rebuilds from the truth.
+    const env = makeEnv();
+    const request: AgentRunRequest = {
+      harness: "claude",
+      agentsMd: "NEW instructions",
+      model: "m2",
+      messages: [],
+    } as never;
+    const plan = buildPlan(
+      [
+        { facet: "workspaceFiles", kind: "refresh-workspace", reason: "r" },
+        { facet: "model", kind: "apply-live", reason: "r" },
+      ],
+      ["workspaceFiles", "model"],
+    );
+
+    const applied = await applyReconcilePlan(env, request, plan, () => {}, {
+      applyModel: async () => "a-different-model",
+    });
+
+    assert.equal(applied, false);
+    assert.equal(committed.length, 0);
+  });
+});

--- a/services/runner/tests/unit/lifecycle-live-routes.test.ts
+++ b/services/runner/tests/unit/lifecycle-live-routes.test.ts
@@ -193,11 +193,24 @@ function turn2(overrides: Partial<AgentRunRequest> = {}): AgentRunRequest {
 
 describe("the live-route gate", () => {
   it("declares EXACTLY the authorized kinds, plus the trivial no-op", () => {
-    // The single place that says how many routes are live. A fourth entry is the whole decision
-    // to make another route live, and it must not happen by accident.
+    // DELIBERATE EDIT. `reopen-session` joined the live set: it keeps the sandbox, the daemon,
+    // the mounts and the workspace, recreating only the ACP session, which is what makes the
+    // uniform tool/MCP/prompt/harness-file routes cheaper than a rebuild. It carries its own
+    // refusal (see `reopen`), so being live-APPLICABLE is not the same as always succeeding.
+    //
+    // The guard still matters: this list is the single place that says how many routes are live,
+    // and a fifth entry must be a decision, never an accident.
     assert.deepEqual(
       [...LIVE_ACTION_KINDS].sort(),
-      ["apply-live", "no-op", "refresh-workspace"],
+      ["apply-live", "no-op", "refresh-workspace", "reopen-session"],
+    );
+    assert.ok(
+      !LIVE_ACTION_KINDS.has("restart-runtime"),
+      "a runtime restart is not live: it loses everything installed in the daemon",
+    );
+    assert.ok(
+      !LIVE_ACTION_KINDS.has("rebuild-sandbox"),
+      "a rebuild is the opposite of a live route",
     );
   });
 
@@ -209,9 +222,9 @@ describe("the live-route gate", () => {
         buildPlan(
           [
             { facet: "workspaceFiles", kind: "refresh-workspace", reason: "r" },
-            { facet: "harnessFiles", kind: "reopen-session", reason: "r" },
+            { facet: "runtime", kind: "restart-runtime", reason: "r" },
           ],
-          ["workspaceFiles", "harnessFiles"],
+          ["workspaceFiles", "runtime"],
         ),
       ),
       false,
@@ -225,8 +238,9 @@ describe("the live-route gate", () => {
           [
             { facet: "workspaceFiles", kind: "refresh-workspace", reason: "r" },
             { facet: "model", kind: "apply-live", reason: "r" },
+            { facet: "harnessFiles", kind: "reopen-session", reason: "r" },
           ],
-          ["workspaceFiles", "model"],
+          ["workspaceFiles", "model", "harnessFiles"],
         ),
       ),
       true,
@@ -304,11 +318,16 @@ describe("FAIL CLOSED: everything that must still rebuild", () => {
     const { engine, calls } = makeEngine();
     const ctx = makeCtx(engine);
     await runWithKeepalive(turn1, undefined, undefined, ctx);
-    // Instructions (live) plus harness files (must escalate).
+    // Instructions (live) plus a model-connection change (restart-runtime: NOT live).
     await runWithKeepalive(
       turn2({
         agentsMd: "REWRITTEN",
-        harnessFiles: [{ path: "a", content: "b" }] as never,
+        modelConnection: {
+          provider: "openai",
+          deployment: "direct",
+          credentialMode: "env",
+          credentials: [],
+        } as never,
       }),
       undefined,
       undefined,
@@ -518,21 +537,62 @@ describe("route selection matches the facet diff", () => {
       live: true,
     });
     assert.deepEqual(routeFor({ model: "m2" }), { kinds: ["apply-live"], live: true });
+    // These three route to a session REOPEN, which is now live-applicable — the sandbox survives
+    // and only the ACP session is recreated. The reopen still refuses at execution time when the
+    // conversation could not be replayed, which is a different question from routing.
     assert.deepEqual(routeFor({ systemPrompt: "sp" }), {
       kinds: ["reopen-session"],
-      live: false,
+      live: true,
     });
     assert.deepEqual(routeFor({ harnessFiles: [{ path: "a", content: "b" }] as never }), {
       kinds: ["reopen-session"],
-      live: false,
+      live: true,
     });
     assert.deepEqual(routeFor({ permissions: { default: "deny" } as never }), {
       kinds: ["reopen-session"],
-      live: false,
+      live: true,
     });
     assert.deepEqual(routeFor({ sandbox: "daytona" }), {
       kinds: ["rebuild-sandbox"],
       live: false,
     });
+  });
+});
+
+describe("reopen: the history condition (adapter-matrix 6.2)", () => {
+  it("a harness-files change now REUSES the sandbox instead of rebuilding", async () => {
+    // The payoff of making reopen live: the uniform tool/MCP/prompt/harness-file routes stop
+    // costing a full sandbox rebuild.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(
+      turn2({ harnessFiles: [{ path: "a", content: "b" }] as never }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.acquire, 1, "the sandbox survives a harness-file change");
+    assert.deepEqual(calls.applied[0].actions, ["reopen-session"]);
+  });
+
+  it("a LAST-MESSAGE-ONLY request still rebuilds, because history cannot be verified", async () => {
+    // The fail-closed half. When the request carries no transcript, the harness's native memory
+    // IS the conversation, and a matching agentSessionId proves only that the adapter accepted
+    // the id — never that it replayed the turns. So the reopen refuses and the caller rebuilds.
+    const { engine, calls } = makeEngine({ apply: "refuse" });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(
+      {
+        ...turn1,
+        harnessFiles: [{ path: "a", content: "b" }] as never,
+        messages: [{ role: "user", content: "only this" }],
+      },
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.acquire, 2, "no transcript to replay means no safe reopen");
   });
 });

--- a/services/runner/tests/unit/workspace-refresh.test.ts
+++ b/services/runner/tests/unit/workspace-refresh.test.ts
@@ -25,6 +25,8 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { fileURLToPath } from "node:url";
+
 import {
   inventoryOf,
   refresh,
@@ -327,5 +329,75 @@ describe("refresh: SCOPE, the facet boundary", () => {
 
     assert.equal(readFileSync(userFile, "utf-8"), "print('mine')");
     assert.ok(existsSync(join(cwd, "src", "app.ts")));
+  });
+});
+
+describe("the parked-without-inventory path: REFUTED", () => {
+  // I flagged this as an open question when the live route landed: apply-plan refuses a workspace
+  // refresh when the environment has no recorded inventory, so could a session park in that
+  // state and be permanently unable to take the route?
+  //
+  // ANSWER: no. The path cannot exist, for three reasons that each have a test below. The
+  // defensive refusal in apply-plan STAYS — it costs one branch and it is the difference between
+  // a rebuild and a silently stale skill if any of this ever changes.
+
+  it("1. materialize ALWAYS returns an inventory, for every plan shape", () => {
+    // There is no "wrote a workspace but recorded nothing" result. `inventoryOf` is total: it
+    // tolerates a partial plan and returns an empty inventory rather than undefined.
+    const shapes: unknown[] = [
+      { isPi: false, acpAgent: "claude", prompt: { agentsMd: "x" }, workspace: { cwd, skillDirs: [] } },
+      { isPi: true, acpAgent: "pi", prompt: {}, workspace: { cwd, skillDirs: [] } },
+      { isPi: false, acpAgent: "codex", prompt: {}, workspace: {} },
+      {},
+    ];
+    for (const plan of shapes) {
+      const inventory = inventoryOf(plan as never);
+      assert.ok(inventory, "an inventory is always produced");
+      assert.ok(Array.isArray([...inventory.skillNames]));
+    }
+  });
+
+  it("2. the acquire path writes the inventory on BOTH materialize branches", () => {
+    // `prepare_workspace` is unconditional inside the acquire try (no enclosing `if`), and both
+    // the first attempt and the post-remount retry assign the inventory. A structural check,
+    // because the alternative is booting a real sandbox.
+    const source = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../src/engines/sandbox_agent/environment.ts",
+          import.meta.url,
+        ),
+      ),
+      "utf-8",
+    );
+    const assignments = source.split("environment.workspaceInventory =").length - 1;
+    const materializations = source.split("await materializeWorkspace(").length - 1;
+    assert.equal(
+      assignments,
+      materializations,
+      "every workspace materialization must record its inventory",
+    );
+    assert.equal(materializations, 2, "the first attempt and the remount retry");
+  });
+
+  it("3. a workspace failure aborts the acquire, so no such environment can park", () => {
+    // The retry path rethrows when it cannot remount, and an acquire that throws never returns an
+    // environment to park. So "parked" implies "materialized" implies "inventory recorded".
+    const source = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../src/engines/sandbox_agent/environment.ts",
+          import.meta.url,
+        ),
+      ),
+      "utf-8",
+    );
+    const idx = source.indexOf("retrying workspace preparation");
+    assert.ok(idx > 0);
+    const after = source.slice(idx, idx + 600);
+    assert.ok(
+      after.includes("throw err;"),
+      "a workspace failure with no viable remount must abort the acquire",
+    );
   });
 });


### PR DESCRIPTION
## Context

Part of the agent-config-editing stack. Targets `agent-config-editing-s3b-core`. Read the stack bottom up.

Some configuration changes need a new harness session but nothing more. The MCP server list, the system prompt, and the tool catalog are all baked in when the ACP session opens, and no harness exposes a live API to change them. Until now the only repair was a full sandbox rebuild, which also threw away the daemon, the mounts, and the workspace.

## Changes

`reopen` closes and reopens the ACP session on the same sandbox. It refuses before touching anything when the conversation could not survive, so a refusal leaves the live session running and the caller rebuilds from a clean state.

The refusal is the interesting half. A reopen may only proceed when the request carries a transcript the turn will replay. Native harness history cannot be positively verified: a matching `agentSessionId` proves the adapter accepted the id, never that it replayed the turns. So a last-message-only request rebuilds instead, and that is the fail-closed side.

This lane also carries two fixes from the final review round, both in `apply-plan.ts`.

The workspace refresh installed the wrong content. It read `env.plan`, which is the plan the environment was built with and is never replaced, while `commitApplied` recorded the incoming request's fingerprint. So editing an agent's instructions rewrote the file with its old text and then reported the new configuration as applied. Every later turn matched that stamp and stopped reconciling, leaving the agent running its old instructions permanently.

Before: `refresh(..., { instructions: env.plan.prompt.agentsMd, skills: env.plan.workspace.skillDirs }, previous)`
After: the manifest is built from the incoming request, and `env.plan` is replaced with the new one only after the write succeeds.

Replacing the plan is not cosmetic. `refresh` derives its returned inventory from the plan it is handed, so passing the old plan would record the old skill names and the next refresh would delete the wrong tree. The old skills temp root is not removed mid-turn, because files this session already reads may still be backed by it; both roots are removed at teardown.

The second fix: on Pi, skills are loaded from one content-addressed snapshot rather than project-local directories, so the refresh writes no skill directories there at all. A Pi skills change was therefore reported as applied after installing none of it, which is the same failure on a different path. The refresh now refuses on Pi when the request carries skills, and the caller rebuilds. This over-refuses: a Pi run that has skills and edits only its instructions now rebuilds. That is the sound side, and narrowing it to a real skills diff is recorded as follow-up.

## Tests / notes

- 10 new tests, including a suite that asserts what the refresh actually installed rather than which action was selected. It reads `CLAUDE.md` back off disk, checks that a departed skill directory is gone and an arriving one is present, and checks that the recorded inventory names what was written. Four of the five fail against the old behavior.
- Recorded boundary: `reopen-session` is not yet a live route. It lands here as machinery and stays out of `LIVE_ACTION_KINDS` in the lane above, because the runner cannot yet build a session init from the incoming request. See `adapter-matrix.md` section 8.

## What to QA

- Edit an agent's instructions in the playground, send a message, and check the agent follows the new text. Before this fix it followed the old text while the runner reported the new configuration as installed.
- Add a skill, send a message, then remove it and send another. The added skill is usable, and the removed one is gone rather than still readable.

## Added by the E2E campaign and review fix rounds (5 Aug, evening)
- The workspace-refresh live route now installs the INCOMING request's instructions and skills (it previously re-installed the acquiring request's content while recording the new fingerprint as applied); env.plan is replaced only after a successful install. On Pi, a request carrying skills refuses the refresh and rebuilds, since Pi has no skill root to install into.
