### PR TITLE
fix(frontend): request_input renders its form again after the transcript replay

### DIFF
--- a/docs/design/agent-chat-interaction-kinds/pr-5859-architecture-review.md
+++ b/docs/design/agent-chat-interaction-kinds/pr-5859-architecture-review.md
@@ -1,0 +1,342 @@
+# PR #5859: agent-chat interaction architecture review
+
+This report explains how the desktop agent chat turns backend events into live and replayed
+frontend interactions. It then reviews PR #5859 from an architecture and clean-code perspective.
+
+## Bottom line
+
+The chat has two routes to the same `UIMessage` model:
+
+1. During a live run, the SDK streams message parts directly into `useChat`.
+2. When a session is opened or refreshed, the frontend fetches the durable record log and
+   `transcriptToMessages` rebuilds the same message parts.
+
+Rendering and responding happen after those routes join. PR #5859 fixes a mismatch between them:
+live `request_input` carried the hint that selects the form widget, while replay dropped it.
+
+An answered `request_input` remains in history, but it is no longer an editable form. Its later
+`tool_result` changes the same tool part to a settled state, and `ElicitationWidget` renders a
+read-only summary of the submitted, declined, or cancelled result.
+
+## The main split
+
+Not every frontend reaction uses the same mechanism.
+
+| Category           | Who performs the work?              | Pause record                         | Frontend response                              |
+| ------------------ | ----------------------------------- | ------------------------------------ | ---------------------------------------------- |
+| Normal server tool | Runner/server                       | None unless approval is required     | Read-only `ToolActivity`                       |
+| Human approval     | User authorizes a server tool       | `interaction_request: user_approval` | `ApprovalDock` calls `addToolApprovalResponse` |
+| Client tool        | Browser performs a user-facing step | `interaction_request: client_tool`   | Registered widget calls `addToolOutput`        |
+
+`request_input` and `request_connection` are client tools. `commit_revision`, schedule creation,
+and subscription creation are server/platform tools. The latter may use human approval, but they
+are not client tools.
+
+## End-to-end flow
+
+```mermaid
+flowchart TD
+    A[Agent calls a tool] --> B{Who must act?}
+
+    B -->|Runner or server| C[Normal tool call]
+    C --> D{Needs human approval?}
+    D -->|No| E[Runner executes it]
+    D -->|Yes| F[Record user_approval interaction]
+    F --> G[ApprovalDock]
+    G --> H[addToolApprovalResponse]
+    H --> E
+
+    B -->|Browser or user| I[Record client_tool interaction]
+    I --> J[Tool part plus data-render hint]
+    J --> K[Client-tool registry]
+    K --> L[request_input: ElicitationWidget]
+    K --> M[request_connection: ConnectToolWidget]
+    L --> N[addToolOutput]
+    M --> N
+
+    E --> O[tool_result]
+    N --> O
+    O --> P[Resume agent turn]
+
+    Q[Durable session records] --> R[transcriptToMessages]
+    R --> S[Rebuilt UIMessage parts]
+    T[Live SSE stream] --> S
+    S --> U[AgentMessage renderer]
+    U --> G
+    U --> K
+    U --> V[ToolActivity]
+```
+
+## The interfaces
+
+### 1. Durable record interface
+
+The backend stores an ordered, append-only session record log. Important event shapes include:
+
+- `tool_call`: the tool name, call ID, and input.
+- `interaction_request`: why execution paused and what the frontend must do.
+- `interaction_response`: a durable human-approval response.
+- `tool_result`: the final output or error for a tool call.
+- `done`: the assistant-turn boundary or paused marker.
+
+The frontend record boundary is `SessionRecord` in
+`web/packages/agenta-entities/src/session/core/schema.ts`. The payload remains an agent event rather
+than being converted into a frontend-specific database model.
+
+### 2. Live message-part interface
+
+The Vercel adapter in `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py` converts live agent
+events into AI SDK message parts. For a client tool it emits:
+
+```text
+tool-input-available(toolCallId, toolName, input)
+data-render(toolCallId, render.kind)
+```
+
+The render hint is a sibling part because strict AI SDK tool parts cannot carry custom fields.
+
+### 3. Replay adapter
+
+`transcriptToMessages` converts durable records into the same message-part shape that the live
+adapter produces. This is the core parity rule:
+
+```text
+same agent event -> same UIMessage parts -> same renderer and behavior
+```
+
+The desktop currently uses the OSS adapter in
+`web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts`. A copied package adapter
+also exists in `web/packages/agenta-chat/src/assets/transcriptToMessages.ts` while the desktop is
+being moved to the package.
+
+### 4. Frontend dispatch interfaces
+
+The renderer separates three concerns:
+
+- `ToolActivity` displays ordinary server tools and completed work.
+- `ApprovalDock` handles `approval-requested` states.
+- `ClientToolPart` handles browser-fulfilled tools.
+
+For client tools, `AgentMessage` builds a `toolCallId -> render hint` map from `data-render` parts.
+The client-tool registry then selects a widget. Its intended selection order is:
+
+```text
+render.kind -> tool name compatibility fallback -> unhandled fallback
+```
+
+Current registered widgets are:
+
+| `render.kind` | Tool-name fallback   | Widget              |
+| ------------- | -------------------- | ------------------- |
+| `elicitation` | `request_input`      | `ElicitationWidget` |
+| `connect`     | `request_connection` | `ConnectToolWidget` |
+
+An unknown parked client tool is settled with `not_handled` rather than leaving the agent hung.
+
+## Live, refresh, and old-message behavior
+
+### During a live turn
+
+1. The stream creates the tool part and render hint.
+2. The registry selects the widget.
+3. The user completes or dismisses it.
+4. The widget calls `addToolOutput`.
+5. The resume predicate waits until the relevant tool parts are settled.
+6. The frontend sends the updated history back and the runner resumes.
+
+Only a decision made in the current browser mount can auto-resume. This prevents an answer loaded
+from history from accidentally running the agent again.
+
+### When records are fetched
+
+`loadSessionMessages` fetches records and calls `transcriptToMessages`. The desktop adopts the
+rebuilt transcript only when:
+
+- the local browser is not currently streaming;
+- the server record count moved beyond the local record watermark; and
+- adopting would not shorten the visible message list.
+
+Record count matters more than message count because a paused turn and its resumed continuation
+are deliberately folded into one assistant message.
+
+### If `request_input` is still pending
+
+Replay creates an `input-available` tool part and restores its `data-render` hint. The registry
+selects `ElicitationWidget`, so the form is actionable again. Partially typed values are best-effort
+browser-local drafts keyed by `toolCallId`; they are not durable session records.
+
+### If `request_input` was already answered
+
+The record order is normally:
+
+```text
+tool_call
+interaction_request(client_tool)
+tool_result
+```
+
+Replay first reconstructs the pending tool. The later `tool_result` updates that same part to
+`output-available` or `output-error`. Because the part is settled:
+
+- the form does not reopen;
+- accepted values can be displayed in a read-only answer summary;
+- decline and cancel display read-only status chips; and
+- loading this history does not auto-resume the agent.
+
+The durable `tool_result` is therefore load-bearing. If a completed run omitted it, replay could
+reconstruct the request as pending. Approval replay has an extra completion cleanup for incomplete
+logs; client tools currently do not.
+
+### Last message versus an older message
+
+An actionable interaction is expected to remain in the last assistant message until it is settled.
+The approval dock, connection dock, queue hold, and auto-resume logic inspect the tail message.
+
+Known settled client tools can render their read-only history in any message. A pending client tool
+in an older message is an invalid transcript shape: it may render, but `addToolOutput` expects to
+settle a part in the last turn and cannot correctly resume that older turn.
+
+## How the five examples map
+
+| User-facing event  | Architecture                                           | Specialized frontend                                                |
+| ------------------ | ------------------------------------------------------ | ------------------------------------------------------------------- |
+| Request input      | Client tool, `render.kind: elicitation`                | Editable form while pending; read-only result after settlement      |
+| Request connection | Client tool, `render.kind: connect`                    | Inline status plus connection actions near the composer             |
+| Human approval     | `user_approval` interaction around a server tool       | Generic `ApprovalDock` with approve/deny actions                    |
+| Commit message     | Input inside the `commit_revision` server tool         | Specialized approval preview, then switch to the committed revision |
+| Add trigger        | `create_schedule` or `create_subscription` server tool | Generic approval card; PR #5863 adds post-success cache refresh     |
+
+The commit message is not its own interaction. It is a field shown inside the specialized commit
+approval body. Adding a trigger currently has no specialized renderer.
+
+### What happens after a successful commit
+
+The commit approval card is only the before-state. After `commit_revision` succeeds, the backend
+emits a `data-committed-revision` message part containing the new revision ID. The frontend then:
+
+1. marks the latest-revision and inspect caches stale;
+2. remembers the previous parameters so it can show what changed; and
+3. switches the playground directly to the new revision ID.
+
+Changing the selected revision ID causes the revision-specific query to load the committed
+configuration. This behavior was introduced across PRs #4925, #4934, and #4936, refined in #5145,
+and repaired for the current commit-result shape in PR #5805.
+
+This signal is strongest on the live path. The durable record replay adapter drops generic `data`
+events, so opening the same session from server records alone does not replay the revision switch.
+The committed revision is still durable; only this automatic UI reaction is not reconstructed.
+
+### What happens after a successful trigger change
+
+Agent trigger tools run on the server, bypassing the browser hooks that normally invalidate trigger
+queries. In the current code, an already-open trigger list can therefore remain stale after
+`create_schedule` or `create_subscription` succeeds.
+
+Open PR [#5863](https://github.com/Agenta-AI/agenta/pull/5863) fixes this by watching newly settled
+trigger tool parts and invalidating the schedule or subscription query after successful mutations.
+It deliberately reacts only to new live results. Reopening old history does not replay cache
+invalidations; a normal fresh query reads the durable trigger data instead.
+
+## What PR #5859 changes
+
+The PR repairs three pieces of client-tool replay. In simpler terms:
+
+1. **Remember which UI to show after refresh.** A saved `request_input` now comes back with both
+   the request and the label saying it needs an elicitation form. Before this change, replay kept
+   the request but lost that label, so the frontend did not know which widget to use.
+2. **Recognize old saved requests too.** Some older records do not contain that UI label. When the
+   tool is named `request_input`, the frontend now uses the form as a compatibility fallback. It is
+   the equivalent of recognizing a package by its sender when its shipping label is missing.
+3. **Keep the conversation paused until the answer is delivered.** The queue and automatic-resume
+   logic now know that `request_input` is completed by the browser. A pending form blocks the next
+   message; once the user answers, the frontend sends that result back and lets the agent continue.
+
+The parser did not need a behavior change. A test using the original failing schema confirms the
+existing elicitation parser supports it.
+
+## Architecture and clean-code review
+
+### P1: replay did not refresh the canonical tool name (fixed in review follow-up)
+
+`replayClientTool` refreshes missing input on an existing part, but it does not refresh the part's
+tool name from `interaction_request.payload.toolName`. The live adapter deliberately re-emits both
+the canonical name and real input when the client-tool interaction arrives.
+
+This matters because the returned message history derives the response's tool name from the UI
+part, while the runner matches a cold-replay client result by exact tool name plus arguments. If the
+earlier `tool_call` used a display name or alias and the interaction carries the stable canonical
+name, the correct form can render through `render.kind`, but its submitted answer can be indexed
+under the stale name and missed by the runner.
+
+Review follow-up:
+
+- Replay now applies the interaction's canonical name and input to an existing part, matching the
+  live stream's refresh behavior.
+- Both adapter suites now cover a drifted `tool_call.name` and stale input.
+
+Relevant seams:
+
+- `web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts:126-144`
+- `web/packages/agenta-chat/src/assets/transcriptToMessages.ts:147-165`
+- `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:754-786`
+- `sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:166-208`
+- `services/runner/src/responder.ts:424-454`
+
+### P2: explicit unknown render kinds fell through to the name fallback (fixed)
+
+The registry comment describes the tool-name path as compatibility for a missing hint. The code
+also uses it when a hint is present but unknown. For example, `request_input` with an explicit
+future `render.kind: display` would silently render the elicitation form.
+
+That weakens `render.kind` as the authoritative contract and can hide producer/frontend version
+mismatches. Name fallback should run only when `renderKind` is absent. An explicit unsupported kind
+should use the unhandled path.
+
+The registry now uses the name fallback only when `render.kind` is absent. A test pins an explicit
+unknown kind to the unhandled path.
+
+### P2: the no-hint resume compatibility promise lacked a direct test (fixed)
+
+Direct tests now prove a name-only old transcript:
+
+- holds the queue while pending; and
+- auto-resumes after `output-available` or `output-error`.
+
+### P3: package parity tests were asymmetric (fixed)
+
+Both replay suites now verify that a later `tool_result` wins over the pending client-tool request.
+
+## Existing architectural debt
+
+These issues predate PR #5859 and should not force a broad refactor in this bug fix:
+
+1. There are two large `transcriptToMessages` implementations with stated manual parity. They have
+   already drifted in approval-manifest and sentinel handling. The package implementation should
+   become the single owner before more interaction kinds are added.
+2. Client-tool identity is repeated in the app registry and playground resume policy. A small pure
+   descriptor exported from a lower package could own known names and render kinds without making
+   state code import React widgets.
+3. The extracted `@agenta/chat` hydration path still adopts history by strictly larger message
+   count. It does not use the desktop's record-watermark guard, so a turn that grows in place can
+   remain stale for package consumers.
+4. Cold resume matches browser results by tool name plus arguments. A durable interaction ID would
+   be a stronger long-term correlation key and would reduce the cost of canonical-name drift.
+5. Desktop has dedicated client-tool widgets, while mobile currently supports generic approvals
+   but does not register client-tool widgets.
+
+## Verdict
+
+The PR fixes the reported replay bug at the correct behavioral seams: record replay, widget
+dispatch compatibility, and resume policy. The main design is coherent: records are the durable
+interface, both live and replay paths converge on AI SDK message parts, and registries keep visual
+specialization out of the wire format.
+
+The review findings above were addressed with focused regression tests. Consolidating the copied
+replay adapter is worthwhile follow-up work, but it is not necessary to keep this regression fix
+focused.
+
+## Existing companion documentation
+
+- `docs/design/agent-chat-interaction-kinds/flow.md`: detailed elicitation round trip.
+- `docs/design/agent-chat-interaction-kinds/decisions.md`: interaction-kind and security decisions.
+- `docs/design/agent-workflows/documentation/tools.md`: broader runner and tool model.

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -622,3 +622,95 @@ describe("transcriptToMessages attachments", () => {
         ).toEqual([{type: "text", text: "Done."}])
     })
 })
