### PR TITLE
feat(frontend): One reader for a trigger's bound agent and honest cron names

### DIFF
--- a/web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx
+++ b/web/oss/src/components/pages/settings/Triggers/components/GatewaySchedulesSection.tsx
@@ -4,6 +4,7 @@ import {
     describeCron,
     isEntityActive,
     triggerDeliveriesDrawerAtom,
+    triggerBoundAgentId,
     triggerScheduleDrawerAtom,
     useTriggerSchedule,
     useTriggerSchedules,
@@ -131,13 +132,7 @@ export default function GatewaySchedulesSection() {
                 key: "workflow",
                 onHeaderCell: () => ({style: {minWidth: 160}}),
                 render: (_, record) => {
-                    const refs = record.data?.references
-                    const wfId =
-                        refs?.application?.id ??
-                        refs?.application_variant?.id ??
-                        refs?.application_revision?.id ??
-                        null
-                    return <BoundWorkflowCell wfId={wfId} />
+                    return <BoundWorkflowCell wfId={triggerBoundAgentId(record.data?.references)} />
                 },
             },
             {

--- a/web/packages/agenta-entities/src/gatewayTrigger/core/cron.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/core/cron.ts
@@ -95,14 +95,42 @@ export function describeCron(expression: string): string {
     if (minute === "0" && hour === "*" && dom === "*" && month === "*" && dow === "*")
         return "Every hour (UTC)"
 
+    // "5 * * * *" fell through to the raw expression, which schedule lists show as a name.
+    if (/^\d+$/.test(minute) && hour === "*" && dom === "*" && month === "*" && dow === "*")
+        return `Every hour at :${pad(minute)} (UTC)`
+
+    const hourStep = hour.match(/^\*\/(\d+)$/)
+    if (/^\d+$/.test(minute) && hourStep && dom === "*" && month === "*" && dow === "*")
+        return `Every ${hourStep[1]} hours at :${pad(minute)} (UTC)`
+
     const isTime = /^\d+$/.test(minute) && /^\d+$/.test(hour)
     if (isTime && dom === "*" && month === "*") {
         const time = `${pad(hour)}:${pad(minute)} UTC`
         if (dow === "*") return `Every day at ${time}`
         if (/^\d$/.test(dow)) return `Every ${DAY_NAMES[Number(dow)]} at ${time}`
+        // "0 9 * * 1-5" / "0 9 * * 1,3" — a day set, not a single day.
+        if (/^[\d,-]+$/.test(dow)) {
+            const days = expandDayList(dow)
+            if (days.length) return `${days.map((day) => DAY_NAMES[day]).join(", ")} at ${time}`
+        }
     }
 
     return `${expression} (UTC)`
+}
+
+/** Expand a cron day-of-week list/range ("1-5", "1,3") into day indexes. */
+function expandDayList(dow: string): number[] {
+    const days = new Set<number>()
+    for (const part of dow.split(",")) {
+        const range = part.match(/^(\d)-(\d)$/)
+        if (range) {
+            for (let day = Number(range[1]); day <= Number(range[2]); day += 1) days.add(day % 7)
+            continue
+        }
+        if (/^\d$/.test(part)) days.add(Number(part))
+        else return []
+    }
+    return [...days].sort((a, b) => a - b)
 }
 
 function pad(value: string): string {

--- a/web/packages/agenta-entities/src/gatewayTrigger/core/types.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/core/types.ts
@@ -305,6 +305,9 @@ export type TriggerStatus = z.infer<typeof triggerStatusSchema>
 export const triggerDeliveryDataSchema = z
     .object({
         event_key: z.string().nullish(),
+        // The session this delivery produced — minted by the dispatcher, so it is present
+        // regardless of which dispatch path ran. Absent on deliveries written before it existed.
+        session_id: z.string().nullish(),
         references: z.record(z.string(), triggerReferenceSchema).nullish(),
         inputs: z.record(z.string(), z.unknown()).nullish(),
         result: z.record(z.string(), z.unknown()).nullish(),
@@ -453,6 +456,24 @@ export interface TriggerScheduleQuery {
 // ---------------------------------------------------------------------------
 
 /** Read `flags.is_active`, defaulting to `true` when the flag is absent. */
+/**
+ * The agent a trigger runs, from its `data.references`.
+ *
+ * One reader for the reference precedence, because a trigger's binding is entity knowledge:
+ * every surface that names the agent behind a schedule or subscription (the rail's next-triggers
+ * list, the settings table) was deriving it independently off the same three keys.
+ */
+export function triggerBoundAgentId(
+    references?: Record<string, {id?: string | null} | undefined> | null,
+): string | null {
+    return (
+        references?.application?.id ??
+        references?.application_variant?.id ??
+        references?.application_revision?.id ??
+        null
+    )
+}
+
 export function isEntityActive(entity?: {flags?: Record<string, unknown> | null} | null): boolean {
     const raw = entity?.flags?.is_active
     return raw === undefined || raw === null ? true : Boolean(raw)

--- a/web/packages/agenta-entities/src/gatewayTrigger/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/index.ts
@@ -55,7 +55,13 @@ export type {
     TriggerSubscriptionResponse,
     TriggerSubscriptionsResponse,
 } from "./core"
-export {isConnectionActive, isConnectionValid, isEntityActive, isEntityValid} from "./core"
+export {
+    isConnectionActive,
+    isConnectionValid,
+    isEntityActive,
+    isEntityValid,
+    triggerBoundAgentId,
+} from "./core"
 // The boundary schemas — exported so Storybook fixtures build their payloads through the
 // SAME validation the API layer uses and cannot drift from the contract silently.
 export {

--- a/web/packages/agenta-entities/tests/unit/gatewayTriggerCron.test.ts
+++ b/web/packages/agenta-entities/tests/unit/gatewayTriggerCron.test.ts
@@ -111,4 +111,18 @@ describe("nextCronRuns", () => {
             "2026-07-06T00:00:00.000Z",
         ])
     })
+
+    it("describes an hourly minute rather than falling back to the expression", () => {
+        expect(describeCron("5 * * * *")).toBe("Every hour at :05 (UTC)")
+    })
+
+    it("describes an hour step", () => {
+        expect(describeCron("30 */2 * * *")).toBe("Every 2 hours at :30 (UTC)")
+    })
+
+    it("describes a day range", () => {
+        expect(describeCron("0 9 * * 1-5")).toBe(
+            "Monday, Tuesday, Wednesday, Thursday, Friday at 09:00 UTC",
+        )
+    })
 })


### PR DESCRIPTION
## Context
Several surfaces need to answer two questions about a gateway trigger: which agent does it run, and when does it fire next. The settings schedules table derived both from raw trigger references inline, and the upcoming agent Home and overview surfaces were about to grow their own copies.

## Changes
`triggerBoundAgentId(references)` reads the bound workflow id out of a trigger's references in one place, and the cron describer now names a schedule by what it does instead of repeating its cadence. `GatewaySchedulesSection` adopts both, so the settings table and the new agent surfaces resolve a trigger's agent the same way.

## Tests / notes
- `gatewayTriggerCron` unit tests cover the new naming.
- These files are identical on `main` and `feat/mobile-parity-and-consolidation`, so this lands on `main` independently. The sessions/agents UX stack (based on `feat/mobile-parity-and-consolidation`) imports `triggerBoundAgentId` from its `oss/home-overview` lane up, so this PR should merge (and reach that base) first.
