### PR TITLE
fix(api): return a clear not-configured status for tool and trigger discovery when Composio is unset

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -793,6 +793,7 @@ else:
 
 tools_adapter_registry = ToolsGatewayRegistry(
     adapters=_composio_adapters,
+    unconfigured=({} if env.composio.enabled else {"composio": "COMPOSIO_API_KEY"}),
 )
 
 tools_service = ToolsService(
@@ -811,6 +812,7 @@ if env.composio.enabled:
 
 triggers_adapter_registry = TriggersGatewayRegistry(
     adapters=_composio_triggers_adapters,
+    unconfigured=({} if env.composio.enabled else {"composio": "COMPOSIO_API_KEY"}),
 )
 
 triggers_dao = TriggersDAO(engine=_transactions_engine)

--- a/api/oss/src/apis/fastapi/tools/router.py
+++ b/api/oss/src/apis/fastapi/tools/router.py
@@ -57,6 +57,7 @@ from oss.src.core.tools.exceptions import (
     ConnectionInvalidError,
     ConnectionNotFoundError,
     DiscoveryUnsupportedError,
+    ProviderNotConfiguredError,
     ProviderNotFoundError,
     ToolSlugInvalidError,
 )
@@ -97,10 +98,12 @@ log = get_module_logger(__name__)
 def handle_adapter_exceptions():
     """Map provider/adapter failures to HTTP, surfacing the upstream detail.
 
-    Unknown providers → 404. Any upstream failure (Composio 4xx such as a
-    rejected argument set, or a malformed response) → 424 carrying the
-    provider's own message so the client can show it instead of a generic 500.
-    A true upstream 5xx → 502.
+    Unknown providers → 404. A recognized provider missing required
+    configuration (e.g. composio without COMPOSIO_API_KEY) → 503, naming the
+    env var, so a self-hoster can tell "not set up" from "endpoint missing".
+    Any upstream failure (Composio 4xx such as a rejected argument set, or a
+    malformed response) → 424 carrying the provider's own message so the
+    client can show it instead of a generic 500. A true upstream 5xx → 502.
     """
 
     def decorator(func):
@@ -108,6 +111,11 @@ def handle_adapter_exceptions():
         async def wrapper(*args, **kwargs):
             try:
                 return await func(*args, **kwargs)
+            except ProviderNotConfiguredError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=str(e),
+                ) from e
             except ProviderNotFoundError as e:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,

--- a/api/oss/src/apis/fastapi/triggers/router.py
+++ b/api/oss/src/apis/fastapi/triggers/router.py
@@ -43,6 +43,7 @@ from oss.src.apis.fastapi.triggers.models import (
 from oss.src.core.triggers.exceptions import (
     AdapterError,
     ConnectionNotFoundError,
+    ProviderNotConfiguredError,
     ProviderNotFoundError,
     ScheduleNotFoundError,
     SubscriptionNotFoundError,
@@ -64,10 +65,12 @@ _ENQUEUE_TIMEOUT_SECONDS = 5.0
 def handle_adapter_exceptions():
     """Map provider/adapter failures to HTTP, surfacing the upstream detail.
 
-    Unknown providers → 404. Any upstream failure (Composio 4xx such as a
-    rejected ``trigger_config``, or a malformed response) → 424 carrying the
-    provider's own message so the client can show it instead of a generic 500.
-    A true upstream 5xx → 502.
+    Unknown providers → 404. A recognized provider missing required
+    configuration (e.g. composio without COMPOSIO_API_KEY) → 503, naming the
+    env var, so a self-hoster can tell "not set up" from "endpoint missing".
+    Any upstream failure (Composio 4xx such as a rejected ``trigger_config``,
+    or a malformed response) → 424 carrying the provider's own message so the
+    client can show it instead of a generic 500. A true upstream 5xx → 502.
     """
 
     def decorator(func):
@@ -75,6 +78,11 @@ def handle_adapter_exceptions():
         async def wrapper(*args, **kwargs):
             try:
                 return await func(*args, **kwargs)
+            except ProviderNotConfiguredError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=str(e),
+                ) from e
             except ProviderNotFoundError as e:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,

--- a/api/oss/src/core/tools/exceptions.py
+++ b/api/oss/src/core/tools/exceptions.py
@@ -17,6 +17,22 @@ class ProviderNotFoundError(ToolsError):
         super().__init__(f"Provider not found: {provider_key}")
 
 
+class ProviderNotConfiguredError(ToolsError):
+    """Raised when provider_key names a provider this deployment recognizes, but
+    whose adapter was not registered because required configuration (e.g. an API
+    key) is missing. Distinct from ``ProviderNotFoundError`` so the API boundary
+    can tell a self-hoster "set this env var" instead of a bare 404.
+    """
+
+    def __init__(self, provider_key: str, *, env_var: str):
+        self.provider_key = provider_key
+        self.env_var = env_var
+        super().__init__(
+            f"{provider_key} is not configured on this deployment. "
+            f"Set {env_var} to enable it."
+        )
+
+
 class ConnectionNotFoundError(ToolsError):
     """Raised when a connection cannot be found."""
 

--- a/api/oss/src/core/tools/registry.py
+++ b/api/oss/src/core/tools/registry.py
@@ -1,7 +1,10 @@
-from typing import Dict, ItemsView
+from typing import Dict, ItemsView, Optional
 
 from oss.src.core.tools.interfaces import ToolsGatewayInterface
-from oss.src.core.tools.exceptions import ProviderNotFoundError
+from oss.src.core.tools.exceptions import (
+    ProviderNotConfiguredError,
+    ProviderNotFoundError,
+)
 
 
 class ToolsGatewayRegistry:
@@ -11,14 +14,24 @@ class ToolsGatewayRegistry:
         self,
         *,
         adapters: Dict[str, ToolsGatewayInterface],
+        unconfigured: Optional[Dict[str, str]] = None,
     ):
         self._adapters = adapters
