### PR TITLE
fix(tests): stop swallowing strict-mode violations in readiness polls

### DIFF
--- a/web/oss/tests/playwright/acceptance/deployment/index.ts
+++ b/web/oss/tests/playwright/acceptance/deployment/index.ts
@@ -10,7 +10,7 @@ import {
     TestSpeedType,
 } from "@agenta/web-tests/playwright/config/testTags"
 import {test} from "@agenta/web-tests/tests/fixtures/base.fixture"
-import {expect} from "@agenta/web-tests/utils"
+import {expect, pollLocatorState} from "@agenta/web-tests/utils"
 
 import {expectAuthenticatedSession} from "../utils/auth"
 import {createScenarios} from "../utils/scenarios"
@@ -91,7 +91,12 @@ const deployVariantToEnv = async (
                 } else {
                     await realRow.click({force: true}).catch(() => null)
                 }
-                return await deployBtn.isEnabled().catch(() => false)
+                // deployBtn is not narrowed with .first(): if a UI change ever makes it
+                // match more than one "Deploy" button, isEnabled() throws a strict-mode
+                // violation. pollLocatorState lets that through instead of swallowing it
+                // into a permanent `false`, so the failure names the real selector bug
+                // instead of a bare poll timeout.
+                return await pollLocatorState(() => deployBtn.isEnabled())
             },
             {timeout: 30000},
         )
@@ -190,7 +195,10 @@ const deploymentTests = () => {
                                 await row.click({force: true}).catch(() => null)
                             }
 
-                            if (await deployBtn.isEnabled().catch(() => false)) {
+                            // See the pollLocatorState comment above: deployBtn isn't
+                            // narrowed with .first(), so a strict-mode violation here must
+                            // surface instead of being swallowed into `false`.
+                            if (await pollLocatorState(() => deployBtn.isEnabled())) {
                                 return true
                             }
                         }

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -10,7 +10,7 @@ import {
     TestSpeedType,
 } from "@agenta/web-tests/playwright/config/testTags"
 import {test} from "@agenta/web-tests/tests/fixtures/base.fixture"
-import {expect} from "@agenta/web-tests/utils"
+import {expect, pollLocatorState} from "@agenta/web-tests/utils"
 
 import {expectAuthenticatedSession} from "../utils/auth"
 import {createScenarios} from "../utils/scenarios"
@@ -82,7 +82,12 @@ const deployFirstVariantToDevelopment = async (
                 } else {
                     await realRow.click({force: true}).catch(() => null)
                 }
-                return await deployBtn.isEnabled().catch(() => false)
+                // deployBtn is not narrowed with .first(): if a UI change ever makes it
+                // match more than one "Deploy" button, isEnabled() throws a strict-mode
+                // violation. pollLocatorState lets that through instead of swallowing it
+                // into a permanent `false`, so the failure names the real selector bug
+                // instead of a bare poll timeout.
+                return await pollLocatorState(() => deployBtn.isEnabled())
             },
             {timeout: 30000},
         )

--- a/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
@@ -3,6 +3,7 @@ import {existsSync, readFileSync} from "fs"
 import {expect, Locator, Page} from "@playwright/test"
 
 import {getProjectMetadataPath} from "../../../../playwright/config/runtime.ts"
+import {pollLocatorState} from "../../../../utils"
 import {UseFn} from "../../types"
 import {FixtureContext} from "../types"
 import type {UIHelpers} from "../uiHelpers/types"
