### PR TITLE
style(frontend): slim trackless scrollbars with a fading thumb, app-wide

### DIFF
--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -917,10 +917,61 @@ body {
     background: transparent;
 }
 
-/* Solid thumb. Mahmoud's verdict on the always-on gradient: a fade should MEAN "more
-   content this way" (fade at the far end at the top, at the near end at the bottom,
-   none mid-scroll) — a static fade is noise. Until a scroll-position-aware fade is
-   proven to work, the thumb stays plain. */
+/* Scroll-position-aware thumb. The fade is a SIGNAL of remaining content: at the top the
+   thumb dissolves at its bottom end ("more below"), at the bottom at its top end, and
+   mid-scroll it is solid, because mid-scroll both directions are already obvious. The two
+   fade lengths are registered custom properties so they can interpolate, a scroll-driven
+   animation moves them on the scroller, and the thumb's gradient reads them back.
+
+   `inherits: true` is load-bearing. ::-webkit-scrollbar-thumb only sees these through
+   inheritance from its scroller; registered with `inherits: false` the thumb silently
+   paints the initial value and the result is pixel-identical to a solid thumb.
+
+   The percentage in min() resolves against the thumb's own box, not the scroller, so the
+   fade is a constant soft tip on a long thumb and cannot swallow a minimum-length one. */
+@property --ag-fade-start {
+    syntax: "<length-percentage>";
+    inherits: true;
+    initial-value: 0px;
+}
+
+@property --ag-fade-end {
+    syntax: "<length-percentage>";
+    inherits: true;
+    initial-value: 0px;
+}
+
+@keyframes ag-thumb-fade {
+    0% {
+        --ag-fade-start: 0px;
+        --ag-fade-end: min(14px, 35%);
+    }
+
+    40%,
+    60% {
+        --ag-fade-start: 0px;
+        --ag-fade-end: 0px;
+    }
+
+    100% {
+        --ag-fade-start: min(14px, 35%);
+        --ag-fade-end: 0px;
+    }
+}
+
+/* Scoped to the scrollers we write, not `*`. On `*` Chromium builds a scroll timeline for
+   every element — 12k of them on a 12k-node page to drive the one that scrolls — which
+   costs ~3.5x page load, ~5x style recalc and halves the scroll frame rate; and the
+   animation-timeline leaks onto any element that sets animation-name through the longhand,
+   turning that element's own animation scroll-driven. Scoped, the same page builds one
+   timeline and holds 60fps. Scrollers outside this list keep the solid thumb; opt in with
+   .ag-scroll-fade. Vertical only — horizontal thumbs stay solid. */
+html,
+:where(.overflow-auto, .overflow-y-auto, .overflow-y-scroll, .ag-scroll-fade) {
+    animation: ag-thumb-fade linear both;
+    animation-timeline: scroll(self block);
+}
+
 ::-webkit-scrollbar-thumb {
     border-radius: 999px;
     background-color: var(--ag-scroll-thumb);
@@ -928,6 +979,38 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
     background-color: var(--ag-scroll-thumb-hover);
+}
+
+/* background-color has to be cleared wherever the gradient paints: the two composite, and
+   a 0.22-alpha thumb painted twice reads as ~0.39. The local --ag-thumb is what keeps
+   :hover working underneath an opaque gradient, which a plain background-color hover rule
+   cannot do. Horizontal thumbs keep the solid rules above. */
+html::-webkit-scrollbar-thumb:vertical,
+:where(
+        .overflow-auto,
+        .overflow-y-auto,
+        .overflow-y-scroll,
+        .ag-scroll-fade
+    )::-webkit-scrollbar-thumb:vertical {
+    --ag-thumb: var(--ag-scroll-thumb);
+    background-color: transparent;
+    background-image: linear-gradient(
+        to bottom,
+        transparent 0%,
+        var(--ag-thumb) var(--ag-fade-start),
+        var(--ag-thumb) calc(100% - var(--ag-fade-end)),
+        transparent 100%
+    );
+}
+
+html::-webkit-scrollbar-thumb:vertical:hover,
+:where(
+        .overflow-auto,
+        .overflow-y-auto,
+        .overflow-y-scroll,
+        .ag-scroll-fade
+    )::-webkit-scrollbar-thumb:vertical:hover {
+    --ag-thumb: var(--ag-scroll-thumb-hover);
 }
 
 /* Quiet scrollbars. The gutter is reserved at the thumb's width whether or not the

--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -892,11 +892,19 @@ body {
 }
 
 /* Global scrollbars: slim, no track, and the thumb dissolves toward its tail end
-   instead of ending in a hard edge. Firefox gets the slim/no-track half (its
-   scrollbar-color cannot paint a gradient). The opt-in classes below override this. */
-* {
-    scrollbar-width: thin;
-    scrollbar-color: var(--ag-scroll-thumb) transparent;
+   instead of ending in a hard edge. Chromium and Safari paint that gradient through the
+   WebKit pseudo-elements below; Firefox gets the slim/no-track half from the standard
+   properties (its scrollbar-color cannot paint a gradient). The opt-in classes below
+   override this.
+
+   The standard properties are scoped to browsers without the pseudo-elements on purpose:
+   since Chrome 121 a non-auto scrollbar-width/scrollbar-color makes Chromium ignore every
+   ::-webkit-scrollbar rule, which would drop the gradient everywhere it is the point. */
+@supports not selector(::-webkit-scrollbar) {
+    * {
+        scrollbar-width: thin;
+        scrollbar-color: var(--ag-scroll-thumb) transparent;
+    }
 }
 
 ::-webkit-scrollbar {
@@ -939,13 +947,20 @@ body {
    only appears while the pointer or focus is inside the scroller. */
 .ag-scroll-quiet {
     scrollbar-gutter: stable;
-    scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
 }
 
-.ag-scroll-quiet:hover,
-.ag-scroll-quiet:focus-within {
-    scrollbar-color: var(--ag-scroll-thumb) transparent;
+/* Same split as above: the standard properties would otherwise switch off this class's own
+   WebKit rules in Chromium. */
+@supports not selector(::-webkit-scrollbar) {
+    .ag-scroll-quiet {
+        scrollbar-width: thin;
+        scrollbar-color: transparent transparent;
+    }
+
+    .ag-scroll-quiet:hover,
+    .ag-scroll-quiet:focus-within {
+        scrollbar-color: var(--ag-scroll-thumb) transparent;
+    }
 }
 
 .ag-scroll-quiet::-webkit-scrollbar {

--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -891,6 +891,49 @@ body {
     display: block;
 }
 
+/* Global scrollbars: slim, no track, and the thumb dissolves toward its tail end
+   instead of ending in a hard edge. Firefox gets the slim/no-track half (its
+   scrollbar-color cannot paint a gradient). The opt-in classes below override this. */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ag-scroll-thumb) transparent;
+}
+
+::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-corner {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background-color: transparent;
+    background-image: linear-gradient(
+        to bottom,
+        var(--ag-scroll-thumb) 0%,
+        var(--ag-scroll-thumb) 55%,
+        transparent 100%
+    );
+}
+
+::-webkit-scrollbar-thumb:horizontal {
+    background-image: linear-gradient(
+        to right,
+        var(--ag-scroll-thumb) 0%,
+        var(--ag-scroll-thumb) 55%,
+        transparent 100%
+    );
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background-image: none;
+    background-color: var(--ag-scroll-thumb-hover);
+}
+
 /* Quiet scrollbars. The gutter is reserved at the thumb's width whether or not the
    content overflows, so revealing the thumb never shifts the content, and the thumb
    only appears while the pointer or focus is inside the scroller. */
@@ -906,8 +949,8 @@ body {
 }
 
 .ag-scroll-quiet::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+    width: 6px;
+    height: 6px;
 }
 
 .ag-scroll-quiet::-webkit-scrollbar-track {
@@ -916,8 +959,9 @@ body {
 
 .ag-scroll-quiet::-webkit-scrollbar-thumb {
     background-color: transparent;
+    background-image: none;
     background-clip: content-box;
-    border: 2px solid transparent;
+    border: 1px solid transparent;
     border-radius: 999px;
     transition: background-color 150ms ease;
 }

--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -917,28 +917,16 @@ body {
     background: transparent;
 }
 
+/* Solid thumb. Mahmoud's verdict on the always-on gradient: a fade should MEAN "more
+   content this way" (fade at the far end at the top, at the near end at the bottom,
+   none mid-scroll) — a static fade is noise. Until a scroll-position-aware fade is
+   proven to work, the thumb stays plain. */
 ::-webkit-scrollbar-thumb {
     border-radius: 999px;
-    background-color: transparent;
-    background-image: linear-gradient(
-        to bottom,
-        var(--ag-scroll-thumb) 0%,
-        var(--ag-scroll-thumb) 55%,
-        transparent 100%
-    );
-}
-
-::-webkit-scrollbar-thumb:horizontal {
-    background-image: linear-gradient(
-        to right,
-        var(--ag-scroll-thumb) 0%,
-        var(--ag-scroll-thumb) 55%,
-        transparent 100%
-    );
+    background-color: var(--ag-scroll-thumb);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background-image: none;
     background-color: var(--ag-scroll-thumb-hover);
 }
 


### PR DESCRIPTION
Mahmoud's scrollbar pattern, applied as the app-wide default:

- **Slimmer**: 6px instead of the browser default (and the opt-in quiet class narrows from 8px to the same 6px, so there is one width everywhere).
- **No track**: the lane behind the thumb is fully transparent, including the corner square where two scrollbars meet.
- **Gradient thumb**: the thumb paints solid through ~55% of its length and dissolves into transparent toward its tail end (downward for vertical, rightward for horizontal), so it ends like a gradient instead of a hard edge. On hover it solidifies to the stronger thumb color so it is easy to grab.

Colors ride the existing `--ag-scroll-thumb` / `--ag-scroll-thumb-hover` theme tokens, so light and dark both work. Firefox cannot paint a gradient thumb, so it gets the slim + trackless half via `scrollbar-color` and keeps a plain thumb.

The existing opt-ins keep their behavior: `ag-scroll-quiet` still reveals its thumb only on hover/focus (now at the shared 6px), and `ag-scroll-no-bar` still hides the bar entirely.