### PR TITLE
fix(frontend): neutralize the dark shell rail's blue cast

### DIFF
--- a/web/oss/src/styles/theme-variables.css
+++ b/web/oss/src/styles/theme-variables.css
@@ -628,8 +628,8 @@
     --ag-strip-card-border: #232327;
     --ag-strip-card-border-hover: #3a3a40;
     --ag-strip-card-hover-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.45);
-    --ag-shell-rail-bg: #121316;
-    --ag-shell-line: #2b2d32;
+    --ag-shell-rail-bg: #101010;
+    --ag-shell-line: #2c2c2c;
     --ag-scroll-thumb: rgba(255, 255, 255, 0.20);
     --ag-scroll-thumb-hover: rgba(255, 255, 255, 0.34);
     --ag-sidebar-bg: var(--ag-shell-rail-bg);

--- a/web/oss/src/styles/theme/palette.ts
+++ b/web/oss/src/styles/theme/palette.ts
@@ -462,8 +462,8 @@ export const templateStrip = {
 // bars from the content. The rail sits one step darker (light: greyer) than the
 // content beside it, and every frame line shares one colour so they read as one frame.
 export const shell = {
-    railBg: {light: "#ffffff", dark: "#121316"},
-    line: {light: "#e3e5e9", dark: "#2b2d32"},
+    railBg: {light: "#ffffff", dark: "#101010"}, // neutral hue (was #121316, read bluish next to #141414)
+    line: {light: "#e3e5e9", dark: "#2c2c2c"},
     scrollThumb: {light: "rgba(15, 23, 42, 0.22)", dark: "rgba(255, 255, 255, 0.20)"},
     scrollThumbHover: {light: "rgba(15, 23, 42, 0.38)", dark: "rgba(255, 255, 255, 0.34)"},
 } satisfies Record<string, Pair>


### PR DESCRIPTION
## What

In dark mode the sidebar rail (`#121316`) and the frame line (`#2b2d32`) carry a blue channel bias, which reads bluish next to the perfectly neutral `#141414` content background. Mahmoud spotted it on a Mac panel.

The numbers made it worse than a tint: the rail was barely darker than the content (relative luminance ~19 vs ~20), so most of the visible separation came from the hue difference, not from darkness.

## The fix

Keep the rail-darker-than-content design, but make darkness do the separating instead of hue:

- `shell.railBg` dark: `#121316` → `#101010` (neutral, a real step darker than `#141414`)
- `shell.line` dark: `#2b2d32` → `#2c2c2c` (neutral, same lightness as before)

Light mode untouched. Source of truth edited in `palette.ts`; `theme-variables.css` regenerated with `generate:tailwind-tokens` (the antd overrides file came out unchanged).