### PR TITLE
feat(frontend): Project- and agent-scoped sessions pages with a filters rail

### DIFF
--- a/web/ee/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/sessions/index.tsx
+++ b/web/ee/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/sessions/index.tsx
@@ -1,0 +1,3 @@
+import AgentSessionsPage from "@agenta/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/sessions"
+
+export default AgentSessionsPage

--- a/web/ee/src/pages/w/[workspace_id]/p/[project_id]/sessions/index.tsx
+++ b/web/ee/src/pages/w/[workspace_id]/p/[project_id]/sessions/index.tsx
@@ -1,0 +1,3 @@
+import SessionsPage from "@agenta/oss/src/pages/w/[workspace_id]/p/[project_id]/sessions"
+
+export default SessionsPage

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -1,13 +1,16 @@
 import {memo, useCallback, useEffect, useRef, useState} from "react"
 
 import {PencilSimple, Plus, X} from "@phosphor-icons/react"
-import {Button, Tooltip} from "antd"
+import {Button, Dropdown, Tooltip} from "antd"
+import type {MenuProps} from "antd"
 import clsx from "clsx"
 import {useAtomValue} from "jotai"
 import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 import {SESSION_SPRING, TAG_VARIANTS} from "../assets/sessionMotion"
+import {useSessionActions} from "../hooks/useSessionActions"
 import {type SessionDotStatus, sessionDotStatusAtomFamily} from "../state/liveness"
+import {useChatScopeKey} from "../state/scope"
 import {type AgentChatSession, sessionFirstUserTextAtomFamily} from "../state/sessions"
 
 import SessionTabLabel, {type SessionTabLabelHandle} from "./SessionTabLabel"
@@ -95,6 +98,8 @@ interface SessionTagProps {
     onSelect: (id: string) => void
     onClose: (id: string) => void
     onRename: (id: string, title: string) => void
+    /** Right-click actions, from the shared `useSessionActions` set. */
+    menu: MenuProps
 }
 
 /** One session chip: status dot + truncated label (double-click or pencil to rename) + hover
@@ -109,6 +114,7 @@ const SessionTag = memo(function SessionTag({
     onSelect,
     onClose,
     onRename,
+    menu,
 }: SessionTagProps) {
     const text = useAtomValue(sessionFirstUserTextAtomFamily(session.id))
     const label = session.title || text || `Chat ${index + 1}`
@@ -196,68 +202,70 @@ const SessionTag = memo(function SessionTag({
             }}
             className="shrink-0 overflow-hidden"
         >
-            <div
-                role="tab"
-                aria-selected={active}
-                tabIndex={0}
-                onClick={handleSelect}
-                onKeyDown={onKeyDown}
-                onMouseEnter={onEnter}
-                onMouseLeave={onLeave}
-                onFocus={onEnter}
-                onBlur={onBlurChip}
-                className={clsx(
-                    // Floor the width so short labels ("hi") still leave a clickable label zone to the
-                    // left of the hover actions (rename/close overlay the right ~58px) — otherwise a
-                    // tiny chip is fully covered on hover and the click lands on a button, not select.
-                    "group relative flex h-7 min-w-[112px] max-w-[180px] cursor-pointer items-center gap-1.5 rounded-md border border-solid px-2 text-xs transition-colors",
-                    // White pill on the recessed chat canvas (raised); the active tab keeps the
-                    // primary text + a 2px accent underline so it's unmistakable against neighbours.
-                    active
-                        ? "border-colorBorder border-b-2 border-b-[var(--ag-surface-accent)] bg-colorBgContainer text-colorText"
-                        : "border-colorBorderSecondary bg-colorBgContainer text-colorTextSecondary hover:border-colorBorder",
-                )}
-            >
-                <SessionStatusDot sessionId={session.id} active={active} />
-                <SessionTabLabel
-                    ref={labelRef}
-                    label={label}
-                    onRename={handleRename}
-                    onEditingChange={setRenaming}
-                    className="block min-w-0 flex-1 truncate"
-                />
-                {/* Hover actions overlay the label's tail — absolutely positioned so no width is
+            <Dropdown menu={menu} trigger={["contextMenu"]}>
+                <div
+                    role="tab"
+                    aria-selected={active}
+                    tabIndex={0}
+                    onClick={handleSelect}
+                    onKeyDown={onKeyDown}
+                    onMouseEnter={onEnter}
+                    onMouseLeave={onLeave}
+                    onFocus={onEnter}
+                    onBlur={onBlurChip}
+                    className={clsx(
+                        // Floor the width so short labels ("hi") still leave a clickable label zone to the
+                        // left of the hover actions (rename/close overlay the right ~58px) — otherwise a
+                        // tiny chip is fully covered on hover and the click lands on a button, not select.
+                        "group relative flex h-7 min-w-[112px] max-w-[180px] cursor-pointer items-center gap-1.5 rounded-md border border-solid px-2 text-xs transition-colors",
+                        // White pill on the recessed chat canvas (raised); the active tab keeps the
+                        // primary text + a 2px accent underline so it's unmistakable against neighbours.
+                        active
+                            ? "border-colorBorder border-b-2 border-b-[var(--ag-surface-accent)] bg-colorBgContainer text-colorText"
+                            : "border-colorBorderSecondary bg-colorBgContainer text-colorTextSecondary hover:border-colorBorder",
+                    )}
+                >
+                    <SessionStatusDot sessionId={session.id} active={active} />
+                    <SessionTabLabel
+                        ref={labelRef}
+                        label={label}
+                        onRename={handleRename}
+                        onEditingChange={setRenaming}
+                        className="block min-w-0 flex-1 truncate"
+                    />
+                    {/* Hover actions overlay the label's tail — absolutely positioned so no width is
                     reserved at rest (no pixel shift). The gradient fades the covered text out under
                     the buttons instead of hard-clipping it. */}
