### PR TITLE
fix(runner): cap oversized gateway tool results before they reach the model

### DIFF
--- a/services/runner/src/tools/callback.ts
+++ b/services/runner/src/tools/callback.ts
@@ -49,8 +49,23 @@ export const MAX_RAW_RESPONSE_BYTES = MAX_BODY_BYTES * 4;
  * the usual ~4 bytes/token for English/JSON text. Env-overridable like the other budgets in this
  * file (e.g. TOOL_CALL_TIMEOUT_MS above).
  */
-export const MAX_GATEWAY_RESULT_BYTES = Number(
-  process.env.AGENTA_AGENT_TOOLS_GATEWAY_RESULT_MAX_BYTES ?? 100_000,
+export const DEFAULT_GATEWAY_RESULT_BYTES = 100_000;
+
+/** Parse a gateway-result byte budget from an env value, falling back to `fallback` for anything
+ *  that is not a positive safe integer. A bare `Number()` would accept `"Infinity"` (which would
+ *  disable the cap), negative values (which make the byte slice keep almost the whole result),
+ *  fractions, and `NaN`, so all of those fall back to the default instead. */
+export function resolveGatewayResultBytes(
+  raw: string | undefined,
+  fallback: number = DEFAULT_GATEWAY_RESULT_BYTES,
+): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export const MAX_GATEWAY_RESULT_BYTES = resolveGatewayResultBytes(
+  process.env.AGENTA_AGENT_TOOLS_GATEWAY_RESULT_MAX_BYTES,
 );
 
 /** Appended in place of the omitted tail when a gateway result is cut at
@@ -85,12 +100,13 @@ function trailingIncompleteUtf8Length(buf: Buffer, end: number): number {
   return 0;
 }
 
-/** Truncate `text` to `maxBytes` (UTF-8) at a character boundary, signaling the cut the same
- *  way the replay transcript does (`transcript.ts` TOOL_RESULT_RENDER_MAX_CHARS) so the model
- *  can tell it was truncated. Guarantees the returned prefix is `<= maxBytes` and the omitted
- *  count is exact and non-negative — a byte-only cut can split a multibyte sequence, which
- *  decodes to U+FFFD and can push the result back over `maxBytes`. An optional `steeringMessage`
- *  is appended after the omitted-count marker, telling the model what to do about the cut
+/** Truncate `text` so the WHOLE returned string (the retained prefix plus the omitted-count
+ *  marker and any `steeringMessage`) stays within `maxBytes` (UTF-8), cutting at a character
+ *  boundary so a multibyte sequence is never split. Room for the suffix is reserved before the
+ *  prefix is chosen, so the budget bounds the entire result, not just the prefix; when `maxBytes`
+ *  is smaller than the suffix itself, the suffix alone is returned. The cut is signaled the same
+ *  way the replay transcript does (`transcript.ts` TOOL_RESULT_RENDER_MAX_CHARS) so the model can
+ *  tell it was truncated, and the optional `steeringMessage` tells it what to do about the cut
  *  (narrow, filter, paginate) instead of leaving it to guess from a bare truncation notice. */
 export function capToolResultText(
   text: string,
@@ -99,10 +115,21 @@ export function capToolResultText(
 ): string {
   const buf = Buffer.from(text, "utf-8");
   if (buf.length <= maxBytes) return text;
-  const safeEnd = maxBytes - trailingIncompleteUtf8Length(buf, maxBytes);
+  // The omitted-byte count is at most the whole buffer length, so `buf.length` bounds the
+  // marker's digit width. Reserving against that upper bound keeps the final string within
+  // `maxBytes` whenever `maxBytes` can hold the suffix at all.
+  const suffixFor = (omitted: number): string => {
+    const marker = ` [... ${omitted} bytes omitted]`;
+    return steeringMessage ? `${marker}\n\n${steeringMessage}` : marker;
+  };
+  const reservedForSuffix = Buffer.byteLength(suffixFor(buf.length), "utf-8");
+  const prefixBudget = Math.max(0, maxBytes - reservedForSuffix);
+  const safeEnd = Math.max(
+    0,
+    prefixBudget - trailingIncompleteUtf8Length(buf, prefixBudget),
+  );
   const truncated = buf.subarray(0, safeEnd).toString("utf-8");
-  const marker = `${truncated} [... ${buf.length - safeEnd} bytes omitted]`;
-  return steeringMessage ? `${marker}\n\n${steeringMessage}` : marker;
+  return `${truncated}${suffixFor(buf.length - safeEnd)}`;
 }
 
 /**

--- a/services/runner/src/tools/callback.ts
+++ b/services/runner/src/tools/callback.ts
@@ -24,19 +24,41 @@ export const EMPTY_OBJECT_SCHEMA = {
 };
 
 /** Bound a tool result body so a malformed/oversized upstream response cannot exhaust runner
- *  memory or blow out the model's context. Same cap and mechanism as tool-mcp-http.ts. */
+ *  memory. Same cap and mechanism as tool-mcp-http.ts. This is a memory-safety ceiling, not the
+ *  model-facing content budget — see `MAX_GATEWAY_RESULT_BYTES` below for that. */
 export const MAX_BODY_BYTES = 1_000_000;
 
 /**
  * Hard ceiling on the RAW wire body read off the socket, before any JSON parsing. Larger than
- * `MAX_BODY_BYTES` (the model-facing cap on the parsed `content` field) because the raw body is
- * a JSON envelope wrapping `content` plus its own quoting/escaping overhead — capping the raw
- * read at exactly `MAX_BODY_BYTES` would truncate the envelope itself and corrupt otherwise
- * well-formed JSON before it ever reaches `capToolResultText`. This is purely a memory-safety
- * backstop against a malformed/oversized upstream; `content` still gets capped to
- * `MAX_BODY_BYTES` after parsing, same as before.
+ * `MAX_BODY_BYTES` because the raw body is a JSON envelope wrapping `content` plus its own
+ * quoting/escaping overhead — capping the raw read at exactly `MAX_BODY_BYTES` would truncate
+ * the envelope itself and corrupt otherwise well-formed JSON before it ever reaches
+ * `capToolResultText`. This is purely a memory-safety backstop against a malformed/oversized
+ * upstream; the parsed `content` field is capped far tighter, to `MAX_GATEWAY_RESULT_BYTES`,
+ * before it ever reaches the model.
  */
 export const MAX_RAW_RESPONSE_BYTES = MAX_BODY_BYTES * 4;
+
+/**
+ * Model-facing cap on ONE gateway/Composio tool result, well below `MAX_BODY_BYTES`. A single
+ * `get_pull_request` call was observed returning ~1 MB (~241,000 tokens) of `content`, which blew
+ * out the whole conversation's context in one turn (issue #5341). `MAX_BODY_BYTES` stays as the
+ * outer memory-safety ceiling on the raw transport; this is the much tighter budget the model
+ * itself should ever see from a gateway call, so an oversized result reads as "narrow your query"
+ * rather than "here is a wall of text, good luck." ~100,000 bytes approximates 25,000 tokens at
+ * the usual ~4 bytes/token for English/JSON text. Env-overridable like the other budgets in this
+ * file (e.g. TOOL_CALL_TIMEOUT_MS above).
+ */
+export const MAX_GATEWAY_RESULT_BYTES = Number(
+  process.env.AGENTA_AGENT_TOOLS_GATEWAY_RESULT_MAX_BYTES ?? 100_000,
+);
+
+/** Appended in place of the omitted tail when a gateway result is cut at
+ *  `MAX_GATEWAY_RESULT_BYTES`, steering the model to narrow the call instead of retrying blind. */
+export const GATEWAY_RESULT_STEERING_MESSAGE =
+  "This result was too large to return in full. Narrow your query (add filters, a smaller " +
+  "date range, or specific fields), request a summary, or paginate and fetch fewer items " +
+  "per call, then try again.";
 
 /** How many trailing bytes of `buf[0..end)` are a truncated (incomplete) UTF-8 sequence that
  *  should be walked back past before decoding — otherwise `Buffer.toString` replaces the
@@ -67,13 +89,20 @@ function trailingIncompleteUtf8Length(buf: Buffer, end: number): number {
  *  way the replay transcript does (`transcript.ts` TOOL_RESULT_RENDER_MAX_CHARS) so the model
  *  can tell it was truncated. Guarantees the returned prefix is `<= maxBytes` and the omitted
  *  count is exact and non-negative — a byte-only cut can split a multibyte sequence, which
- *  decodes to U+FFFD and can push the result back over `maxBytes`. */
-export function capToolResultText(text: string, maxBytes: number = MAX_BODY_BYTES): string {
+ *  decodes to U+FFFD and can push the result back over `maxBytes`. An optional `steeringMessage`
+ *  is appended after the omitted-count marker, telling the model what to do about the cut
+ *  (narrow, filter, paginate) instead of leaving it to guess from a bare truncation notice. */
+export function capToolResultText(
+  text: string,
+  maxBytes: number = MAX_BODY_BYTES,
+  steeringMessage?: string,
+): string {
   const buf = Buffer.from(text, "utf-8");
   if (buf.length <= maxBytes) return text;
   const safeEnd = maxBytes - trailingIncompleteUtf8Length(buf, maxBytes);
   const truncated = buf.subarray(0, safeEnd).toString("utf-8");
-  return `${truncated} [... ${buf.length - safeEnd} bytes omitted]`;
+  const marker = `${truncated} [... ${buf.length - safeEnd} bytes omitted]`;
+  return steeringMessage ? `${marker}\n\n${steeringMessage}` : marker;
 }
 
 /**
@@ -213,7 +242,7 @@ export async function callAgentaTool(
   try {
     parsed = JSON.parse(bodyText);
   } catch {
-    return capToolResultText(bodyText);
+    return capToolResultText(bodyText, MAX_GATEWAY_RESULT_BYTES, GATEWAY_RESULT_STEERING_MESSAGE);
   }
 
   const content = parsed?.call?.data?.content;
@@ -265,10 +294,20 @@ export async function callAgentaTool(
       typeof status?.message === "string" && status.message
         ? `tool call ${callRef} failed: ${status.message}`
         : `tool call ${callRef} failed`;
-    throw new Error(capToolResultText(detail ? `${reason}\n${detail}` : reason));
+    throw new Error(
+      capToolResultText(
+        detail ? `${reason}\n${detail}` : reason,
+        MAX_GATEWAY_RESULT_BYTES,
+        GATEWAY_RESULT_STEERING_MESSAGE,
+      ),
+    );
   }
 
-  if (typeof content === "string") return capToolResultText(content);
-  if (content != null) return capToolResultText(detail);
-  return capToolResultText(bodyText);
+  if (typeof content === "string") {
+    return capToolResultText(content, MAX_GATEWAY_RESULT_BYTES, GATEWAY_RESULT_STEERING_MESSAGE);
+  }
+  if (content != null) {
+    return capToolResultText(detail, MAX_GATEWAY_RESULT_BYTES, GATEWAY_RESULT_STEERING_MESSAGE);
+  }
+  return capToolResultText(bodyText, MAX_GATEWAY_RESULT_BYTES, GATEWAY_RESULT_STEERING_MESSAGE);
 }

--- a/services/runner/tests/unit/callback.test.ts
+++ b/services/runner/tests/unit/callback.test.ts
@@ -15,6 +15,8 @@ import {
   callAgentaTool,
   capToolResultText,
   readBoundedResponseText,
+  resolveGatewayResultBytes,
+  DEFAULT_GATEWAY_RESULT_BYTES,
   MAX_BODY_BYTES,
   MAX_GATEWAY_RESULT_BYTES,
   MAX_RAW_RESPONSE_BYTES,
@@ -44,14 +46,23 @@ describe("capToolResultText", () => {
     assert.ok(capped.startsWith("a".repeat(100)));
   });
 
-  it("respects a custom byte cap", () => {
-    const capped = capToolResultText("abcdefghij", 4);
-    assert.equal(capped, "abcd [... 6 bytes omitted]");
+  it("keeps the whole capped result, marker included, within the byte budget", () => {
+    const capped = capToolResultText("a".repeat(500), 80);
+    assert.ok(
+      Buffer.byteLength(capped, "utf-8") <= 80,
+      "the retained prefix plus the omitted-count marker must fit within the cap",
+    );
+    assert.match(capped, /^a+ \[\.\.\. \d+ bytes omitted\]$/);
   });
 
-  it("appends the steering message after the omitted-count marker when provided", () => {
-    const capped = capToolResultText("abcdefghij", 4, "narrow your query");
-    assert.equal(capped, "abcd [... 6 bytes omitted]\n\nnarrow your query");
+  it("appends the steering message and still stays within the byte budget", () => {
+    const capped = capToolResultText("a".repeat(500), 120, "narrow your query");
+    assert.ok(
+      Buffer.byteLength(capped, "utf-8") <= 120,
+      "the prefix, marker, and steering message together must fit within the cap",
+    );
+    assert.ok(capped.includes("bytes omitted"));
+    assert.ok(capped.endsWith("\n\nnarrow your query"));
   });
 
   it("omits the steering message entirely when text is not truncated", () => {
@@ -60,18 +71,16 @@ describe("capToolResultText", () => {
   });
 
   it("truncates at a UTF-8 character boundary instead of splitting a multibyte sequence", () => {
-    // "café" = c(1) a(1) f(1) é(2 bytes: 0xC3 0xA9). A cap of 4 lands mid-"é" (byte-cap would
-    // slice after the 0xC3 lead byte, decode the dangling continuation-less byte as U+FFFD,
-    // and re-expand to 3 bytes — pushing the result back OVER the 4-byte cap).
-    const capped = capToolResultText("café", 4);
-    const [prefix] = capped.split(" [...");
-    assert.ok(!prefix.includes("�"), "must not contain a replacement character");
+    // "é" is 2 bytes (0xC3 0xA9). A byte-only cut can land mid-character, decode the dangling
+    // lead byte as U+FFFD (3 bytes), and push the result back over the cap. The whole result
+    // must stay within the cap and never contain a replacement character.
+    const capped = capToolResultText("é".repeat(200), 80);
+    assert.ok(!capped.includes("�"), "must not contain a replacement character");
     assert.ok(
-      Buffer.byteLength(prefix, "utf-8") <= 4,
-      "the character-boundary-safe prefix must fit within the byte cap",
+      Buffer.byteLength(capped, "utf-8") <= 80,
+      "the whole result must fit within the byte cap",
     );
-    assert.equal(prefix, "caf"); // the incomplete "é" is walked back past entirely
-    assert.equal(capped, "caf [... 2 bytes omitted]"); // "café" is 5 bytes; 3 kept, 2 omitted
+    assert.ok(capped.includes("bytes omitted"));
   });
 
   it("omitted-byte count is exact and never negative for multibyte content straddling the cap", () => {
@@ -94,6 +103,22 @@ describe("capToolResultText", () => {
         `prefix must fit within the byte cap (cap=${cap})`,
       );
     }
+  });
+});
+
+describe("resolveGatewayResultBytes", () => {
+  it("falls back to the default for absent or invalid env values", () => {
+    for (const raw of [undefined, "Infinity", "-1", "0", "1.5", "notanumber", ""]) {
+      assert.equal(
+        resolveGatewayResultBytes(raw, DEFAULT_GATEWAY_RESULT_BYTES),
+        DEFAULT_GATEWAY_RESULT_BYTES,
+        `expected the default for ${JSON.stringify(raw)}`,
+      );
+    }
+  });
+
+  it("accepts a positive safe integer", () => {
+    assert.equal(resolveGatewayResultBytes("250000", DEFAULT_GATEWAY_RESULT_BYTES), 250_000);
   });
 });
 
@@ -174,7 +199,10 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       "call-1",
       {},
     );
-    assert.ok(Buffer.byteLength(result, "utf-8") < MAX_BODY_BYTES);
+    assert.ok(
+      Buffer.byteLength(result, "utf-8") <= MAX_GATEWAY_RESULT_BYTES,
+      "the model-facing gateway result must not exceed MAX_GATEWAY_RESULT_BYTES",
+    );
     assert.ok(result.includes("bytes omitted"));
     assert.ok(
       result.includes(GATEWAY_RESULT_STEERING_MESSAGE),
@@ -195,6 +223,7 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       "call-1",
       {},
     );
+    assert.ok(Buffer.byteLength(result, "utf-8") <= MAX_GATEWAY_RESULT_BYTES);
     assert.ok(result.includes("bytes omitted"));
     assert.ok(result.includes(GATEWAY_RESULT_STEERING_MESSAGE));
   });
@@ -208,6 +237,7 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       "call-1",
       {},
     );
+    assert.ok(Buffer.byteLength(result, "utf-8") <= MAX_GATEWAY_RESULT_BYTES);
     assert.ok(result.includes("bytes omitted"));
     assert.ok(result.includes(GATEWAY_RESULT_STEERING_MESSAGE));
   });

--- a/services/runner/tests/unit/callback.test.ts
+++ b/services/runner/tests/unit/callback.test.ts
@@ -16,7 +16,9 @@ import {
   capToolResultText,
   readBoundedResponseText,
   MAX_BODY_BYTES,
+  MAX_GATEWAY_RESULT_BYTES,
   MAX_RAW_RESPONSE_BYTES,
+  GATEWAY_RESULT_STEERING_MESSAGE,
 } from "../../src/tools/callback.ts";
 
 const realFetch = globalThis.fetch;
@@ -45,6 +47,16 @@ describe("capToolResultText", () => {
   it("respects a custom byte cap", () => {
     const capped = capToolResultText("abcdefghij", 4);
     assert.equal(capped, "abcd [... 6 bytes omitted]");
+  });
+
+  it("appends the steering message after the omitted-count marker when provided", () => {
+    const capped = capToolResultText("abcdefghij", 4, "narrow your query");
+    assert.equal(capped, "abcd [... 6 bytes omitted]\n\nnarrow your query");
+  });
+
+  it("omits the steering message entirely when text is not truncated", () => {
+    const capped = capToolResultText("hi", 100, "narrow your query");
+    assert.equal(capped, "hi");
   });
 
   it("truncates at a UTF-8 character boundary instead of splitting a multibyte sequence", () => {
@@ -147,8 +159,10 @@ describe("readBoundedResponseText (RUN-TOOLCAP-2: cap before materializing the w
 });
 
 describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
-  it("caps an oversized string `content` before returning it to the model", async () => {
-    const huge = "x".repeat(MAX_BODY_BYTES + 1000);
+  it("caps an oversized string `content` at the gateway budget, well below the raw transport cap", async () => {
+    // A get_pull_request-shaped result: comfortably under the 1 MB raw transport cap, but well
+    // over the much tighter model-facing gateway budget (issue #5341).
+    const huge = "x".repeat(MAX_GATEWAY_RESULT_BYTES + 1000);
     stubFetch(
       200,
       JSON.stringify({ call: { data: { content: huge }, status: "done" } }),
@@ -160,12 +174,16 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       "call-1",
       {},
     );
-    assert.ok(Buffer.byteLength(result, "utf-8") <= MAX_BODY_BYTES + 200);
+    assert.ok(Buffer.byteLength(result, "utf-8") < MAX_BODY_BYTES);
     assert.ok(result.includes("bytes omitted"));
+    assert.ok(
+      result.includes(GATEWAY_RESULT_STEERING_MESSAGE),
+      "an oversized gateway result must carry the steering message telling the model to narrow/paginate",
+    );
   });
 
-  it("caps an oversized non-string `content` (JSON.stringify'd) before returning it", async () => {
-    const huge = { data: "y".repeat(MAX_BODY_BYTES + 1000) };
+  it("caps an oversized non-string `content` (JSON.stringify'd) before returning it, with the steering message", async () => {
+    const huge = { data: "y".repeat(MAX_GATEWAY_RESULT_BYTES + 1000) };
     stubFetch(
       200,
       JSON.stringify({ call: { data: { content: huge }, status: "done" } }),
@@ -178,10 +196,11 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       {},
     );
     assert.ok(result.includes("bytes omitted"));
+    assert.ok(result.includes(GATEWAY_RESULT_STEERING_MESSAGE));
   });
 
   it("caps a raw oversized body when the response is not the expected envelope shape", async () => {
-    stubFetch(200, "z".repeat(MAX_BODY_BYTES + 1000));
+    stubFetch(200, "z".repeat(MAX_GATEWAY_RESULT_BYTES + 1000));
     const result = await callAgentaTool(
       "http://agenta.local/tools/call",
       "Bearer tok",
@@ -190,9 +209,10 @@ describe("callAgentaTool result capping (RUN-TOOLCAP-1)", () => {
       {},
     );
     assert.ok(result.includes("bytes omitted"));
+    assert.ok(result.includes(GATEWAY_RESULT_STEERING_MESSAGE));
   });
 
-  it("leaves a small result untouched", async () => {
+  it("leaves a small result untouched, without the steering message", async () => {
     stubFetch(
       200,
       JSON.stringify({ call: { data: { content: "ok" }, status: "done" } }),


### PR DESCRIPTION
## Summary

A gateway (Composio) tool result reached the model with only the 1 MB raw-transport ceiling (`MAX_BODY_BYTES`) between it and the model context — roughly 250,000 tokens. One `get_pull_request` call once returned ~241,000 tokens of `content` in a single turn and wrecked the conversation.

- Before: `callAgentaTool` capped the parsed `content` field at `MAX_BODY_BYTES` (1,000,000 bytes) before handing it to the model, with only a generic `[... N bytes omitted]` marker.
- After: gateway/callback results are capped at a much smaller, env-overridable budget, `MAX_GATEWAY_RESULT_BYTES` (default 100,000 bytes, ~25,000 tokens; override via `AGENTA_AGENT_TOOLS_GATEWAY_RESULT_MAX_BYTES`). `MAX_BODY_BYTES` is unchanged and still serves as the outer memory-safety ceiling on the raw transport (it's also shared with `tool-mcp-http.ts`'s inbound request cap, so it stays put). On truncation the model now also gets a short steering message telling it to narrow, filter, or paginate instead of retrying blind.

## Test plan

- [x] `pnpm exec vitest run tests/unit/callback.test.ts` — 18/18 passing, including a new test asserting an oversized gateway result is capped below the raw transport ceiling and carries the steering message, plus direct `capToolResultText` coverage for the new `steeringMessage` parameter.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] Full runner unit suite (`pnpm exec vitest run --project unit`) — 122 files / 2091 tests passing.

Fixes #5341