+
+/**
+ * A parked client tool (elicitation) must replay with its `data-render` sibling. Dropping it made
+ * every reload / post-turn transcript adoption resolve the call to NO widget, so the fallback
+ * settled it as `{status: "not_handled"}` instead of showing the form (session a21da9cd).
+ */
+describe("transcriptToMessages parked client tool", () => {
+    const toolCallId = "call_4ySJBKMeiDq4u3hUNGJidwkX|fc_05786f8fb9f28034"
+    const elicitationInput = {
+        message: "To configure the PR reviewer, tell me which repository to monitor.",
+        requestedSchema: {
+            type: "object",
+            required: ["repository"],
+            properties: {repository: {type: "string", title: "Repository"}},
+            "x-ag-stepper": true,
+        },
+    }
+    const clientToolRequest = (payload: Record<string, unknown> = {}): SessionRecord =>
+        record("record-interaction", {
+            type: "interaction_request",
+            id: toolCallId,
+            kind: "client_tool",
+            payload: {
+                toolCallId,
+                toolName: "request_input",
+                input: elicitationInput,
+                render: {kind: "elicitation"},
+                toolCall: {id: toolCallId, name: "request_input", rawInput: elicitationInput},
+                ...payload,
+            },
+        })
+
+    it("replays the render hint as the sibling data part the registry dispatches on", () => {
+        const messages = transcriptToMessages([
+            record("record-call", {
+                type: "tool_call",
+                id: toolCallId,
+                name: "request_input",
+                input: elicitationInput,
+            }),
+            clientToolRequest(),
+            record("record-done-paused", {type: "done", stopReason: "paused"}),
+        ])
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId,
+            state: "input-available",
+            input: elicitationInput,
+        })
+        expect(parts.find((p) => p.type === "data-render")?.data).toEqual({
+            toolCallId,
+            render: {kind: "elicitation"},
+        })
+    })
+
+    it("synthesizes the tool part when the runner parked without surfacing the call", () => {
+        const messages = transcriptToMessages([clientToolRequest()])
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId,
+            state: "input-available",
+            input: elicitationInput,
+        })
+        expect(parts.some((p) => p.type === "data-render")).toBe(true)
+    })
+
+    it("emits no render part when the interaction carries no hint", () => {
+        const messages = transcriptToMessages([clientToolRequest({render: undefined})])
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts.some((p) => p.type === "data-render")).toBe(false)
+        expect(parts[0]).toMatchObject({type: "tool-request_input", state: "input-available"})
+    })
+
+    it("leaves a settled client tool settled (a later tool_result still wins)", () => {
+        const messages = transcriptToMessages([
+            clientToolRequest(),
+            record("record-result", {
+                type: "tool_result",
+                id: toolCallId,
+                output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+            }),
+        ])
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({type: "tool-request_input", state: "output-available"})
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -692,6 +692,25 @@ describe("transcriptToMessages parked client tool", () => {
         expect(parts.some((p) => p.type === "data-render")).toBe(true)
     })
 
+    it("refreshes a drifted tool call with the interaction's canonical name and input", () => {
+        const messages = transcriptToMessages([
+            record("record-call", {
+                type: "tool_call",
+                id: toolCallId,
+                name: "__ag__request_input",
+                input: {message: "stale"},
+            }),
+            clientToolRequest(),
+        ])
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId,
+            input: elicitationInput,
+        })
+    })
+
     it("emits no render part when the interaction carries no hint", () => {
         const messages = transcriptToMessages([clientToolRequest({render: undefined})])
         const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -123,24 +123,25 @@ function replayClientTool(
         reqPayload.toolCallId ?? toolCall.id ?? toolCall.toolCallId ?? payload.id,
     )
     if (!toolCallId) return
+    const toolName = str(reqPayload.toolName ?? toolCall.name ?? toolCall.title)
     const input = reqPayload.input ?? toolCall.rawInput ?? toolCall.input
     let part = index.tools.get(toolCallId)
     if (!part) {
         // The runner parked without first surfacing the tool call — synthesize one.
         part = {
-            type: toolPartType(
-                (reqPayload.toolName as string) ||
-                    (toolCall.name as string) ||
-                    (toolCall.title as string),
-            ),
+            type: toolPartType(toolName),
             toolCallId,
             state: "input-available",
             input,
         }
         draft.parts.push(part)
         index.tools.set(toolCallId, part)
-    } else if (part.input === undefined && input !== undefined) {
-        part.input = input
+    } else {
+        if (toolName) {
+            if (part.type === "dynamic-tool") part.toolName = toolName
+            else part.type = toolPartType(toolName)
+        }
+        if (input !== undefined) part.input = input
     }
     const render = reqPayload.render
     if (render && typeof render === "object" && !Array.isArray(render)) {

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -104,6 +104,50 @@ const isRunnerSentinelError = (part: Part): boolean => {
     )
 }
 
+/**
+ * Replay a parked CLIENT TOOL (`interaction_request` `kind: "client_tool"`): its unsettled tool
+ * part plus the sibling `data-render` part that carries `render.kind` — the ONLY thing that tells
+ * the client-tool registry which widget to dispatch (strict AI SDK tool chunks can't carry it
+ * inline, so the live egress emits the same sibling part). Without it a replayed elicitation
+ * resolves to no widget and the fallback settles it as "not handled by this client".
+ */
+function replayClientTool(
+    draft: DraftMessage,
+    payload: Record<string, unknown>,
+    index: TranscriptIndex,
+    str: (v: unknown) => string,
+): void {
+    const reqPayload = (payload.payload ?? {}) as Record<string, unknown>
+    const toolCall = (reqPayload.toolCall ?? {}) as Record<string, unknown>
+    const toolCallId = str(
+        reqPayload.toolCallId ?? toolCall.id ?? toolCall.toolCallId ?? payload.id,
+    )
+    if (!toolCallId) return
+    const input = reqPayload.input ?? toolCall.rawInput ?? toolCall.input
+    let part = index.tools.get(toolCallId)
+    if (!part) {
+        // The runner parked without first surfacing the tool call — synthesize one.
+        part = {
+            type: toolPartType(
+                (reqPayload.toolName as string) ||
+                    (toolCall.name as string) ||
+                    (toolCall.title as string),
+            ),
+            toolCallId,
+            state: "input-available",
+            input,
+        }
+        draft.parts.push(part)
+        index.tools.set(toolCallId, part)
+    } else if (part.input === undefined && input !== undefined) {
+        part.input = input
+    }
+    const render = reqPayload.render
+    if (render && typeof render === "object" && !Array.isArray(render)) {
+        draft.parts.push({type: "data-render", data: {toolCallId, render}})
+    }
+}
+
 /** Apply one transcript event's payload onto the current assistant/user draft message. */
 function applyEvent(
     draft: DraftMessage,
@@ -199,9 +243,12 @@ function applyEvent(
             return
         }
         case "interaction_request": {
-            // v1 scope: HITL approvals only. The runner emits `kind` `user_approval` for the
-            // Approve/Deny gate; `user_input`/`client_tool` are left to their tool_call/result
-            // parts (a client tool isn't approve/deny) until those are wired.
+            // Two kinds replay: `user_approval` (the Approve/Deny gate, below) and `client_tool`
+            // (a parked browser-fulfilled call). `user_input` is left to its tool_call/result parts.
+            if (payload.kind === "client_tool") {
+                replayClientTool(draft, payload, index, str)
+                return
+            }
             if (payload.kind !== "user_approval") return
             const reqPayload = (payload.payload ?? {}) as Record<string, unknown>
             const toolCall = (reqPayload.toolCall ?? {}) as Record<string, unknown>
@@ -311,7 +358,7 @@ function applyEvent(
             draft.usage = next
             return
         }
-        // done / data / render-hints / attachment_delivery carry no renderable message part — drop.
+        // done / data / attachment_delivery carry no renderable message part — drop.
         default:
             return
     }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
@@ -6,10 +6,14 @@
  * `{approved: false}` envelope. Reading it as a parked client tool made the fallback overwrite that
  * envelope with `{status: "not_handled"}`, so the model saw a failed tool and retried the same call.
  */
+import type {RenderHintLike} from "@agenta/playground"
 import type {ToolUIPart} from "ai"
 import {describe, expect, it} from "vitest"
 
-import {isClientToolPart} from "./meta"
+import ConnectToolWidget from "./ConnectToolWidget"
+import ElicitationWidget from "./ElicitationWidget"
+import {clientToolMeta, isClientToolPart} from "./meta"
+import {resolveClientToolHandler} from "./registry"
 
 const settledCtx = {isStreaming: false, isLastMessage: true}
 
@@ -54,5 +58,46 @@ describe("isClientToolPart", () => {
             output: {connected: true},
         })
         expect(isClientToolPart(part, settledCtx)).toBe(true)
+    })
+})
+
+/**
+ * Registry dispatch. `request_input` MUST resolve to the elicitation form on both axes: the
+ * `render.kind` sibling part (the wire contract) and its tool name (the safety net for a replayed
+ * or old transcript that carries no hint). Falling through to the fallback answers the agent
+ * `{status: "not_handled"}` instead of showing the form.
+ */
+describe("resolveClientToolHandler", () => {
+    const renderMapFor = (kind: string): Map<string, RenderHintLike> =>
+        new Map([["call_1", {kind}]])
+
+    it("resolves request_input by its render kind", () => {
+        const part = toolPart({type: "tool-request_input", state: "input-available"})
+        expect(resolveClientToolHandler(clientToolMeta(part, renderMapFor("elicitation")))).toBe(
+            ElicitationWidget,
+        )
+    })
+
+    it("resolves request_input by tool name when no render hint arrived", () => {
+        const part = toolPart({type: "tool-request_input", state: "input-available"})
+        expect(resolveClientToolHandler(clientToolMeta(part))).toBe(ElicitationWidget)
+    })
+
+    it("still resolves the connect widget on both axes", () => {
+        const part = toolPart({type: "tool-request_connection", state: "input-available"})
+        expect(resolveClientToolHandler(clientToolMeta(part))).toBe(ConnectToolWidget)
+        expect(resolveClientToolHandler(clientToolMeta(part, renderMapFor("connect")))).toBe(
+            ConnectToolWidget,
+        )
+    })
+
+    it("leaves an unknown client tool to the fallback", () => {
+        const part = toolPart({type: "tool-mysteryTool", state: "input-available"})
+        expect(resolveClientToolHandler(clientToolMeta(part))).toBeNull()
+    })
+
+    it("claims a parked request_input while the turn is still streaming (known tool)", () => {
+        const part = toolPart({type: "tool-request_input", state: "input-available"})
+        expect(isClientToolPart(part, {isStreaming: true, isLastMessage: true})).toBe(true)
     })
 })

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
@@ -83,6 +83,11 @@ describe("resolveClientToolHandler", () => {
         expect(resolveClientToolHandler(clientToolMeta(part))).toBe(ElicitationWidget)
     })
 