-                {hot && !renaming && (
-                    <div className="absolute inset-y-0 right-0 flex items-center">
-                        <span
-                            aria-hidden
-                            className="h-full w-3 bg-gradient-to-l from-colorBgContainer to-transparent"
-                        />
-                        <span className="flex h-full items-center gap-0.5 rounded-r-md bg-colorBgContainer pr-1">
-                            <Tooltip title="Rename session" mouseEnterDelay={0.5}>
-                                <Button
-                                    type="text"
-                                    aria-label="Rename session"
-                                    icon={PENCIL_ICON}
-                                    onClick={startRename}
-                                    className="!h-5 !w-5 !min-w-0 shrink-0 !p-0"
-                                />
-                            </Tooltip>
-                            {closable && (
-                                <Button
-                                    type="text"
-                                    aria-label="Close session"
-                                    icon={X_ICON}
-                                    onClick={handleClose}
-                                    className="!h-5 !w-5 !min-w-0 shrink-0 !p-0"
-                                />
-                            )}
-                        </span>
-                    </div>
-                )}
-            </div>
+                    {hot && !renaming && (
+                        <div className="absolute inset-y-0 right-0 flex items-center">
+                            <span
+                                aria-hidden
+                                className="h-full w-3 bg-gradient-to-l from-colorBgContainer to-transparent"
+                            />
+                            <span className="flex h-full items-center gap-0.5 rounded-r-md bg-colorBgContainer pr-1">
+                                <Tooltip title="Rename session" mouseEnterDelay={0.5}>
+                                    <Button
+                                        type="text"
+                                        aria-label="Rename session"
+                                        icon={PENCIL_ICON}
+                                        onClick={startRename}
+                                        className="!h-5 !w-5 !min-w-0 shrink-0 !p-0"
+                                    />
+                                </Tooltip>
+                                {closable && (
+                                    <Button
+                                        type="text"
+                                        aria-label="Close session"
+                                        icon={X_ICON}
+                                        onClick={handleClose}
+                                        className="!h-5 !w-5 !min-w-0 shrink-0 !p-0"
+                                    />
+                                )}
+                            </span>
+                        </div>
+                    )}
+                </div>
+            </Dropdown>
         </motion.div>
     )
 })
@@ -296,6 +304,22 @@ const SessionTagBar = ({
     showSessions = true,
 }: SessionTagBarProps) => {
     const closable = sessions.length > 1
+    // Right-click a chip for the same verbs the sessions list offers. Scope IS the owning agent,
+    // so the local tab cache and the server stay in step.
+    const scope = useChatScopeKey()
+    const {menuItems, onMenuClick} = useSessionActions()
+    const menuFor = useCallback(
+        (session: AgentChatSession): MenuProps => {
+            const target = {
+                sessionId: session.id,
+                appId: scope,
+                name: session.title,
+                archived: Boolean(session.archived),
+            }
+            return {items: menuItems(target), onClick: onMenuClick(target)}
+        },
+        [menuItems, onMenuClick, scope],
+    )
     // Session ids present when the bar first mounted. Seeded once; NOT topped up, so an id that
     // appears later reads as "added after mount" and scrolls smoothly (see SessionTag).
     const presentAtMountRef = useRef<Set<string>>(new Set())
@@ -382,6 +406,7 @@ const SessionTagBar = ({
                                     onSelect={onSelect}
                                     onClose={onClose}
                                     onRename={onRename}
+                                    menu={menuFor(session)}
                                 />
                             ))}
                         </AnimatePresence>

