### PR TITLE
feat(frontend): @agenta/chat — the shared chat engine, composer and approval card

### DIFF
--- a/web/packages/agenta-chat/package.json
+++ b/web/packages/agenta-chat/package.json
@@ -16,6 +16,7 @@
         "check": "pnpm run types:check && pnpm run lint"
     },
     "exports": {
+        "./components": "./src/components/index.ts",
         ".": "./src/index.ts",
         "./model": "./src/model/index.ts",
         "./assets": "./src/assets/index.ts",
@@ -26,8 +27,14 @@
     },
     "dependencies": {
         "@agenta/entities": "workspace:../agenta-entities",
+        "@agenta/entity-ui": "workspace:../agenta-entity-ui",
         "@agenta/playground": "workspace:../agenta-playground",
-        "@agenta/shared": "workspace:../agenta-shared"
+        "@agenta/shared": "workspace:../agenta-shared",
+        "@agenta/ui": "workspace:../agenta-ui",
+        "@phosphor-icons/react": "^2.1.10",
+        "axios": ">=1.13.5 <2.0.0",
+        "motion": "^12.0.0",
+        "zod": "^4.3.6"
     },
     "peerDependencies": {
         "@ai-sdk/react": ">=3.0.0-beta.0",

--- a/web/packages/agenta-chat/src/assets/attachmentRules.ts
+++ b/web/packages/agenta-chat/src/assets/attachmentRules.ts
@@ -1,45 +1,88 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/assets/attachments.ts (2026-07-25);
-// the OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it.
-// Keep byte-parity if either side changes.
-// Adaptations: renamed to attachmentRules.ts on the package side — src/model/attachments.ts
-// already holds the package's `PendingAttachment` staged-upload type, so this file gets a
-// distinct name for the validation/limits concerns copied here.
-/**
- * Attachment guardrails for the agent composer. Files are sent inline as base64 `data:` URLs
- * (see `files.ts`), so an unbounded picker puts arbitrary bytes straight into the request body.
- * These limits cap the count, per-file size, and types.
- *
- * The limits are a single value object, not scattered constants, so they can later be derived
- * from the selected model / harness capabilities (e.g. an image-only model, a larger context
- * window) and passed down in place of `DEFAULT_ATTACHMENT_LIMITS`. That wiring is out of scope
- * here; today everything reads the default.
- */
+// Canonical since the desktop re-plumb: the OSS copy (assets/attachments.ts) is deleted and
+// both apps import this. Named attachmentRules.ts because src/model/attachments.ts already
+// holds the `PendingAttachment` staged-file type.
+/** Attachment guardrails for files staged in the agent composer (uploads or inline sends). */
+
+export type AttachmentKind = "image" | "audio" | "document" | "other"
+
+/** Media types per kind: exact types (`application/pdf`) or `type/` prefixes (`image/`). */
+const KIND_TYPES: Record<AttachmentKind, string[]> = {
+    image: ["image/"],
+    audio: ["audio/"],
+    document: ["application/pdf", "text/", "application/json"],
+    other: [],
+}
+
+/** `accept` hints for the native picker (a hint only — drag/paste is validated regardless). */
+const KIND_ACCEPT_ATTR: Record<AttachmentKind, string> = {
+    image: "image/*",
+    audio: "audio/*",
+    document: "application/pdf,text/plain,text/markdown,text/csv,.md,.csv,application/json",
+    other: "",
+}
+
+const KIND_NOUN: Record<AttachmentKind, string> = {
+    image: "images",
+    audio: "audio",
+    document: "documents",
+    other: "other files",
+}
 
 export interface AttachmentLimits {
-    /** Max files per message. */
+    /** Max files per message, across all kinds. */
     maxCount: number
-    /** Max bytes per file (before base64 inflation, which adds ~33% on the wire). */
-    maxBytes: number
-    /** Accepted media types: exact types (`application/pdf`) or `type/` prefixes (`image/`). */
-    accept: string[]
-    /** `accept` attribute for the native file picker (a hint; drag/paste is validated too). */
-    acceptAttr: string
-    /** Human label for the kinds accepted, e.g. "Images and documents". */
-    label: string
+    /** Kinds the composer accepts. Narrowing this is how capability gating plugs in. */
+    kinds: AttachmentKind[]
+    /** Max bytes per file, per kind. */
+    maxBytes: Record<AttachmentKind, number>
 }
+
+const MB = 1024 * 1024
 
 export const DEFAULT_ATTACHMENT_LIMITS: AttachmentLimits = {
-    maxCount: 5,
-    maxBytes: 5 * 1024 * 1024,
-    accept: ["image/", "application/pdf", "text/", "application/json"],
-    acceptAttr:
-        "image/*,application/pdf,text/plain,text/markdown,text/csv,.md,.csv,application/json",
-    label: "Images and documents",
+    maxCount: 100,
+    kinds: ["image", "audio", "document", "other"],
+    maxBytes: {
+        // A photo off a phone clears 5 MB routinely.
+        image: 10 * MB,
+        // Our own recordings cap near 2.4 MB; the headroom is for uploaded clips.
+        audio: 15 * MB,
+        document: 10 * MB,
+        other: 10 * MB,
+    },
 }
 
-/** Whether a media type is allowed under the limits (prefix or exact match). */
-export const isAcceptedType = (mediaType: string, limits: AttachmentLimits): boolean =>
-    limits.accept.some((a) => (a.endsWith("/") ? mediaType.startsWith(a) : mediaType === a))
+/** Which kind a media type belongs to. */
+export const kindForType = (mediaType: string): AttachmentKind => {
+    for (const kind of ["image", "audio", "document"] as const) {
+        const matches = KIND_TYPES[kind].some((t) =>
+            t.endsWith("/") ? mediaType.startsWith(t) : mediaType === t,
+        )
+        if (matches) return kind
+    }
+    return "other"
+}
+
+/** Whether a media type is allowed under the limits (right kind, and that kind is enabled). */
+export const isAcceptedType = (mediaType: string, limits: AttachmentLimits): boolean => {
+    const kind = kindForType(mediaType)
+    return limits.kinds.includes(kind)
+}
+
+/** `accept` attribute for the native file picker, built from the enabled kinds. */
+export const acceptAttrFor = (limits: AttachmentLimits): string =>
+    limits.kinds.includes("other") ? "" : limits.kinds.map((k) => KIND_ACCEPT_ATTR[k]).join(",")
+
+/** Human summary of what is accepted, e.g. "Images, audio, and documents". */
+export const describeAccepted = (limits: AttachmentLimits): string => {
+    const nouns = limits.kinds.map((k) => KIND_NOUN[k])
+    if (nouns.length === 0) return "No attachments"
+    const sentence =
+        nouns.length === 1
+            ? nouns[0]
+            : `${nouns.slice(0, -1).join(", ")}, and ${nouns[nouns.length - 1]}`
+    return sentence.charAt(0).toUpperCase() + sentence.slice(1)
+}
 
 /** Compact human size: `820 KB`, `4.2 MB`. */
 export const formatBytes = (n: number): string => {
@@ -51,7 +94,7 @@ export const formatBytes = (n: number): string => {
 export interface AttachmentRejection {
     /** The file's name, for the inline message. */
     name: string
-    /** Why it was rejected (verb phrase): "is too large (8.2 MB) · max 5 MB". */
+    /** Why it was rejected (verb phrase): "is too large (8.2 MB) · max 10 MB for images". */
     reason: string
 }
 
@@ -76,22 +119,22 @@ export const validateIncoming = (
 
     for (const file of incoming) {
         const type = file.type || "application/octet-stream"
-        if (!isAcceptedType(type, limits)) {
-            rejections.push({name: file.name, reason: `isn't a supported file type`})
+        const kind = kindForType(type)
+
+        if (!limits.kinds.includes(kind)) {
+            rejections.push({name: file.name, reason: "isn't a supported file type"})
             continue
         }
-        if (file.size > limits.maxBytes) {
+        const maxBytes = limits.maxBytes[kind]
+        if (file.size > maxBytes) {
             rejections.push({
                 name: file.name,
-                reason: `is too large (${formatBytes(file.size)}) · max ${formatBytes(limits.maxBytes)} per file`,
+                reason: `is too large (${formatBytes(file.size)}) · max ${formatBytes(maxBytes)} for ${KIND_NOUN[kind]}`,
             })
             continue
         }
         if (remaining <= 0) {
-            rejections.push({
-                name: file.name,
-                reason: `exceeds the ${limits.maxCount}-file limit`,
-            })
+            rejections.push({name: file.name, reason: `exceeds the ${limits.maxCount}-file limit`})
             continue
         }
         accepted.push(file)
@@ -100,3 +143,10 @@ export const validateIncoming = (
 
     return {accepted, rejections}
 }
+
+/** A file kind an attachment viewer can preview; audio plays inline in the tray instead. */
+export const isViewable = (mediaType: string): boolean =>
+    mediaType.startsWith("image/") ||
+    mediaType === "application/pdf" ||
+    mediaType.startsWith("text/") ||
+    mediaType === "application/json"

--- a/web/packages/agenta-chat/src/assets/attachmentRules.ts
+++ b/web/packages/agenta-chat/src/assets/attachmentRules.ts
@@ -77,10 +77,14 @@ export const acceptAttrFor = (limits: AttachmentLimits): string =>
 export const describeAccepted = (limits: AttachmentLimits): string => {
     const nouns = limits.kinds.map((k) => KIND_NOUN[k])
     if (nouns.length === 0) return "No attachments"
+    // Two items take a bare "and"; the serial comma only belongs to lists of three or more.
+    // (This is user-visible — the composer's empty state renders it.)
     const sentence =
         nouns.length === 1
             ? nouns[0]
-            : `${nouns.slice(0, -1).join(", ")}, and ${nouns[nouns.length - 1]}`
+            : nouns.length === 2
+              ? `${nouns[0]} and ${nouns[1]}`
+              : `${nouns.slice(0, -1).join(", ")}, and ${nouns[nouns.length - 1]}`
     return sentence.charAt(0).toUpperCase() + sentence.slice(1)
 }
 

--- a/web/packages/agenta-chat/src/assets/attachmentTransport.ts
+++ b/web/packages/agenta-chat/src/assets/attachmentTransport.ts
@@ -1,0 +1,129 @@
+import {safeParseWithLogging} from "@agenta/entities/shared"
+import {axios, getAgentaApiUrl} from "@agenta/shared/api"
+import {isAxiosError, isCancel} from "axios"
+import {z} from "zod"
+
+import {DEFAULT_ATTACHMENT_LIMITS, formatBytes, kindForType} from "./attachmentRules"
+
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+const sessionAttachmentResponseSchema = z.object({
+    count: z.number().int().nonnegative(),
+    attachment: z.object({
+        // The server emits lowercase ids, and the adapter deliberately rejects uppercase variants.
+        attachment_id: z.string().regex(CANONICAL_UUID),
+        filename: z.string(),
+        media_type: z.string(),
+        size: z.number().int().nonnegative(),
+        created_at: z.string(),
+    }),
+})
+
+export type SessionAttachmentResponse = z.infer<typeof sessionAttachmentResponseSchema>
+
+export class AttachmentUploadError extends Error {
+    readonly retryable: boolean
+    readonly retryAfterSeconds?: number
+
+    constructor(
+        message = "Couldn't upload the file. Try again.",
+        {
+            retryable = true,
+            retryAfterSeconds,
+        }: {retryable?: boolean; retryAfterSeconds?: number} = {},
+    ) {
+        super(message)
+        this.name = "AttachmentUploadError"
+        this.retryable = retryable
+        this.retryAfterSeconds = retryAfterSeconds
+    }
+}
+
+const retryAfterSeconds = (value: unknown): number | undefined => {
+    const parsed = Number(Array.isArray(value) ? value[0] : value)
+    return Number.isFinite(parsed) && parsed >= 0 ? Math.ceil(parsed) : undefined
+}
+
+const errorForResponse = (error: unknown, file: File): AttachmentUploadError => {
+    if (!isAxiosError(error) || !error.response) return new AttachmentUploadError()
+
+    switch (error.response.status) {
+        case 413: {
+            const kind = kindForType(file.type || "application/octet-stream")
+            const limit = formatBytes(DEFAULT_ATTACHMENT_LIMITS.maxBytes[kind])
+            const label = kind === "other" ? "file" : kind
+            return new AttachmentUploadError(`This file exceeds the ${limit} ${label} limit.`, {
+                retryable: false,
+            })
+        }
+        case 422:
+            return new AttachmentUploadError("This file isn't valid.", {retryable: false})
+        case 429:
+            return new AttachmentUploadError("This session's attachment quota is full.", {
+                retryable: false,
+            })
+        case 409: {
+            const retryIn = retryAfterSeconds(error.response.headers?.["retry-after"])
+            if (retryIn !== undefined) {
+                return new AttachmentUploadError(
+                    `This file is already uploading. Retry in ${retryIn}s.`,
+                    {retryAfterSeconds: retryIn},
+                )
+            }
+            return new AttachmentUploadError("This upload conflicts with an earlier file.", {
+                retryable: false,
+            })
+        }
+        case 404:
+            return new AttachmentUploadError("This backend does not support attachments yet.", {
+                retryable: false,
+            })
+        default:
+            return new AttachmentUploadError()
+    }
+}
+
+export async function uploadAttachment({
+    file,
+    sessionId,
+    idempotencyKey,
+    onProgress,
+    signal,
+}: {
+    file: File
+    sessionId: string
+    idempotencyKey: string
+    onProgress?: (percent: number) => void
+    signal?: AbortSignal
+}): Promise<SessionAttachmentResponse> {
+    const form = new FormData()
+    form.append("file", file, file.name)
+    form.append("idempotency_key", idempotencyKey)
+
+    try {
+        // Axios (not Fern): the Fern client uses fetch, which can't stream upload progress.
+        // The explicit header matters: the shared instance defaults to application/json, and
+        // axios then JSON-serializes the FormData, collapsing the File to {}.
+        const response = await axios.post(`${getAgentaApiUrl()}/sessions/attachments`, form, {
+            params: {session_id: sessionId},
+            headers: {"Content-Type": "multipart/form-data"},
+            signal,
+            onUploadProgress: (event) => {
+                if (onProgress && event.total) {
+                    onProgress(Math.round((event.loaded / event.total) * 100))
+                }
+            },
+        })
+        const validated = safeParseWithLogging(
+            sessionAttachmentResponseSchema,
+            response.data,
+            "[uploadAttachment]",
+        )
+        if (!validated) throw new AttachmentUploadError()
+        return validated
+    } catch (error) {
+        if (signal?.aborted || isCancel(error)) throw error
+        if (error instanceof AttachmentUploadError) throw error
+        throw errorForResponse(error, file)
+    }
+}

--- a/web/packages/agenta-chat/src/assets/files.ts
+++ b/web/packages/agenta-chat/src/assets/files.ts
@@ -97,6 +97,25 @@ export const attachmentRefsToParts = (refs: AttachmentRef[], sessionId: string):
     }))
 
 /**
+ * Where to fetch a file part's bytes from RIGHT NOW.
+ *
+ * A reference part's `url` is baked at build time (`attachmentRefsToParts` here,
+ * `transcriptToMessages` on the replay path) against whatever API host was current then — and
+ * these parts are persisted with the transcript, so a host change (a different deployment, an env
+ * switch, a moved domain) leaves the stored URLs pointing at the old one. The durable identity is
+ * the attachment id in `providerMetadata.agenta` plus the session, so rebuild from those against
+ * the CURRENT runtime host instead of trusting the stored URL.
+ *
+ * Inline `data:` parts and any part that predates the metadata have no id to rebuild from and keep
+ * their stored URL.
+ */
+export const filePartContentUrl = (part: FileUIPart, sessionId: string): string => {
+    const attachmentId = attachmentIdForPart(part)
+    if (!attachmentId || !sessionId) return part.url
+    return attachmentContentUrl(sessionId, attachmentId)
+}
+
+/**
  * A readable label for a file part: the filename, else the tail of its URL.
  *
  * The URL fallback skips `data:` URLs (`fileToPart` emits base64 payloads whose tail is the

--- a/web/packages/agenta-chat/src/assets/files.ts
+++ b/web/packages/agenta-chat/src/assets/files.ts
@@ -1,15 +1,15 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/assets/files.ts (2026-07-25); the
-// OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it. Keep
-// byte-parity if either side changes.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import type {FileUIPart, UIMessage} from "ai"
 
 import type {AttachmentRejection} from "./attachmentRules"
+import {attachmentContentUrl} from "./transcriptToMessages"
 
 /**
- * Multi-modality helpers for the agent chat slice. Attachments are kept entirely on the
- * client: there is no upload server, so a selected file is read into a `data:` URL and
- * sent inline as an AI SDK v6 `file` part (`{type, mediaType, filename, url}`). The service
- * receives the bytes in the request body — same channel as the text.
+ * Multi-modality helpers for the agent chat. Two send strategies share these parts:
+ * - inline (`filesToParts`): the file is read into a `data:` URL and the bytes travel in the
+ *   request body — no upload server involved;
+ * - reference (`attachmentRefsToParts`): the file was uploaded to the sessions attachment
+ *   store first and the part carries a durable content URL instead of bytes.
  */
 
 export type FileKind = "image" | "audio" | "video" | "file"
@@ -68,15 +68,43 @@ export const filesToParts = async (files: File[]): Promise<FilesToPartsResult> =
 export const fileParts = (message: UIMessage): FileUIPart[] =>
     message.parts.filter((p) => p.type === "file") as FileUIPart[]
 
+/** The Agenta attachment id carried by a reference part, if present. */
+export const attachmentIdForPart = (part: FileUIPart): string | null => {
+    const agenta = part.providerMetadata?.agenta
+    if (!agenta || typeof agenta !== "object") return null
+    const attachmentId = (agenta as {attachmentId?: unknown}).attachmentId
+    return typeof attachmentId === "string" && attachmentId ? attachmentId : null
+}
+
+/** A durable attachment an upload settled to — the neutral input for reference parts. */
+export interface AttachmentRef {
+    attachmentId: string
+    filename: string
+    mediaType: string
+    size: number
+}
+
+/** Build reference-carrying `file` parts for uploaded attachments (no inline bytes). */
+export const attachmentRefsToParts = (refs: AttachmentRef[], sessionId: string): FileUIPart[] =>
+    refs.map((ref) => ({
+        type: "file",
+        mediaType: ref.mediaType,
+        filename: ref.filename,
+        url: attachmentContentUrl(sessionId, ref.attachmentId),
+        providerMetadata: {
+            agenta: {attachmentId: ref.attachmentId, size: ref.size},
+        },
+    }))
+
 /**
  * A readable label for a file part: the filename, else the tail of its URL.
  *
- * The URL fallback skips `data:` URLs. `fileToPart` emits `data:<type>;base64,<...>`, whose tail
- * is the payload itself, so an unnamed inline file would be labelled with ~70 characters of
- * base64 instead of a name.
+ * The URL fallback skips `data:` URLs (`fileToPart` emits base64 payloads whose tail is the
+ * payload itself) and attachment REFERENCE parts (their URLs end in the fixed `/content`
+ * segment, which would label every unnamed reference "content").
  */
 export const filePartName = (part: FileUIPart): string => {
     if (part.filename) return part.filename
-    if (part.url.startsWith("data:")) return "attachment"
+    if (part.url.startsWith("data:") || attachmentIdForPart(part)) return "attachment"
     return part.url.split("/").pop()?.split("?")[0] || "file"
 }

--- a/web/packages/agenta-chat/src/assets/index.ts
+++ b/web/packages/agenta-chat/src/assets/index.ts
@@ -1,6 +1,7 @@
 export * from "./toolFormat"
 export * from "./trace"
 export * from "./attachmentRules"
+export * from "./attachmentTransport"
 export * from "./files"
 export * from "./rewind"
 export * from "./transcriptToMessages"

--- a/web/packages/agenta-chat/src/assets/loadSession.ts
+++ b/web/packages/agenta-chat/src/assets/loadSession.ts
@@ -1,9 +1,4 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/assets/loadSession.ts (2026-07-25);
-// the OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it.
-// Keep byte-parity if either side changes.
-// Adaptations: none — `fetchSessionRecordsAtom` already reads `projectIdAtom` internally from
-// `@agenta/entities/session` (an allowed package dep), so no OSS-app-only import is involved and
-// no signature change was needed.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import {fetchSessionRecordsAtom} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 import {getDefaultStore} from "jotai"

--- a/web/packages/agenta-chat/src/assets/motion.ts
+++ b/web/packages/agenta-chat/src/assets/motion.ts
@@ -1,0 +1,4 @@
+import type {Transition} from "motion/react"
+
+/** The slice-wide spring for chrome enter/leave — one physical feel across every surface. */
+export const SESSION_SPRING: Transition = {type: "spring", visualDuration: 0.28, bounce: 0}

--- a/web/packages/agenta-chat/src/assets/rewind.ts
+++ b/web/packages/agenta-chat/src/assets/rewind.ts
@@ -1,6 +1,4 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/assets/rewind.ts (2026-07-25); the
-// OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it. Keep
-// byte-parity if either side changes.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import type {UIMessage} from "ai"
 
 /**

--- a/web/packages/agenta-chat/src/assets/toolFormat.ts
+++ b/web/packages/agenta-chat/src/assets/toolFormat.ts
@@ -1,9 +1,4 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/assets/toolFormat.ts (2026-07-25);
-// the OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it.
-// Keep byte-parity if either side changes.
-// Adaptations: this is the canonical copy of `stripFence` for the package — src/model/toolSummary.ts
-// (copied earlier from ToolActivity.tsx, which itself imports stripFence from this file in OSS) now
-// re-exports it from here instead of holding a second definition.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 /**
  * Shared formatting for tool input/output display (inline step log + Turn Inspector), so both
  * render a payload identically.

--- a/web/packages/agenta-chat/src/assets/trace.ts
+++ b/web/packages/agenta-chat/src/assets/trace.ts
@@ -1,6 +1,4 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/assets/trace.ts (2026-07-25); the
-// OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it. Keep
-// byte-parity if either side changes.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import type {UIMessage} from "ai"
 
 /**

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -1,14 +1,4 @@
-// Copied from web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts (2026-07-25);
-// the OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it.
-//
-// Re-synced 2026-08-03 to full parity with the original: the approval-resume handling (pause
-// folding, the resumed settle pass, tool-call dedup, re-raise under a new toolCallId) — without
-// which a resumed turn replays as still parked and the reload keeps the approval dock up — and
-// user-attachment parts + `filename` on file parts, without which a message that carried files
-// replays as bare text.
-//
-// `attachmentContentUrl` is the package's own copy of the original's `attachmentMedia.ts`
-// builder, on `@agenta/shared/api` rather than the OSS app layer.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import type {SessionRecord} from "@agenta/entities/session"
 import {getAgentaApiUrl} from "@agenta/shared/api"
 import type {UIMessage} from "ai"
@@ -61,6 +51,9 @@ interface DraftMessage {
     paused?: boolean
     /** The turn paused for approval and then RESUMED to completion (a second, non-paused `done`). */
     resumed?: boolean
+    /** The turn's persisted `error` event — replayed through the same `metadata.runError` channel
+     *  the live stream stamps, so a failure renders as the error bubble, not as body text. */
+    runError?: string
 }
 
 interface TranscriptIndex {
@@ -298,8 +291,11 @@ function applyEvent(
             return
         }
         case "error": {
-            // No error part in the renderer; surface the text so the failure stays visible.
-            draft.parts.push({type: "text", text: str(payload.message)})
+            // Stamp the run failure, don't push it as text: a replayed error must render through
+            // the same red bubble as a live one. First non-empty wins — a cascading later error
+            // must not mask the root cause.
+            const message = str(payload.message).trim()
+            if (message && !draft.runError) draft.runError = message
             return
         }
         case "usage": {
@@ -388,7 +384,8 @@ export function transcriptToMessages(records: SessionRecord[]): UIMessage[] | nu
     }
 
     const messages = drafts
-        .filter((d) => d.parts.length > 0)
+        // A turn whose only content was the failure has no parts — keep it, or the error vanishes.
+        .filter((d) => d.parts.length > 0 || d.runError)
         .map((d) => {
             // `getMessageTraceId`/`getMessageUsage` read exactly these, so the hover trace actions
             // and metrics bar light up on reload. traceId stays absent until the backend stamps one;
@@ -397,6 +394,7 @@ export function transcriptToMessages(records: SessionRecord[]): UIMessage[] | nu
             if (d.traceId) metadata.traceId = d.traceId
             if (d.usage) metadata.usage = d.usage
             if (d.paused) metadata.paused = true
+            if (d.runError) metadata.runError = {message: d.runError}
             return {
                 id: d.id,
                 role: d.role,

--- a/web/packages/agenta-chat/src/components/ApprovalCard.tsx
+++ b/web/packages/agenta-chat/src/components/ApprovalCard.tsx
@@ -1,0 +1,565 @@
+/**
+ * The shared approval card — the ONE design for a human-in-the-loop gate, extracted from the
+ * desktop ApprovalDock so mobile renders the identical surface instead of a wireframe copy.
+ *
+ * The card owns what a gate IS: the shield header with the batch count, the tool identity
+ * (raw name + source chip, or the friendly one-sentence ask), and the exact-payload expander.
+ * Everything surface-specific — action buttons, steer panels, always-allow rows, trace links,
+ * registry-rendered bodies — arrives as slots, so each app keeps its own affordances on the
+ * same chrome.
+ */
+import {useEffect, useMemo, useRef, useState, type ReactNode} from "react"
+
+import {HeightCollapse} from "@agenta/ui/height-collapse"
+import {
+    AutosizeTextarea,
+    Button,
+    LoadingButton,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Switch,
+} from "@agenta/ui/ui"
+import {CaretDown, CaretRight, ShieldCheck} from "@phosphor-icons/react"
+
+import {useAlwaysAllowTool} from "../hooks/useAlwaysAllowTool"
+import type {PendingApproval} from "../model/approvals"
+import {resolveToolDisplay} from "../skin/registry"
+
+const formatInput = (input: unknown): string => {
+    if (input == null) return ""
+    // Keep the exact string — the user must approve the payload the tool actually receives. The
+    // one-line preview normalizes whitespace; this expanded view must not alter it.
+    if (typeof input === "string") return input
+    try {
+        return JSON.stringify(input, null, 2)
+    } catch {
+        return String(input)
+    }
+}
+
+/** One-line, whitespace-collapsed payload preview — so a batch peek can be an informed click
+ * without expanding every gate. Truncated; the full payload stays in the card. */
+export const inputPreview = (input: unknown): string => {
+    const s = formatInput(input).replace(/\s+/g, " ").trim()
+    return s.length > 140 ? `${s.slice(0, 140)}…` : s
+}
+
+/** Collapsible exact-payload viewer — the generic approval body, and the fallback (plus the
+ * Build-mode raw view) for specialized renderers. Owns its expand state so a specialized body
+ * can render it anywhere; hosts key it by approval id to recollapse when the gate changes. */
+export const PayloadBlock = ({
+    input,
+    label = "Payload",
+    surfaceClassName = "bg-colorFillQuaternary",
+}: {
+    input: unknown
+    label?: string
+    /** The inset well behind the expander (desktop passes its `ag-surface-inset`). */
+    surfaceClassName?: string
+}) => {
+    const [showPayload, setShowPayload] = useState(false)
+    const payload = useMemo(() => formatInput(input), [input])
+    const payloadPreview = payload.replace(/\s+/g, " ").trim()
+    if (!payload) return null
+    return (
+        <div className={`overflow-hidden rounded ${surfaceClassName}`}>
+            <button
+                type="button"
+                onClick={() => setShowPayload((s) => !s)}
+                aria-expanded={showPayload}
+                className="flex w-full min-w-0 cursor-pointer items-center gap-1.5 border-0 bg-transparent px-2.5 py-1.5 text-left"
+            >
+                <CaretRight
+                    size={11}
+                    weight="bold"
+                    className={`shrink-0 text-colorTextTertiary transition-transform ${
+                        showPayload ? "rotate-90" : ""
+                    }`}
+                />
+                <span className="shrink-0 text-[11px] font-medium text-colorTextSecondary">
+                    {label}
+                </span>
+                {!showPayload ? (
+                    <span className="min-w-0 truncate font-mono text-[11px] text-colorTextTertiary">
+                        {payloadPreview}
+                    </span>
+                ) : null}
+            </button>
+            <HeightCollapse open={showPayload}>
+                <pre className="m-0 max-h-48 overflow-auto whitespace-pre-wrap break-all px-2.5 pb-2.5 font-mono text-[11px] leading-snug text-colorTextSecondary">
+                    {payload}
+                </pre>
+            </HeightCollapse>
+        </div>
+    )
+}
+
+export interface ApprovalCardFrameProps {
+    /** The gate being acted on. */
+    toolName: string
+    input: unknown
+    /** Total pending gates in the paused turn (renders "1 of N" beyond 1). */
+    count: number
+    /** Friendly mode: fold the humanized tool name into one sentence (Chat). Off = the raw
+     * name + source chip line (Build / debugging surfaces). */
+    friendly?: boolean
+    /** Replace the default ask sentence; null = a specialized body owns it (renders nothing). */
+    headline?: ReactNode | null
+    /** Replace the generic PayloadBlock body (a registry-rendered preview). */
+    body?: ReactNode
+    /** The action row (and anything below it) — each surface brings its own. */
+    children?: ReactNode
+    /** Card surface + density (desktop passes its `ag-surface-chat` and a roomier scale for
+     * registry bodies; the default is a bordered token card at the standard density). */
+    className?: string
+    /** The payload well's surface, forwarded to {@link PayloadBlock}. */
+    payloadSurfaceClassName?: string
+    /** Label over the payload expander ("Details" in chat mode, "Payload" in build). */
+    payloadLabel?: string
+}
+
+export interface ApprovalCardProps {
+    /** Pending gates for the paused turn — index 0 is acted on; the rest feed the batch peek. */
+    approvals: PendingApproval[]
+    /** A fired decision is settling (disables the controls, drives the spinners). */
+    responding?: boolean
+    /** Which action fired, for spinner placement on Approve vs Approve all. */
+    respondingSource?: "one" | "all" | "deny-all" | null
+    /** The agent revision — enables the always-allow row (a draft-config grant). */
+    entityId?: string
+    /** Show the Redirect (deny + note) entry point — hosts gate it by their own flag. */
+    steerEnabled?: boolean
+    /** Touch mode: desktop-identical chrome with an invisibly extended ~44px tap area per action. */
+    touch?: boolean
+    /** A host-side failure to surface under the actions (e.g. the detached resume failed). */
+    errorText?: string | null
+    /** Replace the Approve label (a registry body's verb, e.g. "Commit"). */
+    approveLabel?: string
+    /** Left slot of the action row (desktop Build's "View full trace" link). */
+    actionExtra?: ReactNode
+    /** Answer ONE gate; `message` carries a steer note WITH a denial. */
+    onRespond: (args: {approvalId: string; approved: boolean; message?: string}) => void
+    /** Approve the whole batch in one step. */
+    onApproveAll: (approvalIds: string[]) => void
+    /** The peek's turn-level reject — omit to hide "Deny all" (a host without batch deny). */
+    onDenyAll?: (approvalIds: string[]) => void
+    /** Approve the current tool's OTHER pending gates along with it after an always-allow grant
+     * ("don't ask again" shouldn't step through 2/3, 3/3). Omit → only the current gate answers. */
+    onApproveCovered?: (approvalIds: string[]) => void
+    /** Frame passthrough — see {@link ApprovalCardFrameProps}. */
+    friendly?: boolean
+    headline?: ReactNode | null
+    body?: ReactNode
+    className?: string
+    payloadSurfaceClassName?: string
+    payloadLabel?: string
+    /** The batch-peek popover's card + item surfaces (desktop passes its ag-surface-*). */
+    peekSurfaceClassName?: string
+    peekItemSurfaceClassName?: string
+}
+
+/**
+ * THE approval card — one component for the whole decision surface, rendered identically by the
+ * desktop dock and mobile. It owns the frame, the decision row (Approve / Deny / the Approve-all
+ * split button with the informed batch peek / Redirect), the steer panel, and the always-allow
+ * row with its arm-then-apply-on-approve semantics. Hosts adapt only transport: how a response
+ * actually fires (engine stream vs detached resume) arrives as callbacks, and host chrome
+ * (registry bodies, trace links, surfaces) as slots.
+ */
+export const ApprovalCard = ({
+    approvals,
+    responding = false,
+    respondingSource = null,
+    entityId,
+    steerEnabled = false,
+    touch = false,
+    errorText,
+    approveLabel,
+    actionExtra,
+    onRespond,
+    onApproveAll,
+    onDenyAll,
+    onApproveCovered,
+    friendly = true,
+    headline,
+    body,
+    className,
+    payloadSurfaceClassName,
+    payloadLabel,
+    peekSurfaceClassName = "border border-solid border-colorBorderSecondary bg-colorBgContainer",
+    peekItemSurfaceClassName = "bg-colorFillQuaternary",
+}: ApprovalCardProps) => {
+    const current = approvals[0]
+    const count = approvals.length
+    // Armed "always allow this tool" intent for the current gate — applied only when the user
+    // clicks Approve, never on its own (the switch must not progress the flow).
+    const [alwaysAllowArmed, setAlwaysAllowArmed] = useState(false)
+    // Steer: the "Redirect" panel holds an optional instruction sent WITH the denial.
+    const [steerOpen, setSteerOpen] = useState(false)
+    const [steerMessage, setSteerMessage] = useState("")
+    // The field stays mounted inside the collapse, so `autoFocus` only fires at the card's initial
+    // mount — focus it explicitly each time the redirect opens. rAF waits for the expand to start
+    // so focus lands on a laid-out (not height-0) element.
+    const steerInputRef = useRef<HTMLTextAreaElement>(null)
+    useEffect(() => {
+        if (!steerOpen) return
+        const raf = requestAnimationFrame(() => steerInputRef.current?.focus())
+        return () => cancelAnimationFrame(raf)
+    }, [steerOpen])
+    // The current gate changed (we answered one, the next slid in) — disarm and close the panel.
+    const currentId = current?.approvalId
+    useEffect(() => {
+        setAlwaysAllowArmed(false)
+        setSteerOpen(false)
+        setSteerMessage("")
+    }, [currentId])
+
+    const {infoFor, grant} = useAlwaysAllowTool(entityId)
+
+    if (!current) return null
+
+    const display = resolveToolDisplay(current.toolName)
+    const grantInfo = infoFor(current.toolName)
+    const canAlwaysAllow = Boolean(grantInfo.eligible && !grantInfo.alreadyAllowed)
+    // Touch mode must NOT change the chrome — the card renders desktop-identical everywhere.
+    // Instead the tap target extends invisibly to ~44px via an inset pseudo-element.
+    const touchCls = touch
+        ? "relative after:absolute after:-inset-x-1 after:-inset-y-2 after:content-['']"
+        : ""
+
+    const approve = () => {
+        if (responding) return
+        // Apply the armed grant only on approve — never on deny, and never from the switch alone.
+        if (alwaysAllowArmed && canAlwaysAllow) {
+            grant(current.toolName)
+            // "Always allow <tool>" also clears this tool's OTHER pending gates in the batch: the
+            // user said they don't want to be prompted for it again, so its siblings auto-approve
+            // in one step. Other tools stay gated and are shown next.
+            const covered = approvals.filter((a) => a.toolName === current.toolName)
+            if (covered.length > 1 && onApproveCovered) {
+                onApproveCovered(covered.map((a) => a.approvalId))
+                return
+            }
+        }
+        onRespond({approvalId: current.approvalId, approved: true})
+    }
+    const approveAll = () => {
+        if (responding) return
+        if (alwaysAllowArmed && canAlwaysAllow) grant(current.toolName)
+        onApproveAll(approvals.map((a) => a.approvalId))
+    }
+
+    return (
+        <ApprovalCardFrame
+            toolName={current.toolName}
+            input={current.input}
+            count={count}
+            friendly={friendly}
+            headline={headline}
+            className={className}
+            payloadSurfaceClassName={payloadSurfaceClassName}
+            payloadLabel={payloadLabel}
+            // Keyed by approval id so the expander recollapses when the gate changes.
+            body={
+                body ?? (
+                    <PayloadBlock
+                        key={current.approvalId}
+                        input={current.input}
+                        label={payloadLabel ?? (friendly ? "Details" : "Payload")}
+                        surfaceClassName={payloadSurfaceClassName}
+                    />
+                )
+            }
+        >
+            {/* Actions: host extra on the left, decision on the right; Approve is the single
+                primary. The whole row collapses while steering: an explicit deny+redirect
+                shouldn't leave Approve competing, so the redirect panel below becomes the entire
+                action surface. Mirrors the panel's expand (open={!steerOpen} vs open={steerOpen})
+                for one smooth swap. */}
+            <HeightCollapse open={!steerOpen} fade inert>
+                <div className="flex items-center gap-2">
+                    {actionExtra}
+                    <div className="ml-auto flex items-center gap-1.5">
+                        {count > 1 ? (
+                            // Split button: the primary click approves the whole batch; the caret
+                            // opens a peek listing every pending action (so "Approve all" is
+                            // informed, not blind) and the explicit turn-level "Deny all".
+                            <span className="inline-flex">
+                                <LoadingButton
+                                    variant="outline"
+                                    disabled={responding}
+                                    loading={responding && respondingSource === "all"}
+                                    onClick={approveAll}
+                                    className={`rounded-r-none ${touchCls}`}
+                                >
+                                    Approve all
+                                </LoadingButton>
+                                <Popover>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            size="icon"
+                                            disabled={responding}
+                                            aria-label="Batch actions"
+                                            className={`-ml-px rounded-l-none ${touchCls}`}
+                                        >
+                                            <CaretDown size={12} />
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent
+                                        align="end"
+                                        className={`box-border flex max-w-[320px] flex-col gap-1.5 rounded-lg p-2 shadow-md ${peekSurfaceClassName}`}
+                                    >
+                                        <span className="px-1 text-[11px] text-colorTextSecondary">
+                                            Approving all runs these {count} actions:
+                                        </span>
+                                        <div className="flex max-h-56 flex-col gap-1 overflow-auto">
+                                            {approvals.map((a) => {
+                                                const preview = inputPreview(a.input)
+                                                const label =
+                                                    resolveToolDisplay(a.toolName)?.label ??
+                                                    a.toolName
+                                                return (
+                                                    <div
+                                                        key={a.approvalId}
+                                                        className={`box-border rounded px-2 py-1.5 ${peekItemSurfaceClassName}`}
+                                                    >
+                                                        <span
+                                                            className="block truncate text-xs font-medium text-colorText"
+                                                            title={a.toolName}
+                                                        >
+                                                            {label}
+                                                        </span>
+                                                        {preview ? (
+                                                            <span className="block truncate font-mono text-[11px] text-colorTextSecondary">
+                                                                {preview}
+                                                            </span>
+                                                        ) : null}
+                                                    </div>
+                                                )
+                                            })}
+                                        </div>
+                                        {onDenyAll ? (
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                disabled={responding}
+                                                onClick={() =>
+                                                    onDenyAll(approvals.map((a) => a.approvalId))
+                                                }
+                                                className="justify-start text-colorError hover:bg-[var(--ant-color-error-bg)]"
+                                            >
+                                                Deny all
+                                            </Button>
+                                        ) : null}
+                                    </PopoverContent>
+                                </Popover>
+                            </span>
+                        ) : null}
+                        {steerEnabled ? (
+                            <Button
+                                variant="ghost"
+                                disabled={responding}
+                                className={`text-colorTextSecondary ${touchCls}`}
+                                onClick={() => setSteerOpen(true)}
+                            >
+                                Redirect
+                            </Button>
+                        ) : null}
+                        <Button
+                            variant="outline"
+                            disabled={responding}
+                            className={touchCls}
+                            onClick={() =>
+                                onRespond({approvalId: current.approvalId, approved: false})
+                            }
+                        >
+                            Deny
+                        </Button>
+                        <LoadingButton
+                            disabled={responding}
+                            loading={responding && respondingSource === "one"}
+                            onClick={approve}
+                            className={touchCls}
+                        >
+                            {approveLabel ?? "Approve"}
+                        </LoadingButton>
+                    </div>
+                </div>
+            </HeightCollapse>
+
+            {/* Steer: an inline redirect note, revealed on demand by the Redirect button above.
+                Kept inside the card so it collapses with it and can't linger over another
+                session. Complements the action row (open={steerOpen} vs open={!steerOpen}) so
+                one expands exactly as the other collapses. Unmounted (not merely collapsed)
+                while the flag is off: a collapsed HeightCollapse still leaves its controls in
+                the DOM and tab order. */}
+            {steerEnabled ? (
+                <HeightCollapse open={steerOpen} fade inert>
+                    <div className="flex flex-col gap-2 border-0 border-t border-solid border-colorBorderSecondary pt-2.5">
+                        <span className="text-[11px] text-colorTextSecondary">
+                            Deny this step and tell the agent what to do instead — your note runs as
+                            the next message.
+                        </span>
+                        {/* Filled + borderless-at-rest so the redirect reads as a nested field of
+                            the approval card, subordinate to the main composer below. The filled
+                            variant lights its border with the full primary on focus, so we pin
+                            hover/focus to a neutral border and drop the focus glow. */}
+                        <AutosizeTextarea
+                            ref={steerInputRef}
+                            variant="filled"
+                            autoSize={{minRows: 2, maxRows: 6}}
+                            value={steerMessage}
+                            onChange={(e) => setSteerMessage(e.target.value)}
+                            placeholder="e.g. write to staging, not prod — or ask for something else entirely"
+                            disabled={responding}
+                            className="text-xs hover:border-colorBorder focus:border-colorBorder focus:shadow-none"
+                        />
+                        <div className="flex items-center justify-end gap-1.5">
+                            <Button
+                                variant="ghost"
+                                disabled={responding}
+                                className={touchCls}
+                                onClick={() => setSteerOpen(false)}
+                            >
+                                Cancel
+                            </Button>
+                            {/* Default, not primary: Approve is the card's single primary. This is
+                                the confirm for the redirect sub-action, so it stays quiet. */}
+                            <Button
+                                variant="outline"
+                                disabled={responding || !steerMessage.trim()}
+                                className={touchCls}
+                                onClick={() =>
+                                    onRespond({
+                                        approvalId: current.approvalId,
+                                        approved: false,
+                                        message: steerMessage,
+                                    })
+                                }
+                            >
+                                Deny &amp; send
+                            </Button>
+                        </div>
+                    </div>
+                </HeightCollapse>
+            ) : null}
+
+            {/* Always-allow: arms a config write-through so this tool stops asking. The switch
+                only ARMS the intent; the grant is applied when the user clicks Approve. Shown
+                only for gateway / custom-function / builtin gates that aren't already allowed.
+                Collapses while steering — "applies when you approve" contradicts a deny+redirect
+                — as the mirror of the steer panel's expand, for one smooth swap. */}
+            {canAlwaysAllow ? (
+                <HeightCollapse open={!steerOpen} fade inert>
+                    <div className="flex items-center gap-2 border-0 border-t border-solid border-colorBorderSecondary pt-2.5">
+                        <Switch
+                            checked={alwaysAllowArmed}
+                            disabled={responding}
+                            onCheckedChange={setAlwaysAllowArmed}
+                        />
+                        <div className="flex min-w-0 flex-col">
+                            <span className="text-xs text-colorText">
+                                Always allow{" "}
+                                <span className="font-medium">
+                                    {display?.label ?? current.toolName}
+                                </span>{" "}
+                                for this agent
+                            </span>
+                            <span className="text-[11px] text-colorTextSecondary">
+                                Applies when you approve; commit to use it in triggers.
+                            </span>
+                        </div>
+                    </div>
+                </HeightCollapse>
+            ) : null}
+
+            {errorText ? <p className="m-0 text-xs text-colorError">{errorText}</p> : null}
+        </ApprovalCardFrame>
+    )
+}
+
+/**
+ * The card chrome shared by every approval surface: header, identity, headline, body. Actions
+ * arrive as children so the desktop's split-button/steer/always-allow and mobile's touch
+ * targets sit on identical framing.
+ */
+export const ApprovalCardFrame = ({
+    toolName,
+    input,
+    count,
+    friendly = true,
+    headline,
+    body,
+    children,
+    className = "gap-2.5 border border-solid border-colorBorderSecondary bg-colorBgContainer p-3",
+    payloadSurfaceClassName,
+    payloadLabel,
+}: ApprovalCardFrameProps) => {
+    const display = resolveToolDisplay(toolName)
+    return (
+        <div className={`flex flex-col rounded-lg ${className}`}>
+            {/* Header: a quiet primary cue (not an error tint) + the ask + a count when batched. */}
+            <div className="flex items-center gap-2">
+                <ShieldCheck size={15} weight="fill" className="shrink-0 text-colorPrimary" />
+                <span className="text-xs font-medium text-colorText">
+                    Approval needed to continue
+                </span>
+                {count > 1 ? (
+                    <span className="ml-auto text-[11px] tabular-nums text-colorTextSecondary">
+                        1 of {count}
+                    </span>
+                ) : null}
+            </div>
+
+            {/* Identity + ask. Build keeps the raw tool name (debuggers steer by it); Chat folds
+                a humanized name into one sentence — the raw name stays reachable via the title
+                attribute and the payload expander. */}
+            {!friendly ? (
+                <div className="flex min-w-0 items-center gap-2">
+                    <span
+                        className="min-w-0 truncate text-xs font-medium text-colorText"
+                        title={toolName}
+                    >
+                        {toolName}
+                    </span>
+                    {display.source ? (
+                        <span className="shrink-0 rounded border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-1.5 py-px text-[11px] text-colorTextSecondary">
+                            {display.source}
+                        </span>
+                    ) : null}
+                </div>
+            ) : null}
+
+            {headline !== null ? (
+                friendly ? (
+                    <span className="text-xs text-colorTextSecondary" title={toolName}>
+                        {headline ?? (
+                            <>
+                                The agent wants to use{" "}
+                                <span className="font-medium text-colorText">{display.label}</span>
+                                {display.source ? ` from ${display.source}` : ""} before it can keep
+                                going.
+                            </>
+                        )}
+                    </span>
+                ) : (
+                    <span className="text-xs text-colorTextSecondary">
+                        {headline ?? "The agent wants to run this tool before it can keep going."}
+                    </span>
+                )
+            ) : null}
+
+            {body ?? (
+                <PayloadBlock
+                    input={input}
+                    label={payloadLabel ?? (friendly ? "Details" : "Payload")}
+                    surfaceClassName={payloadSurfaceClassName}
+                />
+            )}
+
+            {children}
+        </div>
+    )
+}

--- a/web/packages/agenta-chat/src/components/ApprovalCard.tsx
+++ b/web/packages/agenta-chat/src/components/ApprovalCard.tsx
@@ -348,7 +348,7 @@ export const ApprovalCard = ({
                                                 onClick={() =>
                                                     onDenyAll(approvals.map((a) => a.approvalId))
                                                 }
-                                                className="justify-start text-colorError hover:bg-[var(--ant-color-error-bg)]"
+                                                className="justify-start text-colorError hover:bg-colorErrorBg"
                                             >
                                                 Deny all
                                             </Button>

--- a/web/packages/agenta-chat/src/components/AudioPlayer.tsx
+++ b/web/packages/agenta-chat/src/components/AudioPlayer.tsx
@@ -1,0 +1,133 @@
+import {useEffect, useRef, useState} from "react"
+
+import {Pause, Play} from "@phosphor-icons/react"
+const fmt = (seconds: number): string => {
+    if (!Number.isFinite(seconds) || seconds < 0) return "0:00"
+    const t = Math.floor(seconds)
+    return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`
+}
+
+/**
+ * Inline player for an audio attachment. A voice message should be playable wherever it appears —
+ * in the composer tray before sending, and in the transcript afterwards — so both surfaces share
+ * this rather than showing an inert file chip.
+ */
+const AudioPlayer = ({
+    src,
+    name,
+    className,
+    onError,
+}: {
+    src: string
+    name: string
+    className?: string
+    onError?: () => void
+}) => {
+    const audioRef = useRef<HTMLAudioElement>(null)
+    // True while we nudge the element to resolve an unknown duration (below); the seek would
+    // otherwise show up as a wild current-time reading.
+    const probingRef = useRef(false)
+    const [playing, setPlaying] = useState(false)
+    const [current, setCurrent] = useState(0)
+    const [duration, setDuration] = useState(0)
+
+    useEffect(() => {
+        const el = audioRef.current
+        if (!el) return
+        // A new source voids any probe from the previous one. Without this reset, a src swap mid-probe
+        // leaves probingRef stuck true, which gates off onTimeUpdate below and freezes the timer.
+        probingRef.current = false
+
+        const onPlay = () => setPlaying(true)
+        const onPause = () => setPlaying(false)
+        const onEnded = () => {
+            setPlaying(false)
+            setCurrent(0)
+        }
+        const onTimeUpdate = () => {
+            if (!probingRef.current) setCurrent(el.currentTime)
+        }
+        const finishProbe = () => {
+            el.removeEventListener("timeupdate", finishProbe)
+            if (Number.isFinite(el.duration)) setDuration(el.duration)
+            probingRef.current = false
+            el.currentTime = 0
+            setCurrent(0)
+        }
+        const onLoadedMetadata = () => {
+            if (Number.isFinite(el.duration)) {
+                setDuration(el.duration)
+                return
+            }
+            // A MediaRecorder webm reports an infinite duration until it has been seeked to the
+            // end — so send it there once and read the real value back.
+            probingRef.current = true
+            el.addEventListener("timeupdate", finishProbe)
+            el.currentTime = 1e101
+        }
+
+        el.addEventListener("play", onPlay)
+        el.addEventListener("pause", onPause)
+        el.addEventListener("ended", onEnded)
+        el.addEventListener("timeupdate", onTimeUpdate)
+        el.addEventListener("loadedmetadata", onLoadedMetadata)
+        return () => {
+            el.removeEventListener("play", onPlay)
+            el.removeEventListener("pause", onPause)
+            el.removeEventListener("ended", onEnded)
+            el.removeEventListener("timeupdate", onTimeUpdate)
+            el.removeEventListener("loadedmetadata", onLoadedMetadata)
+            el.removeEventListener("timeupdate", finishProbe)
+        }
+    }, [src])
+
+    const toggle = () => {
+        const el = audioRef.current
+        if (!el) return
+        if (el.paused) el.play().catch(() => {})
+        else el.pause()
+    }
+
+    const progress = duration > 0 ? Math.min(1, current / duration) : 0
+
+    return (
+        <div className={`flex items-center gap-2 ${className ?? ""}`}>
+            <button
+                type="button"
+                onClick={toggle}
+                aria-label={playing ? `Pause ${name}` : `Play ${name}`}
+                className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full border-0 bg-colorFillTertiary text-colorText transition-colors hover:bg-colorFillSecondary"
+            >
+                {playing ? <Pause size={14} weight="fill" /> : <Play size={14} weight="fill" />}
+            </button>
+            {/* Name and time share the top row so they align on one baseline; the bar spans the
+            full width beneath both, rather than the time floating between the two rows. */}
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                <div className="flex items-baseline justify-between gap-2">
+                    <span className="truncate text-xs text-colorText" title={name}>
+                        {name}
+                    </span>
+                    <span className="shrink-0 text-[11px] tabular-nums text-colorTextSecondary">
+                        {fmt(current)}
+                        {duration > 0 ? ` / ${fmt(duration)}` : ""}
+                    </span>
+                </div>
+                <div className="h-0.5 w-full overflow-hidden rounded-full bg-colorFillTertiary">
+                    <div
+                        className="h-full rounded-full bg-colorPrimary"
+                        style={{width: `${progress * 100}%`}}
+                    />
+                </div>
+            </div>
+            <audio
+                ref={audioRef}
+                src={src}
+                preload="metadata"
+                onError={onError}
+                className="hidden"
+            />
+        </div>
+    )
+}
+
+export default AudioPlayer

--- a/web/packages/agenta-chat/src/components/AudioPlayer.tsx
+++ b/web/packages/agenta-chat/src/components/AudioPlayer.tsx
@@ -37,6 +37,11 @@ const AudioPlayer = ({
         // A new source voids any probe from the previous one. Without this reset, a src swap mid-probe
         // leaves probingRef stuck true, which gates off onTimeUpdate below and freezes the timer.
         probingRef.current = false
+        // …and it voids the previous source's readings. `loadedmetadata` for the new one can be a
+        // network round-trip away, and until it fires the row would keep showing the OLD elapsed
+        // time, total and progress fill as if they described the new clip.
+        setCurrent(0)
+        setDuration(0)
 
         const onPlay = () => setPlaying(true)
         const onPause = () => setPlaying(false)

--- a/web/packages/agenta-chat/src/components/ChatComposer.tsx
+++ b/web/packages/agenta-chat/src/components/ChatComposer.tsx
@@ -1,0 +1,170 @@
+/**
+ * THE chat composer — one input for every surface, extracted from the desktop composer dock.
+ * It owns the shared core: the lazy Lexical rich input (markdown, Enter-sends, the send button
+ * that becomes Stop while streaming), the paperclip attach button, the attachments tray in the
+ * input's header slot, and the paste-to-attach path. Host-specific chrome (voice mic, context
+ * budget, onboarding actions) arrives through the `extraPrefix`/`trailing` slots; the
+ * attachment ENGINE (staging + uploads) arrives as the `useComposerAttachments` result so
+ * hosts control the rollout flag and the viewer wiring.
+ */
+import {Suspense, lazy, type ReactNode, type RefObject} from "react"
+
+import {HeightCollapse} from "@agenta/ui/height-collapse"
+import type {RichChatInputHandle} from "@agenta/ui/rich-chat-input"
+import {Button, SimpleTooltip} from "@agenta/ui/ui"
+import {Paperclip} from "@phosphor-icons/react"
+
+import type {useComposerAttachments} from "../hooks/useComposerAttachments"
+
+import ComposerAttachments from "./ComposerAttachments"
+
+// Lexical is the heaviest dependency of the chat chunk — keep it out of the synchronous
+// mount. React.lazy (not next/dynamic) so the imperative handle ref forwards.
+const RichChatInput = lazy(() =>
+    import("@agenta/ui/rich-chat-input").then((m) => ({default: m.RichChatInput})),
+)
+
+export interface ChatComposerProps {
+    onSubmit: (text: string) => void | Promise<void>
+    /** The attachment engine — staging, guardrails, uploads (see useComposerAttachments). */
+    attachments: ReturnType<typeof useComposerAttachments>
+    inputRef?: RefObject<RichChatInputHandle | null>
+    autoFocus?: boolean
+    /** Voice dictation is writing into the input (desktop). */
+    dictating?: boolean
+    /** Width column for the input (desktop passes its chat column; mobile's rail is outside). */
+    className?: string
+    disabled?: boolean
+    hideSendButton?: boolean
+    /** Full placeholder override; when absent, `waitingOnUser` picks the queue message. */
+    placeholder?: string
+    /** The run is parked on the user (HITL) — new sends will queue. */
+    waitingOnUser?: boolean
+    initialMarkdown?: string
+    onChange?: (markdown: string) => void
+    /** A run is streaming — the send button becomes Stop. */
+    streaming?: boolean
+    onStop?: () => void
+    /** Read at event time — attachments are refused right now (a voice take in flight…). */
+    attachmentsBlocked?: () => boolean
+    /** The composer itself is unusable (gates the paperclip alongside `uploadsEnabled`). */
+    composerDisabled?: boolean
+    /** Open a viewable attachment in the host's viewer; omit to disable tile clicks. */
+    onViewAttachment?: (uid: string) => void
+    /** Left of the paperclip: host extras (voice mic, context budget). */
+    extraPrefix?: ReactNode
+    /** The input's trailing slot (onboarding actions). */
+    trailing?: ReactNode
+    /** Suspense fallback while the Lexical chunk hydrates (hosts pass their skeleton). */
+    fallback?: ReactNode
+}
+
+export const ChatComposer = ({
+    onSubmit,
+    attachments,
+    inputRef,
+    autoFocus,
+    dictating,
+    className,
+    disabled,
+    hideSendButton,
+    placeholder,
+    waitingOnUser,
+    initialMarkdown,
+    onChange,
+    streaming,
+    onStop,
+    attachmentsBlocked,
+    composerDisabled,
+    onViewAttachment,
+    extraPrefix,
+    trailing,
+    fallback,
+}: ChatComposerProps) => {
+    const {
+        uploadsEnabled,
+        files,
+        rejections,
+        setRejections,
+        attachmentsOpen,
+        setAttachmentsOpen,
+        limits,
+        atMax,
+        attachmentsSettled,
+        uploadBlockReason,
+        addFiles,
+        removeFile,
+        uploads,
+    } = attachments
+
+    return (
+        <Suspense fallback={fallback ?? null}>
+            <RichChatInput
+                ref={inputRef}
+                autoFocus={autoFocus}
+                dictating={dictating}
+                className={className}
+                onSubmit={onSubmit}
+                disabled={disabled}
+                hideSendButton={hideSendButton}
+                placeholder={
+                    placeholder ??
+                    (waitingOnUser
+                        ? "The agent is waiting for your response — new messages will be queued"
+                        : "Ask the agent… (Enter to send, ⌘/Ctrl+Enter for newline)")
+                }
+                initialMarkdown={initialMarkdown}
+                onChange={onChange}
+                onPasteFile={(pasted) => {
+                    if (!attachmentsBlocked?.()) addFiles(Array.from(pasted))
+                }}
+                sendForceEnabled={files.length > 0 && attachmentsSettled}
+                sendDisabled={files.length > 0 && !attachmentsSettled}
+                sendDisabledReason={uploadBlockReason}
+                streaming={streaming}
+                onStop={onStop}
+                prefix={
+                    <div className="flex items-center gap-2">
+                        {extraPrefix}
+                        {/* Gate the attach button until inline file parts are supported. */}
+                        <SimpleTooltip
+                            title={
+                                !uploadsEnabled
+                                    ? "Attach files coming soon"
+                                    : atMax
+                                      ? `Up to ${limits.maxCount} files`
+                                      : "Attach files"
+                            }
+                        >
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                disabled={!uploadsEnabled || composerDisabled}
+                                onClick={() => setAttachmentsOpen((open) => !open)}
+                                aria-label="Attach files"
+                            >
+                                <Paperclip size={16} />
+                            </Button>
+                        </SimpleTooltip>
+                    </div>
+                }
+                header={
+                    <HeightCollapse open={attachmentsOpen || files.length > 0}>
+                        <ComposerAttachments
+                            files={files}
+                            rejections={rejections}
+                            limits={limits}
+                            onAdd={addFiles}
+                            onRemove={removeFile}
+                            onDismissRejections={() => setRejections([])}
+                            onView={uploadsEnabled ? onViewAttachment : undefined}
+                            onRetry={uploads.retry}
+                            canRetry={uploads.canRetry}
+                        />
+                    </HeightCollapse>
+                }
+                trailing={trailing}
+            />
+        </Suspense>
+    )
+}

--- a/web/packages/agenta-chat/src/components/ComposerAttachments.tsx
+++ b/web/packages/agenta-chat/src/components/ComposerAttachments.tsx
@@ -109,7 +109,7 @@ const StatusOverlay = ({
     if (file.status === "error") {
         return (
             <SimpleTooltip title={typeof file.error === "string" ? file.error : "Upload failed"}>
-                <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-[var(--ant-color-error-bg)] ring-1 ring-inset ring-colorError">
+                <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-colorErrorBg ring-1 ring-inset ring-colorError">
                     {onRetry && canRetry && (
                         <button
                             type="button"
@@ -132,24 +132,57 @@ const StatusOverlay = ({
     return null
 }
 
-/** Shared chip shell: fixed height, one border treatment, room for a trailing remove. */
+/** Shared chip shell: fixed height, one border treatment, room for a trailing remove. Never
+ * interactive itself — see `ViewSurface`. */
 const Chip = ({
     children,
     className,
-    onClick,
+    interactive,
 }: {
     children: ReactNode
     className?: string
-    onClick?: () => void
+    /** The chip contains a view affordance: light up its border on hover like a clickable tile. */
+    interactive?: boolean
 }) => (
     <div
-        role={onClick ? "button" : undefined}
-        onClick={onClick}
-        className={`flex ${TILE} items-center gap-2 rounded-lg border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-2 ${onClick ? "cursor-pointer hover:border-colorBorder" : ""} ${className ?? ""}`}
+        className={`flex ${TILE} items-center gap-2 rounded-lg border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-2 ${interactive ? "hover:border-colorBorder" : ""} ${className ?? ""}`}
     >
         {children}
     </div>
 )
+
+/**
+ * The "open this attachment in the viewer" affordance: a real `<button>` when there is somewhere
+ * to open it, an inert box otherwise.
+ *
+ * It wraps only the tile's CONTENT, never the whole tile — every tile also carries a Remove
+ * `<button>`, and a button inside a button is invalid and unreachable. So the two interactive
+ * parts are siblings. (Previously the tile itself took `role="button"` + `onClick` with no
+ * `tabIndex` and no key handling, which left the view action keyboard-inaccessible entirely.)
+ */
+const ViewSurface = ({
+    onView,
+    name,
+    className,
+    children,
+}: {
+    onView?: () => void
+    name: string
+    className?: string
+    children: ReactNode
+}) =>
+    onView ? (
+        <button
+            type="button"
+            aria-label={`View ${name}`}
+            onClick={onView}
+            className={`cursor-pointer border-0 bg-transparent p-0 text-left ${className ?? ""}`}
+        >
+            {children}
+        </button>
+    ) : (
+        <div className={className}>{children}</div>
+    )
 
 interface ComposerAttachmentsProps {
     files: UploadFile[]
@@ -191,20 +224,56 @@ const ComposerAttachments = ({
     const [previewFailed, setPreviewFailed] = useState<Set<string>>(new Set())
     const atMax = files.length >= limits.maxCount
 
-    // Object URLs for image previews and audio playback, recreated when the list changes and
-    // revoked on cleanup (the list is small, ≤ maxCount). Without revoking, removed files leak.
+    // Object URLs for image previews and audio playback, minted ONCE per row and released only
+    // when that row (or its blob) actually goes away.
+    //
+    // Keyed by uid rather than rebuilt from the array: `files` gets a fresh identity on every
+    // upload progress tick (the tray's `patch` maps the whole list), so revoking and re-minting
+    // whenever the identity changes ran many times a second mid-upload — which handed every <img>
+    // and <audio> a new `src` each tick (thumbnail flicker, playback restarting from zero) and let
+    // a decode against a just-revoked URL latch `previewFailed` for the rest of the session.
+    const urlsRef = useRef(new Map<string, {file: File; url: string}>())
     useEffect(() => {
-        const next: Record<string, string> = {}
+        const urls = urlsRef.current
+        const live = new Set<string>()
+        const remade: string[] = []
+        let changed = false
         files.forEach((f) => {
             const file = f.originFileObj as File | undefined
             const type = file?.type || ""
-            if (file && (type.startsWith("image/") || type.startsWith("audio/"))) {
-                next[f.uid] = URL.createObjectURL(file)
-            }
+            if (!file || !(type.startsWith("image/") || type.startsWith("audio/"))) return
+            live.add(f.uid)
+            const existing = urls.get(f.uid)
+            if (existing?.file === file) return
+            if (existing) URL.revokeObjectURL(existing.url)
+            urls.set(f.uid, {file, url: URL.createObjectURL(file)})
+            remade.push(f.uid)
+            changed = true
         })
-        setPreviews(next)
-        return () => Object.values(next).forEach((u) => URL.revokeObjectURL(u))
+        for (const [uid, entry] of urls) {
+            if (live.has(uid)) continue
+            URL.revokeObjectURL(entry.url)
+            urls.delete(uid)
+            changed = true
+        }
+        if (!changed) return
+        setPreviews(Object.fromEntries([...urls].map(([uid, entry]) => [uid, entry.url])))
+        // A fresh URL deserves a fresh attempt, and a gone row shouldn't keep its verdict —
+        // otherwise nothing ever clears this and the fallback sticks.
+        setPreviewFailed((prev) => {
+            const next = new Set([...prev].filter((uid) => live.has(uid)))
+            remade.forEach((uid) => next.delete(uid))
+            return next.size === prev.size ? prev : next
+        })
     }, [files])
+    // Release whatever is still held when the tray goes away.
+    useEffect(() => {
+        const urls = urlsRef.current
+        return () => {
+            urls.forEach((entry) => URL.revokeObjectURL(entry.url))
+            urls.clear()
+        }
+    }, [])
 
     // A newly added tile lands at the end of the band, which may be off-screen once the row
     // scrolls — bring it into view so attaching something always shows it. `scroll-smooth` on the
@@ -249,7 +318,7 @@ const ComposerAttachments = ({
                             exit={{opacity: 0, height: 0}}
                             className="overflow-hidden"
                         >
-                            <div className="flex flex-col gap-1 rounded-md bg-[var(--ant-color-error-bg)] px-2.5 py-1.5">
+                            <div className="flex flex-col gap-1 rounded-md bg-colorErrorBg px-2.5 py-1.5">
                                 {rejections.map((r) => (
                                     <div
                                         key={`${r.name}-${r.reason}`}
@@ -331,20 +400,21 @@ const ComposerAttachments = ({
                                                 </Chip>
                                             ) : type.startsWith("image/") && url ? (
                                                 <div
-                                                    role={onView ? "button" : undefined}
-                                                    aria-label={
-                                                        onView ? `View ${f.name}` : undefined
-                                                    }
-                                                    onClick={() => onView?.(f.uid)}
-                                                    className={`group relative ${TILE} w-12 overflow-hidden rounded-lg border border-solid border-colorBorderSecondary ${onView ? "cursor-pointer" : ""}`}
+                                                    className={`group relative ${TILE} w-12 overflow-hidden rounded-lg border border-solid border-colorBorderSecondary`}
                                                 >
-                                                    {previewFailed.has(f.uid) ? (
-                                                        <div className="flex h-full w-full items-center justify-center bg-colorFillQuaternary text-colorTextTertiary">
-                                                            <ImageBroken size={18} />
-                                                        </div>
-                                                    ) : (
-                                                        <>
-                                                            {/* Local object URL — next/image can't optimize a blob. */}
+                                                    <ViewSurface
+                                                        onView={
+                                                            onView ? () => onView(f.uid) : undefined
+                                                        }
+                                                        name={f.name}
+                                                        className="block h-full w-full"
+                                                    >
+                                                        {previewFailed.has(f.uid) ? (
+                                                            <div className="flex h-full w-full items-center justify-center bg-colorFillQuaternary text-colorTextTertiary">
+                                                                <ImageBroken size={18} />
+                                                            </div>
+                                                        ) : (
+                                                            /* Local object URL — next/image can't optimize a blob. */
                                                             <img
                                                                 src={url}
                                                                 alt={f.name}
@@ -355,8 +425,8 @@ const ComposerAttachments = ({
                                                                 }
                                                                 className="h-full w-full object-cover"
                                                             />
-                                                        </>
-                                                    )}
+                                                        )}
+                                                    </ViewSurface>
                                                     <RemoveButton
                                                         name={f.name}
                                                         onRemove={remove}
@@ -366,29 +436,35 @@ const ComposerAttachments = ({
                                             ) : (
                                                 <Chip
                                                     className="max-w-[200px]"
-                                                    onClick={
-                                                        onView && isViewable(type)
-                                                            ? () => onView(f.uid)
-                                                            : undefined
-                                                    }
+                                                    interactive={!!onView && isViewable(type)}
                                                 >
-                                                    <Icon
-                                                        size={18}
-                                                        className="shrink-0 text-colorTextSecondary"
-                                                    />
-                                                    <div className="flex min-w-0 flex-col">
-                                                        <span
-                                                            className="truncate text-xs text-colorText"
-                                                            title={f.name}
-                                                        >
-                                                            {f.name}
-                                                        </span>
-                                                        {size && (
-                                                            <span className="text-[11px] text-colorTextSecondary">
-                                                                {size}
+                                                    <ViewSurface
+                                                        onView={
+                                                            onView && isViewable(type)
+                                                                ? () => onView(f.uid)
+                                                                : undefined
+                                                        }
+                                                        name={f.name}
+                                                        className="flex min-w-0 flex-1 items-center gap-2"
+                                                    >
+                                                        <Icon
+                                                            size={18}
+                                                            className="shrink-0 text-colorTextSecondary"
+                                                        />
+                                                        <div className="flex min-w-0 flex-col">
+                                                            <span
+                                                                className="truncate text-xs text-colorText"
+                                                                title={f.name}
+                                                            >
+                                                                {f.name}
                                                             </span>
-                                                        )}
-                                                    </div>
+                                                            {size && (
+                                                                <span className="text-[11px] text-colorTextSecondary">
+                                                                    {size}
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </ViewSurface>
                                                     <RemoveButton name={f.name} onRemove={remove} />
                                                 </Chip>
                                             )}

--- a/web/packages/agenta-chat/src/components/ComposerAttachments.tsx
+++ b/web/packages/agenta-chat/src/components/ComposerAttachments.tsx
@@ -1,0 +1,433 @@
+import {useEffect, useRef, useState, type ReactNode} from "react"
+
+import {SimpleTooltip} from "@agenta/ui/ui"
+import {
+    ArrowClockwise,
+    File as FileIcon,
+    FileText,
+    Image as ImageIcon,
+    ImageBroken,
+    Plus,
+    UploadSimple,
+    WarningCircle,
+    X,
+} from "@phosphor-icons/react"
+import {AnimatePresence, MotionConfig, motion} from "motion/react"
+
+import {
+    acceptAttrFor,
+    type AttachmentLimits,
+    type AttachmentRejection,
+    describeAccepted,
+    formatBytes,
+} from "../assets"
+import {isViewable} from "../assets/attachmentRules"
+import {SESSION_SPRING} from "../assets/motion"
+import type {StagedUpload as UploadFile} from "../model"
+
+import AudioPlayer from "./AudioPlayer"
+
+/** Every tile is the same height, so a row mixing thumbnails, clips and file chips reads as one
+ * band rather than a ragged line. */
+const TILE = "h-12"
+
+/** Items scale in on add and out on remove; `layout` on each one makes the survivors slide into
+ * place instead of jumping. */
+const ITEM_VARIANTS = {
+    initial: {opacity: 0, scale: 0.85},
+    animate: {opacity: 1, scale: 1},
+    exit: {opacity: 0, scale: 0.85},
+}
+
+const iconForType = (mediaType: string) => {
+    if (mediaType.startsWith("image/")) return ImageIcon
+    if (mediaType === "application/pdf" || mediaType.startsWith("text/")) return FileText
+    return FileIcon
+}
+
+/** Shared remove affordance so every tile type dismisses the same way. */
+const RemoveButton = ({
+    name,
+    onRemove,
+    overlay,
+    persistent,
+}: {
+    name: string
+    onRemove: () => void
+    /** Sits on top of a thumbnail rather than inline in a chip. */
+    overlay?: boolean
+    /** Skips the hover reveal: on a scrimmed tile a hidden control reads as no control. */
+    persistent?: boolean
+}) => (
+    <button
+        type="button"
+        aria-label={`Remove ${name}`}
+        onClick={(e) => {
+            e.stopPropagation()
+            onRemove()
+        }}
+        className={
+            overlay
+                ? `absolute right-1 top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border-0 bg-[rgba(0,0,0,0.6)] text-white transition-opacity ${persistent ? "" : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"}`
+                : "flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full border-0 bg-transparent text-colorTextTertiary transition-colors hover:bg-colorFillTertiary hover:text-colorText"
+        }
+    >
+        <X size={11} weight="bold" />
+    </button>
+)
+
+/** Upload state drawn over a tile: a progress scrim while uploading, a retry-able error otherwise.
+ * Reads antd's `UploadFile` fields, so the upload flow only has to set status/percent. */
+const StatusOverlay = ({
+    file,
+    onRetry,
+    canRetry,
+    onRemove,
+}: {
+    file: UploadFile
+    onRetry?: (uid: string) => void
+    canRetry: boolean
+    onRemove: () => void
+}) => {
+    if (file.status === "uploading") {
+        const pct = Math.max(0, Math.min(100, Math.round(file.percent ?? 0)))
+        return (
+            <>
+                <div className="pointer-events-none absolute inset-0 rounded-lg bg-[rgba(0,0,0,0.4)]" />
+                <div className="pointer-events-none absolute inset-x-1.5 bottom-1.5 flex items-center gap-1.5">
+                    <div className="h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-[rgba(255,255,255,0.3)]">
+                        <div
+                            className="h-full rounded-full bg-colorPrimary transition-[width] duration-150"
+                            style={{width: `${pct}%`}}
+                        />
+                    </div>
+                    <span className="text-[10px] font-medium tabular-nums text-white">{pct}%</span>
+                </div>
+            </>
+        )
+    }
+    if (file.status === "error") {
+        return (
+            <SimpleTooltip title={typeof file.error === "string" ? file.error : "Upload failed"}>
+                <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-[var(--ant-color-error-bg)] ring-1 ring-inset ring-colorError">
+                    {onRetry && canRetry && (
+                        <button
+                            type="button"
+                            aria-label={`Retry ${file.name}`}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onRetry(file.uid)
+                            }}
+                            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-full border-0 bg-colorError text-white"
+                        >
+                            <ArrowClockwise size={14} weight="bold" />
+                        </button>
+                    )}
+                    {/* The scrim covers the tile's own remove, so a failure must stay removable here. */}
+                    <RemoveButton name={file.name} onRemove={onRemove} overlay persistent />
+                </div>
+            </SimpleTooltip>
+        )
+    }
+    return null
+}
+
+/** Shared chip shell: fixed height, one border treatment, room for a trailing remove. */
+const Chip = ({
+    children,
+    className,
+    onClick,
+}: {
+    children: ReactNode
+    className?: string
+    onClick?: () => void
+}) => (
+    <div
+        role={onClick ? "button" : undefined}
+        onClick={onClick}
+        className={`flex ${TILE} items-center gap-2 rounded-lg border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-2 ${onClick ? "cursor-pointer hover:border-colorBorder" : ""} ${className ?? ""}`}
+    >
+        {children}
+    </div>
+)
+
+interface ComposerAttachmentsProps {
+    files: UploadFile[]
+    rejections: AttachmentRejection[]
+    limits: AttachmentLimits
+    /** Add picked files through the caller's guardrails (`validateIncoming`). */
+    onAdd: (incoming: File[]) => void
+    onRemove: (uid: string) => void
+    onDismissRejections: () => void
+    /** Open a viewable attachment (image/document) in the Files drawer. */
+    onView?: (uid: string) => void
+    /** Retry a failed upload (wired to the upload flow). */
+    onRetry?: (uid: string) => void
+    /** Whether this upload error can be retried. */
+    canRetry?: (uid: string) => boolean
+}
+
+/**
+ * The composer's attachment panel: a borderless click/drop dropzone when empty, otherwise one band
+ * of equal-height tiles — image thumbnails, playable audio clips and file chips — plus inline
+ * rejection messages and a counter. Custom (not antd X `Attachments`) so the tiles stay small, the
+ * surface has no nested border, and multi-select / multi-drop work. Drag-and-drop onto the whole
+ * panel is owned by the parent; this renders the click path and the file list.
+ */
+const ComposerAttachments = ({
+    files,
+    rejections,
+    limits,
+    onAdd,
+    onRemove,
+    onDismissRejections,
+    onView,
+    onRetry,
+    canRetry,
+}: ComposerAttachmentsProps) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    const [previews, setPreviews] = useState<Record<string, string>>({})
+    // Thumbnails whose object URL failed to decode (corrupt / unsupported image) — show a fallback.
+    const [previewFailed, setPreviewFailed] = useState<Set<string>>(new Set())
+    const atMax = files.length >= limits.maxCount
+
+    // Object URLs for image previews and audio playback, recreated when the list changes and
+    // revoked on cleanup (the list is small, ≤ maxCount). Without revoking, removed files leak.
+    useEffect(() => {
+        const next: Record<string, string> = {}
+        files.forEach((f) => {
+            const file = f.originFileObj as File | undefined
+            const type = file?.type || ""
+            if (file && (type.startsWith("image/") || type.startsWith("audio/"))) {
+                next[f.uid] = URL.createObjectURL(file)
+            }
+        })
+        setPreviews(next)
+        return () => Object.values(next).forEach((u) => URL.revokeObjectURL(u))
+    }, [files])
+
+    // A newly added tile lands at the end of the band, which may be off-screen once the row
+    // scrolls — bring it into view so attaching something always shows it. `scroll-smooth` on the
+    // container is motion-safe, so this respects reduced-motion for free.
+    const scrollRef = useRef<HTMLDivElement>(null)
+    const previousCount = useRef(files.length)
+    useEffect(() => {
+        if (files.length > previousCount.current) {
+            requestAnimationFrame(() => {
+                const el = scrollRef.current
+                if (el) el.scrollLeft = el.scrollWidth
+            })
+        }
+        previousCount.current = files.length
+    }, [files.length])
+
+    const pick = () => inputRef.current?.click()
+    const onInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const list = e.target.files
+        if (list && list.length) onAdd(Array.from(list))
+        e.target.value = "" // let the same file be re-picked after a remove
+    }
+
+    return (
+        <MotionConfig transition={SESSION_SPRING}>
+            <div className="flex flex-col gap-2 p-2">
+                <input
+                    ref={inputRef}
+                    type="file"
+                    multiple
+                    accept={acceptAttrFor(limits)}
+                    onChange={onInput}
+                    className="hidden"
+                />
+
+                <AnimatePresence initial={false}>
+                    {rejections.length > 0 && (
+                        <motion.div
+                            key="rejections"
+                            initial={{opacity: 0, height: 0}}
+                            animate={{opacity: 1, height: "auto"}}
+                            exit={{opacity: 0, height: 0}}
+                            className="overflow-hidden"
+                        >
+                            <div className="flex flex-col gap-1 rounded-md bg-[var(--ant-color-error-bg)] px-2.5 py-1.5">
+                                {rejections.map((r) => (
+                                    <div
+                                        key={`${r.name}-${r.reason}`}
+                                        className="flex items-center gap-1.5 text-xs text-colorError"
+                                    >
+                                        <WarningCircle
+                                            size={13}
+                                            weight="fill"
+                                            className="shrink-0"
+                                        />
+                                        <span className="min-w-0 truncate">
+                                            <span className="font-medium">{r.name}</span> {r.reason}
+                                        </span>
+                                    </div>
+                                ))}
+                                <button
+                                    type="button"
+                                    onClick={onDismissRejections}
+                                    className="flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-0 py-0 text-[11px] text-colorError hover:underline"
+                                >
+                                    <X size={11} /> Dismiss
+                                </button>
+                            </div>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+
+                {files.length === 0 ? (
+                    <button
+                        type="button"
+                        onClick={pick}
+                        className="flex w-full cursor-pointer flex-col items-center gap-1 rounded-lg border-0 bg-transparent px-3 py-3 text-center transition-colors hover:bg-colorFillQuaternary"
+                    >
+                        <UploadSimple size={18} className="text-colorTextTertiary" />
+                        <span className="text-xs font-medium text-colorText">Attach files</span>
+                        <span className="text-[11px] text-colorTextSecondary">
+                            {describeAccepted(limits)} · up to {limits.maxCount} files
+                        </span>
+                    </button>
+                ) : (
+                    <div className="flex items-center gap-2">
+                        {/* One scrolling band rather than wrapping: five audio clips would otherwise
+                        stack into five rows and push the composer down the screen. Mirrors the
+                        session tag bar — contained overscroll so it can't chain to the page, and no
+                        visible scrollbar under a 48px strip. */}
+                        <div
+                            ref={scrollRef}
+                            className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto overscroll-x-contain py-0.5 motion-safe:scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                        >
+                            {/* popLayout: a removed tile leaves the flow at once, so the rest close
+                            the gap while it animates out rather than after. */}
+                            <AnimatePresence initial={false} mode="popLayout">
+                                {files.map((f) => {
+                                    const file = f.originFileObj as File | undefined
+                                    const type = file?.type || ""
+                                    const Icon = iconForType(type)
+                                    const size = file ? formatBytes(file.size) : ""
+                                    const url = previews[f.uid]
+                                    const remove = () => onRemove(f.uid)
+
+                                    return (
+                                        <motion.div
+                                            key={f.uid}
+                                            layout
+                                            className="relative shrink-0"
+                                            variants={ITEM_VARIANTS}
+                                            initial="initial"
+                                            animate="animate"
+                                            exit="exit"
+                                        >
+                                            {type.startsWith("audio/") && url ? (
+                                                <Chip className="w-[248px]">
+                                                    <AudioPlayer
+                                                        src={url}
+                                                        name={f.name}
+                                                        className="min-w-0 flex-1"
+                                                    />
+                                                    <RemoveButton name={f.name} onRemove={remove} />
+                                                </Chip>
+                                            ) : type.startsWith("image/") && url ? (
+                                                <div
+                                                    role={onView ? "button" : undefined}
+                                                    aria-label={
+                                                        onView ? `View ${f.name}` : undefined
+                                                    }
+                                                    onClick={() => onView?.(f.uid)}
+                                                    className={`group relative ${TILE} w-12 overflow-hidden rounded-lg border border-solid border-colorBorderSecondary ${onView ? "cursor-pointer" : ""}`}
+                                                >
+                                                    {previewFailed.has(f.uid) ? (
+                                                        <div className="flex h-full w-full items-center justify-center bg-colorFillQuaternary text-colorTextTertiary">
+                                                            <ImageBroken size={18} />
+                                                        </div>
+                                                    ) : (
+                                                        <>
+                                                            {/* Local object URL — next/image can't optimize a blob. */}
+                                                            <img
+                                                                src={url}
+                                                                alt={f.name}
+                                                                onError={() =>
+                                                                    setPreviewFailed((prev) =>
+                                                                        new Set(prev).add(f.uid),
+                                                                    )
+                                                                }
+                                                                className="h-full w-full object-cover"
+                                                            />
+                                                        </>
+                                                    )}
+                                                    <RemoveButton
+                                                        name={f.name}
+                                                        onRemove={remove}
+                                                        overlay
+                                                    />
+                                                </div>
+                                            ) : (
+                                                <Chip
+                                                    className="max-w-[200px]"
+                                                    onClick={
+                                                        onView && isViewable(type)
+                                                            ? () => onView(f.uid)
+                                                            : undefined
+                                                    }
+                                                >
+                                                    <Icon
+                                                        size={18}
+                                                        className="shrink-0 text-colorTextSecondary"
+                                                    />
+                                                    <div className="flex min-w-0 flex-col">
+                                                        <span
+                                                            className="truncate text-xs text-colorText"
+                                                            title={f.name}
+                                                        >
+                                                            {f.name}
+                                                        </span>
+                                                        {size && (
+                                                            <span className="text-[11px] text-colorTextSecondary">
+                                                                {size}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                    <RemoveButton name={f.name} onRemove={remove} />
+                                                </Chip>
+                                            )}
+                                            <StatusOverlay
+                                                file={f}
+                                                onRetry={onRetry}
+                                                canRetry={canRetry?.(f.uid) ?? true}
+                                                onRemove={remove}
+                                            />
+                                        </motion.div>
+                                    )
+                                })}
+                            </AnimatePresence>
+
+                            {!atMax && (
+                                <motion.div layout className="shrink-0">
+                                    <SimpleTooltip title="Add more">
+                                        <button
+                                            type="button"
+                                            onClick={pick}
+                                            aria-label="Add more files"
+                                            className={`flex ${TILE} w-12 cursor-pointer items-center justify-center rounded-lg border border-dashed border-colorBorder bg-transparent text-colorTextTertiary transition-colors hover:border-colorPrimary hover:bg-colorFillQuaternary hover:text-colorPrimary`}
+                                        >
+                                            <Plus size={16} />
+                                        </button>
+                                    </SimpleTooltip>
+                                </motion.div>
+                            )}
+                        </div>
+
+                        {/* Outside the scroller: the count must stay put rather than scroll away. */}
+                        <span className="shrink-0 text-[11px] tabular-nums text-colorTextTertiary">
+                            {files.length} / {limits.maxCount}
+                        </span>
+                    </div>
+                )}
+            </div>
+        </MotionConfig>
+    )
+}
+
+export default ComposerAttachments

--- a/web/packages/agenta-chat/src/components/index.ts
+++ b/web/packages/agenta-chat/src/components/index.ts
@@ -1,0 +1,11 @@
+export {
+    ApprovalCard,
+    ApprovalCardFrame,
+    PayloadBlock,
+    inputPreview,
+    type ApprovalCardProps,
+    type ApprovalCardFrameProps,
+} from "./ApprovalCard"
+export {ChatComposer, type ChatComposerProps} from "./ChatComposer"
+export {default as ComposerAttachments} from "./ComposerAttachments"
+export {default as AudioPlayer} from "./AudioPlayer"

--- a/web/packages/agenta-chat/src/hooks/index.ts
+++ b/web/packages/agenta-chat/src/hooks/index.ts
@@ -1,5 +1,7 @@
 export * from "./useAgentChatQueue"
 export * from "./useAgentModelKeyStatus"
 export * from "./useComposerAttachments"
+export * from "./useAttachmentUploads"
 export * from "./useApprovalDock"
 export * from "./useAgentConversation"
+export * from "./useAlwaysAllowTool"

--- a/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
@@ -1,10 +1,7 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/hooks/useAgentChatQueue.ts
-// (2026-07-25); the OSS original remains authoritative for the desktop chat until the re-plumb
-// PR deletes it. Keep byte-parity if either side changes.
-// Adaptations: none — every import already resolves to an allowed package dep.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import {useCallback, useEffect, useRef, useState} from "react"
 
-import {canReleaseQueuedMessage, isHitlPending} from "@agenta/playground"
+import {canReleaseQueuedMessage, isHitlPending} from "@agenta/playground/agent-chat"
 import {generateId} from "@agenta/shared/utils"
 import type {FileUIPart, UIMessage} from "ai"
 

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -16,7 +16,11 @@
 // Deliberately omitted (desktop-only): the model-key composer gate — compose `useAgentModelKeyStatus` in the skin instead.
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
-import {revalidateSessionMountsAtom, revalidateSessionRecordsAtom} from "@agenta/entities/session"
+import {
+    revalidateSessionMountsAtom,
+    revalidateSessionRecordsAtom,
+    shouldAdoptServerTranscript,
+} from "@agenta/entities/session"
 import {markTraceAsFresh} from "@agenta/entities/trace"
 import {
     agentShouldResumeAfterApproval,
@@ -45,6 +49,7 @@ import {clearSessionFresh, composerDraftBySession, isSessionFresh} from "../stat
 import {
     persistSessionMessagesAtom,
     sessionMessagesAtom,
+    sessionRecordCountsReadAtom,
     setSessionStatusAtom,
 } from "../state/sessionMessages"
 import {AgentChatTransport} from "../transport/AgentChatTransport"
@@ -164,6 +169,16 @@ export const useAgentConversation = ({
     // Restored (not live-streamed) message ids — the orphaned-resume detection reads this, and a
     // skin can use it to skip entrance animations for restored rows.
     const restoredIdsRef = useRef<Set<string>>(new Set(initialMessages.map((m) => m.id)))
+    // How many durable records the transcript we're RENDERING was built from — the exact test for
+    // "has the server moved on?" (#5530). A message count cannot see a turn grow IN PLACE:
+    // `transcriptToMessages` folds a paused turn into its resume and only closes a message on
+    // `done`, so a mid-approval snapshot and the completed turn have the SAME message count, and a
+    // count-only guard rejects the finished server copy forever. Seeded from the watermark the
+    // cached transcript was persisted with; cleared when a live turn supersedes it (we can't know
+    // what the server logged for that one), so the next open re-syncs from the log.
+    const recordWatermarkRef = useRef<number | undefined>(
+        store.get(sessionRecordCountsReadAtom)[sessionId],
+    )
 
     // `useChat` pins its `Chat` (and thus this transport) for the life of the session `id`; it is
     // NOT recreated when `entityId` changes. So the request builder must read the CURRENT entity
@@ -258,6 +273,44 @@ export const useAgentConversation = ({
     // Set when server hydration for a KNOWN (non-fresh, uncached) session returns no records —
     // its durable history was pruned by retention or never persisted.
     const [historyUnavailable, setHistoryUnavailable] = useState(false)
+
+    /**
+     * THE adoption guard — one implementation for every path that can hand us a server transcript
+     * (hydration, its background revalidation, revalidate-on-open, and the pushed `revalidate`).
+     * They used to carry near-identical copies that had already drifted (only one cleared the
+     * history-unavailable notice) and all of them compared MESSAGE COUNTS only, so an in-place turn
+     * completion — an approval resolving into the same assistant message — was silently skipped.
+     * The rule itself is the shared `shouldAdoptServerTranscript`: the record watermark is the
+     * trigger, the message count only a floor. Returns whether it adopted.
+     */
+    const adoptServerTranscript = useCallback(
+        (transcript: SessionTranscript | null): boolean => {
+            if (!transcript) return false
+            const {messages: serverMsgs, recordCount} = transcript
+            const adopt = shouldAdoptServerTranscript({
+                serverRecordCount: recordCount,
+                serverMessageCount: serverMsgs.length,
+                localMessageCount: messagesRef.current.length,
+                watermark: recordWatermarkRef.current,
+                busy: busyRef.current,
+            })
+            if (!adopt) return false
+            serverMsgs.forEach((m) => restoredIdsRef.current.add(m.id))
+            // Adopting a non-empty server transcript settles the question the notice asks, so it
+            // clears here for every path (the revalidate copy did this, the hydration one didn't).
+            setHistoryUnavailable(false)
+            // Written synchronously, ahead of any React commit: `messagesRef` lags a commit behind,
+            // so two deliveries landing back-to-back (the disk-restored result and the background
+            // refetch) can both see the pre-adoption transcript. It is this watermark, not the
+            // on-screen length, that keeps the guard order-independent.
+            recordWatermarkRef.current = recordCount
+            setMessages(serverMsgs)
+            persistMessages({id: sessionId, messages: serverMsgs, recordCount})
+            return true
+        },
+        [persistMessages, sessionId, setMessages],
+    )
+
     useEffect(() => {
         // A session created brand-new in this browser and not yet run has no backend records —
         // skip the guaranteed-empty query (cleared on first send; after a reload it re-hydrates).
@@ -269,34 +322,28 @@ export const useAgentConversation = ({
         // StrictMode's mount→unmount→mount cycle re-runs the fetch (the first run is cancelled)
         // instead of latching a ref that leaves the transcript blank.
         let cancelled = false
+        // The background refetch can land BEFORE the promise handler below runs (both are
+        // microtasks racing) and `messagesRef` only catches up on the next commit — so record here,
+        // not from what's on screen, that real history was already adopted.
+        let adopted = false
         // Post-restore revalidation: the first result may be the disk-restored log (paints
         // instantly); when the guaranteed background refetch lands, adopt it under the same
-        // guards as the revalidate-on-open effect below — never mid-stream, only when ahead.
-        const adoptRefreshed = ({messages: freshMsgs, recordCount}: SessionTranscript) => {
-            if (cancelled || busyRef.current) return
-            if (freshMsgs.length <= messagesRef.current.length) return
-            freshMsgs.forEach((m) => restoredIdsRef.current.add(m.id))
-            // The restore said "no records" but the server has some — clear the notice.
-            setHistoryUnavailable(false)
-            setMessages(freshMsgs)
-            persistMessages({id: sessionId, messages: freshMsgs, recordCount})
-        }
-        loadSessionMessages(sessionId, adoptRefreshed)
+        // guard as every other path.
+        loadSessionMessages(sessionId, (fresh) => {
+            if (cancelled) return
+            if (adoptServerTranscript(fresh)) adopted = true
+        })
             .then((transcript) => {
                 if (cancelled) return
                 if (!transcript || transcript.messages.length === 0) {
                     // Known session, but the server has no records for it → history was pruned or
-                    // never persisted. Flag it so the skin shows the "unavailable" notice.
-                    setHistoryUnavailable(true)
+                    // never persisted. Flag it so the skin shows the "unavailable" notice — unless
+                    // a refetch already landed real history, which this stale first result must
+                    // not blank out.
+                    if (!adopted) setHistoryUnavailable(true)
                     return
                 }
-                transcript.messages.forEach((m) => restoredIdsRef.current.add(m.id))
-                setMessages(transcript.messages)
-                persistMessages({
-                    id: sessionId,
-                    messages: transcript.messages,
-                    recordCount: transcript.recordCount,
-                })
+                adoptServerTranscript(transcript)
             })
             .finally(() => {
                 if (!cancelled) setIsHydrating(false)
@@ -308,26 +355,17 @@ export const useAgentConversation = ({
     }, [sessionId])
 
     // Revalidate-on-open: a cached session paints instantly from localStorage; in the background
-    // we refetch the durable records ONCE and adopt the server transcript ONLY IF it's strictly
-    // ahead of what we're showing (a turn finished on another device). We never clobber a
-    // transcript that's live (`busyRef`), or that the server isn't strictly ahead of — so a local
-    // optimistic/unsent tail is safe. Reconciliation is by message COUNT, not content.
+    // we refetch the durable records ONCE and adopt the server transcript when the RECORD LOG has
+    // grown past what the cached transcript was built from. We never clobber a transcript that's
+    // live (`busyRef`), and never trade a longer local tail for a shorter server one — so a local
+    // optimistic/unsent tail is safe.
     useEffect(() => {
         if (initialMessages.length === 0 || isSessionFresh(sessionId)) return
         // As above: no persistent ref, so StrictMode's double-mount re-runs the revalidation.
         let cancelled = false
         const adopt = (transcript: SessionTranscript | null) => {
-            if (cancelled || !transcript || transcript.messages.length === 0) return
-            const serverMsgs = transcript.messages
-            const prev = messagesRef.current
-            if (busyRef.current || serverMsgs.length <= prev.length) return
-            serverMsgs.forEach((m) => restoredIdsRef.current.add(m.id))
-            setMessages(serverMsgs)
-            persistMessages({
-                id: sessionId,
-                messages: serverMsgs,
-                recordCount: transcript.recordCount,
-            })
+            if (cancelled) return
+            adoptServerTranscript(transcript)
         }
         // The first result may itself be the disk-restored records log; the callback re-applies
         // the same guarded adoption when the guaranteed background revalidation lands.
@@ -463,10 +501,20 @@ export const useAgentConversation = ({
         })
     }, [error, setMessages])
 
-    // Persist the conversation whenever its stream settles (skip mid-stream).
+    // A live turn makes the transcript no longer a copy of the server's, and we can't know how many
+    // records the runner logged for it — so drop the watermark and let the next open re-sync from
+    // the durable log. MUST stay declared above the persist effect: on the commit where `status`
+    // flips to "submitted", effects run in declaration order, so clearing here is what stops the
+    // persist below from filing a locally-extended transcript under a server watermark.
+    useEffect(() => {
+        if (status === "submitted" || status === "streaming") recordWatermarkRef.current = undefined
+    }, [status])
+
+    // Persist the conversation whenever its stream settles (skip mid-stream), under whatever
+    // watermark the rendered transcript still stands on (undefined once a live turn extended it).
     useEffect(() => {
         if (status === "streaming") return
-        persistMessages({id: sessionId, messages})
+        persistMessages({id: sessionId, messages, recordCount: recordWatermarkRef.current})
     }, [messages, status, sessionId, persistMessages])
 
     // Bound the in-message expand-state store: on settle, drop entries whose owning message is
@@ -485,21 +533,8 @@ export const useAgentConversation = ({
     // Push-signal revalidation: same guarded adoption as revalidate-on-open, callable at any
     // time (a watch relay tick, app foregrounding). Guards make it idempotent and stream-safe.
     const revalidate = useCallback(() => {
-        const adopt = (transcript: SessionTranscript | null) => {
-            if (!transcript || transcript.messages.length === 0) return
-            const serverMsgs = transcript.messages
-            if (busyRef.current || serverMsgs.length <= messagesRef.current.length) return
-            serverMsgs.forEach((m) => restoredIdsRef.current.add(m.id))
-            setHistoryUnavailable(false)
-            setMessages(serverMsgs)
-            persistMessages({
-                id: sessionId,
-                messages: serverMsgs,
-                recordCount: transcript.recordCount,
-            })
-        }
-        loadSessionMessages(sessionId, adopt).then(adopt)
-    }, [persistMessages, sessionId, setMessages])
+        void loadSessionMessages(sessionId, adoptServerTranscript).then(adoptServerTranscript)
+    }, [adoptServerTranscript, sessionId])
 
     // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
     const handleStop = useCallback(() => {

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -22,10 +22,10 @@ import {
     agentShouldResumeAfterApproval,
     buildAgentRequest,
     type LiveAgentInteraction,
-} from "@agenta/playground"
+} from "@agenta/playground/agent-chat"
 import {generateId} from "@agenta/shared/utils"
 import {useChat} from "@ai-sdk/react"
-import type {UIMessage} from "ai"
+import type {FileUIPart, UIMessage} from "ai"
 import {useSetAtom, useStore} from "jotai"
 
 import {filesToParts} from "../assets/files"
@@ -60,6 +60,8 @@ const ignoreStreamRejection = () => {}
 export interface SendInput {
     text: string
     files?: File[]
+    /** Prebuilt file parts (server-uploaded attachment references) — appended after `files`. */
+    parts?: FileUIPart[]
 }
 
 /** The pure scan result of a rewind request; the skin renders any confirm UI and then calls
@@ -127,6 +129,10 @@ export interface AgentConversation {
     approvals: ApprovalDock
     /** Settle a parked client tool part (widgets call this; the resume predicate auto-resends). */
     sendToolOutput: (args: ToolOutputSettleInput) => void
+    /** Re-fetch the durable records and adopt the server transcript under the same guards as
+     * revalidate-on-open (never mid-stream, only when strictly ahead). Wire push signals — a
+     * session watch relay, a foreground event — to this. */
+    revalidate: () => void
 }
 
 /**
@@ -476,6 +482,25 @@ export const useAgentConversation = ({
         pruneExpanded(live)
     }, [messages, status, store, pruneExpanded])
 
+    // Push-signal revalidation: same guarded adoption as revalidate-on-open, callable at any
+    // time (a watch relay tick, app foregrounding). Guards make it idempotent and stream-safe.
+    const revalidate = useCallback(() => {
+        const adopt = (transcript: SessionTranscript | null) => {
+            if (!transcript || transcript.messages.length === 0) return
+            const serverMsgs = transcript.messages
+            if (busyRef.current || serverMsgs.length <= messagesRef.current.length) return
+            serverMsgs.forEach((m) => restoredIdsRef.current.add(m.id))
+            setHistoryUnavailable(false)
+            setMessages(serverMsgs)
+            persistMessages({
+                id: sessionId,
+                messages: serverMsgs,
+                recordCount: transcript.recordCount,
+            })
+        }
+        loadSessionMessages(sessionId, adopt).then(adopt)
+    }, [persistMessages, sessionId, setMessages])
+
     // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
     const handleStop = useCallback(() => {
         const last = messagesRef.current[messagesRef.current.length - 1]
@@ -491,14 +516,16 @@ export const useAgentConversation = ({
     }, [sessionId, stop])
 
     const send = useCallback(
-        async ({text, files}: SendInput) => {
+        async ({text, files, parts}: SendInput) => {
             const trimmed = text.trim()
             const fileObjs = files ?? []
-            if (!trimmed && fileObjs.length === 0) return
+            const refParts = parts ?? []
+            if (!trimmed && fileObjs.length === 0 && refParts.length === 0) return
             // Send what encoded. A file that cannot be read no longer takes the text and the
             // other attachments down with it (`filesToParts` settles each file separately).
             const encoded = fileObjs.length ? await filesToParts(fileObjs) : undefined
-            const fileParts = encoded?.parts.length ? encoded.parts : undefined
+            const merged = [...(encoded?.parts ?? []), ...refParts]
+            const fileParts = merged.length ? merged : undefined
             if (encoded?.rejections.length) {
                 console.warn("[useAgentConversation] attachments could not be read:", {
                     files: encoded.rejections.map((r) => r.name),
@@ -580,5 +607,6 @@ export const useAgentConversation = ({
         clearQueue,
         approvals,
         sendToolOutput,
+        revalidate,
     }
 }

--- a/web/packages/agenta-chat/src/hooks/useAgentModelKeyStatus.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentModelKeyStatus.ts
@@ -1,7 +1,4 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/hooks/useAgentModelKeyStatus.ts
-// (2026-07-25); the OSS original remains authoritative for the desktop chat until the re-plumb
-// PR deletes it. Keep byte-parity if either side changes.
-// Adaptations: none — every import already resolves to an allowed package dep.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import {useMemo} from "react"
 
 import {

--- a/web/packages/agenta-chat/src/hooks/useAlwaysAllowTool.ts
+++ b/web/packages/agenta-chat/src/hooks/useAlwaysAllowTool.ts
@@ -1,0 +1,129 @@
+import {useCallback, useMemo, useRef} from "react"
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {
+    findGrantableHarnessTool,
+    findGrantableTool,
+    gateRulePattern,
+    withHarnessToolAllow,
+    withToolPermission,
+} from "@agenta/entity-ui/tool-permission"
+import {draftConfigChangeSignalAtom} from "@agenta/shared/state"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import {resolveToolDisplay} from "../skin/registry"
+
+export interface ToolGrantInfo {
+    /** The gate maps to a per-tool-config tool (gateway or custom function) whose permission we can set. */
+    eligible: boolean
+    /** The matched tool is already `allow` — the affordance would be a no-op, so hide it. */
+    alreadyAllowed: boolean
+}
+
+const INELIGIBLE: ToolGrantInfo = {eligible: false, alreadyAllowed: false}
+
+/**
+ * "Always allow this tool" for the approval card.
+ *
+ * Config write-through into the draft agent config; `buildAgentRequest` reads the draft, so a grant
+ * takes effect on the paused run's resume and every future run, and a commit carries it to triggers.
+ * Two fields, routed by tool class:
+ *   - a gateway / custom-function tool has a `tools[]` entry → per-tool `permission: "allow"`
+ *     (`specPermission`, the highest-precedence gate). Checked FIRST — it outranks any rule, and a
+ *     verbatim rule pattern would otherwise also match its slug.
+ *   - any other harness tool (`bash`, `Terminal`, `Write`, …) has no enforceable per-tool permission
+ *     → an allow-rule in `harness.permissions.allow`, keyed by the gate name VERBATIM: the runner
+ *     matches `pattern === gate.toolName`, and that string is exactly what the card shows (the
+ *     runner stamps it as `resolvedName`, which the egress prefers). Never canonicalize it, except
+ *     the seven Pi built-ins, which the runner matches case-insensitively (see `gateRulePattern`).
+ * Platform ops (`commit_revision`, schedules), client tools, and MCP tools return `eligible: false`
+ * and always stay gated (see `gateRulePattern`).
+ *
+ * On grant we raise a single draft-change signal that desktop's config pane consumes two ways: the
+ * section it landed in pulses for attention, and a contained banner offers Undo. Hosts without a
+ * config pane (mobile) simply have no consumer — the write itself is the behavior. `revoke` is the
+ * exact inverse (`"ask"` for tools, `allowed:false` for harness rules).
+ */
+export function useAlwaysAllowTool(entityId?: string) {
+    const config = useAtomValue(
+        useMemo(() => workflowMolecule.selectors.configuration(entityId ?? ""), [entityId]),
+    )
+    // Latest config for the deferred Undo click, so it never reverts against a stale snapshot.
+    const configRef = useRef(config)
+    configRef.current = config
+    const setConfiguration = useSetAtom(workflowMolecule.actions.updateConfiguration)
+    // Marks the config section this grant lands in so it can pulse for attention — the user
+    // acted here in the dock, but the write shows up over in the (maybe off-screen) config pane.
+    const raiseDraftSignal = useSetAtom(draftConfigChangeSignalAtom)
+
+    const infoFor = useCallback(
+        (toolName: string): ToolGrantInfo => {
+            if (!entityId) return INELIGIBLE
+            // Gateway / custom-function tools carry a per-tool `permission` in `tools[]`. First:
+            // it outranks a rule, and a verbatim rule pattern would also match its slug.
+            const tool = findGrantableTool(config, toolName)
+            if (tool) return {eligible: true, alreadyAllowed: tool.permission === "allow"}
+            // Any other harness tool (bash, Terminal, Write, …) → `harness.permissions.allow`.
+            const harnessTool = findGrantableHarnessTool(config, toolName)
+            if (harnessTool) return {eligible: true, alreadyAllowed: harnessTool.allowed}
+            // Platform ops (commit_revision, schedules), client tools, MCP → never grantable.
+            return INELIGIBLE
+        },
+        [entityId, config],
+    )
+
+    // Inverse of grant: put the tool back to gated. Reads the LATEST config (ref), since Undo fires
+    // seconds after the grant and the draft may have moved on.
+    const revoke = useCallback(
+        (toolName: string): boolean => {
+            if (!entityId) return false
+            const cfg = configRef.current
+            // Same routing as `grant` — `tools[]` first, then the harness allow-rule.
+            const tool = findGrantableTool(cfg, toolName)
+            const pattern = tool ? null : gateRulePattern(toolName)
+            const next = tool
+                ? withToolPermission(cfg, toolName, "ask")
+                : pattern
+                  ? withHarnessToolAllow(cfg, pattern, false)
+                  : null
+            if (!next) return false
+            setConfiguration(entityId, next)
+            return true
+        },
+        [entityId, setConfiguration],
+    )
+
+    const grant = useCallback(
+        (toolName: string): boolean => {
+            if (!entityId) return false
+            // Route to the field that matches the gate's tool class (see infoFor). `tools[]` first:
+            // its per-tool permission outranks a rule, and a verbatim pattern would match its slug.
+            const tool = findGrantableTool(config, toolName)
+            const pattern = tool ? null : gateRulePattern(toolName)
+            const next = tool
+                ? withToolPermission(config, toolName, "allow")
+                : pattern
+                  ? withHarnessToolAllow(config, pattern, true)
+                  : null
+            if (!next) return false
+            setConfiguration(entityId, next)
+            // A harness allow-rule writes `harness.permissions`, which surfaces in the Advanced →
+            // Permissions group (and classifies as an "advanced" draft change); gateway/custom-function
+            // tools write `tools[]`, surfaced in the Tools section. Pulse the section the change lands in.
+            raiseDraftSignal({
+                revisionId: entityId,
+                sectionKeys: [tool ? "tools" : "advanced"],
+                origin: "approval-dock",
+                summary: `Always allow ${toolName}`,
+                // Friendly display (matches the approval card) — a gateway tool's raw name is a slug.
+                label: resolveToolDisplay(toolName).label,
+                toolName,
+                at: Date.now(),
+            })
+            return true
+        },
+        [entityId, config, setConfiguration, raiseDraftSignal],
+    )
+
+    return {infoFor, grant, revoke}
+}

--- a/web/packages/agenta-chat/src/hooks/useAttachmentUploads.ts
+++ b/web/packages/agenta-chat/src/hooks/useAttachmentUploads.ts
@@ -1,0 +1,196 @@
+import {useCallback, useEffect, useRef} from "react"
+
+import type {StagedUpload as UploadFile} from "../model"
+
+/** Owns upload progress, retry, cancellation, and the validated response on each tray entry. */
+export type AttachmentUploader<TResponse = unknown> = (
+    file: File,
+    ctx: {uid: string; onProgress: (percent: number) => void; signal: AbortSignal},
+) => Promise<TResponse>
+
+type SetAttachmentFiles<TResponse> = (
+    updater: (prev: UploadFile<TResponse>[]) => UploadFile<TResponse>[],
+) => void
+
+export interface AttachmentUploads {
+    /** Start (or restart) upload for these uids. No-op without an `upload` transport. */
+    enqueue: (uids: string[]) => void
+    /** Retry one failed upload when its server-provided delay has elapsed. */
+    retry: (uid: string) => void
+    /** Whether the failed upload should expose a retry action. */
+    canRetry: (uid: string) => boolean
+    /** Abort and release one in-flight upload. */
+    abort: (uid: string) => void
+}
+
+interface UploadFailureDetails {
+    retryable?: boolean
+    retryAfterSeconds?: number
+}
+
+const failureDetails = (error: unknown): UploadFailureDetails =>
+    error && typeof error === "object" ? (error as UploadFailureDetails) : {}
+
+export const isUploadRetryReady = (retryAt: number | undefined, now = Date.now()): boolean =>
+    retryAt === undefined || now >= retryAt
+
+export const removeUploadFile = <TResponse>(
+    uid: string,
+    abort: (uid: string) => void,
+    setFiles: SetAttachmentFiles<TResponse>,
+): void => {
+    abort(uid)
+    setFiles((prev) => prev.filter((file) => file.uid !== uid))
+}
+
+export function useAttachmentUploads<TResponse>(
+    files: UploadFile<TResponse>[],
+    setFiles: SetAttachmentFiles<TResponse>,
+    upload?: AttachmentUploader<TResponse>,
+): AttachmentUploads {
+    // Read the latest files (for the File blob) without making `run` depend on every list change.
+    const filesRef = useRef(files)
+    filesRef.current = files
+    const controllers = useRef(new Map<string, AbortController>())
+    const queued = useRef(new Set<string>())
+    const retryAt = useRef(new Map<string, number>())
+    const retryable = useRef(new Map<string, boolean>())
+    const retryTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+
+    const patch = useCallback(
+        (uid: string, next: Partial<UploadFile<TResponse>>) => {
+            setFiles((prev) => prev.map((f) => (f.uid === uid ? {...f, ...next} : f)))
+        },
+        [setFiles],
+    )
+
+    const run = useCallback(
+        (uid: string) => {
+            if (!upload) return
+            const file = filesRef.current.find((f) => f.uid === uid)?.originFileObj as
+                | File
+                | undefined
+            if (!file) return
+
+            controllers.current.get(uid)?.abort()
+            const controller = new AbortController()
+            controllers.current.set(uid, controller)
+            retryAt.current.delete(uid)
+            retryable.current.delete(uid)
+
+            clearTimeout(retryTimers.current.get(uid))
+            retryTimers.current.delete(uid)
+
+            const release = () => {
+                if (controllers.current.get(uid) === controller) controllers.current.delete(uid)
+            }
+
+            patch(uid, {status: "uploading", percent: 0, error: undefined})
+            upload(file, {
+                uid,
+                onProgress: (percent) => patch(uid, {status: "uploading", percent}),
+                signal: controller.signal,
+            })
+                .then((response) => {
+                    if (controller.signal.aborted) return
+                    release()
+                    patch(uid, {status: "done", percent: 100, response})
+                })
+                .catch((error: unknown) => {
+                    if (controller.signal.aborted) return
+                    release()
+                    const details = failureDetails(error)
+                    retryable.current.set(uid, details.retryable !== false)
+                    if (details.retryAfterSeconds !== undefined) {
+                        retryAt.current.set(uid, Date.now() + details.retryAfterSeconds * 1000)
+                    }
+                    patch(uid, {
+                        status: "error",
+                        error: error instanceof Error ? error.message : "Upload failed",
+                    })
+                })
+        },
+        [upload, patch],
+    )
+
+    const abort = useCallback((uid: string) => {
+        queued.current.delete(uid)
+        retryAt.current.delete(uid)
+        retryable.current.delete(uid)
+        clearTimeout(retryTimers.current.get(uid))
+        retryTimers.current.delete(uid)
+        const controller = controllers.current.get(uid)
+        controllers.current.delete(uid)
+        controller?.abort()
+    }, [])
+    const enqueue = useCallback((uids: string[]) => {
+        uids.forEach((uid) => queued.current.add(uid))
+    }, [])
+    useEffect(() => {
+        // A remounted tray resumes in-flight entries with the same uid/idempotency key.
+        for (const file of files) {
+            if (
+                file.status === "uploading" &&
+                file.originFileObj &&
+                !controllers.current.has(file.uid)
+            ) {
+                queued.current.add(file.uid)
+            }
+        }
+        for (const uid of queued.current) {
+            if (!files.some((file) => file.uid === uid)) continue
+            queued.current.delete(uid)
+            run(uid)
+        }
+    }, [files, run])
+    const retry = useCallback(
+        (uid: string) => {
+            if (retryable.current.get(uid) === false) return
+            const allowedAt = retryAt.current.get(uid)
+            if (!isUploadRetryReady(allowedAt)) {
+                clearTimeout(retryTimers.current.get(uid))
+                retryTimers.current.set(
+                    uid,
+                    setTimeout(
+                        () => {
+                            retryTimers.current.delete(uid)
+                            run(uid)
+                        },
+                        Math.max(0, (allowedAt ?? Date.now()) - Date.now()),
+                    ),
+                )
+                return
+            }
+            run(uid)
+        },
+        [run],
+    )
+    const canRetry = useCallback((uid: string) => retryable.current.get(uid) !== false, [])
+
+    // Abort in-flight uploads on unmount (session switch / pane close).
+    useEffect(() => {
+        const map = controllers.current
+        return () => {
+            map.forEach((controller) => controller.abort())
+            map.clear()
+            retryTimers.current.forEach((timer) => clearTimeout(timer))
+            retryTimers.current.clear()
+        }
+    }, [])
+
+    return {enqueue, retry, canRetry, abort}
+}
+
+/** Aggregate upload state for composer-level messaging and send-gating. */
+export interface AttachmentUploadSummary {
+    uploading: number
+    failed: number
+    /** True while any upload is in flight — send should wait. */
+    busy: boolean
+}
+
+export const summarizeUploads = (files: UploadFile[]): AttachmentUploadSummary => {
+    const uploading = files.filter((f) => f.status === "uploading").length
+    const failed = files.filter((f) => f.status === "error").length
+    return {uploading, failed, busy: uploading > 0}
+}

--- a/web/packages/agenta-chat/src/hooks/useAttachmentUploads.ts
+++ b/web/packages/agenta-chat/src/hooks/useAttachmentUploads.ts
@@ -19,9 +19,17 @@ export interface AttachmentUploads {
     retry: (uid: string) => void
     /** Whether the failed upload should expose a retry action. */
     canRetry: (uid: string) => boolean
-    /** Abort and release one in-flight upload. */
+    /**
+     * Cancel one in-flight upload for good: aborts the request AND settles the row, so the
+     * resume rule below leaves it alone. The row stays in the tray as a retryable failure —
+     * removing the chip is `removeUploadFile`'s job, not this one's.
+     */
     abort: (uid: string) => void
 }
+
+/** What a user-cancelled row reports. Reuses the `error` status (rather than a fourth one every
+ * surface would have to learn) so the existing retry/remove affordances apply unchanged. */
+export const UPLOAD_CANCELLED_MESSAGE = "Upload cancelled"
 
 interface UploadFailureDetails {
     retryable?: boolean
@@ -53,6 +61,13 @@ export function useAttachmentUploads<TResponse>(
     filesRef.current = files
     const controllers = useRef(new Map<string, AbortController>())
     const queued = useRef(new Set<string>())
+    // Uids the USER cancelled in this mount. The resume rule below deliberately restarts any row
+    // that says "uploading" without a live controller — that is how a remounted tray picks its
+    // in-flight entries back up — so a cancel has to be distinguishable from an unmount abort, or
+    // `abort` would only pause the upload until the next `files` identity (which, mid-upload,
+    // is many times a second). Per-mount by construction: a remount gets a fresh ref, so a genuine
+    // remount still resumes.
+    const cancelled = useRef(new Set<string>())
     const retryAt = useRef(new Map<string, number>())
     const retryable = useRef(new Map<string, boolean>())
     const retryTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
@@ -77,6 +92,8 @@ export function useAttachmentUploads<TResponse>(
             controllers.current.set(uid, controller)
             retryAt.current.delete(uid)
             retryable.current.delete(uid)
+            // Starting this uid again is an explicit un-cancel (a retry, or a re-enqueue).
+            cancelled.current.delete(uid)
 
             clearTimeout(retryTimers.current.get(uid))
             retryTimers.current.delete(uid)
@@ -113,26 +130,39 @@ export function useAttachmentUploads<TResponse>(
         [upload, patch],
     )
 
-    const abort = useCallback((uid: string) => {
-        queued.current.delete(uid)
-        retryAt.current.delete(uid)
-        retryable.current.delete(uid)
-        clearTimeout(retryTimers.current.get(uid))
-        retryTimers.current.delete(uid)
-        const controller = controllers.current.get(uid)
-        controllers.current.delete(uid)
-        controller?.abort()
-    }, [])
+    const abort = useCallback(
+        (uid: string) => {
+            queued.current.delete(uid)
+            retryAt.current.delete(uid)
+            retryable.current.delete(uid)
+            clearTimeout(retryTimers.current.get(uid))
+            retryTimers.current.delete(uid)
+            const controller = controllers.current.get(uid)
+            controllers.current.delete(uid)
+            cancelled.current.add(uid)
+            controller?.abort()
+            // Settle the ROW too. Aborting the request alone left it reading "uploading", which is
+            // exactly the shape the resume rule restarts — and it would also hold `attachmentsSettled`
+            // (and therefore send) forever. `error` gives the tile its retry + remove affordances.
+            patch(uid, {status: "error", percent: undefined, error: UPLOAD_CANCELLED_MESSAGE})
+        },
+        [patch],
+    )
     const enqueue = useCallback((uids: string[]) => {
-        uids.forEach((uid) => queued.current.add(uid))
+        uids.forEach((uid) => {
+            cancelled.current.delete(uid)
+            queued.current.add(uid)
+        })
     }, [])
     useEffect(() => {
-        // A remounted tray resumes in-flight entries with the same uid/idempotency key.
+        // A remounted tray resumes in-flight entries with the same uid/idempotency key — but a row
+        // the user cancelled in THIS mount stays cancelled (see `cancelled`).
         for (const file of files) {
             if (
                 file.status === "uploading" &&
                 file.originFileObj &&
-                !controllers.current.has(file.uid)
+                !controllers.current.has(file.uid) &&
+                !cancelled.current.has(file.uid)
             ) {
                 queued.current.add(file.uid)
             }
@@ -141,6 +171,10 @@ export function useAttachmentUploads<TResponse>(
             if (!files.some((file) => file.uid === uid)) continue
             queued.current.delete(uid)
             run(uid)
+        }
+        // Forget cancellations whose row is gone (removed chip), so the set can't grow unbounded.
+        for (const uid of cancelled.current) {
+            if (!files.some((file) => file.uid === uid)) cancelled.current.delete(uid)
         }
     }, [files, run])
     const retry = useCallback(

--- a/web/packages/agenta-chat/src/hooks/useComposerAttachments.ts
+++ b/web/packages/agenta-chat/src/hooks/useComposerAttachments.ts
@@ -1,125 +1,263 @@
-// Assembled from the attachment-state block of
-// web/oss/src/components/AgentChatSlice/AgentConversation.tsx (2026-07-25): the per-session
-// restore/mirror effect, `addFiles` (validateIncoming), `removeFile`, and the submit-time
-// clear + `filesToParts` conversion. The desktop host keeps its own upload-item file type;
-// this hook mirrors the same LOGIC over the package's neutral `PendingAttachment`.
-// Deliberately omitted (desktop-only): the drag/drop DOM handlers and the tray open/close
-// flag — the skin calls `add()` from its own drop/paste surfaces and derives visibility.
 import {useCallback, useEffect, useRef, useState} from "react"
 
-import type {FileUIPart} from "ai"
+import {generateId} from "@agenta/shared/utils"
 
 import {
-    type AttachmentLimits,
     type AttachmentRejection,
     DEFAULT_ATTACHMENT_LIMITS,
+    attachmentRefsToParts,
     validateIncoming,
-} from "../assets/attachmentRules"
-import {filesToParts} from "../assets/files"
-import {type PendingAttachment, toPendingAttachment} from "../model/attachments"
+} from "../assets"
+import {uploadAttachment, type SessionAttachmentResponse} from "../assets/attachmentTransport"
+import type {StagedUpload as UploadFile} from "../model"
 import {attachmentsBySession} from "../state/sessionEphemera"
 
-export interface UseComposerAttachmentsArgs {
-    /** Persist pending files under this session across pane remounts (route re-entry). */
-    sessionId?: string
-    /** Guardrails; defaults to the shared limits (count / size / accepted types). */
-    limits?: AttachmentLimits
-}
+import {removeUploadFile, useAttachmentUploads} from "./useAttachmentUploads"
 
-export interface ComposerAttachments {
-    /** Files staged for the next send, in add order. */
-    files: PendingAttachment[]
-    /** Files turned away by the guardrails on the LAST add (too big, wrong type, over the count). */
-    rejections: AttachmentRejection[]
-    /** The active guardrails, for tray copy ("up to N files, X MB each"). */
-    limits: AttachmentLimits
-    /** The staged set is at the count cap — pickers should disable. */
-    atMax: boolean
-    /** Run incoming files (picker / paste / drop) through the guardrails and stage the accepted. */
-    add: (incoming: File[]) => void
-    /** Unstage one file by its dedup uid. */
-    remove: (uid: string) => void
-    /** Drop everything staged (send consumed them, or the user reset the composer). */
-    clear: () => void
-    /** Dismiss the inline rejection notices without touching the staged files. */
-    dismissRejections: () => void
-    /** Encode the staged files as inline `file` parts for `sendMessage({text, files})`. */
-    toParts: () => Promise<FileUIPart[]>
-}
+type StagedFile = UploadFile<SessionAttachmentResponse>
+
+/** Convert settled upload-tray entries into reference `file` parts via the neutral builder. */
+export const stagedFilesToParts = (files: StagedFile[], sessionId: string) =>
+    attachmentRefsToParts(
+        files.map((file) => {
+            const attachment = file.response?.attachment
+            if (!attachment) throw new Error(`Attachment upload is incomplete: ${file.name}`)
+            return {
+                attachmentId: attachment.attachment_id,
+                filename: attachment.filename,
+                mediaType: attachment.media_type,
+                size: attachment.size,
+            }
+        }),
+        sessionId,
+    )
+
+// `uid` is the tray's React key, its preview-URL key, the remove / view / retry handle, and the
+// upload's idempotency key, so it has to be unique per TRAY ROW. Deriving it from name+mtime+size
+// collided whenever the same file was attached twice (paste then drop) — one remove then wiped
+// both rows and their previews.
+const toUploadFile = (file: File, uploadsEnabled: boolean): StagedFile => ({
+    uid: `att-${generateId()}`,
+    name: file.name,
+    status: uploadsEnabled ? "uploading" : "done",
+    percent: uploadsEnabled ? 0 : 100,
+    originFileObj: file as UploadFile["originFileObj"],
+})
 
 /**
- * Headless composer-attachment state for one session: staging, validation, per-session
- * persistence, and the send-time encoding. The skin owns every surface (tray, drop overlay,
- * paste) and calls `add`/`remove`/`clear`; on submit it awaits `toParts()` then `clear()`s.
+ * Pending composer attachments for one session — the tray, its guardrails, the upload lifecycle,
+ * the preview target, and the whole-panel drag-and-drop that feeds them. Files survive a remount
+ * (route re-entry, tab close/reopen) alongside the composer draft; rejections stay transient.
  */
 export const useComposerAttachments = ({
     sessionId,
-    limits = DEFAULT_ATTACHMENT_LIMITS,
-}: UseComposerAttachmentsArgs = {}): ComposerAttachments => {
+    uploadsEnabled = true,
+}: {
+    sessionId: string
+    /** Hosts gate the whole attachment path on their rollout flag; off = inline-only staging. */
+    uploadsEnabled?: boolean
+}) => {
     // Restored from the per-session store on remount (route re-entry, tab close/reopen) —
     // pending attachments survive alongside the composer draft. Rejections stay transient.
-    const [files, setFiles] = useState<PendingAttachment[]>(() =>
-        sessionId ? (attachmentsBySession.get(sessionId) ?? []) : [],
+    const [files, setFiles] = useState<StagedFile[]>(
+        () => (attachmentsBySession.get(sessionId) as StagedFile[] | undefined) ?? [],
     )
-    // `sessionId` is a prop. Today's only caller mounts one instance per session, but a caller
-    // that swapped it in place would carry the old session's staged files into the new one, and
-    // the mirror effect below would then write them under the new key. Re-seed during render so
-    // that effect never sees a mismatched pair.
-    const [seededFor, setSeededFor] = useState(sessionId)
-    if (sessionId !== seededFor) {
-        setSeededFor(sessionId)
-        setFiles(sessionId ? (attachmentsBySession.get(sessionId) ?? []) : [])
-    }
     useEffect(() => {
-        if (!sessionId) return
         if (files.length > 0) attachmentsBySession.set(sessionId, files)
         else attachmentsBySession.delete(sessionId)
     }, [files, sessionId])
     // Files turned away by the guardrails (too big, wrong type, over the count), shown inline.
+    // Same-tick guard: a paste and a drop can both fire before React re-renders; the render
+    // closure's `files.length` would let both batches validate against the pre-add count.
+    const stagedCountRef = useRef(files.length)
+    useEffect(() => {
+        stagedCountRef.current = files.length
+    }, [files.length])
     const [rejections, setRejections] = useState<AttachmentRejection[]>([])
-
+    // The attachment currently open in the Files-drawer preview (its uid), or null when closed.
+    const [viewingUid, setViewingUid] = useState<string | null>(null)
+    const [attachmentsOpen, setAttachmentsOpen] = useState(false)
+    // Single limits object so it can later be swapped for capability-derived limits.
+    const limits = DEFAULT_ATTACHMENT_LIMITS
     const atMax = files.length >= limits.maxCount
+    // Drag-over state for the whole-panel drop overlay (depth counter avoids child flicker).
+    const dragDepthRef = useRef(0)
+    const [isDragging, setIsDragging] = useState(false)
 
-    // The staged count as of the last accepted batch, not the render closure. Two `add` calls
-    // in one tick (a paste and a drop, or a duplicated drop handler) both read the same
-    // `files.length`, so both compute the same remaining capacity and the staged set can pass
-    // `limits.maxCount`. Re-synced on every render so state remains the source of truth.
-    const countRef = useRef(files.length)
-    countRef.current = files.length
-
-    /** Add files from picker / paste / programmatic sources through the guardrails. */
-    const add = useCallback(
-        (incoming: File[]) => {
-            const {accepted, rejections: rej} = validateIncoming(incoming, countRef.current, limits)
-            if (accepted.length) {
-                countRef.current += accepted.length
-                setFiles((prev) => [...prev, ...accepted.map(toPendingAttachment)])
-            }
-            setRejections(rej)
-        },
-        [limits],
+    // One multipart upload per staged file; the tray uid doubles as the idempotency key, so a
+    // retry reuses the original identity instead of minting a second attachment.
+    const attachmentUploader = useCallback(
+        (
+            file: File,
+            {
+                uid,
+                onProgress,
+                signal,
+            }: {uid: string; onProgress: (percent: number) => void; signal: AbortSignal},
+        ) => uploadAttachment({file, sessionId, idempotencyKey: uid, onProgress, signal}),
+        [sessionId],
     )
+    // Upload lifecycle for the tray (progress / error / retry).
+    const uploads = useAttachmentUploads(files, setFiles, attachmentUploader)
+    // A staged attachment blocks send until its reference exists; without uploads the inline path
+    // only needs every entry to be settled.
+    const attachmentsSettled = uploadsEnabled
+        ? files.every((file) => file.status === "done" && Boolean(file.response?.attachment))
+        : files.every((file) => file.status === "done")
 
-    const remove = useCallback((uid: string) => {
-        setFiles((prev) => prev.filter((f) => f.uid !== uid))
-    }, [])
+    /** Why send is held, for the send button's tooltip. */
+    const uploadBlockReason = files.some((file) => file.status === "error")
+        ? "an upload failed"
+        : files.some((file) => file.status === "uploading")
+          ? "waiting for uploads"
+          : undefined
 
-    const clear = useCallback(() => {
-        setFiles([])
+    /** Add files from paste / programmatic sources through the guardrails. */
+    const addFiles = (incoming: File[], extraRejections: AttachmentRejection[] = []) => {
+        const {accepted, rejections} = validateIncoming(incoming, stagedCountRef.current, limits)
+        const allRejections = [...extraRejections, ...rejections]
+        if (accepted.length) {
+            // Stage once and enqueue the MINTED uids — re-deriving them here is what let the tray
+            // row and its upload disagree about which entry they addressed.
+            const staged = accepted.map((file) => toUploadFile(file, uploadsEnabled))
+            stagedCountRef.current += staged.length
+            setFiles((prev) => [...prev, ...staged])
+            if (uploadsEnabled) uploads.enqueue(staged.map((f) => f.uid))
+        }
+        setRejections(allRejections)
+        // Open for rejections too. Otherwise dropping something unsupported writes a message into
+        // a closed panel and reads as nothing having happened at all.
+        if (accepted.length || allRejections.length) setAttachmentsOpen(true)
+    }
+
+    // Removing a chip also aborts its in-flight request.
+    const removeFile = (uid: string) => removeUploadFile(uid, uploads.abort, setFiles)
+
+    /**
+     * Upload files that never entered the tray (a voice take sent outright) and return their staged
+     * entries. A failure adopts them into the tray so the error is visible and retryable, and
+     * returns null so the caller holds the send.
+     */
+    const uploadExtraFiles = async (extraFiles: File[]): Promise<StagedFile[] | null> => {
+        const staged = extraFiles.map((file) => toUploadFile(file, uploadsEnabled))
+        const results = await Promise.allSettled(
+            staged.map(async (entry) => {
+                const response = await attachmentUploader(entry.originFileObj as File, {
+                    uid: entry.uid,
+                    onProgress: () => undefined,
+                    signal: new AbortController().signal,
+                })
+                return {...entry, status: "done" as const, percent: 100, response}
+            }),
+        )
+        if (results.every((result) => result.status === "fulfilled")) {
+            return results.map((result) => (result as PromiseFulfilledResult<StagedFile>).value)
+        }
+        const settledEntries = results.map((result, index) =>
+            result.status === "fulfilled"
+                ? result.value
+                : {
+                      ...staged[index],
+                      status: "error" as const,
+                      error:
+                          result.reason instanceof Error ? result.reason.message : "Upload failed",
+                  },
+        )
+        setFiles((prev) => [...prev, ...settledEntries])
+        setAttachmentsOpen(true)
+        return null
+    }
+
+    // Native drag-and-drop onto the whole panel. A depth counter ignores dragenter/leave from
+    // nested children so the overlay doesn't flicker; only file drags (not text) are handled.
+    const isFileDrag = (e: React.DragEvent) => Array.from(e.dataTransfer.types).includes("Files")
+
+    /**
+     * Bind the panel's drop target. `isBlocked` is a predicate, read at EVENT time and never at
+     * bind time: whether attachments are refused right now is the conversation's call (a voice take
+     * in flight, a disabled composer), so this hook asks rather than tracking it.
+     */
+    const bindDropTarget = (isBlocked: () => boolean) => {
+        // The panel is ALWAYS a drop target for file drags — preventDefault on enter/over/drop even when
+        // blocked. Otherwise the browser's default action for a file drop is to navigate to it, which
+        // unloads the SPA and discards the whole conversation. Whether we ACCEPT the files is signalled
+        // separately (the overlay + the drop cursor), not by declining to be a drop target.
+        const onDragEnter = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            e.preventDefault()
+            if (isBlocked()) return
+            dragDepthRef.current += 1
+            setIsDragging(true)
+        }
+        const onDragOver = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            e.preventDefault()
+            // Honest cursor: "no drop" while blocked — but we stay a target so the drop is still swallowed.
+            e.dataTransfer.dropEffect = isBlocked() ? "none" : "copy"
+        }
+        const onDragLeave = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            dragDepthRef.current -= 1
+            if (dragDepthRef.current <= 0) {
+                dragDepthRef.current = 0
+                setIsDragging(false)
+            }
+        }
+        const onDrop = (e: React.DragEvent) => {
+            if (!isFileDrag(e)) return
+            e.preventDefault()
+            dragDepthRef.current = 0
+            setIsDragging(false)
+            if (isBlocked()) return
+
+            // A dropped folder still arrives in `files` — as a typeless, zero-byte entry that the
+            // guardrails would reject as "not a supported file type", which is misleading. Name it.
+            // `webkitGetAsEntry` is only valid synchronously, during this event.
+            const folderNames = Array.from(e.dataTransfer.items ?? [])
+                .map((item) => (item.kind === "file" ? item.webkitGetAsEntry() : null))
+                .filter((entry): entry is FileSystemEntry => !!entry?.isDirectory)
+                .map((entry) => entry.name)
+
+            const dropped = Array.from(e.dataTransfer.files).filter(
+                (f) => !folderNames.includes(f.name),
+            )
+            const folderRejections = folderNames.map((name) => ({
+                name,
+                reason: "is a folder — drop the files inside it",
+            }))
+
+            if (dropped.length || folderRejections.length) addFiles(dropped, folderRejections)
+        }
+        return {onDragEnter, onDragOver, onDragLeave, onDrop}
+    }
+
+    /** Drop the attachments a send just carried, plus any rejection notice. */
+    const clearAttachments = (consumedUids: string[]) => {
+        // Only what this send carried: anything staged while it was in flight belongs to the next message.
+        setFiles((prev) => prev.filter((file) => !consumedUids.includes(file.uid)))
         setRejections([])
-    }, [])
+        setAttachmentsOpen(false)
+    }
 
-    const dismissRejections = useCallback(() => setRejections([]), [])
-
-    // A file that cannot be read at submit time is surfaced through the same inline notices the
-    // guardrails use, and the readable ones still go out — losing the whole message because one
-    // attachment went missing is worse than sending without it.
-    const toParts = useCallback(async () => {
-        if (!files.length) return []
-        const {parts, rejections: unreadable} = await filesToParts(files.map((f) => f.file))
-        if (unreadable.length) setRejections((prev) => [...prev, ...unreadable])
-        return parts
-    }, [files])
-
-    return {files, rejections, limits, atMax, add, remove, clear, dismissRejections, toParts}
+    return {
+        uploadsEnabled,
+        files,
+        rejections,
+        setRejections,
+        attachmentsOpen,
+        setAttachmentsOpen,
+        viewingUid,
+        setViewingUid,
+        limits,
+        atMax,
+        attachmentsSettled,
+        uploadBlockReason,
+        isDragging,
+        addFiles,
+        removeFile,
+        uploadExtraFiles,
+        uploads,
+        clearAttachments,
+        bindDropTarget,
+    }
 }

--- a/web/packages/agenta-chat/src/hooks/useComposerAttachments.ts
+++ b/web/packages/agenta-chat/src/hooks/useComposerAttachments.ts
@@ -62,10 +62,12 @@ export const useComposerAttachments = ({
     const [files, setFiles] = useState<StagedFile[]>(
         () => (attachmentsBySession.get(sessionId) as StagedFile[] | undefined) ?? [],
     )
-    useEffect(() => {
-        if (files.length > 0) attachmentsBySession.set(sessionId, files)
-        else attachmentsBySession.delete(sessionId)
-    }, [files, sessionId])
+    // Which session the rows in `files` belong to. The initializer above only runs on MOUNT, and
+    // hosts are not required to remount (or key) the composer per session — this repo's chat
+    // workspace keeps tab panes mounted across switches. Without this, a `sessionId` change on a
+    // mounted hook would write session A's staged rows under session B, orphaning A's entry; and
+    // since `attachmentUploader` closes over `sessionId`, a retry would then upload A's file into B.
+    const filesOwnerRef = useRef(sessionId)
     // Files turned away by the guardrails (too big, wrong type, over the count), shown inline.
     // Same-tick guard: a paste and a drop can both fire before React re-renders; the render
     // closure's `files.length` would let both batches validate against the pre-add count.
@@ -77,6 +79,20 @@ export const useComposerAttachments = ({
     // The attachment currently open in the Files-drawer preview (its uid), or null when closed.
     const [viewingUid, setViewingUid] = useState<string | null>(null)
     const [attachmentsOpen, setAttachmentsOpen] = useState(false)
+    useEffect(() => {
+        // Park whatever is on screen under the session it actually belongs to…
+        const owner = filesOwnerRef.current
+        if (files.length > 0) attachmentsBySession.set(owner, files)
+        else attachmentsBySession.delete(owner)
+        if (owner === sessionId) return
+        // …then adopt the incoming session's own staged rows. (This effect re-runs once more with
+        // the two ids equal, which writes the adopted rows back under the same key — a no-op.)
+        filesOwnerRef.current = sessionId
+        setFiles((attachmentsBySession.get(sessionId) as StagedFile[] | undefined) ?? [])
+        // The preview target and the inline rejections belong to the session we just left.
+        setViewingUid(null)
+        setRejections([])
+    }, [files, sessionId])
     // Single limits object so it can later be swapped for capability-derived limits.
     const limits = DEFAULT_ATTACHMENT_LIMITS
     const atMax = files.length >= limits.maxCount
@@ -99,6 +115,16 @@ export const useComposerAttachments = ({
     )
     // Upload lifecycle for the tray (progress / error / retry).
     const uploads = useAttachmentUploads(files, setFiles, attachmentUploader)
+    // In-flight `uploadExtraFiles` requests — see there. Aborted on unmount, mirroring the tray's
+    // own teardown in `useAttachmentUploads`.
+    const extraControllers = useRef(new Set<AbortController>())
+    useEffect(() => {
+        const inFlight = extraControllers.current
+        return () => {
+            inFlight.forEach((controller) => controller.abort())
+            inFlight.clear()
+        }
+    }, [])
     // A staged attachment blocks send until its reference exists; without uploads the inline path
     // only needs every entry to be settled.
     const attachmentsSettled = uploadsEnabled
@@ -137,17 +163,33 @@ export const useComposerAttachments = ({
      * Upload files that never entered the tray (a voice take sent outright) and return their staged
      * entries. A failure adopts them into the tray so the error is visible and retryable, and
      * returns null so the caller holds the send.
+     *
+     * These bypass `useAttachmentUploads.run`, so that hook holds no controller for them — this one
+     * does, or an unmount (session close, pane swap) would leave them running with nothing able to
+     * cancel them.
+     *
+     * NOTE: unlike `addFiles`, this path uploads regardless of `uploadsEnabled`, while
+     * `toUploadFile` marks the same entries settled-without-a-response when the flag is off. Which
+     * of the two is right depends on whether a send-time upload is meant to happen during the
+     * inline-only rollout — no host calls this yet, so the behavior is left as-is rather than
+     * guessed at.
      */
     const uploadExtraFiles = async (extraFiles: File[]): Promise<StagedFile[] | null> => {
         const staged = extraFiles.map((file) => toUploadFile(file, uploadsEnabled))
         const results = await Promise.allSettled(
             staged.map(async (entry) => {
-                const response = await attachmentUploader(entry.originFileObj as File, {
-                    uid: entry.uid,
-                    onProgress: () => undefined,
-                    signal: new AbortController().signal,
-                })
-                return {...entry, status: "done" as const, percent: 100, response}
+                const controller = new AbortController()
+                extraControllers.current.add(controller)
+                try {
+                    const response = await attachmentUploader(entry.originFileObj as File, {
+                        uid: entry.uid,
+                        onProgress: () => undefined,
+                        signal: controller.signal,
+                    })
+                    return {...entry, status: "done" as const, percent: 100, response}
+                } finally {
+                    extraControllers.current.delete(controller)
+                }
             }),
         )
         if (results.every((result) => result.status === "fulfilled")) {

--- a/web/packages/agenta-chat/src/model/attachments.ts
+++ b/web/packages/agenta-chat/src/model/attachments.ts
@@ -1,17 +1,39 @@
+import {generateId} from "@agenta/shared/utils"
+
 /** A file staged for upload before it's sent — neutral shape, independent of the desktop
- * upload-item type. `uid` mirrors the desktop composer's dedup key so callers can migrate
- * without changing behavior. */
+ * upload-item type. */
 export interface PendingAttachment {
     file: File
     uid: string
     name: string
 }
 
-// uid formula mirrored from `toUploadFile` in
-// web/oss/src/components/AgentChatSlice/AgentConversation.tsx (2026-07-25); the desktop
-// composer keeps its own upload-item type, so only the dedup key is shared here.
+// Unique per staged ROW, not per file identity: a name-mtime-size key collided whenever the
+// same file was attached twice (paste then drop) — one remove then wiped both rows. Mirrors
+// the desktop composer's fix.
 export const toPendingAttachment = (file: File): PendingAttachment => ({
     file,
-    uid: `${file.name}-${file.lastModified}-${file.size}`,
+    uid: `att-${generateId()}`,
     name: file.name,
 })
+
+/**
+ * A file moving through (or done with) the upload pipeline — the neutral replacement for the
+ * antd `UploadFile` shape the desktop tray used. Only the fields the pipeline actually reads.
+ */
+export interface StagedUpload<TResponse = unknown> {
+    /** Unique per staged ROW (the tray's React key, remove/retry handle, upload idempotency key). */
+    uid: string
+    name: string
+    status?: "uploading" | "done" | "error"
+    /** Upload progress 0–100 while `status === "uploading"`. */
+    percent?: number
+    /** The live browser File backing the row (absent on replayed/serialized entries). */
+    originFileObj?: File
+    /** Server response once the upload settled. */
+    response?: TResponse
+    error?: unknown
+    /** Mirror of the File's media type/size, for rows whose blob is gone. */
+    type?: string
+    size?: number
+}

--- a/web/packages/agenta-chat/src/model/error.ts
+++ b/web/packages/agenta-chat/src/model/error.ts
@@ -38,3 +38,8 @@ export const parseAgentRunError = (err: unknown): ParsedRunError => {
     }
     return {message: fallback}
 }
+
+/** A stream error/abort is already surfaced via `useChat`'s `onError` + the in-chat `error`
+ * alert; swallow the floating `sendMessage`/`regenerate` rejection so it doesn't bubble to the
+ * Next.js dev Runtime Error overlay (F-033). */
+export const ignoreStreamRejection = () => {}

--- a/web/packages/agenta-chat/src/model/parts.ts
+++ b/web/packages/agenta-chat/src/model/parts.ts
@@ -54,3 +54,18 @@ export const partToolName = (part: ToolUIPart): string => {
     }
     return type.replace(/^tool-/, "")
 }
+
+/** Assistant message id → its 1-based turn number (records/turns align 1:1 with the assistant
+ * messages — one per `done`). Built once per message set: the per-message scan it replaces was
+ * O(n) inside a render loop, so the transcript paid O(n²) on every streamed commit. */
+export const assistantTurnNumbers = (messages: UIMessage[]): Map<string, number> => {
+    const turns = new Map<string, number>()
+    let n = 0
+    for (const m of messages) {
+        if (m.role === "assistant") {
+            n += 1
+            turns.set(m.id, n)
+        }
+    }
+    return turns
+}

--- a/web/packages/agenta-chat/src/state/expandState.ts
+++ b/web/packages/agenta-chat/src/state/expandState.ts
@@ -1,6 +1,4 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/state/expandState.ts (2026-07-25);
-// the OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it.
-// Keep byte-parity if either side changes.
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
 import type {UIMessage} from "ai"
 import {atom} from "jotai"
 import {atomFamily, selectAtom} from "jotai/utils"

--- a/web/packages/agenta-chat/src/state/sessionEphemera.ts
+++ b/web/packages/agenta-chat/src/state/sessionEphemera.ts
@@ -2,13 +2,13 @@
 // (2026-07-25); the OSS original remains authoritative for the desktop chat until the re-plumb
 // PR deletes it. Keep byte-parity if either side changes.
 // Adaptations:
-//  (a) `attachmentsBySession` is typed `Map<string, PendingAttachment[]>` (../model/attachments)
+//  (a) `attachmentsBySession` holds the staged upload-tray entries (`StagedUpload`)
 //      instead of the desktop's upload-widget file type — the package must not depend on that
 //      desktop UI toolkit.
 //  (b) the desktop's per-session virtualized-list scroll/row-height snapshot map and its cleanup
 //      in `clearSessionEphemera` are OMITTED entirely — that state is desktop-only, and the
 //      package must not depend on the desktop's list-virtualization library either.
-import type {PendingAttachment} from "../model/attachments"
+import type {StagedUpload} from "../model"
 
 /**
  * Per-session in-memory ephemera that must survive pane remounts (route re-entry, tab
@@ -26,7 +26,7 @@ import type {PendingAttachment} from "../model/attachments"
 export const composerDraftBySession = new Map<string, string>()
 
 /** Pending (not yet sent) attachments per session — same lifetime as the drafts. */
-export const attachmentsBySession = new Map<string, PendingAttachment[]>()
+export const attachmentsBySession = new Map<string, StagedUpload<unknown>[]>()
 
 /**
  * Sessions created brand-new in this browser and not yet run. A never-run local session has no

--- a/web/packages/agenta-chat/src/state/sessionMessages.ts
+++ b/web/packages/agenta-chat/src/state/sessionMessages.ts
@@ -1,18 +1,9 @@
-// Copied from web/oss/src/components/AgentChatSlice/state/sessions.ts (2026-07-25) — ONLY the
-// self-contained message-persistence and run-status pieces the conversation host needs
-// (`sessionMessagesAtom` + its record watermark, the quota-guarded persist writer, and the
-// per-session run-status store). The OSS original remains authoritative for the desktop chat
-// until the re-plumb PR deletes it; keep byte-parity on the copied blocks if either side
-// changes. The rest of that file (scope-keyed history/tabs, server reconciliation,
-// archive/delete remotes, timestamps) is app-layer session-LIST state and stays out of the
-// package deliberately.
-//
-// Both copies write the SAME localStorage keys (`agenta:agent-chat:{messages,record-counts}`),
-// so a semantic difference here is a live defect the moment one app writes through the package
-// while the other reads OSS's stores. The ONE deliberate difference: OSS's `dropSessionMessages`
-// is a module-private helper called by its scope-keyed delete/close/prune paths, which do not
-// exist here — the package exposes the same joint deletion as a write atom
-// (`dropSessionMessagesAtom`) so a consumer that forgets a session cannot drop one store only.
+// Canonical since the desktop re-plumb: OSS's sessions.ts deleted its copied blocks and both
+// apps read/write THIS store (localStorage keys `agenta:agent-chat:{messages,record-counts}:v2`).
+// The rest of that OSS file (scope-keyed history/tabs, server reconciliation, archive/delete
+// remotes, timestamps) is app-layer session-LIST state and stays out of the package deliberately.
+// Deletion is exposed as `dropSessionMessagesAtom` so a consumer that forgets a session cannot
+// drop the transcript store without its watermark (the two must never diverge).
 import type {UIMessage} from "ai"
 import {atom, type Getter, type Setter} from "jotai"
 import {atomFamily, atomWithStorage, createJSONStorage} from "jotai/utils"
@@ -39,9 +30,11 @@ const tabLocalStorage = <T>() => {
 }
 
 /** Persisted messages per session id. Written when a conversation's stream settles. Session ids
- * are globally unique, so this store has no scope dimension. */
+ * are globally unique, so this store has no scope dimension.
+ * v2: caches written by the pre-fix mapper hold duplicated approval parts; the key bump forces
+ * one re-sync from records (the watermark otherwise keeps the stale copy authoritative). */
 export const sessionMessagesAtom = atomWithStorage<Record<string, UIMessage[]>>(
-    "agenta:agent-chat:messages",
+    "agenta:agent-chat:messages:v2",
     {},
     tabLocalStorage(),
     STORAGE_OPTS,
@@ -56,7 +49,7 @@ export const sessionMessagesAtom = atomWithStorage<Record<string, UIMessage[]>>(
  * goes through `persistSessionMessagesAtom` and every delete through `dropSessionMessagesAtom`.
  */
 const sessionRecordCountsAtom = atomWithStorage<Record<string, number>>(
-    "agenta:agent-chat:record-counts",
+    "agenta:agent-chat:record-counts:v2",
     {},
     tabLocalStorage(),
     STORAGE_OPTS,

--- a/web/packages/agenta-chat/src/state/sessionMessages.ts
+++ b/web/packages/agenta-chat/src/state/sessionMessages.ts
@@ -29,6 +29,28 @@ const tabLocalStorage = <T>() => {
     return storage
 }
 
+/**
+ * The pre-`:v2` stores. Nothing reads them any more — the key bump below is precisely how the
+ * duplicated-approval-part caches were retired — but `dropSessionMessagesAtom` only ever deletes
+ * the `:v2` keys, so without this they sit in localStorage forever, taking quota from the stores
+ * that ARE used (transcripts with inline attachments make the ~5MB ceiling reachable).
+ *
+ * Dropped once at module load rather than on a re-sync: the v2 stores are already authoritative
+ * from the first read, so there is nothing to migrate and nothing to wait for. Idempotent —
+ * `removeItem` on an absent key is a no-op, so a second import (or a second browser tab) costs
+ * nothing. Guarded for SSR and for browsers that deny storage access entirely.
+ */
+const dropLegacySessionStores = () => {
+    if (typeof window === "undefined") return
+    try {
+        window.localStorage.removeItem("agenta:agent-chat:messages")
+        window.localStorage.removeItem("agenta:agent-chat:record-counts")
+    } catch {
+        // Storage disabled (private mode, blocked cookies) — nothing to clean up there anyway.
+    }
+}
+dropLegacySessionStores()
+
 /** Persisted messages per session id. Written when a conversation's stream settles. Session ids
  * are globally unique, so this store has no scope dimension.
  * v2: caches written by the pre-fix mapper hold duplicated approval parts; the key bump forces

--- a/web/packages/agenta-chat/src/transport/AgentChatTransport.ts
+++ b/web/packages/agenta-chat/src/transport/AgentChatTransport.ts
@@ -221,34 +221,50 @@ const SMOOTH_CHUNK_BUDGET_MS = 1200
 function smoothTextStream(upstream: ReadableStream<AnyChunk>): ReadableStream<AnyChunk> {
     const reader = upstream.getReader()
     const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+    // The pieces of the delta currently being paced out, CARRIED ACROSS `pull()` calls. A delta
+    // used to be flushed entirely within the pull that read it, which was fine only because the
+    // per-piece sleep yielded between pieces — and past ~1,200 pieces the budget share drops below
+    // a millisecond, the sleep is skipped, and the whole thing became one synchronous burst of
+    // thousands of enqueues that never yielded and never re-consulted the consumer. Keeping the
+    // leftovers here lets a pull stop the moment the consumer is full and resume when it asks again.
+    let pending: AnyChunk[] = []
+    let pendingDelay = 0
     return new ReadableStream<AnyChunk>({
         async pull(controller) {
-            const {done, value} = await reader.read()
-            if (done) {
-                controller.close()
-                return
+            if (pending.length === 0) {
+                const {done, value} = await reader.read()
+                if (done) {
+                    controller.close()
+                    return
+                }
+                const chunk = value as {type?: string; delta?: string}
+                // Pace every delta-carrying chunk kind (text-delta, reasoning-delta, and any other
+                // alias the projection uses) — matching exact names is how thinking slipped through.
+                const paced = typeof chunk?.type === "string" && chunk.type.endsWith("-delta")
+                if (!paced || typeof chunk.delta !== "string") {
+                    controller.enqueue(value)
+                    return
+                }
+                // Split keeping whitespace attached to the preceding word, so reassembly is exact.
+                const pieces = chunk.delta.match(/\S+\s*|\s+/g) ?? [chunk.delta]
+                if (pieces.length <= 1) {
+                    controller.enqueue(value)
+                    return
+                }
+                pending = pieces.map((piece) => ({...(value as object), delta: piece}) as AnyChunk)
+                pendingDelay = Math.min(SMOOTH_BASE_MS, SMOOTH_CHUNK_BUDGET_MS / pieces.length)
             }
-            const chunk = value as {type?: string; delta?: string}
-            // Pace every delta-carrying chunk kind (text-delta, reasoning-delta, and any other
-            // alias the projection uses) — matching exact names is how thinking slipped through.
-            const paced = typeof chunk?.type === "string" && chunk.type.endsWith("-delta")
-            if (!paced || typeof chunk.delta !== "string") {
-                controller.enqueue(value)
-                return
-            }
-            // Split keeping whitespace attached to the preceding word, so reassembly is exact.
-            const pieces = chunk.delta.match(/\S+\s*|\s+/g) ?? [chunk.delta]
-            if (pieces.length <= 1) {
-                controller.enqueue(value)
-                return
-            }
-            const delay = Math.min(SMOOTH_BASE_MS, SMOOTH_CHUNK_BUDGET_MS / pieces.length)
-            for (const piece of pieces) {
-                controller.enqueue({...(value as object), delta: piece} as AnyChunk)
-                if (delay >= 1) await sleep(delay)
-            }
+            // Emit until the delta runs out or the consumer stops asking for more. Returning with
+            // pieces still pending is the backpressure: the stream calls `pull` again once its
+            // queue drains, and the cadence below is unchanged for normal-sized deltas.
+            do {
+                controller.enqueue(pending.shift() as AnyChunk)
+                if (pending.length === 0) return
+                if (pendingDelay >= 1) await sleep(pendingDelay)
+            } while ((controller.desiredSize ?? 1) > 0)
         },
         cancel(reason) {
+            pending = []
             return reader.cancel(reason)
         },
     })

--- a/web/packages/agenta-chat/src/transport/AgentChatTransport.ts
+++ b/web/packages/agenta-chat/src/transport/AgentChatTransport.ts
@@ -1,10 +1,5 @@
-// Copied verbatim from web/oss/src/components/AgentChatSlice/assets/AgentChatTransport.ts
-// (2026-07-25); the OSS original remains authoritative for the desktop chat until the re-plumb
-// PR deletes it. Keep byte-parity if either side changes.
-// Adaptations: none — `createNegotiatingFetch`/`NegotiatingFetch` come from `@agenta/playground`
-// and `generateId` from `@agenta/shared/utils`, both already allowed package deps; no OSS-app
-// import was involved.
-import {createNegotiatingFetch, type NegotiatingFetch} from "@agenta/playground"
+// Canonical since the desktop re-plumb: the OSS copy is deleted and both apps import this.
+import {createNegotiatingFetch, type NegotiatingFetch} from "@agenta/playground/agent-chat"
 import {generateId} from "@agenta/shared/utils"
 import {DefaultChatTransport, type UIMessage, type UIMessageChunk} from "ai"
 
@@ -209,6 +204,56 @@ function batchJsonToUiMessageStream(
     })
 }
 
+/** Per-piece pacing for the smooth stream: base cadence, and a per-chunk time budget so a
+ * huge delta (multiple paragraphs in one SSE event) still lands within about a second instead
+ * of faking a minute of typing. */
+const SMOOTH_BASE_MS = 18
+const SMOOTH_CHUNK_BUDGET_MS = 1200
+
+/**
+ * Smooth the text stream: the backend emits deltas at whatever granularity it batches (often
+ * several sentences or paragraphs per event), which makes the UI "type" whole paragraphs at
+ * once. This re-emits each text delta as word-sized pieces on a timed cadence, so downstream
+ * consumers (streamdown's token animation) see genuinely incremental text. Non-text chunks
+ * pass through in order (the pump is sequential, so a tool call never overtakes its preceding
+ * prose). The budget cap keeps total added latency bounded per chunk.
+ */
+function smoothTextStream(upstream: ReadableStream<AnyChunk>): ReadableStream<AnyChunk> {
+    const reader = upstream.getReader()
+    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+    return new ReadableStream<AnyChunk>({
+        async pull(controller) {
+            const {done, value} = await reader.read()
+            if (done) {
+                controller.close()
+                return
+            }
+            const chunk = value as {type?: string; delta?: string}
+            // Pace every delta-carrying chunk kind (text-delta, reasoning-delta, and any other
+            // alias the projection uses) — matching exact names is how thinking slipped through.
+            const paced = typeof chunk?.type === "string" && chunk.type.endsWith("-delta")
+            if (!paced || typeof chunk.delta !== "string") {
+                controller.enqueue(value)
+                return
+            }
+            // Split keeping whitespace attached to the preceding word, so reassembly is exact.
+            const pieces = chunk.delta.match(/\S+\s*|\s+/g) ?? [chunk.delta]
+            if (pieces.length <= 1) {
+                controller.enqueue(value)
+                return
+            }
+            const delay = Math.min(SMOOTH_BASE_MS, SMOOTH_CHUNK_BUDGET_MS / pieces.length)
+            for (const piece of pieces) {
+                controller.enqueue({...(value as object), delta: piece} as AnyChunk)
+                if (delay >= 1) await sleep(delay)
+            }
+        },
+        cancel(reason) {
+            return reader.cancel(reason)
+        },
+    })
+}
+
 export class AgentChatTransport extends DefaultChatTransport<UIMessage> {
     private readonly negotiator: NegotiatingFetch
 
@@ -226,6 +271,7 @@ export class AgentChatTransport extends DefaultChatTransport<UIMessage> {
         // body stream (`resolvedMode(stream)`), so request and parse stay in lockstep.
         if (this.negotiator.resolvedMode(stream) === "batch")
             return batchJsonToUiMessageStream(stream)
-        return super.processResponseStream(stream)
+        // Live stream: smooth coarse backend deltas into word-paced pieces (typing feel).
+        return smoothTextStream(super.processResponseStream(stream))
     }
 }

--- a/web/packages/agenta-chat/tests/unit/assets/attachmentRules.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/attachmentRules.test.ts
@@ -1,7 +1,9 @@
 import {describe, expect, it} from "vitest"
 
 import {
+    type AttachmentLimits,
     DEFAULT_ATTACHMENT_LIMITS,
+    describeAccepted,
     formatBytes,
     isAcceptedType,
     validateIncoming,
@@ -100,5 +102,35 @@ describe("validateIncoming", () => {
         const {accepted, rejections} = validateIncoming([a], 3, limits)
         expect(accepted).toEqual([])
         expect(rejections).toEqual([{name: "a.png", reason: "exceeds the 3-file limit"}])
+    })
+})
+
+// User-visible: the composer's empty state renders this ("Images and audio · up to N files").
+describe("describeAccepted", () => {
+    const withKinds = (kinds: AttachmentLimits["kinds"]): AttachmentLimits => ({
+        ...DEFAULT_ATTACHMENT_LIMITS,
+        kinds,
+    })
+
+    it("names a single kind", () => {
+        expect(describeAccepted(withKinds(["image"]))).toBe("Images")
+    })
+
+    // A two-item list takes a bare "and" — "Images, and audio" is not English.
+    it("joins two kinds without a comma", () => {
+        expect(describeAccepted(withKinds(["image", "audio"]))).toBe("Images and audio")
+    })
+
+    it("keeps the serial comma from three kinds up", () => {
+        expect(describeAccepted(withKinds(["image", "audio", "document"]))).toBe(
+            "Images, audio, and documents",
+        )
+        expect(describeAccepted(withKinds(["image", "audio", "document", "other"]))).toBe(
+            "Images, audio, documents, and other files",
+        )
+    })
+
+    it("says so when nothing is accepted", () => {
+        expect(describeAccepted(withKinds([]))).toBe("No attachments")
     })
 })

--- a/web/packages/agenta-chat/tests/unit/assets/attachmentRules.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/attachmentRules.test.ts
@@ -19,8 +19,18 @@ describe("isAcceptedType", () => {
         expect(isAcceptedType("image/png", DEFAULT_ATTACHMENT_LIMITS)).toBe(true)
     })
 
-    it("rejects an unlisted type", () => {
-        expect(isAcceptedType("application/zip", DEFAULT_ATTACHMENT_LIMITS)).toBe(false)
+    it("accepts any type under the defaults (the 'other' kind is enabled)", () => {
+        expect(isAcceptedType("application/zip", DEFAULT_ATTACHMENT_LIMITS)).toBe(true)
+    })
+
+    it("rejects a kind the limits exclude", () => {
+        const narrowed = {
+            ...DEFAULT_ATTACHMENT_LIMITS,
+            kinds: ["image", "audio", "document"] as const,
+        }
+        expect(isAcceptedType("application/zip", {...narrowed, kinds: [...narrowed.kinds]})).toBe(
+            false,
+        )
     })
 })
 
@@ -46,20 +56,27 @@ describe("validateIncoming", () => {
         expect(rejections).toEqual([])
     })
 
-    it("rejects an unsupported media type", () => {
+    it("rejects a media type whose kind the limits exclude", () => {
+        const limits = {
+            ...DEFAULT_ATTACHMENT_LIMITS,
+            kinds: ["image", "audio", "document"] as ("image" | "audio" | "document")[],
+        }
         const file = makeFile("a.zip", "application/zip", 1024)
-        const {accepted, rejections} = validateIncoming([file], 0)
+        const {accepted, rejections} = validateIncoming([file], 0, limits)
         expect(accepted).toEqual([])
         expect(rejections).toEqual([{name: "a.zip", reason: "isn't a supported file type"}])
     })
 
-    it("rejects a file over the per-file byte limit", () => {
-        const limits = {...DEFAULT_ATTACHMENT_LIMITS, maxBytes: 100}
+    it("rejects a file over its kind's byte limit", () => {
+        const limits = {
+            ...DEFAULT_ATTACHMENT_LIMITS,
+            maxBytes: {...DEFAULT_ATTACHMENT_LIMITS.maxBytes, image: 100},
+        }
         const file = makeFile("big.png", "image/png", 200)
         const {accepted, rejections} = validateIncoming([file], 0, limits)
         expect(accepted).toEqual([])
         expect(rejections).toEqual([
-            {name: "big.png", reason: "is too large (200 B) · max 100 B per file"},
+            {name: "big.png", reason: "is too large (200 B) · max 100 B for images"},
         ])
     })
 

--- a/web/packages/agenta-chat/tests/unit/assets/attachmentTransport.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/attachmentTransport.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+// jsdom's File has no `text()`, and this suite asserts on the multipart body it builds.
+import type {AxiosProgressEvent} from "axios"
+import {CanceledError} from "axios"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+import {axios} from "@agenta/shared/api"
+
+import {AttachmentUploadError, uploadAttachment} from "../../../src/assets/attachmentTransport"
+
+vi.mock("@agenta/shared/api", () => ({
+    axios: {post: vi.fn()},
+    getAgentaApiUrl: vi.fn(() => "https://api.example.test"),
+}))
+
+const attachmentId = "0198f489-8c20-7000-8000-000000000001"
+const idempotencyKey = "0198f489-8c20-7000-8000-000000000002"
+const response = {
+    count: 1,
+    attachment: {
+        attachment_id: attachmentId,
+        filename: "notes.txt",
+        media_type: "text/plain",
+        size: 5,
+        created_at: "2026-07-31T12:00:00Z",
+    },
+}
+
+describe("uploadAttachment", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it("posts the multipart fields and returns a validated response", async () => {
+        vi.mocked(axios.post).mockResolvedValue({data: response})
+        const file = new File(["hello"], "notes.txt", {type: "text/plain"})
+
+        await expect(
+            uploadAttachment({file, sessionId: "session-1", idempotencyKey}),
+        ).resolves.toEqual(response)
+
+        const [url, body, config] = vi.mocked(axios.post).mock.calls[0]
+        expect(url).toBe("https://api.example.test/sessions/attachments")
+        expect(config?.params).toEqual({session_id: "session-1"})
+        expect(body).toBeInstanceOf(FormData)
+        const form = body as FormData
+        expect(form.get("idempotency_key")).toBe(idempotencyKey)
+        const uploaded = form.get("file") as File
+        expect(uploaded.name).toBe("notes.txt")
+        await expect(uploaded.text()).resolves.toBe("hello")
+    })
+
+    it("reports upload progress", async () => {
+        vi.mocked(axios.post).mockResolvedValue({data: response})
+        const onProgress = vi.fn()
+
+        await uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+            onProgress,
+        })
+
+        const config = vi.mocked(axios.post).mock.calls[0][2]
+        config?.onUploadProgress?.({loaded: 1, total: 4} as AxiosProgressEvent)
+        expect(onProgress).toHaveBeenCalledWith(25)
+    })
+
+    it("forwards the abort signal and preserves cancellation", async () => {
+        const controller = new AbortController()
+        vi.mocked(axios.post).mockImplementation(
+            (_url, _body, config) =>
+                new Promise((_resolve, reject) => {
+                    config?.signal?.addEventListener("abort", () => {
+                        reject(new CanceledError("canceled"))
+                    })
+                }),
+        )
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+            signal: controller.signal,
+        })
+        controller.abort()
+
+        await expect(upload).rejects.toBeInstanceOf(CanceledError)
+        expect(vi.mocked(axios.post).mock.calls[0][2]?.signal).toBe(controller.signal)
+    })
+
+    it("turns a network failure into a retryable user-safe error", async () => {
+        vi.mocked(axios.post).mockRejectedValue(new Error("socket path and token details"))
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toMatchObject({
+            name: "AttachmentUploadError",
+            message: "Couldn't upload the file. Try again.",
+            retryable: true,
+        })
+    })
+
+    it.each([
+        [413, "text/plain", "This file exceeds the 10.0 MB document limit."],
+        [422, "text/plain", "This file isn't valid."],
+        [429, "text/plain", "This session's attachment quota is full."],
+        [404, "text/plain", "This backend does not support attachments yet."],
+    ])("maps HTTP %s to a short non-retryable error", async (status, mediaType, message) => {
+        vi.mocked(axios.post).mockRejectedValue({
+            isAxiosError: true,
+            response: {status, headers: {}},
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt", {type: mediaType}),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toMatchObject({message, retryable: false})
+    })
+
+    it("honours Retry-After for an upload already in flight", async () => {
+        vi.mocked(axios.post).mockRejectedValue({
+            isAxiosError: true,
+            response: {status: 409, headers: {"retry-after": "7"}},
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toMatchObject({
+            message: "This file is already uploading. Retry in 7s.",
+            retryable: true,
+            retryAfterSeconds: 7,
+        })
+    })
+
+    it("logs schema drift and throws a controlled retryable error", async () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+        vi.mocked(axios.post).mockResolvedValue({
+            data: {...response, attachment: {...response.attachment, attachment_id: "not-a-uuid"}},
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toBeInstanceOf(AttachmentUploadError)
+        expect(consoleError).toHaveBeenCalledWith(
+            "[uploadAttachment] Validation failed:",
+            expect.any(Object),
+        )
+        consoleError.mockRestore()
+    })
+
+    it("rejects uppercase attachment ids emitted outside the canonical server contract", async () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+        vi.mocked(axios.post).mockResolvedValue({
+            data: {
+                ...response,
+                attachment: {...response.attachment, attachment_id: attachmentId.toUpperCase()},
+            },
+        })
+
+        const upload = uploadAttachment({
+            file: new File(["hello"], "notes.txt"),
+            sessionId: "session-1",
+            idempotencyKey,
+        })
+
+        await expect(upload).rejects.toBeInstanceOf(AttachmentUploadError)
+        consoleError.mockRestore()
+    })
+})

--- a/web/packages/agenta-chat/tests/unit/assets/files.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/files.test.ts
@@ -1,7 +1,13 @@
 import type {FileUIPart, UIMessage} from "ai"
 import {describe, expect, it} from "vitest"
 
-import {fileKind, fileParts, filePartName, filesToParts} from "../../../src/assets/files"
+import {
+    attachmentRefsToParts,
+    fileKind,
+    fileParts,
+    filePartName,
+    filesToParts,
+} from "../../../src/assets/files"
 
 // `filesToParts`/`fileToPart` read a `File` via `FileReader.readAsDataURL`, which the node
 // vitest environment (`environment: "node"` in vitest.config.ts) does not provide — no DOM,
@@ -144,5 +150,46 @@ describe("filesToParts", () => {
             expect(parts).toHaveLength(2)
             expect(rejections).toEqual([])
         })
+    })
+})
+
+const firstAttachmentId = "019c1e0a-f911-7000-8000-000000000001"
+
+describe("attachment reference parts", () => {
+    it("stores size under providerMetadata.agenta", () => {
+        const part = attachmentRefsToParts(
+            [
+                {
+                    attachmentId: firstAttachmentId,
+                    filename: "notes.txt",
+                    mediaType: "text/plain",
+                    size: 42,
+                },
+            ],
+            "session-1",
+        )[0]
+
+        expect(part).toMatchObject({
+            type: "file",
+            filename: "notes.txt",
+            providerMetadata: {
+                agenta: {attachmentId: firstAttachmentId, size: 42},
+            },
+        })
+        expect(part).not.toHaveProperty("size")
+        expect(part.url).toContain(
+            `/sessions/attachments/${firstAttachmentId}/content?session_id=session-1`,
+        )
+    })
+
+    it("labels an unnamed reference part 'attachment', not its URL tail", () => {
+        expect(
+            filePartName({
+                type: "file",
+                mediaType: "text/plain",
+                url: "https://api.example.test/sessions/attachments/id/content?session_id=s",
+                providerMetadata: {agenta: {attachmentId: firstAttachmentId, size: 42}},
+            }),
+        ).toBe("attachment")
     })
 })

--- a/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
@@ -1,7 +1,10 @@
 import type {SessionRecord} from "@agenta/entities/session"
 import {describe, expect, it} from "vitest"
 
-import {transcriptToMessages} from "../../../src/assets/transcriptToMessages"
+import {
+    APPROVED_EXECUTION_RESULT_UNKNOWN,
+    transcriptToMessages,
+} from "../../../src/assets/transcriptToMessages"
 
 const record = (id: string, payload: Record<string, unknown>, sender = "agent"): SessionRecord => ({
     id,
@@ -377,5 +380,359 @@ describe("transcriptToMessages cold approval resume (re-raised tool call id)", (
             approval: {id: "approval-1", approved: false},
         })
         expect(parts.filter((part) => part.state === "approval-requested")).toEqual([])
+    })
+})
+
+describe("transcriptToMessages run failures", () => {
+    const failure = (message: string, id = "record-error"): SessionRecord =>
+        record(id, {type: "error", message})
+
+    it("replays a persisted error through metadata.runError, not as body text", () => {
+        const messages = transcriptToMessages([
+            record("record-text", {type: "message", text: "Working on it."}),
+            failure("tool call toolu_1 exceeded 300000ms"),
+        ])
+
+        expect(messages?.[0].parts).toEqual([{type: "text", text: "Working on it."}])
+        expect(messages?.[0].metadata).toMatchObject({
+            runError: {message: "tool call toolu_1 exceeded 300000ms"},
+        })
+    })
+
+    it("keeps a turn whose only content was the failure", () => {
+        const messages = transcriptToMessages([failure("the agent run failed")])
+
+        expect(messages).toHaveLength(1)
+        expect(messages?.[0].parts).toEqual([])
+        expect(messages?.[0].metadata).toMatchObject({runError: {message: "the agent run failed"}})
+    })
+
+    it("keeps the root cause when a cascading error follows", () => {
+        const messages = transcriptToMessages([
+            failure("first failure", "record-error-1"),
+            failure("second failure", "record-error-2"),
+        ])
+
+        expect(messages?.[0].metadata).toMatchObject({runError: {message: "first failure"}})
+    })
+
+    it("ignores an empty error message", () => {
+        expect(transcriptToMessages([failure("   ")])).toBeNull()
+    })
+})
+
+const firstPart = (records: SessionRecord[]): Record<string, unknown> => {
+    const messages = transcriptToMessages(records)
+    expect(messages).not.toBeNull()
+    return messages?.[0].parts[0] as unknown as Record<string, unknown>
+}
+
+// Ported from the OSS original's "approval hydration" suite (the cases not already covered by
+// the approval-resume suites above).
+describe("transcriptToMessages approval hydration", () => {
+    it("overlays a persisted approval response with the live response shape", () => {
+        const part = firstPart([
+            ...approvalRecords(),
+            record("record-response", {
+                type: "interaction_response",
+                id: "approval-1",
+                kind: "user_approval",
+                payload: {toolCallId: "tool-1", approved: true},
+            }),
+        ])
+
+        expect(part).toEqual({
+            type: "tool-bash",
+            toolCallId: "tool-1",
+            state: "approval-responded",
+            input: {command: "ls"},
+            approval: {id: "approval-1", approved: true},
+        })
+    })
+
+    it("keeps an unanswered request pending", () => {
+        const part = firstPart(approvalRecords())
+
+        expect(part.state).toBe("approval-requested")
+        expect(part.approval).toEqual({id: "approval-1"})
+    })
+
+    it("lets an executed tool result supersede a later approval response", () => {
+        const part = firstPart([
+            ...approvalRecords(),
+            record("record-result", {
+                type: "tool_result",
+                id: "tool-1",
+                output: "done",
+            }),
+            record("record-response", {
+                type: "interaction_response",
+                id: "approval-1",
+                kind: "user_approval",
+                payload: {toolCallId: "tool-1", approved: true},
+            }),
+        ])
+
+        expect(part.state).toBe("output-available")
+        expect(part.output).toBe("done")
+        expect(part.approval).toEqual({id: "approval-1"})
+    })
+
+    it("falls back to the interaction id when the response omits the tool-call id", () => {
+        const part = firstPart([
+            ...approvalRecords(),
+            record("record-response", {
+                type: "interaction_response",
+                id: "approval-1",
+                kind: "user_approval",
+                payload: {approved: false},
+            }),
+        ])
+
+        expect(part.state).toBe("approval-responded")
+        expect(part.approval).toEqual({id: "approval-1", approved: false})
+    })
+
+    it("reopens deferred call b when its turn-2 approval request arrives", () => {
+        const messages = transcriptToMessages([
+            record("record-user", {type: "message", text: "run both writes"}, "user"),
+            record("record-call-a", {
+                type: "tool_call",
+                id: "tool-a",
+                name: "bash",
+                input: {command: "write a"},
+            }),
+            record("record-call-b", {
+                type: "tool_call",
+                id: "tool-b",
+                name: "bash",
+                input: {command: "write b"},
+            }),
+            record("record-request-a", {
+                type: "interaction_request",
+                id: "approval-a",
+                kind: "user_approval",
+                payload: {toolCallId: "tool-a"},
+            }),
+            record("record-result-b-deferred", {
+                type: "tool_result",
+                id: "tool-b",
+                output: "DEFERRED_NOT_EXECUTED: paused for another approval; retry the same call if still required.",
+                isError: true,
+            }),
+            record("record-done-turn-1", {type: "done"}),
+            record("record-user-turn-2", {type: "message", text: "run both writes"}, "user"),
+            record("record-response-a", {
+                type: "interaction_response",
+                id: "approval-a",
+                kind: "user_approval",
+                payload: {toolCallId: "tool-a", approved: true},
+            }),
+            record("record-request-b", {
+                type: "interaction_request",
+                id: "approval-b",
+                kind: "user_approval",
+                payload: {
+                    toolCallId: "tool-b",
+                    toolCall: {
+                        toolCallId: "tool-b",
+                        name: "bash",
+                        rawInput: {command: "write b"},
+                    },
+                },
+            }),
+            record("record-result-a", {
+                type: "tool_result",
+                id: "tool-a",
+                output: APPROVED_EXECUTION_RESULT_UNKNOWN,
+                isError: true,
+            }),
+            record("record-done-turn-2", {type: "done"}),
+        ])
+
+        expect(messages).not.toBeNull()
+        expect(messages?.[0]).toMatchObject({
+            role: "user",
+            parts: [{type: "text", text: "run both writes"}],
+        })
+        const assistantParts = messages
+            ?.filter((message) => message.role === "assistant")
+            .flatMap((message) => message.parts) as unknown as Record<string, unknown>[]
+        const callA = assistantParts.find((part) => part.toolCallId === "tool-a")
+        const callB = assistantParts.find((part) => part.toolCallId === "tool-b")
+
+        expect(callA).toMatchObject({
+            state: "output-error",
+            errorText: APPROVED_EXECUTION_RESULT_UNKNOWN,
+            approval: {id: "approval-a", approved: true},
+        })
+        expect(callB).toEqual({
+            type: "tool-bash",
+            toolCallId: "tool-b",
+            state: "approval-requested",
+            input: {command: "write b"},
+            approval: {id: "approval-b"},
+        })
+        expect(assistantParts.filter((part) => part.state === "approval-requested")).toEqual([
+            callB,
+        ])
+    })
+
+    it("keeps a real tool error closed when a late approval request arrives", () => {
+        const part = firstPart([
+            record("record-call-b", {
+                type: "tool_call",
+                id: "tool-b",
+                name: "bash",
+                input: {command: "write b"},
+            }),
+            record("record-result-b", {
+                type: "tool_result",
+                id: "tool-b",
+                output: "permission denied",
+                isError: true,
+            }),
+            record("record-done-turn-1", {type: "done"}),
+            record("record-request-b", {
+                type: "interaction_request",
+                id: "approval-b",
+                kind: "user_approval",
+                payload: {toolCallId: "tool-b"},
+            }),
+        ])
+
+        expect(part).toEqual({
+            type: "tool-bash",
+            toolCallId: "tool-b",
+            state: "output-error",
+            input: {command: "write b"},
+            errorText: "permission denied",
+        })
+    })
+})
+
+describe("transcriptToMessages paused end-marker", () => {
+    it("flags the message whose turn ended paused (done.stopReason)", () => {
+        const messages = transcriptToMessages([
+            ...approvalRecords(),
+            record("record-done-paused", {type: "done", stopReason: "paused"}),
+        ])
+        expect(messages).not.toBeNull()
+        expect(messages?.[0].metadata).toMatchObject({paused: true})
+    })
+
+    it("does not flag a normally completed turn", () => {
+        const messages = transcriptToMessages([
+            ...approvalRecords(),
+            record("record-done-complete", {type: "done"}),
+        ])
+        expect(messages).not.toBeNull()
+        expect((messages?.[0].metadata as {paused?: boolean} | undefined)?.paused).toBeUndefined()
+    })
+})
+
+/**
+ * Regression guard for issue #5530. The adoption guard must not go back to comparing message
+ * counts: a turn grows IN PLACE here, so the count is identical before and after it completes.
+ * If a mapper change ever makes these counts differ, revisit `shouldAdoptServerTranscript` —
+ * do not "simplify" it back to a count comparison on the strength of that change.
+ */
+describe("transcriptToMessages turn growth is invisible to a message count", () => {
+    const midTurn = (): SessionRecord[] => [
+        ...approvalRecords(),
+        record("record-done-paused", {type: "done", stopReason: "paused"}),
+    ]
+
+    const completed = (): SessionRecord[] => [
+        ...midTurn(),
+        record("record-response", {
+            type: "interaction_response",
+            id: "approval-1",
+            kind: "user_approval",
+            payload: {toolCallId: "tool-1", approved: true},
+        }),
+        record("record-result", {
+            type: "tool_result",
+            id: "tool-1",
+            output: {stdout: "a.txt\nb.txt"},
+        }),
+        record("record-answer", {type: "message", text: "There are two files."}),
+        record("record-done", {type: "done"}),
+    ]
+
+    it("renders the same number of messages before and after the turn finishes", () => {
+        const partial = transcriptToMessages(midTurn())
+        const full = transcriptToMessages(completed())
+
+        expect(partial).toHaveLength(1)
+        expect(full).toHaveLength(1)
+        // Same messages, far more content — and far more records behind it.
+        expect(completed().length).toBeGreaterThan(midTurn().length)
+    })
+
+    it("carries strictly more content in the completed turn", () => {
+        const partial = transcriptToMessages(midTurn())
+        const full = transcriptToMessages(completed())
+
+        expect(full?.[0].parts.length).toBeGreaterThan(partial?.[0].parts.length ?? 0)
+    })
+})
+
+describe("transcriptToMessages attachments", () => {
+    it("rebuilds user attachment references as file parts with filenames", () => {
+        const messages = transcriptToMessages([
+            record(
+                "record-user",
+                {
+                    type: "message",
+                    text: "Inspect this",
+                    attachments: [
+                        {
+                            attachmentId: "019c1e0a-f911-7000-8000-000000000001",
+                            filename: "diagram.png",
+                            mediaType: "image/png",
+                            size: 42,
+                        },
+                    ],
+                },
+                "user",
+            ),
+        ])
+
+        expect(messages?.[0]).toMatchObject({
+            role: "user",
+            parts: [
+                {type: "text", text: "Inspect this"},
+                {
+                    type: "file",
+                    filename: "diagram.png",
+                    mediaType: "image/png",
+                    providerMetadata: {
+                        agenta: {attachmentId: "019c1e0a-f911-7000-8000-000000000001", size: 42},
+                    },
+                },
+            ],
+        })
+        expect((messages?.[0].parts[1] as {url: string}).url).toContain(
+            "/sessions/attachments/019c1e0a-f911-7000-8000-000000000001/content?session_id=session-1",
+        )
+    })
+
+    it("ignores an attachment delivery record instead of rendering a part", () => {
+        const delivery = record("record-delivery", {
+            type: "attachment_delivery",
+            attachmentId: "019c1e0a-f911-7000-8000-000000000001",
+            outcome: "workspace_only",
+            reasonCode: "model_modality_unknown",
+            workingPath: "attachments/019c1e0a-f911-7000-8000-000000000001/archive.zip",
+        })
+
+        expect(transcriptToMessages([delivery])).toBeNull()
+        expect(
+            transcriptToMessages([
+                record("record-text", {type: "message", text: "Done."}),
+                delivery,
+            ])?.[0].parts,
+        ).toEqual([{type: "text", text: "Done."}])
     })
 })

--- a/web/packages/agenta-chat/tests/unit/fixtures/approvalTurn.json
+++ b/web/packages/agenta-chat/tests/unit/fixtures/approvalTurn.json
@@ -1,5 +1,9 @@
 [
-    {"id": "u1", "role": "user", "parts": [{"type": "text", "text": "delete the file and send a mail"}]},
+    {
+        "id": "u1",
+        "role": "user",
+        "parts": [{"type": "text", "text": "delete the file and send a mail"}]
+    },
     {
         "id": "a1",
         "role": "assistant",

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -13,8 +13,8 @@ import type {UIMessage} from "ai"
 import {createStore, Provider} from "jotai"
 import {beforeEach, describe, expect, it, vi} from "vitest"
 
-vi.mock("@agenta/playground", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("@agenta/playground")>()
+vi.mock("@agenta/playground/agent-chat", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@agenta/playground/agent-chat")>()
     return {
         ...actual,
         buildAgentRequest: vi.fn(
@@ -27,9 +27,13 @@ vi.mock("@agenta/playground", async (importOriginal) => {
     }
 })
 
-vi.mock("@agenta/entities/session", async () => {
+vi.mock("@agenta/entities/session", async (importOriginal) => {
     const {atom} = await import("jotai")
+    // Spread the real module: the fresh-session registry lives here now and these tests drive it
+    // directly (`markSessionFresh`), so a mock that only lists the atoms below would drop it.
+    const actual = await importOriginal<typeof import("@agenta/entities/session")>()
     return {
+        ...actual,
         revalidateSessionMountsAtom: atom(null, () => {}),
         revalidateSessionRecordsAtom: atom(null, () => {}),
         // The hydration seam's records fetch: "no server history" for these tests.
@@ -41,7 +45,7 @@ vi.mock("@agenta/entities/trace", () => ({
     markTraceAsFresh: vi.fn(),
 }))
 
-import {buildAgentRequest} from "@agenta/playground"
+import {buildAgentRequest} from "@agenta/playground/agent-chat"
 
 import {useAgentConversation} from "../../../src/hooks/useAgentConversation"
 import {markSessionFresh} from "../../../src/state/sessionEphemera"

--- a/web/packages/agenta-chat/tests/unit/hooks/useAttachmentUploads.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAttachmentUploads.test.ts
@@ -1,7 +1,17 @@
-import type {StagedUpload as UploadFile} from "@agenta/chat/model"
+// @vitest-environment jsdom
+import {useState} from "react"
+
+import {act, renderHook} from "@testing-library/react"
 import {describe, expect, it, vi} from "vitest"
 
-import {isUploadRetryReady, removeUploadFile} from "../../../src/hooks/useAttachmentUploads"
+import type {StagedUpload as UploadFile} from "@agenta/chat/model"
+
+import {
+    isUploadRetryReady,
+    removeUploadFile,
+    UPLOAD_CANCELLED_MESSAGE,
+    useAttachmentUploads,
+} from "../../../src/hooks/useAttachmentUploads"
 
 describe("attachment upload controls", () => {
     it("aborts an in-flight upload before removing its chip", () => {
@@ -23,5 +33,91 @@ describe("attachment upload controls", () => {
     it("holds retry until the Retry-After deadline", () => {
         expect(isUploadRetryReady(7_000, 6_999)).toBe(false)
         expect(isUploadRetryReady(7_000, 7_000)).toBe(true)
+    })
+})
+
+/** Drives the hook the way the tray does: `files` is real state, so every `patch` hands the effect
+ * a NEW array identity — which is exactly what used to restart an aborted upload. */
+const useTray = (upload: Parameters<typeof useAttachmentUploads<string>>[2]) => {
+    const [files, setFiles] = useState<UploadFile<string>[]>([])
+    const uploads = useAttachmentUploads<string>(files, setFiles, upload)
+    return {files, setFiles, uploads}
+}
+
+describe("useAttachmentUploads lifecycle", () => {
+    const stage = (uid: string): UploadFile<string> => ({
+        uid,
+        name: `${uid}.txt`,
+        status: "uploading",
+        percent: 0,
+        originFileObj: new File([new Uint8Array(4)], `${uid}.txt`, {type: "text/plain"}),
+    })
+
+    it("starts an enqueued upload and settles it", async () => {
+        const upload = vi.fn(async () => "ok")
+        const {result} = renderHook(() => useTray(upload))
+        await act(async () => {
+            result.current.setFiles([stage("one")])
+            result.current.uploads.enqueue(["one"])
+        })
+        expect(upload).toHaveBeenCalledTimes(1)
+        expect(result.current.files[0].status).toBe("done")
+        expect(result.current.files[0].response).toBe("ok")
+    })
+
+    // `abort` used only to pause: it dropped the controller but left the row reading "uploading",
+    // which is precisely what the remount-resume rule restarts — and mid-upload the list identity
+    // changes many times a second, so the next progress tick relaunched the request.
+    it("abort cancels for good — the row settles and the resume rule leaves it alone", async () => {
+        // Never resolves on its own, so only the abort can end it.
+        const upload = vi.fn(
+            (_file: File, ctx: {signal: AbortSignal}) =>
+                new Promise<string>((_resolve, reject) => {
+                    ctx.signal.addEventListener("abort", () => reject(new Error("aborted")))
+                }),
+        )
+        const {result} = renderHook(() => useTray(upload))
+        await act(async () => {
+            result.current.setFiles([stage("one")])
+            result.current.uploads.enqueue(["one"])
+        })
+        expect(upload).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            result.current.uploads.abort("one")
+        })
+        expect(result.current.files[0].status).toBe("error")
+        expect(result.current.files[0].error).toBe(UPLOAD_CANCELLED_MESSAGE)
+
+        // A fresh `files` identity (what a progress tick or any other tray edit produces) must not
+        // resurrect it.
+        await act(async () => {
+            result.current.setFiles((prev) => prev.map((f) => ({...f})))
+        })
+        expect(upload).toHaveBeenCalledTimes(1)
+        expect(result.current.files[0].status).toBe("error")
+
+        // An explicit retry is still an un-cancel.
+        await act(async () => {
+            result.current.uploads.retry("one")
+        })
+        expect(upload).toHaveBeenCalledTimes(2)
+    })
+
+    // The unmount teardown aborts controllers directly (not through `abort`), so a tray that comes
+    // back with the same uid still picks its in-flight entry up.
+    it("resumes an in-flight row that was never cancelled by the user", async () => {
+        const upload = vi.fn(
+            (_file: File, ctx: {signal: AbortSignal}) =>
+                new Promise<string>((_resolve, reject) => {
+                    ctx.signal.addEventListener("abort", () => reject(new Error("aborted")))
+                }),
+        )
+        const {result} = renderHook(() => useTray(upload))
+        // A row restored from the per-session store: still "uploading", no controller here.
+        await act(async () => {
+            result.current.setFiles([stage("restored")])
+        })
+        expect(upload).toHaveBeenCalledTimes(1)
     })
 })

--- a/web/packages/agenta-chat/tests/unit/hooks/useAttachmentUploads.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAttachmentUploads.test.ts
@@ -1,0 +1,27 @@
+import type {StagedUpload as UploadFile} from "@agenta/chat/model"
+import {describe, expect, it, vi} from "vitest"
+
+import {isUploadRetryReady, removeUploadFile} from "../../../src/hooks/useAttachmentUploads"
+
+describe("attachment upload controls", () => {
+    it("aborts an in-flight upload before removing its chip", () => {
+        const abort = vi.fn()
+        const files: UploadFile[] = [
+            {uid: "remove-me", name: "first.txt", status: "uploading"},
+            {uid: "keep-me", name: "second.txt", status: "done"},
+        ]
+        let nextFiles: UploadFile[] = []
+
+        removeUploadFile("remove-me", abort, (updater) => {
+            expect(abort).toHaveBeenCalledWith("remove-me")
+            nextFiles = updater(files)
+        })
+
+        expect(nextFiles).toEqual([files[1]])
+    })
+
+    it("holds retry until the Retry-After deadline", () => {
+        expect(isUploadRetryReady(7_000, 6_999)).toBe(false)
+        expect(isUploadRetryReady(7_000, 7_000)).toBe(true)
+    })
+})

--- a/web/packages/agenta-chat/tests/unit/hooks/useComposerAttachments.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useComposerAttachments.test.ts
@@ -1,12 +1,9 @@
 // @vitest-environment jsdom
-import {act, renderHook, waitFor} from "@testing-library/react"
-import {describe, expect, it} from "vitest"
+import {act, renderHook} from "@testing-library/react"
+import {afterEach, describe, expect, it} from "vitest"
 
 import {DEFAULT_ATTACHMENT_LIMITS} from "../../../src/assets/attachmentRules"
-import {
-    useComposerAttachments,
-    type UseComposerAttachmentsArgs,
-} from "../../../src/hooks/useComposerAttachments"
+import {useComposerAttachments} from "../../../src/hooks/useComposerAttachments"
 import {attachmentsBySession} from "../../../src/state/sessionEphemera"
 
 const makeFile = (name: string, type = "text/plain", size = 16): File => {
@@ -14,37 +11,44 @@ const makeFile = (name: string, type = "text/plain", size = 16): File => {
     return new File([blob], name, {type, lastModified: 1_700_000_000_000})
 }
 
-const setup = (args: UseComposerAttachmentsArgs = {}) =>
-    renderHook((props: UseComposerAttachmentsArgs) => useComposerAttachments(props), {
-        initialProps: args,
-    })
+// `uploadsEnabled: false` keeps every test off the network: files stage as settled ("done")
+// without the multipart upload lifecycle.
+const setup = (sessionId = `attach-${Math.random().toString(36).slice(2)}`) => ({
+    sessionId,
+    ...renderHook(() => useComposerAttachments({sessionId, uploadsEnabled: false})),
+})
+
+afterEach(() => {
+    attachmentsBySession.clear()
+})
 
 describe("useComposerAttachments", () => {
-    it("stages accepted files with the shared dedup uid and no rejections", () => {
+    it("stages accepted files settled, with the tray uid minted once and no rejections", () => {
         const {result} = setup()
         act(() => {
-            result.current.add([makeFile("notes.txt")])
+            result.current.addFiles([makeFile("notes.txt")])
         })
         expect(result.current.files).toHaveLength(1)
         expect(result.current.files[0].name).toBe("notes.txt")
-        expect(result.current.files[0].uid).toBe("notes.txt-1700000000000-16")
+        expect(result.current.files[0].uid).toMatch(/^att-/)
+        expect(result.current.files[0].status).toBe("done")
+        expect(result.current.attachmentsSettled).toBe(true)
         expect(result.current.rejections).toHaveLength(0)
         expect(result.current.atMax).toBe(false)
     })
 
-    it("rejects unsupported types and oversized files with a per-file reason", () => {
+    it("rejects oversized files with a per-file reason and stages the rest", () => {
         const {result} = setup()
         act(() => {
-            result.current.add([
-                makeFile("clip.mp4", "video/mp4"),
-                makeFile("huge.txt", "text/plain", DEFAULT_ATTACHMENT_LIMITS.maxBytes + 1),
+            result.current.addFiles([
+                makeFile("huge.txt", "text/plain", DEFAULT_ATTACHMENT_LIMITS.maxBytes.document + 1),
                 makeFile("ok.txt"),
             ])
         })
         expect(result.current.files.map((f) => f.name)).toEqual(["ok.txt"])
-        expect(result.current.rejections.map((r) => r.name)).toEqual(["clip.mp4", "huge.txt"])
-        expect(result.current.rejections[0].reason).toContain("supported file type")
-        expect(result.current.rejections[1].reason).toContain("too large")
+        expect(result.current.rejections.map((r) => r.name)).toEqual(["huge.txt"])
+        // A rejection opens the tray so the message is visible.
+        expect(result.current.attachmentsOpen).toBe(true)
     })
 
     it("caps the staged set at the count limit and flags atMax", () => {
@@ -53,112 +57,76 @@ describe("useComposerAttachments", () => {
             makeFile(`f${i}.txt`),
         )
         act(() => {
-            result.current.add(batch)
+            result.current.addFiles(batch)
         })
         expect(result.current.files).toHaveLength(DEFAULT_ATTACHMENT_LIMITS.maxCount)
         expect(result.current.atMax).toBe(true)
         expect(result.current.rejections).toHaveLength(2)
-        expect(result.current.rejections[0].reason).toContain("limit")
-        // At the cap, another add stages nothing more.
         act(() => {
-            result.current.add([makeFile("extra.txt")])
+            result.current.addFiles([makeFile("extra.txt")])
         })
         expect(result.current.files).toHaveLength(DEFAULT_ATTACHMENT_LIMITS.maxCount)
         expect(result.current.rejections.map((r) => r.name)).toEqual(["extra.txt"])
     })
 
     // A paste and a drop can both fire before React re-renders. Reading the count from the
-    // render closure makes both batches see zero staged files, so the cap is passed.
+    // render closure would make both batches see zero staged files and blow past the cap.
     it("holds the count limit across two adds in the same tick", () => {
         const {result} = setup()
         const half = Math.ceil(DEFAULT_ATTACHMENT_LIMITS.maxCount / 2) + 1
         const batch = (tag: string) =>
             Array.from({length: half}, (_, i) => makeFile(`${tag}${i}.txt`))
         act(() => {
-            result.current.add(batch("a"))
-            result.current.add(batch("b"))
+            result.current.addFiles(batch("a"))
+            result.current.addFiles(batch("b"))
         })
         expect(result.current.files.length).toBeLessThanOrEqual(DEFAULT_ATTACHMENT_LIMITS.maxCount)
         expect(result.current.atMax).toBe(true)
     })
 
-    it("re-seeds from the new session when sessionId changes on a mounted instance", () => {
-        const a = `attach-swap-a-${Date.now()}`
-        const b = `attach-swap-b-${Date.now()}`
-        attachmentsBySession.set(b, [
-            {uid: "seeded", name: "from-b.txt", size: 4, type: "text/plain", file: makeFile("x")},
-        ] as never)
-        const {result, rerender} = setup({sessionId: a})
+    it("persists staged files per session across a remount, keyed by session id", () => {
+        const sessionId = `attach-restore-${Date.now()}`
+        const first = setup(sessionId)
         act(() => {
-            result.current.add([makeFile("from-a.txt")])
+            first.result.current.addFiles([makeFile("keep.txt")])
         })
-        expect(result.current.files.map((f) => f.name)).toEqual(["from-a.txt"])
-
-        rerender({sessionId: b})
-        // Session b's own staged file, not session a's leaking across.
-        expect(result.current.files.map((f) => f.name)).toEqual(["from-b.txt"])
-        // …and session a keeps what it had rather than being overwritten under the new key.
-        expect(attachmentsBySession.get(a)?.map((f) => f.name)).toEqual(["from-a.txt"])
+        first.unmount()
+        expect(attachmentsBySession.get(sessionId)).toHaveLength(1)
+        const second = setup(sessionId)
+        expect(second.result.current.files.map((f) => f.name)).toEqual(["keep.txt"])
+        const other = setup(`${sessionId}-other`)
+        expect(other.result.current.files).toHaveLength(0)
+        // Removing the last file empties the per-session store too.
+        act(() => {
+            second.result.current.removeFile(second.result.current.files[0].uid)
+        })
+        expect(attachmentsBySession.has(sessionId)).toBe(false)
     })
 
-    it("remove unstages one file; dismissRejections keeps files; clear drops both", () => {
+    it("removeFile unstages one; dismissing rejections keeps files; clearAttachments drops only consumed uids", () => {
         const {result} = setup()
         act(() => {
-            result.current.add([
+            result.current.addFiles([
                 makeFile("a.txt"),
                 makeFile("b.txt"),
-                makeFile("bad.mp4", "video/mp4"),
+                makeFile("huge.txt", "text/plain", DEFAULT_ATTACHMENT_LIMITS.maxBytes.document + 1),
             ])
         })
         expect(result.current.files).toHaveLength(2)
         expect(result.current.rejections).toHaveLength(1)
         act(() => {
-            result.current.remove(result.current.files[0].uid)
+            result.current.removeFile(result.current.files[0].uid)
         })
         expect(result.current.files.map((f) => f.name)).toEqual(["b.txt"])
         act(() => {
-            result.current.dismissRejections()
+            result.current.setRejections([])
         })
         expect(result.current.rejections).toHaveLength(0)
         expect(result.current.files).toHaveLength(1)
         act(() => {
-            result.current.clear()
+            result.current.clearAttachments(result.current.files.map((f) => f.uid))
         })
         expect(result.current.files).toHaveLength(0)
-    })
-
-    it("toParts encodes the staged files as inline data-URL file parts", async () => {
-        const {result} = setup()
-        act(() => {
-            result.current.add([makeFile("doc.txt")])
-        })
-        const parts = await result.current.toParts()
-        expect(parts).toHaveLength(1)
-        expect(parts[0]).toMatchObject({type: "file", mediaType: "text/plain", filename: "doc.txt"})
-        expect(parts[0].url.startsWith("data:text/plain;base64,")).toBe(true)
-        // Empty staged set resolves to an empty list without touching FileReader.
-        act(() => {
-            result.current.clear()
-        })
-        await waitFor(async () => expect(await result.current.toParts()).toEqual([]))
-    })
-
-    it("persists staged files per session across a remount, keyed by session id", () => {
-        const sessionId = `attach-restore-${Date.now()}`
-        const first = setup({sessionId})
-        act(() => {
-            first.result.current.add([makeFile("keep.txt")])
-        })
-        first.unmount()
-        expect(attachmentsBySession.get(sessionId)).toHaveLength(1)
-        const second = setup({sessionId})
-        expect(second.result.current.files.map((f) => f.name)).toEqual(["keep.txt"])
-        const other = setup({sessionId: `${sessionId}-other`})
-        expect(other.result.current.files).toHaveLength(0)
-        // Clearing empties the per-session store too.
-        act(() => {
-            second.result.current.clear()
-        })
-        expect(attachmentsBySession.has(sessionId)).toBe(false)
+        expect(result.current.attachmentsOpen).toBe(false)
     })
 })

--- a/web/packages/agenta-chat/tests/unit/hooks/useComposerAttachments.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useComposerAttachments.test.ts
@@ -18,6 +18,16 @@ const setup = (sessionId = `attach-${Math.random().toString(36).slice(2)}`) => (
     ...renderHook(() => useComposerAttachments({sessionId, uploadsEnabled: false})),
 })
 
+/** Same hook, but with the session id as a rerender prop — hosts are free to keep the composer
+ * mounted across a session switch (this repo's chat workspace keeps tab panes mounted). */
+const setupSwitchable = (sessionId: string) =>
+    renderHook(
+        ({id}: {id: string}) => useComposerAttachments({sessionId: id, uploadsEnabled: false}),
+        {
+            initialProps: {id: sessionId},
+        },
+    )
+
 afterEach(() => {
     attachmentsBySession.clear()
 })
@@ -101,6 +111,39 @@ describe("useComposerAttachments", () => {
             second.result.current.removeFile(second.result.current.files[0].uid)
         })
         expect(attachmentsBySession.has(sessionId)).toBe(false)
+    })
+
+    // The initializer only runs on mount, so a session swap under a MOUNTED hook used to write
+    // session A's staged rows under session B (orphaning A's, and pointing a retry at B's upload).
+    it("moves staged files back to their own session when the session changes on a mounted hook", () => {
+        const a = `attach-switch-a-${Date.now()}`
+        const b = `attach-switch-b-${Date.now()}`
+        const {result, rerender} = setupSwitchable(a)
+        act(() => {
+            result.current.addFiles([makeFile("a-only.txt")])
+        })
+        expect(attachmentsBySession.get(a)).toHaveLength(1)
+
+        act(() => {
+            rerender({id: b})
+        })
+        // B starts empty, and A kept its own row.
+        expect(result.current.files).toHaveLength(0)
+        expect(attachmentsBySession.get(a)?.map((f) => f.name)).toEqual(["a-only.txt"])
+        expect(attachmentsBySession.has(b)).toBe(false)
+
+        act(() => {
+            result.current.addFiles([makeFile("b-only.txt")])
+        })
+        expect(attachmentsBySession.get(b)?.map((f) => f.name)).toEqual(["b-only.txt"])
+        expect(attachmentsBySession.get(a)?.map((f) => f.name)).toEqual(["a-only.txt"])
+
+        // Switching back restores A's own tray rather than carrying B's over.
+        act(() => {
+            rerender({id: a})
+        })
+        expect(result.current.files.map((f) => f.name)).toEqual(["a-only.txt"])
+        expect(attachmentsBySession.get(b)?.map((f) => f.name)).toEqual(["b-only.txt"])
     })
 
     it("removeFile unstages one; dismissing rejections keeps files; clearAttachments drops only consumed uids", () => {

--- a/web/packages/agenta-chat/tests/unit/model/attachments.test.ts
+++ b/web/packages/agenta-chat/tests/unit/model/attachments.test.ts
@@ -3,12 +3,12 @@ import {describe, expect, it} from "vitest"
 import {toPendingAttachment} from "../../../src/model/attachments"
 
 describe("toPendingAttachment", () => {
-    it("derives the same uid formula the desktop composer uses", () => {
+    it("mints a unique per-row uid, so the same file staged twice stays two rows", () => {
         const file = new File(["hello"], "notes.txt", {lastModified: 1720000000000})
-        expect(toPendingAttachment(file)).toEqual({
-            file,
-            uid: `notes.txt-1720000000000-${file.size}`,
-            name: "notes.txt",
-        })
+        const first = toPendingAttachment(file)
+        const second = toPendingAttachment(file)
+        expect(first).toMatchObject({file, name: "notes.txt"})
+        expect(first.uid).toMatch(/^att-/)
+        expect(second.uid).not.toBe(first.uid)
     })
 })

--- a/web/packages/agenta-chat/tests/unit/state/sessionMessages.test.ts
+++ b/web/packages/agenta-chat/tests/unit/state/sessionMessages.test.ts
@@ -13,8 +13,8 @@ import {
     setSessionStatusAtom,
 } from "../../../src/state/sessionMessages"
 
-const MESSAGES_KEY = "agenta:agent-chat:messages"
-const COUNTS_KEY = "agenta:agent-chat:record-counts"
+const MESSAGES_KEY = "agenta:agent-chat:messages:v2"
+const COUNTS_KEY = "agenta:agent-chat:record-counts:v2"
 
 const msg = (id: string, text: string): UIMessage =>
     ({id, role: "user", parts: [{type: "text", text}]}) as UIMessage

--- a/web/packages/agenta-chat/tests/unit/transport/AgentChatTransport.test.ts
+++ b/web/packages/agenta-chat/tests/unit/transport/AgentChatTransport.test.ts
@@ -127,4 +127,56 @@ describe("AgentChatTransport", () => {
             {toolCallId: "call-1", output: "hi"},
         ])
     })
+
+    // Smoothing re-emits a coarse backend delta as word-sized pieces. Past the per-chunk time
+    // budget the per-piece delay falls below a millisecond, which used to disable yielding
+    // altogether and flush the whole thing from one `pull()`. Pieces now carry across pulls, so
+    // what must be proved is that the text still reassembles EXACTLY and in order.
+    it("re-emits an oversized delta piece by piece without losing or reordering any of it", async () => {
+        const words = Array.from({length: 4000}, (_, i) => `w${i}`)
+        const text = words.join(" ")
+        const sseBody =
+            [
+                {type: "start", messageId: "assist-1"},
+                {type: "start-step"},
+                {type: "text-start", id: "t1"},
+                {type: "text-delta", id: "t1", delta: text},
+                {type: "text-end", id: "t1"},
+                {type: "finish-step"},
+                {type: "finish"},
+            ]
+                .map((c) => `data: ${JSON.stringify(c)}\n\n`)
+                .join("") + "data: [DONE]\n\n"
+
+        const baseFetch = vi.fn(
+            async () =>
+                new Response(sseBody, {
+                    status: 200,
+                    headers: {"content-type": "text/event-stream"},
+                }),
+        )
+        const transport = new AgentChatTransport({
+            api: "/api/agent/invoke",
+            headers: {Accept: "text/event-stream"},
+            fetch: baseFetch as unknown as typeof fetch,
+        })
+        const chunks = await readAll(
+            await transport.sendMessages({
+                trigger: "submit-message",
+                chatId: "chat-1",
+                messageId: undefined,
+                messages: [userMessage("write a lot")],
+            }),
+        )
+
+        const deltas = chunks.filter((c) => c.type === "text-delta") as {delta: string}[]
+        // Genuinely split up, not passed through whole…
+        expect(deltas.length).toBeGreaterThan(1000)
+        // …and byte-identical once reassembled, in order.
+        expect(deltas.map((c) => c.delta).join("")).toBe(text)
+        // The surrounding chunks keep their positions around it.
+        expect(chunks[0]).toMatchObject({type: "start"})
+        expect(chunks[chunks.length - 1]).toMatchObject({type: "finish"})
+        expect(chunks.filter((c) => c.type === "text-end")).toHaveLength(1)
+    })
 })

--- a/web/packages/agenta-playground/package.json
+++ b/web/packages/agenta-playground/package.json
@@ -20,7 +20,8 @@
         "./state": "./src/state/index.ts",
         "./react": "./src/react/index.ts",
         "./snapshot": "./src/snapshot/index.ts",
-        "./utils": "./src/utils/index.ts"
+        "./utils": "./src/utils/index.ts",
+        "./agent-chat": "./src/agentChat.ts"
     },
     "dependencies": {
         "@agenta/entities": "workspace:../agenta-entities",

--- a/web/packages/agenta-playground/src/agentChat.ts
+++ b/web/packages/agenta-playground/src/agentChat.ts
@@ -1,0 +1,18 @@
+/**
+ * Lean entry for the agent CHAT engine (`@agenta/playground/agent-chat`) — exactly the request
+ * builder, resume/queue predicates and stream negotiation the chat transport needs, imported
+ * from their own modules. The root barrel drags the full execution/controller graph (~900KB of
+ * source) into any bundle that touches it, which is what this subpath exists to avoid — mobile
+ * ships the chat engine without the playground.
+ */
+export {
+    buildAgentRequest,
+    applyBuildKitOverlay,
+    type AgentRequest,
+} from "./state/execution/agentRequest"
+export {
+    agentShouldResumeAfterApproval,
+    type LiveAgentInteraction,
+} from "./state/execution/agentApprovalResume"
+export {canReleaseQueuedMessage, isHitlPending} from "./state/execution/agentMessageQueue"
+export {createNegotiatingFetch, type NegotiatingFetch} from "./state/execution/agentNegotiation"

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -36,7 +36,7 @@ import {getDefaultStore} from "jotai"
 
 import {withBuildKitOverlay} from "./buildKitOverlay"
 import {agentChannelModeAtomFamily} from "./channelMode"
-import {executionHeadersAtom} from "./webWorkerIntegration"
+import {executionHeadersAtom} from "./executionHeaders"
 
 // Re-exported so existing consumers keep importing it from the request builder; the merge
 // implementation now lives in `buildKitOverlay.ts`.

--- a/web/packages/agenta-playground/src/state/execution/executionHeaders.ts
+++ b/web/packages/agenta-playground/src/state/execution/executionHeaders.ts
@@ -1,0 +1,23 @@
+import {atom} from "jotai"
+
+/**
+ * Injectable function that returns auth headers for execution HTTP requests.
+ *
+ * OSS sets this once in AppGlobalWrappers with a function that calls `getJWT()` and returns
+ * `{Authorization: `Bearer ${jwt}`}`.
+ *
+ * A LEAF module on purpose: the request builder (`agentRequest`) needs only this atom, and it
+ * used to reach for it inside `webWorkerIntegration`, whose imports are the entire execution
+ * runner — so every consumer of the lean `@agenta/playground/agent-chat` entry pulled that graph
+ * in behind it. Keep this file dependency-free.
+ *
+ * @example
+ * ```ts
+ * import { getJWT } from "@/oss/services/api"
+ * store.set(executionHeadersAtom, async () => {
+ *     const jwt = await getJWT()
+ *     return jwt ? { Authorization: `Bearer ${jwt}` } : {}
+ * })
+ * ```
+ */
+export const executionHeadersAtom = atom<(() => Promise<Record<string, string>>) | null>(null)

--- a/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
+++ b/web/packages/agenta-playground/src/state/execution/webWorkerIntegration.ts
@@ -84,22 +84,10 @@ function getSharedConcurrencyLimiter(concurrency: number): <T>(fn: () => Promise
 // INJECTABLE AUTH HEADERS
 // ============================================================================
 
-/**
- * Injectable function that returns auth headers for worker HTTP requests.
- *
- * OSS sets this once in AppGlobalWrappers with a function
- * that calls `getJWT()` and returns `{Authorization: \`Bearer ${jwt}\`}`.
- *
- * @example
- * ```ts
- * import { getJWT } from "@/oss/services/api"
- * store.set(executionHeadersAtom, async () => {
- *     const jwt = await getJWT()
- *     return jwt ? { Authorization: `Bearer ${jwt}` } : {}
- * })
- * ```
- */
-export const executionHeadersAtom = atom<(() => Promise<Record<string, string>>) | null>(null)
+// The atom lives in its own leaf module (see executionHeaders.ts) so the lean agent-chat
+// entry can read it without dragging this runner graph; re-exported here for existing callers.
+export {executionHeadersAtom} from "./executionHeaders"
+import {executionHeadersAtom} from "./executionHeaders"
 
 interface ExecutionWorkerBridge {
     postMessageToWorker: (message: unknown) => void


### PR DESCRIPTION
`@agenta/chat` is the chat runtime as a package: the message engine, the composer, and the
approval card. It is the dependency both the OSS chat slice (next lane) and `/m` build on.

antd-free by construction — the mobile app cannot take an antd dependency.
Not run in a browser — static gates only (`pnpm lint-fix` 24/24, `tsc --noEmit` clean
for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`).

Stacked on `pkg/session-surfaces`; review only this lane's diff.