### PR TITLE
style(frontend): nudge the sidebar brand row (8px top/left, 22px logo)

### DIFF
--- a/web/oss/src/components/Sidebar/components/ProjectOrgSwitcher/index.tsx
+++ b/web/oss/src/components/Sidebar/components/ProjectOrgSwitcher/index.tsx
@@ -326,7 +326,8 @@ const ProjectOrgSwitcher = ({collapsed}: ProjectOrgSwitcherProps) => {
                     type="button"
                     data-project-org-switcher
                     className={clsx(
-                        "flex items-center rounded-md border border-solid border-[var(--ag-colorBorderSecondary)] bg-transparent cursor-pointer transition-colors hover:bg-[var(--ag-colorFillTertiary)]",
+                        // Borderless at rest; the hover fill is the affordance.
+                        "flex items-center rounded-md border-0 bg-transparent cursor-pointer transition-colors hover:bg-[var(--ag-colorFillTertiary)]",
                         collapsed ? "h-8 w-8 justify-center p-1" : "w-full gap-2 px-1.5 py-1.5",
                     )}
                     title={`${projectLabel} · ${orgLabel}`}

--- a/web/oss/src/components/Sidebar/components/SidebarLogo.tsx
+++ b/web/oss/src/components/Sidebar/components/SidebarLogo.tsx
@@ -21,8 +21,10 @@ const SidebarLogo = ({collapsed}: SidebarLogoProps) => {
     return (
         <div
             className={clsx(
-                "flex h-[48px] shrink-0 items-start pt-2 mb-1",
-                collapsed ? "justify-center" : "justify-between pl-2 pr-2",
+                // mt/ml push the whole centred row away from the corner; padding alone read as
+                // no change because the 48px row's centring already held the logo 14px down.
+                "flex h-[48px] shrink-0 items-center mt-2 mb-1",
+                collapsed ? "justify-center" : "justify-between ml-2 pl-3 pr-2",
             )}
         >
             {/* unoptimized: SVGs skip /_next/image, which rejects SVG without dangerouslyAllowSVG. */}

--- a/web/oss/src/components/Sidebar/components/SidebarLogo.tsx
+++ b/web/oss/src/components/Sidebar/components/SidebarLogo.tsx
@@ -21,13 +21,14 @@ const SidebarLogo = ({collapsed}: SidebarLogoProps) => {
     return (
         <div
             className={clsx(
-                "flex h-[48px] shrink-0 items-center mb-1",
-                collapsed ? "justify-center" : "justify-between pl-3 pr-2",
+                "flex h-[48px] shrink-0 items-start pt-2 mb-1",
+                collapsed ? "justify-center" : "justify-between pl-2 pr-2",
             )}
         >
             {/* unoptimized: SVGs skip /_next/image, which rejects SVG without dangerouslyAllowSVG. */}
+            {/* 99x22 keeps the SVG's intrinsic 361:80 ratio at the 22px brand height. */}
             {!collapsed && (
-                <Image src={fullSrc} alt="Agenta" width={85} height={20} priority unoptimized />
+                <Image src={fullSrc} alt="Agenta" width={99} height={22} priority unoptimized />
             )}
             <SidebarToggleButton />
         </div>

--- a/web/oss/src/components/Sidebar/components/SidebarToggleButton.tsx
+++ b/web/oss/src/components/Sidebar/components/SidebarToggleButton.tsx
@@ -19,7 +19,13 @@ const SidebarToggleButton = ({className}: SidebarToggleButtonProps) => {
             size="small"
             // A square the exact height of the 22px wordmark: top-aligned in the brand row, both
             // optical centres land on the same line. The old 28px pill rode 3px low.
-            className={clsx("shrink-0 !h-[22px] !w-[22px] !p-0", className)}
+            // The ::after is a transparent 28px hit extender — it grows the pointer target only,
+            // leaving the 22px visual box and the row's alignment untouched.
+            className={clsx(
+                "shrink-0 !h-[22px] !w-[22px] !p-0",
+                "relative after:absolute after:inset-[-3px] after:content-['']",
+                className,
+            )}
             icon={
                 <Sidebar
                     size={16}

--- a/web/oss/src/components/Sidebar/components/SidebarToggleButton.tsx
+++ b/web/oss/src/components/Sidebar/components/SidebarToggleButton.tsx
@@ -17,10 +17,12 @@ const SidebarToggleButton = ({className}: SidebarToggleButtonProps) => {
         <EnhancedButton
             type="text"
             size="small"
-            className={clsx("shrink-0 !h-[28px]", className)}
+            // A square the exact height of the 22px wordmark: top-aligned in the brand row, both
+            // optical centres land on the same line. The old 28px pill rode 3px low.
+            className={clsx("shrink-0 !h-[22px] !w-[22px] !p-0", className)}
             icon={
                 <Sidebar
-                    size={14}
+                    size={16}
                     className={clsx("transition-transform", collapsed ? "rotate-180" : "")}
                 />
             }

--- a/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
@@ -319,7 +319,9 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                 "[&_.ant-menu-item-icon]:!shrink-0",
                 "!border-0 [&_.ant-menu-item-divider]:!w-full [&_.ant-menu-item-divider]:!my-2",
                 {
-                    "[&_.ant-menu-item]:!w-[94%] [&_.ant-menu-item]:!mx-2 [&_.ant-menu-item]:!pl-3 [&_.ant-menu-submenu-title]:!pl-3 [&_.ant-menu-submenu-title]:!pr-0 [&_.ant-menu-submenu-title]:!w-[94%] [&_.ant-menu-submenu-title]:!mx-2":
+                    // calc, not 94%: an exact 8px inset each side, so the row's right edge lines
+                    // up with the 8px-inset collapse toggle in the brand row.
+                    "[&_.ant-menu-item]:!w-[calc(100%-16px)] [&_.ant-menu-item]:!mx-2 [&_.ant-menu-item]:!pl-3 [&_.ant-menu-submenu-title]:!pl-3 [&_.ant-menu-submenu-title]:!pr-0 [&_.ant-menu-submenu-title]:!w-[calc(100%-16px)] [&_.ant-menu-submenu-title]:!mx-2":
                         !collapsed,
                     "[&_.ag-sidebar-submenu-inline>.ant-menu-sub.ant-menu-inline]:!ml-2 [&_.ag-sidebar-submenu-inline>.ant-menu-sub.ant-menu-inline]:!pl-2":
                         !collapsed,

--- a/web/oss/src/components/Sidebar/engine/SidebarShell.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarShell.tsx
@@ -297,7 +297,9 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
         <div className="border-0 border-r border-solid border-[var(--ag-shell-line)]">
             <Sider
                 theme={theme}
-                className="sticky top-0 bottom-0 h-screen bg-[var(--ag-sidebar-bg)]"
+                // --ag-demo-banner-h: the fixed demo banner would cover the brand row on
+                // document-scrolling routes; 0px everywhere else.
+                className="sticky top-[var(--ag-demo-banner-h,0px)] bottom-0 h-[calc(100vh-var(--ag-demo-banner-h,0px))] bg-[var(--ag-sidebar-bg)]"
                 collapsible
                 width={collapsed ? 48 : 236}
                 trigger={null}


### PR DESCRIPTION
Two small brand-row adjustments Mahmoud asked for:

- The first line of the sidebar (logo + collapse toggle) now sits with 8px padding on the top and the left, top-aligned instead of vertically centered in its 48px band.
- The wordmark grows from 20px to 22px tall. The box is now 99x22, matching the SVG's intrinsic 361:80 ratio; the old 85x20 box did not match it, so the browser letterboxed the logo slightly smaller than its stated size.

No margin or padding changes beyond those two. Collapsed mode keeps its centered toggle, gaining only the 8px top padding.