--- a/web/oss/src/components/Sidebar/dynamic/registry.ts
+++ b/web/oss/src/components/Sidebar/dynamic/registry.ts
@@ -7,11 +7,15 @@ import {
     // nonArchivedEvaluatorsAtom,
     promptWorkflowsListQueryStateAtom,
 } from "@agenta/entities/workflow"
+import {ChatsCircleIcon, CircleIcon, PushPinIcon} from "@phosphor-icons/react"
 import {RobotIcon} from "@phosphor-icons/react"
-import {atom} from "jotai"
+import {atom, getDefaultStore} from "jotai"
 
-import {MAIN_SIDEBAR_SCOPE_ID} from "../scopes/constants"
+import {pendingSessionOpenAtom} from "@/oss/components/AgentChatSlice/state/pendingSessionOpen"
 
+import {MAIN_SIDEBAR_SCOPE_ID, SESSIONS_SIDEBAR_KEY} from "../scopes/constants"
+
+import {sidebarSessionsListAtom, type SessionSidebarRef} from "./sessionsSource"
 import {gatedSidebarSource} from "./source"
 import type {
     SidebarEntity,
@@ -52,6 +56,9 @@ export const defineSidebarEntity = <TRef extends SidebarEntityRef>(
     showAllLink: config.showAllPath
         ? (projectURL) => `${projectURL}${config.showAllPath}`
         : undefined,
+    getIcon: config.getIcon ? (ref) => config.getIcon!(ref as TRef) : undefined,
+    getGroup: config.getGroup ? (ref) => config.getGroup!(ref as TRef) : undefined,
+    getOnClick: config.getOnClick ? (ref) => config.getOnClick!(ref as TRef) : undefined,
 })
 
 // ── Add a new dynamic entity by appending one entry here. Nothing else. ──────
