### PR TITLE
test(qa): permanent release-gate cells for agent config editing

### DIFF
--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -175,5 +175,12 @@ client.
   live Gmail and GitHub Composio connections in the target project; skip it otherwise.
 - `resources/seeds/` — representative green `results.json` files kept as regression-seed references.
 
+## Contributing
+
+Before committing any resource script, run the repo-pinned ruff (`uv run --no-sync ruff format`
+then `uv run --no-sync ruff check` from the repo root covers it) — not `uvx`, whose pulled
+version has different defaults and produces a false block. Unformatted resource files break the
+repo-wide format CI job.
+
 Release-night findings and the full evidence history are archived in
 `docs/design/agent-workflows/projects/qa/` (STATUS.md, findings.md, matrix.md).

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -91,15 +91,17 @@ own docstring:
   no tool names, no operation names, no schema hints. Only these cells license a claim about
   what the model can do unprompted.
 
-**Rule: claims of model behavior may only cite mechanism-blind cells.** Every cell currently in
-this directory is coached tier — they test backend paths, correctly, but do not stand in for
+**Rule: claims of model behavior may only cite mechanism-blind cells.** Most cells in this
+directory are coached tier — they test backend paths, correctly, but do not stand in for
 model-discovery evidence. The gap this rule exists to close, found live: asked in plain words to
 "add the skill I saved in your folder," Haiku invented a nonexistent marker syntax
 (`{"@ag.embed": {"@ag.references": ...}}`) and the engine accepted it as literal data — a failure
 none of the coached cells (including `matrix_w7.py`, whose prompt names `@ag.file` outright)
 could ever have caught, because they never test whether the model reaches for the real mechanism
-on its own. The mechanism-blind tier is being built separately as the one-shot benchmark (Tier
-B), reusing `qa_matrix_lib.py` — do not duplicate it here.
+on its own. `resources/matrix_g1_guidance_discovery.py` is this directory's first mechanism-blind
+cell, promoted after the platform-guidance fix closed that exact gap; it reuses `qa_matrix_lib.py`
+the same way the separate one-shot benchmark (Tier B) does — check there before writing a new
+mechanism-blind cell from scratch, to avoid duplicating scaffolding.
 
 ## When results lie
 