+    it("does not reinterpret an explicit unknown render kind by tool name", () => {
+        const part = toolPart({type: "tool-request_input", state: "input-available"})
+        expect(resolveClientToolHandler(clientToolMeta(part, renderMapFor("display")))).toBeNull()
+    })
+
     it("still resolves the connect widget on both axes", () => {
         const part = toolPart({type: "tool-request_connection", state: "input-available"})
         expect(resolveClientToolHandler(clientToolMeta(part))).toBe(ConnectToolWidget)

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
@@ -49,7 +49,7 @@ const BY_TOOL_NAME: Record<string, ClientToolHandler> = {
 
 /** Resolve the widget for a client tool, or `null` when none is registered. */
 export const resolveClientToolHandler = (meta: ClientToolMeta): ClientToolHandler | null => {
-    if (meta.renderKind && BY_RENDER_KIND[meta.renderKind]) return BY_RENDER_KIND[meta.renderKind]
+    if (meta.renderKind !== undefined) return BY_RENDER_KIND[meta.renderKind] ?? null
     if (BY_TOOL_NAME[meta.toolName]) return BY_TOOL_NAME[meta.toolName]
     return null
 }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
@@ -4,16 +4,17 @@
  * Dispatch precedence is **`render.kind` → `toolName` → generic fallback**. `render.kind` is a
  * REQUIRED wire field for interaction kinds — it arrives as a sibling `data-render` part (AI SDK
  * tool chunks are strict), resolved into `meta.renderKind` via the message-scoped render map
- * (@agenta/playground `buildRenderMap`). The `toolName` axis remains for the shipped connect
- * widget, whose v1 wire predates the guarantee. Each later kind is one added entry, not a
- * protocol change. Contract: docs/design/agent-chat-interaction-kinds/decisions.md
+ * (@agenta/playground `buildRenderMap`). The `toolName` axis is the safety net for a hint that
+ * never arrived — the connect widget's v1 wire predates the guarantee, and a transcript persisted
+ * before the replay path carried the sibling part has none. Each later kind is one added entry,
+ * not a protocol change. Contract: docs/design/agent-chat-interaction-kinds/decisions.md
  *
  *   runner interaction_request ──▶ tool part (+ sibling data-render part)
  *                                        │ AgentMessage: buildRenderMap(message.parts)
  *                                        ▼
  *                    ClientToolPart → resolveClientToolHandler(meta)
  *                    render.kind ──▶ BY_RENDER_KIND   (elicitation, connect, …)
- *                    toolName ─────▶ BY_TOOL_NAME     (request_connection)
+ *                    toolName ─────▶ BY_TOOL_NAME     (request_connection, request_input)
  *                    neither ──────▶ UnhandledClientTool (neutral "not handled", auto-settles)
  *                                        │ widget settles: output {action,…} | errorText
  *                                        ▼
@@ -38,9 +39,12 @@ const BY_RENDER_KIND: Record<string, ClientToolHandler> = {
     elicitation: ElicitationWidget,
 }
 
-/** Handlers keyed by `toolName` (checked when no render hint matched). */
+/** Handlers keyed by `toolName` (checked when no render hint matched). Both entries are
+ * platform-reserved static tools, so the name is a safe second axis when the hint is missing —
+ * an old persisted transcript, or any replay path that didn't carry the sibling part. */
 const BY_TOOL_NAME: Record<string, ClientToolHandler> = {
     request_connection: ConnectToolWidget,
+    request_input: ElicitationWidget,
 }
 
 /** Resolve the widget for a client tool, or `null` when none is registered. */

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -144,24 +144,25 @@ function replayClientTool(
         reqPayload.toolCallId ?? toolCall.id ?? toolCall.toolCallId ?? payload.id,
     )
     if (!toolCallId) return
+    const toolName = str(reqPayload.toolName ?? toolCall.name ?? toolCall.title)
     const input = reqPayload.input ?? toolCall.rawInput ?? toolCall.input
     let part = index.tools.get(toolCallId)
     if (!part) {
         // The runner parked without first surfacing the tool call — synthesize one.
         part = {
-            type: toolPartType(
-                (reqPayload.toolName as string) ||
-                    (toolCall.name as string) ||
-                    (toolCall.title as string),
-            ),
+            type: toolPartType(toolName),
             toolCallId,
             state: "input-available",
             input,
         }
         draft.parts.push(part)
         index.tools.set(toolCallId, part)
-    } else if (part.input === undefined && input !== undefined) {
-        part.input = input
+    } else {
+        if (toolName) {
+            if (part.type === "dynamic-tool") part.toolName = toolName
+            else part.type = toolPartType(toolName)
+        }
+        if (input !== undefined) part.input = input
     }
     const render = reqPayload.render
     if (render && typeof render === "object" && !Array.isArray(render)) {

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -125,6 +125,50 @@ const isRunnerSentinelError = (part: Part): boolean => {
     )
 }
 
+/**
+ * Replay a parked CLIENT TOOL (`interaction_request` `kind: "client_tool"`): its unsettled tool
+ * part plus the sibling `data-render` part that carries `render.kind` — the ONLY thing that tells
+ * the client-tool registry which widget to dispatch (strict AI SDK tool chunks can't carry it
+ * inline, so the live egress emits the same sibling part). Without it a replayed elicitation
+ * resolves to no widget and the fallback settles it as "not handled by this client".
+ */
+function replayClientTool(
+    draft: DraftMessage,
+    payload: Record<string, unknown>,
+    index: TranscriptIndex,
+    str: (v: unknown) => string,
+): void {
+    const reqPayload = (payload.payload ?? {}) as Record<string, unknown>
+    const toolCall = (reqPayload.toolCall ?? {}) as Record<string, unknown>
+    const toolCallId = str(
+        reqPayload.toolCallId ?? toolCall.id ?? toolCall.toolCallId ?? payload.id,
+    )
+    if (!toolCallId) return
+    const input = reqPayload.input ?? toolCall.rawInput ?? toolCall.input
+    let part = index.tools.get(toolCallId)
+    if (!part) {
+        // The runner parked without first surfacing the tool call — synthesize one.
+        part = {
+            type: toolPartType(
+                (reqPayload.toolName as string) ||
+                    (toolCall.name as string) ||
+                    (toolCall.title as string),
+            ),
+            toolCallId,
+            state: "input-available",
+            input,
+        }
+        draft.parts.push(part)
+        index.tools.set(toolCallId, part)
+    } else if (part.input === undefined && input !== undefined) {
+        part.input = input
+    }
+    const render = reqPayload.render
+    if (render && typeof render === "object" && !Array.isArray(render)) {
+        draft.parts.push({type: "data-render", data: {toolCallId, render}})
+    }
+}
+
 /** Apply one transcript event's payload onto the current assistant/user draft message. */
 function applyEvent(
     draft: DraftMessage,
@@ -220,9 +264,12 @@ function applyEvent(
             return
         }
         case "interaction_request": {
-            // v1 scope: HITL approvals only. The runner emits `kind` `user_approval` for the
-            // Approve/Deny gate; `user_input`/`client_tool` are left to their tool_call/result
-            // parts (a client tool isn't approve/deny) until those are wired.
+            // Two kinds replay: `user_approval` (the Approve/Deny gate, below) and `client_tool`
+            // (a parked browser-fulfilled call). `user_input` is left to its tool_call/result parts.
+            if (payload.kind === "client_tool") {
+                replayClientTool(draft, payload, index, str)
+                return
+            }
             if (payload.kind !== "user_approval") return
             const reqPayload = (payload.payload ?? {}) as Record<string, unknown>
             const toolCall = (reqPayload.toolCall ?? {}) as Record<string, unknown>
@@ -319,7 +366,7 @@ function applyEvent(
             draft.usage = next
             return
         }
-        // done / data / render-hints carry no renderable message part — drop.
+        // done / data carry no renderable message part — drop.
         default:
             return
     }

--- a/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
@@ -430,10 +430,41 @@ describe("transcriptToMessages parked client tool", () => {
         })
     })
 
+    it("refreshes a drifted tool call with the interaction's canonical name and input", () => {
+        const parts = (transcriptToMessages([
+            record("r-call", {
+                type: "tool_call",
+                id: toolCallId,
+                name: "__ag__request_input",
+                input: {message: "stale"},
+            }),
+            clientToolRequest(),
+        ])?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId,
+            input,
+        })
+    })
+
     it("emits no render part when the interaction carries no hint", () => {
         const parts = (transcriptToMessages([clientToolRequest({render: undefined})])?.[0].parts ??
             []) as unknown as Record<string, unknown>[]
 
         expect(parts.some((p) => p.type === "data-render")).toBe(false)
+    })
+
+    it("leaves a settled client tool settled (a later tool_result still wins)", () => {
+        const parts = (transcriptToMessages([
+            clientToolRequest(),
+            record("r-result", {
+                type: "tool_result",
+                id: toolCallId,
+                output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+            }),
+        ])?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({type: "tool-request_input", state: "output-available"})
     })
 })