@@ -65,6 +72,34 @@ const ENTITIES: SidebarEntity[] = [
         childPath: (workflow) => `/apps/${workflow.id}/playground`,
         emptyLabel: "No prompts",
         showAllPath: "/prompts",
+    }),
+    defineSidebarEntity<SessionSidebarRef>(MAIN_SIDEBAR_SCOPE_ID, SESSIONS_SIDEBAR_KEY, {
+        kind: "app",
+        icon: createElement(ChatsCircleIcon, {size: 14}),
+        listAtom: sidebarSessionsListAtom,
+        getLabel: (session) => session.name || "Untitled session",
+        // The link navigates to the owning agent; the click hands over WHICH session, since the
+        // playground has no way to read that from the route.
+        childPath: (session) => `/apps/${session.appId}/playground`,
+        getOnClick: (session) => () => {
+            if (!session.appId) return
+            getDefaultStore().set(pendingSessionOpenAtom, {
+                appId: session.appId,
+                sessionId: session.sessionId,
+                title: session.name ?? undefined,
+            })
+        },
+        getGroup: (session) => (session.pinned ? "Pinned" : null),
+        getIcon: (session) =>
+            session.pinned
+                ? createElement(PushPinIcon, {size: 14, weight: "fill"})
+                : createElement(CircleIcon, {
+                      size: 10,
+                      weight: session.alive ? "fill" : "regular",
+                  }),
+        emptyLabel: "No sessions",
+        maxItems: 7,
+        showAllPath: "/sessions",
     }),
     defineSidebarEntity(MAIN_SIDEBAR_SCOPE_ID, AGENTS_SIDEBAR_KEY, {
         kind: "app",

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -1,0 +1,112 @@
+import {querySessions, type SessionStream} from "@agenta/entities/session"
+import {pinnedSessionIdsAtom} from "@agenta/sessions/state"
+import {atom} from "jotai"
+import {atomWithQuery} from "jotai-tanstack-query"
+
+import {sessionOpenTarget} from "@/oss/components/AgentChatSlice/assets/sessionOpenTarget"
+import {projectIdAtom} from "@/oss/state/project"
+
+import type {SidebarEntityRef} from "./types"
+
+/** A session row as the sidebar needs it: enough to label it, dot it, and open it. */
+export interface SessionSidebarRef extends SidebarEntityRef {
+    sessionId: string
+    appId: string | null
+    pinned: boolean
+    alive: boolean
+}
+
+/** Deliberately small — the sidebar shows the top of the list, and the sessions page owns
+ * search, filters and paging. Gated by the group's open state like every other entity, so a
+ * collapsed Sessions group costs nothing. Pins are fetched by id in their own query: a pinned
+ * session older than this window must still appear. */
+const SIDEBAR_SESSION_LIMIT = 20
+
+const sidebarSessionsQueryAtom = atomWithQuery<SessionStream[] | null>((get) => {
+    const projectId = get(projectIdAtom)
+    return {
+        queryKey: ["sidebar-sessions", projectId],
+        queryFn: ({signal}) =>
+            querySessions({
+                projectId: projectId ?? "",
+                includeArchived: false,
+                limit: SIDEBAR_SESSION_LIMIT,
+                abortSignal: signal,
+                lowPriority: true,
+            }),
+        enabled: Boolean(projectId),
+        staleTime: 30_000,
+        refetchOnWindowFocus: true,
+    }
+})
+
+const sidebarPinnedSessionsQueryAtom = atomWithQuery<SessionStream[] | null>((get) => {
+    const projectId = get(projectIdAtom)
+    const pinnedIds = get(pinnedSessionIdsAtom)
+    return {
+        queryKey: ["sidebar-sessions-pinned", projectId, pinnedIds],
+        queryFn: ({signal}) =>
+            querySessions({
+                projectId: projectId ?? "",
+                includeArchived: false,
+                sessionIds: pinnedIds,
+                abortSignal: signal,
+                lowPriority: true,
+            }),
+        enabled: Boolean(projectId) && pinnedIds.length > 0,
+        staleTime: 30_000,
+        refetchOnWindowFocus: true,
+    }
+})
+
+/** Null when the row has no open target yet (no turns) — the sidebar drops it rather than
+ * rendering a link to `/apps/null`. */
+const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRef | null => {
+    const target = sessionOpenTarget(row)
+    if (!target) return null
+    return {
+        id: row.session_id,
+        sessionId: row.session_id,
+        name: row.name?.trim() || "Untitled session",
+        appId: target.appId,
+        pinned: pinned.has(row.session_id),
+        alive: Boolean(row.flags?.is_alive),
+    }
+}
+
+/**
+ * Pinned sessions first, then the rest by activity.
+ *
+ * Pins are pulled to the top rather than left in place because a pinned conversation is one you
+ * return to over days — exactly what a recency-ordered list buries. The group headings the
+ * registry renders depend on this ordering.
+ */
+const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
+    const pinned = new Set(get(pinnedSessionIdsAtom))
+    const pinnedRows = get(sidebarPinnedSessionsQueryAtom).data ?? []
+    // Pins come from their own by-id query; the recent window drops them so nothing shows twice.
+    const recentRows = (get(sidebarSessionsQueryAtom).data ?? []).filter(
+        (row) => !pinned.has(row.session_id),
+    )
+
+    const isRef = (ref: SessionSidebarRef | null): ref is SessionSidebarRef => ref !== null
+    return [
+        ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+        ...recentRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+    ]
+})
+
+export const sidebarSessionsListAtom = atom((get) => {
+    const query = get(sidebarSessionsQueryAtom)
+    const pinnedQuery = get(sidebarPinnedSessionsQueryAtom)
+    const hasPins = get(pinnedSessionIdsAtom).length > 0
+    // A failed pin fetch must surface: the recent window excludes pinned ids, so silence here
+    // would just make the pinned sessions vanish.
+    const pinnedFailed = hasPins && pinnedQuery.isError
+    return {
+        data: get(sidebarSessionRefsAtom),
+        isPending: query.isPending || (hasPins && pinnedQuery.isPending),
+        isError: query.isError || pinnedFailed,
+        error: query.error ?? (pinnedFailed ? pinnedQuery.error : null) ?? null,
+    }
+})

--- a/web/oss/src/components/Sidebar/dynamic/types.ts
+++ b/web/oss/src/components/Sidebar/dynamic/types.ts
@@ -49,6 +49,16 @@ export interface SidebarEntityConfig<TRef extends SidebarEntityRef = SidebarEnti
     maxItems?: number
     /** Project-relative path for the "Show all" overflow row. */
     showAllPath?: string
