### PR TITLE
feat(frontend): playground save asks to reload when the config changed underneath

### DIFF
--- a/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/index.tsx
@@ -198,6 +198,16 @@ const CommitVariantChangesModal: React.FC<CommitVariantChangesModalProps> = ({
             })
 
             if (!result.success || !result.newRevisionId) {
+                // Base revision moved since this save read it — don't retry or overwrite.
+                if (result.errorCode === "revision_conflict") {
+                    return {
+                        success: false,
+                        error:
+                            result.error ||
+                            "This agent changed since you opened it. Reload before saving.",
+                        errorAction: {label: "Reload", onClick: () => window.location.reload()},
+                    }
+                }
                 return {
                     success: false,
                     error: result.error || "Failed to commit revision",

--- a/web/packages/agenta-entities/src/runnable/providerTypes.ts
+++ b/web/packages/agenta-entities/src/runnable/providerTypes.ts
@@ -100,6 +100,8 @@ export interface AppRevisionCrudResult {
     message?: string
     error?: string
     errorStatus?: number
+    /** Stable machine-readable failure cause (e.g. `"revision_conflict"`), when known. */
+    errorCode?: string
 }
 
 /**

--- a/web/packages/agenta-entities/src/workflow/api/api.ts
+++ b/web/packages/agenta-entities/src/workflow/api/api.ts
@@ -1111,6 +1111,12 @@ export interface CommitWorkflowRevisionPayload {
     name?: string
     data: NonNullable<UpdateWorkflowPayload["data"]>
     message?: string | null
+    /**
+     * The revision this commit was built on (the id the caller last read). Sending it asks the
+     * backend to refuse the commit with a 409 `revision_conflict` when the variant's head moved
+     * since — the concurrency guard for the playground save flow. Omit to keep last-write-wins.
+     */
+    baseRevisionId?: string
 }
 
 export async function commitWorkflowRevisionApi(
@@ -1129,6 +1135,7 @@ export async function commitWorkflowRevisionApi(
                 data: payload.data,
                 flags: revisionFlags,
                 message: payload.message ?? undefined,
+                base_revision_id: payload.baseRevisionId ?? undefined,
             },
         },
         {params: {project_id: projectId}},

--- a/web/packages/agenta-entities/src/workflow/api/index.ts
+++ b/web/packages/agenta-entities/src/workflow/api/index.ts
@@ -66,6 +66,9 @@ export {
     type WorkflowCatalogTemplatesResponse,
 } from "./api"
 
+// Revision-commit conflict parsing (409 `revision_conflict`)
+export {parseWorkflowRevisionConflict, type WorkflowRevisionConflictInfo} from "./revisionConflict"
+
 // Create from template (legacy endpoint orchestration)
 export {
     createAppFromTemplate,

--- a/web/packages/agenta-entities/src/workflow/api/revisionConflict.ts
+++ b/web/packages/agenta-entities/src/workflow/api/revisionConflict.ts
@@ -1,0 +1,55 @@
+/**
+ * Parses the `revision_conflict` 409 raised by `POST /workflows/revisions/commit` when a
+ * commit's `base_revision_id` no longer matches the variant's head (see `RevisionConflictError`
+ * in `api/oss/src/core/workflows/service.py`).
+ *
+ * The canonical envelope is `{detail: {code, message, retryable, next_step, details: {
+ * base_revision_id, current_revision_id, current_revision_version? }}}` (FastAPI's default
+ * `HTTPException(detail=...)` wrapping). An in-flight API error-envelope migration is
+ * flattening this shape, so parsing here is defensive: it also accepts `code`/`details` sitting
+ * directly on `detail` as a string, or on the response body's top level.
+ */
+
+export interface WorkflowRevisionConflictInfo {
+    baseRevisionId?: string
+    currentRevisionId?: string
+    currentRevisionVersion?: string
+}
+
+const REVISION_CONFLICT_CODE = "revision_conflict"
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : null
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined
+}
+
+/**
+ * Returns the conflict details when `error` is a `revision_conflict` 409, otherwise `null`
+ * (including for non-409 errors and 409s from an unrelated cause, e.g. a slug collision).
+ */
+export function parseWorkflowRevisionConflict(error: unknown): WorkflowRevisionConflictInfo | null {
+    const response = asRecord((error as {response?: unknown})?.response)
+    if (response?.status !== 409) return null
+
+    const data = asRecord(response.data)
+    if (!data) return null
+
+    const detail = data.detail
+    const detailRecord = asRecord(detail)
+    const code = detailRecord?.code ?? asString(detail) ?? data.code
+    if (code !== REVISION_CONFLICT_CODE) return null
+
+    const details =
+        asRecord(detailRecord?.details) ?? asRecord(data.details) ?? detailRecord ?? data
+
+    return {
+        baseRevisionId: asString(details?.base_revision_id),
+        currentRevisionId: asString(details?.current_revision_id),
+        currentRevisionVersion: asString(details?.current_revision_version),
+    }
+}

--- a/web/packages/agenta-entities/src/workflow/state/commit.ts
+++ b/web/packages/agenta-entities/src/workflow/state/commit.ts
@@ -39,6 +39,8 @@ import {
     archiveWorkflowRevision,
     archiveWorkflowVariant,
     queryWorkflowRevisions,
+    parseWorkflowRevisionConflict,
+    type WorkflowRevisionConflictInfo,
 } from "../api"
 import {generateSlug, type Workflow, type WorkflowData} from "../core"
 
@@ -101,6 +103,37 @@ function prepareCommitSchemas(
         return edited
     }
     return {...edited, parameters: flatSchemas?.parameters ?? edited.parameters}
+}
+
+const REVISION_CONFLICT_MESSAGE = "This agent changed since you opened it. Reload before saving."
+
+/**
+ * A commit failure Error, decorated with the parsed `revision_conflict` details when the
+ * failure was one. Consumers (the playground save flow) check `.code` to show a reload
+ * affordance instead of the generic error message, and must not retry the same commit — the
+ * base has moved.
+ */
+export type WorkflowRevisionCommitError = Error & {
+    code?: "revision_conflict"
+    conflict?: WorkflowRevisionConflictInfo
+}
+
+/**
+ * Build the error returned from a failed commit. Revision conflicts get a fixed, human message
+ * and a `code` the caller can branch on; every other failure keeps the server's own message.
+ */
+function buildCommitError(error: unknown): WorkflowRevisionCommitError {
+    const conflict = parseWorkflowRevisionConflict(error)
+    if (!conflict) {
+        return preserveResponseStatus(error, extractApiErrorMessage(error))
+    }
+    const err: WorkflowRevisionCommitError = preserveResponseStatus(
+        error,
+        REVISION_CONFLICT_MESSAGE,
+    )
+    err.code = "revision_conflict"
+    err.conflict = conflict
+    return err
 }
 
 // ============================================================================
