### PR TITLE
fix(frontend): Refresh playground triggers when an agent tool settles

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/messageParts.ts
@@ -1,13 +1,16 @@
 import {type UIMessage} from "ai"
 
+/** A tool call: typed parts encode the name as `tool-<name>`, dynamic ones carry it on `toolName`. */
+export const isToolPart = (p: UIMessage["parts"][number]): boolean =>
+    p.type.startsWith("tool-") || p.type === "dynamic-tool"
+
 /** A part the transcript renders: non-empty prose, files, sources, or tools. */
 export const isVisiblePart = (p: UIMessage["parts"][number]): boolean =>
     (p.type === "text" && Boolean((p as {text?: string}).text?.trim())) ||
     (p.type === "reasoning" && Boolean((p as {text?: string}).text?.trim())) ||
     p.type === "file" ||
     p.type === "source-url" ||
-    p.type.startsWith("tool-") ||
-    p.type === "dynamic-tool"
+    isToolPart(p)
 
 /** A settled assistant turn with no content at all — no answer, reasoning, tool, file, or
  * source part. Mirrors AgentMessage's `!hasContent`; used to collapse a run of "no response"

--- a/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.test.ts
@@ -1,0 +1,80 @@
+import type {UIMessage} from "ai"
+import {describe, expect, it} from "vitest"
+
+import {collectToolCacheEffects, toolCacheEffect} from "./toolCacheEffects"
+
+const assistant = (parts: Record<string, unknown>[]): UIMessage =>
+    ({id: "message-1", role: "assistant", parts}) as unknown as UIMessage
+
+const settled = (name: string, toolCallId = `call-${name}`) => ({
+    type: `tool-${name}`,
+    toolCallId,
+    state: "output-available",
+    output: '{"count":1}',
+})
+
+const effectsOf = (parts: Record<string, unknown>[], seen = new Set<string>()) => [
+    ...collectToolCacheEffects(assistant(parts), seen),
+]
+
+describe("toolCacheEffect", () => {
+    it("routes mutating trigger ops to their list, and nothing else", () => {
+        expect(toolCacheEffect("create_schedule")).toBe("trigger-schedules")
+        expect(toolCacheEffect("pause_schedule")).toBe("trigger-schedules")
+        expect(toolCacheEffect("remove_subscription")).toBe("trigger-subscriptions")
+        expect(toolCacheEffect("list_schedules")).toBeNull()
+        expect(toolCacheEffect("test_subscription")).toBeNull()
+        expect(toolCacheEffect("bash")).toBeNull()
+    })
+
+    it("does not resolve inherited object members for MCP-supplied names", () => {
+        for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty"]) {
+            expect(toolCacheEffect(name)).toBeNull()
+        }
+    })
+})
+
+describe("collectToolCacheEffects", () => {
+    it("invalidates the schedules list when create_schedule settles (#5781)", () => {
+        expect(effectsOf([{type: "text", text: "Scheduled."}, settled("create_schedule")])).toEqual(
+            ["trigger-schedules"],
+        )
+    })
+
+    it("reads the name off a dynamic-tool part too", () => {
+        const part = {
+            type: "dynamic-tool",
+            toolName: "create_schedule",
+            toolCallId: "call-1",
+            state: "output-available",
+        }
+        expect(effectsOf([part])).toEqual(["trigger-schedules"])
+    })
+
+    it("ignores calls that have not succeeded", () => {
+        expect(effectsOf([{...settled("create_schedule"), state: "output-error"}])).toEqual([])
+        expect(effectsOf([{...settled("create_schedule"), state: "input-available"}])).toEqual([])
+    })
+
+    it("collects both lists when a turn touches schedules and subscriptions", () => {
+        const effects = effectsOf([settled("create_schedule"), settled("remove_subscription")])
+        expect(effects.sort()).toEqual(["trigger-schedules", "trigger-subscriptions"])
+    })
+
+    it("records every visited call so it acts once across stream commits", () => {
+        const message = assistant([settled("create_schedule"), settled("list_schedules")])
+        const seen = new Set<string>()
+
+        expect([...collectToolCacheEffects(message, seen)]).toEqual(["trigger-schedules"])
+        expect([...seen].sort()).toEqual(["call-create_schedule", "call-list_schedules"])
+        expect([...collectToolCacheEffects(message, seen)]).toEqual([])
+    })
+
+    it("seeds from hydrated history so reopening a session refetches nothing", () => {
+        const history = assistant([settled("create_schedule", "call-history")])
+        const seen = new Set<string>()
+
+        collectToolCacheEffects(history, seen) // the mount pass records without acting
+        expect([...collectToolCacheEffects(history, seen)]).toEqual([])
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.test.ts
@@ -27,6 +27,15 @@ describe("toolCacheEffect", () => {
         expect(toolCacheEffect("bash")).toBeNull()
     })
 
+    it("routes the same op wrapped by a harness's MCP naming (#5781 under Claude/Codex)", () => {
+        expect(toolCacheEffect("mcp__agenta-tools__create_schedule")).toBe("trigger-schedules")
+        expect(toolCacheEffect("mcp.agenta-tools.create_schedule")).toBe("trigger-schedules")
+    })
+
+    it("ignores a third-party MCP tool of the same bare name", () => {
+        expect(toolCacheEffect("mcp__other__create_schedule")).toBeNull()
+    })
+
     it("does not resolve inherited object members for MCP-supplied names", () => {
         for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty"]) {
             expect(toolCacheEffect(name)).toBeNull()
@@ -49,6 +58,12 @@ describe("collectToolCacheEffects", () => {
             state: "output-available",
         }
         expect(effectsOf([part])).toEqual(["trigger-schedules"])
+    })
+
+    it("invalidates for a Claude-harness call, which arrives MCP-wrapped", () => {
+        expect(effectsOf([settled("mcp__agenta-tools__create_schedule")])).toEqual([
+            "trigger-schedules",
+        ])
     })
 
     it("ignores calls that have not succeeded", () => {

--- a/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.ts
@@ -7,7 +7,7 @@
 import type {ToolUIPart, UIMessage} from "ai"
 
 import {isToolPart} from "./messageParts"
-import {partToolName} from "./toolDisplay"
+import {canonicalToolName, partToolName} from "./toolDisplay"
 
 export type ToolCacheEffect = "trigger-schedules" | "trigger-subscriptions"
 
@@ -25,9 +25,10 @@ const BY_TOOL_NAME = new Map<string, ToolCacheEffect>([
     ["resume_subscription", "trigger-subscriptions"],
 ])
 
-/** The cache a tool invalidates, or null when it touches nothing the client caches. */
+/** The cache a tool invalidates, or null when it touches nothing the client caches. Keyed on the
+ * canonical name — Claude and Codex deliver platform ops wrapped in our internal MCP server. */
 export const toolCacheEffect = (toolName: string): ToolCacheEffect | null =>
