### PR TITLE
feat(frontend): templates pages join the shared layout

### DIFF
--- a/web/oss/src/components/pages/agent-home/components/TemplateDetail/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplateDetail/index.tsx
@@ -82,7 +82,10 @@ const TemplateDetail = ({templateKey}: {templateKey: string}) => {
                 </div>
             </div>
 
-            <div className="flex min-h-0 w-full flex-1 flex-col gap-10 lg:flex-row">
+            {/* One scroller, as in the gallery: `/agent-templates*` is a full-height route, so the
+                layout frame is bounded and unscrolled content below the fold was unreachable.
+                Scrolling here keeps the back link and "Use this template" pinned. */}
+            <div className="flex min-h-0 w-full flex-1 flex-col gap-10 overflow-y-auto pb-2 pr-1 lg:flex-row">
                 {/* What it needs, beside what it does — the same main + rail split the agent
                     overview uses, on one background. */}
                 <aside className="box-border flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-1/3 lg:min-w-[280px] lg:max-w-[340px]">

--- a/web/oss/src/components/pages/agent-home/components/TemplateDetail/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplateDetail/index.tsx
@@ -1,6 +1,8 @@
 import {PageLayout} from "@agenta/ui"
+import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {ArrowLeftIcon, ArrowRightIcon, CheckCircleIcon, LightningIcon} from "@phosphor-icons/react"
 import {Button, Empty, Tag, Tooltip} from "antd"
+import clsx from "clsx"
 import Link from "next/link"
 import {useRouter} from "next/router"
 
@@ -41,38 +43,30 @@ const TemplateDetail = ({templateKey}: {templateKey: string}) => {
     )
 
     return (
-        <PageLayout className="grow min-h-0 !px-14 !pt-0">
-            <div className="flex min-h-0 w-full flex-1 flex-col gap-10 lg:flex-row lg:gap-0">
-                {/* Identity and what it needs — a rail, not a column: it bleeds to the page's own
-                    edges and carries the divider, so the decision half is a distinct surface from
-                    the reading half rather than the same page with a gap down the middle. */}
-                <aside className="box-border flex w-full shrink-0 flex-col gap-6 lg:-mb-4 lg:-ml-14 lg:w-[344px] lg:border-0 lg:border-r lg:border-solid lg:border-colorBorderSecondary lg:bg-colorFillQuaternary lg:px-6 lg:py-6">
-                    <Link
-                        href={`${baseAppURL}/agent-templates`}
-                        className="inline-flex w-fit items-center gap-1 text-xs !text-colorTextSecondary"
-                    >
-                        <ArrowLeftIcon size={14} />
-                        All templates
-                    </Link>
+        <PageLayout className={clsx(pageContentWidthClass, "grow min-h-0")}>
+            {/* Top bar: where you are, how to get back, and the one action — on the page's own
+                top line, like every other detail surface. */}
+            <div className="flex flex-col gap-3">
+                <Link
+                    href={`${baseAppURL}/agent-templates`}
+                    className="inline-flex w-fit items-center gap-1 text-xs !text-colorTextSecondary"
+                >
+                    <ArrowLeftIcon size={14} />
+                    All templates
+                </Link>
 
-                    <div className="flex flex-col gap-3">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div className="flex min-w-0 items-center gap-3">
                         <span
                             aria-hidden
-                            className="flex size-12 items-center justify-center rounded-full text-base font-semibold text-white"
+                            className="flex size-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold text-white"
                             style={{backgroundColor: template.color}}
                         >
                             {template.initials}
                         </span>
-                        <h1 className="m-0 text-2xl font-semibold text-colorText">
+                        <h1 className="m-0 truncate text-2xl font-semibold text-colorText">
                             {template.name}
                         </h1>
-                        <p className="m-0 text-sm leading-relaxed text-colorTextSecondary">
-                            {template.overview || template.description}
-                        </p>
-                        <div className="flex flex-wrap items-center gap-1.5">
-                            <Tag>{template.category}</Tag>
-                            <Tag>{template.trigger}</Tag>
-                        </div>
                     </div>
 
                     <Button
@@ -85,6 +79,22 @@ const TemplateDetail = ({templateKey}: {templateKey: string}) => {
                         Use this template
                         <ArrowRightIcon size={14} />
                     </Button>
+                </div>
+            </div>
+
+            <div className="flex min-h-0 w-full flex-1 flex-col gap-10 lg:flex-row">
+                {/* What it needs, beside what it does — the same main + rail split the agent
+                    overview uses, on one background. */}
+                <aside className="box-border flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-1/3 lg:min-w-[280px] lg:max-w-[340px]">
+                    <div className="flex flex-col gap-3">
+                        <p className="m-0 text-sm leading-relaxed text-colorTextSecondary">
+                            {template.overview || template.description}
+                        </p>
+                        <div className="flex flex-wrap items-center gap-1.5">
+                            <Tag>{template.category}</Tag>
+                            <Tag>{template.trigger}</Tag>
+                        </div>
+                    </div>
 
                     {template.requiredIntegrations.length ? (
                         <section className="flex flex-col gap-2">
@@ -128,7 +138,7 @@ const TemplateDetail = ({templateKey}: {templateKey: string}) => {
                 </aside>
 
                 {/* What it will actually do. */}
-                <div className="flex min-w-0 flex-1 flex-col gap-6 lg:py-4 lg:pl-10">
+                <div className="flex min-w-0 flex-1 flex-col gap-6">
                     {template.example ? (
                         <section className="flex flex-col gap-2">
                             <SectionLabel>Example session</SectionLabel>
@@ -182,7 +192,9 @@ const TemplateDetail = ({templateKey}: {templateKey: string}) => {
                         </section>
                     ) : null}
 
-                    <div className="grid min-w-0 grid-cols-1 items-start gap-6 xl:grid-cols-2">
+                    {/* Stacked, not side by side: the main column is now bounded, and AGENTS.md
+                        at half of it wrapped every other word. */}
+                    <div className="grid min-w-0 grid-cols-1 items-start gap-6">
                         <section className="flex min-w-0 flex-col gap-2">
                             <SectionLabel>Instructions · AGENTS.md</SectionLabel>
                             {/* AGENTS.md is markdown — headings and lists are how it's written,

--- a/web/oss/src/components/pages/agent-home/components/TemplatesGallery/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/TemplatesGallery/index.tsx
@@ -2,7 +2,9 @@ import {useCallback, useDeferredValue, useEffect, useMemo, useState} from "react
 
 import {type SectionRailItem} from "@agenta/entity-ui"
 import {PageLayout} from "@agenta/ui"
+import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {App, Input, Typography} from "antd"
+import clsx from "clsx"
 import {Search} from "lucide-react"
 import {useRouter} from "next/router"
 
@@ -121,51 +123,44 @@ const TemplatesGalleryPage = () => {
     const hasQuery = deferredQuery.length > 0
 
     return (
-        <PageLayout className="grow min-h-0 !p-0">
-            {/* Same rail as the template detail page: its own surface, bled to the page edges,
-                carrying the divider — so browsing and choosing read as two halves of one screen. */}
-            <div className="flex min-h-0 w-full flex-1 flex-col lg:flex-row">
-                <aside className="box-border flex w-full shrink-0 flex-col gap-6 border-0 border-solid border-colorBorderSecondary px-6 py-6 lg:w-[280px] lg:border-r lg:bg-colorFillQuaternary">
-                    <div className="flex min-w-0 flex-col gap-1.5">
-                        <Typography.Title level={2} className="!m-0 !text-[24px] !leading-tight">
-                            {TEMPLATES_GALLERY.title}
-                        </Typography.Title>
-                        <Typography.Text className="!text-[13px] !text-[var(--ag-colorTextSecondary)]">
-                            {TEMPLATES_GALLERY.subtitle}
-                        </Typography.Text>
-                    </div>
-
-                    <nav className="flex flex-col gap-0.5">
-                        {railItems.map((item) => (
-                            <button
-                                key={item.value}
-                                type="button"
-                                aria-current={item.value === active}
-                                onClick={() => handleCategoryChange(item.value)}
-                                className={`box-border flex w-full cursor-pointer items-center gap-2 rounded-lg border-0 px-3 py-2 text-left text-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-colorPrimary ${
-                                    item.value === active
-                                        ? "bg-colorFillSecondary text-colorText"
-                                        : "bg-transparent text-colorTextSecondary hover:bg-colorFillQuaternary"
-                                }`}
-                            >
-                                <span className="min-w-0 flex-1 truncate">{item.label}</span>
-                                <span className="shrink-0 text-xs text-colorTextTertiary">
-                                    {item.count}
-                                </span>
-                            </button>
-                        ))}
-                    </nav>
-                </aside>
+        <PageLayout
+            className={clsx(pageContentWidthClass, "grow min-h-0")}
+            title={TEMPLATES_GALLERY.title}
+            description={TEMPLATES_GALLERY.subtitle}
+        >
+            {/* Filters and grid share the page's own background — one surface, no rail, no
+                divider — so the whole page reads as a single column of content. */}
+            <div className="flex min-h-0 w-full flex-1 flex-col gap-6 lg:flex-row lg:gap-10">
+                <nav className="flex shrink-0 flex-col gap-0.5 lg:w-[180px]">
+                    {railItems.map((item) => (
+                        <button
+                            key={item.value}
+                            type="button"
+                            aria-current={item.value === active}
+                            onClick={() => handleCategoryChange(item.value)}
+                            className={`box-border flex w-full cursor-pointer items-center gap-2 rounded-lg border-0 px-3 py-2 text-left text-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-colorPrimary ${
+                                item.value === active
+                                    ? "bg-colorFillSecondary text-colorText"
+                                    : "bg-transparent text-colorTextSecondary hover:bg-colorFillQuaternary"
+                            }`}
+                        >
+                            <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                            <span className="shrink-0 text-xs text-colorTextTertiary">
+                                {item.count}
+                            </span>
+                        </button>
+                    ))}
+                </nav>
 
                 {/* One scroller: the sections wrapper below scrolls, so search stays pinned. */}
-                <div className="flex min-h-0 flex-1 flex-col gap-5 px-10 py-6">
+                <div className="flex min-h-0 flex-1 flex-col gap-5">
                     <Input
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
                         allowClear
                         prefix={<Search size={14} className="text-[var(--ag-colorTextTertiary)]" />}
                         placeholder={TEMPLATES_GALLERY.searchPlaceholder}
-                        className="w-full sm:w-[320px] self-end"
+                        className="w-full sm:w-[320px]"
                     />
                     {resultCount === 0 ? (
                         <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-[var(--ag-colorBorder)] px-6 py-12 text-center">

--- a/web/oss/src/state/appState/parse.ts
+++ b/web/oss/src/state/appState/parse.ts
@@ -3,7 +3,12 @@ import type {ParsedUrlQuery} from "querystring"
 import type {ParsedAppLocation, QueryRecord, RouteLayer} from "./types"
 
 const isBrowser = typeof window !== "undefined"
-const RESERVED_APP_COLLECTION_ROUTES = new Set(["archived"])
+/**
+ * Static pages under `/apps/` — they sit where an app id would, so without this they parse as
+ * one and put the whole app in the "app" route layer (entity sidebar, bogus `useAppId()`).
+ * Every non-dynamic route under `apps/` belongs here.
+ */
+const RESERVED_APP_COLLECTION_ROUTES = new Set(["archived", "agent-templates"])
 
 const sanitizeId = (value: string | null | undefined): string | null => {
     if (value === undefined || value === null) return null

--- a/web/packages/agenta-ui/src/components/PageLayout.tsx
+++ b/web/packages/agenta-ui/src/components/PageLayout.tsx
@@ -25,6 +25,11 @@ interface HeaderTabsConfig {
 export interface PageLayoutProps {
     title?: ReactNode
     titleLevel?: 1 | 2 | 3 | 4 | 5
+    /**
+     * One line under the title, in the same block so it reads as the title's own. Opt-in: without
+     * it the header keeps its fixed h-11 row, so pages that don't pass one are unchanged.
+     */
+    description?: ReactNode
     headerTabs?: ReactNode
     /** Header tab bar. Local config type (no runtime/type antd). */
     headerTabsProps?: HeaderTabsConfig
@@ -36,6 +41,7 @@ export interface PageLayoutProps {
 const PageLayout = ({
     title,
     titleLevel = 3,
+    description,
     headerTabs,
     headerTabsProps,
     children,
@@ -86,11 +92,14 @@ const PageLayout = ({
                         // (tabs have a taller min-content height) — producing different
                         // header heights and a layout shift when navigating between
                         // tabbed and non-tabbed full-screen table pages.
-                        "flex shrink-0 items-center justify-between gap-3 h-11",
+                        "flex shrink-0 items-center justify-between gap-3",
+                        // A description makes the block taller than one line, so the fixed row
+                        // height only applies without one.
+                        description ? "items-start" : "h-11",
                         headerClassName,
                     )}
                 >
-                    <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
                         {/* antd Title replacement: a real heading sized off antd's own heading
                             tokens so it flips/scales with the theme; `m-0` kills the UA margin
                             (preflight is off). Weight is fontWeightStrong — antd's own Title rule
@@ -106,6 +115,9 @@ const PageLayout = ({
                         >
                             {title}
                         </HeadingTag>
+                        {description ? (
+                            <p className="m-0 text-colorTextSecondary">{description}</p>
+                        ) : null}
                     </div>
                     {headerTabsContent ? (
                         <div className="flex items-center justify-end">{headerTabsContent}</div>


### PR DESCRIPTION
Mahmoud's templates rework, three parts:

## The "opens the first agent" bug
`/apps/agent-templates` sat where an app id sits in the route, so the app-state parser treated `agent-templates` AS an app id — putting the whole gallery in an app's context (agent sidebar, bogus `useAppId()`, and the evaluator templates leaking into view). The path joins `RESERVED_APP_COLLECTION_ROUTES` beside `archived`, so the gallery is a proper project-level page now.

## Gallery layout
Standard page shape: title at the top in the shared centered column with the page description under it (`PageLayout` grows an opt-in `description` prop — pages without one are pixel-unchanged), then two columns on ONE background — no tinted rail, no divider line. Category filters left; search + template grid right.

## Detail layout
Top-and-bottom instead of side-by-side: a top bar with the template's name and back to the gallery; body below.

Layout only — template functionality untouched.