### PR TITLE
fix(tests): match the create-entity confirm dialog by role, not by an antd class

### DIFF
--- a/web/oss/tests/playwright/acceptance/agent-skills/skill-folder-upload.spec.ts
+++ b/web/oss/tests/playwright/acceptance/agent-skills/skill-folder-upload.spec.ts
@@ -135,8 +135,13 @@ test(
                 {timeout: 90000},
             )
             await uiHelpers.clickButton("Create", appCreateDrawer)
+            // Match the dialog by role, not by a component-library class:
+            // `EntityCommitModal` renders through `EnhancedModal`, now a facade over
+            // the @agenta/ui (Radix) `Dialog`, so no `.ant-modal-wrap` exists here.
+            // Radix `aria-hidden`s the launching antd drawer while the modal is open,
+            // so exactly one dialog resolves.
             const confirmModal = page
-                .locator(".ant-modal-wrap")
+                .getByRole("dialog")
                 .filter({has: page.getByRole("button", {name: "Create", exact: true})})
                 .last()
             await expect(confirmModal).toBeVisible({timeout: 15000})

--- a/web/oss/tests/playwright/acceptance/app/test.ts
+++ b/web/oss/tests/playwright/acceptance/app/test.ts
@@ -162,12 +162,14 @@ const testWithAppFixtures = baseTest.extend<AppFixtures>({
             await uiHelpers.clickButton("Create", drawer)
             // The confirmation modal opens — accept it. Wait for the submit
             // button before clicking; isVisible() is an immediate snapshot and
-            // can race the antd modal render.
-            // The modal no longer wraps its buttons in a `.ant-modal-footer`
-            // div (migrated off the raw antd Modal footer), so filter by the
-            // "Create" button itself rather than the footer wrapper.
+            // can race the modal render.
+            // Match the dialog by role, not by a component-library class:
+            // `EntityCommitModal` renders through `EnhancedModal`, now a facade over
+            // the @agenta/ui (Radix) `Dialog`, so no `.ant-modal-wrap` exists here.
+            // Radix `aria-hidden`s the launching antd drawer while the modal is open,
+            // so exactly one dialog resolves.
             const confirmModal = page
-                .locator(".ant-modal-wrap")
+                .getByRole("dialog")
                 .filter({has: page.getByRole("button", {name: "Create", exact: true})})
                 .last()
             const confirmButton = confirmModal.getByRole("button", {
@@ -189,9 +191,7 @@ const testWithAppFixtures = baseTest.extend<AppFixtures>({
             expect(response.workflow.id).toBeTruthy()
             expect(response.workflow.name).toBe(appName)
             expect(response.workflow.created_at).toBeTruthy()
-            await expect(page.locator(".ant-modal-wrap:visible")).toHaveCount(0, {
-                timeout: 15000,
-            })
+            await expect(confirmModal).toBeHidden({timeout: 15000})
             const projectBasePath = getProjectScopedBasePath(page)
             await page.goto(`${projectBasePath}/apps/${response.workflow.id}/playground`, {
                 waitUntil: "domcontentloaded",

--- a/web/oss/tests/playwright/acceptance/prompts/test.ts
+++ b/web/oss/tests/playwright/acceptance/prompts/test.ts
@@ -84,11 +84,13 @@ const testWithPromptsFixtures = baseTest.extend<PromptsFixtures>({
             await expect(createButton).toBeEnabled({timeout: 15000})
             await createButton.click()
 
-            // The modal no longer wraps its buttons in a `.ant-modal-footer`
-            // div (migrated off the raw antd Modal footer), so filter by the
-            // "Create" button itself rather than the footer wrapper.
+            // Match the dialog by role, not by a component-library class:
+            // `EntityCommitModal` renders through `EnhancedModal`, now a facade over
+            // the @agenta/ui (Radix) `Dialog`, so no `.ant-modal-wrap` exists here.
+            // Radix `aria-hidden`s the launching antd drawer while the modal is open,
+            // so exactly one dialog resolves.
             const confirmModal = page
-                .locator(".ant-modal-wrap")
+                .getByRole("dialog")
                 .filter({has: page.getByRole("button", {name: "Create", exact: true})})
                 .last()
             const confirmButton = confirmModal.getByRole("button", {
@@ -102,9 +104,7 @@ const testWithPromptsFixtures = baseTest.extend<PromptsFixtures>({
 
             const createPromptResponse = await createPromptPromise
             expect(createPromptResponse.ok()).toBe(true)
-            await expect(page.locator(".ant-modal-wrap:visible")).toHaveCount(0, {
-                timeout: 15000,
-            })
+            await expect(confirmModal).toBeHidden({timeout: 15000})
         })
     },
 

--- a/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
@@ -208,11 +208,13 @@ const waitForMatchingResponses = async (
 }
 
 const confirmCreateEntityModal = async (page: Page) => {
-    // The commit-confirmation modal no longer wraps its buttons in a
-    // `.ant-modal-footer` div (migrated off the raw antd Modal footer), so
-    // filter by the "Create" button itself rather than the footer wrapper.
+    // Match the dialog by role, not by a component-library class. `EnhancedModal` —
+    // which `EntityCommitModal` renders through — is now a facade over the @agenta/ui
+    // (Radix) `Dialog`, so no `.ant-modal-wrap` exists in this tree any more. Radix
+    // `aria-hidden`s the rest of the document while the modal is open (including the
+    // antd drawer that launched it), so exactly one dialog resolves here.
     const confirmModal = page
-        .locator(".ant-modal-wrap")
+        .getByRole("dialog")
         .filter({
             has: page.getByRole("button", {name: "Create", exact: true}),
         })

--- a/web/tests/tests/fixtures/base.fixture/uiHelpers/helpers.ts
+++ b/web/tests/tests/fixtures/base.fixture/uiHelpers/helpers.ts
@@ -200,8 +200,13 @@ export const clickTableRowIcon = async (
 
 // Confirms a modal dialog by clicking a button named 'Confirm' (case-insensitive)
 export const confirmModal = async (page: Page, buttonText: string | RegExp = /Confirm/i) => {
-    // Wait for any Ant Design modal to be visible
-    const modalLocator = page.locator(".ant-modal")
+    // Wait for any modal to be visible. Modals are mid-migration from antd `Modal`
+    // (`.ant-modal`) to the @agenta/ui Radix `Dialog` behind the `EnhancedModal`
+    // facade (`[data-slot="dialog-content"]`); both render in the app today, so match
+    // either. Deliberately not `getByRole("dialog")` — that would also match an open
+    // antd `Drawer`, which this helper has never targeted. `:visible` keeps a closed
+    // antd modal (which stays mounted, just hidden) from making the union ambiguous.
+    const modalLocator = page.locator('.ant-modal:visible, [data-slot="dialog-content"]:visible')
     await modalLocator.waitFor({state: "visible"})
 
     // Try to find the confirm button inside the modal


### PR DESCRIPTION
## What was broken

The Playwright acceptance suite has been red for at least two releases. The last run against staging ([run 31211001480](https://github.com/Agenta-AI/agenta_cloud/actions/runs/31211001480), "Web tests (eu, acceptance)") reports **43 failed / 10 passed / 14 skipped**.

**28 of those 43 failures are one dead selector.** The shared helper that creates an application waits for the commit-confirmation dialog like this:

```ts
page.locator(".ant-modal-wrap").filter({has: page.getByRole("button", {name: "Create", exact: true})})
```

No such element exists any more. `EntityCommitModal` renders through `EnhancedModal`, and `EnhancedModal` is now a facade over the `@agenta/ui` (Radix) `Dialog` — its own header says so:

> `EnhancedModal` — antd `Modal`-compatible facade over the `@agenta/ui` (Radix) `Dialog`. […] It now renders the `@agenta/ui` Dialog so the ~80 call-sites […] move off antd with NO call-site changes.

The dialog emits `div[role="dialog"][data-slot="dialog-content"]` and no antd markup at all. The wait could only time out. Because `getApp()` creates an application when the project has none, and nearly every test needs an application first, that single selector cascaded through the suite.

This is not a product bug. Creating a prompt through the UI works; the product moved and the test did not follow.

## What changed

Selectors are now **role-based**, which is what should have been there in the first place — a `role="dialog"` query is independent of whichever component library renders it, so the next migration cannot break it the same way.

I verified on the live DOM (EE v0.111.0) that this resolves unambiguously. While the modal is open there is exactly **one** matchable dialog: Radix `aria-hidden`s the rest of the document, including the antd `Drawer` that launched the modal, so the drawer leaves the accessibility tree entirely.

```
[role="dialog"] elements: 2
  - div.ant-drawer-section          → inside an aria-hidden="true" ancestor
  - div[data-slot="dialog-content"] → the commit modal
.ant-modal-wrap elements: 0
Playwright getByRole("dialog").count() = 1
```

The same stale block had been copy-pasted into **four** places; all are fixed together:

| File | Role |
|---|---|
| `web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts` | `confirmCreateEntityModal` — the shared helper behind the cascade |
| `web/oss/tests/playwright/acceptance/app/test.ts` | app-creation fixture |
| `web/oss/tests/playwright/acceptance/prompts/test.ts` | prompt-creation fixture |
| `web/oss/tests/playwright/acceptance/agent-skills/skill-folder-upload.spec.ts` | inline copy |

Two "the modal has closed" assertions counted visible `.ant-modal-wrap` elements, which passed trivially at zero — they now assert on the dialog locator itself.

`uiHelpers.confirmModal` matched `.ant-modal` only. Modals are genuinely half-migrated (60 files on `EnhancedModal`, 57 still on raw antd `<Modal`), so it now matches **either**, scoped to visible elements so a closed-but-still-mounted antd modal cannot make the union ambiguous. Its caller in the playground commit flow (`uiHelpers.confirmModal("Commit")`) targets `EntityCommitModal` and could not have been passing.

No product code changed. The dialog already had a stable hook.

## How it was verified

Against the live EE v0.111.0 deployment at `144.76.237.122:8180`, whose `web/` tree is byte-identical to `origin/release/v0.111.0` (`git diff 6f2cd5b2d0 8485e0f998 -- web/` is empty). The suite mints its own throwaway account and ephemeral project through the normal signup path.

**Before** — the CI failure reproduced exactly, same locator, same call chain:

```
Error: expect(locator).toBeVisible() failed
Locator: locator('.ant-modal-wrap').filter({ has: getByRole('button', { name: 'Create', exact: true }) }).last()
Timeout: 15000ms — element(s) not found
  at confirmCreateEntityModal (apiHelpers/index.ts:225)
  ← createApp (:381) ← getApp (:437) ← app-management.ts:156
```

**After** — every test in the CI failure list that is reachable on this stack now passes:

```
✓ app/index.ts:43          OSS App Creation Flow › creates new completion prompt app
✓ prompts/index.ts:57      OSS Prompts Flow › creates a new prompt via the Create new dropdown
✓ deployment/index.ts:124  Deployment: deploy variant › deploy a variant
✓ deployment/index.ts:229  Deployment: deploy variant › should deploy a variant to staging and production environments
✓ deployment/index.ts:263  Deployment: deploy variant › should show version badge after deploying to Development
✓ agent-skills/skill-folder-upload.spec.ts:95  uploading a skill package parses the folded description …
✓ human-annotation/index.ts:62  Human Annotation › should show the human evaluation entry point on the human tab
```

All seven are in the run's `.ant-modal-wrap` failure list. Tests that were already green in CI stay green — `prompts › navigates to the Prompts page`, `prompts › creates a new folder`, `app › closing the create-app drawer without committing`, `evaluators › should navigate to the evaluators page` — so `confirmModal` widening did not regress the raw-antd call-sites.

The remaining 21 of the 28 are not reachable on this stack for reasons unrelated to the change: the observability and playground specs need a configured model-hub provider, and `app-management.ts:142` hits the `networkidle` limitation described below.

Two tests timed out once on the shared dev box (`page.waitForResponse` and `locator.hover`, both at the 60s test budget, neither on a dialog selector) and passed on re-run. That box hosts several stacks and recompiles routes on first visit; it is load flakiness, not a property of this change.

## What this does *not* fix

This is deliberately scoped to the one class of staleness and its exact duplicates. The suite has drifted in several other places, all from the same antd → `@agenta/ui` (Radix) migration but each needing its own investigation:

| Failures | Stale locator | Now rendered by |
|---|---|---|
| 8 | `.ant-modal` + `input[placeholder="Enter a name..."]` (evaluators create/commit) | `EntityCommitModal` → Radix `Dialog` |
| 1 | `.ant-modal` + `DeleteEvaluatorsModal` title | `EnhancedModal` → Radix `Dialog` |
| 1 | `.ant-modal` (model hub provider key) | to confirm |
| 4 | `.ant-drawer`, `.ant-drawer-body`, `.ant-drawer-content-wrapper` | `EnhancedDrawer` → Radix `Sheet` (32 call-sites) |
| 1 | `getByRole('dialog', {name: 'Remove member'})` | to confirm |

Sweeping those in unreviewed would be a much larger and riskier change, so they are reported rather than bundled. Note that a blanket `.ant-modal` → role replacement across the suite would be **wrong**: API Keys, for one, still renders a raw antd `Modal`, and its selectors are correct today.

One test, `app-management.ts:142` ("should render the app overview page…"), cannot be verified on a local stack: it calls `page.waitForLoadState("networkidle")`, and the verification deployment runs `next dev`, whose HMR websocket (`ws://…/_next/webpack-hmr`) keeps the page from ever reaching network-idle — measured on `/apps`, `/prompts` and `/settings` alike, with zero in-flight requests. Everything the test asserts (the Deployment heading, all three environment cards, "Recent Prompts") renders correctly in the failure snapshot. A production build has no such socket.
