### PR TITLE
refactor(frontend): shared UI primitives — PanelSection, split pane, context menu, composed tooltip

### DIFF
--- a/web/packages/agenta-shared/src/utils/timeAgo.ts
+++ b/web/packages/agenta-shared/src/utils/timeAgo.ts
@@ -5,7 +5,7 @@
  * refetch), so sub-minute precision would only promise a liveness the row doesn't have.
  */
 export const timeAgo = (ts?: number): string => {
-    if (ts == null || !Number.isFinite(ts)) return ""
+    if (!ts) return ""
     const s = Math.max(0, Math.round((Date.now() - ts) / 1000))
     if (s < 60) return "just now"
     const m = Math.round(s / 60)

--- a/web/packages/agenta-ui/package.json
+++ b/web/packages/agenta-ui/package.json
@@ -2,7 +2,10 @@
     "name": "@agenta/ui",
     "version": "0.75.0",
     "private": true,
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "**/*.css"
+    ],
     "main": "./src/index.ts",
     "types": "./src/index.ts",
     "scripts": {

--- a/web/packages/agenta-ui/package.json
+++ b/web/packages/agenta-ui/package.json
@@ -37,7 +37,13 @@
         "./drill-in": "./src/drill-in/index.ts",
         "./drawer": "./src/drawer/index.ts",
         "./type-chip": "./src/type-chip/index.ts",
-        "./ui": "./src/components/ui/index.ts"
+        "./ui": "./src/components/ui/index.ts",
+        "./surfaces.css": "./src/styles/surfaces.css",
+        "./code-editor-styles.css": "./src/styles/code-editor-styles.css",
+        "./editor-theme.css": "./src/styles/editor-theme.css",
+        "./custom-resize-handle.css": "./src/styles/custom-resize-handle.css",
+        "./theme-variables.css": "./src/styles/theme-variables.css",
+        "./height-collapse": "./src/components/HeightCollapse.tsx"
     },
     "peerDependencies": {
         "@lexical/code": ">=0.38.0",
@@ -86,6 +92,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.22",
         "@radix-ui/react-avatar": "^1.2.5",
         "@radix-ui/react-checkbox": "^1.3.9",
+        "@radix-ui/react-context-menu": "^2.3.7",
         "@radix-ui/react-dialog": "^1.1.22",
         "@radix-ui/react-dropdown-menu": "^2.1.22",
         "@radix-ui/react-label": "^2.1.14",

--- a/web/packages/agenta-ui/src/components/PageLayout.tsx
+++ b/web/packages/agenta-ui/src/components/PageLayout.tsx
@@ -38,6 +38,16 @@ export interface PageLayoutProps {
     headerClassName?: string
 }
 
+/** antd's heading ramp as literals (`fontSizeHeading*` / `lineHeightHeading*` from
+ * antd-themeConfig.json), used only as fallbacks for hosts that never generate the vars. */
+const HEADING_SCALE: Record<1 | 2 | 3 | 4 | 5, {fontSize: string; lineHeight: number}> = {
+    1: {fontSize: "32px", lineHeight: 1.25},
+    2: {fontSize: "26px", lineHeight: 1.3076923076923077},
+    3: {fontSize: "20px", lineHeight: 1.4},
+    4: {fontSize: "16px", lineHeight: 1.5},
+    5: {fontSize: "14px", lineHeight: 1.5714285714285714},
+}
+
 const PageLayout = ({
     title,
     titleLevel = 3,
@@ -103,13 +113,16 @@ const PageLayout = ({
                         {/* antd Title replacement: a real heading sized off antd's own heading
                             tokens so it flips/scales with the theme; `m-0` kills the UA margin
                             (preflight is off). Weight is fontWeightStrong — antd's own Title rule
-                            won over the prior `font-medium` className, so 600 IS the baseline. */}
+                            won over the prior `font-medium` className, so 600 IS the baseline.
+                            The literals are fallbacks, not decoration: antd generates the
+                            `--ant-*` vars, so on a host without it (the mobile app) every page
+                            title silently fell back to body text. */}
                         <HeadingTag
                             className="m-0 truncate"
                             style={{
-                                fontSize: `var(--ant-font-size-heading-${titleLevel})`,
-                                lineHeight: `var(--ant-line-height-heading-${titleLevel})`,
-                                fontWeight: "var(--ant-font-weight-strong)",
+                                fontSize: `var(--ant-font-size-heading-${titleLevel}, ${HEADING_SCALE[titleLevel].fontSize})`,
+                                lineHeight: `var(--ant-line-height-heading-${titleLevel}, ${HEADING_SCALE[titleLevel].lineHeight})`,
+                                fontWeight: "var(--ant-font-weight-strong, 600)",
                             }}
                             title={titleText || undefined}
                         >

--- a/web/packages/agenta-ui/src/components/presentational/chat/index.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/chat/index.tsx
@@ -1,0 +1,222 @@
+/**
+ * Chat message chrome, antd-free — the drop-in replacements for the @ant-design/x pieces the
+ * desktop chat used (`Bubble`, `Actions` items, `FileCard`). Metrics mirror antd-x so the swap
+ * is invisible: content 16/12 padding with a 12px radius, `filled` on the fill-content token,
+ * `borderless` flush on the canvas, a 12px avatar gap, and the 4px three-dot typing loader.
+ * Bodies stay caller-owned ReactNodes; nothing here knows about messages or parts.
+ */
+import {type ReactNode} from "react"
+
+import {FileText, FilmStrip, Image as ImageIcon} from "@phosphor-icons/react"
+
+import {cn} from "../../../utils/styles"
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "../../ui/tooltip"
+
+/** The antd-x loading dots: three 4px primary dots on a gentle bounce. */
+export const ChatTypingDots = ({className}: {className?: string}) => (
+    <span className={cn("flex h-8 items-center gap-2 self-center px-0.5", className)}>
+        {[0, 1, 2].map((i) => (
+            <span
+                key={i}
+                className="size-1 rounded-full bg-colorPrimary motion-safe:animate-bounce"
+                style={{animationDuration: "1.2s", animationDelay: `${i * 0.2}s`}}
+            />
+        ))}
+    </span>
+)
+
+export interface ChatBubbleProps {
+    /** `start` hugs the left (assistant), `end` the right (user). */
+    placement?: "start" | "end"
+    /** `filled` paints the content card, `outlined` draws its border, `borderless` sits flush. */
+    variant?: "filled" | "outlined" | "borderless"
+    avatar?: ReactNode
+    /** Typing indicator — replaces the content with the three-dot loader. */
+    loading?: boolean
+    content?: ReactNode
+    className?: string
+    classNames?: {content?: string; body?: string}
+}
+
+/**
+ * One message bubble: avatar column + content column. Pure chrome — the body is whatever the
+ * caller renders (markdown, tool groups, widgets); this only owns placement, fill, and the
+ * typing state.
+ */
+export const ChatBubble = ({
+    placement = "start",
+    variant = "filled",
+    avatar,
+    loading = false,
+    content,
+    className,
+    classNames,
+}: ChatBubbleProps) => (
+    <div
+        className={cn(
+            "flex gap-3",
+            placement === "end" && "flex-row-reverse",
+            loading ? "items-center" : "items-start",
+            className,
+        )}
+    >
+        {avatar ? <div className="shrink-0">{avatar}</div> : null}
+        <div className={cn("flex min-w-0 max-w-full flex-col", classNames?.body)}>
+            {loading ? (
+                <ChatTypingDots />
+            ) : (
+                <div
+                    className={cn(
+                        "relative box-border min-w-0 max-w-full break-words text-xs leading-normal text-colorText",
+                        variant === "filled" && "rounded-xl bg-colorFillSecondary px-4 py-3",
+                        variant === "outlined" &&
+                            "rounded-xl border border-solid border-colorBorderSecondary px-4 py-3",
+                        variant === "borderless" && "min-h-0 bg-transparent p-0",
+                        classNames?.content,
+                    )}
+                >
+                    {content}
+                </div>
+            )}
+        </div>
+    </div>
+)
+
+/** The 24px round icon avatar the bubbles used (antd `Avatar size="small"` look). */
+export const ChatBubbleAvatar = ({icon, className}: {icon: ReactNode; className?: string}) => (
+    <span
+        className={cn(
+            "flex size-6 items-center justify-center rounded-full",
+            "bg-colorTextQuaternary text-white",
+            className,
+        )}
+    >
+        {icon}
+    </span>
+)
+
+/** One toolbar icon button with its tooltip — an antd-x `Actions` item, as plain markup. */
+export const ChatActionIconButton = ({
+    label,
+    icon,
+    onClick,
+}: {
+    label: string
+    icon: ReactNode
+    onClick: () => void
+}) => (
+    <TooltipProvider delayDuration={300}>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    aria-label={label}
+                    onClick={onClick}
+                    className={cn(
+                        "flex size-6 cursor-pointer items-center justify-center rounded border-0",
+                        "bg-transparent text-colorTextSecondary transition-colors",
+                        "hover:bg-colorFillTertiary hover:text-colorText",
+                    )}
+                >
+                    {icon}
+                </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-64 text-xs">{label}</TooltipContent>
+        </Tooltip>
+    </TooltipProvider>
+)
+
+const CARD_WIDTH = "w-[268px] max-w-full"
+
+const KIND_ICONS = {
+    image: ImageIcon,
+    video: FilmStrip,
+    file: FileText,
+} as const
+
+export interface ChatAttachmentCardProps {
+    name: string
+    kind: "image" | "video" | "file"
+    src?: string
+    /** The media source is still being fetched — show the placeholder box instead of a broken img. */
+    loading?: boolean
+    /** Second line of the file chip (media type, a download link, an unavailable note). */
+    description?: ReactNode
+    className?: string
+    onImageError?: () => void
+    onVideoError?: () => void
+}
+
+/**
+ * A message attachment (the antd-x `FileCard` roles): images and video preview inline at the
+ * 268px card width; anything else is a typed chip with the name and a caller-owned description
+ * line. Audio never routes here — the chat keeps its own player.
+ */
+export const ChatAttachmentCard = ({
+    name,
+    kind,
+    src,
+    loading = false,
+    description,
+    className,
+    onImageError,
+    onVideoError,
+}: ChatAttachmentCardProps) => {
+    if (kind === "image") {
+        if (loading || !src) {
+            return (
+                <div
+                    className={cn(
+                        CARD_WIDTH,
+                        "h-[140px] animate-pulse rounded-md bg-colorFillTertiary",
+                        className,
+                    )}
+                    aria-label={`Loading ${name}`}
+                />
+            )
+        }
+        return (
+            <img
+                src={src}
+                alt={name}
+                onError={onImageError}
+                className={cn(
+                    CARD_WIDTH,
+                    "h-auto rounded-md border border-solid border-colorBorderSecondary",
+                    className,
+                )}
+            />
+        )
+    }
+
+    if (kind === "video") {
+        return (
+            <video
+                src={src}
+                controls
+                onError={onVideoError}
+                className={cn(CARD_WIDTH, "rounded-md", className)}
+            />
+        )
+    }
+
+    const Icon = KIND_ICONS[kind]
+    return (
+        <div
+            className={cn(
+                CARD_WIDTH,
+                "box-border flex h-10 items-center gap-2 rounded-md border border-solid",
+                "border-colorBorderSecondary bg-colorBgContainer px-2",
+                className,
+            )}
+        >
+            <Icon size={20} className="shrink-0 text-colorTextSecondary" />
+            <div className="flex min-w-0 flex-col">
+                <span className="truncate text-xs font-medium text-colorText" title={name}>
+                    {name}
+                </span>
+                {description}
+            </div>
+        </div>
+    )
+}

--- a/web/packages/agenta-ui/src/components/presentational/chat/index.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/chat/index.tsx
@@ -162,7 +162,9 @@ export const ChatAttachmentCard = ({
     onImageError,
     onVideoError,
 }: ChatAttachmentCardProps) => {
-    if (kind === "image") {
+    if (kind === "image" || kind === "video") {
+        // Both media kinds share the placeholder: a src-less <video> renders an empty player,
+        // which reads as broken exactly the way a src-less <img> does.
         if (loading || !src) {
             return (
                 <div
@@ -175,7 +177,7 @@ export const ChatAttachmentCard = ({
                 />
             )
         }
-        return (
+        return kind === "image" ? (
             <img
                 src={src}
                 alt={name}
@@ -186,11 +188,7 @@ export const ChatAttachmentCard = ({
                     className,
                 )}
             />
-        )
-    }
-
-    if (kind === "video") {
-        return (
+        ) : (
             <video
                 src={src}
                 controls

--- a/web/packages/agenta-ui/src/components/presentational/index.ts
+++ b/web/packages/agenta-ui/src/components/presentational/index.ts
@@ -272,3 +272,13 @@ export {
     type UseCollapseToggleOptions,
     type UseCollapseToggleReturn,
 } from "./buttons"
+export {HeightCollapse} from "../HeightCollapse"
+export {
+    ChatActionIconButton,
+    ChatAttachmentCard,
+    ChatBubble,
+    ChatBubbleAvatar,
+    ChatTypingDots,
+    type ChatAttachmentCardProps,
+    type ChatBubbleProps,
+} from "./chat"

--- a/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
@@ -84,7 +84,13 @@ export const PanelSection = ({
                 isRail
                     ? // Each section is its own card. Stacked inside one, they read as a single
                       // block: same surface, same colour, a hairline carrying every boundary.
-                      "shrink-0 overflow-hidden rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated"
+                      //
+                      // `overflow-clip`, not `overflow-hidden`: both round the corners, but
+                      // `hidden` also makes the section a scroll container, and a sticky header
+                      // then pins to a box that never scrolls — i.e. `sticky` silently does
+                      // nothing. `clip` establishes no scrollport, so the header pins to the
+                      // real scroller ({@link PanelScroll}) as intended.
+                      "shrink-0 overflow-clip rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated"
                     : ""
             } ${minHeightClassName ?? ""}`}
         >

--- a/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
@@ -14,12 +14,9 @@ import type {ReactNode} from "react"
  */
 
 /** The rail column's frame. Transparent now — the sections are the cards, and a card inside a
- * card was exactly the "one monolithic block" problem. The cap (`max-h-full min-h-0`) lives here,
- * not at call sites: without it {@link PanelScroll} grows with its content and never scrolls. */
+ * card was exactly the "one monolithic block" problem. */
 export const PanelSurface = ({children, className}: {children: ReactNode; className?: string}) => (
-    <div className={`box-border flex max-h-full min-h-0 flex-col ${className ?? ""}`}>
-        {children}
-    </div>
+    <div className={`box-border ${className ?? ""}`}>{children}</div>
 )
 
 /**
@@ -87,9 +84,7 @@ export const PanelSection = ({
                 isRail
                     ? // Each section is its own card. Stacked inside one, they read as a single
                       // block: same surface, same colour, a hairline carrying every boundary.
-                      // `overflow-clip`, not `-hidden`: hidden makes this the sticky header's
-                      // scroll ancestor, so it never pins against PanelScroll.
-                      "shrink-0 overflow-clip rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated"
+                      "shrink-0 overflow-hidden rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated"
                     : ""
             } ${minHeightClassName ?? ""}`}
         >

--- a/web/packages/agenta-ui/src/components/ui/context-menu.tsx
+++ b/web/packages/agenta-ui/src/components/ui/context-menu.tsx
@@ -1,0 +1,94 @@
+import * as React from "react"
+
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
+
+import {cn} from "./utils"
+
+/**
+ * ContextMenu — the right-click counterpart of DropdownMenu, on the Radix primitive. Chrome and
+ * item geometry are copied token-for-token from dropdown-menu.tsx so a context menu and a click
+ * menu over the same rows are indistinguishable.
+ *
+ * antd → @agenta/ui mapping:
+ *   <Dropdown menu={{items}} trigger={["contextMenu"]}><node/></Dropdown>
+ *     → <ContextMenu><ContextMenuTrigger asChild><node/></ContextMenuTrigger>
+ *       <ContextMenuContent><ContextMenuItem/> · <ContextMenuSeparator/></ContextMenuContent>
+ *       </ContextMenu>
+ */
+
+function ContextMenu(props: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+    return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuTrigger(props: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+    return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+}
+
+function ContextMenuContent({
+    className,
+    container,
+    ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content> & {
+    /** Portal target. Defaults to document.body; pass an element to render inline. */
+    container?: HTMLElement | null
+}) {
+    return (
+        <ContextMenuPrimitive.Portal container={container}>
+            <ContextMenuPrimitive.Content
+                data-slot="context-menu-content"
+                className={cn(
+                    // Chrome copied from DropdownMenuContent (antd `.ant-dropdown-menu`).
+                    "relative z-50 box-border max-h-96 overflow-y-auto overflow-x-hidden bg-popover text-popover-foreground shadow-overlay font-portal",
+                    "rounded-control-lg p-1",
+                    className,
+                )}
+                {...props}
+            />
+        </ContextMenuPrimitive.Portal>
+    )
+}
+
+const itemBase = [
+    "relative flex w-full cursor-pointer select-none items-center gap-2 outline-none",
+    "box-border rounded-control-sm px-3 py-input-y-ghost text-field-md",
+    "[&[data-highlighted]]:bg-muted",
+    "data-[disabled]:pointer-events-none data-[disabled]:text-disabled",
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0",
+]
+
+function ContextMenuItem({
+    className,
+    variant = "default",
+    ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+    variant?: "default" | "destructive"
+}) {
+    return (
+        <ContextMenuPrimitive.Item
+            data-slot="context-menu-item"
+            data-variant={variant}
+            className={cn(
+                itemBase,
+                variant === "destructive" &&
+                    "text-error [&[data-highlighted]]:bg-error-bg [&_svg]:text-error",
+                className,
+            )}
+            {...props}
+        />
+    )
+}
+
+function ContextMenuSeparator({
+    className,
+    ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+    return (
+        <ContextMenuPrimitive.Separator
+            data-slot="context-menu-separator"
+            className={cn("mx-1 my-1 h-px bg-border", className)}
+            {...props}
+        />
+    )
+}
+
+export {ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem, ContextMenuSeparator}

--- a/web/packages/agenta-ui/src/components/ui/index.ts
+++ b/web/packages/agenta-ui/src/components/ui/index.ts
@@ -30,6 +30,7 @@ export {
 } from "./select"
 export {Popover, PopoverTrigger, PopoverAnchor, PopoverContent} from "./popover"
 export {Tooltip, TooltipTrigger, TooltipContent, TooltipProvider} from "./tooltip"
+export {SimpleTooltip, type SimpleTooltipProps} from "./tooltip-composed"
 export {RadioGroup, RadioGroupItem, type RadioGroupProps} from "./radio-group"
 export {
     Combobox,
@@ -70,6 +71,14 @@ export {
     DropdownMenuSubContent,
     DropdownMenuPortal,
 } from "./dropdown-menu"
+export {
+    ContextMenu,
+    ContextMenuTrigger,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuSeparator,
+} from "./context-menu"
+export {SplitPane, type SplitPaneProps} from "./split-pane"
 export {Accordion, AccordionItem, AccordionTrigger, AccordionContent} from "./accordion"
 export {
     Skeleton,

--- a/web/packages/agenta-ui/src/components/ui/split-pane.tsx
+++ b/web/packages/agenta-ui/src/components/ui/split-pane.tsx
@@ -1,0 +1,187 @@
+import * as React from "react"
+
+import {cn} from "./utils"
+
+/**
+ * SplitPane — a two-pane horizontal split with one DRIVEN pane (its width is a controlled
+ * `paneSize` in px, rendered as `flex-basis`) and one FILL pane (`flex:1 1 auto`). Replaces the
+ * antd `Splitter` uses where one side is a rail/panel and the other is the canvas.
+ *
+ * Because the driven basis is fully React-controlled (no internal ResizeObserver rewriting
+ * inline styles, which is what antd does), open/close animation is just a CSS transition on
+ * `flex-basis`, gated by `animate` — none of the pre-frame machinery the antd version needed.
+ *
+ * The divider is the agent playground's gutter: a 9px channel (`--ag-surface-gutter`) with a
+ * centred hairline and a grip pill that takes a primary tint on hover/drag (ported from
+ * `.playground-splitter-agent` in globals.css).
+ */
+export interface SplitPaneProps {
+    /** Which side the driven pane sits on. */
+    paneSide: "start" | "end"
+    /** Driven pane width in px (0 collapses it). Controlled. */
+    paneSize: number
+    paneMin?: number
+    paneMax?: number
+    /** The fill pane never shrinks below this during a drag. */
+    fillMin?: number
+    /** Divider dragging enabled. */
+    resizable?: boolean
+    /** Transition the driven pane's flex-basis (240ms, the playground curve). */
+    animate?: boolean
+    /** Hide the divider entirely (collapsed rail). The panes stay mounted. */
+    barHidden?: boolean
+    onResizeStart?: () => void
+    onResize?: (size: number, total: number) => void
+    onResizeEnd?: (size: number, total: number) => void
+    pane: React.ReactNode
+    fill: React.ReactNode
+    className?: string
+    paneClassName?: string
+    fillClassName?: string
+    barClassName?: string
+}
+
+const BAR_WIDTH = 9
+
+const SLIDE = "[transition:flex-basis_240ms_cubic-bezier(0.4,0,0.2,1)]"
+
+export function SplitPane({
+    paneSide,
+    paneSize,
+    paneMin = 0,
+    paneMax = Number.POSITIVE_INFINITY,
+    fillMin = 0,
+    resizable = true,
+    animate = false,
+    barHidden = false,
+    onResizeStart,
+    onResize,
+    onResizeEnd,
+    pane,
+    fill,
+    className,
+    paneClassName,
+    fillClassName,
+    barClassName,
+}: SplitPaneProps) {
+    const rootRef = React.useRef<HTMLDivElement>(null)
+    const [dragging, setDragging] = React.useState(false)
+    const lastRef = React.useRef<{size: number; total: number}>({size: paneSize, total: 0})
+
+    const clamp = React.useCallback(
+        (raw: number, total: number) =>
+            Math.max(paneMin, Math.min(raw, paneMax, Math.max(paneMin, total - fillMin))),
+        [fillMin, paneMax, paneMin],
+    )
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+        if (!resizable) return
+        e.preventDefault()
+        e.currentTarget.setPointerCapture(e.pointerId)
+        setDragging(true)
+        onResizeStart?.()
+    }
+    const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+        if (!dragging) return
+        const rect = rootRef.current?.getBoundingClientRect()
+        if (!rect) return
+        const total = rect.width - BAR_WIDTH
+        const raw =
+            paneSide === "start"
+                ? e.clientX - rect.left - BAR_WIDTH / 2
+                : rect.right - e.clientX - BAR_WIDTH / 2
+        const size = clamp(Math.round(raw), total)
+        lastRef.current = {size, total}
+        onResize?.(size, total)
+    }
+    const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+        if (!dragging) return
+        e.currentTarget.releasePointerCapture(e.pointerId)
+        setDragging(false)
+        onResizeEnd?.(lastRef.current.size, lastRef.current.total)
+    }
+
+    const paneNode = (
+        <div
+            data-slot="split-pane-pane"
+            className={cn(
+                "box-border min-h-0 shrink-0 grow-0 overflow-hidden",
+                animate && !dragging && SLIDE,
+                paneClassName,
+            )}
+            style={{flexBasis: paneSize}}
+        >
+            {pane}
+        </div>
+    )
+
+    const barNode = barHidden ? null : (
+        <div
+            data-slot="split-pane-bar"
+            role="separator"
+            aria-orientation="vertical"
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            className={cn(
+                "group relative z-[5] box-border h-full shrink-0 touch-none select-none bg-[var(--ag-surface-gutter)]",
+                resizable && "cursor-col-resize",
+                barClassName,
+            )}
+            style={{flexBasis: BAR_WIDTH, width: BAR_WIDTH}}
+        >
+            {/* Centre hairline — strengthens to the border tone on hover/drag. */}
+            <span
+                aria-hidden
+                className={cn(
+                    "absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-colorFillQuaternary transition-colors duration-150",
+                    resizable && "group-hover:bg-colorBorder",
+                    dragging && "bg-colorBorder",
+                )}
+            />
+            {/* Grip pill — quiet at rest, a longer primary tint under the pointer. */}
+            {resizable ? (
+                <span
+                    aria-hidden
+                    className={cn(
+                        "absolute left-1/2 top-1/2 h-6 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-colorTextTertiary",
+                        "transition-[background,height,opacity] duration-150",
+                        "group-hover:h-9 group-hover:bg-colorPrimary group-hover:opacity-70",
+                        dragging && "h-9 bg-colorPrimary opacity-70",
+                    )}
+                />
+            ) : null}
+        </div>
+    )
+
+    const fillNode = (
+        <div
+            data-slot="split-pane-fill"
+            className={cn("box-border min-h-0 min-w-0 flex-auto overflow-hidden", fillClassName)}
+        >
+            {fill}
+        </div>
+    )
+
+    return (
+        <div
+            ref={rootRef}
+            data-slot="split-pane"
+            className={cn("flex h-full min-h-0 w-full min-w-0", className)}
+        >
+            {paneSide === "start" ? (
+                <>
+                    {paneNode}
+                    {barNode}
+                    {fillNode}
+                </>
+            ) : (
+                <>
+                    {fillNode}
+                    {barNode}
+                    {paneNode}
+                </>
+            )}
+        </div>
+    )
+}

--- a/web/packages/agenta-ui/src/components/ui/split-pane.tsx
+++ b/web/packages/agenta-ui/src/components/ui/split-pane.tsx
@@ -7,9 +7,14 @@ import {cn} from "./utils"
  * `paneSize` in px, rendered as `flex-basis`) and one FILL pane (`flex:1 1 auto`). Replaces the
  * antd `Splitter` uses where one side is a rail/panel and the other is the canvas.
  *
- * Because the driven basis is fully React-controlled (no internal ResizeObserver rewriting
- * inline styles, which is what antd does), open/close animation is just a CSS transition on
- * `flex-basis`, gated by `animate` — none of the pre-frame machinery the antd version needed.
+ * Because the driven basis is fully React-controlled (nothing here rewrites inline styles the way
+ * antd's ResizeObserver does), open/close animation is just a CSS transition on `flex-basis`,
+ * gated by `animate` — none of the pre-frame machinery the antd version needed. The one observer
+ * it does keep is read-only: it supplies the divider's `aria-value*` bounds and touches no layout.
+ *
+ * The divider is a keyboard-operable window splitter: focusable while `resizable`, Arrow keys
+ * step it (Shift for a coarse step), Home/End jump to the bounds, and every path — pointer or
+ * key — runs the same `onResizeStart → onResize → onResizeEnd` cycle through the same clamp.
  *
  * The divider is the agent playground's gutter: a 9px channel (`--ag-surface-gutter`) with a
  * centred hairline and a grip pill that takes a primary tint on hover/drag (ported from
@@ -30,6 +35,8 @@ export interface SplitPaneProps {
     animate?: boolean
     /** Hide the divider entirely (collapsed rail). The panes stay mounted. */
     barHidden?: boolean
+    /** Accessible name for the divider — it is focusable whenever `resizable`. */
+    barLabel?: string
     onResizeStart?: () => void
     onResize?: (size: number, total: number) => void
     onResizeEnd?: (size: number, total: number) => void
@@ -45,6 +52,11 @@ const BAR_WIDTH = 9
 
 const SLIDE = "[transition:flex-basis_240ms_cubic-bezier(0.4,0,0.2,1)]"
 
+/** Keyboard resize increments — the ARIA window-splitter pattern's arrow step and its coarse
+ * (modifier-held) counterpart. */
+const KEY_STEP = 16
+const KEY_STEP_COARSE = 64
+
 export function SplitPane({
     paneSide,
     paneSize,
@@ -54,6 +66,7 @@ export function SplitPane({
     resizable = true,
     animate = false,
     barHidden = false,
+    barLabel = "Resize panes",
     onResizeStart,
     onResize,
     onResizeEnd,
@@ -67,6 +80,8 @@ export function SplitPane({
     const rootRef = React.useRef<HTMLDivElement>(null)
     const [dragging, setDragging] = React.useState(false)
     const lastRef = React.useRef<{size: number; total: number}>({size: paneSize, total: 0})
+    /** Track width only so the divider can publish `aria-value*`; it never drives layout. */
+    const [measuredTotal, setMeasuredTotal] = React.useState(0)
 
     const clamp = React.useCallback(
         (raw: number, total: number) =>
@@ -74,10 +89,37 @@ export function SplitPane({
         [fillMin, paneMax, paneMin],
     )
 
+    const readTotal = React.useCallback(() => {
+        const rect = rootRef.current?.getBoundingClientRect()
+        return rect ? rect.width - BAR_WIDTH : lastRef.current.total
+    }, [])
+
+    React.useEffect(() => {
+        const el = rootRef.current
+        if (!el || typeof ResizeObserver === "undefined") return
+        const read = () => setMeasuredTotal(el.getBoundingClientRect().width - BAR_WIDTH)
+        read()
+        const observer = new ResizeObserver(read)
+        observer.observe(el)
+        return () => observer.disconnect()
+    }, [])
+
+    /** Both the pointer and keyboard paths land here, so the callback contract is one contract. */
+    const commit = React.useCallback(
+        (size: number, total: number) => {
+            lastRef.current = {size, total}
+            onResize?.(size, total)
+        },
+        [onResize],
+    )
+
     const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
         if (!resizable) return
         e.preventDefault()
         e.currentTarget.setPointerCapture(e.pointerId)
+        // Seed the total up front: a press-and-release with no movement never reaches
+        // `handlePointerMove`, and a `total` of 0 breaks any ratio the caller derives from it.
+        lastRef.current = {size: paneSize, total: readTotal()}
         setDragging(true)
         onResizeStart?.()
     }
@@ -90,16 +132,50 @@ export function SplitPane({
             paneSide === "start"
                 ? e.clientX - rect.left - BAR_WIDTH / 2
                 : rect.right - e.clientX - BAR_WIDTH / 2
-        const size = clamp(Math.round(raw), total)
-        lastRef.current = {size, total}
-        onResize?.(size, total)
+        commit(clamp(Math.round(raw), total), total)
     }
-    const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    /** `pointerup` and `pointercancel` (scroll takeover, browser gesture) share one exit — without
+     * it a cancelled pointer leaves `dragging` stuck true and `onResizeEnd` never fires. */
+    const handlePointerFinish = (e: React.PointerEvent<HTMLDivElement>) => {
         if (!dragging) return
-        e.currentTarget.releasePointerCapture(e.pointerId)
+        if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.currentTarget.releasePointerCapture(e.pointerId)
+        }
         setDragging(false)
         onResizeEnd?.(lastRef.current.size, lastRef.current.total)
     }
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (!resizable) return
+        const total = readTotal()
+        const step = e.shiftKey ? KEY_STEP_COARSE : KEY_STEP
+        // Arrows are spatial: ArrowRight always moves the DIVIDER right, which grows a start-side
+        // pane and shrinks an end-side one.
+        const towardsEnd = paneSide === "start" ? 1 : -1
+        let next: number
+        if (e.key === "ArrowRight") next = paneSize + step * towardsEnd
+        else if (e.key === "ArrowLeft") next = paneSize - step * towardsEnd
+        else if (e.key === "Home") next = paneMin
+        else if (e.key === "End") next = paneMax
+        else return
+        e.preventDefault()
+        const size = clamp(next, total)
+        if (size === paneSize) return
+        // A keystroke is a whole gesture, so it runs the full start → resize → end cycle rather
+        // than a parallel one-shot callback.
+        onResizeStart?.()
+        commit(size, total)
+        onResizeEnd?.(size, total)
+    }
+
+    const ariaValues =
+        resizable && measuredTotal > 0
+            ? {
+                  "aria-valuenow": Math.round(clamp(paneSize, measuredTotal)),
+                  "aria-valuemin": Math.round(clamp(paneMin, measuredTotal)),
+                  "aria-valuemax": Math.round(clamp(paneMax, measuredTotal)),
+              }
+            : undefined
 
     const paneNode = (
         <div
@@ -120,12 +196,18 @@ export function SplitPane({
             data-slot="split-pane-bar"
             role="separator"
             aria-orientation="vertical"
+            aria-label={resizable ? barLabel : undefined}
+            {...ariaValues}
+            tabIndex={resizable ? 0 : undefined}
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
+            onPointerUp={handlePointerFinish}
+            onPointerCancel={handlePointerFinish}
+            onKeyDown={handleKeyDown}
             className={cn(
                 "group relative z-[5] box-border h-full shrink-0 touch-none select-none bg-[var(--ag-surface-gutter)]",
-                resizable && "cursor-col-resize",
+                resizable &&
+                    "cursor-col-resize outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-focus-ring",
                 barClassName,
             )}
             style={{flexBasis: BAR_WIDTH, width: BAR_WIDTH}}

--- a/web/packages/agenta-ui/src/components/ui/tooltip-composed.tsx
+++ b/web/packages/agenta-ui/src/components/ui/tooltip-composed.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "./tooltip"
+
+export interface SimpleTooltipProps {
+    /** Tooltip body. Empty/undefined renders the child bare — antd `Tooltip title` semantics. */
+    title?: React.ReactNode
+    side?: React.ComponentProps<typeof TooltipContent>["side"]
+    className?: string
+    /** Must accept a forwarded ref (the trigger renders asChild). */
+    children: React.ReactElement
+}
+
+/**
+ * The one-liner tooltip — antd's `<Tooltip title>` shape over the Radix primitive, for the
+ * common label-on-hover case. Compose the parts directly when you need controlled open state,
+ * custom delays, or portalling into a specific container.
+ */
+export function SimpleTooltip({title, side, className, children}: SimpleTooltipProps) {
+    if (title == null || title === "") return children
+    return (
+        <TooltipProvider delayDuration={300}>
+            <Tooltip>
+                <TooltipTrigger asChild>{children}</TooltipTrigger>
+                <TooltipContent side={side} className={className}>
+                    {title}
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    )
+}


### PR DESCRIPTION
Four primitives the extracted surfaces all need, hoisted into `@agenta/ui`: `PanelSection`, the
split pane, the context menu, and the composed tooltip that carries its own provider.

They were duplicated across the OSS components that later lanes move into packages; pulling them
up first is what lets those lanes be pure moves.
Not run in a browser — static gates only (`pnpm lint-fix` 24/24, `tsc --noEmit` clean
for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`).

Stacked on `pkg/navigation-ui`; review only this lane's diff.