### PR TITLE
feat(frontend): @agenta/sessions, the headless session-list package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ skills-lock.json
 # Storybook config is real source — carve it out of the dotfile ignore above.
 !web/storybook/.storybook/
 !web/storybook/.storybook/**
+
+# @agenta/sessions test artifacts (vitest writes a junit report on every run).
+web/packages/agenta-sessions/test-results/

--- a/web/oss/next.config.ts
+++ b/web/oss/next.config.ts
@@ -94,6 +94,7 @@ const COMMON_CONFIG: NextConfig = {
         "@agenta/shared",
         "@agenta/ui",
         "@agenta/chat",
+        "@agenta/sessions",
         "@agenta/entities",
         "@agenta/entity-ui",
         "@agenta/playground",

--- a/web/oss/package.json
+++ b/web/oss/package.json
@@ -31,6 +31,7 @@
         "@agenta/playground": "workspace:../packages/agenta-playground",
         "@agenta/playground-ui": "workspace:../packages/agenta-playground-ui",
         "@agenta/sdk": "workspace:../packages/agenta-sdk",
+        "@agenta/sessions": "workspace:../packages/agenta-sessions",
         "@agenta/shared": "workspace:../packages/agenta-shared",
         "@agenta/ui": "workspace:../packages/agenta-ui",
         "@agenta/web-tests": "workspace:../tests",

--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -260,6 +260,19 @@ export interface QuerySessionsParams {
     includeArchived?: boolean
     /** Case-insensitive substring match over the session title (`session_streams.name`). */
     search?: string
+    /** Liveness filter (alive ⊇ running ⊇ attached) against the row's mirrored flags. */
+    flags?: {is_alive?: boolean; is_running?: boolean; is_attached?: boolean}
+    /** Restrict to an explicit id set — the pushdown for any predicate that lives outside the
+     * stream row (client-held pins, sessions named by a pending-interaction lookup). The server
+     * still owns the intersection, the ordering and the windowing, so counts and empty states
+     * stay correct; filtering a fetched page client-side would filter the window, not the set. */
+    sessionIds?: string[]
+    /** Its complement — drop ids already rendered as their own group (pins) from the main list. */
+    excludeSessionIds?: string[]
+    /** Who started the session: "manual", "trigger". Absent means every origin. */
+    origin?: string
+    /** Hide one origin while still showing sessions written before origins were stamped. */
+    excludeOrigin?: string
     appId?: string
     abortSignal?: AbortSignal
     lowPriority?: boolean
@@ -285,6 +298,11 @@ export async function querySessions({
     includeEnded = true,
     includeArchived = true,
     search,
+    flags,
+    sessionIds,
+    excludeSessionIds,
+    origin,
+    excludeOrigin,
     appId,
     abortSignal,
     lowPriority,
@@ -309,10 +327,23 @@ export async function querySessions({
                 include_ended: includeEnded,
                 include_archived: includeArchived,
                 windowing,
-                // TODO(fern-regen): `search` isn't in the generated SessionQueryRequest yet
-                // (regen out of scope) — widen the type until the client picks it up.
+                // TODO(fern-regen): `search`/`flags`/`session_ids`/`exclude_session_ids` aren't in
+                // the generated SessionQueryRequest yet (regen out of scope) — widen the type
+                // until the client picks them up.
                 search,
-            } as AgentaApi.SessionQueryRequest & {search?: string},
+                flags,
+                session_ids: sessionIds,
+                exclude_session_ids: excludeSessionIds,
+                origin,
+                exclude_origin: excludeOrigin,
+            } as AgentaApi.SessionQueryRequest & {
+                search?: string
+                flags?: QuerySessionsParams["flags"]
+                session_ids?: string[]
+                exclude_session_ids?: string[]
+                origin?: string
+                exclude_origin?: string
+            },
             projectScopedRequest(projectId, appId, abortSignal),
         ),
     )
@@ -548,6 +579,43 @@ export async function querySessionMounts({
         data,
         "[querySessionMounts]",
     )
+    return validated?.mounts ?? null
+}
+
+/**
+ * The durable drive bound to an AGENT rather than to a session — the files an agent carries
+ * between runs (its brief, its reference material) as opposed to a session's scratch mount.
+ *
+ * Backed by `POST /mounts/agents/query`, which takes the workflow ARTIFACT id and resolves the
+ * canonical agent id server-side, so callers pass the same id the rest of the app calls `appId`.
+ * Returns at most one mount; the list shape mirrors the session endpoint.
+ */
+export async function queryAgentMounts({
+    artifactId,
+    projectId,
+    appId,
+    abortSignal,
+    lowPriority,
+}: {
+    artifactId: string
+    projectId: string
+    appId?: string
+    abortSignal?: AbortSignal
+    lowPriority?: boolean
+}): Promise<Mount[] | null> {
+    if (!projectId || !artifactId) return null
+
+    const client = lowPriority ? getLowPriorityMountsClient() : getMountsClient()
+    // maxRetries 1: a small query; recover a transient blip once, but never a long retry pit.
+    const data = await callFern("[queryAgentMounts]", () =>
+        client.queryAgentMount(
+            {artifact_id: artifactId},
+            projectScopedRequest(projectId, appId, abortSignal, 1),
+        ),
+    )
+    if (!data) return null
+
+    const validated = safeParseWithLogging(sessionMountsResponseSchema, data, "[queryAgentMounts]")
     return validated?.mounts ?? null
 }
 

--- a/web/packages/agenta-entities/src/session/core/rowStatus.ts
+++ b/web/packages/agenta-entities/src/session/core/rowStatus.ts
@@ -1,0 +1,33 @@
+import {deriveStreamNest} from "./liveness"
+import type {SessionStream} from "./schema"
+
+/**
+ * What a session row's status indicator means. Ordered by urgency, first match wins: a session
+ * that is both running and gated is *waiting*, because the gate is the part a human must act on.
+ */
+export type SessionRowStatus = "waiting" | "running" | "alive" | "ended" | "archived" | "idle"
+
+/**
+ * One definition of a session's list status, shared by every surface that lists sessions.
+ *
+ * `pendingCount` comes from the project-wide actionable-interactions query; pass `undefined` while
+ * it is unresolved, which reads the same as zero here but lets callers hold off on a "waiting"
+ * filter until they actually know.
+ */
+export function deriveSessionRowStatus(
+    row: SessionStream,
+    pendingCount: number | undefined,
+): SessionRowStatus {
+    // A gate outlives the run that raised it — the turn can finish while the request stays
+    // pending — so this is checked before liveness, not after.
+    if ((pendingCount ?? 0) > 0) return "waiting"
+
+    const nest = deriveStreamNest(row)
+    if (nest.isRunning) return "running"
+    if (nest.isAlive) return "alive"
+
+    // A row can be both archived and ended. Archived is the state the user chose, so it wins.
+    if (row.archived_at) return "archived"
+    if (row.deleted_at) return "ended"
+    return "idle"
+}

