### PR TITLE
refactor(frontend): Move the PanelSection family into @agenta/ui

### DIFF
--- a/docs/design/sessions-packages/plan.md
+++ b/docs/design/sessions-packages/plan.md
@@ -1,0 +1,205 @@
+# Sessions / agents UX — package extraction plan
+
+Plan for the lanes that split this work into packages. The branch sits on top of
+`origin/feat/mobile-parity-and-consolidation` (#5691).
+
+---
+
+## Goal
+
+The `/apps`, `/overview`, `/agents`, templates and `/sessions` rework currently sits in
+`web/oss`. Extract it so the **decisions** live in packages and the apps only compose, with
+the UI layer antd-free so `web/mobile` can adopt it after its release.
+
+The test to hold everything to: **changing a rule** — e.g. "automations replaces the set
+rather than adding to it" — **must be one edit in a package that every surface inherits.**
+Today that rule lives in `SessionsPage`, and mobile re-derives its own.
+
+## Layering
+
+```text
+@agenta/shared → @agenta/ui → @agenta/entities → @agenta/sessions → @agenta/sessions-ui
+                                                      headless          antd-free
+```
+
+`@agenta/entities/session` keeps what it owns: the zod schema, the fetch (`querySessions`) and
+the key/request factory (`listOptions`). `@agenta/sessions` is new and owns **orchestration** —
+the mounted hooks with their paging policy, the filters, grouping and view-models. That boundary is what reconciles this
+with the earlier "no new package for entity state" decision.
+
+---
+
+## Lane 1 — `@agenta/ui` primitives + surfaces
+
+Two parts. The second is a move; **the first is new work** and was the surprise from the
+lane-0 audit.
+
+### 1a. Missing primitives — RESOLVED: nothing to build
+
+The lane-0 audit predated the rebase onto `feat/mobile-parity-and-consolidation`, which
+brought the full shadcn/Radix set into `@agenta/ui/src/components/ui/` (exported via the
+`./ui` subpath). `Tooltip`, `DropdownMenu`, and `Switch` all exist, all Radix, antd
+mentioned only in skin comments. `EnhancedButton` is antd-free at **runtime** — a facade
+over `ui/button` (Radix Slot + cva) and the Radix `ui/tooltip` — so `Button` does not
+join the lane either.
+
+`Typography` is not needed — semantic HTML + tokens.
+
+Remaining 1a work is zero; lanes 3–4 import from `@agenta/ui/ui`.
+
+### 1b. Surfaces (move)
+
+`oss/src/components/PanelSection/` → `@agenta/ui`: `PanelSurface`, `PanelScroll`,
+`PanelSection`, `PANEL_ACTION_CLASS`. Already antd-free. Drop the THROWAWAY marker — four
+pages depend on it.
+
+The `RichChatInput` composer fill (`colorFillTertiary`) was already carried across by the
+rebase (`RichChatInput.tsx` uses `bg-[var(--ag-colorFillTertiary)]`) — nothing to do.
+
+**Gotchas to preserve in the move:**
+- Sticky headers need an **opaque** background, never a fill token — rows scroll through rgba.
+- A scroll container with `padding-top` cannot host a `top-0` sticky child; the sticky element
+  supplies its own top spacing. This is documented in the code and must survive extraction.
+
+---
+
+## Lane 2 — `@agenta/sessions` (headless)
+
+**Rule: zero UI imports.** No React components, no antd, no `@agenta/ui`. Hooks and atoms only.
+Enforce with an eslint `no-restricted-imports` rule in the package.
+
+### What moves in
+
+From `oss/src/components/pages/sessions/`:
+
+- `state/filters.ts` — the filter atoms **and their semantics**:
+  - `sessionShowTriggeredAtom` = **mode** (automations *replace* the set → `origin: "trigger"`)
+  - `sessionShowArchivedAtom` = **include** (widens the set)
+  - status: `all` / `live` / `waiting`
+- `state/pins.ts` — per-project pin storage, `toggleSessionPinAtom`. The module doc already
+  notes it's the port for a future server-side implementation; keep that.
+- `state/useSessionList.ts` — the infinite query, cursor handling, the `waitingSessionIds`
+  pushdown, `excludeOrigin` semantics.
+- `assets/sessionRowTitle.ts` (+ its 5 tests), `sessionRowStatus.ts`, `sessionPreview.ts`,
+  `sessionTrigger.ts` (`sessionTriggerName`, `sessionTriggerKind`, `isAutomationSession`).
+
+### What gets built here (currently inline in pages)
+
+- **Grouping rules** — pinned vs recent; when a group header is warranted (only when a pinned
+  group exists); the label (`Recent` vs `Automation runs` by mode).
+- **A row view-model** — a row should reach the UI with nothing left to decide: resolved title,
+  status, preview text, agent id/label, relative time, `isAutomation`, `isPinned`.
+- **A list hook** that returns groups + paging state, so a page renders and does not derive.
+
+### Public API sketch
+
+```ts
+useSessionsList({ agentId?, scope? }) => {
+  groups: {key: "pinned" | "recent"; label?: string; rows: SessionRowVm[]}[]
+  paging: {hasNext: boolean; isLoadingNext: boolean; loadNext(): void}
+  isPending, isError, refetch
+}
+useSessionFilters() => {status, agentId, search, mode, includeArchived, set*}
+useSessionPins()   => {isPinned(id), toggle(id)}
+```
+
+**Do not** move: the rail markup, the antd controls, anything that renders.
+
+---
+
+## Lane 3 — `@agenta/sessions-ui` (antd-free)
+
+**STATUS (2026-08-06): shipped** through `87726d64b2` — `SessionRow` (VM-driven, neutral
+menu shape, `revealActionsOnHover` for touch), the list states, group header, pager, and
+the four filter controls bound to `useSessionFilters`. The desktop page and rail compose
+them; right-click stays an app-side antd affordance. `SessionListCard`'s orchestration
+moved to `useSessionCardList` in lane 2's package; its antd-free re-skin rides with the
+mobile adoption stack.
+
+Depends on lanes 1 + 2. Eslint bans `antd`.
+
+Components: `SessionRow`, `SessionListCard`, the filter **controls** (status list, mode switch,
+archived switch, search input), group header, pager, list empty/error/skeleton states.
+
+### Two rules that make this genuinely reusable
+
+1. **Slots for anything not yet portable.** The agent picker stays antd (`EntityPicker` is out
+   of the migration's scope), so the filter controls take `agentPicker?: ReactNode` and the app
+   injects it. Mobile later injects a sheet. No exceptions to the antd ban, no blocked lane.
+2. **Shells stay per-surface.** A 280px rail and a mobile filter sheet are two shells over one
+   set of controls. The package exports controls; each app owns its shell. This is why the rail
+   markup stays in lane 8.
+
+Affordance note: the kebab and pin are hover-revealed on web. Touch has no hover, so these must
+be props/slots rather than baked in, or mobile inherits a dead control.
+
+---
+
+## Lane 4 — `@agenta/entity-ui` agent surfaces
+
+`AgentCard` (both variants), `NewAgentButton`, `NextTriggers`, `UsageSummary`. Same antd ban and
+slot technique. `AgentCard`'s avatar colour hashes the **workflow id**, not the name — two agents
+share the name "New agent" constantly, and hashing the name gave them the same avatar.
+
+**STATUS (2026-08-06): shipped, with a narrower cut than first listed.** The test applied:
+a component ports only if a headless contract survives with logic left in it.
+
+- `AgentCard` ✅ → `@agenta/entity-ui/agent` (antd-free, eslint-scoped to `src/agent/**`):
+  neutral `AgentCardData` + callbacks; the data-connected cells (`AgentActivityCell`,
+  `UserReference`) arrive as `activity`/`owner` slots. The oss `components/AgentCard`
+  became the adapter, so the two call-sites didn't change.
+- `NextTriggers` ✅ → `NextTriggersSection` in the same module: trigger data via
+  `@agenta/entities/gatewayTrigger`; the classified agents list is app state, so display
+  names arrive as an `agentNames` map from the oss adapter.
+- `UsageSummary` ✗ stays app-side: it is a thin composition over observability dashboard
+  state, `Filters/Sort`, and the dynamic `AnalyticsDashboard` — a port would leave an
+  empty shell, and mobile won't render those charts.
+- `NewAgentButton` ✗ stays app-side: router pushes + the `AGENT_TEMPLATES` catalog; same
+  empty-shell verdict.
+- `timeAgo` graduated to `@agenta/shared/utils` (was about to grow a third copy).
+
+---
+
+## Lanes 5–9 — the apps
+
+`oss/home-overview` → `oss/agents-page` → `oss/templates` (OSS **and** EE routes — a page needs
+both files or it 404s in EE) → `oss/sessions-page` → `oss/seed-attachments`.
+
+Gate for each: **no logic in the page.** If a page derives a title, decides a group, or encodes a
+filter rule, it belongs in lane 2.
+
+Off the line, against main: `api/session-trigger-stamp`, `entities/trigger-helpers`.
+
+---
+
+## Per-lane verification
+
+- `git diff --name-only <base>..<lane>` contains exactly that lane's files
+- `pnpm lint-fix` clean; `pnpm --filter @agenta/oss exec tsc --noEmit` shows no new errors
+  (gate on the error-signature diff, not the count — it fluctuates with cache)
+- Package lanes: `pnpm turbo run build --filter=@agenta/<pkg>` and their unit tests
+- Lanes 1, 3, 4: the package eslint `no-restricted-imports` rule (`antd`, `antd/*`,
+  `@ant-design/*`) is the gate; a `grep -rn antd src` is only a spot check
+
+## Out of scope here
+
+Migrating `mobile/src/features/sessions/` (which today duplicates list logic in
+`useSessionListHead` / `useSessionListScrollRestore`) onto these packages. That is its own stack,
+**after** mobile's release. It is also the lane that proves the extraction was real — without it
+we ship a package and a duplicate side by side.
+
+## Open decisions — RESOLVED
+
+1. **Yes, `EnhancedButton` is antd-free at runtime** (facade over Radix `ui/button` +
+   `ui/tooltip`; local antd-compatible prop types, no antd import). Lane 1a is empty — see
+   above.
+2. **New `@agenta/sessions` package.** The consolidation branch itself created
+   `@agenta/chat` as a headless orchestration package, which settles the precedent: the
+   earlier "no new package" ruling was about *entity state*, and schema/`listOptions`/query
+   stay in `@agenta/entities/session`. Orchestration (filters, grouping, row view-model,
+   pins) mirrors `@agenta/chat`'s shape.
+3. **`@agenta/entity-ui` under a new `./agent` subpath.** The package already exports
+   per-module subpaths (`./variant`, `./workflow`, …), so mobile can import
+   `@agenta/entity-ui/agent` without touching the antd modules. The antd ban is enforced by
+   eslint on that directory. A separate package would add a workspace unit for four
+   components with no distinct dependency profile.

--- a/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
@@ -212,7 +212,10 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                         // Single rounded border around the whole composer; overflow-hidden clips the
                         // editor + toolbar to the rounded corners. The toolbar has no divider of its
                         // own, so the bottom edge reads as one border, not two.
-                        "relative flex flex-col overflow-hidden rounded-lg border border-solid bg-[var(--ag-colorBgContainer)] shadow-[var(--ag-surface-chat-shadow)] transition-colors",
+                        // Filled, not transparent: an outlined box reads as an outline, where a fill reads as
+                        // somewhere to type. A FILL token rather than an opaque surface — it lifts off the
+                        // page in dark and settles into it in light, where "elevated" is the page colour.
+                        "relative flex flex-col overflow-hidden rounded-lg border border-solid bg-[var(--ag-colorFillTertiary)] shadow-[var(--ag-surface-chat-shadow)] transition-colors",
                         // The primary input reads as a defined, slightly-lifted field: a visible edge
                         // + soft shadow, then the accent border on focus (1px, no glow).
                         "border-[var(--ag-composer-border)] focus-within:border-[var(--ag-composer-focus)]",

--- a/web/packages/agenta-ui/src/components/presentational/index.ts
+++ b/web/packages/agenta-ui/src/components/presentational/index.ts
@@ -200,10 +200,15 @@ export {
     NumberedStep,
     PanelFooter,
     ModalContentLayout,
+    PanelSurface,
+    PanelScroll,
+    PanelSection,
+    PANEL_ACTION_CLASS,
     type SplitPanelLayoutProps,
     type NumberedStepProps,
     type PanelFooterProps,
     type ModalContentLayoutProps,
+    type PanelSectionProps,
 } from "./layout"
 
 // ============================================================================

--- a/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
@@ -1,0 +1,126 @@
+import type {ReactNode} from "react"
+
+/**
+ * The section language for rail/page surfaces (`/apps`, `/overview`, `/agents`, `/sessions`).
+ *
+ * Modelled on a project-page idiom rather than on the playground panel. Two rules carry most of
+ * it: the rail is ONE bordered container holding hairline-separated sections, and the main column
+ * has no container at all — bare rows under a muted label. That contrast is what keeps the page
+ * from reading as uniform; when both columns were sheets with filled header bands, every region
+ * looked equally important and the density read as clutter.
+ *
+ * There are no filled bands here. Section headers are distinguished by weight and size, which is
+ * also why the type scale on these pages runs wider than the app's 12px default.
+ */
+
+/** The rail column's frame. Transparent now — the sections are the cards, and a card inside a
+ * card was exactly the "one monolithic block" problem. The cap (`max-h-full min-h-0`) lives here,
+ * not at call sites: without it {@link PanelScroll} grows with its content and never scrolls. */
+export const PanelSurface = ({children, className}: {children: ReactNode; className?: string}) => (
+    <div className={`box-border flex max-h-full min-h-0 flex-col ${className ?? ""}`}>
+        {children}
+    </div>
+)
+
+/**
+ * The scrolling half of the rail, INSIDE {@link PanelSurface}.
+ *
+ * The column used to scroll and the surface rode along inside it, which broke twice: the surface's
+ * own top border scrolled away and left the pinned header floating against nothing, and a surface
+ * told to fill the column clipped whatever exceeded it, since the column never grew past its own
+ * height and so never scrolled. Scrolling belongs inside the frame: the border stays put, the
+ * headers pin just below it, and nothing is unreachable.
+ *
+ * The frame is capped (`max-h-full`), not stretched: a stretched frame is full of empty bordered
+ * container whenever the sections don't reach the bottom, which is most of the time.
+ *
+ * A scroll container with `padding-top` cannot host a `top-0` sticky child; the sticky element
+ * supplies its own top spacing.
+ */
+export const PanelScroll = ({children}: {children: ReactNode}) => (
+    <div className="flex min-h-0 shrink flex-col gap-3 overflow-y-auto pr-1">{children}</div>
+)
+
+/**
+ * The one style for a section header's action — "View all", "Expand", "+ New agent".
+ *
+ * They had drifted into three treatments (accent link, accent link with a leading plus, muted text
+ * with a caret), which read as three different kinds of action sitting in identical headers. A
+ * header action is always secondary to the section's rows: muted at rest, full-strength on hover.
+ */
+export const PANEL_ACTION_CLASS =
+    "inline-flex shrink-0 cursor-pointer items-center gap-1 border-0 bg-transparent p-0 text-xs !text-colorTextSecondary transition-colors hover:!text-colorText"
+
+export interface PanelSectionProps {
+    title: ReactNode
+    /** Rendered beside the title, e.g. a count or a "2 waiting" badge. */
+    titleExtra?: ReactNode
+    /** Rendered at the header's right edge, e.g. "View all". */
+    extra?: ReactNode
+    /**
+     * Pin the header while its own section scrolls past. The background it carries is the opaque
+     * page/rail surface, never a fill token — an rgba fill lets the rows scroll through it visibly,
+     * and `colorBgLayout` is a shade neither surface actually uses.
+     */
+    sticky?: boolean
+    /** `rail` sits inside {@link PanelSurface}; `page` sits bare on the page background. */
+    variant?: "rail" | "page"
+    bodyClassName?: string
+    minHeightClassName?: string
+    children: ReactNode
+}
+
+export const PanelSection = ({
+    title,
+    titleExtra,
+    extra,
+    sticky = false,
+    variant = "rail",
+    bodyClassName,
+    minHeightClassName,
+    children,
+}: PanelSectionProps) => {
+    const isRail = variant === "rail"
+    return (
+        <section
+            className={`flex flex-col ${
+                isRail
+                    ? // Each section is its own card. Stacked inside one, they read as a single
+                      // block: same surface, same colour, a hairline carrying every boundary.
+                      // `overflow-clip`, not `-hidden`: hidden makes this the sticky header's
+                      // scroll ancestor, so it never pins against PanelScroll.
+                      "shrink-0 overflow-clip rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated"
+                    : ""
+            } ${minHeightClassName ?? ""}`}
+        >
+            <div
+                className={`flex shrink-0 items-center justify-between gap-2 ${
+                    isRail
+                        ? `bg-colorBgElevated px-4 pb-2 pt-4 ${sticky ? "sticky top-0 z-10" : ""}`
+                        : `px-2 pb-2 pt-2 ${
+                              // The page surface is colorBgContainer (#141414 dark / #fff light);
+                              // colorBgLayout is pure black and paints a bar the page never uses.
+                              sticky ? "sticky top-0 z-10 bg-colorBgContainer" : ""
+                          }`
+                }`}
+            >
+                <div className="flex min-w-0 items-center gap-2">
+                    <h3
+                        className={`m-0 truncate text-[15px] ${
+                            isRail
+                                ? "font-semibold text-colorText"
+                                : "font-medium text-colorTextSecondary"
+                        }`}
+                    >
+                        {title}
+                    </h3>
+                    {titleExtra}
+                </div>
+                {extra}
+            </div>
+            {/* Rows inside a rail section separate by spacing, never by a rule — a rule inside a
+                section competes with the rule that ends it. Lines mean "new section", nothing else. */}
+            <div className={bodyClassName ?? "flex flex-col gap-0.5 px-2 pb-3"}>{children}</div>
+        </section>
+    )
+}

--- a/web/packages/agenta-ui/src/components/presentational/layout/index.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/layout/index.tsx
@@ -101,3 +101,10 @@ export function NumberedStep({number, title, subtitle, children, className}: Num
 export {SplitPanelLayout, type SplitPanelLayoutProps} from "./SplitPanelLayout"
 export {ModalContentLayout, type ModalContentLayoutProps} from "./ModalContentLayout"
 export {PanelFooter, type PanelFooterProps} from "./PanelFooter"
+export {
+    PanelSurface,
+    PanelScroll,
+    PanelSection,
+    PANEL_ACTION_CLASS,
+    type PanelSectionProps,
+} from "./PanelSection"


### PR DESCRIPTION
## Context
Bottom lane of the sessions/agents UX stack (plan: `docs/design/sessions-packages/plan.md`, included here). The Home, overview, templates and sessions pages all speak one "section language" (surface, scroll area, section header with a right-aligned action). That family lived in the oss app, so nothing outside it (and later, mobile) could reuse it.

## Changes
`PanelSurface`, `PanelScroll`, `PanelSection` and `PANEL_ACTION_CLASS` move to `@agenta/ui`'s presentational layout layer. They were already antd-free. Two behaviors are documented in the code and preserved: sticky section headers need an opaque background (rows scroll through rgba fills), and a scroll container with `padding-top` cannot host a `top-0` sticky child, so the sticky element supplies its own top spacing. `RichChatInput` picks up the composer fill (`colorFillTertiary`) so composers read as fields, not outlines.

## Tests / notes
- `pnpm turbo run build --filter=@agenta/ui` passes; `@agenta/oss` tsc is clean on this lane.
- No consumers change in this PR; the app lanes above adopt the new import path.
