### PR TITLE
[ci] Stop a manual mobile build from taking the released :latest tag

### DIFF
--- a/.github/workflows/17-check-mobile.yml
+++ b/.github/workflows/17-check-mobile.yml
@@ -17,6 +17,11 @@ on:
       - 'web/turbo.json'
       - 'web/patches/**'
       - '.github/workflows/17-check-mobile.yml'
+  # Dispatch builds an ad-hoc image (a preview, a one-off test). It is NOT the release
+  # path: `43 - Release to GHCR` in agenta_cloud publishes agenta-web-mobile:vX.Y.Z and
+  # moves :latest, the same as it does for api, web, services and runner. There is
+  # deliberately no `latest` option here — self-hosters pull :latest by default, so a
+  # manual build must not be able to take that tag away from the released version.
   workflow_dispatch:
     inputs:
       push:
@@ -27,10 +32,6 @@ on:
         description: "Image tag; leave empty for manual-<short-sha>"
         type: string
         default: ""
-      push_latest:
-        description: "Also tag :latest (requires push)"
-        type: boolean
-        default: false
 
 # Least privilege at the top; the two jobs that log in to the registry raise it themselves.
 permissions:
@@ -256,17 +257,10 @@ jobs:
         env:
           IMAGE: ghcr.io/agenta-ai/agenta-web-mobile
           TAG: ${{ needs.prepare.outputs.image_tag }}
-          PUSH_LATEST: ${{ inputs.push_latest }}
         run: |
           set -euo pipefail
           docker buildx imagetools create \
             -t "${IMAGE}:${TAG}" \
             "${IMAGE}:${TAG}-amd64" \
             "${IMAGE}:${TAG}-arm64"
