### PR TITLE
feat(frontend): Consume seeded attachments when a session starts

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -272,11 +272,15 @@ const AgentConversation = ({
     const handleSubmitRef = useRef<(text: string) => void | Promise<void>>(() => {})
     const {firstRunPrompt} = useFirstRunSeed({
         entityId,
+        scopeKey,
         sessionId,
         activeSessionId,
         messagesCount: messages.length,
         modelBlocked,
         handleSubmitRef,
+        // Files picked on Home / the overview, where there was no session to upload against.
+        onSeedFiles: attachments.addFiles,
+        attachmentsSettled,
     })
     const consumedRunNonceRef = useRef<number | null>(null)
 

--- a/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.ts
@@ -17,19 +17,30 @@ import {agentFirstRunSeedAtom} from "../state/firstRunSeed"
  */
 export const useFirstRunSeed = ({
     entityId,
+    scopeKey,
     sessionId,
     activeSessionId,
     messagesCount,
     modelBlocked,
     handleSubmitRef,
+    onSeedFiles,
+    attachmentsSettled = true,
 }: {
     entityId: string
+    /** The chat scope — an app id. Lets a seed aimed at an existing agent match without knowing
+     * which revision the playground happens to be showing. */
+    scopeKey: string
     sessionId: string
     activeSessionId: string | null | undefined
     messagesCount: number
     modelBlocked: boolean
     /** Read at fire time so the transition drives the send, not a stale closure. */
     handleSubmitRef: MutableRefObject<(text: string) => void | Promise<void>>
+    /** The chat's own `addFiles` — seed files go through the same staging paste and drop use. */
+    onSeedFiles?: (files: File[]) => void
+    /** False while seeded files are still staging; the auto-send waits for it, because the
+     * conversation's submit silently rejects un-settled attachments. */
+    attachmentsSettled?: boolean
 }) => {
     const [firstRunSeed, setFirstRunSeed] = useAtom(agentFirstRunSeedAtom)
     const [firstRunPrompt, setFirstRunPrompt] = useState<string | null>(null)
@@ -38,13 +49,27 @@ export const useFirstRunSeed = ({
     const seedConsumedRef = useRef(false)
     useEffect(() => {
         if (seedConsumedRef.current || !firstRunSeed) return
-        if (entityId !== firstRunSeed.revisionId && entityId !== firstRunSeed.appId) return
+        const addressesThisAgent =
+            entityId === firstRunSeed.revisionId ||
+            entityId === firstRunSeed.appId ||
+            scopeKey === firstRunSeed.appId
+        if (!addressesThisAgent) return
         if (activeSessionId !== sessionId || messagesCount > 0) return
         seedConsumedRef.current = true
         setFirstRunPrompt(firstRunSeed.seedMessage)
         setFirstRunAutoSend(!!firstRunSeed.autoSend)
+        if (firstRunSeed.seedFiles?.length) onSeedFiles?.(firstRunSeed.seedFiles)
         setFirstRunSeed(null)
-    }, [firstRunSeed, entityId, activeSessionId, sessionId, messagesCount, setFirstRunSeed])
+    }, [
+        firstRunSeed,
+        entityId,
+        scopeKey,
+        activeSessionId,
+        sessionId,
+        messagesCount,
+        setFirstRunSeed,
+        onSeedFiles,
+    ])
 
     // Fires once, while the conversation is still empty, when EITHER: the model just unblocked (was
     // gated), OR the seed is an explicit "go" (`firstRunAutoSend` — the onboarding Create-agent
@@ -66,7 +91,8 @@ export const useFirstRunSeed = ({
     // whose model is ready and which would otherwise fire this turn. Otherwise a still-gated model
     // (or an already-sent seed) would burn the 10s window before the overlay ever mattered.
     const sendBlockedOnlyOnOverlay =
-        Boolean(firstRunPrompt) &&
+        firstRunPrompt != null &&
+        attachmentsSettled &&
         !autoStartedSeedRef.current &&
         !modelBlocked &&
         (seedWasBlockedRef.current || firstRunAutoSend) &&
@@ -83,7 +109,8 @@ export const useFirstRunSeed = ({
         return () => clearTimeout(timer)
     }, [sendBlockedOnlyOnOverlay, overlayWaitElapsed])
     useEffect(() => {
-        if (!firstRunPrompt || autoStartedSeedRef.current) return
+        // `== null` and not falsy: "" is a file-only seed, and it must still send.
+        if (firstRunPrompt == null || autoStartedSeedRef.current) return
         if (modelBlocked) {
             seedWasBlockedRef.current = true
             return
@@ -91,6 +118,9 @@ export const useFirstRunSeed = ({
         if ((!seedWasBlockedRef.current && !firstRunAutoSend) || messagesCount > 0) return
         // Hold the auto-send until the build-kit overlay settles (or the 10s bound elapses).
         if (!overlayReady && !overlayWaitElapsed) return
+        // Wait for seeded files to finish staging — the submit rejects while they upload, and
+        // this ref must not mark the seed sent on a rejected call.
+        if (!attachmentsSettled) return
         autoStartedSeedRef.current = true
         handleSubmitRef.current(firstRunPrompt)
     }, [
@@ -100,6 +130,7 @@ export const useFirstRunSeed = ({
         messagesCount,
         overlayReady,
         overlayWaitElapsed,
+        attachmentsSettled,
     ])
 
     return {firstRunPrompt}


### PR DESCRIPTION
## Context
Top lane of the stack. Home and the overview collect attachments on the task composer (lane `oss/home-overview`), but nothing consumed them: a session started with files silently dropped them.

## Changes
The conversation reads the first-run seed and sends the collected attachments with the opening message. This is the last step of the seeding flow; the composers below already collect into the seed state.

## Tests / notes
- Two files (`AgentConversation`, `useFirstRunSeed`). `@agenta/oss` tsc adds nothing on this lane.

## What to QA
- On Home, attach a file to the task composer and start a session: the opening message carries the attachment and the agent can read it.
- Same from an agent's overview composer.
- Regression: starting a session without attachments still opens normally.