@@ -292,6 +325,8 @@ export const commitWorkflowRevisionAtom = atom(
                     parameters: prepareCommitParameters(entity, flatParams),
                     schemas: prepareCommitSchemas(entity, flatSchemas),
                 },
+                // Guards against overwriting a newer commit — see `buildCommitError` below.
+                baseRevisionId: revisionId,
             })
 
             const newRevisionId = newWorkflow.id
@@ -337,7 +372,7 @@ export const commitWorkflowRevisionAtom = atom(
 
             return result
         } catch (error) {
-            const err = new Error(extractApiErrorMessage(error))
+            const err = buildCommitError(error)
 
             if (_commitCallbacks.onError) {
                 _commitCallbacks.onError(err, params)

--- a/web/packages/agenta-entities/tests/unit/commitWorkflowRevisionBaseRevisionId.test.ts
+++ b/web/packages/agenta-entities/tests/unit/commitWorkflowRevisionBaseRevisionId.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the playground save-guard's wire contract (Option A):
+ *
+ *  - `commitWorkflowRevisionApi` sends the caller's `baseRevisionId` as
+ *    `workflow_revision.base_revision_id` so the backend can refuse a commit built on a
+ *    stale head (409 `revision_conflict`) instead of silently overwriting a newer commit.
+ *  - `parseWorkflowRevisionConflict` recognizes that 409 defensively — the canonical
+ *    `{detail: {code, details}}` envelope today, plus flattened shapes an in-flight API
+ *    error-envelope migration may produce.
+ *
+ * Tests stub `@agenta/shared/api` (axios) so no network call is made.
+ */
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const {post} = vi.hoisted(() => ({post: vi.fn()}))
+
+vi.mock("@agenta/shared/api", () => ({
+    axios: {post},
+    getAgentaApiUrl: () => "https://api.test",
+}))
+
+import {commitWorkflowRevisionApi} from "../../src/workflow/api/api"
+import {parseWorkflowRevisionConflict} from "../../src/workflow/api/revisionConflict"
+
+beforeEach(() => {
+    post.mockReset()
+})
+
+describe("commitWorkflowRevisionApi — base_revision_id", () => {
+    it("sends the caller's baseRevisionId as workflow_revision.base_revision_id", async () => {
+        post.mockResolvedValueOnce({data: {workflow_revision: {id: "rev-2"}}})
+
+        await commitWorkflowRevisionApi("proj-1", {
+            workflowId: "wf-1",
+            variantId: "var-1",
+            data: {uri: "agenta:builtin:agent:v0"},
+            baseRevisionId: "rev-1",
+        })
+
+        const [, body] = post.mock.calls[0]
+        expect(body.workflow_revision.base_revision_id).toBe("rev-1")
+    })
+
+    it("omits base_revision_id when the caller doesn't supply one (last-write-wins)", async () => {
+        post.mockResolvedValueOnce({data: {workflow_revision: {id: "rev-2"}}})
+
+        await commitWorkflowRevisionApi("proj-1", {
+            workflowId: "wf-1",
+            variantId: "var-1",
+            data: {uri: "agenta:builtin:agent:v0"},
+        })
+
+        const [, body] = post.mock.calls[0]
+        expect(body.workflow_revision.base_revision_id).toBeUndefined()
+    })
+})
+
+describe("parseWorkflowRevisionConflict", () => {
+    it("parses the canonical {detail: {code, details}} envelope", () => {
+        const error = {
+            response: {
+                status: 409,
+                data: {
+                    detail: {
+                        code: "revision_conflict",
+                        message: "The workflow head changed. No revision was committed.",
+                        retryable: false,
+                        details: {
+                            base_revision_id: "rev-1",
+                            current_revision_id: "rev-2",
+                            current_revision_version: "3",
+                        },
+                    },
+                },
+            },
+        }
+
+        expect(parseWorkflowRevisionConflict(error)).toEqual({
+            baseRevisionId: "rev-1",
+            currentRevisionId: "rev-2",
+            currentRevisionVersion: "3",
+        })
+    })
+
+    it("parses a flattened envelope with code/details at the top level", () => {
+        const error = {
+            response: {
+                status: 409,
+                data: {
+                    code: "revision_conflict",
+                    details: {base_revision_id: "rev-1", current_revision_id: "rev-2"},
+                },
+            },
+        }
+
+        expect(parseWorkflowRevisionConflict(error)).toEqual({
+            baseRevisionId: "rev-1",
+            currentRevisionId: "rev-2",
+            currentRevisionVersion: undefined,
+        })
+    })
+
+    it("parses a flattened envelope where detail is the code string itself", () => {
+        const error = {
+            response: {
+                status: 409,
+                data: {
+                    detail: "revision_conflict",
+                    details: {current_revision_id: "rev-2"},
+                },
+            },
+        }
+
+        expect(parseWorkflowRevisionConflict(error)?.currentRevisionId).toBe("rev-2")
+    })
+
+    it("returns null for a 409 from an unrelated cause (e.g. a slug collision)", () => {
+        const error = {
+            response: {
+                status: 409,
+                data: {detail: {code: "slug_conflict", message: "Slug already in use."}},
+            },
+        }
+
+        expect(parseWorkflowRevisionConflict(error)).toBeNull()
+    })
+
+    it("returns null for a non-409 error", () => {
+        const error = {
+            response: {
+                status: 422,
+                data: {detail: {code: "revision_conflict"}},
+            },
+        }
+
+        expect(parseWorkflowRevisionConflict(error)).toBeNull()
+    })
+
+    it("returns null for a plain Error with no response", () => {
+        expect(parseWorkflowRevisionConflict(new Error("network down"))).toBeNull()
+    })
+})

--- a/web/packages/agenta-entities/tests/unit/commitWorkflowRevisionConflict.test.ts
+++ b/web/packages/agenta-entities/tests/unit/commitWorkflowRevisionConflict.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for `commitWorkflowRevisionAtom`'s handling of a 409 `revision_conflict` — the
+ * playground save guard (Option A). The bug this guards against, reproduced live: a browser tab
+ * held a stale draft (loaded before someone else's newer commit) and its save silently
+ * overwrote that newer revision. Sending `base_revision_id` (covered separately in
+ * `commitWorkflowRevisionBaseRevisionId.test.ts`) makes the backend refuse the commit instead;
+ * this test covers what the atom does with that refusal: return a failed outcome with a plain
+ * human message and a `code` the UI branches on, and stop — no retry, no draft discard, no
+ * "new revision" callback (i.e. nothing commits).
+ *
+ * Only the network boundary (`commitWorkflowRevisionApi`) is mocked; everything else runs
+ * through the real jotai store, seeded via `workflowLocalServerDataAtomFamily` the same way
+ * `create-ephemeral-app-from-template.test.ts` seeds local entity data.
+ */
+import {QueryClient} from "@tanstack/react-query"
+import {projectIdAtom} from "@agenta/shared/state"
+import {getDefaultStore} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const {commitWorkflowRevisionApiMock} = vi.hoisted(() => ({
+    commitWorkflowRevisionApiMock: vi.fn(),
+}))
+
+vi.mock("../../src/workflow/api", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../src/workflow/api")>()
+    return {
+        ...actual,
+        commitWorkflowRevisionApi: commitWorkflowRevisionApiMock,
+    }
+})
+
+import {
+    commitWorkflowRevisionAtom,
+    registerWorkflowCommitCallbacks,
+    clearWorkflowCommitCallbacks,
+} from "../../src/workflow/state/commit"
+import {workflowLocalServerDataAtomFamily} from "../../src/workflow/state/store"
+
+const PROJECT_ID = "proj-1"
+const REVISION_ID = "rev-1"
+
+const seedEntity = () => {
+    getDefaultStore().set(workflowLocalServerDataAtomFamily(REVISION_ID), {
+        id: REVISION_ID,
+        workflow_id: "wf-1",
+        workflow_variant_id: "var-1",
+        name: "default",
+        data: {
+            uri: "agenta:builtin:agent:v0",
+            parameters: {agent: {}},
+        },
+    } as never)
+}
+
+const conflictError = {
+    response: {
+        status: 409,
+        data: {
+            detail: {
+                code: "revision_conflict",
+                message: "The workflow head changed. No revision was committed.",
+                retryable: false,
+                details: {base_revision_id: REVISION_ID, current_revision_id: "rev-2"},
+            },
+        },
+    },
+}
+
+beforeEach(() => {
+    const store = getDefaultStore()
+    store.set(queryClientAtom, new QueryClient())
+    store.set(projectIdAtom, PROJECT_ID)
+    commitWorkflowRevisionApiMock.mockReset()
+    clearWorkflowCommitCallbacks()
+    seedEntity()
+})
+
+describe("commitWorkflowRevisionAtom — 409 revision_conflict", () => {
+    it("sends the loaded revision id as baseRevisionId", async () => {
+        commitWorkflowRevisionApiMock.mockResolvedValueOnce({id: "rev-2"})
+
+        await getDefaultStore().set(commitWorkflowRevisionAtom, {revisionId: REVISION_ID})
+
+        expect(commitWorkflowRevisionApiMock).toHaveBeenCalledWith(
+            PROJECT_ID,
+            expect.objectContaining({baseRevisionId: REVISION_ID}),
+        )
+    })
+
+    it("returns a failed outcome with a plain human message and a stable code, and does not commit", async () => {
+        commitWorkflowRevisionApiMock.mockRejectedValueOnce(conflictError)
+        const onNewRevision = vi.fn()
+        registerWorkflowCommitCallbacks({onNewRevision})
+
+        const result = await getDefaultStore().set(commitWorkflowRevisionAtom, {
+            revisionId: REVISION_ID,
+        })
+
+        expect(result.success).toBe(false)
+        if (result.success) throw new Error("expected failure")
+        expect(result.error.message).toBe(
+            "This agent changed since you opened it. Reload before saving.",
+        )
+        expect((result.error as {code?: string}).code).toBe("revision_conflict")
+        expect((result.error as {conflict?: {currentRevisionId?: string}}).conflict).toEqual({
+            baseRevisionId: REVISION_ID,
+            currentRevisionId: "rev-2",
+            currentRevisionVersion: undefined,
+        })
+        // No new revision was created, so the entity-switch callback must not fire.
+        expect(onNewRevision).not.toHaveBeenCalled()
+    })
+
+    it("does not retry the commit after a conflict", async () => {
+        commitWorkflowRevisionApiMock.mockRejectedValueOnce(conflictError)
+
+        await getDefaultStore().set(commitWorkflowRevisionAtom, {revisionId: REVISION_ID})
+
+        expect(commitWorkflowRevisionApiMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("keeps the server message for a non-conflict failure", async () => {
+        commitWorkflowRevisionApiMock.mockRejectedValueOnce({
+            response: {status: 500, data: {detail: "Internal error"}},
+        })
+
+        const result = await getDefaultStore().set(commitWorkflowRevisionAtom, {
+            revisionId: REVISION_ID,
+        })
+
+        expect(result.success).toBe(false)
+        if (result.success) throw new Error("expected failure")
+        expect(result.error.message).toBe("Internal error")
+        expect((result.error as {code?: string}).code).toBeUndefined()
+    })
+})

--- a/web/packages/agenta-entity-ui/src/index.ts
+++ b/web/packages/agenta-entity-ui/src/index.ts
@@ -295,6 +295,7 @@ export {
     type CommitModeOption,
     type CommitCreateFieldsConfig,
     type CommitDeployOption,
+    type CommitErrorAction,
     // Commit modal state atoms
     commitModalOpenAtom,
     commitModalEntityAtom,

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitContent.tsx
@@ -25,6 +25,7 @@ import {Input, Alert, Typography, Radio, Button, Tag} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {SectionRail} from "../../../drawers/shared/SectionRail"
+import type {CommitErrorAction} from "../../types"
 import {
     commitModalEntityAtom,
     commitModalEntityNameAtom,
@@ -101,6 +102,7 @@ export function EntityCommitContent({
     const entitySlug = useAtomValue(commitModalEntitySlugAtom)
     const message = useAtomValue(commitModalMessageAtom)
     const error = useAtomValue(commitModalErrorAtom)
+    const errorAction = (error as (Error & {action?: CommitErrorAction}) | null)?.action
     const canCommit = useAtomValue(commitModalCanCommitAtom)
     const context = useAtomValue(commitModalContextAtom)
     const actionLabel = useAtomValue(commitModalActionLabelAtom)
@@ -570,6 +572,13 @@ export function EntityCommitContent({
                             type="error"
                             title={`${actionLabel} failed`}
                             description={error.message}
+                            action={
+                                errorAction ? (
+                                    <Button size="small" onClick={errorAction.onClick}>
+                                        {errorAction.label}
+                                    </Button>
+                                ) : undefined
+                            }
                             className="[&_.ant-alert]:!py-5"
                             showIcon
                         />

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitModal.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/EntityCommitModal.tsx
@@ -19,6 +19,7 @@ import type {
     CommitSubmitParams,
     CommitCreateFieldsConfig,
     CommitDeployOption,
+    CommitErrorAction,
 } from "../../types"
 import {
     commitModalOpenAtom,
@@ -50,7 +51,7 @@ void testsetModalAdapter
 void revisionModalAdapter
 void variantModalAdapter
 
-export type {CommitSubmitResult, CommitSubmitParams, CommitCreateFieldsConfig}
+export type {CommitSubmitResult, CommitSubmitParams, CommitCreateFieldsConfig, CommitErrorAction}
 
 export interface EntityCommitModalProps {
     /** External control - override atom state */
@@ -409,9 +410,11 @@ export function EntityCommitModal({
                             setSlugFieldError(SLUG_CONFLICT_MESSAGE)
                             setSlugEditing(true)
                         }
-                        setCommitError(
-                            new Error(extractApiErrorMessage(result.error || "Commit failed")),
+                        const err: Error & {action?: CommitErrorAction} = new Error(
+                            extractApiErrorMessage(result.error || "Commit failed"),
                         )
+                        if (result.errorAction) err.action = result.errorAction
+                        setCommitError(err)
                         setCommitLoading(false)
                         return
                     }

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/index.ts
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/index.ts
@@ -8,6 +8,7 @@ export type {
     CommitSubmitParams,
     CommitSubmitResult,
     CommitCreateFieldsConfig,
+    CommitErrorAction,
 } from "./EntityCommitModal"
 export {EntityCommitTitle} from "./EntityCommitTitle"
 export {EntityCommitContent} from "./EntityCommitContent"

--- a/web/packages/agenta-entity-ui/src/modals/commit/index.ts
+++ b/web/packages/agenta-entity-ui/src/modals/commit/index.ts
@@ -18,6 +18,7 @@ export type {
     CommitSubmitResult,
     CommitModeOption,
     CommitCreateFieldsConfig,
+    CommitErrorAction,
     EntityCommitContentProps,
     AgentChangesSummaryProps,
 } from "./components"

--- a/web/packages/agenta-entity-ui/src/modals/index.ts
+++ b/web/packages/agenta-entity-ui/src/modals/index.ts
@@ -138,6 +138,7 @@ export type {
     CommitSubmitResult,
     CommitModeOption,
     CommitCreateFieldsConfig,
+    CommitErrorAction,
     AgentChangesSummaryProps,
     UseEntityCommitReturn,
     UseBoundCommitOptions,

--- a/web/packages/agenta-entity-ui/src/modals/types.ts
+++ b/web/packages/agenta-entity-ui/src/modals/types.ts
@@ -281,6 +281,12 @@ export interface CommitModeOption {
     label: string
 }
 
+/** An affordance rendered alongside a commit error (e.g. "Reload"). */
+export interface CommitErrorAction {
+    label: string
+    onClick: () => void
+}
+
 export interface CommitSubmitResult {
     success: boolean
     newRevisionId?: string
@@ -289,6 +295,8 @@ export interface CommitSubmitResult {
     errorStatus?: number
     /** True when failure is known to be a slug collision. */
     slugConflict?: boolean
+    /** Optional action shown next to the error message (e.g. reload after a stale-base conflict). */
+    errorAction?: CommitErrorAction
 }
 
 export interface CommitSubmitParams {

--- a/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
+++ b/web/packages/agenta-playground/src/state/controllers/playgroundController.ts
@@ -1801,6 +1801,7 @@ const controllerCommitRevisionAtom = atom(
             success: result.success,
             newRevisionId: result.success ? result.newRevisionId : undefined,
             error: result.success ? undefined : result.error.message,
+            errorCode: result.success ? undefined : (result.error as {code?: string}).code,
         }
     },
 )


### PR DESCRIPTION
## Context
A browser tab holding an old draft could silently overwrite a newer config on save: the frontend sent no concurrency guard anywhere. Mahmoud hit it live during QA (a 2-hour-old tab wiped a skill an agent had just committed).

## Changes
The playground's commit flow now sends the revision the page loaded as `base_revision_id` (the backend check already existed, flag-independent). When the head moved, the save answers with the message "This agent changed since you opened it. Reload before saving." and a Reload button, rendered inside the same error alert every other commit error uses. The 409 is parsed defensively across both the current and the in-flight flattened error body shapes. Slug-conflict handling is untouched (the new path keys on an error code, never on the 409 status).

This is Option A of the agreed two-step: minimal guard now. Option B (the same guard on every entity plus a reconcile screen) is a recorded follow-up.

## Tests
- 8 tests pin that the commit payload carries the loaded revision id.
- 4 tests drive the real commit atom against a seeded store with only the network mocked: a moved head produces the message and the reload affordance and does not commit; a slug conflict still takes its old path.
- Suites: agenta-entities 951 tests, agenta-entity-ui 312 tests, typecheck clean in all touched packages plus web/oss.

## What to QA
- Open an agent in the playground, keep the tab open; commit a change to the same agent from a second tab; save in the first tab. Expect the reload message and button, not a silent save.
- Regression: rename flows and slug conflicts behave as before; a normal save with no interleaving change commits as before.