### PR TITLE
feat(frontend): Agents as cards on their own page

### DIFF
--- a/web/oss/src/components/pages/agents/AgentsGrid.tsx
+++ b/web/oss/src/components/pages/agents/AgentsGrid.tsx
@@ -1,0 +1,68 @@
+import {PlusIcon} from "@phosphor-icons/react"
+import {Empty, Skeleton} from "antd"
+
+import AgentCard from "@/oss/components/AgentCard"
+import type {AgentColumnActions} from "@/oss/components/pages/agent-home/components/YourAgentsTable/columns"
+import {useWaitingByAgent} from "@/oss/components/pages/agent-home/components/YourAgentsTable/useAgentActivity"
+import type {AppWorkflowRow} from "@/oss/components/pages/app-management/store"
+
+/**
+ * The agents roster as a card grid.
+ *
+ * The table it replaces put five columns behind a horizontal scroll, so reading an agent meant
+ * scrolling sideways past provenance to reach whether anything is blocked. A card is one agent at
+ * a glance, and the create affordance is the grid's last cell rather than a control set apart from
+ * the things it creates.
+ */
+const AgentsGrid = ({
+    rows,
+    isLoading,
+    actions,
+    onCreate,
+}: {
+    rows: AppWorkflowRow[]
+    isLoading: boolean
+    actions: AgentColumnActions
+    onCreate: () => void
+}) => {
+    const waitingByAgent = useWaitingByAgent()
+
+    if (isLoading && rows.length === 0) {
+        return <Skeleton active paragraph={{rows: 6}} title={false} />
+    }
+
+    // `pt-5` is the room the grid variant's overhanging avatar needs. It belongs to the grid, not
+    // to each card — on the card it left the avatar-less dashed cell misaligned.
+    return (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-x-4 gap-y-10 pt-5">
+            {rows.map((record) => (
+                <AgentCard
+                    key={record.key}
+                    variant="grid"
+                    record={record}
+                    waiting={waitingByAgent.get(record.workflowId) ?? 0}
+                    actions={actions}
+                />
+            ))}
+
+            {/* Dashed, so it reads as a slot to fill rather than an agent that exists. */}
+            <button
+                type="button"
+                onClick={onCreate}
+                className="box-border flex h-full min-h-[148px] cursor-pointer flex-col items-center justify-center gap-1 rounded-xl border border-dashed border-colorBorder bg-transparent p-5 text-center transition-colors hover:border-colorPrimary"
+            >
+                <PlusIcon size={18} className="text-colorTextTertiary" />
+                <span className="text-sm text-colorText">New agent</span>
+                <span className="text-xs text-colorTextTertiary">start blank</span>
+            </button>
+
+            {!isLoading && rows.length === 0 ? (
+                <div className="col-span-full">
+                    <Empty description="No agents yet" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                </div>
+            ) : null}
+        </div>
+    )
+}
+
+export default AgentsGrid

--- a/web/oss/src/components/pages/agents/AgentsPage.tsx
+++ b/web/oss/src/components/pages/agents/AgentsPage.tsx
@@ -4,26 +4,20 @@ import {appTemplatesQueryAtom, createEphemeralAppFromTemplate} from "@agenta/ent
 import {openWorkflowRevisionDrawerAtom} from "@agenta/playground-ui/workflow-revision-drawer"
 import {extractApiErrorMessage} from "@agenta/shared/utils"
 import {PageLayout} from "@agenta/ui"
-import type {TableFeaturePagination, TableScopeConfig} from "@agenta/ui/table"
-import {message} from "antd"
-import type {TableProps} from "antd/es/table"
+import {Input, message} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
+import Link from "next/link"
 import {useRouter} from "next/router"
 
+import NewAgentButton from "@/oss/components/NewAgentButton"
 import {usePlaygroundNavigation} from "@/oss/hooks/usePlaygroundNavigation"
 import useURL from "@/oss/hooks/useURL"
-import {useProjectData} from "@/oss/state/project"
 
-import {
-    createAppWorkflowColumns,
-    type AppWorkflowColumnActions,
-} from "../app-management/components/appWorkflowColumns"
+import type {AgentColumnActions} from "../agent-home/components/YourAgentsTable/columns"
 import {openDeleteAppModalAtom} from "../app-management/modals/DeleteAppModal/store/deleteAppModalStore"
 import {openEditAppModalAtom} from "../app-management/modals/EditAppModal/store/editAppModalStore"
-import type {AppWorkflowRow} from "../app-management/store"
 
