### PR TITLE
fix(api): stop echoing submitted secrets in vault validation errors

### DIFF
--- a/api/oss/src/apis/fastapi/vault/router.py
+++ b/api/oss/src/apis/fastapi/vault/router.py
@@ -3,6 +3,8 @@ from typing import List
 
 from fastapi.responses import JSONResponse
 from fastapi import APIRouter, Request, status, HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.routing import APIRoute
 
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions
@@ -22,6 +24,37 @@ from oss.src.core.access.permissions.service import check_action_access
 log = get_module_logger(__name__)
 
 
+class SecretSafeRoute(APIRoute):
+    """A route whose validation errors never echo what the caller sent.
+
+    FastAPI's validation error carries an ``input`` field holding the offending value, so a
+    malformed create put the submitted provider key straight back into the response body,
+    into the caller's terminal, and into anything logging response bodies on this route. A
+    builder hit it live with a real OpenAI key.
+
+    Scoped by construction rather than by matching the request path: every route on this
+    router gets it, and a later path change cannot silently switch it off. Validation
+    behavior is unchanged, only the echo: the caller still learns which field was wrong and
+    why, which is everything it needs, since it already knows what it sent.
+    """
+
+    def get_route_handler(self):
+        original = super().get_route_handler()
+
+        async def handler(request: Request):
+            try:
+                return await original(request)
+            except RequestValidationError as e:
+                raise RequestValidationError(
+                    [
+                        {key: value for key, value in error.items() if key != "input"}
+                        for error in e.errors()
+                    ]
+                ) from None
+
+        return handler
+
+
 class VaultRouter:
     def __init__(
         self,
@@ -29,7 +62,7 @@ class VaultRouter:
     ):
         self.service = vault_service
 
-        self.router = APIRouter()
+        self.router = APIRouter(route_class=SecretSafeRoute)
 
         self.router.add_api_route(
             "/secrets/",

--- a/api/oss/tests/pytest/unit/vault/test_secret_validation_never_echoes.py
+++ b/api/oss/tests/pytest/unit/vault/test_secret_validation_never_echoes.py
@@ -1,0 +1,85 @@
+"""A malformed vault secret create must not echo the secret back.
+
+FastAPI's validation error carries an `input` field holding the offending value. On these
+routes that value IS the provider credential, so a malformed create put a real key into the
+response body, the caller's terminal, and anything logging response bodies on that route. A
+builder hit it live with an OpenAI key.
+
+Pre-existing on main; not introduced by the agent-config-editing work.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from oss.src.apis.fastapi.vault.router import SecretSafeRoute
+
+
+CANARY = "sk-CANARY-DO-NOT-ECHO-abc123"
+
+
+@pytest.fixture
+def client():
+    """A minimal app carrying the real route class over a body that must validate."""
+    from pydantic import BaseModel, model_validator
+
+    # A MODEL-level validator on purpose: that is what the real route has, and it is what
+    # makes the leak. Pydantic reports the whole validated object as `input`, so the error
+    # carries `data` (the credential) even though the offending field is `kind`. A
+    # field-level validator would report only the bad field and would not reproduce this.
+    class SecretPayload(BaseModel):
+        kind: str
+        data: dict
+
+        @model_validator(mode="after")
+        def _known_kind(self):
+            if self.kind != "provider_key":
+                raise ValueError("The provided kind is not a valid SecretKind enum")
+            return self
+
+    app = FastAPI()
+    app.router.route_class = SecretSafeRoute
+
+    @app.post("/secrets/")
+    async def create(secret: SecretPayload):  # pragma: no cover - shape only
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def _malformed():
+    # The shape the route accepts, with a bad kind and a REAL key beside it. This is what
+    # the builder sent: the request is wrong, the credential in it is not.
+    return {"kind": "NOT_A_VALID_KIND", "data": {"provider": "openai", "key": CANARY}}
+
+
+def test_a_malformed_create_does_not_echo_the_secret(client):
+    response = client.post("/secrets/", json=_malformed())
+
+    assert response.status_code == 422
+    assert CANARY not in response.text, (
+        "the submitted secret value came back in the validation error body"
+    )
+
+
+def test_the_caller_still_learns_which_field_was_wrong(client):
+    # The echo is what goes; the diagnosis stays. A caller already knows what it sent, so
+    # the location and the reason are everything it needs to correct the request.
+    response = client.post("/secrets/", json=_malformed())
+    detail = response.json()["detail"]
+
+    assert detail, "the validation error lost its content along with the echo"
+    first = detail[0]
+    assert first["loc"]
+    assert first["msg"]
+    assert "input" not in first
+
+
+def test_a_well_formed_request_is_unaffected(client):
+    # Only the echo changed, not validation. A valid body still passes.
+    response = client.post(
+        "/secrets/",
+        json={"kind": "provider_key", "data": {"provider": "openai"}},
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Context

`POST /api/vault/v1/secrets/` echoes the submitted secret back to the caller when validation fails. Send a payload with an invalid `kind` and a real provider key, and the 422 response contains the key verbatim inside the pydantic error's `input` field. The cause is that the secret DTO validates at the model level, so pydantic reports the whole submitted object as `input`, including the credential, even when the invalid field is just `kind`. This is pre-existing on main, found during the agent-config-editing QA campaign, and included here as a scope addition because it reflects credentials into response bodies (and from there into logs and traces).

## Changes

The vault router now uses a `SecretSafeRoute` route class that strips `input` from validation error details before the response leaves. Every route on the router inherits it, so a later path change cannot silently switch the redaction off, which a path-matching exception handler could. Validation itself is untouched: the caller still gets `loc` and `msg`, which is all it needs since it already knows what it sent.

Before (422 body, key redacted here):

```
{"detail":[{"type":"value_error","loc":["body","secret"],
  "msg":"...not a valid SecretKind enum",
  "input":{"kind":"NOT_A_VALID_KIND","data":{"provider":"openai","key":"sk-..."}}}]}
```

After: same status, same `loc` and `msg`, no `input` field.

## Tests

- New unit file `test_secret_validation_never_echoes.py` with three checks: a canary value never appears in the error body, `loc` and `msg` survive the redaction, and a well-formed request still succeeds.
- The test fixture deliberately uses a model-level validator to match the real leak shape. A field-level fixture does not bite: pydantic then reports only the offending field's value, and the sibling field carrying the credential never leaks. Verified by removing the fix and confirming the test fails.
- Re-ran the original probe against the running dev stack after the fix: same 422, same diagnosis, canary absent.

## What to QA

- In the app, add an LLM provider key with a valid payload. Saving still works.
- With an API client, POST a secret with an invalid `kind` and a fake key. The 422 response names the bad field but does not contain the fake key anywhere in the body.