--- a/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
@@ -379,3 +379,61 @@ describe("transcriptToMessages cold approval resume (re-raised tool call id)", (
         expect(parts.filter((part) => part.state === "approval-requested")).toEqual([])
     })
 })
+
+/** Parity with the OSS original: a parked client tool replays with its `data-render` sibling, the
+ * only thing the client-tool registry can dispatch on. Without it a reload settles the call as
+ * "not handled by this client" instead of showing the widget. */
+describe("transcriptToMessages parked client tool", () => {
+    const toolCallId = "call_1|fc_1"
+    const input = {message: "Which repository?", requestedSchema: {type: "object", properties: {}}}
+    const clientToolRequest = (payload: Record<string, unknown> = {}): SessionRecord =>
+        record("r-interaction", {
+            type: "interaction_request",
+            id: toolCallId,
+            kind: "client_tool",
+            payload: {
+                toolCallId,
+                toolName: "request_input",
+                input,
+                render: {kind: "elicitation"},
+                ...payload,
+            },
+        })
+
+    it("replays the render hint as a sibling data part", () => {
+        const parts = (transcriptToMessages([
+            record("r-call", {type: "tool_call", id: toolCallId, name: "request_input", input}),
+            clientToolRequest(),
+            record("r-done", {type: "done", stopReason: "paused"}),
+        ])?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId,
+            state: "input-available",
+        })
+        expect(parts.find((p) => p.type === "data-render")?.data).toEqual({
+            toolCallId,
+            render: {kind: "elicitation"},
+        })
+    })
+
+    it("synthesizes the tool part when the runner parked without surfacing the call", () => {
+        const parts = (transcriptToMessages([clientToolRequest()])?.[0].parts ??
+            []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId,
+            state: "input-available",
+            input,
+        })
+    })
+
+    it("emits no render part when the interaction carries no hint", () => {
+        const parts = (transcriptToMessages([clientToolRequest({render: undefined})])?.[0].parts ??
+            []) as unknown as Record<string, unknown>[]
+
+        expect(parts.some((p) => p.type === "data-render")).toBe(false)
+    })
+})

