### PR TITLE
fix(tests): retire the remaining stale antd selectors

### DIFF
--- a/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
@@ -141,7 +141,10 @@ const openAutoEvaluationModal = async (page: Page) => {
     await ensureAutoEvaluationsContext(page)
     await (await getAutoEvaluationCreateButton(page)).click()
 
-    const modal = page.locator(".ant-modal").first()
+    // NewEvaluationModal renders via EnhancedModal, a facade over the @agenta/ui
+    // (Radix) Dialog — DialogContent carries data-slot="dialog-content", not the
+    // antd .ant-modal wrapper this used to match.
+    const modal = page.locator('[data-slot="dialog-content"]').first()
     await expect(modal).toBeVisible()
     await expect(modal.getByText(AUTO_EVALUATION_MODAL_TITLE).first()).toBeVisible()
     await expect(

--- a/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
@@ -425,31 +425,36 @@ async function selectMockModel(page: Page): Promise<void> {
 
     await modelButton.click()
 
-    // The configure popover contains "Configure" somewhere in its header area.
-    // Use a partial-text match so "Configure model" and "Configure" both match.
+    // The configure popover is a Radix Popover (@agenta/ui), not an antd Popover —
+    // PopoverContent renders with data-slot="popover-content", not .ant-popover.
+    // It contains "Configure" somewhere in its header area; a partial-text match
+    // covers both "Configure model" and "Configure".
     const configurePopover = page
-        .locator(".ant-popover")
+        .locator('[data-slot="popover-content"]')
         .filter({has: page.getByText(/Configure/i)})
         .last()
     await expect(configurePopover).toBeVisible({timeout: 15000})
 
-    // Find the model selector inside the popover. When currentModel is known, narrow
-    // to the select that displays it; otherwise fall back to the first select.
-    const modelSelect =
-        currentModel.length > 0
-            ? configurePopover.locator(".ant-select").filter({hasText: currentModel}).first()
-            : configurePopover.locator(".ant-select").first()
-    await expect(modelSelect).toBeVisible({timeout: 15000})
-    await modelSelect.click()
+    // The model select (SelectLLMProviderBase, also @agenta/ui) is itself a nested
+    // Radix Popover: a disclosure button (aria-haspopup="listbox", deliberately not
+    // role="combobox" — see SelectLLMProviderBase.tsx) that opens a search input plus
+    // a role="listbox"/role="option" list. Not an antd Select/dropdown.
+    const modelSelectTrigger = configurePopover.locator('[aria-haspopup="listbox"]').first()
+    await expect(modelSelectTrigger).toBeVisible({timeout: 15000})
+    await modelSelectTrigger.click()
 
-    const dropdown = page.locator(".ant-select-dropdown").last()
-    await expect(dropdown).toBeVisible({timeout: 15000})
+    // The select's own popover portals to <body> as a sibling of configurePopover, so
+    // grab the most recently opened data-slot="popover-content" instead of nesting.
+    const modelListPopover = page.locator('[data-slot="popover-content"]').last()
+    await expect(modelListPopover).toBeVisible({timeout: 15000})
 
-    const searchInput = dropdown.locator("input").first()
+    const searchInput = modelListPopover.getByPlaceholder("Search")
     await expect(searchInput).toBeVisible({timeout: 15000})
     await searchInput.fill(MOCK_MODEL_NAME)
 
-    const mockModelOption = dropdown.getByText(new RegExp(`(^|/)${MOCK_MODEL_NAME}$`)).last()
+    const mockModelOption = modelListPopover
+        .getByRole("option", {name: new RegExp(`(^|/)${MOCK_MODEL_NAME}$`)})
+        .last()
     await expect(mockModelOption).toBeVisible({timeout: 15000})
     await mockModelOption.click()
 


### PR DESCRIPTION
## Summary

Two selectors missed by the earlier antd → Radix migration passes (f85c5ac5e1, ef89e25567, 1fafabb0ab, 45c401fffd, 0adbd26438), both confirmed against the live EE dev stack (`agenta-ee-dev-rel112`, http://144.76.237.122:8180):

- **`auto-evaluation/tests.ts`'s `openAutoEvaluationModal`** matched `.ant-modal`. `NewEvaluationModal` renders through `EnhancedModal`, a facade over the `@agenta/ui` (Radix) `Dialog` — the real wrapper is `[data-slot="dialog-content"]`. Every test that opens this modal timed out at 60s before reaching its own assertions.
- **`providerHelpers`' `selectMockModel`** matched `.ant-popover` / `.ant-select` / `.ant-select-dropdown` for the playground's model-configure popover and its nested model picker. Both are now `@agenta/ui` (Radix) Popovers — matched via `[data-slot="popover-content"]`, the trigger's `aria-haspopup="listbox"`, and `getByRole("option")` instead of antd classes. This is the shared helper behind most of the observability/playground failures: every test that needs to pick the mock test model failed here before reaching the rest of the test.

## How I got the true failure list

Ran the full OSS acceptance suite (80 tests) against the live stack. 22 failed. Per the brief's two named traps: confirmed `app-management.ts`'s "render app overview page" and both `use-api/index.ts` tests fail inside an unguarded `page.waitForLoadState("networkidle")` — pre-existing, dev-server-only, unrelated to selectors, left untouched.

The run overlapped two live-stack events the coordinator flagged mid-task: a ~1-2min 502 window (~21:19-21:22 UTC, a workspace rebase) and a type-scale CSS change that landed ~21:05-21:15 UTC. I reconstructed exact per-test timestamps from the `results/` artifact directory mtimes and cross-checked every failure against both windows before treating it as real. ~10 of the 22 failures fell inside one of these windows; most were re-verified with a clean rerun after the stack stabilized.

## What this PR fixes vs. leaves open

**Fixed and verified live** (rerun after the fix): the `.ant-modal` fix turns "should show an error when attempting to create an evaluation with a mismatched testset" from a 60s timeout into a 14s pass. The popover fix turns all 6 `observability/index.ts` "view traces" failures into passes reaching real trace data (one had a one-off slow-indexing retry that's a stack timing issue, not the selector).

**Confirmed NOT a selector issue, left untouched:**
- `app-management.ts:165` and both `use-api/index.ts` tests — the documented pre-existing `networkidle` trap.
- `agent-chat/attach-send-render-reload.spec.ts` — fails in ~300ms with `POST /workflows/ -> 404` (an HTML 404, not JSON). Root cause: `apiBase(page)` in `agent-chat/tests.ts` builds off `new URL(page.url())`, but the test never navigates before seeding, so `page.url()` is `"about:blank"` and its origin serializes to the string `"null"`. This is a real bug, but it's a URL-construction bug in test-fixture code, not a stale selector — out of this PR's scope, flagging for a follow-up.
- After the modal fix, "should run a single evaluation" and "should delete an evaluation run" now advance past the modal into `openAutoEvaluationRunFromList`'s search-input flow and fail there on a `toHaveValue` mismatch — looks like a typing/re-render race, not a stale selector.
- `evaluators/index.ts:245`'s `.ant-message` toast wait, `evaluators/tests.ts:84`'s `waitForEvaluatorsQuery` timeout, `human-annotation/tests.ts:798`'s annotation-form predicate timeout, and `testsset-management.ts`'s "should delete a testset" (union selector for the confirm modal never becomes visible) — none showed a stale antd class in their call path; look like flakiness or a real product-timing issue, not selectors. Recommend a follow-up investigation rather than a blind selector swap.

I did **not** touch the `NEXT_PUBLIC_AGENTA_EMAIL_DELIVERY_ENABLED`-gated test or weaken/delete any test to make it pass.

## Test plan
- [x] Full OSS acceptance suite run against the live EE dev stack (80 tests, baseline: 22 failed / 26 skipped / 32 passed)
- [x] Scoped rerun of the two fixed sites plus every failure that overlapped the contamination windows, after the stack stabilized
- [x] `.ant-modal` fix confirmed: "mismatched testset" test now passes cleanly (14s)
- [x] Popover fix confirmed: observability suite passes through real trace data (5/6 clean, 1 one-off retry)