### PR TITLE
fix(frontend): stop in-app template picks looping agent creation

### DIFF
--- a/web/oss/src/components/pages/agent-home/OnboardingEntry.tsx
+++ b/web/oss/src/components/pages/agent-home/OnboardingEntry.tsx
@@ -7,6 +7,7 @@ import {useRouter} from "next/router"
 import {useAgentsFirstRun} from "@/oss/components/pages/agents/store"
 import {urlAtom} from "@/oss/state/url"
 
+import {useAgentHomeVariants} from "./hooks/useAgentHomeVariants"
 import OnboardingLoader from "./PlaygroundOnboarding/OnboardingLoader"
 
 import AgentHome from "./index"
@@ -15,7 +16,8 @@ import AgentHome from "./index"
  * Entry gate for playground-native onboarding (`NEXT_PUBLIC_AGENT_PLAYGROUND_ONBOARDING`). Decides
  * BEFORE painting anything so we never flash the wrong surface:
  *  - first-run (no agents yet) → redirect to the ephemeral onboarding playground (`/playground`);
- *  - returning (has agents)    → the agent-home list, as before.
+ *  - returning (has agents)    → the agent-home list, as before;
+ *  - `?new=1` (either case)    → the agent-home create surface, which the user asked for by name.
  *
  * While the list is empty we're either still confirming it or already redirecting, and the loader
  * covers both so we never flash the wrong surface. A non-empty list is conclusive immediately, so
@@ -26,6 +28,9 @@ const OnboardingEntry = () => {
     const router = useRouter()
     const {resolving, firstRun} = useAgentsFirstRun()
     const {projectURL} = useAtomValue(urlAtom)
+    // `?new=1` asks for the create surface by name (and may carry a `?template=` seed for it), so
+    // it outranks the first-run redirect — which would drop the user on a bare onboarding chat.
+    const {creatingAgent} = useAgentHomeVariants()
 
     // Warm the agent-template cache now so the ephemeral mint on `/playground` finds it cached (no
     // fetch) — overlaps that network with the agents query + redirect. Same cache agent-home warms.
@@ -38,12 +43,13 @@ const OnboardingEntry = () => {
     }, [])
 
     useEffect(() => {
+        if (creatingAgent) return
         if (!firstRun || !projectURL) return
         void router.replace(`${projectURL}/playground`)
-    }, [firstRun, projectURL, router])
+    }, [creatingAgent, firstRun, projectURL, router])
 
     // The shared onboarding loader, so the whole flow reads as one continuous "setting up" screen.
