### PR TITLE
fix(sdk): the build-an-agent skill stops teaching the deprecated commit shape when ordered operations are on

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -28,8 +28,17 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from ..flags import ordered_operations_enabled
 from ..skills import SkillFile, SkillTemplate
 from .agent_templates import build_agent_template_skill_files
+
+# Read once, at import, exactly like the op catalog builds its tool descriptions. The skill
+# TEACHES the commit surface the catalog ADVERTISES, and one deployment must show one shape:
+# a model that sees the ordered form in the tool description and the legacy form in its skill
+# picks between them unpredictably. That is not hypothetical — a live agent followed a legacy
+# `delta.set` example from this skill against an ordered-operations deployment and replaced a
+# skills list it meant to append to.
+_ORDERED = ordered_operations_enabled()
 
 # The base AGENTS.md preamble. The author's own ``instructions`` are appended after this, so
 # the final AGENTS.md is ``AGENTA_PREAMBLE`` + the author's project conventions.
@@ -99,7 +108,25 @@ GETTING_STARTED_WITH_AGENTA_SKILL = SkillTemplate(
 # of guessing against an `additionalProperties: true` commit schema. A drift test (test_agenta_
 # builtins_reference_files.py) asserts this text names every top-level template field and every
 # tool `type`, so a schema that grows without updating this file fails CI.
-_CONFIG_SCHEMA_REFERENCE = """\
+#
+# Assembled in three pieces: an intro and a commit chapter that follow the deployment's commit
+# surface, around the field-by-field middle that is the same either way.
+_CONFIG_SCHEMA_INTRO_ORDERED = """\
+# The agent config, field by field
+
+Read this before your first `commit_revision`, and whenever a run misbehaves after a commit and
+you need to check the shape.
+
+`parameters.agent` is one object. You change it one field or one list entry at a time, through
+`commit_revision`'s `delta.operations`; a target starts at the configuration root, so every field
+below is addressed as `["parameters", "agent", ...]`. The portable definition — `instructions`,
+`llm`, `tools`, `mcps`, `skills` — is flat on it; the execution parts — `harness`, `runner`,
+`sandbox` — are nested sub-objects. The commit checks your target, NOT the value you write into
+it: a misplaced or misspelled field inside an entry commits fine and only bites when the agent
+next runs. Get the shape right from this reference, and verify with `test_run` after every commit.
+"""
+
+_CONFIG_SCHEMA_INTRO_LEGACY = """\
 # The agent config, field by field
 
 Read this before your first `commit_revision`, and whenever a run misbehaves after a commit and
@@ -111,6 +138,9 @@ you need to check the shape.
 `harness`, `runner`, `sandbox` — are nested sub-objects. The commit does NOT validate this shape:
 a misplaced or misspelled field commits fine and only bites when the agent next runs. Get the
 shape right from this reference, and verify with `test_run` after every commit.
+"""
+
+_CONFIG_SCHEMA_FIELDS = """\
 
 ## The whole object
 
@@ -187,7 +217,9 @@ runner default for that one tool). The six `type` values:
     NOT set `version`; the environment is the pin).
   Optionally add the model-facing surface: `name`, `description`, and `input_schema`.
 - `platform` — an existing Agenta endpoint exposed as a tool: `{ "type": "platform", "op":
-  "discover_tools" }`. The catalog owns everything else about it.
+  "discover_tools" }`. The catalog owns everything else about it. You never commit one: the
+  platform tools you call are injected into your run, and a commit whose `tools` carries a
+  `platform` entry is refused.
 
 ### mcps
 
@@ -245,6 +277,244 @@ the run:
   `permissions` (optional) is the security boundary: `{ "network": { "mode": "on"|"off"|
   "allowlist", "allowlist": ["<CIDR>"] }, "filesystem": "on"|"readonly"|"off", "enforcement":
   "strict"|"best_effort" }`.
+"""
+
+# The commit chapter for a deployment that serves the ordered-operations surface: the
+# read-then-commit loop, the target grammar, the seven operations, and the failure modes the
+# contracts (docs/design/agent-config-editing/contracts/) actually produce. Every example
+# validates against the ordered arm of `_COMMIT_REVISION_INPUT_SCHEMA`; a test asserts it.
+_CONFIG_SCHEMA_COMMIT_ORDERED = """\
+
+## How a commit works
+
+Every change to your configuration is two calls:
+
+1. `read_config` the part you are about to change. The answer carries `base_revision_id`, and the
+   text comes back exactly as stored.
+2. `commit_revision` with that `base_revision_id` and `delta.operations`. The operations run in
+   array order, and if one fails nothing is committed.
+
+You do not write a commit message. The server derives it from your operations.
+
+### Targets
+
+A target is an array of segments from the configuration root. A string segment names an object
+field. An object segment `{"list": L, "key": K}` names ONE entry of list L and stands in place of
+L's name — write the selector instead of the list name, never both.
+
+```json
+["parameters", "agent", {"list": "skills", "key": "release-qa"},
+ {"list": "files", "key": "references/checklist.md"}, "content"]
+```
+
+The keyed lists: `skills` and `mcps` by `name`, `tools` by the tool's `name` (a `reference` tool
+by `name`, else its `slug`), and a skill's `files` by `path`. Any other list takes no selector.
+
+### The seven operations
+
+| Operation | What it does | Last target segment | Carries |
+|---|---|---|---|
+| `set` | replace one field | a field name | `value` |
+| `merge` | deep-merge an object into one field | a field name | `value` |
+| `remove` | delete one field | a field name | — |
+| `edit_text` | replace exact substrings in one string field | a field name | `edits` |
+| `add_item` | append one entry to a list | the list name | `value` |
+| `replace_item` | replace one entry | a selector | `value` |
+| `remove_item` | delete one entry | a selector | — |
+
+`edits` is a list of `{ "old_text": "...", "new_text": "..." }`. `old_text` must occur exactly
+once in that field and match character for character, line breaks included. Copy it out of what
+`read_config` returned; never retype it from memory.
+
+Lists change one entry at a time. You never resend a list to add to it, and nothing you leave out
+is dropped.
+
+To put a workspace file's text into a value, write `{"@ag.file": "<path>"}` where the string would
+go, after writing the file under `.agenta-imports/`. It works anywhere a string is allowed inside
+`value`, and nowhere inside `edits`.
+
+## Mistakes that break your agent
+
+The first group is refused. Read `next_step` on the refusal: it says what to do. `retryable`
+answers a different question — whether sending the SAME call again could work — and it is false
+for almost every refusal, which means correct the call rather than repeat it.
+
+- A stale `base_revision_id`: the head moved between your read and your commit, and the commit
+  answers 409. Call `read_config` again, re-anchor your edits to what it returns, and send the
+  commit again with the new `base_revision_id`.
+- A target that does not exist (`target_not_found`), or a selector on a list that has no key
+  (`unkeyed_collection`). Read that part of the configuration and correct the target.
+- The wrong last segment for the operation (`invalid_target_shape`): `add_item` ends on the list
+  NAME; `replace_item` and `remove_item` end on a selector.
+- An `old_text` that is not there (`text_not_found`) or occurs more than once (`text_not_unique`).
+  Copy the anchor from the read, and add surrounding lines until it appears once.
+- A read that is too big (`output_too_large`). A read is never shortened; the refusal lists
+  `children`, and you read one of those instead.
+- A `platform` tool entry in `tools` (`platform_tool_not_committable`) — the ops you were given
+  to build with, such as `commit_revision`, `test_run`, and `read_config`. They are injected into
+  your run and are not part of your configuration. Remove them and commit again.
+
+The second group commits fine and bites later, at a different spot, because the commit checks
+your target and not the value you wrote into it. Your two detectors are `test_run` (read the
+`resolved` block and the executed tool list, not just the status) and a skill that fails to load
+on the next run.
+
+- `slug` or `content` as top-level fields on a skill entry. The skill's Markdown goes in `body`;
+  a bundled file's text goes in that file's `content` inside `files`. Bites at RUN time: skill
+  parsing rejects the unknown keys and the run fails to load the skill.
+- Any unknown or misspelled key in a skill entry or a tool entry. Same failure point: the run
+  rejects the entry when it parses the config, not the commit.
+- `harness.kind: "claude"` paired with a non-Anthropic `provider`. Claude reaches `anthropic`
+  only. Bites at RUN time: the run's Model & Harness never resolves and the agent never runs.
+- A raw model id on the `claude` harness (Claude selects by alias) or an alias like `sonnet` on a
+  `pi_core`/`pi_agenta` harness (Pi selects by provider/id). Bites silently: the run falls back to
+  a default model with no error. Only `test_run`'s `resolved` block shows the fallback.
+- Naming an `@ag.embed` entry with a selector. An embed has no key, so no operation can address
+  it. Leave those entries where they are.
+
+## Example requests
+
+These are complete `commit_revision` payloads, ready to adapt. Field names match exactly; only the
+values are placeholders. Every `base_revision_id` below is the one the preceding `read_config`
+returned.
+
+Change your instructions — the common case, one `set`:
+
+```json
+{
+  "workflow_revision": {
+    "base_revision_id": "019c4f1e-7a2b-73c8-9f10-2b6d5a1c8e04",
+    "delta": {
+      "operations": [
+        {
+          "operation": "set",
+          "target": ["parameters", "agent", "instructions", "agents_md"],
+          "value": "You triage inbound support emails. For each email: (1) classify it as bug, billing, or question; (2) draft a one-paragraph reply; (3) hand off billing issues instead of answering them."
+        }
+      ]
+    }
+  },
+  "description": "Setting your persona: triage inbound support emails."
+}
+```
+
+`description` is optional, at the top level beside `workflow_revision`. The user sees it next to
+the approval card; it is not stored.
+
+Add a skill — one `add_item`, with the entry as its `value`. The other skills are untouched:
+
+```json
+{
+  "workflow_revision": {
+    "base_revision_id": "019c4f1e-7a2b-73c8-9f10-2b6d5a1c8e04",
+    "delta": {
+      "operations": [
+        {
+          "operation": "add_item",
+          "target": ["parameters", "agent", "skills"],
+          "value": {
+            "name": "code-review-checklist",
+            "description": "Use when reviewing a pull request for style and correctness issues.",
+            "body": "# Code review checklist\\n\\nWalk every changed file against `references/checklist.md` before approving.\\n",
+            "files": [
+              {
+                "path": "references/checklist.md",
+                "content": "- No commented-out code\\n- Tests cover the new branch\\n- Error messages are actionable\\n"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Edit a skill's body in place — `edit_text`, anchored on text you read:
+
+```json
+{
+  "workflow_revision": {
+    "base_revision_id": "019c4f1e-7a2b-73c8-9f10-2b6d5a1c8e04",
+    "delta": {
+      "operations": [
+        {
+          "operation": "edit_text",
+          "target": ["parameters", "agent", {"list": "skills", "key": "code-review-checklist"}, "body"],
+          "edits": [
+            {
+              "old_text": "Walk every changed file against `references/checklist.md` before approving.",
+              "new_text": "Walk every changed file against `references/checklist.md`, then post one summary comment."
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+Remove a skill — `remove_item`, target ending on the selector:
+
+```json
+{
+  "workflow_revision": {
+    "base_revision_id": "019c4f1e-7a2b-73c8-9f10-2b6d5a1c8e04",
+    "delta": {
+      "operations": [
+        {
+          "operation": "remove_item",
+          "target": ["parameters", "agent", {"list": "skills", "key": "code-review-checklist"}]
+        }
+      ]
+    }
+  }
+}
+```
+
+Add one tool — `add_item` on `tools`, with the entry `discover_tools` returned and the
+`connection` slug filled in. Your existing tools stay as they are:
+
+```json
+{
+  "workflow_revision": {
+    "base_revision_id": "019c4f1e-7a2b-73c8-9f10-2b6d5a1c8e04",
+    "delta": {
+      "operations": [
+        {
+          "operation": "add_item",
+          "target": ["parameters", "agent", "tools"],
+          "value": {
+            "type": "gateway",
+            "provider": "composio",
+            "integration": "github",
+            "action": "GITHUB_CREATE_AN_ISSUE",
+            "connection": "conn_9f3a1c",
+            "name": "create_github_issue"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Two changes in one commit are two entries in `operations`, applied in the order you wrote them.
+
+Don't forget:
+
+- Read first. `base_revision_id` comes from `read_config`, never from memory. On a 409, read
+  again and send the commit again with the new one.
+- One entry at a time. `add_item`, `replace_item`, and `remove_item` leave every other entry
+  alone, so you never resend a list.
+- Copy `old_text` out of the read, character for character, including line breaks.
+- Copy `@ag.embed` entries through unchanged; do not try to inline or edit what they point at.
+- After the user connects an integration, re-run `discover_tools` before committing the tool, so
+  the `connection` slug is current.
+- Touch `harness`, `runner`, `sandbox`, and `llm` only when you are intentionally changing them.
+"""
+
+_CONFIG_SCHEMA_COMMIT_LEGACY = """\
 
 ## How a delta commits (merge semantics)
 
@@ -254,8 +524,8 @@ the run:
   value.
 - **Lists replace wholesale.** `tools`, `skills`, and `mcps` are NOT merged item by item — the
   list you send REPLACES the old one. To add one tool, send the full list (your current entries
-  plus the new one). Sending only the new tool wipes the rest, including the platform ops you
-  configure yourself with — which severs them on your next run.
+  plus the new one). Sending only the new tool wipes the rest — every skill, MCP, and gateway
+  tool you left out is gone on your next run.
 - `remove` takes dotted paths, e.g. `parameters.agent.tools`.
 
 ## Mistakes that break your agent
@@ -276,7 +546,7 @@ on the next run.
   `pi_core`/`pi_agenta` harness (Pi selects by provider/id). Bites silently: the run falls back
   to a default model with no error. Only `test_run`'s `resolved` block shows the fallback.
 - Sending a short `tools`/`skills`/`mcps` list. Bites on the NEXT run: lists replace wholesale,
-  so everything you left out is gone — including the platform ops you configure yourself with.
+  so every entry you left out is gone.
 - Rebuilding the whole `parameters.agent` object instead of a narrow delta. Prefer a `delta.set`
   that touches only what you change, so `harness`, `runner`, `sandbox`, and `llm` survive the
   deep merge untouched.
@@ -340,8 +610,9 @@ wholesale too, so include your existing entries (this example assumes the list w
 }
 ```
 
-Adding ONE gateway tool — `tools` replaces wholesale, so resend every entry you already have (your
-existing platform ops, any `@ag.embed` tool) plus the new one. The gateway
+Adding ONE gateway tool — `tools` replaces wholesale, so resend every entry you already have (any
+`@ag.embed` tool, every gateway tool) plus the new one. Leave every `platform` entry out: those
+tools are injected into your run, and a commit that carries one is refused. The gateway
 entry is copied from what `discover_tools` returned, with the `connection` slug filled in.
 CAVEAT: the list below is SHORTENED to keep the example readable — in a real commit, resend your
 ENTIRE current tools list, every entry you have, not this subset:
@@ -349,15 +620,12 @@ ENTIRE current tools list, every entry you have, not this subset:
 ```json
 {
   "workflow_revision": {
-    "message": "Add the GitHub create-issue tool alongside the existing build-kit tools.",
+    "message": "Add the GitHub create-issue tool.",
     "delta": {
       "set": {
         "parameters": {
           "agent": {
             "tools": [
-              { "type": "platform", "op": "discover_tools" },
-              { "type": "platform", "op": "commit_revision" },
-              { "type": "platform", "op": "test_run" },
               { "@ag.embed": { "@ag.references": { "workflow": { "slug": "__ag__some_tool" } },
                                 "@ag.selector": { "path": "parameters.tool" } } },
               {
@@ -392,8 +660,8 @@ Dropping one field with `delta.remove` — a dotted path, no `set` required:
 
 Don't forget:
 
-- Re-send the complete list for `tools`, `skills`, and `mcps`. A one-entry list wipes the rest,
-  including the platform ops you rely on every run.
+- Re-send the complete list for `tools`, `skills`, and `mcps`, minus every `platform` entry. A
+  one-entry list wipes the rest.
 - Copy `@ag.embed` entries through unchanged; do not try to inline or edit what they point at.
 - `message` is a real commit message. Say what changed and why, not a placeholder.
 - After the user connects an integration, re-run `discover_tools` before committing the tool, so
@@ -401,6 +669,12 @@ Don't forget:
 - Keep `harness`, `runner`, `sandbox`, and `llm` out of `delta.set` unless you are intentionally
   changing them; a narrow delta preserves them through the deep merge.
 """
+
+_CONFIG_SCHEMA_REFERENCE = (
+    (_CONFIG_SCHEMA_INTRO_ORDERED if _ORDERED else _CONFIG_SCHEMA_INTRO_LEGACY)
+    + _CONFIG_SCHEMA_FIELDS
+    + (_CONFIG_SCHEMA_COMMIT_ORDERED if _ORDERED else _CONFIG_SCHEMA_COMMIT_LEGACY)
+)
 
 # Bundled reference file: the `inputs_fields` template language. Verified against the runtime
 # resolver (agenta.sdk.utils.resolvers.resolve_target_fields / resolve_json_selector) and the
@@ -543,7 +817,11 @@ Don't forget:
 """
 
 
-_BUILD_AN_AGENT_BODY = """\
+# SKILL.md, assembled from a common spine plus the three passages that describe HOW a commit is
+# made. Those three follow the deployment's commit surface (see `_ORDERED` above); everything
+# else — the decision table, discovery, triggers, verification, the footguns — is the same either
+# way, and lives in one copy so it cannot drift between the two arms.
+_BUILD_HEAD = """\
 # Build an Agenta agent
 
 You turn a plain-language request into a working, verified Agenta agent. You are configuring
@@ -567,6 +845,30 @@ You decide four things under `parameters.agent`:
 - `tools`: integration actions and platform ops you can call.
 - `skills`: reusable know-how packaged as skill templates.
 - A trigger: either a schedule or an event subscription, only when the user asked for one.
+"""
+
+_BUILD_SHAPE_ORDERED = """\
+
+Everything else is fixed unless the user explicitly asks to change it. Configure yourself with
+`commit_revision` by changing `parameters.agent` fields; do not create a separate app.
+
+Editing files in your workspace does not change your configuration. That copy is rebuilt, and
+the edits are lost. Change your instructions and configuration only through `commit_revision`.
+
+Every commit is the same loop: `read_config` the part you are about to change, then
+`commit_revision` with the `base_revision_id` that read returned and a list of `delta.operations`.
+Each operation changes one field or one list entry, and leaves everything else alone.
+
+Read `references/config-schema.md` before your first `commit_revision`. It gives:
+
+- the exact shape of every field,
+- the tool-entry types,
+- the skill-entry shape,
+- the operations a commit is made of, with a worked example of each,
+- the mistakes that break your agent.
+"""
+
+_BUILD_SHAPE_LEGACY = """\
 
 Everything else is fixed unless the user explicitly asks to change it. Configure yourself with
 `commit_revision` by setting `parameters.agent` fields; do not create a separate app.
@@ -581,6 +883,9 @@ Read `references/config-schema.md` before your first `commit_revision`. It gives
 - the skill-entry shape,
 - the delta merge semantics,
 - the mistakes that break your agent.
+"""
+
+_BUILD_TABLE_AND_LOOP = """\
 
 Read `references/trigger-inputs.md` before you write a schedule or subscription's
 `inputs_fields`.
@@ -628,9 +933,22 @@ Do not discover tools or triggers for an ask that does not need them.
 4. If a needed connection is not ready, call `request_connection` for that integration and stop.
    Give the user the connection request and wait for them. Re-run `discover_tools` after they
    connect; do not silently create, fake, or skip connections.
+"""
+
+_BUILD_STEP5_ORDERED = """\
+5. Configure yourself. `read_config` the parts you are about to change, then `commit_revision`
+   with that `base_revision_id`: `add_item` each chosen `capability.tool` entry and needed
+   alternative onto `tools`, and `set` `instructions.agents_md`. This is an approval stop. If the
+   commit is denied or fails, earlier connections or triggers are not undone.
+"""
+
+_BUILD_STEP5_LEGACY = """\
 5. Configure yourself. Put the chosen `capability.tool` entries and needed alternatives in
    `tools`, write `instructions.agents_md`, and call `commit_revision`. This is an approval stop.
    If the commit is denied or fails, earlier connections or triggers are not undone.
+"""
+
+_BUILD_LOOP_TAIL = """\
 6. Verify with `test_run`. First warn the user that this is a real run: external write tools may
    perform their action if approved. Then call `test_run` with `inputs.messages` as a blunt
    instruction-framed test message and `expectations.terminal_tool` set to the final tool that
@@ -690,6 +1008,40 @@ Example:
   pushes the run to reach for a shell or code tool to sift it, which trips a separate
   code-execution approval gate and derails the run. Pick the narrowest action (a `FIND_*` or
   `GET_A_*` over a `LIST_ALL_*`), resolve an id once, and pin it into the instructions.
+"""
+
+_BUILD_TOOLS_AND_FAILURES_ORDERED = """\
+
+## Prefer wired tools
+
+Prefer your wired tools (`read_config`, `discover_tools`, `request_input`, `request_connection`,
+`commit_revision`, `test_run`, `query_spans`, `create_schedule`, `list_schedules`,
+`discover_triggers`, `create_subscription`, `test_subscription`, `list_deliveries`,
+`remove_schedule`, `remove_subscription`) over harness builtins. Touch Terminal, RemoteTrigger,
+File tools, or raw HTTP only when your wired tools cannot do the job, and say so when you do.
+
+## When something fails
+
+- A denied or failed `commit_revision` does not undo earlier connections or triggers; they still
+  exist. Do not redo them.
+- A refused commit says what to do next in `next_step`. `retryable` only says whether the SAME
+  call could work, and it is false for most refusals: correct the call rather than repeat it.
+- A commit refused with 409 means the head moved between your read and your commit. Call
+  `read_config` again, re-anchor your edits to what it returns, and send the commit again with the
+  new `base_revision_id`.
+- The commit checks your targets, not your values: a wrong shape inside an entry commits fine and
+  surfaces at run time — a skill fails to load, the model silently falls back, a tool goes missing.
+  So verify with `test_run` after every commit: read `resolved` and the executed tool list, and
+  when something is off, check the shape against `references/config-schema.md` and commit the fix;
+  do not start over.
+- After any commit, existing schedules and subscriptions still point at the previous revision.
+  Re-point them so they run the new config.
+- If `test_run`'s `resolved` harness or model differs from what you committed, the config silently
+  fell back (usually a harness/model/provider mismatch). Fix it against `references/config-schema.md`
+  and re-test.
+"""
+
+_BUILD_TOOLS_AND_FAILURES_LEGACY = """\
 
 ## Prefer wired tools
 
@@ -713,6 +1065,9 @@ HTTP only when your wired tools cannot do the job, and say so when you do.
 - If `test_run`'s `resolved` harness or model differs from what you committed, the config silently
   fell back (usually a harness/model/provider mismatch). Fix it against `references/config-schema.md`
   and re-test.
+"""
+
+_BUILD_FOOTGUNS = """\
 
 ## Footguns
 
@@ -724,6 +1079,20 @@ HTTP only when your wired tools cannot do the job, and say so when you do.
 - A subscription without a ready connection never fires.
 - Trigger inputs must match what the instructions expect, or the run starts empty.
 """
+
+_BUILD_AN_AGENT_BODY = (
+    _BUILD_HEAD
+    + (_BUILD_SHAPE_ORDERED if _ORDERED else _BUILD_SHAPE_LEGACY)
+    + _BUILD_TABLE_AND_LOOP
+    + (_BUILD_STEP5_ORDERED if _ORDERED else _BUILD_STEP5_LEGACY)
+    + _BUILD_LOOP_TAIL
+    + (
+        _BUILD_TOOLS_AND_FAILURES_ORDERED
+        if _ORDERED
+        else _BUILD_TOOLS_AND_FAILURES_LEGACY
+    )
+    + _BUILD_FOOTGUNS
+)
 
 BUILD_AN_AGENT_SKILL = SkillTemplate(
     name="build-an-agent",

--- a/sdks/python/agenta/sdk/agents/flags.py
+++ b/sdks/python/agenta/sdk/agents/flags.py
@@ -1,0 +1,34 @@
+"""Deployment flags the agent surface reads at import.
+
+One definition, because two readers of the same switch is how a model ends up seeing two
+shapes at once. The op catalog decides which commit surface to advertise from
+:func:`ordered_operations_enabled`, and the ``build-an-agent`` skill decides which commit
+surface to TEACH from the same call. A live agent once followed the skill's example over the
+tool description and replaced a list it meant to append to; that is only possible when the two
+can disagree.
+
+This module imports nothing but ``os`` on purpose. ``agenta.sdk.agents.platform`` is kept out
+of the eager import path (it reaches the SDK singleton), so an adapter cannot import the
+catalog just to read a flag.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["ORDERED_OPERATIONS_ENV", "ordered_operations_enabled"]
+
+# Gate for the ordered-operations commit surface: `read_config` plus `delta.operations`.
+ORDERED_OPERATIONS_ENV = "AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED"
+
+# Mirrors `_TRUTHY` in `api/oss/src/utils/env.py`, which the SDK cannot import: that module
+# is the API's foundational config and pulls the whole API package in behind it. The two
+# sets must accept the same spellings, or a deployment written as `enabled` turns the
+# ordered arm on in the API while the catalog keeps advertising the legacy surface. The
+# equality is pinned by `api/oss/tests/pytest/unit/workflows/test_ordered_operations_flag.py`,
+# which is on the one side that can import both.
+_TRUTHY = frozenset({"true", "1", "t", "y", "yes", "on", "enable", "enabled"})
+
+
+def ordered_operations_enabled() -> bool:
+    return (os.getenv(ORDERED_OPERATIONS_ENV) or "").strip().lower() in _TRUTHY

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -26,12 +26,12 @@ imported platform package.
 
 from __future__ import annotations
 
-import os
 from copy import deepcopy
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from agenta.sdk.agents.flags import ORDERED_OPERATIONS_ENV, ordered_operations_enabled
 from agenta.sdk.agents.tools.errors import UnknownPlatformOpError
 from agenta.sdk.agents.tools.models import ToolCall
 from agenta.sdk.utils.types import CATALOG_TYPES
@@ -818,19 +818,11 @@ _QUERY_SPANS_INPUT_SCHEMA: Dict[str, Any] = {
 # One switch for the API and the model-facing catalog: the SDK runs inside the API
 # process, so both read the same variable. The rollout order needs API support to exist
 # before the catalog advertises the shape (gate 3, plan ruling).
-_ORDERED_OPERATIONS_ENV = "AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED"
-
-# Mirrors `_TRUTHY` in `api/oss/src/utils/env.py`, which the SDK cannot import: that module
-# is the API's foundational config and pulls the whole API package in behind it. The two
-# sets must accept the same spellings, or a deployment written as `enabled` turns the
-# ordered arm on in the API while the catalog keeps advertising the legacy surface. The
-# equality is pinned by `api/oss/tests/pytest/unit/workflows/test_ordered_operations_flag.py`,
-# which is on the one side that can import both.
-_TRUTHY = frozenset({"true", "1", "t", "y", "yes", "on", "enable", "enabled"})
-
-
-def _ordered_operations_enabled() -> bool:
-    return (os.getenv(_ORDERED_OPERATIONS_ENV) or "").strip().lower() in _TRUTHY
+# The switch itself lives in `agenta.sdk.agents.flags`, a leaf module, because the
+# `build-an-agent` skill reads it too and an adapter cannot import this package (it reaches
+# the SDK singleton). Re-exported under the private names this module has always used.
+_ORDERED_OPERATIONS_ENV = ORDERED_OPERATIONS_ENV
+_ordered_operations_enabled = ordered_operations_enabled
 
 
 # The legacy description, for the flag-off surface. The wholesale-list sentence names the

--- a/sdks/python/oss/tests/pytest/unit/agents/test_build_an_agent_commit_teaching.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_build_an_agent_commit_teaching.py
@@ -1,0 +1,206 @@
+"""The ``build-an-agent`` skill teaches the commit shape the deployment actually serves.
+
+The skill body and its ``references/config-schema.md`` are assembled at import from
+``AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED``, exactly like the op catalog assembles the
+``commit_revision`` description and input schema. The two must agree: an agent that reads the
+ordered form in its tool description and the legacy form in its skill picks between them from
+call to call. That is not a theory — a live agent followed a `delta.set` example out of this
+skill against an ordered-operations deployment, sent a one-entry ``skills`` list, and replaced
+the user's existing skill.
+
+So these tests read the skill in BOTH flag states (a subprocess each, since the flag is read at
+import) and assert that neither state ever mentions the other's shape.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+import jsonschema
+import pytest
+
+FLAG = "AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED"
+
+_PROBE = """
+import json
+from agenta.sdk.agents.adapters.agenta_builtins import BUILD_AN_AGENT_SKILL
+from agenta.sdk.agents.platform.op_catalog import get_platform_op
+
+print(json.dumps({
+    "body": BUILD_AN_AGENT_SKILL.body,
+    "files": {f.path: f.content for f in BUILD_AN_AGENT_SKILL.files},
+    "commit_schema": get_platform_op("commit_revision").resolved_input_schema(),
+}))
+"""
+
+# Every spelling of the legacy commit shape. The skill is the model's copy-paste source, so one
+# of these surviving into an ordered deployment is the incident again.
+LEGACY_COMMIT_MARKERS = ("delta.set", "delta.remove", "wholesale", "replaces the old")
+
+
+def _skill(flag_value):
+    env = dict(os.environ)
+    if flag_value is None:
+        env.pop(FLAG, None)
+    else:
+        env[FLAG] = flag_value
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+@pytest.fixture(scope="module")
+def ordered():
+    return _skill("true")
+
+
+@pytest.fixture(scope="module")
+def legacy():
+    return _skill(None)
+
+
+def _commit_surface(skill):
+    """The two files that teach how a commit is made."""
+    return {
+        "SKILL.md": skill["body"],
+        "references/config-schema.md": skill["files"]["references/config-schema.md"],
+    }
+
+
+def _example_payloads(config_schema):
+    """The JSON blocks under `## Example requests` that are whole `commit_revision` calls."""
+    section = config_schema.split("## Example requests", 1)[1]
+    blocks = re.findall(r"```json\n(.*?)```", section, flags=re.DOTALL)
+    payloads = [json.loads(block) for block in blocks]
+    return [p for p in payloads if isinstance(p, dict) and "workflow_revision" in p]
+
+
+class TestOrderedModeNeverTeachesTheLegacyShape:
+    """The class detector for the data-loss incident."""
+
+    @pytest.mark.parametrize("marker", LEGACY_COMMIT_MARKERS)
+    def test_the_commit_surface_never_names_the_legacy_delta(self, ordered, marker):
+        for name, content in _commit_surface(ordered).items():
+            assert marker not in content, (
+                f"{name} still teaches the legacy commit shape ({marker!r}) while the "
+                "deployment serves ordered operations; a model that sees both shapes picks "
+                "one unpredictably"
+            )
+
+    def test_no_example_writes_a_commit_message(self, ordered):
+        # With ordered operations on, the server derives the message from the operations and
+        # `message` is off the model-visible schema entirely. An example that writes one earns
+        # a schema rejection on a closed object.
+        config_schema = ordered["files"]["references/config-schema.md"]
+        assert '"message"' not in config_schema
+
+    def test_a_playbook_may_name_delta_set_only_for_test_run(self, ordered):
+        # `test_run` keeps its uncommitted `delta.set` in both flag states, and the playbooks
+        # legitimately name it. Anywhere else, in any bundled file, it is the legacy commit.
+        for path, content in ordered["files"].items():
+            if path == "references/config-schema.md":
+                continue
+            for line in content.splitlines():
+                if "delta.set" in line or "delta.remove" in line:
+                    assert "test_run" in line, (
+                        f"{path} names a commit delta outside a test_run context: {line!r}"
+                    )
+
+
+class TestOrderedModeTeachesTheOrderedShape:
+    @pytest.mark.parametrize(
+        "phrase",
+        ["read_config", "base_revision_id", "delta.operations"],
+    )
+    def test_the_skill_body_teaches_the_read_then_commit_loop(self, ordered, phrase):
+        assert phrase in ordered["body"]
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            "set",
+            "merge",
+            "remove",
+            "edit_text",
+            "add_item",
+            "replace_item",
+            "remove_item",
+        ],
+    )
+    def test_the_reference_documents_every_operation(self, ordered, operation):
+        assert f"`{operation}`" in ordered["files"]["references/config-schema.md"]
+
+    @pytest.mark.parametrize(
+        "failure",
+        ["409", "target_not_found", "text_not_unique", "output_too_large", "next_step"],
+    )
+    def test_the_reference_documents_the_ordered_failure_modes(self, ordered, failure):
+        assert failure in ordered["files"]["references/config-schema.md"]
+
+    def test_the_examples_cover_the_cases_an_agent_actually_commits(self, ordered):
+        # The five things a builder agent does: rewrite its instructions, add a skill, edit a
+        # skill it already has, drop one, and wire a tool. Each is one operation on one target
+        # tail, which is what the model copies.
+        payloads = _example_payloads(ordered["files"]["references/config-schema.md"])
+        shapes = set()
+        for payload in payloads:
+            for operation in payload["workflow_revision"]["delta"]["operations"]:
+                tail = operation["target"][-1]
+                shapes.add((operation["operation"], json.dumps(tail, sort_keys=True)))
+        assert ("set", '"agents_md"') in shapes
+        assert ("add_item", '"skills"') in shapes
+        assert ("add_item", '"tools"') in shapes
+        assert ("edit_text", '"body"') in shapes
+        assert (
+            "remove_item",
+            '{"key": "code-review-checklist", "list": "skills"}',
+        ) in (shapes)
+
+    def test_every_example_validates_against_the_real_commit_schema(self, ordered):
+        # Field for field against what the catalog advertises: the schema is closed at every
+        # level, so an invented field, a `message`, or a missing `base_revision_id` fails here.
+        schema = ordered["commit_schema"]
+        payloads = _example_payloads(ordered["files"]["references/config-schema.md"])
+        assert len(payloads) == 5
+        for payload in payloads:
+            jsonschema.validate(payload, schema)
+
+
+class TestLegacyModeKeepsTheLegacyTeaching:
+    """The mirror: a flag-off deployment really does work the legacy way."""
+
+    def test_the_reference_still_teaches_the_delta_merge_semantics(self, legacy):
+        config_schema = legacy["files"]["references/config-schema.md"]
+        assert "## How a delta commits (merge semantics)" in config_schema
+        assert "delta.set" in config_schema
+        assert "wholesale" in config_schema
+        assert '"message"' in config_schema
+
+    @pytest.mark.parametrize(
+        "phrase", ["read_config", "base_revision_id", "operations"]
+    )
+    def test_nothing_mentions_the_ordered_shape(self, legacy, phrase):
+        # `read_config` does not exist on a flag-off deployment, so naming it would send the
+        # agent after a tool it does not have.
+        for name, content in _commit_surface(legacy).items():
+            assert phrase not in content, f"{name} names the ordered shape ({phrase!r})"
+
+    def test_every_example_validates_against_the_real_commit_schema(self, legacy):
+        schema = legacy["commit_schema"]
+        section = legacy["files"]["references/config-schema.md"].split(
+            "## Example requests", 1
+        )[1]
+        payloads = [
+            json.loads(block)
+            for block in re.findall(r"```json\n(.*?)```", section, flags=re.DOTALL)
+        ]
+        assert len(payloads) == 4
+        for payload in payloads:
+            jsonschema.validate(payload, schema)


### PR DESCRIPTION
## Context

The playground bundles a `build-an-agent` skill into every builder agent. Its body and its
`references/config-schema.md` still taught the old commit format — `workflow_revision.delta.set`
with wholesale list replacement, plus four copy-paste JSON examples of that shape — while the
`commit_revision` tool, on a deployment with `AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED` on,
serves a schema and description for the ordered form only (`read_config` for a
`base_revision_id`, then `delta.operations` with `add_item` / `remove_item` / anchored
`edit_text`).

A live agent read both, followed the skill's example over the tool description, sent a
one-element `skills` list under `delta.set`, and wiped the user's existing skill. `op_catalog`
already records why this happens, in the comment on the delta arm: a model that sees both shapes
picks a different one from call to call. The catalog closed that hole for the tool schema; the
skill was still open.

## Changes

The skill content is now flag-conditional, on the same predicate the catalog uses. With the flag
on, the commit teaching describes only the ordered form; with it off, the legacy teaching is
byte-identical to what shipped, because flag-off deployments really do work that way. Neither
state mentions the other's shape.

Before (ordered deployment, what the skill told the agent to send):

```json
{"workflow_revision": {"message": "Add a code-review-checklist skill.",
  "delta": {"set": {"parameters": {"agent": {"skills": [{"name": "code-review-checklist", "...": "..."}]}}}}}}
```

After:

```json
{"workflow_revision": {"base_revision_id": "019c4f1e-7a2b-73c8-9f10-2b6d5a1c8e04",
  "delta": {"operations": [{"operation": "add_item", "target": ["parameters", "agent", "skills"],
                            "value": {"name": "code-review-checklist", "...": "..."}}]}}}
```

- `agenta/sdk/agents/flags.py` (new): `ordered_operations_enabled()` moves to a leaf module so
  the skill and the catalog read one definition. `op_catalog` re-exports the private names it
  always had, so `test_ordered_operations_flag.py` keeps importing them from there. The adapter
  cannot import the `platform` package itself — it reaches the SDK singleton and is deliberately
  kept off the eager import path.
- `agenta_builtins.py`: `SKILL.md` and `references/config-schema.md` are assembled from a common
  spine plus the passages that describe how a commit is made. The ordered arm teaches the
  read-then-commit loop, the target grammar, the seven operations, worked examples for the five
  things a builder agent actually commits (instructions, add a skill, edit a skill body, remove a
  skill, add a tool), and the failure modes from the contracts: a stale `base_revision_id`
  answers 409 and you re-read, `target_not_found`, `text_not_unique`, a read refused with
  `output_too_large` returns `children`, and `next_step` rather than `retryable` is the recovery
  field. It also drops the derived-message teaching (`message` is off the ordered schema) and
  adds `read_config` to the wired-tools list, where it exists.
- One fix that applies in **both** arms: the skill said a `platform` tool entry is something you
  commit, and the legacy example resent three of them inside `tools`. The server refuses any
  `platform`-kind entry on an agent's commit (`platform_tool_not_committable`), so that example
  was a guaranteed refusal, and it contradicted the legacy tool description. The entries are out
  of the example and the rule is stated where the tool types are documented.

The playbooks under `agent_templates/` needed no change: their `delta.set.parameters.agent.tools`
references are `test_run`'s uncommitted delta, which keeps the legacy shape in both flag states.

## Tests

New `oss/tests/pytest/unit/agents/test_build_an_agent_commit_teaching.py` reads the skill in both
flag states (one subprocess each, since the flag is read at import) and asserts:

- the ordered commit surface never says `delta.set`, `delta.remove`, or `wholesale` — the class
  detector for this incident;
- a bundled file may name `delta.set` only on a line that also names `test_run`;
- every ordered example validates against `commit_revision`'s real resolved input schema, which
  is closed at every level, and the five examples cover the five operations an agent commits;
- the ordered reference documents every operation and the ordered failure modes;
- the mirror: with the flag off, the reference still teaches the merge semantics and names
  nothing from the ordered form.

Green in both flag states: the SDK unit suite (`oss/tests/pytest/unit`, 2003 passed; the one
failure, `test_streaming.py::test_cli_stream_terminal_only_on_empty_request`, fails identically
on the unmodified branch) and the API unit suite (2085 passed), including
`test_static_catalog.py`, `test_build_kit_overlay.py`, and `test_ordered_operations_flag.py`.
`ruff format` and `ruff check` clean on every touched file.