+        # provider_key -> required env var, for providers this deployment
+        # recognizes but whose adapter wasn't built (e.g. composio without
+        # COMPOSIO_API_KEY). Lets get() raise ProviderNotConfiguredError
+        # instead of ProviderNotFoundError for those keys.
+        self._unconfigured = unconfigured or {}
 
     def get(self, provider_key: str) -> ToolsGatewayInterface:
         adapter = self._adapters.get(provider_key)
-        if not adapter:
-            raise ProviderNotFoundError(provider_key)
-        return adapter
+        if adapter:
+            return adapter
+        if provider_key in self._unconfigured:
+            raise ProviderNotConfiguredError(
+                provider_key, env_var=self._unconfigured[provider_key]
+            )
+        raise ProviderNotFoundError(provider_key)
 
     def keys(self) -> list[str]:
         return list(self._adapters.keys())

--- a/api/oss/src/core/triggers/exceptions.py
+++ b/api/oss/src/core/triggers/exceptions.py
@@ -17,6 +17,22 @@ class ProviderNotFoundError(TriggersError):
         super().__init__(f"Provider not found: {provider_key}")
 
 
+class ProviderNotConfiguredError(TriggersError):
+    """Raised when provider_key names a provider this deployment recognizes, but
+    whose adapter was not registered because required configuration (e.g. an API
+    key) is missing. Distinct from ``ProviderNotFoundError`` so the API boundary
+    can tell a self-hoster "set this env var" instead of a bare 404.
+    """
+
+    def __init__(self, provider_key: str, *, env_var: str):
+        self.provider_key = provider_key
+        self.env_var = env_var
+        super().__init__(
+            f"{provider_key} is not configured on this deployment. "
+            f"Set {env_var} to enable it."
+        )
+
+
 class SubscriptionNotFoundError(TriggersError):
     """Raised when a subscription_id does not exist in the project."""
 

--- a/api/oss/src/core/triggers/registry.py
+++ b/api/oss/src/core/triggers/registry.py
@@ -1,7 +1,10 @@
-from typing import Dict, ItemsView
+from typing import Dict, ItemsView, Optional
 
 from oss.src.core.triggers.interfaces import TriggersGatewayInterface
-from oss.src.core.triggers.exceptions import ProviderNotFoundError
+from oss.src.core.triggers.exceptions import (
+    ProviderNotConfiguredError,
+    ProviderNotFoundError,
+)
 
 
 class TriggersGatewayRegistry:
@@ -11,14 +14,24 @@ class TriggersGatewayRegistry:
         self,
         *,
         adapters: Dict[str, TriggersGatewayInterface],
+        unconfigured: Optional[Dict[str, str]] = None,
     ):
         self._adapters = adapters
+        # provider_key -> required env var, for providers this deployment
+        # recognizes but whose adapter wasn't built (e.g. composio without
+        # COMPOSIO_API_KEY). Lets get() raise ProviderNotConfiguredError
+        # instead of ProviderNotFoundError for those keys.
+        self._unconfigured = unconfigured or {}
 
     def get(self, provider_key: str) -> TriggersGatewayInterface:
         adapter = self._adapters.get(provider_key)