+    /** Per-row icon, overriding the shared kind icon — for rows whose state differs from each
+     * other (a session's liveness dot, say), where one icon for the whole group says nothing. */
+    getIcon?: (ref: TRef) => ReactElement
+    /** Group heading a row belongs under, or null for none. Consecutive rows sharing a label
+     * render beneath one disabled header. Refs must already be ordered by group; this inserts
+     * headings, it does not sort. */
+    getGroup?: (ref: TRef) => string | null
+    /** Extra work on click, alongside following `childPath` — e.g. handing the target to the
+     * surface being navigated to. Runs in the default jotai store, not a hook. */
+    getOnClick?: (ref: TRef) => () => void
 }
 
 /**
@@ -66,4 +76,7 @@ export interface SidebarEntity {
     emptyLabel?: string
     maxItems: number
     showAllLink?: (projectURL: string) => string
+    getIcon?: (ref: SidebarEntityRef) => ReactElement
+    getGroup?: (ref: SidebarEntityRef) => string | null
+    getOnClick?: (ref: SidebarEntityRef) => () => void
 }

--- a/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
+++ b/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
@@ -84,13 +84,32 @@ export const resolveChildren = (
     }
 
     const visibleRefs = refs.slice(0, entity.maxItems)
-    const children: SidebarConfig[] = visibleRefs.map((ref) => ({
-        key: `${entity.parentKey}-${ref.id}`,
-        title: entity.getLabel(ref),
-        link: entity.childLink(ref, projectURL),
-        icon: icon(),
-        isDynamic: true,
-    }))
+    const children: SidebarConfig[] = []
+    let currentGroup: string | null = null
+    for (const ref of visibleRefs) {
+        // Headings are inserted, not sorted — an entity supplying `getGroup` must already order
+        // its refs by group, or the same heading would appear more than once.
+        const group = entity.getGroup?.(ref) ?? null
+        if (group && group !== currentGroup) {
+            children.push({
+                key: `${entity.parentKey}-group-${group}`,
+                title: group,
+                icon: icon(),
+                disabled: true,
+                isDynamic: true,
+                isPlaceholder: true,
+            })
+        }
+        currentGroup = group
+        children.push({
+            key: `${entity.parentKey}-${ref.id}`,
+            title: entity.getLabel(ref),
+            link: entity.childLink(ref, projectURL),
+            icon: entity.getIcon?.(ref) ?? icon(),
+            isDynamic: true,
+            onClick: entity.getOnClick?.(ref),
+        })
+    }
 
     if (entity.showAllLink && refs.length > visibleRefs.length) {
         children.push({

--- a/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
+++ b/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
@@ -11,6 +11,7 @@ import {
     HouseIcon,
     ListChecksIcon,
     RobotIcon,
+    ChatsCircleIcon,
 } from "@phosphor-icons/react"
 import {useAtomValue} from "jotai"
 
@@ -35,7 +36,7 @@ import {
     useSidebarDynamicChildren,
 } from "../../dynamic/useSidebarDynamicChildren"
 import {SidebarConfig} from "../../engine/types"
-import {HOME_SIDEBAR_KEY} from "../../scopes/constants"
+import {HOME_SIDEBAR_KEY, SESSIONS_SIDEBAR_KEY} from "../../scopes/constants"
 
 export interface MainSidebarItems {
     projectItems: SidebarConfig[]
@@ -81,6 +82,15 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 icon: getEntityKindIcon("app"),
                 isHidden: hideAdvancedNav,
                 disabled: !hasProjectURL,
+            },
+            {
+                key: SESSIONS_SIDEBAR_KEY,
+                title: "Sessions",
+                link: `${projectURL}/sessions`,
+                icon: <ChatsCircleIcon size={14} />,
+                // Sessions only exist once an agent has run — a dead-end during onboarding.
+                disabled: !hasProjectURL || deadEndNavDisabled,
+                tooltip: deadEndNavDisabled ? "Your sessions will appear here" : undefined,
             },
             {
                 key: AGENTS_SIDEBAR_KEY,
@@ -167,6 +177,17 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 icon: <RocketIcon size={14} />,
                 isHidden,
                 disabled: !hasProjectURL,
+            },
+            {
+                key: "app-sessions-link",
+                title: "Sessions",
+                link: `${appURL || recentlyVisitedAppURL}/sessions`,
+                icon: <ChatsCircleIcon size={14} />,
+                isHidden,
+                disabled: !hasProjectURL,
+                // Only agents hold conversations — a prompt app or evaluator would get an
+                // always-empty list.
+                workflowCategories: ["agent"],
             },
             {
                 key: "app-variants-link",

--- a/web/oss/src/components/Sidebar/scopes/constants.ts
+++ b/web/oss/src/components/Sidebar/scopes/constants.ts
@@ -4,3 +4,7 @@ export const WORKFLOW_SIDEBAR_SCOPE_ID = "workflow"
 
 /** Key of the project-scope "Home" item. Single source shared by useSidebarConfig + mainScope. */
 export const HOME_SIDEBAR_KEY = "app-management-link"