-import AgentsTableSection from "./AgentsTableSection"
-import {useAgentsSelection} from "./hooks/useAgentsSelection"
+import AgentsGrid from "./AgentsGrid"
 import {
     agentsSearchTermAtom,
     agentsWorkflowsAtom,
@@ -33,7 +27,6 @@ import {
 
 export default function AgentsPage() {
     const router = useRouter()
-    const {projectId} = useProjectData()
     const {baseAppURL, projectURL} = useURL()
     const {goToPlayground} = usePlaygroundNavigation()
     const setOpenDrawer = useSetAtom(openWorkflowRevisionDrawerAtom)
@@ -46,8 +39,6 @@ export default function AgentsPage() {
     const refetchAgents = useSetAtom(refetchAgentsWorkflowsAtom)
 
     useAtomValue(appTemplatesQueryAtom)
-
-    const {selectedRows, rowSelection, clearSelection} = useAgentsSelection(rows)
 
     const handleCreate = useCallback(async () => {
         try {
@@ -63,24 +54,9 @@ export default function AgentsPage() {
         }
     }, [setOpenDrawer])
 
-    const handleArchived = useCallback(() => {
-        clearSelection()
-        refetchAgents()
-    }, [clearSelection, refetchAgents])
+    const handleArchived = useCallback(() => refetchAgents(), [refetchAgents])
 
-    const handleArchive = useCallback(() => {
-        if (!selectedRows.length) {
-            router.push(`${projectURL}/agents/archived`)
-            return
-        }
-
-        openDeleteAppModal({
-            apps: selectedRows.map((row) => ({id: row.workflowId, name: row.name})),
-            onArchived: handleArchived,
-        })
-    }, [handleArchived, openDeleteAppModal, projectURL, router, selectedRows])
-
-    const columnActions = useMemo<AppWorkflowColumnActions>(
+    const cardActions = useMemo<AgentColumnActions>(
         () => ({
             onOpen: (record) => router.push(`${baseAppURL}/${record.workflowId}/overview`),
             onOpenPlayground: (record) => goToPlayground(undefined, {appId: record.workflowId}),
@@ -88,9 +64,9 @@ export default function AgentsPage() {
                 openEditAppModal({
                     id: record.workflowId,
                     name: record.name,
-                    onRenamed: () => refetchAgents(),
+                    onRenamed: refetchAgents,
                 }),
-            onDelete: (record) =>
+            onArchive: (record) =>
                 openDeleteAppModal({
                     id: record.workflowId,
                     name: record.name,
@@ -98,65 +74,42 @@ export default function AgentsPage() {
                 }),
         }),
         [
+            router,
             baseAppURL,
             goToPlayground,
-            handleArchived,
-            openDeleteAppModal,
             openEditAppModal,
+            openDeleteAppModal,
             refetchAgents,
-            router,
+            handleArchived,
         ],
-    )
-    const columns = useMemo(() => createAppWorkflowColumns(columnActions), [columnActions])
-
-    const tableScope = useMemo<TableScopeConfig>(
-        () => ({
-            scopeId: projectId ? `agents-${projectId}` : "agents",
-            pageSize: Math.max(rows.length, 1),
-            enableInfiniteScroll: false,
-        }),
-        [projectId, rows.length],
-    )
-    const pagination = useMemo<TableFeaturePagination<AppWorkflowRow>>(
-        () => ({
-            rows,
-            loadNextPage: () => undefined,
-            resetPages: () => undefined,
-        }),
-        [rows],
-    )
-    const tableProps = useMemo<TableProps<AppWorkflowRow>>(
-        () => ({
-            bordered: true,
-            size: "small",
-            virtual: true,
-            sticky: true,
-            tableLayout: "fixed",
-            scroll: {x: "max-content"},
-            loading: isLoading,
-            onRow: (record) => ({
-                // Primary click opens the agent in the playground (its main surface), not overview.
-                onClick: () => goToPlayground(undefined, {appId: record.workflowId}),
-                className: "cursor-pointer",
-            }),
-        }),
-        [goToPlayground, isLoading],
     )
 
     return (
         <PageLayout className="grow min-h-0" title="Agents">
-            <AgentsTableSection
-                columns={columns}
+            <div className="flex items-center gap-3">
+                <NewAgentButton />
+                <Input
+                    allowClear
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    placeholder="Search agents by name…"
+                    className="max-w-80"
+                />
+                {/* The table's bulk-archive control was also the only route to the archived
+                    list; the grid has no bulk mode, so the link stands on its own. */}
+                <Link
+                    href={`${projectURL}/agents/archived`}
+                    className="ml-auto shrink-0 text-xs !text-colorTextSecondary"
+                >
+                    Archived agents
+                </Link>
+            </div>
+
+            <AgentsGrid
                 rows={rows}
-                tableScope={tableScope}
-                pagination={pagination}
-                rowSelection={rowSelection}
-                tableProps={tableProps}
-                searchTerm={searchTerm}
-                selectedCount={selectedRows.length}
-                onSearchChange={setSearchTerm}
+                isLoading={isLoading}
+                actions={cardActions}
                 onCreate={handleCreate}
-                onArchive={handleArchive}
             />
         </PageLayout>
     )


### PR DESCRIPTION
## Context
Second app lane. The agents roster existed as a table on Home; a dedicated `/agents` page renders the same data as cards.

## Changes
`AgentsGrid` renders the shared `AgentCard` (from `@agenta/entity-ui/agent` via the oss adapter) with a create cell aligned to the card grid, waiting badges from the session list, and the same column actions (open, edit, delete) as the Home roster. `AgentsPage` composes the grid with `NewAgentButton`, which creates blank or from a template from one control.

## Tests / notes
- Two files; all data and card logic live in the lanes below. `@agenta/oss` tsc adds nothing on this lane.

## What to QA
- Open the agents page: agents render as cards with activity, owner and waiting badges; the create cell matches card spacing.
- Regression: card actions (open in playground, edit, delete) still work from both the page and the Home roster.
