### PR TITLE
style(frontend): grey resting icons in the overview Configuration card

### DIFF
--- a/web/oss/src/components/pages/overview/agent/AgentConfigurationCard.tsx
+++ b/web/oss/src/components/pages/overview/agent/AgentConfigurationCard.tsx
@@ -33,7 +33,10 @@ interface ConfigRow {
 
 /** An unset row says what to do about it — every row opens the playground anyway. */
 const emptyAction = (label: string) => ({summary: label, status: "default" as const})
-const stated = (summary: string) => ({summary, status: "complete" as const})
+// "default", not "complete": complete tints the icon green, and a read-only card full of
+// green checkmark-colored icons reads as noise. Grey is the resting state; only the
+// required-but-empty warning keeps a color.
+const stated = (summary: string) => ({summary, status: "default" as const})
 
 /**
  * What this agent IS, in one card.


### PR DESCRIPTION
The agent overview's Configuration card marked every configured row `status="complete"`, and the shared accordion primitive tints a complete row's icon with the success green — so the whole card lit up green. Mahmoud's call: grey everywhere, like the rest of the app.

Rows now rest in the default grey. The one colored state that remains is the amber "Choose a model" warning, which flags the only required-but-empty setting. One line plus a comment; the shared primitive is untouched, so the playground's own use of `complete` is unaffected.