### PR TITLE
fix(runner): Pi's validation error names the misplaced property

### DIFF
--- a/services/runner/docker/Dockerfile.dev
+++ b/services/runner/docker/Dockerfile.dev
@@ -84,6 +84,15 @@ RUN node_modules/.bin/tsx scripts/pin-codex-adapter.ts install-agent codex --age
 # to `on-request` so Agenta-tool gates park WARM. Fails the build if the preset drifts.
 RUN node_modules/.bin/tsx scripts/patch-codex-acp-approvals.ts
 
+# Name the offending key when Pi rejects a tool call for an unexpected property. Pi validates tool
+# arguments against the advertised schema before it dispatches, and typebox's stock message names
+# the OBJECT that has an extra property but never the property itself, so a model has to guess
+# which of the keys it sent is the extra one (seen in live QA on `workflow_revision`). The patch is
+# message formatting only: it changes no validation logic, and it exits non-zero if Pi's formatter
+# no longer matches, so a pi-ai bump breaks the build rather than silently restoring the
+# unactionable message. Retires when upstream Pi names the key itself.
+RUN node_modules/.bin/tsx scripts/patch-pi-validation-message.ts
+
 # No USER node here (unlike Dockerfile.gh): dev rebuilds dist/ under /app and mkdir's /pi-agent
 # at container start, both root-owned paths — not a FUSE constraint (fusermount works non-root).
 

--- a/services/runner/docker/Dockerfile.gh
+++ b/services/runner/docker/Dockerfile.gh
@@ -117,6 +117,15 @@ RUN node_modules/.bin/tsx scripts/pin-codex-adapter.ts install-agent codex --age
 # than silently shipping cold approvals. Retires when upstream codex-acp#310 lands.
 RUN node_modules/.bin/tsx scripts/patch-codex-acp-approvals.ts
 
+# Name the offending key when Pi rejects a tool call for an unexpected property. Pi validates tool
+# arguments against the advertised schema before it dispatches, and typebox's stock message names
+# the OBJECT that has an extra property but never the property itself, so a model has to guess
+# which of the keys it sent is the extra one (seen in live QA on `workflow_revision`). The patch is
+# message formatting only: it changes no validation logic, and it exits non-zero if Pi's formatter
+# no longer matches, so a pi-ai bump breaks the build rather than silently restoring the
+# unactionable message. Retires when upstream Pi names the key itself.
+RUN node_modules/.bin/tsx scripts/patch-pi-validation-message.ts
+
 # Call the local tsx binary directly to avoid pnpm/corepack HOME writes when the
 # container runs as a non-root host uid.
 CMD ["node_modules/.bin/tsx", "src/server.ts"]

--- a/services/runner/docker/Dockerfile.gh
+++ b/services/runner/docker/Dockerfile.gh
@@ -73,6 +73,20 @@ COPY skills ./skills
 # src/extensions/agenta.ts or the tracer.
 RUN pnpm run build:extension
 
+# Name the offending key when Pi rejects a tool call for an unexpected property. Pi validates tool
+# arguments against the advertised schema before it dispatches, and typebox's stock message names
+# the OBJECT that has an extra property but never the property itself, so a model has to guess
+# which of the keys it sent is the extra one (seen in live QA on `workflow_revision`). The patch is
+# message formatting only: it changes no validation logic, and it exits non-zero if Pi's formatter
+# no longer matches, so a pi-ai bump breaks the build rather than silently restoring the
+# unactionable message. Retires when upstream Pi names the key itself.
+#
+# Runs here, still root, because `@earendil-works/pi-ai` came in via the `pnpm install` above
+# (also root). Below this point the image drops to `USER node`, and that user cannot write into a
+# root-owned node_modules — unlike the codex-acp patches, which target a package `node` itself
+# installs later.
+RUN node_modules/.bin/tsx scripts/patch-pi-validation-message.ts
+
 ENV NODE_ENV=production \
     AGENTA_RUNNER_PORT=8765
 
