### PR TITLE
fix(frontend): A finished upload confirms itself instead of vanishing

### DIFF
--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -15,7 +15,7 @@
  * keyboard nav ({@link useDriveTreeKeyboard}), selection reveal ({@link useDriveTreeReveal}) and
  * "Download all" ({@link useDriveDownloadAll}).
  */
-import {type ReactNode, useCallback, useState} from "react"
+import {type ReactNode, useCallback, useRef, useState} from "react"
 
 import {type MountFile} from "@agenta/entities/session"
 import {useAtomValue} from "jotai"
@@ -47,6 +47,7 @@ import {useDriveTreeViewport} from "./useDriveTreeViewport"
 import {useDriveUploads} from "./useDriveUploads"
 import {driveHasMixedOrigins, type SessionDriveData} from "./useSessionDrive"
 import {useTreeGroupScroll} from "./useTreeGroupScroll"
+import {useUploadReveal} from "./useUploadReveal"
 
 export type {DriveId, DriveScope} from "./driveTypes"
 
@@ -120,6 +121,11 @@ export function DriveExplorer({
         projectId,
     })
 
+    // Uploads sit ABOVE the tree, but a finished upload is only explainable AGAINST the tree (is the
+    // file in the listing, or did a filter swallow it?) — so the completion callback forwards through
+    // a ref that useUploadReveal fills in once both halves exist.
+    const revealUpload = useRef<(path: string) => void>(() => undefined)
+    const onUploaded = useCallback((path: string) => revealUpload.current(path), [])
     // Uploads sit ABOVE the tree: their in-flight files are folded into the build below, so each one
     // renders as a real row/tile under its destination folder.
     const {
@@ -134,7 +140,7 @@ export function DriveExplorer({
         removeStaged,
         retryUpload,
         dismissUpload,
-    } = useDriveUploads({drive, explicitFiles, select, stagedFiles, onStagedChange})
+    } = useDriveUploads({drive, explicitFiles, select, stagedFiles, onStagedChange, onUploaded})
 
     const {
         lazyTree,
@@ -158,6 +164,18 @@ export function DriveExplorer({
         originFilter,
         showHidden,
         showGitignored,
+    })
+    // Closes the loop opened above: a completed upload toasts, and anything the filters would have
+    // hidden (a dotfile, a git-ignored `.env`) reveals itself instead of blinking out.
+    revealUpload.current = useUploadReveal({
+        files: lazyTree.files,
+        loadedDirs: lazyTree.loadedDirs,
+        fetchingDirs: lazyTree.fetchingDirs,
+        inGitScope,
+        showHidden,
+        setShowHidden,
+        showGitignored,
+        setShowGitignored,
     })
     const selectedNode = selectedPath != null ? nodeByPath.get(selectedPath) : undefined
     // The root and any node flagged a folder render the grid; everything else the preview. In lazy

--- a/web/oss/src/components/Drives/useDriveUploads.ts
+++ b/web/oss/src/components/Drives/useDriveUploads.ts
@@ -33,6 +33,7 @@ export function useDriveUploads({
     select,
     stagedFiles,
     onStagedChange,
+    onUploaded,
 }: {
     drive: SessionDriveData
     /** Local-file mode — there is no mount to write to, so every upload affordance stays off. */
@@ -41,11 +42,13 @@ export function useDriveUploads({
     select: (path: string | null) => void
     stagedFiles?: DroppedFile[]
     onStagedChange?: (files: DroppedFile[]) => void
+    /** One file's write landed, at its presented path — see {@link useUploadReveal}. */
+    onUploaded?: (path: string) => void
 }) {
     // Upload state lives here (above the tree) so in-flight uploads can be injected as synthetic files —
     // buildDriveTree then nests each UNDER its destination folder, and the real tree row / file tile
     // renders it in place (decorated via pendingUploadByPath), rather than a separate pinned list.
-    const mountUpload = useMountUpload()
+    const mountUpload = useMountUpload(onUploaded)
     const uploadPath = useCallback(
         (it: MountUploadItem) =>
             it.presentedFolder ? `${it.presentedFolder}/${it.relativePath}` : it.relativePath,

--- a/web/oss/src/components/Drives/useMountUpload.ts
+++ b/web/oss/src/components/Drives/useMountUpload.ts
@@ -65,10 +65,18 @@ export interface MountUpload {
     dismiss: (id: string) => void
 }
 
-export function useMountUpload(): MountUpload {
+/**
+ * @param onUploaded called with the PRESENTED (drive-root-relative) path of each file whose write
+ * landed — the hook drops its optimistic item at that moment, so this is the host's only chance to
+ * account for a file the listing filters will hide (see {@link useUploadReveal}).
+ */
+export function useMountUpload(onUploaded?: (path: string) => void): MountUpload {
     const projectId = useAtomValue(projectIdAtom)
     const queryClient = useAtomValue(queryClientAtom)
     const [items, setItems] = useState<MountUploadItem[]>([])
+    // Held in a ref so a fresh callback identity never re-creates `run` (and with it the pump).
+    const onUploadedRef = useRef(onUploaded)
+    onUploadedRef.current = onUploaded
 
     // Per-item inputs kept for retry, plus abort controllers for cleanup.
     const sources = useRef(new Map<string, {dropped: DroppedFile; target: MountUploadTarget}>())
@@ -116,6 +124,12 @@ export function useMountUpload(): MountUpload {
                     sources.current.delete(id)
                     setItems((prev) => prev.filter((it) => it.id !== id))
                     refreshListing()
+                    const {presentedFolder} = src.target
+                    onUploadedRef.current?.(
+                        presentedFolder
+                            ? `${presentedFolder}/${src.dropped.relativePath}`
+                            : src.dropped.relativePath,
+                    )
                 })
                 .catch((e: unknown) => {
                     running.current = Math.max(0, running.current - 1)

--- a/web/oss/src/components/Drives/useUploadReveal.test.ts
+++ b/web/oss/src/components/Drives/useUploadReveal.test.ts
@@ -1,0 +1,97 @@
+import {describe, expect, it} from "vitest"
+
+import {ruleOnBatch, type UploadBatch} from "./useUploadReveal"
+
+const batch = (over: Partial<UploadBatch> = {}): UploadBatch => ({
+    key: "k",
+    paths: ["agent-files/agenta/hosting/.env.ee.dev"],
+    at: 0,
+    sawFetch: false,
+    ...over,
+})
+const DIR = "agent-files/agenta/hosting"
+
+const rule = (over: Parameters<typeof ruleOnBatch>[0]) => ruleOnBatch(over).verdict
+
+describe("ruleOnBatch", () => {
+    it("confirms a batch whose file is in the listing", () => {
+        expect(
+            rule({
+                batch: batch(),
+                seen: new Set(["agent-files/agenta/hosting/.env.ee.dev"]),
+                loadedDirs: new Set([DIR]),
+                fetchingDirs: new Set(),
+                now: 10_000,
+            }),
+        ).toBe("confirmed")
+    })
+
+    it("waits while the destination listing is still refetching", () => {
+        expect(
+            rule({
+                batch: batch({sawFetch: true}),
+                seen: new Set(),
+                loadedDirs: new Set([DIR]),
+                fetchingDirs: new Set([DIR]),
+                now: 5_000,
+            }),
+        ).toBe("waiting")
+    })
+
+    it("waits out the settle floor when no refetch was ever observed", () => {
+        const args = {
+            batch: batch(),
+            seen: new Set<string>(),
+            loadedDirs: new Set([DIR]),
+            fetchingDirs: new Set<string>(),
+        }
+        expect(rule({...args, now: 300})).toBe("waiting")
+        expect(rule({...args, now: 1_500})).toBe("filtered")
+    })
+
+    it("rules immediately once the observed refetch has settled", () => {
+        expect(
+            rule({
+                batch: batch({sawFetch: true}),
+                seen: new Set(),
+                loadedDirs: new Set([DIR]),
+                fetchingDirs: new Set(),
+                now: 400,
+            }),
+        ).toBe("filtered")
+    })
+
+    it("never rules on a directory it has not loaded — it gives up instead", () => {
+        const args = {
+            batch: batch(),
+            seen: new Set<string>(),
+            loadedDirs: new Set<string>(),
+            fetchingDirs: new Set<string>(),
+        }
+        expect(rule({...args, now: 2_000})).toBe("waiting")
+        expect(rule({...args, now: 6_000})).toBe("unresolved")
+    })
+
+    it("carries sawFetch forward once the refetch has been seen", () => {
+        const seen = ruleOnBatch({
+            batch: batch(),
+            seen: new Set(),
+            loadedDirs: new Set([DIR]),
+            fetchingDirs: new Set([DIR]),
+            now: 100,
+        })
+        expect(seen).toEqual({verdict: "waiting", sawFetch: true})
+    })
+
+    it("treats a root-level upload as living in the root directory", () => {
+        expect(
+            rule({
+                batch: batch({paths: [".env"]}),
+                seen: new Set(),
+                loadedDirs: new Set([""]),
+                fetchingDirs: new Set(),
+                now: 2_000,
+            }),
+        ).toBe("filtered")
+    })
+})

--- a/web/oss/src/components/Drives/useUploadReveal.ts
+++ b/web/oss/src/components/Drives/useUploadReveal.ts
@@ -1,0 +1,195 @@
+/**
+ * useUploadReveal — an upload must never finish by vanishing. {@link useMountUpload} drops the
+ * optimistic tile the moment the write lands and the real file takes its place from the refetched
+ * listing — except when the drive's own filters hide it: a dotfile with hidden files off, or an
+ * `.env` / build artefact the repo gitignores. The tile then blinks out into nothing, which reads as
+ * a FAILED upload (it isn't) — the report that prompted this.
+ *
+ * So every completed batch toasts, and whatever the filters would have swallowed is REVEALED.
+ * Hidden-ness is decidable from the path; git-ignored-ness is not (the listing simply omits the
+ * entry), so a file that never arrives in a directory we have loaded AND settled is taken as
+ * git-ignored: the toggle flips and the toast says why the view changed.
+ */
+import {useCallback, useEffect, useRef, useState} from "react"
+
+import {type MountFile} from "@agenta/entities/session"
+import {App} from "antd"
+
+import {isHiddenPath} from "./driveTree"
+
+/** How long a batch waits for its destination listing to settle before we rule on it, and the hard
+ * stop after which an unconfirmed batch is dropped without a verdict (never flip a filter on a
+ * guess). Both measured from the moment the upload landed. */
+const SETTLE_MS = 1500
+const GIVE_UP_MS = 6000
+/** Uploads completing within this window toast as ONE message — a dropped folder is one event. */
+const BATCH_MS = 300
+
+const dirOf = (path: string) => {
+    const slash = path.lastIndexOf("/")
+    return slash === -1 ? "" : path.slice(0, slash)
+}
+const nameOf = (path: string) => path.slice(path.lastIndexOf("/") + 1)
+
+const label = (paths: string[]) =>
+    paths.length === 1 ? `Uploaded ${nameOf(paths[0])}` : `Uploaded ${paths.length} files`
+
+/** One toasted group of uploads, watched until its files show up in the listing. */
+export interface UploadBatch {
+    key: string
+    /** Presented (drive-root-relative) paths — the same space the tree's files live in. */
+    paths: string[]
+    at: number
+    /** The destination listing was seen refetching — the batch's cue that a verdict is meaningful. */
+    sawFetch: boolean
+}
+
+/** What to do with a watched batch on this pass. `filtered` = the listing settled without it, so
+ * only the gitignore filter can be hiding it; `unresolved` = we never got a settled listing to rule
+ * against (an unsubscribed folder), so the batch is dropped WITHOUT touching a filter. */
+export type BatchVerdict = "confirmed" | "filtered" | "waiting" | "unresolved"
+
+/**
+ * The rule for one watched batch — pure, so the (subtle) settle/give-up timing is testable.
+ * A verdict is only meaningful once every destination directory is loaded and no longer in flight;
+ * `sawFetch` catches the refetch the upload's own invalidation kicks off, and the age floor covers
+ * the case where that refetch was too quick (or too inactive) to ever be observed.
+ */
+export function ruleOnBatch({
+    batch,
+    seen,
+    loadedDirs,
+    fetchingDirs,
+    now,
+}: {
+    batch: UploadBatch
+    /** Paths currently in the listing. */
+    seen: ReadonlySet<string>
+    loadedDirs: ReadonlySet<string>
+    fetchingDirs: ReadonlySet<string>
+    now: number
+}): {verdict: BatchVerdict; sawFetch: boolean} {
+    const missing = batch.paths.filter((p) => !seen.has(p))
+    if (!missing.length) return {verdict: "confirmed", sawFetch: batch.sawFetch}
+    const dirs = [...new Set(missing.map(dirOf))]
+    const sawFetch = batch.sawFetch || dirs.some((d) => fetchingDirs.has(d))
+    const age = now - batch.at
+    const settled =
+        dirs.every((d) => loadedDirs.has(d) && !fetchingDirs.has(d)) &&
+        (sawFetch || age >= SETTLE_MS)
+    if (settled) return {verdict: "filtered", sawFetch}
+    if (age >= GIVE_UP_MS) return {verdict: "unresolved", sawFetch}
+    return {verdict: "waiting", sawFetch}
+}
+
+export function useUploadReveal({
+    files,
+    loadedDirs,
+    fetchingDirs,
+    inGitScope,
+    showHidden,
+    setShowHidden,
+    showGitignored,
+    setShowGitignored,
+}: {
+    /** Raw lazy-tree files (pre hidden/origin filtering) — presence here means "the listing has it". */
+    files: MountFile[]
+    loadedDirs: Set<string>
+    fetchingDirs: Set<string>
+    inGitScope: boolean
+    showHidden: boolean
+    setShowHidden: (next: boolean) => void
+    showGitignored: boolean
+    setShowGitignored: (next: boolean) => void
+}) {
+    const {message} = App.useApp()
+    const [batches, setBatches] = useState<UploadBatch[]>([])
+    // Completed paths held for BATCH_MS so a folder drop toasts once, not once per file.
+    const buffer = useRef<string[]>([])
+    const flushTimer = useRef<number | null>(null)
+    const seq = useRef(0)
+    // Read inside the debounced flush, which must not re-key on every filter change.
+    const showHiddenRef = useRef(showHidden)
+    showHiddenRef.current = showHidden
+
+    const flush = useCallback(() => {
+        flushTimer.current = null
+        const paths = buffer.current
+        buffer.current = []
+        if (!paths.length) return
+        // Hidden-ness is knowable now, so reveal before the toast and say so in it.
+        const revealHidden = !showHiddenRef.current && paths.some(isHiddenPath)
+        if (revealHidden) setShowHidden(true)
+        const key = `drive-upload-${(seq.current += 1)}`
+        message.open({
+            type: "success",
+            key,
+            content: revealHidden ? `${label(paths)} · showing hidden files` : label(paths),
+        })
+        setBatches((prev) => [...prev, {key, paths, at: Date.now(), sawFetch: false}])
+    }, [message, setShowHidden])
+
+    /** Call when one upload's write has landed, with its presented path. */
+    const onUploaded = useCallback(
+        (path: string) => {
+            buffer.current.push(path)
+            if (flushTimer.current == null) {
+                flushTimer.current = window.setTimeout(flush, BATCH_MS)
+            }
+        },
+        [flush],
+    )
+
+    // Batches age out on their own schedule, so drive the re-check off a ticker that runs ONLY while
+    // something is being watched.
+    const [ticks, tick] = useState(0)
+    useEffect(() => {
+        if (!batches.length) return
+        const id = window.setInterval(() => tick((n) => n + 1), 400)
+        return () => window.clearInterval(id)
+    }, [batches.length])
+
+    useEffect(() => {
+        void ticks // re-check on every tick: the settle/give-up rulings below are age-based
+        if (!batches.length) return
+        const seen = new Set(files.map((f) => f.path))
+        const now = Date.now()
+        let revealed = false
+        const next: UploadBatch[] = []
+        for (const batch of batches) {
+            const {verdict, sawFetch} = ruleOnBatch({batch, seen, loadedDirs, fetchingDirs, now})
+            if (verdict === "filtered" && inGitScope && !showGitignored) {
+                revealed = true
+                message.open({
+                    type: "success",
+                    key: batch.key,
+                    content: `${label(batch.paths)} · showing git-ignored files`,
+                })
+            }
+            if (verdict !== "waiting") continue
+            next.push(sawFetch === batch.sawFetch ? batch : {...batch, sawFetch})
+        }
+        if (revealed) setShowGitignored(true)
+        if (next.length !== batches.length || next.some((b, i) => b !== batches[i]))
+            setBatches(next)
+    }, [
+        ticks,
+        batches,
+        files,
+        loadedDirs,
+        fetchingDirs,
+        inGitScope,
+        showGitignored,
+        setShowGitignored,
+        message,
+    ])
+
+    useEffect(
+        () => () => {
+            if (flushTimer.current != null) window.clearTimeout(flushTimer.current)
+        },
+        [],
+    )
+
+    return onUploaded
+}


### PR DESCRIPTION
## Context

Uploading a file into an agent's drive can look like it failed. The optimistic tile shows progress, then disappears the moment the write lands, and the real file takes its place from the refetched listing. When a drive filter hides that file, nothing takes its place. The tile just blinks out into an empty grid.

Two filters do this. Hidden files (any dot-prefixed path) when the eye toggle is off, and git-ignored files, which are off by default. An `.env` dropped into a cloned repo hits both, since the root `.gitignore` carries `**/*.env*`. Nothing else confirmed the write either: the drive only toasted for downloads, never for uploads.

## Changes

Every completed upload now toasts, and anything the filters would have swallowed reveals itself instead of vanishing.

Hidden-ness is decidable from the path, so `showHidden` flips before the toast fires and the message explains the change: `Uploaded .env.ee.dev · showing hidden files`.

Git-ignored-ness is not decidable on the client. The listing simply omits the entry, so absence is the only available signal. The new `useUploadReveal` hook watches each completed batch against the refetched directory. A file still missing from a settled listing flips the git-ignored toggle, and the toast updates to `· showing git-ignored files`.

Uploads that finish within 300ms of each other toast as one message, so dropping a folder gives you one line instead of one per file.

The settle rule is the subtle part, so it lives in a pure function (`ruleOnBatch`) rather than buried in an effect. It rules on a batch only once every destination directory is loaded and no longer fetching. It gets there either by observing the refetch that the upload's own cache invalidation kicks off, or after a 1.5s floor when that refetch was too quick to observe. A directory that never loads (an upload into a collapsed folder, say) ages out at 6s and is dropped without a verdict, so a filter never flips on a guess.

## Tests

- Seven unit tests on `ruleOnBatch` covering confirm, wait, the settle floor, the observed refetch, give-up, and a root-level upload.
- `tsc --noEmit` and eslint are clean on the touched files.
- Not verified against a running stack. The interesting paths need a real mount with a git-ignored destination.

## What to QA

- Open the Files drawer on a session whose drive holds a cloned repo. Drop a `.env` file into a folder inside it. You get an "Uploaded ... showing git-ignored files" toast, the git-ignored toggle (the dashed-file icon) turns on, and the file stays visible where the progress tile was.
- Turn hidden files off with the eye in the toolbar, then upload any dotfile. The toast says "showing hidden files" and the eye flips back on.
- Upload a normal file into a plain folder. One success toast, the file appears in place, and neither toggle changes.
- Drop a folder of several files at once. One toast for the batch, not one per file.
- Regression: make an upload fail (kill the network mid-write). The red retry tile still appears in the grid and no success toast fires.