-        if not adapter:
-            raise ProviderNotFoundError(provider_key)
-        return adapter
+        if adapter:
+            return adapter
+        if provider_key in self._unconfigured:
+            raise ProviderNotConfiguredError(
+                provider_key, env_var=self._unconfigured[provider_key]
+            )
+        raise ProviderNotFoundError(provider_key)
 
     def keys(self) -> list[str]:
         return list(self._adapters.keys())

--- a/api/oss/tests/pytest/unit/tools/test_discovery.py
+++ b/api/oss/tests/pytest/unit/tools/test_discovery.py
@@ -31,7 +31,13 @@ from oss.src.core.tools.providers.composio.dtos import (
     ComposioSearchQueryResult,
     ComposioSearchResult,
 )
-from oss.src.core.tools.exceptions import AdapterError, DiscoveryUnsupportedError
+from oss.src.core.tools.exceptions import (
+    AdapterError,
+    DiscoveryUnsupportedError,
+    ProviderNotConfiguredError,
+    ProviderNotFoundError,
+)
+from oss.src.core.tools.registry import ToolsGatewayRegistry
 from oss.src.core.tools.service import ToolsService
 
 FIXTURE = Path(__file__).parent / "fixtures" / "composio_search_tools.json"
@@ -604,6 +610,57 @@ async def test_discover_route_maps_unsupported_provider_to_422(monkeypatch):
             body=CapabilitiesQuery(use_cases=["x"], provider="agenta"),
         )
     assert caught.value.status_code == 422
+
+
+async def test_discover_route_maps_provider_not_configured_to_503(monkeypatch):
+    # Composio disabled (no COMPOSIO_API_KEY) -> the service raises
+    # ProviderNotConfiguredError, not the generic ProviderNotFoundError. A
+    # self-hoster must see a clear "not configured" status, not a bare 404.
+    async def _discover(**_kwargs):
+        raise ProviderNotConfiguredError("composio", env_var="COMPOSIO_API_KEY")
+
+    async def _allow(**_kwargs):
+        return True
+
+    monkeypatch.setattr("oss.src.apis.fastapi.tools.router.check_action_access", _allow)
+
+    with pytest.raises(HTTPException) as caught:
+        await _router_with_discover(_discover).discover_capabilities(
+            _request(),
+            body=CapabilitiesQuery(use_cases=["create a github issue"]),
+        )
+
+    assert caught.value.status_code == 503
+    assert "COMPOSIO_API_KEY" in caught.value.detail
+    assert "composio" in caught.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Registry: composio unset (unconfigured) vs a genuinely unknown provider
+# ---------------------------------------------------------------------------
+
+
+def test_registry_raises_not_configured_for_known_but_disabled_provider():
+    registry = ToolsGatewayRegistry(
+        adapters={},
+        unconfigured={"composio": "COMPOSIO_API_KEY"},
+    )
+
+    with pytest.raises(ProviderNotConfiguredError) as caught:
+        registry.get("composio")
+
+    assert caught.value.env_var == "COMPOSIO_API_KEY"
+    assert "COMPOSIO_API_KEY" in str(caught.value)
+
+
+def test_registry_raises_not_found_for_unknown_provider():
+    registry = ToolsGatewayRegistry(
+        adapters={},
+        unconfigured={"composio": "COMPOSIO_API_KEY"},
+    )
+
+    with pytest.raises(ProviderNotFoundError):
+        registry.get("some-other-provider")
 
 
 def test_capabilities_query_rejects_empty_use_cases():

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_discovery.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_discovery.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from oss.src.apis.fastapi.triggers.models import TriggerDiscoveryQuery
@@ -19,7 +20,12 @@ from oss.src.core.triggers.dtos import (
     TriggerConnection,
     TriggerDiscoveryConnectionState,
 )
