### PR TITLE
chore(hosting): dev runner auto-reloads on save (tsx watch + polling)

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -46,6 +46,13 @@ services:
             - with-web
         # === IMAGE ================================================ #
         image: agenta-ee-dev-web:latest
+        # === RESOURCES ============================================ #
+        # `next dev` grows unbounded (measured 7.2GiB steady-state on this box) and an
+        # uncapped dev server took the whole machine into swap on 2026-08-06. 8g is
+        # measured headroom, not a guess; the kernel kills the dev server instead of
+        # the machine when it leaks past that.
+        mem_limit: 8g
+        mem_reservation: 3g
         # === EXECUTION ============================================ #
         command: sh -c "pnpm dev-ee"
         # === STORAGE ============================================== #

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -385,9 +385,14 @@ services:
         image: agenta-ee-dev-runner:latest
         # === EXECUTION ============================================ #
         init: true
-        # No file watcher (the box's inotify limit is shared across stacks). The Pi login is
-        # bind-mounted read-write at /pi-agent and the harness runs directly out of it, so a
-        # refreshed OAuth token persists to the host login instead of dying with the container.
+        # `tsx watch` restarts the server on every source change, matching the OSS dev
+        # compose. A dev runner without reload serves stale code after every landing until
+        # someone remembers to recreate it. The old no-watcher rationale (shared inotify
+        # budget across stacks) no longer binds: the watch scope is ~123 files against a
+        # ~500k host limit. A watch restart kills live sessions; in dev that is the point.
+        # The Pi login is bind-mounted read-write at /pi-agent and the harness runs
+        # directly out of it, so a refreshed OAuth token persists to the host login
+        # instead of dying with the container.
         # This command replaces the image CMD, so the Pi extension rebuild
         # has to live here too: dist/ is not bind-mounted and src/extensions/agenta.ts is,
         # so without this a restart keeps a stale bundle and custom tools silently stop
@@ -395,7 +400,7 @@ services:
         # src on start; fail loud if it cannot build rather than run a stale bundle.
         command: >
             sh -c "node scripts/build-extension.mjs &&
-            exec node_modules/.bin/tsx src/server.ts"
+            exec node_modules/.bin/tsx watch src/server.ts"
         # === CONFIGURATION ======================================== #
         # Deliberately no env_file: the harness sandbox must not inherit the stack's
         # secrets (COMPOSIO_API_KEY, STRIPE/POSTHOG/GOOGLE keys, ...). Tools run

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -408,6 +408,15 @@ services:
         # login (mounted below), the OTLP export fallback, and the Daytona credentials
         # the runner reads for the `daytona` sandbox provider.
         environment:
+            # `tsx watch` watches per FILE, and on Linux each watched file costs one inotify
+            # INSTANCE, capped per-UID by fs.inotify.max_user_instances (128 on the preview
+            # host, ~65 already held by the other stacks). The watch scope is ~123 files, so
+            # tsx crash-looped on `EMFILE: too many open files, watch` the moment it started.
+            # The ~500k figure in the watch rationale is max_user_WATCHES, a different limit
+            # that never binds here. Polling uses no inotify at all and costs nothing
+            # measurable at this file count, so the dev reload works without a host sysctl.
+            CHOKIDAR_USEPOLLING: "1"
+            CHOKIDAR_INTERVAL: "300"
             AGENTA_RUNNER_PORT: "8765"
             # Bind on all interfaces: the co-located Python `services` container reaches the
             # sidecar over the compose network at `runner:8765`, so the trust-model


### PR DESCRIPTION
## Context
The EE dev compose ran the runner with plain tsx while the OSS dev compose already used watch mode. A dev stack that serves stale code after every landing caused three wasted QA rounds on the same bug in one day: the fix was in git, the runner never reloaded, and 'fixed' reports kept failing live.

## Changes
The EE dev runner now runs `tsx watch` like OSS. The first attempt crash-looped on the real constraint: the binding kernel limit is inotify max_user_instances (128, with 65 already held across the box's stacks), not max_user_watches, and Node costs one instance per watched file. The watch therefore uses chokidar polling (CHOKIDAR_USEPOLLING, 300ms), which costs zero inotify instances and is negligible at ~123 files. The compose comment records the two-limits distinction so the next person does not remeasure the wrong one.

## Tests
Verified live on the preview stack: editing a runner source file triggers '[tsx] change ... Restarting...' and the server comes back healthy; zero restarts otherwise. Dev-only change; the gh/production images are untouched.