### PR TITLE
refactor(frontend): agent-path playground chrome off antd

### DIFF
--- a/web/oss/src/components/EntityIdentity/AgentNameInline.tsx
+++ b/web/oss/src/components/EntityIdentity/AgentNameInline.tsx
@@ -1,7 +1,7 @@
 import {useState} from "react"
 
+import {Input} from "@agenta/ui/ui"
 import {PencilSimple} from "@phosphor-icons/react"
-import {Input, Typography} from "antd"
 
 import {useRenameApp} from "./useRenameApp"
 
@@ -51,15 +51,19 @@ const AgentNameInline = ({workflowId, name, onRenamed}: AgentNameInlineProps) =>
             <div className="flex min-w-0 flex-col">
                 <Input
                     autoFocus
+                    size="sm"
                     value={draft}
-                    status={error ? "error" : undefined}
+                    aria-invalid={error ? true : undefined}
                     onChange={(e) => {
                         setDraft(e.target.value)
                         if (error) setError(null)
                     }}
-                    onPressEnter={commit}
                     onBlur={commit}
                     onKeyDown={(e) => {
+                        // Let the IME keep the Enter that confirms a composition candidate
+                        // (CJK, etc.) — committing there would rename to a half-typed name.
+                        if (e.nativeEvent.isComposing) return
+                        if (e.key === "Enter") void commit()
                         if (e.key === "Escape") setEditing(false)
                     }}
                     onFocus={(e) => e.target.select()}