-    BY_TOOL_NAME.get(toolName) ?? null
+    BY_TOOL_NAME.get(canonicalToolName(toolName)) ?? null
 
 /** Effects owed by `message`'s successful tool calls, skipping ids in `seen` — which this RECORDS
  * every visited call into, so each acts once. */

--- a/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolCacheEffects.ts
@@ -1,0 +1,51 @@
+/**
+ * Which client cache a settled tool call invalidates. Platform ops run server-side, so a tool that
+ * mutates project data leaves the browser's cache stale until a reload (#5781) — the settled part
+ * is the only signal available. The durable fix is a backend `data-*` signal like
+ * `data-committed-revision`; until the runner can emit one, this registry stands in.
+ */
+import type {ToolUIPart, UIMessage} from "ai"
+
+import {isToolPart} from "./messageParts"
+import {partToolName} from "./toolDisplay"
+
+export type ToolCacheEffect = "trigger-schedules" | "trigger-subscriptions"
+
+/** Mutating trigger ops by wire name (`op_catalog.py`). `list_*`, `discover_triggers` and
+ * `test_subscription` leave both lists unchanged, so they are absent. A Map, not an object —
+ * tool names are third-party strings, and `{}[toolName]` would resolve `toString` et al. */
+const BY_TOOL_NAME = new Map<string, ToolCacheEffect>([
+    ["create_schedule", "trigger-schedules"],
+    ["remove_schedule", "trigger-schedules"],
+    ["pause_schedule", "trigger-schedules"],
+    ["resume_schedule", "trigger-schedules"],
+    ["create_subscription", "trigger-subscriptions"],
+    ["remove_subscription", "trigger-subscriptions"],
+    ["pause_subscription", "trigger-subscriptions"],
+    ["resume_subscription", "trigger-subscriptions"],
+])
+
+/** The cache a tool invalidates, or null when it touches nothing the client caches. */
+export const toolCacheEffect = (toolName: string): ToolCacheEffect | null =>
+    BY_TOOL_NAME.get(toolName) ?? null
+
+/** Effects owed by `message`'s successful tool calls, skipping ids in `seen` — which this RECORDS
+ * every visited call into, so each acts once. */
+export function collectToolCacheEffects(
+    message: UIMessage,
+    seen: Set<string>,
+): Set<ToolCacheEffect> {
+    const effects = new Set<ToolCacheEffect>()
+    for (const part of message.parts) {
+        if (!isToolPart(part)) continue
+        const tool = part as {toolCallId?: string; state?: string}
+        // Successful only — a failed create must not invalidate.
+        if (tool.state !== "output-available") continue
+        const toolCallId = tool.toolCallId ?? ""
+        if (!toolCallId || seen.has(toolCallId)) continue
+        seen.add(toolCallId)
+        const effect = toolCacheEffect(partToolName(part as ToolUIPart))
+        if (effect) effects.add(effect)
+    }
+    return effects
+}

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
@@ -103,13 +103,19 @@ describe("canonicalToolName", () => {
         expect(canonicalToolName("commit_revision")).toBe("commit_revision")
     })
 
