### PR TITLE
fix(frontend): shared page gutters and centered max-width column

### DIFF
--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -2,10 +2,12 @@ import {useCallback, useEffect, useRef, useState} from "react"
 
 import {appTemplatesQueryAtom} from "@agenta/entities/workflow"
 import {PageLayout} from "@agenta/ui"
+import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {PanelScroll, PanelSurface} from "@agenta/ui/components/presentational"
 import type {RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {ArrowLeftIcon} from "@phosphor-icons/react"
 import {App, Typography} from "antd"
+import clsx from "clsx"
 import {useAtomValue} from "jotai"
 import Link from "next/link"
 import {useRouter} from "next/router"
@@ -141,7 +143,7 @@ const StripHome: React.FC = () => {
     }, [message, posthog])
 
     return (
-        <PageLayout className="grow min-h-0 !pb-0">
+        <PageLayout className={clsx(pageContentWidthClass, "grow min-h-0")}>
             {/* First run stays a centered document — one question, one answer, nothing to
                 resume yet — and scrolls inside the frame rather than moving the page. A
                 returning user gets a workspace: two columns that fill the frame and scroll
@@ -155,8 +157,8 @@ const StripHome: React.FC = () => {
             <div
                 className={
                     firstRun
-                        ? "mx-auto flex w-full min-h-0 max-w-[1040px] flex-1 flex-col overflow-y-auto px-6 pb-20 pt-14"
-                        : "flex min-h-0 w-full flex-1 gap-10 overflow-hidden pb-6 pl-14 pr-10 pt-8"
+                        ? "mx-auto flex w-full min-h-0 max-w-[1040px] flex-1 flex-col overflow-y-auto"
+                        : "flex min-h-0 w-full flex-1 gap-10 overflow-hidden"
                 }
             >
                 <div

--- a/web/oss/src/components/pages/agents/AgentsGrid.tsx
+++ b/web/oss/src/components/pages/agents/AgentsGrid.tsx
@@ -34,7 +34,9 @@ const AgentsGrid = ({
     // `pt-5` is the room the grid variant's overhanging avatar needs. It belongs to the grid, not
     // to each card — on the card it left the avatar-less dashed cell misaligned.
     return (
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-x-4 gap-y-10 pt-5">
+        // auto-rows-fr: every row the same height. The h-full cards stretch to their row, and
+        // the create cell's min-h made the LAST row taller than the rest without it.
+        <div className="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-x-4 gap-y-10 pt-5">
             {rows.map((record) => (
                 <AgentCard
                     key={record.key}

--- a/web/oss/src/components/pages/agents/AgentsPage.tsx
+++ b/web/oss/src/components/pages/agents/AgentsPage.tsx
@@ -4,7 +4,9 @@ import {appTemplatesQueryAtom, createEphemeralAppFromTemplate} from "@agenta/ent
 import {openWorkflowRevisionDrawerAtom} from "@agenta/playground-ui/workflow-revision-drawer"
 import {extractApiErrorMessage} from "@agenta/shared/utils"
 import {PageLayout} from "@agenta/ui"
+import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {Input, message} from "antd"
+import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
 import Link from "next/link"
 import {useRouter} from "next/router"
@@ -85,7 +87,7 @@ export default function AgentsPage() {
     )
 
     return (
-        <PageLayout className="grow min-h-0" title="Agents">
+        <PageLayout className={clsx(pageContentWidthClass, "grow min-h-0")} title="Agents">
             <div className="flex items-center gap-3">
                 <NewAgentButton />
                 <Input

--- a/web/oss/src/components/pages/agents/ArchivedAgentsPage.tsx
+++ b/web/oss/src/components/pages/agents/ArchivedAgentsPage.tsx
@@ -1,6 +1,8 @@
 import {PageLayout} from "@agenta/ui"
+import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {ArrowLeft} from "@phosphor-icons/react"
 import {Button} from "antd"
+import clsx from "clsx"
 import {useRouter} from "next/router"
 
 import ApplicationManagementSection from "@/oss/components/pages/app-management/components/ApplicationManagementSection"
@@ -24,7 +26,7 @@ export default function ArchivedAgentsPage() {
     )
 
     return (
-        <PageLayout title={title} className="grow min-h-0">
+        <PageLayout title={title} className={clsx(pageContentWidthClass, "grow min-h-0")}>
             <ApplicationManagementSection mode="archived" agentScope />
         </PageLayout>
     )

--- a/web/oss/src/components/pages/sessions/SessionsPage.tsx
+++ b/web/oss/src/components/pages/sessions/SessionsPage.tsx
@@ -11,7 +11,9 @@ import {
     SessionRow,
 } from "@agenta/sessions-ui"
 import {PageLayout} from "@agenta/ui"
+import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {Dropdown} from "antd"
+import clsx from "clsx"
 import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 import {ROW_VARIANTS, SESSION_SPRING} from "@/oss/components/AgentChatSlice/assets/sessionMotion"
@@ -108,7 +110,7 @@ const SessionsPage = ({scopedAgentId, title = "Sessions"}: Props) => {
     )
 
     return (
-        <PageLayout className="grow min-h-0" title={title}>
+        <PageLayout className={clsx(pageContentWidthClass, "grow min-h-0")} title={title}>
             <div className="flex flex-col flex-1 min-h-0">
                 <SessionFiltersBar
                     waitingCount={list.waitingCount}

--- a/web/oss/src/components/pages/settings/components/SettingsPageShell.tsx
+++ b/web/oss/src/components/pages/settings/components/SettingsPageShell.tsx
@@ -1,18 +1,20 @@
 import type {ReactNode} from "react"
 
+import {pageContentWidthClass, pageGutterClass} from "@agenta/ui/components/page-width"
 import {ArrowSquareOut} from "@phosphor-icons/react"
 import clsx from "clsx"
 
 /**
  * SettingsPageShell — the frame every Settings tab renders inside.
  *
- * Standalone by design: it does NOT wrap `PageLayout`. Settings has its own gutter scale,
- * its own content cap, and a mandatory description, none of which the other 15 PageLayout
- * pages want. Keeping them separate means Settings can evolve without touching Prompts,
- * Agents, Evaluators, Observability or Testsets.
+ * Standalone by design: it does NOT wrap `PageLayout`. Settings has its own gutter scale
+ * and a mandatory description, neither of which the other 15 PageLayout pages want. Keeping
+ * them separate means Settings can evolve without touching Prompts, Agents, Evaluators,
+ * Observability or Testsets. The content cap is the shared one (`pageContentWidthClass`).
  *
- * Renders the gutter, the content cap and the header. Each tab's search and actions live
- * in its own table shell (`filters` / `primaryActions`), not in the central page switch.
+ * Renders the gutter, the centered content column and the header. Each tab's search and
+ * actions live in its own table shell (`filters` / `primaryActions`), not in the central
+ * page switch.
  */
 export interface SettingsPageShellProps {
     title: ReactNode
@@ -24,11 +26,10 @@ export interface SettingsPageShellProps {
     /** Optional tertiary docs link, rendered at the far right of the header. */
     docs?: {label: string; href: string}
     /**
-     * Content cap. `full` (default) = no cap. `table` = 1120px, `form` = 640px. Caps the
-     * body only — the header and its divider always span the full page width. All
-     * left-anchored, so eye travel from the nav rail to the content stays constant.
+     * Body width inside the shared centered column. `full` (default) fills it; `form` caps
+     * at 640px, left-anchored, because a form field wider than that is unreadable.
      */
-    variant?: "full" | "table" | "form"
+    variant?: "full" | "form"
     /**
      * Bound the page height so a table that scrolls internally does not grow the page.
      * Needed by tabs hosting a virtualized table.
@@ -48,15 +49,15 @@ const SettingsPageShell = ({
     return (
         <div
             className={clsx(
-                "flex w-full flex-col self-stretch",
-                // Gutter: 16 / 24 / 32 / 40 as the viewport widens, replacing the flat 16px
-                // every Settings page used to inherit at every size. Vertical rhythm is
-                // fixed (32 top, 64 bottom).
-                "px-4 pt-8 pb-16 md:px-6 lg:px-8 xl:px-10",
+                "flex flex-col self-stretch",
+                // Same gutters + centered column as every PageLayout page, so Settings lines up
+                // with the rest of the app instead of keeping its own scale.
+                pageGutterClass,
+                pageContentWidthClass,
                 fullHeight ? "h-full min-h-0" : "min-h-full",
             )}
         >
-            <div className={clsx("flex w-full flex-col gap-6", fullHeight && "min-h-0 flex-1")}>
+            <div className={clsx("flex flex-col gap-6", fullHeight && "min-h-0 flex-1")}>
                 <header className="flex items-start justify-between gap-6 border-0 border-b border-solid border-colorBorderSecondary pb-6">
                     <div className="flex min-w-0 flex-col gap-1">
                         {/* Sized off antd's own heading tokens so it scales and flips with
@@ -87,14 +88,11 @@ const SettingsPageShell = ({
                     ) : null}
                 </header>
 
-                {/* The cap lives on the content only, so the header + its divider span the
-                    full page width while the body stays left-anchored at its variant width. */}
                 <div
                     className={clsx(
                         "flex flex-col",
                         fullHeight && "min-h-0 flex-1",
                         variant === "form" && "max-w-[640px]",
-                        variant === "table" && "max-w-[1120px]",
                     )}
                 >
                     {children}

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
@@ -1,6 +1,7 @@
 import {memo, useState} from "react"
 
 import {PageLayout} from "@agenta/ui"
+import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {MoreOutlined} from "@ant-design/icons"
 import {Copy, PencilSimple, Trash} from "@phosphor-icons/react"
 import {Button, Dropdown, Space, Typography} from "antd"
@@ -162,10 +163,10 @@ const OverviewContent = () => {
             <WorkflowPageTitle title="Overview" />
             {/* The agent branch runs inside the layout's bounded frame (it asks for it), so the
                 page column must be allowed to shrink or its children can't take a definite
-                height and the per-column scrolls collapse back into one page scroll. */}
-            {/* The inset matches Home's, applied at page level so the title and the columns
-                share one left edge. */}
-            <PageLayout className={clsx("gap-8", isAgent && "min-h-0 !pl-[4.5rem] !pr-14 !pb-0")}>
+                height and the per-column scrolls collapse back into one page scroll. It also
+                takes the shared centred column, like Home — the prompt-app/evaluator branch
+                below stays full width for its charts and evaluation tables. */}
+            <PageLayout className={clsx("gap-8", isAgent && [pageContentWidthClass, "min-h-0"])}>
                 <AppDetailsSection />
 
                 {/* An agent's overview is its own surface. Charts move into that layout's usage

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/settings/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/settings/index.tsx
@@ -77,14 +77,8 @@ interface SettingsProps {
     AuditLogComponent?: React.ComponentType
 }
 
-/** Tabs that render a form rather than a table, so they cap at 640 instead of 1120. */
+/** Tabs that render a form rather than a table, so they cap at 640 inside the page column. */
 const FORM_TABS = new Set<SettingsTabKey>(["account", "preferences"])
-
-/**
- * Tabs that render nothing but a virtualized table needing the full page to scroll
- * internally. Everything else that isn't a form gets the 1120 table cap.
- */
-const FULL_WIDTH_TABS = new Set<SettingsTabKey>(["auditLog"])
 
 export const Settings: React.FC<SettingsProps> = ({AuditLogComponent}) => {
     const [tabQuery] = useQueryParam("tab", undefined, "replace")
@@ -191,13 +185,7 @@ export const Settings: React.FC<SettingsProps> = ({AuditLogComponent}) => {
                 title={title}
                 description={getSettingsTabDescription(resolvedTab, settingsAccess)}
                 docs={getSettingsTabDocs(resolvedTab)}
-                variant={
-                    FORM_TABS.has(resolvedTab)
-                        ? "form"
-                        : FULL_WIDTH_TABS.has(resolvedTab)
-                          ? "full"
-                          : "table"
-                }
+                variant={FORM_TABS.has(resolvedTab) ? "form" : "full"}
                 // Audit Log's virtual table needs a bounded parent to scroll internally.
                 fullHeight={resolvedTab === "auditLog"}
             >

--- a/web/packages/agenta-ui/package.json
+++ b/web/packages/agenta-ui/package.json
@@ -29,6 +29,7 @@
         "./components/selection": "./src/components/selection/index.ts",
         "./components/presentational": "./src/components/presentational/index.ts",
         "./components/modal": "./src/components/modal/index.ts",
+        "./components/page-width": "./src/components/pageWidth.ts",
         "./styles": "./src/utils/styles.ts",
         "./utils": "./src/utils/index.ts",
         "./hooks": "./src/hooks/index.ts",

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
@@ -723,7 +723,17 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
             >
                 <ColumnVisibilityFlagProvider scopeId={resolvedScopeId}>
                     {beforeTable}
-                    <div ref={containerRef} className={cn(containerClassName)}>
+                    {/* An empty table has nothing to scroll to, but rc-table still hands its
+                        placeholder body the numeric `scroll.x` — which on a bordered table is a
+                        pixel wider than the body's own viewport, so a horizontal scrollbar sits
+                        under every empty table. Suppress it while there are no rows. */}
+                    <div
+                        ref={containerRef}
+                        className={cn(
+                            "[&_.ant-table-empty_.ant-table-body]:!overflow-x-hidden",
+                            containerClassName,
+                        )}
+                    >
                         <Table<RecordType>
                             ref={tableComponentRef}
                             className={tableClassName}

--- a/web/packages/agenta-ui/src/components/PageLayout.tsx
+++ b/web/packages/agenta-ui/src/components/PageLayout.tsx
@@ -1,5 +1,6 @@
 import type {ElementType, ReactNode} from "react"
 
+import {pageGutterClass} from "./pageWidth"
 import {Tabs, TabsList, TabsTrigger} from "./ui/tabs"
 import {cn} from "./ui/utils"
 
@@ -69,7 +70,13 @@ const PageLayout = ({
     )
 
     return (
-        <div className={cn("flex w-full flex-col gap-4 p-4 self-stretch min-h-full", className)}>
+        <div
+            className={cn(
+                "flex w-full flex-col gap-4 self-stretch min-h-full",
+                pageGutterClass,
+                className,
+            )}
+        >
             {title ? (
                 <div
                     className={cn(

--- a/web/packages/agenta-ui/src/components/index.ts
+++ b/web/packages/agenta-ui/src/components/index.ts
@@ -75,6 +75,8 @@ export {HeightCollapse, type HeightCollapseProps} from "./HeightCollapse"
 
 export {default as PageLayout, type PageLayoutProps} from "./PageLayout"
 
+export {pageContentWidthClass, pageGutterClass} from "./pageWidth"
+
 export {EntityCard, type EntityCardProps} from "./EntityCard"
 
 // ============================================================================

--- a/web/packages/agenta-ui/src/components/pageWidth.ts
+++ b/web/packages/agenta-ui/src/components/pageWidth.ts
@@ -4,8 +4,11 @@
  * The app layout used to give pages 24px side padding; it was dropped when pages moved onto
  * `PageLayout`, which only carried 16px, and every page has felt cramped since. `PageLayout`
  * applies this for the pages that use it; a page with its own shell applies it directly.
+ *
+ * `box-border` is load-bearing, not decoration: Tailwind preflight is off app-wide, so a plain div
+ * is content-box and `w-full` + `px-16` would size the box 128px wider than its parent.
  */
-export const pageGutterClass = "px-16 pb-8 pt-14"
+export const pageGutterClass = "box-border px-16 pb-8 pt-14"
 
 /**
  * The shared cap for a centered page column, applied to the box that carries
@@ -24,4 +27,4 @@ export const pageGutterClass = "px-16 pb-8 pt-14"
  * <PageLayout className={pageContentWidthClass}>…</PageLayout>
  * ```
  */
-export const pageContentWidthClass = "mx-auto w-full max-w-[1248px]"
+export const pageContentWidthClass = "box-border mx-auto w-full max-w-[1248px]"

--- a/web/packages/agenta-ui/src/components/pageWidth.ts
+++ b/web/packages/agenta-ui/src/components/pageWidth.ts
@@ -1,0 +1,27 @@
+/**
+ * Page gutters: 56px top, 64px sides, 32px bottom.
+ *
+ * The app layout used to give pages 24px side padding; it was dropped when pages moved onto
+ * `PageLayout`, which only carried 16px, and every page has felt cramped since. `PageLayout`
+ * applies this for the pages that use it; a page with its own shell applies it directly.
+ */
+export const pageGutterClass = "px-16 pb-8 pt-14"
+
+/**
+ * The shared cap for a centered page column, applied to the box that carries
+ * `pageGutterClass` — so 1248 = a 1120px content column plus its two 64px gutters.
+ *
+ * 1120 is the width Settings' tables were already designed at. The cap engages only above
+ * ~1490px of viewport; below that a page just fills its gutters, so laptops keep the full
+ * width and only larger screens turn the surplus into symmetric margins.
+ *
+ * Put it on the same element as the gutters — `PageLayout`'s `className`, or a custom shell's
+ * outermost box — so title and content share one column:
+ *
+ * ```tsx
+ * import {pageContentWidthClass} from "@agenta/ui/components/page-width"
+ *
+ * <PageLayout className={pageContentWidthClass}>…</PageLayout>
+ * ```
+ */
+export const pageContentWidthClass = "mx-auto w-full max-w-[1248px]"


### PR DESCRIPTION
## What

Pages felt cramped since Dec 2025, when the 24px layout-level side padding was dropped (2f77dc9e15) and pages inherited only PageLayout's 16px. And on very large screens nothing capped the content, so lines ran the full monitor width.

One shared rule now owns both, in `@agenta/ui` (`components/page-width`):

- **`pageGutterClass`** = 56px top, 64px sides, 32px bottom (Mahmoud's spec). `PageLayout` applies it by default, so every PageLayout page gets it; pages that deliberately go edge-to-edge (`!p-0` overrides like the playground) keep winning.
- **`pageContentWidthClass`** = a centered 1120px content column (1248px box including its own gutters). It engages only above ~1490px viewport; laptops keep their full width. Applied to Settings, home, and sessions now; other pages can opt in with one class.

Settings drops its private gutter scale and its private 1120 table cap for the shared ones (its `variant="table"` is gone; forms still cap at 640px). The page title aligns to the same centered column as the content.

## Empty-table scrollbar

Every empty table showed a horizontal scrollbar: rc-table hands its empty-state body the numeric `scroll.x`, which on a bordered table is a pixel wider than the body's viewport. The IVT container now suppresses horizontal overflow only while the table has no rows.

## Base

Stacked on #5833 (the sessions toolbar revert) because the sessions page wrapper line builds on it; this PR's diff is exactly the nine layout files.

## Screenshots

Verified at 2560x1400 and 1440x900 on the rel112 QA stack: settings (projects, API keys, preferences, audit log), home, sessions, observability, agents. Settings/home/sessions center above ~1490px; observability and agents keep full width with the new gutters.