### PR TITLE
test(frontend): config panel preserves skill entries it does not author

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemListOps.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemListOps.ts
@@ -1,0 +1,35 @@
+/**
+ * List edits behind the config item drawer (tools / MCP servers / skills).
+ *
+ * Its own module, free of React and of `ITEM_KINDS`, so the preservation guarantee below is
+ * testable in the package's node-environment unit tests.
+ *
+ * The guarantee: editing ONE entry rewrites only that index. Every other entry is carried over by
+ * reference, so an entry the panel cannot render, cannot classify, or deliberately shows read-only
+ * survives a neighbour's edit byte-identical. A stored `@ag.embed` reference is the case that
+ * matters: the agent can commit shapes the panel was never taught, and a save must never be the
+ * thing that drops them.
+ */
+
+export type ItemEditMode = "create" | "edit"
+
+/** Apply the drawer's draft to a list: append on create, replace at index on edit. */
+export const applyItemToList = (
+    list: readonly unknown[],
+    edit: {mode: ItemEditMode; index: number},
+    draft: unknown,
+): unknown[] => {
+    const next = [...list]
+    if (edit.mode === "create") {
+        next.push(draft)
+        return next
+    }
+    // Out of range would otherwise extend the array with holes and silently reshape the list.
+    if (edit.index < 0 || edit.index >= next.length) return next
+    next[edit.index] = draft
+    return next
+}
+
+/** Drop one entry by index, leaving the rest untouched. */
+export const removeItemFromList = (list: readonly unknown[], index: number): unknown[] =>
+    list.filter((_, i) => i !== index)

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
@@ -8,6 +8,7 @@ import type {ConfigItemView} from "../ConfigItemDrawer"
 
 import {cloneItem} from "./agentTemplateUtils"
 import {ITEM_KINDS, type ItemKind, type ItemKindDef} from "./itemKinds"
