### PR TITLE
docs(design): Composio tools rework — per-connection sessions over the gateway

### DIFF
--- a/docs/design/composio-tools-rework/README.md
+++ b/docs/design/composio-tools-rework/README.md
@@ -1,41 +1,39 @@
 # Composio tools rework
 
-This folder plans a redesign of how Agenta agents use third-party tools
-(Slack, GitHub, and so on) through Composio. Today each tool action is a
-separate entry in the agent's saved config, resolved live at every run. That
-design causes a cluster of bugs and does not scale. We move to referencing the
-integration once and letting a Composio session expose the tools over MCP.
+This folder plans a change to how Agenta agents use outside tools like Slack and GitHub,
+through a service called Composio.
+
+Today, giving an agent an app means adding one setup entry for every single action, and
+an app has about a hundred actions. That is slow and it breaks in several ways. We change
+it so the setup names the app once, and the model gets two small tools at run time: a
+**search** tool to find an action, and a **run** tool to use it.
 
 ## Read in this order
 
-1. **context.md** — why this work exists, the bugs it fixes, goals and non-goals.
-2. **research.md** — how the system works today, in the code, with file
-   references, plus what Composio and the industry do. Includes the live spike
-   results.
-3. **design.md** — the proposed architecture, the main design choice and its
-   recommendation, and the API changes.
-4. **plan.md** — the phases to build it, in order.
-5. **status.md** — current state, decisions taken, and open questions. This is
-   the source of truth for progress.
+1. **context.md**: the problem in plain words, the bugs it fixes, and what we want.
+2. **design.md**: the plan. What we build, how a run works step by step, and what we
+   chose not to do.
+3. **plan.md**: the three parts we build, in order.
+4. **research.md**: background. How things work today, with code references, and what we
+   learned from testing against the live Composio key.
+5. **api-design.md**: the exact backend changes, for the engineer who builds it.
+6. **experiment.md**: two checks to run before we commit to this design. Not run yet.
+7. **status.md**: where we are now, what we decided, and open questions.
 
-The spike results that back these docs (the live tests against Composio) are
-summarized in research.md section 3.
+If you only read one file, read **design.md**.
 
-## Glossary
+## Words we use
 
-- **Harness**: the agent runtime the model runs inside (Claude Code, Codex, or
-  Pi). It calls tools and talks to the model.
-- **Runner**: our service (`services/runner/`) that starts a sandbox, sets up
-  the harness, and delivers tools to it.
-- **Sandbox**: the isolated environment the harness runs in, local or on Daytona.
-- **Agenta API**: the backend (`api/oss/`) that holds config and secrets and
-  makes the calls to Composio.
-- **Gateway tool**: our name for a third-party tool routed through a provider
-  like Composio.
-- **Composio session**: a server-side object at Composio (their "Tool Router")
-  that holds a set of tools for one user and exposes them over an MCP endpoint.
-- **Meta-tool**: one of the six tools a Composio session exposes (search,
-  get-schemas, multi-execute, manage-connections, workbench, bash). The model
-  uses these instead of seeing every action's schema.
-- **Warm session / warm sandbox**: a parked sandbox the runner reuses between
-  turns to avoid a slow cold start. A fingerprint over the config decides reuse.
+- **Agent**: what the user builds in Agenta. It runs an AI model and can call tools.
+- **Model**: the AI itself (Claude, GPT, and so on).
+- **Composio**: the outside service that stores each user's app logins and runs the tool
+  calls for us.
+- **Connection**: one saved login to one app, like a user's GitHub account.
+- **Action**: one operation in an app, like "create an issue".
+- **Our backend (the Agenta API)**: our servers. They hold our secret keys and talk to
+  Composio.
+- **Runner and sandbox**: the runner starts the model in a locked box (the sandbox) and
+  gives it tools. Secrets must never enter that box.
+- **Search tool and run tool**: the two tools the model gets. Search finds matching
+  actions; run uses one.
+- **Warm sandbox**: a ready box the runner keeps between turns so the agent starts fast.

--- a/docs/design/composio-tools-rework/README.md
+++ b/docs/design/composio-tools-rework/README.md
@@ -1,0 +1,41 @@
+# Composio tools rework
+
+This folder plans a redesign of how Agenta agents use third-party tools
+(Slack, GitHub, and so on) through Composio. Today each tool action is a
+separate entry in the agent's saved config, resolved live at every run. That
+design causes a cluster of bugs and does not scale. We move to referencing the
+integration once and letting a Composio session expose the tools over MCP.
+
+## Read in this order
+
+1. **context.md** — why this work exists, the bugs it fixes, goals and non-goals.
+2. **research.md** — how the system works today, in the code, with file
+   references, plus what Composio and the industry do. Includes the live spike
+   results.
+3. **design.md** — the proposed architecture, the main design choice and its
+   recommendation, and the API changes.
+4. **plan.md** — the phases to build it, in order.
+5. **status.md** — current state, decisions taken, and open questions. This is
+   the source of truth for progress.
+
+The spike results that back these docs (the live tests against Composio) are
+summarized in research.md section 3.
+
+## Glossary
+
+- **Harness**: the agent runtime the model runs inside (Claude Code, Codex, or
+  Pi). It calls tools and talks to the model.
+- **Runner**: our service (`services/runner/`) that starts a sandbox, sets up
+  the harness, and delivers tools to it.
+- **Sandbox**: the isolated environment the harness runs in, local or on Daytona.
+- **Agenta API**: the backend (`api/oss/`) that holds config and secrets and
+  makes the calls to Composio.
+- **Gateway tool**: our name for a third-party tool routed through a provider
+  like Composio.
+- **Composio session**: a server-side object at Composio (their "Tool Router")
+  that holds a set of tools for one user and exposes them over an MCP endpoint.
+- **Meta-tool**: one of the six tools a Composio session exposes (search,
+  get-schemas, multi-execute, manage-connections, workbench, bash). The model
+  uses these instead of seeing every action's schema.
+- **Warm session / warm sandbox**: a parked sandbox the runner reuses between
+  turns to avoid a slow cold start. A fingerprint over the config decides reuse.