+    it("unwraps the Codex dot form of the same server", () => {
+        expect(canonicalToolName("mcp.agenta-tools.commit_revision")).toBe("commit_revision")
+    })
+
     it("leaves another server's tool wrapped, so it cannot collide with a platform tool", () => {
         expect(canonicalToolName("mcp__other__commit_revision")).toBe("mcp__other__commit_revision")
         expect(canonicalToolName("mcp__other__x")).toBe("mcp__other__x")
+        expect(canonicalToolName("mcp.other.commit_revision")).toBe("mcp.other.commit_revision")
     })
 
     it("never returns an empty name", () => {
         expect(canonicalToolName("mcp__agenta-tools__")).toBe("mcp__agenta-tools__")
+        expect(canonicalToolName("mcp.agenta-tools.")).toBe("mcp.agenta-tools.")
         expect(canonicalToolName("")).toBe("")
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
@@ -33,21 +33,29 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
     Boolean(value && typeof value === "object" && !Array.isArray(value))
 
 /** Our in-sandbox MCP server (runner: `INTERNAL_TOOL_MCP_SERVER_NAME`). */
-const INTERNAL_MCP_PREFIX = "mcp__agenta-tools__"
+const INTERNAL_MCP_SERVER = "agenta-tools"
+
+/** How each harness wraps a tool of that server: Claude `mcp__<server>__`, Codex `mcp.<server>.`
+ * (runner `client-tools.ts` strips the same two). */
+const INTERNAL_MCP_PREFIXES = [`mcp__${INTERNAL_MCP_SERVER}__`, `mcp.${INTERNAL_MCP_SERVER}.`]
 
 /**
  * The platform tool name behind a harness wrapper.
  *
  * Pi sends `commit_revision`; Claude exposes the same tool over MCP and sends
- * `mcp__agenta-tools__commit_revision`. Anything keyed BY tool name must key on this, or one call
- * renders two different ways depending on the harness.
+ * `mcp__agenta-tools__commit_revision`, Codex `mcp.agenta-tools.commit_revision`. Anything keyed
+ * BY tool name must key on this, or one call behaves differently depending on the harness.
  *
  * Only OUR server is unwrapped. A third-party MCP tool keeps its full name, so it can never
  * collide with a platform tool of the same bare name. NOT for permission rules: those must match
  * the wire name verbatim (see `useAlwaysAllowTool`).
  */
-export const canonicalToolName = (raw: string): string =>
-    raw.startsWith(INTERNAL_MCP_PREFIX) ? raw.slice(INTERNAL_MCP_PREFIX.length) || raw : raw
+export const canonicalToolName = (raw: string): string => {
+    for (const prefix of INTERNAL_MCP_PREFIXES) {
+        if (raw.startsWith(prefix)) return raw.slice(prefix.length) || raw
+    }
+    return raw
+}
 
 /** Special cases, keyed by wire name. */
 const BY_TOOL_NAME: Record<string, ToolDisplayOverride> = {

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -9,6 +9,7 @@ import {useAtomValue} from "jotai"
 import {useAlwaysAllowTool} from "@/oss/hooks/useAlwaysAllowTool"
 
 import {isAgentChatSteerEnabled} from "../assets/constants"
+import {isToolPart} from "../assets/messageParts"
 import {canonicalToolName, partToolName, resolveToolDisplay} from "../assets/toolDisplay"
 import {chatPanelMaximizedAtom} from "../state/panelLayout"
 
@@ -45,8 +46,6 @@ const manifestsByToolCallId = (parts: UIMessage["parts"] = []): Map<string, unkn
     return found
 }
 
-const isToolPart = (type: string) => type.startsWith("tool-") || type === "dynamic-tool"
-
 /**
  * Approvals the run is currently blocked on. HITL only ever pauses the LAST assistant turn (see
  * `isHitlPending`), so we read pending tool gates off that turn — a turn can request several at
@@ -60,7 +59,7 @@ export const getPendingApprovals = (messages: UIMessage[]): PendingApproval[] =>
     for (const part of last.parts ?? []) {
         const p = part as ToolUIPart
         const approval = (p as {approval?: ApprovalRef}).approval
-        if (isToolPart(p.type as string) && p.state === "approval-requested" && approval?.id) {
+        if (isToolPart(part) && p.state === "approval-requested" && approval?.id) {
             out.push({
                 approvalId: approval.id,
                 toolName: partToolName(p),

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -42,6 +42,7 @@ import {captureTurnRequestAtom} from "../state/turnCaptures"
 import {useFileActivityDetector} from "./useFileActivityDetector"
 import {type ScrollIntent} from "./useScrollIntent"
 import {useSessionHydration} from "./useSessionHydration"
+import {useToolCacheInvalidation} from "./useToolCacheInvalidation"
 
 /**
  * The chat stream for one session tab: transport, `useChat`, and every side effect that belongs to
@@ -186,6 +187,9 @@ export const useAgentChatSession = ({
     // Mid-stream drive signals: settled write-ish tool calls append file-activity entries (and
     // throttle-revalidate the drives) as the turn streams, not just at onFinish.
     useFileActivityDetector({sessionId, messages})
+
+    // Server-side platform ops (create_schedule, …) stale the client cache with no other signal.
+    useToolCacheInvalidation({sessionId, messages})
 
     const {isHydrating, hydratedEmpty, runningElsewhere} = useSessionHydration({
         sessionId,

--- a/web/oss/src/components/AgentChatSlice/hooks/useFileActivityDetector.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useFileActivityDetector.ts
@@ -4,6 +4,7 @@ import {detectFileActivity, recordFileActivityAtom} from "@agenta/entities/sessi
 import type {ToolUIPart, UIMessage} from "ai"
 import {useSetAtom} from "jotai"
 
+import {isToolPart} from "../assets/messageParts"
 import {partToolName} from "../assets/toolDisplay"
 
 /**
@@ -34,8 +35,7 @@ export function useFileActivityDetector({
         const last = messages[messages.length - 1]
         if (!last || last.role !== "assistant") return
         for (const part of last.parts) {
-            const type = part.type as string
-            if (type !== "dynamic-tool" && !type.startsWith("tool-")) continue
+            if (!isToolPart(part)) continue
             const tool = part as {toolCallId?: string; state?: string; input?: unknown}
             // Only settled, successful calls — the file exists (or is gone) once output landed.
             if (tool.state !== "output-available") continue

--- a/web/oss/src/components/AgentChatSlice/hooks/useToolCacheInvalidation.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useToolCacheInvalidation.ts
@@ -1,0 +1,47 @@
+import {useEffect, useRef} from "react"
+
+import {
+    invalidateTriggerSchedules,
+    invalidateTriggerSubscriptions,
+} from "@agenta/entities/gatewayTrigger"
+import type {UIMessage} from "ai"
+
+import {collectToolCacheEffects} from "../assets/toolCacheEffects"
+
+const INVALIDATORS = {
+    "trigger-schedules": invalidateTriggerSchedules,
+    "trigger-subscriptions": invalidateTriggerSubscriptions,
+} as const
+
+/**
+ * Drops the caches a settled tool call staled, so the config panel updates mid-stream instead of
+ * on the next reload (#5781). Scans the tail message (the one that updates during a turn); each
+ * tool call acts once. The first pass of a session only records its history — otherwise reopening
+ * a session would replay it as refetches.
+ */
+export function useToolCacheInvalidation({
+    sessionId,
+    messages,
+}: {
+    sessionId: string
+    messages: UIMessage[]
+}) {
+    const seenRef = useRef<Set<string>>(new Set())
+    const seededSessionRef = useRef<string | null>(null)
+
+    useEffect(() => {
+        // Nothing to seed from yet — spending the seed here would let async-hydrated history
+        // through as if it were live.
+        if (messages.length === 0) return
+        const seeding = seededSessionRef.current !== sessionId
+        if (seeding) {
+            seededSessionRef.current = sessionId
+            seenRef.current = new Set()
+        }
+        const last = messages[messages.length - 1]
+        if (!last || last.role !== "assistant") return
+        const effects = collectToolCacheEffects(last, seenRef.current)
+        if (seeding) return
+        for (const effect of effects) INVALIDATORS[effect]()
+    }, [messages, sessionId])
+}

--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSchedule.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSchedule.ts
@@ -19,11 +19,8 @@ import type {
     TriggerScheduleEdit,
     TriggerScheduleResponse,
 } from "../core/types"
+import {invalidateTriggerSchedules} from "../state/invalidate"
 import {applyScheduleActiveOptimistic} from "../state/optimistic"
-
-const invalidateSchedules = () => {
-    queryClient.invalidateQueries({queryKey: ["triggers", "schedules"]})
-}
 
 // Single schedule (used to source the full PUT body before editing).
 export const triggerScheduleQueryAtomFamily = atomFamily((scheduleId: string) =>
@@ -45,7 +42,7 @@ export const useTriggerSchedule = (scheduleId?: string) => {
             setIsMutating(true)
             try {
                 const res = await fn()
-                invalidateSchedules()
+                invalidateTriggerSchedules()
                 // Seed the detail cache with the create/edit result so a drawer that
                 // selects the just-saved schedule reads it immediately (no loading flash);
                 // it still background-refetches since the list invalidation marks it stale.
@@ -77,7 +74,7 @@ export const useTriggerSchedule = (scheduleId?: string) => {
         setIsMutating(true)
         try {
             await deleteTriggerSchedule(id)
-            invalidateSchedules()
+            invalidateTriggerSchedules()
         } finally {
             setIsMutating(false)
         }
@@ -89,10 +86,10 @@ export const useTriggerSchedule = (scheduleId?: string) => {
         const rollback = applyScheduleActiveOptimistic(id, active)
         try {
             await (active ? startTriggerSchedule(id) : stopTriggerSchedule(id))
-            invalidateSchedules()
+            invalidateTriggerSchedules()
         } catch (error) {
             rollback()
-            invalidateSchedules()
+            invalidateTriggerSchedules()
             throw error
         }
     }, [])

--- a/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSubscription.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSubscription.ts
@@ -1,6 +1,5 @@
 import {useCallback, useState} from "react"
 
-import {queryClient} from "@agenta/shared/api"
 import {useAtomValue} from "jotai"
 import {atomFamily} from "jotai/utils"
 import {atomWithQuery} from "jotai-tanstack-query"
@@ -21,11 +20,8 @@ import type {
     TriggerSubscriptionEdit,
     TriggerSubscriptionResponse,
 } from "../core/types"
+import {invalidateTriggerSubscriptions} from "../state/invalidate"
 import {applySubscriptionActiveOptimistic} from "../state/optimistic"
-
-const invalidateSubscriptions = () => {
-    queryClient.invalidateQueries({queryKey: ["triggers", "subscriptions"]})
-}
 
 // Single subscription (used to source the full PUT body before editing).
 export const triggerSubscriptionQueryAtomFamily = atomFamily((subscriptionId: string) =>
@@ -49,7 +45,7 @@ export const useTriggerSubscription = (subscriptionId?: string) => {
             setIsMutating(true)
             try {
                 const res = await fn()
-                invalidateSubscriptions()
+                invalidateTriggerSubscriptions()
                 return res.subscription ?? null
             } finally {
                 setIsMutating(false)
@@ -77,7 +73,7 @@ export const useTriggerSubscription = (subscriptionId?: string) => {
         setIsMutating(true)
         try {
             await deleteTriggerSubscription(id)
-            invalidateSubscriptions()
+            invalidateTriggerSubscriptions()
         } finally {
             setIsMutating(false)
         }
@@ -89,10 +85,10 @@ export const useTriggerSubscription = (subscriptionId?: string) => {
         const rollback = applySubscriptionActiveOptimistic(id, active)
         try {
             await (active ? startTriggerSubscription(id) : stopTriggerSubscription(id))
-            invalidateSubscriptions()
+            invalidateTriggerSubscriptions()
         } catch (error) {
             rollback()
-            invalidateSubscriptions()
+            invalidateTriggerSubscriptions()
             throw error
         }
     }, [])

--- a/web/packages/agenta-entities/src/gatewayTrigger/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/index.ts
@@ -136,6 +136,8 @@ export {
 export {
     applyScheduleActiveOptimistic,
     applySubscriptionActiveOptimistic,
+    invalidateTriggerSchedules,
+    invalidateTriggerSubscriptions,
     triggerCatalogDrawerOpenAtom,
     triggerDeliveriesDrawerAtom,
     triggerEventsDrawerAtom,

--- a/web/packages/agenta-entities/src/gatewayTrigger/state/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/state/index.ts
@@ -13,6 +13,7 @@ export type {
     ScheduleDrawerState,
     SubscriptionDrawerState,
 } from "./atoms"
+export {invalidateTriggerSchedules, invalidateTriggerSubscriptions} from "./invalidate"
 export {applyScheduleActiveOptimistic, applySubscriptionActiveOptimistic} from "./optimistic"
 export {
     triggerDeliveriesPaginatedStore,

--- a/web/packages/agenta-entities/src/gatewayTrigger/state/invalidate.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/state/invalidate.ts
@@ -1,0 +1,12 @@
+/** Trigger list invalidation, in one place — the drawers mutate through it, and so does the
+ * playground when an agent's server-side platform op settles. Prefix-matches the detail family. */
+
+import {queryClient} from "@agenta/shared/api"
+
+export function invalidateTriggerSchedules(): void {
+    queryClient.invalidateQueries({queryKey: ["triggers", "schedules"]})
+}
+
+export function invalidateTriggerSubscriptions(): void {
+    queryClient.invalidateQueries({queryKey: ["triggers", "subscriptions"]})
+}


### PR DESCRIPTION
## Context

Ask an agent in the playground to schedule something. It calls `create_schedule`, tells you it worked, and the Triggers section of the config panel keeps showing the old list until you reload the page.

Platform ops run server-side. The runner POSTs the API endpoint directly, so the browser never sees the request and never learns the trigger list changed. The Triggers section reads a TanStack query with a 30s `staleTime` and no refetch on window focus, so nothing invalidates it.

## Changes

A settled tool call in the chat stream is the only signal the client gets, so this PR reacts to it. A small registry maps the eight mutating trigger ops from `op_catalog.py` to the cache they stale, and `useToolCacheInvalidation` scans the streaming assistant turn and invalidates the matching query keys. `list_*`, `discover_triggers`, and `test_subscription` change nothing, so they are absent from the registry. Only `output-available` counts, so a failed create does not invalidate.

This mirrors `useFileActivityDetector`, which already reacts to settled write-ish tools the same way. Each `toolCallId` acts once, and the first pass of a session only records its history, so reopening a session does not replay it as refetches.

The registry keys on the canonical tool name, not the wire name. The same op arrives under three spellings depending on the harness, because Claude and Codex receive our platform tools through the runner's internal `agenta-tools` MCP server:

```
pi_core / pi_agenta   create_schedule
claude                mcp__agenta-tools__create_schedule
codex                 mcp.agenta-tools.create_schedule
```


`canonicalToolName` already unwrapped Claude's form. It now unwraps Codex's dot form too, matching the runner's own `bareToolName` stripper in `client-tools.ts`. Only our server is unwrapped, so a third-party `mcp__other__create_schedule` still resolves to nothing and cannot invalidate your cache. That extension also fixes a second surface: Codex-harness approval cards for `commit_revision` were falling back to the generic raw-JSON renderer for the same reason.

Two small cleanups came along. The two module-private invalidate helpers in `@agenta/entities` merge into one `gatewayTrigger/state/invalidate` module, so the trigger query keys live in one place. And the three inline copies of the `isToolPart` predicate collapse onto the one exported from `messageParts`.

## Tests

- Unit tests for the registry and the scanner, including both MCP-wrapped spellings and a third-party server that must not match.
- `npx vitest run src/components/AgentChatSlice` in `web/oss`: 144 passing.
- `tsc --noEmit` and `pnpm lint-fix` clean.

Worth a reviewer's eye: this is a client-side stand-in. The durable fix is a backend signal on the stream, such as a `data-committed-revision` frame, and the registry should go away when the runner can emit one.

## What to QA

- In the playground, ask a Pi agent to create a schedule. The Triggers section shows it as soon as the tool call settles, with no reload.
- Repeat on a Claude-harness agent, then a Codex one. Same result. These are the two that were broken.
- Ask the agent to pause, resume, then remove the schedule. Each action lands in the panel on its own.
- Do the same four with a subscription. The subscriptions list updates and the schedules list is left alone.
- Ask for a schedule that fails, for example an invalid cron. The panel must not change.
- Reopen a session that already created a trigger. Opening it triggers no refetch, and the existing trigger is still listed.
- Regression: create and delete a schedule from the Triggers drawer itself. It still updates as before.
