### PR TITLE
fix(tests): retire the remaining stale antd selectors, per emitter

### DIFF
--- a/web/ee/tests/playwright/acceptance/members/index.ts
+++ b/web/ee/tests/playwright/acceptance/members/index.ts
@@ -108,6 +108,28 @@ const submitInviteMembersModal = async (inviteModal: any) => {
  * in the members table with "Invitation Pending" status.
  * Returns the invited email so callers can locate the row.
  */
+/**
+ * A row in the members table.
+ *
+ * The table is virtualised: the semantic `<table>` carries only the `<thead>` and each
+ * body row is a `[data-row-key]` node outside it, so `locator("tr")` only ever matches
+ * the header.
+ */
+const memberRow = (page: any, email: string) =>
+    page.locator("[data-row-key]").filter({hasText: email}).first()
+
+/**
+ * Closes the "Invited user link" dialog that opens after a successful invite.
+ * No-op if it is not showing, so callers need not care whether it appeared.
+ */
+const dismissInvitedUserLinkDialog = async (page: any) => {
+    const dialog = page.getByRole("dialog", {name: "Invited user link"})
+    if (!(await dialog.isVisible().catch(() => false))) return
+    // `exact` matters: the footer also carries a "Copy & Close" button.
+    await dialog.getByRole("button", {name: "Close", exact: true}).click()
+    await expect(dialog).toBeHidden({timeout: 10000})
+}
+
 const invitePendingMember = async (page: any, apiHelpers: any, uiHelpers: any): Promise<string> => {
     const testEmail = createInviteEmail("test-member")
 
@@ -133,8 +155,13 @@ const invitePendingMember = async (page: any, apiHelpers: any, uiHelpers: any): 
     // timing races between listener registration and the async form submit).
     await submitInviteMembersModal(inviteModal)
 
-    // Wait for the pending row to appear in the refreshed table
-    await expect(page.getByText(testEmail)).toBeVisible({timeout: 15000})
+    // Submitting opens the "Invited user link" dialog ON TOP of the members table, and
+    // that dialog shows the invitee's address. Waiting on the email alone therefore
+    // passes against text inside the DIALOG, while the table behind it may not have
+    // refreshed at all — which is why callers then failed to find the row. Close it
+    // first, then wait for the row itself.
+    await dismissInvitedUserLinkDialog(page)
+    await expect(memberRow(page, testEmail)).toBeVisible({timeout: 15000})
 
     return testEmail
 }
@@ -192,12 +219,20 @@ const membersTests = () => {
             })
 
             await scenarios.then(
-                "the invited member appears in the members list with an Invitation Pending tag",
+                "the invited member appears in the members list with a Pending status chip",
                 async () => {
-                    await expect(page.getByText("Invitation Pending").first()).toBeVisible({
-                        timeout: 15000,
+                    // The status chip used to read "Invitation Pending"; it is now a chip
+                    // reading just "Pending" (the row is already an invitation, so the word
+                    // added nothing). The chip is a bare <span> with no role or accessible
+                    // name of its own, so scope to the member's row — "Pending" on its own
+                    // is generic enough to match unrelated text elsewhere on the page.
+                    await dismissInvitedUserLinkDialog(page)
+
+                    const row = memberRow(page, testEmail)
+                    await expect(row).toBeVisible({timeout: 15000})
+                    await expect(row.getByText("Pending", {exact: true})).toBeVisible({
+                        timeout: 10000,
                     })
-                    await expect(page.getByText(testEmail)).toBeVisible({timeout: 10000})
                 },
             )
         },
@@ -223,10 +258,10 @@ const membersTests = () => {
             })
 
             await scenarios.when("the user opens the actions menu for that member", async () => {
-                const memberRow = page.locator("tr").filter({hasText: testEmail})
-                await expect(memberRow).toBeVisible({timeout: 10000})
+                const row = memberRow(page, testEmail)
+                await expect(row).toBeVisible({timeout: 10000})
                 // ⋯ button is the last button in the row
-                await memberRow.locator("button").last().click()
+                await row.locator("button").last().click()
             })
 
             await scenarios.and("the user clicks Resend invitation", async () => {
@@ -262,9 +297,9 @@ const membersTests = () => {
             })
 
             await scenarios.when("the user opens the actions menu for that member", async () => {
-                const memberRow = page.locator("tr").filter({hasText: testEmail})
-                await expect(memberRow).toBeVisible({timeout: 10000})
-                await memberRow.locator("button").last().click()
+                const row = memberRow(page, testEmail)
+                await expect(row).toBeVisible({timeout: 10000})
+                await row.locator("button").last().click()
             })
 
             await scenarios.and("the user clicks Remove and confirms", async () => {

--- a/web/ee/tests/playwright/acceptance/members/index.ts
+++ b/web/ee/tests/playwright/acceptance/members/index.ts
@@ -270,8 +270,10 @@ const membersTests = () => {
             await scenarios.and("the user clicks Remove and confirms", async () => {
                 await page.locator(".ant-dropdown-menu-item").filter({hasText: "Remove"}).click()
 
-                // AlertPopup renders as a modal.confirm dialog — title "Remove member"
-                const confirmDialog = page.getByRole("dialog", {name: "Remove member"})
+                // `AlertPopup` calls `modal.confirm` from `@agenta/ui/app-message`, which
+                // renders a Radix `AlertDialog`. Its content carries role="alertdialog",
+                // a distinct role from "dialog" — so `getByRole("dialog")` never matches.
+                const confirmDialog = page.getByRole("alertdialog", {name: "Remove member"})
                 await expect(confirmDialog).toBeVisible({timeout: 10000})
                 await Promise.all([
                     waitForRemoveResponse(page),

--- a/web/oss/tests/playwright/acceptance/evaluators/index.ts
+++ b/web/oss/tests/playwright/acceptance/evaluators/index.ts
@@ -389,12 +389,15 @@ const testEvaluators = () => {
             await createHumanEvaluatorFromDrawer(page, {evaluatorName, feedbackName})
 
             // Step 4: Verify the success message (already checked inside the helper,
-            // but we confirm the final state here as well)
+            // but we confirm the final state here as well).
+            // The HUMAN evaluator path toasts through `@agenta/ui/app-message`, which
+            // renders a `role="status"` notification rather than an antd `.ant-message`
+            // node. The automatic-evaluator assertions elsewhere in this file still use
+            // `.ant-message` and are still correct: that path toasts through antd
+            // (`WorkflowRevisionDrawerWrapper` imports `message` from "antd"). Same
+            // message text, two different emitters.
             await expect(
-                page
-                    .locator(".ant-message")
-                    .getByText(HUMAN_EVALUATOR_CREATE_SUCCESS_MESSAGE)
-                    .first(),
+                page.getByRole("status").getByText(HUMAN_EVALUATOR_CREATE_SUCCESS_MESSAGE).first(),
             ).toBeVisible({timeout: 10000})
 
             // Step 5: Verify the new evaluator appears in the Human tab table.

--- a/web/oss/tests/playwright/acceptance/evaluators/tests.ts
+++ b/web/oss/tests/playwright/acceptance/evaluators/tests.ts
@@ -152,8 +152,19 @@ const selectEvaluatorTemplate = async (page: Page, templateName: string) => {
     return drawer.first()
 }
 
+/**
+ * A success toast. These are no longer antd `message` nodes (`.ant-message`): the
+ * @agenta/ui app-message service renders its own `Notification`, which carries
+ * `role="status"` for ordinary toasts and `role="alert"` for errors.
+ */
+const successToast = (page: Page, text: string) => page.getByRole("status").getByText(text).first()
+
+// Matched by role, not by a component-library class: `EntityCommitModal` renders
+// through `EnhancedModal`, which is a facade over the @agenta/ui (Radix) `Dialog`,
+// so there is no `.ant-modal` in this tree. The name-input filter keeps this
+// pointed at the commit modal specifically.
 const getEvaluatorCommitModal = (page: Page) =>
-    page.locator(".ant-modal").filter({
+    page.getByRole("dialog").filter({
         has: page.locator(`input[placeholder="${EVALUATOR_COMMIT_MODAL_NAME_PLACEHOLDER}"]`),
     })
 
@@ -340,11 +351,12 @@ const createHumanEvaluatorFromDrawer = async (
     await expect(createButton).toBeVisible()
     await createButton.click()
 
-    // Wait for the human evaluator create drawer to open
-    const drawer = page
-        .locator(".ant-drawer")
-        .filter({hasText: HUMAN_EVALUATOR_DRAWER_TITLE})
-        .first()
+    // Wait for the human evaluator create drawer to open. This one is the
+    // `AnnotateDrawer`, which renders through `EnhancedDrawer` — a facade over the
+    // @agenta/ui (Radix) `Sheet` — so it is a `role="dialog"` node, not `.ant-drawer`.
+    // (The evaluator create/view/edit drawers elsewhere in this file are still the antd
+    // `WorkflowRevisionDrawer`; their `.ant-drawer` selectors remain correct.)
+    const drawer = page.getByRole("dialog").filter({hasText: HUMAN_EVALUATOR_DRAWER_TITLE}).first()
     await expect(drawer).toBeVisible({timeout: 10000})
 
     // Fill in the evaluator name
@@ -405,9 +417,9 @@ const createHumanEvaluatorFromDrawer = async (
     await creationPromise
 
     // Verify the success message
-    await expect(
-        page.locator(".ant-message").getByText(HUMAN_EVALUATOR_CREATE_SUCCESS_MESSAGE).first(),
-    ).toBeVisible({timeout: 10000})
+    await expect(successToast(page, HUMAN_EVALUATOR_CREATE_SUCCESS_MESSAGE)).toBeVisible({
+        timeout: 10000,
+    })
 
     // Verify the drawer closes
     await expect(drawer).toHaveCount(0, {timeout: 10000})
@@ -482,9 +494,11 @@ const editEvaluatorAndSaveNewVersion = async (page: Page, evaluatorName: string)
     await expect(commitButton).toBeEnabled({timeout: 20000})
     await commitButton.click()
 
-    // EntityCommitModal opens — identified by the commit message textarea
+    // EntityCommitModal opens — identified by the commit message textarea. Matched by
+    // role: `EnhancedModal` is a facade over the @agenta/ui (Radix) `Dialog`, so there
+    // is no `.ant-modal` here.
     const commitModal = page
-        .locator(".ant-modal")
+        .getByRole("dialog")
         .filter({
             has: page.locator(`textarea[placeholder="${EVALUATOR_COMMIT_MESSAGE_PLACEHOLDER}"]`),
         })
@@ -498,9 +512,7 @@ const editEvaluatorAndSaveNewVersion = async (page: Page, evaluatorName: string)
     await expect(modalCommitBtn).toBeEnabled({timeout: 5000})
     await modalCommitBtn.click()
 
-    await expect(
-        page.locator(".ant-message").getByText(EVALUATOR_COMMIT_SUCCESS_MESSAGE).first(),
-    ).toBeVisible({timeout: 15000})
+    await expect(successToast(page, EVALUATOR_COMMIT_SUCCESS_MESSAGE)).toBeVisible({timeout: 15000})
 }
 
 /**
@@ -511,17 +523,16 @@ const deleteEvaluator = async (page: Page, evaluatorName: string) => {
     await openEvaluatorRowMenu(page, evaluatorName)
     await page.getByRole("menuitem", {name: EVALUATOR_DELETE_MENU_ITEM}).click()
 
-    // DeleteEvaluatorsModal
+    // DeleteEvaluatorsModal — also an `EnhancedModal`, so match by role rather than
+    // `.ant-modal`.
     const deleteModal = page
-        .locator(".ant-modal")
+        .getByRole("dialog")
         .filter({hasText: EVALUATOR_DELETE_MODAL_TITLE})
         .first()
     await expect(deleteModal).toBeVisible({timeout: 10000})
     await deleteModal.getByRole("button", {name: EVALUATOR_DELETE_MENU_ITEM}).click()
 
-    await expect(
-        page.locator(".ant-message").getByText(EVALUATOR_DELETE_SUCCESS_MESSAGE).first(),
-    ).toBeVisible({timeout: 10000})
+    await expect(successToast(page, EVALUATOR_DELETE_SUCCESS_MESSAGE)).toBeVisible({timeout: 10000})
 
     // Verify the row is gone
     await expect

--- a/web/oss/tests/playwright/acceptance/human-annotation/index.ts
+++ b/web/oss/tests/playwright/acceptance/human-annotation/index.ts
@@ -10,6 +10,7 @@ import {errors, type Page} from "@playwright/test"
 
 import {
     expect,
+    humanEvaluationModal,
     goToHumanEvaluationStep,
     openHumanEvaluationModal,
     selectHumanEvaluationModalTableInput,
@@ -186,7 +187,7 @@ const humanAnnotationTests = () => {
                 skipEvaluatorCreation: true,
             })
 
-            await expect(page.locator(".ant-modal").first()).toHaveCount(0)
+            await expect(humanEvaluationModal(page)).toHaveCount(0)
 
             await expect
                 .poll(() => new URL(page.url()).pathname)
@@ -263,7 +264,7 @@ const humanAnnotationTests = () => {
                 evaluatorMetricName: INLINE_EVALUATOR_METRIC_NAME,
             })
 
-            await expect(page.locator(".ant-modal").first()).toHaveCount(0)
+            await expect(humanEvaluationModal(page)).toHaveCount(0)
             await expect
                 .poll(() => new URL(page.url()).pathname)
                 .toContain(`${getProjectScopedBasePath(page)}/apps/${appId}/evaluations/results/`)
@@ -333,7 +334,7 @@ const humanAnnotationTests = () => {
                 evaluatorMetricName: INLINE_EVALUATOR_METRIC_NAME,
             })
 
-            await expect(page.locator(".ant-modal").first()).toHaveCount(0)
+            await expect(humanEvaluationModal(page)).toHaveCount(0)
 
             // Annotate the first scenario (initially shown after run creation)
             await annotateCurrentHumanScenario({

--- a/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
@@ -499,11 +499,23 @@ const openHumanAnnotateView = async (page: Page) => {
     await expect(page.locator("#focus-section-annotations")).toBeVisible()
 }
 
+/**
+ * The "New Human Evaluation" modal, scoped by its title.
+ *
+ * Callers assert this has closed. Do not use a bare `getByRole("dialog")` for that:
+ * drawers are Radix `Sheet`s and also carry `role="dialog"`, so an unscoped count
+ * fails whenever any drawer happens to be open.
+ */
+const humanEvaluationModal = (page: Page) =>
+    page.getByRole("dialog").filter({hasText: HUMAN_EVALUATION_MODAL_TITLE})
+
 const openHumanEvaluationModal = async (page: Page) => {
     await ensureHumanEvaluationsContext(page)
     await (await getHumanEvaluationCreateButton(page, 60000)).click()
 
-    const modal = page.locator(".ant-modal").first()
+    // Matched by role: this modal renders through `EnhancedModal`, a facade over the
+    // @agenta/ui (Radix) `Dialog`, so there is no `.ant-modal`.
+    const modal = page.getByRole("dialog").first()
     await expect(modal).toBeVisible()
     await expect(modal.getByText(HUMAN_EVALUATION_MODAL_TITLE).first()).toBeVisible()
     await expect(
@@ -846,8 +858,10 @@ const testWithHumanFixtures = baseTest.extend<HumanEvaluationFixtures>({
                 await expect(createEvaluatorButton).toBeVisible()
                 await createEvaluatorButton.click()
 
+                // Matched by role: this drawer renders through `EnhancedDrawer`, a facade
+                // over the @agenta/ui (Radix) `Sheet`.
                 const evaluatorDrawer = page
-                    .locator(".ant-drawer-content-wrapper")
+                    .getByRole("dialog")
                     .filter({
                         has: page.locator('input[placeholder="Enter a unique slug"]'),
                     })
@@ -882,7 +896,7 @@ const testWithHumanFixtures = baseTest.extend<HumanEvaluationFixtures>({
 
                 await expect(evaluatorSlugInput).toHaveCount(0)
                 await expect(
-                    page.locator(".ant-message").getByText("Evaluator created successfully"),
+                    page.getByRole("status").getByText("Evaluator created successfully"),
                 ).toBeVisible()
             }
 
@@ -941,7 +955,7 @@ const testWithHumanFixtures = baseTest.extend<HumanEvaluationFixtures>({
                 await annotateButton.click()
 
                 await expect(
-                    page.locator(".ant-message").getByText("Annotations saved successfully"),
+                    page.getByRole("status").getByText("Annotations saved successfully"),
                 ).toBeVisible()
 
                 await expect(
@@ -960,6 +974,7 @@ const testWithHumanFixtures = baseTest.extend<HumanEvaluationFixtures>({
 export {
     testWithHumanFixtures as test,
     expect,
+    humanEvaluationModal,
     openHumanEvaluationModal,
     goToHumanEvaluationStep,
     selectHumanEvaluationModalTableInput,

--- a/web/oss/tests/playwright/acceptance/settings/model-hub.ts
+++ b/web/oss/tests/playwright/acceptance/settings/model-hub.ts
@@ -11,6 +11,7 @@ import {
 } from "@agenta/web-tests/playwright/config/testTags"
 import {test} from "@agenta/web-tests/tests/fixtures/base.fixture"
 import {expect} from "@agenta/web-tests/utils"
+import type {Locator} from "@playwright/test"
 
 import {expectAuthenticatedSession} from "../utils/auth"
 import {createScenarios} from "../utils/scenarios"
@@ -29,6 +30,24 @@ import {buildAcceptanceTags} from "../utils/tags"
  * NOTE: Authentication is globally handled in Playwright config/globalSetup.
  * Info: Adding secret at the bigening of the all tests and then removing the secret in the end of all the tests
  */
+// Product copy for the custom-providers section. The section header is plural; the
+// button that opens its create form is "Add endpoint". Note that the provider-KIND
+// label in the type dropdown is still the singular "OpenAI-compatible endpoint" — a
+// different string in a different place, deliberately left as-is below.
+const CUSTOM_PROVIDERS_SECTION_HEADER = "OpenAI-compatible endpoints"
+const CUSTOM_PROVIDER_ADD_BUTTON_LABEL = "Add endpoint"
+
+/**
+ * A data row in one of the provider tables.
+ *
+ * These tables are virtualised: the semantic `<table>` carries only the `<thead>`, and
+ * each body row is rendered outside it as a `[data-row-key]` node with no `row`/`cell`
+ * role. Matching on `getByRole("row")`/`getByRole("cell")` therefore only ever sees the
+ * header. `[data-row-key]` is how the rest of this suite addresses virtualised rows.
+ */
+const providerRow = (section: Locator, name: string) =>
+    section.locator("[data-row-key]").filter({hasText: name}).first()
+
 const scenarios = createScenarios(test)
 
 const tags = buildAcceptanceTags({
@@ -67,14 +86,10 @@ const modelHubTests = () => {
 
         await scenarios.then('the "Custom providers" table lists the "mock" provider', async () => {
             const customProvidersSection = page
-                .getByText("OpenAI-compatible endpoint", {exact: true})
+                .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
                 .locator("xpath=ancestor::section[1]")
                 .first()
-            const providersTable = customProvidersSection.getByRole("table").first()
-            const mockRow = providersTable
-                .getByRole("row")
-                .filter({has: page.getByRole("cell", {name: "mock", exact: true})})
-                .first()
+            const mockRow = providerRow(customProvidersSection, "mock")
 
             await expect(mockRow).toBeVisible({timeout: 15000})
             await expect(mockRow).toContainText("mock")
@@ -85,6 +100,11 @@ const modelHubTests = () => {
         "should configure a standard provider key and verify it is listed",
         {tag: tagsLight},
         async ({page, testProviderHelpers}, testInfo) => {
+            // Captured before configuring so the "then" step can assert the count went
+            // down. Counting rows instead does not work: the table is virtualised, so the
+            // DOM holds only the rows currently in view.
+            let configureNowCountBefore = 0
+
             await scenarios.given("the user is authenticated", async () => {
                 await expectAuthenticatedSession(page)
             })
@@ -114,9 +134,15 @@ const modelHubTests = () => {
                         "All standard providers are already configured — skipping standard provider key test",
                     )
 
+                    configureNowCountBefore = await standardProvidersSection
+                        .getByRole("button", {name: "Configure now"})
+                        .count()
+
                     await configureNowButton.click()
 
-                    const modal = page.locator(".ant-modal").last()
+                    // Matched by role: this modal renders through `EnhancedModal`, a facade
+                    // over the @agenta/ui (Radix) `Dialog`, so there is no `.ant-modal`.
+                    const modal = page.getByRole("dialog").last()
                     await expect(modal).toBeVisible({timeout: 15000})
                     await modal.getByPlaceholder("Enter API key").fill("sk-test-e2e-cleanup")
                     await modal.getByRole("button", {name: "Confirm"}).click()
@@ -136,13 +162,13 @@ const modelHubTests = () => {
                         name: "Configure now",
                     })
 
-                    // At least one provider is now configured (count reduced or a key is visible)
-                    const remainingCount = await configureNowButtons.count()
-                    const providersTable = standardProvidersSection.getByRole("table").first()
-                    const allRows = providersTable.getByRole("row")
-                    const rowCount = await allRows.count()
-                    // Verify that not all rows still show Configure now
-                    expect(remainingCount).toBeLessThan(rowCount - 1)
+                    // One more provider is configured than before, so one fewer row offers
+                    // "Configure now". Comparing against a row count does not work here —
+                    // the table is virtualised, so the number of rows in the DOM depends on
+                    // the viewport rather than on how many providers exist.
+                    await expect
+                        .poll(() => configureNowButtons.count(), {timeout: 15000})
+                        .toBeLessThan(configureNowCountBefore)
                 },
             )
 
@@ -154,16 +180,24 @@ const modelHubTests = () => {
                         .locator("xpath=ancestor::section[1]")
                         .first()
 
-                    // AntD renders color="danger" buttons with class ant-btn-color-dangerous
-                    // This button only renders in rows where a key is already configured
-                    const trashButton = standardProvidersSection
-                        .locator(".ant-btn-color-dangerous")
+                    // Deleting is no longer a visible danger button — it is an entry in the
+                    // row's actions menu. That menu only renders for rows that already have
+                    // a key, so "the first row with an actions button" IS a configured row.
+                    const configuredRow = standardProvidersSection
+                        .locator("[data-row-key]")
+                        .filter({has: page.locator("button")})
                         .first()
+                    await expect(configuredRow).toBeVisible({timeout: 15000})
+                    await configuredRow.locator("button").last().click()
 
-                    await expect(trashButton).toBeVisible({timeout: 15000})
-                    await trashButton.click()
+                    // Scope by name: the sidebar navigation also uses role="menuitem".
+                    const removeKeyItem = page.getByRole("menuitem", {name: "Remove key"})
+                    await expect(removeKeyItem).toBeVisible({timeout: 10000})
+                    await removeKeyItem.click()
 
-                    const deleteModal = page.locator(".ant-modal").last()
+                    // Matched by role: this confirmation renders through `EnhancedModal`
+                    // (Radix `Dialog`), so there is no `.ant-modal`.
+                    const deleteModal = page.getByRole("dialog").last()
                     await expect(deleteModal).toBeVisible({timeout: 15000})
                     await deleteModal.getByRole("button", {name: "Delete"}).click()
                     await expect(deleteModal).not.toBeVisible({timeout: 15000})
@@ -206,31 +240,39 @@ const modelHubTests = () => {
                 "the user creates a new custom provider via the drawer",
                 async () => {
                     const customProvidersSection = page
-                        .getByText("OpenAI-compatible endpoint", {exact: true})
+                        .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
                         .locator("xpath=ancestor::section[1]")
                         .first()
 
-                    // The section's own label IS the trigger button now — "Create" was
-                    // renamed to "OpenAI-compatible endpoint".
-                    const createButton = customProvidersSection.getByRole("button", {
-                        name: "OpenAI-compatible endpoint",
-                        exact: true,
-                    })
+                    // The button that opens the create form. It is rendered twice inside
+                    // the section (header + empty-state row), hence `.first()`.
+                    const createButton = customProvidersSection
+                        .getByRole("button", {
+                            name: CUSTOM_PROVIDER_ADD_BUTTON_LABEL,
+                            exact: true,
+                        })
+                        .first()
                     await expect(createButton).toBeVisible({timeout: 15000})
                     await createButton.click()
 
-                    const drawer = page.locator(".ant-drawer-content-wrapper").last()
+                    // Matched by role: the configure-provider drawer renders through
+                    // `EnhancedDrawer`, a facade over the @agenta/ui (Radix) `Sheet`, so
+                    // there is no `.ant-drawer-content-wrapper`.
+                    const drawer = page.getByRole("dialog").last()
                     await expect(drawer).toBeVisible({timeout: 15000})
                     await expect(drawer.getByText("Configure provider")).toBeVisible({
                         timeout: 15000,
                     })
 
-                    // Select "OpenAI-compatible endpoint" from the provider type dropdown
-                    const providerSelect = drawer.locator(".ant-select").first()
+                    // Select "OpenAI-compatible endpoint" from the provider type dropdown.
+                    // This is no longer an antd Select: it is a Radix Popover whose trigger
+                    // is a disclosure button (`aria-haspopup="listbox"`) and whose entries
+                    // carry `role="option"`.
+                    const providerSelect = drawer.locator('button[aria-haspopup="listbox"]').first()
                     await expect(providerSelect).toBeVisible({timeout: 15000})
                     await providerSelect.click()
 
-                    const options = page.locator(".ant-select-item-option")
+                    const options = page.getByRole("option")
                     await expect(options.first()).toBeVisible({timeout: 15000})
 
                     const optionTexts = (await options.allTextContents()).map((t) => t.trim())
@@ -266,18 +308,11 @@ const modelHubTests = () => {
                 "the new custom provider row appears in the Custom providers table",
                 async () => {
                     const customProvidersSection = page
-                        .getByText("OpenAI-compatible endpoint", {exact: true})
+                        .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
                         .locator("xpath=ancestor::section[1]")
                         .first()
 
-                    const newRow = customProvidersSection
-                        .getByRole("table")
-                        .first()
-                        .getByRole("row")
-                        .filter({
-                            has: page.getByRole("cell", {name: providerName, exact: true}),
-                        })
-                        .first()
+                    const newRow = providerRow(customProvidersSection, providerName)
 
                     await expect(newRow).toBeVisible({timeout: 15000})
                 },
@@ -285,20 +320,23 @@ const modelHubTests = () => {
 
             await scenarios.when("the user deletes the newly created custom provider", async () => {
                 const customProvidersSection = page
-                    .getByText("OpenAI-compatible endpoint", {exact: true})
+                    .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
                     .locator("xpath=ancestor::section[1]")
                     .first()
 
-                const newRow = customProvidersSection
-                    .getByRole("table")
-                    .first()
-                    .getByRole("row")
-                    .filter({has: page.getByRole("cell", {name: providerName, exact: true})})
-                    .first()
+                const newRow = providerRow(customProvidersSection, providerName)
 
-                await newRow.locator("button").first().click()
+                // The row's single button opens its actions menu; deleting is an entry in it.
+                await newRow.locator("button").last().click()
 
-                const deleteModal = page.locator(".ant-modal").last()
+                // Scope by name: the sidebar navigation also uses role="menuitem".
+                const deleteItem = page.getByRole("menuitem", {name: "Delete endpoint"})
+                await expect(deleteItem).toBeVisible({timeout: 10000})
+                await deleteItem.click()
+
+                // Matched by role: this confirmation renders through `EnhancedModal`
+                // (Radix `Dialog`), so there is no `.ant-modal`.
+                const deleteModal = page.getByRole("dialog").last()
                 await expect(deleteModal).toBeVisible({timeout: 15000})
                 await deleteModal.getByRole("button", {name: "Delete"}).click()
                 await expect(deleteModal).not.toBeVisible({timeout: 30000})
@@ -306,16 +344,11 @@ const modelHubTests = () => {
 
             await scenarios.then("the deleted provider row is no longer visible", async () => {
                 const customProvidersSection = page
-                    .getByText("OpenAI-compatible endpoint", {exact: true})
+                    .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
                     .locator("xpath=ancestor::section[1]")
                     .first()
 
-                const deletedRow = customProvidersSection
-                    .getByRole("table")
-                    .first()
-                    .getByRole("row")
-                    .filter({has: page.getByRole("cell", {name: providerName, exact: true})})
-                    .first()
+                const deletedRow = providerRow(customProvidersSection, providerName)
 
                 await expect(deletedRow).not.toBeVisible({timeout: 15000})
             })

--- a/web/oss/tests/playwright/acceptance/testsset/testset-management.ts
+++ b/web/oss/tests/playwright/acceptance/testsset/testset-management.ts
@@ -15,7 +15,17 @@ import {
     TestSpeedType,
 } from "@agenta/web-tests/playwright/config/testTags"
 
+import type {Page} from "@playwright/test"
+
 const scenarios = createScenarios(test)
+
+/**
+ * The testcase edit drawer. It renders through `EnhancedDrawer` — a facade over the
+ * @agenta/ui (Radix) `Sheet` — so it is a `role="dialog"` node with no `.ant-drawer`
+ * wrapper and no separate `.ant-drawer-body` element; field lookups scope to the
+ * dialog itself. (The commit modals in this file are matched separately.)
+ */
+const testcaseDrawer = (page: Page) => page.getByRole("dialog")
 
 const smokeTags = buildAcceptanceTags({
     scope: [TestScope.DATASETS],
@@ -82,9 +92,9 @@ const testsetTests = () => {
                     // Close the drawer so the Commit button is accessible.
                     // The drawer has closeIcon={null} — no X button. Use the footer "Cancel" button.
                     // "Cancel" on an unedited new row just calls onClose() without discarding.
-                    await expect(page.locator(".ant-drawer")).toBeVisible({timeout: 5000})
-                    await page.locator(".ant-drawer").getByRole("button", {name: "Cancel"}).click()
-                    await expect(page.locator(".ant-drawer")).toBeHidden({timeout: 5000})
+                    await expect(testcaseDrawer(page)).toBeVisible({timeout: 5000})
+                    await testcaseDrawer(page).getByRole("button", {name: "Cancel"}).click()
+                    await expect(testcaseDrawer(page)).toBeHidden({timeout: 5000})
 
                     // Commit the new testset
                     await page.getByRole("button", {name: "Commit"}).click()
@@ -207,7 +217,7 @@ const testsetTests = () => {
                     await cell.click()
 
                     // Wait for the edit drawer to open
-                    const drawerBody = page.locator(".ant-drawer-body")
+                    const drawerBody = testcaseDrawer(page)
                     await expect(drawerBody).toBeVisible({timeout: 10000})
 
                     // Find the contenteditable Lexical editor field in the drawer
@@ -228,12 +238,12 @@ const testsetTests = () => {
                     // Lexical onChange has fired and updated the draft atom (hasSessionDirty=true).
                     // Wait for it to be enabled before clicking — this implicitly confirms the
                     // draft was updated.
-                    const applyButton = page
-                        .locator(".ant-drawer")
-                        .getByRole("button", {name: "Apply and Continue Editing"})
+                    const applyButton = testcaseDrawer(page).getByRole("button", {
+                        name: "Apply and Continue Editing",
+                    })
                     await expect(applyButton).toBeEnabled({timeout: 5000})
                     await applyButton.click()
-                    await expect(page.locator(".ant-drawer")).toBeHidden({timeout: 5000})
+                    await expect(testcaseDrawer(page)).toBeHidden({timeout: 5000})
 
                     // Commit the changes
                     await page.getByRole("button", {name: "Commit"}).click()
@@ -307,25 +317,23 @@ const testsetTests = () => {
 
                     // The drawer opens for the new row. We must edit the Lexical field in a way
                     // that reliably updates its EditorState before closing the drawer.
-                    await expect(page.locator(".ant-drawer")).toBeVisible({timeout: 5000})
-                    await expect(page.locator(".ant-drawer-body")).not.toContainText(
-                        "No items to display",
-                        {timeout: 5000},
-                    )
-                    const newRowField = page
-                        .locator(".ant-drawer-body")
+                    await expect(testcaseDrawer(page)).toBeVisible({timeout: 5000})
+                    await expect(testcaseDrawer(page)).not.toContainText("No items to display", {
+                        timeout: 5000,
+                    })
+                    const newRowField = testcaseDrawer(page)
                         .locator('[contenteditable="true"], input, textarea')
                         .first()
                     await expect(newRowField).toBeVisible({timeout: 5000})
                     await newRowField.fill("new-row-value")
                     await expect(newRowField).toContainText("new-row-value", {timeout: 5000})
 
-                    const newRowApplyBtn = page
-                        .locator(".ant-drawer")
-                        .getByRole("button", {name: "Apply and Continue Editing"})
+                    const newRowApplyBtn = testcaseDrawer(page).getByRole("button", {
+                        name: "Apply and Continue Editing",
+                    })
                     await expect(newRowApplyBtn).toBeEnabled({timeout: 5000})
                     await newRowApplyBtn.click()
-                    await expect(page.locator(".ant-drawer")).toBeHidden({timeout: 5000})
+                    await expect(testcaseDrawer(page)).toBeHidden({timeout: 5000})
 
                     await expect(
                         page.locator("[data-row-key]").filter({hasText: "new-row-value"}).first(),

--- a/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
@@ -14,6 +14,12 @@ import type {
     TestProviderProfileInfo,
 } from "./types"
 
+// Header of the custom-providers ("OpenAI-compatible endpoints") section, and the
+// label of the button that opens its create form. Both are product copy; keep them
+// here so a rename is a one-line fix rather than a hunt through the helpers.
+const CUSTOM_PROVIDERS_SECTION_HEADER = "OpenAI-compatible endpoints"
+const CUSTOM_PROVIDER_ADD_BUTTON_LABEL = "Add endpoint"
+
 const MOCK_PROVIDER_NAME = "mock"
 const MOCK_PROVIDER_KIND = "custom"
 const MOCK_MODEL_NAME = "gpt-6"
@@ -145,8 +151,14 @@ async function waitForModelsPageReady(page: Page): Promise<void> {
                     .locator(".ant-spin-spinning")
                     .isVisible()
                     .catch(() => false)
+                // `.first()` matters: the section renders this button twice (once in the
+                // header, once in the empty-state row). Without it the locator is strict-mode
+                // ambiguous, `isEnabled()` throws, and the `.catch` below turns that into a
+                // permanent `false` — the poll then times out with a "never reached a stable
+                // ready state" message that says nothing about the real cause.
                 const createButtonEnabled = await customProvidersSection
-                    .getByRole("button", {name: "OpenAI-compatible endpoint"})
+                    .getByRole("button", {name: CUSTOM_PROVIDER_ADD_BUTTON_LABEL})
+                    .first()
                     .isEnabled()
                     .catch(() => false)
 
@@ -189,10 +201,12 @@ async function navigateToModels(page: Page, uiHelpers: UIHelpers): Promise<void>
 }
 
 function getCustomProvidersSection(page: Page): Locator {
-    // The custom-providers section no longer has a dedicated header label — its
-    // section-identifying text IS the "OpenAI-compatible endpoint" trigger button now.
+    // Anchored on the section's own header text. This used to key off the
+    // "OpenAI-compatible endpoint" trigger button, but that button is now labelled
+    // "Add endpoint", so the old anchor matched nothing and the section could never
+    // be found. The header reads "OpenAI-compatible endpoints" (plural).
     return page
-        .getByText("OpenAI-compatible endpoint", {exact: true})
+        .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
         .locator("xpath=ancestor::section[1]")
         .first()
 }


### PR DESCRIPTION
Follow-up to #5816, which has landed; this is now based on `release/v0.111.0` directly.

#5816 fixed the one dead selector behind 28 of the 43 acceptance failures. This fixes the other 15, plus six tests that CI reported as green and that a v0.111.0 build breaks.

Every change below was reproduced against the live EE v0.111.0 deployment before it was written, and re-run after. Nothing here touches product code.

## The 15 remaining CI failures

All the same antd → `@agenta/ui` (Radix) migration, reaching different selectors.

| Was | Now | Failures |
|---|---|---|
| `.ant-modal` + name input / commit textarea / delete title | `getByRole("dialog")` — `EntityCommitModal` and `DeleteEvaluatorsModal` are `EnhancedModal` (Radix `Dialog`) | 9 |
| `.ant-drawer` + "Create new evaluator" | `getByRole("dialog")` — `AnnotateDrawer` is an `EnhancedDrawer` (Radix `Sheet`) | 1 |
| `.ant-drawer`, `.ant-drawer-body` (testcase edit drawer) | `getByRole("dialog")` via a named `testcaseDrawer()` helper | 3 |
| `.ant-modal`, `.ant-drawer-content-wrapper` (Model Hub) | `getByRole("dialog")` | 2 |
| `getByRole("dialog", {name: "Remove member"})` | `getByRole("alertdialog", …)` | 1 |

Three toast assertions also moved from `.ant-message` to `getByRole("status")`: the `@agenta/ui` app-message service renders its own `Notification` (`role="status"`, `role="alert"` for errors).

## The judgement call this PR is really about

**A blanket `.ant-modal` → role replacement would have broken eight working assertions.** The application is genuinely half-migrated, and the two halves are not separable by grepping for a class name:

- `evaluators/index.ts` asserts **"Evaluator created successfully"** in both the automatic and the human flow. Same string, two emitters: the automatic path toasts through **antd** (`WorkflowRevisionDrawerWrapper` imports `message` from `"antd"`) and its `.ant-message` selectors are correct; only the human path goes through `@agenta/ui`. One line changed, eight left alone.
- The evaluator create / view / edit drawers are still the antd `WorkflowRevisionDrawer`, so their `.ant-drawer` selectors stay. Only the `AnnotateDrawer` moved.
- The "Commit Changes" modals in the testset spec are still raw antd and are untouched.
- API Keys still renders a real antd `Modal`; its selectors were already correct and are untouched.

Each of these was decided by reading which component renders that specific element, not by pattern-matching the test.

## Three tests that CI says are green and are not

`Settings: Model Hub` is a separate finding worth flagging on its own. Three commits on this release branch — `66498ab9c6`, `ad7d182ff9`, `4e9669fc5e`, **none of them on `main`** — reshaped that page. The last CI run tested `main`, so its baseline cannot show this. Against a v0.111.0 build all three model-hub tests fail:

- The custom-providers section was anchored on a trigger button labelled "OpenAI-compatible endpoint". That button is now **"Add endpoint"**, so the anchor matched nothing and every model-hub test died at setup with a misleading *"Models page never reached a stable ready state"*.
- That readiness poll also called `isEnabled()` on a locator matching the button **twice** (header + empty state). Strict mode threw, a `.catch` swallowed it into a permanent `false`, and the poll could only ever time out. This is why the real cause was invisible.
- The provider tables are now **virtualised**: the semantic `<table>` holds only the `<thead>`, and body rows live outside it as `[data-row-key]` nodes with no `row`/`cell` role. Row lookups now use `[data-row-key]`, which is how the rest of this suite addresses virtualised rows. The "not every row still says Configure now" check compared against a row count, which virtualisation makes meaningless — the DOM holds only what is in view — so it now records the count before configuring and asserts it went down.
- Deleting a provider was a visible danger button and is now an entry in the row's **actions menu**, so the tests open the menu and click "Remove key" / "Delete endpoint". Menu items are scoped by name because the sidebar navigation also uses `role="menuitem"`.


## Newly broken by PR #5783, after the CI baseline was taken

PR #5783 merged into the release branch mid-review, taking staging from 43 failures to 46. Three of the newly-failing tests are here. All three are stale tests, not product bugs.

**The two members tests** waited on the text `Invitation Pending`. The members table now renders a chip reading just `Pending`. `StatusIndicator` is a bare `<span>` — no role, no accessible name, no test id — so there is nothing semantic to target and the assertion is **scoped to the member's row** instead, since `Pending` alone is generic enough to match unrelated text.

Two further things in that file were broken by the same PR and would have blocked these tests anyway:

- The members table is now **virtualised**, so `locator("tr")` matched only the header. Two call sites.
- `invitePendingMember` waited for the invitee's email and called that "the row appeared". Submitting an invite opens the **"Invited user link" dialog on top of the table**, and that dialog contains the email — so the wait was satisfied by text inside the dialog while the table behind it had not refreshed, and every later step ran with a dialog covering the page. It now dismisses the dialog and waits for the row.

**The model hub test** (`should allow full add provider`) needed no new work: the fix already in this PR — anchoring the section on its real header rather than on a renamed button — covers it. Verified passing against a build that carries #5783.

### One correction to the brief

The claim that the new settings frame renders no `<section>` element does not hold for the Model Hub page on the current release head. Measured on the live build carrying #5783: **3 `<section>` elements**, the `OpenAI-compatible endpoints` header has a `<section>` ancestor, and `ancestor::section[1]` resolves to exactly one node. All three model-hub tests pass through that step. The heading rename to plural was the whole problem, and it is fixed. Flagging it only because it may be load-bearing in reasoning elsewhere.

### `should resend an invitation` — assertion deliberately unchanged

This one is **not** stale, and changing it would break CI. The resend succeeds (`POST …/invite/resend` → 200), but the product branches on `isEmailInvitationsEnabled()` (`NEXT_PUBLIC_AGENTA_EMAIL_DELIVERY_ENABLED`): with delivery **off**, as on the verification box, it reopens the invited-user-link dialog instead of toasting `Invitation sent!` — that dialog is in the failure snapshot. CI runs with delivery on, so the existing assertion is correct there, and the test should pass now that the shared setup above is fixed. It still fails locally, and that is expected.

## Verification

Against the live EE v0.111.0 stack, whose `web/` tree is identical to the release branch.

| Spec | Before | After |
|---|---|---|
| `evaluators` | 1 passed / 8 failed | **10 passed / 0 failed** |
| `testsset` | 3 passed / 3 failed | **6 passed / 0 failed** |
| `settings/model-hub` | 0 passed / 3 failed | **3 passed / 0 failed** |
| `human-annotation` (the 3 CI-listed) | 0 passed / 3 failed | **3 passed / 0 failed** |
| `members` (EE) | 0 passed / 3 failed | **2 passed / 1 failed** — the third is the email-delivery branch above |

A consolidated run of everything touched (`evaluators`, `testsset`, `model-hub`, `app`, `prompts`, `agent-skills`, `deployment`) gives **26 passed / 3 failed**. All three of those are known and none is a regression: `app-management`'s `networkidle` wait (see #5816 — a dev-server HMR socket means it can never settle locally), and two that pass on a re-run in isolation (`prompts › creates a new prompt`, `testsset › upload from CSV`) — load flakiness on a box hosting several stacks.

## What is explicitly NOT verified

~~**The `Remove member` fix is reasoned, not run.**~~ **Now live-verified.** Fixing the members setup above let this test run end to end on the stack, and it passes — so the `alertdialog` change is confirmed rather than inferred. The reasoning that produced it is kept below because it is still the explanation.

Originally: That test cannot execute on this stack — inviting a member does not work there, and the two sibling tests CI passes also fail locally before reaching this line, with the invitee never appearing. What *is* verified is the mechanism, link by link: `members/index.ts` → `AlertPopup.tsx` imports `modal` from `@agenta/ui/app-message` → `AppMessageRenderer` renders confirms as `<AlertDialog>` → `role: "alertdialog"` in the installed `@radix-ui/react-alert-dialog@1.1.23` on the running stack. `alertdialog` is a distinct role from `dialog`, so the old selector could not have matched.

**Two human-annotation tests still fail locally and are deliberately untouched**: "annotate a scenario from the annotate tab" and "annotate multiple scenarios". CI **skips** both, so they are outside the failure set, and they block on the annotation form never appearing — the invocation output has to be produced or seeded first. That is a data dependency, not a selector, and it wants its own investigation.

## Also worth knowing

Browser work against this deployment must use the public address, not loopback: the frontend is pinned to an absolute API origin, so a browser pointed at `127.0.0.1` is blocked by CORS at signup. Two agents have now lost time to this independently.