@@ -72,13 +76,13 @@ const AgentNameInline = ({workflowId, name, onRenamed}: AgentNameInlineProps) =>
 
     return (
         <div className="group/name flex min-w-0 items-center gap-1">
-            <Typography
-                className="truncate whitespace-nowrap text-[16px] leading-[18px] font-[600] cursor-pointer"
+            <span
+                className="truncate whitespace-nowrap text-[16px] leading-[18px] font-[600] text-colorText cursor-pointer"
                 onDoubleClick={startEditing}
                 title="Double-click to rename"
             >
                 {name || "Agent"}
-            </Typography>
+            </span>
 
             <PencilSimple
                 size={13}

--- a/web/oss/src/components/Playground/Components/AgentCommitNotice.tsx
+++ b/web/oss/src/components/Playground/Components/AgentCommitNotice.tsx
@@ -3,8 +3,8 @@ import {useLayoutEffect, useRef, useState} from "react"
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {agentSelfCommitSignalAtom} from "@agenta/shared/state"
 import {HeightCollapse} from "@agenta/ui"
+import {Button} from "@agenta/ui/ui"
 import {Robot} from "@phosphor-icons/react"
-import {Button} from "antd"
 import {useAtom, useAtomValue} from "jotai"
 
 /**
@@ -90,8 +90,8 @@ const AgentCommitNotice = ({revisionId}: {revisionId: string}) => {
                             </div>
                         </div>
                         <Button
-                            type="text"
-                            className="!h-6 shrink-0 !px-2 !text-xs"
+                            variant="ghost"
+                            className="h-6 shrink-0 px-2 text-xs"
                             onClick={() => setSignal(null)}
                         >
                             Dismiss

--- a/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
+++ b/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
@@ -4,7 +4,7 @@ import {isLocalDraftId} from "@agenta/entities/shared"
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {createWorkflowRevisionAdapter} from "@agenta/entity-ui/selection"
 import {playgroundController} from "@agenta/playground"
-import {Tooltip} from "antd"
+import {SimpleTooltip} from "@agenta/ui/ui"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -65,8 +65,8 @@ const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
                 borderlessTrigger
             />
             {variantRevision !== null && variantRevision !== undefined && (
-                <Tooltip
-                    styles={{root: {maxWidth: 360}}}
+                <SimpleTooltip
+                    className="max-w-[360px]"
                     title={
                         commitMessage ? (
                             <div className="flex flex-col gap-1">
@@ -85,9 +85,9 @@ const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
                     <span className="cursor-default rounded bg-[var(--ant-color-fill-secondary)] px-1.5 py-0.5 text-xs text-[var(--ant-color-text-secondary)]">
                         v{variantRevision}
                     </span>
-                </Tooltip>
+                </SimpleTooltip>
             )}
-            <Tooltip title={hasChanges ? "Draft — unsaved changes" : "Saved"}>
+            <SimpleTooltip title={hasChanges ? "Draft — unsaved changes" : "Saved"}>
                 <span className="flex items-center gap-1.5 text-xs text-[var(--ant-color-text-tertiary)]">
                     <span
                         className="h-[7px] w-[7px] rounded-full"
@@ -99,7 +99,7 @@ const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
                     />
                     {hasChanges ? "Draft" : "Saved"}
                 </span>
-            </Tooltip>
+            </SimpleTooltip>
         </div>
     )
 }

--- a/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
+++ b/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
@@ -2,8 +2,8 @@ import {useEffect, useRef} from "react"
 
 import {draftConfigChangeSignalAtom} from "@agenta/shared/state"
 import {HeightCollapse} from "@agenta/ui"
+import {Button} from "@agenta/ui/ui"
 import {ArrowCounterClockwise, ShieldCheck, X} from "@phosphor-icons/react"
-import {Button} from "antd"
 import {useAtom} from "jotai"
 
 import {useAlwaysAllowTool} from "@/oss/hooks/useAlwaysAllowTool"
@@ -61,23 +61,25 @@ const AlwaysAllowedNotice = ({revisionId}: {revisionId: string}) => {
                     </div>
                     <div className="flex shrink-0 items-center gap-1">
                         <Button
-                            type="text"
-                            className="!h-6 !gap-1 !rounded-md !px-2 !text-xs !font-medium !text-colorPrimary !bg-[color-mix(in_srgb,var(--ag-colorPrimary)_12%,transparent)] hover:!bg-[color-mix(in_srgb,var(--ag-colorPrimary)_22%,transparent)]"
-                            icon={<ArrowCounterClockwise size={12} weight="bold" />}
+                            variant="ghost"
+                            className="h-6 gap-1 rounded-md bg-[color-mix(in_srgb,var(--ag-colorPrimary)_12%,transparent)] px-2 text-xs font-medium text-colorPrimary hover:bg-[color-mix(in_srgb,var(--ag-colorPrimary)_22%,transparent)]"
                             onClick={() => {
                                 if (shown?.toolName) revoke(shown.toolName)
                                 setSignal(null)
                             }}
                         >
+                            <ArrowCounterClockwise size={12} weight="bold" />
                             Undo
                         </Button>
                         <Button
-                            type="text"
+                            variant="ghost"
+                            size="icon-sm"
                             aria-label="Dismiss"
-                            className="!h-6 !w-6 !px-0 !text-colorTextTertiary hover:!bg-colorFillTertiary hover:!text-colorText"
-                            icon={<X size={13} />}
+                            className="h-6 w-6 p-0 text-colorTextTertiary hover:bg-colorFillTertiary hover:text-colorText"
                             onClick={() => setSignal(null)}
-                        />
+                        >
+                            <X size={13} />
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -12,6 +12,7 @@ import {EmptyState, ExecutionHeader, useEntitySelector} from "@agenta/playground
 import ExecutionItems, {
     type PlaygroundGenerationsProps,
 } from "@agenta/playground-ui/execution-items"
+import {SplitPane} from "@agenta/ui/ui"
 import {Button, Splitter, Typography} from "antd"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
@@ -269,6 +270,9 @@ const PlaygroundMainView = ({
         return () => clearTimeout(t)
     }, [chatMaximized])
     const animateSplit = justToggled || holdAnimate
+    // Agent split runs on the kit SplitPane (controlled px): the dragged width persists for the
+    // mount; 440 is the summary panel's cap and its default.
+    const [agentPaneSize, setAgentPaneSize] = useState(440)
 
     const variantRefs = useRef<(HTMLDivElement | null)[]>([])
     const {configPanelRef, setConfigPanelRef, setGenerationPanelRef} = usePlaygroundScrollSync({
@@ -354,209 +358,329 @@ const PlaygroundMainView = ({
                     "ag-app-ground": isAgentConfig,
                 })}
             >
-                <Splitter
-                    key={`${splitterKey}-splitter`}
-                    className={clsx("h-full playground-splitter", {
-                        // Agent mode has no collapse pill (Build/Chat lives in the header), so the
-                        // drag handle needs its own discoverability treatment (a visible grip).
-                        "playground-splitter-agent": isAgentConfig,
-                        "playground-splitter-collapsed": configCollapsed,
-                        "playground-splitter-animated": animateSplit,
-                    })}
-                    orientation={isComparisonView ? "vertical" : "horizontal"}
-                >
-                    <SplitterPanel
-                        defaultSize={configDefaultSize}
-                        size={configCollapsed ? 0 : undefined}
-                        min="20%"
-                        max={configMaxSize}
-                        // antd panels default to overflow:auto; the section inside owns scrolling, and
-                        // a transient overflow leaves Chrome's thin panel scrollbar stuck full-height.
-                        className="!h-full !overflow-hidden"
-                        collapsible={splitCollapsible}
-                        key={`${splitterKey}-splitter-panel-config`}
+                {isAgentConfig && !isComparisonView ? (
+                    /* Agent build split — the kit SplitPane (the same primitive the chat panel
+                       uses): controlled px width, the Build/Chat toggle collapses to 0 with the
+                       flex-basis transition, and the bar IS the grip treatment that
+                       .playground-splitter-agent used to bolt onto antd. Single view only: the
+                       agent branch never renders comparison chrome, so the markup below is the
+                       single-view subset of the legacy panels. */
+                    <SplitPane
+                        paneSide="start"
+                        paneSize={configCollapsed ? 0 : agentPaneSize}
+                        paneMin={300}
+                        paneMax={440}
+                        fillMin={420}
+                        animate={animateSplit}
+                        barHidden={configCollapsed}
+                        // Controlled width: the drag must write through per tick, or the pane
+                        // only snaps at pointer-up.
+                        onResize={(size) => setAgentPaneSize(size)}
+                        onResizeEnd={(size) => setAgentPaneSize(size)}
+                        className="h-full"
+                        pane={
+                            <div className="ag-panel-raised group relative flex h-full min-h-0 w-full flex-col">
+                                <section
+                                    ref={setConfigPanelRef}
+                                    className="ag-scroll-no-bar min-h-0 w-full grow overflow-y-auto"
+                                >
+                                    {renderConfigOverride ??
+                                        (configEntityIds.length > 0 ? (
+                                            configEntityIds.map((variantId) => (
+                                                <div
+                                                    // Stable key: an agent self-commit switches the
+                                                    // revision in place — a prop change, not a remount.
+                                                    key={
+                                                        renderAgentGenerationHost
+                                                            ? "agent-config-host"
+                                                            : `variant-config-${variantId}`
+                                                    }
+                                                >
+                                                    <PlaygroundVariantConfig
+                                                        variantId={variantId}
+                                                        embedded={embedded}
+                                                        externalViewMode={configViewMode}
+                                                        onViewModeChange={onConfigViewModeChange}
+                                                    />
+                                                </div>
+                                            ))
+                                        ) : (
+                                            <div className="h-full w-full p-4">
+                                                <div className="h-[260px] rounded-lg border border-solid border-[var(--ag-rgba-051729-08)] bg-[var(--ag-c-FFFFFF)]" />
+                                            </div>
+                                        ))}
+                                </section>
+                                <OverlayScrollbar target={configPanelRef} />
+                                {primaryConfigId ? (
+                                    <>
+                                        <ProviderKeyNotice revisionId={primaryConfigId} />
+                                        <AlwaysAllowedNotice revisionId={primaryConfigId} />
+                                        <AgentCommitNotice revisionId={primaryConfigId} />
+                                    </>
+                                ) : null}
+                            </div>
+                        }
+                        fill={
+                            <div className="@container h-full min-w-0">
+                                <section
+                                    ref={setGenerationPanelRef}
+                                    className="playground-generation ag-scroll-quiet ag-canvas h-full w-full grow overflow-y-auto overflow-x-hidden"
+                                >
+                                    {runDisabled ? (
+                                        <RunDisabledPlaceholder>
+                                            {runDisabledContent}
+                                        </RunDisabledPlaceholder>
+                                    ) : !hasAnyLayoutEntity ? (
+                                        <GenerationPanelPlaceholder />
+                                    ) : (
+                                        layoutEntityIds.map((variantId) => {
+                                            if (renderAgentGenerationHost) {
+                                                return (
+                                                    <ExecutionItems
+                                                        key="agent-generation-host"
+                                                        entityId={variantId}
+                                                        renderTestsetActions={renderTestsetActions}
+                                                    />
+                                                )
+                                            }
+                                            if (
+                                                singleEntityQuery.isPending &&
+                                                !singleEntityQuery.data
+                                            ) {
+                                                return (
+                                                    <AgentChatSkeleton key="agent-generation-skeleton" />
+                                                )
+                                            }
+                                            return displayedEntities.includes(variantId) ||
+                                                isEvaluatorMode ? (
+                                                <ExecutionItems
+                                                    key={variantId}
+                                                    entityId={variantId}
+                                                    renderTestsetActions={renderTestsetActions}
+                                                />
+                                            ) : (
+                                                <GenerationPanelPlaceholder
+                                                    key={`generation-placeholder-${variantId}`}
+                                                />
+                                            )
+                                        })
+                                    )}
+                                </section>
+                            </div>
+                        }
+                    />
+                ) : (
+                    <Splitter
+                        key={`${splitterKey}-splitter`}
+                        className={clsx("h-full playground-splitter", {
+                            // Agent mode has no collapse pill (Build/Chat lives in the header), so the
+                            // drag handle needs its own discoverability treatment (a visible grip).
+                            "playground-splitter-agent": isAgentConfig,
+                            "playground-splitter-collapsed": configCollapsed,
+                            "playground-splitter-animated": animateSplit,
+                        })}
+                        orientation={isComparisonView ? "vertical" : "horizontal"}
                     >
-                        {/* Column: [scrolling config sections][bottom-pinned agent-commit notice].
+                        <SplitterPanel
+                            defaultSize={configDefaultSize}
+                            size={configCollapsed ? 0 : undefined}
+                            min="20%"
+                            max={configMaxSize}
+                            // antd panels default to overflow:auto; the section inside owns scrolling, and
+                            // a transient overflow leaves Chrome's thin panel scrollbar stuck full-height.
+                            className="!h-full !overflow-hidden"
+                            collapsible={splitCollapsible}
+                            key={`${splitterKey}-splitter-panel-config`}
+                        >
+                            {/* Column: [scrolling config sections][bottom-pinned agent-commit notice].
                             The notice lives OUTSIDE the scroller, so it sits at the pane's bottom
                             edge regardless of content height or scroll position. */}
-                        <div
-                            className={clsx("group relative flex h-full min-h-0 w-full flex-col", {
-                                // Config = the raised authoring surface (covers the notice too).
-                                "ag-panel-raised": isAgentConfig,
-                            })}
-                        >
-                            <section
-                                ref={setConfigPanelRef}
-                                className={clsx([
+                            <div
+                                className={clsx(
+                                    "group relative flex h-full min-h-0 w-full flex-col",
                                     {
-                                        "ag-scroll-no-bar grow w-full min-h-0 overflow-y-auto":
+                                        // Config = the raised authoring surface (covers the notice too).
+                                        "ag-panel-raised": isAgentConfig,
+                                    },
+                                )}
+                            >
+                                <section
+                                    ref={setConfigPanelRef}
+                                    className={clsx([
+                                        {
+                                            "ag-scroll-no-bar grow w-full min-h-0 overflow-y-auto":
+                                                !isComparisonView,
+                                            "grow w-full min-h-0 overflow-x-auto flex [&::-webkit-scrollbar]:w-0":
+                                                isComparisonView,
+                                        },
+                                    ])}
+                                >
+                                    <>
+                                        {isComparisonView && hasDisplayedEntities && (
+                                            <PromptComparisonVariantNavigation
+                                                className="[&::-webkit-scrollbar]:w-0 w-[400px] sticky left-0 z-10 h-full overflow-y-auto overflow-x-hidden flex-shrink-0 border-0 border-r border-solid border-[var(--ag-rgba-051729-06)] bg-[var(--ag-c-FFFFFF)]"
+                                                handleScroll={handleScroll}
+                                            />
+                                        )}
+                                        {renderConfigOverride && !isComparisonView ? (
+                                            renderConfigOverride
+                                        ) : configEntityIds.length > 0 ? (
+                                            configEntityIds.map((variantId, index) => (
+                                                <div
+                                                    // Agents get a STABLE key (like the chat host): a
+                                                    // self-commit switches the revision in place, so the
+                                                    // config panel must update as a prop change — a remount
+                                                    // replays the sections' collapsed→open entrance.
+                                                    key={
+                                                        renderAgentGenerationHost
+                                                            ? "agent-config-host"
+                                                            : `variant-config-${variantId}`
+                                                    }
+                                                    className={clsx([
+                                                        {
+                                                            "[&::-webkit-scrollbar]:w-0 min-w-[400px] flex-1 h-full max-h-full overflow-y-auto flex-shrink-0 border-0 border-r border-solid border-[var(--ag-rgba-051729-06)] relative":
+                                                                isComparisonView,
+                                                        },
+                                                    ])}
+                                                    ref={(el) => {
+                                                        variantRefs.current[index] = el
+                                                    }}
+                                                >
+                                                    <PlaygroundVariantConfig
+                                                        variantId={variantId}
+                                                        embedded={embedded}
+                                                        externalViewMode={configViewMode}
+                                                        onViewModeChange={onConfigViewModeChange}
+                                                    />
+                                                </div>
+                                            ))
+                                        ) : (
+                                            <div className="h-full w-full p-4">
+                                                <div className="h-[260px] rounded-lg border border-solid border-[var(--ag-rgba-051729-08)] bg-[var(--ag-c-FFFFFF)]" />
+                                            </div>
+                                        )}
+                                    </>
+                                </section>
+                                {!isComparisonView ? (
+                                    <OverlayScrollbar target={configPanelRef} />
+                                ) : null}
+                                {!isComparisonView && isAgentConfig && primaryConfigId ? (
+                                    <>
+                                        <ProviderKeyNotice revisionId={primaryConfigId} />
+                                        <AlwaysAllowedNotice revisionId={primaryConfigId} />
+                                        <AgentCommitNotice revisionId={primaryConfigId} />
+                                    </>
+                                ) : null}
+                            </div>
+                        </SplitterPanel>
+
+                        <SplitterPanel
+                            className={clsx("!h-full @container min-w-0", {
+                                "!overflow-y-hidden flex flex-col": isComparisonView,
+                                // Same stuck-scrollbar guard as the config panel (chat section scrolls itself).
+                                "!overflow-hidden": !isComparisonView,
+                            })}
+                            collapsible={splitCollapsible}
+                            defaultSize={runsDefaultSize}
+                            key={`${isComparisonView ? "comparison" : "single"}-splitter-panel-runs`}
+                        >
+                            {isComparisonView && <ExecutionHeader />}
+                            <section
+                                ref={setGenerationPanelRef}
+                                className={clsx([
+                                    "playground-generation",
+                                    {
+                                        "ag-scroll-quiet grow w-full h-full overflow-y-auto overflow-x-hidden":
                                             !isComparisonView,
-                                        "grow w-full min-h-0 overflow-x-auto flex [&::-webkit-scrollbar]:w-0":
+                                        "grow w-full h-full overflow-auto [&::-webkit-scrollbar]:w-0":
                                             isComparisonView,
+                                        // Chat = the recessed canvas the message/composer surfaces sit on.
+                                        "ag-canvas": isAgentConfig,
                                     },
                                 ])}
                             >
-                                <>
-                                    {isComparisonView && hasDisplayedEntities && (
-                                        <PromptComparisonVariantNavigation
-                                            className="[&::-webkit-scrollbar]:w-0 w-[400px] sticky left-0 z-10 h-full overflow-y-auto overflow-x-hidden flex-shrink-0 border-0 border-r border-solid border-[var(--ag-rgba-051729-06)] bg-[var(--ag-c-FFFFFF)]"
-                                            handleScroll={handleScroll}
-                                        />
-                                    )}
-                                    {renderConfigOverride && !isComparisonView ? (
-                                        renderConfigOverride
-                                    ) : configEntityIds.length > 0 ? (
-                                        configEntityIds.map((variantId, index) => (
+                                {/* This component renders Output component header section */}
+                                {isComparisonView ? (
+                                    <div className="flex min-w-fit sticky top-0 z-[5]">
+                                        <PlaygroundComparisonGenerationInputHeader className="!w-[400px] shrink-0 sticky left-0 top-0 z-[99] bg-[var(--ag-c-FFFFFF)]" />
+
+                                        {layoutEntityIds.map((variantId) => (
                                             <div
-                                                // Agents get a STABLE key (like the chat host): a
-                                                // self-commit switches the revision in place, so the
-                                                // config panel must update as a prop change — a remount
-                                                // replays the sections' collapsed→open entrance.
-                                                key={
-                                                    renderAgentGenerationHost
-                                                        ? "agent-config-host"
-                                                        : `variant-config-${variantId}`
-                                                }
-                                                className={clsx([
-                                                    {
-                                                        "[&::-webkit-scrollbar]:w-0 min-w-[400px] flex-1 h-full max-h-full overflow-y-auto flex-shrink-0 border-0 border-r border-solid border-[var(--ag-rgba-051729-06)] relative":
-                                                            isComparisonView,
-                                                    },
-                                                ])}
-                                                ref={(el) => {
-                                                    variantRefs.current[index] = el
-                                                }}
+                                                key={variantId}
+                                                className="relative !min-w-[400px] flex-1 shrink-0"
                                             >
-                                                <PlaygroundVariantConfig
-                                                    variantId={variantId}
-                                                    embedded={embedded}
-                                                    externalViewMode={configViewMode}
-                                                    onViewModeChange={onConfigViewModeChange}
+                                                <GenerationComparisonOutputHeader
+                                                    entityId={variantId}
+                                                    className="w-full"
                                                 />
+                                                <div className="absolute right-2 top-1/2 -translate-y-1/2 z-[6]">
+                                                    <PanelSessionInspectorButton
+                                                        entityId={variantId}
+                                                    />
+                                                </div>
                                             </div>
-                                        ))
-                                    ) : (
-                                        <div className="h-full w-full p-4">
-                                            <div className="h-[260px] rounded-lg border border-solid border-[var(--ag-rgba-051729-08)] bg-[var(--ag-c-FFFFFF)]" />
-                                        </div>
-                                    )}
-                                </>
-                            </section>
-                            {!isComparisonView ? (
-                                <OverlayScrollbar target={configPanelRef} />
-                            ) : null}
-                            {!isComparisonView && isAgentConfig && primaryConfigId ? (
-                                <>
-                                    <ProviderKeyNotice revisionId={primaryConfigId} />
-                                    <AlwaysAllowedNotice revisionId={primaryConfigId} />
-                                    <AgentCommitNotice revisionId={primaryConfigId} />
-                                </>
-                            ) : null}
-                        </div>
-                    </SplitterPanel>
+                                        ))}
+                                    </div>
+                                ) : null}
 
-                    <SplitterPanel
-                        className={clsx("!h-full @container min-w-0", {
-                            "!overflow-y-hidden flex flex-col": isComparisonView,
-                            // Same stuck-scrollbar guard as the config panel (chat section scrolls itself).
-                            "!overflow-hidden": !isComparisonView,
-                        })}
-                        collapsible={splitCollapsible}
-                        defaultSize={runsDefaultSize}
-                        key={`${isComparisonView ? "comparison" : "single"}-splitter-panel-runs`}
-                    >
-                        {isComparisonView && <ExecutionHeader />}
-                        <section
-                            ref={setGenerationPanelRef}
-                            className={clsx([
-                                "playground-generation",
-                                {
-                                    "ag-scroll-quiet grow w-full h-full overflow-y-auto overflow-x-hidden":
-                                        !isComparisonView,
-                                    "grow w-full h-full overflow-auto [&::-webkit-scrollbar]:w-0":
-                                        isComparisonView,
-                                    // Chat = the recessed canvas the message/composer surfaces sit on.
-                                    "ag-canvas": isAgentConfig,
-                                },
-                            ])}
-                        >
-                            {/* This component renders Output component header section */}
-                            {isComparisonView ? (
-                                <div className="flex min-w-fit sticky top-0 z-[5]">
-                                    <PlaygroundComparisonGenerationInputHeader className="!w-[400px] shrink-0 sticky left-0 top-0 z-[99] bg-[var(--ag-c-FFFFFF)]" />
-
-                                    {layoutEntityIds.map((variantId) => (
-                                        <div
-                                            key={variantId}
-                                            className="relative !min-w-[400px] flex-1 shrink-0"
-                                        >
-                                            <GenerationComparisonOutputHeader
-                                                entityId={variantId}
-                                                className="w-full"
-                                            />
-                                            <div className="absolute right-2 top-1/2 -translate-y-1/2 z-[6]">
-                                                <PanelSessionInspectorButton entityId={variantId} />
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            ) : null}
-
-                            {/* ATOM-LEVEL OPTIMIZATION: Execution-item components using focused atom subscriptions
+                                {/* ATOM-LEVEL OPTIMIZATION: Execution-item components using focused atom subscriptions
                             Comparison view: Uses renderableExecutionRows for row grouping
                             Single view: Uses displayedEntities for per-execution panels */}
-                            {runDisabled ? (
-                                <RunDisabledPlaceholder>
-                                    {runDisabledContent}
-                                </RunDisabledPlaceholder>
-                            ) : !hasAnyLayoutEntity ? (
-                                <GenerationPanelPlaceholder />
-                            ) : isComparisonView && hasDisplayedEntities ? (
-                                <GenerationComparisonRenderer />
-                            ) : (
-                                layoutEntityIds.map((variantId) => {
-                                    // Single-agent view: a stable key so a revision switch updates
-                                    // the entityId prop instead of remounting the live conversation.
-                                    // Rendered unconditionally (not gated on `displayedEntities`) so
-                                    // it can't blink to the placeholder during the atomic id swap.
-                                    if (renderAgentGenerationHost) {
-                                        return (
+                                {runDisabled ? (
+                                    <RunDisabledPlaceholder>
+                                        {runDisabledContent}
+                                    </RunDisabledPlaceholder>
+                                ) : !hasAnyLayoutEntity ? (
+                                    <GenerationPanelPlaceholder />
+                                ) : isComparisonView && hasDisplayedEntities ? (
+                                    <GenerationComparisonRenderer />
+                                ) : (
+                                    layoutEntityIds.map((variantId) => {
+                                        // Single-agent view: a stable key so a revision switch updates
+                                        // the entityId prop instead of remounting the live conversation.
+                                        // Rendered unconditionally (not gated on `displayedEntities`) so
+                                        // it can't blink to the placeholder during the atomic id swap.
+                                        if (renderAgentGenerationHost) {
+                                            return (
+                                                <ExecutionItems
+                                                    key="agent-generation-host"
+                                                    entityId={variantId}
+                                                    renderTestsetActions={renderTestsetActions}
+                                                />
+                                            )
+                                        }
+                                        // Agent identified early (persisted agent-type map) but the
+                                        // revision hasn't resolved the flag yet — hold the chat pane's
+                                        // shape instead of a blank canvas until the host mounts.
+                                        // Data presence ends the skeleton: a restored body is renderable
+                                        // even if a pending-shaped state lingers.
+                                        if (
+                                            isAgentConfig &&
+                                            singleEntityQuery.isPending &&
+                                            !singleEntityQuery.data
+                                        ) {
+                                            return (
+                                                <AgentChatSkeleton key="agent-generation-skeleton" />
+                                            )
+                                        }
+                                        return displayedEntities.includes(variantId) ||
+                                            isEvaluatorMode ? (
                                             <ExecutionItems
-                                                key="agent-generation-host"
+                                                key={variantId}
                                                 entityId={variantId}
                                                 renderTestsetActions={renderTestsetActions}
                                             />
+                                        ) : (
+                                            <GenerationPanelPlaceholder
+                                                key={`generation-placeholder-${variantId}`}
+                                            />
                                         )
-                                    }
-                                    // Agent identified early (persisted agent-type map) but the
-                                    // revision hasn't resolved the flag yet — hold the chat pane's
-                                    // shape instead of a blank canvas until the host mounts.
-                                    // Data presence ends the skeleton: a restored body is renderable
-                                    // even if a pending-shaped state lingers.
-                                    if (
-                                        isAgentConfig &&
-                                        singleEntityQuery.isPending &&
-                                        !singleEntityQuery.data
-                                    ) {
-                                        return <AgentChatSkeleton key="agent-generation-skeleton" />
-                                    }
-                                    return displayedEntities.includes(variantId) ||
-                                        isEvaluatorMode ? (
-                                        <ExecutionItems
-                                            key={variantId}
-                                            entityId={variantId}
-                                            renderTestsetActions={renderTestsetActions}
-                                        />
-                                    ) : (
-                                        <GenerationPanelPlaceholder
-                                            key={`generation-placeholder-${variantId}`}
-                                        />
-                                    )
-                                })
-                            )}
-                        </section>
-                    </SplitterPanel>
-                </Splitter>
+                                    })
+                                )}
+                            </section>
+                        </SplitterPanel>
+                    </Splitter>
+                )}
                 <PlaygroundFocusDrawer />
             </div>
         </main>

--- a/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/assets/CommitVariantChangesButton/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/assets/CommitVariantChangesButton/index.tsx
@@ -1,8 +1,8 @@
 import {cloneElement, isValidElement, useCallback, useState} from "react"
 
 import {workflowMolecule} from "@agenta/entities/workflow"
+import {EnhancedButton} from "@agenta/ui/components/presentational"
 import {FloppyDiskBack, Plus} from "@phosphor-icons/react"
-import {Button} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -50,7 +50,7 @@ const CommitVariantChangesButton = ({
                     },
                 )
             ) : (
-                <Button
+                <EnhancedButton
                     type="text"
                     icon={icon && resolvedIcon}
                     onClick={() => setIsDeployModalOpen(true)}
@@ -58,7 +58,7 @@ const CommitVariantChangesButton = ({
                     {...props}
                 >
                     {resolvedLabel}
-                </Button>
+                </EnhancedButton>
             )}
 
             <CommitVariantChangesModal

--- a/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/assets/types.d.ts
+++ b/web/oss/src/components/Playground/Components/Modals/CommitVariantChangesModal/assets/types.d.ts
@@ -1,5 +1,5 @@
-import {ButtonProps} from "antd"
-import {ModalProps} from "antd"
+import type {EnhancedButtonProps as ButtonProps} from "@agenta/ui/components/presentational"
+import type {EnhancedModalProps as ModalProps} from "@agenta/ui"
 
 export interface CommitVariantChangesModalProps extends ModalProps {
     variantId: string

--- a/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantButton/types.d.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantButton/types.d.ts
@@ -1,4 +1,4 @@
-import {ButtonProps} from "antd"
+import type {EnhancedButtonProps as ButtonProps} from "@agenta/ui/components/presentational"
 
 export interface DeployVariantButtonProps extends ButtonProps {
     variantId?: string

--- a/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantModalContent/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantModalContent/index.tsx
@@ -5,13 +5,17 @@ import {useAtom, useAtomValue} from "jotai"
 
 import {deployNoteAtom, deploySelectedEnvAtom} from "../../store/deployVariantModalStore"
 
-import {deployModalEnvironmentsTableAtom, type DeployModalEnvRow} from "./tableDataAtom"
+import {deployModalEnvironmentsTableAtom} from "./tableDataAtom"
 
 /** The environments picker — a plain radio table (three rows), replacing antd Table. */
 const DeployVariantModalContent = ({variantName, revision, isLoading}: any) => {
-    const data = useAtomValue(deployModalEnvironmentsTableAtom)
+    const {rows, isPending: isEnvironmentsPending} = useAtomValue(deployModalEnvironmentsTableAtom)
     const [selectedEnvName, setSelectedEnvName] = useAtom(deploySelectedEnvAtom)
     const [note, setNote] = useAtom(deployNoteAtom)
+
+    // The rows come from the environments query, so the skeleton has to track THAT — not just
+    // the publish mutation, or the placeholder rows would be pickable as deployment targets.
+    const showSkeleton = Boolean(isLoading) || isEnvironmentsPending
 
     return (
         <section className="flex flex-col gap-4" data-tour="deploy-variant-modal">
@@ -36,14 +40,14 @@ const DeployVariantModalContent = ({variantName, revision, isLoading}: any) => {
                         </tr>
                     </thead>
                     <tbody>
-                        {isLoading ? (
+                        {showSkeleton ? (
                             <tr>
                                 <td colSpan={3} className="px-3 py-3">
                                     <Skeleton className="h-16 w-full" />
                                 </td>
                             </tr>
                         ) : (
-                            (data as DeployModalEnvRow[]).map((record) => (
+                            rows.map((record) => (
                                 <tr
                                     key={record.name}
                                     onClick={() => setSelectedEnvName([record.name])}

--- a/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantModalContent/index.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantModalContent/index.tsx
@@ -1,85 +1,81 @@
-import {useMemo} from "react"
-
 import {VariantNameCell} from "@agenta/entity-ui/variant"
 import {CommitMessageInput, Tag, VersionBadge} from "@agenta/ui"
-import {Typography, Table} from "antd"
-import {ColumnsType} from "antd/es/table"
+import {Skeleton} from "@agenta/ui/ui"
 import {useAtom, useAtomValue} from "jotai"
 
 import {deployNoteAtom, deploySelectedEnvAtom} from "../../store/deployVariantModalStore"
 
 import {deployModalEnvironmentsTableAtom, type DeployModalEnvRow} from "./tableDataAtom"
 
+/** The environments picker — a plain radio table (three rows), replacing antd Table. */
 const DeployVariantModalContent = ({variantName, revision, isLoading}: any) => {
     const data = useAtomValue(deployModalEnvironmentsTableAtom)
     const [selectedEnvName, setSelectedEnvName] = useAtom(deploySelectedEnvAtom)
     const [note, setNote] = useAtom(deployNoteAtom)
 
-    const columns: ColumnsType<DeployModalEnvRow> = useMemo(
-        () => [
-            {
-                title: "Environment",
-                dataIndex: "environment",
-                key: "environment",
-                onHeaderCell: () => ({
-                    style: {minWidth: 160},
-                }),
-                render: (_, record) => {
-                    return <Tag env={record.name} />
-                },
-            },
-            {
-                title: "Current variant",
-                dataIndex: "deployment",
-                key: "deployment",
-                onHeaderCell: () => ({
-                    style: {minWidth: 160},
-                }),
-                render: (_, record) => (
-                    <VariantNameCell
-                        revisionId={record.deployedAppVariantRevisionId as any}
-                        revisionName={record.deployedVariantName}
-                        showBadges={false}
-                        hideDiscard
-                    />
-                ),
-            },
-        ],
-        [],
-    )
-
     return (
         <section className="flex flex-col gap-4" data-tour="deploy-variant-modal">
-            <Typography.Text>
+            <span className="text-xs text-colorText">
                 Select an environment to deploy <span className="font-medium">{variantName}</span>{" "}
                 {typeof revision !== "undefined" && (
                     <VersionBadge version={revision} variant="chip" />
                 )}
-            </Typography.Text>
+            </span>
 
-            <Table
-                rowSelection={{
-                    type: "radio",
-                    columnWidth: 48,
-                    selectedRowKeys: selectedEnvName,
-                    onChange: (selectedRowKeys: React.Key[]) => {
-                        setSelectedEnvName(selectedRowKeys as string[])
-                    },
-                }}
-                loading={isLoading}
-                className={`ph-no-capture`}
-                columns={columns}
-                dataSource={data as any}
-                rowKey="name"
-                pagination={false}
-                bordered
-                onRow={(env) => ({
-                    className: "cursor-pointer",
-                    onClick: () => {
-                        setSelectedEnvName([env.name])
-                    },
-                })}
-            />
+            <div className="ph-no-capture overflow-hidden rounded-md border border-solid border-colorBorderSecondary">
+                <table className="w-full border-collapse text-xs">
+                    <thead>
+                        <tr className="border-0 border-b border-solid border-colorBorderSecondary bg-colorFillQuaternary text-left">
+                            <th className="w-12 px-3 py-2 font-medium" aria-label="Select" />
+                            <th className="min-w-[160px] px-3 py-2 font-medium text-colorText">
+                                Environment
+                            </th>
+                            <th className="min-w-[160px] px-3 py-2 font-medium text-colorText">
+                                Current variant
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {isLoading ? (
+                            <tr>
+                                <td colSpan={3} className="px-3 py-3">
+                                    <Skeleton className="h-16 w-full" />
+                                </td>
+                            </tr>
+                        ) : (
+                            (data as DeployModalEnvRow[]).map((record) => (
+                                <tr
+                                    key={record.name}
+                                    onClick={() => setSelectedEnvName([record.name])}
+                                    className="cursor-pointer border-0 border-b border-solid border-colorBorderSecondary last:border-b-0 hover:bg-colorFillQuaternary"
+                                >
+                                    <td className="px-3 py-2">
+                                        <input
+                                            type="radio"
+                                            name="deploy-environment"
+                                            aria-label={`Deploy to ${record.name}`}
+                                            checked={selectedEnvName.includes(record.name)}
+                                            onChange={() => setSelectedEnvName([record.name])}
+                                            className="accent-[var(--ag-colorPrimary)]"
+                                        />
+                                    </td>
+                                    <td className="px-3 py-2">
+                                        <Tag env={record.name} />
+                                    </td>
+                                    <td className="px-3 py-2">
+                                        <VariantNameCell
+                                            revisionId={record.deployedAppVariantRevisionId as any}
+                                            revisionName={record.deployedVariantName}
+                                            showBadges={false}
+                                            hideDiscard
+                                        />
+                                    </td>
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
+            </div>
 
             <CommitMessageInput value={note} onChange={setNote} />
         </section>

--- a/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantModalContent/tableDataAtom.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/assets/DeployVariantModalContent/tableDataAtom.ts
@@ -12,24 +12,39 @@ export interface DeployModalEnvRow {
 
 const PLACEHOLDER_ROWS: DeployModalEnvRow[] = [{name: "dev"}, {name: "stage"}, {name: "prod"}]
 
+export interface DeployModalEnvironmentsTable {
+    rows: DeployModalEnvRow[]
+    /**
+     * True while the environments query has not produced rows yet, so `rows` are the
+     * placeholders. The table MUST render its skeleton (not the rows) while this is set:
+     * a placeholder row is not a real deployment target and must not be selectable.
+     * A settled-but-empty result is NOT pending — it keeps today's placeholder rows.
+     */
+    isPending: boolean
+}
+
 // Lean selector for the Deploy Variant modal table
 // - Only exposes fields used by the table
 // - Bakes in placeholders when environments are loading or empty
 export const deployModalEnvironmentsTableAtom = selectAtom(
     appEnvironmentsLoadableAtom,
-    (loadable) => {
+    (loadable): DeployModalEnvironmentsTable => {
         const isLoading = loadable?.isLoading ?? loadable?.isFetching
-        const envs = loadable?.data ?? null
+        const envs = Array.isArray(loadable?.data) ? loadable.data : null
+        const isPending = Boolean(isLoading) || envs === null
 
-        if (isLoading || !Array.isArray(envs) || envs.length === 0) {
-            return PLACEHOLDER_ROWS
+        if (isPending || envs === null || envs.length === 0) {
+            return {rows: PLACEHOLDER_ROWS, isPending}
         }
 
-        return envs.map((e) => ({
-            name: e.name,
-            deployedAppVariantRevisionId: e.deployedRevisionId ?? null,
-            deployedVariantName: e.deployedVariantName ?? null,
-        })) as DeployModalEnvRow[]
+        return {
+            rows: envs.map((e) => ({
+                name: e.name,
+                deployedAppVariantRevisionId: e.deployedRevisionId ?? null,
+                deployedVariantName: e.deployedVariantName ?? null,
+            })) as DeployModalEnvRow[],
+            isPending: false,
+        }
     },
     deepEqual,
 )

--- a/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/types.d.ts
+++ b/web/oss/src/components/Playground/Components/Modals/DeployVariantModal/types.d.ts
@@ -1,5 +1,5 @@
 import type {AppEnvironmentDeployment} from "@agenta/entities/environment"
-import {ModalProps} from "antd"
+import type {EnhancedModalProps as ModalProps} from "@agenta/ui"
 
 export interface ExtendedEnvironment extends AppEnvironmentDeployment {
     revision?:

--- a/web/oss/src/components/Playground/Components/Modals/RefinePromptModal/assets/InstructionsPanel.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/RefinePromptModal/assets/InstructionsPanel.tsx
@@ -1,14 +1,15 @@
 /**
- * InstructionsPanel - Left panel for entering refinement guidelines
+ * InstructionsPanel - Left panel for entering refinement guidelines.
  *
- * Uses @ant-design/x Bubble for conversation display, Sender for input,
- * and Prompts for predefined quick-actions.
+ * The conversation renders with the shared `ChatBubble` chrome; the quick-action chip and the
+ * guideline composer are small local pieces (Enter sends, Shift+Enter breaks the line) — the
+ * previous @ant-design/x Bubble/Prompts/Sender trio without the extra dependency.
  */
 
-import {type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState} from "react"
+import {type MutableRefObject, useCallback, useEffect, useRef, useState} from "react"
 
-import {BulbOutlined} from "@ant-design/icons"
-import {Bubble, Prompts, Sender} from "@ant-design/x"
+import {ChatBubble} from "@agenta/ui/components/presentational"
+import {Lightbulb, PaperPlaneRight} from "@phosphor-icons/react"
 import {Spin} from "antd"
 import {useAtomValue} from "jotai"
 
@@ -25,13 +26,7 @@ interface InstructionsPanelProps {
     submitRef: MutableRefObject<(() => void) | null>
 }
 
-const PREDEFINED_PROMPTS = [
-    {
-        key: "optimize",
-        icon: <BulbOutlined />,
-        label: "Optimize the prompt using best practices",
-    },
-]
+const OPTIMIZE_PROMPT = "Optimize the prompt using best practices"
 
 const InstructionsPanel: React.FC<InstructionsPanelProps> = ({
     revisionId,
@@ -83,55 +78,7 @@ const InstructionsPanel: React.FC<InstructionsPanelProps> = ({
         }
     }, [handleCmdEnterSubmit, submitRef])
 
-    const handlePromptClick = useCallback(
-        (info: {data: {key: string; label?: React.ReactNode}}) => {
-            if (isLoading) return
-            const text = typeof info.data.label === "string" ? info.data.label : ""
-            if (text) {
-                handleSubmit(text)
-            }
-        },
-        [isLoading, handleSubmit],
-    )
-
-    // Memoize bubble items to avoid re-creation on every render
-    const bubbleItems = useMemo(() => {
-        const items: {
-            key: string
-            role: string
-            content: string
-            variant?: "filled" | "outlined" | "shadow" | "borderless"
-        }[] = []
-
-        for (const iteration of iterations) {
-            items.push({
-                key: `${iteration.id}-guidelines`,
-                role: "user",
-                content: iteration.guidelines,
-                variant: "filled",
-            })
-            items.push({
-                key: `${iteration.id}-explanation`,
-                role: "assistant",
-                content: iteration.explanation,
-                variant: "outlined",
-            })
-        }
-
-        // Add pending guidelines while waiting for response
-        if (pendingGuidelines) {
-            items.push({
-                key: "pending-guidelines",
-                role: "user",
-                content: pendingGuidelines,
-                variant: "filled",
-            })
-        }
-
-        return items
-    }, [iterations, pendingGuidelines])
-
-    const hasContent = bubbleItems.length > 0 || isLoading
+    const hasContent = iterations.length > 0 || !!pendingGuidelines || isLoading
 
     return (
         <div className="flex h-full flex-col">
@@ -147,20 +94,34 @@ const InstructionsPanel: React.FC<InstructionsPanelProps> = ({
                         </div>
                     </div>
                 ) : (
-                    <Bubble.List
-                        items={bubbleItems}
-                        style={{fontSize: 12}}
-                        role={{
-                            user: {
-                                placement: "end",
-                                variant: "filled",
-                            },
-                            assistant: {
-                                placement: "start",
-                                variant: "outlined",
-                            },
-                        }}
-                    />
+                    <div className="flex flex-col gap-3">
+                        {iterations.map((iteration) => (
+                            <div key={iteration.id} className="flex flex-col gap-3">
+                                <ChatBubble
+                                    placement="end"
+                                    variant="filled"
+                                    className="justify-end"
+                                    classNames={{content: "!text-xs whitespace-pre-wrap"}}
+                                    content={iteration.guidelines}
+                                />
+                                <ChatBubble
+                                    placement="start"
+                                    variant="outlined"
+                                    classNames={{content: "!text-xs whitespace-pre-wrap"}}
+                                    content={iteration.explanation}
+                                />
+                            </div>
+                        ))}
+                        {pendingGuidelines ? (
+                            <ChatBubble
+                                placement="end"
+                                variant="filled"
+                                className="justify-end"
+                                classNames={{content: "!text-xs whitespace-pre-wrap"}}
+                                content={pendingGuidelines}
+                            />
+                        ) : null}
+                    </div>
                 )}
 
                 {/* Loading indicator */}
@@ -172,36 +133,46 @@ const InstructionsPanel: React.FC<InstructionsPanelProps> = ({
                 ) : null}
             </div>
 
-            {/* Predefined prompts + Sender input */}
+            {/* Predefined prompt + composer */}
             <div className="border-t border-[var(--ag-rgba-051729-06)] px-3 pb-3 pt-2">
-                {/* Predefined prompts */}
                 <div className="mb-2">
-                    <Prompts
-                        items={PREDEFINED_PROMPTS}
-                        onItemClick={handlePromptClick}
-                        styles={{
-                            item: {
-                                fontSize: 11,
-                                padding: "4px 10px",
-                            },
-                        }}
-                    />
+                    <button
+                        type="button"
+                        disabled={isLoading}
+                        onClick={() => handleSubmit(OPTIMIZE_PROMPT)}
+                        className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-solid border-colorBorderSecondary bg-colorBgContainer px-2.5 py-1 text-[11px] text-colorTextSecondary transition-colors hover:bg-colorFillTertiary hover:text-colorText disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        <Lightbulb size={12} />
+                        {OPTIMIZE_PROMPT}
+                    </button>
                 </div>
 
-                {/* Sender input */}
-                <Sender
-                    value={inputValue}
-                    onChange={setInputValue}
-                    onSubmit={handleSubmit}
-                    placeholder="Describe how to refine your prompt…"
-                    loading={isLoading}
-                    disabled={isLoading}
-                    style={{fontSize: 12}}
-                    styles={{
-                        input: {minHeight: 0, padding: "2px 0"},
-                        suffix: {alignSelf: "flex-end"},
-                    }}
-                />
+                <div className="flex items-end gap-1.5 rounded-lg border border-solid border-colorBorder bg-colorBgContainer px-2.5 py-1.5 focus-within:border-colorPrimary">
+                    <textarea
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                        onKeyDown={(e) => {
+                            // Enter sends; Shift+Enter breaks the line (the Sender's contract).
+                            if (e.key === "Enter" && !e.shiftKey) {
+                                e.preventDefault()
+                                handleSubmit(inputValue)
+                            }
+                        }}
+                        placeholder="Describe how to refine your prompt…"
+                        disabled={isLoading}
+                        rows={2}
+                        className="min-w-0 flex-1 resize-none border-0 bg-transparent p-0 py-0.5 text-xs text-colorText outline-none placeholder:text-colorTextQuaternary"
+                    />
+                    <button
+                        type="button"
+                        aria-label="Send"
+                        disabled={isLoading || !inputValue.trim()}
+                        onClick={() => handleSubmit(inputValue)}
+                        className="flex size-6 shrink-0 cursor-pointer items-center justify-center self-end rounded-full border-0 bg-colorPrimary text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                        {isLoading ? <Spin size="small" /> : <PaperPlaneRight size={13} />}
+                    </button>
+                </div>
             </div>
         </div>
     )

--- a/web/oss/src/components/Playground/Components/Modals/RefinePromptModal/assets/InstructionsPanel.tsx
+++ b/web/oss/src/components/Playground/Components/Modals/RefinePromptModal/assets/InstructionsPanel.tsx
@@ -152,6 +152,10 @@ const InstructionsPanel: React.FC<InstructionsPanelProps> = ({
                         value={inputValue}
                         onChange={(e) => setInputValue(e.target.value)}
                         onKeyDown={(e) => {
+                            // Let the IME keep the Enter that confirms a composition candidate
+                            // (CJK, etc.) — intercepting it would submit a half-written guideline.
+                            if (e.nativeEvent.isComposing) return
+
                             // Enter sends; Shift+Enter breaks the line (the Sender's contract).
                             if (e.key === "Enter" && !e.shiftKey) {
                                 e.preventDefault()

--- a/web/oss/src/components/Playground/Components/PlaygroundGenerations/assets/GatewayToolExecuteButton.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundGenerations/assets/GatewayToolExecuteButton.tsx
@@ -1,8 +1,16 @@
 import React, {useCallback, useState} from "react"
 
 import {executeToolCall} from "@agenta/entities/gatewayTool"
+import {message} from "@agenta/ui/app-message"
+import {
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    LoadingButton,
+} from "@agenta/ui/ui"
 import {CaretDown, Lightning} from "@phosphor-icons/react"
-import {Dropdown, message as antMessage} from "antd"
 import {v4 as uuidv4} from "uuid"
 
 // Gateway tool function name format: tools__{provider}__{integration}__{action}__{connection}
@@ -57,7 +65,7 @@ const GatewayToolExecuteButton: React.FC<Props> = ({
                     onExecuteAndSendToChat?.()
                 }
             } catch {
-                antMessage.error("Tool execution failed")
+                message.error("Tool execution failed")
             } finally {
                 setExecutingId(null)
             }
@@ -71,25 +79,36 @@ const GatewayToolExecuteButton: React.FC<Props> = ({
     return (
         <div className="flex flex-col gap-1">
             {gatewayPayloads.map((p) => (
-                <Dropdown.Button
-                    key={p.callId || p.name}
-                    size="small"
-                    icon={<CaretDown size={12} />}
-                    loading={executingId === (p.callId || p.name || "default")}
-                    onClick={() => handleExecute(p, true)}
-                    menu={{
-                        items: [
-                            {
-                                key: "call-and-send",
-                                label: "Call tool",
-                            },
-                        ],
-                        onClick: () => handleExecute(p, false),
-                    }}
-                >
-                    <Lightning size={12} />
-                    Call tool and send to chat
-                </Dropdown.Button>
+                // Split button: the primary click calls AND sends; the caret offers the plain call.
+                <span key={p.callId || p.name} className="inline-flex">
+                    <LoadingButton
+                        variant="outline"
+                        size="sm"
+                        loading={executingId === (p.callId || p.name || "default")}
+                        onClick={() => handleExecute(p, true)}
+                        className="rounded-r-none"
+                    >
+                        <Lightning size={12} />
+                        Call tool and send to chat
+                    </LoadingButton>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="outline"
+                                size="icon-sm"
+                                aria-label="Tool call options"
+                                className="-ml-px rounded-l-none"
+                            >
+                                <CaretDown size={12} />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem onSelect={() => handleExecute(p, false)}>
+                                Call tool
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </span>
             ))}
         </div>
     )

--- a/web/oss/src/components/Playground/Components/PlaygroundGenerations/assets/GatewayToolExecuteButton.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundGenerations/assets/GatewayToolExecuteButton.tsx
@@ -13,6 +13,12 @@ import {
 import {CaretDown, Lightning} from "@phosphor-icons/react"
 import {v4 as uuidv4} from "uuid"
 
+// Identity of an in-flight execution. Derived in one place so the primary button and the
+// menu item that trigger the same call agree on what "busy" means.
+function executionId(p: GatewayToolPayloadInfo): string {
+    return p.callId || p.name || "default"
+}
+
 // Gateway tool function name format: tools__{provider}__{integration}__{action}__{connection}
 // Double-underscore is used because LLM providers forbid dots in function names.
 // The /tools/call API normalises __ → . before parsing.
@@ -43,7 +49,7 @@ const GatewayToolExecuteButton: React.FC<Props> = ({
 
     const handleExecute = useCallback(
         async (p: GatewayToolPayloadInfo, sendToChat: boolean) => {
-            const execId = p.callId || p.name || "default"
+            const execId = executionId(p)
             const toolCallId = p.callId || `call_${uuidv4()}`
             setExecutingId(execId)
 
@@ -78,38 +84,49 @@ const GatewayToolExecuteButton: React.FC<Props> = ({
 
     return (
         <div className="flex flex-col gap-1">
-            {gatewayPayloads.map((p) => (
-                // Split button: the primary click calls AND sends; the caret offers the plain call.
-                <span key={p.callId || p.name} className="inline-flex">
-                    <LoadingButton
-                        variant="outline"
-                        size="sm"
-                        loading={executingId === (p.callId || p.name || "default")}
-                        onClick={() => handleExecute(p, true)}
-                        className="rounded-r-none"
-                    >
-                        <Lightning size={12} />
-                        Call tool and send to chat
-                    </LoadingButton>
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <Button
-                                variant="outline"
-                                size="icon-sm"
-                                aria-label="Tool call options"
-                                className="-ml-px rounded-l-none"
-                            >
-                                <CaretDown size={12} />
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                            <DropdownMenuItem onSelect={() => handleExecute(p, false)}>
-                                Call tool
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                </span>
-            ))}
+            {gatewayPayloads.map((p) => {
+                // Both halves of the split button drive the SAME call, so they share one
+                // in-flight flag: without it the menu item could start a second execution
+                // while the primary one is still running and both would write a response
+                // back for the same tool call.
+                const isExecuting = executingId === executionId(p)
+
+                return (
+                    // Split button: the primary click calls AND sends; the caret offers the plain call.
+                    <span key={p.callId || p.name} className="inline-flex">
+                        <LoadingButton
+                            variant="outline"
+                            size="sm"
+                            loading={isExecuting}
+                            onClick={() => handleExecute(p, true)}
+                            className="rounded-r-none"
+                        >
+                            <Lightning size={12} />
+                            Call tool and send to chat
+                        </LoadingButton>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    size="icon-sm"
+                                    aria-label="Tool call options"
+                                    className="-ml-px rounded-l-none"
+                                >
+                                    <CaretDown size={12} />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                    disabled={isExecuting}
+                                    onSelect={() => handleExecute(p, false)}
+                                >
+                                    Call tool
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </span>
+                )
+            })}
         </div>
     )
 }

--- a/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
@@ -671,7 +671,7 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                     {isAgentWorkflow ? (
                         <div className="flex min-w-0 items-center gap-2">
                             <SimpleTooltip title="Agent">
-                                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[var(--ant-color-fill-secondary)] text-[var(--ag-c-13C2C2)]">
+                                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-colorFillSecondary text-cyan-6">
                                     <Robot size={15} weight="fill" />
                                 </span>
                             </SimpleTooltip>

--- a/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
@@ -19,21 +19,30 @@ import {useEnrichedEvaluatorOnlyAdapter as useEvaluatorOnlyAdapter} from "@agent
 import {playgroundController, isAgentModeAtomFamily} from "@agenta/playground"
 import {usePlaygroundLayout} from "@agenta/playground-ui/hooks"
 import {textColors} from "@agenta/ui"
+import {message} from "@agenta/ui/app-message"
 import {VersionBadge} from "@agenta/ui/components/presentational"
-import {CloseOutlined, DownOutlined, MoreOutlined} from "@ant-design/icons"
-import {Check, Gavel, GearSix, PencilSimple, Plus, Robot} from "@phosphor-icons/react"
 import {
     Button,
-    Divider,
-    Dropdown,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
     Segmented,
-    Space,
-    Tag,
-    Tooltip,
-    Typography,
-    message,
-    type MenuProps,
-} from "antd"
+    SimpleTooltip,
+} from "@agenta/ui/ui"
+import {
+    CaretDown,
+    Check,
+    DotsThree,
+    Gavel,
+    GearSix,
+    PencilSimple,
+    Plus,
+    Robot,
+    X,
+} from "@phosphor-icons/react"
 import clsx from "clsx"
 import {atom, useAtomValue, useSetAtom, useStore} from "jotai"
 import dynamic from "next/dynamic"
@@ -69,12 +78,21 @@ import RunEvaluationButton from "./RunEvaluationButton"
 const SelectVariant = dynamic(() => import("../Menus/SelectVariant"), {
     ssr: false,
     loading: () => (
-        <Space.Compact size="small">
-            <Button className="flex items-center gap-1" icon={<Plus size={14} />} disabled>
+        <span className="inline-flex">
+            <Button variant="outline" size="sm" disabled className="rounded-r-none">
+                <Plus size={14} />
                 Compare
             </Button>
-            <Button icon={<DownOutlined style={{fontSize: 10}} />} disabled />
-        </Space.Compact>
+            <Button
+                variant="outline"
+                size="icon-sm"
+                disabled
+                aria-label="Compare options"
+                className="-ml-px rounded-l-none"
+            >
+                <CaretDown size={10} />
+            </Button>
+        </span>
     ),
 })
 
@@ -159,14 +177,8 @@ const EvaluatorTag: React.FC<{
     }, [evaluatorName, runnableData])
 
     return (
-        <Tag
-            closable
-            closeIcon={<CloseOutlined style={{fontSize: 10}} />}
-            onClose={(e) => {
-                e.preventDefault()
-                onDisconnect(node.id)
-            }}
-            className="flex items-center gap-1 !mr-0 max-w-[160px]"
+        <span
+            className="flex max-w-[160px] items-center gap-1 rounded border border-solid border-colorBorder bg-colorFillQuaternary px-[7px] text-xs leading-5 text-colorText"
             style={
                 color
                     ? {
@@ -178,7 +190,15 @@ const EvaluatorTag: React.FC<{
             }
         >
             <span className="truncate">{label}</span>
-        </Tag>
+            <button
+                type="button"
+                aria-label={`Disconnect ${typeof label === "string" ? label : "evaluator"}`}
+                onClick={() => onDisconnect(node.id)}
+                className="flex shrink-0 cursor-pointer items-center border-0 bg-transparent p-0 text-inherit opacity-60 hover:opacity-100"
+            >
+                <X size={10} />
+            </button>
+        </span>
     )
 }
 
@@ -284,58 +304,52 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
     const itemEstimate = useAtomValue(agentChatItemEstimateAtom)
     const setItemEstimate = useSetAtom(agentChatItemEstimateAtom)
 
-    const settingsMenuItems: MenuProps["items"] = useMemo(
+    interface SettingsMenuGroup {
+        key: string
+        label: string
+        children: {
+            key: string
+            label: string
+            checked: boolean
+            disabled?: boolean
+            onClick: () => void
+        }[]
+    }
+    const settingsMenuItems: SettingsMenuGroup[] = useMemo(
         () => [
             ...(virtualizationAvailable
                 ? [
                       {
                           key: "virtualization",
-                          type: "group" as const,
                           label: "Virtualization (spike)",
                           children: [
                               {
                                   key: "virt-enable",
                                   label: "Virtualize messages",
-                                  icon: virtualize ? (
-                                      <Check size={14} />
-                                  ) : (
-                                      <span className="inline-block w-[14px]" />
-                                  ),
+                                  checked: virtualize,
                                   onClick: () => setVirtualize(!virtualize),
                               },
                           ],
                       },
                       {
                           key: "virt-overscan",
-                          type: "group" as const,
                           label: "Overscan",
                           children: AGENT_CHAT_OVERSCAN_OPTIONS.map((option) => ({
                               key: `overscan-${option.value}`,
                               label: option.label,
                               disabled: !virtualize,
-                              icon:
-                                  overscan === option.value ? (
-                                      <Check size={14} />
-                                  ) : (
-                                      <span className="inline-block w-[14px]" />
-                                  ),
+                              checked: overscan === option.value,
                               onClick: () => setOverscan(option.value),
                           })),
                       },
                       {
                           key: "virt-estimate",
-                          type: "group" as const,
                           label: "Row estimate",
                           children: AGENT_CHAT_ITEM_ESTIMATE_OPTIONS.map((option) => ({
                               key: `estimate-${option.value}`,
                               label: option.label,
                               disabled: !virtualize,
-                              icon:
-                                  itemEstimate === option.value ? (
-                                      <Check size={14} />
-                                  ) : (
-                                      <span className="inline-block w-[14px]" />
-                                  ),
+                              checked: itemEstimate === option.value,
                               onClick: () => setItemEstimate(option.value),
                           })),
                       },
@@ -640,36 +654,27 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
             >
                 <div className="flex shrink-0 items-center gap-2">
                     {currentWorkflow?.flags?.is_custom ? (
-                        <Dropdown
-                            trigger={["click"]}
-                            styles={{
-                                root: {
-                                    width: 180,
-                                },
-                            }}
-                            menu={{
-                                items: [
-                                    ...[
-                                        {
-                                            key: "configure",
-                                            label: "Configure workflow",
-                                            icon: <PencilSimple size={16} />,
-                                            onClick: openModal,
-                                        },
-                                    ],
-                                ],
-                            }}
-                        >
-                            <Button type="text" icon={<MoreOutlined />} />
-                        </Dropdown>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="icon" aria-label="Workflow options">
+                                    <DotsThree size={16} />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="start" className="w-[180px]">
+                                <DropdownMenuItem onSelect={openModal}>
+                                    <PencilSimple size={16} />
+                                    Configure workflow
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                     ) : null}
                     {isAgentWorkflow ? (
                         <div className="flex min-w-0 items-center gap-2">
-                            <Tooltip title="Agent">
+                            <SimpleTooltip title="Agent">
                                 <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[var(--ant-color-fill-secondary)] text-[var(--ag-c-13C2C2)]">
                                     <Robot size={15} weight="fill" />
                                 </span>
-                            </Tooltip>
+                            </SimpleTooltip>
                             {renameWorkflowId ? (
                                 <AgentNameInline
                                     workflowId={renameWorkflowId}
@@ -677,21 +682,24 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                                     onRenamed={setDisplayAgentName}
                                 />
                             ) : (
-                                <Typography className="truncate whitespace-nowrap text-[16px] leading-[18px] font-[600]">
+                                <span className="truncate whitespace-nowrap text-[16px] font-[600] leading-[18px] text-colorText">
                                     {agentName || "Agent"}
-                                </Typography>
+                                </span>
                             )}
                             {rootEntityId ? (
                                 <>
-                                    <Divider orientation="vertical" className="!mx-1 h-5" />
+                                    <span
+                                        aria-hidden
+                                        className="mx-1 h-5 w-px shrink-0 bg-colorBorderSecondary"
+                                    />
                                     <AgentRevisionSelector variantId={rootEntityId} />
                                 </>
                             ) : null}
                         </div>
                     ) : (
-                        <Typography className="whitespace-nowrap text-[16px] leading-[18px] font-[600]">
+                        <span className="whitespace-nowrap text-[16px] font-[600] leading-[18px] text-colorText">
                             Playground
-                        </Typography>
+                        </span>
                     )}
                 </div>
 
@@ -718,13 +726,16 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                     )}
                     {showEvalActions && (
                         <>
-                            <Divider orientation="vertical" className="!mx-0 h-5" />
+                            <span
+                                aria-hidden
+                                className="mx-0 h-5 w-px shrink-0 bg-colorBorderSecondary"
+                            />
                             <span
                                 className="relative inline-flex"
                                 onPointerEnter={handleActivateEvaluatorPicker}
                                 onFocus={handleActivateEvaluatorPicker}
                             >
-                                <Tooltip title="Add evaluators to automatically score outputs in the playground.">
+                                <SimpleTooltip title="Add evaluators to automatically score outputs in the playground.">
                                     <span>
                                         <EntityPicker<WorkflowRevisionSelectionResult>
                                             variant="popover-cascader"
@@ -755,8 +766,8 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                                                 connectedEvaluatorNodes.length > 0 ? (
                                                     <div className="border-0 border-t border-solid border-[var(--ag-rgba-051729-06)] p-2">
                                                         <Button
-                                                            size="small"
-                                                            danger
+                                                            variant="destructive-outline"
+                                                            size="sm"
                                                             className="w-full"
                                                             onClick={handleDisconnectAll}
                                                         >
@@ -767,7 +778,7 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                                             }
                                         />
                                     </span>
-                                </Tooltip>
+                                </SimpleTooltip>
                                 <EvaluatorTemplateDropdown
                                     onSelect={handleTemplateSelect}
                                     open={templateDropdownOpen}
@@ -779,21 +790,28 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                             </span>
                             <TestsetDropdown />
                             {isProjectLevelPlayground ? (
-                                <Tooltip title="Compare mode is unavailable in project-level playground">
-                                    <Space.Compact size="small">
+                                <SimpleTooltip title="Compare mode is unavailable in project-level playground">
+                                    <span className="inline-flex">
                                         <Button
-                                            className="flex items-center gap-1"
-                                            icon={<Plus size={14} />}
+                                            variant="outline"
+                                            size="sm"
                                             disabled
+                                            className="rounded-r-none"
                                         >
+                                            <Plus size={14} />
                                             Compare
                                         </Button>
                                         <Button
-                                            icon={<DownOutlined style={{fontSize: 10}} />}
+                                            variant="outline"
+                                            size="icon-sm"
                                             disabled
-                                        />
-                                    </Space.Compact>
-                                </Tooltip>
+                                            aria-label="Compare options"
+                                            className="-ml-px rounded-l-none"
+                                        >
+                                            <CaretDown size={10} />
+                                        </Button>
+                                    </span>
+                                </SimpleTooltip>
                             ) : (
                                 <SelectVariant
                                     showAsCompare
@@ -815,19 +833,40 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                                     {label: "Chat", value: "chat"},
                                 ]}
                             />
-                            {(settingsMenuItems?.length ?? 0) > 0 && (
-                                <Dropdown
-                                    trigger={["click"]}
-                                    placement="bottomRight"
-                                    styles={{root: {width: 180}}}
-                                    menu={{items: settingsMenuItems}}
-                                >
-                                    <Button
-                                        type="text"
-                                        icon={<GearSix size={16} />}
-                                        aria-label="Playground settings"
-                                    />
-                                </Dropdown>
+                            {settingsMenuItems.length > 0 && (
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            aria-label="Playground settings"
+                                        >
+                                            <GearSix size={16} />
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent align="end" className="w-[200px]">
+                                        {settingsMenuItems.map((group, index) => (
+                                            <React.Fragment key={group.key}>
+                                                {index > 0 ? <DropdownMenuSeparator /> : null}
+                                                <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+                                                {group.children.map((item) => (
+                                                    <DropdownMenuItem
+                                                        key={item.key}
+                                                        disabled={item.disabled}
+                                                        onSelect={item.onClick}
+                                                    >
+                                                        {item.checked ? (
+                                                            <Check size={14} />
+                                                        ) : (
+                                                            <span className="inline-block w-[14px]" />
+                                                        )}
+                                                        {item.label}
+                                                    </DropdownMenuItem>
+                                                ))}
+                                            </React.Fragment>
+                                        ))}
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
                             )}
                         </>
                     )}

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
@@ -11,9 +11,9 @@ import {VariantDetailsWithStatus} from "@agenta/entity-ui/variant"
 import {isAgentModeAtomFamily, playgroundController} from "@agenta/playground"
 import {message} from "@agenta/ui/app-message"
 import {Tag} from "@agenta/ui/components"
-import {MoreOutlined} from "@ant-design/icons"
-import {Trash} from "@phosphor-icons/react"
-import {Button, Tooltip} from "antd"
+import {EnhancedButton} from "@agenta/ui/components/presentational"
+import {SimpleTooltip} from "@agenta/ui/ui"
+import {DotsThree, Trash} from "@phosphor-icons/react"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -32,7 +32,7 @@ const PlaygroundVariantHeaderMenu = dynamic(
         ssr: false,
         // Reserve the kebab's 32px footprint while the chunk loads so it doesn't pop in and
         // shift Commit/Deploy leftward on the (skeletonized) agent config header.
-        loading: () => <Button type="text" icon={<MoreOutlined size={14} />} disabled />,
+        loading: () => <EnhancedButton type="text" icon={<DotsThree size={14} />} disabled />,
     },
 )
 
@@ -270,9 +270,9 @@ const PlaygroundVariantConfigHeader = ({
             <div className="flex items-center justify-end gap-2 shrink-0 grow min-w-0">
                 {extraActions}
                 {hasPresets && onLoadPreset && (
-                    <Button size="small" onClick={onLoadPreset}>
+                    <EnhancedButton size="small" onClick={onLoadPreset}>
                         Load Preset
-                    </Button>
+                    </EnhancedButton>
                 )}
                 {isLocalDraftVariant ? (
                     <>
@@ -283,15 +283,15 @@ const PlaygroundVariantConfigHeader = ({
                             size="small"
                         />
                         {!rawEntity?.meta?.__ephemeral && (
-                            <Tooltip title="Discard draft">
-                                <Button
+                            <SimpleTooltip title="Discard draft">
+                                <EnhancedButton
                                     type="text"
                                     size="small"
                                     danger
                                     icon={<Trash size={16} />}
                                     onClick={handleDiscardLocalDraft}
                                 />
-                            </Tooltip>
+                            </SimpleTooltip>
                         )}
                     </>
                 ) : (

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/index.tsx
@@ -20,7 +20,7 @@ import {
     type ConfigViewMode,
 } from "@agenta/entity-ui"
 import {hasPendingHydrationAtomFamily, isAgentModeAtomFamily} from "@agenta/playground"
-import {Select} from "antd"
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@agenta/ui/ui"
 import clsx from "clsx"
 import {atom, useAtomValue, useSetAtom} from "jotai"
 import {selectAtom} from "jotai/utils"
@@ -240,17 +240,21 @@ const PlaygroundVariantConfig: React.FC<
     const viewModeSelector = useMemo(
         () => (
             <Select
-                size="small"
-                variant="borderless"
                 value={viewMode}
-                onChange={setViewMode}
-                options={[
-                    {label: "Form", value: "form"},
-                    {label: "JSON", value: "json"},
-                    {label: "YAML", value: "yaml"},
-                ]}
-                className="w-[90px] [&_.ant-select-selector]:!px-1 text-xs"
-            />
+                onValueChange={(value) => setViewMode(value as ConfigViewMode)}
+            >
+                <SelectTrigger
+                    size="sm"
+                    className="w-[90px] border-transparent bg-transparent px-1 text-xs shadow-none"
+                >
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="form">Form</SelectItem>
+                    <SelectItem value="json">JSON</SelectItem>
+                    <SelectItem value="yaml">YAML</SelectItem>
+                </SelectContent>
+            </Select>
         ),
         [viewMode, setViewMode],
     )

--- a/web/oss/src/components/Playground/Components/ProviderKeyNotice.tsx
+++ b/web/oss/src/components/Playground/Components/ProviderKeyNotice.tsx
@@ -2,8 +2,8 @@ import {useEffect, useRef} from "react"
 
 import {providerKeyAddedSignalAtom} from "@agenta/shared/state"
 import {HeightCollapse} from "@agenta/ui"
+import {Button} from "@agenta/ui/ui"
 import {CheckCircle, X} from "@phosphor-icons/react"
-import {Button} from "antd"
 import {useAtom} from "jotai"
 
 /**
@@ -58,12 +58,14 @@ const ProviderKeyNotice = ({revisionId}: {revisionId: string}) => {
                         </div>
                     </div>
                     <Button
-                        type="text"
+                        variant="ghost"
+                        size="icon-sm"
                         aria-label="Dismiss"
-                        className="!h-6 !w-6 shrink-0 !px-0 !text-colorTextTertiary hover:!bg-colorFillTertiary hover:!text-colorText"
-                        icon={<X size={13} />}
+                        className="h-6 w-6 shrink-0 p-0 text-colorTextTertiary hover:bg-colorFillTertiary hover:text-colorText"
                         onClick={() => setSignal(null)}
-                    />
+                    >
+                        <X size={13} />
+                    </Button>
                 </div>
             </div>
         </HeightCollapse>


### PR DESCRIPTION
The agent-path playground chrome drops antd so the same chrome can render inside `/m`.
Not run in a browser — static gates only (`pnpm lint-fix` 24/24, `tsc --noEmit` clean
for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`).

Stacked on `mobile/chat-and-shell`; review only this lane's diff.