### PR TITLE
fix(frontend): the running-elsewhere strip stops accusing your own tab

### DIFF
--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -127,6 +127,7 @@ export const useAgentChatSession = ({
 
     const revalidateSessionMounts = useSetAtom(revalidateSessionMountsAtom)
     const revalidateSessionRecords = useSetAtom(revalidateSessionRecordsAtom)
+    const queryClient = useQueryClient()
     // Only a gate settled in this mount may trigger an automatic resume; hydrated answers stay inert.
     const liveGateInteractionRef = useRef<LiveAgentInteraction | null>(null)
 
@@ -162,10 +163,15 @@ export const useAgentChatSession = ({
         // (historical traces get no such grace; a 404 there means the trace is gone).
         // A finished turn may also have written files: mark the session's drive data stale so
         // every mount surface (open or opened later) refetches — no live channel exists for this.
+        // Liveness too: nothing else invalidates it at turn end, so the project-wide poll's cached
+        // `is_running: true` outlived the answer by up to 15s (#5844). Safe to refetch immediately —
+        // the runner awaits its `is_running: false` heartbeat BEFORE closing this stream
+        // (services/runner/src/server.ts `aliveWatchdog.release()`), so the flag is already cleared.
         onFinish: ({message}) => {
             markTraceAsFresh(getMessageTraceId(message))
             revalidateSessionMounts(sessionId)
             revalidateSessionRecords(sessionId)
+            void queryClient.invalidateQueries({queryKey: ["session-liveness"]})
         },
         onError: (err) => {
             // Render the error in-chat (the `error` alert below); swallow it here so an
@@ -360,7 +366,6 @@ export const useAgentChatSession = ({
     }, [messages])
 
     const projectId = useAtomValue(projectIdAtom)
-    const queryClient = useQueryClient()
 
     const handleStop = useCallback(() => {
         markStopped()

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -7,7 +7,7 @@ import {useAtomValue, useSetAtom} from "jotai"
 import {projectIdAtom} from "@/oss/state/project"
 
 import {loadSessionMessages, type SessionTranscript} from "../assets/loadSession"
-import {sessionLivenessAtomFamily} from "../state/liveness"
+import {sessionRunningElsewhereAtomFamily} from "../state/liveness"
 import {useChatScopeKey} from "../state/scope"
 import {isSessionFresh} from "../state/sessionEphemera"
 import {activeSessionIdAtomFamily} from "../state/sessions"
@@ -210,10 +210,12 @@ export const useSessionHydration = ({
     // There is no push channel to browsers: the runner publishes every event to Redis, but the only
     // consumer is the ingest worker that writes them to the DB. So a session driven from another tab
     // or device is followed by re-reading the durable log on a timer, and the adoption guard above
-    // decides whether anything actually changed. `isRunning` also covers OUR stream, so exclude the
-    // case where this browser is the one driving.
-    const {nest} = useAtomValue(sessionLivenessAtomFamily(sessionId))
-    const runningElsewhere = nest.isRunning && !busy
+    // decides whether anything actually changed. `isRunning` also covers OUR stream, so the atom
+    // excludes every case where this browser is the one driving (#5844).
+    // `busy` stays as a second guard: it flips on the SEND commit, one commit before the status
+    // atom the derivation reads, so it hides the strip a frame earlier when a local send takes over
+    // a session that genuinely was running elsewhere.
+    const runningElsewhere = useAtomValue(sessionRunningElsewhereAtomFamily(sessionId)) && !busy
 
     useEffect(() => {
         if (!runningElsewhere) return

--- a/web/oss/src/components/AgentChatSlice/state/liveness.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/liveness.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pins the running-elsewhere decision (#5844): the strip appeared in the very tab that had just
+ * answered, because `is_running` is a 15s poll snapshot while the local run-state is instant.
+ */
+import {describe, expect, it} from "vitest"
+
+import {isRunningElsewhere} from "./liveness"
+
+/** A session this browser has never run: no settle stamp, so the flag is trusted as-is. */
+const neverRanHere = {localStatus: "idle", localSettledAt: undefined} as const
+
+describe("isRunningElsewhere", () => {
+    it("shows a genuinely remote run", () => {
+        expect(
+            isRunningElsewhere({...neverRanHere, isRunning: true, livenessUpdatedAt: 1_000}),
+        ).toBe(true)
+    })
+
+    it("stays hidden when nothing is running", () => {
+        expect(
+            isRunningElsewhere({...neverRanHere, isRunning: false, livenessUpdatedAt: 1_000}),
+        ).toBe(false)
+    })
+
+    it("stays hidden for active local states", () => {
+        for (const localStatus of ["running", "awaiting"] as const) {
+            expect(
+                isRunningElsewhere({
+                    localStatus,
+                    isRunning: true,
+                    localSettledAt: undefined,
+                    livenessUpdatedAt: 1_000,
+                }),
+            ).toBe(false)
+        }
+    })
+
+    it("distrusts stale liveness after a local error", () => {
+        expect(
+            isRunningElsewhere({
+                localStatus: "error",
+                isRunning: true,
+                localSettledAt: 5_000,
+                livenessUpdatedAt: 4_000,
+            }),
+        ).toBe(false)
+    })
+
+    it("shows a remote run refreshed after a local error", () => {
+        expect(
+            isRunningElsewhere({
+                localStatus: "error",
+                isRunning: true,
+                localSettledAt: 5_000,
+                livenessUpdatedAt: 5_001,
+            }),
+        ).toBe(true)
+    })
+
+    it("distrusts a liveness snapshot taken before our own turn ended", () => {
+        expect(
+            isRunningElsewhere({
+                localStatus: "idle",
+                isRunning: true,
+                localSettledAt: 5_000,
+                livenessUpdatedAt: 4_000,
+            }),
+        ).toBe(false)
+    })
+
+    it("trusts the flag again once liveness has been re-read since the turn ended", () => {
+        expect(
+            isRunningElsewhere({
+                localStatus: "idle",
+                isRunning: true,
+                localSettledAt: 5_000,
+                livenessUpdatedAt: 5_001,
+            }),
+        ).toBe(true)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/state/liveness.ts
+++ b/web/oss/src/components/AgentChatSlice/state/liveness.ts
@@ -12,7 +12,11 @@ import {atomWithQuery} from "jotai-tanstack-query"
 
 import {projectIdAtom} from "@/oss/state/project"
 
-import {type SessionRunStatus, sessionStatusAtomFamily} from "./sessions"
+import {
+    type SessionRunStatus,
+    sessionLocalSettledAtAtomFamily,
+    sessionStatusAtomFamily,
+} from "./sessions"
 
 /**
  * Backend liveness for the project's sessions (cross-device truth). The tab dot reads this to
@@ -95,4 +99,46 @@ export const sessionDotStatusAtomFamily = atomFamily((sessionId: string) =>
         if (nest.isAlive) return "alive"
         return "idle"
     }),
+)
+
+/**
+ * "Is someone ELSE running this session?" — the decision behind the running-elsewhere strip and
+ * the transcript catch-up poll, as a pure function so it can be pinned by tests.
+ *
+ * `isRunning` is a project-wide poll snapshot (10s stale-time, 15s interval); the local run-state
+ * is instant. Two guards close that gap (#5844):
+ *  - an active local state means THIS browser owns the session, so a locally busy or
+ *    approval-parked session never reads as remote (an error is settled, not active);
+ *  - once a local turn has settled, the flag is only trusted again after liveness has been re-read
+ *    (`livenessUpdatedAt` past the settle). Without this, every answer flipped `busy` false against
+ *    a cached `is_running: true` and the strip appeared in the very tab that just ran the turn.
+ */
+export const isRunningElsewhere = ({
+    localStatus,
+    isRunning,
+    localSettledAt,
+    livenessUpdatedAt,
+}: {
+    localStatus: SessionRunStatus
+    isRunning: boolean
+    /** When this browser's own run of the session last settled; absent if it never ran one. */
+    localSettledAt: number | undefined
+    /** `dataUpdatedAt` of the liveness query the `isRunning` flag came from. */
+    livenessUpdatedAt: number
+}): boolean => {
+    if (localStatus === "running" || localStatus === "awaiting") return false
+    if (!isRunning) return false
+    return localSettledAt === undefined || livenessUpdatedAt > localSettledAt
+}
+
+/** `isRunningElsewhere` bound to this session's local status and the shared liveness query. */
+export const sessionRunningElsewhereAtomFamily = atomFamily((sessionId: string) =>
+    atom((get): boolean =>
+        isRunningElsewhere({
+            localStatus: get(sessionStatusAtomFamily(sessionId)),
+            isRunning: get(sessionLivenessAtomFamily(sessionId)).nest.isRunning,
+            localSettledAt: get(sessionLocalSettledAtAtomFamily(sessionId)),
+            livenessUpdatedAt: get(aliveStreamsQueryAtom).dataUpdatedAt,
+        }),
+    ),
 )

--- a/web/oss/src/components/AgentChatSlice/state/sessions.runStatus.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.runStatus.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The local run-state record and its settle stamp — the input the running-elsewhere derivation
+ * uses to distrust a liveness snapshot older than this browser's own turn (#5844).
+ */
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {
+    sessionLocalSettledAtAtomFamily,
+    sessionStatusAtomFamily,
+    setSessionStatusAtom,
+} from "./sessions"
+
+describe("setSessionStatusAtom", () => {
+    it("stamps the settle time only on a non-idle → idle transition", () => {
+        const store = createStore()
+        const id = `run-status-${Date.now()}`
+
+        expect(store.get(sessionStatusAtomFamily(id))).toBe("idle")
+        // Idle → idle is a no-op: an unvisited session must not look like one that just finished.
+        store.set(setSessionStatusAtom, {id, status: "idle"})
+        expect(store.get(sessionLocalSettledAtAtomFamily(id))).toBeUndefined()
+
+        store.set(setSessionStatusAtom, {id, status: "running"})
+        expect(store.get(sessionStatusAtomFamily(id))).toBe("running")
+        expect(store.get(sessionLocalSettledAtAtomFamily(id))).toBeUndefined()
+
+        const before = Date.now()
+        store.set(setSessionStatusAtom, {id, status: "idle"})
+        const settledAt = store.get(sessionLocalSettledAtAtomFamily(id))
+        expect(settledAt).toBeGreaterThanOrEqual(before)
+        expect(store.get(sessionStatusAtomFamily(id))).toBe("idle")
+    })
+
+    it("stamps an active run when it errors without restamping on cleanup", () => {
+        const store = createStore()
+        const id = `run-status-parked-${Date.now()}`
+
+        store.set(setSessionStatusAtom, {id, status: "awaiting"})
+        store.set(setSessionStatusAtom, {id, status: "error"})
+        const settledAt = store.get(sessionLocalSettledAtAtomFamily(id))
+        expect(settledAt).toBeGreaterThan(0)
+
+        store.set(setSessionStatusAtom, {id, status: "idle"})
+        expect(store.get(sessionLocalSettledAtAtomFamily(id))).toBe(settledAt)
+    })
+
+    it("does not stamp an error without a preceding local run", () => {
+        const store = createStore()
+        const id = `run-status-hydrated-error-${Date.now()}`
+
+        store.set(setSessionStatusAtom, {id, status: "error"})
+        expect(store.get(sessionLocalSettledAtAtomFamily(id))).toBeUndefined()
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -881,20 +881,46 @@ export const isSessionStreamingAtomFamily = atomFamily((id: string) =>
     atom((get) => get(sessionStatusByIdAtom)[id] === "running"),
 )
 
+/**
+ * When each session's LOCAL run last settled (ms epoch), stamped when an active run becomes idle
+ * or errors. Read by the running-elsewhere derivation: backend liveness is a poll snapshot
+ * up to 15s stale, so a flag fetched BEFORE our own turn ended says nothing about whether anyone
+ * else is running it (#5844). In-memory only — it describes this browser tab, not history.
+ */
+const sessionLocalSettledAtByIdAtom = atom<Record<string, number>>({})
+
+/** When this browser's run of a session last settled; `undefined` if it never ran one here. */
+export const sessionLocalSettledAtAtomFamily = atomFamily((id: string) =>
+    selectAtom(sessionLocalSettledAtByIdAtom, (map) => map[id]),
+)
+
 /** Set a session's run state. "idle" is the default, so it's stored as ABSENCE: passing "idle"
  * deletes the entry (clear-on-unmount) instead of accumulating idle keys for every closed session. */
 export const setSessionStatusAtom = atom(
     null,
     (get, set, {id, status}: {id: string; status: SessionRunStatus}) => {
         const cur = get(sessionStatusByIdAtom)
+        const wasActive = cur[id] === "running" || cur[id] === "awaiting"
         if (status === "idle") {
             if (!(id in cur)) return
+            if (wasActive) {
+                set(sessionLocalSettledAtByIdAtom, {
+                    ...get(sessionLocalSettledAtByIdAtom),
+                    [id]: Date.now(),
+                })
+            }
             const next = {...cur}
             delete next[id]
             set(sessionStatusByIdAtom, next)
             return
         }
         if (cur[id] === status) return
+        if (status === "error" && wasActive) {
+            set(sessionLocalSettledAtByIdAtom, {
+                ...get(sessionLocalSettledAtByIdAtom),
+                [id]: Date.now(),
+            })
+        }
         set(sessionStatusByIdAtom, {...cur, [id]: status})
     },
 )


### PR DESCRIPTION
Fixes #5844.

## Root cause

`runningElsewhere = nest.isRunning && !busy` mixed an instant local signal with a stale one: `busy` drops when the stream closes, while `nest.isRunning` comes from the project-wide liveness poll (staleTime 10s / refetch 15s). Nothing refreshed it at turn end, so for up to about 15 seconds after every answer, the tab that ran the turn accused itself of running elsewhere.

## The fix

1. **Turn-end invalidation** refreshes the liveness query in `onFinish`. The runner clears its heartbeat before ending the response stream, so the immediate refetch sees the settled server state.
2. **Local-first derivation** treats `running` and `awaiting` as active ownership by this tab. `error` is correctly treated as settled, not active, so a newer liveness result can still reveal a subsequent run from another tab.
3. **Settlement stamp** records active-to-idle and active-to-error transitions. The derivation only trusts liveness data newer than that local settlement, preventing stale backend state from flashing the strip after either a successful or failed local turn.

This also avoids unnecessary transcript catch-up polling after local turns and subscribes the dock to the derived boolean instead of every liveness poll result.

## Verification

- 163/163 AgentChatSlice tests pass, including regression coverage for stale and refreshed liveness after a local error.
- `tsc --noEmit` passes.
- ESLint and Prettier pass for the changed files.

Live check: create an agent and send a message. The strip must not appear in the same tab after success, while awaiting approval, or from stale liveness after an error. A fresh run from a second tab must still show the strip.