--- a/web/packages/agenta-entities/src/session/core/schema.ts
+++ b/web/packages/agenta-entities/src/session/core/schema.ts
@@ -109,6 +109,9 @@ export const sessionStreamSchema = z.object({
     name: z.string().nullish(),
     description: z.string().nullish(),
     turn_id: z.string().nullish(),
+    // Reserved `ag.*` tags. `ag.origin` says a run was automated; `ag.trigger.*` says which
+    // automation, stamped at dispatch because nothing links a session back to a trigger after.
+    tags: z.record(z.string(), z.unknown()).nullish(),
     status: z.object({code: z.string().nullish(), message: z.string().nullish()}).nullish(),
     flags: z
         .object({
@@ -125,6 +128,16 @@ export const sessionStreamSchema = z.object({
     // `/sessions/query` only (WP0-R3): the session's latest turn's workflow/agent references —
     // absent for a session with no turns yet, and for a plain stream fetch (not query'd).
     references: z.array(sessionReferenceSchema).nullish(),
+    // `/sessions/query` only: the session's newest `message` record, so a row can say what
+    // happened rather than only when. Absent for a session with no message yet.
+    last_message: z
+        .object({
+            text: z.string(),
+            /** "user" or "agent" — a row prefixes your own words so a preview isn't read as a reply. */
+            source: z.string().nullish(),
+            timestamp: z.string().nullish(),
+        })
+        .nullish(),
 })
 
 export const sessionStreamsResponseSchema = z.object({

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -21,6 +21,7 @@ export {
     archiveSession as archiveSessionRemote,
     unarchiveSession as unarchiveSessionRemote,
     querySessionMounts,
+    queryAgentMounts,
     queryMountFiles,
     queryLatestMountFiles,
     readMountFile,
@@ -68,6 +69,15 @@ export {
     type SessionStreamNest,
     type SandboxLiveness,
 } from "./core/liveness"
+export {deriveSessionRowStatus, type SessionRowStatus} from "./core/rowStatus"
+export {
+    sessionListQueryOptions,
+    nextSessionCursor,
+    sessionRowsFromPages,
+    SESSIONS_PAGE_SIZE,
+    type SessionListCursor,
+    type SessionListFilters,
+} from "./state/listOptions"
 export {shouldAdoptServerTranscript, type TranscriptAdoptionInput} from "./core/transcriptAdoption"
 export {deriveMountRows, mountBreadcrumbs, type MountRow} from "./core/mountBrowser"
 export {pickCwdMount} from "./core/mountSelection"

--- a/web/packages/agenta-entities/src/session/state/listOptions.ts
+++ b/web/packages/agenta-entities/src/session/state/listOptions.ts
@@ -1,0 +1,114 @@
+import {querySessions} from "../api/api"
+import type {SessionStream} from "../core/schema"
+
+export const SESSIONS_PAGE_SIZE = 30
+
+/** Cursor pair for the activity-ordered window: the last row's id + its activity timestamp. */
+export interface SessionListCursor {
+    next: string
+    newest: string
+}
+
+export interface SessionListFilters {
+    projectId: string
+    search?: string
+    /** Agent workflow id — matched against the turns' references. */
+    agentId?: string | null
+    includeArchived?: boolean
+    includeEnded?: boolean
+    /** Liveness, matched against the row's mirrored flags. */
+    flags?: {is_alive?: boolean; is_running?: boolean; is_attached?: boolean}
+    /** Restrict to an explicit id set — the pushdown for predicates that live outside the stream
+     * row (client-held pins, sessions named by a pending-interaction lookup). */
+    sessionIds?: string[]
+    /** Its complement, so a separately-rendered group (pins) is not listed twice. */
+    excludeSessionIds?: string[]
+    /** Who started the session. The sessions list hides automation runs unless asked. */
+    origin?: string
+    /** Hide one origin. Sessions with no stamp still show — absence is not a match. */
+    excludeOrigin?: string
+    limit?: number
+}
+
+/**
+ * Query key and fetcher for one page of the project's session list.
+ *
+ * An options factory, not a mounted query: query-client policy (stale times, refetch cadence,
+ * suspense) belongs to the app that mounts it, and desktop and mobile do not agree on it. What
+ * they must agree on is the key and the request, which is what lives here.
+ *
+ * Every filter is a server predicate on purpose. Narrowing a fetched page in the browser filters
+ * the window rather than the set, which gets counts and empty states wrong.
+ */
+export const sessionListQueryOptions = (filters: SessionListFilters) => {
+    const {
+        projectId,
+        search = "",
+        agentId = null,
+        includeArchived = false,
+        includeEnded = true,
+        flags,
+        sessionIds,
+        excludeSessionIds,
+        origin,
+        excludeOrigin,
+        limit = SESSIONS_PAGE_SIZE,
+    } = filters
+
+    return {
+        queryKey: [
+            "session-list",
+            projectId,
+            search,
+            agentId,
+            includeArchived,
+            includeEnded,
+            flags ?? null,
+            sessionIds ?? null,
+            excludeSessionIds ?? null,
+            origin ?? null,
+            excludeOrigin ?? null,
+            limit,
+        ] as const,
+        queryFn: ({
+            pageParam,
+            signal,
+        }: {
+            pageParam?: SessionListCursor | null
+            signal?: AbortSignal
+        }) =>
+            querySessions({
+                projectId,
+                search: search.trim() || undefined,
+                references: agentId ? [{id: agentId}] : undefined,
+                includeArchived,
+                includeEnded,
+                flags,
+                sessionIds,
+                excludeSessionIds: excludeSessionIds?.length ? excludeSessionIds : undefined,
+                origin,
+                excludeOrigin,
+                limit,
+                next: pageParam?.next,
+                newest: pageParam?.newest,
+                abortSignal: signal,
+            }),
+        limit,
+    }
+}
+
+/** The cursor for the page after `page`, or `undefined` when it was the last one. */
+export const nextSessionCursor = (
+    page: SessionStream[] | null,
+    limit = SESSIONS_PAGE_SIZE,
+): SessionListCursor | undefined => {
+    if (!page || page.length < limit) return undefined
+    const last = page[page.length - 1]
+    const newest = last.updated_at ?? last.created_at
+    return last.id && newest ? {next: last.id, newest} : undefined
+}
+
+/** Flatten loaded pages, dropping failed ones — `querySessions` resolves null on failure. */
+export const sessionRowsFromPages = (
+    pages: (SessionStream[] | null)[] | undefined,
+): SessionStream[] => (pages ?? []).filter(Boolean).flat() as SessionStream[]

--- a/web/packages/agenta-sessions/eslint.config.mjs
+++ b/web/packages/agenta-sessions/eslint.config.mjs
@@ -1,0 +1,40 @@
+/**
+ * @agenta/sessions is HEADLESS: orchestration only, zero UI imports. The bans below are the
+ * package's contract — mobile consumes these hooks without pulling antd or web components.
+ */
+import base from "../eslint.config.mjs"
+
+export default [
+    ...base,
+    {
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [
+                        {
+                            name: "@agenta/sdk",
+                            message:
+                                "Import per-resource accessors from '@agenta/sdk/resources' — the root barrel bundles all 27 Fern resource clients.",
+                        },
+                    ],
+                    patterns: [
+                        {
+                            group: [
+                                "antd",
+                                "antd/*",
+                                "@ant-design/*",
+                                "@agenta/ui",
+                                "@agenta/ui/*",
+                                "@agenta/entity-ui",
+                                "@agenta/entity-ui/*",
+                            ],
+                            message:
+                                "@agenta/sessions is headless — no UI imports. Rendering belongs in @agenta/sessions-ui or the app.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+]

--- a/web/packages/agenta-sessions/package.json
+++ b/web/packages/agenta-sessions/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "@agenta/sessions",
+    "version": "0.1.0",
+    "private": true,
+    "sideEffects": false,
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "scripts": {
+        "build": "tsc --noEmit",
+        "types:check": "tsc --noEmit",
+        "lint": "eslint --config ./eslint.config.mjs src/",
+        "test": "pnpm run test:unit",
+        "test:unit": "vitest run",
+        "test:watch": "vitest",
+        "test:coverage": "vitest run --coverage",
+        "check": "pnpm run types:check && pnpm run lint"
+    },
+    "exports": {
+        ".": "./src/index.ts",
+        "./state": "./src/state/index.ts",
+        "./row": "./src/row/index.ts"
+    },
+    "dependencies": {
+        "@agenta/entities": "workspace:../agenta-entities",
+        "@agenta/shared": "workspace:../agenta-shared"
+    },
+    "peerDependencies": {
+        "@tanstack/react-query": ">=5.0.0",
+        "jotai": ">=2.0.0",
+        "react": ">=18.0.0"
+    },
+    "devDependencies": {
+        "@tanstack/react-query": "5.100.9",
+        "@types/node": "^20.19.20",
+        "@types/react": "^19.0.10",
+        "@vitest/coverage-v8": "^4.1.4",
+        "jotai": "^2.15.0",
+        "react": "^19.0.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.4"
+    }
+}

--- a/web/packages/agenta-sessions/src/index.ts
+++ b/web/packages/agenta-sessions/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @agenta/sessions — headless orchestration for session lists.
+ *
+ * `@agenta/entities/session` owns the schema, the query options, and the wire types; this
+ * package owns the DECISIONS a session surface makes: filter semantics, the waiting pushdown,
+ * pins, row derivation (title / status / preview / trigger). Rendering lives in
+ * `@agenta/sessions-ui` (antd-free) or the app — this package imports no UI, enforced by
+ * eslint (`eslint.config.mjs` here).
+ */
+export * from "./state"
+export * from "./row"

--- a/web/packages/agenta-sessions/src/row/index.ts
+++ b/web/packages/agenta-sessions/src/row/index.ts
@@ -1,0 +1,17 @@
+export {
+    SESSION_ORIGIN_TAG,
+    SESSION_TRIGGER_NAME_TAG,
+    SESSION_TRIGGER_KIND_TAG,
+    sessionTriggerName,
+    sessionTriggerKind,
+    isAutomationSession,
+} from "./sessionTrigger"
+export {sessionRowTitle, type SessionRowTitle} from "./sessionRowTitle"
+export {sessionPreviewText} from "./sessionPreview"
+export {
+    sessionRowStatus,
+    pendingGateLabel,
+    type SessionRowStatus,
+    type SessionRowStatusMeta,
+} from "./sessionRowStatus"
+export {sessionRowVm, type SessionRowVm} from "./viewModel"

--- a/web/packages/agenta-sessions/src/row/sessionPreview.ts
+++ b/web/packages/agenta-sessions/src/row/sessionPreview.ts
@@ -1,0 +1,22 @@
+import type {SessionStream} from "@agenta/entities/session"
+
+/** A row is one line of preview; anything past this is truncated by CSS anyway. */
+const MAX_LENGTH = 160
+
+/**
+ * The last thing said in a session, as a row subtitle.
+ *
+ * Human messages are prefixed because the row already names the agent beside them — an
+ * unprefixed preview of "check my emails" reads as something the agent said. `record_source`
+ * distinguishes the human side from the agent's, but records carry no author id, so this can't
+ * tell your message from a teammate's in a shared project.
+ */
+export function sessionPreviewText(row: SessionStream): string | null {
+    const message = row.last_message
+    // Newlines would either break the row or render as a space run inside a single line.
+    const text = message?.text?.replace(/\s+/g, " ").trim()
+    if (!text) return null
+
+    const clipped = text.length <= MAX_LENGTH ? text : `${text.slice(0, MAX_LENGTH).trimEnd()}…`
+    return message?.source === "user" ? `You: ${clipped}` : clipped
+}

--- a/web/packages/agenta-sessions/src/row/sessionRowStatus.ts
+++ b/web/packages/agenta-sessions/src/row/sessionRowStatus.ts
@@ -1,0 +1,71 @@
+import {
+    deriveSessionRowStatus,
+    type SessionRowStatus,
+    type SessionStream,
+} from "@agenta/entities/session"
+
+export type {SessionRowStatus}
+
+export interface SessionRowStatusMeta {
+    status: SessionRowStatus
+    label: string
+    /** antd semantic token class for the dot. */
+    dotClassName: string
+    /** Only `waiting` and `running` justify a pulse; a warm sandbox is not activity. */
+    pulse: boolean
+    /** Text shown inline on the row. Set only where a colour alone would under-report the state. */
+    chipLabel?: string
+    chipClassName?: string
+}
+
+/** Presentation for each status. The status itself is derived in `@agenta/entities/session`, so
+ * every surface that lists sessions agrees on what a row IS; only the styling lives here. */
+const META: Record<SessionRowStatus, Omit<SessionRowStatusMeta, "status">> = {
+    // A blocked session is the only row that costs you something to miss, so it is the only one
+    // that gets words — a 8px dot is not a call to action.
+    waiting: {
+        label: "Waiting on you",
+        dotClassName: "bg-colorWarning",
+        pulse: true,
+        chipLabel: "Waiting",
+        chipClassName: "bg-colorWarningBg text-colorWarningText",
+    },
+    running: {label: "Running", dotClassName: "bg-colorSuccess", pulse: true},
+    alive: {label: "Ready to resume", dotClassName: "bg-colorInfoBorder", pulse: false},
+    ended: {label: "Ended", dotClassName: "bg-colorTextQuaternary", pulse: false},
+    archived: {label: "Archived", dotClassName: "bg-colorTextQuaternary", pulse: false},
+    idle: {label: "Idle", dotClassName: "bg-colorBorder", pulse: false},
+}
+
+export function sessionRowStatus(
+    row: SessionStream,
+    pendingCount: number | undefined,
+): SessionRowStatusMeta {
+    const status = deriveSessionRowStatus(row, pendingCount)
+    return {status, ...META[status]}
+}
+
+/**
+ * What a blocked session is actually asking for. The gate poll already carries `kind` and the row
+ * used to throw it away, so a waiting row said only that it was stuck — never whether it wanted a
+ * decision, a message, or a tool run.
+ *
+ * Nouns, never imperatives. "Approve" in a chip is a button, and this one does nothing: the row
+ * opens the session, where the gate is already docked above the composer. Approving from a list
+ * would mean approving an action you haven't read, so the label names the state and leaves the
+ * decision on the surface that shows what is being decided.
+ */
+export function pendingGateLabel(kinds: string[] | undefined): string {
+    if (!kinds?.length) return "Waiting"
+    if (kinds.length > 1) return "Multiple"
+    switch (kinds[0]) {
+        case "user_approval":
+            return "Approval"
+        case "user_input":
+            return "Input"
+        case "client_tool":
+            return "Tool call"
+        default:
+            return "Waiting"
+    }
+}

--- a/web/packages/agenta-sessions/src/row/sessionRowTitle.ts
+++ b/web/packages/agenta-sessions/src/row/sessionRowTitle.ts
@@ -1,0 +1,27 @@
+/**
+ * What a session row leads with.
+ *
+ * A session gets a name when someone types one, so automation runs never have one — nobody was
+ * there. Such a row led with "Untitled session" over the only informative thing it had.
+ *
+ * Precedence is by how specific the label is: a typed name, then the automation that fired the
+ * run, then the message itself. The message is dropped from the second line when it is already
+ * the title, so a row never prints the same text twice.
+ */
+export interface SessionRowTitle {
+    title: string
+    /** Null when the title IS the message. */
+    subtitle: string | null
+}
+
+export function sessionRowTitle(
+    name: string | null | undefined,
+    preview: string | null,
+    triggerName?: string | null,
+): SessionRowTitle {
+    const named = name?.trim()
+    if (named) return {title: named, subtitle: preview}
+    if (triggerName) return {title: triggerName, subtitle: preview}
+    if (preview) return {title: preview, subtitle: null}
+    return {title: "Untitled session", subtitle: null}
+}

--- a/web/packages/agenta-sessions/src/row/sessionTrigger.ts
+++ b/web/packages/agenta-sessions/src/row/sessionTrigger.ts
@@ -1,0 +1,36 @@
+import type {SessionStream} from "@agenta/entities/session"
+
+/**
+ * Which automation started a session, read off the reserved tags the dispatcher stamps.
+ *
+ * Only the dispatcher knows this — nothing links a session back to a trigger afterwards — so
+ * the row reads a snapshot taken when the run started, not a live join. A renamed automation
+ * therefore keeps its old name on past runs.
+ */
+export const SESSION_ORIGIN_TAG = "ag.origin"
+export const SESSION_TRIGGER_NAME_TAG = "ag.trigger.name"
+export const SESSION_TRIGGER_KIND_TAG = "ag.trigger.kind"
+
+const tag = (row: SessionStream, key: string): string | null => {
+    const value = row.tags?.[key]
+    return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+export function sessionTriggerName(row: SessionStream): string | null {
+    return tag(row, SESSION_TRIGGER_NAME_TAG)
+}
+
+/** "schedule" (a cron fired) or "subscription" (an event arrived). */
+export function sessionTriggerKind(row: SessionStream): string | null {
+    return tag(row, SESSION_TRIGGER_KIND_TAG)
+}
+
+/**
+ * Was this run started by an automation rather than by a person?
+ *
+ * `ag.origin` is the stamp the server filters on; the trigger name is a later addition, so a run
+ * dispatched before it existed is still an automation and must group with them.
+ */
+export function isAutomationSession(row: SessionStream): boolean {
+    return tag(row, SESSION_ORIGIN_TAG) === "trigger" || Boolean(sessionTriggerName(row))
+}

--- a/web/packages/agenta-sessions/src/row/viewModel.ts
+++ b/web/packages/agenta-sessions/src/row/viewModel.ts
@@ -1,0 +1,62 @@
+import type {SessionStream} from "@agenta/entities/session"
+import {isValidUUID} from "@agenta/shared/utils"
+
+import type {SessionPending} from "../state/useSessionList"
+
+import {sessionPreviewText} from "./sessionPreview"
+import {pendingGateLabel, sessionRowStatus, type SessionRowStatusMeta} from "./sessionRowStatus"
+import {sessionRowTitle} from "./sessionRowTitle"
+import {isAutomationSession, sessionTriggerName} from "./sessionTrigger"
+
+/**
+ * A session row with nothing left to decide: every precedence rule (title, status, preview,
+ * trigger) is applied here, so a surface renders fields instead of re-deriving them — and every
+ * surface agrees on what a row says.
+ */
+export interface SessionRowVm {
+    id: string
+    title: string
+    /** Null when the title IS the message — a row never prints the same text twice. */
+    subtitle: string | null
+    status: SessionRowStatusMeta
+    pending: SessionPending | undefined
+    /**
+     * The owning agent, from the latest turn's references. Null when the session has no turns
+     * yet — such a row has nowhere to open, so callers disable the action.
+     */
+    agentId: string | null
+    /** ISO timestamp of last activity. Formatting relative time is the UI's job. */
+    activityAt: string | null
+    isAutomation: boolean
+    isPinned: boolean
+    /** The wire row, for actions that need fields the view-model doesn't carry. */
+    stream: SessionStream
+}
+
+export function sessionRowVm(
+    row: SessionStream,
+    {pinned, pending}: {pinned: boolean; pending: SessionPending | undefined},
+): SessionRowVm {
+    const {title, subtitle} = sessionRowTitle(
+        row.name,
+        sessionPreviewText(row),
+        sessionTriggerName(row),
+    )
+    const status = sessionRowStatus(row, pending?.count)
+    return {
+        id: row.session_id,
+        title,
+        subtitle,
+        // One source for the chip text: a waiting chip names WHAT is being asked, so surfaces
+        // render `status.chipLabel` and never re-derive it from the gate kinds themselves.
+        status: status.chipLabel
+            ? {...status, chipLabel: pendingGateLabel(pending?.kinds)}
+            : status,
+        pending,
+        agentId: row.references?.find((ref) => ref.id && isValidUUID(ref.id))?.id ?? null,
+        activityAt: row.updated_at ?? row.created_at ?? null,
+        isAutomation: isAutomationSession(row),
+        isPinned: pinned,
+        stream: row,
+    }
+}

--- a/web/packages/agenta-sessions/src/state/filters.ts
+++ b/web/packages/agenta-sessions/src/state/filters.ts
@@ -1,0 +1,58 @@
+import {atom} from "jotai"
+
+/**
+ * Every filter here maps to a server predicate — see `useSessionList`. Nothing narrows a fetched
+ * page client-side, because that would filter the window rather than the set.
+ */
+export type SessionStatusFilter = "all" | "live" | "waiting"
+
+export const sessionSearchAtom = atom("")
+/** Agent workflow id, matched against the turns' references. */
+export const sessionAgentFilterAtom = atom<string | null>(null)
+export const sessionStatusFilterAtom = atom<SessionStatusFilter>("all")
+export const sessionShowArchivedAtom = atom(false)
+/** Automation runs are sessions too, so without this they sit in the list indistinguishable from
+ * your own work. Hidden by default; the chip opts back in. */
+export const sessionShowTriggeredAtom = atom(false)
+
+/** Everything the agent-scoped page can still narrow by — its agent comes from the route. */
+export const sessionFiltersActiveExceptAgentAtom = atom(
+    (get) =>
+        Boolean(get(sessionSearchAtom).trim()) ||
+        get(sessionStatusFilterAtom) !== "all" ||
+        get(sessionShowArchivedAtom) ||
+        get(sessionShowTriggeredAtom),
+)
+
+export const sessionFiltersActiveAtom = atom(
+    (get) => get(sessionFiltersActiveExceptAgentAtom) || Boolean(get(sessionAgentFilterAtom)),
+)
+
+export const resetSessionFiltersAtom = atom(null, (_get, set) => {
+    set(sessionSearchAtom, "")
+    set(sessionAgentFilterAtom, null)
+    set(sessionStatusFilterAtom, "all")
+    set(sessionShowArchivedAtom, false)
+    set(sessionShowTriggeredAtom, false)
+})
+
+export interface SessionScope {
+    agentId?: string | null
+    /** The card's origin restriction — "trigger" for the automations list. */
+    origin?: string | null
+    status?: SessionStatusFilter
+}
+
+/**
+ * Point the sessions page at the same set a card was showing.
+ *
+ * Without this, "View all" under *Automation runs* landed on a list that hides automations by
+ * default — the one thing you were looking at. Filters are reset first so a scope never inherits
+ * whatever was left over from the last visit.
+ */
+export const applySessionScopeAtom = atom(null, (_get, set, scope: SessionScope) => {
+    set(resetSessionFiltersAtom)
+    if (scope.agentId) set(sessionAgentFilterAtom, scope.agentId)
+    if (scope.origin === "trigger") set(sessionShowTriggeredAtom, true)
+    if (scope.status) set(sessionStatusFilterAtom, scope.status)
+})

--- a/web/packages/agenta-sessions/src/state/index.ts
+++ b/web/packages/agenta-sessions/src/state/index.ts
@@ -1,0 +1,34 @@
+export {
+    sessionSearchAtom,
+    sessionAgentFilterAtom,
+    sessionStatusFilterAtom,
+    sessionShowArchivedAtom,
+    sessionShowTriggeredAtom,
+    sessionFiltersActiveAtom,
+    sessionFiltersActiveExceptAgentAtom,
+    resetSessionFiltersAtom,
+    applySessionScopeAtom,
+    type SessionScope,
+    type SessionStatusFilter,
+} from "./filters"
+export {pinnedSessionIdsAtom, isSessionPinnedAtom, toggleSessionPinAtom} from "./pins"
+export {
+    useSessionList,
+    useActionableInteractions,
+    pendingBySessionId,
+    rowsFromPages,
+    SESSIONS_PAGE_SIZE,
+    type SessionPending,
+} from "./useSessionList"
+export {
+    useSessionsList,
+    useSessionFilters,
+    useSessionPins,
+    type SessionGroup,
+    type UseSessionsListArgs,
+} from "./useSessionsList"
+export {
+    useSessionCardList,
+    type SessionCardGroup,
+    type UseSessionCardListArgs,
+} from "./useSessionCardList"

--- a/web/packages/agenta-sessions/src/state/pins.ts
+++ b/web/packages/agenta-sessions/src/state/pins.ts
@@ -1,0 +1,40 @@
+import {projectIdAtom} from "@agenta/shared/state"
+import {atom} from "jotai"
+import {atomWithStorage} from "jotai/utils"
+
+/**
+ * Pinned sessions, per project.
+ *
+ * Local-only for now, deliberately: storing a pin server-side is trivial (`session_streams`
+ * already has `tags`), but reconciling pin lists across devices is not, and that is the part
+ * worth designing rather than improvising. This module is the port — nothing outside it knows
+ * where pins live, so the server implementation swaps in here.
+ *
+ * Keyed by project, NOT by app: the sessions page is project-wide, unlike the chat slice's
+ * app-scoped session store.
+ */
+const pinnedByProjectAtom = atomWithStorage<Record<string, string[]>>("agenta:sessions:pinned", {})
+
+export const pinnedSessionIdsAtom = atom<string[]>((get) => {
+    const projectId = get(projectIdAtom)
+    return projectId ? (get(pinnedByProjectAtom)[projectId] ?? []) : []
+})
+
+export const isSessionPinnedAtom = atom((get) => {
+    const pinned = new Set(get(pinnedSessionIdsAtom))
+    return (sessionId: string) => pinned.has(sessionId)
+})
+
+export const toggleSessionPinAtom = atom(null, (get, set, sessionId: string) => {
+    const projectId = get(projectIdAtom)
+    if (!projectId) return
+
+    const all = get(pinnedByProjectAtom)
+    const current = all[projectId] ?? []
+    set(pinnedByProjectAtom, {
+        ...all,
+        [projectId]: current.includes(sessionId)
+            ? current.filter((id) => id !== sessionId)
+            : [sessionId, ...current],
+    })
+})

--- a/web/packages/agenta-sessions/src/state/useSessionCardList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionCardList.ts
@@ -1,0 +1,179 @@
+import {useCallback, useMemo, useState} from "react"
+
+import {type SessionStream} from "@agenta/entities/session"
+import {projectIdAtom} from "@agenta/shared/state"
+import {useAtomValue} from "jotai"
+
+import {sessionRowVm, type SessionRowVm} from "../row/viewModel"
+
+import {pinnedSessionIdsAtom} from "./pins"
+import {
+    pendingBySessionId,
+    rowsFromPages,
+    useActionableInteractions,
+    useSessionList,
+} from "./useSessionList"
+
+export interface SessionCardGroup {
+    key: "waiting" | "pinned" | "recent"
+    /** Absent when the heading is noise — a lone "Recent" over a plain list is one. */
+    label?: string
+    rows: SessionRowVm[]
+}
+
+export interface UseSessionCardListArgs {
+    /** Scope to one agent's sessions — the app overview. Omit for the whole project. */
+    agentId?: string
+    /** Restrict to one origin (e.g. automation runs). Omit for everything but automations. */
+    origin?: string
+    /** Caps the CARD, not each group — pinning a visible row is a pure reorder, never growth. */
+    limit?: number
+    /** Pinned sessions lead the list, and are excluded from the recent rows below them. */
+    withPinned?: boolean
+}
+
+/**
+ * A capped session list for a card surface (Home, an agent's overview). Groups run
+ * waiting → pinned → recent: waiting leads because a blocked session is the only row that costs
+ * you something to miss; the rest is history you can browse at your own pace.
+ *
+ * The gate poll is project-wide, so its ids alone can't be trusted as this card's waiting set —
+ * they go back to the server as a `session_ids` pushdown, which intersects them with the card's
+ * own scope (agent, origin, archived). Membership and order stay the server's; which GROUP a
+ * loaded row renders in is decided here, so pinning moves it without waiting on two refetches.
+ * A waiting session that is also pinned renders once, in the group you must act on.
+ *
+ * "Show more" reveals in place, a page at a time — wanting three more rows is not the "View all"
+ * errand, and the list's own query already holds the next page.
+ */
+export const useSessionCardList = ({
+    agentId,
+    origin,
+    limit = 7,
+    withPinned = false,
+}: UseSessionCardListArgs = {}) => {
+    const [extraRows, setExtraRows] = useState(0)
+    const projectId = useAtomValue(projectIdAtom) ?? ""
+    const pinnedIds = useAtomValue(pinnedSessionIdsAtom)
+
+    const interactions = useActionableInteractions(projectId)
+    const pendingBySession = useMemo(
+        () => pendingBySessionId(interactions.data),
+        [interactions.data],
+    )
+    const waitingIds = useMemo(
+        () => (pendingBySession ? [...pendingBySession.keys()] : []),
+        [pendingBySession],
+    )
+    const useWaiting = waitingIds.length > 0
+
+    const waitingQuery = useSessionList({
+        agentId,
+        origin,
+        sessionIds: waitingIds,
+        showTriggered: Boolean(origin),
+        enabled: useWaiting,
+    })
+    const usePins = withPinned && pinnedIds.length > 0
+    const pinnedQuery = useSessionList({agentId, origin, sessionIds: pinnedIds, enabled: usePins})
+    const listQuery = useSessionList({
+        agentId,
+        origin,
+        excludeSessionIds: withPinned ? [...pinnedIds, ...waitingIds] : waitingIds,
+        // Automations are their own list here, so they must not also appear in the recent one.
+        showTriggered: Boolean(origin),
+    })
+
+    const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds])
+    // Memoized: `rowsFromPages` mints a new array per call, and an unstable array here would
+    // re-derive every row VM (and re-render every memoized row) on every render.
+    const listRows = useMemo(() => rowsFromPages(listQuery.data?.pages), [listQuery.data?.pages])
+    const waitingRowsAll = useMemo(
+        () => (useWaiting ? rowsFromPages(waitingQuery.data?.pages) : []),
+        [useWaiting, waitingQuery.data?.pages],
+    )
+    const waitingSet = useMemo(
+        () => new Set(waitingRowsAll.map((row) => row.session_id)),
+        [waitingRowsAll],
+    )
+    const pinnedRowsAll = useMemo(
+        () => (usePins ? rowsFromPages(pinnedQuery.data?.pages) : []),
+        [usePins, pinnedQuery.data?.pages],
+    )
+    const knownById = useMemo(() => {
+        const byId = new Map<string, SessionStream>()
+        for (const row of [...pinnedRowsAll, ...listRows]) byId.set(row.session_id, row)
+        return byId
+    }, [pinnedRowsAll, listRows])
+
+    const shownLimit = limit + extraRows
+    const {groups, isEmpty, shownCount} = useMemo(() => {
+        const waitingRows = waitingRowsAll.slice(0, shownLimit)
+        const allPinned = usePins
+            ? pinnedIds.flatMap((id) => {
+                  const row = knownById.get(id)
+                  return row && !waitingSet.has(id) ? [row] : []
+              })
+            : []
+        const pinnedRows = allPinned.slice(0, Math.max(0, shownLimit - waitingRows.length))
+        const recentRows = listRows
+            // Only a card that RENDERS a pinned group may withhold pinned rows from here. Automation
+            // runs doesn't, so filtering them out unconditionally made pinning one delete it from view.
+            .filter(
+                (row) =>
+                    (!withPinned || !pinnedSet.has(row.session_id)) &&
+                    !waitingSet.has(row.session_id),
+            )
+            .slice(0, Math.max(0, shownLimit - waitingRows.length - pinnedRows.length))
+
+        const grouped = waitingRows.length > 0 || pinnedRows.length > 0
+        const vm = (row: SessionStream) =>
+            sessionRowVm(row, {
+                pinned: pinnedSet.has(row.session_id),
+                pending: pendingBySession?.get(row.session_id),
+            })
+        const result: SessionCardGroup[] = []
+        if (waitingRows.length > 0)
+            result.push({key: "waiting", label: "Waiting on you", rows: waitingRows.map(vm)})
+        if (pinnedRows.length > 0)
+            result.push({key: "pinned", label: "Pinned", rows: pinnedRows.map(vm)})
+        result.push({
+            key: "recent",
+            label: grouped && recentRows.length > 0 ? "Recent" : undefined,
+            rows: recentRows.map(vm),
+        })
+        return {
+            groups: result,
+            isEmpty: recentRows.length === 0 && pinnedRows.length === 0 && waitingRows.length === 0,
+            shownCount: recentRows.length + pinnedRows.length + waitingRows.length,
+        }
+    }, [
+        waitingRowsAll,
+        shownLimit,
+        usePins,
+        pinnedIds,
+        knownById,
+        waitingSet,
+        listRows,
+        withPinned,
+        pinnedSet,
+        pendingBySession,
+    ])
+
+    const canShowMore = !isEmpty && (listRows.length > shownCount || Boolean(listQuery.hasNextPage))
+    const {hasNextPage, isFetchingNextPage, fetchNextPage} = listQuery
+    const showMore = useCallback(() => {
+        setExtraRows((shown) => shown + limit)
+        if (hasNextPage && !isFetchingNextPage) void fetchNextPage()
+    }, [limit, hasNextPage, isFetchingNextPage, fetchNextPage])
+
+    return {
+        groups,
+        isPending: listQuery.isPending,
+        isEmpty,
+        /** All gated rows in this card's scope — the header's "N waiting" badge. */
+        waitingTotal: waitingRowsAll.length,
+        canShowMore,
+        showMore,
+    }
+}

--- a/web/packages/agenta-sessions/src/state/useSessionList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionList.ts
@@ -1,0 +1,153 @@
+import {
+    nextSessionCursor,
+    queryInteractions,
+    sessionListQueryOptions,
+    sessionRowsFromPages,
+    SESSIONS_PAGE_SIZE,
+    type SessionInteraction,
+    type SessionListCursor,
+} from "@agenta/entities/session"
+import {projectIdAtom} from "@agenta/shared/state"
+import {keepPreviousData, useInfiniteQuery, useQuery} from "@tanstack/react-query"
+import {useAtomValue} from "jotai"
+
+import {type SessionStatusFilter} from "./filters"
+
+export {SESSIONS_PAGE_SIZE}
+
+/**
+ * Every session in the project with a pending human gate, in one unpaginated call. Two jobs: the
+ * per-row "waiting" badge, and the id set the "Waiting" filter pushes down to the server.
+ *
+ * Cadence mirrors mobile: 15s while anything is pending (a running turn is what mints new gates),
+ * 30s when idle, re-checked on focus.
+ */
+export const useActionableInteractions = (projectId: string) =>
+    useQuery<SessionInteraction[] | null>({
+        queryKey: ["sessions-page", "actionable-interactions", projectId],
+        queryFn: ({signal}) =>
+            queryInteractions({projectId, actionableOnly: true, abortSignal: signal}),
+        enabled: Boolean(projectId),
+        staleTime: 10_000,
+        refetchInterval: (query) => ((query.state.data?.length ?? 0) > 0 ? 15_000 : 30_000),
+        refetchOnWindowFocus: true,
+    })
+
+export interface SessionPending {
+    count: number
+    /** Distinct gate kinds still open. Carries what the session is asking for, not just that it
+     * asks — "approve" and "needs input" are different calls to action. */
+    kinds: string[]
+}
+
+/** `session_id → pending gates`; `undefined` until the poll resolves. */
+export const pendingBySessionId = (
+    interactions: SessionInteraction[] | null | undefined,
+): Map<string, SessionPending> | undefined => {
+    if (!interactions) return undefined
+    const bySession = new Map<string, SessionPending>()
+    for (const interaction of interactions) {
+        const entry = bySession.get(interaction.session_id) ?? {count: 0, kinds: []}
+        entry.count += 1
+        if (interaction.kind && !entry.kinds.includes(interaction.kind))
+            entry.kinds.push(interaction.kind)
+        bySession.set(interaction.session_id, entry)
+    }
+    return bySession
+}
+
+interface SessionListOptions {
+    /** Ids rendered as their own group (pins) — excluded so nothing appears twice. */
+    excludeSessionIds?: string[]
+    /** Restrict to these ids; used by the pinned group to fetch exactly its own rows. */
+    sessionIds?: string[]
+    status?: SessionStatusFilter
+    search?: string
+    agentId?: string | null
+    includeArchived?: boolean
+    /** Include automation-started sessions in the default list. Off by default. */
+    showTriggered?: boolean
+    /** Restrict to ONE origin — the automations list. Distinct from `showTriggered`, which only
+     * widens the default list rather than narrowing it. */
+    origin?: string
+    /** Ids of sessions with a pending gate — the pushdown behind the "Waiting" filter. */
+    waitingSessionIds?: string[]
+    /** Page size. Drop it for callers that want one row (a roster's "last active") rather than
+     * a list — a full page per row is a lot of list to throw away. */
+    limit?: number
+    enabled?: boolean
+}
+
+/**
+ * The project-wide session list, windowed on the server's activity ordering.
+ *
+ * Every filter is a server predicate: `search`, `references` (agent), `include_archived`, `flags`
+ * (live), and a `session_ids` pushdown for the predicates that live outside the stream row
+ * (waiting-on-you, pins). Narrowing a fetched page in the browser would filter the window rather
+ * than the set — wrong counts, and an empty first page while later pages hold matches.
+ *
+ * The key and the request come from `@agenta/entities/session`; the query-client policy (stale
+ * time, refetch cadence) stays here, because desktop and mobile don't agree on it. Mobile adopts
+ * the same factory once its session PRs stop moving.
+ */
+export const useSessionList = ({
+    excludeSessionIds,
+    sessionIds,
+    status = "all",
+    search = "",
+    agentId = null,
+    includeArchived = false,
+    showTriggered = false,
+    origin,
+    waitingSessionIds,
+    limit,
+    enabled = true,
+}: SessionListOptions = {}) => {
+    const projectId = useAtomValue(projectIdAtom) ?? ""
+
+    // "Waiting" narrows to the gated ids; combined with an explicit set, the server intersects.
+    const restrictIds =
+        status === "waiting" ? intersectIds(sessionIds, waitingSessionIds ?? []) : sessionIds
+    // A waiting filter whose poll hasn't resolved must not query — an absent id set would read as
+    // "no restriction" and show every session under a "Waiting" chip.
+    const waitingUnresolved = status === "waiting" && waitingSessionIds === undefined
+
+    const options = sessionListQueryOptions({
+        projectId,
+        search,
+        agentId,
+        includeArchived,
+        origin,
+        // Exclude rather than match: a session written before origins were stamped has no tag,
+        // and must still appear in the default list. Skipped when asking for one origin outright.
+        excludeOrigin: origin || showTriggered ? undefined : "trigger",
+        flags: status === "live" ? {is_alive: true} : undefined,
+        sessionIds: restrictIds,
+        excludeSessionIds,
+        limit,
+    })
+
+    return useInfiniteQuery({
+        queryKey: options.queryKey,
+        // A waiting filter whose poll hasn't resolved must not query: an absent id set reads as
+        // "no restriction", which would show every session under a "Waiting" chip.
+        enabled: Boolean(projectId) && enabled && !waitingUnresolved,
+        initialPageParam: null as SessionListCursor | null,
+        queryFn: ({pageParam, signal}) => options.queryFn({pageParam, signal}),
+        getNextPageParam: (lastPage) => nextSessionCursor(lastPage, options.limit),
+        // Pins and filters are part of the key, so every toggle mints a new query. Without this
+        // the list would fall back to `pending` and flash its skeleton — the rows are still valid,
+        // only their membership is being rechecked.
+        placeholderData: keepPreviousData,
+        staleTime: 30_000,
+    })
+}
+
+/** Flatten loaded pages, dropping failed ones (`querySessions` resolves null on failure). */
+export const rowsFromPages = sessionRowsFromPages
+
+const intersectIds = (a: string[] | undefined, b: string[]): string[] => {
+    if (!a) return b
+    const other = new Set(b)
+    return a.filter((id) => other.has(id))
+}

--- a/web/packages/agenta-sessions/src/state/useSessionsList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionsList.ts
@@ -1,0 +1,205 @@
+import {useCallback, useMemo} from "react"
+
+import {type SessionStream} from "@agenta/entities/session"
+import {projectIdAtom} from "@agenta/shared/state"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import {sessionRowVm, type SessionRowVm} from "../row/viewModel"
+
+import {
+    resetSessionFiltersAtom,
+    sessionAgentFilterAtom,
+    sessionFiltersActiveAtom,
+    sessionFiltersActiveExceptAgentAtom,
+    sessionSearchAtom,
+    sessionShowArchivedAtom,
+    sessionShowTriggeredAtom,
+    sessionStatusFilterAtom,
+} from "./filters"
+import {isSessionPinnedAtom, pinnedSessionIdsAtom, toggleSessionPinAtom} from "./pins"
+import {
+    pendingBySessionId,
+    rowsFromPages,
+    useActionableInteractions,
+    useSessionList,
+} from "./useSessionList"
+
+export interface SessionGroup {
+    key: "pinned" | "recent"
+    /**
+     * Present only when the group warrants a heading: pins always carry one, and the main list
+     * gets a counterpart ONLY while a pinned group is showing — without one, the rows below the
+     * pins read as more pinned rows that lost their heading.
+     */
+    label?: string
+    rows: SessionRowVm[]
+}
+
+export interface UseSessionsListArgs {
+    /**
+     * Route-supplied agent scope (`/apps/[app_id]/sessions`). Overrides the agent filter rather
+     * than writing to it, so the project page's filter is never left holding a value the user
+     * did not choose.
+     */
+    agentId?: string | null
+}
+
+/**
+ * The organised session list: groups (pins first), one pager, every filter a server predicate.
+ *
+ * Pins render as their own group, fetched by id, and are excluded from the main list so nothing
+ * appears twice; both queries are server-ordered, so there is only ever one ordering. Which group
+ * a loaded row shows in is decided here from the pin set, so pinning moves the row on the same
+ * frame rather than after both queries refetch under their new keys.
+ *
+ * The automations switch picks WHICH sessions, it doesn't add a second set: one list, one pager.
+ * Mixing both in one recency-ordered feed meant a busy schedule buried your own sessions, and
+ * grouping them client-side made paging back-fill a group above another.
+ */
+export const useSessionsList = ({agentId: scopedAgentId}: UseSessionsListArgs = {}) => {
+    const projectId = useAtomValue(projectIdAtom) ?? ""
+    const search = useAtomValue(sessionSearchAtom)
+    const agentFilter = useAtomValue(sessionAgentFilterAtom)
+    const agentId = scopedAgentId ?? agentFilter
+    const status = useAtomValue(sessionStatusFilterAtom)
+    const includeArchived = useAtomValue(sessionShowArchivedAtom)
+    const showTriggered = useAtomValue(sessionShowTriggeredAtom)
+    const projectFiltersActive = useAtomValue(sessionFiltersActiveAtom)
+    const scopedFiltersActive = useAtomValue(sessionFiltersActiveExceptAgentAtom)
+    const filtersActive = scopedAgentId ? scopedFiltersActive : projectFiltersActive
+    const resetFilters = useSetAtom(resetSessionFiltersAtom)
+    const pinnedIds = useAtomValue(pinnedSessionIdsAtom)
+
+    const interactions = useActionableInteractions(projectId)
+    const pendingBySession = useMemo(
+        () => pendingBySessionId(interactions.data),
+        [interactions.data],
+    )
+    const waitingIds = useMemo(
+        () => (pendingBySession ? [...pendingBySession.keys()] : undefined),
+        [pendingBySession],
+    )
+
+    const shared = {
+        search,
+        agentId,
+        status,
+        includeArchived,
+        showTriggered,
+        waitingSessionIds: waitingIds,
+    }
+    const pinnedQuery = useSessionList({
+        ...shared,
+        sessionIds: pinnedIds,
+        // Pins are mode-independent: without this, default mode's `excludeOrigin` filter would
+        // drop a pinned automation run from its own group.
+        showTriggered: true,
+        enabled: pinnedIds.length > 0,
+    })
+    const listQuery = useSessionList({
+        ...shared,
+        origin: showTriggered ? "trigger" : undefined,
+        excludeSessionIds: pinnedIds,
+    })
+
+    const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds])
+    // Memoized: `rowsFromPages` mints a new array per call, and an unstable array here would
+    // re-derive every row VM (and re-render every memoized row) on every render.
+    const listRows = useMemo(() => rowsFromPages(listQuery.data?.pages), [listQuery.data?.pages])
+    const pinnedRowsAll = useMemo(
+        () => rowsFromPages(pinnedQuery.data?.pages),
+        [pinnedQuery.data?.pages],
+    )
+    const knownById = useMemo(() => {
+        const byId = new Map<string, SessionStream>()
+        for (const row of [...pinnedRowsAll, ...listRows]) byId.set(row.session_id, row)
+        return byId
+    }, [pinnedRowsAll, listRows])
+
+    const groups = useMemo(() => {
+        const vm = (row: SessionStream, pinned: boolean) =>
+            sessionRowVm(row, {pinned, pending: pendingBySession?.get(row.session_id)})
+        const pinnedRows = pinnedIds.flatMap((id) => {
+            const row = knownById.get(id)
+            return row ? [vm(row, true)] : []
+        })
+        const recentRows = listRows
+            .filter((row) => !pinnedSet.has(row.session_id))
+            .map((row) => vm(row, false))
+
+        const result: SessionGroup[] = []
+        if (pinnedRows.length > 0)
+            result.push({key: "pinned", label: `Pinned ${pinnedRows.length}`, rows: pinnedRows})
+        result.push({
+            key: "recent",
+            label:
+                pinnedRows.length > 0 && recentRows.length > 0
+                    ? showTriggered
+                        ? "Automation runs"
+                        : "Recent"
+                    : undefined,
+            rows: recentRows,
+        })
+        return result
+    }, [pinnedIds, knownById, listRows, pinnedSet, pendingBySession, showTriggered])
+
+    const refetchList = listQuery.refetch
+    const refetchPinned = pinnedQuery.refetch
+    const refetch = useCallback(() => {
+        void refetchList()
+        void refetchPinned()
+    }, [refetchList, refetchPinned])
+
+    return {
+        groups,
+        isEmpty: groups.every((group) => group.rows.length === 0),
+        paging: {
+            hasNext: Boolean(listQuery.hasNextPage),
+            isLoadingNext: listQuery.isFetchingNextPage,
+            loadNext: () => void listQuery.fetchNextPage(),
+        },
+        isPending: listQuery.isPending || (pinnedIds.length > 0 && pinnedQuery.isPending),
+        isError: listQuery.isError || pinnedQuery.isError,
+        refetch,
+        /** Distinct sessions with an open gate — the rail's "Waiting" count. */
+        waitingCount: pendingBySession?.size,
+        filtersActive,
+        resetFilters,
+    }
+}
+
+/** The filter surface, as one hook — what the controls in `@agenta/sessions-ui` bind to. */
+export const useSessionFilters = () => {
+    const search = useAtomValue(sessionSearchAtom)
+    const agentId = useAtomValue(sessionAgentFilterAtom)
+    const status = useAtomValue(sessionStatusFilterAtom)
+    const includeArchived = useAtomValue(sessionShowArchivedAtom)
+    const mode = useAtomValue(sessionShowTriggeredAtom)
+    const setSearch = useSetAtom(sessionSearchAtom)
+    const setAgentId = useSetAtom(sessionAgentFilterAtom)
+    const setStatus = useSetAtom(sessionStatusFilterAtom)
+    const setIncludeArchived = useSetAtom(sessionShowArchivedAtom)
+    const setMode = useSetAtom(sessionShowTriggeredAtom)
+    const reset = useSetAtom(resetSessionFiltersAtom)
+    return {
+        search,
+        agentId,
+        status,
+        includeArchived,
+        /** True = the automations mode: the list shows trigger-started sessions INSTEAD. */
+        mode,
+        setSearch,
+        setAgentId,
+        setStatus,
+        setIncludeArchived,
+        setMode,
+        reset,
+    }
+}
+
+export const useSessionPins = () => {
+    const ids = useAtomValue(pinnedSessionIdsAtom)
+    const isPinned = useAtomValue(isSessionPinnedAtom)
+    const toggle = useSetAtom(toggleSessionPinAtom)
+    return {ids, isPinned, toggle}
+}

--- a/web/packages/agenta-sessions/tests/unit/sessionPreview.test.ts
+++ b/web/packages/agenta-sessions/tests/unit/sessionPreview.test.ts
@@ -1,0 +1,44 @@
+import type {SessionStream} from "@agenta/entities/session"
+import {describe, expect, it} from "vitest"
+
+import {sessionPreviewText} from "../../src/row/sessionPreview"
+
+const row = (last_message?: SessionStream["last_message"]): SessionStream =>
+    ({
+        project_id: "22222222-2222-4222-8222-222222222222",
+        session_id: "sess-1",
+        last_message,
+    }) as SessionStream
+
+describe("sessionPreviewText", () => {
+    it("shows an agent message as it stands", () => {
+        expect(sessionPreviewText(row({text: "Opened the PR.", source: "agent"}))).toBe(
+            "Opened the PR.",
+        )
+    })
+
+    it("marks the human side, which the agent name beside it would otherwise claim", () => {
+        expect(sessionPreviewText(row({text: "check my emails", source: "user"}))).toBe(
+            "You: check my emails",
+        )
+    })
+
+    it("flattens newlines so a pasted spec stays one line", () => {
+        expect(sessionPreviewText(row({text: "Line one\n\n   line two", source: "agent"}))).toBe(
+            "Line one line two",
+        )
+    })
+
+    it("truncates on length with an ellipsis", () => {
+        const text = "x".repeat(200)
+        const preview = sessionPreviewText(row({text, source: "agent"}))
+
+        expect(preview).toHaveLength(161)
+        expect(preview?.endsWith("…")).toBe(true)
+    })
+
+    it("has nothing to show for a session with no message", () => {
+        expect(sessionPreviewText(row())).toBeNull()
+        expect(sessionPreviewText(row({text: "   ", source: "agent"}))).toBeNull()
+    })
+})

--- a/web/packages/agenta-sessions/tests/unit/sessionRowStatus.test.ts
+++ b/web/packages/agenta-sessions/tests/unit/sessionRowStatus.test.ts
@@ -1,0 +1,76 @@
+/**
+ * A gate outlives the run that raised it, so "waiting" must win over liveness — otherwise a
+ * session needing an answer reads as merely "running" and the user never acts on it.
+ */
+import type {SessionStream} from "@agenta/entities/session"
+import {describe, expect, it} from "vitest"
+
+import {pendingGateLabel, sessionRowStatus} from "../../src/row/sessionRowStatus"
+
+const row = (overrides: Partial<SessionStream> = {}): SessionStream =>
+    ({
+        project_id: "22222222-2222-4222-8222-222222222222",
+        session_id: "sess-1",
+        ...overrides,
+    }) as SessionStream
+
+const statusOf = (r: SessionStream, pending?: number) => sessionRowStatus(r, pending).status
+
+describe("sessionRowStatus", () => {
+    it("reports a pending gate ahead of a live run", () => {
+        const running = row({flags: {is_alive: true, is_running: true}})
+        expect(statusOf(running, 1)).toBe("waiting")
+        expect(statusOf(running, 0)).toBe("running")
+    })
+
+    it("reports a gate even after the run that raised it finished", () => {
+        expect(statusOf(row(), 2)).toBe("waiting")
+    })
+
+    it("separates a running turn from a merely warm sandbox", () => {
+        expect(statusOf(row({flags: {is_alive: true, is_running: true}}))).toBe("running")
+        expect(statusOf(row({flags: {is_alive: true}}))).toBe("alive")
+    })
+
+    it("prefers archived over ended, since archiving is the deliberate act", () => {
+        const both = row({deleted_at: "2026-08-01T00:00:00Z", archived_at: "2026-08-02T00:00:00Z"})
+        expect(statusOf(both)).toBe("archived")
+        expect(statusOf(row({deleted_at: "2026-08-01T00:00:00Z"}))).toBe("ended")
+    })
+
+    it("falls back to idle for a session that has simply gone quiet", () => {
+        expect(statusOf(row())).toBe("idle")
+    })
+
+    it("only pulses for states that need attention", () => {
+        expect(sessionRowStatus(row(), 1).pulse).toBe(true)
+        expect(sessionRowStatus(row({flags: {is_alive: true, is_running: true}})).pulse).toBe(true)
+        expect(sessionRowStatus(row({flags: {is_alive: true}})).pulse).toBe(false)
+        expect(sessionRowStatus(row()).pulse).toBe(false)
+    })
+})
+
+describe("pendingGateLabel", () => {
+    it("names what the session is asking for", () => {
+        expect(pendingGateLabel(["user_approval"])).toBe("Approval")
+        expect(pendingGateLabel(["user_input"])).toBe("Input")
+        expect(pendingGateLabel(["client_tool"])).toBe("Tool call")
+    })
+
+    it("names a state rather than commanding one, because the chip does not act", () => {
+        // The gate is answered in the session, where what is being decided is on screen.
+        for (const kinds of [["user_approval"], ["user_input"], ["client_tool"], undefined]) {
+            expect(pendingGateLabel(kinds)).not.toMatch(/^(Approve|Answer|Run|Reply|Open)$/)
+        }
+    })
+
+    it("falls back to the generic label when the kind is unknown or absent", () => {
+        expect(pendingGateLabel(undefined)).toBe("Waiting")
+        expect(pendingGateLabel([])).toBe("Waiting")
+        expect(pendingGateLabel(["something_new"])).toBe("Waiting")
+    })
+
+    it("does not claim one action when several are open", () => {
+        expect(pendingGateLabel(["user_approval", "user_input"])).toBe("Multiple")
+    })
+})

--- a/web/packages/agenta-sessions/tests/unit/sessionRowTitle.test.ts
+++ b/web/packages/agenta-sessions/tests/unit/sessionRowTitle.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from "vitest"
+
+import {sessionRowTitle} from "../../src/row/sessionRowTitle"
+
+describe("sessionRowTitle", () => {
+    it("leads with the name when there is one", () => {
+        expect(sessionRowTitle("approval-flow-test", "You: make me a file")).toEqual({
+            title: "approval-flow-test",
+            subtitle: "You: make me a file",
+        })
+    })
+
+    it("names the automation when one fired the run", () => {
+        expect(sessionRowTitle(null, "Digest sent.", "Nightly digest")).toEqual({
+            title: "Nightly digest",
+            subtitle: "Digest sent.",
+        })
+    })
+
+    it("prefers a typed name over the automation's", () => {
+        // Someone renamed the run; that beats the automation that started it.
+        expect(
+            sessionRowTitle("Investigating the spike", "Digest sent.", "Nightly digest"),
+        ).toEqual({title: "Investigating the spike", subtitle: "Digest sent."})
+    })
+
+    it("leads with the message when nobody named the session", () => {
+        // A run from before the trigger stamp existed, or a nameless manual session.
+        expect(sessionRowTitle(null, "Ran the nightly digest.")).toEqual({
+            title: "Ran the nightly digest.",
+            subtitle: null,
+        })
+    })
+
+    it("does not print the message twice", () => {
+        expect(sessionRowTitle("   ", "Hello!").subtitle).toBeNull()
+    })
+
+    it("falls back only when there is nothing to say", () => {
+        expect(sessionRowTitle(null, null)).toEqual({title: "Untitled session", subtitle: null})
+    })
+})

--- a/web/packages/agenta-sessions/tsconfig.json
+++ b/web/packages/agenta-sessions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "rootDir": "src",
+        "tsBuildInfoFile": ".tsbuildinfo",
+        "moduleResolution": "bundler"
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/web/packages/agenta-sessions/vitest.config.ts
+++ b/web/packages/agenta-sessions/vitest.config.ts
@@ -1,0 +1,17 @@
+import {defineConfig} from "vitest/config"
+
+export default defineConfig({
+    test: {
+        include: ["tests/unit/**/*.test.ts"],
+        environment: "node",
+        reporters: ["default", "junit"],
+        outputFile: {junit: "./test-results/junit.xml"},
+        coverage: {
+            provider: "v8",
+            include: ["src/**/*.ts"],
+            exclude: ["src/**/index.ts"],
+            reporter: ["text", "lcov", "json-summary"],
+            reportsDirectory: "./coverage",
+        },
+    },
+})

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -496,6 +496,9 @@ importers:
       '@agenta/sdk':
         specifier: workspace:../packages/agenta-sdk
         version: link:../packages/agenta-sdk
+      '@agenta/sessions':
+        specifier: workspace:../packages/agenta-sessions
+        version: link:../packages/agenta-sessions
       '@agenta/shared':
         specifier: workspace:../packages/agenta-shared
         version: link:../packages/agenta-shared
@@ -1429,6 +1432,40 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/agenta-sessions:
+    dependencies:
+      '@agenta/entities':
+        specifier: workspace:../agenta-entities
+        version: link:../agenta-entities
+      '@agenta/shared':
+        specifier: workspace:../agenta-shared
+        version: link:../agenta-shared
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.9
+        version: 5.100.9(react@19.2.6)
+      '@types/node':
+        specifier: ^20.19.20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^19.0.10
+        version: 19.2.14
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.6(vitest@4.1.6)
+      jotai:
+        specifier: ^2.15.0
+        version: 2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.1.5(@types/node@20.19.39)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.22.4)(yaml@2.8.4))
 
   packages/agenta-shared:
     dependencies:

--- a/web/turbo.json
+++ b/web/turbo.json
@@ -84,6 +84,11 @@
             "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
             "outputs": [".tsbuildinfo"]
         },
+        "@agenta/sessions#build": {
+            "dependsOn": ["@agenta/shared#build", "@agenta/entities#build"],
+            "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
+            "outputs": [".tsbuildinfo"]
+        },
         "@agenta/oss#build": {
             "dependsOn": [
                 "@agenta/shared#build",
@@ -92,7 +97,8 @@
                 "@agenta/entity-ui#build",
                 "@agenta/playground#build",
                 "@agenta/playground-ui#build",
-                "@agenta/chat#build"
+                "@agenta/chat#build",
+                "@agenta/sessions#build"
             ],
             "inputs": [
                 "src/**",
@@ -114,7 +120,8 @@
                 "@agenta/entity-ui#build",
                 "@agenta/playground#build",
                 "@agenta/playground-ui#build",
-                "@agenta/chat#build"
+                "@agenta/chat#build",
+                "@agenta/sessions#build"
             ],
             "inputs": [
                 "src/**",
@@ -170,6 +177,10 @@
             "inputs": ["src/**/*.ts", "src/**/*.tsx"],
             "outputs": []
         },
+        "@agenta/sessions#lint": {
+            "inputs": ["src/**/*.ts", "src/**/*.tsx", "eslint.config.*"],
+            "outputs": []
+        },
         "@agenta/oss#lint": {
             "dependsOn": [
                 "@agenta/shared#lint",
@@ -178,7 +189,8 @@
                 "@agenta/entity-ui#lint",
                 "@agenta/playground#lint",
                 "@agenta/playground-ui#lint",
-                "@agenta/chat#lint"
+                "@agenta/chat#lint",
+                "@agenta/sessions#lint"
             ],
             "inputs": [
                 "src/**/*.ts",
@@ -241,6 +253,11 @@
             "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
             "outputs": []
         },
+        "@agenta/sessions#types:check": {
+            "dependsOn": ["@agenta/shared#types:check", "@agenta/entities#types:check"],
+            "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
+            "outputs": []
+        },
         "@agenta/oss#types:check": {
             "dependsOn": [
                 "@agenta/shared#types:check",
@@ -249,7 +266,8 @@
                 "@agenta/entity-ui#types:check",
                 "@agenta/playground#types:check",
                 "@agenta/playground-ui#types:check",
-                "@agenta/chat#types:check"
+                "@agenta/chat#types:check",
+                "@agenta/sessions#types:check"
             ],
             "inputs": [
                 "src/**",


### PR DESCRIPTION
## Context
Second lane of the sessions/agents UX stack. The session list's rules (filter semantics, grouping, row derivation, pins) lived inside `SessionsPage`, so every surface that shows sessions (Home, overview, the sidebar, and later mobile) re-derived its own. The test this package is held to: changing a rule, like "automations replace the set rather than adding to it", must be one edit that every surface inherits.

## Changes
New headless package `@agenta/sessions` (hooks and atoms only, zero UI imports, enforced by eslint):
- `state/`: the filter atoms with their semantics (show-triggered is a mode that replaces the set; show-archived widens it), per-project pins, the infinite list query with cursor handling and the `waitingSessionIds` pushdown, and the grouping hooks `useSessionsList` / `useSessionCardList` that return render-ready groups plus paging state.
- `row/`: title, status, preview and trigger helpers plus `SessionRowVm`, so a row reaches the UI with nothing left to decide.

The session entity keeps what it owns in `@agenta/entities/session`: the zod schema, `listOptions`, `rowStatus` and the query itself. `web/.gitignore` learns about the package's vitest junit output.

## Tests / notes
- 21 unit tests in `tests/unit` (title, status, preview) pass; package builds under turbo.
- `grep 'from "antd"' src` is empty; `@agenta/oss` tsc is clean on this lane.
