### PR TITLE
feat(frontend): Agent surfaces in @agenta/entity-ui/agent, antd-free

### DIFF
--- a/web/packages/agenta-entity-ui/eslint.config.mjs
+++ b/web/packages/agenta-entity-ui/eslint.config.mjs
@@ -1,0 +1,39 @@
+/**
+ * Base packages config, plus one directory contract: `src/agent/**` is antd-FREE so mobile can
+ * adopt the agent surfaces. The rest of the package still uses antd (EntityPicker, modals) and
+ * is unaffected.
+ */
+import base from "../eslint.config.mjs"
+
+export default [
+    ...base,
+    {
+        files: ["src/agent/**"],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [
+                        {
+                            name: "@agenta/sdk",
+                            message:
+                                "Import per-resource accessors from '@agenta/sdk/resources' — the root barrel bundles all 27 Fern resource clients.",
+                        },
+                        {
+                            name: "@agenta/ui",
+                            message:
+                                "Import a subpath ('@agenta/ui/ui', '@agenta/ui/components/presentational') — the root barrel exports antd-backed components.",
+                        },
+                    ],
+                    patterns: [
+                        {
+                            group: ["antd", "antd/*", "@ant-design/*"],
+                            message:
+                                "src/agent is antd-free. Use the Radix primitives from '@agenta/ui/ui', or take the element as a slot.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+]

--- a/web/packages/agenta-entity-ui/package.json
+++ b/web/packages/agenta-entity-ui/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "tsc --noEmit",
         "types:check": "tsc --noEmit",
-        "lint": "eslint --config ../eslint.config.mjs src/",
+        "lint": "eslint --config ./eslint.config.mjs src/",
         "test": "vitest run",
         "test:unit": "vitest run",
         "test:watch": "vitest"
@@ -16,6 +16,7 @@
     "exports": {
         ".": "./src/index.ts",
         "./adapters": "./src/adapters/index.ts",
+        "./agent": "./src/agent/index.ts",
         "./drawers/shared": "./src/drawers/shared/index.ts",
         "./drill-in": "./src/DrillInView/index.ts",
         "./gatewayTool": "./src/gatewayTool/index.ts",

--- a/web/packages/agenta-entity-ui/src/DrillInView/index.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/index.ts
@@ -394,3 +394,7 @@ export type {
     SectionTitleBadgeProps,
     SectionTitleBadgeTone,
 } from "./SchemaControls/agentTemplate/SectionTitleBadge"
+
+// The panel's instructions file row, reused read-only by surfaces that show an agent's brief
+// without editing it (the agent overview).
+export {InstructionsFileRow} from "./SchemaControls/agentTemplate/ItemRow"

--- a/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
@@ -1,0 +1,216 @@
+import type {ReactNode} from "react"
+
+import {timeAgo} from "@agenta/shared/utils"
+import {
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@agenta/ui/ui"
+import {DotsThreeIcon, Note, PencilSimple, Rocket, Trash} from "@phosphor-icons/react"
+
+import {Tip} from "./Tip"
+
+/** Deterministic so an agent keeps its colour across surfaces and reloads — index into a fixed
+ * ramp by name, never random. */
+const AVATAR_COLORS = [
+    "#3b5bdb",
+    "#2b8a3e",
+    "#9c6644",
+    "#7048e8",
+    "#c92a2a",
+    "#0b7285",
+    "#5f3dc4",
+    "#a9762a",
+]
+
+/** Initials come from the NAME, the colour from the ID: two agents can share a name (they often
+ * do — "New agent"), and hashing the name gave them the same avatar, which is the one case the
+ * avatar exists to solve. */
+export const agentAvatar = (name: string, id: string) => {
+    const words = name.trim().split(/\s+/).filter(Boolean)
+    const initials =
+        (words.length > 1 ? `${words[0][0]}${words[1][0]}` : (words[0] ?? "").slice(0, 2)) || "?"
+    let hash = 0
+    for (const char of id) hash = (hash * 31 + char.charCodeAt(0)) >>> 0
+    return {initials: initials.toUpperCase(), color: AVATAR_COLORS[hash % AVATAR_COLORS.length]}
+}
+
+/** What the card needs to know about an agent — nothing app-shaped. */
+export interface AgentCardData {
+    id: string
+    name: string
+    description?: string | null
+    /** ISO timestamp of the last configuration change — the grid footer's right edge. */
+    updatedAt?: string | null
+}
+
+export interface AgentCardProps {
+    agent: AgentCardData
+    /** Sessions blocked on you for this agent — the amber badge beside the name. */
+    waiting?: number
+    /** `grid` is the Agents page (a wider cell); `rail` is the home column. */
+    variant?: "rail" | "grid"
+    /** Data-connected cells stay app-side and arrive as slots: last activity (rail title
+     * line) and creator (grid footer). */
+    activity?: ReactNode
+    owner?: ReactNode
+    onOpenOverview: () => void
+    onOpenPlayground: () => void
+    onRename: () => void
+    onArchive: () => void
+}
+
+/**
+ * One agent, as a card. The same card on the rail and on the Agents page — the two differ only in
+ * how much room they have, not in what an agent IS.
+ *
+ * The avatar is the point: two agents both named "New agent" are indistinguishable in a text row,
+ * and a name is the one field we cannot rely on being distinct.
+ */
+export const AgentCard = ({
+    agent,
+    waiting = 0,
+    variant = "rail",
+    activity,
+    owner,
+    onOpenOverview,
+    onOpenPlayground,
+    onRename,
+    onArchive,
+}: AgentCardProps) => {
+    const {initials, color} = agentAvatar(agent.name, agent.id)
+    const isGrid = variant === "grid"
+
+    const avatar = (
+        <span
+            aria-hidden
+            className={`flex shrink-0 items-center justify-center rounded-full font-semibold text-white ${
+                isGrid
+                    ? // Straddling the top edge, as in the design: it reads as the agent's mark on
+                      // the card rather than as the first cell of a row.
+                      "absolute -top-5 left-4 size-10 border-2 border-solid border-colorBgContainer text-sm"
+                    : "size-10 text-sm"
+            }`}
+            style={{background: color}}
+        >
+            {initials}
+        </span>
+    )
+
+    const title = (
+        <div className="flex min-w-0 items-center gap-2">
+            <span className="min-w-0 truncate text-[15px] font-semibold text-colorText">
+                {agent.name}
+            </span>
+            {waiting > 0 ? (
+                <Tip title={`${waiting} waiting on you`}>
+                    <span className="shrink-0 rounded bg-colorWarningBg px-1.5 py-0.5 text-[11px] leading-none text-colorWarningText">
+                        {waiting} waiting
+                    </span>
+                </Tip>
+            ) : null}
+            {/* The rail puts activity on the title line, where the design shows the session
+                count; the grid carries it in the footer instead. */}
+            {!isGrid && activity ? (
+                <span className="ml-auto shrink-0 text-xs text-colorTextTertiary">{activity}</span>
+            ) : null}
+        </div>
+    )
+
+    const description = agent.description ? (
+        <span className="line-clamp-2 text-[13px] leading-snug text-colorTextSecondary">
+            {agent.description}
+        </span>
+    ) : null
+
+    const menu = (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="Agent actions"
+                    className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                    onClick={(event) => event.stopPropagation()}
+                >
+                    <DotsThreeIcon size={14} />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+                <DropdownMenuItem onSelect={onOpenOverview}>
+                    <Note size={16} />
+                    Open overview
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={onOpenPlayground}>
+                    <Rocket size={16} />
+                    Open in playground
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={onRename}>
+                    <PencilSimple size={16} />
+                    Rename
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive" onSelect={onArchive}>
+                    <Trash size={16} />
+                    Archive
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+
+    return (
+        <div
+            role="button"
+            tabIndex={0}
+            onClick={onOpenPlayground}
+            onKeyDown={(event) => {
+                // Only the card itself: the menu trigger is a child, and its Enter/Space must
+                // not also open the playground.
+                if (event.target !== event.currentTarget) return
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault()
+                    onOpenPlayground()
+                }
+            }}
+            className={`group box-border flex cursor-pointer flex-col transition-colors ${
+                isGrid
+                    ? "relative h-full gap-2.5 rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated p-5 pt-8 hover:border-colorBorder"
+                    : // No frame in the rail: the section around it is already a card, and a card
+                      // inside a card is the look we just spent the day removing.
+                      "gap-2 rounded-lg p-3 hover:bg-colorFillQuaternary"
+            }`}
+        >
+            {isGrid ? avatar : null}
+
+            {isGrid ? (
+                <>
+                    <div className="flex items-start justify-between gap-2">
+                        {title}
+                        {menu}
+                    </div>
+                    {description}
+                    {/* Footer: who made it and when it last ran. The design's integration badges
+                        belong on this line — an agent's tools aren't on the row yet. */}
+                    <div className="mt-auto flex items-center gap-2 pt-3 text-xs text-colorTextTertiary">
+                        {owner}
+                        <span className="ml-auto shrink-0">
+                            {agent.updatedAt ? timeAgo(Date.parse(agent.updatedAt)) : "—"}
+                        </span>
+                    </div>
+                </>
+            ) : (
+                <div className="flex items-start gap-3">
+                    {avatar}
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                        {title}
+                        {description}
+                    </div>
+                    {menu}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/agent/NextTriggersSection.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/NextTriggersSection.tsx
@@ -1,0 +1,211 @@
+import {useEffect, useMemo, useState} from "react"
+
+import {
+    describeCron,
+    nextCronRuns,
+    triggerBoundAgentId,
+    useTriggerSchedules,
+    useTriggerSubscriptions,
+} from "@agenta/entities/gatewayTrigger"
+import {dayjs} from "@agenta/shared/utils"
+import {PanelSection} from "@agenta/ui/components/presentational"
+import {SkeletonBlock} from "@agenta/ui/ui"
+import {LightningIcon} from "@phosphor-icons/react"
+
+import {Tip} from "./Tip"
+
+const LIST_SIZE = 5
+
+/** `formatDay` renders in UTC; a next-run time is only meaningful in the reader's own day. */
+const formatNextRun = (at: Date) => {
+    const run = dayjs(at)
+    const days = run.startOf("day").diff(dayjs().startOf("day"), "day")
+    if (days === 0) return run.format("HH:mm")
+    if (days === 1) return `tomorrow ${run.format("HH:mm")}`
+    if (days < 7) return run.format("ddd HH:mm")
+    return run.format("D MMM HH:mm")
+}
+
+/**
+ * What is going to fire, soonest first.
+ *
+ * Automations already appear on these pages as runs that HAPPENED. That answers "did it work",
+ * never "is anything coming" — a schedule that silently stopped firing looks identical to one
+ * that has simply not come round yet. Schedules project forward from their own cron expression;
+ * event subscriptions have no next time by nature, so they say what they are instead and sort
+ * after everything dated.
+ */
+interface UpcomingTrigger {
+    id: string
+    /** What it does. Falls back to the cadence in words, never to a cron expression. */
+    name: string
+    /** Which agent runs it, and how often. */
+    subtitle: string
+    detail: string
+    /** Absent for event subscriptions — they fire when the world does. */
+    at: Date | null
+    tooltip: string
+}
+
+export interface NextTriggersSectionProps {
+    /** Scope to one agent's triggers. On that agent's own page the binding is the premise, so
+     * rows drop the agent name and lead with the cadence instead. */
+    agentId?: string
+    /** Agent display names by workflow id. The classified agents list is app state, so the app
+     * hands the names over; an unknown id reads as "Unassigned agent". */
+    agentNames?: ReadonlyMap<string, string>
+}
+
+export const NextTriggersSection = ({agentId, agentNames}: NextTriggersSectionProps = {}) => {
+    const {
+        schedules,
+        isLoading: schedulesLoading,
+        error: schedulesError,
+        refetch: refetchSchedules,
+    } = useTriggerSchedules()
+    const {
+        subscriptions,
+        isLoading: subscriptionsLoading,
+        error: subscriptionsError,
+        refetch: refetchSubscriptions,
+    } = useTriggerSubscriptions()
+
+    // A minute clock: the queries don't poll, so without it a passed run keeps showing as "next".
+    const [now, setNow] = useState(() => new Date())
+    useEffect(() => {
+        const interval = setInterval(() => setNow(new Date()), 60_000)
+        return () => clearInterval(interval)
+    }, [])
+
+    const rows = useMemo<UpcomingTrigger[]>(() => {
+        const describeAgent = (references: unknown) => {
+            const boundId = triggerBoundAgentId(references as never)
+            return (boundId && agentNames?.get(boundId)) || "Unassigned agent"
+        }
+        const isInScope = (references: unknown) =>
+            !agentId || triggerBoundAgentId(references as never) === agentId
+
+        const scheduled = schedules
+            .filter(
+                (schedule) =>
+                    schedule.flags?.is_active !== false &&
+                    !schedule.deleted_at &&
+                    isInScope(schedule.data?.references),
+            )
+            .map((schedule, index) => {
+                const expression = schedule.data?.schedule ?? ""
+                const [next] = nextCronRuns(expression, 1, now)
+                const cadence = describeCron(expression)
+                const agent = describeAgent(schedule.data?.references)
+                return {
+                    id: schedule.id ?? `schedule-${index}`,
+                    // An unnamed schedule reads as its cadence, never as "5 * * * *".
+                    name: schedule.name || cadence,
+                    // Scoped to one agent, an unnamed schedule's title already IS the cadence.
+                    subtitle: agentId
+                        ? schedule.name
+                            ? cadence
+                            : ""
+                        : schedule.name
+                          ? `${agent} · ${cadence}`
+                          : agent,
+                    detail: next ? formatNextRun(next) : "—",
+                    at: next ?? null,
+                    tooltip: cadence,
+                }
+            })
+
+        const evented = subscriptions
+            .filter(
+                (subscription) =>
+                    subscription.flags?.is_active !== false &&
+                    isInScope(subscription.data?.references),
+            )
+            .map((subscription, index) => {
+                const eventKey = subscription.data?.event_key ?? ""
+                const agent = describeAgent(subscription.data?.references)
+                return {
+                    id: subscription.id ?? `subscription-${index}`,
+                    name: subscription.name || eventKey || "Event trigger",
+                    subtitle: agentId
+                        ? subscription.name
+                            ? eventKey
+                            : ""
+                        : eventKey && subscription.name
+                          ? `${agent} · ${eventKey}`
+                          : agent,
+                    detail: "on event",
+                    at: null,
+                    tooltip: eventKey ? `Fires on ${eventKey}` : "Fires when its event arrives",
+                }
+            })
+
+        // Dated first and soonest-first; undated (event) triggers keep their own order after them.
+        return [...scheduled, ...evented]
+            .sort((a, b) => {
+                if (a.at && b.at) return a.at.getTime() - b.at.getTime()
+                if (a.at) return -1
+                if (b.at) return 1
+                return 0
+            })
+            .slice(0, LIST_SIZE)
+    }, [schedules, subscriptions, agentNames, agentId, now])
+
+    const isLoading = schedulesLoading || subscriptionsLoading
+    const error = schedulesError ?? subscriptionsError
+
+    return (
+        <PanelSection title="Next triggers">
+            {isLoading ? (
+                <div className="flex flex-col gap-2 px-2 py-2">
+                    <SkeletonBlock active className="h-4 w-3/4" />
+                    <SkeletonBlock active className="h-4 w-1/2" />
+                </div>
+            ) : error && rows.length === 0 ? (
+                // A failed fetch must not read as "nothing scheduled" — that claim is false.
+                <p className="m-0 px-2 py-3 text-xs text-colorTextTertiary">
+                    Couldn't load triggers.{" "}
+                    <button
+                        type="button"
+                        onClick={() => {
+                            void refetchSchedules()
+                            void refetchSubscriptions()
+                        }}
+                        className="cursor-pointer border-0 bg-transparent p-0 text-xs text-colorTextSecondary underline"
+                    >
+                        Retry
+                    </button>
+                </p>
+            ) : rows.length === 0 ? (
+                <p className="m-0 px-2 py-3 text-xs text-colorTextTertiary">
+                    {agentId
+                        ? "No triggers bound to this agent yet."
+                        : "Nothing scheduled. Give an agent a trigger and its next run shows up here."}
+                </p>
+            ) : (
+                rows.map((row) => (
+                    <Tip key={row.id} title={row.tooltip} side="left">
+                        <div className="box-border flex items-start gap-2 rounded-lg px-2 py-2.5">
+                            <LightningIcon
+                                size={16}
+                                className="mt-0.5 shrink-0 text-colorTextTertiary"
+                                weight="fill"
+                            />
+                            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                                <span className="truncate text-sm text-colorText">{row.name}</span>
+                                {row.subtitle ? (
+                                    <span className="truncate text-[13px] text-colorTextSecondary">
+                                        {row.subtitle}
+                                    </span>
+                                ) : null}
+                            </span>
+                            <span className="mt-0.5 shrink-0 text-xs text-colorTextSecondary">
+                                {row.detail}
+                            </span>
+                        </div>
+                    </Tip>
+                ))
+            )}
+        </PanelSection>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/agent/Tip.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/Tip.tsx
@@ -1,0 +1,24 @@
+import type {ReactNode} from "react"
+
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
+
+/** Radix tooltip in antd's ergonomic shape (`title` + child). No title → just the child. */
+export const Tip = ({
+    title,
+    side,
+    children,
+}: {
+    title: ReactNode
+    side?: "top" | "right" | "bottom" | "left"
+    children: ReactNode
+}) => {
+    if (title == null) return <>{children}</>
+    return (
+        <TooltipProvider delayDuration={100}>
+            <Tooltip>
+                <TooltipTrigger asChild>{children}</TooltipTrigger>
+                <TooltipContent side={side}>{title}</TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/agent/index.ts
+++ b/web/packages/agenta-entity-ui/src/agent/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Agent surfaces — antd-free (eslint-enforced for this directory), so mobile can adopt them.
+ * Data-connected cells (activity, owner) and the classified agents list stay app-side and
+ * arrive as slots/props; the components own only what an agent card or trigger row IS.
+ */
+export {AgentCard, agentAvatar, type AgentCardData, type AgentCardProps} from "./AgentCard"
+export {NextTriggersSection, type NextTriggersSectionProps} from "./NextTriggersSection"

--- a/web/packages/agenta-entity-ui/src/index.ts
+++ b/web/packages/agenta-entity-ui/src/index.ts
@@ -54,6 +54,7 @@ export {
     AgentConfigSkeleton,
     AgentOperationsSections,
     AgentOperationsSkeleton,
+    InstructionsFileRow,
     preloadAgentTemplateControl,
     useDrillIn,
     type PlaygroundConfigSectionProps,


### PR DESCRIPTION
## Context
Fourth lane of the sessions/agents UX stack. The agent card and next-triggers surfaces were built in the oss app for Home, the agents page and the overview. Only the components that survive a headless contract port here; `UsageSummary` and `NewAgentButton` stay app-side deliberately (a port would leave an empty shell over app state).

## Changes
New `@agenta/entity-ui/agent` subpath (the package already exports per-module subpaths, so mobile can import it without touching the antd modules):
- `AgentCard` takes a neutral `AgentCardData` plus callbacks. The data-connected cells arrive as `activity` / `owner` slots. The avatar colour hashes the workflow id, not the name: two agents named "New agent" kept getting the same avatar.
- `NextTriggersSection` reads trigger data via `@agenta/entities/gatewayTrigger` and takes display names as an `agentNames` map, because the classified agents list is app state.

The antd ban is eslint-scoped to `src/agent/**`; the rest of the package still uses antd. `DrillInView` exports the accordion primitives the overview lane composes.

## Tests / notes
- 301 package unit tests pass; `grep 'from "antd"' src/agent` is empty.
- Depends on `entities/trigger-helpers` (targets `main`): `NextTriggersSection` imports `triggerBoundAgentId`, so the package build goes green once that PR reaches this stack's base. Everything else on this lane is clean.
