### PR TITLE
fix(frontend): drop the Pinned heading row from the sidebar sessions list

### DIFF
--- a/web/oss/src/components/Sidebar/dynamic/registry.ts
+++ b/web/oss/src/components/Sidebar/dynamic/registry.ts
@@ -57,7 +57,6 @@ export const defineSidebarEntity = <TRef extends SidebarEntityRef>(
         ? (projectURL) => `${projectURL}${config.showAllPath}`
         : undefined,
     getIcon: config.getIcon ? (ref) => config.getIcon!(ref as TRef) : undefined,
-    getGroup: config.getGroup ? (ref) => config.getGroup!(ref as TRef) : undefined,
     getOnClick: config.getOnClick ? (ref) => config.getOnClick!(ref as TRef) : undefined,
 })
 
@@ -89,7 +88,6 @@ const ENTITIES: SidebarEntity[] = [
                 title: session.name ?? undefined,
             })
         },
-        getGroup: (session) => (session.pinned ? "Pinned" : null),
         getIcon: (session) =>
             session.pinned
                 ? createElement(PushPinIcon, {size: 14, weight: "fill"})

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -78,8 +78,7 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
  * Pinned sessions first, then the rest by activity.
  *
  * Pins are pulled to the top rather than left in place because a pinned conversation is one you
- * return to over days — exactly what a recency-ordered list buries. The group headings the
- * registry renders depend on this ordering.
+ * return to over days — exactly what a recency-ordered list buries.
  */
 const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     const pinned = new Set(get(pinnedSessionIdsAtom))

--- a/web/oss/src/components/Sidebar/dynamic/types.ts
+++ b/web/oss/src/components/Sidebar/dynamic/types.ts
@@ -52,10 +52,6 @@ export interface SidebarEntityConfig<TRef extends SidebarEntityRef = SidebarEnti
     /** Per-row icon, overriding the shared kind icon — for rows whose state differs from each
      * other (a session's liveness dot, say), where one icon for the whole group says nothing. */
     getIcon?: (ref: TRef) => ReactElement
-    /** Group heading a row belongs under, or null for none. Consecutive rows sharing a label
-     * render beneath one disabled header. Refs must already be ordered by group; this inserts
-     * headings, it does not sort. */
-    getGroup?: (ref: TRef) => string | null
     /** Extra work on click, alongside following `childPath` — e.g. handing the target to the
      * surface being navigated to. Runs in the default jotai store, not a hook. */
     getOnClick?: (ref: TRef) => () => void
@@ -77,6 +73,5 @@ export interface SidebarEntity {
     maxItems: number
     showAllLink?: (projectURL: string) => string
     getIcon?: (ref: SidebarEntityRef) => ReactElement
-    getGroup?: (ref: SidebarEntityRef) => string | null
     getOnClick?: (ref: SidebarEntityRef) => () => void
 }

--- a/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
+++ b/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
@@ -85,22 +85,7 @@ export const resolveChildren = (
 
     const visibleRefs = refs.slice(0, entity.maxItems)
     const children: SidebarConfig[] = []
-    let currentGroup: string | null = null
     for (const ref of visibleRefs) {
-        // Headings are inserted, not sorted — an entity supplying `getGroup` must already order
-        // its refs by group, or the same heading would appear more than once.
-        const group = entity.getGroup?.(ref) ?? null
-        if (group && group !== currentGroup) {
-            children.push({
-                key: `${entity.parentKey}-group-${group}`,
-                title: group,
-                icon: icon(),
-                disabled: true,
-                isDynamic: true,
-                isPlaceholder: true,
-            })
-        }
-        currentGroup = group
         children.push({
             key: `${entity.parentKey}-${ref.id}`,
             title: entity.getLabel(ref),


### PR DESCRIPTION
## What

Pinning a session made the sidebar's Sessions list grow a disabled menu row labeled "Pinned" above the pinned entries. Mahmoud wants that row gone: the pin icon and the pins-first ordering already communicate the state.

## How

The row came from the dynamic sidebar children's group-heading machinery (`getGroup` in the entity registry): consecutive rows sharing a group label got a disabled heading row injected above them. The sessions source (`pinned ? "Pinned" : null`) was the only user of that machinery, so this removes the whole mechanism, not just the label: `registry.ts`, `types.ts`, `useSidebarDynamicChildren.ts`, and the sessions source's comment referencing it. Grep-verified nothing else consumes it (the `getGroupKey` APIs in tables/filters are unrelated).

Pinned sessions keep their pin icon and still sort first; nothing else changes.

## Verified live

Pin → item moves to the top with its pin icon, no header row. Second pin → both at top, still no header. Unpin → recency order restored. Screenshots in the session records.