### PR TITLE
chore: never track QA gate run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ services/runner/tests/results/
 !.husky/
 !.husky/**
 !.coderabbit.yaml
+
+# QA gate run outputs: machine artifacts with per-run probe tokens that trip secret
+# scanners (and once rode a blanket commit onto a public branch). Never tracked.
+.agents/skills/agent-release-gate/qa-gate-runs/
 !.dockerignore
 !api/.dockerignore
 !services/.dockerignore


### PR DESCRIPTION
Tonight's secret-scan alarm, resolved: gitleaks flagged 11 `generic-api-key` hits in `.agents/skills/agent-release-gate/qa-gate-runs/` artifacts that briefly rode a blanket commit onto a pushed (then immediately replaced) branch. Verified with the scanner plus a field-level inspection: every hit is the gate's own synthetic `QA-CWD-<hex>` probe token (`cwd_token` fields and agent `reply` echoes), and the files contain zero real key patterns. **No credential was exposed; nothing needs rotation.**

The recurrence path is real though: the run outputs sit untracked in working trees where multiple agents commit, and any blanket add sweeps them in — which then fails every downstream secret scan. One ignore line closes it.