### PR TITLE
feat(frontend): Template cards, a gallery rail, and a template detail page

### DIFF
--- a/web/ee/src/pages/w/[workspace_id]/p/[project_id]/apps/agent-templates/[template_key].tsx
+++ b/web/ee/src/pages/w/[workspace_id]/p/[project_id]/apps/agent-templates/[template_key].tsx
@@ -1,0 +1,3 @@
+import TemplateDetailPage from "@agenta/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/agent-templates/[template_key]"
+
+export default TemplateDetailPage

--- a/web/oss/src/components/pages/agent-home/components/TemplateDetail/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplateDetail/index.tsx
@@ -1,0 +1,227 @@
+import {PageLayout} from "@agenta/ui"
+import {ArrowLeftIcon, ArrowRightIcon, CheckCircleIcon, LightningIcon} from "@phosphor-icons/react"
+import {Button, Empty, Tag, Tooltip} from "antd"
+import Link from "next/link"
+import {useRouter} from "next/router"
+
+import Markdown from "@/oss/components/AgentChatSlice/assets/markdown"
+import useURL from "@/oss/hooks/useURL"
+
+import {AGENT_TEMPLATES, PROVIDERS} from "../../assets/templates"
+
+const SectionLabel = ({children}: {children: React.ReactNode}) => (
+    <h2 className="m-0 text-[11px] font-semibold uppercase tracking-wide text-colorTextTertiary">
+        {children}
+    </h2>
+)
+
+/**
+ * One template, in full.
+ *
+ * Everything here is a field the template already declares — connections and their scopes, the
+ * tools it calls, its AGENTS.md, when it fires, its example session (labelled as an example).
+ * The design's usage counter, "saves ~2h/week" and last-updated date have nothing behind them,
+ * so they are absent rather than invented.
+ */
+const TemplateDetail = ({templateKey}: {templateKey: string}) => {
+    const router = useRouter()
+    const {baseAppURL} = useURL()
+    const template = AGENT_TEMPLATES.find((entry) => entry.key === templateKey)
+
+    if (!template) {
+        return (
+            <PageLayout className="grow min-h-0">
+                <Empty description="Template not found" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            </PageLayout>
+        )
+    }
+
+    const tools = template.requiredIntegrations.flatMap((integration) =>
+        integration.tools.map((tool) => ({...tool, provider: integration.slug})),
+    )
+
+    return (
+        <PageLayout className="grow min-h-0 !px-14 !pt-0">
+            <div className="flex min-h-0 w-full flex-1 flex-col gap-10 lg:flex-row lg:gap-0">
+                {/* Identity and what it needs — a rail, not a column: it bleeds to the page's own
+                    edges and carries the divider, so the decision half is a distinct surface from
+                    the reading half rather than the same page with a gap down the middle. */}
+                <aside className="box-border flex w-full shrink-0 flex-col gap-6 lg:-mb-4 lg:-ml-14 lg:w-[344px] lg:border-0 lg:border-r lg:border-solid lg:border-colorBorderSecondary lg:bg-colorFillQuaternary lg:px-6 lg:py-6">
+                    <Link
+                        href={`${baseAppURL}/agent-templates`}
+                        className="inline-flex w-fit items-center gap-1 text-xs !text-colorTextSecondary"
+                    >
+                        <ArrowLeftIcon size={14} />
+                        All templates
+                    </Link>
+
+                    <div className="flex flex-col gap-3">
+                        <span
+                            aria-hidden
+                            className="flex size-12 items-center justify-center rounded-full text-base font-semibold text-white"
+                            style={{backgroundColor: template.color}}
+                        >
+                            {template.initials}
+                        </span>
+                        <h1 className="m-0 text-2xl font-semibold text-colorText">
+                            {template.name}
+                        </h1>
+                        <p className="m-0 text-sm leading-relaxed text-colorTextSecondary">
+                            {template.overview || template.description}
+                        </p>
+                        <div className="flex flex-wrap items-center gap-1.5">
+                            <Tag>{template.category}</Tag>
+                            <Tag>{template.trigger}</Tag>
+                        </div>
+                    </div>
+
+                    <Button
+                        type="primary"
+                        size="large"
+                        onClick={() =>
+                            void router.push(`${baseAppURL}?new=1&template=${template.key}`)
+                        }
+                    >
+                        Use this template
+                        <ArrowRightIcon size={14} />
+                    </Button>
+
+                    {template.requiredIntegrations.length ? (
+                        <section className="flex flex-col gap-2">
+                            <SectionLabel>Connections it uses</SectionLabel>
+                            {template.requiredIntegrations.map((integration) => (
+                                <div
+                                    key={integration.slug}
+                                    className="box-border flex items-center gap-2 rounded-lg border border-solid border-colorBorderSecondary bg-colorBgElevated px-3 py-2"
+                                >
+                                    <span className="shrink-0 text-sm text-colorText">
+                                        {PROVIDERS[integration.slug]?.label ?? integration.slug}
+                                    </span>
+                                    <Tooltip title={integration.scope}>
+                                        <span className="ml-auto min-w-0 truncate text-right text-xs text-colorTextTertiary">
+                                            {integration.scope}
+                                        </span>
+                                    </Tooltip>
+                                </div>
+                            ))}
+                        </section>
+                    ) : null}
+
+                    {template.triggerDescription ? (
+                        <section className="flex flex-col gap-2">
+                            <SectionLabel>Also included</SectionLabel>
+                            <div className="box-border flex items-center gap-2 rounded-lg border border-solid border-colorBorderSecondary bg-colorBgElevated px-3 py-2">
+                                <LightningIcon
+                                    size={14}
+                                    weight="fill"
+                                    className="shrink-0 text-colorTextTertiary"
+                                />
+                                <span className="shrink-0 text-sm text-colorText">Trigger</span>
+                                <Tooltip title={template.triggerDescription}>
+                                    <span className="ml-auto min-w-0 truncate text-right text-xs text-colorTextTertiary">
+                                        {template.triggerDescription}
+                                    </span>
+                                </Tooltip>
+                            </div>
+                        </section>
+                    ) : null}
+                </aside>
+
+                {/* What it will actually do. */}
+                <div className="flex min-w-0 flex-1 flex-col gap-6 lg:py-4 lg:pl-10">
+                    {template.example ? (
+                        <section className="flex flex-col gap-2">
+                            <SectionLabel>Example session</SectionLabel>
+                            <div className="box-border flex flex-col gap-3 rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated p-4">
+                                <span className="w-fit self-end rounded-lg bg-colorFillTertiary px-3 py-1.5 text-sm text-colorText">
+                                    {template.example.prompt}
+                                </span>
+
+                                <span className="text-xs text-colorTextTertiary">
+                                    {template.name} · {template.example.steps.length} steps
+                                </span>
+                                <ol className="m-0 flex list-none flex-col gap-1.5 p-0">
+                                    {template.example.steps.map((step) => (
+                                        <li
+                                            key={step}
+                                            className="flex items-center gap-2 text-sm text-colorTextSecondary"
+                                        >
+                                            <CheckCircleIcon
+                                                size={14}
+                                                className="shrink-0 text-colorSuccess"
+                                            />
+                                            {step}
+                                        </li>
+                                    ))}
+                                </ol>
+
+                                <p className="m-0 text-sm leading-relaxed text-colorText">
+                                    {template.example.reply}
+                                </p>
+
+                                {template.example.artifacts?.length || template.example.status ? (
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        {template.example.artifacts?.map((artifact) => (
+                                            <Tag key={artifact} className="!m-0 font-mono !text-xs">
+                                                {artifact}
+                                            </Tag>
+                                        ))}
+                                        {template.example.status ? (
+                                            <Tag color="warning" className="!m-0">
+                                                {template.example.status}
+                                            </Tag>
+                                        ) : null}
+                                    </div>
+                                ) : null}
+                            </div>
+                            {/* Say what it is. An illustrative run presented as a real one is a
+                                lie about what the agent has already done for someone. */}
+                            <span className="text-xs text-colorTextTertiary">
+                                An example of how this template runs — not a recorded session.
+                            </span>
+                        </section>
+                    ) : null}
+
+                    <div className="grid min-w-0 grid-cols-1 items-start gap-6 xl:grid-cols-2">
+                        <section className="flex min-w-0 flex-col gap-2">
+                            <SectionLabel>Instructions · AGENTS.md</SectionLabel>
+                            {/* AGENTS.md is markdown — headings and lists are how it's written,
+                                and a <pre> printed the syntax instead of the structure. The chat's
+                                own renderer, so a template's instructions read the same here as
+                                they do in a conversation. */}
+                            <div className="box-border max-h-[420px] overflow-auto rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated p-4">
+                                <Markdown
+                                    content={template.instructions}
+                                    className="!text-[13px]"
+                                />
+                            </div>
+                        </section>
+
+                        {tools.length ? (
+                            <section className="flex min-w-0 flex-col gap-2">
+                                <SectionLabel>Tools it can call</SectionLabel>
+                                <div className="box-border flex flex-col rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated p-2">
+                                    {tools.map((tool) => (
+                                        <div
+                                            key={`${tool.provider}-${tool.name}`}
+                                            className="flex items-center gap-2 rounded-lg px-2 py-2"
+                                        >
+                                            <span className="min-w-0 flex-1 truncate font-mono text-[13px] text-colorText">
+                                                {tool.name}
+                                            </span>
+                                            <span className="shrink-0 text-xs text-colorTextTertiary">
+                                                {PROVIDERS[tool.provider]?.label ?? tool.provider}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </section>
+                        ) : null}
+                    </div>
+                </div>
+            </div>
+        </PageLayout>
+    )
+}
+
+export default TemplateDetail

--- a/web/oss/src/components/pages/agent-home/components/TemplatesGallery/TemplateSection.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplatesGallery/TemplateSection.tsx
@@ -22,7 +22,9 @@ const TemplateSection = ({category, templates, onSelectTemplate}: TemplateSectio
                 </span>
             </div>
 
-            <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 xl:grid-cols-3">
+            {/* `pt-5` is the room the card's overhanging monogram needs — it belongs to the grid,
+                not to each card, so every cell in a row still starts at the same y. */}
+            <div className="grid grid-cols-1 gap-x-4 gap-y-10 pt-5 sm:grid-cols-2 xl:grid-cols-3">
                 {templates.map((template) => (
                     <TemplateCard
                         key={template.key}

--- a/web/oss/src/components/pages/agent-home/components/TemplatesGallery/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplatesGallery/index.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useDeferredValue, useEffect, useMemo, useState} from "react"
 
-import {SectionRail, type SectionRailItem} from "@agenta/entity-ui"
+import {type SectionRailItem} from "@agenta/entity-ui"
 import {PageLayout} from "@agenta/ui"
 import {App, Input, Typography} from "antd"
 import {useAtomValue} from "jotai"
@@ -19,7 +19,6 @@ import {
     templateCategories,
     type AgentTemplate,
 } from "../../assets/templates"
-import {useTemplateSelect} from "../../hooks/useTemplateSelect"
 import TemplateSetupDrawer, {type TemplateSetupResult} from "../TemplateSetupDrawer"
 
 import TemplateSection from "./TemplateSection"
@@ -96,7 +95,13 @@ const TemplatesGalleryPage = () => {
     // Template card click: builder mode → straight to a seeded playground; else open the setup
     // drawer. Gated by NEXT_PUBLIC_AGENT_TEMPLATE_BUILDER.
     const [setupTemplate, setSetupTemplate] = useState<AgentTemplate | null>(null)
-    const handleSelectTemplate = useTemplateSelect(setSetupTemplate)
+    // A card opens the template rather than creating from it: the detail page is where you find
+    // out what it needs before committing, which is the point of having one.
+    const handleSelectTemplate = useCallback(
+        (template: AgentTemplate) =>
+            void router.push(`${baseAppURL}/agent-templates/${template.key}`),
+        [router, baseAppURL],
+    )
 
     // TODO(Phase B): create the ephemeral draft from the template + open the playground.
     const handleTemplateCreate = useCallback(
@@ -130,35 +135,52 @@ const TemplatesGalleryPage = () => {
     const hasQuery = deferredQuery.length > 0
 
     return (
-        <PageLayout className="grow min-h-0">
-            <div className="mx-auto flex min-h-0 w-full max-w-[1200px] flex-1 flex-col gap-5 pt-6">
-                <div className="flex shrink-0 flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
+        <PageLayout className="grow min-h-0 !p-0">
+            {/* Same rail as the template detail page: its own surface, bled to the page edges,
+                carrying the divider — so browsing and choosing read as two halves of one screen. */}
+            <div className="flex min-h-0 w-full flex-1 flex-col lg:flex-row">
+                <aside className="box-border flex w-full shrink-0 flex-col gap-6 border-0 border-solid border-colorBorderSecondary px-6 py-6 lg:w-[280px] lg:border-r lg:bg-colorFillQuaternary">
                     <div className="flex min-w-0 flex-col gap-1.5">
                         <Typography.Title level={2} className="!m-0 !text-[24px] !leading-tight">
                             {TEMPLATES_GALLERY.title}
                         </Typography.Title>
-                        <Typography.Text className="max-w-[560px] !text-[13px] !text-[var(--ag-colorTextSecondary)]">
+                        <Typography.Text className="!text-[13px] !text-[var(--ag-colorTextSecondary)]">
                             {TEMPLATES_GALLERY.subtitle}
                         </Typography.Text>
                     </div>
 
+                    <nav className="flex flex-col gap-0.5">
+                        {railItems.map((item) => (
+                            <button
+                                key={item.value}
+                                type="button"
+                                aria-current={item.value === active}
+                                onClick={() => handleCategoryChange(item.value)}
+                                className={`box-border flex w-full cursor-pointer items-center gap-2 rounded-lg border-0 px-3 py-2 text-left text-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-colorPrimary ${
+                                    item.value === active
+                                        ? "bg-colorFillSecondary text-colorText"
+                                        : "bg-transparent text-colorTextSecondary hover:bg-colorFillQuaternary"
+                                }`}
+                            >
+                                <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                                <span className="shrink-0 text-xs text-colorTextTertiary">
+                                    {item.count}
+                                </span>
+                            </button>
+                        ))}
+                    </nav>
+                </aside>
+
+                {/* One scroller: the sections wrapper below scrolls, so search stays pinned. */}
+                <div className="flex min-h-0 flex-1 flex-col gap-5 px-10 py-6">
                     <Input
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
                         allowClear
                         prefix={<Search size={14} className="text-[var(--ag-colorTextTertiary)]" />}
                         placeholder={TEMPLATES_GALLERY.searchPlaceholder}
-                        className="w-full sm:w-[280px]"
+                        className="w-full sm:w-[320px] self-end"
                     />
-                </div>
-
-                <SectionRail
-                    items={railItems}
-                    value={active}
-                    onChange={handleCategoryChange}
-                    railWidth="w-[160px]"
-                    fill
-                >
                     {resultCount === 0 ? (
                         <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-[var(--ag-colorBorder)] px-6 py-12 text-center">
                             <Typography.Text className="text-xs text-[var(--ag-colorTextSecondary)]">
@@ -189,7 +211,7 @@ const TemplatesGalleryPage = () => {
                             ))}
                         </div>
                     )}
-                </SectionRail>
+                </div>
             </div>
 
             <TemplateSetupDrawer

--- a/web/oss/src/components/pages/agent-home/components/TemplatesSection/TemplateCard.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplatesSection/TemplateCard.tsx
@@ -7,33 +7,42 @@ interface TemplateCardProps {
     onSelect: (template: AgentTemplate) => void
 }
 
-/** Info-rich starter-template tile: monogram + name, description, tools·trigger meta + provider logos. */
+/**
+ * A template, in the same card shape an agent uses.
+ *
+ * A template IS an agent you haven't made yet, so the two read as one object type: monogram
+ * straddling the top edge, name, description, then a footer of the connections it needs. The
+ * design's "1.2k uses" has no telemetry behind it — the footer carries what the template actually
+ * declares (its tools and when it fires) instead of an invented popularity number.
+ */
 const TemplateCard = ({template, onSelect}: TemplateCardProps) => {
     return (
         <button
             type="button"
             onClick={() => onSelect(template)}
-            className="group flex h-full min-h-[132px] cursor-pointer flex-col gap-3 rounded-lg border border-solid border-transparent bg-[var(--ag-colorFillQuaternary)] p-4 text-left transition-colors hover:border-[var(--ag-colorBorderSecondary)] hover:bg-[var(--ag-colorFillTertiary)]"
+            className="group relative box-border flex h-full cursor-pointer flex-col gap-2.5 rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated p-5 pt-8 text-left transition-colors hover:border-colorBorder"
         >
-            <div className="flex items-center gap-3">
-                <span
-                    className="flex size-9 shrink-0 items-center justify-center rounded-lg text-xs font-semibold text-white"
-                    style={{backgroundColor: template.color}}
-                >
-                    {template.initials}
-                </span>
-                <span className="truncate text-sm font-medium">{template.name}</span>
-            </div>
+            <span
+                aria-hidden
+                className="absolute -top-5 left-4 flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-solid border-colorBgContainer text-sm font-semibold text-white"
+                style={{backgroundColor: template.color}}
+            >
+                {template.initials}
+            </span>
 
-            <p className="m-0 line-clamp-2 text-[13px] leading-snug text-[var(--ag-colorTextSecondary)]">
+            <span className="truncate text-[15px] font-semibold text-colorText">
+                {template.name}
+            </span>
+
+            <p className="m-0 line-clamp-2 text-[13px] leading-snug text-colorTextSecondary">
                 {template.description}
             </p>
 
-            <div className="mt-auto flex items-center justify-between gap-2">
-                <span className="truncate text-[11px] text-[var(--ag-colorTextTertiary)]">
+            <div className="mt-auto flex items-center gap-2 pt-3">
+                <ProviderMarks providers={templateProviderSlugs(template)} />
+                <span className="ml-auto truncate text-xs text-colorTextTertiary">
                     {template.toolsSummary} · {template.trigger}
                 </span>
-                <ProviderMarks providers={templateProviderSlugs(template)} />
             </div>
         </button>
     )

--- a/web/oss/src/components/pages/agent-home/components/TemplatesSection/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplatesSection/index.tsx
@@ -73,9 +73,9 @@ const TemplatesSection = ({onSelectTemplate, onBrowseAll, hideHeader}: Templates
                 railWidth="w-[132px]"
             >
                 {filtered.length > 0 ? (
-                    // auto-fill fills the content column with ~320px cards (2–4 cols by width),
-                    // fixed row height so switching categories never reflows card sizes.
-                    <div className="grid auto-rows-[132px] grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-3">
+                    // auto-fill fills the content column with ~320px cards (2–4 cols by width);
+                    // rows size to their content.
+                    <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-x-4 gap-y-10 pt-5">
                         {filtered.map((template) => (
                             <TemplateCard
                                 key={template.key}

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/agent-templates/[template_key].tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/agent-templates/[template_key].tsx
@@ -1,0 +1,16 @@
+import dynamic from "next/dynamic"
+import {useRouter} from "next/router"
+
+const TemplateDetail = dynamic(
+    () => import("@/oss/components/pages/agent-home/components/TemplateDetail"),
+)
+
+/** One template in full, reached from the gallery. */
+export default function TemplateDetailPage() {
+    const {query} = useRouter()
+    const templateKey = Array.isArray(query.template_key)
+        ? query.template_key[0]
+        : query.template_key
+
+    return templateKey ? <TemplateDetail templateKey={templateKey} /> : null
+}


### PR DESCRIPTION
## Context
Third app lane. Templates were a strip and a gallery with no detail view; a template's fields (instructions, providers, example session) had nowhere to render.

## Changes
Template cards take the agent card shape, the gallery gets the detail page's rail, and a new detail page renders each template from the fields it declares: markdown instructions, provider marks, and an example session honestly labelled as an example. The six templates from the design get example sessions. The route is registered in OSS and EE (a page needs both files or it 404s in EE).

## Tests / notes
- `@agenta/oss` tsc adds nothing on this lane. The EE route is a re-export shim over the OSS page.

## What to QA
- Open the templates gallery, pick a template: the detail page shows the rail, markdown instructions, and the example session.
- On EE, open the same template detail route: it renders (not 404).
- Regression: creating an agent from a template still lands in the playground with the template applied.
