### PR TITLE
feat(frontend): make the Pro Trial banner dismissible

### DIFF
--- a/web/ee/src/components/SidebarBanners/state/atoms.ts
+++ b/web/ee/src/components/SidebarBanners/state/atoms.ts
@@ -70,9 +70,10 @@ export const eeBannersAtom = atom((get): BannerConfig[] => {
         const trialText = getTrialTimeText(subscription.period_end)
 
         banners.push({
-            id: "trial-banner",
+            // Keyed on the trial end so a new trial period shows the banner again.
+            id: `trial-banner-${subscription.period_end}`,
             type: "trial",
-            dismissible: false,
+            dismissible: true,
             title: `${planName} Trial`,
             description: `${trialText}. Upgrade today to keep pro plan features.`,
             action: {

--- a/web/oss/src/components/SidebarBanners/state/atoms.ts
+++ b/web/oss/src/components/SidebarBanners/state/atoms.ts
@@ -118,13 +118,17 @@ export const visibleBannersAtom = atom((get) => {
         (a, b) => PRIORITY_ORDER[a.type] - PRIORITY_ORDER[b.type],
     )
 
+    // Trial banners are time-bound and must stay visible for the whole trial, so they are
+    // exempt from the cap even though they are dismissible.
+    const countsTowardCap = (banner: BannerConfig) => banner.dismissible && banner.type !== "trial"
+
     const cappedDismissibleBanners = sortedBanners
-        .filter((banner) => banner.dismissible)
+        .filter(countsTowardCap)
         .slice(0, MAX_DISMISSIBLE_SIDEBAR_BANNERS)
 
-    const nonDismissibleBanners = sortedBanners.filter((banner) => !banner.dismissible)
+    const uncappedBanners = sortedBanners.filter((banner) => !countsTowardCap(banner))
 
-    return [...cappedDismissibleBanners, ...nonDismissibleBanners]
+    return [...cappedDismissibleBanners, ...uncappedBanners]
         .filter((banner) => !dismissedIds.includes(banner.id))
         .sort((a, b) => PRIORITY_ORDER[a.type] - PRIORITY_ORDER[b.type])
 })


### PR DESCRIPTION
Mahmoud wants an X on the "Pro Trial ends in N days" sidebar card.

The sidebar banner system already renders a dismiss X and persists dismissed ids for any banner marked dismissible; the trial banner simply opted out. This flips it on, with two details:

- The banner id is keyed on the trial's `period_end`, so dismissing this trial's card does not hide the card for a future, different trial.
- Trial banners are exempt from the dismissible-banner display cap, so an active trial notice cannot be silently crowded out by other dismissible banners while it is still relevant.

EE banner definition + the OSS visibility atom; both themes come free from the existing banner component.