### PR TITLE
fix(api): use Composio v3.1 consistently (#5174)

### DIFF
--- a/api/entrypoints/dispatcher_composio.py
+++ b/api/entrypoints/dispatcher_composio.py
@@ -36,7 +36,7 @@ INGRESS_URL = os.getenv(
     "AGENTA_INGRESS_URL", "http://api:8000/triggers/composio/events/"
 )
 COMPOSIO_API_URL = os.getenv(
-    "COMPOSIO_API_URL", "https://backend.composio.dev/api/v3"
+    "COMPOSIO_API_URL", "https://backend.composio.dev/api/v3.1"
 ).rstrip("/")
 
 

--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -786,9 +786,7 @@ _composio_adapters = {}
 if env.composio.enabled:
     _composio_adapters["composio"] = ComposioToolsAdapter(
         api_key=env.composio.api_key,  # type: ignore[arg-type]  # guarded by .enabled
-        # v3.1 so discover (list/search) and resolve/execute agree on one slug
-        # set — see ComposioConfig.tools_api_url and #5174.
-        api_url=env.composio.tools_api_url,
+        api_url=env.composio.api_url,
     )
 else:
     log.warning("Composio not enabled — set COMPOSIO_API_KEY to activate gateway tools")

--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -786,7 +786,9 @@ _composio_adapters = {}
 if env.composio.enabled:
     _composio_adapters["composio"] = ComposioToolsAdapter(
         api_key=env.composio.api_key,  # type: ignore[arg-type]  # guarded by .enabled
-        api_url=env.composio.api_url,
+        # v3.1 so discover (list/search) and resolve/execute agree on one slug
+        # set — see ComposioConfig.tools_api_url and #5174.
+        api_url=env.composio.tools_api_url,
     )
 else:
     log.warning("Composio not enabled — set COMPOSIO_API_KEY to activate gateway tools")

--- a/api/oss/src/core/tools/providers/composio/catalog.py
+++ b/api/oss/src/core/tools/providers/composio/catalog.py
@@ -209,13 +209,14 @@ class ComposioCatalogClient:
         """
         page_limit = min(limit, MAX_PAGE_SIZE) if limit else DEFAULT_PAGE_SIZE
 
-        # Do NOT pin ``toolkit_versions=latest`` here: Composio's "latest" toolkit
-        # version emits SHORT action slugs (e.g. GITHUB_ACCEPT_REPOSITORY_INVITATION)
-        # that its single-tool GET and execute endpoints reject unless the same
-        # version is threaded through — and execute rejects the latest short slugs
-        # outright. The default (pinned) toolkit version emits the canonical LONG
-        # slugs (GITHUB_ACCEPT_A_REPOSITORY_INVITATION) that get_action AND execute
-        # both accept with no version param, so list/get/execute stay consistent.
+        # Slug consistency comes from the adapter's base URL, not from a version
+        # param here. The tools adapter is pinned to Composio API v3.1 (see
+        # ComposioConfig.tools_api_url, #5174) so this LIST, COMPOSIO_SEARCH_TOOLS,
+        # get_action, and execute all resolve the SAME v3.1 slug spelling. Do NOT
+        # add ``toolkit_versions=latest`` or any per-call version override: mixing
+        # a version scope here against a differently-scoped get/execute is exactly
+        # what surfaces "tools that don't exist" — a listed slug that resolve/execute
+        # then 404 with Tool_ToolNotFound.
         params: Dict[str, Any] = {
             "toolkit_slug": integration_key,
             "include_deprecated": False,

--- a/api/oss/src/core/tools/providers/composio/catalog.py
+++ b/api/oss/src/core/tools/providers/composio/catalog.py
@@ -209,14 +209,9 @@ class ComposioCatalogClient:
         """
         page_limit = min(limit, MAX_PAGE_SIZE) if limit else DEFAULT_PAGE_SIZE
 
-        # Slug consistency comes from the adapter's base URL, not from a version
-        # param here. The tools adapter is pinned to Composio API v3.1 (see
-        # ComposioConfig.tools_api_url, #5174) so this LIST, COMPOSIO_SEARCH_TOOLS,
-        # get_action, and execute all resolve the SAME v3.1 slug spelling. Do NOT
-        # add ``toolkit_versions=latest`` or any per-call version override: mixing
-        # a version scope here against a differently-scoped get/execute is exactly
-        # what surfaces "tools that don't exist" — a listed slug that resolve/execute
-        # then 404 with Tool_ToolNotFound.
+        # The shared Composio base URL pins every adapter to v3.1. Do not add a
+        # per-call version override here: list, search, get, and execute must use
+        # the same scope or discovery can return slugs that resolution rejects.
         params: Dict[str, Any] = {
             "toolkit_slug": integration_key,
             "include_deprecated": False,

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -686,12 +686,9 @@ class ComposioConfig(BaseModel):
     """Composio integration configuration"""
 
     api_key: str | None = os.getenv("COMPOSIO_API_KEY")
-    api_url: str = os.getenv("COMPOSIO_API_URL", "https://backend.composio.dev/api/v3")
-    # Base URL the *tools* adapter (discover/resolve/execute) talks to. Pinned to
-    # Composio API v3.1 while the rest of the integration stays on v3 — see
-    # ``tools_api_url`` below for why. Override only to point at a self-hosted
-    # Composio; leave unset to derive v3.1 from ``api_url``.
-    tools_api_url_override: str | None = os.getenv("COMPOSIO_TOOLS_API_URL")
+    api_url: str = os.getenv(
+        "COMPOSIO_API_URL", "https://backend.composio.dev/api/v3.1"
+    )
     # Dev: when set, unknown-trigger drops log at WARNING instead of INFO.
     webhook_target: str | None = os.getenv("COMPOSIO_WEBHOOK_TARGET")
     # Override the registered webhook URL. Composio requires public HTTPS; in dev
@@ -715,32 +712,6 @@ class ComposioConfig(BaseModel):
     def enabled(self) -> bool:
         """Composio enabled if API key is present"""
         return bool(self.api_key)
-
-    @property
-    def tools_api_url(self) -> str:
-        """Base URL for the tools adapter — pinned to Composio API v3.1.
-
-        Composio spells action slugs differently per toolkit version, and its
-        endpoints scope to different versions by default. COMPOSIO_SEARCH_TOOLS
-        (discovery) returns slugs at the v3.1 spelling; on the v3 default a subset
-        of those slugs 404 with Tool_ToolNotFound when get_action/execute try to
-        resolve them — so discovery surfaces "tools that don't exist" (#5174).
-        Keeping list/search/get/execute all on v3.1 makes every path agree on one
-        slug set (verified live: 125/125 v3.1-list slugs resolve+execute on v3.1,
-        and every previously-broken search slug resolves on v3.1).
-
-        Only the *tools* adapter needs this; the connections, triggers, and
-        integration-catalog adapters talk to version-agnostic ``/toolkits`` and
-        stay on ``api_url``. Derived from ``api_url`` so a host override is
-        preserved and only the version segment is forced to v3.1.
-        """
-        if self.tools_api_url_override:
-            return self.tools_api_url_override.rstrip("/")
-        base = self.api_url.rstrip("/")
-        for seg in ("/api/v3.1", "/api/v3"):
-            if base.endswith(seg):
-                return base[: -len(seg)] + "/api/v3.1"
-        return base
 
     model_config = ConfigDict(extra="ignore")
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -687,6 +687,11 @@ class ComposioConfig(BaseModel):
 
     api_key: str | None = os.getenv("COMPOSIO_API_KEY")
     api_url: str = os.getenv("COMPOSIO_API_URL", "https://backend.composio.dev/api/v3")
+    # Base URL the *tools* adapter (discover/resolve/execute) talks to. Pinned to
+    # Composio API v3.1 while the rest of the integration stays on v3 — see
+    # ``tools_api_url`` below for why. Override only to point at a self-hosted
+    # Composio; leave unset to derive v3.1 from ``api_url``.
+    tools_api_url_override: str | None = os.getenv("COMPOSIO_TOOLS_API_URL")
     # Dev: when set, unknown-trigger drops log at WARNING instead of INFO.
     webhook_target: str | None = os.getenv("COMPOSIO_WEBHOOK_TARGET")
     # Override the registered webhook URL. Composio requires public HTTPS; in dev
@@ -710,6 +715,32 @@ class ComposioConfig(BaseModel):
     def enabled(self) -> bool:
         """Composio enabled if API key is present"""
         return bool(self.api_key)
+
+    @property
+    def tools_api_url(self) -> str:
+        """Base URL for the tools adapter — pinned to Composio API v3.1.
+
+        Composio spells action slugs differently per toolkit version, and its
+        endpoints scope to different versions by default. COMPOSIO_SEARCH_TOOLS
+        (discovery) returns slugs at the v3.1 spelling; on the v3 default a subset
+        of those slugs 404 with Tool_ToolNotFound when get_action/execute try to
+        resolve them — so discovery surfaces "tools that don't exist" (#5174).
+        Keeping list/search/get/execute all on v3.1 makes every path agree on one
+        slug set (verified live: 125/125 v3.1-list slugs resolve+execute on v3.1,
+        and every previously-broken search slug resolves on v3.1).
+
+        Only the *tools* adapter needs this; the connections, triggers, and
+        integration-catalog adapters talk to version-agnostic ``/toolkits`` and
+        stay on ``api_url``. Derived from ``api_url`` so a host override is
+        preserved and only the version segment is forced to v3.1.
+        """
+        if self.tools_api_url_override:
+            return self.tools_api_url_override.rstrip("/")
+        base = self.api_url.rstrip("/")
+        for seg in ("/api/v3.1", "/api/v3"):
+            if base.endswith(seg):
+                return base[: -len(seg)] + "/api/v3.1"
+        return base
 
     model_config = ConfigDict(extra="ignore")
 

--- a/api/oss/tests/manual/tools/README.md
+++ b/api/oss/tests/manual/tools/README.md
@@ -69,7 +69,7 @@ Background jobs handle the complete flow (file + Redis).
 Composio Catalog Generator
 ============================================================
 
-📡 Connecting to Composio API: https://backend.composio.dev/api/v3
+📡 Connecting to Composio API: https://backend.composio.dev/api/v3.1
 
 🔄 Fetching integrations...
 ✅ Fetched 150 integrations

--- a/api/oss/tests/manual/triggers/try_composio_triggers.py
+++ b/api/oss/tests/manual/triggers/try_composio_triggers.py
@@ -174,7 +174,7 @@ def _rest(composio: Composio) -> Any:
     import httpx  # local: only the webhook commands need raw REST
 
     return httpx.Client(
-        base_url=os.getenv("COMPOSIO_API_URL", "https://backend.composio.dev/api/v3"),
+        base_url=os.getenv("COMPOSIO_API_URL", "https://backend.composio.dev/api/v3.1"),
         headers={
             "x-api-key": os.environ["COMPOSIO_API_KEY"],
             "Content-Type": "application/json",
@@ -332,7 +332,7 @@ def cmd_converge(composio: Composio) -> None:
             "Set AGENTA_WEBHOOK_URL to a registration target for the convergence run"
         )
     n = int(os.getenv("CONTAINERS", "6"))
-    base = os.getenv("COMPOSIO_API_URL", "https://backend.composio.dev/api/v3")
+    base = os.getenv("COMPOSIO_API_URL", "https://backend.composio.dev/api/v3.1")
     key = os.environ["COMPOSIO_API_KEY"]
     headers = {"x-api-key": key, "Content-Type": "application/json"}
     cache = _SharedCache()

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py
@@ -33,7 +33,7 @@ import pytest
 
 _COMPOSIO_ENABLED = bool(os.getenv("COMPOSIO_API_KEY"))
 _COMPOSIO_API_URL = os.getenv(
-    "COMPOSIO_API_URL", "https://backend.composio.dev/api/v3"
+    "COMPOSIO_API_URL", "https://backend.composio.dev/api/v3.1"
 ).rstrip("/")
 
 

--- a/api/oss/tests/pytest/unit/tools/test_composio_version_alignment.py
+++ b/api/oss/tests/pytest/unit/tools/test_composio_version_alignment.py
@@ -1,0 +1,147 @@
+"""Composio discover/resolve/execute must agree on ONE toolkit-version scope (#5174).
+
+The bug: COMPOSIO_SEARCH_TOOLS (discovery) returns action slugs spelled at the
+v3.1 toolkit version, but the tools adapter resolved and executed them against the
+v3 default, where a subset of those slugs 404 with ``Tool_ToolNotFound`` — discovery
+surfacing "tools that don't exist". The fix pins the tools adapter to v3.1 so list,
+search, get_action, and execute all resolve the same slug set.
+
+Two layers here:
+
+* ``TestToolsApiUrlDerivation`` — pure unit, always runs. Pins the v3.1 derivation
+  and the override/host-preservation behavior that the fix rests on.
+* ``TestSearchSlugsResolveUnderPinnedScope`` — integration, requires COMPOSIO_API_KEY.
+  The regression itself: a slug returned by COMPOSIO_SEARCH_TOOLS must GET-resolve and
+  execute-resolve (never ``Tool_ToolNotFound``) under the pinned tools scope.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from oss.src.utils.env import ComposioConfig
+
+
+V31 = "https://backend.composio.dev/api/v3.1"
+# Composio error code for a slug that does not exist at the requested scope. A
+# missing connected account is a DIFFERENT 404 (code 1810) and means "found".
+TOOL_NOT_FOUND = 2401
+
+
+class TestToolsApiUrlDerivation:
+    """tools_api_url forces the version segment to v3.1 while preserving the host."""
+
+    def test_default_v3_is_pinned_to_v31(self):
+        cfg = ComposioConfig(api_url="https://backend.composio.dev/api/v3")
+        assert cfg.tools_api_url == V31
+
+    def test_already_v31_stays_v31(self):
+        cfg = ComposioConfig(api_url="https://backend.composio.dev/api/v3.1")
+        assert cfg.tools_api_url == V31
+
+    def test_trailing_slash_is_normalized(self):
+        cfg = ComposioConfig(api_url="https://backend.composio.dev/api/v3/")
+        assert cfg.tools_api_url == V31
+
+    def test_self_hosted_host_is_preserved(self):
+        cfg = ComposioConfig(api_url="https://composio.internal.example.com/api/v3")
+        assert cfg.tools_api_url == "https://composio.internal.example.com/api/v3.1"
+
+    def test_explicit_override_wins(self):
+        cfg = ComposioConfig(
+            api_url="https://backend.composio.dev/api/v3",
+            tools_api_url_override="https://composio.internal/api/v3.1/",
+        )
+        assert cfg.tools_api_url == "https://composio.internal/api/v3.1"
+
+
+# ---------------------------------------------------------------------------
+# Integration: the real "tools that don't exist" regression
+# ---------------------------------------------------------------------------
+
+_API_KEY = os.getenv("COMPOSIO_API_KEY")
+
+pytestmark_integration = pytest.mark.skipif(
+    not _API_KEY,
+    reason="COMPOSIO_API_KEY not set; skipping live Composio slug-alignment check",
+)
+
+
+@pytest.mark.integration
+@pytestmark_integration
+class TestSearchSlugsResolveUnderPinnedScope:
+    """A slug from COMPOSIO_SEARCH_TOOLS must resolve+execute under the pinned scope.
+
+    Uses ``GMAIL_GET_DRAFT`` / ``GOOGLESHEETS_VALUES_GET`` — real slugs the search
+    tool recommends that 404 (Tool_ToolNotFound) on the v3 default but resolve on
+    v3.1. If the tools adapter regresses to v3 these assertions fail with 2401.
+    """
+
+    _HEADERS = {"x-api-key": _API_KEY or "", "Content-Type": "application/json"}
+    # Slugs empirically confirmed to disagree between v3 default and v3.1 (#5174).
+    _SEARCH_SLUGS = [
+        "GMAIL_GET_DRAFT",
+        "GMAIL_UPDATE_DRAFT",
+        "GOOGLESHEETS_VALUES_GET",
+        "GOOGLESHEETS_VALUES_UPDATE",
+        "NOTION_UPSERT_ROW_DATABASE",
+    ]
+
+    def _tools_url(self) -> str:
+        # Exercise the same derivation the app uses, from the default v3 base.
+        return ComposioConfig(
+            api_url="https://backend.composio.dev/api/v3"
+        ).tools_api_url
+
+    def test_pinned_scope_is_v31(self):
+        assert self._tools_url() == V31
+
+    def test_search_slugs_get_resolve(self):
+        base = self._tools_url()
+        with httpx.Client(timeout=30) as c:
+            for slug in self._SEARCH_SLUGS:
+                r = c.get(f"{base}/tools/{slug}", headers=self._HEADERS)
+                assert r.status_code == 200, (
+                    f"{slug} did not GET-resolve under {base}: "
+                    f"{r.status_code} {r.text[:200]}"
+                )
+
+    def test_search_slugs_execute_resolve(self):
+        base = self._tools_url()
+        with httpx.Client(timeout=30) as c:
+            for slug in self._SEARCH_SLUGS:
+                r = c.post(
+                    f"{base}/tools/execute/{slug}",
+                    headers=self._HEADERS,
+                    json={"arguments": {}, "user_id": "pytest-nonexistent-user"},
+                )
+                # Missing connected account (1810) is fine — it proves the slug was
+                # FOUND. The regression is Tool_ToolNotFound (2401), which must not occur.
+                code = None
+                if r.status_code != 200:
+                    code = (r.json().get("error") or {}).get("code")
+                assert code != TOOL_NOT_FOUND, (
+                    f"{slug} 404'd as Tool_ToolNotFound under {base} — discover/execute "
+                    f"version scopes disagree again (#5174)"
+                )
+
+    def test_v3_default_still_rejects_these_slugs(self):
+        # Guards the premise: on v3 these slugs genuinely 404 as Tool_ToolNotFound,
+        # so the pinning above is load-bearing and not a no-op.
+        base = "https://backend.composio.dev/api/v3"
+        with httpx.Client(timeout=30) as c:
+            offenders = []
+            for slug in self._SEARCH_SLUGS:
+                r = c.get(f"{base}/tools/{slug}", headers=self._HEADERS)
+                if (
+                    r.status_code == 404
+                    and (r.json().get("error") or {}).get("code") == TOOL_NOT_FOUND
+                ):
+                    offenders.append(slug)
+            assert offenders, (
+                "Expected at least one search slug to be missing on the v3 default; "
+                "if none are, Composio changed its scoping and the pin may be revisitable."
+            )

--- a/api/oss/tests/pytest/unit/tools/test_composio_version_alignment.py
+++ b/api/oss/tests/pytest/unit/tools/test_composio_version_alignment.py
@@ -1,18 +1,9 @@
-"""Composio discover/resolve/execute must agree on ONE toolkit-version scope (#5174).
+"""Composio discovery and execution must agree on one API scope (#5174).
 
 The bug: COMPOSIO_SEARCH_TOOLS (discovery) returns action slugs spelled at the
 v3.1 toolkit version, but the tools adapter resolved and executed them against the
-v3 default, where a subset of those slugs 404 with ``Tool_ToolNotFound`` — discovery
-surfacing "tools that don't exist". The fix pins the tools adapter to v3.1 so list,
-search, get_action, and execute all resolve the same slug set.
-
-Two layers here:
-
-* ``TestToolsApiUrlDerivation`` — pure unit, always runs. Pins the v3.1 derivation
-  and the override/host-preservation behavior that the fix rests on.
-* ``TestSearchSlugsResolveUnderPinnedScope`` — integration, requires COMPOSIO_API_KEY.
-  The regression itself: a slug returned by COMPOSIO_SEARCH_TOOLS must GET-resolve and
-  execute-resolve (never ``Tool_ToolNotFound``) under the pinned tools scope.
+v3 default, where a subset of those slugs 404 with ``Tool_ToolNotFound``. The fix
+pins the whole Composio integration to v3.1 through its shared API URL.
 """
 
 from __future__ import annotations
@@ -31,31 +22,8 @@ V31 = "https://backend.composio.dev/api/v3.1"
 TOOL_NOT_FOUND = 2401
 
 
-class TestToolsApiUrlDerivation:
-    """tools_api_url forces the version segment to v3.1 while preserving the host."""
-
-    def test_default_v3_is_pinned_to_v31(self):
-        cfg = ComposioConfig(api_url="https://backend.composio.dev/api/v3")
-        assert cfg.tools_api_url == V31
-
-    def test_already_v31_stays_v31(self):
-        cfg = ComposioConfig(api_url="https://backend.composio.dev/api/v3.1")
-        assert cfg.tools_api_url == V31
-
-    def test_trailing_slash_is_normalized(self):
-        cfg = ComposioConfig(api_url="https://backend.composio.dev/api/v3/")
-        assert cfg.tools_api_url == V31
-
-    def test_self_hosted_host_is_preserved(self):
-        cfg = ComposioConfig(api_url="https://composio.internal.example.com/api/v3")
-        assert cfg.tools_api_url == "https://composio.internal.example.com/api/v3.1"
-
-    def test_explicit_override_wins(self):
-        cfg = ComposioConfig(
-            api_url="https://backend.composio.dev/api/v3",
-            tools_api_url_override="https://composio.internal/api/v3.1/",
-        )
-        assert cfg.tools_api_url == "https://composio.internal/api/v3.1"
+def test_default_composio_api_scope_is_v31():
+    assert ComposioConfig.model_fields["api_url"].default == V31
 
 
 # ---------------------------------------------------------------------------
@@ -90,17 +58,11 @@ class TestSearchSlugsResolveUnderPinnedScope:
         "NOTION_UPSERT_ROW_DATABASE",
     ]
 
-    def _tools_url(self) -> str:
-        # Exercise the same derivation the app uses, from the default v3 base.
-        return ComposioConfig(
-            api_url="https://backend.composio.dev/api/v3"
-        ).tools_api_url
-
     def test_pinned_scope_is_v31(self):
-        assert self._tools_url() == V31
+        assert ComposioConfig.model_fields["api_url"].default == V31
 
     def test_search_slugs_get_resolve(self):
-        base = self._tools_url()
+        base = V31
         with httpx.Client(timeout=30) as c:
             for slug in self._SEARCH_SLUGS:
                 r = c.get(f"{base}/tools/{slug}", headers=self._HEADERS)
@@ -110,7 +72,7 @@ class TestSearchSlugsResolveUnderPinnedScope:
                 )
 
     def test_search_slugs_execute_resolve(self):
-        base = self._tools_url()
+        base = V31
         with httpx.Client(timeout=30) as c:
             for slug in self._SEARCH_SLUGS:
                 r = c.post(

--- a/docs/design/agent-workflows/projects/trigger-discovery-catalog/scripts/discovery_eval.py
+++ b/docs/design/agent-workflows/projects/trigger-discovery-catalog/scripts/discovery_eval.py
@@ -48,7 +48,7 @@ SERVICE = _repo_root() / "api" / "oss" / "src" / "core" / "triggers" / "service.
 # status.md). It lives only in this local cache and is fetched live when absent.
 CATALOG_CACHE = Path.home() / ".cache" / "agenta-discovery-eval" / "catalog.json"
 
-COMPOSIO_API_URL = "https://backend.composio.dev/api/v3"
+COMPOSIO_API_URL = "https://backend.composio.dev/api/v3.1"
 
 WANTED = {
     "_DISCOVERY_MIN_PRIMARY_TERMS",

--- a/docs/designs/gateway-tools/PR.md
+++ b/docs/designs/gateway-tools/PR.md
@@ -91,7 +91,7 @@ created_at / updated_at / deleted_at + …_by_id columns
 | Env Var | Default | Required |
 |---------|---------|----------|
 | `COMPOSIO_API_KEY` | — | Yes — presence enables Composio automatically |
-| `COMPOSIO_API_URL` | `https://backend.composio.dev/api/v3` | No |
+| `COMPOSIO_API_URL` | `https://backend.composio.dev/api/v3.1` | No |
 
 ---
 

--- a/docs/designs/gateway-tools/TOOLS_IMPLEMENTATION.md
+++ b/docs/designs/gateway-tools/TOOLS_IMPLEMENTATION.md
@@ -185,7 +185,7 @@ api/oss/src/
 export COMPOSIO_API_KEY="your-composio-api-key"
 
 # Optional (already has defaults)
-export COMPOSIO_API_URL="https://backend.composio.dev/api/v3"
+export COMPOSIO_API_URL="https://backend.composio.dev/api/v3.1"
 ```
 
 ### Code Setup

--- a/docs/designs/gateway-tools/composio-integration.md
+++ b/docs/designs/gateway-tools/composio-integration.md
@@ -1,12 +1,12 @@
 # Gateway Tools — Composio Integration
 
-How Agenta integrates with the Composio API (v3) as the first gateway provider.
+How Agenta integrates with the Composio API (v3.1) as the first gateway provider.
 
 ---
 
 ## Composio API Overview
 
-- **Base URL**: `https://backend.composio.dev/api/v3`
+- **Base URL**: `https://backend.composio.dev/api/v3.1`
 - **Auth**: Header `x-api-key: <COMPOSIO_API_KEY>`
 - **Pagination**: Cursor-based (`cursor` + `limit` params, `next_cursor` in response)
 - **Rate Limits**: 20k requests / 10 min (starter/hobby), 100k (growth)
@@ -437,7 +437,7 @@ class ComposioAdapter(GatewayAdapterInterface):
     def __init__(
         self,
         *,
-        api_url: str = "https://backend.composio.dev/api/v3",
+        api_url: str = "https://backend.composio.dev/api/v3.1",
         default_api_key: str | None = None,
     ):
         self.api_url = api_url
@@ -516,7 +516,7 @@ All caches use `cachetools.TTLCache` (in-memory, per-process). No shared cache n
 COMPOSIO_API_KEY=cmp_live_...
 
 # Optional: override Composio API base URL (for testing/staging)
-COMPOSIO_API_URL=https://backend.composio.dev/api/v3
+COMPOSIO_API_URL=https://backend.composio.dev/api/v3.1
 ```
 
 ---

--- a/docs/designs/gateway-tools/implementation-spec.md
+++ b/docs/designs/gateway-tools/implementation-spec.md
@@ -545,7 +545,7 @@ No changes to `secretkind_enum` or any secrets tables.
 ```python
 class ComposioConfig(BaseModel):
     api_key: str | None = os.getenv("COMPOSIO_API_KEY")
-    api_url: str = os.getenv("COMPOSIO_API_URL") or "https://backend.composio.dev/api/v3"
+    api_url: str = os.getenv("COMPOSIO_API_URL") or "https://backend.composio.dev/api/v3.1"
 
     model_config = ConfigDict(extra="ignore")
 

--- a/docs/designs/gateway-tools/providers.md
+++ b/docs/designs/gateway-tools/providers.md
@@ -47,7 +47,7 @@ Each provider implementation:
 ```
 # Environment variables
 COMPOSIO_API_KEY=<your_key>                              # Required — presence enables Composio
-COMPOSIO_API_URL=https://backend.composio.dev/api/v3    # Optional (default shown)
+COMPOSIO_API_URL=https://backend.composio.dev/api/v3.1  # Optional (default shown)
 ```
 
 **Usage in entrypoints:**

--- a/docs/designs/gateway-tools/specs.md
+++ b/docs/designs/gateway-tools/specs.md
@@ -1661,7 +1661,7 @@ Maps between Agenta DTOs and Composio's V3 API.
 
 ```python
 class ComposioAdapter(GatewayAdapterInterface):
-    def __init__(self, *, api_key: str, base_url: str = "https://backend.composio.dev/api/v3"):
+    def __init__(self, *, api_key: str, base_url: str = "https://backend.composio.dev/api/v3.1"):
         self.api_key = api_key
         self.base_url = base_url
 

--- a/docs/designs/gateway-triggers/wp/WP1-status.md
+++ b/docs/designs/gateway-triggers/wp/WP1-status.md
@@ -28,7 +28,7 @@
   - Create/upsert instance: `POST /trigger_instances/{slug}/upsert` (body `connected_account_id`, `trigger_config`)
   - Enable/disable instance: `PATCH /trigger_instances/manage/{trigger_id}` (body `status` = `"enable"`/`"disable"`)
   - Delete instance: `DELETE /trigger_instances/manage/{trigger_id}`
-  - All paths are relative to `env.composio.api_url` (default `/api/v3`); adapter builds `f"{api_url}{path}"` exactly like `ComposioToolsAdapter`. Docs currently surface these under the `v3.1` minor; the path *segments* (what E5 asked to confirm) are stable across v3/v3.1 and we keep the shared `env.composio.api_url` base.
+  - All paths are relative to `env.composio.api_url` (default `/api/v3.1`); adapter builds `f"{api_url}{path}"` exactly like `ComposioToolsAdapter`. The path *segments* (what E5 asked to confirm) are stable across v3/v3.1 and every Composio adapter uses the shared base.
 
 ## Notes / blockers
 

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -221,6 +221,9 @@ AGENTA_INSECURE_EGRESS_ALLOWED=true
 # ================================================================== #
 # COMPOSIO_API_KEY=
 # COMPOSIO_API_URL=https://backend.composio.dev/api/v3
+# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
+# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
+# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -220,10 +220,7 @@ AGENTA_INSECURE_EGRESS_ALLOWED=true
 # composio
 # ================================================================== #
 # COMPOSIO_API_KEY=
-# COMPOSIO_API_URL=https://backend.composio.dev/api/v3
-# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
-# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
-# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
+# COMPOSIO_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -223,6 +223,9 @@ AGENTA_RUNNER_TOKEN=replace-me
 # ================================================================== #
 # COMPOSIO_API_KEY=
 # COMPOSIO_API_URL=https://backend.composio.dev/api/v3
+# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
+# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
+# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -222,10 +222,7 @@ AGENTA_RUNNER_TOKEN=replace-me
 # composio
 # ================================================================== #
 # COMPOSIO_API_KEY=
-# COMPOSIO_API_URL=https://backend.composio.dev/api/v3
-# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
-# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
-# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
+# COMPOSIO_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -222,10 +222,7 @@ AGENTA_INSECURE_EGRESS_ALLOWED=true
 # composio
 # ================================================================== #
 # COMPOSIO_API_KEY=
-# COMPOSIO_API_URL=https://backend.composio.dev/api/v3
-# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
-# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
-# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
+# COMPOSIO_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -223,6 +223,9 @@ AGENTA_INSECURE_EGRESS_ALLOWED=true
 # ================================================================== #
 # COMPOSIO_API_KEY=
 # COMPOSIO_API_URL=https://backend.composio.dev/api/v3
+# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
+# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
+# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -223,6 +223,9 @@ AGENTA_RUNNER_TOKEN=replace-me
 # ================================================================== #
 # COMPOSIO_API_KEY=
 # COMPOSIO_API_URL=https://backend.composio.dev/api/v3
+# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
+# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
+# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -222,10 +222,7 @@ AGENTA_RUNNER_TOKEN=replace-me
 # composio
 # ================================================================== #
 # COMPOSIO_API_KEY=
-# COMPOSIO_API_URL=https://backend.composio.dev/api/v3
-# Tools discover/resolve/execute are pinned to v3.1 for slug consistency (#5174);
-# override only for a self-hosted Composio. Derived from COMPOSIO_API_URL if unset.
-# COMPOSIO_TOOLS_API_URL=https://backend.composio.dev/api/v3.1
+# COMPOSIO_API_URL=https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # crisp

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -173,7 +173,7 @@ global:
 # ================================================================== #
 # composio:
 #   apiKey:
-#   apiUrl: https://backend.composio.dev/api/v3
+#   apiUrl: https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # === crisp ===

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -160,7 +160,7 @@ agenta:
 # ================================================================== #
 # composio:
 #   apiKey:
-#   apiUrl: https://backend.composio.dev/api/v3
+#   apiUrl: https://backend.composio.dev/api/v3.1
 
 # ================================================================== #
 # === crisp ===


### PR DESCRIPTION
## Context

Composio discovery returned v3.1 action slugs while Agenta resolved and executed them against v3. Some discovered tools therefore failed with `Tool_ToolNotFound` even though Composio had just returned them.

## Changes

The entire Composio integration now uses one shared `COMPOSIO_API_URL`, defaulting to `https://backend.composio.dev/api/v3.1`. Connections, catalog, tools, triggers, the local trigger bridge, examples, tests, and supporting documentation all use that same scope.

Before, most adapters used v3 while the tools adapter derived a separate v3.1 URL. Now every adapter receives `env.composio.api_url`; there is no tools-only URL or `COMPOSIO_TOOLS_API_URL` override.

This intentionally does not migrate saved v3-only action slugs.

## Tests / notes

- `ruff format` and `ruff check --fix` passed for the changed Python files.
- `uv run pytest oss/tests/pytest/unit/tools/test_composio_version_alignment.py -m "not integration"` passed.
- The trigger ingress acceptance suite collects all six tests successfully.
- Live Composio integration tests remain `COMPOSIO_API_KEY`-gated.

Fixes #5174