@@ -153,14 +154,16 @@ async function waitForModelsPageReady(page: Page): Promise<void> {
                     .catch(() => false)
                 // `.first()` matters: the section renders this button twice (once in the
                 // header, once in the empty-state row). Without it the locator is strict-mode
-                // ambiguous, `isEnabled()` throws, and the `.catch` below turns that into a
-                // permanent `false` — the poll then times out with a "never reached a stable
-                // ready state" message that says nothing about the real cause.
-                const createButtonEnabled = await customProvidersSection
-                    .getByRole("button", {name: CUSTOM_PROVIDER_ADD_BUTTON_LABEL})
-                    .first()
-                    .isEnabled()
-                    .catch(() => false)
+                // ambiguous and `isEnabled()` throws — pollLocatorState lets that throw
+                // through instead of swallowing it, so a future selector regression fails
+                // loudly instead of timing out with a "never reached a stable ready state"
+                // message that names no real cause.
+                const createButtonEnabled = await pollLocatorState(() =>
+                    customProvidersSection
+                        .getByRole("button", {name: CUSTOM_PROVIDER_ADD_BUTTON_LABEL})
+                        .first()
+                        .isEnabled(),
+                )
 
                 return (
                     hasScopedSettingsPath &&

--- a/web/tests/utils/index.ts
+++ b/web/tests/utils/index.ts
@@ -1,1 +1,21 @@
 export {expect, type Locator} from "@playwright/test"
+
+/**
+ * Runs a Playwright locator boolean check (isEnabled, isVisible, isChecked, ...)
+ * meant to be polled until true. Swallows "not there yet" failures so the poll can
+ * keep retrying, but rethrows a strict-mode violation — the locator matched more
+ * than one element — because that means the selector itself is broken and no amount
+ * of polling will fix it. Left unguarded, `.catch(() => false)` turns that error into
+ * a permanent `false`, and the poll times out with a message that names no real cause
+ * (e.g. "page never reached a stable ready state") instead of the actual selector bug.
+ */
+export async function pollLocatorState(check: () => Promise<boolean>): Promise<boolean> {
+    try {
+        return await check()
+    } catch (error) {
+        if (error instanceof Error && /strict mode violation/i.test(error.message)) {
+            throw error
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Context

Four readiness polls in the acceptance suite chained `isEnabled().catch(() => false)` on a locator that isn't narrowed with `.first()`. When such a locator ever matches more than one element, Playwright throws a strict-mode violation, and the bare `.catch` turned that into a permanent `false`. The poll then timed out with a message that names no real cause, e.g. `Models page never reached a stable ready state`, sending the reader hunting for a timeout that never existed. An agent working on this suite lost its longest single detour to exactly this; the actual cause was a stale selector matching two "Add endpoint" buttons on the Models page.

That specific selector was already fixed on `release/v0.111.0` (commit `1fafabb0ab`, `.first()` added with a comment). This PR fixes the underlying pattern so the *next* strict-mode violation, wherever it happens, fails loudly instead of reproducing the same detour.

## Changes

Added `pollLocatorState` to `web/tests/utils/index.ts`:

```ts
export async function pollLocatorState(check: () => Promise<boolean>): Promise<boolean> {
    try {
        return await check()
    } catch (error) {
        if (error instanceof Error && /strict mode violation/i.test(error.message)) {
            throw error
        }
        return false
    }
}
```

It still swallows "not there yet" failures so polling keeps working the way it always has, but a strict-mode violation (or any other error) now propagates instead of being flattened into `false`.

Wired it into the four `isEnabled().catch(() => false)` sites named in the report:

- `web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts` (`waitForModelsPageReady`) — the models fixture.
- `web/oss/tests/playwright/acceptance/use-api/index.ts` (`deployFirstVariantToDevelopment`'s deploy-button poll) — the use-api helper.
- `web/oss/tests/playwright/acceptance/deployment/index.ts`, two sites: `deployVariantToEnv`'s poll and the inline "select a variant to deploy" scenario's poll — the deployment helpers.

**Before / after** (captured with a scratch two-button fixture reproducing the exact `deployBtn = page.getByRole("button", {name: "Deploy"})` shape, no `.first()`):

```
=== BEFORE (old .catch(() => false) shape) ===
FAILURE MESSAGE: Models page never reached a stable ready state

=== AFTER (pollLocatorState) ===
FAILURE MESSAGE: locator.isEnabled: Error: strict mode violation: getByRole('button', { name: 'Deploy' }) resolved to 2 elements:
    1) <button id="a">Deploy</button> aka locator('[id="a"]')
    2) <button id="b">Deploy</button> aka locator('[id="b"]')
```

The failure now names the real selector bug instead of a generic timeout.

## Left alone (out of scope)

The `.catch(() => false)` habit is much wider than these four call sites: 80 sites across the acceptance suite use the same general shape (27 alone in `playwright/global-setup.ts`; the rest spread across `human-annotation`, `auto-evaluation`, `evaluators`, `observability`, `authHelpers`, `playground`, and one in `web/ee`). Most of those chain off a `.first()`/`.last()`-narrowed locator or a genuinely optional element, so they don't carry the same strict-mode risk, but I didn't audit every one individually. Scoping this PR to the four sites the incident actually named, per the report; widening the fix to the rest of the suite is a separate, larger cleanup Mahmoud hasn't scoped yet.

No product code touched, no selectors changed.

## Tests

Ran against the live `release/v0.111.0` deployment at `http://144.76.237.122:8180` (EE, mock LLM provider):

- `settings/model-hub.spec.ts` — `should allow full add provider` (exercises the models-fixture fix via `ensureTestProvider` → `waitForModelsPageReady`): **passed**.
- `deployment/deploy-variant.spec.ts` — both tests, `deploy a variant` and `should deploy a variant to staging and production environments` (exercise both deployment-helper sites): **passed**.
- `use-api/use-api.spec.ts` — `should show deployment TypeScript snippet for Fetch Prompt/Config and Invoke LLM`: the fixed `deployFirstVariantToDevelopment` step (containing the `pollLocatorState` change) completed and the test moved on to the next scenario, then timed out inside the *unmodified* `openDeploymentUseApiDrawer` at `page.waitForLoadState("networkidle")`. I confirmed this is a pre-existing, unrelated environment limitation, not a regression: the sibling test `should show variant TypeScript snippet for Fetch Prompt/Config and Invoke LLM`, which never touches any of the code this PR changes, times out at the identical `networkidle` call in `openVariantUseApiDrawer`. `networkidle` never resolves against a `--dev` server because the hot-reload socket stays open; this affects local dev-mode runs, not CI against a production build.
- `pnpm lint-fix` in `web/`: clean, no new warnings in the touched files.

Not independently verified: the `use-api.spec.ts` suite reaching a full green run on this deployment, blocked by the `networkidle`/dev-server issue above (pre-existing, out of scope for this PR).