@@ -116,15 +130,6 @@ RUN node_modules/.bin/tsx scripts/pin-codex-adapter.ts install-agent codex --age
 # It exits non-zero if the preset no longer matches, so a codex-acp bump breaks the build rather
 # than silently shipping cold approvals. Retires when upstream codex-acp#310 lands.
 RUN node_modules/.bin/tsx scripts/patch-codex-acp-approvals.ts
-
-# Name the offending key when Pi rejects a tool call for an unexpected property. Pi validates tool
-# arguments against the advertised schema before it dispatches, and typebox's stock message names
-# the OBJECT that has an extra property but never the property itself, so a model has to guess
-# which of the keys it sent is the extra one (seen in live QA on `workflow_revision`). The patch is
-# message formatting only: it changes no validation logic, and it exits non-zero if Pi's formatter
-# no longer matches, so a pi-ai bump breaks the build rather than silently restoring the
-# unactionable message. Retires when upstream Pi names the key itself.
-RUN node_modules/.bin/tsx scripts/patch-pi-validation-message.ts
 
 # Call the local tsx binary directly to avoid pnpm/corepack HOME writes when the
 # container runs as a non-root host uid.

--- a/services/runner/scripts/patch-pi-validation-message.ts
+++ b/services/runner/scripts/patch-pi-validation-message.ts
@@ -1,0 +1,89 @@
+/**
+ * Name the offending key when Pi rejects a tool call for an unexpected property.
+ *
+ * Runs in the runner image build, after `pnpm install`, so the baked copy of
+ * `@earendil-works/pi-ai` tells a model WHICH property to remove instead of only that the object
+ * has one too many. See `src/tools/pi-validation-patch.ts` for why, for the scope this does not
+ * cover, and for how the patch retires once upstream lands it.
+ *
+ * Exits non-zero when the package is missing or its formatter no longer matches the anchor, so a
+ * Pi version bump breaks the image build instead of silently restoring the unactionable message.
+ *
+ *   tsx scripts/patch-pi-validation-message.ts
+ */
+import { existsSync, readFileSync, readdirSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import {
+  applyPiValidationMessagePatch,
+  PI_VALIDATION_BUNDLE_PATH,
+} from "../src/tools/pi-validation-patch.ts";
+
+const PI_AI = join("@earendil-works", "pi-ai");
+
+/**
+ * Every installed copy of the file.
+ *
+ * `require.resolve` is not usable here: neither Pi package declares an `exports` entry for its
+ * `package.json`, and `pi-ai` is not hoisted to the top level, so both lookups throw. What is
+ * stable is the layout. `node_modules/@earendil-works/pi-coding-agent` is a symlink into the pnpm
+ * store, and the `pi-ai` its own resolution uses is its sibling inside that same store entry, so
+ * one `realpath` finds the copy Node would actually load.
+ *
+ * The store is also swept for any other copy, because a build-time patch should leave no
+ * unpatched duplicate behind for a different peer set to resolve to.
+ */
+function validationBundlePaths(): string[] {
+  const found = new Set<string>();
+  const add = (dir: string): void => {
+    const bundle = join(dir, PI_VALIDATION_BUNDLE_PATH);
+    if (existsSync(bundle)) found.add(realpathSync(bundle));
+  };
+
+  try {
+    const real = realpathSync(join("node_modules", "@earendil-works", "pi-coding-agent"));
+    add(join(dirname(dirname(real)), PI_AI));
+  } catch {
+    // Not installed at the top level; the store sweep below still covers it.
+  }
+  add(join("node_modules", PI_AI));
+
+  try {
+    const store = join("node_modules", ".pnpm");
+    for (const entry of readdirSync(store)) {
+      add(join(store, entry, "node_modules", PI_AI));
+    }
+  } catch {
+    // No pnpm store (a different installer, or a pruned image); the paths above are the answer.
+  }
+  return [...found];
+}
+
+const bundles = validationBundlePaths();
+if (bundles.length === 0) {
+  console.error(
+    "patch-pi-validation-message: no installed @earendil-works/pi-ai validation bundle found. " +
+      "Run `pnpm install` first, or drop this step if Pi is no longer a dependency.",
+  );
+  process.exit(1);
+}
+
+for (const bundle of bundles) {
+  const outcome = applyPiValidationMessagePatch(readFileSync(bundle, "utf8"));
+  if (outcome.kind === "anchor-missing") {
+    console.error(
+      `patch-pi-validation-message: the validation formatter anchor is missing in ${bundle}. ` +
+        "pi-ai changed how it formats validation errors: re-verify the message shape and update " +
+        "src/tools/pi-validation-patch.ts (or drop the patch if upstream now names the key).",
+    );
+    process.exit(1);
+  }
+  if (outcome.kind === "already-patched") {
+    console.log(`patch-pi-validation-message: already naming the key in ${bundle}`);
+    continue;
+  }
+  writeFileSync(bundle, outcome.source);
+  console.log(
+    `patch-pi-validation-message: an unexpected property now names the key in ${bundle}`,
+  );
+}

--- a/services/runner/src/tools/pi-validation-patch.ts
+++ b/services/runner/src/tools/pi-validation-patch.ts
@@ -1,0 +1,126 @@
+/**
+ * Build-time patch for Pi's tool-argument validation message (`@earendil-works/pi-ai`).
+ *
+ * WHY THIS EXISTS. Pi validates a tool call against the advertised JSON schema with typebox,
+ * before it dispatches, and formats each failure as `  - <path>: <message>`. For a closed object
+ * that message is typebox's `must not have additional properties`, which names the OBJECT and not
+ * the offending key. A model then reads "workflow_revision: must not have additional properties"
+ * and has to guess which of the properties it sent is the extra one. Mahmoud watched exactly that
+ * in live QA.
+ *
+ * The key is not missing, only unused. typebox reports it:
+ *
+ *   { keyword: "additionalProperties", instancePath: "/workflow_revision",
+ *     params: { additionalProperties: ["description"] }, message: "must not have..." }
+ *
+ * Pi already special-cases the `required` keyword to name the missing property from
+ * `params.requiredProperties`. This patch gives `additionalProperties` the same treatment, from
+ * `params.additionalProperties`. It is message formatting only. It changes no validation logic, so
+ * a call that failed still fails and a call that passed still passes.
+ *
+ * SCOPE, STATED PLAINLY. This patches the copy of Pi that ships in the RUNNER image, so it covers
+ * runs where Pi executes on the runner host. A Daytona run executes Pi inside the sandbox image
+ * from its own install, which this does not reach. That half needs the same patch wherever that
+ * image is built, and until then the two paths word this error differently.
+ *
+ * VERSION-PIN FRICTION, ACCEPTED. The anchor is the exact `.map(...)` line pi-ai 0.80.6 ships, so
+ * a Pi upgrade will usually not match it and the image build will fail until someone re-reads the
+ * formatter and updates the anchor here. That cost is accepted deliberately: the alternative is a
+ * loose pattern that keeps matching something after the surrounding code has moved, which is how a
+ * patch silently rewrites the wrong line. Whoever bumps Pi owns this file for ten minutes.
+ *
+ * RETIREMENT. Send it upstream to Pi and drop this once an accepted release ships it.
+ * `applyPiValidationMessagePatch` reports `already-patched` for a source that already carries the
+ * formatter, so the transition is safe.
+ *
+ * FAILING LOUDLY IS THE POINT. The image build calls this and exits non-zero on `anchor-missing`.
+ * A Pi version whose formatter no longer matches must break the build rather than silently ship a
+ * message the model cannot act on.
+ */
+
+/** The file inside the package that formats a validation failure. */
+export const PI_VALIDATION_BUNDLE_PATH = "dist/utils/validation.js";
+
+/** The name the injected function takes inside Pi's module scope. Prefixed so it cannot collide. */
+export const INJECTED_FN_NAME = "__agentaValidationMessage";
+
+/**
+ * The message for one typebox validation error.
+ *
+ * SELF-CONTAINED ON PURPOSE. This function's own source is what the patch injects into Pi (see
+ * `injectedSource`), so it must not reference anything from this module. A helper called from here
+ * would be undefined inside Pi and would throw while formatting an error, which is the worst place
+ * to throw.
+ *
+ * Written in plain JavaScript terms for the same reason: what runs inside Pi is this text.
+ */
+export function piValidationMessage(error: {
+  keyword?: string;
+  message?: string;
+  params?: { additionalProperties?: unknown };
+}): string {
+  if (error.keyword === "additionalProperties") {
+    const keys = error.params?.additionalProperties;
+    if (Array.isArray(keys) && keys.length > 0) {
+      const named = keys.map((key) => `'${String(key)}'`).join(", ");
+      return keys.length === 1
+        ? `unexpected property ${named}. Remove it from this object.`
+        : `unexpected properties ${named}. Remove them from this object.`;
+    }
+  }
+  return error.message ?? "";
+}
+
+/**
+ * The exact call Pi makes today, and the call the patch replaces it with.
+ *
+ * The anchor covers the whole `.map(...)` line rather than just `${error.message}`: that shorter
+ * string occurs elsewhere, and a patch that can bind in more than one place is a patch that can
+ * bind in the wrong one.
+ */
+export const STOCK_MAP_LINE =
+  "        .map((error) => `  - ${formatValidationPath(error)}: ${error.message}`)";
+
+export const PATCHED_MAP_LINE =
+  "        .map((error) => `  - ${formatValidationPath(error)}: ${" +
+  INJECTED_FN_NAME +
+  "(error)}`)";
+
+/** Where the injected function is placed: immediately before Pi's own path formatter. */
+const DEFINITION_ANCHOR = "function formatValidationPath(error) {";
+
+/** The function text the patch writes into Pi, derived from the real function so they cannot drift. */
+export function injectedSource(): string {
+  return `function ${INJECTED_FN_NAME}(error) ${bodyOf(piValidationMessage)}\n`;
+}
+
+/** The body of `fn`, from its own source. Keeping the derivation here keeps the drift risk at zero. */
+function bodyOf(fn: (...args: never[]) => unknown): string {
+  const source = fn.toString();
+  const start = source.indexOf("{");
+  if (start < 0) throw new Error("pi-validation-patch: cannot read the formatter body");
+  return source.slice(start);
+}
+
+export type PiValidationPatchOutcome =
+  | { kind: "patched"; source: string }
+  | { kind: "already-patched" }
+  | { kind: "anchor-missing" };
+
+/**
+ * Apply the patch to one `validation.js` source.
+ *
+ * Pure and idempotent: it reports `already-patched` rather than injecting a second copy, so a
+ * rebuild over an installed image is safe.
+ */
+export function applyPiValidationMessagePatch(
+  source: string,
+): PiValidationPatchOutcome {
+  if (source.includes(INJECTED_FN_NAME)) return { kind: "already-patched" };
+  if (!source.includes(STOCK_MAP_LINE)) return { kind: "anchor-missing" };
+  if (!source.includes(DEFINITION_ANCHOR)) return { kind: "anchor-missing" };
+  const patched = source
+    .replace(DEFINITION_ANCHOR, `${injectedSource()}${DEFINITION_ANCHOR}`)
+    .replace(STOCK_MAP_LINE, PATCHED_MAP_LINE);
+  return { kind: "patched", source: patched };
+}

--- a/services/runner/tests/unit/pi-validation-patch.test.ts
+++ b/services/runner/tests/unit/pi-validation-patch.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import {
+  applyPiValidationMessagePatch,
+  injectedSource,
+  INJECTED_FN_NAME,
+  piValidationMessage,
+  STOCK_MAP_LINE,
+} from "../../src/tools/pi-validation-patch.ts";
+
+/**
+ * Verbatim from the installed bundle (`@earendil-works/pi-ai` 0.80.6,
+ * `dist/utils/validation.js`). Keep it byte-exact: the patch's only job is to rewrite this shape,
+ * so a fixture that drifts from the real bundle proves nothing.
+ */
+const VALIDATION_SECTION = `function formatValidationPath(error) {
+    if (error.keyword === "required") {
+        const requiredProperties = error.params.requiredProperties;
+        const requiredProperty = requiredProperties?.[0];
+        if (requiredProperty) {
+            const basePath = error.instancePath.replace(/^\\//, "").replace(/\\//g, ".");
+            return basePath ? \`\${basePath}.\${requiredProperty}\` : requiredProperty;
+        }
+    }
+    const path = error.instancePath.replace(/^\\//, "").replace(/\\//g, ".");
+    return path || "root";
+}
+export function validateToolArguments(tool, toolCall) {
+    if (validator.Check(args)) {
+        return args;
+    }
+    const errors = validator
+        .Errors(args)
+${STOCK_MAP_LINE}
+        .join("\\n") || "Unknown validation error";
+    const errorMessage = \`Validation failed for tool "\${toolCall.name}":\\n\${errors}\`;
+    throw new Error(errorMessage);
+}
+`;
+
+/**
+ * A typebox `additionalProperties` error, exactly as typebox 1.1.38 reports one. Captured by
+ * compiling a closed nested schema and reading `validator.Errors(...)`, which is what Pi does.
+ * The offending keys arrive in `params`, never in `instancePath`, which is the whole reason the
+ * stock message could not name them.
+ */
+const extraPropertyError = (keys: string[]) => ({
+  keyword: "additionalProperties",
+  instancePath: "/workflow_revision",
+  params: { additionalProperties: keys },
+  message: "must not have additional properties",
+});
+
+/** The formatter as it runs INSIDE Pi: evaluated from the text the patch injects. */
+function patchedFormatter(): (error: unknown) => string {
+  const factory = new Function(
+    `${injectedSource()}\nreturn ${INJECTED_FN_NAME};`,
+  ) as () => (error: unknown) => string;
+  return factory();
+}
+
+describe("the patched Pi validation message", () => {
+  it("names the offending property, which is the whole point", () => {
+    // The live QA symptom: "workflow_revision: must not have additional properties" told the model
+    // an object had an extra key and left it to guess which.
+    const message = patchedFormatter()(extraPropertyError(["description"]));
+
+    assert.match(message, /'description'/);
+    assert.match(message, /unexpected property/);
+    assert.match(message, /Remove it from this object/);
+    assert.doesNotMatch(message, /must not have additional properties/);
+  });
+
+  it("names every offending property when there is more than one", () => {
+    const message = patchedFormatter()(
+      extraPropertyError(["description", "extra"]),
+    );
+
+    assert.match(message, /'description', 'extra'/);
+    assert.match(message, /unexpected properties/);
+    assert.match(message, /Remove them from this object/);
+  });
+
+  it("leaves every other validation error exactly as typebox worded it", () => {
+    // The patch is message formatting for ONE keyword. A missing required field already names the
+    // field through Pi's own path formatter, and nothing here may disturb it.
+    const format = patchedFormatter();
+    assert.equal(
+      format({
+        keyword: "required",
+        params: { requiredProperties: ["message"] },
+        message: "must have required properties message",
+      }),
+      "must have required properties message",
+    );
+    assert.equal(
+      format({ keyword: "type", params: {}, message: "must be string" }),
+      "must be string",
+    );
+  });
+
+  it("falls back to the stock message when the keys are absent", () => {
+    // Defensive: a typebox version that stops populating `params` must degrade to today's message
+    // rather than throw while formatting an error.
+    const format = patchedFormatter();
+    assert.equal(
+      format({
+        keyword: "additionalProperties",
+        params: {},
+        message: "must not have additional properties",
+      }),
+      "must not have additional properties",
+    );
+    assert.equal(
+      format({
+        keyword: "additionalProperties",
+        params: { additionalProperties: [] },
+        message: "must not have additional properties",
+      }),
+      "must not have additional properties",
+    );
+  });
+
+  it("injects the same function the module exports, so the two cannot drift", () => {
+    // The injected text is derived from `piValidationMessage` itself. If someone edits the
+    // exported function, the patched bundle changes with it.
+    const injected = patchedFormatter();
+    for (const keys of [["a"], ["a", "b"]]) {
+      assert.equal(
+        injected(extraPropertyError(keys)),
+        piValidationMessage(extraPropertyError(keys)),
+      );
+    }
+  });
+});
+
+describe("applyPiValidationMessagePatch", () => {
+  it("routes the message through the injected formatter", () => {
+    const outcome = applyPiValidationMessagePatch(VALIDATION_SECTION);
+
+    assert.equal(outcome.kind, "patched");
+    const patched = (outcome as { source: string }).source;
+    assert.match(patched, /\$\{__agentaValidationMessage\(error\)\}/);
+    assert.doesNotMatch(patched, /\$\{error\.message\}/);
+    assert.ok(
+      patched.includes(`function ${INJECTED_FN_NAME}(error)`),
+      "the formatter is defined in the bundle it is called from",
+    );
+  });
+
+  it("defines the formatter before it is used", () => {
+    // A function declaration hoists, but reading the source in order is how the next person
+    // checks this patch, and a definition after its call site reads like a bug.
+    const patched = (
+      applyPiValidationMessagePatch(VALIDATION_SECTION) as { source: string }
+    ).source;
+
+    assert.ok(
+      patched.indexOf(`function ${INJECTED_FN_NAME}`) <
+        patched.indexOf(`${INJECTED_FN_NAME}(error)}`),
+    );
+  });
+
+  it("changes nothing else in the bundle", () => {
+    const patched = (
+      applyPiValidationMessagePatch(VALIDATION_SECTION) as { source: string }
+    ).source;
+    const restored = patched
+      .replace(`${injectedSource()}`, "")
+      .replace(
+        `\${${INJECTED_FN_NAME}(error)}`,
+        "${error.message}",
+      );
+
+    assert.equal(restored, VALIDATION_SECTION);
+  });
+
+  it("is idempotent, so a rebuilt or already-baked image is a no-op", () => {
+    const once = applyPiValidationMessagePatch(VALIDATION_SECTION) as {
+      source: string;
+    };
+    assert.equal(
+      applyPiValidationMessagePatch(once.source).kind,
+      "already-patched",
+    );
+  });
+
+  it("reports anchor-missing when Pi changes its formatter, so the build fails loudly", () => {
+    // The retirement path too: when upstream names the key itself, the anchor stops matching and
+    // the build says so instead of shipping a patch that no longer applies.
+    assert.equal(
+      applyPiValidationMessagePatch(
+        VALIDATION_SECTION.replace(STOCK_MAP_LINE, "        .map(format)"),
+      ).kind,
+      "anchor-missing",
+    );
+    assert.equal(
+      applyPiValidationMessagePatch(
+        VALIDATION_SECTION.replace("function formatValidationPath(error) {", ""),
+      ).kind,
+      "anchor-missing",
+    );
+  });
+});


### PR DESCRIPTION
## Context
When a model sends a tool call with a property in the wrong place, Pi's own schema validation rejects it with "must not have additional properties". The message names the object but not the offending property, so the model has to guess what to remove. Live QA hit this twice on the commit tool: the model nested `description` one level too deep, and the retry cost a full round trip each time.

## Changes
A build-time patch to `@earendil-works/pi-ai` (the same mechanism as the existing codex-approvals patch): the additionalProperties error now names the keys.

Before: `workflow_revision: must not have additional properties`
After: `workflow_revision: unexpected property 'description'. Remove it from this object.`

Message formatting only; the same calls pass and fail as before. The patch anchors on the exact line pi-ai 0.80.6 ships and fails the image build loudly on a version bump, which is the deliberate trade against silently patching the wrong line. Applied in both runner Dockerfiles.

Known limit: this reaches Pi running on the runner host. A Daytona run executes Pi inside the sandbox image, which this repo does not build; until that image carries the same patch, the two paths word this error differently.

## Tests / notes
10 tests: the formatter as injected (one key, two keys), other keywords untouched, degraded params fall back to the stock message, idempotency, and anchor-missing on a changed bundle. The injected text is derived from the exported function, and a test asserts they agree, so the two cannot drift. Runner suite green (1969 tests).
Candidate for upstreaming to Pi; that call is Mahmoud's.
