### PR TITLE
fix(frontend): centre the agent name against its avatar in the rail card

### DIFF
--- a/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
@@ -202,9 +202,13 @@ export const AgentCard = ({
                     </div>
                 </>
             ) : (
-                {/* items-center, not start: without a description the title is one 24px line
-                    against a 40px avatar, and top-alignment left the name riding high. */}
-                <div className="flex items-center gap-3">
+                <div
+                    className={`flex gap-3 ${
+                        // Without a description the title is one 24px line against a 40px
+                        // avatar, and top-alignment left the name riding high.
+                        description ? "items-start" : "items-center"
+                    }`}
+                >
                     {avatar}
                     <div className="flex min-w-0 flex-1 flex-col gap-1">
                         {title}

--- a/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
@@ -102,7 +102,12 @@ export const AgentCard = ({
 
     const title = (
         <div className="flex min-w-0 items-center gap-2">
-            <span className="min-w-0 truncate text-base font-semibold text-colorText">
+            {/* Rail rows read like session rows (14/regular); the grid card keeps a heading. */}
+            <span
+                className={`min-w-0 truncate text-colorText ${
+                    isGrid ? "text-base font-semibold" : "text-sm"
+                }`}
+            >
                 {agent.name}
             </span>
             {waiting > 0 ? (

--- a/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
@@ -202,7 +202,9 @@ export const AgentCard = ({
                     </div>
                 </>
             ) : (
-                <div className="flex items-start gap-3">
+                {/* items-center, not start: without a description the title is one 24px line
+                    against a 40px avatar, and top-alignment left the name riding high. */}
+                <div className="flex items-center gap-3">
                     {avatar}
                     <div className="flex min-w-0 flex-1 flex-col gap-1">
                         {title}


### PR DESCRIPTION
The "Your agents" rail card top-aligned its 40px avatar with the text block. With a description, two text lines fill the height and it reads fine; without one — the common case, since our create flows do not write descriptions — the single 24px name line hugged the top while the circle centred lower, so the name and icon misaligned.

`items-center` fixes the bare case and stays correct for the described case (a two-line block centres against the circle).

One-word change plus the comment. Live-checkable on the QA stack rail.