### PR TITLE
fix(frontend): session rows match the homepage — pin, status icons, sizes

### DIFF
--- a/web/oss/src/components/pages/sessions/components/SessionListCard.tsx
+++ b/web/oss/src/components/pages/sessions/components/SessionListCard.tsx
@@ -2,10 +2,10 @@ import {useCallback, useMemo} from "react"
 
 import {type SessionRowVm} from "@agenta/sessions/row"
 import {applySessionScopeAtom, useSessionCardList, useSessionPins} from "@agenta/sessions/state"
-import {SessionAgentName} from "@agenta/sessions-ui"
+import {SessionAgentName, SessionPinButton, SessionStatusIcon} from "@agenta/sessions-ui"
 import {PANEL_ACTION_CLASS, PanelSection} from "@agenta/ui/components/presentational"
-import {ArrowRightIcon, ChatCircleIcon, ClockIcon, PushPinIcon} from "@phosphor-icons/react"
-import {Dropdown, Skeleton, Tooltip} from "antd"
+import {ArrowRightIcon} from "@phosphor-icons/react"
+import {Dropdown, Skeleton} from "antd"
 import {useSetAtom} from "jotai"
 import {AnimatePresence, MotionConfig, motion} from "motion/react"
 import Link from "next/link"
@@ -125,20 +125,7 @@ const SessionListCard = ({
                         }}
                         className="group box-border flex w-full cursor-pointer items-start gap-3 border-0 border-b border-solid border-colorBorderSecondary bg-transparent px-2 py-3 text-left hover:bg-colorFillQuaternary"
                     >
-                        {/* A glyph for the KIND of row, with the status as a dot on its shoulder.
-                            Two lists in the same column read as one long list when every row leads
-                            with the same dot; the clock and the chat bubble separate them without
-                            a heading. */}
-                        <Tooltip title={vm.status.label}>
-                            <span className="relative mt-0.5 flex shrink-0 text-colorTextTertiary">
-                                {origin ? <ClockIcon size={18} /> : <ChatCircleIcon size={18} />}
-                                <span
-                                    className={`absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-solid border-colorBgContainer ${vm.status.dotClassName} ${
-                                        vm.status.pulse ? "motion-safe:animate-pulse" : ""
-                                    }`}
-                                />
-                            </span>
-                        </Tooltip>
+                        <SessionStatusIcon status={vm.status} automation={Boolean(origin)} />
                         <span className="flex min-w-0 flex-1 flex-col gap-1">
                             <span className="flex w-full items-center gap-2">
                                 <span className="min-w-0 flex-1 truncate text-sm text-colorText">