--- a/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
@@ -72,11 +72,11 @@ const isRespondedToolPart = (part: ToolPartLike): boolean =>
  */
 /**
  * Known browser-fulfilled client tools, mirroring the app-layer registry's `BY_TOOL_NAME`
- * (v1: `request_connection`). The package cannot import that registry (layering), so it tracks
- * the same names. A part dispatches as a client tool by `render.kind` (finer axis) OR this name,
- * matching the registry's `render.kind -> toolName` precedence.
+ * (`request_connection`, `request_input`). The package cannot import that registry (layering), so
+ * it tracks the same names. A part dispatches as a client tool by `render.kind` (finer axis) OR
+ * this name, matching the registry's `render.kind -> toolName` precedence.
  */
-const CLIENT_TOOL_NAMES = new Set(["request_connection"])
+const CLIENT_TOOL_NAMES = new Set(["request_connection", "request_input"])
 
 const toolPartName = (part: ToolPartLike): string =>
     typeof part.type === "string" ? part.type.replace(/^tool-/, "") : ""

--- a/web/packages/agenta-playground/tests/unit/renderMap.test.ts
+++ b/web/packages/agenta-playground/tests/unit/renderMap.test.ts
@@ -109,6 +109,32 @@ describe("resume predicate × render map", () => {
         expect(agentShouldResumeAfterApproval({messages: [user, message]})).toBe(true)
     })
 
