### PR TITLE
fix(sdk): playground auto-refresh after an agent commit (regression from the migration)

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -862,7 +862,15 @@ def _committed_revision_data(tool_name: Any, output: Any) -> Optional[Dict[str, 
             payload = json.loads(payload)
         except json.JSONDecodeError:
             return None
-    if not isinstance(payload, dict) or not payload.get("count"):
+    if not isinstance(payload, dict):
+        return None
+    # Two success shapes exist. The handler-mode commit (the migration) answers
+    # {"status": "committed", "workflow_revision": {...}} and carries no "count";
+    # the legacy route shape carried {"count": N, ...}. Gate on either, because a
+    # projector that recognizes only one silently drops the playground's refresh
+    # signal for the other (live incident, session b024a6b0: commits stored fine
+    # and the playground never switched to the new version).
+    if payload.get("status") != "committed" and not payload.get("count"):
         return None
 
     revision = payload.get("workflow_revision")

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_park.py
@@ -526,6 +526,56 @@ async def test_commit_revision_tool_result_emits_refresh_data_part() -> None:
 
 
 @pytest.mark.asyncio
+async def test_commit_revision_handler_shape_emits_refresh_data_part() -> None:
+    """The handler-mode commit answers {"status": "committed", ...} with no "count".
+
+    The projector must emit the refresh part for this shape too. It did not, and the
+    suite stayed green because every fixture here pinned the legacy count shape while
+    the live output moved (session b024a6b0: the commit stored, the playground never
+    switched). This test pins the CURRENT live shape.
+    """
+    stream = AgentStream(
+        _records(
+            [
+                {
+                    "kind": "event",
+                    "event": {
+                        "type": "tool_result",
+                        "id": "tool-commit-1",
+                        "output": (
+                            '{"status":"committed","warnings":[],"workflow_revision":{'
+                            '"workflow_variant_id":"variant-1",'
+                            '"id":"revision-1",'
+                            '"version":"4"'
+                            "}}"
+                        ),
+                    },
+                },
+                {"kind": "event", "event": {"type": "done", "stopReason": "stop"}},
+                {
+                    "kind": "result",
+                    "result": {
+                        "ok": True,
+                        "output": "",
+                        "stopReason": "stop",
+                        "sessionId": "conv-1",
+                        "traceId": "trace-1",
+                    },
+                },
+            ]
+        )
+    )
+    parts = [part async for part in agent_run_to_vercel_parts(stream)]
+
+    committed = next(p for p in parts if p["type"] == "data-committed-revision")
+    assert committed["data"] == {
+        "variantId": "variant-1",
+        "revisionId": "revision-1",
+        "version": "4",
+    }
+
+
+@pytest.mark.asyncio
 async def test_commit_revision_result_only_emits_refresh_data_part() -> None:
     parts = [
         part


### PR DESCRIPTION
## Context

Mahmoud's live QA found that after an agent commits a config change and the user approves it, the playground no longer switches to the new version automatically. The commit stores correctly; only the refresh signal is missing.

## Changes

The SDK's stream adapter projects a successful commit_revision tool output into the data-committed-revision stream part the playground listens for. Its gate required the legacy output's count field. The migrated handler-mode commit answers {"status": "committed", ...} with no count, so the projector silently returned nothing. The gate now accepts either shape, with a comment recording the incident.

Before: no data-committed-revision part in the stream (verified in the reported session: zero occurrences across 108 events).
After: the part streams with correct variantId, revisionId, and version (live-verified with the gate's commit round trip; token match; version bump observed).

## Tests

- New unit test pinning the CURRENT handler shape (it cannot pass without the fix). The old tests only pinned the legacy shape, which is why the suite stayed green through the regression.
- Full adapter suite: 15 passed.