### PR TITLE
[fix] Approval parks hold for 10 minutes, not 30

### DIFF
--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -37,13 +37,19 @@ const APPROVAL_TTL_ENV = "AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS";
 const POOL_MAX_ENV = "AGENTA_RUNNER_SESSION_POOL_MAX";
 
 const DEFAULT_TTL_MS = 60_000;
-// Thirty minutes. An approval park by definition has a pending interaction row waiting on a
-// human, and answers increasingly arrive from a phone minutes later (mobile approvals plan,
+// Ten minutes. An approval park by definition has a pending interaction row waiting on a human,
+// and answers increasingly arrive from a phone minutes later (mobile approvals plan,
 // 2026-07-27 §4b-4): a 5-minute window pushed most of those onto the slower cold-replay path.
+// Thirty was the first attempt at covering that; ten covers the same phone-latency case while
+// bounding a second, unrelated exposure — a rotated provider credential stays usable on a warm
+// sandbox until that sandbox is replaced, because `holdForMechanism` waits a fixed 10s for
+// propagation and declares delivery done without checking (credential-delivery-port.ts). Idle
+// parks are already bounded at 60s generic / 120s Daytona; an approval park is the only window
+// long enough to matter, so it is the one worth keeping short.
 // The window is still bounded by the mount-credential expiry check, expiry degrades to cold
 // (never fails the turn), and an awaiting_approval entry keeps holding a pool slot — override
 // via AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS if warm slots are contended.
-const DEFAULT_APPROVAL_TTL_MS = 1_800_000;
+const DEFAULT_APPROVAL_TTL_MS = 600_000;
 const DEFAULT_POOL_MAX = 8;
 const DAYTONA_TTL_ENV = "AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS";
 const DAYTONA_POOL_MAX_ENV = "AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM";

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -40,12 +40,8 @@ const DEFAULT_TTL_MS = 60_000;
 // Ten minutes. An approval park by definition has a pending interaction row waiting on a human,
 // and answers increasingly arrive from a phone minutes later (mobile approvals plan,
 // 2026-07-27 §4b-4): a 5-minute window pushed most of those onto the slower cold-replay path.
-// Thirty was the first attempt at covering that; ten covers the same phone-latency case while
-// bounding a second, unrelated exposure — a rotated provider credential stays usable on a warm
-// sandbox until that sandbox is replaced, because `holdForMechanism` waits a fixed 10s for
-// propagation and declares delivery done without checking (credential-delivery-port.ts). Idle
-// parks are already bounded at 60s generic / 120s Daytona; an approval park is the only window
-// long enough to matter, so it is the one worth keeping short.
+// Thirty was the first attempt at covering that; ten covers the same phone-latency case without
+// holding a pool slot for half an hour on a gate nobody is coming back to.
 // The window is still bounded by the mount-credential expiry check, expiry degrades to cold
 // (never fails the turn), and an awaiting_approval entry keeps holding a pool slot — override
 // via AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS if warm slots are contended.

--- a/services/runner/src/lifecycle/session-coordinator.ts
+++ b/services/runner/src/lifecycle/session-coordinator.ts
@@ -647,7 +647,7 @@ export async function runWithKeepalive(
 
   // A parked prompt that REJECTS while the session sits in awaiting_approval means the harness
   // or sandbox died mid-park; the dead session must not occupy a pool slot until the approval TTL
-  // (30 minutes by default) expires. Identity-checked: the handler evicts only while THIS exact
+  // (10 minutes by default) expires. Identity-checked: the handler evicts only while THIS exact
   // entry is still parked at the key. A rejection that lands after a successful checkout (the
   // resume is in flight and owns the environment; its own try/catch handles the failure) or
   // after a supersede is not ours and does nothing. `evict` is idempotent through the session's

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -181,13 +181,13 @@ describe("readKeepaliveConfig", () => {
     }
   });
 
-  it("defaults: on, 60s idle, 30m approval, cap 8", () => {
-    // The approval window is the pending-interaction park: 30 minutes so a phone-latency
+  it("defaults: on, 60s idle, 10m approval, cap 8", () => {
+    // The approval window is the pending-interaction park: 10 minutes so a phone-latency
     // answer warm-resumes instead of cold-replaying (mobile approvals plan §4b-4).
     assert.deepEqual(readKeepaliveConfig("local"), {
       enabled: true,
       ttlMs: 60_000,
-      approvalTtlMs: 1_800_000,
+      approvalTtlMs: 600_000,
       poolMax: 8,
     });
   });
@@ -196,9 +196,9 @@ describe("readKeepaliveConfig", () => {
     process.env.AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS = "300000";
     assert.equal(readKeepaliveConfig("local").approvalTtlMs, 300_000);
     process.env.AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS = "0";
-    assert.equal(readKeepaliveConfig("local").approvalTtlMs, 1_800_000);
+    assert.equal(readKeepaliveConfig("local").approvalTtlMs, 600_000);
     process.env.AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS = "nope";
-    assert.equal(readKeepaliveConfig("local").approvalTtlMs, 1_800_000);
+    assert.equal(readKeepaliveConfig("local").approvalTtlMs, 600_000);
   });
 
   it("reads truthy spellings for the flag and positive ints for the numbers", () => {


### PR DESCRIPTION
## Context

The approval park is how long a sandbox stays warm while a run sits waiting for a human to approve or deny a tool call. Answer while it is parked and the run resumes warm and continues immediately. Answer after it expires and the sandbox is gone, so the system rebuilds it and replays the conversation, which is slow.

PR #5687 widened that window from 5 minutes to 30, because answers arriving from a phone were usually landing after the 5 minutes were up and taking the slow path every time.

Mahmoud asked for 10 instead of 30.

## Changes

The default approval park goes from 30 minutes to 10.

Ten still covers the case #5687 was fixing. The problem it addressed was answers landing a few minutes late, not half an hour late. The value remains overridable through `AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS`, so a deployment that wants longer can still set it.

## Correction to an earlier version of this description

An earlier draft of this PR justified the change partly as bounding a credential-rotation exposure. **That reasoning was wrong and has been removed.**

The claim was that a rotated provider key stays usable until the sandbox is replaced, so a longer park window meant a longer exposure. Reading `runCredentialDelivery` (`services/runner/src/providers/credential-delivery-port.ts:784-855`) shows otherwise: the delivery updates the secret, verifies that the slots the provider reports installing match the ones requested (lines 826-835), and only then waits the hold. The credential genuinely lands, and it lands while the sandbox keeps running, so sandbox lifetime does not extend the exposure at all.

There is a real but much smaller gap there: the hold is a fixed 10 seconds while measured propagation is 12 to 20, so a turn beginning inside that gap can still use the old key while the runner has already reported success. That is a roughly ten-second correctness gap, it is tracked separately, and **it is unrelated to this change**.

So this PR should be judged purely on its own question: is 10 minutes long enough for someone to answer an approval from their phone? If 30 was the right answer to that, this should be closed rather than merged.

## Tests / notes

- `session-pool.test.ts` updated to pin 600000 rather than 1800000, and the test name changed from "30m approval" to "10m approval".
- Two stale "30 minutes by default" comments corrected, in `session-identity.ts` and `session-coordinator.ts:650`.
- All 77 session-pool unit tests pass.