### PR TITLE
ci: server-side secret scan on every push and pull request

### DIFF
--- a/.github/workflows/17-secret-scan.yml
+++ b/.github/workflows/17-secret-scan.yml
@@ -1,0 +1,48 @@
+name: 17 - secret scan
+
+# Server-side secret scanning. The local pre-commit hook only guards commits a human
+# types; commits created by tooling and pushed by other plumbing bypass it entirely
+# (that is how four conflicted commits with full tree copies reached a release branch
+# unscanned in August 2026). This job sees every pushed commit regardless of origin.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the pushed RANGE can be scanned, not just the head tree.
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          ./gitleaks version
+
+      - name: Scan the pushed range
+        run: |
+          # Pull requests: scan exactly the commits the PR adds.
+          # Pushes: scan from the previous tip; a new branch scans its whole history
+          # relative to the default branch.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE="origin/${{ github.base_ref }}..HEAD"
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ] && git cat-file -e "${{ github.event.before }}" 2>/dev/null; then
+            RANGE="${{ github.event.before }}..${{ github.sha }}"
+          else
+            RANGE="origin/${{ github.event.repository.default_branch }}..${{ github.sha }}"
+          fi
+          echo "scanning $RANGE"
+          ./gitleaks git --no-banner --exit-code 1 --log-opts="$RANGE" .

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,6 +6,12 @@ useDefault = true
 
 [allowlist]
 paths = [
+  # ------------------------------------------------------- QA RUN RECORDS
+  # Gate-run and benchmark result files carry deliberate high-entropy MARKER
+  # strings (QA-CWD-*, QA-APPROVE-*) that the release-gate cells write and read
+  # back to prove storage round trips. They are test artifacts, not credentials.
+  '''^\.agents/skills/agent-release-gate/resources/qa-gate-runs/.*''',
+  '''^benchmarks/agent-config-editing/results/.*''',
   # ---------------------------------------------------------------- PUBLIC DOCS
   '''^website/docs/reference/api/.*\.mdx''',
   '''^core/docs/docs/reference/api/.*\.mdx''',


### PR DESCRIPTION
## Context

The repo runs gitleaks only in local hooks (husky pre-commit and pre-push). Those guard commits a human types. Commits created by tooling and pushed by other plumbing bypass them entirely: that is how four conflicted commits carrying ~50k-file tree copies reached the release branch unscanned this week, found first by a coworker's manual scan. The trees contained no real secrets (verified with gitleaks itself), but nothing in the pipeline would have caught it if they had.

## Changes

One workflow: on every push and every pull request, install gitleaks and scan exactly the pushed or proposed commit range with the repo's existing `.gitleaks.toml`. The server sees every commit regardless of what created it, which closes the bypass class. New branches scan their whole history relative to the default branch, so nothing arrives unscanned.

## Tests

The workflow runs on this PR itself as its first execution. The scan range logic covers the three event shapes (PR, push to existing branch, push of a new branch).