### PR TITLE
fix(frontend): give the templates gallery its baseAppURL

### DIFF
--- a/web/oss/src/components/pages/agent-home/components/TemplatesGallery/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplatesGallery/index.tsx
@@ -6,6 +6,8 @@ import {App, Input, Typography} from "antd"
 import {Search} from "lucide-react"
 import {useRouter} from "next/router"
 
+import useURL from "@/oss/hooks/useURL"
+
 import {TEMPLATES_GALLERY} from "../../assets/constants"
 import {
     AGENT_TEMPLATES,
@@ -30,6 +32,7 @@ const matchesQuery = (template: AgentTemplate, query: string) => {
 const TemplatesGalleryPage = () => {
     const router = useRouter()
     const {message} = App.useApp()
+    const {baseAppURL} = useURL()
 
     const categories = useMemo(() => templateCategories(), [])
     const [active, setActive] = useState(ALL_TEMPLATES_CATEGORY)

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/agent-templates/[template_key].tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/agent-templates/[template_key].tsx
@@ -1,8 +1,11 @@
 import dynamic from "next/dynamic"
 import {useRouter} from "next/router"
 
+// Client-only: the AGENTS.md renderer pulls in katex's stylesheet, which Node can't parse
+// during prerender.
 const TemplateDetail = dynamic(
     () => import("@/oss/components/pages/agent-home/components/TemplateDetail"),
+    {ssr: false},
 )
 
 /** One template in full, reached from the gallery. */


### PR DESCRIPTION
## What

The web image does not build on `release/v0.112.0` or on any PR based on it:

```
./src/components/pages/agent-home/components/TemplatesGallery/index.tsx:85:33
Type error: Cannot find name 'baseAppURL'.
```

`handleSelectTemplate` uses `baseAppURL` in a template literal and in its dependency array, but the component never obtains it. Introduced by f91582540c (template cards / gallery rail / template detail page), which is already merged into the release branch, so every open PR inherits the red `build-image (agenta-web)` check from the base.

## The fix

Two lines: import `useURL` and read `baseAppURL` from it, the same pattern the neighboring `NewAgentButton` and `usePlaygroundNavigation` already use.

## Why lint did not catch it

The TypeScript lint/format jobs pass; only `next build`'s type check (which runs inside the image build) compiles this path. Full `tsc` over `web/oss` after the fix: zero errors.

## Urgency

Merging this unblocks the `build-image (agenta-web)` check on all six open release PRs (#5832-#5837) at once.