+
+/** Key of the project-scope "Sessions" item — see the entity registry for its dynamic children.
+ * The agent-scope item is `app-sessions-link` in `useSidebarConfig`. */
+export const SESSIONS_SIDEBAR_KEY = "project-sessions-link"

--- a/web/oss/src/components/pages/sessions/SessionsPage.tsx
+++ b/web/oss/src/components/pages/sessions/SessionsPage.tsx
@@ -1,0 +1,162 @@
+import {Fragment, useCallback} from "react"
+
+import {type SessionRowVm} from "@agenta/sessions/row"
+import {useSessionPins, useSessionsList} from "@agenta/sessions/state"
+import {
+    SessionGroupHeader,
+    SessionListEmpty,
+    SessionListError,
+    SessionListLoadMore,
+    SessionListSkeleton,
+    SessionRow,
+} from "@agenta/sessions-ui"
+import {PageLayout} from "@agenta/ui"
+import {Dropdown} from "antd"
+import {AnimatePresence, MotionConfig, motion} from "motion/react"
+
+import {ROW_VARIANTS, SESSION_SPRING} from "@/oss/components/AgentChatSlice/assets/sessionMotion"
+import {useOpenAgentSession} from "@/oss/components/AgentChatSlice/hooks/useOpenAgentSession"
+import {
+    useSessionActions,
+    type SessionActionTarget,
+} from "@/oss/components/AgentChatSlice/hooks/useSessionActions"
+
+import {toSessionMenuEntries} from "./assets/menuEntries"
+import SessionFiltersRail from "./components/SessionFiltersRail"
+
+interface Props {
+    /** Route-supplied agent scope (`/apps/[app_id]/sessions`). Omit for the project-wide list. */
+    scopedAgentId?: string
+    title?: string
+}
+
+/**
+ * The session list — sessions are the unit of work, so this is where they get organised. The
+ * organisation (groups, pins, filter semantics, paging) is `@agenta/sessions`' decision and the
+ * rows are `@agenta/sessions-ui`'s; this page owns the shell, the motion, and the app-side
+ * actions (open on a playground, the shared context menu).
+ */
+const SessionsPage = ({scopedAgentId, title = "Sessions"}: Props) => {
+    const list = useSessionsList({agentId: scopedAgentId})
+    const {toggle: togglePin} = useSessionPins()
+    const openSession = useOpenAgentSession()
+    const sessionActions = useSessionActions()
+
+    const renderRow = useCallback(
+        (vm: SessionRowVm) => {
+            const target: SessionActionTarget = {
+                sessionId: vm.id,
+                appId: vm.agentId,
+                name: vm.stream.name,
+                archived: Boolean(vm.stream.archived_at),
+            }
+            const open = () => {
+                if (vm.agentId)
+                    openSession({
+                        appId: vm.agentId,
+                        sessionId: vm.id,
+                        title: vm.stream.name?.trim() || undefined,
+                    })
+            }
+            const onSelect = (key: string) => {
+                if (key === "open") open()
+                if (key === "rename") sessionActions.rename(target)
+                if (key === "pin") togglePin(vm.id)
+                if (key === "archive") void sessionActions.setArchived(target)
+                if (key === "delete") sessionActions.remove(target)
+            }
+            const items = sessionActions.menuItems(target, {onOpen: open})
+
+            return (
+                <motion.div
+                    key={vm.id}
+                    layout
+                    variants={ROW_VARIANTS}
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                    className="overflow-hidden"
+                >
+                    {/* Right-click stays an app affordance (antd, matching the playground's
+                        session bar); the row's own kebab renders the same verbs via the
+                        package's neutral menu. */}
+                    <Dropdown
+                        trigger={["contextMenu"]}
+                        menu={{
+                            items,
+                            onClick: ({key, domEvent}) => {
+                                domEvent.stopPropagation()
+                                onSelect(key)
+                            },
+                        }}
+                    >
+                        <div>
+                            <SessionRow
+                                row={vm}
+                                showAgent={!scopedAgentId}
+                                menuItems={toSessionMenuEntries(items)}
+                                onMenuSelect={onSelect}
+                                onOpen={open}
+                                onTogglePin={togglePin}
+                            />
+                        </div>
+                    </Dropdown>
+                </motion.div>
+            )
+        },
+        [openSession, scopedAgentId, sessionActions, togglePin],
+    )
+
+    return (
+        <PageLayout className="grow min-h-0 !p-0">
+            <div className="flex min-h-0 w-full flex-1 flex-col lg:flex-row">
+                <SessionFiltersRail
+                    title={title}
+                    waitingCount={list.waitingCount}
+                    hideAgentFilter={Boolean(scopedAgentId)}
+                />
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">
+                    {list.isError ? (
+                        <SessionListError onRetry={list.refetch} />
+                    ) : list.isPending ? (
+                        <SessionListSkeleton />
+                    ) : (
+                        <MotionConfig transition={SESSION_SPRING} reducedMotion="user">
+                            {/* Group headers sit OUTSIDE AnimatePresence. Framer bumps z-index on
+                                layout-animating elements, so an animated row paints over a sticky
+                                sibling no matter which element carries the `sticky`. Keeping the
+                                headers out of the animated subtree removes the fight entirely. */}
+                            {list.groups.map((group) => (
+                                <Fragment key={group.key}>
+                                    {group.label ? (
+                                        <SessionGroupHeader label={group.label} />
+                                    ) : null}
+                                    <AnimatePresence initial={false}>
+                                        {group.rows.map(renderRow)}
+                                    </AnimatePresence>
+                                </Fragment>
+                            ))}
+
+                            {list.paging.hasNext ? (
+                                <SessionListLoadMore
+                                    loading={list.paging.isLoadingNext}
+                                    onClick={list.paging.loadNext}
+                                />
+                            ) : null}
+
+                            {list.isEmpty ? (
+                                <SessionListEmpty
+                                    filtered={list.filtersActive}
+                                    onClearFilters={list.resetFilters}
+                                />
+                            ) : null}
+                        </MotionConfig>
+                    )}
+                </div>
+            </div>
+        </PageLayout>
+    )
+}
+
+export default SessionsPage

