### PR TITLE
fix(frontend): show the agent overview without Classic Mode

### DIFF
--- a/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
+++ b/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
@@ -166,7 +166,9 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 title: "Overview",
                 link: `${appURL || recentlyVisitedAppURL}/overview`,
                 icon: <DesktopIcon size={14} />,
-                isHidden: isHidden || hideAdvancedNav,
+                // Overview is available in both navs — simplified mode hides the advanced
+                // surfaces around it, not the workflow's own overview.
+                isHidden,
                 // Enabled for evaluators too — scoped by the workflow id as the `application` reference.
                 disabled: !hasProjectURL,
             },


### PR DESCRIPTION
## What

The app rail's "Overview" entry was hidden whenever Classic Mode was off (`isHidden || hideAdvancedNav` in `useSidebarConfig`), so in the default simplified nav the agent overview was reachable only by typing its URL. There was no route guard — only the nav entry was gated.

Overview now follows the ordinary app-in-context rule and shows in BOTH navs. Three lines, one file.

## Still gated by Classic Mode, on purpose

Project nav: Prompts and the Evaluation group (Test sets, Evaluators, Evaluation runs, Annotation Queues). App nav: Registry, Evaluations. Untouched.

## Verified live (both flag states, screenshots in the session records)

- Classic OFF (fresh account default): rail shows Overview / Playground / Sessions / Observability; the overview renders fully; also reached through the agent card's action menu.
- Classic ON: same page, rail additionally shows Registry and Evaluations. No regression.

## Notes

- The change un-hides Overview for every workflow kind in simplified mode, not only agents — prompt apps/evaluators are themselves unreachable in simplified mode, so narrowing it to agents would add machinery that buys nothing today.
- Clicking an agent card's body still opens the playground; that is the card's design, independent of this flag.