### PR TITLE
ci: auto-review release/* PRs with CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# CodeRabbit only auto-reviews PRs whose base is the default branch, so every PR into a
+# release/* branch was skipped ("Auto reviews are disabled on base/target branches other
+# than the default branch") — which is most of the review traffic during a release.
+#
+# `inheritance: true` is load-bearing, not decoration. Configuration sources do NOT merge
+# by default: a repo config file replaces the whole Organization UI configuration, and any
+# field it omits falls through to CodeRabbit's schema defaults rather than to our org
+# settings. Without it this two-line file would silently reset ~20 org choices (the chill
+# profile, collapsed walkthroughs, the disabled poem, slop detection, finishing touches).
+# With it, this file adds the base branches and changes nothing else.
+inheritance: true
+
+reviews:
+  auto_review:
+    # The default branch is always reviewed; these are additional. Regex, so this covers
+    # release/v0.112.0 and every release branch after it.
+    base_branches:
+      - "release/.*"

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ services/runner/tests/results/
 !.github/**
 !.husky/
 !.husky/**
+!.coderabbit.yaml
 !.dockerignore
 !api/.dockerignore
 !services/.dockerignore


### PR DESCRIPTION
Every PR into a `release/*` branch was skipped by CodeRabbit ("Auto reviews are disabled on base/target branches other than the default branch") — which during a release is most of the review traffic. Tonight that meant hand-triggering reviews on fourteen PRs, and even the manual triggers behaved inconsistently.

## Why a repo file (and not the org dashboard)

CodeRabbit's precedence puts a repository `.coderabbit.yaml` ABOVE the Organization UI, so this is fixable in-repo. Verified against CodeRabbit's own resolved configuration output (`@coderabbitai configuration`): no higher-precedence overrides exist in this org.

## Why `inheritance: true` is load-bearing

Configuration sources do not merge by default: a repo file REPLACES the org configuration wholesale, and omitted fields fall through to schema defaults, not to our org settings. A naive two-line file would silently reset ~20 org choices (the chill profile, collapsed walkthroughs, the disabled poem, slop detection, finishing touches, and more — read off the resolved config). `inheritance: true` switches on field-level merging so this file adds the base-branch regex and changes nothing else. The comment in the file says so, so nobody later "simplifies" it away.

Also adds a `.gitignore` exception — the root dotfile rule (`.*`) was ignoring the config file itself.