@@ -202,6 +204,31 @@ proves nothing about the durable working directory (LESSONS #16).
   A reliable deterministic trigger (e.g. a genuine cold-resume stale-approval replay, or a crafted
   duplicate `toolCallId`) is an open follow-up; until then, treat any SKIP from this cell as "the
   invariant was not tested this run," never as green.
+- `resources/matrix_g1_guidance_discovery.py` — **[mechanism-blind]** does the platform guidance
+  actually change what the model does? The trial prompt is Mahmoud's own verbatim phrasing from
+  the live session that found the bug ("can you add gstack-autoplan skill to your skills (i saved
+  it in your folder)") — no tool, operation, or marker syntax named. Before the guidance existed,
+  this exact phrasing made a model copy the skill into its own harness-local skills folder and
+  claim success without ever proposing a commit, 3/3 live (session b59cb549). Two parts per
+  harness/model/sandbox leg: PROBE reads the rendered instructions file out of the workspace and
+  asserts the fenced platform-guidance block and the skill-location sentence are really there;
+  TRIALS run the prompt N times, PASS only when a commit_revision gate fires, is approved, and the
+  STORED revision carries the skill (copying into the harness's own folder is a FAIL). Setup
+  gotchas baked into `qa_matrix_lib.py` (`PI_CORE_HARNESS_KIND`, `PI_CORE_HAIKU_MODEL`): the Pi
+  harness kind enum is `"pi_core"` (bare `"pi"` 500s), and `pi_core` rejects a bare `"haiku"` model
+  id (needs `"claude-haiku-4-5"`); codex accepts its curated short alias (`"gpt-5.6-luna"`) bare.
+  Both legs need `sandbox=daytona` + a vault key (codex: OpenAI; pi_core: the same Anthropic key
+  `matrix_w1_daytona.py` documents) and SKIP with the exact reason when the credential is missing
+  or ambiguous. Verified 2026-08-06: codex SKIPPED (this project's vault held an ambiguous/missing
+  OpenAI credential — open item with Mahmoud, same blocker as `matrix_w7_per_harness.py`'s codex
+  leg); pi_core scored **2/3, not 4/4** — a real, reproducible finding, not noise: trial 2's model
+  ran `cp -r agent-files/gstack-autoplan .agenta-imports/` (copying the whole directory) then
+  referenced a marker path that didn't match where the file landed, and the engine correctly
+  denied it fail-closed (`approved-content resolution failed ...: gstack-autoplan/SKILL.md does
+  not exist under .agenta-imports/.; deny`). Not a product bug — the deny is doing its job — but
+  evidence that even with the guidance present, pi_core+haiku still fumbles the exact
+  copy-then-reference mechanics some of the time. Worth a call on whether the guidance text should
+  say "copy the FILE, not the directory" more explicitly, or whether 2/3 is an acceptable bar.
 
 ### The lifecycle cells (`matrix_l*.py`) — cold ↔ warm, and what survives each transition
 

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -159,6 +159,14 @@ proves nothing about the durable working directory (LESSONS #16).
   (every other cell runs local). Needs a funded provider vault key (see the file's own docstring
   for the exact vault-secret shape and the `provider_key` slug gotcha). PASS confirms
   `DaytonaWorkspaceReader` and the placeholder-secrets flow live.
+- `resources/matrix_t8_saved_files.py` — **[coached]** T8: the Daytona remote agent mount (the
+  durable `agent-files/` folder the playground file drawer writes into), which needs the ngrok
+  tunnel the runner discovers at sandbox-acquire time. Writes a marker file into the mount via
+  the mounts API (`POST /mounts/agents/sign` + `PUT /mounts/{id}/files`) before the run, then
+  asserts the runner log line `remote agent mount active for artifact=<id>` appears, a tool
+  output actually carries the real marker content (not hallucinated), and the commit lands with
+  it. Verified PASS 3/3 runs after the tunnel-seat fix (2026-08-06); this line was absent on
+  every attempt before that fix landed.
 
 **Known verification gap, recorded rather than pretended away:** the cold-resume
 stale-approval-regate path (`shouldRegateStaleApproval`, acp-interactions.ts — a stored `allow`

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -168,6 +168,68 @@ proves nothing about the durable working directory (LESSONS #16).
   it. Verified PASS 3/3 runs after the tunnel-seat fix (2026-08-06); this line was absent on
   every attempt before that fix landed.
 
+### The lifecycle cells (`matrix_l*.py`) — cold ↔ warm, and what survives each transition
+
+These four cover the session-lifecycle work: which config changes are applied to a RUNNING
+sandbox and which tear it down, and what happens to a pending approval, a client tool and the
+durable mount across each transition. They all assert the STORED turn ledger
+(`POST /sessions/turns/query` → one `sandbox_id` per turn) or the STORED interaction rows
+(`POST /sessions/interactions/query`), never the SSE echo — nothing about warm-versus-rebuilt
+ever reaches the stream. An empty ledger FAILS a cell; missing evidence is not evidence.
+
+- `resources/matrix_l1_lifecycle_routes.py` — **MANDATORY. [mechanism-blind]** the routing matrix
+  itself: for each kind of mid-conversation config change, assert the route the runner took. One
+  sandbox id = applied in place, two = rebuilt. Blocks on the four unambiguous cases (no change
+  and an instructions edit must stay warm; a permissions edit and a tool-catalog edit must
+  escalate) and reports the `model` case rather than guessing at a deployment's connection shape.
+  This is the cell that would have caught the `cold1` rot described below.
+- `resources/matrix_l2_approval_across_config_change.py` — **MANDATORY. [coached]** the killer
+  combination: an approval answered while a config change rides along in the SAME request. It is
+  the regression test for the applied-state bug (the pool used to stamp the INCOMING fingerprint
+  on the approval-resume path, so the next turn continued warm on an environment running
+  something else). Asserts the gated commit lands, the approval row ends `resolved`/`responded`,
+  and — the real tell — the config change is not swallowed: it takes effect on the FOLLOWING
+  turn, warm for an instructions edit and via a rebuild for a permissions edit.
+- `resources/matrix_l3_abandoned_approval.py` — **MANDATORY. [coached]** the user sends a new
+  message instead of answering the card. Asserts the gated tool does NOT run (an unanswered
+  approval is not consent), the row is swept to `cancelled` rather than left `pending`, and the
+  session still works. `cancelled` vs `pending` is the loud-vs-silent distinction: a `pending` row
+  is a card sitting on the page that no process is waiting on.
+- `resources/matrix_l5_live_route_observed.py` — **MANDATORY. [mechanism-blind, with a control]**
+  the other half of L1: an instructions edit applied to a running session must actually be
+  OBSERVED by the harness, not merely written to disk. Runs the same configuration on a fresh cold
+  session as a control, so a warm failure isolates the runner rather than blaming the model; when
+  the control also fails it reports INCONCLUSIVE instead of a confident wrong verdict.
+  **Currently FAILS (2026-08-06, claude/local):** the warm session goes on answering from the
+  instructions it started with while the pool reports the new fingerprint — see the finding note
+  below.
+- `resources/matrix_l4_client_tool_lifecycle.py` — **nice-to-have. [coached]** the client-tool
+  round trip, and the only cell that covers client tools at all. Asserts the browser's result
+  reaches the model and the `client_tool` interaction is stored. It RECORDS rather than asserts
+  the sandbox count, which is two today: a client-tool pause is deliberately not parkable
+  (`"warm-hold": RESERVED, not built`, #5384), so every client-tool round trip currently costs a
+  rebuild. If that number ever reads one, the warm hold landed and the docstring needs updating.
+
+**Open finding the lifecycle cells surfaced (2026-08-06, claude on local, reproduced 3×):** the
+`workspaceFiles` live route rewrites the instruction file and advances applied state, but the
+running harness never re-reads it. A warm session keeps obeying the instructions it started with
+while the pool reports the NEW fingerprint, so every later turn matches and continues warm and the
+user's edit has no effect until something else evicts the session. A cold session with the
+identical configuration obeys it immediately, which is what isolates the runner. This is the
+failure `desired-state.ts` refuses to allow for the `prompts` facet ("refreshing them and claiming
+the model saw the change would be a lie") reappearing on the facet that WAS made live — and note
+the direction: before the live route existed, an instructions edit forced a rebuild and therefore
+took effect on the next turn, so this is a regression in what the user sees, not a speedup.
+`matrix_l5_live_route_observed.py` is the repro.
+
+**Why `cold1` changed (read before trusting an old green):** that tier used to force its eviction
+by editing `instructions.agents_md`. `agentsMd` is the `workspaceFiles` facet, which the
+lifecycle work made one of exactly two LIVE routes, so an instructions edit is now satisfied in
+place — the tier would have gone on passing while measuring warm reuse, and `park`'s "one sandbox
+id is meaningful" argument rests on `cold1` reporting two on the same deployment. It now moves
+`harness.permissions` (the `harnessSession` facet → `reopen-session`, deliberately not live) and
+ASSERTS two distinct sandbox ids. Any future forcing function needs the same check.
+
 **Known verification gap, recorded rather than pretended away:** the cold-resume
 stale-approval-regate path (`shouldRegateStaleApproval`, acp-interactions.ts — a stored `allow`
 for a marker call whose frozen bytes no longer exist must raise a FRESH gate, not execute on
@@ -179,6 +241,14 @@ silently drops the stale decision on resume rather than raising a new card or ex
 itself worth a second look, separate from the original regate question). Do not write a new
 wire cell for this without a different approach (e.g. a runner-side hook) than a pure HTTP
 client.
+
+*A candidate approach, found while building the `matrix_l*` cells and not yet tried:* a turn that
+raises an approval gate AND a client-tool pause together takes the `mixed-gate-no-park` branch in
+`session-coordinator.ts` (`approvalToPark` refuses when `nonParkablePauseCount > 0`), so the
+environment is destroyed with the approval still pending — "gate pending → environment evicted"
+without any intervening user turn and without touching the message history. Answering afterwards
+lands on a pool miss and takes the cold decision-map path, which is exactly the state
+`shouldRegateStaleApproval` guards. Worth a spike before concluding this needs a runner-side hook.
 - `resources/qa_longctx.py` — optional long-context / Gmail / concurrent-session probes. Needs
   live Gmail and GitHub Composio connections in the target project; skip it otherwise.
 - `resources/seeds/` — representative green `results.json` files kept as regression-seed references.

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -177,10 +177,12 @@ proves nothing about the durable working directory (LESSONS #16).
   (no vault dependency); codex and pi_core need a funded OpenAI `provider_key` vault secret
   (mirrors cells X1/C3 in `qa_product.py`) and correctly SKIP with the exact reason when it's
   missing or ambiguous — a SKIP here is an untested harness, not a pass, and must be named as such
-  in any release summary. Verified PASS on claude (2026-08-06); codex/pi SKIPPED on this shared
-  preview stack because its vault held zero — then, transiently, an ambiguous multiple — OpenAI
-  candidates (other concurrent agents' activity on the same shared project); provisioning a
-  dedicated, unambiguous OpenAI key for this project is an open follow-up.
+  in any release summary. `--only <harness>` runs a single leg without re-spending budget on the
+  others. Verified PASS on claude (2026-08-06). codex/pi initially SKIPPED on this shared preview
+  stack because its vault held zero — then, transiently, an ambiguous multiple — OpenAI candidates
+  (other concurrent agents' activity on the same shared project); resolved 2026-08-06 by stocking
+  one unambiguous OpenAI `provider_key` secret (no stale entries existed to remove). Re-verified
+  PASS on codex after stocking the key (session 58ce3a58-8d04-40ac-99e4-c44eaa5d7b06).
 - `resources/matrix_w7_daytona.py` — **[coached]** matrix_w7.py's exact scenario with
   `sandbox=daytona` instead of local. The local-only original W7 is exactly why this bug hid: the
   Daytona transport rejects NUL bytes in argv, which the `@ag.file` manifest walk was emitting, so
@@ -219,16 +221,27 @@ proves nothing about the durable working directory (LESSONS #16).
   id (needs `"claude-haiku-4-5"`); codex accepts its curated short alias (`"gpt-5.6-luna"`) bare.
   Both legs need `sandbox=daytona` + a vault key (codex: OpenAI; pi_core: the same Anthropic key
   `matrix_w1_daytona.py` documents) and SKIP with the exact reason when the credential is missing
-  or ambiguous. Verified 2026-08-06: codex SKIPPED (this project's vault held an ambiguous/missing
-  OpenAI credential — open item with Mahmoud, same blocker as `matrix_w7_per_harness.py`'s codex
-  leg); pi_core scored **2/3, not 4/4** — a real, reproducible finding, not noise: trial 2's model
-  ran `cp -r agent-files/gstack-autoplan .agenta-imports/` (copying the whole directory) then
-  referenced a marker path that didn't match where the file landed, and the engine correctly
-  denied it fail-closed (`approved-content resolution failed ...: gstack-autoplan/SKILL.md does
-  not exist under .agenta-imports/.; deny`). Not a product bug — the deny is doing its job — but
-  evidence that even with the guidance present, pi_core+haiku still fumbles the exact
-  copy-then-reference mechanics some of the time. Worth a call on whether the guidance text should
-  say "copy the FILE, not the directory" more explicitly, or whether 2/3 is an acceptable bar.
+  or ambiguous. `--only <leg>` runs a single leg without re-spending trial budget on the other.
+  Neither leg has yet scored a clean 4/4 live, and both failure modes are real, reproducible model
+  mechanics misses, not noise or infra flake — treat this cell's discovery rate as a genuine open
+  quality question, not a settled pass:
+  - **pi_core: 2/3** (2026-08-06). Trial 2's model ran `cp -r agent-files/gstack-autoplan
+    .agenta-imports/` (copying the whole directory) then referenced a marker path that didn't
+    match where the file landed; the engine correctly denied it fail-closed
+    (`approved-content resolution failed ...: gstack-autoplan/SKILL.md does not exist under
+    .agenta-imports/.; deny`). Not a product bug — the deny is doing its job — but evidence the
+    model fumbles the exact copy-then-reference mechanics some of the time.
+  - **codex: 2/3** (2026-08-06, re-verified after stocking a clean OpenAI vault key — the earlier
+    SKIP was purely the missing/ambiguous credential, now resolved). Trial 1 didn't attempt the
+    mechanism at all: zero gates approved, the model just replied "I can't add skills by simply
+    placing files in the skills folder; skills must be enabled through the agent configuration"
+    (session 4fa17164-3ada-4ef6-86b5-63bf1c64f10b) — it named the right concept but never called
+    read_config/commit_revision to act on it. Trials 2 and 3 passed cleanly (sessions
+    4c6a758b-39a3-4789-890e-06f3d68196b6, bf8a1283-667c-45c7-ab0d-b112e12106db).
+
+  Worth a call: whether the guidance text needs to be more directive (e.g. explicitly say "copy
+  the FILE, not the directory" and "always attempt the tool calls, don't just describe the
+  mechanism"), or whether ~2/3 is an acceptable bar for this feature's launch.
 
 ### The lifecycle cells (`matrix_l*.py`) — cold ↔ warm, and what survives each transition
 

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -243,6 +243,30 @@ proves nothing about the durable working directory (LESSONS #16).
   the FILE, not the directory" and "always attempt the tool calls, don't just describe the
   mechanism"), or whether ~2/3 is an acceptable bar for this feature's launch.
 
+### Builtin capability cells (`matrix_b*.py`) — does the harness's own tooling still work
+
+- `resources/matrix_b1_builtin_find.py` — **[coached, harness-mechanism test]** one native
+  file-search call per harness (write three known marker files, then ask the model to locate
+  them via its own search capability — never a manual directory listing), asserting the exact
+  filenames come back in the TOOL OUTPUT payload, never the reply. Exists because nothing else in
+  the gate ever exercised a harness builtin: verify-runner's overnight diagnosis found Pi's
+  `find` builtin dead 52/52 across two benchmark runs (it shells out to the vendored `fd` binary
+  with a flag that only exists from fd 9 onward; the runner image ships fd 8.6.0) — a total
+  capability loss that sat invisible with nothing calling it. This cell closes that discoverability
+  gap for the class, not just this one instance. **Open discrepancy, not yet reconciled**: this
+  cell's own pi_core leg PASSED twice, live, with real filenames back
+  (2026-08-07, sessions dd9c51ef-92d0-4780-855e-da6f48e07d9f and
+  47f02ab1-61ec-4db8-a0d6-2d96e98b9188) — which does not match "52/52 failed". Either the break is
+  conditional on a flag/option this cell's simple case never exercises, or something already
+  changed; needs reconciling with verify-runner before Pi's `find` gets called either fixed or
+  still broken. **Codex SKIPs by design**, not tested: its exec output doesn't land in the
+  `tool-output-available` payload's `.output` field (the same quirk `qa_product.py`'s `j2_mount`
+  already names and skips codex for), so this cell's evidence extraction cannot see codex's real
+  results — a codex-shaped extraction is a follow-up. Claude PASSED cleanly on the two-turn
+  version (session 4081e9ee-11c1-4f12-8245-6c390f90e9d8). Needed two EXPLICIT turns (write, then
+  search) — one combined instruction left claude stopping after the write step without
+  attempting the search at all.
+
 ### The lifecycle cells (`matrix_l*.py`) — cold ↔ warm, and what survives each transition
 
 These four cover the session-lifecycle work: which config changes are applied to a RUNNING

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -276,7 +276,10 @@ ever reaches the stream. An empty ledger FAILS a cell; missing evidence is not e
   a control, so a failure isolates the runner rather than blaming the model; when the control also
   fails it reports INCONCLUSIVE instead of a confident wrong verdict. It asserts the edit, never
   the route, so it stays meaningful if the facet is ever made live again. **Failed 2026-08-06
-  (claude/local) and now passes** — see the finding note below.
+  (claude/local) and now passes** — see the finding note below. Extended 2026-08-06 (overnight
+  gate run) to all three harnesses in one invocation (`--only <harness>` for a single leg) —
+  this MANDATORY blocker cell had only ever run on claude; codex and pi_core were a named gap.
+  Verified PASS on all three the same night the harness matrix landed.
 - `resources/matrix_l4_client_tool_lifecycle.py` — **nice-to-have. [coached]** the client-tool
   round trip, and the only cell that covers client tools at all. Asserts the browser's result
   reaches the model and the `client_tool` interaction is stored. It RECORDS rather than asserts

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -77,6 +77,30 @@ mutation. This script does: create a real workflow + revision, invoke a live age
 revision landed with REST fetch-back. Treat a FAIL here as blocking, the same as any other gate
 FAIL.
 
+## Tiers: coached vs. mechanism-blind
+
+Every cell in this gate (`qa_product.py`'s journeys, `qa_commit_approval.py`,
+`qa_probe.py`, and all `matrix_w*.py` cells) declares which of two tiers it belongs to, in its
+own docstring:
+
+- **Coached (backend-path test).** The prompt names the mechanism verbatim — which tool, which
+  operation, which target path. This proves OUR CODE works (the gate, the base check, the
+  authorization handoff, the sandbox path) when the right call is made. It proves NOTHING about
+  whether a model finds that call from a plain-language human ask.
+- **Mechanism-blind (model-behavior test).** The prompt is phrased the way a real user types —
+  no tool names, no operation names, no schema hints. Only these cells license a claim about
+  what the model can do unprompted.
+
+**Rule: claims of model behavior may only cite mechanism-blind cells.** Every cell currently in
+this directory is coached tier — they test backend paths, correctly, but do not stand in for
+model-discovery evidence. The gap this rule exists to close, found live: asked in plain words to
+"add the skill I saved in your folder," Haiku invented a nonexistent marker syntax
+(`{"@ag.embed": {"@ag.references": ...}}`) and the engine accepted it as literal data — a failure
+none of the coached cells (including `matrix_w7.py`, whose prompt names `@ag.file` outright)
+could ever have caught, because they never test whether the model reaches for the real mechanism
+on its own. The mechanism-blind tier is being built separately as the one-shot benchmark (Tier
+B), reusing `qa_matrix_lib.py` — do not duplicate it here.
+
 ## When results lie
 
 The runtime **fails open**: a component can break, get logged, and the turn still succeeds with a
@@ -99,28 +123,54 @@ proves nothing about the durable working directory (LESSONS #16).
   side per cell before this driver runs again; do not resolve it blind.
 - `resources/qa_probe.py` — a one-turn wire probe: `uv run resources/qa_probe.py` confirms the
   product path answers at all before running the full gate.
-- `resources/qa_commit_approval.py` — the mandatory pre-handoff commit-approval round trip (see
-  above). Self-contained; does not import `qa_product.py`, so it still runs while that file is
-  broken.
+- `resources/qa_commit_approval.py` — **[coached]** the mandatory pre-handoff commit-approval
+  round trip (see above). Self-contained; does not import `qa_product.py`, so it still runs
+  while that file is broken.
 - `resources/qa_matrix_lib.py` — shared helpers (session/turn plumbing, workflow/revision REST
   calls, the multi-round approval loop) for the `matrix_w*.py` adversarial cells below. Import
   only, no CLI.
-- `resources/matrix_w3.py` — two sessions, disjoint edits, one hits a stale `base_revision_id`
-  and must recover; asserts both edits land in the final head. Guards the optimistic-concurrency
-  base check.
-- `resources/matrix_w4.py` — a pending approval whose base goes stale while it waits (a second
-  session commits first); the EXECUTE-time check must catch it, not just the gate-time check.
-- `resources/matrix_w5.py` — interrupt a running turn (steer) then use the session again. Caught
-  a real bug: the durable mount never gets re-established after a steer, breaking every
-  subsequent turn on that session. Distinct from Mahmoud's own steer repro (that one is a
+- `resources/matrix_w3.py` — **[coached, with a narrow mechanism-blind sliver]** two sessions,
+  disjoint edits; session B is given a stale `base_revision_id` and ZERO coaching on recovery.
+  Two-tier pass: autonomous correct recovery passes outright; a model that diagnoses the 409
+  correctly and asks before re-attempting a config write ALSO passes (that is desirable caution,
+  not a failure) once one bare "yes, retry" permission (no mechanics) completes the recovery.
+  Guards both the optimistic-concurrency base check and the instructive-error design (a 409 must
+  be readable without coaching). The initial action in both sessions is still coached — only the
+  RECOVERY step is mechanism-blind; don't cite this cell for "the model finds commit_revision
+  unprompted."
+- `resources/matrix_w4.py` — **[coached]** a pending approval whose base goes stale while it
+  waits (a second session commits first); the EXECUTE-time check must catch it, not just the
+  gate-time check.
+- `resources/matrix_w5.py` — **[coached]** interrupt a running turn (steer) then use the session
+  again. Caught a real bug: the durable mount never gets re-established after a steer, breaking
+  every subsequent turn on that session. Distinct from Mahmoud's own steer repro (that one is a
   turn-currency/heartbeat bug; this is a mount-lifecycle bug) — keep the two separate when
   triaging.
-- `resources/matrix_w7.py` — an agent writes a workspace file and commits it via an `@ag.file`
-  marker; asserts the approval manifest carries digest+bytes and the commit lands with the exact
-  bytes. Caught a real bug: the gate approves cleanly but execution then always refuses with
-  `authorization_missing` — no file-marker commit can currently land. Also blocks any test of the
-  stale-approval-regate mechanism (that mechanism is specifically about file-marker
-  authorizations going stale).
+- `resources/matrix_w7.py` — **[coached]** an agent writes a workspace file and commits it via an
+  `@ag.file` marker; asserts the approval manifest carries digest+bytes and the commit lands with
+  the exact bytes. Caught a real bug (fixed, PR #5763-adjacent runner fix): the gate approved
+  cleanly but execution always refused with `authorization_missing` — no file-marker commit could
+  land. Re-verified PASS after the fix. Note: `DEFERRED_NOT_EXECUTED` on a queued second tool
+  call is benign (another gate is already pending), not a real tool error — don't let it fail
+  this cell. Naming `@ag.file` verbatim in the prompt is correct for this cell's backend-path
+  purpose but means it cannot catch a model failing to find the marker syntax unprompted — see
+  Tiers above.
+- `resources/matrix_w1_daytona.py` — **[coached]** the commit round-trip on `sandbox=daytona`
+  (every other cell runs local). Needs a funded provider vault key (see the file's own docstring
+  for the exact vault-secret shape and the `provider_key` slug gotcha). PASS confirms
+  `DaytonaWorkspaceReader` and the placeholder-secrets flow live.
+
+**Known verification gap, recorded rather than pretended away:** the cold-resume
+stale-approval-regate path (`shouldRegateStaleApproval`, acp-interactions.ts — a stored `allow`
+for a marker call whose frozen bytes no longer exist must raise a FRESH gate, not execute on
+stale content) has unit coverage through the real wiring (the F8 tests) but no live wire-level
+cell. A scripted client cannot force "gate pending → environment evicted → gate answered"
+without violating the message-history contract real clients honor (confirmed: inserting an
+intervening turn triggers `approval-mismatch(history)` eviction correctly, but the runner then
+silently drops the stale decision on resume rather than raising a new card or executing —
+itself worth a second look, separate from the original regate question). Do not write a new
+wire cell for this without a different approach (e.g. a runner-side hook) than a pure HTTP
+client.
 - `resources/qa_longctx.py` — optional long-context / Gmail / concurrent-session probes. Needs
   live Gmail and GitHub Composio connections in the target project; skip it otherwise.
 - `resources/seeds/` — representative green `results.json` files kept as regression-seed references.

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -61,6 +61,22 @@ location with `AGENTA_QA_RUNS_DIR`). Runs are written to the current working dir
 the skill. `SKIP` is expected where a journey does not apply to a cell (for example `mcp` on any Pi
 cell — user MCP is Claude-only). Any `FAIL` blocks the release until triaged.
 
+**A SKIPped integration test in a security- or concurrency-bearing area is a FAILURE in your
+summary line, not green.** State it as "N passed, M skipped OF WHICH k are untested claims" and
+name the k. A commit-lock race test skipping for want of a reachable Postgres is exactly how a
+one-line syntax error (`SET LOCAL lock_timeout` with a bind parameter, which Postgres rejects
+outright) survived 1911 green tests before a human hit it as his first live action.
+
+**Before a human gets a deployment URL, run `resources/qa_commit_approval.py` too.** It is not
+part of `qa_product.py`'s cell × journey matrix — none of that matrix's journeys drive a live turn
+against a REAL, saved workflow revision (the `commit` journey only exercises the REST API; `chat`,
+`tool`, `approve`/`deny` all run against an inline, unsaved config), so nothing else in the gate
+observes the S3b single-use execution-authorization gate actually firing around a real config
+mutation. This script does: create a real workflow + revision, invoke a live agent turn that calls
+`read_config` then `commit_revision`, expect the pause, approve it in-band, and verify the new
+revision landed with REST fetch-back. Treat a FAIL here as blocking, the same as any other gate
+FAIL.
+
 ## When results lie
 
 The runtime **fails open**: a component can break, get logged, and the turn still succeeds with a
@@ -77,9 +93,34 @@ proves nothing about the durable working directory (LESSONS #16).
   approve, deny, commit, warm, cold1, cold2, mcp) with a one-line meaning for each, the continuity
   tiers and their method, and a table of what each cell needs beyond the three env vars.
 - `resources/LESSONS.md` — the traps. Read before writing or trusting any agent QA test.
-- `resources/qa_product.py` — the gate driver (cells × journeys).
+- `resources/qa_product.py` — the gate driver (cells × journeys). **Currently broken**: two
+  unresolved git merge conflicts sit inside the `CELLS` dict (P2/P3 definitions), a SyntaxError
+  that fails the whole file on import, not just those cells. Needs a human to pick the correct
+  side per cell before this driver runs again; do not resolve it blind.
 - `resources/qa_probe.py` — a one-turn wire probe: `uv run resources/qa_probe.py` confirms the
   product path answers at all before running the full gate.
+- `resources/qa_commit_approval.py` — the mandatory pre-handoff commit-approval round trip (see
+  above). Self-contained; does not import `qa_product.py`, so it still runs while that file is
+  broken.
+- `resources/qa_matrix_lib.py` — shared helpers (session/turn plumbing, workflow/revision REST
+  calls, the multi-round approval loop) for the `matrix_w*.py` adversarial cells below. Import
+  only, no CLI.
+- `resources/matrix_w3.py` — two sessions, disjoint edits, one hits a stale `base_revision_id`
+  and must recover; asserts both edits land in the final head. Guards the optimistic-concurrency
+  base check.
+- `resources/matrix_w4.py` — a pending approval whose base goes stale while it waits (a second
+  session commits first); the EXECUTE-time check must catch it, not just the gate-time check.
+- `resources/matrix_w5.py` — interrupt a running turn (steer) then use the session again. Caught
+  a real bug: the durable mount never gets re-established after a steer, breaking every
+  subsequent turn on that session. Distinct from Mahmoud's own steer repro (that one is a
+  turn-currency/heartbeat bug; this is a mount-lifecycle bug) — keep the two separate when
+  triaging.
+- `resources/matrix_w7.py` — an agent writes a workspace file and commits it via an `@ag.file`
+  marker; asserts the approval manifest carries digest+bytes and the commit lands with the exact
+  bytes. Caught a real bug: the gate approves cleanly but execution then always refuses with
+  `authorization_missing` — no file-marker commit can currently land. Also blocks any test of the
+  stale-approval-regate mechanism (that mechanism is specifically about file-marker
+  authorizations going stale).
 - `resources/qa_longctx.py` — optional long-context / Gmail / concurrent-session probes. Needs
   live Gmail and GitHub Composio connections in the target project; skip it otherwise.
 - `resources/seeds/` — representative green `results.json` files kept as regression-seed references.

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -167,6 +167,41 @@ proves nothing about the durable working directory (LESSONS #16).
   output actually carries the real marker content (not hallucinated), and the commit lands with
   it. Verified PASS 3/3 runs after the tunnel-seat fix (2026-08-06); this line was absent on
   every attempt before that fix landed.
+- `resources/matrix_w7_per_harness.py` — **[coached]** matrix_w7.py's exact scenario run
+  identically on all three harnesses (claude, codex, pi_core), each classified PASS/FAIL/SKIP
+  independently. Exists because W7 originally ran on Claude only, and that scenario-coverage gap
+  is exactly what let the Codex approve-then-fail P0 (2026-08-06) ship: commit_revision + file
+  marker + HITL approval on a harness this suite never exercised. claude uses subscription auth
+  (no vault dependency); codex and pi_core need a funded OpenAI `provider_key` vault secret
+  (mirrors cells X1/C3 in `qa_product.py`) and correctly SKIP with the exact reason when it's
+  missing or ambiguous — a SKIP here is an untested harness, not a pass, and must be named as such
+  in any release summary. Verified PASS on claude (2026-08-06); codex/pi SKIPPED on this shared
+  preview stack because its vault held zero — then, transiently, an ambiguous multiple — OpenAI
+  candidates (other concurrent agents' activity on the same shared project); provisioning a
+  dedicated, unambiguous OpenAI key for this project is an open follow-up.
+- `resources/matrix_w7_daytona.py` — **[coached]** matrix_w7.py's exact scenario with
+  `sandbox=daytona` instead of local. The local-only original W7 is exactly why this bug hid: the
+  Daytona transport rejects NUL bytes in argv, which the `@ag.file` manifest walk was emitting, so
+  no workspace-file commit could EVER land on Daytona, on any harness, until the 2026-08-06 fix
+  (found during the same P0 triage, live-verified twice on codex+Daytona: sessions f3fa4335,
+  f2f22056). This cell is the sandbox-axis regression guard, staying on the claude harness. Needs
+  the same funded Anthropic vault key as `matrix_w1_daytona.py`. Verified PASS (2026-08-06).
+- `resources/matrix_invariant_commit_auth_refusal.py` — **[coached scenario; the invariant itself
+  is mechanism-level]** the generic invariant: no `tool_result` with empty output and
+  `isError:false` may exist for a call whose runner log says `[commit-auth] refused` (the
+  silent-blank-success class — the P0's actual failure shape, distinct from the scenario-coverage
+  gap `matrix_w7_per_harness.py` addresses). The check itself
+  (`qa_matrix_lib.check_no_blank_success_on_refusal`) reads the runner's own log line against the
+  wire outcome and is meant to be reusable by any cell that exercises marker-carrying commits, not
+  just this one. This cell's trigger is best-effort: run W7's flow, let the legitimate commit
+  consume its authorization record, then REPLAY the byte-identical approval-carrying request
+  (a duplicate submission) hoping to force a second, doomed `authorizeExecution` attempt. Verified
+  2026-08-06: the replay did NOT reproduce a refusal (the runner treats the identical replayed
+  history as already-resolved and answers conversationally instead of re-invoking the tool), so
+  the cell correctly SKIPped rather than claiming a false pass on an invariant it never exercised.
+  A reliable deterministic trigger (e.g. a genuine cold-resume stale-approval replay, or a crafted
+  duplicate `toolCallId`) is an open follow-up; until then, treat any SKIP from this cell as "the
+  invariant was not tested this run," never as green.
 
 ### The lifecycle cells (`matrix_l*.py`) — cold ↔ warm, and what survives each transition
 
@@ -180,29 +215,28 @@ ever reaches the stream. An empty ledger FAILS a cell; missing evidence is not e
 - `resources/matrix_l1_lifecycle_routes.py` — **MANDATORY. [mechanism-blind]** the routing matrix
   itself: for each kind of mid-conversation config change, assert the route the runner took. One
   sandbox id = applied in place, two = rebuilt. Blocks on the four unambiguous cases (no change
-  and an instructions edit must stay warm; a permissions edit and a tool-catalog edit must
-  escalate) and reports the `model` case rather than guessing at a deployment's connection shape.
-  This is the cell that would have caught the `cold1` rot described below.
+  must stay warm; an instructions edit, a permissions edit and a tool-catalog edit must escalate)
+  and reports the `model` case rather than guessing at a deployment's connection shape. This is
+  the cell that would have caught the `cold1` rot described below.
 - `resources/matrix_l2_approval_across_config_change.py` — **MANDATORY. [coached]** the killer
   combination: an approval answered while a config change rides along in the SAME request. It is
   the regression test for the applied-state bug (the pool used to stamp the INCOMING fingerprint
   on the approval-resume path, so the next turn continued warm on an environment running
   something else). Asserts the gated commit lands, the approval row ends `resolved`/`responded`,
   and — the real tell — the config change is not swallowed: it takes effect on the FOLLOWING
-  turn, warm for an instructions edit and via a rebuild for a permissions edit.
+  turn, via a rebuild, in both the instructions and the permissions variant.
 - `resources/matrix_l3_abandoned_approval.py` — **MANDATORY. [coached]** the user sends a new
   message instead of answering the card. Asserts the gated tool does NOT run (an unanswered
   approval is not consent), the row is swept to `cancelled` rather than left `pending`, and the
   session still works. `cancelled` vs `pending` is the loud-vs-silent distinction: a `pending` row
   is a card sitting on the page that no process is waiting on.
 - `resources/matrix_l5_live_route_observed.py` — **MANDATORY. [mechanism-blind, with a control]**
-  the other half of L1: an instructions edit applied to a running session must actually be
-  OBSERVED by the harness, not merely written to disk. Runs the same configuration on a fresh cold
-  session as a control, so a warm failure isolates the runner rather than blaming the model; when
-  the control also fails it reports INCONCLUSIVE instead of a confident wrong verdict.
-  **Currently FAILS (2026-08-06, claude/local):** the warm session goes on answering from the
-  instructions it started with while the pool reports the new fingerprint — see the finding note
-  below.
+  the other half of L1: an instructions edit made mid-conversation must actually be OBSERVED by
+  the harness, not merely written to disk. Runs the same configuration on a fresh cold session as
+  a control, so a failure isolates the runner rather than blaming the model; when the control also
+  fails it reports INCONCLUSIVE instead of a confident wrong verdict. It asserts the edit, never
+  the route, so it stays meaningful if the facet is ever made live again. **Failed 2026-08-06
+  (claude/local) and now passes** — see the finding note below.
 - `resources/matrix_l4_client_tool_lifecycle.py` — **nice-to-have. [coached]** the client-tool
   round trip, and the only cell that covers client tools at all. Asserts the browser's result
   reaches the model and the `client_tool` interaction is stored. It RECORDS rather than asserts
@@ -210,25 +244,34 @@ ever reaches the stream. An empty ledger FAILS a cell; missing evidence is not e
   (`"warm-hold": RESERVED, not built`, #5384), so every client-tool round trip currently costs a
   rebuild. If that number ever reads one, the warm hold landed and the docstring needs updating.
 
-**Open finding the lifecycle cells surfaced (2026-08-06, claude on local, reproduced 3×):** the
-`workspaceFiles` live route rewrites the instruction file and advances applied state, but the
-running harness never re-reads it. A warm session keeps obeying the instructions it started with
-while the pool reports the NEW fingerprint, so every later turn matches and continues warm and the
-user's edit has no effect until something else evicts the session. A cold session with the
-identical configuration obeys it immediately, which is what isolates the runner. This is the
+**Finding the lifecycle cells surfaced (2026-08-06, claude on local, reproduced 3×) — FIXED:** the
+`workspaceFiles` live route rewrote the instruction file and advanced applied state, but the
+running harness never re-read it. A warm session kept obeying the instructions it started with
+while the pool reported the NEW fingerprint, so every later turn matched and continued warm and the
+user's edit had no effect until something else evicted the session. A cold session with the
+identical configuration obeyed it immediately, which is what isolated the runner. This was the
 failure `desired-state.ts` refuses to allow for the `prompts` facet ("refreshing them and claiming
 the model saw the change would be a lie") reappearing on the facet that WAS made live — and note
 the direction: before the live route existed, an instructions edit forced a rebuild and therefore
-took effect on the next turn, so this is a regression in what the user sees, not a speedup.
+took effect on the next turn, so it was a regression in what the user sees, not a speedup.
 `matrix_l5_live_route_observed.py` is the repro.
 
+The fix withdrew the route: `workspaceFiles` now routes to `rebuild-sandbox` in the capability
+table, and `refresh-workspace` left `LIVE_ACTION_KINDS` so restoring the table alone fails closed.
+An instructions edit costs a sandbox again, which is what it cost before the optimisation. **L1's
+`instructions` case therefore expects TWO sandbox ids, and L2's first variant expects two as
+well** — if you are reading an old green from before 2026-08-06, those cells expected one. The
+intended next shape is refresh THEN reopen the session, which needs the reopen to build its
+session init from the incoming request first, and needs proving on L5 rather than asserting.
+
 **Why `cold1` changed (read before trusting an old green):** that tier used to force its eviction
-by editing `instructions.agents_md`. `agentsMd` is the `workspaceFiles` facet, which the
-lifecycle work made one of exactly two LIVE routes, so an instructions edit is now satisfied in
-place — the tier would have gone on passing while measuring warm reuse, and `park`'s "one sandbox
-id is meaningful" argument rests on `cold1` reporting two on the same deployment. It now moves
-`harness.permissions` (the `harnessSession` facet → `reopen-session`, deliberately not live) and
-ASSERTS two distinct sandbox ids. Any future forcing function needs the same check.
+by editing `instructions.agents_md`, which the lifecycle work briefly made a LIVE route — the tier
+would have gone on passing while measuring warm reuse, and `park`'s "one sandbox id is meaningful"
+argument rests on `cold1` reporting two on the same deployment. It now moves `harness.permissions`
+(the `harnessSession` facet → `reopen-session`, deliberately not live) and ASSERTS two distinct
+sandbox ids. It stays there even though an instructions edit escalates again today: a forcing
+function should depend on a route that is escalated by POLICY, not by current capability. Any
+future forcing function needs the same check.
 
 **Known verification gap, recorded rather than pretended away:** the cold-resume
 stale-approval-regate path (`shouldRegateStaleApproval`, acp-interactions.ts — a stored `allow`

--- a/.agents/skills/agent-release-gate/resources/matrix_b1_builtin_find.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_b1_builtin_find.py
@@ -1,0 +1,278 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (harness-mechanism test). The prompt directs the model to use its file-search
+capability by name, so this proves the MECHANISM works when invoked, not that a model reaches
+for it unprompted. That's the correct scope for this cell: it exists to catch a builtin tool
+being silently DEAD, not to measure discovery.
+
+B1: one native file-search call per harness, asserting real results come back.
+
+THE GAP THIS CLOSES. Nothing in the release gate exercised harness BUILTINS before this cell --
+every other cell drives the platform tools (read_config, commit_revision) or the bash/terminal
+builtin. verify-runner's overnight diagnosis found Pi's `find` builtin dead in 52/52 calls across
+two benchmark runs: it shells out to the vendored `fd` binary with a flag that only exists from fd
+9 onward, but the image ships fd 8.6.0 (`fdfind 8.6.0` -- confirmed live on the preview stack,
+2026-08-07). A total capability loss on one harness sat invisible because nothing in the gate ever
+called it -- this cell is what makes that CLASS of bug undiscoverable-no-more (see the
+discoverability-review pattern: an undiscovered bug earns a standing check for the class, not
+just a fix).
+
+DISCREPANCY, RECORDED RATHER THAN SMOOTHED OVER. This cell's own pi_core leg PASSED both times it
+was run live (2026-08-07, sessions dd9c51ef-92d0-4780-855e-da6f48e07d9f and
+47f02ab1-61ec-4db8-a0d6-2d96e98b9188), tool_names_seen=['Bash', 'find'], real filenames back in
+the tool-output payload -- which does not match "52/52 failed". Two explanations, neither
+confirmed: the benchmark's calls may pass a flag or option this cell's simple prefix search never
+exercises (so the break is conditional, not total), or something already changed underneath. This
+needs reconciling with verify-runner before anyone reports Pi's `find` as either "fixed" or "still
+100% broken" -- right now the honest state is "this cell's narrow case works; the benchmark's
+broader usage does not," and those are different claims.
+
+CODEX IS SKIPPED, NOT TESTED. Codex does not expose its shell as an agenta `bash`/`Terminal` tool
+-- it runs commands through native ACP exec frames whose output does not land in the
+`tool-output-available` payload's `.output` field (the same quirk `qa_product.py`'s `j2_mount`
+docstring already names and skips codex for). This cell's evidence extraction reads that field, so
+codex settles cleanly with no error and would still report a false FAIL if not skipped explicitly.
+A codex-shaped extraction (reading its native exec frames instead) is a follow-up, same as
+j2_mount's -- until then, codex's builtin-find coverage is a real, named gap, not a passing cell.
+
+WHY "PER HARNESS" AND NOT "THE SAME TOOL NAME THREE TIMES". Each harness has its own native
+file-search mechanism, and they are NOT the same code path: Pi has a literal `find` builtin
+(vendored, fd-backed -- the one under investigation above); Claude Code's builtin toolset exposes
+`Glob`. The cell does not hardcode which tool name fires -- it writes known marker files, asks the
+model (by capability, not by exact tool name) to locate them via search rather than manually
+listing the directory, and asserts on the TOOL OUTPUT PAYLOAD (never the reply text) that every
+expected filename actually came back. Two explicit turns (write, then search), not one combined
+instruction -- a single multi-step message left claude stopping after the write without
+attempting the search at all on first try; separating the steps (same pattern as L5 and T8)
+removed that ambiguity.
+
+  uv run matrix_b1_builtin_find.py           # all three harnesses (codex SKIPs by design)
+  uv run matrix_b1_builtin_find.py --only pi_core
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    archive,
+    create_workflow,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+HARNESSES = {
+    "claude": {
+        "kind": "claude",
+        "model": "haiku",
+        "provider": "anthropic",
+        "connection": {"mode": "self_managed", "slug": None},
+    },
+    "codex": {
+        "kind": "codex",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+    "pi_core": {
+        "kind": "pi_core",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+}
+
+MISSING_CREDENTIAL_MARKERS = (
+    "connection",
+    "not found for provider",
+    "no connections",
+    "multiple connections",
+    "requires a mounted subscription",
+    "credential",
+)
+
+
+def harness_agent_config(spec: dict) -> dict:
+    return {
+        "instructions": {"agents_md": "Be terse. Do exactly what is asked."},
+        "llm": {
+            "model": spec["model"],
+            "provider": spec["provider"],
+            "connection": spec["connection"],
+            "extras": {},
+        },
+        "tools": [],
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": spec["kind"]},
+        "sandbox": {"kind": "local"},
+    }
+
+
+def b1_for(harness_name: str) -> dict:
+    if harness_name == "codex":
+        # Codex does not expose its shell as an agenta `bash`/`Terminal` tool -- it runs
+        # commands through native ACP exec frames whose output does not land in the
+        # `tool-output-available` payload's `.output` field the way local bash/Pi's `find` do
+        # (same quirk `qa_product.py`'s `j2_mount` docstring already names and skips codex for).
+        # Verified live 2026-08-07: codex's exec calls settle cleanly with no error, but this
+        # cell's evidence extraction reads that field, so it would report a false FAIL -- a
+        # codex-shaped extraction (reading its native exec frames) is the follow-up, same as
+        # j2_mount's.
+        return {
+            "status": "SKIP",
+            "why": (
+                "codex's exec output does not land in tool-output-available's `.output` field "
+                "(documented quirk, see qa_product.py j2_mount); this cell's evidence "
+                "extraction cannot observe codex's real results, so it cannot assert here yet"
+            ),
+        }
+    spec = HARNESSES[harness_name]
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, f"qa-b1-{harness_name}")
+    try:
+        cfg = harness_agent_config(spec)
+        rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
+        references = refs(wf, var, rev_id)
+
+        tag = f"qafind{hexid}"
+        expected = [f"{tag}-1.txt", f"{tag}-2.txt", f"sub/{tag}-3.txt"]
+        session_id = str(uuid.uuid4())
+
+        # TWO EXPLICIT TURNS, not one combined instruction. A single multi-step message left
+        # both claude and codex stopping after the write step without ever attempting the
+        # search -- ambiguous whether that is a capability failure or the model just not
+        # reaching step 2 in one turn. Separating the steps (same pattern as L5's edit-then-ask
+        # and T8's write-then-read) removes that ambiguity: the search step gets its own turn,
+        # with the write turn's own settlement (and any of its approvals) already resolved.
+        write_prompt = (
+            f"Using your bash/shell tool, create these three files under the current "
+            f"directory, each containing exactly the text 'ok': {tag}-1.txt, {tag}-2.txt, and "
+            f"sub/{tag}-3.txt (create the sub directory too if it does not exist). Then reply "
+            "with exactly: WROTE"
+        )
+        msgs = [user_msg(write_prompt)]
+        try:
+            write_turns, write_status = run_until_settled(
+                session_id, msgs, {"agent": cfg}, references, max_rounds=6
+            )
+        except RuntimeError as e:
+            return {"status": "FAIL", "why": f"run_until_settled (write) raised: {e}"}
+
+        if not write_status["settled"]:
+            why = write_status.get("why", "")
+            if any(m in why.lower() for m in MISSING_CREDENTIAL_MARKERS):
+                return {
+                    "status": "SKIP",
+                    "why": f"missing credential for harness={harness_name}: {why}",
+                }
+            return {
+                "status": "FAIL",
+                "why": f"write step never settled: {write_status}",
+            }
+
+        search_prompt = (
+            f"Using your file-search / find capability (not by manually listing the "
+            f"directory), locate every file whose name starts with '{tag}'. Report the exact "
+            "list of paths you found, one per line, nothing else."
+        )
+        msgs = msgs + [write_turns[-1].assistant_message(), user_msg(search_prompt)]
+        try:
+            search_turns, search_status = run_until_settled(
+                session_id, msgs, {"agent": cfg}, references, max_rounds=6
+            )
+        except RuntimeError as e:
+            return {"status": "FAIL", "why": f"run_until_settled (search) raised: {e}"}
+
+        if not search_status["settled"]:
+            return {
+                "status": "FAIL",
+                "why": f"search step never settled: {search_status}",
+            }
+
+        turns = write_turns + search_turns
+        any_errors = any(t.errors for t in turns)
+
+        # Never trust the reply. A model can echo filenames it just wrote without the search
+        # tool ever having run, or without it returning anything real -- the same class of
+        # mistake L5's control and T8's real-read check exist to rule out. Require the evidence
+        # to live in a TOOL OUTPUT payload, not the prose.
+        all_tool_output_text = " ".join(
+            str(t.tool_payloads.get(c["toolCallId"], {}).get("output") or "")
+            for t in turns
+            for c in t.tool_calls
+        )
+        found_in_tool_output = [f for f in expected if f in all_tool_output_text]
+        search_tool_names = sorted(
+            {
+                (c.get("toolName") or "")
+                for t in turns
+                for c in t.tool_calls
+                if (c.get("toolName") or "").lower()
+                in ("find", "glob", "bash", "terminal", "shell", "exec")
+                or (c.get("toolName") or "").lower().startswith("exec")
+            }
+        )
+
+        core_ok = not any_errors and len(found_in_tool_output) == len(expected)
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"any_errors={any_errors}, expected={expected}, "
+                f"found_in_tool_output={found_in_tool_output}, "
+                f"tool_names_seen={search_tool_names}"
+            ),
+            "session_id": session_id,
+            "workflow_id": wf,
+        }
+    except Exception as e:  # noqa: BLE001 -- classify infra errors as SKIP, never crash the matrix
+        msg = str(e)
+        if any(m in msg.lower() for m in MISSING_CREDENTIAL_MARKERS):
+            return {
+                "status": "SKIP",
+                "why": f"missing credential for harness={harness_name}: {msg}",
+            }
+        return {
+            "status": "FAIL",
+            "why": f"unhandled exception: {type(e).__name__}: {msg}",
+        }
+    finally:
+        archive(wf)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--only",
+        choices=list(HARNESSES),
+        help="run a single harness instead of the full matrix",
+    )
+    args = p.parse_args()
+    harness_names = [args.only] if args.only else list(HARNESSES)
+
+    results = {}
+    for harness_name in harness_names:
+        print(f"\n=== B1 x {harness_name} ===", file=sys.stderr)
+        results[harness_name] = b1_for(harness_name)
+
+    print("\n=== B1-BUILTIN-FIND RESULTS ===")
+    print(json.dumps(results, indent=2, default=str))
+
+    any_fail = any(r["status"] == "FAIL" for r in results.values())
+    skipped = [h for h, r in results.items() if r["status"] == "SKIP"]
+    if skipped:
+        print(
+            f"\nSKIPPED (untested, not passed): {', '.join(skipped)}", file=sys.stderr
+        )
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/agent-release-gate/resources/matrix_g1_guidance_discovery.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_g1_guidance_discovery.py
@@ -1,0 +1,341 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: mechanism-blind (model-behavior test). The trial prompt is Mahmoud's own verbatim
+phrasing from the live session that found the bug ("can you add gstack-autoplan skill to your
+skills (i saved it in your folder)") -- it names no tool, no operation, no marker syntax. This is
+what makes a PASS here mean something a coached cell like matrix_w7*.py cannot: it is evidence the
+model finds `read_config` / `commit_revision` / the skills folder / the `@ag.file` marker entirely
+on its own, from the platform guidance rendered into its instructions file, not from being told.
+
+G1: does the platform guidance actually change what the model does? Before this guidance existed,
+Mahmoud's exact phrasing above made a model copy the skill file into its own harness-local skills
+folder (`.codex/skills` / `.claude/skills`) and claim success without ever proposing a commit --
+3 times out of 3, live, session b59cb549. Two parts, in order, per harness/model/sandbox leg:
+
+  PROBE  -- ask the agent to print its rendered instructions file verbatim, and assert the fenced
+            platform-guidance block and the skill-location sentence are really IN THE WORKSPACE.
+            Read, not assumed -- a probe that only checked the config's authored text would miss
+            a guidance-rendering regression entirely.
+  TRIALS -- Mahmoud's verbatim prompt, N times, on the same harness/model/mount. A trial PASSES
+            only when a commit_revision gate fires, the approval lands, and the STORED revision
+            row carries the skill. Copying into the harness's own skills folder is a FAIL.
+
+Live-verified 2026-08-06 by the fixer agent (script this cell promotes:
+`/home/mahmoud/.claude/jobs/8a4c460e/tmp/guidance_verify.py`): discovery went 0/3 to 4/4 overall
+(3/3 codex+gpt-5.6-luna+daytona, 1/1 pi_core+claude-haiku-4-5+daytona), stored rows verified, and
+the platform-guidance fenced block confirmed absent from all four STORED revisions afterward (the
+guidance strip holds -- the model reads the block but does not copy it back into the config it
+commits).
+
+Setup gotchas baked into `qa_matrix_lib` (`PI_CORE_HARNESS_KIND`, `PI_CORE_HAIKU_MODEL`) so
+nobody relearns them: the Pi harness kind enum is `"pi_core"` (bare `"pi"` 500s), and `pi_core`
+rejects a bare `"haiku"` model id (needs the qualified `"claude-haiku-4-5"`); codex accepts its
+curated short alias (`"gpt-5.6-luna"`) bare.
+
+Both legs run on `sandbox=daytona` with a vault-managed key (Daytona rejects subscription auth by
+design): codex needs a funded OpenAI `provider_key` secret, pi_core+claude-haiku-4-5 needs the
+same Anthropic one `matrix_w1_daytona.py` documents. A leg SKIPs with the exact reason when its
+vault credential is missing or ambiguous -- never silently omitted.
+
+  uv run matrix_g1_guidance_discovery.py
+"""
+
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+import httpx
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    BASE,
+    KEY,
+    PI_CORE_HAIKU_MODEL,
+    PI_CORE_HARNESS_KIND,
+    PROJECT,
+    approval_reply,
+    create_workflow,
+    invoke,
+    latest_revision,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+INSTRUCTIONS_FILE_FOR_HARNESS = {"claude": "CLAUDE.md"}
+DEFAULT_INSTRUCTIONS_FILE = "AGENTS.md"
+FENCE_START = "<!-- agenta:platform-guidance:start -->"
+FENCE_END = "<!-- agenta:platform-guidance:end -->"
+SKILL_SENTENCE = "parameters.agent.skills"
+
+# Mahmoud's words, verbatim, from the records table of session b59cb549.
+PROMPT = "can you add gstack-autoplan skill to your skills (i saved it in your folder)"
+
+AUTHORED_INSTRUCTIONS = (
+    "You are an unfriendly hello-world agent running on the Agenta agent service.\n\n"
+    "- Greet the user warmly.\n"
+    "- Answer the user's message in one or two short sentences."
+)
+
+SKILL_MD = """---
+name: gstack-autoplan
+description: Auto-review pipeline that runs the gstack CEO, design, engineering, and DX reviews sequentially with automatic decisions.
+---
+
+# Autoplan
+
+Run the four review passes in order and decide automatically using the six decision principles.
+
+1. CEO review - is this worth building at all?
+2. Design review - does the shape fit the product?
+3. Engineering review - is the implementation sound?
+4. DX review - can a developer actually use it?
+"""
+
+LIVE_TOOLS = [
+    {"type": "platform", "op": "read_config"},
+    {"type": "platform", "op": "commit_revision"},
+]
+
+LEGS = {
+    "codex": {
+        "harness": "codex",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "sandbox": "daytona",
+        "connection": {"mode": "agenta", "slug": None},
+        "trials": 3,
+    },
+    "pi_core": {
+        "harness": PI_CORE_HARNESS_KIND,
+        "model": PI_CORE_HAIKU_MODEL,
+        "provider": "anthropic",
+        "sandbox": "daytona",
+        "connection": {"mode": "agenta", "slug": None},
+        "trials": 3,
+    },
+}
+
+MISSING_CREDENTIAL_MARKERS = (
+    "connection",
+    "not found for provider",
+    "no connections",
+    "multiple connections",
+    "requires a mounted subscription",
+    "credential",
+)
+
+
+def agent_cfg(leg: dict, tools: list[dict]) -> dict:
+    return {
+        "instructions": {"agents_md": AUTHORED_INSTRUCTIONS},
+        "llm": {
+            "model": leg["model"],
+            "provider": leg["provider"],
+            "connection": leg["connection"],
+            "extras": {},
+        },
+        "tools": tools,
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": leg["harness"]},
+        "sandbox": {"kind": leg["sandbox"]},
+        "runner": {"kind": "sidecar", "permissions": {"default": "allow_reads"}},
+    }
+
+
+def sign_agent_mount(artifact_id: str) -> str:
+    r = httpx.post(
+        f"{BASE}/api/mounts/agents/sign",
+        params={"project_id": PROJECT, "artifact_id": artifact_id, "name": "default"},
+        headers={"Authorization": f"ApiKey {KEY}"},
+        timeout=60.0,
+    )
+    if r.status_code != 200:
+        raise RuntimeError(f"sign agent mount HTTP {r.status_code}: {r.text[:300]}")
+    return r.json()["mount"]["id"]
+
+
+def write_mount_file(mount_id: str, path: str, content: str) -> None:
+    r = httpx.put(
+        f"{BASE}/api/mounts/{mount_id}/files",
+        params={"project_id": PROJECT, "path": path},
+        content=content.encode("utf-8"),
+        headers={"Authorization": f"ApiKey {KEY}", "Content-Type": "text/plain"},
+        timeout=60.0,
+    )
+    if r.status_code != 200:
+        raise RuntimeError(f"write mount file HTTP {r.status_code}: {r.text[:300]}")
+
+
+def drive(session_id, msgs, params, references, max_rounds=8):
+    """Invoke, approving every gate, until settled. Returns (turns, gates_approved, status)."""
+    turns, gates = [], 0
+    for _ in range(max_rounds):
+        t = invoke(session_id, msgs, params, references, log=False)
+        turns.append(t)
+        if t.errors:
+            return turns, gates, {"settled": False, "why": f"wire errors: {t.errors}"}
+        if not t.approval:
+            return turns, gates, {"settled": True}
+        gates += 1
+        msgs = msgs + [approval_reply(t, approved=True)]
+    return turns, gates, {"settled": False, "why": "max_rounds exhausted"}
+
+
+def new_agent(leg: dict, label: str):
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, f"qa-g1-{label}")
+    rev_id, ver = seed_and_baseline(wf, var, agent_cfg(leg, []), hexid)
+    mount_id = sign_agent_mount(wf)
+    write_mount_file(mount_id, "gstack-autoplan/SKILL.md", SKILL_MD)
+    return wf, var, rev_id, ver
+
+
+def probe(leg: dict, leg_name: str) -> dict:
+    """Read the rendered instructions file OUT OF THE WORKSPACE and check the fenced block."""
+    wf, var, rev_id, ver = new_agent(leg, f"{leg_name}-probe")
+    references = refs(wf, var, rev_id)
+    params = {"agent": agent_cfg(leg, LIVE_TOOLS)}
+    session_id = str(uuid.uuid4())
+    instructions_file = INSTRUCTIONS_FILE_FOR_HARNESS.get(
+        leg["harness"], DEFAULT_INSTRUCTIONS_FILE
+    )
+    prompt = (
+        f"Use your bash tool to run: cat {instructions_file}\n"
+        "Then paste the file's COMPLETE contents verbatim in your reply inside a fenced code "
+        "block, including any HTML comments. Do not summarize, do not omit anything."
+    )
+    turns, _, status = drive(session_id, [user_msg(prompt)], params, references)
+    text = "".join(t.reply for t in turns)
+    return {
+        "session_id": session_id,
+        "workflow_id": wf,
+        "instructions_file": instructions_file,
+        "settled": status,
+        "fence_start_present": FENCE_START in text,
+        "fence_end_present": FENCE_END in text,
+        "skill_sentence_present": SKILL_SENTENCE in text,
+        "reply": text,
+    }
+
+
+def trial(leg: dict, leg_name: str, n: int) -> dict:
+    wf, var, rev_id, ver = new_agent(leg, f"{leg_name}-t{n}")
+    references = refs(wf, var, rev_id)
+    params = {"agent": agent_cfg(leg, LIVE_TOOLS)}
+    session_id = str(uuid.uuid4())
+    turns, gates, status = drive(session_id, [user_msg(PROMPT)], params, references)
+
+    time.sleep(1.5)
+    newest = latest_revision(wf)
+    skills = (
+        (newest.get("data") or {})
+        .get("parameters", {})
+        .get("agent", {})
+        .get("skills", [])
+        if newest
+        else []
+    )
+    landed = bool(skills) and "autoplan" in json.dumps(skills).lower()
+    version_bumped = newest is not None and int(newest.get("version") or -1) > int(
+        ver or -1
+    )
+    guidance_leaked_into_commit = newest is not None and FENCE_START in json.dumps(
+        newest.get("data") or {}
+    )
+    text = "".join(t.reply for t in turns)
+    return {
+        "trial": n,
+        "status": "FAIL"
+        if not status["settled"]
+        else (
+            "PASS"
+            if (landed and version_bumped and not guidance_leaked_into_commit)
+            else "FAIL"
+        ),
+        "session_id": session_id,
+        "workflow_id": wf,
+        "gates_approved": gates,
+        "settled": status,
+        "new_revision_id": newest.get("id") if newest else None,
+        "skills_stored": skills,
+        "guidance_leaked_into_commit": guidance_leaked_into_commit,
+        "mentions_harness_folder": ".codex/skills" in text or ".claude/skills" in text,
+        "final_text": text[-400:],
+    }
+
+
+def run_leg(leg_name: str) -> dict:
+    leg = LEGS[leg_name]
+    try:
+        p = probe(leg, leg_name)
+    except (RuntimeError, KeyError) as e:
+        msg = str(e)
+        if any(m in msg.lower() for m in MISSING_CREDENTIAL_MARKERS):
+            return {
+                "status": "SKIP",
+                "why": f"missing credential for leg={leg_name}: {msg}",
+            }
+        return {
+            "status": "FAIL",
+            "why": f"probe setup failed: {type(e).__name__}: {msg}",
+        }
+    if not p["settled"].get("settled"):
+        why = p["settled"].get("why", "")
+        if any(m in why.lower() for m in MISSING_CREDENTIAL_MARKERS):
+            return {
+                "status": "SKIP",
+                "why": f"missing credential for leg={leg_name}: {why}",
+            }
+        return {
+            "status": "FAIL",
+            "why": f"probe never settled: {p['settled']}",
+            "probe": p,
+        }
+    if not (p["fence_start_present"] and p["skill_sentence_present"]):
+        return {
+            "status": "FAIL",
+            "why": "guidance not found in the rendered instructions file -- trials would prove "
+            "nothing about the guidance's effect",
+            "probe": {k: v for k, v in p.items() if k != "reply"},
+        }
+
+    results = [trial(leg, leg_name, n) for n in range(1, leg["trials"] + 1)]
+    passed = sum(1 for r in results if r["status"] == "PASS")
+    any_leak = any(r["guidance_leaked_into_commit"] for r in results)
+    return {
+        "status": "PASS" if (passed == leg["trials"] and not any_leak) else "FAIL",
+        "why": (
+            f"discovery_rate={passed}/{leg['trials']}, "
+            f"guidance_leaked_into_any_commit={any_leak} (the strip must hold: the model reads "
+            "the block but must never copy it back into a committed config)"
+        ),
+        "probe": {k: v for k, v in p.items() if k != "reply"},
+        "trials": results,
+    }
+
+
+def main() -> int:
+    all_results = {}
+    for leg_name in LEGS:
+        print(f"\n=== G1 x {leg_name} ===", file=sys.stderr)
+        all_results[leg_name] = run_leg(leg_name)
+
+    print("\n=== G1 GUIDANCE-DISCOVERY RESULTS ===")
+    print(json.dumps(all_results, indent=2, default=str))
+
+    skipped = [n for n, r in all_results.items() if r["status"] == "SKIP"]
+    if skipped:
+        print(
+            f"\nSKIPPED (untested, not passed): {', '.join(skipped)}", file=sys.stderr
+        )
+    return 1 if any(r["status"] == "FAIL" for r in all_results.values()) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/agent-release-gate/resources/matrix_g1_guidance_discovery.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_g1_guidance_discovery.py
@@ -42,6 +42,7 @@ vault credential is missing or ambiguous -- never silently omitted.
   uv run matrix_g1_guidance_discovery.py
 """
 
+import argparse
 import json
 import pathlib
 import sys
@@ -321,8 +322,18 @@ def run_leg(leg_name: str) -> dict:
 
 
 def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--only",
+        choices=list(LEGS),
+        help="run a single leg instead of the full matrix (e.g. to re-verify one leg without "
+        "re-spending trial budget on the others)",
+    )
+    args = p.parse_args()
+    leg_names = [args.only] if args.only else list(LEGS)
+
     all_results = {}
-    for leg_name in LEGS:
+    for leg_name in leg_names:
         print(f"\n=== G1 x {leg_name} ===", file=sys.stderr)
         all_results[leg_name] = run_leg(leg_name)
 

--- a/.agents/skills/agent-release-gate/resources/matrix_invariant_commit_auth_refusal.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_invariant_commit_auth_refusal.py
@@ -1,0 +1,186 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (backend-path test) for the trigger scenario; the INVARIANT it checks
+(`qa_matrix_lib.check_no_blank_success_on_refusal`) is mechanism-level and harness-agnostic --
+it reads the runner's own log line, never model prose, so it is meant to ride along on every
+cell that exercises commit_revision with a workspace-file marker (matrix_w7*.py,
+matrix_t8_saved_files.py), not just this one.
+
+The generic invariant: no `tool_result` with empty output and `isError:false` may exist for a
+call whose runner log says "[commit-auth] refused" -- the silent-blank-success class. Added
+after the Codex approve-then-fail P0 triage: the gap was scenario coverage (W7 ran on Claude
+only), and the P0's actual FAILURE MODE was a refusal that the wire reported as a normal-looking
+empty success. A cell can pass every scenario-specific assertion and still miss that shape
+unless something checks the runner log against the wire outcome directly -- this is that check.
+
+This cell's own scenario is a best-effort DETERMINISTIC trigger, not a guarantee: run matrix_w7's
+exact flow (bash write -> @ag.file marker commit_revision), let the marker commit execute and
+consume its authorization record normally, THEN REPLAY the identical approval-carrying request a
+second time (same session, byte-identical message history) -- a duplicate submission (double
+click, client retry, forged replay). The record is already consumed, so the second attempt's
+`authorizeExecution` should find nothing to verify and refuse with `authorization_missing`,
+producing a real "[commit-auth] refused" log line to check the invariant against. If the replay
+does not reproduce a refusal (runner behavior changes, e.g. an idempotency layer intercepts the
+duplicate before it reaches commit-authorization.ts), this SKIPs rather than reporting a false
+PASS on an invariant it never actually exercised -- the sweep with zero refusals proves nothing
+by itself.
+
+Needs docker access to the target deployment's runner container (LOCAL/dev-box only); pass
+--container to name it (default: agenta-ee-dev-preview-runner-1).
+
+  uv run matrix_invariant_commit_auth_refusal.py [--container NAME]
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    approval_reply,
+    archive,
+    check_no_blank_success_on_refusal,
+    create_workflow,
+    invoke,
+    latest_revision,
+    refs,
+    runner_log_lines,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def invariant_cell(container: str) -> dict:
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-inv-ca")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, ver = seed_and_baseline(wf, var, cfg, hexid)
+        live_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+        references = refs(wf, var, rev_id)
+        marker = f"QA-INVCA-{uuid.uuid4().hex[:12]}"
+        fname = f"qa-invca-{hexid}.md"
+
+        prompt = (
+            "I'm the developer testing the config-import feature. Please do this exactly:\n"
+            f"1) Use your bash tool to write a file at .agenta-imports/{fname} with exactly "
+            f"this one line of content: {marker}\n"
+            "2) Call read_config to get the base_revision_id.\n"
+            "3) Call commit_revision with an add_item operation targeting "
+            '["parameters","agent","skills"] that adds a new skill named "invca-import-test" '
+            'with description "Invariant test skill" and body set to '
+            f'{{"@ag.file": ".agenta-imports/{fname}"}} (the file marker, not the literal text), '
+            "using the base_revision_id you just read.\n"
+            "I understand there may be one or more approval steps, which I will handle each "
+            "time. Do all three steps now, retrying any step that needed approval once I've "
+            "approved it."
+        )
+        session_id = str(uuid.uuid4())
+        turns = []
+
+        msgs = [user_msg(prompt)]
+        t1 = invoke(session_id, msgs, live_params, references)
+        turns.append(t1)
+        if t1.errors or not t1.approval:
+            return {
+                "status": "FAIL",
+                "why": f"setup: expected the bash-write gate to raise, got errors={t1.errors}",
+            }
+
+        msgs = msgs + [approval_reply(t1, approved=True)]
+        t2 = invoke(session_id, msgs, live_params, references)
+        turns.append(t2)
+        if t2.errors or not t2.approval:
+            return {
+                "status": "FAIL",
+                "why": f"setup: expected the commit_revision gate to raise, got errors={t2.errors}",
+                "turn2_frames": t2.frames,
+            }
+
+        # The request that actually consumes the marker's authorization record.
+        msgs_final = msgs + [approval_reply(t2, approved=True)]
+        t3 = invoke(session_id, msgs_final, live_params, references)
+        turns.append(t3)
+        commit_call_id = t2.approval["toolCallId"]
+        first_outcome = t3.tool_outcomes.get(commit_call_id)
+        if t3.errors or first_outcome != "available":
+            return {
+                "status": "FAIL",
+                "why": (
+                    "setup: the FIRST (legitimate) commit attempt did not succeed, so a "
+                    f"replay proves nothing. errors={t3.errors}, outcome={first_outcome}"
+                ),
+                "turn3_frames": t3.frames,
+            }
+
+        # THE TRIGGER: replay the byte-identical approval-carrying request. The record it
+        # would need is already consumed by t3.
+        since = time.strftime("%Y-%m-%dT%H:%M:%S")
+        t3_replay = invoke(session_id, msgs_final, live_params, references)
+        turns.append(t3_replay)
+
+        time.sleep(1.0)  # let the log line land before we scan for it
+        try:
+            log_lines = runner_log_lines(container, since="2m")
+        except RuntimeError as e:
+            return {
+                "status": "SKIP",
+                "why": f"could not read runner logs ({e}); cannot check the invariant at all",
+            }
+
+        check = check_no_blank_success_on_refusal(turns, log_lines)
+        replay_outcome = t3_replay.tool_outcomes.get(commit_call_id)
+
+        if not check["refusals"]:
+            return {
+                "status": "SKIP",
+                "why": (
+                    "the replay did not reproduce a '[commit-auth] refused' log line (runner "
+                    f"behavior may have changed since this was written) -- replay_outcome="
+                    f"{replay_outcome!r}. The invariant was not exercised this run; this is not "
+                    "a pass on it."
+                ),
+                "replay_frames": t3_replay.frames,
+                "since": since,
+            }
+
+        core_ok = len(check["violations"]) == 0
+        time.sleep(0.5)
+        newest = latest_revision(wf)
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(
+            ver or -1
+        )
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"refusals_observed={check['refusals']}, "
+                f"violations={check['violations']}, "
+                f"replay_wire_outcome={replay_outcome!r} (must be error/denied, never a blank "
+                f"available), version_bumped_once={version_bumped} (only the first, legitimate "
+                "commit should have landed)"
+            ),
+            "session_id": session_id,
+            "workflow_id": wf,
+            "commit_call_id": commit_call_id,
+            "check": check,
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--container", default="agenta-ee-dev-preview-runner-1")
+    args = p.parse_args()
+    r = invariant_cell(args.container)
+    print("\n=== COMMIT-AUTH REFUSAL INVARIANT RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
@@ -9,14 +9,14 @@ did with the session between two turns.
 L1: the cold -> warm routing matrix. For each kind of mid-conversation config change, assert the
 route the runner actually took, read back from the STORED turn ledger.
 
-WHY THIS CELL EXISTS. The v1 lifecycle work made exactly TWO config changes applicable to a
-running environment, and left every other change escalating to a rebuild
+WHY THIS CELL EXISTS. The v1 lifecycle work made ONE config change applicable to a running
+environment, and left every other change escalating to a rebuild
 (`services/runner/src/lifecycle/reconciliation-router.ts`):
 
     facet            change                       action            sandbox survives?
     ---------------- ---------------------------- ----------------- -----------------
-    workspaceFiles   instructions / skills        refresh-workspace YES  (live)
     model            the model id alone           apply-live        YES  (live)
+    workspaceFiles   instructions / skills        rebuild-sandbox   no   -> rebuild
     prompts          system / append prompts      reopen-session    no   -> rebuild
     harnessFiles     harness-rendered files       reopen-session    no   -> rebuild
     harnessSession   permissions, MCP list, mode  reopen-session    no   -> rebuild
@@ -27,6 +27,13 @@ running environment, and left every other change escalating to a rebuild
 `isLivelyApplicable` is all-or-nothing, so a change that moves a live facet AND an escalating one
 rebuilds. That routing table is the whole product promise of "editing your agent no longer throws
 your sandbox away", and NOTHING else in the gate asserts it.
+
+`workspaceFiles` WAS LIVE, AND THIS TABLE ASSERTED IT. The route was withdrawn because it was a
+silent lie: the refresh rewrote the instruction file, but the harness had already read that file
+at session start, so the model kept obeying the old instructions while applied state advanced.
+`matrix_l5_live_route_observed.py` is the cell that caught it, and it is why this cell alone was
+never enough. Two sandbox ids for an instructions edit is the CORRECTED expectation, not a
+regression: it is what an instructions edit cost before the live route existed.
 
 WHAT MAKES THE ASSERTION REAL. Warm-versus-rebuilt never reaches the SSE stream. The turn ledger
 does: the runner stamps `sandbox_id` on every turn row. ONE distinct id across the session means
@@ -84,10 +91,12 @@ CASES = [
     ),
     (
         "instructions",
-        1,
+        2,
         True,
-        "agents_md is the `workspaceFiles` facet -> refresh-workspace, the flagship live route: "
-        "editing an agent's instructions mid-conversation must NOT cost a sandbox",
+        "agents_md is the `workspaceFiles` facet -> rebuild-sandbox. It was the flagship LIVE "
+        "route and the route was withdrawn: no harness re-reads its instruction file, so a warm "
+        "refresh left the model obeying the old instructions. An edit that takes effect is worth "
+        "more than a sandbox, so the escalation must actually happen",
     ),
     (
         "harness_permissions",
@@ -215,9 +224,10 @@ def l1():
             "workflow_id": wf,
             "cases": results,
             "runner_log_grep": (
-                "warm cases: `[keepalive] live-route key=... applied=[workspaceFiles="
-                "refresh-workspace]` or `[keepalive] hit-continue`; rebuild cases: "
-                "`[keepalive] mismatch (config) ...; evict + cold`"
+                "warm cases: `[keepalive] hit-continue` or `[keepalive] live-route key=... "
+                "applied=[model=apply-live]`; rebuild cases: `[keepalive] mismatch (config) ...; "
+                "evict + cold`, with the shadow line naming the facet, e.g. "
+                "`facets=[workspaceFiles=rebuild-sandbox]`"
             ),
         }
     finally:

--- a/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
@@ -1,0 +1,231 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: mechanism-blind (no model behaviour is asserted). Every turn is "reply with exactly X",
+so nothing here depends on what a model decides to do -- the cell asserts only what the RUNNER
+did with the session between two turns.
+
+L1: the cold -> warm routing matrix. For each kind of mid-conversation config change, assert the
+route the runner actually took, read back from the STORED turn ledger.
+
+WHY THIS CELL EXISTS. The v1 lifecycle work made exactly TWO config changes applicable to a
+running environment, and left every other change escalating to a rebuild
+(`services/runner/src/lifecycle/reconciliation-router.ts`):
+
+    facet            change                       action            sandbox survives?
+    ---------------- ---------------------------- ----------------- -----------------
+    workspaceFiles   instructions / skills        refresh-workspace YES  (live)
+    model            the model id alone           apply-live        YES  (live)
+    prompts          system / append prompts      reopen-session    no   -> rebuild
+    harnessFiles     harness-rendered files       reopen-session    no   -> rebuild
+    harnessSession   permissions, MCP list, mode  reopen-session    no   -> rebuild
+    toolCatalog      custom tools, tool callback  reopen-session    no   -> rebuild
+    sandbox          harness kind, sandbox kind   rebuild-sandbox   no   -> rebuild
+
+`reopen-session` is deliberately NOT in `LIVE_ACTION_KINDS`, so those four facets escalate; and
+`isLivelyApplicable` is all-or-nothing, so a change that moves a live facet AND an escalating one
+rebuilds. That routing table is the whole product promise of "editing your agent no longer throws
+your sandbox away", and NOTHING else in the gate asserts it.
+
+WHAT MAKES THE ASSERTION REAL. Warm-versus-rebuilt never reaches the SSE stream. The turn ledger
+does: the runner stamps `sandbox_id` on every turn row. ONE distinct id across the session means
+the sandbox was never replaced; TWO means it was deleted and rebuilt. That is a stored row, not a
+response echo, which is the standing rule for this gate.
+
+An EMPTY ledger fails the cell. It is missing evidence, not evidence of stability -- the exact
+false green the continuity journeys in qa_product.py were rewritten to remove.
+
+THIS CELL ASSERTS ONLY HALF THE REQUIREMENT, AND ON ITS OWN THAT IS THE DANGEROUS HALF. "The
+sandbox survived" is worth nothing unless the running harness actually OBSERVED the change. See
+`matrix_l5_live_route_observed.py` for the other half; a green here plus a red there means the
+runner is keeping a sandbox that is quietly running the old configuration.
+
+THE `model` CASE IS EVIDENCE-ONLY, ON PURPOSE. Changing the model id should move the `model`
+facet alone (apply-live, warm), but if a deployment's connection shape is keyed off the model
+then the `runtime` facet moves too and the plan escalates -- correctly. Rather than encode a
+guess as a blocker, this cell REPORTS the observed route for `model` and blocks only on the four
+cases whose routing is unambiguous in the capability table.
+
+  uv run matrix_l1_lifecycle_routes.py
+"""
+
+import json
+import pathlib
+import sys
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    archive,
+    create_workflow,
+    invoke,
+    ledger_ids,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+# (case, expected distinct sandbox ids, blocking?, why)
+#
+# "warm" == 1 (the environment was reconfigured in place, or nothing changed).
+# "rebuild" == 2 (the old sandbox was torn down and a new one built).
+CASES = [
+    (
+        "no_change",
+        1,
+        True,
+        "nothing moved, so the pool must hit-continue; a rebuild here means warm reuse is broken "
+        "outright and every other case in this table is meaningless",
+    ),
+    (
+        "instructions",
+        1,
+        True,
+        "agents_md is the `workspaceFiles` facet -> refresh-workspace, the flagship live route: "
+        "editing an agent's instructions mid-conversation must NOT cost a sandbox",
+    ),
+    (
+        "harness_permissions",
+        2,
+        True,
+        "permissions are the `harnessSession` facet -> reopen-session, which is NOT live. A "
+        "permission change MUST escalate: applying it in place would be a security-relevant "
+        "change silently routed through an in-place refresh",
+    ),
+    (
+        "tools",
+        2,
+        True,
+        "custom tools are the `toolCatalog` facet -> reopen-session in v1 (uniform across "
+        "harnesses because Codex cannot take a live tool update). A warm result here means a turn "
+        "ran against a tool catalog the request never described",
+    ),
+    (
+        "model",
+        1,
+        False,
+        "the `model` facet is the other live route (setModel on the running session), but a "
+        "deployment whose connection shape is keyed off the model moves `runtime` too and "
+        "correctly escalates -- reported, not blocking",
+    ),
+]
+
+
+def mutate(case: str, params: dict) -> dict:
+    """Return a deep copy of `params` with exactly ONE facet moved."""
+    p = json.loads(json.dumps(params))
+    agent = p["agent"]
+    marker = uuid.uuid4().hex[:8]
+    if case == "no_change":
+        return p
+    if case == "instructions":
+        agent["instructions"]["agents_md"] = f"{BASELINE} (l1 {marker})"
+        return p
+    if case == "harness_permissions":
+        # A rule for a tool this turn never calls: it moves the facet without changing what the
+        # turn is allowed to do, so a routing failure cannot hide behind a behaviour change.
+        agent.setdefault("harness", {})["permissions"] = {
+            "allow": [],
+            "ask": [f"QaNeverCalledTool{marker}"],
+            "deny": [],
+        }
+        return p
+    if case == "tools":
+        # Drop one platform tool from the catalog. The turn calls neither.
+        agent["tools"] = [LIVE_TOOLS[0]]
+        return p
+    if case == "model":
+        agent["llm"]["model"] = "sonnet"
+        return p
+    raise ValueError(f"unknown case {case}")
+
+
+def run_case(case: str, wf: str, var: str, rev_id: str, base_params: dict) -> dict:
+    session_id = str(uuid.uuid4())
+    references = refs(wf, var, rev_id)
+
+    msgs = [user_msg("Reply with exactly: ONE")]
+    t1 = invoke(session_id, msgs, base_params, references, log=False)
+    if t1.errors:
+        return {"case": case, "ok": False, "why": f"turn 1 errored: {t1.errors[:1]}"}
+
+    msgs = msgs + [t1.assistant_message(), user_msg("Reply with exactly: TWO")]
+    t2 = invoke(session_id, msgs, mutate(case, base_params), references, log=False)
+    if t2.errors:
+        return {"case": case, "ok": False, "why": f"turn 2 errored: {t2.errors[:1]}"}
+
+    agents, sandboxes = ledger_ids(session_id)
+    return {
+        "case": case,
+        "session_id": session_id,
+        "agent_session_ids": agents,
+        "sandbox_ids": sandboxes,
+        "distinct_sandboxes": len(sandboxes),
+        "ledger_available": bool(sandboxes),
+    }
+
+
+def l1():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-l1")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
+        base_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+
+        results = []
+        blocking_failures = []
+        for case, expected, blocking, why in CASES:
+            r = run_case(case, wf, var, rev_id, base_params)
+            r["expected_sandboxes"] = expected
+            r["blocking"] = blocking
+            r["rationale"] = why
+            if "ok" in r and not r["ok"]:
+                verdict = "ERROR"
+            elif not r.get("ledger_available"):
+                # Missing evidence is a failure, never a pass. A silent ledger means the cell
+                # cannot see the thing it exists to assert.
+                verdict = "NO_EVIDENCE"
+            elif r["distinct_sandboxes"] == expected:
+                verdict = "OK"
+            else:
+                verdict = "WRONG_ROUTE"
+            r["verdict"] = verdict
+            if blocking and verdict != "OK":
+                blocking_failures.append(
+                    f"{case}: expected {expected} sandbox id(s) "
+                    f"({'warm' if expected == 1 else 'rebuild'}), got "
+                    f"{r.get('distinct_sandboxes')} [{verdict}] -- {why}"
+                )
+            results.append(r)
+
+        ok = not blocking_failures
+        return {
+            "status": "PASS" if ok else "FAIL",
+            "why": (
+                "every blocking route matched the capability table"
+                if ok
+                else " | ".join(blocking_failures)
+            ),
+            "workflow_id": wf,
+            "cases": results,
+            "runner_log_grep": (
+                "warm cases: `[keepalive] live-route key=... applied=[workspaceFiles="
+                "refresh-workspace]` or `[keepalive] hit-continue`; rebuild cases: "
+                "`[keepalive] mismatch (config) ...; evict + cold`"
+            ),
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = l1()
+    print("\n=== L1 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))
+    sys.exit(0 if r["status"] == "PASS" else 1)

--- a/.agents/skills/agent-release-gate/resources/matrix_l2_approval_across_config_change.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l2_approval_across_config_change.py
@@ -31,14 +31,21 @@ stamp. This cell asserts the OBSERVABLE consequence of that, so the class cannot
      fingerprint (the old bug), turn 3 would match and continue warm on the old configuration,
      and the new instructions would never take effect at all.
 
-Two variants, because the two routes fail differently:
+Two variants, because two different facets must both survive the same treatment:
 
-  live    -- the change is an instructions edit (`workspaceFiles` -> refresh-workspace). The
-             sandbox must survive the whole session (ONE sandbox id) and turn 3 must obey the new
-             instructions.
-  rebuild -- the change is a permissions edit (`harnessSession` -> reopen-session, which is not
-             live). The gated tool must still land, and the escalation must actually happen by
-             turn 3 (TWO sandbox ids) rather than being lost.
+  instructions -- the change is an instructions edit (`workspaceFiles` -> rebuild-sandbox).
+  permissions  -- the change is a permissions edit (`harnessSession` -> reopen-session, which is
+                  not live).
+
+In both, the gated tool must still land and the escalation must actually happen by turn 3 (TWO
+sandbox ids) rather than being lost.
+
+THE `instructions` VARIANT USED TO EXPECT ONE SANDBOX ID, and that was the live workspace refresh.
+The route was withdrawn: no harness re-reads its instruction file, so the refresh left the model
+obeying the old instructions while applied state claimed the new ones. See
+`matrix_l5_live_route_observed.py`. Both variants therefore escalate today, and both now have a
+MECHANICAL witness that the change took effect -- the second sandbox id -- instead of the model
+prose the live variant had to fall back on.
 
   uv run matrix_l2_approval_across_config_change.py
 """
@@ -119,9 +126,9 @@ def run_variant(variant: str, wf: str, var: str, rev_id: str, cfg: dict) -> dict
     echo = f"L2ECHO{uuid.uuid4().hex[:6].upper()}"
 
     changed = json.loads(json.dumps(base_params))
-    if variant == "live":
+    if variant == "instructions":
         changed["agent"]["instructions"]["agents_md"] = ECHO_RULE.format(token=echo)
-        expected_sandboxes, route = 1, "workspaceFiles -> refresh-workspace (live)"
+        expected_sandboxes, route = 2, "workspaceFiles -> rebuild-sandbox (escalates)"
     else:
         changed["agent"].setdefault("harness", {})["permissions"] = {
             "allow": [],
@@ -161,25 +168,17 @@ def run_variant(variant: str, wf: str, var: str, rev_id: str, cfg: dict) -> dict
     t3 = invoke(session_id, msgs3, changed, references, log=False)
     agents, sandboxes = ledger_ids(session_id)
 
-    # WHAT BLOCKS, AND WHAT ONLY GETS REPORTED. The two variants can be held to different
-    # standards because only one of them has a mechanical witness.
+    # WHAT BLOCKS, AND WHAT ONLY GETS REPORTED. "The change took effect" is now MECHANICAL for
+    # both variants: each facet escalates, so the escalation shows up as a second sandbox id in the
+    # stored ledger. Blocking.
     #
-    #   rebuild -- "the change took effect" IS mechanical: the escalation shows up as a second
-    #              sandbox id in the stored ledger. Blocking.
-    #   live    -- the only mechanical witness that a workspace refresh RAN is the runner's own
-    #              `live-route ... applied=[workspaceFiles=refresh-workspace]` log line, which a
-    #              pure HTTP client cannot see. The probe below asks the model to obey a rule the
-    #              new instructions carry, which is MODEL PROSE -- exactly what this gate refuses
-    #              to hang a verdict on (a model that ignores an instruction would fail a healthy
-    #              product). So it is reported, and the blocking assertions for this variant are
-    #              the ones that are real side effects: the gated commit landed, the approval row
-    #              is terminal, and the sandbox was never replaced.
+    # The prose probe below asks the model to obey a rule the new instructions carry. It is MODEL
+    # PROSE -- exactly what this gate refuses to hang a verdict on, since a model that ignores an
+    # instruction would fail a healthy product -- so it is reported as corroboration only. The
+    # cell that DOES hold the "an edit is observed" line, with a cold control to keep a model
+    # failure from being read as a runner failure, is `matrix_l5_live_route_observed.py`.
     prose_probe_saw_new_instructions = echo in t3.reply.upper()
-    applied_after = (
-        len(sandboxes) >= 2
-        if variant == "rebuild"
-        else prose_probe_saw_new_instructions
-    )
+    applied_after = len(sandboxes) >= 2
 
     ok = (
         gated
@@ -188,7 +187,7 @@ def run_variant(variant: str, wf: str, var: str, rev_id: str, cfg: dict) -> dict
         and approval_ok
         and bool(sandboxes)
         and len(sandboxes) == expected_sandboxes
-        and (variant != "rebuild" or bool(applied_after))
+        and bool(applied_after)
         and not t3.errors
     )
     return {
@@ -202,8 +201,8 @@ def run_variant(variant: str, wf: str, var: str, rev_id: str, cfg: dict) -> dict
         "approval_row_statuses": statuses,
         "approval_rows_ok": approval_ok,
         "config_applied_on_next_turn": applied_after,
-        # Reported for the `live` variant, never blocking -- see the comment above. The runner log
-        # is the definitive witness there.
+        # Corroboration, never blocking -- see the comment above. Meaningful for the
+        # `instructions` variant only; the `permissions` variant changes no reply.
         "prose_probe_saw_new_instructions": prose_probe_saw_new_instructions,
         "expected_sandboxes": expected_sandboxes,
         "sandbox_ids": sandboxes,
@@ -223,13 +222,13 @@ def l2():
         # Each variant commits an edit_text whose anchor is the BASELINE string, and the first
         # variant's commit replaces it. So the second variant gets its own workflow rather than
         # an anchor that no longer matches the stored text.
-        results = [run_variant("live", wf, var, rev_id, cfg)]
+        results = [run_variant("instructions", wf, var, rev_id, cfg)]
 
         hexid2 = uuid.uuid4().hex[:8]
         wf2, var2 = create_workflow(hexid2, "qa-l2b")
         try:
             rev_id2, _ = seed_and_baseline(wf2, var2, cfg, hexid2)
-            results.append(run_variant("rebuild", wf2, var2, rev_id2, cfg))
+            results.append(run_variant("permissions", wf2, var2, rev_id2, cfg))
         finally:
             archive(wf2)
 
@@ -251,9 +250,9 @@ def l2():
             ),
             "variants": results,
             "runner_log_grep": (
-                "`[keepalive] resume key=... answered=1 approve=1` on the answering turn, then on "
-                "the FOLLOWING turn either `[keepalive] live-route ... applied=` (live variant) or "
-                "`[keepalive] mismatch (config) ...; evict + cold` (rebuild variant)"
+                "`[keepalive] resume key=... answered=1 approve=1` on the answering turn, then "
+                "`[keepalive] mismatch (config) ...; evict + cold` on the FOLLOWING turn, in both "
+                "variants"
             ),
         }
     finally:

--- a/.agents/skills/agent-release-gate/resources/matrix_l2_approval_across_config_change.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l2_approval_across_config_change.py
@@ -1,0 +1,267 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (the prompt names read_config/commit_revision explicitly). This cell proves the
+LIFECYCLE behaviour around an approval, not that a model reaches for the config tools unprompted.
+
+L2: a pending approval that is answered while a CONFIG CHANGE rides along in the same request --
+the combination that used to execute a gated tool against a sandbox running something else.
+
+THE BUG THIS IS THE REGRESSION TEST FOR. The pool used to store a `configFingerprint` its CALLER
+supplied, and the caller supplied the INCOMING request's value. On the ordinary path that is
+harmless: dispatch has already proved incoming and parked configurations equal. On the
+APPROVAL-RESUME path it is not, because that branch never compares configurations at all
+(`session-coordinator.ts`, the `awaiting_approval` branch: it checks the parked gate, the history
+fingerprint, credentials and the mount -- never the config). So the re-park stamped a
+configuration the environment had never applied, the NEXT turn read that stamp, found a match,
+and continued warm on an environment running something else.
+
+The fix was structural rather than a patch: `LiveSession.configFingerprint` is now a GETTER that
+reads through to `environment.appliedState`, and `AppliedState.commitApplied` is the only way to
+advance it (`engines/sandbox_agent/applied-state.ts`). There is no parameter left for a caller to
+stamp. This cell asserts the OBSERVABLE consequence of that, so the class cannot come back:
+
+  1. The gated tool still EXECUTES on the resume, with its original byte-exact arguments. The
+     config change riding along does not cancel the human's decision.
+  2. The approval's stored interaction row ends `resolved` / `responded` -- never `cancelled`,
+     never stuck `pending`.
+  3. The config change is NOT SWALLOWED. Because the resume ignores config, the change takes
+     effect on the FOLLOWING turn instead. That is the tell: if the re-park stamped the incoming
+     fingerprint (the old bug), turn 3 would match and continue warm on the old configuration,
+     and the new instructions would never take effect at all.
+
+Two variants, because the two routes fail differently:
+
+  live    -- the change is an instructions edit (`workspaceFiles` -> refresh-workspace). The
+             sandbox must survive the whole session (ONE sandbox id) and turn 3 must obey the new
+             instructions.
+  rebuild -- the change is a permissions edit (`harnessSession` -> reopen-session, which is not
+             live). The gated tool must still land, and the escalation must actually happen by
+             turn 3 (TWO sandbox ids) rather than being lost.
+
+  uv run matrix_l2_approval_across_config_change.py
+"""
+
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    approval_reply,
+    archive,
+    create_workflow,
+    interactions,
+    invoke,
+    latest_revision,
+    ledger_ids,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+# The instructions the `live` variant switches to mid-approval. The suffix rule is what makes the
+# change OBSERVABLE in a reply, so "the new config took effect" is asserted rather than assumed.
+ECHO_RULE = "Be terse. End every reply with the exact word {token} on its own line."
+
+
+def commit_prompt(token: str) -> str:
+    return (
+        "I'm the developer testing the config-editing feature. Please: 1) call read_config to "
+        "get the base_revision_id, 2) call commit_revision with an edit_text operation targeting "
+        '["parameters","agent","instructions","agents_md"] that replaces the exact text '
+        f"'{BASELINE}' with '{token}', using the base_revision_id you just read. There is an "
+        "approval step I will handle. Go ahead and make the two tool calls."
+    )
+
+
+def settle_with_change(
+    session_id: str,
+    msgs: list,
+    base_params: dict,
+    changed_params: dict,
+    references: dict,
+    max_rounds: int = 6,
+) -> tuple[list, dict]:
+    """Run the approval flow, switching to `changed_params` from the moment the FIRST gate is
+    answered. That is the whole point of the cell: the config change and the approval decision
+    arrive in the SAME request."""
+    turns = []
+    params = base_params
+    for i in range(max_rounds):
+        t = invoke(session_id, msgs, params, references, log=False)
+        turns.append(t)
+        if t.errors:
+            return turns, {"settled": False, "why": f"wire errors: {t.errors[:1]}"}
+        if not t.approval:
+            return turns, {"settled": True, "rounds": i + 1}
+        msgs = msgs + [approval_reply(t, approved=True)]
+        # From here on every request carries the NEW configuration alongside the decision.
+        params = changed_params
+    return turns, {"settled": False, "why": "max_rounds exhausted, still gated"}
+
+
+def approval_rows(session_id: str) -> list:
+    return [r for r in interactions(session_id) if r.get("kind") == "user_approval"]
+
+
+def run_variant(variant: str, wf: str, var: str, rev_id: str, cfg: dict) -> dict:
+    session_id = str(uuid.uuid4())
+    references = refs(wf, var, rev_id)
+    base_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+    token = f"QA-L2-{uuid.uuid4().hex[:10]}"
+    echo = f"L2ECHO{uuid.uuid4().hex[:6].upper()}"
+
+    changed = json.loads(json.dumps(base_params))
+    if variant == "live":
+        changed["agent"]["instructions"]["agents_md"] = ECHO_RULE.format(token=echo)
+        expected_sandboxes, route = 1, "workspaceFiles -> refresh-workspace (live)"
+    else:
+        changed["agent"].setdefault("harness", {})["permissions"] = {
+            "allow": [],
+            "ask": [f"QaNeverCalledTool{uuid.uuid4().hex[:6]}"],
+            "deny": [],
+        }
+        expected_sandboxes, route = 2, "harnessSession -> reopen-session (escalates)"
+
+    msgs = [user_msg(commit_prompt(token))]
+    turns, status = settle_with_change(
+        session_id, msgs, base_params, changed, references
+    )
+    gated = any(t.approval for t in turns)
+
+    # (1) the gated tool executed: the commit is a STORED revision row, not a frame.
+    time.sleep(1.0)
+    newest = latest_revision(wf)
+    committed = (
+        newest is not None
+        and (newest.get("data") or {})
+        .get("parameters", {})
+        .get("agent", {})
+        .get("instructions", {})
+        .get("agents_md")
+        == token
+    )
+
+    # (2) the approval died loudly or not at all -- never silently.
+    rows = approval_rows(session_id)
+    statuses = [r.get("status") for r in rows]
+    approval_ok = bool(rows) and all(s in ("resolved", "responded") for s in statuses)
+
+    # (3) the config change was not swallowed: it takes effect on the turn AFTER the resume,
+    # because the resume branch itself never compares configurations.
+    last = turns[-1]
+    msgs3 = msgs + [last.assistant_message(), user_msg("Say hello.")]
+    t3 = invoke(session_id, msgs3, changed, references, log=False)
+    agents, sandboxes = ledger_ids(session_id)
+
+    # WHAT BLOCKS, AND WHAT ONLY GETS REPORTED. The two variants can be held to different
+    # standards because only one of them has a mechanical witness.
+    #
+    #   rebuild -- "the change took effect" IS mechanical: the escalation shows up as a second
+    #              sandbox id in the stored ledger. Blocking.
+    #   live    -- the only mechanical witness that a workspace refresh RAN is the runner's own
+    #              `live-route ... applied=[workspaceFiles=refresh-workspace]` log line, which a
+    #              pure HTTP client cannot see. The probe below asks the model to obey a rule the
+    #              new instructions carry, which is MODEL PROSE -- exactly what this gate refuses
+    #              to hang a verdict on (a model that ignores an instruction would fail a healthy
+    #              product). So it is reported, and the blocking assertions for this variant are
+    #              the ones that are real side effects: the gated commit landed, the approval row
+    #              is terminal, and the sandbox was never replaced.
+    prose_probe_saw_new_instructions = echo in t3.reply.upper()
+    applied_after = (
+        len(sandboxes) >= 2
+        if variant == "rebuild"
+        else prose_probe_saw_new_instructions
+    )
+
+    ok = (
+        gated
+        and status.get("settled", False)
+        and committed
+        and approval_ok
+        and bool(sandboxes)
+        and len(sandboxes) == expected_sandboxes
+        and (variant != "rebuild" or bool(applied_after))
+        and not t3.errors
+    )
+    return {
+        "variant": variant,
+        "route": route,
+        "ok": ok,
+        "raised_approval": gated,
+        "settled": status.get("settled", False),
+        "settle_why": status.get("why"),
+        "gated_commit_landed": committed,
+        "approval_row_statuses": statuses,
+        "approval_rows_ok": approval_ok,
+        "config_applied_on_next_turn": applied_after,
+        # Reported for the `live` variant, never blocking -- see the comment above. The runner log
+        # is the definitive witness there.
+        "prose_probe_saw_new_instructions": prose_probe_saw_new_instructions,
+        "expected_sandboxes": expected_sandboxes,
+        "sandbox_ids": sandboxes,
+        "agent_session_ids": agents,
+        "ledger_available": bool(sandboxes),
+        "turn3_errors": t3.errors[:1],
+        "session_id": session_id,
+    }
+
+
+def l2():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-l2")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
+        # Each variant commits an edit_text whose anchor is the BASELINE string, and the first
+        # variant's commit replaces it. So the second variant gets its own workflow rather than
+        # an anchor that no longer matches the stored text.
+        results = [run_variant("live", wf, var, rev_id, cfg)]
+
+        hexid2 = uuid.uuid4().hex[:8]
+        wf2, var2 = create_workflow(hexid2, "qa-l2b")
+        try:
+            rev_id2, _ = seed_and_baseline(wf2, var2, cfg, hexid2)
+            results.append(run_variant("rebuild", wf2, var2, rev_id2, cfg))
+        finally:
+            archive(wf2)
+
+        failures = [
+            f"{r['variant']}: gated={r['raised_approval']} settled={r['settled']} "
+            f"commit_landed={r['gated_commit_landed']} approval_rows={r['approval_row_statuses']} "
+            f"config_applied_next_turn={r['config_applied_on_next_turn']} "
+            f"sandboxes={r['sandbox_ids']} (expected {r['expected_sandboxes']})"
+            for r in results
+            if not r["ok"]
+        ]
+        return {
+            "status": "PASS" if not failures else "FAIL",
+            "why": (
+                "a pending approval survives a config change riding along with the answer, the "
+                "gated tool lands, and the config change takes effect on the following turn"
+                if not failures
+                else " | ".join(failures)
+            ),
+            "variants": results,
+            "runner_log_grep": (
+                "`[keepalive] resume key=... answered=1 approve=1` on the answering turn, then on "
+                "the FOLLOWING turn either `[keepalive] live-route ... applied=` (live variant) or "
+                "`[keepalive] mismatch (config) ...; evict + cold` (rebuild variant)"
+            ),
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = l2()
+    print("\n=== L2 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))
+    sys.exit(0 if r["status"] == "PASS" else 1)

--- a/.agents/skills/agent-release-gate/resources/matrix_l3_abandoned_approval.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l3_abandoned_approval.py
@@ -1,0 +1,200 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (the prompt names read_config/commit_revision explicitly).
+
+L3: the user ABANDONS a pending approval -- they send a new message instead of answering the
+card. This is the single most common way an approval dies in real usage, and until this cell
+nothing in the gate covered it.
+
+WHAT MUST HAPPEN, and why each half matters:
+
+  1. THE GATED TOOL MUST NOT RUN. An unanswered approval is not consent. The commit must not
+     appear as a revision row. This is the safety half.
+
+  2. THE APPROVAL MUST DIE LOUDLY. At every turn start the runner sweeps prior turns' still-
+     pending gates (`services/runner/src/sessions/interactions.ts:cancelStaleInteractions` ->
+     `POST /sessions/interactions/cancel-stale`), sparing this turn's own gates by `turn_id` and
+     any gate this turn answers in-band by token. The abandoned row must therefore end
+     `cancelled`.
+
+     `cancelled` versus `pending` IS the whole assertion. A row left `pending` is an approval
+     card that sits on the user's page forever with nothing behind it: no process is waiting on
+     the token, the session that raised it is gone, and answering it can only fail. A row moved
+     to `cancelled` is a state a client can see and re-render. The runner-side half is already
+     coherent -- the dispatch finds an approval-parked session with no matching decision, logs
+     `approval-mismatch (unknown)` and evicts with the `session-incompatible` teardown reason,
+     which PARKS the sandbox rather than deleting it (`engines/sandbox_agent/teardown.ts`,
+     `PARKABLE_REASONS`) because nothing inside it went stale. This cell asserts the DURABLE half.
+
+  3. THE SESSION MUST STILL WORK. The steer reply itself has to complete; an abandoned approval
+     must not poison the conversation.
+
+WHAT THIS CELL DELIBERATELY DOES NOT ASSERT: the sandbox id. Whether the abandoned session's
+sandbox is stopped-and-reconnected or rebuilt is provider-dependent (a stop is only meaningful
+where a sandbox can be restarted), and this matrix runs on `sandbox=local`. The ids are reported
+as evidence, never as the verdict -- see L1 for the routing assertions that ARE provider-stable.
+
+  uv run matrix_l3_abandoned_approval.py
+"""
+
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    archive,
+    create_workflow,
+    interactions,
+    invoke,
+    latest_revision,
+    ledger_ids,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+# The sweep is fire-and-forget at turn start, so the row transitions a moment after the steer
+# turn begins. Poll rather than read once -- a single early read would report `pending` and fail
+# the cell for a timing reason instead of a product reason.
+CANCEL_POLL_SECONDS = 20.0
+CANCEL_POLL_INTERVAL = 1.0
+
+
+def approval_rows(session_id: str) -> list:
+    return [r for r in interactions(session_id) if r.get("kind") == "user_approval"]
+
+
+def await_terminal_approval(session_id: str) -> list:
+    """Poll until no approval row is still `pending`, or the budget runs out."""
+    deadline = time.time() + CANCEL_POLL_SECONDS
+    rows = approval_rows(session_id)
+    while time.time() < deadline:
+        rows = approval_rows(session_id)
+        if rows and all(r.get("status") != "pending" for r in rows):
+            return rows
+        time.sleep(CANCEL_POLL_INTERVAL)
+    return rows
+
+
+def l3():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-l3")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
+        params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+        references = refs(wf, var, rev_id)
+        session_id = str(uuid.uuid4())
+        token = f"QA-L3-{uuid.uuid4().hex[:10]}"
+
+        # Turn 1: raise the approval gate and leave it hanging.
+        prompt = (
+            "I'm the developer testing the config-editing feature. Please: 1) call read_config "
+            "to get the base_revision_id, 2) call commit_revision with an edit_text operation "
+            'targeting ["parameters","agent","instructions","agents_md"] that replaces the exact '
+            f"text '{BASELINE}' with '{token}', using the base_revision_id you just read. There "
+            "is an approval step I will handle. Go ahead and make the two tool calls."
+        )
+        msgs = [user_msg(prompt)]
+        t1 = invoke(session_id, msgs, params, references, log=False)
+        if t1.errors:
+            return {
+                "status": "FAIL",
+                "why": f"turn 1 errored before any gate: {t1.errors[:1]}",
+                "workflow_id": wf,
+            }
+        gated = t1.approval is not None
+        pending_now = approval_rows(session_id)
+
+        # Turn 2: ABANDON it. A new user message, no approval decision anywhere in the payload.
+        msgs2 = msgs + [
+            t1.assistant_message(),
+            user_msg("Never mind. Reply with exactly: MOVED"),
+        ]
+        t2 = invoke(session_id, msgs2, params, references, log=False)
+        steer_ok = not t2.errors and "MOVED" in t2.reply.upper()
+
+        rows = await_terminal_approval(session_id)
+        statuses = [r.get("status") for r in rows]
+        died_loudly = bool(rows) and all(s == "cancelled" for s in statuses)
+        left_pending = any(s == "pending" for s in statuses)
+
+        # The gated commit must NOT have landed: nobody approved it.
+        time.sleep(1.0)
+        newest = latest_revision(wf)
+        leaked = (
+            newest is not None
+            and (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("instructions", {})
+            .get("agents_md")
+            == token
+        )
+
+        agents, sandboxes = ledger_ids(session_id)
+        ok = gated and steer_ok and died_loudly and not leaked
+
+        why_parts = []
+        if not gated:
+            why_parts.append(
+                "turn 1 never raised an approval gate, so the cell tested nothing"
+            )
+        if leaked:
+            why_parts.append(
+                "SAFETY: the gated commit landed even though the approval was never answered"
+            )
+        if left_pending:
+            why_parts.append(
+                "the abandoned approval row is still `pending` -- it died SILENTLY, leaving a "
+                "card on the page that no process is waiting on"
+            )
+        elif not died_loudly:
+            why_parts.append(
+                f"the abandoned approval row(s) ended {statuses}, expected all `cancelled`"
+            )
+        if not steer_ok:
+            why_parts.append(
+                f"the steer turn did not complete cleanly: errors={t2.errors[:1]} "
+                f"reply={t2.reply[:120]!r}"
+            )
+
+        return {
+            "status": "PASS" if ok else "FAIL",
+            "why": (
+                "an abandoned approval does not execute, is swept to `cancelled`, and leaves the "
+                "session usable"
+                if ok
+                else " | ".join(why_parts)
+            ),
+            "workflow_id": wf,
+            "session_id": session_id,
+            "raised_approval": gated,
+            "approval_rows_while_pending": [r.get("status") for r in pending_now],
+            "approval_rows_after_abandon": statuses,
+            "gated_commit_leaked": leaked,
+            "steer_turn_ok": steer_ok,
+            "sandbox_ids_evidence_only": sandboxes,
+            "agent_session_ids_evidence_only": agents,
+            "runner_log_grep": (
+                "`[keepalive] approval-mismatch (unknown) key=...; evict + cold` on the steer "
+                "turn, and `[interactions] cancel-stale OK session=...` from the sweep"
+            ),
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = l3()
+    print("\n=== L3 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))
+    sys.exit(0 if r["status"] == "PASS" else 1)

--- a/.agents/skills/agent-release-gate/resources/matrix_l4_client_tool_lifecycle.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l4_client_tool_lifecycle.py
@@ -1,0 +1,223 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (the prompt names the client tool and tells the model to call it).
+
+L4: a CLIENT TOOL round trip -- the third lifecycle axis, and the one with no coverage at all
+before this cell.
+
+WHAT A CLIENT TOOL DOES TO THE SESSION, and why it belongs in a lifecycle matrix. A client tool
+(`{"type": "client", ...}`) is fulfilled by the browser across a turn boundary: the model calls
+it, the runner emits a `client_tool` interaction request, THE TURN ENDS PAUSED, and the next turn
+resumes with the browser's result replayed out of the message history
+(`services/runner/src/responder.ts:extractClientToolOutputs`, keyed by
+`approvedCallKey(toolName, args)` and read only from the CURRENT turn).
+
+That pause is NOT an approval pause, and the difference is the whole point:
+
+  - An ACP approval gate parks the session ALIVE (`awaiting_approval`), so the human's answer
+    resumes the very same process and the gated tool runs with its original byte-exact arguments.
+  - A client-tool pause is explicitly NOT parkable. `shouldPark` refuses a `paused` result, and
+    `approvalToPark` refuses when the environment recorded no parkable ACP gate, so the
+    coordinator takes the `no-park:paused` branch and DESTROYS the environment
+    (`lifecycle/session-coordinator.ts`). The warm-hold disposition that would keep the call open
+    inside a live turn is declared and deliberately NOT BUILT
+    (`engines/sandbox_agent/client-tools.ts`: `"warm-hold": RESERVED, not built`, issue #5384).
+
+So today every client-tool round trip costs a full sandbox rebuild. That is a real warm-reuse
+hole, and this cell exists to PIN IT rather than discover it again later: it asserts the round
+trip works, and it records the sandbox count so the day the warm hold lands, the number moves and
+somebody has to come here and say so deliberately.
+
+The correctness half is what blocks: the browser's result must actually reach the model, and the
+`client_tool` interaction must be STORED (a row in `/sessions/interactions/`), not merely
+streamed.
+
+OBSERVED NUANCE, recorded but not asserted (2026-08-06): a client-tool row that was FULFILLED
+successfully still ends up stored as `cancelled`, not `responded`/`resolved`. The browser answers
+in-band through the messages plane, and the next turn's `cancelStaleInteractions` sweep spares
+only the tokens it recognises as in-band answers -- which covers approval replies, not client-tool
+outputs -- so the row is swept as though it had been abandoned. The round trip itself works, so
+this cell asserts only that no row is left `pending`. It is the durable RECORD that lies: anything
+reading the stored interactions later (a reconnecting client, an audit) cannot tell a fulfilled
+client tool from an abandoned one. Worth fixing, not worth blocking a release on.
+
+FIRST-RUN NOTE. If turn 1 ends without a recognizable paused client-tool call, this cell FAILS
+and prints the frames it did see. That is deliberate: a SKIP here would be an untested claim, and
+the frame list is exactly what a reader needs to fix the cell.
+
+  uv run matrix_l4_client_tool_lifecycle.py
+"""
+
+import json
+import pathlib
+import sys
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    agent_config,
+    archive,
+    create_workflow,
+    interactions,
+    invoke,
+    ledger_ids,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+TOOL_NAME = "qa_ask_browser"
+CLIENT_TOOL = {
+    "type": "client",
+    "name": TOOL_NAME,
+    "description": (
+        "Ask the user's browser for the current session marker. Takes no arguments and returns "
+        "a short string. Call it whenever you are asked for the session marker."
+    ),
+    "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+}
+
+
+def fulfil(turn, call_id: str, output: str) -> dict:
+    """Build the assistant message that carries the BROWSER'S RESULT for `call_id`.
+
+    The runner reads client-tool outputs only from the CURRENT turn (everything after the last
+    user message), so this message is appended with NO new user message after it -- exactly the
+    shape the playground sends, and the same shape `approval_reply` uses for a decision."""
+    message = turn.assistant_message()
+    for part in message["parts"]:
+        if part.get("toolCallId") == call_id:
+            part["state"] = "output-available"
+            part["output"] = output
+            return message
+    raise ValueError(f"client tool call {call_id} missing from the assistant message")
+
+
+def l4():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-l4")
+    try:
+        cfg = agent_config(
+            tools=[CLIENT_TOOL],
+            instructions=(
+                "Be terse. When the user asks for the session marker, call the "
+                f"{TOOL_NAME} tool and then report exactly what it returned."
+            ),
+        )
+        rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
+        params = {"agent": cfg}
+        references = refs(wf, var, rev_id)
+        session_id = str(uuid.uuid4())
+        marker = f"L4MARK{uuid.uuid4().hex[:8].upper()}"
+
+        # Turn 1: the model calls the client tool, and the turn must PAUSE with no output for it.
+        msgs = [user_msg("What is the session marker? Use your tool.")]
+        t1 = invoke(session_id, msgs, params, references, log=False)
+        if t1.errors:
+            return {
+                "status": "FAIL",
+                "why": f"turn 1 errored: {t1.errors[:1]}",
+                "workflow_id": wf,
+            }
+
+        paused_calls = [
+            c
+            for c in t1.tool_calls
+            if TOOL_NAME in (c.get("toolName") or "")
+            and t1.tool_outcomes.get(c["toolCallId"]) is None
+        ]
+        if not paused_calls:
+            return {
+                "status": "FAIL",
+                "why": (
+                    "turn 1 never produced a PAUSED client-tool call, so the round trip could not "
+                    "be exercised. Either the model did not call the tool, or the paused call "
+                    "reaches the wire in a shape this cell does not recognize -- the frames and "
+                    "tool calls below are what to fix it against."
+                ),
+                "workflow_id": wf,
+                "session_id": session_id,
+                "turn1_frames": t1.frames,
+                "turn1_tool_calls": t1.tool_calls,
+                "turn1_tool_outcomes": t1.tool_outcomes,
+                "turn1_finish_reason": t1.finish_reason,
+                "turn1_reply": t1.reply[:300],
+            }
+        call_id = paused_calls[0]["toolCallId"]
+
+        # The interaction must be STORED, not merely streamed.
+        rows_paused = [
+            r for r in interactions(session_id) if r.get("kind") == "client_tool"
+        ]
+
+        # Turn 2: the browser answers. No new user message -- the result belongs to this turn.
+        msgs2 = msgs + [fulfil(t1, call_id, marker)]
+        t2 = invoke(session_id, msgs2, params, references, log=False)
+        delivered = marker in t2.reply.upper()
+
+        agents, sandboxes = ledger_ids(session_id)
+        rows_after = [
+            r for r in interactions(session_id) if r.get("kind") == "client_tool"
+        ]
+        statuses = [r.get("status") for r in rows_after]
+        stored = bool(rows_after)
+        no_orphan_pending = all(s != "pending" for s in statuses)
+
+        ok = delivered and stored and no_orphan_pending and not t2.errors
+
+        why_parts = []
+        if not delivered:
+            why_parts.append(
+                f"the browser's result never reached the model: {marker} is absent from the "
+                f"resumed reply ({t2.reply[:160]!r})"
+            )
+        if not stored:
+            why_parts.append(
+                "no `client_tool` interaction row was stored, so the call existed only on the "
+                "stream -- nothing durable for a reconnecting client to render"
+            )
+        elif not no_orphan_pending:
+            why_parts.append(
+                f"a `client_tool` row is still `pending` after the round trip completed: {statuses}"
+            )
+        if t2.errors:
+            why_parts.append(f"the resumed turn errored: {t2.errors[:1]}")
+
+        return {
+            "status": "PASS" if ok else "FAIL",
+            "why": (
+                "the client-tool round trip completes, the result reaches the model, and the "
+                "interaction is stored"
+                if ok
+                else " | ".join(why_parts)
+            ),
+            "workflow_id": wf,
+            "session_id": session_id,
+            "result_reached_model": delivered,
+            "client_tool_rows_while_paused": [r.get("status") for r in rows_paused],
+            "client_tool_rows_after": statuses,
+            # RECORDED, NOT ASSERTED. Two ids is today's expected cost: a client-tool pause is
+            # not parkable, so the environment is destroyed and the resume rebuilds. If this ever
+            # reads 1, the warm hold (#5384) landed and this cell's docstring needs updating --
+            # that is a deliberate change, not a regression.
+            "sandbox_ids": sandboxes,
+            "distinct_sandboxes_recorded": len(sandboxes),
+            "warm_hold_landed_if_this_is_1": len(sandboxes),
+            "agent_session_ids": agents,
+            "runner_log_grep": (
+                "`[keepalive] non-parkable-gate-no-park key=...` then `[keepalive] evict ... "
+                "reason=no-park:paused` on turn 1, and a fresh `[keepalive] miss ...; cold` on "
+                "turn 2"
+            ),
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = l4()
+    print("\n=== L4 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))
+    sys.exit(0 if r["status"] == "PASS" else 1)

--- a/.agents/skills/agent-release-gate/resources/matrix_l5_live_route_observed.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l5_live_route_observed.py
@@ -5,13 +5,13 @@
 """TIER: mechanism-blind, with a control. Nothing here depends on a model choosing a tool; it
 depends only on whether the model can SEE its own current instructions.
 
-L5: an instructions edit applied to a RUNNING session must actually be OBSERVED by the harness.
+L5: an instructions edit made mid-conversation must actually be OBSERVED by the harness on the
+very next turn.
 
-WHY THIS IS A SEPARATE CELL FROM L1. L1 asserts the ROUTE: an instructions edit keeps the sandbox
-(one sandbox id) instead of rebuilding it. That is only half the requirement, and on its own it is
-the dangerous half -- "we kept the sandbox" is worth nothing if the running harness goes on
-obeying the configuration it was started with. This cell asserts the OTHER half: that the new
-instructions took effect.
+WHY THIS IS A SEPARATE CELL FROM L1. L1 asserts the ROUTE the runner took. This cell asserts the
+thing the user actually cares about: that the edit took effect. The two are independent, and this
+cell is the one that found the bug -- L1 was green throughout, because keeping the sandbox was
+precisely what the broken behaviour did.
 
 THE FAILURE THIS EXISTS TO CATCH, in the project's own words. `desired-state.ts` explains why the
 `prompts` facet is deliberately NOT live:
@@ -21,26 +21,32 @@ THE FAILURE THIS EXISTS TO CATCH, in the project's own words. `desired-state.ts`
      location or content already. Refreshing them and claiming the model saw the change would be
      a lie, so a prompt change escalates."
 
-`workspaceFiles` (instructions and skills) was made live anyway, and the same argument applies to
-it on any harness that reads its instruction file once at session start. If it does, then
-`applyReconcilePlan` rewrites the file, `commitApplied` advances the applied state, the pool now
-reports the NEW fingerprint -- so every later turn matches and continues warm -- while the model
-keeps answering from the OLD instructions. That is a silent lie in applied state, which is the
+`workspaceFiles` (instructions and skills) was made live anyway, and the same argument always
+applied to it: every harness reads its instruction file once, at session start. So
+`applyReconcilePlan` rewrote the file, `commitApplied` advanced the applied state, the pool
+reported the NEW fingerprint -- so every later turn matched and continued warm -- while the model
+kept answering from the OLD instructions. That is a silent lie in applied state, which is the
 exact class the whole applied-state design was built to make unrepresentable.
 
-Note the direction of the risk: before the live route existed, an instructions edit forced a
-rebuild and therefore took effect on the very next turn. A warm-reuse optimisation that makes
-edits stop taking effect is a REGRESSION in what the user sees, not a speedup.
+THE FIX, AND WHAT THIS CELL ASSERTS NOW. `workspaceFiles` routes to `rebuild-sandbox`, so an
+instructions edit escalates and the next turn runs on an environment built from the new
+instructions. The cell therefore expects TWO sandbox ids and REQUIRES the edit to be observed.
+Note the direction of the risk it guards: before the live route existed, an instructions edit
+forced a rebuild and therefore took effect on the very next turn. A warm-reuse optimisation that
+makes edits stop taking effect is a REGRESSION in what the user sees, not a speedup. If someone
+makes this facet live again -- the intended shape is refresh THEN reopen the session -- this cell
+is what must stay green, and `stayed_warm` below becomes reportable evidence rather than a
+failure.
 
-THE CONTROL IS WHAT MAKES THIS AIRTIGHT. A warm turn that fails to use the new instructions could
+THE CONTROL IS WHAT MAKES THIS AIRTIGHT. A turn that fails to use the new instructions could
 always be blamed on the model. So the cell runs the SAME configuration on a fresh COLD session and
-requires it to succeed there. Cold pass + warm fail isolates the runner: the configuration is
-correct and reachable, and only the live route is at fault. If BOTH fail, the cell reports
-INCONCLUSIVE rather than blaming the live route -- that is a model or deployment problem, and
-saying so is more useful than a confident wrong verdict.
+requires it to succeed there. Cold pass + mid-conversation fail isolates the runner: the
+configuration is correct and reachable, and only the reconciliation route is at fault. If BOTH
+fail, the cell reports INCONCLUSIVE rather than blaming the route -- that is a model or deployment
+problem, and saying so is more useful than a confident wrong verdict.
 
 The probe never mentions the passphrase before the edit, so a stale answer cannot be conversational
-stickiness -- the warm session has no reason to know the word at all.
+stickiness -- the continued session has no reason to know the word at all.
 
   uv run matrix_l5_live_route_observed.py
 """
@@ -92,8 +98,11 @@ def l5():
 
         msgs = msgs + [t1.assistant_message(), user_msg("What is the passphrase?")]
         t2 = invoke(session_id, msgs, changed, references, log=False)
-        warm_observed = secret in t2.reply.upper()
+        edit_observed = secret in t2.reply.upper()
         agents, sandboxes = ledger_ids(session_id)
+        # REPORTED, NEVER BLOCKING. The route is L1's assertion, and this cell must stay green
+        # through any future change of route: what it protects is that the edit takes effect, by
+        # whatever mechanism. Today the mechanism is a rebuild, so this reads False.
         stayed_warm = len(sandboxes) == 1
 
         # THE CONTROL: the same configuration, on a session that has never run.
@@ -111,52 +120,50 @@ def l5():
             return {
                 "status": "FAIL",
                 "why": (
-                    "INCONCLUSIVE about the live route: a COLD session with these instructions "
-                    "did not use the passphrase either, so the configuration never reached the "
-                    "model on any path. Fix that first -- this cell cannot say anything about "
-                    "the refresh until the control passes."
+                    "INCONCLUSIVE about the reconciliation route: a COLD session with these "
+                    "instructions did not use the passphrase either, so the configuration never "
+                    "reached the model on any path. Fix that first -- this cell cannot say "
+                    "anything about a mid-conversation edit until the control passes."
                 ),
                 "workflow_id": wf,
                 "cold_control_observed": cold_observed,
                 "cold_control_reply": t3.reply[:300],
-                "warm_observed": warm_observed,
-                "warm_reply": t2.reply[:300],
+                "edit_observed": edit_observed,
+                "reply_after_edit": t2.reply[:300],
             }
 
-        ok = warm_observed and stayed_warm and not t2.errors
+        ok = edit_observed and not t2.errors
         return {
             "status": "PASS" if ok else "FAIL",
             "why": (
-                "an instructions edit applied to a running session is observed by the harness on "
-                "the very next turn, without rebuilding the sandbox"
+                "an instructions edit made mid-conversation is observed by the harness on the "
+                "very next turn"
                 if ok
                 else (
-                    "the live workspace refresh is a SILENT LIE: the warm session did not use the "
-                    "new instructions, while a cold session with the identical configuration did. "
-                    "The runner rewrote the instruction file and advanced applied state, so the "
-                    "pool now reports the NEW fingerprint and every later turn continues warm -- "
-                    "but the harness is still running the configuration it started with, and the "
-                    "user's edit has no effect until something else evicts the session"
-                )
-                if not warm_observed
-                else (
-                    "the new instructions were observed, but the session did not stay warm "
-                    f"(sandbox ids: {sandboxes}) -- this cell's premise no longer holds, so check "
-                    "L1's routing assertions"
+                    "the instructions edit is DEAD: the next turn did not use the new "
+                    "instructions, while a cold session with the identical configuration did. "
+                    "If the runner took a live route it rewrote the instruction file and advanced "
+                    "applied state -- so the pool reports the NEW fingerprint and every later turn "
+                    "continues warm -- while the harness still runs the configuration it started "
+                    "with, and the user's edit has no effect until something else evicts the "
+                    "session. Check the shadow line: `facets=[workspaceFiles=...]` names the route "
+                    "the runner chose"
                 )
             ),
             "workflow_id": wf,
             "session_id": session_id,
-            "warm_observed_new_instructions": warm_observed,
-            "warm_reply": t2.reply[:300],
+            "edit_observed": edit_observed,
+            "reply_after_edit": t2.reply[:300],
             "cold_control_observed": cold_observed,
             "cold_control_reply": t3.reply[:300],
+            # Reported, never blocking. See where it is computed.
             "stayed_warm": stayed_warm,
             "sandbox_ids": sandboxes,
             "agent_session_ids": agents,
             "runner_log_grep": (
-                "`[keepalive] live-route key=... applied=[workspaceFiles=refresh-workspace] "
-                "generation=N` -- the line that claims the refresh landed"
+                "`[keepalive] mismatch (config) key=...; evict + cold` with "
+                "`facets=[workspaceFiles=rebuild-sandbox]` on the shadow line -- the escalation "
+                "that makes the edit take effect"
             ),
         }
     finally:

--- a/.agents/skills/agent-release-gate/resources/matrix_l5_live_route_observed.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l5_live_route_observed.py
@@ -1,0 +1,170 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: mechanism-blind, with a control. Nothing here depends on a model choosing a tool; it
+depends only on whether the model can SEE its own current instructions.
+
+L5: an instructions edit applied to a RUNNING session must actually be OBSERVED by the harness.
+
+WHY THIS IS A SEPARATE CELL FROM L1. L1 asserts the ROUTE: an instructions edit keeps the sandbox
+(one sandbox id) instead of rebuilding it. That is only half the requirement, and on its own it is
+the dangerous half -- "we kept the sandbox" is worth nothing if the running harness goes on
+obeying the configuration it was started with. This cell asserts the OTHER half: that the new
+instructions took effect.
+
+THE FAILURE THIS EXISTS TO CATCH, in the project's own words. `desired-state.ts` explains why the
+`prompts` facet is deliberately NOT live:
+
+    "For Pi these land as files under the agent directory, and the adapter matrix records
+     active-session observation as NOT GUARANTEED: a running process may have captured their
+     location or content already. Refreshing them and claiming the model saw the change would be
+     a lie, so a prompt change escalates."
+
+`workspaceFiles` (instructions and skills) was made live anyway, and the same argument applies to
+it on any harness that reads its instruction file once at session start. If it does, then
+`applyReconcilePlan` rewrites the file, `commitApplied` advances the applied state, the pool now
+reports the NEW fingerprint -- so every later turn matches and continues warm -- while the model
+keeps answering from the OLD instructions. That is a silent lie in applied state, which is the
+exact class the whole applied-state design was built to make unrepresentable.
+
+Note the direction of the risk: before the live route existed, an instructions edit forced a
+rebuild and therefore took effect on the very next turn. A warm-reuse optimisation that makes
+edits stop taking effect is a REGRESSION in what the user sees, not a speedup.
+
+THE CONTROL IS WHAT MAKES THIS AIRTIGHT. A warm turn that fails to use the new instructions could
+always be blamed on the model. So the cell runs the SAME configuration on a fresh COLD session and
+requires it to succeed there. Cold pass + warm fail isolates the runner: the configuration is
+correct and reachable, and only the live route is at fault. If BOTH fail, the cell reports
+INCONCLUSIVE rather than blaming the live route -- that is a model or deployment problem, and
+saying so is more useful than a confident wrong verdict.
+
+The probe never mentions the passphrase before the edit, so a stale answer cannot be conversational
+stickiness -- the warm session has no reason to know the word at all.
+
+  uv run matrix_l5_live_route_observed.py
+"""
+
+import json
+import pathlib
+import sys
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    agent_config,
+    archive,
+    create_workflow,
+    invoke,
+    ledger_ids,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+
+def l5():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-l5")
+    try:
+        secret = f"ZEBRA{uuid.uuid4().hex[:6].upper()}"
+        # The baseline says NOTHING about a passphrase, so the warm session cannot know the word
+        # from anywhere except the refreshed instructions.
+        cfg = agent_config(instructions="Be terse.")
+        rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
+        base_params = {"agent": cfg}
+        references = refs(wf, var, rev_id)
+
+        session_id = str(uuid.uuid4())
+        msgs = [user_msg("Reply with exactly: ONE")]
+        t1 = invoke(session_id, msgs, base_params, references, log=False)
+        if t1.errors:
+            return {
+                "status": "FAIL",
+                "why": f"turn 1 errored: {t1.errors[:1]}",
+                "workflow_id": wf,
+            }
+
+        changed = json.loads(json.dumps(base_params))
+        changed["agent"]["instructions"]["agents_md"] = (
+            f"Be terse. The passphrase is {secret}. If asked for the passphrase, reply with it."
+        )
+
+        msgs = msgs + [t1.assistant_message(), user_msg("What is the passphrase?")]
+        t2 = invoke(session_id, msgs, changed, references, log=False)
+        warm_observed = secret in t2.reply.upper()
+        agents, sandboxes = ledger_ids(session_id)
+        stayed_warm = len(sandboxes) == 1
+
+        # THE CONTROL: the same configuration, on a session that has never run.
+        cold_session = str(uuid.uuid4())
+        t3 = invoke(
+            cold_session,
+            [user_msg("What is the passphrase?")],
+            changed,
+            references,
+            log=False,
+        )
+        cold_observed = secret in t3.reply.upper()
+
+        if not cold_observed:
+            return {
+                "status": "FAIL",
+                "why": (
+                    "INCONCLUSIVE about the live route: a COLD session with these instructions "
+                    "did not use the passphrase either, so the configuration never reached the "
+                    "model on any path. Fix that first -- this cell cannot say anything about "
+                    "the refresh until the control passes."
+                ),
+                "workflow_id": wf,
+                "cold_control_observed": cold_observed,
+                "cold_control_reply": t3.reply[:300],
+                "warm_observed": warm_observed,
+                "warm_reply": t2.reply[:300],
+            }
+
+        ok = warm_observed and stayed_warm and not t2.errors
+        return {
+            "status": "PASS" if ok else "FAIL",
+            "why": (
+                "an instructions edit applied to a running session is observed by the harness on "
+                "the very next turn, without rebuilding the sandbox"
+                if ok
+                else (
+                    "the live workspace refresh is a SILENT LIE: the warm session did not use the "
+                    "new instructions, while a cold session with the identical configuration did. "
+                    "The runner rewrote the instruction file and advanced applied state, so the "
+                    "pool now reports the NEW fingerprint and every later turn continues warm -- "
+                    "but the harness is still running the configuration it started with, and the "
+                    "user's edit has no effect until something else evicts the session"
+                )
+                if not warm_observed
+                else (
+                    "the new instructions were observed, but the session did not stay warm "
+                    f"(sandbox ids: {sandboxes}) -- this cell's premise no longer holds, so check "
+                    "L1's routing assertions"
+                )
+            ),
+            "workflow_id": wf,
+            "session_id": session_id,
+            "warm_observed_new_instructions": warm_observed,
+            "warm_reply": t2.reply[:300],
+            "cold_control_observed": cold_observed,
+            "cold_control_reply": t3.reply[:300],
+            "stayed_warm": stayed_warm,
+            "sandbox_ids": sandboxes,
+            "agent_session_ids": agents,
+            "runner_log_grep": (
+                "`[keepalive] live-route key=... applied=[workspaceFiles=refresh-workspace] "
+                "generation=N` -- the line that claims the refresh landed"
+            ),
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = l5()
+    print("\n=== L5 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))
+    sys.exit(0 if r["status"] == "PASS" else 1)

--- a/.agents/skills/agent-release-gate/resources/matrix_l5_live_route_observed.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l5_live_route_observed.py
@@ -48,9 +48,17 @@ problem, and saying so is more useful than a confident wrong verdict.
 The probe never mentions the passphrase before the edit, so a stale answer cannot be conversational
 stickiness -- the continued session has no reason to know the word at all.
 
-  uv run matrix_l5_live_route_observed.py
+PER-HARNESS (added 2026-08-06): this cell originally ran on Claude only -- the same
+scenario-coverage gap that let the Codex approve-then-fail P0 ship (see
+matrix_w7_per_harness.py). This blocker cell now runs on all three harnesses in one invocation.
+claude uses subscription auth; codex and pi_core need a funded OpenAI `provider_key` vault
+secret and SKIP with the exact reason when it's missing or ambiguous.
+
+  uv run matrix_l5_live_route_observed.py           # all three harnesses
+  uv run matrix_l5_live_route_observed.py --only codex
 """
 
+import argparse
 import json
 import pathlib
 import sys
@@ -58,7 +66,6 @@ import uuid
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
-    agent_config,
     archive,
     create_workflow,
     invoke,
@@ -68,15 +75,63 @@ from qa_matrix_lib import (  # noqa: E402
     user_msg,
 )
 
+HARNESSES = {
+    "claude": {
+        "kind": "claude",
+        "model": "haiku",
+        "provider": "anthropic",
+        "connection": {"mode": "self_managed", "slug": None},
+    },
+    "codex": {
+        "kind": "codex",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+    "pi_core": {
+        "kind": "pi_core",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+}
 
-def l5():
+MISSING_CREDENTIAL_MARKERS = (
+    "connection",
+    "not found for provider",
+    "no connections",
+    "multiple connections",
+    "requires a mounted subscription",
+    "credential",
+)
+
+
+def harness_agent_config(spec: dict, instructions: str) -> dict:
+    return {
+        "instructions": {"agents_md": instructions},
+        "llm": {
+            "model": spec["model"],
+            "provider": spec["provider"],
+            "connection": spec["connection"],
+            "extras": {},
+        },
+        "tools": [],
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": spec["kind"]},
+        "sandbox": {"kind": "local"},
+    }
+
+
+def l5_for(harness_name: str) -> dict:
+    spec = HARNESSES[harness_name]
     hexid = uuid.uuid4().hex[:8]
-    wf, var = create_workflow(hexid, "qa-l5")
+    wf, var = create_workflow(hexid, f"qa-l5-{harness_name}")
     try:
         secret = f"ZEBRA{uuid.uuid4().hex[:6].upper()}"
         # The baseline says NOTHING about a passphrase, so the warm session cannot know the word
         # from anywhere except the refreshed instructions.
-        cfg = agent_config(instructions="Be terse.")
+        cfg = harness_agent_config(spec, "Be terse.")
         rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
         base_params = {"agent": cfg}
         references = refs(wf, var, rev_id)
@@ -85,9 +140,15 @@ def l5():
         msgs = [user_msg("Reply with exactly: ONE")]
         t1 = invoke(session_id, msgs, base_params, references, log=False)
         if t1.errors:
+            why = "; ".join(t1.errors[:1])
+            if any(m in why.lower() for m in MISSING_CREDENTIAL_MARKERS):
+                return {
+                    "status": "SKIP",
+                    "why": f"missing credential for harness={harness_name}: {why}",
+                }
             return {
                 "status": "FAIL",
-                "why": f"turn 1 errored: {t1.errors[:1]}",
+                "why": f"turn 1 errored: {why}",
                 "workflow_id": wf,
             }
 
@@ -166,12 +227,47 @@ def l5():
                 "that makes the edit take effect"
             ),
         }
+    except Exception as e:  # noqa: BLE001 -- classify infra errors as SKIP, never crash the matrix
+        msg = str(e)
+        if any(m in msg.lower() for m in MISSING_CREDENTIAL_MARKERS):
+            return {
+                "status": "SKIP",
+                "why": f"missing credential for harness={harness_name}: {msg}",
+            }
+        return {
+            "status": "FAIL",
+            "why": f"unhandled exception: {type(e).__name__}: {msg}",
+        }
     finally:
         archive(wf)
 
 
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--only",
+        choices=list(HARNESSES),
+        help="run a single harness instead of the full matrix",
+    )
+    args = p.parse_args()
+    harness_names = [args.only] if args.only else list(HARNESSES)
+
+    results = {}
+    for harness_name in harness_names:
+        print(f"\n=== L5 x {harness_name} ===", file=sys.stderr)
+        results[harness_name] = l5_for(harness_name)
+
+    print("\n=== L5-PER-HARNESS RESULTS ===")
+    print(json.dumps(results, indent=2, default=str))
+
+    any_fail = any(r["status"] == "FAIL" for r in results.values())
+    skipped = [h for h, r in results.items() if r["status"] == "SKIP"]
+    if skipped:
+        print(
+            f"\nSKIPPED (untested, not passed): {', '.join(skipped)}", file=sys.stderr
+        )
+    return 1 if any_fail else 0
+
+
 if __name__ == "__main__":
-    r = l5()
-    print("\n=== L5 RESULT ===")
-    print(json.dumps(r, indent=2, default=str))
-    sys.exit(0 if r["status"] == "PASS" else 1)
+    raise SystemExit(main())

--- a/.agents/skills/agent-release-gate/resources/matrix_t8_saved_files.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_t8_saved_files.py
@@ -1,0 +1,208 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""T8 verification: the Daytona remote agent mount (the durable `agent-files/` folder the
+playground file drawer writes into) after the tunnel fix. Writes a marker file into the agent's
+durable mount via the mounts API BEFORE the run (same surface the file drawer uses), then asks a
+live Daytona agent to read it and commit one line from it. Asserts: the runner log line
+"remote agent mount active for artifact=<id>" appears (absent all day before the tunnel fix),
+the agent's read reflects the REAL marker content (not hallucinated), and the commit lands with
+it.
+
+TIER: coached (backend-path test) -- the prompt names the folder (`agent-files/`) and the
+commit mechanism explicitly. This proves the mount/tunnel path works, not that a model finds
+agent-files/ unprompted from a plain ask ("the skill I saved in your folder").
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+import uuid
+
+import httpx
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    archive,
+    create_workflow,
+    latest_revision,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASE = os.environ["AGENTA_BASE"]
+PROJECT = os.environ["AGENTA_PROJECT_ID"]
+KEY = os.environ["AGENTA_API_KEY"]
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def daytona_agent_config(tools):
+    return {
+        "instructions": {"agents_md": BASELINE},
+        "llm": {
+            "model": "haiku",
+            "provider": "anthropic",
+            "connection": {"mode": "agenta", "slug": None},
+            "extras": {},
+        },
+        "tools": tools,
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": "claude"},
+        "sandbox": {"kind": "daytona"},
+    }
+
+
+LIVE_TOOLS = [
+    {"type": "platform", "op": "read_config"},
+    {"type": "platform", "op": "commit_revision"},
+]
+
+
+def sign_agent_mount(artifact_id: str) -> str:
+    r = httpx.post(
+        f"{BASE}/api/mounts/agents/sign",
+        params={"project_id": PROJECT, "artifact_id": artifact_id, "name": "default"},
+        headers={"Authorization": f"ApiKey {KEY}"},
+        timeout=60.0,
+    )
+    if r.status_code != 200:
+        raise RuntimeError(f"sign agent mount HTTP {r.status_code}: {r.text[:300]}")
+    return r.json()["mount"]["id"]
+
+
+def write_marker_file(mount_id: str, path: str, content: str) -> None:
+    r = httpx.put(
+        f"{BASE}/api/mounts/{mount_id}/files",
+        params={"project_id": PROJECT, "path": path},
+        content=content.encode("utf-8"),
+        headers={"Authorization": f"ApiKey {KEY}", "Content-Type": "text/plain"},
+        timeout=60.0,
+    )
+    if r.status_code != 200:
+        raise RuntimeError(f"write marker file HTTP {r.status_code}: {r.text[:300]}")
+
+
+def t8_saved_files():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-t8")
+    try:
+        base_cfg = daytona_agent_config([])
+        live_cfg = daytona_agent_config(LIVE_TOOLS)
+        rev_id, ver = seed_and_baseline(wf, var, base_cfg, hexid)
+        references = refs(wf, var, rev_id)
+
+        marker = f"QA-T8-{uuid.uuid4().hex[:16]}"
+        fname = f"qa-t8-{hexid}.txt"
+        mount_id = sign_agent_mount(wf)
+        write_marker_file(mount_id, fname, f"{marker}\n")
+
+        prompt = (
+            "I'm the developer testing the saved-files feature. Please do this exactly:\n"
+            f"1) Use your bash tool to read the file agent-files/{fname} (your durable agent "
+            "folder) and report its exact content.\n"
+            "2) Call read_config to get the base_revision_id.\n"
+            "3) Call commit_revision with an add_item operation targeting "
+            '["parameters","agent","skills"] that adds a new skill named "t8-saved-files-test" '
+            'with description "Saved-files test" and body set to the EXACT one-line content '
+            "you read from that file (the literal text, not a file marker), using the "
+            "base_revision_id you just read.\n"
+            "There is an approval step I will handle. Do all three steps now."
+        )
+        session_id = str(uuid.uuid4())
+        turns, status = run_until_settled(
+            session_id,
+            [user_msg(prompt)],
+            {"agent": live_cfg},
+            references,
+            max_rounds=8,
+        )
+        if not status["settled"]:
+            return {
+                "status": "FAIL",
+                "why": f"never settled: {status}",
+                "frames_per_turn": [t.frames for t in turns],
+            }
+
+        # Capture the read's own output as independent evidence the agent saw REAL content --
+        # scan every turn (the successful read may land in a later turn than the first gate).
+        read_output = None
+        for t in turns:
+            for tcid, outcome in t.tool_outcomes.items():
+                if outcome == "available":
+                    payload = t.tool_payloads.get(tcid, {})
+                    if payload.get("output") and marker in json.dumps(
+                        payload.get("output")
+                    ):
+                        read_output = payload.get("output")
+
+        # DEFERRED_NOT_EXECUTED (a second tool call queued behind an already-pending gate) and
+        # InputValidationError on the harness's OWN builtin Read tool (a model arg-name mistake,
+        # "path" vs "file_path" -- self-corrected on the next attempt) are both irrelevant noise
+        # for what T8 actually verifies (the mount/tunnel path), not backend failures.
+        benign_markers = ("DEFERRED_NOT_EXECUTED", "InputValidationError")
+        backend_errors = [
+            t.tool_payloads.get(tcid, {}).get("errorText", "")
+            for t in turns
+            for tcid, outcome in t.tool_outcomes.items()
+            if outcome == "error"
+            and not any(
+                m in t.tool_payloads.get(tcid, {}).get("errorText", "")
+                for m in benign_markers
+            )
+        ]
+        any_real_tool_error = bool(backend_errors)
+
+        time.sleep(1.0)
+        newest = latest_revision(wf)
+        skills = (
+            (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("skills", [])
+            if newest
+            else []
+        )
+        skill = next(
+            (s for s in skills if s.get("name") == "t8-saved-files-test"), None
+        )
+        body_matches = skill is not None and marker in json.dumps(skill.get("body"))
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(
+            ver or -1
+        )
+        real_read = read_output is not None
+
+        core_ok = (
+            real_read and not any_real_tool_error and version_bumped and body_matches
+        )
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"real_read (a tool output carried the real marker)={real_read}, "
+                f"any_real_tool_error={any_real_tool_error}, version_bumped={version_bumped}, "
+                f"body_matches={body_matches}. Check runner logs for 'remote agent mount active "
+                f"for artifact={wf}' separately."
+            ),
+            "workflow_id": wf,
+            "session_id": session_id,
+            "mount_id": mount_id,
+            "marker": marker,
+            "read_output": read_output,
+            "committed_skill_body": (skill or {}).get("body"),
+            "rounds": len(turns),
+            "frames_per_turn": [t.frames for t in turns],
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = t8_saved_files()
+    print("\n=== T8 SAVED-FILES RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_w1_daytona.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w1_daytona.py
@@ -25,6 +25,7 @@ connections for provider '<provider>'" (more than one candidate, ambiguous with 
 
   uv run matrix_w1_daytona.py
 """
+
 import json
 import pathlib
 import sys
@@ -92,7 +93,11 @@ def w1_daytona():
         session_id = str(uuid.uuid4())
         t1 = invoke(session_id, [user_msg(prompt)], {"agent": live_cfg}, references)
         if t1.errors:
-            return {"status": "FAIL", "why": f"turn1 wire errors: {t1.errors}", "turn1_frames": t1.frames}
+            return {
+                "status": "FAIL",
+                "why": f"turn1 wire errors: {t1.errors}",
+                "turn1_frames": t1.frames,
+            }
         if not t1.approval:
             return {
                 "status": "FAIL",
@@ -103,7 +108,11 @@ def w1_daytona():
         msgs = [user_msg(prompt), approval_reply(t1, approved=True)]
         t2 = invoke(session_id, msgs, {"agent": live_cfg}, references)
         if t2.errors:
-            return {"status": "FAIL", "why": f"turn2 wire errors: {t2.errors}", "turn2_frames": t2.frames}
+            return {
+                "status": "FAIL",
+                "why": f"turn2 wire errors: {t2.errors}",
+                "turn2_frames": t2.frames,
+            }
         outcome = t2.tool_outcomes.get(t1.approval["toolCallId"])
         if outcome != "available":
             payload = t2.tool_payloads.get(t1.approval["toolCallId"], {})
@@ -117,12 +126,17 @@ def w1_daytona():
         time.sleep(1.0)
         newest = latest_revision(wf)
         new_token = (
-            (newest.get("data") or {}).get("parameters", {}).get("agent", {})
-            .get("instructions", {}).get("agents_md")
+            (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("instructions", {})
+            .get("agents_md")
             if newest
             else None
         )
-        version_bumped = newest is not None and int(newest.get("version") or -1) > int(ver or -1)
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(
+            ver or -1
+        )
         token_match = new_token == token
         ok = version_bumped and token_match
         return {

--- a/.agents/skills/agent-release-gate/resources/matrix_w1_daytona.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w1_daytona.py
@@ -1,0 +1,144 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (backend-path test). The prompt names the exact tool/operation/target -- this
+proves the Daytona sandbox-creation, DaytonaWorkspaceReader, and placeholder-secrets path work,
+not that a model reaches for read_config/commit_revision unprompted on Daytona. Do not cite for
+model one-shot-discovery claims.
+
+W1-Daytona: the commit round-trip (matrix_w3.py's session-A shape) with sandbox=daytona.
+Daytona rejects subscription auth by design, so this cell uses a vault key
+(connection.mode=agenta) instead of self_managed -- exercises DaytonaWorkspaceReader and the
+Daytona sandbox-creation + placeholder-secrets flow live, distinct from every other cell in this
+suite (all of which run local sandbox).
+
+Needs a funded Anthropic (or OpenAI) vault key in the target project. If the vault is empty,
+add one: POST /api/vault/v1/secrets/ with
+{"slug": "...", "header": {"name": "..."}, "secret": {"kind": "provider_key",
+"data": {"kind": "anthropic", "provider": {"key": "<key>"}}}}. Then reference it with
+connection={"mode": "agenta", "slug": None} (a `provider_key`-kind secret's connection slug IS
+its provider name, e.g. "anthropic" -- never the secret's own slug; `slug: None` resolves
+unambiguously when the vault holds exactly one key per provider). Getting this wrong produces
+either "connection '<slug>' not found for provider '<provider>'" (wrong slug) or "multiple
+connections for provider '<provider>'" (more than one candidate, ambiguous with slug=None).
+
+  uv run matrix_w1_daytona.py
+"""
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    approval_reply,
+    archive,
+    create_workflow,
+    invoke,
+    latest_revision,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def daytona_agent_config(tools):
+    return {
+        "instructions": {"agents_md": BASELINE},
+        "llm": {
+            "model": "haiku",
+            "provider": "anthropic",
+            "connection": {"mode": "agenta", "slug": None},
+            "extras": {},
+        },
+        "tools": tools,
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": "claude"},
+        "sandbox": {"kind": "daytona"},
+    }
+
+
+DAYTONA_LIVE_TOOLS = [
+    {"type": "platform", "op": "read_config"},
+    {"type": "platform", "op": "commit_revision"},
+]
+
+
+def w1_daytona():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-w1dtn")
+    try:
+        # read_config/commit_revision must NOT be in the PERSISTED baseline's tools list
+        # (platform_tool_not_committable) but ARE needed on the live invoke params.
+        base_cfg = daytona_agent_config([])
+        live_cfg = daytona_agent_config(DAYTONA_LIVE_TOOLS)
+        rev_id, ver = seed_and_baseline(wf, var, base_cfg, hexid)
+        references = refs(wf, var, rev_id)
+        token = f"QA-W1DTN-{uuid.uuid4().hex[:12]}"
+
+        prompt = (
+            "I'm the developer testing the config-editing feature. Please: 1) call "
+            "read_config to get the base_revision_id, 2) call commit_revision with an "
+            'edit_text operation targeting ["parameters","agent","instructions","agents_md"] '
+            f"that replaces the exact text '{BASELINE}' with '{token}', using the "
+            "base_revision_id you just read. There is an approval step I will handle. Go "
+            "ahead and make the two tool calls."
+        )
+        session_id = str(uuid.uuid4())
+        t1 = invoke(session_id, [user_msg(prompt)], {"agent": live_cfg}, references)
+        if t1.errors:
+            return {"status": "FAIL", "why": f"turn1 wire errors: {t1.errors}", "turn1_frames": t1.frames}
+        if not t1.approval:
+            return {
+                "status": "FAIL",
+                "why": "expected tool-approval-request; gate never fired",
+                "turn1_frames": t1.frames,
+                "turn1_reply": t1.reply,
+            }
+        msgs = [user_msg(prompt), approval_reply(t1, approved=True)]
+        t2 = invoke(session_id, msgs, {"agent": live_cfg}, references)
+        if t2.errors:
+            return {"status": "FAIL", "why": f"turn2 wire errors: {t2.errors}", "turn2_frames": t2.frames}
+        outcome = t2.tool_outcomes.get(t1.approval["toolCallId"])
+        if outcome != "available":
+            payload = t2.tool_payloads.get(t1.approval["toolCallId"], {})
+            return {
+                "status": "FAIL",
+                "why": f"approved call outcome={outcome!r}",
+                "payload": payload,
+                "turn2_frames": t2.frames,
+            }
+
+        time.sleep(1.0)
+        newest = latest_revision(wf)
+        new_token = (
+            (newest.get("data") or {}).get("parameters", {}).get("agent", {})
+            .get("instructions", {}).get("agents_md")
+            if newest
+            else None
+        )
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(ver or -1)
+        token_match = new_token == token
+        ok = version_bumped and token_match
+        return {
+            "status": "PASS" if ok else "FAIL",
+            "why": f"version {ver}->{newest.get('version') if newest else None}, token_match={token_match}",
+            "workflow_id": wf,
+            "session_id": session_id,
+            "new_revision_id": newest.get("id") if newest else None,
+            "turn1_frames": t1.frames,
+            "turn2_frames": t2.frames,
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = w1_daytona()
+    print("\n=== W1-DAYTONA RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_w3.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w3.py
@@ -31,6 +31,7 @@ engine's structured error detail through to the model instead of a bare HTTP sta
 
   uv run matrix_w3.py
 """
+
 import json
 import pathlib
 import sys
@@ -57,9 +58,15 @@ BASELINE = "Be terse. Do exactly what is asked."
 
 def _edits_present(wf, token_a, skill_name):
     final = latest_revision(wf)
-    final_agent = (final.get("data") or {}).get("parameters", {}).get("agent", {}) if final else {}
+    final_agent = (
+        (final.get("data") or {}).get("parameters", {}).get("agent", {})
+        if final
+        else {}
+    )
     a_present = final_agent.get("instructions", {}).get("agents_md") == token_a
-    b_skill = next((s for s in final_agent.get("skills", []) if s.get("name") == skill_name), None)
+    b_skill = next(
+        (s for s in final_agent.get("skills", []) if s.get("name") == skill_name), None
+    )
     b_present = b_skill is not None
     return a_present, b_present, final
 
@@ -85,7 +92,9 @@ def w3():
             "ahead and make the two tool calls."
         )
         session_a = str(uuid.uuid4())
-        turns_a, status_a = run_until_settled(session_a, [user_msg(prompt_a)], live_params, references)
+        turns_a, status_a = run_until_settled(
+            session_a, [user_msg(prompt_a)], live_params, references
+        )
         if not status_a["settled"]:
             return {"status": "FAIL", "why": f"session A never settled: {status_a}"}
         time.sleep(1.0)
@@ -115,7 +124,10 @@ def w3():
 
         conflict_seen = any(
             outcome == "error"
-            and ("409" in json.dumps(t.tool_payloads.get(tcid, {})) or "conflict" in json.dumps(t.tool_payloads.get(tcid, {})).lower())
+            and (
+                "409" in json.dumps(t.tool_payloads.get(tcid, {}))
+                or "conflict" in json.dumps(t.tool_payloads.get(tcid, {})).lower()
+            )
             for t in turns_b
             for tcid, outcome in t.tool_outcomes.items()
         )
@@ -143,7 +155,8 @@ def w3():
         # nudge -- no mechanics, no mention of read_config -- and see if it completes.
         last_reply = turns_b[-1].reply if turns_b else ""
         diagnosed = any(
-            kw in last_reply.lower() for kw in ("conflict", "stale", "409", "base_revision")
+            kw in last_reply.lower()
+            for kw in ("conflict", "stale", "409", "base_revision")
         )
         if not diagnosed:
             return {
@@ -156,7 +169,9 @@ def w3():
                 "turns_b_frames": [t.frames for t in turns_b],
             }
 
-        t_nudge = invoke(session_b, [user_msg("Yes, please retry.")], live_params, references)
+        t_nudge = invoke(
+            session_b, [user_msg("Yes, please retry.")], live_params, references
+        )
         cur_msgs = [user_msg("Yes, please retry.")]
         cur_t = t_nudge
         nudge_turns = [t_nudge]

--- a/.agents/skills/agent-release-gate/resources/matrix_w3.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w3.py
@@ -1,0 +1,150 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""W3: guards against the optimistic-concurrency base check silently accepting a stale commit or
+losing one side of a two-writer conflict -- two sessions, disjoint edits, one must 409 on a stale
+base_revision_id and recover; asserts BOTH edits land in the final head.
+
+NOTE per team-lead direction (runner bug: commit-revision errors lose all structured detail on
+the wire -- see product-bug report): the prompt EXPLICITLY coaches the retry mechanics (call
+read_config again on a 409, retry with the fresh base_revision_id). This tests that the base
+check correctly rejects a stale commit and that a coached retry lands cleanly -- it does NOT test
+whether the model can discover the retry path from the error text alone (impossible right now,
+since the wire only shows a bare HTTP status). A follow-up W3-discovery run (no coaching) is owed
+once the runner fix lands (PR #5763).
+
+  uv run matrix_w3.py
+"""
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    archive,
+    create_workflow,
+    latest_revision,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def w3():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-w3")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, ver = seed_and_baseline(wf, var, cfg, hexid)
+        live_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+        references = refs(wf, var, rev_id)
+        token_a = f"QA-W3A-{uuid.uuid4().hex[:12]}"
+
+        # Session A: edit_text on instructions.agents_md. Commits FIRST -- lands cleanly.
+        prompt_a = (
+            "I'm the developer testing the config-editing feature. Please: 1) call "
+            "read_config to get the base_revision_id, 2) call commit_revision with an "
+            'edit_text operation targeting ["parameters","agent","instructions","agents_md"] '
+            f"that replaces the exact text '{BASELINE}' with '{token_a}', using the "
+            "base_revision_id you just read. There is an approval step I will handle. Go "
+            "ahead and make the two tool calls."
+        )
+        session_a = str(uuid.uuid4())
+        turns_a, status_a = run_until_settled(session_a, [user_msg(prompt_a)], live_params, references)
+        if not status_a["settled"]:
+            return {"status": "FAIL", "why": f"session A never settled: {status_a}"}
+
+        time.sleep(1.0)
+        after_a = latest_revision(wf)
+        a_landed = after_a is not None and int(after_a.get("version") or -1) > int(ver or -1)
+        if not a_landed:
+            return {
+                "status": "FAIL",
+                "why": "session A's edit did not land",
+                "turns_a_frames": [t.frames for t in turns_a],
+            }
+
+        # Session B: read_config was done AGAINST THE OLD BASE (simulating a session that
+        # started concurrently, before A committed) -- add_item a new skill, disjoint from A's
+        # edit, but its base_revision_id is now stale (head moved to A's revision).
+        prompt_b = (
+            "I'm the developer testing the config-editing feature, and testing conflict "
+            "recovery specifically. Please: 1) call read_config to get the base_revision_id, "
+            "2) call commit_revision with an add_item operation targeting "
+            '["parameters","agent","skills"] that adds a new skill named "w3-session-b" with '
+            'description "Added by session B" and body "test", using the '
+            f"base_revision_id '{rev_id}' (NOT the one from your read_config call -- use this "
+            "exact stale id, on purpose, to test conflict handling). If that commit fails "
+            "with a 409 conflict (a stale base_revision_id), call read_config AGAIN to get "
+            "the current base_revision_id, then retry the exact same add_item operation with "
+            "the fresh base_revision_id. There is an approval step for each attempt, which I "
+            "will handle. Go ahead."
+        )
+        session_b = str(uuid.uuid4())
+        turns_b, status_b = run_until_settled(
+            session_b, [user_msg(prompt_b)], live_params, references, max_rounds=10
+        )
+        if not status_b["settled"]:
+            return {
+                "status": "FAIL",
+                "why": f"session B never settled: {status_b}",
+                "turns_b_frames": [t.frames for t in turns_b],
+            }
+
+        # Look for the conflict signal anywhere in session B's tool outcomes.
+        conflict_seen = False
+        conflict_payload = None
+        for t in turns_b:
+            for tcid, outcome in t.tool_outcomes.items():
+                payload = t.tool_payloads.get(tcid, {})
+                blob = json.dumps(payload)
+                if outcome == "error" and ("409" in blob or "conflict" in blob.lower()):
+                    conflict_seen = True
+                    conflict_payload = payload
+
+        time.sleep(1.0)
+        final = latest_revision(wf)
+        final_agent = (final.get("data") or {}).get("parameters", {}).get("agent", {}) if final else {}
+        a_edit_present = final_agent.get("instructions", {}).get("agents_md") == token_a
+        b_skill = next(
+            (s for s in final_agent.get("skills", []) if s.get("name") == "w3-session-b"), None
+        )
+        b_edit_present = b_skill is not None
+        final_version_high_enough = final is not None and int(final.get("version") or -1) >= int(
+            after_a.get("version") or -1
+        ) + 1
+
+        core_ok = conflict_seen and a_edit_present and b_edit_present and final_version_high_enough
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"conflict_seen={conflict_seen}, a_edit_present={a_edit_present}, "
+                f"b_edit_present={b_edit_present}, final_version_high_enough={final_version_high_enough} "
+                f"(after_a v{after_a.get('version')}, final v{final.get('version') if final else None}). "
+                f"NOTE: retry was explicitly coached in the prompt (runner error-detail bug in "
+                f"effect); this tests mechanics, not model-driven discovery of the recovery path."
+            ),
+            "workflow_id": wf,
+            "session_a": session_a,
+            "session_b": session_b,
+            "conflict_payload": conflict_payload,
+            "final_revision_id": final.get("id") if final else None,
+            "turns_a_frames": [t.frames for t in turns_a],
+            "turns_b_frames": [t.frames for t in turns_b],
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = w3()
+    print("\n=== W3 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_w3.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w3.py
@@ -2,17 +2,32 @@
 # requires-python = ">=3.10"
 # dependencies = ["httpx>=0.27"]
 # ///
-"""W3: guards against the optimistic-concurrency base check silently accepting a stale commit or
-losing one side of a two-writer conflict -- two sessions, disjoint edits, one must 409 on a stale
-base_revision_id and recover; asserts BOTH edits land in the final head.
+"""TIER: coached (backend-path test). Both prompts name the mechanism verbatim (which tool,
+which operation, which target path) for the INITIAL action in each session -- this cell proves
+the base-check and error-detail plumbing work, not that a model discovers the mechanism from a
+plain-language ask. The one mechanism-blind sliver inside it: session B's RECOVERY from the 409
+is not coached (see below) -- but that is a narrow claim about recovering from a named failure,
+not evidence a model can find commit_revision/read_config unprompted in the first place. Do not
+cite this cell for "the model can edit its own config one-shot from a human ask" -- that claim
+needs a mechanism-blind cell (Tier B, the one-shot benchmark).
 
-NOTE per team-lead direction (runner bug: commit-revision errors lose all structured detail on
-the wire -- see product-bug report): the prompt EXPLICITLY coaches the retry mechanics (call
-read_config again on a 409, retry with the fresh base_revision_id). This tests that the base
-check correctly rejects a stale commit and that a coached retry lands cleanly -- it does NOT test
-whether the model can discover the retry path from the error text alone (impossible right now,
-since the wire only shows a bare HTTP status). A follow-up W3-discovery run (no coaching) is owed
-once the runner fix lands (PR #5763).
+W3: guards against the optimistic-concurrency base check silently accepting a stale commit,
+AND against the instructive-error design regressing (a 409 must let the model find its own way
+back without being coached). Two sessions, disjoint edits: session A commits cleanly; session B
+is deliberately given a stale base_revision_id and ZERO coaching on what to do if it fails.
+
+Two-tier pass, per team-lead ruling 2026-08-06 (post PR #5763, which passes the change-set
+engine's structured error detail through to the model instead of a bare HTTP status):
+  - STAGE 1 (autonomous correct recovery): session B hits the 409, retries on its own
+    initiative with a fresh base_revision_id, and both edits land. PASS outright.
+  - STAGE 2 (diagnose-and-ask): session B hits the 409, correctly explains the conflict and
+    names the recovery step in its reply, but stops and asks before re-attempting a config
+    write. This is DESIRABLE behavior, not a failure -- the guarded failure mode is a silent
+    WRONG retry, not a model that checks before mutating config on a rejected commit. Send one
+    bare permission nudge ("yes, retry") with no mechanics coached; if both edits land after
+    that, PASS.
+  - Anything else -- the model doesn't recognize the conflict, gives up, corrupts the edit, or
+    fails to land even after being told to retry -- FAILS.
 
   uv run matrix_w3.py
 """
@@ -26,8 +41,10 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
     LIVE_TOOLS,
     agent_config,
+    approval_reply,
     archive,
     create_workflow,
+    invoke,
     latest_revision,
     refs,
     run_until_settled,
@@ -36,6 +53,15 @@ from qa_matrix_lib import (  # noqa: E402
 )
 
 BASELINE = "Be terse. Do exactly what is asked."
+
+
+def _edits_present(wf, token_a, skill_name):
+    final = latest_revision(wf)
+    final_agent = (final.get("data") or {}).get("parameters", {}).get("agent", {}) if final else {}
+    a_present = final_agent.get("instructions", {}).get("agents_md") == token_a
+    b_skill = next((s for s in final_agent.get("skills", []) if s.get("name") == skill_name), None)
+    b_present = b_skill is not None
+    return a_present, b_present, final
 
 
 def w3():
@@ -47,8 +73,9 @@ def w3():
         live_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
         references = refs(wf, var, rev_id)
         token_a = f"QA-W3A-{uuid.uuid4().hex[:12]}"
+        skill_name = "w3-session-b"
 
-        # Session A: edit_text on instructions.agents_md. Commits FIRST -- lands cleanly.
+        # Session A: commits cleanly first, establishing the stale base for session B.
         prompt_a = (
             "I'm the developer testing the config-editing feature. Please: 1) call "
             "read_config to get the base_revision_id, 2) call commit_revision with an "
@@ -61,32 +88,19 @@ def w3():
         turns_a, status_a = run_until_settled(session_a, [user_msg(prompt_a)], live_params, references)
         if not status_a["settled"]:
             return {"status": "FAIL", "why": f"session A never settled: {status_a}"}
-
         time.sleep(1.0)
         after_a = latest_revision(wf)
-        a_landed = after_a is not None and int(after_a.get("version") or -1) > int(ver or -1)
-        if not a_landed:
-            return {
-                "status": "FAIL",
-                "why": "session A's edit did not land",
-                "turns_a_frames": [t.frames for t in turns_a],
-            }
+        if not (after_a and int(after_a.get("version") or -1) > int(ver or -1)):
+            return {"status": "FAIL", "why": "session A's edit did not land"}
 
-        # Session B: read_config was done AGAINST THE OLD BASE (simulating a session that
-        # started concurrently, before A committed) -- add_item a new skill, disjoint from A's
-        # edit, but its base_revision_id is now stale (head moved to A's revision).
+        # Session B: NO coaching. Told to use a specific stale base_revision_id, on purpose,
+        # and left to handle any failure entirely on its own.
         prompt_b = (
-            "I'm the developer testing the config-editing feature, and testing conflict "
-            "recovery specifically. Please: 1) call read_config to get the base_revision_id, "
-            "2) call commit_revision with an add_item operation targeting "
-            '["parameters","agent","skills"] that adds a new skill named "w3-session-b" with '
-            'description "Added by session B" and body "test", using the '
-            f"base_revision_id '{rev_id}' (NOT the one from your read_config call -- use this "
-            "exact stale id, on purpose, to test conflict handling). If that commit fails "
-            "with a 409 conflict (a stale base_revision_id), call read_config AGAIN to get "
-            "the current base_revision_id, then retry the exact same add_item operation with "
-            "the fresh base_revision_id. There is an approval step for each attempt, which I "
-            "will handle. Go ahead."
+            "I'm the developer testing the config-editing feature. Please call commit_revision "
+            'with an add_item operation targeting ["parameters","agent","skills"] that adds a '
+            f'new skill named "{skill_name}" with description "Added by session B" and body '
+            f"\"test\", using the base_revision_id '{rev_id}' exactly (do not call read_config "
+            "first -- use that exact id). There is an approval step I will handle. Go ahead."
         )
         session_b = str(uuid.uuid4())
         turns_b, status_b = run_until_settled(
@@ -99,46 +113,79 @@ def w3():
                 "turns_b_frames": [t.frames for t in turns_b],
             }
 
-        # Look for the conflict signal anywhere in session B's tool outcomes.
-        conflict_seen = False
-        conflict_payload = None
-        for t in turns_b:
-            for tcid, outcome in t.tool_outcomes.items():
-                payload = t.tool_payloads.get(tcid, {})
-                blob = json.dumps(payload)
-                if outcome == "error" and ("409" in blob or "conflict" in blob.lower()):
-                    conflict_seen = True
-                    conflict_payload = payload
-
-        time.sleep(1.0)
-        final = latest_revision(wf)
-        final_agent = (final.get("data") or {}).get("parameters", {}).get("agent", {}) if final else {}
-        a_edit_present = final_agent.get("instructions", {}).get("agents_md") == token_a
-        b_skill = next(
-            (s for s in final_agent.get("skills", []) if s.get("name") == "w3-session-b"), None
+        conflict_seen = any(
+            outcome == "error"
+            and ("409" in json.dumps(t.tool_payloads.get(tcid, {})) or "conflict" in json.dumps(t.tool_payloads.get(tcid, {})).lower())
+            for t in turns_b
+            for tcid, outcome in t.tool_outcomes.items()
         )
-        b_edit_present = b_skill is not None
-        final_version_high_enough = final is not None and int(final.get("version") or -1) >= int(
-            after_a.get("version") or -1
-        ) + 1
+        if not conflict_seen:
+            return {
+                "status": "FAIL",
+                "why": "expected a 409 conflict on session B's stale base_revision_id; never saw one",
+                "turns_b_frames": [t.frames for t in turns_b],
+            }
 
-        core_ok = conflict_seen and a_edit_present and b_edit_present and final_version_high_enough
+        a_present, b_present, final = _edits_present(wf, token_a, skill_name)
+        if a_present and b_present:
+            return {
+                "status": "PASS",
+                "why": "STAGE 1: session B recovered autonomously (no coaching) and both edits landed",
+                "stage": 1,
+                "workflow_id": wf,
+                "session_a": session_a,
+                "session_b": session_b,
+                "final_revision_id": final.get("id") if final else None,
+            }
+
+        # STAGE 2: session B likely diagnosed the conflict and asked rather than auto-retrying.
+        # Confirm the diagnosis is coherent (names the conflict), then send ONE bare permission
+        # nudge -- no mechanics, no mention of read_config -- and see if it completes.
+        last_reply = turns_b[-1].reply if turns_b else ""
+        diagnosed = any(
+            kw in last_reply.lower() for kw in ("conflict", "stale", "409", "base_revision")
+        )
+        if not diagnosed:
+            return {
+                "status": "FAIL",
+                "why": (
+                    "session B hit the 409 but its reply does not show a coherent diagnosis "
+                    "(no mention of conflict/stale/base_revision) and neither edit landed"
+                ),
+                "last_reply": last_reply,
+                "turns_b_frames": [t.frames for t in turns_b],
+            }
+
+        t_nudge = invoke(session_b, [user_msg("Yes, please retry.")], live_params, references)
+        cur_msgs = [user_msg("Yes, please retry.")]
+        cur_t = t_nudge
+        nudge_turns = [t_nudge]
+        settled2 = not t_nudge.approval and not t_nudge.errors
+        for _ in range(8):
+            if cur_t.errors or not cur_t.approval:
+                break
+            cur_msgs = cur_msgs + [approval_reply(cur_t, approved=True)]
+            cur_t = invoke(session_b, cur_msgs, live_params, references)
+            nudge_turns.append(cur_t)
+            if not cur_t.approval:
+                settled2 = True
+                break
+
+        a_present2, b_present2, final2 = _edits_present(wf, token_a, skill_name)
+        ok = settled2 and a_present2 and b_present2
         return {
-            "status": "PASS" if core_ok else "FAIL",
+            "status": "PASS" if ok else "FAIL",
             "why": (
-                f"conflict_seen={conflict_seen}, a_edit_present={a_edit_present}, "
-                f"b_edit_present={b_edit_present}, final_version_high_enough={final_version_high_enough} "
-                f"(after_a v{after_a.get('version')}, final v{final.get('version') if final else None}). "
-                f"NOTE: retry was explicitly coached in the prompt (runner error-detail bug in "
-                f"effect); this tests mechanics, not model-driven discovery of the recovery path."
+                f"STAGE 2 (diagnose-and-ask, then a bare 'yes, retry' with zero mechanics "
+                f"coached): settled2={settled2}, a_present={a_present2}, b_present={b_present2}"
             ),
+            "stage": 2,
             "workflow_id": wf,
             "session_a": session_a,
             "session_b": session_b,
-            "conflict_payload": conflict_payload,
-            "final_revision_id": final.get("id") if final else None,
-            "turns_a_frames": [t.frames for t in turns_a],
-            "turns_b_frames": [t.frames for t in turns_b],
+            "diagnosis_reply": last_reply,
+            "final_revision_id": final2.get("id") if final2 else None,
+            "nudge_frames": [t.frames for t in nudge_turns],
         }
     finally:
         archive(wf)

--- a/.agents/skills/agent-release-gate/resources/matrix_w4.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w4.py
@@ -1,0 +1,159 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""W4: guards against the base-staleness check running only at gate time instead of execute
+time -- session A raises its approval gate while holding base X, session B commits before A is
+approved (head moves past X), THEN A is approved. The EXECUTE-TIME check must catch the
+staleness and 409; a gate-time-only check would miss it and silently overwrite B's commit.
+
+Same runner error-detail bug as W3 -- A's recovery is coached in the prompt (see matrix_w3.py's
+docstring; fix on PR #5763).
+
+  uv run matrix_w4.py
+"""
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    approval_reply,
+    archive,
+    create_workflow,
+    invoke,
+    latest_revision,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def w4():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-w4")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, ver = seed_and_baseline(wf, var, cfg, hexid)
+        live_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+        references = refs(wf, var, rev_id)
+        token_a = f"QA-W4A-{uuid.uuid4().hex[:12]}"
+
+        # Session A: raise the gate, but DO NOT approve yet.
+        prompt_a = (
+            "I'm the developer testing the config-editing feature. Please: 1) call "
+            "read_config to get the base_revision_id, 2) call commit_revision with an "
+            'edit_text operation targeting ["parameters","agent","instructions","agents_md"] '
+            f"that replaces the exact text '{BASELINE}' with '{token_a}', using the "
+            "base_revision_id you just read. There is an approval step I will handle. If "
+            "that commit fails with a 409 conflict after I approve it (a stale "
+            "base_revision_id, because someone else committed while you were waiting for "
+            "approval), call read_config AGAIN to get the current base_revision_id, then "
+            "retry the exact same edit_text operation with the fresh base_revision_id. Go "
+            "ahead and make the two tool calls."
+        )
+        session_a = str(uuid.uuid4())
+        t_a1 = invoke(session_a, [user_msg(prompt_a)], live_params, references)
+        if t_a1.errors or not t_a1.approval:
+            return {
+                "status": "FAIL",
+                "why": f"session A's gate never raised as expected: errors={t_a1.errors}",
+                "turn_a1_frames": t_a1.frames,
+            }
+        # A is now PARKED, holding an authorization/approval tied to base=rev_id (v1).
+
+        # Session B: commits cleanly against the SAME base, moving head past it.
+        token_b = f"QA-W4B-{uuid.uuid4().hex[:12]}"
+        prompt_b = (
+            "I'm the developer testing the config-editing feature. Please: 1) call "
+            "read_config to get the base_revision_id, 2) call commit_revision with an "
+            'add_item operation targeting ["parameters","agent","skills"] that adds a new '
+            'skill named "w4-session-b" with description "Added by session B" and body '
+            f"'{token_b}', using the base_revision_id you just read. There is an approval "
+            "step I will handle. Go ahead."
+        )
+        session_b = str(uuid.uuid4())
+        turns_b, status_b = run_until_settled(session_b, [user_msg(prompt_b)], live_params, references)
+        if not status_b["settled"]:
+            return {"status": "FAIL", "why": f"session B never settled: {status_b}"}
+
+        time.sleep(1.0)
+        after_b = latest_revision(wf)
+        b_landed = after_b is not None and int(after_b.get("version") or -1) > int(ver or -1)
+        if not b_landed:
+            return {"status": "FAIL", "why": "session B's edit did not land; cannot test A's staleness"}
+
+        # NOW approve A. Its base (rev_id, v1) is stale -- head is now after_b's version.
+        msgs_a = [user_msg(prompt_a), approval_reply(t_a1, approved=True)]
+        # Continue A's session with a run_until_settled-style manual loop (starting from t_a1).
+        turns_a = [t_a1]
+        cur_msgs = msgs_a
+        settled = False
+        for _ in range(8):
+            t = invoke(session_a, cur_msgs, live_params, references)
+            turns_a.append(t)
+            if t.errors:
+                break
+            if not t.approval:
+                settled = True
+                break
+            cur_msgs = cur_msgs + [approval_reply(t, approved=True)]
+
+        if not settled:
+            return {
+                "status": "FAIL",
+                "why": "session A never settled after being approved post-staleness",
+                "turns_a_frames": [t.frames for t in turns_a],
+            }
+
+        conflict_seen = False
+        conflict_payload = None
+        for t in turns_a:
+            for tcid, outcome in t.tool_outcomes.items():
+                payload = t.tool_payloads.get(tcid, {})
+                blob = json.dumps(payload)
+                if outcome == "error" and ("409" in blob or "conflict" in blob.lower()):
+                    conflict_seen = True
+                    conflict_payload = payload
+
+        time.sleep(1.0)
+        final = latest_revision(wf)
+        final_agent = (final.get("data") or {}).get("parameters", {}).get("agent", {}) if final else {}
+        a_edit_present = final_agent.get("instructions", {}).get("agents_md") == token_a
+        b_skill = next(
+            (s for s in final_agent.get("skills", []) if s.get("name") == "w4-session-b"), None
+        )
+        b_edit_present = b_skill is not None and token_b in json.dumps(b_skill.get("body"))
+
+        core_ok = conflict_seen and a_edit_present and b_edit_present
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"conflict_seen={conflict_seen} (execute-time base check caught the staleness "
+                f"under a pending approval), a_edit_present={a_edit_present}, "
+                f"b_edit_present={b_edit_present}. NOTE: A's recovery was explicitly coached "
+                f"(runner error-detail bug in effect)."
+            ),
+            "workflow_id": wf,
+            "session_a": session_a,
+            "session_b": session_b,
+            "conflict_payload": conflict_payload,
+            "final_revision_id": final.get("id") if final else None,
+            "turns_a_frames": [t.frames for t in turns_a],
+            "turns_b_frames": [t.frames for t in turns_b],
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = w4()
+    print("\n=== W4 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_w4.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w4.py
@@ -17,6 +17,7 @@ docstring; fix on PR #5763).
 
   uv run matrix_w4.py
 """
+
 import json
 import pathlib
 import sys
@@ -85,15 +86,22 @@ def w4():
             "step I will handle. Go ahead."
         )
         session_b = str(uuid.uuid4())
-        turns_b, status_b = run_until_settled(session_b, [user_msg(prompt_b)], live_params, references)
+        turns_b, status_b = run_until_settled(
+            session_b, [user_msg(prompt_b)], live_params, references
+        )
         if not status_b["settled"]:
             return {"status": "FAIL", "why": f"session B never settled: {status_b}"}
 
         time.sleep(1.0)
         after_b = latest_revision(wf)
-        b_landed = after_b is not None and int(after_b.get("version") or -1) > int(ver or -1)
+        b_landed = after_b is not None and int(after_b.get("version") or -1) > int(
+            ver or -1
+        )
         if not b_landed:
-            return {"status": "FAIL", "why": "session B's edit did not land; cannot test A's staleness"}
+            return {
+                "status": "FAIL",
+                "why": "session B's edit did not land; cannot test A's staleness",
+            }
 
         # NOW approve A. Its base (rev_id, v1) is stale -- head is now after_b's version.
         msgs_a = [user_msg(prompt_a), approval_reply(t_a1, approved=True)]
@@ -130,12 +138,23 @@ def w4():
 
         time.sleep(1.0)
         final = latest_revision(wf)
-        final_agent = (final.get("data") or {}).get("parameters", {}).get("agent", {}) if final else {}
+        final_agent = (
+            (final.get("data") or {}).get("parameters", {}).get("agent", {})
+            if final
+            else {}
+        )
         a_edit_present = final_agent.get("instructions", {}).get("agents_md") == token_a
         b_skill = next(
-            (s for s in final_agent.get("skills", []) if s.get("name") == "w4-session-b"), None
+            (
+                s
+                for s in final_agent.get("skills", [])
+                if s.get("name") == "w4-session-b"
+            ),
+            None,
         )
-        b_edit_present = b_skill is not None and token_b in json.dumps(b_skill.get("body"))
+        b_edit_present = b_skill is not None and token_b in json.dumps(
+            b_skill.get("body")
+        )
 
         core_ok = conflict_seen and a_edit_present and b_edit_present
         return {

--- a/.agents/skills/agent-release-gate/resources/matrix_w4.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w4.py
@@ -2,7 +2,12 @@
 # requires-python = ">=3.10"
 # dependencies = ["httpx>=0.27"]
 # ///
-"""W4: guards against the base-staleness check running only at gate time instead of execute
+"""TIER: coached (backend-path test). Both prompts name the exact tool, operation, and target
+path -- this proves the execute-time base check works, not that a model finds commit_revision
+from a plain-language ask. Do not cite for model one-shot-discovery claims; use a Tier B
+(mechanism-blind) cell for that.
+
+W4: guards against the base-staleness check running only at gate time instead of execute
 time -- session A raises its approval gate while holding base X, session B commits before A is
 approved (head moves past X), THEN A is approved. The EXECUTE-TIME check must catch the
 staleness and 409; a gate-time-only check would miss it and silently overwrite B's commit.

--- a/.agents/skills/agent-release-gate/resources/matrix_w5.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w5.py
@@ -2,7 +2,11 @@
 # requires-python = ">=3.10"
 # dependencies = ["httpx>=0.27"]
 # ///
-"""W5: guards against the durable workspace mount not being re-established after a steer --
+"""TIER: coached (backend-path test). The post-steer prompt names the exact tool/operation/
+target -- this proves the mount and steer lifecycle work, not that a model reaches for
+read_config/commit_revision unprompted. Do not cite for model one-shot-discovery claims.
+
+W5: guards against the durable workspace mount not being re-established after a steer --
 interrupt a running turn (send a second message on the same session while the first is mid-
 flight, the force-interrupt "steer" path), then assert a NEW turn on that session still works.
 

--- a/.agents/skills/agent-release-gate/resources/matrix_w5.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w5.py
@@ -21,6 +21,7 @@ turn). Keep both repros distinct when triaging -- do not fold this into that tic
 
   uv run matrix_w5.py
 """
+
 import json
 import pathlib
 import sys
@@ -73,12 +74,16 @@ def w5():
 
         # Interrupt: send a NEW user message on the SAME session while turn 1 is in flight.
         steer_prompt = "Stop what you're doing. Just reply with exactly: STEERED"
-        t_steer = invoke(session_id, [user_msg(steer_prompt)], live_params, references, log=False)
+        t_steer = invoke(
+            session_id, [user_msg(steer_prompt)], live_params, references, log=False
+        )
 
         th.join(timeout=30)
         turn1 = result_holder.get("turn")
 
-        steer_ok = t_steer.finish_reason == "stop" and "STEERED" in t_steer.reply.upper()
+        steer_ok = (
+            t_steer.finish_reason == "stop" and "STEERED" in t_steer.reply.upper()
+        )
 
         # Now a NEW turn on the SAME session must commit successfully afterward.
         token = f"QA-W5-{uuid.uuid4().hex[:12]}"
@@ -94,13 +99,19 @@ def w5():
             session_id, [user_msg(commit_prompt)], live_params, references
         )
 
-        post_interrupt_works = status_c["settled"] and not any(t.errors for t in turns_c)
+        post_interrupt_works = status_c["settled"] and not any(
+            t.errors for t in turns_c
+        )
         time.sleep(1.0)
         newest = latest_revision(wf)
         commit_landed = (
             newest is not None
-            and (newest.get("data") or {}).get("parameters", {}).get("agent", {})
-            .get("instructions", {}).get("agents_md") == token
+            and (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("instructions", {})
+            .get("agents_md")
+            == token
         )
 
         core_ok = steer_ok and post_interrupt_works and commit_landed

--- a/.agents/skills/agent-release-gate/resources/matrix_w5.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w5.py
@@ -1,0 +1,125 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""W5: guards against the durable workspace mount not being re-established after a steer --
+interrupt a running turn (send a second message on the same session while the first is mid-
+flight, the force-interrupt "steer" path), then assert a NEW turn on that session still works.
+
+Caught a real, 100%-reproducible bug on first run: the steer's force-interrupt unmounts the
+turn's cwd, a fresh mount is created for the steer reply itself, but the FOLLOWING turn never
+gets a remount and crashes with "Path ... does not exist" (services/runner mount lifecycle,
+not the API). This exercises the same STEER mechanism as Mahmoud's own repro
+(sessions/test_steer_via_command_interrupts_old_turn.py, out-of-project) but catches a DIFFERENT
+symptom: that one is a turn-currency/heartbeat bug (is_current_turn stays true on the displaced
+turn); this one is a filesystem-mount-lifecycle bug (the cwd is never remounted for the next
+turn). Keep both repros distinct when triaging -- do not fold this into that ticket.
+
+  uv run matrix_w5.py
+"""
+import json
+import pathlib
+import sys
+import threading
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    archive,
+    create_workflow,
+    invoke,
+    latest_revision,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def w5():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-w5")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, ver = seed_and_baseline(wf, var, cfg, hexid)
+        live_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+        references = refs(wf, var, rev_id)
+        session_id = str(uuid.uuid4())
+
+        # Turn 1: a long-running bash command to keep the turn busy while we interrupt it.
+        long_prompt = (
+            "Use your bash tool to run exactly this command and report its output: "
+            "sleep 20 && echo LONG_TURN_DONE"
+        )
+        result_holder = {}
+
+        def run_long_turn():
+            result_holder["turn"] = invoke(
+                session_id, [user_msg(long_prompt)], live_params, references, log=False
+            )
+
+        th = threading.Thread(target=run_long_turn, daemon=True)
+        th.start()
+        time.sleep(3.0)  # let turn 1 actually start and be mid-flight
+
+        # Interrupt: send a NEW user message on the SAME session while turn 1 is in flight.
+        steer_prompt = "Stop what you're doing. Just reply with exactly: STEERED"
+        t_steer = invoke(session_id, [user_msg(steer_prompt)], live_params, references, log=False)
+
+        th.join(timeout=30)
+        turn1 = result_holder.get("turn")
+
+        steer_ok = t_steer.finish_reason == "stop" and "STEERED" in t_steer.reply.upper()
+
+        # Now a NEW turn on the SAME session must commit successfully afterward.
+        token = f"QA-W5-{uuid.uuid4().hex[:12]}"
+        commit_prompt = (
+            "I'm the developer testing the config-editing feature. Please: 1) call "
+            "read_config to get the base_revision_id, 2) call commit_revision with an "
+            'edit_text operation targeting ["parameters","agent","instructions","agents_md"] '
+            f"that replaces the exact text '{BASELINE}' with '{token}', using the "
+            "base_revision_id you just read. There is an approval step I will handle. Go "
+            "ahead and make the two tool calls."
+        )
+        turns_c, status_c = run_until_settled(
+            session_id, [user_msg(commit_prompt)], live_params, references
+        )
+
+        post_interrupt_works = status_c["settled"] and not any(t.errors for t in turns_c)
+        time.sleep(1.0)
+        newest = latest_revision(wf)
+        commit_landed = (
+            newest is not None
+            and (newest.get("data") or {}).get("parameters", {}).get("agent", {})
+            .get("instructions", {}).get("agents_md") == token
+        )
+
+        core_ok = steer_ok and post_interrupt_works and commit_landed
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"steer_ok={steer_ok} (turn1 was interrupted, steer turn replied cleanly), "
+                f"post_interrupt_works={post_interrupt_works} (new turn on same session settled "
+                f"without wire errors), commit_landed={commit_landed}"
+            ),
+            "workflow_id": wf,
+            "session_id": session_id,
+            "turn1_frames_if_captured": turn1.frames if turn1 else None,
+            "turn1_finish_reason": turn1.finish_reason if turn1 else None,
+            "steer_turn_frames": t_steer.frames,
+            "steer_turn_reply": t_steer.reply,
+            "commit_turns_frames": [t.frames for t in turns_c],
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = w5()
+    print("\n=== W5 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_w7.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7.py
@@ -25,6 +25,7 @@ and re-verified PASS (2026-08-06); this repro stays in the docstring as the regr
 
   uv run matrix_w7.py
 """
+
 import json
 import pathlib
 import sys
@@ -73,7 +74,9 @@ def w7():
             "approved it."
         )
         session_id = str(uuid.uuid4())
-        turns, status = run_until_settled(session_id, [user_msg(prompt)], live_params, references)
+        turns, status = run_until_settled(
+            session_id, [user_msg(prompt)], live_params, references
+        )
 
         if not status["settled"]:
             return {
@@ -90,8 +93,12 @@ def w7():
                 if f.get("type") == "data-approval-manifest":
                     manifest_frames.append(f)
         manifest_evidence = manifest_frames[0].get("data") if manifest_frames else None
-        digest_present = bool(manifest_evidence) and "digest" in json.dumps(manifest_evidence)
-        bytes_present = bool(manifest_evidence) and "bytes" in json.dumps(manifest_evidence)
+        digest_present = bool(manifest_evidence) and "digest" in json.dumps(
+            manifest_evidence
+        )
+        bytes_present = bool(manifest_evidence) and "bytes" in json.dumps(
+            manifest_evidence
+        )
 
         any_errors = any(t.errors for t in turns)
         # DEFERRED_NOT_EXECUTED is benign: it fires when the model queues a second tool call
@@ -109,13 +116,20 @@ def w7():
         time.sleep(1.0)
         newest = latest_revision(wf)
         skills = (
-            (newest.get("data") or {}).get("parameters", {}).get("agent", {}).get("skills", [])
+            (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("skills", [])
             if newest
             else []
         )
         w7_skill = next((s for s in skills if s.get("name") == "w7-import-test"), None)
-        body_matches = w7_skill is not None and marker in json.dumps(w7_skill.get("body"))
-        version_bumped = newest is not None and int(newest.get("version") or -1) > int(ver or -1)
+        body_matches = w7_skill is not None and marker in json.dumps(
+            w7_skill.get("body")
+        )
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(
+            ver or -1
+        )
 
         core_ok = (
             not any_errors

--- a/.agents/skills/agent-release-gate/resources/matrix_w7.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7.py
@@ -2,7 +2,16 @@
 # requires-python = ">=3.10"
 # dependencies = ["httpx>=0.27"]
 # ///
-"""W7: guards against the file-marker execution-authorization handoff being broken -- an agent
+"""TIER: coached (backend-path test). The prompt names the mechanism verbatim: 'body set to
+{"@ag.file": ".agenta-imports/<file>"} (the file marker, not the literal text)'. This is
+CORRECT for this cell's purpose -- proving the backend mint/gate/execute path works -- but it
+means this cell says NOTHING about whether a model finds the @ag.file mechanism from a plain
+human ask like "add the skill I saved in your folder". It does not (root-caused live: Haiku
+invented a nonexistent {"@ag.embed": {"@ag.references": ...}} syntax instead, and the engine
+accepted it as literal data). Never cite this cell for a model-discovery claim; that needs a
+Tier B (mechanism-blind) cell.
+
+W7: guards against the file-marker execution-authorization handoff being broken -- an agent
 writes a workspace file and commits it via an `@ag.file` marker (contract: change-set.md 6,
 workspace-import.md 8). Asserts the approval manifest carries digest+bytes+path, AND that the
 approved commit actually lands with the exact file content.
@@ -11,9 +20,8 @@ Caught a real, 100%-reproducible bug on first run: mintForGate correctly mints a
 record and the manifest renders correctly, the HITL gate correctly fires and gets approved
 ("[HITL] gate ... outcome=allow" in runner logs), but authorizeExecution then IMMEDIATELY refuses
 with `authorization_missing` every single time -- the mint-to-consume handoff never succeeds, so
-no file-marker commit can ever land (services/runner/src/tools/commit-authorization.ts). This
-blocks W11 too (its stale-approval-regate mechanism is specifically about file-marker
-authorizations). Do not treat a PASS here as proven until this bug is confirmed fixed.
+no file-marker commit can ever land (services/runner/src/tools/commit-authorization.ts). FIXED
+and re-verified PASS (2026-08-06); this repro stays in the docstring as the regression signature.
 
   uv run matrix_w7.py
 """

--- a/.agents/skills/agent-release-gate/resources/matrix_w7.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7.py
@@ -1,0 +1,131 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""W7: guards against the file-marker execution-authorization handoff being broken -- an agent
+writes a workspace file and commits it via an `@ag.file` marker (contract: change-set.md 6,
+workspace-import.md 8). Asserts the approval manifest carries digest+bytes+path, AND that the
+approved commit actually lands with the exact file content.
+
+Caught a real, 100%-reproducible bug on first run: mintForGate correctly mints an authorization
+record and the manifest renders correctly, the HITL gate correctly fires and gets approved
+("[HITL] gate ... outcome=allow" in runner logs), but authorizeExecution then IMMEDIATELY refuses
+with `authorization_missing` every single time -- the mint-to-consume handoff never succeeds, so
+no file-marker commit can ever land (services/runner/src/tools/commit-authorization.ts). This
+blocks W11 too (its stale-approval-regate mechanism is specifically about file-marker
+authorizations). Do not treat a PASS here as proven until this bug is confirmed fixed.
+
+  uv run matrix_w7.py
+"""
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    LIVE_TOOLS,
+    agent_config,
+    archive,
+    create_workflow,
+    latest_revision,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def w7():
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-w7")
+    try:
+        cfg = agent_config(instructions=BASELINE)
+        rev_id, ver = seed_and_baseline(wf, var, cfg, hexid)
+        live_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+        references = refs(wf, var, rev_id)
+        marker = f"QA-W7-{uuid.uuid4().hex[:12]}"
+        fname = f"qa-w7-{hexid}.md"
+
+        prompt = (
+            "I'm the developer testing the config-import feature. Please do this exactly:\n"
+            f"1) Use your bash tool to write a file at .agenta-imports/{fname} with exactly "
+            f"this one line of content: {marker}\n"
+            "2) Call read_config to get the base_revision_id.\n"
+            "3) Call commit_revision with an add_item operation targeting "
+            '["parameters","agent","skills"] that adds a new skill named "w7-import-test" '
+            'with description "Import test skill" and body set to '
+            f'{{"@ag.file": ".agenta-imports/{fname}"}} (the file marker, not the literal text), '
+            "using the base_revision_id you just read.\n"
+            "I understand there may be one or more approval steps, which I will handle each "
+            "time. Do all three steps now, retrying any step that needed approval once I've "
+            "approved it."
+        )
+        session_id = str(uuid.uuid4())
+        turns, status = run_until_settled(session_id, [user_msg(prompt)], live_params, references)
+
+        if not status["settled"]:
+            return {
+                "status": "FAIL",
+                "why": f"never settled: {status}",
+                "rounds": len(turns),
+                "frames_per_turn": [t.frames for t in turns],
+            }
+
+        # Manifest evidence: the data-approval-manifest frame, wherever it landed.
+        manifest_frames = []
+        for t in turns:
+            for f in t.raw_frames:
+                if f.get("type") == "data-approval-manifest":
+                    manifest_frames.append(f)
+        manifest_evidence = manifest_frames[0].get("data") if manifest_frames else None
+        digest_present = bool(manifest_evidence) and "digest" in json.dumps(manifest_evidence)
+        bytes_present = bool(manifest_evidence) and "bytes" in json.dumps(manifest_evidence)
+
+        any_errors = any(t.errors for t in turns)
+        any_tool_error = any("error" in t.tool_outcomes.values() for t in turns)
+
+        time.sleep(1.0)
+        newest = latest_revision(wf)
+        skills = (
+            (newest.get("data") or {}).get("parameters", {}).get("agent", {}).get("skills", [])
+            if newest
+            else []
+        )
+        w7_skill = next((s for s in skills if s.get("name") == "w7-import-test"), None)
+        body_matches = w7_skill is not None and marker in json.dumps(w7_skill.get("body"))
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(ver or -1)
+
+        core_ok = (
+            not any_errors
+            and not any_tool_error
+            and version_bumped
+            and body_matches
+            and len(manifest_frames) > 0
+        )
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"rounds={len(turns)}, any_tool_error={any_tool_error}, "
+                f"version_bumped={version_bumped}, body_matches_exact_bytes={body_matches}, "
+                f"manifest_frames_found={len(manifest_frames)}, "
+                f"manifest_has_digest={digest_present}, manifest_has_bytes={bytes_present}"
+            ),
+            "session_id": session_id,
+            "workflow_id": wf,
+            "manifest_evidence": manifest_evidence,
+            "new_revision_id": newest.get("id") if newest else None,
+            "committed_skill_body": (w7_skill or {}).get("body"),
+            "frames_per_turn": [t.frames for t in turns],
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = w7()
+    print("\n=== W7 RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_w7.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7.py
@@ -86,7 +86,17 @@ def w7():
         bytes_present = bool(manifest_evidence) and "bytes" in json.dumps(manifest_evidence)
 
         any_errors = any(t.errors for t in turns)
-        any_tool_error = any("error" in t.tool_outcomes.values() for t in turns)
+        # DEFERRED_NOT_EXECUTED is benign: it fires when the model queues a second tool call
+        # behind an already-pending gate (only one gate is active at a time) and just means
+        # "retry me once the other one resolves" -- not a real failure. Distinguish it from a
+        # genuine tool error so a healthy multi-gate sequence doesn't read as broken.
+        real_tool_errors = [
+            t.tool_payloads.get(tcid, {}).get("errorText", "")
+            for t in turns
+            for tcid, outcome in t.tool_outcomes.items()
+            if outcome == "error"
+        ]
+        any_tool_error = any("DEFERRED_NOT_EXECUTED" not in e for e in real_tool_errors)
 
         time.sleep(1.0)
         newest = latest_revision(wf)

--- a/.agents/skills/agent-release-gate/resources/matrix_w7_daytona.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7_daytona.py
@@ -1,0 +1,216 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (backend-path test). Same caveat as matrix_w7.py: the prompt names the `@ag.file`
+mechanism verbatim, proving the backend path works, not that a model discovers it unprompted.
+Never cite for a model-discovery claim.
+
+W7-Daytona: matrix_w7.py's workspace-file-marker-through-approval scenario (write a file with the
+bash tool, then commit_revision with an `@ag.file` marker pointing at it, through the HITL gate),
+run with sandbox=daytona instead of local. Exists because the local-only W7 is exactly why a real
+bug hid for as long as it did: the Daytona transport rejects NUL bytes in argv, and the manifest
+walk that resolves `@ag.file` markers was emitting them -- so no workspace-file commit could EVER
+land on Daytona, on ANY harness, until the 2026-08-06 fix (found and fixed during the Codex
+approve-then-fail P0 triage, live-verified twice on codex+Daytona: sessions f3fa4335, f2f22056).
+This cell is the sandbox-axis regression guard for that bug: it stays on the claude harness (the
+harness axis is matrix_w7_per_harness.py's job) and varies only local vs daytona.
+
+Auth: a vault key (connection.mode=agenta), never subscription -- Daytona rejects subscription
+auth by design ("Use a managed API key ... or run this harness on the local sandbox"). Needs a
+funded Anthropic provider_key secret in the target project's vault; see matrix_w1_daytona.py's
+docstring for how to add one. If the vault has none, this SKIPs with the exact missing-credential
+reason -- it must never be silently omitted from a run's results.
+
+  uv run matrix_w7_daytona.py
+"""
+
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    archive,
+    create_workflow,
+    latest_revision,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+
+def daytona_agent_config(tools: list[dict]) -> dict:
+    return {
+        "instructions": {"agents_md": BASELINE},
+        "llm": {
+            "model": "haiku",
+            "provider": "anthropic",
+            "connection": {"mode": "agenta", "slug": None},
+            "extras": {},
+        },
+        "tools": tools,
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": "claude"},
+        "sandbox": {"kind": "daytona"},
+    }
+
+
+LIVE_TOOLS = [
+    {"type": "platform", "op": "read_config"},
+    {"type": "platform", "op": "commit_revision"},
+]
+
+MISSING_CREDENTIAL_MARKERS = (
+    "connection",
+    "not found for provider",
+    "no connections",
+    "multiple connections",
+    "credential",
+)
+
+
+def w7_daytona() -> dict:
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, "qa-w7dtn")
+    try:
+        base_cfg = daytona_agent_config([])
+        live_cfg = daytona_agent_config(LIVE_TOOLS)
+        rev_id, ver = seed_and_baseline(wf, var, base_cfg, hexid)
+        references = refs(wf, var, rev_id)
+        marker = f"QA-W7DTN-{uuid.uuid4().hex[:12]}"
+        fname = f"qa-w7dtn-{hexid}.md"
+
+        prompt = (
+            "I'm the developer testing the config-import feature. Please do this exactly:\n"
+            f"1) Use your bash tool to write a file at .agenta-imports/{fname} with exactly "
+            f"this one line of content: {marker}\n"
+            "2) Call read_config to get the base_revision_id.\n"
+            "3) Call commit_revision with an add_item operation targeting "
+            '["parameters","agent","skills"] that adds a new skill named "w7dtn-import-test" '
+            'with description "Import test skill" and body set to '
+            f'{{"@ag.file": ".agenta-imports/{fname}"}} (the file marker, not the literal text), '
+            "using the base_revision_id you just read.\n"
+            "I understand there may be one or more approval steps, which I will handle each "
+            "time. Do all three steps now, retrying any step that needed approval once I've "
+            "approved it."
+        )
+        session_id = str(uuid.uuid4())
+        try:
+            turns, status = run_until_settled(
+                session_id,
+                [user_msg(prompt)],
+                {"agent": live_cfg},
+                references,
+                max_rounds=8,
+            )
+        except RuntimeError as e:
+            return {"status": "FAIL", "why": f"run_until_settled raised: {e}"}
+
+        if not status["settled"]:
+            why = status.get("why", "")
+            if any(m in why.lower() for m in MISSING_CREDENTIAL_MARKERS):
+                return {
+                    "status": "SKIP",
+                    "why": f"missing/ambiguous Daytona vault credential: {why}",
+                }
+            return {
+                "status": "FAIL",
+                "why": f"never settled: {status}",
+                "rounds": len(turns),
+                "frames_per_turn": [t.frames for t in turns],
+            }
+
+        manifest_frames = [
+            f
+            for t in turns
+            for f in t.raw_frames
+            if f.get("type") == "data-approval-manifest"
+        ]
+        manifest_evidence = manifest_frames[0].get("data") if manifest_frames else None
+        digest_present = bool(manifest_evidence) and "digest" in json.dumps(
+            manifest_evidence
+        )
+        bytes_present = bool(manifest_evidence) and "bytes" in json.dumps(
+            manifest_evidence
+        )
+
+        any_errors = any(t.errors for t in turns)
+        # DEFERRED_NOT_EXECUTED is benign (a second tool call queued behind an already-pending
+        # gate); everything else is a real failure worth catching, in particular the NUL-byte
+        # argv rejection this cell exists to guard -- that surfaced as a genuine tool error on
+        # the commit_revision call, not a benign marker.
+        real_tool_errors = [
+            t.tool_payloads.get(tcid, {}).get("errorText", "")
+            for t in turns
+            for tcid, outcome in t.tool_outcomes.items()
+            if outcome == "error"
+        ]
+        any_tool_error = any("DEFERRED_NOT_EXECUTED" not in e for e in real_tool_errors)
+
+        time.sleep(1.0)
+        newest = latest_revision(wf)
+        skills = (
+            (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("skills", [])
+            if newest
+            else []
+        )
+        w7_skill = next(
+            (s for s in skills if s.get("name") == "w7dtn-import-test"), None
+        )
+        body_matches = w7_skill is not None and marker in json.dumps(
+            w7_skill.get("body")
+        )
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(
+            ver or -1
+        )
+
+        core_ok = (
+            not any_errors
+            and not any_tool_error
+            and version_bumped
+            and body_matches
+            and len(manifest_frames) > 0
+        )
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"rounds={len(turns)}, any_tool_error={any_tool_error}, "
+                f"real_tool_errors={real_tool_errors}, "
+                f"version_bumped={version_bumped}, body_matches_exact_bytes={body_matches}, "
+                f"manifest_frames_found={len(manifest_frames)}, "
+                f"manifest_has_digest={digest_present}, manifest_has_bytes={bytes_present}"
+            ),
+            "session_id": session_id,
+            "workflow_id": wf,
+            "new_revision_id": newest.get("id") if newest else None,
+            "committed_skill_body": (w7_skill or {}).get("body"),
+        }
+    except Exception as e:  # noqa: BLE001 -- classify infra errors as SKIP, never crash the run
+        msg = str(e)
+        if any(m in msg.lower() for m in MISSING_CREDENTIAL_MARKERS):
+            return {
+                "status": "SKIP",
+                "why": f"missing/ambiguous Daytona vault credential: {msg}",
+            }
+        return {
+            "status": "FAIL",
+            "why": f"unhandled exception: {type(e).__name__}: {msg}",
+        }
+    finally:
+        archive(wf)
+
+
+if __name__ == "__main__":
+    r = w7_daytona()
+    print("\n=== W7-DAYTONA RESULT ===")
+    print(json.dumps(r, indent=2, default=str))

--- a/.agents/skills/agent-release-gate/resources/matrix_w7_per_harness.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7_per_harness.py
@@ -1,0 +1,255 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached (backend-path test). Same caveat as matrix_w7.py: the prompt names the `@ag.file`
+mechanism verbatim, so this proves the backend mint/gate/execute path works per harness, not that
+a model discovers the mechanism unprompted. Never cite for a model-discovery claim.
+
+W7 x harness: matrix_w7.py's workspace-file-marker-through-approval scenario, run identically on
+all three harnesses (claude, codex, pi_core). Exists because W7 originally ran on Claude only, and
+that gap let a 100%-broken path ship: the Codex approve-then-fail P0 (2026-08-06) was this exact
+scenario -- commit_revision + file marker + HITL approval -- on a harness this suite never
+exercised. The approve path is the same code from the frontend and from these scripts (confirmed
+in the P0 triage), so this cell can and must cover every harness a user can pick.
+
+Root cause the P0 needed on top of the original W7 fix: Codex delivers MCP tool arguments as a
+JSON-RPC envelope, which the gate did not unwrap before validating -- FIXED, live-verified twice
+(sessions f3fa4335, f2f22056) via the codex+Daytona path. Along the way a second Daytona-only bug
+fell: the Daytona transport rejects NUL bytes in argv, which the manifest walk was emitting, so no
+workspace-file commit could ever land on Daytona -- also fixed. See matrix_w7_daytona.py for that
+sandbox axis; this cell stays on the local sandbox and varies only the harness.
+
+Auth per harness (kept deliberately different, matching how each harness is actually used):
+  claude   -- subscription (self_managed), haiku: identical to matrix_w7.py, cheapest, no vault
+              dependency, and the config this suite has run longest.
+  codex    -- vault-managed key (connection.mode=agenta), gpt-5.6-luna, provider openai. Needs a
+              funded OpenAI provider_key secret in the target project's vault (see
+              matrix_w1_daytona.py's docstring for the exact POST /api/vault/v1/secrets/ shape;
+              same idea, kind="openai"). Mirrors cell X1 in qa_product.py.
+  pi       -- same vault-managed OpenAI key, harness kind "pi_core", gpt-5.6-luna. Mirrors cell C3.
+A harness whose vault key is missing SKIPs with the exact missing-secret reason rather than being
+silently omitted -- per the standing rule that skips are untested claims, not passes.
+
+  uv run matrix_w7_per_harness.py
+"""
+
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    archive,
+    create_workflow,
+    latest_revision,
+    refs,
+    run_until_settled,
+    seed_and_baseline,
+    user_msg,
+)
+
+BASELINE = "Be terse. Do exactly what is asked."
+
+HARNESSES = {
+    "claude": {
+        "kind": "claude",
+        "model": "haiku",
+        "provider": "anthropic",
+        "connection": {"mode": "self_managed", "slug": None},
+    },
+    "codex": {
+        "kind": "codex",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+    "pi": {
+        "kind": "pi_core",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+}
+
+LIVE_TOOLS = [
+    {"type": "platform", "op": "read_config"},
+    {"type": "platform", "op": "commit_revision"},
+]
+
+
+def harness_agent_config(spec: dict, tools: list[dict]) -> dict:
+    return {
+        "instructions": {"agents_md": BASELINE},
+        "llm": {
+            "model": spec["model"],
+            "provider": spec["provider"],
+            "connection": spec["connection"],
+            "extras": {},
+        },
+        "tools": tools,
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": spec["kind"]},
+        "sandbox": {"kind": "local"},
+    }
+
+
+# Missing-vault-key and missing-subscription errors surface as a wire `error` frame or an HTTP
+# 4xx/5xx from the very first invoke, never as a partial run -- so a name match on the message is
+# enough to classify SKIP (untested) vs FAIL (the scenario ran and broke).
+MISSING_CREDENTIAL_MARKERS = (
+    "connection",
+    "not found for provider",
+    "no connections",
+    "requires a mounted subscription",
+    "credential",
+)
+
+
+def w7_for(harness_name: str) -> dict:
+    spec = HARNESSES[harness_name]
+    hexid = uuid.uuid4().hex[:8]
+    wf, var = create_workflow(hexid, f"qa-w7-{harness_name}")
+    try:
+        base_cfg = harness_agent_config(spec, [])
+        live_cfg = harness_agent_config(spec, LIVE_TOOLS)
+        rev_id, ver = seed_and_baseline(wf, var, base_cfg, hexid)
+        references = refs(wf, var, rev_id)
+        marker = f"QA-W7-{harness_name.upper()}-{uuid.uuid4().hex[:12]}"
+        fname = f"qa-w7-{harness_name}-{hexid}.md"
+
+        prompt = (
+            "I'm the developer testing the config-import feature. Please do this exactly:\n"
+            f"1) Use your bash tool to write a file at .agenta-imports/{fname} with exactly "
+            f"this one line of content: {marker}\n"
+            "2) Call read_config to get the base_revision_id.\n"
+            "3) Call commit_revision with an add_item operation targeting "
+            '["parameters","agent","skills"] that adds a new skill named "w7-import-test" '
+            'with description "Import test skill" and body set to '
+            f'{{"@ag.file": ".agenta-imports/{fname}"}} (the file marker, not the literal text), '
+            "using the base_revision_id you just read.\n"
+            "I understand there may be one or more approval steps, which I will handle each "
+            "time. Do all three steps now, retrying any step that needed approval once I've "
+            "approved it."
+        )
+        session_id = str(uuid.uuid4())
+        try:
+            turns, status = run_until_settled(
+                session_id, [user_msg(prompt)], {"agent": live_cfg}, references
+            )
+        except RuntimeError as e:
+            return {"status": "FAIL", "why": f"run_until_settled raised: {e}"}
+
+        if not status["settled"]:
+            why = status.get("why", "")
+            if any(m in why.lower() for m in MISSING_CREDENTIAL_MARKERS):
+                return {
+                    "status": "SKIP",
+                    "why": f"missing credential for harness={harness_name}: {why}",
+                }
+            return {
+                "status": "FAIL",
+                "why": f"never settled: {status}",
+                "rounds": len(turns),
+                "frames_per_turn": [t.frames for t in turns],
+            }
+
+        manifest_frames = [
+            f
+            for t in turns
+            for f in t.raw_frames
+            if f.get("type") == "data-approval-manifest"
+        ]
+        manifest_evidence = manifest_frames[0].get("data") if manifest_frames else None
+        digest_present = bool(manifest_evidence) and "digest" in json.dumps(
+            manifest_evidence
+        )
+        bytes_present = bool(manifest_evidence) and "bytes" in json.dumps(
+            manifest_evidence
+        )
+
+        any_errors = any(t.errors for t in turns)
+        real_tool_errors = [
+            t.tool_payloads.get(tcid, {}).get("errorText", "")
+            for t in turns
+            for tcid, outcome in t.tool_outcomes.items()
+            if outcome == "error"
+        ]
+        any_tool_error = any("DEFERRED_NOT_EXECUTED" not in e for e in real_tool_errors)
+
+        time.sleep(1.0)
+        newest = latest_revision(wf)
+        skills = (
+            (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("skills", [])
+            if newest
+            else []
+        )
+        w7_skill = next((s for s in skills if s.get("name") == "w7-import-test"), None)
+        body_matches = w7_skill is not None and marker in json.dumps(
+            w7_skill.get("body")
+        )
+        version_bumped = newest is not None and int(newest.get("version") or -1) > int(
+            ver or -1
+        )
+
+        core_ok = (
+            not any_errors
+            and not any_tool_error
+            and version_bumped
+            and body_matches
+            and len(manifest_frames) > 0
+        )
+        return {
+            "status": "PASS" if core_ok else "FAIL",
+            "why": (
+                f"rounds={len(turns)}, any_tool_error={any_tool_error}, "
+                f"version_bumped={version_bumped}, body_matches_exact_bytes={body_matches}, "
+                f"manifest_frames_found={len(manifest_frames)}, "
+                f"manifest_has_digest={digest_present}, manifest_has_bytes={bytes_present}"
+            ),
+            "session_id": session_id,
+            "workflow_id": wf,
+            "new_revision_id": newest.get("id") if newest else None,
+        }
+    except Exception as e:  # noqa: BLE001 -- classify infra errors as SKIP, never crash the matrix
+        msg = str(e)
+        if any(m in msg.lower() for m in MISSING_CREDENTIAL_MARKERS):
+            return {
+                "status": "SKIP",
+                "why": f"missing credential for harness={harness_name}: {msg}",
+            }
+        return {
+            "status": "FAIL",
+            "why": f"unhandled exception: {type(e).__name__}: {msg}",
+        }
+    finally:
+        archive(wf)
+
+
+def main() -> int:
+    results = {}
+    for harness_name in HARNESSES:
+        print(f"\n=== W7 x {harness_name} ===", file=sys.stderr)
+        results[harness_name] = w7_for(harness_name)
+
+    print("\n=== W7-PER-HARNESS RESULTS ===")
+    print(json.dumps(results, indent=2, default=str))
+
+    any_fail = any(r["status"] == "FAIL" for r in results.values())
+    skipped = [h for h, r in results.items() if r["status"] == "SKIP"]
+    if skipped:
+        print(
+            f"\nSKIPPED (untested, not passed): {', '.join(skipped)}",
+            file=sys.stderr,
+        )
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/agent-release-gate/resources/matrix_w7_per_harness.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7_per_harness.py
@@ -34,6 +34,7 @@ silently omitted -- per the standing rule that skips are untested claims, not pa
   uv run matrix_w7_per_harness.py
 """
 
+import argparse
 import json
 import pathlib
 import sys
@@ -233,8 +234,18 @@ def w7_for(harness_name: str) -> dict:
 
 
 def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--only",
+        choices=list(HARNESSES),
+        help="run a single harness instead of the full matrix (e.g. to re-verify one leg "
+        "without re-spending budget on the others)",
+    )
+    args = p.parse_args()
+    harness_names = [args.only] if args.only else list(HARNESSES)
+
     results = {}
-    for harness_name in HARNESSES:
+    for harness_name in harness_names:
         print(f"\n=== W7 x {harness_name} ===", file=sys.stderr)
         results[harness_name] = w7_for(harness_name)
 

--- a/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215437/results.json
+++ b/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215437/results.json
@@ -1,0 +1,169 @@
+{
+  "C1": {
+    "config": {
+      "harness": "claude",
+      "sandbox": "local",
+      "model": "sonnet",
+      "provider": "anthropic",
+      "connection": {
+        "mode": "self_managed",
+        "slug": null
+      }
+    },
+    "journeys": {
+      "warm": {
+        "pass": true,
+        "why": "warm: 3 turns on one live daemon; the durable cwd token survived (in reply=True), and the turn ledger shows a single harness session + sandbox (stable=True)",
+        "session_id": "153e4da4-0d3a-4433-a265-c628a06d5681",
+        "cwd_token": "QA-CWD-fd3443419b3f-1786046081",
+        "evidence": {
+          "tier": "warm",
+          "transition": "none (same daemon, same live mount)",
+          "mount_id": "019fd8a4-59df-7850-b2fe-dad0f8eb1671",
+          "cwd_token_in_store": true,
+          "times_ms": {
+            "first": 5818,
+            "last": 4734
+          },
+          "agent_session_ids": [
+            "ef8d0d72-65a1-43d9-a916-3062253b2fe7"
+          ],
+          "sandbox_ids": [
+            "local/127.0.0.1:42011"
+          ],
+          "zero_byte_objects_in_cwd": [],
+          "runner_log_grep": "[keepalive] hit-continue",
+          "ledger_available": true,
+          "warm_ids_stable": true
+        },
+        "turn_write": {
+          "http": 200,
+          "ms": 5818,
+          "finish": "stop",
+          "frames": [
+            "start",
+            "start-step",
+            "tool-input-start",
+            "tool-input-available",
+            "tool-input-available",
+            "tool-output-available",
+            "text-start",
+            "text-delta",
+            "text-delta",
+            "text-end",
+            "finish-step",
+            "finish"
+          ],
+          "tools": [
+            "Terminal"
+          ],
+          "approval": false,
+          "errors": [],
+          "reply": "WROTE"
+        },
+        "turn_resumed": {
+          "http": 200,
+          "ms": 4734,
+          "finish": "stop",
+          "frames": [
+            "start",
+            "start-step",
+            "tool-input-start",
+            "tool-input-available",
+            "tool-input-available",
+            "tool-output-available",
+            "text-start",
+            "text-delta",
+            "text-delta",
+            "text-end",
+            "finish-step",
+            "finish"
+          ],
+          "tools": [
+            "Terminal"
+          ],
+          "approval": false,
+          "errors": [],
+          "reply": "QA-CWD-fd3443419b3f-1786046081"
+        }
+      },
+      "cold1": {
+        "pass": true,
+        "why": "cold 1: the pooled session was evicted and rebuilt on the same runner (two sandbox ids in the ledger=True \u2014 one id would mean the change was applied in place and this tier measured warm reuse); the cwd token came back from the store (in reply=True) and the agent read a file that only ever existed as an object (store-only file readable=True)",
+        "session_id": "5c6bf75b-ad6f-44fd-a1a0-0dce480babd5",
+        "cwd_token": "QA-CWD-fd3443419b3f-1786046094",
+        "evidence": {
+          "tier": "cold1",
+          "transition": "harnessSession facet change (a permission rule) -> not live-applicable, so the runner evicts the pooled session and rebuilds cold",
+          "mount_id": "019fd8a4-8b16-7151-82e3-b14c2d8f86be",
+          "cwd_token_in_store": true,
+          "times_ms": {
+            "first": 6392,
+            "last": 6074
+          },
+          "agent_session_ids": [
+            "a5e959f1-8d91-49ec-9735-80d885d4e626"
+          ],
+          "sandbox_ids": [
+            "local/127.0.0.1:41555",
+            "local/127.0.0.1:35429"
+          ],
+          "zero_byte_objects_in_cwd": [],
+          "runner_log_grep": "[keepalive] mismatch (config) ...; evict + cold",
+          "ledger_available": true,
+          "rebuilt_sandbox": true
+        },
+        "turn_write": {
+          "http": 200,
+          "ms": 6392,
+          "finish": "stop",
+          "frames": [
+            "start",
+            "start-step",
+            "tool-input-start",
+            "tool-input-available",
+            "tool-input-available",
+            "tool-output-available",
+            "text-start",
+            "text-delta",
+            "text-delta",
+            "text-end",
+            "finish-step",
+            "finish"
+          ],
+          "tools": [
+            "Terminal"
+          ],
+          "approval": false,
+          "errors": [],
+          "reply": "WROTE"
+        },
+        "turn_resumed": {
+          "http": 200,
+          "ms": 6074,
+          "finish": "stop",
+          "frames": [
+            "start",
+            "start-step",
+            "tool-input-start",
+            "tool-input-available",
+            "tool-input-available",
+            "tool-output-available",
+            "text-start",
+            "text-delta",
+            "text-delta",
+            "text-end",
+            "finish-step",
+            "finish"
+          ],
+          "tools": [
+            "Terminal"
+          ],
+          "approval": false,
+          "errors": [],
+          "reply": "QA-CWD-fd3443419b3f-1786046094\nQA-STORE-6ffbd10e555a"
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215437/summary.md
+++ b/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215437/summary.md
@@ -1,0 +1,3 @@
+| cell | harness | sandbox | model | warm | cold1 |
+|---|---|---|---|---|---|
+| C1 | claude | local | sonnet | PASS | PASS |

--- a/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215512/results.json
+++ b/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215512/results.json
@@ -1,0 +1,102 @@
+{
+  "C2": {
+    "config": {
+      "harness": "claude",
+      "sandbox": "daytona",
+      "model": "sonnet",
+      "provider": "anthropic",
+      "connection": {
+        "mode": "agenta",
+        "slug": null
+      }
+    },
+    "journeys": {
+      "park": {
+        "pass": true,
+        "why": "park: the session idled past the pool TTL so the sandbox was PARKED, and the next turn reconnected to the SAME sandbox rather than rebuilding one (same sandbox across turns=True, versus two sandbox ids on cold1); the cwd token came back (in reply=True) and the store-only file was readable (True). On Daytona this is the one tier that proves a credential Secret still resolves after the sandbox was stopped and started again",
+        "session_id": "6075e462-52e9-4bc5-9580-a62f1500de5c",
+        "cwd_token": "QA-CWD-f0fc97fe-f186-46ce-ada8-843fb418855a-1786046126",
+        "evidence": {
+          "tier": "park",
+          "transition": "165s idle, so the session pool expires the session and PARKS the sandbox (stop, not delete); the next turn must reconnect to it",
+          "mount_id": "019fd8a4-e4c8-7a93-bf7b-910f8be4d2ef",
+          "cwd_token_in_store": true,
+          "times_ms": {
+            "first": 15683,
+            "last": 15336
+          },
+          "agent_session_ids": [
+            "ddb67254-955f-4a4d-a19c-8bbd0a630967"
+          ],
+          "sandbox_ids": [
+            "daytona/f0fc97fe-f186-46ce-ada8-843fb418855a"
+          ],
+          "zero_byte_objects_in_cwd": [],
+          "runner_log_grep": "[keepalive] evict ... reason=expire, then `reconnected sandbox=<id>`",
+          "ledger_available": true,
+          "reconnected_same_sandbox": true
+        },
+        "turn_write": {
+          "http": 200,
+          "ms": 15683,
+          "finish": "stop",
+          "frames": [
+            "start",
+            "start-step",
+            "reasoning-start",
+            "reasoning-delta",
+            "reasoning-end",
+            "tool-input-start",
+            "tool-input-available",
+            "tool-input-available",
+            "tool-output-available",
+            "tool-input-start",
+            "tool-input-available",
+            "tool-input-available",
+            "tool-output-available",
+            "text-start",
+            "text-delta",
+            "text-end",
+            "finish-step",
+            "finish"
+          ],
+          "tools": [
+            "ToolSearch",
+            "Terminal"
+          ],
+          "approval": false,
+          "errors": [],
+          "reply": "WROTE"
+        },
+        "turn_resumed": {
+          "http": 200,
+          "ms": 15336,
+          "finish": "stop",
+          "frames": [
+            "start",
+            "start-step",
+            "reasoning-start",
+            "reasoning-delta",
+            "reasoning-end",
+            "tool-input-start",
+            "tool-input-available",
+            "tool-input-available",
+            "tool-output-available",
+            "text-start",
+            "text-delta",
+            "text-delta",
+            "text-end",
+            "finish-step",
+            "finish"
+          ],
+          "tools": [
+            "Terminal"
+          ],
+          "approval": false,
+          "errors": [],
+          "reply": "QA-CWD-f0fc97fe-f186-46ce-ada8-843fb418855a-1786046126\nQA-STORE-5228f718d18d"
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215512/summary.md
+++ b/.agents/skills/agent-release-gate/resources/qa-gate-runs/20260806-215512/summary.md
@@ -1,0 +1,3 @@
+| cell | harness | sandbox | model | park |
+|---|---|---|---|---|
+| C2 | claude | daytona | sonnet | PASS |

--- a/.agents/skills/agent-release-gate/resources/qa_commit_approval.py
+++ b/.agents/skills/agent-release-gate/resources/qa_commit_approval.py
@@ -115,9 +115,7 @@ class Turn:
                 if text_buf:
                     parts.append({"type": "text", "text": "".join(text_buf)})
                     text_buf = []
-                call = next(
-                    c for c in self.tool_calls if c["toolCallId"] == seg["id"]
-                )
+                call = next(c for c in self.tool_calls if c["toolCallId"] == seg["id"])
                 part: dict = {
                     "type": f"tool-{call['toolName']}",
                     "toolCallId": call["toolCallId"],
@@ -135,10 +133,7 @@ class Turn:
                     part["errorText"] = self.tool_payloads.get(
                         call["toolCallId"], {}
                     ).get("errorText")
-                if (
-                    self.approval
-                    and self.approval["toolCallId"] == call["toolCallId"]
-                ):
+                if self.approval and self.approval["toolCallId"] == call["toolCallId"]:
                     part["state"] = "approval-requested"
                     part["approval"] = {"id": self.approval["approvalId"]}
                 parts.append(part)
@@ -147,7 +142,9 @@ class Turn:
         return {"id": str(uuid.uuid4()), "role": "assistant", "parts": parts}
 
 
-def invoke(session_id: str, messages: list[dict], parameters: dict, references: dict) -> Turn:
+def invoke(
+    session_id: str, messages: list[dict], parameters: dict, references: dict
+) -> Turn:
     url = f"{BASE}/services/agent/v0/invoke"
     body = {
         "session_id": session_id,
@@ -165,7 +162,10 @@ def invoke(session_id: str, messages: list[dict], parameters: dict, references: 
         with client.stream(
             "POST",
             url,
-            params={"project_id": PROJECT, "application_id": references["application"]["id"]},
+            params={
+                "project_id": PROJECT,
+                "application_id": references["application"]["id"],
+            },
             json=body,
             headers=headers,
         ) as r:
@@ -213,8 +213,14 @@ def invoke(session_id: str, messages: list[dict], parameters: dict, references: 
                         "approvalId": f.get("approvalId"),
                         "toolCallId": f.get("toolCallId"),
                     }
-                    print(f"  !! approval-request: {json.dumps(f)[:400]}", file=sys.stderr)
-                elif ftype in ("tool-output-available", "tool-output-error", "tool-output-denied"):
+                    print(
+                        f"  !! approval-request: {json.dumps(f)[:400]}", file=sys.stderr
+                    )
+                elif ftype in (
+                    "tool-output-available",
+                    "tool-output-error",
+                    "tool-output-denied",
+                ):
                     tcid = f.get("toolCallId")
                     if tcid:
                         t.tool_outcomes[tcid] = ftype.replace("tool-output-", "")
@@ -227,10 +233,15 @@ def invoke(session_id: str, messages: list[dict], parameters: dict, references: 
                             )
                         else:
                             t.tool_payloads[tcid] = {"errorText": f.get("errorText")}
-                            print(f"  !! {ftype}: {json.dumps(f)[:400]}", file=sys.stderr)
+                            print(
+                                f"  !! {ftype}: {json.dumps(f)[:400]}", file=sys.stderr
+                            )
                 elif ftype == "data-committed-revision":
                     t.committed_revision = f.get("data")
-                    print(f"  !! data-committed-revision: {json.dumps(f)[:400]}", file=sys.stderr)
+                    print(
+                        f"  !! data-committed-revision: {json.dumps(f)[:400]}",
+                        file=sys.stderr,
+                    )
                 elif ftype == "error":
                     t.errors.append(json.dumps(f)[:500])
                     print(f"  !! error: {json.dumps(f)[:500]}", file=sys.stderr)
@@ -263,12 +274,19 @@ def main() -> int:
                 "workflow": {
                     "slug": f"qa-commit-approve-{hexid}",
                     "name": f"QA commit-approve {hexid}",
-                    "flags": {"is_custom": True, "is_evaluator": False, "is_feedback": False},
+                    "flags": {
+                        "is_custom": True,
+                        "is_evaluator": False,
+                        "is_feedback": False,
+                    },
                 }
             },
         )
         if r.status_code != 200:
-            result = {"pass": False, "why": f"create workflow HTTP {r.status_code}: {r.text[:300]}"}
+            result = {
+                "pass": False,
+                "why": f"create workflow HTTP {r.status_code}: {r.text[:300]}",
+            }
             return 1
         workflow_id = r.json()["workflow"]["id"]
         print(f"workflow_id={workflow_id}", file=sys.stderr)
@@ -285,7 +303,10 @@ def main() -> int:
             },
         )
         if r.status_code != 200:
-            result = {"pass": False, "why": f"create variant HTTP {r.status_code}: {r.text[:300]}"}
+            result = {
+                "pass": False,
+                "why": f"create variant HTTP {r.status_code}: {r.text[:300]}",
+            }
             return 1
         variant_id = r.json()["workflow_variant"]["id"]
         print(f"variant_id={variant_id}", file=sys.stderr)
@@ -315,7 +336,10 @@ def main() -> int:
                         "slug": slug,
                         "name": f"QA commit-approve {hexid} rev",
                         "message": message,
-                        "data": {"uri": "agenta:builtin:agent:v0", "parameters": parameters},
+                        "data": {
+                            "uri": "agenta:builtin:agent:v0",
+                            "parameters": parameters,
+                        },
                         "workflow_id": workflow_id,
                         "workflow_variant_id": variant_id,
                     }
@@ -325,14 +349,20 @@ def main() -> int:
         # v0 seed (nulled by the DAO -- known behavior).
         r = commit(base_params, "seed", f"qa-commit-approve-seed-{hexid}")
         if r.status_code != 200:
-            result = {"pass": False, "why": f"seed commit HTTP {r.status_code}: {r.text[:300]}"}
+            result = {
+                "pass": False,
+                "why": f"seed commit HTTP {r.status_code}: {r.text[:300]}",
+            }
             return 1
         seed_version = r.json()["workflow_revision"].get("version")
 
         # v1: the REAL baseline revision we run the agent against.
         r = commit(base_params, "QA baseline", f"qa-commit-approve-baseline-{hexid}")
         if r.status_code != 200:
-            result = {"pass": False, "why": f"baseline commit HTTP {r.status_code}: {r.text[:300]}"}
+            result = {
+                "pass": False,
+                "why": f"baseline commit HTTP {r.status_code}: {r.text[:300]}",
+            }
             return 1
         baseline = r.json()["workflow_revision"]
         baseline_revision_id = baseline["id"]
@@ -362,11 +392,18 @@ def main() -> int:
 
         session_id = str(uuid.uuid4())
         print(f"session_id={session_id}", file=sys.stderr)
-        print("--- turn 1: expect read_config to run, commit_revision to pause ---", file=sys.stderr)
+        print(
+            "--- turn 1: expect read_config to run, commit_revision to pause ---",
+            file=sys.stderr,
+        )
         t1 = invoke(session_id, [user_msg(prompt)], live_params, references)
 
         if t1.errors:
-            result = {"pass": False, "why": f"turn 1 wire errors: {t1.errors}", "turn1_frames": t1.frames}
+            result = {
+                "pass": False,
+                "why": f"turn 1 wire errors: {t1.errors}",
+                "turn1_frames": t1.frames,
+            }
             return 1
 
         if not t1.approval:
@@ -385,10 +422,14 @@ def main() -> int:
             return 1
 
         gated_call = next(
-            (c for c in t1.tool_calls if c["toolCallId"] == t1.approval["toolCallId"]), None
+            (c for c in t1.tool_calls if c["toolCallId"] == t1.approval["toolCallId"]),
+            None,
         )
         gated_name = (gated_call or {}).get("toolName")
-        print(f"gated tool: {gated_name} input={json.dumps((gated_call or {}).get('input'))[:400]}", file=sys.stderr)
+        print(
+            f"gated tool: {gated_name} input={json.dumps((gated_call or {}).get('input'))[:400]}",
+            file=sys.stderr,
+        )
 
         if gated_name and "commit" not in gated_name.lower():
             result = {
@@ -399,17 +440,24 @@ def main() -> int:
             return 1
 
         # Resume with approval, exactly the browser's addToolApprovalResponse -> re-POST-history.
-        print("--- turn 2: approve, expect commit_revision to execute + a new revision ---", file=sys.stderr)
+        print(
+            "--- turn 2: approve, expect commit_revision to execute + a new revision ---",
+            file=sys.stderr,
+        )
         msgs = [user_msg(prompt), approval_reply(t1, approved=True)]
         t2 = invoke(session_id, msgs, live_params, references)
 
         if t2.errors:
-            result = {"pass": False, "why": f"turn 2 wire errors: {t2.errors}", "turn2_frames": t2.frames}
+            result = {
+                "pass": False,
+                "why": f"turn 2 wire errors: {t2.errors}",
+                "turn2_frames": t2.frames,
+            }
             return 1
 
-        gated_outcome = t2.tool_outcomes.get(t1.approval["toolCallId"]) or t1.tool_outcomes.get(
+        gated_outcome = t2.tool_outcomes.get(
             t1.approval["toolCallId"]
-        )
+        ) or t1.tool_outcomes.get(t1.approval["toolCallId"])
         if gated_outcome != "available":
             result = {
                 "pass": False,
@@ -420,11 +468,13 @@ def main() -> int:
             return 1
 
         # Wire evidence of the new revision, straight off the tool's own output payload.
-        commit_output = (
-            t2.tool_payloads.get(t1.approval["toolCallId"], {}).get("output")
-            or t1.tool_payloads.get(t1.approval["toolCallId"], {}).get("output")
+        commit_output = t2.tool_payloads.get(t1.approval["toolCallId"], {}).get(
+            "output"
+        ) or t1.tool_payloads.get(t1.approval["toolCallId"], {}).get("output")
+        print(
+            f"commit_revision output: {json.dumps(commit_output)[:600]}",
+            file=sys.stderr,
         )
-        print(f"commit_revision output: {json.dumps(commit_output)[:600]}", file=sys.stderr)
 
         # Never trust the tool echo alone -- fetch the workflow's revisions back over REST and
         # confirm the new one carries the token and the version bumped past the baseline.
@@ -446,10 +496,16 @@ def main() -> int:
                 "commit_output": commit_output,
             }
             return 1
-        revisions = r.json().get("workflow_revisions") or r.json().get("workflow_revision") or []
+        revisions = (
+            r.json().get("workflow_revisions")
+            or r.json().get("workflow_revision")
+            or []
+        )
         if isinstance(revisions, dict):
             revisions = [revisions]
-        newest = max(revisions, key=lambda rv: int(rv.get("version") or -1), default=None)
+        newest = max(
+            revisions, key=lambda rv: int(rv.get("version") or -1), default=None
+        )
         if not newest:
             result = {
                 "pass": False,

--- a/.agents/skills/agent-release-gate/resources/qa_commit_approval.py
+++ b/.agents/skills/agent-release-gate/resources/qa_commit_approval.py
@@ -1,0 +1,500 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""Commit-approval round trip: a real workflow revision, a live agent turn that reads its own
+config (read_config), edits it (commit_revision), pauses on the S3b single-use execution
+authorization gate (a tool-approval-request frame), resumes on approval via the in-band protocol
+the browser uses, and the new revision is verified on the wire (REST fetch-back, not model prose).
+
+This is a mandatory smoke check before handing a deployment URL to a human: it is the only
+journey that exercises the approval gate around a real config mutation end to end. Run it after
+any standalone deploy, alongside the rest of the release-gate smoke.
+
+Credentials: AGENTA_BASE, AGENTA_PROJECT_ID, AGENTA_API_KEY (same three the playground needs).
+Cell: Claude harness, local sandbox, subscription auth (self_managed) -- the default "use my
+subscription" path, same as C1 in the release gate.
+
+  uv run qa_commit_approval.py
+
+Two facts that bite, learned the hard way while writing this:
+- `read_config` / `commit_revision` are the playground's OWN tools. Declaring either in the
+  PERSISTED config's `tools` list makes every future commit on that config fail with
+  `platform_tool_not_committable` ("These are playground tools, not part of your
+  configuration"). They still need to be declared on the LIVE invoke's `parameters.agent.tools`
+  for the running agent to have them at all -- an empty `tools` list leaves the model reporting
+  it has neither tool. So: commit an empty-tools baseline, invoke with them added on top.
+- A prompt that sounds like it is trying to rush past confirmation ("do this now, do not ask for
+  confirmation in chat") reads to Claude as a prompt-injection/social-engineering attempt and it
+  refuses outright, correctly. State the request plainly instead: who you are, why you want the
+  change, and that you understand and will handle the approval step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+
+import httpx
+
+BASE = os.environ["AGENTA_BASE"]
+PROJECT = os.environ["AGENTA_PROJECT_ID"]
+KEY = os.environ["AGENTA_API_KEY"]
+
+BASELINE_INSTRUCTIONS = "Be terse. Do exactly what is asked."
+TOKEN = f"QA-APPROVE-{uuid.uuid4().hex[:12]}"
+
+
+def api_call(method: str, path: str, timeout: float = 60.0, **kwargs) -> httpx.Response:
+    return httpx.request(
+        method,
+        f"{BASE}/api{path}",
+        params={"project_id": PROJECT},
+        headers={"Authorization": f"ApiKey {KEY}", "Content-Type": "application/json"},
+        timeout=timeout,
+        **kwargs,
+    )
+
+
+def agent_config(tools: list[dict]) -> dict:
+    return {
+        "instructions": {"agents_md": BASELINE_INSTRUCTIONS},
+        "llm": {
+            "model": "sonnet",
+            "provider": "anthropic",
+            "connection": {"mode": "self_managed", "slug": None},
+            "extras": {},
+        },
+        "tools": tools,
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": "claude"},
+        "sandbox": {"kind": "local"},
+    }
+
+
+def user_msg(text: str) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "role": "user",
+        "parts": [{"type": "text", "text": text}],
+    }
+
+
+class Turn:
+    def __init__(self) -> None:
+        self.frames: list[str] = []
+        self.text_parts: list[str] = []
+        self.tool_calls: list[dict] = []
+        self.tool_outcomes: dict[str, str] = {}
+        self.tool_payloads: dict[str, dict] = {}
+        self.approval: dict | None = None
+        self.finish_reason: str | None = None
+        self.errors: list[str] = []
+        self.committed_revision = None
+        self._segments: list[dict] = []
+        self.raw_frames: list[dict] = []
+
+    @property
+    def reply(self) -> str:
+        return "".join(self.text_parts)
+
+    def assistant_message(self) -> dict:
+        """Rebuild the UIMessage the browser would hold for this turn -- text + tool parts, in
+        the order they first appeared, each tool part carrying its FINAL (fully-streamed) input
+        and its outcome so far."""
+        parts = []
+        text_buf = []
+        for seg in self._segments:
+            if seg["kind"] == "text":
+                text_buf.append(seg["text"])
+            else:
+                if text_buf:
+                    parts.append({"type": "text", "text": "".join(text_buf)})
+                    text_buf = []
+                call = next(
+                    c for c in self.tool_calls if c["toolCallId"] == seg["id"]
+                )
+                part: dict = {
+                    "type": f"tool-{call['toolName']}",
+                    "toolCallId": call["toolCallId"],
+                    "input": call["input"],
+                    "state": "input-available",
+                }
+                outcome = self.tool_outcomes.get(call["toolCallId"])
+                if outcome == "available":
+                    part["state"] = "output-available"
+                    part["output"] = self.tool_payloads.get(call["toolCallId"], {}).get(
+                        "output"
+                    )
+                elif outcome == "error":
+                    part["state"] = "output-error"
+                    part["errorText"] = self.tool_payloads.get(
+                        call["toolCallId"], {}
+                    ).get("errorText")
+                if (
+                    self.approval
+                    and self.approval["toolCallId"] == call["toolCallId"]
+                ):
+                    part["state"] = "approval-requested"
+                    part["approval"] = {"id": self.approval["approvalId"]}
+                parts.append(part)
+        if text_buf:
+            parts.append({"type": "text", "text": "".join(text_buf)})
+        return {"id": str(uuid.uuid4()), "role": "assistant", "parts": parts}
+
+
+def invoke(session_id: str, messages: list[dict], parameters: dict, references: dict) -> Turn:
+    url = f"{BASE}/services/agent/v0/invoke"
+    body = {
+        "session_id": session_id,
+        "references": references,
+        "data": {"inputs": {"messages": messages}, "parameters": parameters},
+    }
+    headers = {
+        "Authorization": f"ApiKey {KEY}",
+        "Accept": "text/event-stream",
+        "x-ag-messages-format": "vercel",
+        "Content-Type": "application/json",
+    }
+    t = Turn()
+    with httpx.Client(timeout=180.0) as client:
+        with client.stream(
+            "POST",
+            url,
+            params={"project_id": PROJECT, "application_id": references["application"]["id"]},
+            json=body,
+            headers=headers,
+        ) as r:
+            print(f"  HTTP {r.status_code}", file=sys.stderr)
+            if r.status_code >= 400:
+                t.errors.append(f"HTTP {r.status_code}: {r.read().decode()[:1000]}")
+                return t
+            for line in r.iter_lines():
+                if not line or line.startswith(":") or not line.startswith("data: "):
+                    continue
+                payload = line[6:]
+                if payload == "[DONE]":
+                    break
+                try:
+                    f = json.loads(payload)
+                except json.JSONDecodeError:
+                    t.errors.append(f"malformed SSE frame: {payload[:200]}")
+                    continue
+                t.raw_frames.append(f)
+                ftype = f.get("type", "?")
+                t.frames.append(ftype)
+                if ftype == "text-delta":
+                    delta = f.get("delta", "")
+                    t.text_parts.append(delta)
+                    if t._segments and t._segments[-1]["kind"] == "text":
+                        t._segments[-1]["text"] += delta
+                    else:
+                        t._segments.append({"kind": "text", "text": delta})
+                elif ftype == "tool-input-available":
+                    call = {
+                        "toolCallId": f.get("toolCallId"),
+                        "toolName": f.get("toolName"),
+                        "input": f.get("input"),
+                    }
+                    is_new = not any(
+                        c["toolCallId"] == call["toolCallId"] for c in t.tool_calls
+                    )
+                    t.tool_calls = [
+                        c for c in t.tool_calls if c["toolCallId"] != call["toolCallId"]
+                    ] + [call]
+                    if is_new:
+                        t._segments.append({"kind": "tool", "id": call["toolCallId"]})
+                elif ftype == "tool-approval-request":
+                    t.approval = {
+                        "approvalId": f.get("approvalId"),
+                        "toolCallId": f.get("toolCallId"),
+                    }
+                    print(f"  !! approval-request: {json.dumps(f)[:400]}", file=sys.stderr)
+                elif ftype in ("tool-output-available", "tool-output-error", "tool-output-denied"):
+                    tcid = f.get("toolCallId")
+                    if tcid:
+                        t.tool_outcomes[tcid] = ftype.replace("tool-output-", "")
+                        if ftype == "tool-output-available":
+                            t.tool_payloads[tcid] = {"output": f.get("output")}
+                            print(
+                                f"  tool-output-available toolCallId={tcid}: "
+                                f"{json.dumps(f.get('output'))[:300]}",
+                                file=sys.stderr,
+                            )
+                        else:
+                            t.tool_payloads[tcid] = {"errorText": f.get("errorText")}
+                            print(f"  !! {ftype}: {json.dumps(f)[:400]}", file=sys.stderr)
+                elif ftype == "data-committed-revision":
+                    t.committed_revision = f.get("data")
+                    print(f"  !! data-committed-revision: {json.dumps(f)[:400]}", file=sys.stderr)
+                elif ftype == "error":
+                    t.errors.append(json.dumps(f)[:500])
+                    print(f"  !! error: {json.dumps(f)[:500]}", file=sys.stderr)
+                elif ftype == "finish":
+                    t.finish_reason = f.get("finishReason")
+                    print(f"  !! finish: {json.dumps(f)[:400]}", file=sys.stderr)
+    return t
+
+
+def approval_reply(turn: Turn, approved: bool) -> dict:
+    message = turn.assistant_message()
+    for part in message["parts"]:
+        if part.get("toolCallId") == turn.approval["toolCallId"]:
+            part["state"] = "approval-responded"
+            part["approval"] = {"id": turn.approval["approvalId"], "approved": approved}
+            return message
+    raise ValueError("gated tool call missing from assistant message")
+
+
+def main() -> int:
+    hexid = uuid.uuid4().hex[:8]
+    workflow_id = None
+    result = {"pass": False, "why": "not run"}
+    try:
+        # 1. Create a REAL workflow app + variant (the exact shape the playground commits).
+        r = api_call(
+            "POST",
+            "/workflows/",
+            json={
+                "workflow": {
+                    "slug": f"qa-commit-approve-{hexid}",
+                    "name": f"QA commit-approve {hexid}",
+                    "flags": {"is_custom": True, "is_evaluator": False, "is_feedback": False},
+                }
+            },
+        )
+        if r.status_code != 200:
+            result = {"pass": False, "why": f"create workflow HTTP {r.status_code}: {r.text[:300]}"}
+            return 1
+        workflow_id = r.json()["workflow"]["id"]
+        print(f"workflow_id={workflow_id}", file=sys.stderr)
+
+        r = api_call(
+            "POST",
+            "/workflows/variants/",
+            json={
+                "workflow_variant": {
+                    "slug": f"qa-commit-approve-{hexid}-v",
+                    "name": f"QA commit-approve {hexid} v",
+                    "workflow_id": workflow_id,
+                }
+            },
+        )
+        if r.status_code != 200:
+            result = {"pass": False, "why": f"create variant HTTP {r.status_code}: {r.text[:300]}"}
+            return 1
+        variant_id = r.json()["workflow_variant"]["id"]
+        print(f"variant_id={variant_id}", file=sys.stderr)
+
+        # read_config and commit_revision must NOT be in the PERSISTED config's `tools` list
+        # (committing one is rejected: `platform_tool_not_committable` -- confirmed empirically).
+        # But they DO need to be declared for the LIVE invoke call to make them available to the
+        # running agent (an empty `tools` list left the model reporting it had neither tool).
+        # So: commit an empty `tools` baseline, but invoke with them added on top.
+        base_params = {"agent": agent_config([])}
+        live_params = {
+            "agent": {
+                **base_params["agent"],
+                "tools": [
+                    {"type": "platform", "op": "read_config"},
+                    {"type": "platform", "op": "commit_revision"},
+                ],
+            }
+        }
+
+        def commit(parameters: dict, message: str, slug: str) -> httpx.Response:
+            return api_call(
+                "POST",
+                "/workflows/revisions/commit",
+                json={
+                    "workflow_revision": {
+                        "slug": slug,
+                        "name": f"QA commit-approve {hexid} rev",
+                        "message": message,
+                        "data": {"uri": "agenta:builtin:agent:v0", "parameters": parameters},
+                        "workflow_id": workflow_id,
+                        "workflow_variant_id": variant_id,
+                    }
+                },
+            )
+
+        # v0 seed (nulled by the DAO -- known behavior).
+        r = commit(base_params, "seed", f"qa-commit-approve-seed-{hexid}")
+        if r.status_code != 200:
+            result = {"pass": False, "why": f"seed commit HTTP {r.status_code}: {r.text[:300]}"}
+            return 1
+        seed_version = r.json()["workflow_revision"].get("version")
+
+        # v1: the REAL baseline revision we run the agent against.
+        r = commit(base_params, "QA baseline", f"qa-commit-approve-baseline-{hexid}")
+        if r.status_code != 200:
+            result = {"pass": False, "why": f"baseline commit HTTP {r.status_code}: {r.text[:300]}"}
+            return 1
+        baseline = r.json()["workflow_revision"]
+        baseline_revision_id = baseline["id"]
+        baseline_version = baseline.get("version")
+        print(
+            f"baseline revision_id={baseline_revision_id} version {seed_version}->{baseline_version}",
+            file=sys.stderr,
+        )
+
+        references = {
+            "application": {"id": workflow_id},
+            "application_variant": {"id": variant_id},
+            "application_revision": {"id": baseline_revision_id},
+        }
+
+        prompt = (
+            "I'm the developer of this agent and I'm testing the config-editing feature you "
+            "have access to (read_config and commit_revision). I'd like you to update your "
+            "own instructions text as a test of that feature, and I understand there is an "
+            "approval step before the change takes effect, which I will approve.\n\n"
+            "Please: 1) call read_config to see your current configuration and get the "
+            f"base_revision_id, 2) call commit_revision with an edit_text operation "
+            'targeting ["parameters","agent","instructions","agents_md"] that replaces the '
+            f"exact current text '{BASELINE_INSTRUCTIONS}' with the new text '{TOKEN}', using "
+            "the base_revision_id you just read. Go ahead and make the two tool calls."
+        )
+
+        session_id = str(uuid.uuid4())
+        print(f"session_id={session_id}", file=sys.stderr)
+        print("--- turn 1: expect read_config to run, commit_revision to pause ---", file=sys.stderr)
+        t1 = invoke(session_id, [user_msg(prompt)], live_params, references)
+
+        if t1.errors:
+            result = {"pass": False, "why": f"turn 1 wire errors: {t1.errors}", "turn1_frames": t1.frames}
+            return 1
+
+        if not t1.approval:
+            result = {
+                "pass": False,
+                "why": (
+                    "expected a tool-approval-request frame for commit_revision; the gate "
+                    "never fired. This is the S3b execution-authorization check -- a miss "
+                    "here means commit_revision executed WITHOUT approval, or never got "
+                    "called at all."
+                ),
+                "turn1_frames": t1.frames,
+                "turn1_tool_calls": t1.tool_calls,
+                "turn1_reply": t1.reply,
+            }
+            return 1
+
+        gated_call = next(
+            (c for c in t1.tool_calls if c["toolCallId"] == t1.approval["toolCallId"]), None
+        )
+        gated_name = (gated_call or {}).get("toolName")
+        print(f"gated tool: {gated_name} input={json.dumps((gated_call or {}).get('input'))[:400]}", file=sys.stderr)
+
+        if gated_name and "commit" not in gated_name.lower():
+            result = {
+                "pass": False,
+                "why": f"the gated tool was '{gated_name}', not commit_revision -- wrong tool paused",
+                "turn1_frames": t1.frames,
+            }
+            return 1
+
+        # Resume with approval, exactly the browser's addToolApprovalResponse -> re-POST-history.
+        print("--- turn 2: approve, expect commit_revision to execute + a new revision ---", file=sys.stderr)
+        msgs = [user_msg(prompt), approval_reply(t1, approved=True)]
+        t2 = invoke(session_id, msgs, live_params, references)
+
+        if t2.errors:
+            result = {"pass": False, "why": f"turn 2 wire errors: {t2.errors}", "turn2_frames": t2.frames}
+            return 1
+
+        gated_outcome = t2.tool_outcomes.get(t1.approval["toolCallId"]) or t1.tool_outcomes.get(
+            t1.approval["toolCallId"]
+        )
+        if gated_outcome != "available":
+            result = {
+                "pass": False,
+                "why": f"approved commit_revision call did not report tool-output-available (got {gated_outcome!r})",
+                "turn2_frames": t2.frames,
+                "turn2_payloads": t2.tool_payloads,
+            }
+            return 1
+
+        # Wire evidence of the new revision, straight off the tool's own output payload.
+        commit_output = (
+            t2.tool_payloads.get(t1.approval["toolCallId"], {}).get("output")
+            or t1.tool_payloads.get(t1.approval["toolCallId"], {}).get("output")
+        )
+        print(f"commit_revision output: {json.dumps(commit_output)[:600]}", file=sys.stderr)
+
+        # Never trust the tool echo alone -- fetch the workflow's revisions back over REST and
+        # confirm the new one carries the token and the version bumped past the baseline.
+        time.sleep(1.0)
+        r = api_call(
+            "POST",
+            "/workflows/revisions/query",
+            # `workflow_revision` is an ATTRIBUTE filter (flags/version), not parent-scoping --
+            # it silently accepts (and ignores) an unknown `workflow_id` key and returns every
+            # revision in the project. Scoping to one workflow needs the top-level `workflow_refs`
+            # list instead (confirmed against WorkflowRevisionQueryRequest in
+            # api/oss/src/apis/fastapi/workflows/models.py).
+            json={"workflow_refs": [{"id": workflow_id}]},
+        )
+        if r.status_code != 200:
+            result = {
+                "pass": False,
+                "why": f"revisions query HTTP {r.status_code}: {r.text[:300]}",
+                "commit_output": commit_output,
+            }
+            return 1
+        revisions = r.json().get("workflow_revisions") or r.json().get("workflow_revision") or []
+        if isinstance(revisions, dict):
+            revisions = [revisions]
+        newest = max(revisions, key=lambda rv: int(rv.get("version") or -1), default=None)
+        if not newest:
+            result = {
+                "pass": False,
+                "why": "no revisions returned from query",
+                "commit_output": commit_output,
+            }
+            return 1
+        new_token = (
+            (newest.get("data") or {})
+            .get("parameters", {})
+            .get("agent", {})
+            .get("instructions", {})
+            .get("agents_md")
+        )
+        version_bumped = int(newest.get("version") or -1) > int(baseline_version or -1)
+        token_match = new_token == TOKEN
+        ok = token_match and version_bumped
+
+        result = {
+            "pass": ok,
+            "why": (
+                f"approval fired (turn1 finish={t1.finish_reason}), commit_revision ran "
+                f"post-approval (outcome={gated_outcome}), newest revision version "
+                f"{baseline_version}->{newest.get('version')} (bumped={version_bumped}), "
+                f"content token_match={token_match} (expected {TOKEN!r}, got {new_token!r})"
+            ),
+            "session_id": session_id,
+            "workflow_id": workflow_id,
+            "baseline_revision_id": baseline_revision_id,
+            "new_revision_id": newest.get("id"),
+            "turn1_frames": t1.frames,
+            "turn2_frames": t2.frames,
+            "token": TOKEN,
+        }
+        return 0 if ok else 1
+    finally:
+        print("\n=== RESULT ===")
+        print(json.dumps(result, indent=2, default=str))
+        if workflow_id:
+            try:
+                api_call("POST", f"/workflows/{workflow_id}/archive")
+                print(f"\narchived workflow {workflow_id}", file=sys.stderr)
+            except Exception as e:  # noqa: BLE001
+                print(f"\narchive failed (non-fatal): {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import subprocess
 import sys
 import uuid
 
@@ -499,3 +501,71 @@ def run_until_settled(
         "rounds": max_rounds,
         "why": "max_rounds exhausted, still gated",
     }
+
+
+# ---------------------------------------------------------------------------
+# The generic invariant: no tool_result with empty output and isError:false may exist for a call
+# whose runner log says "[commit-auth] refused" (the silent-blank-success class). Added after the
+# Codex approve-then-fail P0 triage found that W7 covered only Claude, so this reusable check is
+# meant to ride along on EVERY cell that exercises commit_revision with a workspace-file marker
+# (matrix_w7*.py, matrix_t8_saved_files.py) rather than living in one standalone script -- the
+# condition it guards is a rare defense-in-depth failure (a call that WAS approved still refuses
+# at execute time: a stale cold-resume record, a digest/generation mismatch, a lost race), not
+# something every run can be relied on to reproduce. A run that never triggers a refusal is not
+# a false pass: `refusals` is simply empty and `violations` is trivially empty too. What this
+# guards against is the P0's actual shape -- the runner log said refused, but the wire told the
+# human (and this suite) a blank success.
+def runner_log_lines(container: str, since: str = "5m") -> list[str]:
+    """Recent lines from a runner container's docker logs, oldest first. LOCAL/dev-box only --
+    needs docker access to the target deployment. On a remote deployment, fetch the log text by
+    whatever operator channel exists and pass it straight to `check_no_blank_success_on_refusal`
+    instead of calling this."""
+    try:
+        out = subprocess.run(
+            ["docker", "logs", container, "--since", since],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        raise RuntimeError(f"docker logs {container} failed: {e}") from e
+    return (out.stdout + out.stderr).splitlines()
+
+
+_REFUSED_RE = re.compile(r"\[commit-auth\] refused .*\bcall=(\S+)")
+
+
+def refused_call_ids(log_lines: list[str]) -> list[str]:
+    """Every toolCallId a `[commit-auth] refused ...` log line named, in log order."""
+    ids = []
+    for line in log_lines:
+        m = _REFUSED_RE.search(line)
+        if m:
+            ids.append(m.group(1))
+    return ids
+
+
+def check_no_blank_success_on_refusal(turns: list[Turn], log_lines: list[str]) -> dict:
+    """The invariant itself: for every toolCallId the runner logged as `[commit-auth] refused`,
+    the SAME call's wire outcome (across all turns) must NOT be an "available" tool-output with
+    empty/falsy content. A refusal must surface as an error or a denial on the wire -- never as a
+    blank "available" that reads as success. Returns {"refusals": [...], "violations": [...]}; a
+    cell should treat any non-empty `violations` as an automatic FAIL regardless of what its own
+    scenario-specific assertions say."""
+    refused_ids = refused_call_ids(log_lines)
+    violations = []
+    for call_id in refused_ids:
+        for t in turns:
+            if call_id not in t.tool_outcomes:
+                continue
+            outcome = t.tool_outcomes[call_id]
+            payload = t.tool_payloads.get(call_id, {})
+            if outcome == "available" and not payload.get("output"):
+                violations.append(
+                    {
+                        "toolCallId": call_id,
+                        "outcome": outcome,
+                        "payload": payload,
+                    }
+                )
+    return {"refusals": refused_ids, "violations": violations}

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -382,6 +382,84 @@ def approval_reply(turn: Turn, approved: bool) -> dict:
     raise ValueError("gated tool call missing from assistant message")
 
 
+def turn_ledger(session_id: str, limit: int = 20) -> list[dict]:
+    """The session's turn rows, newest first.
+
+    THE ONLY CONTINUITY SIGNAL A PURE HTTP CLIENT CAN SEE. Nothing about warm-versus-cold ever
+    reaches the SSE stream, so an assertion built on the reply text cannot tell a reused daemon
+    from a rebuilt one. The runner writes `agent_session_id` and `sandbox_id` on every turn
+    (`services/runner/src/engines/sandbox_agent/run-turn.ts` -> `appendSessionTurn` ->
+    `POST /sessions/turns/`), which makes this a STORED outcome rather than an echo.
+
+    Returns [] when the ledger is unavailable, which callers must treat as MISSING EVIDENCE and
+    fail on -- never as evidence of stability."""
+    r = api_call(
+        "POST",
+        "/sessions/turns/query",
+        json={
+            "query": {"session_id": session_id},
+            "windowing": {"limit": limit, "order": "descending"},
+        },
+    )
+    if r.status_code != 200:
+        return []
+    return r.json().get("turns") or []
+
+
+def ledger_ids(session_id: str) -> tuple[list[str], list[str]]:
+    """(agent_session_ids, sandbox_ids) across the session's ledger, de-duplicated.
+
+    ONE sandbox id  = the sandbox was never replaced (warm reuse, an applied-in-place config
+                      change, or a park/reconnect -- a stopped sandbox keeps its id).
+    TWO sandbox ids = the sandbox was deleted and rebuilt.
+
+    The agent session id deliberately SURVIVES a rebuild (preserving it is the entire job of the
+    session-continuity store), so it is corroboration, never the verdict."""
+    rows = turn_ledger(session_id)
+    agents = list(
+        {r.get("agent_session_id") for r in rows if r.get("agent_session_id")}
+    )
+    sandboxes = list({r.get("sandbox_id") for r in rows if r.get("sandbox_id")})
+    return agents, sandboxes
+
+
+def interactions(session_id: str, limit: int = 50) -> list[dict]:
+    """The session's stored interaction rows (approvals, client tools, user input).
+
+    The second STORED outcome this matrix asserts on. Every approval gate and every client-tool
+    call writes a row here with a `kind` and a lifecycle `status`
+    (`api/oss/src/core/sessions/interactions/dtos.py`):
+
+      pending   -- awaiting a reaction
+      responded -- answered through the interactions API plane
+      resolved  -- answered in-band, through the messages plane (what the playground does)
+      cancelled -- the runner abandoned the gate; nobody is waiting on the token
+
+    `cancelled` is the one that matters for lifecycle testing: it is the difference between an
+    approval that died LOUDLY (a row a client can see and re-render) and one that died silently
+    while the card sat on the page forever."""
+    r = api_call(
+        "POST",
+        "/sessions/interactions/query",
+        json={
+            "query": {"session_id": session_id},
+            "windowing": {"limit": limit, "order": "descending"},
+        },
+    )
+    if r.status_code != 200:
+        return []
+    return r.json().get("interactions") or []
+
+
+def interaction_states(session_id: str) -> list[tuple[str, str]]:
+    """[(kind, status)] for the session's interaction rows, newest first. Convenience over
+    `interactions` for the common assertion "no approval row was left `pending`"."""
+    return [
+        (row.get("kind") or "?", row.get("status") or "?")
+        for row in interactions(session_id)
+    ]
+
+
 def refs(workflow_id: str, variant_id: str, revision_id: str) -> dict:
     return {
         "application": {"id": workflow_id},

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -155,11 +155,56 @@ def seed_and_baseline(
     return rev["id"], rev.get("version")
 
 
+def _handler_call(
+    call_ref: str, arguments: dict, timeout: float = 60.0
+) -> httpx.Response:
+    """Call a platform-tool handler through the generic `/tools/call` seam.
+
+    The agent endpoints (`/workflows/revisions/read-config` and `.../commit/agent`) are
+    gone: every detail of both was agent-shaped, so the logic moved behind registered
+    handlers reached by call_ref. These probes take the same transport a live agent takes.
+
+    The response is translated back into the shape these helpers have always returned, so
+    gate cells keep reading `.status_code` and `.json()`. Note what HTTP status now means:
+    the seam answers 200 for a domain FAILURE too, with `STATUS_CODE_ERROR` and the
+    canonical error envelope in the content. A failure is surfaced here as a non-200 with
+    the envelope as the body, so a cell that checks `status_code != 200` still sees a
+    failure, and a cell that reads the body gets `code` / `retryable` / `next_step`.
+    """
+    response = api_call(
+        "POST",
+        "/tools/call",
+        timeout=timeout,
+        json={
+            "data": {
+                "id": f"qa-{uuid.uuid4().hex[:8]}",
+                "function": {"name": call_ref, "arguments": arguments},
+            }
+        },
+    )
+    if response.status_code != 200:
+        return response
+
+    call = (response.json() or {}).get("call") or {}
+    content = ((call.get("data") or {}).get("content")) or "null"
+    status_code = ((call.get("status") or {}).get("code")) or "STATUS_CODE_OK"
+    try:
+        payload = json.loads(content)
+    except (TypeError, json.JSONDecodeError):
+        payload = {"raw": content}
+
+    return httpx.Response(
+        status_code=200 if status_code == "STATUS_CODE_OK" else 422,
+        json=payload,
+        request=response.request,
+    )
+
+
 def read_config_direct(variant_id: str, path: list | None = None) -> httpx.Response:
-    body = {"target": {"workflow_variant_id": variant_id}}
+    target: dict = {"workflow_variant_id": variant_id}
     if path is not None:
-        body["target"]["path"] = path
-    return api_call("POST", "/workflows/revisions/read-config", json=body)
+        target["path"] = path
+    return _handler_call("tools.agenta.read_config", {"target": target})
 
 
 def commit_agent_direct(
@@ -171,10 +216,9 @@ def commit_agent_direct(
     `workflow_variant_id` is normally injected by the runner from run context
     ($ctx.workflow.variant.id) when a live agent calls commit_revision -- a direct probe has no
     run context, so it must be supplied explicitly or the endpoint 400s asking for it."""
-    return api_call(
-        "POST",
-        "/workflows/revisions/commit/agent",
-        json={
+    return _handler_call(
+        "tools.agenta.commit_revision",
+        {
             "description": description,
             "workflow_revision": {
                 "base_revision_id": base_revision_id,

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -1,0 +1,380 @@
+"""Shared helpers for the W1-W12 adversarial config-editing matrix (matrix_w3/w4/w5/w7.py).
+Import-only, no CLI. Uses the smallest workable model (Claude haiku, subscription auth) to keep
+these cheap to run repeatedly."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+
+import httpx
+
+BASE = os.environ["AGENTA_BASE"]
+PROJECT = os.environ["AGENTA_PROJECT_ID"]
+KEY = os.environ["AGENTA_API_KEY"]
+
+MODEL = "haiku"
+PROVIDER = "anthropic"
+
+
+def api_call(method: str, path: str, timeout: float = 60.0, **kwargs) -> httpx.Response:
+    return httpx.request(
+        method,
+        f"{BASE}/api{path}",
+        params={"project_id": PROJECT},
+        headers={"Authorization": f"ApiKey {KEY}", "Content-Type": "application/json"},
+        timeout=timeout,
+        **kwargs,
+    )
+
+
+def agent_config(tools: list[dict] | None = None, instructions: str = "Be terse.") -> dict:
+    return {
+        "instructions": {"agents_md": instructions},
+        "llm": {
+            "model": MODEL,
+            "provider": PROVIDER,
+            "connection": {"mode": "self_managed", "slug": None},
+            "extras": {},
+        },
+        "tools": tools or [],
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": "claude"},
+        "sandbox": {"kind": "local"},
+    }
+
+
+LIVE_TOOLS = [
+    {"type": "platform", "op": "read_config"},
+    {"type": "platform", "op": "commit_revision"},
+]
+
+
+def user_msg(text: str) -> dict:
+    return {"id": str(uuid.uuid4()), "role": "user", "parts": [{"type": "text", "text": text}]}
+
+
+def create_workflow(hexid: str, slug_prefix: str = "qa-matrix") -> tuple[str, str]:
+    r = api_call(
+        "POST",
+        "/workflows/",
+        json={
+            "workflow": {
+                "slug": f"{slug_prefix}-{hexid}",
+                "name": f"QA matrix {hexid}",
+                "flags": {"is_custom": True, "is_evaluator": False, "is_feedback": False},
+            }
+        },
+    )
+    if r.status_code != 200:
+        raise RuntimeError(f"create workflow HTTP {r.status_code}: {r.text[:300]}")
+    workflow_id = r.json()["workflow"]["id"]
+
+    r = api_call(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"{slug_prefix}-{hexid}-v",
+                "name": f"QA matrix {hexid} v",
+                "workflow_id": workflow_id,
+            }
+        },
+    )
+    if r.status_code != 200:
+        raise RuntimeError(f"create variant HTTP {r.status_code}: {r.text[:300]}")
+    variant_id = r.json()["workflow_variant"]["id"]
+    return workflow_id, variant_id
+
+
+def commit_direct(
+    workflow_id: str, variant_id: str, parameters: dict, message: str, slug: str
+) -> httpx.Response:
+    """The LEGACY/unscoped commit route -- not confined to parameters.agent. Used to set up
+    baselines and to probe unscoped-write behavior (W6, W12)."""
+    return api_call(
+        "POST",
+        "/workflows/revisions/commit",
+        json={
+            "workflow_revision": {
+                "slug": slug,
+                "name": f"QA matrix rev {slug}",
+                "message": message,
+                "data": {"uri": "agenta:builtin:agent:v0", "parameters": parameters},
+                "workflow_id": workflow_id,
+                "workflow_variant_id": variant_id,
+            }
+        },
+    )
+
+
+def seed_and_baseline(
+    workflow_id: str, variant_id: str, agent_cfg: dict, hexid: str
+) -> tuple[str, str]:
+    """v0 seed (nulled by the DAO) then v1 baseline. Returns (baseline_revision_id, version)."""
+    params = {"agent": agent_cfg}
+    r = commit_direct(workflow_id, variant_id, params, "seed", f"qa-matrix-seed-{hexid}")
+    if r.status_code != 200:
+        raise RuntimeError(f"seed commit HTTP {r.status_code}: {r.text[:300]}")
+    r = commit_direct(workflow_id, variant_id, params, "baseline", f"qa-matrix-baseline-{hexid}")
+    if r.status_code != 200:
+        raise RuntimeError(f"baseline commit HTTP {r.status_code}: {r.text[:300]}")
+    rev = r.json()["workflow_revision"]
+    return rev["id"], rev.get("version")
+
+
+def read_config_direct(variant_id: str, path: list | None = None) -> httpx.Response:
+    body = {"target": {"workflow_variant_id": variant_id}}
+    if path is not None:
+        body["target"]["path"] = path
+    return api_call("POST", "/workflows/revisions/read-config", json=body)
+
+
+def commit_agent_direct(
+    base_revision_id: str, delta: dict, variant_id: str, description: str = ""
+) -> httpx.Response:
+    """Direct call to the SCOPED agent commit route, bypassing a live model (used where the
+    matrix wants a raw-API probe rather than an agent-driven call: W6, W9, W10, W12).
+
+    `workflow_variant_id` is normally injected by the runner from run context
+    ($ctx.workflow.variant.id) when a live agent calls commit_revision -- a direct probe has no
+    run context, so it must be supplied explicitly or the endpoint 400s asking for it."""
+    return api_call(
+        "POST",
+        "/workflows/revisions/commit/agent",
+        json={
+            "description": description,
+            "workflow_revision": {
+                "base_revision_id": base_revision_id,
+                "workflow_variant_id": variant_id,
+                "delta": delta,
+            },
+        },
+    )
+
+
+def latest_revision(workflow_id: str) -> dict | None:
+    """Fetch the newest revision for a workflow. `workflow_refs` is the correct parent-scoping
+    filter -- `workflow_revision.workflow_id` is silently ignored (that field is an ATTRIBUTE
+    filter, not parent-scoping) and returns every revision in the project, which produced a false
+    FAIL in early matrix runs when an archived workflow's revision won a stale version tie-break."""
+    r = api_call(
+        "POST",
+        "/workflows/revisions/query",
+        json={"workflow_refs": [{"id": workflow_id}]},
+    )
+    if r.status_code != 200:
+        raise RuntimeError(f"revisions query HTTP {r.status_code}: {r.text[:300]}")
+    revisions = r.json().get("workflow_revisions") or []
+    if not revisions:
+        return None
+    return max(revisions, key=lambda rv: int(rv.get("version") or -1))
+
+
+def archive(workflow_id: str) -> None:
+    try:
+        api_call("POST", f"/workflows/{workflow_id}/archive")
+    except Exception as e:  # noqa: BLE001
+        print(f"archive failed (non-fatal): {e}", file=sys.stderr)
+
+
+class Turn:
+    def __init__(self) -> None:
+        self.frames: list[str] = []
+        self.text_parts: list[str] = []
+        self.tool_calls: list[dict] = []
+        self.tool_outcomes: dict[str, str] = {}
+        self.tool_payloads: dict[str, dict] = {}
+        self.approval: dict | None = None
+        self.finish_reason: str | None = None
+        self.errors: list[str] = []
+        self.committed_revision = None
+        self._segments: list[dict] = []
+        self.raw_frames: list[dict] = []
+
+    @property
+    def reply(self) -> str:
+        return "".join(self.text_parts)
+
+    def assistant_message(self) -> dict:
+        parts = []
+        text_buf: list[str] = []
+        for seg in self._segments:
+            if seg["kind"] == "text":
+                text_buf.append(seg["text"])
+            else:
+                if text_buf:
+                    parts.append({"type": "text", "text": "".join(text_buf)})
+                    text_buf = []
+                call = next(c for c in self.tool_calls if c["toolCallId"] == seg["id"])
+                part: dict = {
+                    "type": f"tool-{call['toolName']}",
+                    "toolCallId": call["toolCallId"],
+                    "input": call["input"],
+                    "state": "input-available",
+                }
+                outcome = self.tool_outcomes.get(call["toolCallId"])
+                if outcome == "available":
+                    part["state"] = "output-available"
+                    part["output"] = self.tool_payloads.get(call["toolCallId"], {}).get("output")
+                elif outcome == "error":
+                    part["state"] = "output-error"
+                    part["errorText"] = self.tool_payloads.get(call["toolCallId"], {}).get(
+                        "errorText"
+                    )
+                if self.approval and self.approval["toolCallId"] == call["toolCallId"]:
+                    part["state"] = "approval-requested"
+                    part["approval"] = {"id": self.approval["approvalId"]}
+                parts.append(part)
+        if text_buf:
+            parts.append({"type": "text", "text": "".join(text_buf)})
+        return {"id": str(uuid.uuid4()), "role": "assistant", "parts": parts}
+
+
+def invoke(
+    session_id: str,
+    messages: list[dict],
+    parameters: dict,
+    references: dict,
+    log: bool = True,
+) -> Turn:
+    url = f"{BASE}/services/agent/v0/invoke"
+    body = {
+        "session_id": session_id,
+        "references": references,
+        "data": {"inputs": {"messages": messages}, "parameters": parameters},
+    }
+    headers = {
+        "Authorization": f"ApiKey {KEY}",
+        "Accept": "text/event-stream",
+        "x-ag-messages-format": "vercel",
+        "Content-Type": "application/json",
+    }
+    t = Turn()
+    with httpx.Client(timeout=180.0) as client:
+        with client.stream(
+            "POST",
+            url,
+            params={"project_id": PROJECT, "application_id": references["application"]["id"]},
+            json=body,
+            headers=headers,
+        ) as r:
+            if log:
+                print(f"  HTTP {r.status_code}", file=sys.stderr)
+            if r.status_code >= 400:
+                t.errors.append(f"HTTP {r.status_code}: {r.read().decode()[:1000]}")
+                return t
+            for line in r.iter_lines():
+                if not line or line.startswith(":") or not line.startswith("data: "):
+                    continue
+                payload = line[6:]
+                if payload == "[DONE]":
+                    break
+                try:
+                    f = json.loads(payload)
+                except json.JSONDecodeError:
+                    t.errors.append(f"malformed SSE frame: {payload[:200]}")
+                    continue
+                t.raw_frames.append(f)
+                ftype = f.get("type", "?")
+                t.frames.append(ftype)
+                if ftype == "text-delta":
+                    delta = f.get("delta", "")
+                    t.text_parts.append(delta)
+                    if t._segments and t._segments[-1]["kind"] == "text":
+                        t._segments[-1]["text"] += delta
+                    else:
+                        t._segments.append({"kind": "text", "text": delta})
+                elif ftype == "tool-input-available":
+                    call = {
+                        "toolCallId": f.get("toolCallId"),
+                        "toolName": f.get("toolName"),
+                        "input": f.get("input"),
+                    }
+                    is_new = not any(c["toolCallId"] == call["toolCallId"] for c in t.tool_calls)
+                    t.tool_calls = [
+                        c for c in t.tool_calls if c["toolCallId"] != call["toolCallId"]
+                    ] + [call]
+                    if is_new:
+                        t._segments.append({"kind": "tool", "id": call["toolCallId"]})
+                elif ftype == "tool-approval-request":
+                    t.approval = {
+                        "approvalId": f.get("approvalId"),
+                        "toolCallId": f.get("toolCallId"),
+                    }
+                    if log:
+                        print(f"  !! approval-request: {json.dumps(f)[:400]}", file=sys.stderr)
+                elif ftype in ("tool-output-available", "tool-output-error", "tool-output-denied"):
+                    tcid = f.get("toolCallId")
+                    if tcid:
+                        t.tool_outcomes[tcid] = ftype.replace("tool-output-", "")
+                        if ftype == "tool-output-available":
+                            t.tool_payloads[tcid] = {"output": f.get("output")}
+                            if log:
+                                print(
+                                    f"  tool-output-available {tcid}: "
+                                    f"{json.dumps(f.get('output'))[:300]}",
+                                    file=sys.stderr,
+                                )
+                        else:
+                            t.tool_payloads[tcid] = {"errorText": f.get("errorText")}
+                            if log:
+                                print(f"  !! {ftype}: {json.dumps(f)[:400]}", file=sys.stderr)
+                elif ftype == "data-committed-revision":
+                    t.committed_revision = f.get("data")
+                    if log:
+                        print(f"  !! data-committed-revision: {json.dumps(f)[:400]}", file=sys.stderr)
+                elif ftype == "error":
+                    t.errors.append(json.dumps(f)[:500])
+                    if log:
+                        print(f"  !! error: {json.dumps(f)[:500]}", file=sys.stderr)
+                elif ftype == "finish":
+                    t.finish_reason = f.get("finishReason")
+                    if log:
+                        print(f"  !! finish: {json.dumps(f)[:400]}", file=sys.stderr)
+    return t
+
+
+def approval_reply(turn: Turn, approved: bool) -> dict:
+    message = turn.assistant_message()
+    for part in message["parts"]:
+        if part.get("toolCallId") == turn.approval["toolCallId"]:
+            part["state"] = "approval-responded"
+            part["approval"] = {"id": turn.approval["approvalId"], "approved": approved}
+            return message
+    raise ValueError("gated tool call missing from assistant message")
+
+
+def refs(workflow_id: str, variant_id: str, revision_id: str) -> dict:
+    return {
+        "application": {"id": workflow_id},
+        "application_variant": {"id": variant_id},
+        "application_revision": {"id": revision_id},
+    }
+
+
+def run_until_settled(
+    session_id: str,
+    initial_msgs: list[dict],
+    parameters: dict,
+    references: dict,
+    approve: bool = True,
+    max_rounds: int = 6,
+) -> tuple[list[Turn], dict]:
+    """Some flows raise MORE THAN ONE approval gate in sequence (e.g. W7: a gated bash write,
+    THEN a gated commit_revision once the write completes). Keep invoking and auto-answering
+    every gate the same way until a turn finishes with no pending approval, or max_rounds is
+    hit. Returns (all turns in order, {"settled": bool, "rounds": n})."""
+    turns: list[Turn] = []
+    msgs = list(initial_msgs)
+    for i in range(max_rounds):
+        t = invoke(session_id, msgs, parameters, references)
+        turns.append(t)
+        if t.errors:
+            return turns, {"settled": False, "rounds": i + 1, "why": f"wire errors: {t.errors}"}
+        if not t.approval:
+            return turns, {"settled": True, "rounds": i + 1}
+        msgs = msgs + [approval_reply(t, approved=approve)]
+    return turns, {"settled": False, "rounds": max_rounds, "why": "max_rounds exhausted, still gated"}

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -1,6 +1,7 @@
 """Shared helpers for the W1-W12 adversarial config-editing matrix (matrix_w3/w4/w5/w7.py).
 Import-only, no CLI. Uses the smallest workable model (Claude haiku, subscription auth) to keep
 these cheap to run repeatedly."""
+
 from __future__ import annotations
 
 import json
@@ -29,7 +30,9 @@ def api_call(method: str, path: str, timeout: float = 60.0, **kwargs) -> httpx.R
     )
 
 
-def agent_config(tools: list[dict] | None = None, instructions: str = "Be terse.") -> dict:
+def agent_config(
+    tools: list[dict] | None = None, instructions: str = "Be terse."
+) -> dict:
     return {
         "instructions": {"agents_md": instructions},
         "llm": {
@@ -53,7 +56,11 @@ LIVE_TOOLS = [
 
 
 def user_msg(text: str) -> dict:
-    return {"id": str(uuid.uuid4()), "role": "user", "parts": [{"type": "text", "text": text}]}
+    return {
+        "id": str(uuid.uuid4()),
+        "role": "user",
+        "parts": [{"type": "text", "text": text}],
+    }
 
 
 def create_workflow(hexid: str, slug_prefix: str = "qa-matrix") -> tuple[str, str]:
@@ -64,7 +71,11 @@ def create_workflow(hexid: str, slug_prefix: str = "qa-matrix") -> tuple[str, st
             "workflow": {
                 "slug": f"{slug_prefix}-{hexid}",
                 "name": f"QA matrix {hexid}",
-                "flags": {"is_custom": True, "is_evaluator": False, "is_feedback": False},
+                "flags": {
+                    "is_custom": True,
+                    "is_evaluator": False,
+                    "is_feedback": False,
+                },
             }
         },
     )
@@ -115,10 +126,14 @@ def seed_and_baseline(
 ) -> tuple[str, str]:
     """v0 seed (nulled by the DAO) then v1 baseline. Returns (baseline_revision_id, version)."""
     params = {"agent": agent_cfg}
-    r = commit_direct(workflow_id, variant_id, params, "seed", f"qa-matrix-seed-{hexid}")
+    r = commit_direct(
+        workflow_id, variant_id, params, "seed", f"qa-matrix-seed-{hexid}"
+    )
     if r.status_code != 200:
         raise RuntimeError(f"seed commit HTTP {r.status_code}: {r.text[:300]}")
-    r = commit_direct(workflow_id, variant_id, params, "baseline", f"qa-matrix-baseline-{hexid}")
+    r = commit_direct(
+        workflow_id, variant_id, params, "baseline", f"qa-matrix-baseline-{hexid}"
+    )
     if r.status_code != 200:
         raise RuntimeError(f"baseline commit HTTP {r.status_code}: {r.text[:300]}")
     rev = r.json()["workflow_revision"]
@@ -218,12 +233,14 @@ class Turn:
                 outcome = self.tool_outcomes.get(call["toolCallId"])
                 if outcome == "available":
                     part["state"] = "output-available"
-                    part["output"] = self.tool_payloads.get(call["toolCallId"], {}).get("output")
+                    part["output"] = self.tool_payloads.get(call["toolCallId"], {}).get(
+                        "output"
+                    )
                 elif outcome == "error":
                     part["state"] = "output-error"
-                    part["errorText"] = self.tool_payloads.get(call["toolCallId"], {}).get(
-                        "errorText"
-                    )
+                    part["errorText"] = self.tool_payloads.get(
+                        call["toolCallId"], {}
+                    ).get("errorText")
                 if self.approval and self.approval["toolCallId"] == call["toolCallId"]:
                     part["state"] = "approval-requested"
                     part["approval"] = {"id": self.approval["approvalId"]}
@@ -257,7 +274,10 @@ def invoke(
         with client.stream(
             "POST",
             url,
-            params={"project_id": PROJECT, "application_id": references["application"]["id"]},
+            params={
+                "project_id": PROJECT,
+                "application_id": references["application"]["id"],
+            },
             json=body,
             headers=headers,
         ) as r:
@@ -293,7 +313,9 @@ def invoke(
                         "toolName": f.get("toolName"),
                         "input": f.get("input"),
                     }
-                    is_new = not any(c["toolCallId"] == call["toolCallId"] for c in t.tool_calls)
+                    is_new = not any(
+                        c["toolCallId"] == call["toolCallId"] for c in t.tool_calls
+                    )
                     t.tool_calls = [
                         c for c in t.tool_calls if c["toolCallId"] != call["toolCallId"]
                     ] + [call]
@@ -305,8 +327,15 @@ def invoke(
                         "toolCallId": f.get("toolCallId"),
                     }
                     if log:
-                        print(f"  !! approval-request: {json.dumps(f)[:400]}", file=sys.stderr)
-                elif ftype in ("tool-output-available", "tool-output-error", "tool-output-denied"):
+                        print(
+                            f"  !! approval-request: {json.dumps(f)[:400]}",
+                            file=sys.stderr,
+                        )
+                elif ftype in (
+                    "tool-output-available",
+                    "tool-output-error",
+                    "tool-output-denied",
+                ):
                     tcid = f.get("toolCallId")
                     if tcid:
                         t.tool_outcomes[tcid] = ftype.replace("tool-output-", "")
@@ -321,11 +350,17 @@ def invoke(
                         else:
                             t.tool_payloads[tcid] = {"errorText": f.get("errorText")}
                             if log:
-                                print(f"  !! {ftype}: {json.dumps(f)[:400]}", file=sys.stderr)
+                                print(
+                                    f"  !! {ftype}: {json.dumps(f)[:400]}",
+                                    file=sys.stderr,
+                                )
                 elif ftype == "data-committed-revision":
                     t.committed_revision = f.get("data")
                     if log:
-                        print(f"  !! data-committed-revision: {json.dumps(f)[:400]}", file=sys.stderr)
+                        print(
+                            f"  !! data-committed-revision: {json.dumps(f)[:400]}",
+                            file=sys.stderr,
+                        )
                 elif ftype == "error":
                     t.errors.append(json.dumps(f)[:500])
                     if log:
@@ -373,8 +408,16 @@ def run_until_settled(
         t = invoke(session_id, msgs, parameters, references)
         turns.append(t)
         if t.errors:
-            return turns, {"settled": False, "rounds": i + 1, "why": f"wire errors: {t.errors}"}
+            return turns, {
+                "settled": False,
+                "rounds": i + 1,
+                "why": f"wire errors: {t.errors}",
+            }
         if not t.approval:
             return turns, {"settled": True, "rounds": i + 1}
         msgs = msgs + [approval_reply(t, approved=approve)]
-    return turns, {"settled": False, "rounds": max_rounds, "why": "max_rounds exhausted, still gated"}
+    return turns, {
+        "settled": False,
+        "rounds": max_rounds,
+        "why": "max_rounds exhausted, still gated",
+    }

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -20,6 +20,19 @@ KEY = os.environ["AGENTA_API_KEY"]
 MODEL = "haiku"
 PROVIDER = "anthropic"
 
+# Harness-kind and model-id gotchas, found live during the platform-guidance discovery
+# verification (2026-08-06). Bake these in so nobody re-derives them the hard way:
+#
+#   - The Pi harness's kind enum value is "pi_core" -- the short name "pi" 500s at the
+#     workflow-invoke layer (see matrix_w7_per_harness.py's HARNESSES dict, which already gets
+#     this right).
+#   - "pi_core" REJECTS a bare "haiku" model id; unlike codex (which accepts short curated
+#     aliases like "gpt-5.6-luna" bare), pi_core needs the fully qualified
+#     "claude-haiku-4-5". Passing bare "haiku" on pi_core is a silent footgun, not an obvious
+#     400 -- verify against a real run before assuming a short alias carries over from claude.
+PI_CORE_HARNESS_KIND = "pi_core"
+PI_CORE_HAIKU_MODEL = "claude-haiku-4-5"
+
 
 def api_call(method: str, path: str, timeout: float = 60.0, **kwargs) -> httpx.Response:
     return httpx.request(

--- a/.agents/skills/agent-release-gate/resources/qa_product.py
+++ b/.agents/skills/agent-release-gate/resources/qa_product.py
@@ -997,20 +997,23 @@ def _continuity(cell: dict, tier: str) -> dict:
         # Force the eviction from the CLIENT, with byte-faithful history, by moving a facet that
         # CANNOT be applied to a running environment.
         #
-        # THIS USED TO EDIT `instructions.agents_md`, AND THAT STOPPED WORKING. `agentsMd` is the
-        # `workspaceFiles` facet, and the v1 lifecycle work made that one of exactly two LIVE
-        # routes (`reconciliation-router.ts`: workspaceFiles -> refresh-workspace, which IS in
-        # `LIVE_ACTION_KINDS`). So an instructions edit is now satisfied in place: the sandbox is
-        # never torn down, the durable cwd is never unmounted, and this tier would have gone on
-        # passing while measuring warm reuse — a false green, and one that also dissolves `park`'s
-        # rationale, since park's "one sandbox id is meaningful" argument rests on cold1
-        # reporting two on the same deployment.
+        # THIS USED TO EDIT `instructions.agents_md`, AND THAT STOPPED WORKING FOR A WHILE. The v1
+        # lifecycle work made `agentsMd` (the `workspaceFiles` facet) a LIVE route, so an
+        # instructions edit was satisfied in place: the sandbox was never torn down, the durable
+        # cwd was never unmounted, and this tier would have gone on passing while measuring warm
+        # reuse — a false green, and one that also dissolves `park`'s rationale, since park's "one
+        # sandbox id is meaningful" argument rests on cold1 reporting two on the same deployment.
         #
-        # `harness.permissions` is the `harnessSession` facet -> `reopen-session`, which is
-        # deliberately NOT live (a permission change must never be routed through an in-place
-        # refresh), so it still escalates to a rebuild. A rule naming a tool this journey never
-        # calls moves the facet without changing what the turn may do, so the transition cannot
-        # be confused with a behaviour change.
+        # That live route has since been withdrawn (no harness re-reads its instruction file, so
+        # the edit never took effect — see `matrix_l5_live_route_observed.py`), which means an
+        # instructions edit would force an eviction again today. The forcing function stays on
+        # `harness.permissions` anyway: it is the `harnessSession` facet -> `reopen-session`, which
+        # is deliberately NOT live and can never BECOME live, because a permission change must
+        # never be routed through an in-place refresh. A tier that depends on a route staying
+        # escalated should depend on the one that is escalated by policy, not by capability.
+        #
+        # A rule naming a tool this journey never calls moves the facet without changing what the
+        # turn may do, so the transition cannot be confused with a behaviour change.
         params = json.loads(json.dumps(params))
         params.setdefault("harness", {})["permissions"] = {
             "allow": [],

--- a/.agents/skills/agent-release-gate/resources/qa_product.py
+++ b/.agents/skills/agent-release-gate/resources/qa_product.py
@@ -994,17 +994,33 @@ def _continuity(cell: dict, tier: str) -> dict:
         msgs = msgs + [t_mid.assistant_message()]
         transition = "none (same daemon, same live mount)"
     elif tier == "cold1":
-        # Force the eviction from the CLIENT, with byte-faithful history: `agentsMd` is a
-        # configFingerprint input (session-identity.ts), so changing the instructions makes the
-        # next turn mismatch on `config` -> `evict + cold`. The teardown unmounts the durable cwd
-        # and the cold acquire remounts it — a real store round trip, driven by a real product
-        # action (editing an agent's instructions mid-session). Editing the TRANSCRIPT instead
-        # would trip the history guard, which is a different (and deliberately hostile) path.
+        # Force the eviction from the CLIENT, with byte-faithful history, by moving a facet that
+        # CANNOT be applied to a running environment.
+        #
+        # THIS USED TO EDIT `instructions.agents_md`, AND THAT STOPPED WORKING. `agentsMd` is the
+        # `workspaceFiles` facet, and the v1 lifecycle work made that one of exactly two LIVE
+        # routes (`reconciliation-router.ts`: workspaceFiles -> refresh-workspace, which IS in
+        # `LIVE_ACTION_KINDS`). So an instructions edit is now satisfied in place: the sandbox is
+        # never torn down, the durable cwd is never unmounted, and this tier would have gone on
+        # passing while measuring warm reuse — a false green, and one that also dissolves `park`'s
+        # rationale, since park's "one sandbox id is meaningful" argument rests on cold1
+        # reporting two on the same deployment.
+        #
+        # `harness.permissions` is the `harnessSession` facet -> `reopen-session`, which is
+        # deliberately NOT live (a permission change must never be routed through an in-place
+        # refresh), so it still escalates to a rebuild. A rule naming a tool this journey never
+        # calls moves the facet without changing what the turn may do, so the transition cannot
+        # be confused with a behaviour change.
         params = json.loads(json.dumps(params))
-        params["instructions"]["agents_md"] += (
-            f" (qa-continuity {uuid.uuid4().hex[:8]})"
+        params.setdefault("harness", {})["permissions"] = {
+            "allow": [],
+            "ask": [f"QaNeverCalledTool{uuid.uuid4().hex[:8]}"],
+            "deny": [],
+        }
+        transition = (
+            "harnessSession facet change (a permission rule) -> not live-applicable, so the "
+            "runner evicts the pooled session and rebuilds cold"
         )
-        transition = "config-fingerprint change -> the runner evicts the pooled session and rebuilds cold"
     elif tier == "park":
         # Change NOTHING and simply wait. That is the whole point: a config change makes the
         # runner delete the sandbox and build a fresh one (that is `cold1`), whereas an idle
@@ -1170,6 +1186,24 @@ def _continuity(cell: dict, tier: str) -> dict:
         evidence["reconnected_same_sandbox"] = same_sandbox
         ok = ok and ledger_available and same_sandbox
 
+    if tier == "cold1":
+        # ASSERT the rebuild, do not merely report it.
+        #
+        # This tier only means something if the transition actually evicted the session: the whole
+        # point is that the durable cwd was unmounted and remounted, which is where #5692 lives. A
+        # reply carrying the token proves nothing on its own, because a session that was never
+        # evicted answers exactly the same way — that is how the old `agents_md` forcing function
+        # could rot into a warm-reuse test without anyone noticing. TWO distinct sandbox ids is
+        # the stored witness that the sandbox really was replaced.
+        #
+        # An empty ledger fails here for the same reason it fails in `warm` and `park`: missing
+        # evidence is not evidence.
+        ledger_available = bool(agents or sandboxes)
+        rebuilt = len(sandboxes) >= 2
+        evidence["ledger_available"] = ledger_available
+        evidence["rebuilt_sandbox"] = rebuilt
+        ok = ok and ledger_available and rebuilt
+
     if tier == "warm":
         # A warm continuation cannot have rebuilt the harness session or the sandbox. More than
         # one distinct id across the ledger means the turn was NOT served warm, so the cell did
@@ -1197,7 +1231,9 @@ def _continuity(cell: dict, tier: str) -> dict:
             + ")"
         ),
         "cold1": (
-            f"cold 1: the pooled session was evicted and rebuilt on the same runner; the cwd token "
+            f"cold 1: the pooled session was evicted and rebuilt on the same runner "
+            f"(two sandbox ids in the ledger={evidence.get('rebuilt_sandbox')} — one id would mean "
+            f"the change was applied in place and this tier measured warm reuse); the cwd token "
             f"came back from the store (in reply={cwd_back}) and the agent read a file that only "
             f"ever existed as an object (store-only file readable={store_back})"
         ),


### PR DESCRIPTION
## Context
The agent-config-editing E2E campaign (5 August) found four product bugs that 1900+ unit tests, two external review rounds, and the deploy smoke checks all missed. The cells that caught or exercised them are worth keeping as permanent, re-runnable checks rather than one-off scripts.

## Changes
Six additions to the agent-release-gate skill's resources, driven the same way the gate drives everything: the product SSE endpoint, assertions on frames and real side effects, never on model prose.
- `qa_commit_approval.py`: the full commit-approval round trip (gate, in-band approve, execute, independent fetch-back of the revision). The mandatory last step before handing a deployed stack to a human.
- `matrix_w3.py` / `matrix_w4.py`: two-session concurrency (disjoint edits both land through conflict recovery; the execute-time base check catches a head moved under a pending approval).
- `matrix_w5.py`: steer mid-turn, then a next turn (caught the pre-existing mount-loss bug).
- `matrix_w7.py`: workspace-file import through the approval gate (caught the authorization id-mismatch bug).
- `qa_matrix_lib.py`: their shared plumbing.
SKILL.md documents each cell and the bug class it guards. It also records that `resources/qa_product.py` currently fails to import (pre-existing unresolved merge conflict in the tree it was copied from) so nobody trusts `--all` until that is resolved.

## Tests / notes
Each cell was run against a live preview stack during the campaign; W5 and W7 correctly stayed red until their fixes landed, and W3/W4 pass. These are integration cells needing a running deployment and the three gate env vars; they are not part of any unit suite.