-          if [ "${PUSH_LATEST}" = "true" ]; then
-            docker buildx imagetools create \
-              -t "${IMAGE}:latest" \
-              "${IMAGE}:${TAG}-amd64" \
-              "${IMAGE}:${TAG}-arm64"
-          fi
-          echo "- Merged \`agenta-web-mobile:${TAG}\` (linux/amd64 + linux/arm64; latest=${PUSH_LATEST})" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Merged \`agenta-web-mobile:${TAG}\` (linux/amd64 + linux/arm64)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/17-check-mobile.yml
+++ b/.github/workflows/17-check-mobile.yml
@@ -120,6 +120,14 @@ jobs:
             echo "::error::image_tag is longer than 128 characters"
             exit 1
           fi
+          # Dropping the `push_latest` input is not enough on its own: `image_tag` is free text,
+          # so `image_tag=latest` reaches the same `imagetools create -t "${IMAGE}:${TAG}"` and
+          # takes the tag anyway. The release path owns `:latest` (`43 - Release to GHCR` in
+          # agenta_cloud); a manual build must not be able to claim it by either route.
+          if [ "$TAG" = "latest" ]; then
+            echo "::error::image_tag cannot be 'latest' — the release workflow owns that tag"
+            exit 1
+          fi
 
           echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "cache_scope=${CACHE_SCOPE}" >> "$GITHUB_OUTPUT"
@@ -132,8 +140,8 @@ jobs:
     name: build-image
     # Also `typecheck`, not just `prepare`: `web/mobile/next.config.ts` sets
     # `typescript.ignoreBuildErrors: true`, so the build and the smoke test can both pass while
-    # the dedicated typecheck fails. Without this, a dispatch with `push=true` publishes that
-    # tag and `merge-manifests` can move `latest` onto it.
+    # the dedicated typecheck fails. Without this, a dispatch with `push=true` would still
+    # publish an image with unchecked types — it just can no longer be tagged `latest`.
     needs: [prepare, typecheck]
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/docs/design/agenta-mobile/README.md
+++ b/docs/design/agenta-mobile/README.md
@@ -293,11 +293,13 @@ pnpm dev-mobile   # → http://localhost:3000/m, check light+dark
   image (both arches) on mobile-path PRs and typechecks `@agenta/mobile`; lint (`turbo run lint`
   in workflow 11) and `@agenta/chat` unit tests (recursive package discovery in workflow 12)
   were already covered by their generic mechanisms — verified, not changed. **First publication
-  ordering:** merge → run `17 - check mobile` via `workflow_dispatch` with `push=true,
-  push_latest=true` → only then can operators pass `--with-mobile` to `bash ./hosting/docker-compose/run.sh --oss --gh` (or `--ee`). Until that first
-  dispatch-push, the `with-web-mobile` compose profile stays opt-in on purpose — `docker compose
-  up`/`pull` would fail the whole stack against a `ghcr.io/agenta-ai/agenta-web-mobile:latest`
-  that doesn't exist yet.
+  ordering:** `17 - check mobile` no longer publishes `latest` — there is no `push_latest` input,
+  and `image_tag=latest` is rejected outright. Publication is owned by `43 - Release to GHCR` in
+  the private `agenta_cloud` repo, the same as api, web, services and runner; only after that
+  pipeline has published `agenta-web-mobile` once can operators pass `--with-mobile` to
+  `bash ./hosting/docker-compose/run.sh --oss --gh` (or `--ee`). Until then, the `with-web-mobile`
+  compose profile stays opt-in on purpose — `docker compose up`/`pull` would fail the whole stack
+  against a `ghcr.io/agenta-ai/agenta-web-mobile:latest` that doesn't exist yet.
 - **Design-doc staleness:** `docs/designs/sessions/**` predates the streams-merge/turns model;
   don't trust it over the code. The memory file `project_agenta_mobile_discovery` (assistant
   memory) mirrors this handoff.


### PR DESCRIPTION
## Context

Agenta-AI/agenta_cloud#1665 adds `agenta-web-mobile` to `43 - Release to GHCR`, so from v0.111 the release pipeline publishes the mobile image alongside api, web, services and runner. Part of publishing is moving `ghcr.io/agenta-ai/agenta-web-mobile:latest` onto the released version, exactly as it does for the other four.

This workflow could move that tag too. A manual dispatch with `push_latest=true` retagged `:latest` onto whatever commit was dispatched. That was harmless while nothing else owned the tag and no image had ever been published. It stops being harmless the moment a released version lives there.

It matters because `:latest` is the default a self-hoster gets:

```
image: ghcr.io/agenta-ai/${AGENTA_WEB_MOBILE_IMAGE_NAME:-agenta-web-mobile}:${AGENTA_WEB_MOBILE_IMAGE_TAG:-latest}
```

So a one-off build dispatched from a feature branch could quietly become what every opted-in self-host deployment pulls on its next restart.

## Changes

Dropped the `push_latest` input and the `latest` branch of the manifest stitch. Dispatch still builds and pushes an explicit tag (`manual-<short-sha>`, or whatever `image_tag` is set to), which is what makes it useful for a preview or a one-off. It just cannot claim `:latest` any more.

The comment on `workflow_dispatch` now says where the release path actually is, so the next person does not have to reconstruct it.

Nothing else changes. The PR-triggered path (typecheck, two-arch build, `/m` smoke test, non-root check) is untouched, and dispatch never pushed `:latest` by default anyway, so no existing usage breaks.

## Tests / notes

- The workflow parses, every `run:` block parses as bash, and no reference to `push_latest` or `PUSH_LATEST` survives anywhere in `.github/` or `hosting/`.
- Nothing to QA. This removes an option from a manual workflow.

Ordering: this is safe to merge before or after agenta_cloud#1665. Merged first it removes the footgun early; merged after it closes the window where two workflows both claim `:latest`.

While checking the related profile-name mismatch I found this repo is the consistent one. Every profile here is `with-`prefixed (`with-web`, `with-nginx`, `with-traefik`, `with-tunnel`, `with-web-mobile`), so nothing needs renaming on this side. The cloud compose spells it bare `web-mobile`, which is the side worth aligning, and that is a change for the other repo.