--- a/docs/design/composio-tools-rework/api-design.md
+++ b/docs/design/composio-tools-rework/api-design.md
@@ -1,0 +1,133 @@
+# API design
+
+Concrete backend changes for Option 1 (call the session's meta-tools over REST as
+our own callback tools). See `design.md` for the reasoning and the rejected
+Option 2.
+
+## 1. Config schema
+
+Add a per-connection type to the tool config union in
+`sdks/python/agenta/sdk/agents/tools/models.py`. It uses a distinct discriminator
+so it does not collide with the existing per-action `gateway` type, which stays.
+
+```python
+class GatewayToolkitConfig(ToolConfigBase):
+    type: Literal["gateway_toolkit"] = "gateway_toolkit"
+    provider: str = "composio"
+    integration: str
+    connection: str            # project-scoped connection slug
+    tools: ToolkitPolicy       # authorization policy
+    # permission (allow|ask|deny) comes from ToolConfigBase
+```
+
+```python
+class ToolkitPolicy(BaseModel):
+    mode: Literal["all", "include"] = "all"
+    actions: list[str] | None = None   # required when mode == "include"
+```
+
+`actions` are Agenta action keys. The adapter maps them to Composio slugs, so the
+stored config does not depend on Composio's slug spelling. The SDK is the
+canonical persisted contract; the API aliases it as it does today
+(`api/oss/src/core/tools/dtos.py:200`).
+
+## 2. Session mapping table
+
+Store the Composio session id in a small dedicated table, not in the connection
+`data` blob, because one connection can back several policies and the blob update
+is an unlocked read-modify-write.
+
+```
+gateway_sessions
+  project_id        uuid
+  connection_id     uuid        # the resolved connection UUID
+  policy_hash       text        # canonical hash of the tool policy
+  provider_session_id text      # Composio trs_...
+  unique (project_id, connection_id, policy_hash)
+```
+
+The uniqueness constraint gives safe get-or-create. Sessions do not expire, so no
+expiry column and no timer.
+
+## 3. Session lifecycle service
+
+Add a service under `api/oss/src/core/tools/providers/composio/`:
+
+- `get_or_create_session(project_id, connection, policy) -> provider_session_id`
+  Looks up `(project_id, connection_id, policy_hash)`. On a hit, returns the id.
+  On a miss, creates a session and inserts the row:
+  ```python
+  composio.sessions.create(
+      user_id=str(project_id),
+      toolkits=[integration],
+      tools={integration: {"enable": composio_slugs}} if mode == "include" else None,
+      connected_accounts={integration: connection.provider_connection_id},
+      manage_connections=False,
+      workbench={"enable": False},
+  )
+  ```
+  Note: no `mcp=True`, because Option 1 uses REST, not MCP.
+- `execute_meta(provider_session_id, meta_tool, arguments)` calls Composio's
+  session execute endpoint. This is the one call the meta-tools relay to.
+- Recreate lazily: if execute reports the session gone, create a new one and
+  retry once.
+
+Composio's `user_id` stays `str(project_id)`, unchanged
+(`api/oss/src/core/gateway/connections/service.py:174`).
+
+## 4. Resolution change (run start)
+
+Today the gateway resolver returns exactly one `ResolvedTool` per config
+(`sdks/python/agenta/sdk/agents/platform/gateway.py:193`). The new type resolves
+to a few meta-tool callback specs. The seams to change:
+
+- The gateway resolver contract: allow one config to produce several specs.
+- `GatewayToolResolution` and `ResolvedToolSet` to carry them
+  (`sdks/python/agenta/sdk/agents/tools/models.py:436`).
+- Each spec is a callback tool with a `call_ref` that names the connection and
+  the meta-tool, for example `composio.<connection-uuid>.search`, so the names
+  are unique and stable.
+- No per-action Composio calls at run start, so the serial resolve loop and its
+  all-or-nothing failure (#5173) are gone for the new type.
+
+## 5. Execute path
+
+`POST /tools/call` (`api/oss/src/apis/fastapi/tools/router.py:1129`) gains a
+branch: when the `call_ref` names a Composio meta-tool, it calls the session
+lifecycle service's `execute_meta`, which calls Composio with the key injected
+from `env.composio`. This reuses the existing handler, permission check, tracing,
+and result path. The Composio-facing call is the existing adapter's execute shape
+(`api/oss/src/core/tools/providers/composio/adapter.py:166`), pointed at the
+session execute endpoint.
+
+## 6. Result cap
+
+Lower the callback result cap to a byte budget well below one megabyte
+(`services/runner/src/tools/callback.ts`), and on overflow replace the body with a
+short message naming the size and telling the model to narrow, filter, or
+paginate. Closes #5341, and it applies to the current per-action path too.
+
+## 7. Error handling (closes #5407, #5173)
+
+- When `COMPOSIO_API_KEY` is absent, return a clear 501 or 503 that says Composio
+  is not configured, instead of the current bare 404
+  (`api/entrypoints/routers.py`).
+- With sessions there is no per-action resolve loop, so one dead action no longer
+  fails the whole run. A tool that fails at call time returns its own error and
+  the rest keep working.
+- Stale action in an explicit `include` policy: validate the actions when
+  creating the session, and if Composio rejects one, drop it with a named warning
+  rather than failing the whole session create.
+
+## 8. Version drift (root of #5174)
+
+Sessions manage toolkit versions in one scope, so the discovery-versus-resolve
+drift is gone by design. No version field is added.
+
+## 9. What does not change
+
+- The `gateway_connections` table and the OAuth connect flow.
+- The runner. Option 1 delivers callback tools, which the runner already handles
+  on every harness including Pi.
+- The frontend connect and permission flows. The drawer gains a connection-level
+  entry instead of per-action rows, but that is a separate frontend task.

--- a/docs/design/composio-tools-rework/api-design.md
+++ b/docs/design/composio-tools-rework/api-design.md
@@ -1,13 +1,13 @@
 # API design
 
-Concrete backend changes for Option 1 (call the session's meta-tools over REST as
-our own callback tools). See `design.md` for the reasoning and the rejected
-Option 2.
+Concrete backend changes for the design in `design.md`. One config entry resolves
+into two callback tools, search and execute, both routed through the Composio
+adapter we already use. There is no session table and no session service.
 
 ## 1. Config schema
 
 Add a per-connection type to the tool config union in
-`sdks/python/agenta/sdk/agents/tools/models.py`. It uses a distinct discriminator
+`sdks/python/agenta/sdk/agents/tools/models.py`. It uses a distinct discriminator,
 so it does not collide with the existing per-action `gateway` type, which stays.
 
 ```python
@@ -26,108 +26,94 @@ class ToolkitPolicy(BaseModel):
     actions: list[str] | None = None   # required when mode == "include"
 ```
 
-`actions` are Agenta action keys. The adapter maps them to Composio slugs, so the
-stored config does not depend on Composio's slug spelling. The SDK is the
+The `actions` are Agenta action keys. The server maps them to Composio slugs, so
+the stored config does not depend on how Composio spells a slug. The SDK holds the
 canonical persisted contract; the API aliases it as it does today
 (`api/oss/src/core/tools/dtos.py:200`).
 
-## 2. Session mapping table
+## 2. Resolution: one config, two callback tools
 
-Store the Composio session id in a small dedicated table, not in the connection
-`data` blob, because one connection can back several policies and the blob update
-is an unlocked read-modify-write.
+Today the gateway resolver returns exactly one spec per config, and the SDK
+enforces that count: the resolver rejects a response whose spec count does not
+match the ref count (`sdks/python/agenta/sdk/agents/platform/gateway.py:196`). The
+new type must produce two specs from one config, so this is the seam that changes.
 
-```
-gateway_sessions
-  project_id        uuid
-  connection_id     uuid        # the resolved connection UUID
-  policy_hash       text        # canonical hash of the tool policy
-  provider_session_id text      # Composio trs_...
-  unique (project_id, connection_id, policy_hash)
-```
+- Relax the resolver contract so one `gateway_toolkit` config yields several specs
+  instead of exactly one. The `gateway_toolkit` path returns two; the old
+  per-action path still returns one.
+- Carry the several specs through `GatewayToolResolution` and `ResolvedToolSet`
+  (`sdks/python/agenta/sdk/agents/tools/models.py:436`).
+- Give each spec a `call_ref` that names the connection and the tool, so the names
+  are unique and stable across runs:
+  `composio.<connection-uuid>.search` and `composio.<connection-uuid>.execute`.
+- Make no per-action Composio calls at run start. The serial resolve loop and its
+  all-or-nothing failure (#5173) are gone for the new type, because resolution now
+  produces two fixed specs without touching Composio.
 
-The uniqueness constraint gives safe get-or-create. Sessions do not expire, so no
-expiry column and no timer.
+The two `call_ref` values are stable for the life of the connection and contain no
+volatile id, so the warm-sandbox fingerprint stays stable across runs
+(`services/runner/src/engines/sandbox_agent/session-identity.ts:207`).
 
-## 3. Session lifecycle service
+## 3. Execute path: the two meta-tools at /tools/call
 
-Add a service under `api/oss/src/core/tools/providers/composio/`:
+`POST /tools/call` (`api/oss/src/apis/fastapi/tools/router.py:1129`) gains a branch
+for the two Composio meta-tools. Both use the existing Composio adapter with the
+key injected from `env.composio` (`api/oss/src/core/tools/providers/composio/adapter.py:54`).
 
-- `get_or_create_session(project_id, connection, policy) -> provider_session_id`
-  Looks up `(project_id, connection_id, policy_hash)`. On a hit, returns the id.
-  On a miss, creates a session and inserts the row:
-  ```python
-  composio.sessions.create(
-      user_id=str(project_id),
-      toolkits=[integration],
-      tools={integration: {"enable": composio_slugs}} if mode == "include" else None,
-      connected_accounts={integration: connection.provider_connection_id},
-      manage_connections=False,
-      workbench={"enable": False},
-  )
-  ```
-  Note: no `mcp=True`, because Option 1 uses REST, not MCP.
-- `execute_meta(provider_session_id, meta_tool, arguments)` calls Composio's
-  session execute endpoint. This is the one call the meta-tools relay to.
-- Recreate lazily: if execute reports the session gone, create a new one and
-  retry once.
+- **search** calls `COMPOSIO_SEARCH_TOOLS` through the adapter's existing search
+  path (`adapter.py:225`, `search_capabilities`). It returns the matching action
+  slugs and each one's input schema inline. Pin the call to the latest toolkit
+  version (section 5).
+- **execute** first checks the requested slug against the config's policy. If the
+  policy is `include` and the slug is not listed, it returns a permission error
+  without calling Composio. Otherwise it runs the action through the adapter's
+  existing execute path (`adapter.py:166`, `execute`), resolving the connection's
+  account per call from the connection's provider account id
+  (`api/oss/src/core/gateway/connections/dtos.py:68`). Pin the call to the latest
+  version.
 
+Both reuse the existing handler, permission gate, tracing, and result path.
 Composio's `user_id` stays `str(project_id)`, unchanged
 (`api/oss/src/core/gateway/connections/service.py:174`).
 
-## 4. Resolution change (run start)
+## 4. Policy enforcement
 
-Today the gateway resolver returns exactly one `ResolvedTool` per config
-(`sdks/python/agenta/sdk/agents/platform/gateway.py:193`). The new type resolves
-to a few meta-tool callback specs. The seams to change:
+The allow-list lives on the config entry and is enforced at the execute callback in
+the API, not in any server-side filter. When the policy is `include`, the API
+rejects a slug the list does not name and returns a clear error, which the model
+reads and recovers from. When the policy is `all`, every slug in the toolkit is
+allowed. There is no session-side filter to configure or keep in sync.
 
-- The gateway resolver contract: allow one config to produce several specs.
-- `GatewayToolResolution` and `ResolvedToolSet` to carry them
-  (`sdks/python/agenta/sdk/agents/tools/models.py:436`).
-- Each spec is a callback tool with a `call_ref` that names the connection and
-  the meta-tool, for example `composio.<connection-uuid>.search`, so the names
-  are unique and stable.
-- No per-action Composio calls at run start, so the serial resolve loop and its
-  all-or-nothing failure (#5173) are gone for the new type.
+## 5. Version pinning (root of #5174)
 
-## 5. Execute path
+Pin both the search call and the execute call to the latest toolkit version. Call
+Composio API v3.1, which defaults tool endpoints to the latest version, or pass an
+explicit latest version. `ComposioConfig` (`api/oss/src/utils/env.py:685`) has no
+version field today; the version is baked into the default URL, which is why
+discovery and resolve disagree now. After the pin, a slug that search returns is one
+that execute can run. A rare mismatch stays possible and is handled as a soft
+per-call error, not a run-ending failure.
 
-`POST /tools/call` (`api/oss/src/apis/fastapi/tools/router.py:1129`) gains a
-branch: when the `call_ref` names a Composio meta-tool, it calls the session
-lifecycle service's `execute_meta`, which calls Composio with the key injected
-from `env.composio`. This reuses the existing handler, permission check, tracing,
-and result path. The Composio-facing call is the existing adapter's execute shape
-(`api/oss/src/core/tools/providers/composio/adapter.py:166`), pointed at the
-session execute endpoint.
+## 6. Result cap (closes #5341)
 
-## 6. Result cap
-
-Lower the callback result cap to a byte budget well below one megabyte
+Lower the callback result cap to a byte and token budget well below one megabyte
 (`services/runner/src/tools/callback.ts`), and on overflow replace the body with a
-short message naming the size and telling the model to narrow, filter, or
-paginate. Closes #5341, and it applies to the current per-action path too.
+short steering message that names the size and tells the model to narrow, filter,
+or paginate. This also helps the current per-action path.
 
-## 7. Error handling (closes #5407, #5173)
+## 7. Clear not-configured error (closes #5407)
 
-- When `COMPOSIO_API_KEY` is absent, return a clear 501 or 503 that says Composio
-  is not configured, instead of the current bare 404
-  (`api/entrypoints/routers.py`).
-- With sessions there is no per-action resolve loop, so one dead action no longer
-  fails the whole run. A tool that fails at call time returns its own error and
-  the rest keep working.
-- Stale action in an explicit `include` policy: validate the actions when
-  creating the session, and if Composio rejects one, drop it with a named warning
-  rather than failing the whole session create.
+When `COMPOSIO_API_KEY` is absent, return a clear 501 or 503 that says Composio is
+not configured, instead of the current bare 404 (`api/entrypoints/routers.py`). A
+self-hoster can then diagnose the missing key.
 
-## 8. Version drift (root of #5174)
+## 8. What does not change
 
-Sessions manage toolkit versions in one scope, so the discovery-versus-resolve
-drift is gone by design. No version field is added.
-
-## 9. What does not change
-
+- No session table, no session service, no session id storage, no PATCH, no
+  get-or-create, no connected-account pinned at create. Each execute passes the
+  account per call.
 - The `gateway_connections` table and the OAuth connect flow.
-- The runner. Option 1 delivers callback tools, which the runner already handles
-  on every harness including Pi.
-- The frontend connect and permission flows. The drawer gains a connection-level
-  entry instead of per-action rows, but that is a separate frontend task.
+- The runner. It delivers the two callback tools on every harness including Pi,
+  through the internal channel it already uses for every Agenta tool.
+- The existing per-action `gateway` type stays, so old configs keep parsing and the
+  compat layer gives a migration path.

--- a/docs/design/composio-tools-rework/context.md
+++ b/docs/design/composio-tools-rework/context.md
@@ -10,9 +10,10 @@ hurts today and what we want instead.
 ## How it works today
 
 The user picks actions one at a time in the drawer. Each pick adds one entry to the
-agent's setup, for example "Composio, GitHub, GET_AN_ISSUE, github-main". When the agent
-runs, our backend asks Composio to look up every action, one call each, with no reuse.
-Then it sends every action's full description to the model, on every turn.
+agent's setup, for example "Composio, GitHub, GET_AN_ISSUE, github-main". Our backend
+(the Agenta API, not the runner) does the next part. At the start of every run, before
+the model produces a word, it asks Composio to look up every action, one call each, with
+no reuse. Then it sends every action's full description to the model, on every turn.
 
 ## The problems this causes
 
@@ -31,6 +32,12 @@ Then it sends every action's full description to the model, on every turn.
 
 These are not five separate bugs. They come from one choice: we treat each action as a
 fixed tool that we look up one by one.
+
+The first four bugs are now fixed and shipped, as small separate changes to the current
+system: the result cap (#5341, PR #5811), the clear "not set up" error (#5407, PR #5812),
+the broken-tool fix (#5173, PR #5813), and the version pin (#5174, PR #5814). Those fixes
+patch today's system. The redesign below removes the root cause, so the last problem (a
+hundred entries) also goes away.
 
 ## What we want instead
 

--- a/docs/design/composio-tools-rework/context.md
+++ b/docs/design/composio-tools-rework/context.md
@@ -1,0 +1,80 @@
+# Context
+
+## What this is
+
+Agenta lets a user give an agent third-party tools, such as sending a Slack
+message or reading a GitHub issue. We route those through Composio, a service
+that stores each user's connections (their Slack token, their GitHub token) and
+runs the tool calls. This document explains why the current design hurts and
+what we want instead.
+
+## How it works today, in one paragraph
+
+The user picks tool actions one at a time in the drawer. Each pick writes one
+entry into the agent's saved config, for example "Composio, GitHub, GET_AN_ISSUE,
+connection github-main". At the start of every run, the Agenta API asks Composio
+to resolve each action, one live HTTP call per action, with no cache. The
+resolved tool schemas all go to the model, in full, every turn.
+
+## The bugs this causes
+
+- **One dead tool kills the whole run.** Resolution is all-or-nothing. If one
+  action no longer resolves, the entire agent fails to start, with an error that
+  names no tool. (GitHub issue #5173.)
+- **Discovery offers tools that resolution cannot find.** Our discovery path and
+  our resolve path hit Composio on different default versions, so a tool that
+  discovery shows as ready then fails to resolve with a 404. (#5174.)
+- **One huge result wrecks the conversation.** A tool result enters the model
+  context with only a 1 megabyte cap. One `get_pull_request` returned about
+  241,000 tokens and broke the session. (#5341.)
+- **A missing key looks like a missing endpoint.** With no Composio key
+  configured, discovery returns a bare 404 that a self-hoster cannot diagnose.
+  (#5407.)
+- **A toolkit has about 100 actions.** Giving an agent GitHub means adding up to
+  a hundred config entries, one per action, and sending a hundred schemas to the
+  model every turn. This is slow, expensive, and degrades tool selection.
+
+These are not five unrelated bugs. They are one design choice: we treat each
+action as a static, individually resolved tool in the agent's config.
+
+## What we want instead
+
+The agent config names the integration and the connection once, plus a filter
+of which tools are allowed. At run start, the Agenta API opens a Composio
+session for that connection and exposes it to the harness over MCP. The model
+then sees a small set of meta-tools, searches for what it needs, and calls it.
+Composio manages the tool versions and the credentials. The heavy per-action
+resolution disappears.
+
+## Goals
+
+- Reference an integration once, not one entry per action.
+- Remove the all-or-nothing startup failure and the version drift by design.
+- Keep large results out of the model context.
+- Keep our control point: per-tool permissions, tracing, and a result cap stay
+  on our side.
+- Keep the Composio credential where it is today, in the Agenta API, never in
+  the sandbox.
+- Keep warm sandbox reuse intact.
+
+## Non-goals (for the first version)
+
+- Pi over MCP. Pi loads tools through its own extension today; wiring Pi to
+  consume MCP servers is later work.
+- Per-tenant rate limiting against Composio's per-organization limit.
+- Interactive "ask before this one specific action" prompts, if the chosen
+  design only supports asking at the meta-tool level. To be decided in design.
+- Cost tracking and billing of meta-tool calls.
+- A general second tool provider. The design leaves room for one, but we build
+  and prove Composio first.
+
+## Fixed facts that shaped the design (from live spikes)
+
+- Calling a Composio session's MCP endpoint needs the project-wide Composio key
+  with session-write access. That same access can create and widen sessions for
+  any user in the project, so the key can reach every tenant's connections.
+  There is no session-scoped credential. So the key must never enter the sandbox.
+- Composio sessions do not expire. We create one per connection and reuse it.
+- Session filters update in place without changing the MCP URL.
+- Composio's own result-trimming hooks do not run over MCP, so the large-result
+  fix must be ours.

--- a/docs/design/composio-tools-rework/context.md
+++ b/docs/design/composio-tools-rework/context.md
@@ -1,80 +1,65 @@
 # Context
 
-## What this is
+## What this is about
 
-Agenta lets a user give an agent third-party tools, such as sending a Slack
-message or reading a GitHub issue. We route those through Composio, a service
-that stores each user's connections (their Slack token, their GitHub token) and
-runs the tool calls. This document explains why the current design hurts and
-what we want instead.
+Agenta lets a user give an agent real-world tools, like sending a Slack message or
+reading a GitHub issue. We run those tools through Composio, an outside service that
+stores each user's app logins and makes the calls for us. This document explains what
+hurts today and what we want instead.
 
-## How it works today, in one paragraph
+## How it works today
 
-The user picks tool actions one at a time in the drawer. Each pick writes one
-entry into the agent's saved config, for example "Composio, GitHub, GET_AN_ISSUE,
-connection github-main". At the start of every run, the Agenta API asks Composio
-to resolve each action, one live HTTP call per action, with no cache. The
-resolved tool schemas all go to the model, in full, every turn.
+The user picks actions one at a time in the drawer. Each pick adds one entry to the
+agent's setup, for example "Composio, GitHub, GET_AN_ISSUE, github-main". When the agent
+runs, our backend asks Composio to look up every action, one call each, with no reuse.
+Then it sends every action's full description to the model, on every turn.
 
-## The bugs this causes
+## The problems this causes
 
-- **One dead tool kills the whole run.** Resolution is all-or-nothing. If one
-  action no longer resolves, the entire agent fails to start, with an error that
-  names no tool. (GitHub issue #5173.)
-- **Discovery offers tools that resolution cannot find.** Our discovery path and
-  our resolve path hit Composio on different default versions, so a tool that
-  discovery shows as ready then fails to resolve with a 404. (#5174.)
-- **One huge result wrecks the conversation.** A tool result enters the model
-  context with only a 1 megabyte cap. One `get_pull_request` returned about
-  241,000 tokens and broke the session. (#5341.)
-- **A missing key looks like a missing endpoint.** With no Composio key
-  configured, discovery returns a bare 404 that a self-hoster cannot diagnose.
-  (#5407.)
-- **A toolkit has about 100 actions.** Giving an agent GitHub means adding up to
-  a hundred config entries, one per action, and sending a hundred schemas to the
-  model every turn. This is slow, expensive, and degrades tool selection.
+- **One broken tool kills the whole agent.** If one action can no longer be looked up,
+  the whole agent fails to start, and the error names no tool. (#5173)
+- **The lookup and the run disagree.** Our lookup and our run step use different versions
+  of the app's action list. So the lookup can offer an action that the run step then
+  cannot find, and the user gets a "not found" error. (#5174)
+- **One huge result breaks the chat.** A tool result can reach the model with almost no
+  limit. One GitHub call once returned about 241,000 tokens and broke the session. (#5341)
+- **A missing key looks like a broken feature.** If Composio is not set up, the user gets
+  a bare "not found" error that gives no hint about the real cause. (#5407)
+- **A single app means about a hundred entries.** GitHub has around a hundred actions. So
+  the agent's setup swells to a hundred entries, and the model sees a hundred
+  descriptions every turn. That is slow, costly, and makes the model pick worse.
 
-These are not five unrelated bugs. They are one design choice: we treat each
-action as a static, individually resolved tool in the agent's config.
+These are not five separate bugs. They come from one choice: we treat each action as a
+fixed tool that we look up one by one.
 
 ## What we want instead
 
-The agent config names the integration and the connection once, plus a filter
-of which tools are allowed. At run start, the Agenta API opens a Composio
-session for that connection and exposes it to the harness over MCP. The model
-then sees a small set of meta-tools, searches for what it needs, and calls it.
-Composio manages the tool versions and the credentials. The heavy per-action
-resolution disappears.
+The setup names the app and the connection once, plus which actions are allowed. When the
+agent runs, our backend gives the model two small tools: a search tool and a run tool.
+The model searches for the action it needs, then runs it, in the same turn. The heavy
+one-by-one lookup goes away. The design doc explains this in full.
 
 ## Goals
 
-- Reference an integration once, not one entry per action.
-- Remove the all-or-nothing startup failure and the version drift by design.
-- Keep large results out of the model context.
-- Keep our control point: per-tool permissions, tracing, and a result cap stay
-  on our side.
-- Keep the Composio credential where it is today, in the Agenta API, never in
-  the sandbox.
-- Keep warm sandbox reuse intact.
+- Name an app once, not one entry per action.
+- Remove the all-or-nothing failure and the version mismatch by design.
+- Stop huge results from flooding the model.
+- Keep our safety controls: permissions, tracing, and a size cap stay on our side.
+- Keep the Composio key on our servers, never in the sandbox where the model runs.
+- Keep fast agent restarts working (do not throw away a warm sandbox for no reason).
 
-## Non-goals (for the first version)
+## Not in the first version
 
-- Pi over MCP. Pi loads tools through its own extension today; wiring Pi to
-  consume MCP servers is later work.
-- Per-tenant rate limiting against Composio's per-organization limit.
-- Interactive "ask before this one specific action" prompts, if the chosen
-  design only supports asking at the meta-tool level. To be decided in design.
-- Cost tracking and billing of meta-tool calls.
-- A general second tool provider. The design leaves room for one, but we build
-  and prove Composio first.
+- Making Pi use this over MCP. Pi loads tools its own way today; we do not change that now.
+- Limiting how fast we call Composio per customer.
+- Asking the user before one specific action (only asking before any action is in scope).
+- Tracking cost per call.
+- A second tool provider besides Composio. The design leaves room for one, but we prove
+  Composio first.
 
-## Fixed facts that shaped the design (from live spikes)
+## A fact that shaped the design
 
-- Calling a Composio session's MCP endpoint needs the project-wide Composio key
-  with session-write access. That same access can create and widen sessions for
-  any user in the project, so the key can reach every tenant's connections.
-  There is no session-scoped credential. So the key must never enter the sandbox.
-- Composio sessions do not expire. We create one per connection and reuse it.
-- Session filters update in place without changing the MCP URL.
-- Composio's own result-trimming hooks do not run over MCP, so the large-result
-  fix must be ours.
+The Composio key is powerful. It can reach every workspace's connections, not just one.
+We tested this against the live key. There is no weaker key that does only what we need.
+So the key must stay on our servers and never enter the sandbox. Our design keeps it
+there.

--- a/docs/design/composio-tools-rework/design.md
+++ b/docs/design/composio-tools-rework/design.md
@@ -1,44 +1,45 @@
 # Design
 
-This document proposes the new architecture. It states the parts both options
-share, gives the two options for how the harness reaches the Composio session,
-compares them, and recommends one. It ends with the shared concerns: large
-results, permissions, session lifecycle, and security.
+This is the plan. It says what we build and why. Read `context.md` first for the
+problem. Read `research.md` for how things work today.
 
-Read `context.md` for why, and `research.md` for how the system works today.
+## Words we use here
 
-## 1. Summary
+- **Agent**: the thing the user builds in Agenta. It runs an AI model and can call tools.
+- **Model**: the AI itself (Claude, GPT, and so on).
+- **Tool**: an action the model can take, like "send a Slack message".
+- **Composio**: an outside service. It stores each user's logins to apps like GitHub
+  and Slack, and it runs the tool calls for us.
+- **Connection**: one saved login to one app, for example a user's GitHub account.
+- **Our backend**: the Agenta API. It holds our secret keys and talks to Composio.
+- **The runner and the sandbox**: the runner starts the model in an isolated box (the
+  sandbox) and feeds it tools. Secrets must never enter that box.
 
-Replace the one-entry-per-action config with one entry per connection plus a
-tool policy. At run start, the Agenta API opens a Composio session that holds the
-policy and the connected account, and exposes the tools. The model then calls a
-few meta-tools (search, get schemas, execute) instead of holding a hundred
-schemas. The Composio key stays in the Agenta API; the sandbox never holds it.
+## The problem in one line
 
-Two options for how the harness reaches the session:
+To give an agent GitHub today, we add one setup entry for every single GitHub action.
+GitHub has about a hundred actions. So the agent gets a hundred entries, and the model
+sees a hundred tool descriptions at once. That is slow, it costs a lot, and it breaks
+in several ways (see `context.md`).
 
-- **Option 1, call the session's meta-tools over REST as our own tools
-  (recommended).** The API resolves the connection into a few callback tool
-  specs, one per meta-tool. The runner delivers them through its existing
-  internal channel. When the model calls one, it relays to `POST /tools/call`,
-  which calls Composio's session execute endpoint over plain HTTP, the same way
-  we call Composio today. Reuses all our existing machinery and works on every
-  harness including Pi.
-- **Option 2, proxy the session as an MCP server.** The API runs an MCP endpoint
-  that forwards to Composio; the harness dials it like a user MCP server. Cleaner
-  in theory, but it needs real streaming-proxy machinery, does not work on Pi,
-  and moves the trust boundary. Kept here as the considered alternative.
+## The idea
 
-Both keep the model experience identical: the session exposes the same
-meta-tools either way. The difference is transport and which machinery we reuse.
+Store one entry for the whole connection, not one entry per action. Then, when the
+agent runs, give the model two small tools instead of a hundred:
 
-## 2. The config change (both options)
+- A **search** tool. The model says what it wants, like "create an issue". The tool
+  returns the few matching actions and how to call each one.
+- A **run** tool. The model picks one action and fills in its inputs. The tool runs it
+  and returns the result.
 
-Today an agent stores one entry per action. We replace that with one entry per
-connection and its tool policy. To avoid colliding with the existing per-action
-`gateway` type, the new entry uses a distinct discriminator.
+So the model searches, picks, and runs, all in the same turn. It never sees a hundred
+descriptions. It sees two tools.
 
-```
+## What the setup entry looks like
+
+One entry names the app and the connection, and says which actions are allowed.
+
+```json
 {
   "type": "gateway_toolkit",
   "provider": "composio",
@@ -49,207 +50,76 @@ connection and its tool policy. To avoid colliding with the existing per-action
 }
 ```
 
-or, to restrict the actions:
+- `integration` is which app, here GitHub.
+- `connection` is which saved login to use. The secret token is not here. Only a name
+  that points to it.
+- `tools` says which actions are allowed. `all` means the whole app. To allow only some,
+  list them: `{ "mode": "include", "actions": ["CREATE_ISSUE", "GET_ISSUE"] }`.
+- `permission` is the default: allow, ask the user first, or deny.
 
-```
-"tools": { "mode": "include", "actions": ["CREATE_ISSUE", "GET_ISSUE"] }
-```
+We give this entry a new type name, `gateway_toolkit`, so it does not clash with the
+old one-per-action entry, which still works.
 
-Classified by what each field is, not the feature it serves:
+## How a run works, step by step
 
-- `provider` and `integration` are **routing**: they select the adapter and the
-  toolkit.
-- `connection` is **routing to a credential**: it names the stored connection
-  whose token Composio uses. The token never appears here. Because a connection
-  slug is unique only within a project, provider, and integration, the resolved
-  identity uses the connection's UUID, not the slug alone.
-- `tools` is **authorization policy**: `all` lets the model use the whole
-  toolkit; `include` limits it to named actions. `actions` are Agenta action
-  keys; the adapter maps them to Composio slugs server-side, so the stored config
-  never depends on Composio's slug spelling.
-- `permission` is **policy**: the default allow, ask, or deny.
+1. The agent starts. Our backend turns the one entry into the two tools, search and run.
+2. The runner hands both tools to the model, the same way it hands over every other
+   tool. Nothing new goes into the sandbox.
+3. The model calls search with a description. The call comes back to our backend. Our
+   backend asks Composio and returns the matching actions and their inputs.
+4. The model calls run with one action and its inputs. The call comes back to our
+   backend. Our backend checks the action is allowed, runs it with the saved login, and
+   returns the result.
 
-This entry replaces up to a hundred per-action rows. The existing per-action
-`gateway` type stays so old configs keep parsing, and the compat layer gives a
-migration path.
+The secret key stays in our backend the whole time. The model only ever sees the two
+tools and their results.
 
-## 3. What the model sees (both options)
+## Why we build it this way
 
-A Composio session exposes meta-tools. We use three: search tools, get schemas,
-and multi-execute. We turn off the others:
+- **We reuse what we have.** The two tools travel the same road every other tool
+  travels. There is little new code.
+- **It works with all three runtimes, including Pi.** The other option we looked at does
+  not work with Pi. This one does.
+- **The secret key stays on our servers.** It never enters the sandbox. This is the same
+  as today.
+- **One broken action no longer kills the agent.** If an action cannot run, only that
+  one call fails. The model reads the error and tries another action. This fixes #5173,
+  because nothing has to resolve up front any more.
 
-- **Manage connections: off.** The frontend already lets the agent ask the user
-  to connect an integration, so we reuse that.
-- **Workbench and bash: off.** We do not depend on Composio's sandbox for large
-  results (section 7).
+## Big results
 
-The model searches for the action it needs and calls it through multi-execute.
-The real action, for example `GITHUB_CREATE_ISSUE`, is an argument to
-multi-execute, not a separate tool. This is true in both options and matters for
-permissions (section 8).
+Some actions return a huge amount of text. Today that can flood the model and break the
+chat. We cut the result down before it reaches the model, and we add a short note that
+tells the model to ask for less (filter, or fetch fewer items). This fixes #5341.
 
-## 4. Option 1: call the session's meta-tools over REST (recommended)
+## Versions: why one setting matters
 
-### How it works
+Search and run must use the same version of the app's action list. If they differ,
+search can offer an action that run then cannot find, and the user gets a "not found"
+error. We fix this by always using Composio's newest version (their v3.1 endpoints).
+Then whatever search offers, run can use. This fixes #5174.
 
-1. The agent config names the integration, connection, and tool policy.
-2. At run start, the Agenta API gets or creates a Composio session for this
-   policy (section 9), pinned to the connection's connected account, and stores
-   the session id.
-3. The API resolves the connection into a few callback tool specs, one per
-   meta-tool, named so they cannot collide, for example
-   `composio.<connection-uuid>.search`.
-4. The runner delivers them through its existing internal channel. Nothing new in
-   the runner.
-5. When the model calls a meta-tool, the runner relays it to `POST /tools/call`.
-6. `/tools/call` calls Composio's session execute endpoint over plain HTTP, with
-   the key injected from `env.composio`, and returns the result. This is the same
-   call shape we already use to execute a Composio tool today; the spikes
-   confirmed the meta-tools are callable this way over REST, not only over MCP.
+## One decision for you
 
-### Why this is the recommended shape
+Permissions. We can make the agent ask the user before any action on a connection. That
+is easy. Asking before one specific action, like "ask before delete but not before
+read", is harder and needs more work, because of how the model calls the run tool. We
+suggest shipping the simple version first and adding the specific one later.
 
-- It reuses everything: the callback transport, the result cap, tracing, the
-  permission gate, and credential isolation all already exist on this path.
-- It works on every harness. The runner refuses external MCP servers on Pi, so
-  Option 2 cannot serve Pi; this option can, because it uses our callback tools.
-- The Composio key stays exactly where it is today, in the API. The sandbox holds
-  only the run's own bearer, as it does for callback tools now.
-- No new streaming-proxy machinery. We call an HTTP endpoint and get a result.
+## Keeping the key safe
 
-### What is new
+The Composio key is powerful. It can reach every workspace's connections, not just one.
+So it must stay on our servers and never enter the sandbox where the model runs. This
+plan keeps it there, exactly as today.
 
-- A session lifecycle service (section 9).
-- The Composio adapter gains a session-execute call (execute a meta-tool against
-  a session). This is close to the existing execute call.
-- Resolution changes from one spec per action to a few meta-tool specs per
-  connection. This changes the gateway resolver, which today returns exactly one
-  spec per config. The plan names the exact seams (`GatewayToolResolution`,
-  `ToolResolver`, `/tools/resolve`).
+## What we chose not to do, and why
 
-## 5. Option 2: proxy the session as an MCP server (considered, not recommended)
+We looked at two other shapes and dropped both.
 
-### How it works
-
-The API runs an MCP endpoint. The config resolves to one MCP server entry whose
-URL points at that endpoint, delivered through the runner's user-MCP path. The
-harness dials it; the endpoint injects the Composio key and forwards to the
-session's MCP URL.
-
-### Why we do not recommend it for the first version
-
-- **It does not work on Pi.** The runner refuses external MCP servers for Pi
-  (`services/runner/src/engines/sandbox_agent/run-plan.ts:591`). Option 1 has no
-  such limit.
-- **It is not a thin proxy once it does real work.** To cap a large result it
-  must read and rewrite the response, so it cannot simply stream bytes through;
-  it must understand the MCP streaming-HTTP protocol, session headers, and
-  message framing. That is real, ongoing surface.
-- **It moves the trust boundary.** Today the callback authorization stays
-  runner-side. This option puts a project-scoped Agenta token in the sandbox MCP
-  config, which on a local run is plaintext, and a shell in the sandbox could
-  call the forward URL directly and skip the interactive gate. Making it safe
-  needs a short-lived, forward-only capability, which is more machinery.
-
-It stays on record because it is the natural shape if we later host user-provided
-MCP servers, where the harness genuinely must speak MCP.
-
-## 6. Comparison
-
-| Concern | Option 1: REST meta-tools as callback tools | Option 2: MCP proxy |
-|---|---|---|
-| Works on Pi | Yes | No (runner refuses external MCP on Pi) |
-| New API code | A session-execute call on the adapter | A streaming MCP proxy endpoint |
-| Reuses result cap, tracing, permissions | Yes, all existing | Partly; the proxy re-implements capping |
-| Composio key location | API, unchanged | API, but a project token enters the sandbox |
-| Trust boundary vs today | Same | Changed (token in sandbox, gate can be skipped) |
-| Deny / ask | Yes, per meta-tool via existing gate | Yes, per connection |
-| Warm fingerprint | Stable | Stable if URL keyed on connection |
-| Future user-hosted MCP servers | Needs the same work again | Direct fit |
-
-Both deliver the same model experience and the same integration-level config. The
-recommendation is Option 1 because it reuses our machinery, works on Pi, keeps the
-trust boundary, and avoids a streaming proxy. Choose Option 2 only if hosting
-user-provided MCP servers becomes a near-term requirement.
-
-## 7. Large results
-
-Composio's own result trimming does not run when we drive the session, so the fix
-is ours. For the first version: cap the result at a byte budget well below the
-current one megabyte, and return a short message that names the size and tells the
-model to narrow, filter, or paginate. This reuses the cap the callback path
-already has (`services/runner/src/tools/callback.ts`) at a lower limit, and it
-closes #5341.
-
-Two richer options are deferred:
-
-- Write the full result to a file in the sandbox mount and return the path. This
-  fits Option 1, because the runner is in the data path, but it needs mid-run
-  writes into the sandbox and is not needed for the first version.
-- Composio's workbench keeps a large result in Composio's sandbox and returns a
-  preview. Available if a use case needs server-side piping.
-
-## 8. Permissions and the one product decision
-
-The real action is an argument to multi-execute, so the harness gate sees the
-meta-tool, not the action. Per-action allow and deny run at `/tools/call`, which
-reads the arguments. Interactive "ask the user before this one specific action"
-does not work at the harness gate, because the gate does not see the action.
-"Ask before any Composio action" works today. We propose to ship that and treat
-per-action interactive ask as a later addition, raised from `/tools/call` if we
-build it.
-
-## 9. Session lifecycle
-
-A Composio session holds a tool policy and a connected-account binding. Two agents
-can share one connection with different policies, so the session is keyed on the
-policy, not the connection alone:
-
-```
-(project_id, connection_uuid, tool_policy_hash) -> composio_session_id
-```
-
-This lives in a small dedicated mapping table with a uniqueness constraint, which
-gives safe get-or-create. It does not live in the connection's `data` blob,
-because that row is owned by the connections domain and its update is an unlocked
-read-modify-write, so it cannot give safe get-or-create for many policies on one
-connection.
-
-Rules:
-
-- **Immutable per policy.** A session is created for a policy hash and never
-  edited. A policy change creates a new session under a new hash. We do not PATCH
-  a session in place, which removes the cross-agent race and the need to reason
-  about warm reuse across a policy change.
-- **Reused across runs and conversations** for the same policy. Sessions do not
-  expire (documented), and our meta-tool use is stateless because the workbench
-  is off, so one session per policy is safe. If Composio session state ever leaks
-  between conversations, we add the conversation id to the key; not needed now.
-- **Pinned to the connected account.** Session creation passes Composio's
-  `connected_accounts` for the toolkit, set to the connection's provider account
-  id (`api/oss/src/core/gateway/connections/dtos.py:68`), so calls run through the
-  account the config names, not whichever account Composio would pick.
-- **Recreated lazily.** If Composio reports the session gone, we create a new one
-  and retry. No background garbage collection in the first version.
-
-A policy edit changes the resolved tool specs, which changes the warm-session
-fingerprint, so the harness session reopens on its own. We do not try to keep a
-warm sandbox across a policy change, because that would risk running under stale
-permissions.
-
-## 10. Security recap
-
-The Composio key is a project-wide credential. It reaches every Agenta workspace's
-connections, because Composio's user is our project and all workspaces share one
-Composio project. So the key stays in the Agenta API and never enters the sandbox.
-Option 1 keeps this exactly as today. Option 2 weakens it, which is one reason we
-do not recommend it.
-
-## 11. Extensibility
-
-The design leaves room for a second provider or a user's own hosted MCP server,
-but we do not build for that now. The rule that keeps a future hosted tool safe:
-its sandbox-visible identity is keyed on provider and connection and stays stable
-for the life of the connection, while the volatile upstream session id and the
-provider credential live only in the API. A user-hosted MCP server is the case
-where Option 2's shape becomes the right one; until then Option 1 is simpler.
+1. **Use Composio "sessions".** Composio offers a ready-made box that holds the action
+   filter, the version, the login, and a code sandbox. We do each of those ourselves
+   with far less machinery, so we skip the box. We can revisit it later if we want their
+   extra features.
+2. **Expose the tools as an MCP server.** We would run a small server and let the agent
+   connect to it. We dropped it because it does not work with Pi, it needs a heavier
+   server, and it would push the secret key closer to the sandbox.

--- a/docs/design/composio-tools-rework/design.md
+++ b/docs/design/composio-tools-rework/design.md
@@ -1,0 +1,255 @@
+# Design
+
+This document proposes the new architecture. It states the parts both options
+share, gives the two options for how the harness reaches the Composio session,
+compares them, and recommends one. It ends with the shared concerns: large
+results, permissions, session lifecycle, and security.
+
+Read `context.md` for why, and `research.md` for how the system works today.
+
+## 1. Summary
+
+Replace the one-entry-per-action config with one entry per connection plus a
+tool policy. At run start, the Agenta API opens a Composio session that holds the
+policy and the connected account, and exposes the tools. The model then calls a
+few meta-tools (search, get schemas, execute) instead of holding a hundred
+schemas. The Composio key stays in the Agenta API; the sandbox never holds it.
+
+Two options for how the harness reaches the session:
+
+- **Option 1, call the session's meta-tools over REST as our own tools
+  (recommended).** The API resolves the connection into a few callback tool
+  specs, one per meta-tool. The runner delivers them through its existing
+  internal channel. When the model calls one, it relays to `POST /tools/call`,
+  which calls Composio's session execute endpoint over plain HTTP, the same way
+  we call Composio today. Reuses all our existing machinery and works on every
+  harness including Pi.
+- **Option 2, proxy the session as an MCP server.** The API runs an MCP endpoint
+  that forwards to Composio; the harness dials it like a user MCP server. Cleaner
+  in theory, but it needs real streaming-proxy machinery, does not work on Pi,
+  and moves the trust boundary. Kept here as the considered alternative.
+
+Both keep the model experience identical: the session exposes the same
+meta-tools either way. The difference is transport and which machinery we reuse.
+
+## 2. The config change (both options)
+
+Today an agent stores one entry per action. We replace that with one entry per
+connection and its tool policy. To avoid colliding with the existing per-action
+`gateway` type, the new entry uses a distinct discriminator.
+
+```
+{
+  "type": "gateway_toolkit",
+  "provider": "composio",
+  "integration": "github",
+  "connection": "github-main",
+  "tools": { "mode": "all" },
+  "permission": "ask"
+}
+```
+
+or, to restrict the actions:
+
+```
+"tools": { "mode": "include", "actions": ["CREATE_ISSUE", "GET_ISSUE"] }
+```
+
+Classified by what each field is, not the feature it serves:
+
+- `provider` and `integration` are **routing**: they select the adapter and the
+  toolkit.
+- `connection` is **routing to a credential**: it names the stored connection
+  whose token Composio uses. The token never appears here. Because a connection
+  slug is unique only within a project, provider, and integration, the resolved
+  identity uses the connection's UUID, not the slug alone.
+- `tools` is **authorization policy**: `all` lets the model use the whole
+  toolkit; `include` limits it to named actions. `actions` are Agenta action
+  keys; the adapter maps them to Composio slugs server-side, so the stored config
+  never depends on Composio's slug spelling.
+- `permission` is **policy**: the default allow, ask, or deny.
+
+This entry replaces up to a hundred per-action rows. The existing per-action
+`gateway` type stays so old configs keep parsing, and the compat layer gives a
+migration path.
+
+## 3. What the model sees (both options)
+
+A Composio session exposes meta-tools. We use three: search tools, get schemas,
+and multi-execute. We turn off the others:
+
+- **Manage connections: off.** The frontend already lets the agent ask the user
+  to connect an integration, so we reuse that.
+- **Workbench and bash: off.** We do not depend on Composio's sandbox for large
+  results (section 7).
+
+The model searches for the action it needs and calls it through multi-execute.
+The real action, for example `GITHUB_CREATE_ISSUE`, is an argument to
+multi-execute, not a separate tool. This is true in both options and matters for
+permissions (section 8).
+
+## 4. Option 1: call the session's meta-tools over REST (recommended)
+
+### How it works
+
+1. The agent config names the integration, connection, and tool policy.
+2. At run start, the Agenta API gets or creates a Composio session for this
+   policy (section 9), pinned to the connection's connected account, and stores
+   the session id.
+3. The API resolves the connection into a few callback tool specs, one per
+   meta-tool, named so they cannot collide, for example
+   `composio.<connection-uuid>.search`.
+4. The runner delivers them through its existing internal channel. Nothing new in
+   the runner.
+5. When the model calls a meta-tool, the runner relays it to `POST /tools/call`.
+6. `/tools/call` calls Composio's session execute endpoint over plain HTTP, with
+   the key injected from `env.composio`, and returns the result. This is the same
+   call shape we already use to execute a Composio tool today; the spikes
+   confirmed the meta-tools are callable this way over REST, not only over MCP.
+
+### Why this is the recommended shape
+
+- It reuses everything: the callback transport, the result cap, tracing, the
+  permission gate, and credential isolation all already exist on this path.
+- It works on every harness. The runner refuses external MCP servers on Pi, so
+  Option 2 cannot serve Pi; this option can, because it uses our callback tools.
+- The Composio key stays exactly where it is today, in the API. The sandbox holds
+  only the run's own bearer, as it does for callback tools now.
+- No new streaming-proxy machinery. We call an HTTP endpoint and get a result.
+
+### What is new
+
+- A session lifecycle service (section 9).
+- The Composio adapter gains a session-execute call (execute a meta-tool against
+  a session). This is close to the existing execute call.
+- Resolution changes from one spec per action to a few meta-tool specs per
+  connection. This changes the gateway resolver, which today returns exactly one
+  spec per config. The plan names the exact seams (`GatewayToolResolution`,
+  `ToolResolver`, `/tools/resolve`).
+
+## 5. Option 2: proxy the session as an MCP server (considered, not recommended)
+
+### How it works
+
+The API runs an MCP endpoint. The config resolves to one MCP server entry whose
+URL points at that endpoint, delivered through the runner's user-MCP path. The
+harness dials it; the endpoint injects the Composio key and forwards to the
+session's MCP URL.
+
+### Why we do not recommend it for the first version
+
+- **It does not work on Pi.** The runner refuses external MCP servers for Pi
+  (`services/runner/src/engines/sandbox_agent/run-plan.ts:591`). Option 1 has no
+  such limit.
+- **It is not a thin proxy once it does real work.** To cap a large result it
+  must read and rewrite the response, so it cannot simply stream bytes through;
+  it must understand the MCP streaming-HTTP protocol, session headers, and
+  message framing. That is real, ongoing surface.
+- **It moves the trust boundary.** Today the callback authorization stays
+  runner-side. This option puts a project-scoped Agenta token in the sandbox MCP
+  config, which on a local run is plaintext, and a shell in the sandbox could
+  call the forward URL directly and skip the interactive gate. Making it safe
+  needs a short-lived, forward-only capability, which is more machinery.
+
+It stays on record because it is the natural shape if we later host user-provided
+MCP servers, where the harness genuinely must speak MCP.
+
+## 6. Comparison
+
+| Concern | Option 1: REST meta-tools as callback tools | Option 2: MCP proxy |
+|---|---|---|
+| Works on Pi | Yes | No (runner refuses external MCP on Pi) |
+| New API code | A session-execute call on the adapter | A streaming MCP proxy endpoint |
+| Reuses result cap, tracing, permissions | Yes, all existing | Partly; the proxy re-implements capping |
+| Composio key location | API, unchanged | API, but a project token enters the sandbox |
+| Trust boundary vs today | Same | Changed (token in sandbox, gate can be skipped) |
+| Deny / ask | Yes, per meta-tool via existing gate | Yes, per connection |
+| Warm fingerprint | Stable | Stable if URL keyed on connection |
+| Future user-hosted MCP servers | Needs the same work again | Direct fit |
+
+Both deliver the same model experience and the same integration-level config. The
+recommendation is Option 1 because it reuses our machinery, works on Pi, keeps the
+trust boundary, and avoids a streaming proxy. Choose Option 2 only if hosting
+user-provided MCP servers becomes a near-term requirement.
+
+## 7. Large results
+
+Composio's own result trimming does not run when we drive the session, so the fix
+is ours. For the first version: cap the result at a byte budget well below the
+current one megabyte, and return a short message that names the size and tells the
+model to narrow, filter, or paginate. This reuses the cap the callback path
+already has (`services/runner/src/tools/callback.ts`) at a lower limit, and it
+closes #5341.
+
+Two richer options are deferred:
+
+- Write the full result to a file in the sandbox mount and return the path. This
+  fits Option 1, because the runner is in the data path, but it needs mid-run
+  writes into the sandbox and is not needed for the first version.
+- Composio's workbench keeps a large result in Composio's sandbox and returns a
+  preview. Available if a use case needs server-side piping.
+
+## 8. Permissions and the one product decision
+
+The real action is an argument to multi-execute, so the harness gate sees the
+meta-tool, not the action. Per-action allow and deny run at `/tools/call`, which
+reads the arguments. Interactive "ask the user before this one specific action"
+does not work at the harness gate, because the gate does not see the action.
+"Ask before any Composio action" works today. We propose to ship that and treat
+per-action interactive ask as a later addition, raised from `/tools/call` if we
+build it.
+
+## 9. Session lifecycle
+
+A Composio session holds a tool policy and a connected-account binding. Two agents
+can share one connection with different policies, so the session is keyed on the
+policy, not the connection alone:
+
+```
+(project_id, connection_uuid, tool_policy_hash) -> composio_session_id
+```
+
+This lives in a small dedicated mapping table with a uniqueness constraint, which
+gives safe get-or-create. It does not live in the connection's `data` blob,
+because that row is owned by the connections domain and its update is an unlocked
+read-modify-write, so it cannot give safe get-or-create for many policies on one
+connection.
+
+Rules:
+
+- **Immutable per policy.** A session is created for a policy hash and never
+  edited. A policy change creates a new session under a new hash. We do not PATCH
+  a session in place, which removes the cross-agent race and the need to reason
+  about warm reuse across a policy change.
+- **Reused across runs and conversations** for the same policy. Sessions do not
+  expire (documented), and our meta-tool use is stateless because the workbench
+  is off, so one session per policy is safe. If Composio session state ever leaks
+  between conversations, we add the conversation id to the key; not needed now.
+- **Pinned to the connected account.** Session creation passes Composio's
+  `connected_accounts` for the toolkit, set to the connection's provider account
+  id (`api/oss/src/core/gateway/connections/dtos.py:68`), so calls run through the
+  account the config names, not whichever account Composio would pick.
+- **Recreated lazily.** If Composio reports the session gone, we create a new one
+  and retry. No background garbage collection in the first version.
+
+A policy edit changes the resolved tool specs, which changes the warm-session
+fingerprint, so the harness session reopens on its own. We do not try to keep a
+warm sandbox across a policy change, because that would risk running under stale
+permissions.
+
+## 10. Security recap
+
+The Composio key is a project-wide credential. It reaches every Agenta workspace's
+connections, because Composio's user is our project and all workspaces share one
+Composio project. So the key stays in the Agenta API and never enters the sandbox.
+Option 1 keeps this exactly as today. Option 2 weakens it, which is one reason we
+do not recommend it.
+
+## 11. Extensibility
+
+The design leaves room for a second provider or a user's own hosted MCP server,
+but we do not build for that now. The rule that keeps a future hosted tool safe:
+its sandbox-visible identity is keyed on provider and connection and stays stable
+for the life of the connection, while the volatile upstream session id and the
+provider credential live only in the API. A user-hosted MCP server is the case
+where Option 2's shape becomes the right one; until then Option 1 is simpler.

--- a/docs/design/composio-tools-rework/design.md
+++ b/docs/design/composio-tools-rework/design.md
@@ -84,20 +84,28 @@ tools and their results.
   as today.
 - **One broken action no longer kills the agent.** If an action cannot run, only that
   one call fails. The model reads the error and tries another action. This fixes #5173,
-  because nothing has to resolve up front any more.
+  because nothing has to resolve up front any more. The current system already got this
+  fix (PR #5813).
 
 ## Big results
 
 Some actions return a huge amount of text. Today that can flood the model and break the
 chat. We cut the result down before it reaches the model, and we add a short note that
-tells the model to ask for less (filter, or fetch fewer items). This fixes #5341.
+tells the model to ask for less (filter, or fetch fewer items). This fixes #5341, and it
+is already shipped (PR #5811).
+
+There is a second path that already happens sometimes: a large result is saved to a file
+in the sandbox, and the model reads the file instead of getting the whole thing in the
+chat. We keep both. The cut-down note is the simple default; the file in the sandbox
+handles the cases where the model still needs the full data.
 
 ## Versions: why one setting matters
 
 Search and run must use the same version of the app's action list. If they differ,
 search can offer an action that run then cannot find, and the user gets a "not found"
 error. We fix this by always using Composio's newest version (their v3.1 endpoints).
-Then whatever search offers, run can use. This fixes #5174.
+Then whatever search offers, run can use. This fixes #5174, and it is already shipped
+(PR #5814).
 
 ## One decision for you
 
@@ -105,6 +113,24 @@ Permissions. We can make the agent ask the user before any action on a connectio
 is easy. Asking before one specific action, like "ask before delete but not before
 read", is harder and needs more work, because of how the model calls the run tool. We
 suggest shipping the simple version first and adding the specific one later.
+
+## Side idea: let the agent set up its own tools
+
+This is a separate change from the design above, and it could be its own PR. Note it here
+so we do not lose it.
+
+When the user builds an agent by talking to it, the agent can set itself up. Today it may
+stop and ask the user at each step. We could add a default that lets the agent do this on
+its own, with no question to the user:
+
+1. Find an integration, like GitHub.
+2. Check which integrations already have a connection (a saved login).
+3. If one is connected, add it to the agent and commit.
+
+This is a build-time choice (the agent editing its own setup), not the run-time choice
+above (the agent using a tool). We would keep it safe by limiting it: the agent only adds
+an integration that is already connected, so it never starts a login flow on its own. We
+can decide later whether this is on by default or an opt-in.
 
 ## Keeping the key safe
 

--- a/docs/design/composio-tools-rework/experiment.md
+++ b/docs/design/composio-tools-rework/experiment.md
@@ -1,0 +1,81 @@
+# Experiments
+
+Two checks to run before committing to the new design. Neither has run yet. This
+file is a proposal, not a result.
+
+## 1. Can the smallest models use search-then-execute?
+
+The new design replaces a flat list of tool schemas with two tools: a search tool
+and an execute tool. The model must first search for the action, read the returned
+schema, then call execute with a slug and arguments. That extra step is indirection
+the flat list does not have.
+
+**Hypothesis.** The largest models handle the indirection with no loss. The
+smallest, cheapest models may struggle: they may skip the search step, execute a
+slug they never searched for, or loop on search without ever executing. If so, the
+new pattern would cost accuracy exactly where cost pressure pushes users toward
+small models.
+
+**Models.** The cheapest model in each harness family:
+
+| Model            | Harness family |
+|------------------|----------------|
+| Haiku            | Claude         |
+| Luna             | Codex          |
+| DeepSeek V4 Flash| Pi             |
+
+Test each model on the harness that hosts it.
+
+**Tasks.** A small set of representative tool jobs, each with a checkable side
+effect:
+
+- Create a GitHub issue titled a given string in a test repository.
+- Post a Slack message with a given body to a test channel.
+- Find and read the most recent issue in a test repository, then report its title.
+
+**Method.** Run each task two ways against the same test connections:
+
+- **Old (flat list).** The allowed action schemas are listed directly, as today.
+- **New (search + execute).** Only the search and execute tools are exposed.
+
+Run several trials per cell. Measure two numbers: the task success rate (did the
+checked side effect happen, or the correct value get reported) and the number of
+tool calls the model made to get there.
+
+**What a pass looks like.** For each model, the new mode reaches a success rate
+within a small margin of the old mode, without a large jump in tool calls. That
+would show the indirection is affordable even for small models.
+
+**What would make us reconsider.** A clear success-rate drop or a runaway tool-call
+count in the new mode on any small model. Two responses are possible: keep both
+modes and pick the flat list for small models under a schema-count threshold, or
+improve the search tool's output (tighter results, clearer schemas) and retest. A
+drop on the largest models would instead question the pattern itself.
+
+## 2. Spike: does a searched tool execute cleanly at the pinned version?
+
+The design pins the Composio calls to the latest toolkit version so a slug that
+search returns is one execute can run (section 8 of `design.md`). This spike checks
+that assumption against the live Composio key. The orchestrator runs it; it is
+described here, not run.
+
+**Steps.**
+
+1. Call `COMPOSIO_SEARCH_TOOLS` for a common intent (for example "create a GitHub
+   issue"), with the toolkit version pinned to latest (Composio API v3.1).
+2. Take one action slug from the returned results, and read its input schema from
+   the same response.
+3. Execute that slug with valid arguments against a test connection, at the same
+   pinned latest version.
+4. Confirm the execute call succeeds and returns a real result, not a version or
+   not-found error.
+
+**What it confirms.** A found tool executes cleanly when both calls pin to latest,
+so the search-versus-execute mismatch (#5174) does not resurface and the rare soft
+failure the design tolerates is in fact rare. A failure here means the pin does not
+fully align the two calls, and the soft-failure path must carry more weight than
+the design assumes.
+
+Use test connections and test channels only. Do not put real Composio identifiers
+(account, session, or key values, or real project UUIDs) in this file or in the
+spike output that gets shared.

--- a/docs/design/composio-tools-rework/plan.md
+++ b/docs/design/composio-tools-rework/plan.md
@@ -4,18 +4,19 @@ We build this in three parts. Each part ships and can be tested on its own. Toge
 they build the design in `design.md`: one setup entry becomes a search tool and a run
 tool.
 
-## Part 1: three quick fixes (ship first)
+## Part 1: quick fixes (done and shipped)
 
-These do not need the redesign. The first two remove pain we have today. The third is
-needed before Part 2 can work.
+These did not need the redesign. They removed pain in today's system, and the version pin
+is also needed before Part 2. All four are merged into release/v0.112.0.
 
-- **Cap big results (#5341).** Cut a tool result down to a safe size before it reaches
-  the model, and add a note telling the model to ask for less. This also helps the
-  current setup.
-- **Clear "not set up" error (#5407).** When Composio has no key, return a clear "not
-  configured" message instead of a bare "not found".
+- **Cap big results (#5341).** Cut a tool result down to a safe size, and tell the model
+  to ask for less. Shipped, PR #5811.
+- **Clear "not set up" error (#5407).** Return a clear "not configured" message instead
+  of a bare "not found". Shipped, PR #5812.
+- **Broken tool no longer kills the agent (#5173).** Drop the one dead tool, keep the
+  rest. Shipped, PR #5813.
 - **Pin the version (#5174).** Always call Composio's newest version, so search and run
-  use the same action list. Part 2 depends on this.
+  use the same action list. Shipped, PR #5814.
 
 ## Part 2: one app working end to end (backend)
 
@@ -39,12 +40,19 @@ breaks for current users.
 - The drawer lets the user add one connection entry (app, connection, allowed actions)
   instead of one row per action. The backend from Part 2 already accepts it.
 
+## Possible follow-up (separate, maybe its own PR)
+
+- **Let the agent set up its own tools.** A default that lets the agent find an
+  integration, check which ones already have a connection, and add and commit a connected
+  one without asking the user. This is a build-time choice, separate from the run-time
+  design above. See `design.md`, "Side idea".
+
 ## Not in this plan
 
 - Composio sessions and their MCP server. Dropped; see `design.md`.
 - Special work for Pi. The two tools already reach Pi the normal way.
-- Composio's code sandbox, and saving big results to a file for the model to read. The
-  size cap is the first answer.
+- Composio's code sandbox. The size cap, and the existing option to save a big result to
+  a file in the sandbox, are enough for now.
 - Asking before one specific action.
 - Limiting call rate per customer.
 - A second tool provider.

--- a/docs/design/composio-tools-rework/plan.md
+++ b/docs/design/composio-tools-rework/plan.md
@@ -1,58 +1,59 @@
 # Plan
 
-Three vertical slices, each shippable and testable on its own. This plan builds
-Option 1 from `design.md` (call the session's meta-tools over REST as callback
-tools).
+We build this in three parts. Each part ships and can be tested on its own. Together
+they build the design in `design.md`: one setup entry becomes a search tool and a run
+tool.
 
-## Slice 1: the two quick fixes (independent, ship first)
+## Part 1: three quick fixes (ship first)
 
-These do not depend on the redesign and remove live pain.
+These do not need the redesign. The first two remove pain we have today. The third is
+needed before Part 2 can work.
 
-- Lower the callback result cap to a byte budget well below one megabyte, with a
-  steering message. Closes #5341, and it helps the current per-action path too.
-- Return a clear 501 or 503 when Composio is not configured, instead of a bare
-  404. Closes #5407.
+- **Cap big results (#5341).** Cut a tool result down to a safe size before it reaches
+  the model, and add a note telling the model to ask for less. This also helps the
+  current setup.
+- **Clear "not set up" error (#5407).** When Composio has no key, return a clear "not
+  configured" message instead of a bare "not found".
+- **Pin the version (#5174).** Always call Composio's newest version, so search and run
+  use the same action list. Part 2 depends on this.
 
-## Slice 2: one session-backed connection, end to end (backend)
+## Part 2: one app working end to end (backend)
 
-Build the whole path for the new config type, behind the existing per-action path
-so nothing breaks. In one slice, because the parts have no value apart:
+Build the whole new path for the new setup entry, hidden behind the old path so nothing
+breaks for current users.
 
-- Add the `gateway_toolkit` config type and the tool policy to the SDK union.
-- Add the `gateway_sessions` mapping table and the session lifecycle service:
-  get-or-create keyed on policy, pinned to the connected account, lazy recreate.
-- Change the gateway resolver to return the meta-tool callback specs for the new
-  type.
-- Add the `/tools/call` branch that runs a meta-tool against the session.
-- Wire connection-level allow, ask, and deny through the existing gate, and
-  per-action allow and deny at `/tools/call`.
-- Confirm end to end on a real harness with the agent release gate: the model
-  searches, calls a tool, gets a result, permissions and tracing work, and the
-  warm sandbox reopens after a policy edit.
+- Add the new setup entry type and its "which actions are allowed" field.
+- Change the backend so one entry produces the two tools, search and run, instead of one
+  tool per action.
+- Make search ask Composio for matching actions, and make run call the chosen action,
+  both with the key that stays on our servers.
+- Reject a run call for an action the setup did not allow.
+- Let the agent ask, allow, or deny at the connection level, using the controls we
+  already have.
+- Test it end to end on a real agent runtime: the model searches, runs a tool, gets a
+  result, permissions work, a broken action fails on its own without killing the run,
+  and a fast restart still works after a setup change.
 
-## Slice 3: the frontend authoring path
+## Part 3: the setup screen
 
-- The drawer adds a connection-level entry (integration, connection, tool policy)
-  instead of per-action rows. The backend already accepts the new shape from
-  Slice 2.
+- The drawer lets the user add one connection entry (app, connection, allowed actions)
+  instead of one row per action. The backend from Part 2 already accepts it.
 
-## Out of scope
+## Not in this plan
 
-- Pi is supported by Option 1 automatically, so nothing special is needed. Option
-  2 and its Pi limit are not built.
-- Per-tenant rate limiting against Composio's per-organization limit.
-- Per-action interactive "ask".
-- Writing large results to a file in the sandbox mount, and Composio's workbench.
-  The byte cap is the first-version answer.
-- Background session garbage collection.
+- Composio sessions and their MCP server. Dropped; see `design.md`.
+- Special work for Pi. The two tools already reach Pi the normal way.
+- Composio's code sandbox, and saving big results to a file for the model to read. The
+  size cap is the first answer.
+- Asking before one specific action.
+- Limiting call rate per customer.
 - A second tool provider.
 
 ## Testing
 
-- Slice 1 gets unit tests for the cap and the error.
-- Slice 2's session service and execute path get integration tests against a
-  Composio test connection (they call the live service, so they are integration
-  tests, not unit tests). The end-to-end check uses the agent release gate.
-- Two hard security tests: the sandbox never receives the Composio key, only the
-  run bearer; and the resolved tool identity contains no Composio session id, so
-  the warm fingerprint stays stable across unrelated runs.
+- Part 1 gets small tests for the size cap and the clear error, plus a check that an
+  action found by search can be run after the version pin.
+- Part 2's search and run get tests against a real Composio test connection. The end to
+  end check uses the agent release gate.
+- Two safety tests: the sandbox never gets the Composio key, and a setup change does not
+  needlessly throw away a warm sandbox.

--- a/docs/design/composio-tools-rework/plan.md
+++ b/docs/design/composio-tools-rework/plan.md
@@ -1,0 +1,58 @@
+# Plan
+
+Three vertical slices, each shippable and testable on its own. This plan builds
+Option 1 from `design.md` (call the session's meta-tools over REST as callback
+tools).
+
+## Slice 1: the two quick fixes (independent, ship first)
+
+These do not depend on the redesign and remove live pain.
+
+- Lower the callback result cap to a byte budget well below one megabyte, with a
+  steering message. Closes #5341, and it helps the current per-action path too.
+- Return a clear 501 or 503 when Composio is not configured, instead of a bare
+  404. Closes #5407.
+
+## Slice 2: one session-backed connection, end to end (backend)
+
+Build the whole path for the new config type, behind the existing per-action path
+so nothing breaks. In one slice, because the parts have no value apart:
+
+- Add the `gateway_toolkit` config type and the tool policy to the SDK union.
+- Add the `gateway_sessions` mapping table and the session lifecycle service:
+  get-or-create keyed on policy, pinned to the connected account, lazy recreate.
+- Change the gateway resolver to return the meta-tool callback specs for the new
+  type.
+- Add the `/tools/call` branch that runs a meta-tool against the session.
+- Wire connection-level allow, ask, and deny through the existing gate, and
+  per-action allow and deny at `/tools/call`.
+- Confirm end to end on a real harness with the agent release gate: the model
+  searches, calls a tool, gets a result, permissions and tracing work, and the
+  warm sandbox reopens after a policy edit.
+
+## Slice 3: the frontend authoring path
+
+- The drawer adds a connection-level entry (integration, connection, tool policy)
+  instead of per-action rows. The backend already accepts the new shape from
+  Slice 2.
+
+## Out of scope
+
+- Pi is supported by Option 1 automatically, so nothing special is needed. Option
+  2 and its Pi limit are not built.
+- Per-tenant rate limiting against Composio's per-organization limit.
+- Per-action interactive "ask".
+- Writing large results to a file in the sandbox mount, and Composio's workbench.
+  The byte cap is the first-version answer.
+- Background session garbage collection.
+- A second tool provider.
+
+## Testing
+
+- Slice 1 gets unit tests for the cap and the error.
+- Slice 2's session service and execute path get integration tests against a
+  Composio test connection (they call the live service, so they are integration
+  tests, not unit tests). The end-to-end check uses the agent release gate.
+- Two hard security tests: the sandbox never receives the Composio key, only the
+  run bearer; and the resolved tool identity contains no Composio session id, so
+  the warm fingerprint stays stable across unrelated runs.

--- a/docs/design/composio-tools-rework/research.md
+++ b/docs/design/composio-tools-rework/research.md
@@ -1,8 +1,14 @@
 # Research
 
-This file records how the system works today, in the code, and the outside
-facts that constrain the design. It is grounded in the repo on `main` and in
-live tests against Composio. File references use `path:line`.
+This file is background for engineers. It records how the system works today, in
+the code, and the outside facts we learned by testing against Composio. For the
+plan itself, read `design.md`, not this file.
+
+One note to avoid confusion: some sections below describe Composio "sessions" and
+an MCP server. Those are things Composio offers and shapes we looked at and
+dropped. The plan does not use them. See `design.md` for what we build.
+
+File references use `path:line`.
 
 ## 1. How a third-party tool works today
 
@@ -135,23 +141,29 @@ token result in #5341 reached the model intact.
   So the large-result fix must be ours.
 - **Rate limits are per organization**, shared by all our tenants.
 
-## 3. Spike results (live key, 5-6 August)
+## 3. Spike results (live key, 5-7 August)
 
 We tested against the live Composio key. The load-bearing results:
 
-- The session's meta-tools and its tools are callable over plain REST (through
-  the session execute call), not only over MCP. This is what makes the
-  recommended design reuse our existing call path instead of speaking MCP.
-- A scoped key limited to Sessions=read-only was denied on the MCP endpoint with
-  the message that the route "requires 'sessions' write access". So there is no
-  scoped key that both drives the session and stays confined. The key stays
-  server-side.
-- A key-injecting proxy let a client holding no Composio key drive Composio
-  tools, including a workbench call that ran a GitHub call and returned only a
-  filtered summary. This confirmed the forwarding shape and the keyless sandbox.
-- Latency: session create about half a second; the search meta-tool about two
-  seconds because it runs a model on Composio's side; the workbench about three
-  seconds cold, then about half a second warm.
+- Search and execute are callable over plain HTTP, one call each, with no
+  Composio session. Composio's search (`COMPOSIO_SEARCH_TOOLS`) returns matching
+  slugs and their input schemas in one response, and a returned slug executes
+  directly. This is what lets the design use a search tool and an execute tool
+  without a session object.
+- The version pin fixes the discover-versus-resolve drift. We searched six real
+  use cases across GitHub, Slack, Gmail, and Notion and got 40 tool slugs. On
+  Composio's v3 default version, 36 resolved and 4 returned a 404, which is the
+  #5174 drift live. On v3.1, which defaults to the latest version, all 40
+  resolved. Zero of the 40 failed even on latest. So pinning to v3.1 aligns
+  search and execute, and a found tool that cannot resolve is rare, not routine.
+  This tests version resolvability, which is what we control; a specific call can
+  still fail on bad arguments or a broken connection, as always.
+- The Composio key cannot be safely reduced for the sandbox. A key scoped to
+  read-only sessions was denied even from reading a session, and the scope that
+  drives a session also creates and widens sessions for any workspace in the
+  project. So the key stays in the Agenta API, whatever design we pick.
+- Latency: the search call is about two seconds, because Composio runs a model
+  inside it. A plain execute call is well under a second.
 
 ## 4. Tool-piping ("toolbox") options
 
@@ -168,10 +180,24 @@ intermediate results out of context.
   slices the file. This works for any tool, keeps the data in our control, and
   avoids depending on Composio's workbench.
 
-## 5. The runner delivery decision (resolved in design.md)
+## 5. How tools reach the harness (why the design reuses it)
 
-The open question that the design must answer: do we expose a Composio session
-as our own callback tools through the internal channel, or as an MCP server that
-the harness dials at an Agenta-hosted endpoint that forwards to Composio? The
-answer depends on whether the second shape keeps our permissions and tracing.
-The runner-plumbing findings and the decision live in design.md.
+The runner already delivers every Agenta tool to the harness through one internal
+channel: a loopback tool server for Claude and Codex running locally, an uploaded
+relay for Daytona, and Pi's own tool registration. When the model calls a tool,
+the call runs on our side and the Agenta API holds the Composio key. The new
+design adds two ordinary tools (search and execute) to this same channel, so it
+needs no new runner path and works on every harness, including Pi. See design.md
+for the end-to-end flow.
+
+## 6. A version caveat the code already navigates
+
+Composio's endpoints do not agree on how they spell an action slug across
+toolkit versions. The catalog list endpoint on the latest version returns short
+slugs that the single-tool and execute endpoints reject, while the default
+version returns the long slugs that all endpoints accept
+(`api/oss/src/core/tools/providers/composio/catalog.py:212`). Our search endpoint
+returns long slugs, and those resolve on v3.1 but 404 on some tools on the v3
+default (section 3). So a version fix is not a single switch to latest; it must
+keep the slug spelling consistent across list, search, get, and execute. This is
+the delicate part of #5174.

--- a/docs/design/composio-tools-rework/research.md
+++ b/docs/design/composio-tools-rework/research.md
@@ -1,0 +1,177 @@
+# Research
+
+This file records how the system works today, in the code, and the outside
+facts that constrain the design. It is grounded in the repo on `main` and in
+live tests against Composio. File references use `path:line`.
+
+## 1. How a third-party tool works today
+
+### 1.1 The saved config entry
+
+An agent stores one entry per action. The model lives at
+`sdks/python/agenta/sdk/agents/tools/models.py:89` (`GatewayToolConfig`):
+`provider` (default `composio`), `integration`, `action`, `connection`, and an
+optional `name`. Its `reference` property is
+`tools.{provider}.{integration}.{action}.{connection}`.
+
+The frontend still writes an older shape, a function tool whose name encodes the
+five parts. The compat layer (`sdks/python/agenta/sdk/agents/tools/compat.py:12`)
+parses both. It keeps only the five slug parts and drops any description or
+schema the frontend embedded, so a description edited in the drawer never reaches
+the model.
+
+Connections live in the `gateway_connections` table
+(`api/oss/src/dbs/postgres/gateway/connections/dbes.py:38`), unique per project,
+provider, integration, and slug. Tools and triggers share these rows. The
+Composio identity sits in an opaque `data` JSON blob; the connected-account id is
+read through a property, not a column.
+
+### 1.2 Discovery
+
+The agent calls the platform operation `discover_tools`. The Agenta API calls
+Composio's `COMPOSIO_SEARCH_TOOLS` meta-tool
+(`api/oss/src/core/tools/providers/composio/adapter.py:225`). The API returns at
+most one primary tool per use case plus a few alternatives, and marks a tool
+"ready" from our connection state alone
+(`api/oss/src/core/tools/discovery.py`). It never checks that the tool will
+resolve, which is why discovery can offer a tool that resolve then cannot find.
+
+### 1.3 Resolve at run start
+
+The SDK resolves all tools before the run starts
+(`sdks/python/agenta/sdk/agents/handler.py:242`). For each action the API makes
+one live HTTP GET to Composio (`adapter.py:117`, `get_action`). The calls are
+serial and uncached. Ten tools cost ten round trips before the first token. If
+one fails, the whole request fails; there is no partial path. This is the
+all-or-nothing failure of #5173. The failure happens at three layers: the API
+service loop (`api/oss/src/core/tools/service.py:416`), the per-tool resolve, and
+the SDK gateway resolver (`platform/gateway.py:113`).
+
+### 1.4 Version drift (#5174)
+
+We call Composio API v3 with no version. Composio v3 defaults tool endpoints to a
+frozen snapshot (`00000000_00`), while the search meta-tool and API v3.1 default
+to the latest version. So discovery sees the latest catalog and resolve sees the
+frozen one, and a tool present in one can be a 404 in the other. `ComposioConfig`
+(`api/oss/src/utils/env.py:685`) has no version field; the version is baked into
+the default URL.
+
+### 1.5 Execute
+
+The model's tool call reaches the API at `POST /tools/call`
+(`api/oss/src/apis/fastapi/tools/router.py:1129`). The API resolves the
+connection again, then calls Composio (`adapter.py:166`, `execute`). A
+business-level tool failure returns HTTP 200 with an error status inside the
+result; only infrastructure faults become 4xx or 5xx. The Composio key is read
+from `env.composio` and injected as an `x-api-key` header (`adapter.py:54`). The
+key lives only in the API.
+
+### 1.6 How tools reach the harness (the runner)
+
+The runner delivers tools in two separate layers
+(`services/runner/src/engines/sandbox_agent/mcp.ts:355`, `buildSessionMcpServers`).
+
+- **Internal `agenta-tools` channel.** The runner advertises the run's resolved
+  tools to the harness itself. On Claude and Codex running locally, it stands up
+  a loopback HTTP MCP server (`services/runner/src/tools/tool-mcp-http.ts`). On
+  Daytona, where the loopback is unreachable from the sandbox, it uploads a
+  stdio shim (`tool-mcp-stdio.ts`) whose calls a runner-side relay executes
+  (`relay.ts`). On Pi there is no MCP; Pi loads tools through its bundled
+  extension.
+- **User MCP servers.** Any MCP server the user declared is delivered as an
+  entry the harness dials directly (`mcp.ts`, `toAcpMcpServers`). On Daytona this
+  works because it is a genuinely remote URL, and secret headers are swapped for
+  a Daytona placeholder at egress.
+
+When the model calls an internal-channel tool, the call executes server-side: the
+runner holds the callback bearer and posts to the API's `/tools/call`, and the
+API holds the Composio key. No Agenta or Composio credential enters the sandbox
+today (`services/runner/src/tools/callback.ts`).
+
+### 1.7 The warm-sandbox fingerprint (a hard constraint)
+
+The runner reuses a parked sandbox between turns when a fingerprint matches
+(`services/runner/src/engines/sandbox_agent/session-identity.ts:207`). The
+fingerprint hashes the whole resolved tool array and every MCP server's
+connection URL; only credential values are stripped. So any value visible to the
+sandbox that changes when we recreate a Composio session (a session id inside a
+tool identity or an MCP URL) would evict every warm sandbox. The session id must
+stay server-side.
+
+### 1.8 Result size caps today
+
+A live tool result is capped only at 1 megabyte
+(`services/runner/src/tools/callback.ts`), which is roughly 250,000 tokens. The
+4,000-character cap people remember applies only when the runner replays old
+turns into a cold session (`transcript.ts`), not live. This is why the 241,000
+token result in #5341 reached the model intact.
+
+## 2. What Composio provides (documented, and tested live)
+
+- **Sessions (their Tool Router).** One session per user holds a filtered set of
+  tools and exposes six meta-tools: search, get-schemas, multi-execute,
+  manage-connections, a Python workbench, and a bash tool. With `mcp=True` the
+  session exposes an MCP endpoint (`session.mcp.url` plus headers).
+- **The MCP credential is the project key.** Tested live: `session.mcp.headers`
+  is `{x-api-key: <our project key>}`. Calling the endpoint needs session-write
+  access, which also creates and widens sessions for any user in the project.
+  There is no session-scoped credential. The Agenta-to-Composio identity mapping
+  sets Composio's `user_id` to the Agenta `project_id`
+  (`api/oss/src/core/gateway/connections/service.py:174`), so "any user in the
+  project" means any Agenta workspace's connections. This is why the key must
+  never enter the sandbox.
+- **Sessions do not expire.** Composio's docs state sessions "persist on the
+  server and don't expire", and the session object carries no expiry field. We
+  create one per connection and reuse it. (Two unrelated timers exist: file
+  download URLs expire after one hour, half-finished connections after ten
+  minutes.)
+- **Filters update in place.** `PATCH` on the session changes filters without
+  changing the MCP URL, so a config edit does not force a new session.
+- **Version drift dies.** Search returns the tool schemas in the same response,
+  so discovery and execution share one scope. There is no second endpoint on a
+  different default version to disagree with.
+- **Result-trimming hooks do not run over MCP.** Composio's `afterExecute` and
+  schema modifiers only run on their direct SDK path, not over the MCP endpoint.
+  So the large-result fix must be ours.
+- **Rate limits are per organization**, shared by all our tenants.
+
+## 3. Spike results (live key, 5-6 August)
+
+We tested against the live Composio key. The load-bearing results:
+
+- The session's meta-tools and its tools are callable over plain REST (through
+  the session execute call), not only over MCP. This is what makes the
+  recommended design reuse our existing call path instead of speaking MCP.
+- A scoped key limited to Sessions=read-only was denied on the MCP endpoint with
+  the message that the route "requires 'sessions' write access". So there is no
+  scoped key that both drives the session and stays confined. The key stays
+  server-side.
+- A key-injecting proxy let a client holding no Composio key drive Composio
+  tools, including a workbench call that ran a GitHub call and returned only a
+  filtered summary. This confirmed the forwarding shape and the keyless sandbox.
+- Latency: session create about half a second; the search meta-tool about two
+  seconds because it runs a model on Composio's side; the workbench about three
+  seconds cold, then about half a second warm.
+
+## 4. Tool-piping ("toolbox") options
+
+The question is whether the model can call several tools in one script and keep
+intermediate results out of context.
+
+- Composio's workbench meta-tool does this over MCP, keyless in the sandbox,
+  proven in the spike.
+- Anthropic's native programmatic tool calling cannot call MCP-sourced tools
+  (documented). OpenAI's Responses API allows it but only on OpenAI models. Pi
+  has none.
+- Our own alternative, preferred: the API's forward point writes a large result
+  to a file in the sandbox mount and returns the path, and the agent reads or
+  slices the file. This works for any tool, keeps the data in our control, and
+  avoids depending on Composio's workbench.
+
+## 5. The runner delivery decision (resolved in design.md)
+
+The open question that the design must answer: do we expose a Composio session
+as our own callback tools through the internal channel, or as an MCP server that
+the harness dials at an Agenta-hosted endpoint that forwards to Composio? The
+answer depends on whether the second shape keeps our permissions and tracing.
+The runner-plumbing findings and the decision live in design.md.

--- a/docs/design/composio-tools-rework/status.md
+++ b/docs/design/composio-tools-rework/status.md
@@ -4,10 +4,10 @@ Where we are, what we decided, and what is still open.
 
 ## Stage
 
-Two tracks are running.
+Two tracks.
 
-- **Quick bug fixes to the current system.** Shipping now, one small PR each. Three are
-  merged, one is open. See "Bug fixes" below.
+- **Quick bug fixes to the current system.** Done. All four are merged into
+  release/v0.112.0. See "Bug fixes" below.
 - **The redesign.** Planned in these documents. Not built yet.
 
 ## What we decided
@@ -24,12 +24,17 @@ Two tracks are running.
 - **Keep the Composio key on our servers.** It can reach every workspace's connections,
   so it must never enter the sandbox.
 
-## Bug fixes (current system, shipping now)
+## Bug fixes (current system, all shipped)
+
+All four are merged into release/v0.112.0.
 
 - **#5341 big results:** merged (PR #5811).
-- **#5407 clear "not set up" error:** open (PR #5812).
+- **#5407 clear "not set up" error:** merged (PR #5812).
 - **#5173 one broken tool no longer kills the agent:** merged (PR #5813).
 - **#5174 version pin:** merged (PR #5814).
+
+Note on big results: besides the size cap, a large result is sometimes saved to a file in
+the sandbox, and the model reads the file. We keep both.
 
 ## Open questions
 
@@ -39,6 +44,8 @@ Two tracks are running.
   `experiment.md`.
 - Should we let the user ask before one specific action, not just before any action? This
   needs extra work. It is a product call.
+- Should we let the agent set up its own tools (find, check connection, add, commit)
+  without asking? A separate, maybe-later change. See `design.md`, "Side idea".
 - What happens to agents that still use the old one-per-action setup? We already accept
   both, so they keep working.
 

--- a/docs/design/composio-tools-rework/status.md
+++ b/docs/design/composio-tools-rework/status.md
@@ -1,0 +1,95 @@
+# Status
+
+Source of truth for progress and decisions. Newest decisions at the top of each
+list.
+
+## Stage
+
+Planning. Producing design docs for a PR. No code changed.
+
+## Decisions taken
+
+- **Move from per-action config entries to per-connection, tools exposed over a
+  Composio session (MCP).** Fixes #5173, #5174, and the hundred-entries problem
+  by design. (2026-08-06)
+- **The Composio key never enters the sandbox.** Proven necessary: the only
+  credential that drives the session MCP endpoint is the project key, which
+  reaches every tenant's connections. The Agenta API holds it and forwards.
+  (2026-08-06)
+- **One session per connection, reused forever.** Sessions do not expire
+  (documented). No recreate-on-expiry logic needed. (2026-08-06)
+- **Large results: write to a file in the sandbox mount, return the path.** Our
+  own approach, provider-agnostic. We do not depend on Composio's workbench.
+  (2026-08-06, Mahmoud)
+- **Disable Composio's connection-manager meta-tool.** The frontend already lets
+  the agent ask for a connection; we reuse that. (2026-08-06, Mahmoud)
+
+## The main design choice (both go in the PR)
+
+Two shapes for how the harness reaches the session, both in the PR with a
+comparison:
+
+- **Option 1, call the meta-tools over REST as our own callback tools
+  (recommended).** Reuses the callback transport, cap, tracing, and permissions;
+  works on Pi; keeps the key in the API.
+- **Option 2, proxy the session as an MCP server.** Cleaner in theory, but does
+  not work on Pi, needs a streaming proxy, and moves the trust boundary.
+
+**Recommendation flipped to Option 1 after the Codex review.** The deciding fact:
+the session's meta-tools are callable over plain REST (proven in the spikes), so
+we do not need MCP at all, and the REST path reuses everything we have and runs
+on Pi. Option 2 (the earlier lead) is documented as the alternative and the right
+shape only if we later host user-provided MCP servers.
+
+## Codex review outcome (2026-08-06)
+
+Ran a staff-engineer architecture and soundness review through Codex at xhigh.
+Accepted and folded in:
+
+- Flip to Option 1 (REST meta-tools), because Composio exposes the meta-tools
+  over REST and it reuses our machinery and works on Pi.
+- Session keyed on the tool policy, not the connection, and immutable per policy.
+  Fixes the cross-agent PATCH race. Removes in-place PATCH and warm-reuse-across-
+  policy-change gymnastics.
+- Session state lives in a dedicated `gateway_sessions` mapping table with a
+  uniqueness constraint, not the connection `data` blob.
+- Pin the connected account at session creation.
+- Distinct config discriminator (`gateway_toolkit`), policy vocabulary
+  (`all` / `include` + actions), actions are Agenta keys mapped to slugs
+  server-side.
+- Name the resolver seam change (one config yields several meta-tool specs).
+- Handle a stale action in an explicit policy gracefully at session create.
+- Restructure the plan into three vertical slices.
+
+Pushed back on (judgment, pre-PMF):
+
+- Codex wanted the session keyed per conversation too. Our meta-tool use is
+  stateless and the workbench is off, so per-policy keying is enough. Noted as a
+  refinement only if state leaks.
+- Kept both options documented, per Mahmoud's request, rather than deleting
+  Option 2.
+
+## Open questions
+
+- Does Shape A keep deny, interactive "ask", and tracing? (Investigation in
+  progress.)
+- Permission granularity: if the model only sees meta-tools, "ask before this
+  one specific action" may need action-level enforcement at the API. Product
+  call.
+- Search relevance on our real use cases. Needs a hands-on check.
+- Migration of existing per-action config entries. The compat layer already
+  normalizes two shapes.
+
+## Answered by research (see research.md section 3)
+
+- Session TTL: sessions do not expire.
+- Scoped credential: none that both drives MCP and stays confined.
+- Piping tool calls in a script: Composio's workbench does it over MCP; harness
+  native features do not help portably.
+
+## Reviews planned
+
+- Architecture and repo-conformance review (Codex, staff-engineer lens).
+- Correctness and soundness review, with an explicit guard against over-scoping.
+  Pre-product-market-fit: every unwarranted piece of complexity is a new thing
+  to maintain and a new place for bugs.

--- a/docs/design/composio-tools-rework/status.md
+++ b/docs/design/composio-tools-rework/status.md
@@ -1,95 +1,50 @@
 # Status
 
-Source of truth for progress and decisions. Newest decisions at the top of each
-list.
+Where we are, what we decided, and what is still open.
 
 ## Stage
 
-Planning. Producing design docs for a PR. No code changed.
+Two tracks are running.
 
-## Decisions taken
+- **Quick bug fixes to the current system.** Shipping now, one small PR each. Three are
+  merged, one is open. See "Bug fixes" below.
+- **The redesign.** Planned in these documents. Not built yet.
 
-- **Move from per-action config entries to per-connection, tools exposed over a
-  Composio session (MCP).** Fixes #5173, #5174, and the hundred-entries problem
-  by design. (2026-08-06)
-- **The Composio key never enters the sandbox.** Proven necessary: the only
-  credential that drives the session MCP endpoint is the project key, which
-  reaches every tenant's connections. The Agenta API holds it and forwards.
-  (2026-08-06)
-- **One session per connection, reused forever.** Sessions do not expire
-  (documented). No recreate-on-expiry logic needed. (2026-08-06)
-- **Large results: write to a file in the sandbox mount, return the path.** Our
-  own approach, provider-agnostic. We do not depend on Composio's workbench.
-  (2026-08-06, Mahmoud)
-- **Disable Composio's connection-manager meta-tool.** The frontend already lets
-  the agent ask for a connection; we reuse that. (2026-08-06, Mahmoud)
+## What we decided
 
-## The main design choice (both go in the PR)
+- **Store one setup entry per connection, not one per action.** This fixes the
+  all-or-nothing failure, the version mismatch, and the hundred-entries problem by design.
+- **Give the model two tools at run time: search and run.** The model finds an action,
+  then uses it. It no longer sees a hundred descriptions.
+- **Do not use Composio's "sessions".** Their ready-made box holds a filter, a version, a
+  login, and a code sandbox. We do each of those ourselves with far less code. See
+  `design.md` for why.
+- **Always call Composio's newest version (v3.1)**, so search and run agree. This is the
+  fix for #5174.
+- **Keep the Composio key on our servers.** It can reach every workspace's connections,
+  so it must never enter the sandbox.
 
-Two shapes for how the harness reaches the session, both in the PR with a
-comparison:
+## Bug fixes (current system, shipping now)
 
-- **Option 1, call the meta-tools over REST as our own callback tools
-  (recommended).** Reuses the callback transport, cap, tracing, and permissions;
-  works on Pi; keeps the key in the API.
-- **Option 2, proxy the session as an MCP server.** Cleaner in theory, but does
-  not work on Pi, needs a streaming proxy, and moves the trust boundary.
-
-**Recommendation flipped to Option 1 after the Codex review.** The deciding fact:
-the session's meta-tools are callable over plain REST (proven in the spikes), so
-we do not need MCP at all, and the REST path reuses everything we have and runs
-on Pi. Option 2 (the earlier lead) is documented as the alternative and the right
-shape only if we later host user-provided MCP servers.
-
-## Codex review outcome (2026-08-06)
-
-Ran a staff-engineer architecture and soundness review through Codex at xhigh.
-Accepted and folded in:
-
-- Flip to Option 1 (REST meta-tools), because Composio exposes the meta-tools
-  over REST and it reuses our machinery and works on Pi.
-- Session keyed on the tool policy, not the connection, and immutable per policy.
-  Fixes the cross-agent PATCH race. Removes in-place PATCH and warm-reuse-across-
-  policy-change gymnastics.
-- Session state lives in a dedicated `gateway_sessions` mapping table with a
-  uniqueness constraint, not the connection `data` blob.
-- Pin the connected account at session creation.
-- Distinct config discriminator (`gateway_toolkit`), policy vocabulary
-  (`all` / `include` + actions), actions are Agenta keys mapped to slugs
-  server-side.
-- Name the resolver seam change (one config yields several meta-tool specs).
-- Handle a stale action in an explicit policy gracefully at session create.
-- Restructure the plan into three vertical slices.
-
-Pushed back on (judgment, pre-PMF):
-
-- Codex wanted the session keyed per conversation too. Our meta-tool use is
-  stateless and the workbench is off, so per-policy keying is enough. Noted as a
-  refinement only if state leaks.
-- Kept both options documented, per Mahmoud's request, rather than deleting
-  Option 2.
+- **#5341 big results:** merged (PR #5811).
+- **#5407 clear "not set up" error:** open (PR #5812).
+- **#5173 one broken tool no longer kills the agent:** merged (PR #5813).
+- **#5174 version pin:** merged (PR #5814).
 
 ## Open questions
 
-- Does Shape A keep deny, interactive "ask", and tracing? (Investigation in
-  progress.)
-- Permission granularity: if the model only sees meta-tools, "ask before this
-  one specific action" may need action-level enforcement at the API. Product
-  call.
-- Search relevance on our real use cases. Needs a hands-on check.
-- Migration of existing per-action config entries. The compat layer already
-  normalizes two shapes.
+- Does Composio's search return the right actions for our real use cases? Needs a hands-on
+  check. See `experiment.md`.
+- Can the smallest models handle "search then run" as well as a flat list of tools? See
+  `experiment.md`.
+- Should we let the user ask before one specific action, not just before any action? This
+  needs extra work. It is a product call.
+- What happens to agents that still use the old one-per-action setup? We already accept
+  both, so they keep working.
 
-## Answered by research (see research.md section 3)
+## History
 
-- Session TTL: sessions do not expire.
-- Scoped credential: none that both drives MCP and stays confined.
-- Piping tool calls in a script: Composio's workbench does it over MCP; harness
-  native features do not help portably.
-
-## Reviews planned
-
-- Architecture and repo-conformance review (Codex, staff-engineer lens).
-- Correctness and soundness review, with an explicit guard against over-scoping.
-  Pre-product-market-fit: every unwarranted piece of complexity is a new thing
-  to maintain and a new place for bugs.
+Earlier drafts used a Composio session, first driven over plain calls, then behind an MCP
+server. We dropped both to keep the design small. A Codex review of those drafts still
+holds on the small points (the new setup type, the "which actions are allowed" field, and
+the three-part plan), but its session-specific advice no longer applies.


### PR DESCRIPTION
## What this is

Design docs only, no code. A plan to rework how agents use third-party
(Composio) tools.

## Problem

Today each tool action is a separate entry in the agent's saved config, resolved
live at run start with one uncached serial HTTP call per action. This causes:

- One dead action fails the whole run, with an error that names no tool (#5173).
- Discovery offers tools that resolve then cannot find, a version drift (#5174).
- One 241k-token result wrecks a session (#5341).
- A missing key returns a bare 404 that reads as a missing endpoint (#5407).
- A toolkit like GitHub means ~100 config entries and ~100 schemas per turn.

These are one design choice: each action is a static, individually resolved tool.

## Proposal

One config entry per connection plus a tool policy. At run start the Agenta API
opens a Composio session that holds the policy and the connected account and
exposes the tools. The model calls a few meta-tools (search, get schemas,
execute) instead of holding every schema. The Composio key stays in the API and
never enters the sandbox (proven necessary: the session credential is the
project-wide key that reaches every tenant's connections).

Two shapes are documented with a comparison:

- **Recommended: call the session meta-tools over REST as our own callback
  tools.** Reuses the callback transport, result cap, tracing, and permissions;
  works on every harness including Pi; keeps the key in the API.
- **Considered: proxy the session as an MCP server.** Cleaner in theory but does
  not work on Pi, needs a streaming proxy, and moves the trust boundary.

## Reading order

`README` → `context` → `research` → `design` → `api-design` → `plan`, with
`status` as the source of truth for decisions.

## Review

The design was reviewed for architecture, repo-conformance, and soundness (Codex,
staff-engineer lens). Its accepted findings are folded in: the REST recommendation,
session keyed on tool policy in a dedicated table, pinning the connected account,
a distinct config discriminator, and the resolver seam change. `status.md` records
what was accepted and what was pushed back on.

Base is `release/v0.110.0` per the never-merge-to-main convention.