+    it("request_input with no render part still resumes by name", () => {
+        const message = {
+            id: "a1",
+            role: "assistant",
+            parts: [{type: "step-start"}, settledTool("request_input", "call_e")],
+        }
+        expect(agentShouldResumeAfterApproval({messages: [user, message]})).toBe(true)
+    })
+
+    it("request_input errors with no render part still resume by name", () => {
+        const message = {
+            id: "a1",
+            role: "assistant",
+            parts: [
+                {type: "step-start"},
+                {
+                    type: "tool-request_input",
+                    toolCallId: "call_e",
+                    state: "output-error",
+                    errorText: "Could not render input",
+                },
+            ],
+        }
+        expect(agentShouldResumeAfterApproval({messages: [user, message]})).toBe(true)
+    })
+
     it("a pending elicitation (input-available) does not resume", () => {
         const message = {
             id: "a1",
@@ -176,6 +202,19 @@ describe("queue gating × pending client tools (T7)", () => {
                 id: "a1",
                 role: "assistant",
                 parts: [{type: "step-start"}, pendingTool("request_connection", "call_c")],
+            },
+        ]
+        expect(isHitlPending(messages)).toBe(true)
+        expect(canReleaseQueuedMessage("ready", messages)).toBe(false)
+    })
+
+    it("request_input pending by bare toolName (no render part) also holds the queue", () => {
+        const messages = [
+            user,
+            {
+                id: "a1",
+                role: "assistant",
+                parts: [{type: "step-start"}, pendingTool("request_input", "call_e")],
             },
         ]
         expect(isHitlPending(messages)).toBe(true)

--- a/web/packages/agenta-shared/tests/unit/elicitation.test.ts
+++ b/web/packages/agenta-shared/tests/unit/elicitation.test.ts
@@ -326,6 +326,75 @@ describe("parseElicitationPayload", () => {
         expect(parsed.channels.items?.enum).toEqual(["slack", "email"])
     })
 
+    it("accepts the stepper + choice-card payload from the PR-reviewer session verbatim", () => {
+        // Verbatim `request_input` input from session a21da9cd (the "not handled" report): a
+        // stepper form whose two choice fields use the oneOf/const idiom with defaults. It must
+        // parse and build fields — a widget that can't render this settles a degradation instead.
+        const payload = {
+            message: "To configure the PR reviewer, tell me which repository to monitor.",
+            requestedSchema: {
+                type: "object",
+                required: ["repository", "review_posture", "risk_criteria"],
+                properties: {
+                    repository: {
+                        type: "string",
+                        title: "Repository",
+                        description: "GitHub repository in owner/repo form.",
+                    },
+                    risk_criteria: {
+                        type: "string",
+                        title: "Risk criteria",
+                        default: "diff",
+                        oneOf: [
+                            {
+                                const: "diff",
+                                title: "Discover from the diff (recommended)",
+                                description: "Prioritize auth, secrets, migrations, deletions.",
+                            },
+                            {
+                                const: "security",
+                                title: "Security-sensitive review",
+                                description: "Emphasize auth, secrets, permissions, migrations.",
+                            },
+                        ],
+                    },
+                    review_posture: {
+                        type: "string",
+                        title: "Review posture",
+                        default: "advisory",
+                        oneOf: [
+                            {const: "advisory", title: "Advisory comments (recommended)"},
+                            {const: "blocking", title: "Request changes when tests are missing"},
+                        ],
+                    },
+                },
+                "x-ag-stepper": true,
+            },
+        }
+        const result = parseElicitationPayload(payload)
+        expect(result.ok).toBe(true)
+        if (!result.ok) return
+        expect(result.payload.requestedSchema["x-ag-stepper"]).toBe(true)
+        expect(result.payload.requestedSchema.properties.risk_criteria.enum).toEqual([
+            "diff",
+            "security",
+        ])
+        const fields = buildFormFieldsFromSchema(
+            result.payload.requestedSchema as unknown as Record<string, unknown>,
+            "",
+            {formats: true, openEnums: true},
+        )
+        expect(fields.map((f) => f.name).sort()).toEqual([
+            "repository",
+            "review_posture",
+            "risk_criteria",
+        ])
+        expect(fields.find((f) => f.name === "review_posture")?.enumValues).toEqual([
+            "advisory",
+            "blocking",
+        ])
+    })
+
     it("rejects malformed oneOf options", () => {
         const payload = validPayload()
         ;(payload.requestedSchema.properties as Record<string, unknown>).process = {


### PR DESCRIPTION
Mahmoud's regression: an agent calls `request_input` with a schema, and instead of the question form the chat shows "Not handled by this client."

## Root cause — not a broken renderer, a missing replay branch

The live render worked. The durable-record replay adapter (`transcriptToMessages`) had never implemented the client-tool branch (`// v1 scope: HITL approvals only`), so when the record watermark reset at turn end and hydration adopted the server transcript, the parked `request_input` came back as a bare tool part without its `data-render` hint. The dispatcher matched neither axis and fell through to the auto-settling "not handled" fallback. That is why the form appeared to work, then flipped seconds after the turn parked.

## The fix

1. Replay a parked client-tool interaction as its tool part PLUS the render-hint sibling (both parity copies of the adapter).
2. `request_input` resolves by tool name as the second dispatch axis (the same axis `request_connection` already uses) — covers transcripts persisted before hints existed.
3. `request_input` joins `CLIENT_TOOL_NAMES` in the approval-resume path.

No parser change needed — `parseElicitationPayload` already handles the `oneOf` options and `x-ag-stepper`; pinned with the verbatim payload from the failing session.

## Verification

Replayed the REAL 17 records of the failing session through the actual code: before → `renderKind: undefined` (unhandled), after → `elicitation` + `ElicitationWidget`. Each fix half independently restores dispatch. 158 + 244 + 215 + 338 tests pass across the four touched packages; new tests pin the replay, both dispatch axes, and the verbatim stepper payload.

## Live repro

New chat on a build-kit agent → ask it to build a PR reviewer → the stepper form must appear AND still be a form 5-10s after the turn parks (the adoption tick that used to break it).