--- a/web/oss/src/components/pages/sessions/assets/menuEntries.ts
+++ b/web/oss/src/components/pages/sessions/assets/menuEntries.ts
@@ -1,0 +1,25 @@
+import type {ReactNode} from "react"
+
+import type {SessionMenuEntry} from "@agenta/sessions-ui"
+import type {MenuProps} from "antd"
+
+/**
+ * antd menu items → the package's neutral shape. `useSessionActions.menuItems` stays the single
+ * source of the verbs (the playground session bar renders the same antd items), so the sessions
+ * surfaces adapt at the edge instead of forking the list.
+ */
+export const toSessionMenuEntries = (items: MenuProps["items"]): SessionMenuEntry[] =>
+    (items ?? []).flatMap((item): SessionMenuEntry[] => {
+        if (!item) return []
+        if ("type" in item && item.type === "divider") return [{type: "divider"}]
+        if ("label" in item && item.key != null)
+            return [
+                {
+                    key: String(item.key),
+                    label: item.label as ReactNode,
+                    danger: "danger" in item ? Boolean(item.danger) : false,
+                    disabled: "disabled" in item ? Boolean(item.disabled) : false,
+                },
+            ]
+        return []
+    })

--- a/web/oss/src/components/pages/sessions/components/SessionFiltersRail.tsx
+++ b/web/oss/src/components/pages/sessions/components/SessionFiltersRail.tsx
@@ -1,0 +1,77 @@
+import {useSessionFilters} from "@agenta/sessions/state"
+import {
+    SessionArchivedControl,
+    SessionModeControl,
+    SessionSearchControl,
+    SessionStatusListControl,
+} from "@agenta/sessions-ui"
+import {Select, Typography} from "antd"
+import {useAtomValue} from "jotai"
+
+import {agentsWorkflowsAtom} from "../../agents/store"
+
+const RailLabel = ({children}: {children: React.ReactNode}) => (
+    <h2 className="m-0 text-[11px] font-semibold uppercase tracking-wide text-colorTextTertiary">
+        {children}
+    </h2>
+)
+
+interface Props {
+    title: string
+    waitingCount: number | undefined
+    /** The agent-scoped page fixes the agent from the route, so the picker would only lie. */
+    hideAgentFilter?: boolean
+}
+
+/**
+ * The session filters as a rail — the SHELL. The controls themselves come from
+ * `@agenta/sessions-ui` and bind to the shared filter atoms, so this file owns only the 280px
+ * column, the group labels, and the agent picker (antd `Select`, which stays app-injected until
+ * the EntityPicker migrates off antd).
+ */
+const SessionFiltersRail = ({title, waitingCount, hideAgentFilter}: Props) => {
+    const {agentId, setAgentId} = useSessionFilters()
+    const agents = useAtomValue(agentsWorkflowsAtom)
+
+    return (
+        <aside className="box-border flex w-full shrink-0 flex-col gap-6 overflow-y-auto border-0 border-solid border-colorBorderSecondary px-6 py-6 lg:w-[280px] lg:border-r lg:bg-colorFillQuaternary">
+            <Typography.Title level={2} className="!m-0 !text-[24px] !leading-tight">
+                {title}
+            </Typography.Title>
+
+            <SessionSearchControl />
+
+            <SessionStatusListControl waitingCount={waitingCount} />
+
+            {hideAgentFilter ? null : (
+                <section className="flex flex-col gap-2">
+                    <RailLabel>Agent</RailLabel>
+                    <Select
+                        allowClear
+                        value={agentId}
+                        onChange={(value) => setAgentId(value ?? null)}
+                        placeholder="All agents"
+                        options={agents.map((agent) => ({
+                            value: agent.workflowId,
+                            label: agent.name,
+                        }))}
+                    />
+                </section>
+            )}
+
+            {/* Two different kinds of switch, so two headings: one picks WHICH sessions, the
+                other widens the set. Under one "Include" label they read as the same thing. */}
+            <section className="flex flex-col gap-3">
+                <RailLabel>Show</RailLabel>
+                <SessionModeControl />
+            </section>
+
+            <section className="flex flex-col gap-3">
+                <RailLabel>Include</RailLabel>
+                <SessionArchivedControl />
+            </section>
+        </aside>
+    )
+}
+
+export default SessionFiltersRail

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/sessions/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/sessions/index.tsx
@@ -1,0 +1,22 @@
+import SessionsPage from "@/oss/components/pages/sessions/SessionsPage"
+import RequireWorkflowKind from "@/oss/components/RequireWorkflowKind"
+import {useAppId} from "@/oss/hooks/useAppId"
+
+/**
+ * One agent's sessions, on the agent's own rail — the same page as `/sessions`, scoped by the
+ * route rather than by a filter, so it survives a reload and a pasted link.
+ *
+ * Evaluators are redirected by the guard (`sessions` is disabled for them); the rail only offers
+ * this item for agents.
+ */
+const AgentSessionsRoute = () => {
+    const appId = useAppId()
+
+    return (
+        <RequireWorkflowKind allowed={["app"]} currentRoute="sessions">
+            {appId ? <SessionsPage scopedAgentId={appId} /> : null}
+        </RequireWorkflowKind>
+    )
+}
+
+export default AgentSessionsRoute

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/sessions/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/sessions/index.tsx
@@ -1,0 +1,1 @@
+export {default} from "@/oss/components/pages/sessions/SessionsPage"

