### PR TITLE
fix(frontend): home scrolls with the page; the rail stays pinned

### DIFF
--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -71,10 +71,6 @@ const layoutRouteFlagsAtom = atom<LayoutRouteFlags>((get) => {
     // Covers /agents and /agents/archived, both full-height InfiniteVirtualTable pages.
     const isAgents = pathname.includes("/agents")
     const isSessions = pathname.includes("/sessions")
-    // The apps INDEX only (Home): its two columns scroll independently, so it needs the bounded
-    // frame. Anchored to the end of the path so an app's own sub-routes — /apps/<id>/overview,
-    // /apps/<id>/playground — keep whichever layout they already had.
-    const isAppsHome = /\/apps\/?$/.test(pathname)
 
     return {
         isAuthRoute:
@@ -96,8 +92,8 @@ const layoutRouteFlagsAtom = atom<LayoutRouteFlags>((get) => {
             isAgentTemplates ||
             isAgents ||
             isSessions ||
-            isAppsHome ||
-            // Asked for by the page — see `layoutFullHeightRequestAtom`.
+            // Asked for by the page — see `layoutFullHeightRequestAtom`. Home is one of these:
+            // its returning branch scrolls with the page, its first-run branch asks for the frame.
             get(layoutFullHeightRequestAtom),
     }
 })

--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -296,7 +296,14 @@ const AppWithVariants = memo(
         }, [demoReturnHintDismissed, lastNonDemoProject, navigate, setDemoReturnHintPending])
 
         return (
-            <div className={clsx([{"flex flex-col grow min-h-0": isFullHeight}])}>
+            <div
+                className={clsx([
+                    {"flex flex-col grow min-h-0": isFullHeight},
+                    // The demo banner is `fixed`, so it covers anything the page pins to the
+                    // viewport top. Sticky content reads this var to offset itself past it.
+                    project?.is_demo && "[--ag-demo-banner-h:38px]",
+                ])}
+            >
                 <Modal
                     title="Want to revisit the demo?"
                     open={isDemoReturnModalOpen}

--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -8,7 +8,7 @@ import type {RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {ArrowLeftIcon} from "@phosphor-icons/react"
 import {App, Typography} from "antd"
 import clsx from "clsx"
-import {useAtomValue} from "jotai"
+import {useAtomValue, useSetAtom} from "jotai"
 import Link from "next/link"
 import {useRouter} from "next/router"
 
@@ -24,6 +24,7 @@ import {useTemplateProvenance} from "@/oss/components/TemplateStrip/hooks/useTem
 import UsageSummary from "@/oss/components/UsageSummary"
 import useURL from "@/oss/hooks/useURL"
 import {usePostHogAg} from "@/oss/lib/helpers/analytics/hooks/usePostHogAg"
+import {layoutFullHeightRequestAtom} from "@/oss/state/layout/fullHeight"
 
 import {HERO, RETURNING_HERO} from "./assets/constants"
 import {captureFirstAgentIntent, truncateForCapture} from "./assets/onboardingAnalytics"
@@ -62,11 +63,20 @@ const StripHome: React.FC = () => {
     useAtomValue(appTemplatesQueryAtom)
 
     const agents = useAtomValue(agentsWorkflowsAtom)
+    const requestFullHeight = useSetAtom(layoutFullHeightRequestAtom)
     const agentsLoading = useAtomValue(agentsWorkflowsLoadingAtom)
     const isFirstRun = firstRunOverride ?? (!agentsLoading && agents.length === 0)
     // The create-an-agent surface IS the first-run surface — describe it, pick a template, send.
     // A returning user gets there via `?new=1` rather than through the task composer.
     const firstRun = isFirstRun || creatingAgent
+
+    // Only the centred first-run document wants the layout's bounded frame. The workspace scrolls
+    // with the page, so it must NOT ask — see `layoutFullHeightRequestAtom`.
+    useEffect(() => {
+        if (!firstRun) return
+        requestFullHeight(true)
+        return () => requestFullHeight(false)
+    }, [firstRun, requestFullHeight])
 
     const provenance = useTemplateProvenance({
         composerApi: {
@@ -144,21 +154,18 @@ const StripHome: React.FC = () => {
 
     return (
         <PageLayout className={clsx(pageContentWidthClass, "grow min-h-0")}>
-            {/* First run stays a centered document — one question, one answer, nothing to
-                resume yet — and scrolls inside the frame rather than moving the page. A
-                returning user gets a workspace: two columns that fill the frame and scroll
-                independently, so starting work and resuming it are both always on screen
-                instead of one being scrolled past.
+            {/* First run stays a centered document in the layout's bounded frame — one question,
+                one answer, nothing to resume yet — and scrolls inside it.
 
-                Both fill the layout's own full-height frame (`isFullHeight`, which is what
-                puts the `100dvh` calc on the content wrapper) instead of restating a viewport
-                height here. Asserting one locally on a route the layout thinks is a normal
-                flowing document gave the body its own scrollbar underneath the columns'. */}
+                The workspace scrolls with the PAGE instead: one scrollbar, the browser's own,
+                wherever the pointer is. Only the rail is pinned, and it scrolls internally just
+                when it outgrows the viewport. `items-start` is what lets it: a stretched flex
+                item is as tall as the row and has nothing to travel within. */}
             <div
                 className={
                     firstRun
                         ? "mx-auto flex w-full min-h-0 max-w-[1040px] flex-1 flex-col overflow-y-auto"
-                        : "flex min-h-0 w-full flex-1 gap-10 overflow-hidden"
+                        : "flex w-full flex-1 items-start gap-10"
                 }
             >
                 <div
@@ -166,7 +173,7 @@ const StripHome: React.FC = () => {
                         firstRun
                             ? "flex w-full flex-col"
                             : // `min-w-0` or a wide table would push the column past its share.
-                              "box-border flex min-w-0 flex-1 flex-col gap-14 overflow-y-auto pr-4"
+                              "box-border flex min-w-0 flex-1 flex-col gap-14"
                     }
                 >
                     <div
@@ -268,13 +275,16 @@ const StripHome: React.FC = () => {
                     )}
                 </div>
 
-                {/* Right column, post-swap: what you could start. Scrolls on its own.
+                {/* Right column, post-swap: what you could start. Pinned while the page scrolls;
+                    the cap is what lets `PanelScroll` inside take over once the rail outgrows the
+                    viewport. Both the sticky offset and the height it subtracts are the page's own
+                    56/32 gutters.
 
                     A third of the width rather than a fixed 400px, which held its proportion
                     only at one screen size — it read as a third on a large display and as a
                     slab on a laptop. */}
                 {!firstRun ? (
-                    <div className="box-border flex min-h-0 w-1/3 min-w-[340px] max-w-[520px] shrink-0 grow-0 flex-col pr-1">
+                    <div className="sticky top-14 box-border flex max-h-[calc(100vh-5.5rem)] min-h-0 w-1/3 min-w-[340px] max-w-[520px] shrink-0 grow-0 flex-col pr-1">
                         <PanelSurface>
                             <PanelScroll>
                                 {/* Rows, not the scroller: a 238px card and a six-tab category

--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -284,9 +284,12 @@ const StripHome: React.FC = () => {
 
                     A third of the width rather than a fixed 400px, which held its proportion
                     only at one screen size — it read as a third on a large display and as a
-                    slab on a laptop. */}
+                    slab on a laptop.
+
+                    `--ag-demo-banner-h` is the layout's fixed demo banner (0 outside a demo
+                    workspace): without it the banner covered the pinned rail's top 22px. */}
                 {!firstRun ? (
-                    <div className="sticky top-4 box-border flex max-h-[calc(100vh-3rem)] min-h-0 w-1/3 min-w-[340px] max-w-[520px] shrink-0 grow-0 flex-col pr-1">
+                    <div className="sticky top-[calc(1rem+var(--ag-demo-banner-h,0px))] box-border flex max-h-[calc(100vh-3rem-var(--ag-demo-banner-h,0px))] min-h-0 w-1/3 min-w-[340px] max-w-[520px] shrink-0 grow-0 flex-col pr-1">
                         <PanelSurface>
                             <PanelScroll>
                                 {/* Rows, not the scroller: a 238px card and a six-tab category

--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -275,16 +275,18 @@ const StripHome: React.FC = () => {
                     )}
                 </div>
 
-                {/* Right column, post-swap: what you could start. Pinned while the page scrolls;
-                    the cap is what lets `PanelScroll` inside take over once the rail outgrows the
-                    viewport. Both the sticky offset and the height it subtracts are the page's own
-                    56/32 gutters.
+                {/* Right column, post-swap: what you could start. It scrolls up with the page
+                    first and only pins on arrival — which is what the offset buys: sticky pins
+                    the moment the element reaches `top`, so an offset equal to its resting y
+                    (the 56px gutter) would pin it from scroll zero and it would never travel.
+                    16px leaves it 40px of travel and a little air once pinned. The cap is what
+                    lets `PanelScroll` inside take over when the rail outgrows the viewport.
 
                     A third of the width rather than a fixed 400px, which held its proportion
                     only at one screen size — it read as a third on a large display and as a
                     slab on a laptop. */}
                 {!firstRun ? (
-                    <div className="sticky top-14 box-border flex max-h-[calc(100vh-5.5rem)] min-h-0 w-1/3 min-w-[340px] max-w-[520px] shrink-0 grow-0 flex-col pr-1">
+                    <div className="sticky top-4 box-border flex max-h-[calc(100vh-3rem)] min-h-0 w-1/3 min-w-[340px] max-w-[520px] shrink-0 grow-0 flex-col pr-1">
                         <PanelSurface>
                             <PanelScroll>
                                 {/* Rows, not the scroller: a 238px card and a six-tab category

--- a/web/oss/src/components/pages/agent-home/components/YourAgentsTable/index.tsx
+++ b/web/oss/src/components/pages/agent-home/components/YourAgentsTable/index.tsx
@@ -6,7 +6,7 @@ import {
     type TableFeaturePagination,
     type TableScopeConfig,
 } from "@agenta/ui/table"
-import {ArrowRightIcon, PlusIcon} from "@phosphor-icons/react"
+import {ArrowRightIcon} from "@phosphor-icons/react"
 import {Typography} from "antd"
 import type {TableProps} from "antd/es/table"
 import {useAtomValue, useSetAtom} from "jotai"
@@ -165,22 +165,13 @@ const YourAgentsTable = ({forceEmpty = false, variant = "table"}: YourAgentsTabl
                 title="Your agents"
                 bodyClassName="flex flex-col gap-1 px-2 pb-3"
                 extra={
-                    <div className="flex shrink-0 items-center gap-3">
-                        <button
-                            type="button"
-                            onClick={() => router.push(`${baseAppURL}?new=1`)}
-                            className={PANEL_ACTION_CLASS}
-                        >
-                            <PlusIcon size={14} />
-                            New agent
-                        </button>
-                        {/* An arrow means the action leaves the page. In-place reveals
-                            ("View all 28", "Expand") deliberately don't carry one. */}
-                        <Link href={`${projectURL}/agents`} className={PANEL_ACTION_CLASS}>
-                            All agents
-                            <ArrowRightIcon size={12} />
-                        </Link>
-                    </div>
+                    // One action only: the page header already carries "New agent", so a second
+                    // one here was noise. An arrow means the action leaves the page; in-place
+                    // reveals ("View all 28", "Expand") deliberately don't carry one.
+                    <Link href={`${projectURL}/agents`} className={PANEL_ACTION_CLASS}>
+                        All agents
+                        <ArrowRightIcon size={12} />
+                    </Link>
                 }
             >
                 {showEmpty ? (


### PR DESCRIPTION
The returning-user home page was a bounded frame whose main column scrolled INSIDE itself — an inner scrollbar next to a static page, which looked bad with any real number of sessions.

Now it work:

- The page itself scrolls — one scrollbar, the browser's own, wherever the pointer is.
- The right rail (Your agents / Next triggers / Usage) is sticky, and scrolls its own content when taller than the viewport.
- The first-run home (a centered document with no rail) keeps its bounded frame by ASKING for it via `layoutFullHeightRequestAtom`; the static route flag for apps-home is gone, so playground/evaluator and the other full-height surfaces are untouched.

Stacked on #5836 (its StripHome edits build on the shared-column work there).