-    if (resolving) {
+    if (resolving && !creatingAgent) {
         return <OnboardingLoader />
     }
 

--- a/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
+++ b/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
@@ -72,6 +72,10 @@ export function useConsumePendingTemplate(): boolean {
         void (async () => {
             const won = await claimTemplate(pendingGeneration)
             if (!won) {
+                // The generation was already claimed, so its agent exists (or is being created by
+                // the winner). Drop the key rather than leaving it stored to re-arm this hook — and
+                // flash the onboarding loader — on every later page.
+                clearTemplate(pendingGeneration)
                 if (startedRef.current === generationId) startedRef.current = null
                 setHolding(false)
                 return

--- a/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
+++ b/web/oss/src/components/pages/agent-home/hooks/useConsumePendingTemplate.ts
@@ -76,8 +76,12 @@ export function useConsumePendingTemplate(): boolean {
                 // the winner). Drop the key rather than leaving it stored to re-arm this hook — and
                 // flash the onboarding loader — on every later page.
                 clearTemplate(pendingGeneration)
-                if (startedRef.current === generationId) startedRef.current = null
-                setHolding(false)
+                // Only drop the loader if this generation is still the current one — a later
+                // capture may have re-armed it while this claim was in flight.
+                if (startedRef.current === generationId) {
+                    startedRef.current = null
+                    setHolding(false)
+                }
                 return
             }
 

--- a/web/oss/src/state/url/template.test.ts
+++ b/web/oss/src/state/url/template.test.ts
@@ -148,6 +148,16 @@ describe("captureTemplateFromUrl", () => {
         expect(win.location.href).not.toContain("template=")
     })
 
+    it("ignores the key on the in-app create surface, where it only seeds the composer", () => {
+        installWindow(`/apps?new=1&template=${KNOWN_KEY}`)
+        const url = new URL(`https://cloud.agenta.ai/apps?new=1&template=${KNOWN_KEY}`)
+        expect(captureTemplateFromUrl(url)).toBeNull()
+        expect(getDefaultStore().get(activeTemplateAtom)).toBeNull()
+        expect(readTemplateFromStorage()).toBeNull()
+        // The param stays put — the create surface reads it to pre-select the template.
+        expect(url.searchParams.get("template")).toBe(KNOWN_KEY)
+    })
+
     it("falls back to the stored key when the URL has none (region recapture leaves storage intact)", () => {
         installWindow("/")
         persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})

--- a/web/oss/src/state/url/template.test.ts
+++ b/web/oss/src/state/url/template.test.ts
@@ -159,6 +159,29 @@ describe("captureTemplateFromUrl", () => {
         expect(win.location.href).toContain(`template=${KNOWN_KEY}`)
     })
 
+    it("does not restore a stored key on the create surface, and leaves it for a later load", () => {
+        installWindow(`/apps?new=1&template=${KNOWN_KEY}`)
+        // A record another tab captured from a real website deep-link.
+        persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})
+
+        const url = new URL(`https://cloud.agenta.ai/apps?new=1&template=${KNOWN_KEY}`)
+        expect(captureTemplateFromUrl(url)).toBeNull()
+        expect(getDefaultStore().get(activeTemplateAtom)).toBeNull()
+
+        // The record survives: this URL says nothing about the other tab's intent.
+        expect(readTemplateFromStorage()?.key).toBe(KNOWN_KEY)
+        expect(captureTemplateFromUrl(new URL("https://cloud.agenta.ai/apps"))).toBe(KNOWN_KEY)
+    })
+
+    it("disarms an already-active template when the user reaches the create surface", () => {
+        installWindow("/")
+        const pending = capturePending()
+        expect(getDefaultStore().get(activeTemplateAtom)).toEqual(pending)
+
+        captureTemplateFromUrl(new URL("https://cloud.agenta.ai/apps?new=1"))
+        expect(getDefaultStore().get(activeTemplateAtom)).toBeNull()
+    })
+
     it("falls back to the stored key when the URL has none (region recapture leaves storage intact)", () => {
         installWindow("/")
         persistTemplateToStorage({key: KNOWN_KEY, capturedAt: Date.now()})

--- a/web/oss/src/state/url/template.test.ts
+++ b/web/oss/src/state/url/template.test.ts
@@ -149,13 +149,14 @@ describe("captureTemplateFromUrl", () => {
     })
 
     it("ignores the key on the in-app create surface, where it only seeds the composer", () => {
-        installWindow(`/apps?new=1&template=${KNOWN_KEY}`)
+        const win = installWindow(`/apps?new=1&template=${KNOWN_KEY}`)
         const url = new URL(`https://cloud.agenta.ai/apps?new=1&template=${KNOWN_KEY}`)
         expect(captureTemplateFromUrl(url)).toBeNull()
         expect(getDefaultStore().get(activeTemplateAtom)).toBeNull()
         expect(readTemplateFromStorage()).toBeNull()
-        // The param stays put — the create surface reads it to pre-select the template.
-        expect(url.searchParams.get("template")).toBe(KNOWN_KEY)
+        // The param stays put — the create surface reads it to pre-select the template. Assert the
+        // browser URL, not the detached one: only the former proves cleanup left it alone.
+        expect(win.location.href).toContain(`template=${KNOWN_KEY}`)
     })
 
     it("falls back to the stored key when the URL has none (region recapture leaves storage intact)", () => {

--- a/web/oss/src/state/url/template.ts
+++ b/web/oss/src/state/url/template.ts
@@ -139,12 +139,15 @@ export const persistTemplateToStorage = (pending: PendingTemplate | null) => {
  * regional host after a region redirect: the query string is preserved across the switch but
  * localStorage is not shared between hosts, so the key is re-saved under the host the user lands on.
  *
- * A create-surface URL (`?new=1&template=…`) is never captured: there the key seeds a composer,
- * and treating it as a deep-link made every in-app template pick create an agent.
+ * A create-surface URL (`?new=1&template=…`) neither captures nor restores: there the key seeds a
+ * composer, and arming the consumer made every in-app template pick create an agent. A record
+ * another tab stored from a real deep-link is left in storage, not cleared — this URL says nothing
+ * about that tab's intent, and the TTL already bounds it — so a later non-create load still honours it.
  */
 export const captureTemplateFromUrl = (url: URL): string | null => {
     const store = getDefaultStore()
-    const urlKey = isCreateSurfaceUrl(url) ? null : parseTemplateFromUrl(url)
+    const createSurface = isCreateSurfaceUrl(url)
+    const urlKey = createSurface ? null : parseTemplateFromUrl(url)
     const storedRecord = readStoredTemplateRecord()
 
     if (storedRecord && isExpired(storedRecord)) {
@@ -154,6 +157,11 @@ export const captureTemplateFromUrl = (url: URL): string | null => {
             store.set(activeTemplateAtom, null)
             return null
         }
+    }
+
+    if (createSurface) {
+        store.set(activeTemplateAtom, null)
+        return null
     }
 
     if (urlKey) {

--- a/web/oss/src/state/url/template.ts
+++ b/web/oss/src/state/url/template.ts
@@ -12,6 +12,16 @@ export const TEMPLATE_URL_PARAM = "template"
 const TEMPLATE_STORAGE_KEY = "pendingTemplate"
 const TEMPLATE_CLAIM_KEY = "pendingTemplateClaim"
 
+/**
+ * The in-app create surface (`/apps?new=1&template=…`, pushed by the New agent menu, the home
+ * strip and the template gallery) reuses `template` to PRE-SELECT a template in its composer.
+ * Consuming that as a website deep-link created an agent — and redirected to its playground — on
+ * every arrival at such a URL, so `new` marks the URLs the deep-link consumer must ignore.
+ */
+const CREATE_SURFACE_URL_PARAM = "new"
+
+const isCreateSurfaceUrl = (url: URL): boolean => !!url.searchParams.get(CREATE_SURFACE_URL_PARAM)
+
 // A real signup can include email verification and a provider round-trip, so the key must outlive
 // several minutes; thirty is comfortably longer than any real signup and short enough that a
 // forgotten key cannot create an agent later.
@@ -123,10 +133,13 @@ export const persistTemplateToStorage = (pending: PendingTemplate | null) => {
  * measures from arrival and a key that survives many navigations still ages. This also runs on a
  * regional host after a region redirect: the query string is preserved across the switch but
  * localStorage is not shared between hosts, so the key is re-saved under the host the user lands on.
+ *
+ * A create-surface URL (`?new=1&template=…`) is never captured: there the key seeds a composer,
+ * and treating it as a deep-link made every in-app template pick create an agent.
  */
 export const captureTemplateFromUrl = (url: URL): string | null => {
     const store = getDefaultStore()
-    const urlKey = parseTemplateFromUrl(url)
+    const urlKey = isCreateSurfaceUrl(url) ? null : parseTemplateFromUrl(url)
     const storedRecord = readStoredTemplateRecord()
 
     if (storedRecord && isExpired(storedRecord)) {

--- a/web/oss/src/state/url/template.ts
+++ b/web/oss/src/state/url/template.ts
@@ -20,7 +20,12 @@ const TEMPLATE_CLAIM_KEY = "pendingTemplateClaim"
  */
 const CREATE_SURFACE_URL_PARAM = "new"
 
-const isCreateSurfaceUrl = (url: URL): boolean => !!url.searchParams.get(CREATE_SURFACE_URL_PARAM)
+// The same accepted values as `useAgentHomeVariants`, which decides whether the create surface
+// actually opens: any looser reading here would skip capture on a URL that then renders Home.
+const isCreateSurfaceUrl = (url: URL): boolean => {
+    const value = url.searchParams.get(CREATE_SURFACE_URL_PARAM)
+    return value === "1" || value === "true"
+}
 
 // A real signup can include email verification and a provider round-trip, so the key must outlive
 // several minutes; thirty is comfortably longer than any real signup and short enough that a


### PR DESCRIPTION
## What happened

Creating an app from a template threw the user into a loop: every visit to the site redirected to the newest changelog-writer playground, every UI action created yet another agent (15 duplicates in the QA database, eleven of them in a one-minute burst), and new sessions/chats got stuck.

## Root cause

The in-app create surface (`?new=1&template=...`) reuses the `template` query param to pre-select a template in its composer. The website deep-link capture (`captureTemplateFromUrl`) treated those in-app URLs as deep links, so each arrival persisted a pending-template key to localStorage. `useConsumePendingTemplate` then minted an agent from it and redirected to its playground. When the claim raced and lost, the stored key was never cleared, so the loop re-armed on every page load.

## The fix

- `captureTemplateFromUrl` ignores create-surface URLs (`?new=1`), so an in-app template pick never registers as a deep link.
- A lost claim now clears the stored key, so a browser already stuck in this state recovers on its own.
- `OnboardingEntry` stands down from its first-run playground redirect when the user asked for the create surface by name (`?new=1`).

## Verification

- 18/18 unit tests pass in `web/oss/src/state/url/template.test.ts`, including new cases for the create-surface URLs.
- On the rel112 QA stack, no new duplicate agents have been created since the fix hot-reloaded; the 15 junk agents were soft-deleted.