@@ -164,26 +151,10 @@ const SessionListCard = ({
                                 <span className="w-16 shrink-0 text-right text-xs text-colorTextTertiary">
                                     {vm.activityAt ? timeAgo(Date.parse(vm.activityAt)) : "—"}
                                 </span>
-                                <Tooltip title={vm.isPinned ? "Unpin" : "Pin"}>
-                                    <button
-                                        type="button"
-                                        aria-label={vm.isPinned ? "Unpin session" : "Pin session"}
-                                        onClick={(event) => {
-                                            event.stopPropagation()
-                                            togglePin(vm.id)
-                                        }}
-                                        className={`shrink-0 cursor-pointer border-0 bg-transparent p-0 text-colorTextTertiary ${
-                                            vm.isPinned
-                                                ? ""
-                                                : "opacity-0 focus:opacity-100 group-hover:opacity-100"
-                                        }`}
-                                    >
-                                        <PushPinIcon
-                                            size={14}
-                                            weight={vm.isPinned ? "fill" : "regular"}
-                                        />
-                                    </button>
-                                </Tooltip>
+                                <SessionPinButton
+                                    pinned={vm.isPinned}
+                                    onToggle={() => togglePin(vm.id)}
+                                />
                             </span>
                             {/* What actually happened, so deciding whether to reopen a session
                             doesn't mean opening it. Indented past the status dot. Absent when the

--- a/web/oss/tailwind.config.ts
+++ b/web/oss/tailwind.config.ts
@@ -144,6 +144,7 @@ export const createConfig = (content: string[] = []): Config => {
             "../packages/agenta-entities/src/**/*.{js,ts,jsx,tsx}",
             "../packages/agenta-playground/src/**/*.{js,ts,jsx,tsx}",
             "../packages/agenta-playground-ui/src/**/*.{js,ts,jsx,tsx}",
+            "../packages/agenta-sessions-ui/src/**/*.{js,ts,jsx,tsx}",
             ...content,
         ],
         theme: {

--- a/web/packages/agenta-sessions-ui/src/SessionListStates.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionListStates.tsx
@@ -70,7 +70,7 @@ export const SessionListLoadMore = ({
 /** A list group's heading. Plain (non-motion) so `sticky` is never fighting a transform. */
 export const SessionGroupHeader = ({label}: {label: string}) => (
     <div className="sticky top-0 z-20 bg-colorBgContainer pb-1 pt-4">
-        <p className="m-0 rounded bg-colorBgElevated px-3 py-1 text-xs text-colorTextTertiary">
+        <p className="m-0 px-2 pt-1 text-[11px] uppercase tracking-wide text-colorTextTertiary">
             {label}
         </p>
     </div>

--- a/web/packages/agenta-sessions-ui/src/SessionPinButton.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionPinButton.tsx
@@ -26,7 +26,10 @@ export const SessionPinButton = ({
                 onToggle()
             }}
             className={clsx(
-                "shrink-0 cursor-pointer border-0 bg-transparent p-0 text-colorTextTertiary",
+                "relative shrink-0 cursor-pointer border-0 bg-transparent p-0 text-colorTextTertiary",
+                // Transparent ::after hit extender: a ~26px pointer target around the unchanged
+                // 14px icon. Absolute, so the trailing controls' h-5 box and the row do not grow.
+                "after:absolute after:inset-[-6px] after:content-['']",
                 !pinned && revealOnHover && "opacity-0 focus:opacity-100 group-hover:opacity-100",
             )}
         >

--- a/web/packages/agenta-sessions-ui/src/SessionPinButton.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionPinButton.tsx
@@ -1,0 +1,36 @@
+import {PushPinIcon} from "@phosphor-icons/react"
+import clsx from "clsx"
+
+import {Tip} from "./assets/Tip"
+
+/**
+ * Pin and unpin as ONE control: a pinned row keeps the same pin, filled, and its tooltip reads
+ * "Unpin". A separate unpin glyph made the pinned state look like a fault to undo.
+ */
+export const SessionPinButton = ({
+    pinned,
+    onToggle,
+    revealOnHover = true,
+}: {
+    pinned: boolean
+    onToggle: () => void
+    /** Web reveals an unpinned row's pin on hover; touch has no hover, so it stays visible there. */
+    revealOnHover?: boolean
+}) => (
+    <Tip title={pinned ? "Unpin" : "Pin"}>
+        <button
+            type="button"
+            aria-label={pinned ? "Unpin session" : "Pin session"}
+            onClick={(event) => {
+                event.stopPropagation()
+                onToggle()
+            }}
+            className={clsx(
+                "shrink-0 cursor-pointer border-0 bg-transparent p-0 text-colorTextTertiary",
+                !pinned && revealOnHover && "opacity-0 focus:opacity-100 group-hover:opacity-100",
+            )}
+        >
+            <PushPinIcon size={14} weight={pinned ? "fill" : "regular"} />
+        </button>
+    </Tip>
+)

--- a/web/packages/agenta-sessions-ui/src/SessionRow.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionRow.tsx
@@ -10,12 +10,13 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@agenta/ui/ui"
-import {DotsThreeIcon, PushPinIcon, PushPinSlashIcon} from "@phosphor-icons/react"
+import {DotsThreeIcon} from "@phosphor-icons/react"
 import clsx from "clsx"
 
-import {Tip} from "./assets/Tip"
 import {isMenuDivider, type SessionMenuEntry} from "./menu"
 import {SessionAgentName} from "./SessionAgentName"
+import {SessionPinButton} from "./SessionPinButton"
+import {SessionStatusIcon} from "./SessionStatusIcon"
 
 export interface SessionRowProps {
     row: SessionRowVm
@@ -57,20 +58,11 @@ const SessionRowImpl = ({
         <div
             onClick={handleOpen}
             className={clsx(
-                "group flex items-center gap-3 px-3 py-2 border-solid border-0 border-b border-colorBorderSecondary",
+                "group flex items-start gap-3 px-2 py-3 border-solid border-0 border-b border-colorBorderSecondary",
                 openable ? "cursor-pointer hover:bg-colorFillQuaternary" : "cursor-default",
             )}
         >
-            <Tip title={row.status.label}>
-                <span
-                    aria-label={row.status.label}
-                    className={clsx(
-                        "shrink-0 w-2 h-2 rounded-full",
-                        row.status.dotClassName,
-                        row.status.pulse && "motion-safe:animate-pulse",
-                    )}
-                />
-            </Tip>
+            <SessionStatusIcon status={row.status} automation={row.isAutomation} />
 
             <button
                 type="button"
@@ -80,96 +72,89 @@ const SessionRowImpl = ({
                     handleOpen()
                 }}
                 className={clsx(
-                    "flex-1 min-w-0 flex flex-col gap-0.5 border-0 bg-transparent p-0 text-left",
+                    "flex-1 min-w-0 flex flex-col gap-1 border-0 bg-transparent p-0 text-left",
                     openable ? "cursor-pointer" : "cursor-default",
                 )}
             >
-                <span className="w-full text-xs text-colorText truncate">{row.title}</span>
+                <span className="w-full text-sm text-colorText truncate">{row.title}</span>
                 {row.subtitle ? (
-                    <span className="w-full truncate text-[11px] text-colorTextTertiary">
+                    <span className="w-full truncate text-[13px] text-colorTextTertiary">
                         {row.subtitle}
                     </span>
                 ) : null}
             </button>
 
-            {row.status.chipLabel ? (
-                <span
-                    className={clsx(
-                        "shrink-0 rounded px-1.5 py-0.5 text-[11px] leading-none",
-                        row.status.chipClassName,
-                    )}
-                >
-                    {row.status.chipLabel}
-                </span>
-            ) : null}
-
-            {showAgent ? (
-                <span className="w-40 shrink-0 truncate">
-                    {renderAgent ? (
-                        renderAgent(row.agentId)
-                    ) : (
-                        <SessionAgentName agentId={row.agentId} />
-                    )}
-                </span>
-            ) : null}
-
-            <span className="w-24 shrink-0 text-xs text-colorTextTertiary text-right">
-                {row.activityAt ? timeAgo(Date.parse(row.activityAt)) : "—"}
-            </span>
-
-            {onTogglePin ? (
-                <Tip title={row.isPinned ? "Unpin" : "Pin"}>
-                    <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        aria-label={row.isPinned ? "Unpin session" : "Pin session"}
+            {/* h-5 = the title's line box, so the trailing controls centre on the TITLE rather
+                than on a row whose height the subtitle decides. */}
+            <div className="flex h-5 shrink-0 items-center gap-3">
+                {row.status.chipLabel ? (
+                    <span
                         className={clsx(
-                            "shrink-0",
-                            !row.isPinned &&
-                                revealActionsOnHover &&
-                                "opacity-0 group-hover:opacity-100 focus:opacity-100",
+                            "shrink-0 rounded px-1.5 py-0.5 text-xs leading-none",
+                            row.status.chipClassName,
                         )}
-                        onClick={(event) => {
-                            event.stopPropagation()
-                            onTogglePin(row.id)
-                        }}
                     >
-                        {row.isPinned ? <PushPinSlashIcon size={14} /> : <PushPinIcon size={14} />}
-                    </Button>
-                </Tip>
-            ) : null}
+                        {row.status.chipLabel}
+                    </span>
+                ) : null}
 
-            {menuItems?.length ? (
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            aria-label="Session actions"
-                            className="shrink-0"
+                {showAgent ? (
+                    <span className="w-40 shrink-0 truncate">
+                        {renderAgent ? (
+                            renderAgent(row.agentId)
+                        ) : (
+                            <SessionAgentName agentId={row.agentId} />
+                        )}
+                    </span>
+                ) : null}
+
+                <span className="w-24 shrink-0 text-xs text-colorTextTertiary text-right">
+                    {row.activityAt ? timeAgo(Date.parse(row.activityAt)) : "—"}
+                </span>
+
+                {onTogglePin ? (
+                    <SessionPinButton
+                        pinned={row.isPinned}
+                        onToggle={() => onTogglePin(row.id)}
+                        revealOnHover={revealActionsOnHover}
+                    />
+                ) : null}
+
+                {menuItems?.length ? (
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                aria-label="Session actions"
+                                className="shrink-0"
+                                onClick={(event) => event.stopPropagation()}
+                            >
+                                <DotsThreeIcon size={14} />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                            align="end"
                             onClick={(event) => event.stopPropagation()}
                         >
-                            <DotsThreeIcon size={14} />
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
-                        {menuItems.map((entry, index) =>
-                            isMenuDivider(entry) ? (
-                                <DropdownMenuSeparator key={`divider-${index}`} />
-                            ) : (
-                                <DropdownMenuItem
-                                    key={entry.key}
-                                    disabled={entry.disabled}
-                                    variant={entry.danger ? "destructive" : "default"}
-                                    onSelect={() => onMenuSelect?.(entry.key)}
-                                >
-                                    {entry.label}
-                                </DropdownMenuItem>
-                            ),
-                        )}
-                    </DropdownMenuContent>
-                </DropdownMenu>
-            ) : null}
+                            {menuItems.map((entry, index) =>
+                                isMenuDivider(entry) ? (
+                                    <DropdownMenuSeparator key={`divider-${index}`} />
+                                ) : (
+                                    <DropdownMenuItem
+                                        key={entry.key}
+                                        disabled={entry.disabled}
+                                        variant={entry.danger ? "destructive" : "default"}
+                                        onSelect={() => onMenuSelect?.(entry.key)}
+                                    >
+                                        {entry.label}
+                                    </DropdownMenuItem>
+                                ),
+                            )}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                ) : null}
+            </div>
         </div>
     )
 }

--- a/web/packages/agenta-sessions-ui/src/SessionStatusIcon.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionStatusIcon.tsx
@@ -1,0 +1,35 @@
+import {type SessionRowStatusMeta} from "@agenta/sessions/row"
+import {ChatCircleIcon, ClockIcon} from "@phosphor-icons/react"
+import clsx from "clsx"
+
+import {Tip} from "./assets/Tip"
+
+/**
+ * A glyph for the KIND of row, with the status as a dot on its shoulder. Two lists in the same
+ * column read as one long list when every row leads with the same dot; the clock and the chat
+ * bubble separate them without a heading.
+ */
+export const SessionStatusIcon = ({
+    status,
+    automation = false,
+}: {
+    status: SessionRowStatusMeta
+    /** Automation runs lead with a clock, your own conversations with a chat bubble. */
+    automation?: boolean
+}) => (
+    <Tip title={status.label}>
+        <span
+            aria-label={status.label}
+            className="relative mt-0.5 flex shrink-0 text-colorTextTertiary"
+        >
+            {automation ? <ClockIcon size={18} /> : <ChatCircleIcon size={18} />}
+            <span
+                className={clsx(
+                    "absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-solid border-colorBgContainer",
+                    status.dotClassName,
+                    status.pulse && "motion-safe:animate-pulse",
+                )}
+            />
+        </span>
+    </Tip>
+)

--- a/web/packages/agenta-sessions-ui/src/index.ts
+++ b/web/packages/agenta-sessions-ui/src/index.ts
@@ -7,6 +7,8 @@
  */
 export {SessionRow, type SessionRowProps} from "./SessionRow"
 export {SessionAgentName} from "./SessionAgentName"
+export {SessionPinButton} from "./SessionPinButton"
+export {SessionStatusIcon} from "./SessionStatusIcon"
 export {type SessionMenuEntry, isMenuDivider} from "./menu"
 export {
     SessionListSkeleton,

--- a/web/packages/agenta-sessions/src/state/useSessionsList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionsList.ts
@@ -91,9 +91,11 @@ export const useSessionsList = ({agentId: scopedAgentId}: UseSessionsListArgs = 
     const pinnedQuery = useSessionList({
         ...shared,
         sessionIds: pinnedIds,
-        // Pins are mode-independent: without this, default mode's `excludeOrigin` filter would
-        // drop a pinned automation run from its own group.
+        // Default mode is lenient about pins: without this, its `excludeOrigin` filter would drop
+        // a pinned automation run from its own group. The automations mode still narrows, though —
+        // a Pinned group heading a list of automation runs must not hold your own conversations.
         showTriggered: true,
+        origin: showTriggered ? "trigger" : undefined,
         enabled: pinnedIds.length > 0,
     })
     const listQuery = useSessionList({


### PR DESCRIPTION
Four of Mahmoud's five sessions-page items (the fifth was an investigation, answered below).

## Pin behavior
The sessions page unpinned via a pin-with-a-minus icon. The home table's behavior is the right one: a pinned row shows a plain pin, hover says "Unpin", click unpins. That control is now a shared `SessionPinButton` used by both surfaces.

## Status icons
The homepage's row glyph (chat bubble for conversations, clock for automation runs, status as a colored dot on its shoulder) is now a shared `SessionStatusIcon`, and the sessions page uses it instead of its bare 8px dot. The "invisible idle" mystery: idle's dot is `bg-colorBorder`, a color designed to be barely-there; on the shoulder of a glyph it reads as intended.

## Sizes
Row title, preview, timestamp, and chips move to the homepage's ladder (title `text-sm`, secondary 13px, icons 18px) — interim alignment ahead of the global type-scale work.

## Pins vs filters (the investigated bug)
Pins DO honor search, agent, status, and archived — those were already applied server-side to the pinned query. The mode switch was the exception, half-deliberate: a pinned automation run shows in the default view (kept — your pins stay visible), but the automations view also showed pinned CONVERSATIONS (fixed — that view now narrows pins to trigger-origin sessions).

## Base
Stacked on #5833 (same files). 21/21 unit tests pass in `@agenta/sessions`.