+import {applyItemToList, removeItemFromList} from "./itemListOps"
 
 export interface EditingState {
     kind: ItemKind
@@ -58,13 +59,11 @@ export function useConfigItemDrawer({
     )
 
     // Apply the drawer's draft to the config: append (create) or replace at index (edit).
+    // The list transform is `itemListOps` so its preservation guarantee is unit-tested.
     const commitDraft = useCallback(() => {
         if (!editing) return
         const {field} = ITEM_KINDS[editing.kind]
-        const next = [...fieldArray(field)]
-        if (editing.mode === "create") next.push(draft)
-        else next[editing.index] = draft
-        onChange({...config, [field]: next})
+        onChange({...config, [field]: applyItemToList(fieldArray(field), editing, draft)})
         setEditing(null)
     }, [editing, draft, config, onChange, fieldArray])
 
@@ -72,7 +71,7 @@ export function useConfigItemDrawer({
     const removeItem = useCallback(
         (kind: ItemKind, index: number) => {
             const {field} = ITEM_KINDS[kind]
-            onChange({...config, [field]: fieldArray(field).filter((_, i) => i !== index)})
+            onChange({...config, [field]: removeItemFromList(fieldArray(field), index)})
         },
         [config, onChange, fieldArray],
     )

--- a/web/packages/agenta-entity-ui/tests/unit/skillsSurviveNeighbourEdit.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/skillsSurviveNeighbourEdit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * A skills entry the panel did not author must survive a neighbour's edit, byte-identical.
+ *
+ * This exists because of a real data-loss report: an agent committed a skill as an `@ag.embed`
+ * reference, and a later save stored `skills: []`. The forensics cleared the panel (the entry was
+ * never in that browser's draft, which predated the agent's commit), but "the save path preserves
+ * what it did not author" was an assumed property with nothing pinning it. Now it is pinned.
+ *
+ * Three shapes, chosen because each is preserved for a DIFFERENT reason:
+ *   a) a valid `@ag.embed` reference — recognized, rendered as a read-only "Skill reference";
+ *   b) the malformed embed from that session (`@ag.references: {file: …}`) — an embed the engine
+ *      should never have stored, whose value resolves to nothing the panel understands;
+ *   c) a `__ag__` static — recognized and deliberately NOT editable.
+ *
+ * The test asserts the stored array, not any panel state, and compares against a deep-frozen
+ * original so a mutation in place fails instead of passing by shared reference.
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    applyItemToList,
+    removeItemFromList,
+} from "../../src/DrillInView/SchemaControls/agentTemplate/itemListOps"
+
+const VALID_EMBED = {
+    "@ag.embed": {
+        "@ag.references": {workflow: {slug: "release-qa"}},
+        "@ag.selector": {path: "parameters.skill"},
+    },
+}
+
+// Exactly the shape from session cfa9d1ed: the agent invented a file reference.
+const MALFORMED_EMBED = {
+    "@ag.embed": {
+        "@ag.references": {
+            file: "/tmp/agenta/mounts/019fd681-26a8-7d80-93c6-a18a009f8a95/019fd6a7-097b-7041-a19c-732ac2823da3-agent/gstack-autoplan/SKILL.md",
+        },
+    },
+}
+
+const STATIC_EMBED = {
+    "@ag.embed": {
+        "@ag.references": {workflow: {slug: "__ag__getting_started_with_agenta"}},
+        "@ag.selector": {path: "parameters.skill"},
+    },
+}
+
+const INLINE_SKILL = {name: "release-notes", description: "Draft release notes.", body: "Read it."}
+
+const deepFreeze = <T>(value: T): T => {
+    if (value && typeof value === "object") {
+        Object.values(value).forEach(deepFreeze)
+        Object.freeze(value)
+    }
+    return value
+}
+
+/** The stored list as the agent left it: three unauthored shapes plus one editable skill. */
+const storedSkills = () =>
+    deepFreeze([VALID_EMBED, MALFORMED_EMBED, STATIC_EMBED, INLINE_SKILL] as unknown[])
+
+describe("editing a neighbouring skill", () => {
+    it("leaves every entry the panel did not author byte-identical", () => {
+        const list = storedSkills()
+        const edited = {...INLINE_SKILL, body: "Read the changelog first."}
+
+        // The user opens the one editable skill (index 3) and saves it.
+        const next = applyItemToList(list, {mode: "edit", index: 3}, edited)
+
+        expect(next).toHaveLength(4)
+        expect(next[0]).toEqual(VALID_EMBED)
+        expect(next[1]).toEqual(MALFORMED_EMBED)
+        expect(next[2]).toEqual(STATIC_EMBED)
+        expect(next[3]).toEqual(edited)
+    })
+
+    it.each([
+        ["a valid @ag.embed reference", 0, VALID_EMBED],
+        ["the malformed embed from the reported session", 1, MALFORMED_EMBED],
+        ["a __ag__ static skill", 2, STATIC_EMBED],
+    ])("keeps %s across the save", (_label, index, entry) => {
+        const next = applyItemToList(storedSkills(), {mode: "edit", index: 3}, {name: "edited"})
+
+        // Deep equality AND the exact stored value, so a re-serialization that reorders or drops a
+        // marker key (`@ag.selector`, the nested `@ag.references`) fails here.
+        expect(next[index as number]).toEqual(entry)
+        expect(JSON.stringify(next[index as number])).toBe(JSON.stringify(entry))
+    })
+
+    it("adds a new skill without disturbing the stored ones", () => {
+        const next = applyItemToList(storedSkills(), {mode: "create", index: -1}, {name: "new"})
+
+        expect(next).toHaveLength(5)
+        expect(next.slice(0, 4)).toEqual(storedSkills())
+    })
+
+    it("refuses an out-of-range index rather than reshaping the list", () => {
+        // A stale drawer index must not punch a hole into the stored array.
+        const list = storedSkills()
+
+        expect(applyItemToList(list, {mode: "edit", index: 9}, {name: "x"})).toEqual(list)
+        expect(applyItemToList(list, {mode: "edit", index: -1}, {name: "x"})).toEqual(list)
+    })
+})
+
+describe("removing one skill", () => {
+    it("drops only the named index and preserves the unauthored neighbours", () => {
+        const next = removeItemFromList(storedSkills(), 3)
+
+        expect(next).toEqual([VALID_EMBED, MALFORMED_EMBED, STATIC_EMBED])
+    })
+})


### PR DESCRIPTION
## Context
During live QA a stored skill entry vanished after a save from the playground's configuration panel. The investigation cleared the panel itself: its list writer replaces one index and preserves everything else. The real cause was a stale browser draft overwriting a newer revision (a separate finding, tracked separately). This PR pins the panel's innocence with regression tests so the preservation property can never silently regress.

## Changes
The list transform moves into a small pure module (`itemListOps.ts`) so a node test can reach it without dragging React components in; `useConfigItemDrawer` is rewired to it, behavior-identical. One real hardening rode along: an out-of-range drawer index previously extended the array with holes; it now leaves the list unchanged, with a test.

## Tests / notes
Seven tests: a stored list holding a valid embed reference, the malformed embed shape from the live session (verbatim), a platform static entry, and an ordinary skill; editing the ordinary one must leave the other three byte-identical (deep-frozen fixture, equality plus serialized comparison). Bite-verified by making the transform drop non-editable entries: six of seven fail.

One caveat for reviewers: these tests prove the panel preserves what it does not author. They do NOT fix the data loss from the live session; that is the missing save-concurrency guard, tracked as its own decision. A green suite here must not be read as that fix.
