### PR TITLE
refactor(frontend): ONE agent-overview arrangement — the composition joins the components in @agenta/entity-ui

### DIFF
--- a/web/mobile/src/features/agents/AgentOverviewScreen.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewScreen.tsx
@@ -1,7 +1,12 @@
 import {useMemo} from "react"
 
 import {agentWorkflowsListQueryStateAtom, type Workflow} from "@agenta/entities/workflow"
-import {AgentConfigSummaryCard, agentAvatar, NextTriggersSection} from "@agenta/entity-ui/agent"
+import {
+    AgentConfigSummaryCard,
+    agentAvatar,
+    AgentOverviewLayout,
+    NextTriggersSection,
+} from "@agenta/entity-ui/agent"
 import {SessionCardList} from "@agenta/sessions-ui"
 import {useAtomValue} from "jotai"
 
@@ -53,7 +58,7 @@ export const AgentOverviewScreen = ({
                 <ScreenScaffold
                     header={
                         <div className="border-border shrink-0 border-b px-2 pb-3 pt-2">
-                            <ContentRail className="flex items-center gap-2">
+                            <ContentRail className="flex items-center gap-2 lg:max-w-none">
                                 {/* Nav is the drawer, as on every other screen — not a per-screen
                                     back button. Home is one drawer entry away. */}
                                 <NavDrawer workspaceId={workspaceId} projectId={projectId} />
@@ -70,45 +75,64 @@ export const AgentOverviewScreen = ({
                         </div>
                     }
                 >
-                    <ContentRail>
-                        <AgentOverviewSection title="Sessions" viewAllHref={`${base}/sessions`}>
-                            <div className="px-2">
-                                <SessionCardList
-                                    withPinned
-                                    agentId={agentId}
-                                    limit={6}
-                                    emptyText="Conversations with this agent will show up here."
-                                    onOpenRow={sessionMenu.open}
-                                    menuFor={sessionMenu.menuFor}
-                                    onMenuSelect={sessionMenu.onMenuSelect}
-                                    alwaysShowPin
-                                />
-                            </div>
-                        </AgentOverviewSection>
+                    {/* The SHARED arrangement the desktop overview uses — activity left, the
+                        agent's own state as a rail. `gap-0` below lg keeps the phone's stacked
+                        rhythm, which the sections already own through their own padding. */}
+                    <ContentRail className="lg:max-w-none">
+                        <AgentOverviewLayout
+                            className="gap-0 lg:gap-6"
+                            main={
+                                <>
+                                    <AgentOverviewSection
+                                        title="Sessions"
+                                        viewAllHref={`${base}/sessions`}
+                                    >
+                                        <div className="px-2">
+                                            <SessionCardList
+                                                withPinned
+                                                agentId={agentId}
+                                                limit={6}
+                                                emptyText="Conversations with this agent will show up here."
+                                                onOpenRow={sessionMenu.open}
+                                                menuFor={sessionMenu.menuFor}
+                                                onMenuSelect={sessionMenu.onMenuSelect}
+                                                alwaysShowPin
+                                            />
+                                        </div>
+                                    </AgentOverviewSection>
 
-                        <AgentOverviewSection title="Automation runs">
-                            <div className="px-2">
-                                <SessionCardList
-                                    origin="trigger"
-                                    agentId={agentId}
-                                    limit={5}
-                                    emptyText="Runs from automations bound to this agent will show up here."
-                                    onOpenRow={sessionMenu.open}
-                                    menuFor={sessionMenu.menuFor}
-                                    onMenuSelect={sessionMenu.onMenuSelect}
-                                    alwaysShowPin
-                                />
-                            </div>
-                        </AgentOverviewSection>
+                                    <AgentOverviewSection title="Automation runs">
+                                        <div className="px-2">
+                                            <SessionCardList
+                                                origin="trigger"
+                                                agentId={agentId}
+                                                limit={5}
+                                                emptyText="Runs from automations bound to this agent will show up here."
+                                                onOpenRow={sessionMenu.open}
+                                                menuFor={sessionMenu.menuFor}
+                                                onMenuSelect={sessionMenu.onMenuSelect}
+                                                alwaysShowPin
+                                            />
+                                        </div>
+                                    </AgentOverviewSection>
+                                </>
+                            }
+                            rail={
+                                <>
+                                    {/* Scoped to this agent; automation RUNS say what already happened. */}
+                                    <div className="px-2 pt-2 lg:pt-0">
+                                        <NextTriggersSection
+                                            agentId={agentId}
+                                            agentNames={agentNames}
+                                        />
+                                    </div>
 
-                        {/* Scoped to this agent; automation RUNS above say what already happened. */}
-                        <div className="px-2 pt-2">
-                            <NextTriggersSection agentId={agentId} agentNames={agentNames} />
-                        </div>
-
-                        <div className="px-2 pb-6 pt-2">
-                            <AgentConfigSummaryCard appId={agentId} />
-                        </div>
+                                    <div className="px-2 pb-6 pt-2">
+                                        <AgentConfigSummaryCard appId={agentId} />
+                                    </div>
+                                </>
+                            }
+                        />
                     </ContentRail>
                 </ScreenScaffold>
             </AppShell>

--- a/web/oss/src/components/pages/overview/agent/AgentOverview.tsx
+++ b/web/oss/src/components/pages/overview/agent/AgentOverview.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect} from "react"
 
+import {AgentOverviewLayout} from "@agenta/entity-ui/agent"
 import {PanelScroll, PanelSurface} from "@agenta/ui/components/presentational"
 import {RichChatInput} from "@agenta/ui/rich-chat-input"
 import {useSetAtom} from "jotai"
@@ -73,8 +74,10 @@ const AgentOverview = ({appId, agentName}: Props) => {
         // Below `lg` the columns stack and the page itself scrolls; at `lg` each column takes the
         // frame's height and scrolls on its own, so reading a long session list never carries the
         // configuration rail off screen with it.
-        <div className="flex min-h-0 w-full flex-1 flex-col items-start gap-10 overflow-y-auto lg:flex-row lg:overflow-hidden">
-            <div className="flex w-full min-w-0 flex-col gap-6 lg:h-full lg:flex-1 lg:overflow-y-auto lg:pr-4">
+        <AgentOverviewLayout
+            scroll
+            main={
+                <>
                 <RichChatInput
                     // The column scrolls, so every child of it is shrinkable by default and this
                     // one collapsed to a hairline under the title once the lists overflowed.
@@ -133,9 +136,9 @@ const AgentOverview = ({appId, agentName}: Props) => {
                         viewAllHref={sessionsHref}
                     />
                 </div>
-            </div>
-
-            <div className="flex min-h-0 w-full shrink-0 grow-0 flex-col lg:h-full lg:w-1/3 lg:min-w-[340px] lg:max-w-[520px] lg:pr-1">
+                </>
+            }
+            rail={
                 <PanelSurface className="flex max-h-full min-h-0 flex-col">
                     <PanelScroll>
                         <AgentConfigurationCard appId={appId} />
@@ -149,8 +152,8 @@ const AgentOverview = ({appId, agentName}: Props) => {
                         <UsageSummary variant="strip" />
                     </PanelScroll>
                 </PanelSurface>
-            </div>
-        </div>
+            }
+        />
     )
 }
 

--- a/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
@@ -1,0 +1,59 @@
+import type {ReactNode} from "react"
+
+import clsx from "clsx"
+
+export interface AgentOverviewLayoutProps {
+    /** The reading column: what happened — the activity lists, and a composer where the host has one. */
+    main: ReactNode
+    /** The rail: what the agent IS — configuration, files, triggers, usage. Each host brings the
+     * cards it can serve; the layout only places them. */
+    rail: ReactNode
+    /**
+     * The frame owns the height and each column scrolls on its own (the desktop page, which is a
+     * full-height frame). Default: both columns are plain blocks and the host's page scrolls —
+     * nesting a scroller inside an already-scrolling screen strands the rail, which is the bug
+     * `ScreenScaffold`'s `fill` exists to avoid on mobile.
+     */
+    scroll?: boolean
+    /** Host spacing — the stacked gap below lg is content rhythm, not layout. */
+    className?: string
+}
+
+/**
+ * THE agent overview arrangement, shared by the desktop page and the mobile screen: activity
+ * reads in a flexible left column, the agent's own state stands as a fixed-width rail beside it,
+ * and the two stack below lg. One definition so the two surfaces cannot drift — the components
+ * inside the slots are already shared (`AgentConfigSummaryCard`, `NextTriggersSection`,
+ * `SessionCardList`); this is the composition that was still being written twice.
+ */
+export const AgentOverviewLayout = ({
+    main,
+    rail,
+    scroll = false,
+    className,
+}: AgentOverviewLayoutProps) => (
+    <div
+        className={clsx(
+            "flex w-full flex-col items-start gap-10 lg:flex-row",
+            scroll && "min-h-0 flex-1 overflow-y-auto lg:overflow-hidden",
+            className,
+        )}
+    >
+        <div
+            className={clsx(
+                "flex w-full min-w-0 flex-col gap-6 lg:flex-1",
+                scroll && "lg:h-full lg:overflow-y-auto lg:pr-4",
+            )}
+        >
+            {main}
+        </div>
+        <div
+            className={clsx(
+                "flex w-full shrink-0 grow-0 flex-col lg:w-1/3 lg:min-w-[340px] lg:max-w-[520px]",
+                scroll && "min-h-0 lg:h-full lg:pr-1",
+            )}
+        >
+            {rail}
+        </div>
+    </div>
+)

--- a/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from "react"
 
-import clsx from "clsx"
+import {cn} from "@agenta/ui/ui"
 
 export interface AgentOverviewLayoutProps {
     /** The reading column: what happened — the activity lists, and a composer where the host has one. */
@@ -33,14 +33,14 @@ export const AgentOverviewLayout = ({
     className,
 }: AgentOverviewLayoutProps) => (
     <div
-        className={clsx(
+        className={cn(
             "flex w-full flex-col items-start gap-10 lg:flex-row",
-            scroll && "min-h-0 flex-1 overflow-y-auto lg:overflow-hidden",
+            scroll && "lg:min-h-0 lg:flex-1 lg:overflow-hidden",
             className,
         )}
     >
         <div
-            className={clsx(
+            className={cn(
                 "flex w-full min-w-0 flex-col gap-6 lg:flex-1",
                 scroll && "lg:h-full lg:overflow-y-auto lg:pr-4",
             )}
@@ -48,7 +48,7 @@ export const AgentOverviewLayout = ({
             {main}
         </div>
         <div
-            className={clsx(
+            className={cn(
                 "flex w-full shrink-0 grow-0 flex-col lg:w-1/3 lg:min-w-[340px] lg:max-w-[520px]",
                 scroll && "min-h-0 lg:h-full lg:pr-1",
             )}

--- a/web/packages/agenta-entity-ui/src/agent/index.ts
+++ b/web/packages/agenta-entity-ui/src/agent/index.ts
@@ -10,3 +10,4 @@ export {agentConfigSummary, prettifyKind, type AgentConfigSummary} from "./agent
 export {agentLatestRevisionAtomFamily} from "./state"
 export {AgentCardGrid, type AgentCardGridProps} from "./AgentCardGrid"
 export {AgentRosterGrid, type AgentRosterEntry, type AgentRosterGridProps} from "./AgentRosterGrid"
+export {AgentOverviewLayout, type AgentOverviewLayoutProps} from "./AgentOverviewLayout"


### PR DESCRIPTION
Desktop and `/m` were arranging the same agent-overview components two different ways. The
arrangement itself moves into `@agenta/entity-ui`, so there is one composition, not two.

Small lane (4 files) deliberately — it is the seam the next lane builds on.
Not run in a browser — static gates only (`pnpm lint-fix` 24/24, `tsc --noEmit` clean
for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`).

Stacked on `mobile/agents-templates-settings`; review only this lane's diff.