--- a/web/oss/src/state/workflow/destinations.ts
+++ b/web/oss/src/state/workflow/destinations.ts
@@ -18,6 +18,7 @@ export type WorkflowRouteSegment =
     | "playground"
     | "variants"
     | "traces"
+    | "sessions"
 
 const DISABLED_FOR_EVALUATOR: ReadonlySet<WorkflowRouteSegment> = new Set([
     // `overview` and `evaluations` are now allowed for evaluators — Overview
@@ -27,6 +28,8 @@ const DISABLED_FOR_EVALUATOR: ReadonlySet<WorkflowRouteSegment> = new Set([
     // disabled (no meaningful evaluator surface yet).
     "endpoints",
     "deployments",
+    // Only agents hold conversations; an evaluator's session list is always empty.
+    "sessions",
 ])
 
 export interface ResolveWorkflowDestinationArgs {


### PR DESCRIPTION
## Context
Fourth app lane. Sessions had no page of their own: they lived in the playground's session bar. This adds a project-wide `/sessions` page and a per-agent sessions page, both render-only over the packages below.

## Changes
- `SessionsPage` renders `@agenta/sessions`' groups with `@agenta/sessions-ui`'s rows: pinned and recent groups, sticky group headers, per-group paging, and automations as a mode (they replace the set) rather than a second list.
- The filters render as a 280px rail: status, automations mode, archived, search, with the agent picker injected as a slot (it is still antd).
- Pinned and recent sessions surface in the sidebar; session actions (pin, archive, rename, open on the agent's playground) work from the list and from the playground's session bar.
- Routes land in OSS and EE, project-wide and per-agent.

## Tests / notes
- `@agenta/oss` tsc adds nothing on this lane. The page derives nothing: groups, labels and row view-models come from `@agenta/sessions`.

## What to QA
- Open the project `/sessions` page: pinned group leads when present, recent below, automations hidden until the mode is switched.
- Switch to automations mode: the list is replaced (not appended), and the group label changes to Automation runs.
- Open an agent's sessions page from its sidebar: the same page scoped to that agent.
- Regression: pinning from the row menu moves the row in place; right-click still shows the app-side context menu.
