### PR TITLE
feat(api): Stamp a session's trigger origin, add liveness filters and last message

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -884,6 +884,7 @@ _triggers_dispatcher = TriggersDispatcher(
     triggers_dao=triggers_dao,
     workflows_service=workflows_service,
     dispatch_fn=_dispatch_detached_run,
+    streams_service=session_streams_service,
 )
 
 _triggers_worker = TriggersWorker(
@@ -1093,6 +1094,8 @@ sessions_service = SessionsService(
     turns_service=session_turns_service,
     interactions_service=interactions_service,
     mounts_service=mounts_service,
+    # Read-only, for the list's message preview — records themselves stay the records router's.
+    records_service=records_service,
 )
 
 sessions = SessionsRouter(

--- a/api/entrypoints/worker_queues.py
+++ b/api/entrypoints/worker_queues.py
@@ -50,6 +50,7 @@ from oss.src.core.evaluators.service import EvaluatorsService, SimpleEvaluatorsS
 from oss.src.core.queries.service import QueriesService
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
 from oss.src.core.sessions.records.service import RecordsService
+from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.core.testcases.service import TestcasesService
 from oss.src.core.testsets.service import SimpleTestsetsService, TestsetsService
 from oss.src.core.tracing.service import TracingService
@@ -69,7 +70,9 @@ from oss.src.dbs.postgres.queries.dbes import (
 )
 from oss.src.dbs.postgres.sessions.interactions.dao import SessionInteractionsDAO
 from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 from oss.src.dbs.redis.sessions.watch import SessionsWatchPublisher
+from oss.src.dbs.redis.shared.engine import get_lock_engine
 from oss.src.dbs.postgres.shared.engine import (
     get_analytics_engine,
     get_transactions_engine,
@@ -177,9 +180,19 @@ def _build_triggers_broker() -> tuple[AsyncBroker, int]:
     workflows_service.embeds_service = embeds_service
     environments_service.embeds_service = embeds_service
 
+    # Triggers dispatched through the queue must be stamped as automation-started too —
+    # without this composition they'd reach the sessions list indistinguishable from a
+    # person's own work, which is the whole point of the origin tag.
+    streams_service = SessionStreamsService(
+        streams_dao=SessionStreamsDAO(engine=get_transactions_engine()),
+        lock_engine=get_lock_engine(),
+        watch_publisher=SessionsWatchPublisher(),
+    )
+
     triggers_dispatcher = TriggersDispatcher(
         triggers_dao=triggers_dao,
         workflows_service=workflows_service,
+        streams_service=streams_service,
     )
     TriggersWorker(
         broker=broker, dispatcher=triggers_dispatcher, triggers_dao=triggers_dao

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from oss.src.core.sessions.dtos import SessionListItem
 from oss.src.core.sessions.streams.dtos import (
     SessionStream,
+    SessionStreamQueryFlags,
 )
 from oss.src.core.sessions.records.dtos import SessionRecord
 from oss.src.core.sessions.interactions.dtos import (
@@ -36,10 +37,26 @@ class SessionQueryRequest(BaseModel):
     include_archived: bool = False
     # Case-insensitive substring match over the session title (`session_streams.name`).
     search: Optional[str] = None
+    # Liveness filter (alive ⊇ running ⊇ attached) against the row's mirrored flags.
+    flags: Optional[SessionStreamQueryFlags] = None
+    # Restrict to / exclude an explicit id set — the pushdown for predicates that live outside
+    # the stream row (client-held pins, sessions named by a pending-interaction lookup), so the
+    # server still owns the intersection, the ordering and the windowing.
+    session_ids: Optional[List[str]] = None
+    exclude_session_ids: Optional[List[str]] = None
+    # Also return `total`. Off by default — a filter chip wants it, a scroll page does not.
+    include_total: bool = False
+    # Who started the session: "manual", "trigger", … Absent means every origin.
+    origin: Optional[str] = None
+    # Its negation — hides one origin while still showing sessions with no stamp at all.
+    exclude_origin: Optional[str] = None
 
 
 class SessionsResponse(BaseModel):
     count: int = 0
+    # Total matching rows ignoring windowing, when `include_total` was requested. `count` stays
+    # the number of rows in THIS page, per the shared envelope convention.
+    total: Optional[int] = None
     # `SessionListItem` = `SessionStream` + the latest turn's `references` (WP0-R3),
     # absent (excluded by response_model_exclude_none) when the session has no turns yet.
     sessions: List[SessionListItem] = Field(default_factory=list)

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -1648,17 +1648,32 @@ class SessionsRootRouter:
         ):
             raise FORBIDDEN_EXCEPTION
 
+        query = SessionQuery(
+            references=body.references,
+            include_ended=body.include_ended,
+            include_archived=body.include_archived,
+            search=body.search,
+            flags=body.flags,
+            session_ids=body.session_ids,
+            exclude_session_ids=body.exclude_session_ids,
+            include_total=body.include_total,
+            origin=body.origin,
+            exclude_origin=body.exclude_origin,
+        )
         sessions = await self.sessions_service.query_sessions(
             project_id=UUID(str(project_id)),
-            query=SessionQuery(
-                references=body.references,
-                include_ended=body.include_ended,
-                include_archived=body.include_archived,
-                search=body.search,
-            ),
+            query=query,
             windowing=body.windowing,
         )
-        return SessionsResponse(count=len(sessions), sessions=sessions)
+        total = (
+            await self.sessions_service.count_sessions(
+                project_id=UUID(str(project_id)),
+                query=query,
+            )
+            if body.include_total
+            else None
+        )
+        return SessionsResponse(count=len(sessions), total=total, sessions=sessions)
 
     @intercept_exceptions()
     async def delete_session(

--- a/api/oss/src/core/sessions/dtos.py
+++ b/api/oss/src/core/sessions/dtos.py
@@ -2,7 +2,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from oss.src.core.sessions.streams.dtos import SessionStream
+from oss.src.core.sessions.records.dtos import SessionMessagePreview
+from oss.src.core.sessions.streams.dtos import SessionStream, SessionStreamQueryFlags
 from oss.src.core.shared.dtos import Reference
 
 
@@ -10,15 +11,57 @@ class SessionListItem(SessionStream):
     """A `/sessions/query` row, enriched at READ time with the session's HIGHEST
     `turn_index` turn's `references` — the agent/workflow that produced the latest turn.
 
-    Hydrated by `SessionsService.query_sessions` via a batch turns lookup; never
-    denormalized onto `session_streams` (see that method's docstring)."""
+    Also carries the session's last message, so a row can say what happened rather than only
+    when. Both enrichments are batch lookups keyed on the whole page; never one call per row.
+
+    Hydrated by `SessionsService.query_sessions`; never denormalized onto `session_streams`
+    (see that method's docstring)."""
 
     references: Optional[List[Reference]] = None
+    # The session's newest `message` record, hydrated by the same batch pattern. Absent when the
+    # session has no message yet, or when the deployment runs without the records (tracing) engine.
+    last_message: Optional[SessionMessagePreview] = None
+
+
+# Reserved tag naming WHO started a session. Lives in `tags` rather than a column: the sessions
+# list must be able to hide automation runs by default, and a jsonb tag with a GIN index filters
+# as well as a column would without a migration.
+SESSION_ORIGIN_TAG = "ag.origin"
+
+SESSION_ORIGIN_MANUAL = "manual"
+SESSION_ORIGIN_TRIGGER = "trigger"
+
+# WHICH automation started the session. Written by the same single writer as the origin tag
+# (`SessionStreamsService.set_origin`), so the tags stay one write and never need a merge.
+SESSION_TRIGGER_ID_TAG = "ag.trigger.id"
+SESSION_TRIGGER_NAME_TAG = "ag.trigger.name"
+SESSION_TRIGGER_KIND_TAG = "ag.trigger.kind"
+
+SESSION_TRIGGER_KIND_SCHEDULE = "schedule"
+SESSION_TRIGGER_KIND_SUBSCRIPTION = "subscription"
+
+
+class SessionTriggerRef(BaseModel):
+    """The automation that started a session.
+
+    The name is a SNAPSHOT taken at dispatch, not a live join: a row is history, and resolving
+    names at read time would make the session list depend on the triggers domain. Renaming an
+    automation therefore does not retitle its past runs — the id is stamped alongside so a
+    read-time resolve can supersede the snapshot later without a migration.
+    """
+
+    id: str
+    name: Optional[str] = None
+    # "schedule" (a cron fired) or "subscription" (an event arrived).
+    kind: Optional[str] = None
 
 
 class SessionQuery(BaseModel):
     """Root `/sessions/query` filter: reference-scoped, joined through the turns'
-    references (WP1's GIN `.contains()`), not denormalized onto the stream row."""
+    references (WP1's GIN `.contains()`), not denormalized onto the stream row.
+
+    Every predicate a list view offers must live here. A client that filters a windowed
+    page filters the window, not the set — wrong counts, wrong empty states."""
 
     references: Optional[List[Reference]] = None
     # Include ended (killed) sessions so the durable list keeps resumable history — absence then
@@ -28,3 +71,21 @@ class SessionQuery(BaseModel):
     include_archived: bool = False
     # Case-insensitive substring match over the session title (`session_streams.name`).
     search: Optional[str] = None
+    # Liveness (alive ⊇ running ⊇ attached), matched against the row's mirrored `flags`.
+    flags: Optional[SessionStreamQueryFlags] = None
+    # Restrict to an explicit id set. The pushdown for any predicate that lives outside the
+    # stream row — pinned ids held client-side, sessions named by a pending-interaction lookup —
+    # so the server still owns the intersection, the ordering and the windowing.
+    session_ids: Optional[List[str]] = None
+    # Its complement: drop known ids from the list, so a group rendered separately (pins) does
+    # not appear twice.
+    exclude_session_ids: Optional[List[str]] = None
+    # Also return the total matching rows, ignoring windowing. Off by default: a filter chip
+    # wants it, a scroll page does not, and it costs a second query.
+    include_total: bool = False
+    # Who started the session (`SESSION_ORIGIN_*`). A triggered run is a session like any other,
+    # so without this filter an automation's work is indistinguishable from your own in the list.
+    origin: Optional[str] = None
+    # The negation, which containment cannot express: hide automation runs while still showing
+    # every session written before origins were stamped (their tags are NULL, not "manual").
+    exclude_origin: Optional[str] = None

--- a/api/oss/src/core/sessions/records/dtos.py
+++ b/api/oss/src/core/sessions/records/dtos.py
@@ -39,5 +39,21 @@ class SessionRecord(Lifecycle):
     span_id: Optional[OTelSpanId] = None
 
 
+class SessionMessagePreview(BaseModel):
+    """The last thing said in a session, for a list row.
+
+    A session row carried a title and a timestamp, so deciding whether a session was worth
+    reopening meant opening it. Only `message` records are considered: `done`/`usage` are
+    bookkeeping, `thought` is not addressed to anyone, and a `tool_call` says what the agent
+    reached for rather than what it concluded.
+    """
+
+    session_id: str
+    text: str
+    # "user" or "agent" — the row prefixes your own messages so a preview isn't mistaken for a reply.
+    source: Optional[str] = None
+    timestamp: Optional[datetime] = None
+
+
 class SessionRecordQuery(BaseModel):
     session_id: str

--- a/api/oss/src/core/sessions/records/interfaces.py
+++ b/api/oss/src/core/sessions/records/interfaces.py
@@ -1,7 +1,8 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from oss.src.core.sessions.records.dtos import (
+    SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
 )
@@ -37,4 +38,12 @@ class RecordsDAOInterface:
         project_id: UUID,
         record_id: UUID,
     ) -> Optional[SessionRecord]:
+        raise NotImplementedError
+
+    async def latest_message_per_session(
+        self,
+        *,
+        project_id: UUID,
+        session_ids: List[str],
+    ) -> Dict[str, SessionMessagePreview]:
         raise NotImplementedError

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -1,7 +1,8 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from oss.src.core.sessions.records.dtos import (
+    SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
 )
@@ -47,4 +48,19 @@ class RecordsService:
         return await self.records_dao.get_event(
             project_id=project_id,
             record_id=record_id,
+        )
+
+    async def latest_message_per_session(
+        self,
+        *,
+        project_id: UUID,
+        session_ids: List[str],
+    ) -> Dict[str, SessionMessagePreview]:
+        """One batched lookup for a whole page — never one call per row."""
+        if not session_ids:
+            return {}
+
+        return await self.records_dao.latest_message_per_session(
+            project_id=project_id,
+            session_ids=session_ids,
         )

--- a/api/oss/src/core/sessions/service.py
+++ b/api/oss/src/core/sessions/service.py
@@ -2,8 +2,8 @@
 
 Orchestrates across the session facets (streams, turns, interactions, mounts),
 anchored on `session_id` — the universal handle. Fan-out NEVER routes through
-`stream_id`. Records (tracing DB) are untouched here; tracing retention owns
-them.
+`stream_id`. Records (tracing DB) are READ here for the list's message preview and
+never written; tracing retention still owns their lifecycle.
 
 peek is NOT a verb and NOT built here: the individual reads (this service's
 `query_sessions`, the streams/turns/records fetch-and-query endpoints) are the
@@ -11,17 +11,34 @@ whole surface. The front-end composes them — see `apis/fastapi/sessions/router
 module docstring for the read-walk.
 """
 
-from typing import List, Optional
+from typing import List, Optional, Set
 from uuid import UUID
 
-from oss.src.core.shared.dtos import Reference, Windowing
-from oss.src.core.sessions.dtos import SessionListItem, SessionQuery
+from oss.src.core.shared.dtos import Windowing
+from oss.src.core.sessions.dtos import SESSION_ORIGIN_TAG, SessionListItem, SessionQuery
 from oss.src.core.sessions.streams.dtos import SessionStream, SessionStreamQuery
 from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.core.sessions.turns.dtos import SessionTurnQuery
 from oss.src.core.sessions.turns.service import SessionTurnsService
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
+from oss.src.core.sessions.records.service import RecordsService
 from oss.src.core.mounts.service import MountsService
+
+
+def _stream_filter(query: Optional[SessionQuery]) -> SessionStreamQuery:
+    """The row predicate shared by the list and its total."""
+    return SessionStreamQuery(
+        include_ended=bool(query and query.include_ended),
+        include_archived=bool(query and query.include_archived),
+        search=query.search if query else None,
+        flags=query.flags if query else None,
+        tags={SESSION_ORIGIN_TAG: query.origin} if query and query.origin else None,
+        exclude_tags=(
+            {SESSION_ORIGIN_TAG: query.exclude_origin}
+            if query and query.exclude_origin
+            else None
+        ),
+    )
 
 
 class SessionsService:
@@ -32,11 +49,15 @@ class SessionsService:
         turns_service: SessionTurnsService,
         interactions_service: SessionInteractionsService,
         mounts_service: MountsService,
+        # Optional: records live in the tracing DB, so a deployment without that engine still
+        # lists sessions — it just lists them without previews.
+        records_service: Optional[RecordsService] = None,
     ) -> None:
         self.streams_service = streams_service
         self.turns_service = turns_service
         self.interactions_service = interactions_service
         self.mounts_service = mounts_service
+        self.records_service = records_service
 
     async def query_sessions(
         self,
@@ -55,38 +76,39 @@ class SessionsService:
         proves hot.
 
         Each row is enriched (READ-time only, see `SessionListItem`) with its latest
-        turn's `references` via a single batch lookup keyed on every listed
-        `session_id` — never one `latest_turn` call per row (WP0-R3).
+        turn's `references` and its last message, each via a single batch lookup keyed on
+        every listed `session_id` — never one call per row (WP0-R3).
         """
-        session_ids: Optional[List[str]] = None
-
-        references: Optional[List[Reference]] = query.references if query else None
-        if references:
-            matching_turns = await self.turns_service.query_turns(
-                project_id=project_id,
-                query=SessionTurnQuery(references=references),
-            )
-            session_ids = sorted({turn.session_id for turn in matching_turns})
-            if not session_ids:
-                return []
+        session_ids = await self._resolve_session_ids(
+            project_id=project_id, query=query
+        )
+        if session_ids is not None and not session_ids:
+            return []
 
         streams = await self.streams_service.query_streams(
             project_id=project_id,
-            filter=SessionStreamQuery(
-                include_ended=bool(query and query.include_ended),
-                include_archived=bool(query and query.include_archived),
-                search=query.search if query else None,
-            ),
+            filter=_stream_filter(query),
             windowing=windowing,
             session_ids=session_ids,
+            exclude_session_ids=query.exclude_session_ids if query else None,
         )
 
         if not streams:
             return []
 
+        listed_ids = [stream.session_id for stream in streams]
+
         latest_turns = await self.turns_service.latest_turn_per_session(
             project_id=project_id,
-            session_ids=[stream.session_id for stream in streams],
+            session_ids=listed_ids,
+        )
+        previews = (
+            await self.records_service.latest_message_per_session(
+                project_id=project_id,
+                session_ids=listed_ids,
+            )
+            if self.records_service
+            else {}
         )
 
         items = []
@@ -96,9 +118,66 @@ class SessionsService:
                 SessionListItem(
                     **stream.model_dump(),
                     references=turn.references if turn else None,
+                    last_message=previews.get(stream.session_id),
                 )
             )
         return items
+
+    async def count_sessions(
+        self,
+        *,
+        project_id: UUID,
+        #
+        query: Optional[SessionQuery] = None,
+    ) -> int:
+        """Total sessions matching the filter, ignoring windowing — what a filter chip
+        shows. Same predicate as `query_sessions`, so a page and its total agree."""
+        session_ids = await self._resolve_session_ids(
+            project_id=project_id, query=query
+        )
+        if session_ids is not None and not session_ids:
+            return 0
+
+        return await self.streams_service.count_streams(
+            project_id=project_id,
+            filter=_stream_filter(query),
+            session_ids=session_ids,
+            exclude_session_ids=query.exclude_session_ids if query else None,
+        )
+
+    async def _resolve_session_ids(
+        self,
+        *,
+        project_id: UUID,
+        query: Optional[SessionQuery],
+    ) -> Optional[List[str]]:
+        """The id set to restrict the stream query to, or `None` for no restriction.
+
+        `references` resolves through the turns; `session_ids` arrives from the caller
+        (pins, a pending-interaction lookup). Given both, the restriction is their
+        INTERSECTION — each narrows, so an id must satisfy both. An empty list (as opposed
+        to `None`) means the filters can match nothing, and callers short-circuit on it.
+        """
+        if not query:
+            return None
+
+        from_references: Optional[Set[str]] = None
+        if query.references:
+            matching_turns = await self.turns_service.query_turns(
+                project_id=project_id,
+                query=SessionTurnQuery(references=query.references),
+            )
+            from_references = {turn.session_id for turn in matching_turns}
+
+        explicit: Optional[Set[str]] = (
+            set(query.session_ids) if query.session_ids is not None else None
+        )
+
+        if from_references is None:
+            return None if explicit is None else sorted(explicit)
+        if explicit is None:
+            return sorted(from_references)
+        return sorted(from_references & explicit)
 
     async def delete_session(
         self,

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -73,6 +73,10 @@ class SessionStreamQuery(BaseModel):
     include_archived: bool = False
     # Case-insensitive substring match over `name` (the session title).
     search: Optional[str] = None
+    # jsonb containment against the row's `tags` — carries the origin filter.
+    tags: Optional[Dict[str, Any]] = None
+    # Its negation. A row with NULL tags PASSES: absence of a stamp is not a match.
+    exclude_tags: Optional[Dict[str, Any]] = None
 
 
 class CommandMode(str, Enum):

--- a/api/oss/src/core/sessions/streams/interfaces.py
+++ b/api/oss/src/core/sessions/streams/interfaces.py
@@ -54,7 +54,18 @@ class SessionStreamsDAOInterface(ABC):
         filter: SessionStreamQuery,
         windowing: Optional[Windowing] = None,
         session_ids: Optional[List[str]] = None,
+        exclude_session_ids: Optional[List[str]] = None,
     ) -> List[SessionStream]: ...
+
+    @abstractmethod
+    async def count(
+        self,
+        *,
+        project_id: UUID,
+        filter: SessionStreamQuery,
+        session_ids: Optional[List[str]] = None,
+        exclude_session_ids: Optional[List[str]] = None,
+    ) -> int: ...
 
     @abstractmethod
     async def update(

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -13,7 +13,7 @@ Command matrix (inputs/data × force):
 """
 
 import uuid_utils.compat as uuid
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 from uuid import UUID
 
 from oss.src.utils.logging import get_module_logger
@@ -65,6 +65,13 @@ from oss.src.core.sessions.streams.types import (
     SessionIdInvalid,
     SessionStreamAlreadyExists,
     SessionTurnInUse,
+)
+from oss.src.core.sessions.dtos import (
+    SESSION_ORIGIN_TAG,
+    SESSION_TRIGGER_ID_TAG,
+    SESSION_TRIGGER_KIND_TAG,
+    SESSION_TRIGGER_NAME_TAG,
+    SessionTriggerRef,
 )
 from oss.src.core.sessions.streams.interfaces import SessionStreamsDAOInterface
 from oss.src.core.sessions.streams.runner_client import kill_runner_sandbox
@@ -675,6 +682,53 @@ class SessionStreamsService:
                 header=header,
             )
 
+    async def set_origin(
+        self,
+        *,
+        project_id: UUID,
+        user_id: Optional[UUID],
+        session_id: str,
+        origin: str,
+        trigger: Optional[SessionTriggerRef] = None,
+    ) -> Optional[SessionStream]:
+        """Record WHO started a session, and which automation did, as reserved tags.
+
+        Written before the run, so the row usually does not exist yet — hence the same
+        create-or-update shape as `set_header`. Tags are replaced wholesale, which is safe only
+        because this is the first writer; the trigger identity is stamped HERE rather than by a
+        second writer for exactly that reason.
+        """
+        _validate_session_id(session_id)
+        tags: Dict[str, Any] = {SESSION_ORIGIN_TAG: origin}
+        if trigger is not None:
+            tags[SESSION_TRIGGER_ID_TAG] = trigger.id
+            if trigger.name:
+                tags[SESSION_TRIGGER_NAME_TAG] = trigger.name
+            if trigger.kind:
+                tags[SESSION_TRIGGER_KIND_TAG] = trigger.kind
+        updated = await self._dao.update(
+            project_id=project_id,
+            user_id=user_id,
+            session_id=session_id,
+            stream=SessionStreamEdit(tags=tags),
+        )
+        if updated is not None:
+            return updated
+        try:
+            return await self._dao.create(
+                project_id=project_id,
+                user_id=user_id,
+                stream=SessionStreamCreate(session_id=session_id, tags=tags),
+            )
+        except SessionStreamAlreadyExists:
+            # A concurrent first heartbeat won the race; the row exists now.
+            return await self._dao.update(
+                project_id=project_id,
+                user_id=user_id,
+                session_id=session_id,
+                stream=SessionStreamEdit(tags=tags),
+            )
+
     async def query_streams(
         self,
         *,
@@ -682,6 +736,7 @@ class SessionStreamsService:
         filter: SessionStreamQuery,
         windowing: Optional[Windowing] = None,
         session_ids: Optional[List[str]] = None,
+        exclude_session_ids: Optional[List[str]] = None,
     ) -> List[SessionStream]:
         if filter.session_id:
             _validate_session_id(filter.session_id)
@@ -690,6 +745,24 @@ class SessionStreamsService:
             filter=filter,
             windowing=windowing,
             session_ids=session_ids,
+            exclude_session_ids=exclude_session_ids,
+        )
+
+    async def count_streams(
+        self,
+        *,
+        project_id: UUID,
+        filter: SessionStreamQuery,
+        session_ids: Optional[List[str]] = None,
+        exclude_session_ids: Optional[List[str]] = None,
+    ) -> int:
+        if filter.session_id:
+            _validate_session_id(filter.session_id)
+        return await self._dao.count(
+            project_id=project_id,
+            filter=filter,
+            session_ids=session_ids,
+            exclude_session_ids=exclude_session_ids,
         )
 
     async def hard_delete(

--- a/api/oss/src/core/triggers/dtos.py
+++ b/api/oss/src/core/triggers/dtos.py
@@ -361,6 +361,9 @@ class TriggerScheduleQuery(BaseModel):
 
 class TriggerDeliveryData(BaseModel):
     event_key: Optional[str] = None
+    # The session this delivery produced. Minted by the dispatcher rather than read back from the
+    # run, so the link survives the detached path (which returns only a run id).
+    session_id: Optional[str] = None
     #
     references: Optional[Dict[str, Reference]] = None
     inputs: Optional[Dict[str, Any]] = None

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from sqlalchemy import select
@@ -6,6 +6,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from oss.src.core.sessions.records.dtos import (
+    SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
 )
@@ -124,6 +125,62 @@ class RecordsDAO(RecordsDAOInterface):
 
             dbes = (await session.execute(stmt)).scalars().all()
             return [map_record_dbe_to_dto(dbe=dbe) for dbe in dbes]
+
+    async def latest_message_per_session(
+        self,
+        *,
+        project_id: UUID,
+        session_ids: List[str],
+    ) -> Dict[str, SessionMessagePreview]:
+        """The newest `message` record for each of `session_ids`, in ONE query.
+
+        `DISTINCT ON` rather than a per-session fetch: a list page asks for up to fifty
+        previews at once, and fifty round-trips per render is not a preview, it is a fan-out.
+        Ordering mirrors `get_records` reversed — producer event time is the only key that is
+        monotonic across turns (`record_index` restarts every turn).
+        """
+        if not session_ids:
+            return {}
+
+        async with self.engine.session() as session:
+            stmt = (
+                select(
+                    RecordDBE.session_id,
+                    RecordDBE.record_source,
+                    RecordDBE.attributes,
+                    RecordDBE.timestamp,
+                    RecordDBE.created_at,
+                )
+                .where(
+                    RecordDBE.project_id == project_id,
+                    RecordDBE.session_id.in_(session_ids),
+                    RecordDBE.record_type == "message",
+                    RecordDBE.deleted_at.is_(None),
+                )
+                .distinct(RecordDBE.session_id)
+                .order_by(
+                    RecordDBE.session_id,
+                    RecordDBE.timestamp.desc().nullslast(),
+                    RecordDBE.created_at.desc(),
+                    RecordDBE.record_index.desc(),
+                )
+            )
+
+            rows = (await session.execute(stmt)).all()
+
+        previews: Dict[str, SessionMessagePreview] = {}
+        for row in rows:
+            text = (row.attributes or {}).get("text")
+            # A message whose payload carries no text (attachment-only) has nothing to preview.
+            if not isinstance(text, str) or not text.strip():
+                continue
+            previews[row.session_id] = SessionMessagePreview(
+                session_id=row.session_id,
+                text=text.strip(),
+                source=row.record_source,
+                timestamp=row.timestamp or row.created_at,
+            )
+        return previews
 
     async def get_event(
         self,

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy import delete as sa_delete, func, select
+from sqlalchemy import delete as sa_delete, func, not_, or_, select
 from sqlalchemy.exc import IntegrityError
 
 from oss.src.core.sessions.streams.dtos import (
@@ -115,6 +115,76 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
             return None
         return map_stream_dbe_to_dto(stream_dbe=dbe)
 
+    @staticmethod
+    def _apply_filters(
+        stmt,
+        *,
+        project_id: UUID,
+        filter: SessionStreamQuery,
+        session_ids: Optional[List[str]] = None,
+        exclude_session_ids: Optional[List[str]] = None,
+    ):
+        """Shared row predicate for `query` and `count` — one definition, so a filtered
+        page and its total can never disagree."""
+        stmt = stmt.where(SessionStreamDBE.project_id == project_id)
+        if not filter.include_ended:
+            stmt = stmt.where(SessionStreamDBE.deleted_at.is_(None))
+        if not filter.include_archived:
+            stmt = stmt.where(SessionStreamDBE.archived_at.is_(None))
+        if filter.session_id is not None:
+            stmt = stmt.where(SessionStreamDBE.session_id == filter.session_id)
+        if session_ids is not None:
+            stmt = stmt.where(SessionStreamDBE.session_id.in_(session_ids))
+        # Empty exclusions would render an always-true `NOT IN ()`; skip instead.
+        if exclude_session_ids:
+            stmt = stmt.where(SessionStreamDBE.session_id.not_in(exclude_session_ids))
+        if filter.flags is not None:
+            flags_filter = filter.flags.model_dump(
+                exclude_none=True, exclude_unset=True
+            )
+            if flags_filter:
+                stmt = stmt.where(SessionStreamDBE.flags.contains(flags_filter))
+        if filter.tags:
+            stmt = stmt.where(SessionStreamDBE.tags.contains(filter.tags))
+        if filter.exclude_tags:
+            # `NOT (tags @> …)` is NULL — not true — for a row with no tags, which would drop
+            # every session written before origins were stamped. Admit those explicitly.
+            stmt = stmt.where(
+                or_(
+                    SessionStreamDBE.tags.is_(None),
+                    not_(SessionStreamDBE.tags.contains(filter.exclude_tags)),
+                )
+            )
+        term = filter.search.strip() if filter.search else ""
+        if term:
+            # Escape LIKE metacharacters so a literal `%`/`_` in the search term
+            # doesn't act as a wildcard.
+            escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            stmt = stmt.where(SessionStreamDBE.name.ilike(f"%{escaped}%", escape="\\"))
+        return stmt
+
+    async def count(
+        self,
+        *,
+        project_id: UUID,
+        filter: SessionStreamQuery,
+        session_ids: Optional[List[str]] = None,
+        exclude_session_ids: Optional[List[str]] = None,
+    ) -> int:
+        """Total rows matching the filter, ignoring windowing — the number a filter chip
+        shows. Deliberately separate from `query` so a page fetch pays for it only when a
+        caller asks."""
+        async with self.engine.session() as session:
+            stmt = self._apply_filters(
+                select(func.count()).select_from(SessionStreamDBE),
+                project_id=project_id,
+                filter=filter,
+                session_ids=session_ids,
+                exclude_session_ids=exclude_session_ids,
+            )
+            result = await session.execute(stmt)
+        return int(result.scalar_one() or 0)
+
     async def query(
         self,
         *,
@@ -122,35 +192,16 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
         filter: SessionStreamQuery,
         windowing: Optional[Windowing] = None,
         session_ids: Optional[List[str]] = None,
+        exclude_session_ids: Optional[List[str]] = None,
     ) -> List[SessionStream]:
         async with self.engine.session() as session:
-            stmt = select(SessionStreamDBE).where(
-                SessionStreamDBE.project_id == project_id,
+            stmt = self._apply_filters(
+                select(SessionStreamDBE),
+                project_id=project_id,
+                filter=filter,
+                session_ids=session_ids,
+                exclude_session_ids=exclude_session_ids,
             )
-            if not filter.include_ended:
-                stmt = stmt.where(SessionStreamDBE.deleted_at.is_(None))
-            if not filter.include_archived:
-                stmt = stmt.where(SessionStreamDBE.archived_at.is_(None))
-            if filter.session_id is not None:
-                stmt = stmt.where(SessionStreamDBE.session_id == filter.session_id)
-            if session_ids is not None:
-                stmt = stmt.where(SessionStreamDBE.session_id.in_(session_ids))
-            if filter.flags is not None:
-                flags_filter = filter.flags.model_dump(
-                    exclude_none=True, exclude_unset=True
-                )
-                if flags_filter:
-                    stmt = stmt.where(SessionStreamDBE.flags.contains(flags_filter))
-            term = filter.search.strip() if filter.search else ""
-            if term:
-                # Escape LIKE metacharacters so a literal `%`/`_` in the search term
-                # doesn't act as a wildcard.
-                escaped = (
-                    term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-                )
-                stmt = stmt.where(
-                    SessionStreamDBE.name.ilike(f"%{escaped}%", escape="\\")
-                )
             if windowing:
                 stmt = apply_windowing(
                     stmt=stmt,

--- a/api/oss/src/tasks/asyncio/triggers/dispatcher.py
+++ b/api/oss/src/tasks/asyncio/triggers/dispatcher.py
@@ -11,7 +11,7 @@ Self-contained so it can run inside its own TaskIQ worker process.
 
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Union
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import uuid_utils.compat as uuid_compat
 
@@ -25,6 +25,13 @@ from oss.src.core.triggers.dtos import (
     TriggerSubscription,
 )
 from oss.src.core.triggers.interfaces import TriggersDAOInterface
+from oss.src.core.sessions.dtos import (
+    SESSION_ORIGIN_TRIGGER,
+    SESSION_TRIGGER_KIND_SCHEDULE,
+    SESSION_TRIGGER_KIND_SUBSCRIPTION,
+    SessionTriggerRef,
+)
+from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.core.workflows.service import WorkflowsService
 from oss.src.utils.logging import get_module_logger
 
@@ -44,10 +51,14 @@ class TriggersDispatcher:
         triggers_dao: TriggersDAOInterface,
         workflows_service: WorkflowsService,
         dispatch_fn: Optional[Callable] = None,
+        streams_service: Optional[SessionStreamsService] = None,
     ):
         self.triggers_dao = triggers_dao
         self.workflows_service = workflows_service
         self._dispatch_fn = dispatch_fn
+        # Optional so existing wiring keeps working; without it a triggered session is
+        # indistinguishable from one a human started.
+        self._streams_service = streams_service
 
     def _build_context(
         self,
@@ -306,9 +317,37 @@ class TriggersDispatcher:
             )
             return
 
+        # Mint the session here rather than letting the runner fall back to its own: owning the
+        # id is what lets this delivery name the session it produced, and lets the row be marked
+        # as automation-started before the run creates it.
+        session_id = uuid4().hex
+        delivery_data = delivery_data.model_copy(update={"session_id": session_id})
+        if self._streams_service is not None:
+            try:
+                await self._streams_service.set_origin(
+                    project_id=project_id,
+                    user_id=user_id,
+                    session_id=session_id,
+                    origin=SESSION_ORIGIN_TRIGGER,
+                    # Stamped here because this is the only place that knows WHICH automation
+                    # fired: nothing links a session back to a trigger afterwards.
+                    trigger=SessionTriggerRef(
+                        id=str(entity.id),
+                        name=entity.name,
+                        kind=(
+                            SESSION_TRIGGER_KIND_SUBSCRIPTION
+                            if is_subscription
+                            else SESSION_TRIGGER_KIND_SCHEDULE
+                        ),
+                    ),
+                )
+            except Exception as e:  # best-effort: a missing tag must not block the run
+                log.warning("[TRIGGERS DISPATCHER] origin stamp failed: %s", e)
+
         request = WorkflowServiceRequest(
             references=references,
             selector=selector,
+            session_id=session_id,
             data=WorkflowRequestData(
                 inputs=inputs if isinstance(inputs, dict) else {"value": inputs},
             ),

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
@@ -1,0 +1,327 @@
+"""Unit tests for the server-side session-list filters: `flags`, `session_ids`,
+`exclude_session_ids`, and `include_total`.
+
+The rule these enforce: a list view's predicates all run server-side. A client that
+filters a windowed page filters the window, not the set — wrong counts, wrong empty
+states. The DAO already honoured flags and an id set; only the public query hid them.
+
+(a) DAO-level: statement-compilation only (no DB), mirroring
+`test_query_sessions_windowing.py`'s dummy-engine monkeypatch pattern.
+(b) Service-level: fake streams/turns services, mirroring `test_sessions_root_service.py`,
+asserting the filters forward and that `references` + `session_ids` INTERSECT.
+"""
+
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from oss.src.core.sessions.dtos import SessionQuery
+from oss.src.core.sessions.service import SessionsService
+from oss.src.core.sessions.streams.dtos import (
+    SessionStream,
+    SessionStreamQuery,
+    SessionStreamQueryFlags,
+)
+from oss.src.dbs.postgres.sessions.streams import dao as dao_module
+
+
+# ---------------------------------------------------------------------------------- #
+# (a) DAO — statement compilation
+# ---------------------------------------------------------------------------------- #
+
+
+class _DummyScalars:
+    def all(self):
+        return []
+
+
+class _DummyResult:
+    def scalars(self):
+        return _DummyScalars()
+
+    def scalar_one(self):
+        return 0
+
+
+class _DummySession:
+    def __init__(self):
+        self.captured_stmt = None
+
+    async def execute(self, stmt):
+        self.captured_stmt = stmt
+        return _DummyResult()
+
+
+class _DummySessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _dao(monkeypatch):
+    session = _DummySession()
+    mock_engine = type(
+        "MockEngine", (), {"session": lambda self: _DummySessionContext(session)}
+    )()
+    monkeypatch.setattr(dao_module, "get_transactions_engine", lambda: mock_engine)
+    return dao_module.SessionStreamsDAO(), session
+
+
+async def _run_query(monkeypatch, **kwargs):
+    dao, session = _dao(monkeypatch)
+    await dao.query(project_id=uuid4(), filter=kwargs.pop("filter"), **kwargs)
+    return session.captured_stmt
+
+
+@pytest.mark.asyncio
+async def test_flags_compile_to_a_jsonb_containment_check(monkeypatch):
+    stmt = await _run_query(
+        monkeypatch,
+        filter=SessionStreamQuery(flags=SessionStreamQueryFlags(is_alive=True)),
+    )
+
+    # A JSONB value has no literal renderer, so compile with binds against the real dialect.
+    compiled = stmt.compile(dialect=postgresql.dialect())
+
+    assert "session_streams.flags @>" in str(compiled).replace("\n", " ")
+    assert {"is_alive": True} in compiled.params.values()
+
+
+@pytest.mark.asyncio
+async def test_unset_flags_add_no_predicate(monkeypatch):
+    # An all-None flags object must not narrow to `flags @> {}` (which matches everything
+    # but still costs an index probe) — model_dump(exclude_none) empties it.
+    stmt = await _run_query(
+        monkeypatch, filter=SessionStreamQuery(flags=SessionStreamQueryFlags())
+    )
+
+    sql = str(stmt.compile(dialect=postgresql.dialect()))
+
+    assert "@>" not in sql
+
+
+@pytest.mark.asyncio
+async def test_exclude_session_ids_compiles_to_not_in(monkeypatch):
+    stmt = await _run_query(
+        monkeypatch, filter=SessionStreamQuery(), exclude_session_ids=["a", "b"]
+    )
+
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "NOT IN" in sql.upper()
+
+
+@pytest.mark.asyncio
+async def test_empty_exclusions_add_no_predicate(monkeypatch):
+    # `NOT IN ()` is always true — skipping it keeps the statement (and its plan) clean.
+    stmt = await _run_query(
+        monkeypatch, filter=SessionStreamQuery(), exclude_session_ids=[]
+    )
+
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "NOT IN" not in sql.upper()
+
+
+@pytest.mark.asyncio
+async def test_count_shares_the_query_predicate_without_windowing(monkeypatch):
+    dao, session = _dao(monkeypatch)
+
+    await dao.count(
+        project_id=uuid4(),
+        filter=SessionStreamQuery(search="refund", include_ended=True),
+        exclude_session_ids=["pinned-1"],
+    )
+    sql = str(session.captured_stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "count(" in sql.lower()
+    assert "lower(session_streams.name) LIKE lower(" in sql
+    assert "NOT IN" in sql.upper()
+    # A total must not be windowed, or it would just re-report the page size.
+    assert "LIMIT" not in sql.upper()
+
+
+# ---------------------------------------------------------------------------------- #
+# (b) Service — forwarding and intersection
+# ---------------------------------------------------------------------------------- #
+
+
+_PROJECT = uuid4()
+
+
+def _stream(session_id: str) -> SessionStream:
+    return SessionStream(id=uuid4(), project_id=_PROJECT, session_id=session_id)
+
+
+class _FakeStreamsService:
+    def __init__(self, streams: Optional[List[SessionStream]] = None):
+        self.streams = streams if streams is not None else []
+        self.captured: Dict[str, object] = {}
+        self.count_captured: Dict[str, object] = {}
+
+    async def query_streams(
+        self,
+        *,
+        project_id,
+        filter,
+        windowing=None,
+        session_ids=None,
+        exclude_session_ids=None,
+    ):
+        self.captured = {
+            "filter": filter,
+            "session_ids": session_ids,
+            "exclude_session_ids": exclude_session_ids,
+        }
+        return self.streams
+
+    async def count_streams(
+        self, *, project_id, filter, session_ids=None, exclude_session_ids=None
+    ):
+        self.count_captured = {
+            "filter": filter,
+            "session_ids": session_ids,
+            "exclude_session_ids": exclude_session_ids,
+        }
+        return 42
+
+
+class _FakeTurn:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.references = None
+
+
+class _FakeTurnsService:
+    def __init__(self, session_ids: List[str]):
+        self.session_ids = session_ids
+
+    async def query_turns(self, *, project_id, query):
+        return [_FakeTurn(sid) for sid in self.session_ids]
+
+    async def latest_turn_per_session(self, *, project_id, session_ids):
+        return {}
+
+
+def _service(streams_service, turns_service) -> SessionsService:
+    return SessionsService(
+        streams_service=streams_service,
+        turns_service=turns_service,
+        interactions_service=None,
+        mounts_service=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_flags_and_exclusions_forward_to_the_streams_query():
+    streams = _FakeStreamsService([_stream("s1")])
+    service = _service(streams, _FakeTurnsService([]))
+
+    await service.query_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(
+            flags=SessionStreamQueryFlags(is_running=True),
+            exclude_session_ids=["pinned-1"],
+        ),
+    )
+
+    assert streams.captured["filter"].flags == SessionStreamQueryFlags(is_running=True)
+    assert streams.captured["exclude_session_ids"] == ["pinned-1"]
+
+
+@pytest.mark.asyncio
+async def test_session_ids_restrict_the_query_when_no_references_are_given():
+    streams = _FakeStreamsService([_stream("s1")])
+    service = _service(streams, _FakeTurnsService([]))
+
+    await service.query_sessions(
+        project_id=_PROJECT, query=SessionQuery(session_ids=["s2", "s1"])
+    )
+
+    assert streams.captured["session_ids"] == ["s1", "s2"]
+
+
+@pytest.mark.asyncio
+async def test_references_and_session_ids_intersect():
+    # Each is a narrowing filter, so only ids satisfying BOTH survive — a pinned session
+    # belonging to another agent must not appear under an agent filter.
+    streams = _FakeStreamsService([_stream("s2")])
+    service = _service(streams, _FakeTurnsService(["s1", "s2"]))
+
+    await service.query_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(references=[{"id": str(uuid4())}], session_ids=["s2", "s3"]),
+    )
+
+    assert streams.captured["session_ids"] == ["s2"]
+
+
+@pytest.mark.asyncio
+async def test_disjoint_reference_and_id_filters_short_circuit_to_empty():
+    streams = _FakeStreamsService([_stream("s1")])
+    service = _service(streams, _FakeTurnsService(["s1"]))
+
+    result = await service.query_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(references=[{"id": str(uuid4())}], session_ids=["s9"]),
+    )
+
+    assert result == []
+    # An empty intersection can match nothing, so the stream query must not run at all.
+    assert streams.captured == {}
+
+
+@pytest.mark.asyncio
+async def test_an_explicitly_empty_id_set_matches_nothing():
+    streams = _FakeStreamsService([_stream("s1")])
+    service = _service(streams, _FakeTurnsService([]))
+
+    result = await service.query_sessions(
+        project_id=_PROJECT, query=SessionQuery(session_ids=[])
+    )
+
+    assert result == []
+    assert streams.captured == {}
+
+
+@pytest.mark.asyncio
+async def test_count_uses_the_same_predicate_as_the_list():
+    streams = _FakeStreamsService([_stream("s1")])
+    service = _service(streams, _FakeTurnsService([]))
+    query = SessionQuery(
+        search="refund",
+        include_ended=True,
+        flags=SessionStreamQueryFlags(is_alive=True),
+        exclude_session_ids=["pinned-1"],
+    )
+
+    await service.query_sessions(project_id=_PROJECT, query=query)
+    total = await service.count_sessions(project_id=_PROJECT, query=query)
+
+    assert total == 42
+    assert streams.count_captured["filter"] == streams.captured["filter"]
+    assert (
+        streams.count_captured["exclude_session_ids"]
+        == streams.captured["exclude_session_ids"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_count_short_circuits_on_an_empty_intersection():
+    streams = _FakeStreamsService([])
+    service = _service(streams, _FakeTurnsService(["s1"]))
+
+    total = await service.count_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(references=[{"id": str(uuid4())}], session_ids=["s9"]),
+    )
+
+    assert total == 0
+    assert streams.count_captured == {}

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_references.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_references.py
@@ -58,7 +58,13 @@ class _FakeStreamsService:
         self.rows = rows
 
     async def query_streams(
-        self, *, project_id, filter, windowing=None, session_ids=None
+        self,
+        *,
+        project_id,
+        filter,
+        windowing=None,
+        session_ids=None,
+        exclude_session_ids=None,
     ):
         if session_ids is not None:
             return [s for s in self.rows if s.session_id in session_ids]

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_search.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_search.py
@@ -145,7 +145,13 @@ class _FakeStreamsService:
         self.query_calls: list[dict] = []
 
     async def query_streams(
-        self, *, project_id, filter, windowing=None, session_ids=None
+        self,
+        *,
+        project_id,
+        filter,
+        windowing=None,
+        session_ids=None,
+        exclude_session_ids=None,
     ):
         self.query_calls.append({"project_id": project_id, "filter": filter})
         return [self.row] if self.row else []

--- a/api/oss/tests/pytest/unit/sessions/test_session_last_message.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_last_message.py
@@ -1,0 +1,220 @@
+"""Unit tests for the session list's last-message preview.
+
+A session row used to carry a title and a timestamp, so deciding whether a session was worth
+reopening meant opening it. The preview closes that, under one constraint: it must cost the
+list ONE query, not one per row — the alternative (`POST /sessions/records/query` per row) is
+the fan-out the sessions router's module docstring rules out.
+
+(a) DAO-level: statement compilation only (no DB), mirroring `test_query_sessions_filters.py`.
+(b) Service-level: fake services, asserting the preview is a single batched call keyed on the
+    whole page and that a deployment without the records engine still lists sessions.
+"""
+
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from oss.src.core.sessions.dtos import SessionQuery
+from oss.src.core.sessions.records.dtos import SessionMessagePreview
+from oss.src.core.sessions.service import SessionsService
+from oss.src.core.sessions.streams.dtos import SessionStream
+from oss.src.dbs.postgres.sessions.records import dao as records_dao_module
+
+
+# ---------------------------------------------------------------------------------- #
+# (a) DAO — statement compilation
+# ---------------------------------------------------------------------------------- #
+
+
+class _DummyResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _DummySession:
+    def __init__(self, rows=()):
+        self.captured_stmt = None
+        self._rows = list(rows)
+
+    async def execute(self, stmt):
+        self.captured_stmt = stmt
+        return _DummyResult(self._rows)
+
+
+class _DummySessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Row:
+    def __init__(self, session_id, record_source, attributes, timestamp=None):
+        self.session_id = session_id
+        self.record_source = record_source
+        self.attributes = attributes
+        self.timestamp = timestamp
+        self.created_at = None
+
+
+def _dao(rows=()):
+    session = _DummySession(rows)
+    engine = type(
+        "MockEngine", (), {"session": lambda self: _DummySessionContext(session)}
+    )()
+    return records_dao_module.RecordsDAO(engine=engine), session
+
+
+@pytest.mark.asyncio
+async def test_preview_is_one_distinct_on_query_for_the_whole_page():
+    dao, session = _dao()
+
+    await dao.latest_message_per_session(
+        project_id=uuid4(), session_ids=["a", "b", "c"]
+    )
+
+    sql = str(session.captured_stmt.compile(dialect=postgresql.dialect())).replace(
+        "\n", " "
+    )
+
+    # One statement, one row per session — not three round-trips.
+    assert "DISTINCT ON (records.session_id)" in sql
+    assert "records.session_id IN" in sql
+
+
+@pytest.mark.asyncio
+async def test_preview_reads_messages_only():
+    # `done`/`usage` are bookkeeping and `thought` is not addressed to anyone; a row previewing
+    # either says nothing about what happened.
+    dao, session = _dao()
+
+    await dao.latest_message_per_session(project_id=uuid4(), session_ids=["a"])
+
+    compiled = session.captured_stmt.compile(dialect=postgresql.dialect())
+
+    assert "records.record_type" in str(compiled).replace("\n", " ")
+    assert "message" in compiled.params.values()
+
+
+@pytest.mark.asyncio
+async def test_newest_message_wins_on_producer_event_time():
+    # `record_index` restarts every turn, so ordering on it alone would preview the newest
+    # message OF THE FIRST TURN once a session has more than one.
+    dao, session = _dao()
+
+    await dao.latest_message_per_session(project_id=uuid4(), session_ids=["a"])
+
+    sql = str(session.captured_stmt.compile(dialect=postgresql.dialect())).replace(
+        "\n", " "
+    )
+
+    assert "ORDER BY records.session_id, records.timestamp DESC NULLS LAST" in sql
+
+
+@pytest.mark.asyncio
+async def test_no_ids_asks_the_database_nothing():
+    dao, session = _dao()
+
+    assert (
+        await dao.latest_message_per_session(project_id=uuid4(), session_ids=[]) == {}
+    )
+    assert session.captured_stmt is None
+
+
+@pytest.mark.asyncio
+async def test_a_message_without_text_has_nothing_to_preview():
+    # An attachment-only message carries no `text`; a row must not preview an empty string.
+    dao, _ = _dao(
+        rows=[
+            _Row("with-text", "user", {"type": "message", "text": "  ship it  "}),
+            _Row("no-text", "agent", {"type": "message"}),
+            _Row("blank", "agent", {"type": "message", "text": "   "}),
+            _Row("no-attributes", "agent", None),
+        ]
+    )
+
+    previews = await dao.latest_message_per_session(
+        project_id=uuid4(),
+        session_ids=["with-text", "no-text", "blank", "no-attributes"],
+    )
+
+    assert set(previews) == {"with-text"}
+    assert previews["with-text"].text == "ship it"
+    assert previews["with-text"].source == "user"
+
+
+# ---------------------------------------------------------------------------------- #
+# (b) Service — batching and graceful absence
+# ---------------------------------------------------------------------------------- #
+
+
+class _FakeStreamsService:
+    def __init__(self, streams):
+        self._streams = streams
+
+    async def query_streams(self, **kwargs):
+        return self._streams
+
+
+class _FakeTurnsService:
+    async def latest_turn_per_session(self, **kwargs):
+        return {}
+
+
+class _FakeRecordsService:
+    def __init__(self, previews: Dict[str, SessionMessagePreview]):
+        self._previews = previews
+        self.calls: List[Optional[List[str]]] = []
+
+    async def latest_message_per_session(self, *, project_id, session_ids):
+        self.calls.append(list(session_ids))
+        return self._previews
+
+
+def _stream(session_id: str) -> SessionStream:
+    return SessionStream(project_id=uuid4(), session_id=session_id)
+
+
+def _service(records_service=None) -> SessionsService:
+    return SessionsService(
+        streams_service=_FakeStreamsService([_stream("a"), _stream("b")]),
+        turns_service=_FakeTurnsService(),
+        interactions_service=object(),
+        mounts_service=object(),
+        records_service=records_service,
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_whole_page_is_previewed_in_one_call():
+    records = _FakeRecordsService(
+        {"a": SessionMessagePreview(session_id="a", text="ship it", source="user")}
+    )
+
+    items = await _service(records).query_sessions(
+        project_id=uuid4(), query=SessionQuery()
+    )
+
+    assert records.calls == [["a", "b"]]
+    assert items[0].last_message.text == "ship it"
+    # A session with no message yet is a row without a preview, not a missing row.
+    assert items[1].last_message is None
+
+
+@pytest.mark.asyncio
+async def test_sessions_still_list_without_the_records_engine():
+    items = await _service(records_service=None).query_sessions(
+        project_id=uuid4(), query=SessionQuery()
+    )
+
+    assert [item.session_id for item in items] == ["a", "b"]
+    assert all(item.last_message is None for item in items)

--- a/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
@@ -1,0 +1,138 @@
+"""Unit tests for the automation stamp on a session row.
+
+An automation run is a session nobody named, so its row could say what the run did but never
+what fired it: `ag.origin` recorded only THAT something automated started it. The trigger's
+identity is stamped by the same writer as the origin — `set_origin` replaces tags wholesale, so
+a second writer would need a merge it does not have.
+
+The name is a snapshot, not a live join; see `SessionTriggerRef`.
+"""
+
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+from oss.src.core.sessions.dtos import (
+    SESSION_ORIGIN_MANUAL,
+    SESSION_ORIGIN_TAG,
+    SESSION_ORIGIN_TRIGGER,
+    SESSION_TRIGGER_ID_TAG,
+    SESSION_TRIGGER_KIND_SCHEDULE,
+    SESSION_TRIGGER_KIND_TAG,
+    SESSION_TRIGGER_NAME_TAG,
+    SessionTriggerRef,
+)
+from oss.src.core.sessions.streams.dtos import SessionStream
+from oss.src.core.sessions.streams.service import SessionStreamsService
+
+
+class _RecordingDAO:
+    """Captures what `set_origin` writes. `update` returning a row is the common path — the
+    stream usually does not exist yet, but either branch writes the same tags."""
+
+    def __init__(self, *, row_exists: bool = True) -> None:
+        self.row_exists = row_exists
+        self.updated_tags: Optional[Dict[str, Any]] = None
+        self.created_tags: Optional[Dict[str, Any]] = None
+
+    async def update(self, *, project_id, user_id, session_id, stream):
+        self.updated_tags = stream.tags
+        if not self.row_exists:
+            return None
+        return SessionStream(
+            id=uuid4(),
+            project_id=project_id,
+            session_id=session_id,
+            tags=stream.tags,
+        )
+
+    async def create(self, *, project_id, user_id, stream):
+        self.created_tags = stream.tags
+        return SessionStream(
+            id=uuid4(),
+            project_id=project_id,
+            session_id=stream.session_id,
+            tags=stream.tags,
+        )
+
+
+def _service(dao) -> SessionStreamsService:
+    return SessionStreamsService(streams_dao=dao, lock_engine=None)
+
+
+SESSION_ID = "0" * 32
+PROJECT_ID = UUID(int=1)
+
+
+@pytest.mark.asyncio
+async def test_manual_origin_stamps_no_trigger():
+    dao = _RecordingDAO()
+    await _service(dao).set_origin(
+        project_id=PROJECT_ID,
+        user_id=None,
+        session_id=SESSION_ID,
+        origin=SESSION_ORIGIN_MANUAL,
+    )
+    assert dao.updated_tags == {SESSION_ORIGIN_TAG: SESSION_ORIGIN_MANUAL}
+
+
+@pytest.mark.asyncio
+async def test_trigger_identity_rides_the_origin_write():
+    # One write, not two: the tags column is replaced wholesale.
+    dao = _RecordingDAO()
+    trigger_id = str(uuid4())
+    await _service(dao).set_origin(
+        project_id=PROJECT_ID,
+        user_id=None,
+        session_id=SESSION_ID,
+        origin=SESSION_ORIGIN_TRIGGER,
+        trigger=SessionTriggerRef(
+            id=trigger_id,
+            name="Nightly digest",
+            kind=SESSION_TRIGGER_KIND_SCHEDULE,
+        ),
+    )
+    assert dao.updated_tags == {
+        SESSION_ORIGIN_TAG: SESSION_ORIGIN_TRIGGER,
+        SESSION_TRIGGER_ID_TAG: trigger_id,
+        SESSION_TRIGGER_NAME_TAG: "Nightly digest",
+        SESSION_TRIGGER_KIND_TAG: SESSION_TRIGGER_KIND_SCHEDULE,
+    }
+    assert dao.created_tags is None
+
+
+@pytest.mark.asyncio
+async def test_unnamed_trigger_omits_the_name_rather_than_stamping_empty():
+    # A blank name would render as a blank row title; absence lets the row fall back.
+    dao = _RecordingDAO()
+    trigger_id = str(uuid4())
+    await _service(dao).set_origin(
+        project_id=PROJECT_ID,
+        user_id=None,
+        session_id=SESSION_ID,
+        origin=SESSION_ORIGIN_TRIGGER,
+        trigger=SessionTriggerRef(id=trigger_id, name=None, kind=None),
+    )
+    assert dao.updated_tags == {
+        SESSION_ORIGIN_TAG: SESSION_ORIGIN_TRIGGER,
+        SESSION_TRIGGER_ID_TAG: trigger_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_branch_stamps_the_same_tags():
+    # The row usually does NOT exist yet — the stamp happens before the run creates it.
+    dao = _RecordingDAO(row_exists=False)
+    trigger_id = str(uuid4())
+    await _service(dao).set_origin(
+        project_id=PROJECT_ID,
+        user_id=None,
+        session_id=SESSION_ID,
+        origin=SESSION_ORIGIN_TRIGGER,
+        trigger=SessionTriggerRef(
+            id=trigger_id, name="On PR opened", kind="subscription"
+        ),
+    )
+    assert dao.created_tags == dao.updated_tags
+    assert dao.created_tags[SESSION_TRIGGER_NAME_TAG] == "On PR opened"

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
@@ -65,7 +65,13 @@ class _FakeStreamsService:
         self.query_calls: list[dict] = []
 
     async def query_streams(
-        self, *, project_id, filter, windowing=None, session_ids=None
+        self,
+        *,
+        project_id,
+        filter,
+        windowing=None,
+        session_ids=None,
+        exclude_session_ids=None,
     ):
         self.query_calls.append(
             {
@@ -208,15 +214,34 @@ async def test_delete_session_fans_out_to_turns_interactions_mounts_and_stream()
     ]
 
 
+class _ExplodingRecordsService:
+    """Any records call at all fails the test."""
+
+    async def latest_message_per_session(self, **kwargs):
+        raise AssertionError("delete must not read or write records")
+
+
 @pytest.mark.asyncio
 async def test_delete_session_never_touches_records():
-    # No records service is even injected into SessionsService -- the fan-out
-    # has no path to a records call. This test pins that absence structurally:
-    # SessionsService's constructor accepts no records_service.
-    import inspect
+    # The fan-out deletes streams, turns, interactions and mounts; records live in the
+    # tracing DB and their lifecycle is tracing retention's, not this service's. The list
+    # query DOES read them for its preview, so the invariant can no longer be pinned by the
+    # constructor's shape -- it is pinned by wiring in a records service that explodes on
+    # contact and running the delete against it.
+    streams = _FakeStreamsService(row=None)
+    svc = SessionsService(
+        streams_service=streams,
+        turns_service=_FakeTurnsService(),
+        interactions_service=_FakeInteractionsService(),
+        mounts_service=_FakeMountsService(),
+        records_service=_ExplodingRecordsService(),
+    )
 
-    params = inspect.signature(SessionsService.__init__).parameters
-    assert "records_service" not in params
+    await svc.delete_session(project_id=_PROJECT, user_id=_USER, session_id=_SESSION)
+
+    assert streams.hard_delete_calls == [
+        {"project_id": _PROJECT, "session_id": _SESSION}
+    ]
 
 
 @pytest.mark.asyncio
@@ -296,12 +321,17 @@ async def test_query_sessions_no_filter_returns_all_streams():
 
     result = await svc.query_sessions(project_id=_PROJECT)
 
-    # `SessionListItem` (stream fields + `references`), not the bare `SessionStream` --
-    # equality is type-sensitive in pydantic, so compare the inherited fields as a dict
-    # (full-field pinning) and assert the added field separately.
+    # `SessionListItem` (stream fields + the read-time enrichments), not the bare
+    # `SessionStream` -- equality is type-sensitive in pydantic, so compare the inherited
+    # fields as a dict (full-field pinning) and assert the added fields separately.
     assert len(result) == 1
-    assert result[0].model_dump(exclude={"references"}) == stream.model_dump()
+    assert (
+        result[0].model_dump(exclude={"references", "last_message"})
+        == stream.model_dump()
+    )
     assert result[0].references is None
+    # No records service wired here, so the row lists without a preview rather than failing.
+    assert result[0].last_message is None
     assert streams.query_calls[0]["session_ids"] is None
 
 


### PR DESCRIPTION
## Context
The sessions UX rework needs three things the sessions API did not provide: knowing which sessions an automation started (so the list can hide them by default and show them as a mode), filtering the list by liveness or an explicit id set (for the "waiting" pushdown), and a per-session last message for previews.

## Changes
- Sessions created by a dispatched trigger are stamped with `origin: "trigger"` and a reference to the trigger that started them. Queue-dispatched triggers stamp the same way.
- The session list accepts an origin filter (used to exclude automation runs by default), a liveness filter, and an explicit id set.
- A session can report its last message, so list rows render a preview without loading the transcript.

## Tests / notes
- New unit tests: `test_session_trigger_stamp`, `test_session_last_message`, `test_query_sessions_filters`; updated root-service, search and references tests.
- Based on `feat/mobile-parity-and-consolidation`, not `main`: the changes build on that branch's session liveness and records work, and the patch does not apply on `main` (two of the test files do not exist there).