-from oss.src.core.triggers.exceptions import AdapterError
+from oss.src.core.triggers.exceptions import (
+    AdapterError,
+    ProviderNotConfiguredError,
+    ProviderNotFoundError,
+)
+from oss.src.core.triggers.registry import TriggersGatewayRegistry
 from oss.src.core.triggers.service import (
     TriggersService,
     _TRIGGER_DISCOVERY_NO_CONFIDENT_MATCH_NOTE,
@@ -201,6 +207,60 @@ async def test_discover_route_returns_trigger_capabilities(monkeypatch):
     assert captured["use_cases"] == ["new github issue opened"]
     assert captured["provider_key"] == "composio"
     assert captured["limit_alternatives"] == 2
+
+
+async def test_discover_route_maps_provider_not_configured_to_503(monkeypatch):
+    # Composio disabled (no COMPOSIO_API_KEY) -> the service raises
+    # ProviderNotConfiguredError, not the generic ProviderNotFoundError. A
+    # self-hoster must see a clear "not configured" status, not a bare 404.
+    async def _discover(**_kwargs):
+        raise ProviderNotConfiguredError("composio", env_var="COMPOSIO_API_KEY")
+
+    async def _allow(**_kwargs):
+        return True
+
+    monkeypatch.setattr(
+        "oss.src.apis.fastapi.triggers.router.check_action_access",
+        _allow,
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await _router_with_discover(_discover).discover_triggers(
+            _request(),
+            body=TriggerDiscoveryQuery(use_cases=["new github issue opened"]),
+        )
+
+    assert caught.value.status_code == 503
+    assert "COMPOSIO_API_KEY" in caught.value.detail
+    assert "composio" in caught.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Registry: composio unset (unconfigured) vs a genuinely unknown provider
+# ---------------------------------------------------------------------------
+
+
+def test_registry_raises_not_configured_for_known_but_disabled_provider():
+    registry = TriggersGatewayRegistry(
+        adapters={},
+        unconfigured={"composio": "COMPOSIO_API_KEY"},
+    )
+
+    with pytest.raises(ProviderNotConfiguredError) as caught:
+        registry.get("composio")
+
+    assert caught.value.env_var == "COMPOSIO_API_KEY"
+    assert "COMPOSIO_API_KEY" in str(caught.value)
+
+
+def test_registry_raises_not_found_for_unknown_provider():
+    registry = TriggersGatewayRegistry(
+        adapters={},
+        unconfigured={"composio": "COMPOSIO_API_KEY"},
+    )
+
+    with pytest.raises(ProviderNotFoundError):
+        registry.get("some-other-provider")
 
 
 def test_discover_route_is_registered_at_expected_path():


### PR DESCRIPTION
## Summary

On a self-hosted deployment without `COMPOSIO_API_KEY` set, `POST /tools/discover` and `POST /triggers/discover` (and any other adapter lookup for the `composio` provider) returned a bare **404** — `"Provider not found: composio"`. That reads as "endpoint missing," so a self-hoster can't tell a real bug from a missing setup step.

**Before**: `404 Not Found` — `{"detail": "Provider not found: composio"}`

**After**: `503 Service Unavailable` — `{"detail": "composio is not configured on this deployment. Set COMPOSIO_API_KEY to enable it."}`

A genuinely unknown `provider_key` (a typo, or any value other than `composio`) still returns `404` — that distinction matters because `provider` is a free-form string field on the request body, not a validated enum.

## Root cause

`ToolsGatewayRegistry.get()` / `TriggersGatewayRegistry.get()` raise a single `ProviderNotFoundError` for any missing adapter, whether the key is genuinely unknown or just unconfigured (composio's adapter is only registered when `env.composio.enabled` is true). The router's `handle_adapter_exceptions` mapped that one exception straight to 404.

## Fix

- Added `ProviderNotConfiguredError` to both `oss.src.core.tools.exceptions` and `oss.src.core.triggers.exceptions` — raised when a provider is recognized by the deployment but its adapter wasn't built due to missing config.
- Both `ToolsGatewayRegistry` and `TriggersGatewayRegistry` now accept an `unconfigured: Dict[provider_key, env_var]` map. `get()` raises `ProviderNotConfiguredError` for keys in that map instead of the generic `ProviderNotFoundError`.
- `api/entrypoints/routers.py` wires `unconfigured={"composio": "COMPOSIO_API_KEY"}` when `env.composio.enabled` is false.
- `handle_adapter_exceptions` in both the tools and triggers FastAPI routers now maps `ProviderNotConfiguredError` → `503` with the env var named in the detail message, before falling back to `404` for `ProviderNotFoundError`.

Since `registry.get()` is the single choke point every tools/triggers adapter call goes through (discovery, catalog browse, resolve, execute), this fix isn't discovery-only — any call that hits the unconfigured `composio` provider now gets the same clear `503` instead of a bare `404`.

## Testing

Added targeted unit tests for both domains:
- `api/oss/tests/pytest/unit/tools/test_discovery.py` — router-level test asserting `POST /tools/discover` maps `ProviderNotConfiguredError` to `503` with `COMPOSIO_API_KEY` in the detail, plus registry-level tests distinguishing "known but unconfigured" from "unknown provider."
- `api/oss/tests/pytest/unit/triggers/test_triggers_discovery.py` — same coverage for `POST /triggers/discover`.

Ran the full `tools` + `triggers` unit suites locally: 238 passed. `ruff format --check` and `ruff check` clean on all touched files.

Fixes #5407