### PR TITLE
feat(frontend): @agenta/sessions-ui, the session list's antd-free components

### DIFF
--- a/web/oss/next.config.ts
+++ b/web/oss/next.config.ts
@@ -95,6 +95,7 @@ const COMMON_CONFIG: NextConfig = {
         "@agenta/ui",
         "@agenta/chat",
         "@agenta/sessions",
+        "@agenta/sessions-ui",
         "@agenta/entities",
         "@agenta/entity-ui",
         "@agenta/playground",

--- a/web/oss/package.json
+++ b/web/oss/package.json
@@ -32,6 +32,7 @@
         "@agenta/playground-ui": "workspace:../packages/agenta-playground-ui",
         "@agenta/sdk": "workspace:../packages/agenta-sdk",
         "@agenta/sessions": "workspace:../packages/agenta-sessions",
+        "@agenta/sessions-ui": "workspace:../packages/agenta-sessions-ui",
         "@agenta/shared": "workspace:../packages/agenta-shared",
         "@agenta/ui": "workspace:../packages/agenta-ui",
         "@agenta/web-tests": "workspace:../tests",

--- a/web/packages/agenta-sessions-ui/eslint.config.mjs
+++ b/web/packages/agenta-sessions-ui/eslint.config.mjs
@@ -1,0 +1,39 @@
+/**
+ * @agenta/sessions-ui is antd-FREE by contract — mobile consumes these components without
+ * pulling antd. Anything not yet portable (the agent picker) is a slot the app injects.
+ * `@agenta/ui` is allowed via subpaths only: its ROOT barrel still exports antd-backed
+ * components (EnhancedModal), which would defeat the ban transitively.
+ */
+import base from "../eslint.config.mjs"
+
+export default [
+    ...base,
+    {
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [
+                        {
+                            name: "@agenta/sdk",
+                            message:
+                                "Import per-resource accessors from '@agenta/sdk/resources' — the root barrel bundles all 27 Fern resource clients.",
+                        },
+                        {
+                            name: "@agenta/ui",
+                            message:
+                                "Import a subpath ('@agenta/ui/ui', '@agenta/ui/components/presentational') — the root barrel exports antd-backed components.",
+                        },
+                    ],
+                    patterns: [
+                        {
+                            group: ["antd", "antd/*", "@ant-design/*"],
+                            message:
+                                "@agenta/sessions-ui is antd-free. Use the Radix primitives from '@agenta/ui/ui', or take the element as a slot.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+]

--- a/web/packages/agenta-sessions-ui/package.json
+++ b/web/packages/agenta-sessions-ui/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@agenta/sessions-ui",
+    "version": "0.1.0",
+    "private": true,
+    "sideEffects": false,
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "scripts": {
+        "build": "tsc --noEmit",
+        "types:check": "tsc --noEmit",
+        "lint": "eslint --config ./eslint.config.mjs src/",
+        "check": "pnpm run types:check && pnpm run lint"
+    },
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "dependencies": {
+        "@agenta/entities": "workspace:../agenta-entities",
+        "@agenta/sessions": "workspace:../agenta-sessions",
+        "@agenta/shared": "workspace:../agenta-shared",
+        "@agenta/ui": "workspace:../agenta-ui",
+        "@phosphor-icons/react": "^2.1.10",
+        "clsx": "^2.1.1"
+    },
+    "peerDependencies": {
+        "@tanstack/react-query": ">=5.0.0",
+        "jotai": ">=2.0.0",
+        "react": ">=18.0.0"
+    },
+    "devDependencies": {
+        "@tanstack/react-query": "5.100.9",
+        "@types/node": "^20.19.20",
+        "@types/react": "^19.0.10",
+        "jotai": "^2.15.0",
+        "react": "^19.0.0",
+        "typescript": "^5.9.3"
+    }
+}

--- a/web/packages/agenta-sessions-ui/src/SessionAgentName.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionAgentName.tsx
@@ -1,0 +1,26 @@
+import {useMemo} from "react"
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {useAtomValue} from "jotai"
+
+/**
+ * The owning agent's name for a session row. Reads the workflow ARTIFACT's name — never a
+ * revision's, which carries the variant label or nothing at all (see web/CLAUDE.md).
+ */
+export const SessionAgentName = ({agentId}: {agentId: string | null}) => {
+    const nameAtom = useMemo(
+        () => workflowMolecule.selectors.artifactName(agentId ?? ""),
+        [agentId],
+    )
+    const name = useAtomValue(nameAtom)
+
+    if (!agentId) {
+        return (
+            <span className="text-xs text-colorTextTertiary" title="This session has no turns yet">
+                No agent yet
+            </span>
+        )
+    }
+
+    return <span className="text-xs text-colorTextSecondary truncate">{name || "Agent"}</span>
+}

--- a/web/packages/agenta-sessions-ui/src/SessionListStates.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionListStates.tsx
@@ -1,0 +1,77 @@
+import {Button, SkeletonBlock} from "@agenta/ui/ui"
+import {MagnifyingGlassIcon, WarningCircleIcon} from "@phosphor-icons/react"
+
+/** Mirrors a row's geometry so real rows replace it without shifting the list. */
+export const SessionListSkeleton = ({rows = 8}: {rows?: number}) => (
+    <div aria-busy="true" aria-label="Loading sessions">
+        {Array.from({length: rows}, (_, index) => (
+            <div
+                key={index}
+                className="flex items-center gap-3 px-3 py-2 border-solid border-0 border-b border-colorBorderSecondary"
+            >
+                <span className="shrink-0 w-2 h-2 rounded-full bg-colorFillSecondary" />
+                <SkeletonBlock active className="h-4 min-w-0 flex-1" />
+                <SkeletonBlock active className="h-4 w-40 flex-none" />
+                <SkeletonBlock active className="h-4 w-24 flex-none" />
+            </div>
+        ))}
+    </div>
+)
+
+export const SessionListEmpty = ({
+    filtered,
+    onClearFilters,
+}: {
+    filtered: boolean
+    onClearFilters: () => void
+}) => (
+    <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+        <MagnifyingGlassIcon size={24} className="text-colorTextQuaternary" />
+        <p className="m-0 text-xs text-colorTextSecondary">
+            {filtered ? "No sessions match these filters." : "No sessions yet."}
+        </p>
+        {filtered ? (
+            <Button variant="link" onClick={onClearFilters}>
+                Clear filters
+            </Button>
+        ) : (
+            <p className="m-0 text-xs text-colorTextTertiary">
+                Start a conversation with an agent and it will show up here.
+            </p>
+        )}
+    </div>
+)
+
+export const SessionListError = ({onRetry}: {onRetry: () => void}) => (
+    <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+        <WarningCircleIcon size={24} className="text-colorError" />
+        <p className="m-0 text-xs text-colorTextSecondary">Couldn&apos;t load your sessions.</p>
+        <Button variant="outline" onClick={onRetry}>
+            Try again
+        </Button>
+    </div>
+)
+
+/** One group's pager. Each group loads its own next page, in place. */
+export const SessionListLoadMore = ({
+    loading,
+    onClick,
+}: {
+    loading: boolean
+    onClick: () => void
+}) => (
+    <div className="flex justify-center py-3">
+        <Button variant="outline" disabled={loading} onClick={onClick}>
+            {loading ? "Loading…" : "Load more"}
+        </Button>
+    </div>
+)
+
+/** A list group's heading. Plain (non-motion) so `sticky` is never fighting a transform. */
+export const SessionGroupHeader = ({label}: {label: string}) => (
+    <div className="sticky top-0 z-20 -mx-6 bg-colorBgContainer px-6 pb-1 pt-4">
+        <p className="m-0 rounded bg-colorBgElevated px-3 py-1 text-xs text-colorTextTertiary">
+            {label}
+        </p>
+    </div>
+)

--- a/web/packages/agenta-sessions-ui/src/SessionRow.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionRow.tsx
@@ -1,0 +1,177 @@
+import {memo, type ReactNode} from "react"
+
+import {type SessionRowVm} from "@agenta/sessions/row"
+import {timeAgo} from "@agenta/shared/utils"
+import {
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@agenta/ui/ui"
+import {DotsThreeIcon, PushPinIcon, PushPinSlashIcon} from "@phosphor-icons/react"
+import clsx from "clsx"
+
+import {Tip} from "./assets/Tip"
+import {isMenuDivider, type SessionMenuEntry} from "./menu"
+import {SessionAgentName} from "./SessionAgentName"
+
+export interface SessionRowProps {
+    row: SessionRowVm
+    /** Off on an agent-scoped list, where every row names the same agent. */
+    showAgent?: boolean
+    /**
+     * Web reveals the pin on hover; touch has no hover, so a touch surface turns this off and
+     * the actions stay visible. Baked-in hover styling would hand mobile a dead control.
+     */
+    revealActionsOnHover?: boolean
+    /** Replaces the built-in agent name — e.g. a surface that links the agent. */
+    renderAgent?: (agentId: string | null) => ReactNode
+    /** The app's verbs for this row, in the neutral shape. No items → no kebab. */
+    menuItems?: SessionMenuEntry[]
+    onMenuSelect?: (key: string) => void
+    onOpen?: () => void
+    onTogglePin?: (sessionId: string) => void
+}
+
+const SessionRowImpl = ({
+    row,
+    showAgent = true,
+    revealActionsOnHover = true,
+    renderAgent,
+    menuItems,
+    onMenuSelect,
+    onOpen,
+    onTogglePin,
+}: SessionRowProps) => {
+    const openable = Boolean(row.agentId && onOpen)
+    const handleOpen = () => {
+        if (openable) onOpen?.()
+    }
+
+    return (
+        // A plain container, not an ARIA button: descendants of a button role are
+        // presentational, which would hide the pin, menu and agent slot from AT. The click
+        // here is a pointer convenience; the TITLE button below is the semantic open action.
+        <div
+            onClick={handleOpen}
+            className={clsx(
+                "group flex items-center gap-3 px-3 py-2 border-solid border-0 border-b border-colorBorderSecondary",
+                openable ? "cursor-pointer hover:bg-colorFillQuaternary" : "cursor-default",
+            )}
+        >
+            <Tip title={row.status.label}>
+                <span
+                    aria-label={row.status.label}
+                    className={clsx(
+                        "shrink-0 w-2 h-2 rounded-full",
+                        row.status.dotClassName,
+                        row.status.pulse && "motion-safe:animate-pulse",
+                    )}
+                />
+            </Tip>
+
+            <button
+                type="button"
+                disabled={!openable}
+                onClick={(event) => {
+                    event.stopPropagation()
+                    handleOpen()
+                }}
+                className={clsx(
+                    "flex-1 min-w-0 flex flex-col gap-0.5 border-0 bg-transparent p-0 text-left",
+                    openable ? "cursor-pointer" : "cursor-default",
+                )}
+            >
+                <span className="w-full text-xs text-colorText truncate">{row.title}</span>
+                {row.subtitle ? (
+                    <span className="w-full truncate text-[11px] text-colorTextTertiary">
+                        {row.subtitle}
+                    </span>
+                ) : null}
+            </button>
+
+            {row.status.chipLabel ? (
+                <span
+                    className={clsx(
+                        "shrink-0 rounded px-1.5 py-0.5 text-[11px] leading-none",
+                        row.status.chipClassName,
+                    )}
+                >
+                    {row.status.chipLabel}
+                </span>
+            ) : null}
+
+            {showAgent ? (
+                <span className="w-40 shrink-0 truncate">
+                    {renderAgent ? (
+                        renderAgent(row.agentId)
+                    ) : (
+                        <SessionAgentName agentId={row.agentId} />
+                    )}
+                </span>
+            ) : null}
+
+            <span className="w-24 shrink-0 text-xs text-colorTextTertiary text-right">
+                {row.activityAt ? timeAgo(Date.parse(row.activityAt)) : "—"}
+            </span>
+
+            {onTogglePin ? (
+                <Tip title={row.isPinned ? "Unpin" : "Pin"}>
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={row.isPinned ? "Unpin session" : "Pin session"}
+                        className={clsx(
+                            "shrink-0",
+                            !row.isPinned &&
+                                revealActionsOnHover &&
+                                "opacity-0 group-hover:opacity-100 focus:opacity-100",
+                        )}
+                        onClick={(event) => {
+                            event.stopPropagation()
+                            onTogglePin(row.id)
+                        }}
+                    >
+                        {row.isPinned ? <PushPinSlashIcon size={14} /> : <PushPinIcon size={14} />}
+                    </Button>
+                </Tip>
+            ) : null}
+
+            {menuItems?.length ? (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            aria-label="Session actions"
+                            className="shrink-0"
+                            onClick={(event) => event.stopPropagation()}
+                        >
+                            <DotsThreeIcon size={14} />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+                        {menuItems.map((entry, index) =>
+                            isMenuDivider(entry) ? (
+                                <DropdownMenuSeparator key={`divider-${index}`} />
+                            ) : (
+                                <DropdownMenuItem
+                                    key={entry.key}
+                                    disabled={entry.disabled}
+                                    variant={entry.danger ? "destructive" : "default"}
+                                    onSelect={() => onMenuSelect?.(entry.key)}
+                                >
+                                    {entry.label}
+                                </DropdownMenuItem>
+                            ),
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            ) : null}
+        </div>
+    )
+}
+
+export const SessionRow = memo(SessionRowImpl)

--- a/web/packages/agenta-sessions-ui/src/assets/Tip.tsx
+++ b/web/packages/agenta-sessions-ui/src/assets/Tip.tsx
@@ -1,0 +1,24 @@
+import type {ReactNode} from "react"
+
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
+
+/** Radix tooltip in antd's ergonomic shape (`title` + child). No title → just the child. */
+export const Tip = ({
+    title,
+    side,
+    children,
+}: {
+    title: ReactNode
+    side?: "top" | "right" | "bottom" | "left"
+    children: ReactNode
+}) => {
+    if (title == null) return <>{children}</>
+    return (
+        <TooltipProvider delayDuration={100}>
+            <Tooltip>
+                <TooltipTrigger asChild>{children}</TooltipTrigger>
+                <TooltipContent side={side}>{title}</TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    )
+}

--- a/web/packages/agenta-sessions-ui/src/controls/SessionFilterControls.tsx
+++ b/web/packages/agenta-sessions-ui/src/controls/SessionFilterControls.tsx
@@ -1,0 +1,150 @@
+import {useEffect, useRef, useState, type ReactNode} from "react"
+
+import {useSessionFilters, type SessionStatusFilter} from "@agenta/sessions/state"
+import {SearchInput, Switch} from "@agenta/ui/ui"
+import {MagnifyingGlassIcon} from "@phosphor-icons/react"
+
+import {Tip} from "../assets/Tip"
+
+/**
+ * The session filter CONTROLS — each binds to `useSessionFilters`, so every surface narrows the
+ * same set. Shells stay per-surface: a 280px rail and a mobile filter sheet are two shells over
+ * these same controls, which is why no rail markup lives here. The agent picker is not among
+ * them — it stays an app-injected slot (`EntityPicker`/antd `Select` are out of scope).
+ */
+
+const STATUSES: {value: SessionStatusFilter; label: string}[] = [
+    {value: "all", label: "All sessions"},
+    {value: "live", label: "Live"},
+    {value: "waiting", label: "Waiting on you"},
+]
+
+/** Applied filter writes are debounced; every keystroke would otherwise refetch both lists. */
+const SEARCH_DEBOUNCE_MS = 300
+
+export const SessionSearchControl = ({placeholder = "Search sessions"}: {placeholder?: string}) => {
+    const {search, setSearch} = useSessionFilters()
+    const [draft, setDraft] = useState(search)
+    const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+    // Distinguishes our own debounced write landing from an outside one (reset, another
+    // surface) — only the outside write may clobber the draft and cancel a pending write.
+    const lastApplied = useRef(search)
+
+    useEffect(() => {
+        if (search === lastApplied.current) return
+        if (timer.current) {
+            clearTimeout(timer.current)
+            timer.current = null
+        }
+        lastApplied.current = search
+        setDraft(search)
+    }, [search])
+    useEffect(
+        () => () => {
+            if (timer.current) clearTimeout(timer.current)
+        },
+        [],
+    )
+
+    const apply = (value: string) => {
+        lastApplied.current = value
+        setSearch(value)
+    }
+
+    return (
+        <SearchInput
+            allowClear
+            value={draft}
+            placeholder={placeholder}
+            prefix={<MagnifyingGlassIcon size={14} className="text-colorTextTertiary" />}
+            onChange={(event) => {
+                const value = event.target.value
+                setDraft(value)
+                if (timer.current) clearTimeout(timer.current)
+                // Clearing applies immediately — an empty box showing filtered rows reads broken.
+                if (value === "") apply(value)
+                else
+                    timer.current = setTimeout(() => {
+                        timer.current = null
+                        apply(value)
+                    }, SEARCH_DEBOUNCE_MS)
+            }}
+        />
+    )
+}
+
+/** The status choice as a list you read, not a segmented control you decode. */
+export const SessionStatusListControl = ({waitingCount}: {waitingCount?: number}) => {
+    const {status, setStatus} = useSessionFilters()
+    return (
+        <nav className="flex flex-col gap-0.5">
+            {STATUSES.map((option) => (
+                <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={option.value === status}
+                    onClick={() => setStatus(option.value)}
+                    className={`box-border flex w-full cursor-pointer items-center gap-2 rounded-lg border-0 px-3 py-2 text-left text-sm transition-colors ${
+                        option.value === status
+                            ? "bg-colorFillSecondary text-colorText"
+                            : "bg-transparent text-colorTextSecondary hover:bg-colorFillQuaternary"
+                    }`}
+                >
+                    <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                    {option.value === "waiting" && waitingCount ? (
+                        <span className="shrink-0 rounded bg-colorWarningBg px-1.5 py-0.5 text-[11px] leading-none text-colorWarningText">
+                            {waitingCount}
+                        </span>
+                    ) : null}
+                </button>
+            ))}
+        </nav>
+    )
+}
+
+const ToggleRow = ({
+    checked,
+    onChange,
+    tooltip,
+    children,
+}: {
+    checked: boolean
+    onChange: (checked: boolean) => void
+    tooltip: string
+    children: ReactNode
+}) => (
+    <Tip title={tooltip} side="right">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-colorTextSecondary">
+            <Switch checked={checked} onCheckedChange={onChange} />
+            {children}
+        </label>
+    </Tip>
+)
+
+/** Picks WHICH sessions: automation runs INSTEAD of the ones you started. */
+export const SessionModeControl = () => {
+    const {mode, setMode} = useSessionFilters()
+    return (
+        <ToggleRow
+            checked={mode}
+            onChange={setMode}
+            tooltip="Runs started by an automation, instead of the sessions you started"
+        >
+            Automation runs
+        </ToggleRow>
+    )
+}
+
+/** Widens the set: archived sessions are hidden but recoverable. */
+export const SessionArchivedControl = () => {
+    const {includeArchived, setIncludeArchived} = useSessionFilters()
+    return (
+        <ToggleRow
+            checked={includeArchived}
+            onChange={setIncludeArchived}
+            tooltip="Archived sessions are hidden but recoverable"
+        >
+            Archived
+        </ToggleRow>
+    )
+}

--- a/web/packages/agenta-sessions-ui/src/index.ts
+++ b/web/packages/agenta-sessions-ui/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @agenta/sessions-ui — antd-free components over `@agenta/sessions`.
+ *
+ * The package exports controls and rows; each app owns its shell (the rail, a sheet). Anything
+ * not yet portable — the agent picker — is a slot the app injects, never an antd import here
+ * (eslint-enforced, see eslint.config.mjs).
+ */
+export {SessionRow, type SessionRowProps} from "./SessionRow"
+export {SessionAgentName} from "./SessionAgentName"
+export {type SessionMenuEntry, isMenuDivider} from "./menu"
+export {
+    SessionListSkeleton,
+    SessionListEmpty,
+    SessionListError,
+    SessionListLoadMore,
+    SessionGroupHeader,
+} from "./SessionListStates"
+export {
+    SessionSearchControl,
+    SessionStatusListControl,
+    SessionModeControl,
+    SessionArchivedControl,
+} from "./controls/SessionFilterControls"

--- a/web/packages/agenta-sessions-ui/src/menu.ts
+++ b/web/packages/agenta-sessions-ui/src/menu.ts
@@ -1,0 +1,15 @@
+import type {ReactNode} from "react"
+
+/**
+ * The neutral menu contract for a session row's actions.
+ *
+ * The app owns the verbs (they must match its other session surfaces); the package owns the
+ * rendering. Neutral rather than antd's `MenuProps["items"]` so the same items drive a Radix
+ * menu here and whatever a touch surface renders later.
+ */
+export type SessionMenuEntry =
+    | {key: string; label: ReactNode; danger?: boolean; disabled?: boolean}
+    | {type: "divider"}
+
+export const isMenuDivider = (entry: SessionMenuEntry): entry is {type: "divider"} =>
+    "type" in entry

--- a/web/packages/agenta-sessions-ui/tsconfig.json
+++ b/web/packages/agenta-sessions-ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "rootDir": "src",
+        "tsBuildInfoFile": ".tsbuildinfo",
+        "moduleResolution": "bundler"
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx", "../css-modules.d.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -19,6 +19,7 @@ export type {FilterItemLabel} from "./filterItems"
 // Date/time utilities
 export {default as dayjs} from "./dayjs"
 export {normalizeEntityTimestamps, normalizeTimestamps, parseEntityDate} from "./entityTransforms"
+export {timeAgo} from "./timeAgo"
 
 // Path utilities for nested data navigation
 export {

--- a/web/packages/agenta-shared/src/utils/timeAgo.ts
+++ b/web/packages/agenta-shared/src/utils/timeAgo.ts
@@ -1,0 +1,16 @@
+/**
+ * Coarse relative time for an activity stamp — "just now", "5m ago", "3d ago".
+ *
+ * Deliberately coarse: list rows re-render on their own cadence (a shared minute tick, a
+ * refetch), so sub-minute precision would only promise a liveness the row doesn't have.
+ */
+export const timeAgo = (ts?: number): string => {
+    if (ts == null || !Number.isFinite(ts)) return ""
+    const s = Math.max(0, Math.round((Date.now() - ts) / 1000))
+    if (s < 60) return "just now"
+    const m = Math.round(s / 60)
+    if (m < 60) return `${m}m ago`
+    const h = Math.round(m / 60)
+    if (h < 24) return `${h}h ago`
+    return `${Math.round(h / 24)}d ago`
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
       '@agenta/sessions':
         specifier: workspace:../packages/agenta-sessions
         version: link:../packages/agenta-sessions
+      '@agenta/sessions-ui':
+        specifier: workspace:../packages/agenta-sessions-ui
+        version: link:../packages/agenta-sessions-ui
       '@agenta/shared':
         specifier: workspace:../packages/agenta-shared
         version: link:../packages/agenta-shared
@@ -1466,6 +1469,46 @@ importers:
       vitest:
         specifier: ^4.1.4
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.1.5(@types/node@20.19.39)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.22.4)(yaml@2.8.4))
+
+  packages/agenta-sessions-ui:
+    dependencies:
+      '@agenta/entities':
+        specifier: workspace:../agenta-entities
+        version: link:../agenta-entities
+      '@agenta/sessions':
+        specifier: workspace:../agenta-sessions
+        version: link:../agenta-sessions
+      '@agenta/shared':
+        specifier: workspace:../agenta-shared
+        version: link:../agenta-shared
+      '@agenta/ui':
+        specifier: workspace:../agenta-ui
+        version: link:../agenta-ui
+      '@phosphor-icons/react':
+        specifier: ^2.1.10
+        version: 2.1.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.9
+        version: 5.100.9(react@19.2.6)
+      '@types/node':
+        specifier: ^20.19.20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^19.0.10
+        version: 19.2.14
+      jotai:
+        specifier: ^2.15.0
+        version: 2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/agenta-shared:
     dependencies:

--- a/web/turbo.json
+++ b/web/turbo.json
@@ -89,6 +89,16 @@
             "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
             "outputs": [".tsbuildinfo"]
         },
+        "@agenta/sessions-ui#build": {
+            "dependsOn": [
+                "@agenta/shared#build",
+                "@agenta/ui#build",
+                "@agenta/entities#build",
+                "@agenta/sessions#build"
+            ],
+            "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
+            "outputs": [".tsbuildinfo"]
+        },
         "@agenta/oss#build": {
             "dependsOn": [
                 "@agenta/shared#build",
@@ -98,7 +108,8 @@
                 "@agenta/playground#build",
                 "@agenta/playground-ui#build",
                 "@agenta/chat#build",
-                "@agenta/sessions#build"
+                "@agenta/sessions#build",
+                "@agenta/sessions-ui#build"
             ],
             "inputs": [
                 "src/**",
@@ -121,7 +132,8 @@
                 "@agenta/playground#build",
                 "@agenta/playground-ui#build",
                 "@agenta/chat#build",
-                "@agenta/sessions#build"
+                "@agenta/sessions#build",
+                "@agenta/sessions-ui#build"
             ],
             "inputs": [
                 "src/**",
@@ -181,6 +193,10 @@
             "inputs": ["src/**/*.ts", "src/**/*.tsx", "eslint.config.*"],
             "outputs": []
         },
+        "@agenta/sessions-ui#lint": {
+            "inputs": ["src/**/*.ts", "src/**/*.tsx", "eslint.config.*"],
+            "outputs": []
+        },
         "@agenta/oss#lint": {
             "dependsOn": [
                 "@agenta/shared#lint",
@@ -190,7 +206,8 @@
                 "@agenta/playground#lint",
                 "@agenta/playground-ui#lint",
                 "@agenta/chat#lint",
-                "@agenta/sessions#lint"
+                "@agenta/sessions#lint",
+                "@agenta/sessions-ui#lint"
             ],
             "inputs": [
                 "src/**/*.ts",
@@ -258,6 +275,16 @@
             "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
             "outputs": []
         },
+        "@agenta/sessions-ui#types:check": {
+            "dependsOn": [
+                "@agenta/shared#types:check",
+                "@agenta/ui#types:check",
+                "@agenta/entities#types:check",
+                "@agenta/sessions#types:check"
+            ],
+            "inputs": ["src/**", "tsconfig.json", "../tsconfig.base.json", "../css-modules.d.ts"],
+            "outputs": []
+        },
         "@agenta/oss#types:check": {
             "dependsOn": [
                 "@agenta/shared#types:check",
@@ -267,7 +294,8 @@
                 "@agenta/playground#types:check",
                 "@agenta/playground-ui#types:check",
                 "@agenta/chat#types:check",
-                "@agenta/sessions#types:check"
+                "@agenta/sessions#types:check",
+                "@agenta/sessions-ui#types:check"
             ],
             "inputs": [
                 "src/**",


### PR DESCRIPTION
## Context
Third lane of the sessions/agents UX stack. With the rules in `@agenta/sessions`, the row and control markup still lived in the oss pages, styled with antd. Mobile forked before the antd migration and cannot import any of it.

## Changes
New antd-free package `@agenta/sessions-ui`: `SessionRow` (driven by `SessionRowVm`, neutral menu shape, `revealActionsOnHover` so touch surfaces can keep actions visible), the list empty/error/skeleton states, group header, pager, and the four filter controls bound to `useSessionFilters`. Anything not yet portable stays a slot: the agent picker is still antd (`EntityPicker`), so the controls take it as `agentPicker?: ReactNode` and the app injects it. Shells stay per-surface; the package exports controls, each app owns its rail or sheet.

Eslint bans `antd` and the `@agenta/ui` root barrel (subpaths only). `timeAgo` graduates to `@agenta/shared/utils` before it grows a third copy.

## Tests / notes
- Package builds under turbo; `grep 'from "antd"' src` is empty; `@agenta/oss` tsc is clean on this lane.
- The desktop page and rail that compose these arrive in the `oss/sessions-page` lane above.
