### PR TITLE
fix(frontend): collapse toggle in the agent-scoped sidebar

### DIFF
--- a/web/oss/src/components/Sidebar/scopes/workflowScope.tsx
+++ b/web/oss/src/components/Sidebar/scopes/workflowScope.tsx
@@ -23,9 +23,17 @@ const WorkflowSidebarHeader = ({collapsed, lastPath}: SidebarSlotContext) => (
                 collapsed ? "justify-center" : "justify-between px-1.5",
             ].join(" ")}
         >
-            <SidebarBackButton collapsed={collapsed} lastPath={lastPath} />
+            {/* Collapsed leads with the TOGGLE — the spot every collapsed rail puts it — and
+                Back takes the next band. Expanded: Back left, toggle right, one row. */}
+            {collapsed ? <SidebarToggleButton /> : <SidebarBackButton collapsed={false} lastPath={lastPath} />}
             {!collapsed && <SidebarToggleButton />}
         </div>
+
+        {collapsed && (
+            <div className="w-full h-[45px] shrink-0 flex items-center justify-center border-0 border-b border-solid border-[var(--ag-shell-line)]">
+                <SidebarBackButton collapsed lastPath={lastPath} />
+            </div>
+        )}
 
         <div
             className={[
@@ -35,13 +43,6 @@ const WorkflowSidebarHeader = ({collapsed, lastPath}: SidebarSlotContext) => (
         >
             <WorkflowPicker collapsed={collapsed} />
         </div>
-
-        {/* Not stacked under Back like Settings: that shifts both rules off the header's y. */}
-        {collapsed && (
-            <div className="w-full shrink-0 flex justify-center py-1">
-                <SidebarToggleButton />
-            </div>
-        )}
     </>
 )
 

--- a/web/oss/src/components/Sidebar/scopes/workflowScope.tsx
+++ b/web/oss/src/components/Sidebar/scopes/workflowScope.tsx
@@ -25,7 +25,11 @@ const WorkflowSidebarHeader = ({collapsed, lastPath}: SidebarSlotContext) => (
         >
             {/* Collapsed leads with the TOGGLE — the spot every collapsed rail puts it — and
                 Back takes the next band. Expanded: Back left, toggle right, one row. */}
-            {collapsed ? <SidebarToggleButton /> : <SidebarBackButton collapsed={false} lastPath={lastPath} />}
+            {collapsed ? (
+                <SidebarToggleButton />
+            ) : (
+                <SidebarBackButton collapsed={false} lastPath={lastPath} />
+            )}
             {!collapsed && <SidebarToggleButton />}
         </div>
 

--- a/web/oss/src/components/Sidebar/scopes/workflowScope.tsx
+++ b/web/oss/src/components/Sidebar/scopes/workflowScope.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from "react"
 
 import SidebarBackButton from "../components/SidebarBackButton"
+import SidebarToggleButton from "../components/SidebarToggleButton"
 import WorkflowPicker from "../components/WorkflowPicker"
 import type {SidebarScope, SidebarSection, SidebarSlotContext} from "../engine/types"
 
@@ -19,10 +20,11 @@ const WorkflowSidebarHeader = ({collapsed, lastPath}: SidebarSlotContext) => (
         <div
             className={[
                 "w-full h-[45px] shrink-0 flex items-center border-0 border-b border-solid border-[var(--ag-shell-line)]",
-                collapsed ? "justify-center" : "px-1.5",
+                collapsed ? "justify-center" : "justify-between px-1.5",
             ].join(" ")}
         >
             <SidebarBackButton collapsed={collapsed} lastPath={lastPath} />
+            {!collapsed && <SidebarToggleButton />}
         </div>
 
         <div
@@ -33,6 +35,13 @@ const WorkflowSidebarHeader = ({collapsed, lastPath}: SidebarSlotContext) => (
         >
             <WorkflowPicker collapsed={collapsed} />
         </div>
+
+        {/* Not stacked under Back like Settings: that shifts both rules off the header's y. */}
+        {collapsed && (
+            <div className="w-full shrink-0 flex justify-center py-1">
+                <SidebarToggleButton />
+            </div>
+        )}
     </>
 )
 


### PR DESCRIPTION
Opening an agent switches to the workflow-scoped sidebar, which offered only a Back button — no way to collapse the rail (the Settings scope got its toggle restored in 2281ffa2f0; this scope never did).

- **Expanded**: one row — Back on the left, the collapse toggle on the right, same row rhythm as the main sidebar's brand row.
- **Collapsed**: Back stays centred in the 45px header band and the toggle sits in its own small row beneath it. Deliberately not the exact Settings stacking: keeping Back inside the band keeps the header's frame line on the same y as the content's rules, which is the point of the 45px band.

Same `SidebarToggleButton` component as the main sidebar (22px square). The collapsed flag is the shared sidebar atom, so collapsing inside an agent and navigating back keeps the state consistent.