### PR TITLE
feat(frontend): DataTable — the antd-free table the shared settings pages needed

### DIFF
--- a/web/mobile/package.json
+++ b/web/mobile/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@agenta/mobile",
-    "version": "0.1.0",
+    "version": "0.111.0",
     "private": true,
     "engines": {
         "node": "24.x"

--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -2,14 +2,24 @@ import {useMemo} from "react"
 
 import {useProfile} from "@agenta/entities/profile"
 import {
-    CLOSED_SETTINGS_ACCESS,
     getSettingsSidebarTabs,
     getSettingsTabDescription,
     getSettingsTabLabel,
     SETTINGS_SCOPES,
     type SettingsTabKey,
 } from "@agenta/settings"
-import {AccountPage, PreferencesPage, SettingsPageShell} from "@agenta/settings-ui"
+import {useApiKeys, type SettingsAccess} from "@agenta/settings"
+import {
+    AccountPage,
+    ApiKeysPage,
+    NamedSecretTable,
+    PreferencesPage,
+    ProjectsPage,
+    SecretProviderTable,
+    SettingsPageShell,
+    WebhooksPage,
+} from "@agenta/settings-ui"
+import {getEnv} from "@agenta/shared/api"
 import {useThemeMode} from "@agenta/ui/theme"
 import {useRouter} from "next/router"
 
@@ -29,14 +39,82 @@ const THEME_OPTIONS = [
     {mode: "system", label: "System default"},
 ]
 
-/** Tabs this app can actually render; the rest are listed nowhere rather than dead-ending. */
-const AVAILABLE: SettingsTabKey[] = ["preferences", "account"]
+/** Tabs this app has a page for. The rest are listed nowhere rather than dead-ending. */
+const AVAILABLE: SettingsTabKey[] = [
+    "apiKeys",
+    "llms",
+    "secrets",
+    "webhooks",
+    "projects",
+    "account",
+    "preferences",
+]
+
+/**
+ * One tab's body. Every page comes from @agenta/settings-ui; this host passes no create/edit
+ * dialogs, so each renders read-only — the lists and their empty states, none of the write
+ * affordances, which the desktop supplies through its own modals.
+ */
+const TabBody = ({
+    tab,
+    access,
+    user,
+    theme,
+}: {
+    tab: SettingsTabKey
+    access: SettingsAccess
+    user: {username?: string | null; email?: string | null} | null
+    theme: {options: {mode: string; label: string}[]; mode: string; onSelect: (m: string) => void}
+}) => {
+    const keys = useApiKeys({
+        workspaceId: "",
+        canView: tab === "apiKeys" && access.canViewApiKeys,
+        canEdit: false,
+        confirmDelete: async () => false,
+        onCreated: () => undefined,
+    })
+
+    switch (tab) {
+        case "preferences":
+            return <PreferencesPage theme={theme} />
+        case "account":
+            return <AccountPage username={user?.username} email={user?.email} />
+        case "apiKeys":
+            return (
+                <ApiKeysPage
+                    rows={keys.keys}
+                    listing={keys.listing}
+                    creating={false}
+                    canView={access.canViewApiKeys}
+                    canEdit={false}
+                    onReload={keys.list}
+                    onCreate={() => undefined}
+                    onDelete={() => undefined}
+                />
+            )
+        case "llms":
+            return (
+                <div className="flex flex-col gap-8">
+                    <SecretProviderTable type="standard" />
+                    <SecretProviderTable type="custom" />
+                </div>
+            )
+        case "secrets":
+            return <NamedSecretTable />
+        case "webhooks":
+            return <WebhooksPage />
+        case "projects":
+            return <ProjectsPage projects={[]} isLoading={false} />
+        default:
+            return null
+    }
+}
 
 /**
  * Settings on /m: the desktop's own tab model as a rail, with one tab open at a time.
  *
- * Access stays CLOSED until this app can compute real edition and permission flags, so nothing
- * gated can appear; the rail is further narrowed to the tabs that exist here.
+ * Every page is the shared one. This host is read-only — it brings no create/edit dialogs — so
+ * the rail lists what it can show and each page renders without its write affordances.
  */
 export const SettingsScreen = ({
     workspaceId,
@@ -51,7 +129,22 @@ export const SettingsScreen = ({
     const {themeMode, setMode} = useThemeMode()
     const {user} = useProfile()
 
-    const access = CLOSED_SETTINGS_ACCESS
+    // Read-only host: it renders lists but brings none of the create/edit dialogs, so every
+    // write affordance stays off. View flags are optimistic — the API authorizes regardless, and
+    // each page has an empty state — while edition comes from the same env the desktop reads.
+    const isEE = getEnv("NEXT_PUBLIC_AGENTA_LICENSE") === "ee"
+    const access: SettingsAccess = useMemo(
+        () => ({
+            billingEnabled: false,
+            canShowTools: false,
+            canShowTriggers: false,
+            canViewApiKeys: true,
+            canViewEvents: false,
+            isEE,
+            isOwner: false,
+        }),
+        [isEE],
+    )
     const requested = typeof router.query.tab === "string" ? router.query.tab : null
     const active: SettingsTabKey = AVAILABLE.includes(requested as SettingsTabKey)
         ? (requested as SettingsTabKey)
@@ -124,19 +217,16 @@ export const SettingsScreen = ({
                                 title={getSettingsTabLabel(active, access)}
                                 description={getSettingsTabDescription(active, access)}
                             >
-                                {active === "preferences" ? (
-                                    <PreferencesPage
-                                        theme={{
-                                            options: THEME_OPTIONS,
-                                            mode: themeMode,
-                                            onSelect: (mode) => setMode(mode as typeof themeMode),
-                                        }}
-                                    />
-                                ) : (
-                                    // Identity only: deleting an account is an EE capability and
-                                    // this app has no EE surface.
-                                    <AccountPage username={user?.username} email={user?.email} />
-                                )}
+                                <TabBody
+                                    tab={active}
+                                    access={access}
+                                    user={user}
+                                    theme={{
+                                        options: THEME_OPTIONS,
+                                        mode: themeMode,
+                                        onSelect: (mode) => setMode(mode as typeof themeMode),
+                                    }}
+                                />
                             </SettingsPageShell>
                         </div>
                     </div>

--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -21,11 +21,13 @@ import {
 } from "@agenta/settings-ui"
 import {getEnv} from "@agenta/shared/api"
 import {useThemeMode} from "@agenta/ui/theme"
+import {useQuery} from "@tanstack/react-query"
 import {useRouter} from "next/router"
 
 import {ContentRail} from "@/components/ContentRail"
 import {PageTitle} from "@/components/PageTitle"
 import {ScreenScaffold} from "@/components/ScreenScaffold"
+import {fetchProjects} from "@/lib/context"
 import {cn} from "@/lib/utils"
 
 import {useBindProjectContext} from "../context/useBindProjectContext"
@@ -60,19 +62,33 @@ const TabBody = ({
     access,
     user,
     theme,
+    workspaceId,
 }: {
     tab: SettingsTabKey
     access: SettingsAccess
     user: {username?: string | null; email?: string | null} | null
     theme: {options: {mode: string; label: string}[]; mode: string; onSelect: (m: string) => void}
+    workspaceId: string
 }) => {
     const keys = useApiKeys({
-        workspaceId: "",
+        workspaceId,
         canView: tab === "apiKeys" && access.canViewApiKeys,
         canEdit: false,
         confirmDelete: async () => false,
         onCreated: () => undefined,
     })
+
+    // The app's own projects query — same key and staleTime as the drawer switcher and
+    // `useCurrentProject`, so this tab reuses their cache instead of issuing its own request.
+    const projects = useQuery({
+        queryKey: ["mobile", "projects"],
+        queryFn: () => fetchProjects(),
+        staleTime: 30_000,
+    })
+    const projectRows = useMemo(
+        () => (projects.data?.kind === "ok" ? projects.data.projects : []),
+        [projects.data],
+    )
 
     switch (tab) {
         case "preferences":
@@ -104,7 +120,13 @@ const TabBody = ({
         case "webhooks":
             return <WebhooksPage />
         case "projects":
-            return <ProjectsPage projects={[]} isLoading={false} />
+            return (
+                <ProjectsPage
+                    projects={projectRows}
+                    isLoading={projects.isLoading}
+                    workspaceId={workspaceId}
+                />
+            )
         default:
             return null
     }
@@ -221,6 +243,7 @@ export const SettingsScreen = ({
                                     tab={active}
                                     access={access}
                                     user={user}
+                                    workspaceId={workspaceId}
                                     theme={{
                                         options: THEME_OPTIONS,
                                         mode: themeMode,

--- a/web/mobile/src/lib/context.ts
+++ b/web/mobile/src/lib/context.ts
@@ -76,6 +76,10 @@ const projectRowSchema = z.object({
     workspace_id: z.string().nullish(),
     workspace_name: z.string().nullish(),
     is_demo: z.boolean().nullish(),
+    // Only the settings list reads these two; every other consumer ignores them. They stay
+    // optional because the schema is a drift check, not a contract we want to fail on.
+    user_role: z.string().nullish(),
+    is_default_project: z.boolean().optional(),
 })
 
 export type MobileProject = z.infer<typeof projectRowSchema>

--- a/web/packages/agenta-settings-ui/src/ApiKeysPage.tsx
+++ b/web/packages/agenta-settings-ui/src/ApiKeysPage.tsx
@@ -7,7 +7,7 @@ import {
     InfiniteVirtualTableFeatureShell,
     type StandardColumnDef,
 } from "@agenta/ui/table"
-import {Alert, Button, EmptyState, Tooltip, TooltipContent, TooltipTrigger} from "@agenta/ui/ui"
+import {Alert, Button, EmptyState, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
 import {ArrowClockwise, Plus, Trash} from "@phosphor-icons/react"
 
 export interface ApiKeysPageProps {
@@ -130,7 +130,8 @@ export const ApiKeysPage = ({
             primaryActions={
                 canEdit ? (
                     <>
-                        <Tooltip>
+                        <TooltipProvider>
+                            <Tooltip>
                             <TooltipTrigger asChild>
                                 <Button
                                     variant="outline"
@@ -143,6 +144,7 @@ export const ApiKeysPage = ({
                             </TooltipTrigger>
                             <TooltipContent>Reload API keys</TooltipContent>
                         </Tooltip>
+                            </TooltipProvider>
                         <Button disabled={creating || listing} onClick={onCreate}>
                             <Plus size={14} />
                             Generate key

--- a/web/packages/agenta-settings-ui/src/ApiKeysPage.tsx
+++ b/web/packages/agenta-settings-ui/src/ApiKeysPage.tsx
@@ -1,13 +1,16 @@
-import {useMemo} from "react"
-
-import {useStaticTable, type ApiKeyRow} from "@agenta/settings"
+import type {ApiKeyRow} from "@agenta/settings"
 import {StatusIndicator} from "@agenta/ui/components/presentational"
 import {
-    createStandardColumns,
-    InfiniteVirtualTableFeatureShell,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {Alert, Button, EmptyState, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
+    Alert,
+    Button,
+    DataTable,
+    EmptyState,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+    type DataTableColumn,
+} from "@agenta/ui/ui"
 import {ArrowClockwise, Plus, Trash} from "@phosphor-icons/react"
 
 export interface ApiKeysPageProps {
@@ -22,7 +25,39 @@ export interface ApiKeysPageProps {
 }
 
 const formatDate = (value?: string | null) =>
-    value ? new Date(value).toLocaleDateString() : undefined
+    value ? new Date(value).toLocaleDateString() : "—"
+
+const COLUMNS: DataTableColumn<ApiKeyRow>[] = [
+    {
+        key: "prefix",
+        title: "API key",
+        width: 360,
+        mono: true,
+        render: (record) => record.prefix.padEnd(40, "\u2022"),
+    },
+    {key: "created_at", title: "Created", width: 150, render: (r) => formatDate(r.created_at)},
+    {
+        key: "expiration_date",
+        title: "Expires",
+        width: 150,
+        render: (record) => {
+            const date = record.expiration_date ? new Date(record.expiration_date) : null
+            if (!date) return "Never"
+            return date < new Date() ? (
+                <StatusIndicator tone="error" label="Expired" />
+            ) : (
+                date.toLocaleDateString()
+            )
+        },
+    },
+    {
+        key: "last_used_at",
+        title: "Last used",
+        width: 190,
+        render: (record) =>
+            record.last_used_at ? new Date(record.last_used_at).toLocaleString() : "Never used",
+    },
+]
 
 /**
  * The API keys table: the prefix, when it was made, when it expires, when it was last used.
@@ -40,76 +75,6 @@ export const ApiKeysPage = ({
     onCreate,
     onDelete,
 }: ApiKeysPageProps) => {
-    const columns = useMemo(
-        () =>
-            createStandardColumns<ApiKeyRow>([
-                {
-                    type: "mono",
-                    key: "prefix",
-                    title: "API key",
-                    width: 360,
-                    fixed: "left",
-                    getValue: (record) => record.prefix.padEnd(40, "•"),
-                },
-                {
-                    type: "text",
-                    key: "created_at",
-                    title: "Created",
-                    width: 150,
-                    render: (_value, record) => formatDate(record.created_at) ?? "—",
-                },
-                {
-                    type: "text",
-                    key: "expiration_date",
-                    title: "Expires",
-                    width: 150,
-                    render: (_value, record) => {
-                        const date = record.expiration_date
-                            ? new Date(record.expiration_date)
-                            : null
-                        if (!date) return "Never"
-                        return date < new Date() ? (
-                            <StatusIndicator tone="error" label="Expired" />
-                        ) : (
-                            date.toLocaleDateString()
-                        )
-                    },
-                },
-                {
-                    type: "text",
-                    key: "last_used_at",
-                    title: "Last used",
-                    width: 190,
-                    render: (_value, record) =>
-                        record.last_used_at
-                            ? new Date(record.last_used_at).toLocaleString()
-                            : "Never used",
-                },
-                ...(canEdit
-                    ? [
-                          {
-                              type: "actions",
-                              showCopyId: false,
-                              items: [
-                                  {
-                                      key: "delete",
-                                      label: "Delete key",
-                                      icon: <Trash size={16} />,
-                                      danger: true,
-                                      onClick: (record: ApiKeyRow) => onDelete(record.prefix),
-                                  },
-                              ],
-                          } satisfies StandardColumnDef<ApiKeyRow>,
-                      ]
-                    : []),
-            ]),
-        [canEdit, onDelete],
-    )
-
-    const {tableScope, pagination} = useStaticTable<ApiKeyRow>("settings-api-keys", rows, {
-        loading: listing,
-    })
-
     if (!canView) {
         return (
             <Alert
@@ -121,30 +86,42 @@ export const ApiKeysPage = ({
     }
 
     return (
-        <InfiniteVirtualTableFeatureShell<ApiKeyRow>
-            tableScope={tableScope}
-            autoHeight={false}
-            columns={columns}
-            rowKey="key"
-            pagination={pagination}
+        <DataTable<ApiKeyRow>
+            columns={COLUMNS}
+            rows={rows}
+            rowKey={(record) => record.key}
+            loading={listing}
+            actions={
+                canEdit
+                    ? (record) => [
+                          {
+                              key: "delete",
+                              label: "Delete key",
+                              icon: <Trash size={16} />,
+                              danger: true,
+                              onClick: () => onDelete(record.prefix),
+                          },
+                      ]
+                    : undefined
+            }
             primaryActions={
                 canEdit ? (
                     <>
                         <TooltipProvider>
                             <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    aria-label="Reload API keys"
-                                    disabled={listing}
-                                    onClick={onReload}
-                                >
-                                    <ArrowClockwise size={14} />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Reload API keys</TooltipContent>
-                        </Tooltip>
-                            </TooltipProvider>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        aria-label="Reload API keys"
+                                        disabled={listing}
+                                        onClick={onReload}
+                                    >
+                                        <ArrowClockwise size={14} />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>Reload API keys</TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
                         <Button disabled={creating || listing} onClick={onCreate}>
                             <Plus size={14} />
                             Generate key
@@ -152,36 +129,29 @@ export const ApiKeysPage = ({
                     </>
                 ) : null
             }
-            tableProps={{
-                size: "small",
-                bordered: true,
-                tableLayout: "fixed",
-                locale: {
-                    emptyText: (
-                        <EmptyState
-                            image="simple"
-                            description={
-                                <div className="flex flex-col gap-1">
-                                    <span className="text-xs font-medium text-colorText">
-                                        No API keys yet
-                                    </span>
-                                    <span>
-                                        Generate a key to authenticate requests to the Agenta API
-                                        from your code, CI jobs, and SDKs.
-                                    </span>
-                                </div>
-                            }
-                        >
-                            {canEdit ? (
-                                <Button variant="outline" disabled={creating} onClick={onCreate}>
-                                    <Plus size={14} />
-                                    Generate key
-                                </Button>
-                            ) : null}
-                        </EmptyState>
-                    ),
-                },
-            }}
+            empty={
+                <EmptyState
+                    image="simple"
+                    description={
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs font-medium text-colorText">
+                                No API keys yet
+                            </span>
+                            <span>
+                                Generate a key to authenticate requests to the Agenta API from your
+                                code, CI jobs, and SDKs.
+                            </span>
+                        </div>
+                    }
+                >
+                    {canEdit ? (
+                        <Button variant="outline" disabled={creating} onClick={onCreate}>
+                            <Plus size={14} />
+                            Generate key
+                        </Button>
+                    ) : null}
+                </EmptyState>
+            }
         />
     )
 }

--- a/web/packages/agenta-settings-ui/src/projects/ProjectsPage.tsx
+++ b/web/packages/agenta-settings-ui/src/projects/ProjectsPage.tsx
@@ -2,33 +2,21 @@ import {useCallback, useMemo, useState} from "react"
 
 import {createProject, deleteProject, patchProject} from "@agenta/entities/project"
 import type {ProjectsResponse} from "@agenta/entities/project"
-import {useStaticTable} from "@agenta/settings"
-import {extractApiErrorMessage} from "@agenta/shared/utils"
 import {message} from "@agenta/ui/app-message"
 import {Tag} from "@agenta/ui/components/presentational"
-import {
-    createStandardColumns,
-    InfiniteVirtualTableFeatureShell,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {EmptyState} from "@agenta/ui/ui"
-import {Button, Input} from "@agenta/ui/ui"
+import {Button, DataTable, EmptyState, Input, type DataTableColumn} from "@agenta/ui/ui"
 import {CheckCircle, PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
 import {useMutation, useQueryClient} from "@tanstack/react-query"
-
-/**
- * Mutation failures arrive either as an axios-style payload (`response.data.detail`) or as a
- * plain `Error`. `extractApiErrorMessage` reads both, but stringifies anything it cannot read —
- * so when that is all it found, show the per-action copy instead of `[object Object]`.
- */
-const mutationErrorMessage = (error: unknown, fallback: string): string => {
-    const detail = extractApiErrorMessage(error)
-    return !detail || detail === String(error) ? fallback : detail
-}
 
 interface ProjectFormValues {
     name: string
     make_default?: boolean
+}
+
+/** Axios surfaces the backend's reason on `response.data.detail`. */
+const errorDetail = (error: unknown, fallback: string): string => {
+    const axiosLike = error as {response?: {data?: {detail?: string}}; message?: string}
+    return axiosLike?.response?.data?.detail || axiosLike?.message || fallback
 }
 
 interface ProjectRow extends ProjectsResponse {
@@ -100,8 +88,8 @@ export const ProjectsPage = ({
             void invalidateProjects()
             setCreateModalOpen(false)
         },
-        onError: (error: unknown) => {
-            message.error(mutationErrorMessage(error, "Unable to create project"))
+        onError: (error) => {
+            message.error(errorDetail(error, "Unable to create project"))
         },
     })
 
@@ -114,8 +102,8 @@ export const ProjectsPage = ({
             setRenameModalOpen(false)
             setActiveProject(null)
         },
-        onError: (error: unknown) => {
-            message.error(mutationErrorMessage(error, "Unable to rename project"))
+        onError: (error) => {
+            message.error(errorDetail(error, "Unable to rename project"))
         },
     })
 
@@ -125,8 +113,8 @@ export const ProjectsPage = ({
             message.success("Default project updated")
             void invalidateProjects()
         },
-        onError: (error: unknown) => {
-            message.error(mutationErrorMessage(error, "Unable to set default"))
+        onError: (error) => {
+            message.error(errorDetail(error, "Unable to set default"))
         },
     })
 
@@ -136,8 +124,8 @@ export const ProjectsPage = ({
             message.success("Project deleted")
             void invalidateProjects()
         },
-        onError: (error: unknown) => {
-            message.error(mutationErrorMessage(error, "Unable to delete project"))
+        onError: (error) => {
+            message.error(errorDetail(error, "Unable to delete project"))
         },
     })
 
@@ -183,81 +171,72 @@ export const ProjectsPage = ({
         setRenameModalOpen(true)
     }, [])
 
-    const columns = useMemo(
-        () =>
-            createStandardColumns<ProjectRow>([
-                {
-                    type: "entity",
-                    key: "project_name",
-                    title: "Project",
-                    width: 260,
-                    fixed: "left",
-                    getName: (record) => record.project_name,
-                    getChips: (record) => (record.is_default_project ? [{label: "Default"}] : []),
-                },
-                // Its own column, not a second line under the name.
-                {type: "slug", key: "project_id", title: "Project ID", width: 330},
-                {
-                    type: "text",
-                    key: "user_role",
-                    title: "Your role",
-                    width: 140,
-                    render: (_value, record) =>
-                        record.user_role ? <Tag className="m-0" label={record.user_role} /> : "—",
-                },
-                {
-                    type: "actions",
-                    showCopyId: false,
-                    items: [
-                        {
-                            key: "rename",
-                            label: "Rename",
-                            icon: <PencilSimpleLine size={16} />,
-                            onClick: (record: ProjectRow) => openRenameModal(record),
-                        },
-                        {
-                            key: "default",
-                            label: "Set as default",
-                            icon: <CheckCircle size={16} />,
-                            hidden: (record: ProjectRow) => Boolean(record.is_default_project),
-                            disabled: () => defaultMutation.isPending,
-                            onClick: (record: ProjectRow) => handleMakeDefault(record),
-                        },
-                        {type: "divider"},
-                        {
-                            key: "delete",
-                            label: "Delete project",
-                            icon: <Trash size={16} />,
-                            danger: true,
-                            // The last project in a workspace cannot be removed, and the
-                            // default project must be reassigned first.
-                            disabled: (record: ProjectRow) =>
-                                !canDeleteProjects || Boolean(record.is_default_project),
-                            onClick: (record: ProjectRow) => handleDelete(record),
-                        },
-                    ],
-                } satisfies StandardColumnDef<ProjectRow>,
-            ]),
-        [
-            canDeleteProjects,
-            defaultMutation.isPending,
-            handleDelete,
-            handleMakeDefault,
-            openRenameModal,
+    const columns = useMemo<DataTableColumn<ProjectRow>[]>(
+        () => [
+            {
+                key: "project_name",
+                title: "Project",
+                width: 260,
+                render: (record) => (
+                    <div className="flex min-w-0 items-center gap-2">
+                        <span className="truncate font-medium">{record.project_name}</span>
+                        {record.is_default_project ? <Tag className="m-0" label="Default" /> : null}
+                    </div>
+                ),
+            },
+            // Its own column, not a second line under the name.
+            {
+                key: "project_id",
+                title: "Project ID",
+                width: 330,
+                mono: true,
+                render: (r) => r.project_id,
+            },
+            {
+                key: "user_role",
+                title: "Your role",
+                width: 140,
+                render: (record) =>
+                    record.user_role ? <Tag className="m-0" label={record.user_role} /> : "—",
+            },
         ],
+        [],
     )
 
-    const {tableScope, pagination} = useStaticTable<ProjectRow>("settings-projects", rows, {
-        loading: isLoading,
-    })
     return (
         <div className="flex flex-col gap-2">
-            <InfiniteVirtualTableFeatureShell<ProjectRow>
-                tableScope={tableScope}
-                autoHeight={false}
+            <DataTable<ProjectRow>
                 columns={columns}
-                rowKey="key"
-                pagination={pagination}
+                rows={rows}
+                rowKey={(record) => record.key}
+                loading={isLoading}
+                actions={(record) => [
+                    {
+                        key: "rename",
+                        label: "Rename",
+                        icon: <PencilSimpleLine size={16} />,
+                        onClick: () => openRenameModal(record),
+                    },
+                    {
+                        key: "default",
+                        label: "Set as default",
+                        icon: <CheckCircle size={16} />,
+                        hidden: Boolean(record.is_default_project),
+                        disabled: defaultMutation.isPending,
+                        onClick: () => handleMakeDefault(record),
+                    },
+                    {type: "divider"},
+                    {
+                        key: "delete",
+                        label: "Delete project",
+                        icon: <Trash size={16} />,
+                        danger: true,
+                        // The last project in a workspace cannot be removed, and the
+                        // default project must be reassigned first.
+                        disabled: !canDeleteProjects || Boolean(record.is_default_project),
+                        onClick: () => handleDelete(record),
+                    },
+                ]}
                 filters={
                     <Input
                         placeholder="Search projects"
@@ -273,39 +252,34 @@ export const ProjectsPage = ({
                         New project
                     </Button>
                 }
-                tableProps={{
-                    size: "small",
-                    bordered: true,
-                    tableLayout: "fixed",
-                    locale: {
-                        emptyText: searchTerm.trim() ? (
-                            <EmptyState
-                                image="simple"
-                                description={`No projects match “${searchTerm.trim()}”`}
-                            />
-                        ) : (
-                            <EmptyState
-                                image="simple"
-                                description={
-                                    <div className="flex flex-col gap-1">
-                                        <span className="text-xs font-medium text-colorText">
-                                            No projects in this workspace yet
-                                        </span>
-                                        <span>
-                                            Create a project to organize your agents, datasets, and
-                                            deployments.
-                                        </span>
-                                    </div>
-                                }
-                            >
-                                <Button variant="outline" onClick={() => setCreateModalOpen(true)}>
-                                    <Plus size={14} />
-                                    New project
-                                </Button>
-                            </EmptyState>
-                        ),
-                    },
-                }}
+                empty={
+                    searchTerm.trim() ? (
+                        <EmptyState
+                            image="simple"
+                            description={`No projects match “${searchTerm.trim()}”`}
+                        />
+                    ) : (
+                        <EmptyState
+                            image="simple"
+                            description={
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-xs font-medium text-colorText">
+                                        No projects in this workspace yet
+                                    </span>
+                                    <span>
+                                        Create a project to organize your agents, datasets, and
+                                        deployments.
+                                    </span>
+                                </div>
+                            }
+                        >
+                            <Button variant="outline" onClick={() => setCreateModalOpen(true)}>
+                                <Plus size={14} />
+                                New project
+                            </Button>
+                        </EmptyState>
+                    )
+                }
             />
 
             {renderCreateDialog?.({

--- a/web/packages/agenta-settings-ui/src/projects/ProjectsPage.tsx
+++ b/web/packages/agenta-settings-ui/src/projects/ProjectsPage.tsx
@@ -4,7 +4,14 @@ import {createProject, deleteProject, patchProject} from "@agenta/entities/proje
 import type {ProjectsResponse} from "@agenta/entities/project"
 import {message} from "@agenta/ui/app-message"
 import {Tag} from "@agenta/ui/components/presentational"
-import {Button, DataTable, EmptyState, Input, type DataTableColumn} from "@agenta/ui/ui"
+import {
+    Button,
+    DataTable,
+    EmptyState,
+    Input,
+    type DataTableAction,
+    type DataTableColumn,
+} from "@agenta/ui/ui"
 import {CheckCircle, PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
 import {useMutation, useQueryClient} from "@tanstack/react-query"
 
@@ -65,6 +72,9 @@ export const ProjectsPage = ({
         return projects.filter((project) => project.workspace_id === workspaceId)
     }, [projects, workspaceId])
     const canDeleteProjects = scopedProjects.length > 1
+    // Create, rename and delete all need a dialog from the host. A host that brings none (mobile)
+    // gets the list read-only rather than affordances that open nothing.
+    const canEdit = Boolean(renderCreateDialog || renderRenameDialog || renderDeleteDialog)
 
     const rows = useMemo<ProjectRow[]>(() => {
         const all = scopedProjects.map((project) => ({...project, key: project.project_id}))
@@ -203,6 +213,43 @@ export const ProjectsPage = ({
         [],
     )
 
+    const rowActions = useCallback(
+        (record: ProjectRow): (DataTableAction<ProjectRow> | {type: "divider"})[] => [
+            {
+                key: "rename",
+                label: "Rename",
+                icon: <PencilSimpleLine size={16} />,
+                onClick: () => openRenameModal(record),
+            },
+            {
+                key: "default",
+                label: "Set as default",
+                icon: <CheckCircle size={16} />,
+                hidden: Boolean(record.is_default_project),
+                disabled: defaultMutation.isPending,
+                onClick: () => handleMakeDefault(record),
+            },
+            {type: "divider"},
+            {
+                key: "delete",
+                label: "Delete project",
+                icon: <Trash size={16} />,
+                danger: true,
+                // The last project in a workspace cannot be removed, and the default project
+                // must be reassigned first.
+                disabled: !canDeleteProjects || Boolean(record.is_default_project),
+                onClick: () => handleDelete(record),
+            },
+        ],
+        [
+            canDeleteProjects,
+            defaultMutation.isPending,
+            handleDelete,
+            handleMakeDefault,
+            openRenameModal,
+        ],
+    )
+
     return (
         <div className="flex flex-col gap-2">
             <DataTable<ProjectRow>
@@ -210,33 +257,7 @@ export const ProjectsPage = ({
                 rows={rows}
                 rowKey={(record) => record.key}
                 loading={isLoading}
-                actions={(record) => [
-                    {
-                        key: "rename",
-                        label: "Rename",
-                        icon: <PencilSimpleLine size={16} />,
-                        onClick: () => openRenameModal(record),
-                    },
-                    {
-                        key: "default",
-                        label: "Set as default",
-                        icon: <CheckCircle size={16} />,
-                        hidden: Boolean(record.is_default_project),
-                        disabled: defaultMutation.isPending,
-                        onClick: () => handleMakeDefault(record),
-                    },
-                    {type: "divider"},
-                    {
-                        key: "delete",
-                        label: "Delete project",
-                        icon: <Trash size={16} />,
-                        danger: true,
-                        // The last project in a workspace cannot be removed, and the
-                        // default project must be reassigned first.
-                        disabled: !canDeleteProjects || Boolean(record.is_default_project),
-                        onClick: () => handleDelete(record),
-                    },
-                ]}
+                actions={canEdit ? rowActions : undefined}
                 filters={
                     <Input
                         placeholder="Search projects"
@@ -247,10 +268,12 @@ export const ProjectsPage = ({
                     />
                 }
                 primaryActions={
-                    <Button onClick={() => setCreateModalOpen(true)} disabled={isLoading}>
-                        <Plus size={14} />
-                        New project
-                    </Button>
+                    canEdit ? (
+                        <Button onClick={() => setCreateModalOpen(true)} disabled={isLoading}>
+                            <Plus size={14} />
+                            New project
+                        </Button>
+                    ) : null
                 }
                 empty={
                     searchTerm.trim() ? (
@@ -273,10 +296,12 @@ export const ProjectsPage = ({
                                 </div>
                             }
                         >
-                            <Button variant="outline" onClick={() => setCreateModalOpen(true)}>
-                                <Plus size={14} />
-                                New project
-                            </Button>
+                            {canEdit ? (
+                                <Button variant="outline" onClick={() => setCreateModalOpen(true)}>
+                                    <Plus size={14} />
+                                    New project
+                                </Button>
+                            ) : null}
                         </EmptyState>
                     )
                 }

--- a/web/packages/agenta-settings-ui/src/secrets/NamedSecretTable.tsx
+++ b/web/packages/agenta-settings-ui/src/secrets/NamedSecretTable.tsx
@@ -139,7 +139,8 @@ export const NamedSecretTable = ({
                                             variant="outline"
                                             aria-label="Reload secrets"
                                             disabled={loading}
-                                            onClick={mutate}
+                                            // `mutate` takes no arguments; as the handler it would be handed the click event.
+                                            onClick={() => mutate()}
                                         >
                                             <ArrowClockwise size={14} />
                                         </Button>

--- a/web/packages/agenta-settings-ui/src/secrets/NamedSecretTable.tsx
+++ b/web/packages/agenta-settings-ui/src/secrets/NamedSecretTable.tsx
@@ -11,8 +11,13 @@ import {
     type StandardColumnDef,
 } from "@agenta/ui/table"
 import {EmptyState} from "@agenta/ui/ui"
-import {Button, Tooltip, TooltipContent, TooltipTrigger} from "@agenta/ui/ui"
 import {ArrowClockwise, PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
+import {Tag} from "@agenta/ui/components/presentational"
+import {Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
+
+import {useStaticTable} from "@agenta/settings"
+import {formatDay} from "@agenta/shared/utils/dateTime"
+
 
 /**
  * Mask stored secret content for display. `text` is masked like an API key
@@ -145,6 +150,7 @@ export const NamedSecretTable = ({
                     pagination={pagination}
                     primaryActions={
                         <>
+                            <TooltipProvider>
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <Button
@@ -160,6 +166,7 @@ export const NamedSecretTable = ({
                                 </TooltipTrigger>
                                 <TooltipContent>Reload secrets</TooltipContent>
                             </Tooltip>
+                            </TooltipProvider>
                             <Button
                                 disabled={loading}
                                 onClick={() => {

--- a/web/packages/agenta-settings-ui/src/secrets/NamedSecretTable.tsx
+++ b/web/packages/agenta-settings-ui/src/secrets/NamedSecretTable.tsx
@@ -6,18 +6,16 @@ import type {LlmProvider} from "@agenta/shared/types"
 import {formatDay} from "@agenta/shared/utils/dateTime"
 import {Tag} from "@agenta/ui/components/presentational"
 import {
-    createStandardColumns,
-    InfiniteVirtualTableFeatureShell,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {EmptyState} from "@agenta/ui/ui"
+    Button,
+    DataTable,
+    EmptyState,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+    type DataTableColumn,
+} from "@agenta/ui/ui"
 import {ArrowClockwise, PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
-import {Tag} from "@agenta/ui/components/presentational"
-import {Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
-
-import {useStaticTable} from "@agenta/settings"
-import {formatDay} from "@agenta/shared/utils/dateTime"
-
 
 /**
  * Mask stored secret content for display. `text` is masked like an API key
@@ -72,48 +70,50 @@ export const NamedSecretTable = ({
         [namedSecrets],
     )
 
-    const columns = useMemo(
-        () =>
-            createStandardColumns<SecretRow>([
-                {type: "text", key: "name", title: "Name", width: 200, fixed: "left"},
-                {type: "slug", key: "slug", title: "Slug", width: 240},
-                {
-                    type: "text",
-                    key: "content",
-                    title: "Value",
-                    width: 200,
-                    render: (_value, record) => (
-                        <span className="ph-no-capture">{maskContent(record)}</span>
-                    ),
-                },
-                {
-                    type: "text",
-                    key: "format",
-                    title: "Format",
-                    width: 120,
-                    render: (_value, record) => (
-                        <Tag className="bg-colorFillTertiary px-2 py-[1px]">{record.format}</Tag>
-                    ),
-                },
-                {
-                    type: "text",
-                    key: "created_at",
-                    title: "Created",
-                    width: 160,
-                    render: (_value, record) =>
-                        record.created_at
-                            ? formatDay({date: record.created_at, outputFormat: "YYYY-MM-DD HH:mm"})
-                            : "-",
-                },
-                {
-                    type: "actions",
-                    showCopyId: false,
-                    items: [
+    const columns = useMemo<DataTableColumn<SecretRow>[]>(
+        () => [
+            {key: "name", title: "Name", width: 200, render: (record) => record.name},
+            {key: "slug", title: "Slug", width: 240, mono: true, render: (record) => record.slug},
+            {
+                key: "content",
+                title: "Value",
+                width: 200,
+                render: (record) => <span className="ph-no-capture">{maskContent(record)}</span>,
+            },
+            {
+                key: "format",
+                title: "Format",
+                width: 120,
+                render: (record) => <Tag>{record.format}</Tag>,
+            },
+            {
+                key: "created_at",
+                title: "Created",
+                width: 160,
+                render: (record) =>
+                    record.created_at
+                        ? formatDay({date: record.created_at, outputFormat: "YYYY-MM-DD HH:mm"})
+                        : "-",
+            },
+        ],
+        [],
+    )
+
+    return (
+        <>
+            <div className="flex flex-col gap-2">
+                <DataTable<SecretRow>
+                    className="ph-no-capture"
+                    columns={columns}
+                    rows={rows}
+                    rowKey={(record) => record.key}
+                    loading={loading}
+                    actions={(record) => [
                         {
                             key: "edit",
                             label: "Edit",
                             icon: <PencilSimpleLine size={16} />,
-                            onClick: (record: SecretRow) => {
+                            onClick: () => {
                                 setSelectedSecret(record)
                                 setIsConfigModalOpen(true)
                             },
@@ -124,48 +124,28 @@ export const NamedSecretTable = ({
                             label: "Delete",
                             icon: <Trash size={16} />,
                             danger: true,
-                            onClick: (record: SecretRow) => {
+                            onClick: () => {
                                 setSelectedSecret(record)
                                 setIsDeleteModalOpen(true)
                             },
                         },
-                    ],
-                } satisfies StandardColumnDef<SecretRow>,
-            ]),
-        [],
-    )
-
-    const {tableScope, pagination} = useStaticTable<SecretRow>("settings-vault-secrets", rows, {
-        loading,
-    })
-    return (
-        <>
-            <div className="flex flex-col gap-2">
-                <InfiniteVirtualTableFeatureShell<SecretRow>
-                    className="ph-no-capture"
-                    tableScope={tableScope}
-                    autoHeight={false}
-                    columns={columns}
-                    rowKey={(record) => record.key}
-                    pagination={pagination}
+                    ]}
                     primaryActions={
                         <>
                             <TooltipProvider>
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button
-                                        variant="outline"
-                                        aria-label="Reload secrets"
-                                        disabled={loading}
-                                        // `mutate` takes no arguments; called as the handler
-                                        // directly it would be handed the click event.
-                                        onClick={() => mutate()}
-                                    >
-                                        <ArrowClockwise size={14} />
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>Reload secrets</TooltipContent>
-                            </Tooltip>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            aria-label="Reload secrets"
+                                            disabled={loading}
+                                            onClick={mutate}
+                                        >
+                                            <ArrowClockwise size={14} />
+                                        </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>Reload secrets</TooltipContent>
+                                </Tooltip>
                             </TooltipProvider>
                             <Button
                                 disabled={loading}
@@ -179,40 +159,33 @@ export const NamedSecretTable = ({
                             </Button>
                         </>
                     }
-                    tableProps={{
-                        size: "small",
-                        bordered: true,
-                        tableLayout: "fixed",
-                        locale: {
-                            emptyText: (
-                                <EmptyState
-                                    image="simple"
-                                    description={
-                                        <div className="flex flex-col gap-1">
-                                            <span className="text-xs font-medium text-colorText">
-                                                No secrets yet
-                                            </span>
-                                            <span>
-                                                Store a named secret to reference credentials
-                                                without exposing their values.
-                                            </span>
-                                        </div>
-                                    }
-                                >
-                                    <Button
-                                        variant="outline"
-                                        onClick={() => {
-                                            setSelectedSecret(null)
-                                            setIsConfigModalOpen(true)
-                                        }}
-                                    >
-                                        <Plus size={14} />
-                                        Create secret
-                                    </Button>
-                                </EmptyState>
-                            ),
-                        },
-                    }}
+                    empty={
+                        <EmptyState
+                            image="simple"
+                            description={
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-xs font-medium text-colorText">
+                                        No secrets yet
+                                    </span>
+                                    <span>
+                                        Store a named secret to reference credentials without
+                                        exposing their values.
+                                    </span>
+                                </div>
+                            }
+                        >
+                            <Button
+                                variant="outline"
+                                onClick={() => {
+                                    setSelectedSecret(null)
+                                    setIsConfigModalOpen(true)
+                                }}
+                            >
+                                <Plus size={14} />
+                                Create secret
+                            </Button>
+                        </EmptyState>
+                    }
                 />
             </div>
 

--- a/web/packages/agenta-settings-ui/src/secrets/SecretProviderTable.tsx
+++ b/web/packages/agenta-settings-ui/src/secrets/SecretProviderTable.tsx
@@ -210,7 +210,8 @@ export const SecretProviderTable = ({
                                                 variant="outline"
                                                 aria-label="Reload providers"
                                                 disabled={loading}
-                                                onClick={mutate}
+                                                // `mutate` takes no arguments; as the handler it would be handed the click event.
+                                                onClick={() => mutate()}
                                             >
                                                 <ArrowClockwise size={14} />
                                             </Button>

--- a/web/packages/agenta-settings-ui/src/secrets/SecretProviderTable.tsx
+++ b/web/packages/agenta-settings-ui/src/secrets/SecretProviderTable.tsx
@@ -7,17 +7,16 @@ import {formatDay} from "@agenta/shared/utils/dateTime"
 import {Tag} from "@agenta/ui/components/presentational"
 import {LLMIconMap} from "@agenta/ui/llm-icons"
 import {
-    createStandardColumns,
-    InfiniteVirtualTableFeatureShell,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {EmptyState} from "@agenta/ui/ui"
+    Button,
+    DataTable,
+    EmptyState,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+    type DataTableColumn,
+} from "@agenta/ui/ui"
 import {ArrowClockwise, PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
-import {Tag} from "@agenta/ui/components/presentational"
-import {Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
-
-import {useStaticTable} from "@agenta/settings"
-import {formatDay} from "@agenta/shared/utils/dateTime"
 
 export interface ProviderDialogState {
     selectedProvider: LlmProvider | null
@@ -68,110 +67,110 @@ export const SecretProviderTable = ({
         [sourceRows],
     )
 
-    const columns = useMemo(
-        () =>
-            createStandardColumns<ProviderRow>([
-                {
-                    type: "text",
-                    key: "name",
-                    title: isCustom ? "Name" : "Provider",
-                    width: 320,
-                    fixed: "left",
-                    render: (_value, record) => {
-                        const Icon = LLMIconMap[record.title as string]
-                        return isCustom ? (
-                            record?.name
-                        ) : (
-                            <div className="flex items-center gap-2 min-w-0">
-                                {Icon && <Icon className="w-5 h-5 shrink-0" />}
-                                <span className="truncate">{record?.title}</span>
-                            </div>
-                        )
-                    },
+    const columns = useMemo<DataTableColumn<ProviderRow>[]>(
+        () => [
+            {
+                key: "name",
+                title: isCustom ? "Name" : "Provider",
+                width: 320,
+                render: (record) => {
+                    const Icon = LLMIconMap[record.title as string]
+                    return isCustom ? (
+                        record?.name
+                    ) : (
+                        <div className="flex min-w-0 items-center gap-2">
+                            {Icon && <Icon className="size-5 shrink-0" />}
+                            <span className="truncate">{record?.title}</span>
+                        </div>
+                    )
                 },
-                ...(!isCustom
-                    ? [
-                          {
-                              type: "text",
-                              key: "key",
-                              title: "API key",
-                              width: 260,
-                              render: (_value: unknown, record: ProviderRow) => {
-                                  const apiKey = record.source.key
-                                  if (!apiKey) {
-                                      return (
-                                          <Button
-                                              size="sm"
-                                              onClick={(e) => {
-                                                  e.stopPropagation()
-                                                  setIsAddProviderSecretModalOpen(true)
-                                                  setSelectedProvider(record.source)
-                                              }}
-                                          >
-                                              Configure now
-                                          </Button>
-                                      )
-                                  }
+            },
+            ...(!isCustom
+                ? [
+                      {
+                          key: "key",
+                          title: "API key",
+                          width: 260,
+                          render: (record: ProviderRow) => {
+                              const apiKey = record.source.key
+                              if (!apiKey) {
                                   return (
-                                      <span className="font-mono text-xs">
-                                          {`${apiKey.slice(0, 3)}...${apiKey.slice(-3)}`}
-                                      </span>
+                                      <Button
+                                          size="sm"
+                                          variant="outline"
+                                          onClick={(e) => {
+                                              e.stopPropagation()
+                                              setIsAddProviderSecretModalOpen(true)
+                                              setSelectedProvider(record.source)
+                                          }}
+                                      >
+                                          Configure now
+                                      </Button>
                                   )
-                              },
-                          } satisfies StandardColumnDef<ProviderRow>,
-                      ]
-                    : []),
-                ...(isCustom
-                    ? [
-                          {
-                              type: "text",
-                              key: "provider",
-                              title: "Provider",
-                              width: 180,
-                              render: (_value: unknown, record: ProviderRow) => (
-                                  <Tag className="bg-colorFillTertiary px-2 py-[1px]">
-                                      {record?.provider}
-                                  </Tag>
-                              ),
-                          } satisfies StandardColumnDef<ProviderRow>,
-                          {
-                              type: "text",
-                              key: "models",
-                              title: "Models",
-                              width: 260,
-                              render: (_value: unknown, record: ProviderRow) => {
-                                  const models = record?.models ?? []
-                                  if (models.length === 0)
-                                      return <span className="text-colorTextSecondary">-</span>
-                                  return (
-                                      <span className="truncate" title={models.join(", ")}>
-                                          {models.join(", ")}
-                                      </span>
-                                  )
-                              },
-                          } satisfies StandardColumnDef<ProviderRow>,
-                      ]
-                    : []),
-                {
-                    type: "text",
-                    key: "created_at",
-                    title: "Connected",
-                    width: 170,
-                    render: (_value, record) =>
-                        record.created_at
-                            ? formatDay({date: record.created_at, outputFormat: "YYYY-MM-DD HH:mm"})
-                            : "-",
-                },
-                {
-                    type: "actions",
-                    showCopyId: false,
-                    items: [
+                              }
+                              return (
+                                  <span className="font-mono text-xs">
+                                      {`${apiKey.slice(0, 3)}...${apiKey.slice(-3)}`}
+                                  </span>
+                              )
+                          },
+                      } satisfies DataTableColumn<ProviderRow>,
+                  ]
+                : []),
+            ...(isCustom
+                ? [
+                      {
+                          key: "provider",
+                          title: "Provider",
+                          width: 180,
+                          render: (record: ProviderRow) => <Tag>{record?.provider}</Tag>,
+                      } satisfies DataTableColumn<ProviderRow>,
+                      {
+                          key: "models",
+                          title: "Models",
+                          width: 260,
+                          render: (record: ProviderRow) => {
+                              const models = record?.models ?? []
+                              if (models.length === 0)
+                                  return <span className="text-colorTextSecondary">-</span>
+                              return (
+                                  <span className="block truncate" title={models.join(", ")}>
+                                      {models.join(", ")}
+                                  </span>
+                              )
+                          },
+                      } satisfies DataTableColumn<ProviderRow>,
+                  ]
+                : []),
+            {
+                key: "created_at",
+                title: "Connected",
+                width: 170,
+                render: (record) =>
+                    record.created_at
+                        ? formatDay({date: record.created_at, outputFormat: "YYYY-MM-DD HH:mm"})
+                        : "-",
+            },
+        ],
+        [isCustom],
+    )
+
+    return (
+        <>
+            <section className="flex flex-col gap-2">
+                <DataTable<ProviderRow>
+                    className="ph-no-capture"
+                    columns={columns}
+                    rows={rows}
+                    rowKey={(record) => record.key}
+                    loading={loading}
+                    actions={(record) => [
                         {
                             key: "edit",
                             label: isCustom ? "Edit endpoint" : "Edit key",
                             icon: <PencilSimpleLine size={16} />,
-                            hidden: (record: ProviderRow) => !isCustom && !record.source.key,
-                            onClick: (record: ProviderRow) => {
+                            hidden: !isCustom && !record.source.key,
+                            onClick: () => {
                                 setSelectedProvider(record.source)
                                 if (isCustom) setIsConfigProviderOpen(true)
                                 else setIsAddProviderSecretModalOpen(true)
@@ -182,35 +181,13 @@ export const SecretProviderTable = ({
                             label: isCustom ? "Delete endpoint" : "Remove key",
                             icon: <Trash size={16} />,
                             danger: true,
-                            hidden: (record: ProviderRow) => !isCustom && !record.source.key,
-                            onClick: (record: ProviderRow) => {
+                            hidden: !isCustom && !record.source.key,
+                            onClick: () => {
                                 setSelectedProvider(record.source)
                                 setIsDeleteModalOpen(true)
                             },
                         },
-                    ],
-                } satisfies StandardColumnDef<ProviderRow>,
-            ]),
-        [isCustom],
-    )
-
-    const {tableScope, pagination} = useStaticTable<ProviderRow>(
-        isCustom ? "settings-llm-custom" : "settings-llm-standard",
-        rows,
-        {loading},
-    )
-    return (
-        <>
-            <section className="flex flex-col gap-2">
-                <InfiniteVirtualTableFeatureShell<ProviderRow>
-                    className="ph-no-capture"
-                    tableScope={tableScope}
-                    columns={columns}
-                    rowKey="key"
-                    pagination={pagination}
-                    // Fixed height sized to row count; autoHeight would grow unbounded here.
-                    autoHeight={false}
-                    rowHeight={40}
+                    ]}
                     title={
                         <div className="flex flex-col gap-1">
                             <p className="m-0 font-medium text-colorText">
@@ -227,20 +204,20 @@ export const SecretProviderTable = ({
                         isCustom ? (
                             <>
                                 <TooltipProvider>
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button
-                                        variant="outline"
-                                        aria-label="Reload providers"
-                                        disabled={loading}
-                                        onClick={mutate}
-                                    >
-                                        <ArrowClockwise size={14} />
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>Reload providers</TooltipContent>
-                            </Tooltip>
-                            </TooltipProvider>
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <Button
+                                                variant="outline"
+                                                aria-label="Reload providers"
+                                                disabled={loading}
+                                                onClick={mutate}
+                                            >
+                                                <ArrowClockwise size={14} />
+                                            </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Reload providers</TooltipContent>
+                                    </Tooltip>
+                                </TooltipProvider>
                                 <Button
                                     disabled={loading}
                                     onClick={() => setIsConfigProviderOpen(true)}
@@ -251,52 +228,47 @@ export const SecretProviderTable = ({
                             </>
                         ) : null
                     }
-                    tableProps={{
-                        size: "small",
-                        bordered: true,
-                        tableLayout: "fixed",
-                        locale: {
-                            emptyText: isCustom ? (
-                                <EmptyState
-                                    image="simple"
-                                    description={
-                                        <div className="flex flex-col gap-1">
-                                            <span className="text-xs font-medium text-colorText">
-                                                No custom endpoints
-                                            </span>
-                                            <span>
-                                                Point Agenta at a self-hosted or proxied model that
-                                                speaks the OpenAI API.
-                                            </span>
-                                        </div>
-                                    }
+                    empty={
+                        isCustom ? (
+                            <EmptyState
+                                image="simple"
+                                description={
+                                    <div className="flex flex-col gap-1">
+                                        <span className="text-xs font-medium text-colorText">
+                                            No custom endpoints
+                                        </span>
+                                        <span>
+                                            Point Agenta at a self-hosted or proxied model that
+                                            speaks the OpenAI API.
+                                        </span>
+                                    </div>
+                                }
+                            >
+                                <Button
+                                    variant="outline"
+                                    onClick={() => setIsConfigProviderOpen(true)}
                                 >
-                                    <Button
-                                        variant="outline"
-                                        onClick={() => setIsConfigProviderOpen(true)}
-                                    >
-                                        <Plus size={14} />
-                                        Add endpoint
-                                    </Button>
-                                </EmptyState>
-                            ) : (
-                                <EmptyState
-                                    image="simple"
-                                    description={
-                                        <div className="flex flex-col gap-1">
-                                            <span className="text-xs font-medium text-colorText">
-                                                No providers to show
-                                            </span>
-                                            <span>
-                                                The provider list could not be loaded. Reload the
-                                                page to try again.
-                                            </span>
-                                        </div>
-                                    }
-                                />
-                            ),
-                        },
-                    }}
+                                    <Plus size={14} />
+                                    Add endpoint
+                                </Button>
+                            </EmptyState>
+                        ) : (
+                            <EmptyState
+                                image="simple"
+                                description={
+                                    <div className="flex flex-col gap-1">
+                                        <span className="text-xs font-medium text-colorText">
+                                            No providers to show
+                                        </span>
+                                        <span>
+                                            The provider list could not be loaded. Reload the page
+                                            to try again.
+                                        </span>
+                                    </div>
+                                }
+                            />
+                        )
+                    }
                 />
             </section>
 

--- a/web/packages/agenta-settings-ui/src/secrets/SecretProviderTable.tsx
+++ b/web/packages/agenta-settings-ui/src/secrets/SecretProviderTable.tsx
@@ -12,8 +12,12 @@ import {
     type StandardColumnDef,
 } from "@agenta/ui/table"
 import {EmptyState} from "@agenta/ui/ui"
-import {Button, Tooltip, TooltipContent, TooltipTrigger} from "@agenta/ui/ui"
 import {ArrowClockwise, PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
+import {Tag} from "@agenta/ui/components/presentational"
+import {Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
+
+import {useStaticTable} from "@agenta/settings"
+import {formatDay} from "@agenta/shared/utils/dateTime"
 
 export interface ProviderDialogState {
     selectedProvider: LlmProvider | null
@@ -222,22 +226,21 @@ export const SecretProviderTable = ({
                     primaryActions={
                         isCustom ? (
                             <>
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <Button
-                                            variant="outline"
-                                            aria-label="Reload providers"
-                                            disabled={loading}
-                                            // `mutate` takes no arguments; called as the
-                                            // handler directly it would be handed the click
-                                            // event.
-                                            onClick={() => mutate()}
-                                        >
-                                            <ArrowClockwise size={14} />
-                                        </Button>
-                                    </TooltipTrigger>
-                                    <TooltipContent>Reload providers</TooltipContent>
-                                </Tooltip>
+                                <TooltipProvider>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        aria-label="Reload providers"
+                                        disabled={loading}
+                                        onClick={mutate}
+                                    >
+                                        <ArrowClockwise size={14} />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>Reload providers</TooltipContent>
+                            </Tooltip>
+                            </TooltipProvider>
                                 <Button
                                     disabled={loading}
                                     onClick={() => setIsConfigProviderOpen(true)}

--- a/web/packages/agenta-settings-ui/src/webhooks/WebhooksPage.tsx
+++ b/web/packages/agenta-settings-ui/src/webhooks/WebhooksPage.tsx
@@ -1,5 +1,22 @@
 import {useCallback, useMemo, useState} from "react"
 
+import {ActiveToggle} from "@agenta/entity-ui/gatewayTrigger"
+import {
+    InfiniteVirtualTableFeatureShell,
+    createStandardColumns,
+    type StandardColumnDef,
+} from "@agenta/ui/table"
+import {EmptyState} from "@agenta/ui/ui"
+import {ArrowClockwise, PencilSimpleLine, Play, Plus, Trash} from "@phosphor-icons/react"
+import {message} from "@agenta/ui/app-message"
+import {Button, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
+import {useAtom, useSetAtom} from "jotai"
+
+import {useStaticTable} from "@agenta/settings"
+import {
+    WEBHOOK_TEST_FAILURE_MESSAGE,
+    handleTestResult,
+} from "@agenta/entities/webhook"
 import type {WebhookProvider, WebhookSubscription} from "@agenta/entities/webhook"
 import {WEBHOOK_TEST_FAILURE_MESSAGE, handleTestResult} from "@agenta/entities/webhook"
 import {setWebhookActiveAtom, testWebhookAtom, webhooksAtom} from "@agenta/entities/webhook"
@@ -278,7 +295,8 @@ export const WebhooksPage = ({
                 }
                 primaryActions={
                     <>
-                        <Tooltip>
+                        <TooltipProvider>
+                            <Tooltip>
                             <TooltipTrigger asChild>
                                 <Button
                                     variant="outline"
@@ -291,6 +309,7 @@ export const WebhooksPage = ({
                             </TooltipTrigger>
                             <TooltipContent>Reload all webhooks</TooltipContent>
                         </Tooltip>
+                            </TooltipProvider>
                         <Button onClick={handleCreate} disabled={isLoading}>
                             <Plus size={14} />
                             Subscribe

--- a/web/packages/agenta-settings-ui/src/webhooks/WebhooksPage.tsx
+++ b/web/packages/agenta-settings-ui/src/webhooks/WebhooksPage.tsx
@@ -1,22 +1,5 @@
 import {useCallback, useMemo, useState} from "react"
 
-import {ActiveToggle} from "@agenta/entity-ui/gatewayTrigger"
-import {
-    InfiniteVirtualTableFeatureShell,
-    createStandardColumns,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {EmptyState} from "@agenta/ui/ui"
-import {ArrowClockwise, PencilSimpleLine, Play, Plus, Trash} from "@phosphor-icons/react"
-import {message} from "@agenta/ui/app-message"
-import {Button, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
-import {useAtom, useSetAtom} from "jotai"
-
-import {useStaticTable} from "@agenta/settings"
-import {
-    WEBHOOK_TEST_FAILURE_MESSAGE,
-    handleTestResult,
-} from "@agenta/entities/webhook"
 import type {WebhookProvider, WebhookSubscription} from "@agenta/entities/webhook"
 import {WEBHOOK_TEST_FAILURE_MESSAGE, handleTestResult} from "@agenta/entities/webhook"
 import {setWebhookActiveAtom, testWebhookAtom, webhooksAtom} from "@agenta/entities/webhook"
@@ -26,15 +9,18 @@ import {
     webhookToDeleteAtom,
 } from "@agenta/entities/webhook"
 import {ActiveToggle} from "@agenta/entity-ui/gatewayTrigger"
-import {useStaticTable} from "@agenta/settings"
 import {message} from "@agenta/ui/app-message"
 import {
-    InfiniteVirtualTableFeatureShell,
-    createStandardColumns,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {EmptyState} from "@agenta/ui/ui"
-import {Button, Input, Tooltip, TooltipContent, TooltipTrigger} from "@agenta/ui/ui"
+    Button,
+    DataTable,
+    EmptyState,
+    Input,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+    type DataTableColumn,
+} from "@agenta/ui/ui"
 import {ArrowClockwise, PencilSimpleLine, Play, Plus, Trash} from "@phosphor-icons/react"
 import {useAtom, useSetAtom} from "jotai"
 
@@ -177,113 +163,94 @@ export const WebhooksPage = ({
         )
     }, [webhooks, searchTerm])
 
-    const columns = useMemo(
-        () =>
-            createStandardColumns<WebhookRow>([
-                {
-                    type: "text",
-                    key: "name",
-                    title: "Name",
-                    width: 200,
-                    fixed: "left",
-                    render: (_value, record) => <span>{record.name || "-"}</span>,
+    const columns = useMemo<DataTableColumn<WebhookRow>[]>(
+        () => [
+            {key: "name", title: "Name", width: 200, render: (record) => record.name || "-"},
+            {
+                key: "provider",
+                title: "Type",
+                width: 110,
+                render: (record) =>
+                    getProviderLabel(record.data?.url) === "github" ? "GitHub" : "Webhook",
+            },
+            {
+                key: "url",
+                title: "Target",
+                width: 320,
+                render: (record) => {
+                    const url = record.data?.url
+                    return (
+                        <span className="block truncate" title={url}>
+                            {formatDestination(url)}
+                        </span>
+                    )
                 },
-                {
-                    type: "text",
-                    key: "provider",
-                    title: "Type",
-                    width: 110,
-                    render: (_value, record) =>
-                        getProviderLabel(record.data?.url) === "github" ? "GitHub" : "Webhook",
+            },
+            {
+                key: "events",
+                title: "Events",
+                width: 220,
+                render: (record) => {
+                    const value = record.data?.event_types?.join(", ") || "-"
+                    return (
+                        <span className="block truncate" title={value}>
+                            {value}
+                        </span>
+                    )
                 },
-                {
-                    type: "text",
-                    key: "url",
-                    title: "Target",
-                    width: 320,
-                    render: (_value, record) => {
-                        const url = record.data?.url
-                        return (
-                            <span className="block truncate" title={url}>
-                                {formatDestination(url)}
-                            </span>
-                        )
-                    },
-                },
-                {
-                    type: "text",
-                    key: "events",
-                    title: "Events",
-                    width: 220,
-                    render: (_value, record) => {
-                        const value = record.data?.event_types?.join(", ") || "-"
-                        return (
-                            <span className="block truncate" title={value}>
-                                {value}
-                            </span>
-                        )
-                    },
-                },
-                {
-                    // The toggle shows the state and changes it, so it lives in Status.
-                    type: "text",
-                    key: "status",
-                    title: "Status",
-                    width: 120,
-                    render: (_value, record) => (
-                        <div onClick={(event) => event.stopPropagation()}>
-                            <ActiveToggle
-                                active={isWebhookActive(record)}
-                                onToggle={handleToggle(record)}
-                                activatedMessage="Webhook resumed"
-                                pausedMessage="Webhook paused"
-                                errorMessage="Failed to update webhook"
-                            />
-                        </div>
-                    ),
-                },
-                {
-                    type: "actions",
-                    showCopyId: false,
-                    items: [
-                        {
-                            key: "test",
-                            label: "Test",
-                            icon: <Play size={16} />,
-                            disabled: () => testingWebhookId !== null,
-                            onClick: (record: WebhookRow) => handleTestWebhook(record),
-                        },
-                        {
-                            key: "edit",
-                            label: "Edit",
-                            icon: <PencilSimpleLine size={16} />,
-                            onClick: (record: WebhookRow) => handleEdit(record),
-                        },
-                        {type: "divider"},
-                        {
-                            key: "delete",
-                            label: "Delete",
-                            icon: <Trash size={16} />,
-                            danger: true,
-                            onClick: (record: WebhookRow) => handleDeleteClick(record),
-                        },
-                    ],
-                } satisfies StandardColumnDef<WebhookRow>,
-            ]),
-        [handleDeleteClick, handleEdit, handleTestWebhook, handleToggle, testingWebhookId],
+            },
+            {
+                // The toggle shows the state and changes it, so it lives in Status.
+                key: "status",
+                title: "Status",
+                width: 120,
+                render: (record) => (
+                    <div onClick={(event) => event.stopPropagation()}>
+                        <ActiveToggle
+                            active={isWebhookActive(record)}
+                            onToggle={handleToggle(record)}
+                            activatedMessage="Webhook resumed"
+                            pausedMessage="Webhook paused"
+                            errorMessage="Failed to update webhook"
+                        />
+                    </div>
+                ),
+            },
+        ],
+        [handleToggle],
     )
 
-    const {tableScope, pagination} = useStaticTable<WebhookRow>("settings-webhooks", rows, {
-        loading: isLoading,
-    })
     return (
         <div className="flex flex-col gap-2">
-            <InfiniteVirtualTableFeatureShell<WebhookRow>
-                tableScope={tableScope}
-                autoHeight={false}
+            <DataTable<WebhookRow>
                 columns={columns}
-                rowKey="key"
-                pagination={pagination}
+                rows={rows}
+                rowKey={(record) => record.key}
+                loading={isLoading}
+                onRowClick={handleEdit}
+                actions={(record) => [
+                    {
+                        key: "test",
+                        label: "Test",
+                        icon: <Play size={16} />,
+                        disabled: testingWebhookId !== null,
+                        onClick: () => handleTestWebhook(record),
+                    },
+                    {
+                        key: "edit",
+                        label: "Edit",
+                        icon: <PencilSimpleLine size={16} />,
+                        onClick: () => handleEdit(record),
+                    },
+                    {type: "divider"},
+                    {
+                        key: "delete",
+                        label: "Delete",
+                        icon: <Trash size={16} />,
+                        danger: true,
+                        onClick: () => handleDeleteClick(record),
+                    },
+                ]}
                 filters={
                     <Input
                         placeholder="Search webhooks"
@@ -297,62 +264,53 @@ export const WebhooksPage = ({
                     <>
                         <TooltipProvider>
                             <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    aria-label="Reload all webhooks"
-                                    disabled={reloading}
-                                    onClick={reloadAll}
-                                >
-                                    <ArrowClockwise size={14} />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Reload all webhooks</TooltipContent>
-                        </Tooltip>
-                            </TooltipProvider>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        aria-label="Reload all webhooks"
+                                        disabled={reloading}
+                                        onClick={reloadAll}
+                                    >
+                                        <ArrowClockwise size={14} />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>Reload all webhooks</TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
                         <Button onClick={handleCreate} disabled={isLoading}>
                             <Plus size={14} />
                             Subscribe
                         </Button>
                     </>
                 }
-                tableProps={{
-                    size: "small",
-                    bordered: true,
-                    tableLayout: "fixed",
-                    locale: {
-                        emptyText: searchTerm.trim() ? (
-                            <EmptyState
-                                image="simple"
-                                description={`No webhooks match “${searchTerm.trim()}”`}
-                            />
-                        ) : (
-                            <EmptyState
-                                image="simple"
-                                description={
-                                    <div className="flex flex-col gap-1">
-                                        <span className="text-xs font-medium text-colorText">
-                                            No webhooks yet
-                                        </span>
-                                        <span>
-                                            Subscribe an endpoint to receive workflow events as
-                                            signed HTTP requests.
-                                        </span>
-                                    </div>
-                                }
-                            >
-                                <Button variant="outline" onClick={handleCreate}>
-                                    <Plus size={14} />
-                                    Subscribe
-                                </Button>
-                            </EmptyState>
-                        ),
-                    },
-                    onRow: (record: WebhookRow) => ({
-                        onClick: () => handleEdit(record),
-                        className: "cursor-pointer",
-                    }),
-                }}
+                empty={
+                    searchTerm.trim() ? (
+                        <EmptyState
+                            image="simple"
+                            description={`No webhooks match “${searchTerm.trim()}”`}
+                        />
+                    ) : (
+                        <EmptyState
+                            image="simple"
+                            description={
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-xs font-medium text-colorText">
+                                        No webhooks yet
+                                    </span>
+                                    <span>
+                                        Subscribe an endpoint to receive workflow events as signed
+                                        HTTP requests.
+                                    </span>
+                                </div>
+                            }
+                        >
+                            <Button variant="outline" onClick={handleCreate}>
+                                <Plus size={14} />
+                                Subscribe
+                            </Button>
+                        </EmptyState>
+                    )
+                }
             />
 
             {renderDrawer?.({onSuccess: handleModalSuccess})}

--- a/web/packages/agenta-ui/src/components/ui/data-table.tsx
+++ b/web/packages/agenta-ui/src/components/ui/data-table.tsx
@@ -29,6 +29,9 @@ export interface DataTableAction<T> {
     label: ReactNode
     icon?: ReactNode
     danger?: boolean
+    disabled?: boolean
+    /** Drop the item entirely for this row — e.g. "Set as default" on the default row. */
+    hidden?: boolean
     onClick: (record: T) => void
 }
 
@@ -46,6 +49,9 @@ export interface DataTableProps<T> {
     filters?: ReactNode
     /** Right of the toolbar — the primary buttons. */
     primaryActions?: ReactNode
+    /** Above the toolbar — a heading for the table itself. */
+    title?: ReactNode
+    onRowClick?: (record: T) => void
     className?: string
 }
 
@@ -69,6 +75,8 @@ export function DataTable<T>({
     skeletonRows = 5,
     filters,
     primaryActions,
+    title,
+    onRowClick,
     className,
 }: DataTableProps<T>) {
     const showSkeleton = loading && rows.length === 0
@@ -76,6 +84,8 @@ export function DataTable<T>({
 
     return (
         <div className={clsx("flex min-w-0 flex-col gap-2", className)}>
+            {title ? <div>{title}</div> : null}
+
             {filters || primaryActions ? (
                 <div className="flex flex-wrap items-center gap-2">
                     {filters}
@@ -123,7 +133,11 @@ export function DataTable<T>({
                             : rows.map((record) => (
                                   <tr
                                       key={rowKey(record)}
-                                      className="border-0 border-b border-solid border-colorBorderSecondary last:border-b-0 hover:bg-colorFillQuaternary"
+                                      onClick={onRowClick ? () => onRowClick(record) : undefined}
+                                      className={clsx(
+                                          "border-0 border-b border-solid border-colorBorderSecondary last:border-b-0 hover:bg-colorFillQuaternary",
+                                          onRowClick && "cursor-pointer",
+                                      )}
                                   >
                                       {columns.map((column) => (
                                           <td
@@ -141,11 +155,11 @@ export function DataTable<T>({
                                           </td>
                                       ))}
                                       {actions ? (
-                                          <td className={clsx(CELL, "text-right")}>
-                                              <RowActions
-                                                  items={actions(record)}
-                                                  record={record}
-                                              />
+                                          <td
+                                              className={clsx(CELL, "text-right")}
+                                              onClick={(event) => event.stopPropagation()}
+                                          >
+                                              <RowActions items={actions(record)} record={record} />
                                           </td>
                                       ) : null}
                                   </tr>
@@ -166,7 +180,15 @@ const RowActions = <T,>({
     items: (DataTableAction<T> | {type: "divider"})[]
     record: T
 }) => {
-    if (items.length === 0) return null
+    const visible = items.filter((item) => "type" in item || !item.hidden)
+    // Hiding every action can leave a divider stranded at either end.
+    const trimmed = visible.filter(
+        (item, index) =>
+            !("type" in item) ||
+            (visible.slice(0, index).some((prior) => !("type" in prior)) &&
+                visible.slice(index + 1).some((next) => !("type" in next))),
+    )
+    if (!trimmed.some((item) => !("type" in item))) return null
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -179,13 +201,14 @@ const RowActions = <T,>({
                 </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-[180px]">
-                {items.map((item, index) =>
+                {trimmed.map((item, index) =>
                     "type" in item ? (
                         <DropdownMenuSeparator key={`divider-${index}`} />
                     ) : (
                         <DropdownMenuItem
                             key={item.key}
-                            className={clsx(item.danger && "!text-colorError")}
+                            disabled={item.disabled}
+                            className={clsx(item.danger && !item.disabled && "!text-colorError")}
                             onSelect={() => item.onClick(record)}
                         >
                             {item.icon}

--- a/web/packages/agenta-ui/src/components/ui/data-table.tsx
+++ b/web/packages/agenta-ui/src/components/ui/data-table.tsx
@@ -134,9 +134,30 @@ export function DataTable<T>({
                                   <tr
                                       key={rowKey(record)}
                                       onClick={onRowClick ? () => onRowClick(record) : undefined}
+                                      // A clickable row is a control, so it takes focus and answers
+                                      // Enter/Space like one. Rows without `onRowClick` stay plain
+                                      // markup — they must not become focus stops.
+                                      role={onRowClick ? "button" : undefined}
+                                      tabIndex={onRowClick ? 0 : undefined}
+                                      onKeyDown={
+                                          onRowClick
+                                              ? (event) => {
+                                                    // Only the row itself: controls inside a cell
+                                                    // handle their own keys, and Space on a
+                                                    // container that does not preventDefault also
+                                                    // scrolls the page.
+                                                    if (event.target !== event.currentTarget) return
+                                                    if (event.key !== "Enter" && event.key !== " ")
+                                                        return
+                                                    event.preventDefault()
+                                                    onRowClick(record)
+                                                }
+                                              : undefined
+                                      }
                                       className={clsx(
                                           "border-0 border-b border-solid border-colorBorderSecondary last:border-b-0 hover:bg-colorFillQuaternary",
-                                          onRowClick && "cursor-pointer",
+                                          onRowClick &&
+                                              "cursor-pointer outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring",
                                       )}
                                   >
                                       {columns.map((column) => (

--- a/web/packages/agenta-ui/src/components/ui/data-table.tsx
+++ b/web/packages/agenta-ui/src/components/ui/data-table.tsx
@@ -1,0 +1,199 @@
+import type {ReactNode} from "react"
+
+import {DotsThreeVertical} from "@phosphor-icons/react"
+import clsx from "clsx"
+
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "./dropdown-menu"
+import {SkeletonBlock} from "./skeleton"
+
+export interface DataTableColumn<T> {
+    key: string
+    title?: ReactNode
+    /** Fixed pixel width. Omit to share the remaining space. */
+    width?: number
+    align?: "left" | "right" | "center"
+    /** Monospace + tabular figures — ids, prefixes, slugs. */
+    mono?: boolean
+    className?: string
+    render: (record: T) => ReactNode
+}
+
+export interface DataTableAction<T> {
+    key: string
+    label: ReactNode
+    icon?: ReactNode
+    danger?: boolean
+    onClick: (record: T) => void
+}
+
+export interface DataTableProps<T> {
+    columns: DataTableColumn<T>[]
+    rows: T[]
+    rowKey: (record: T) => string
+    /** Per-row overflow menu, rendered as a trailing column. */
+    actions?: (record: T) => (DataTableAction<T> | {type: "divider"})[]
+    /** Shown instead of rows when there are none and nothing is loading. */
+    empty?: ReactNode
+    loading?: boolean
+    skeletonRows?: number
+    /** Left of the toolbar — search and filters. */
+    filters?: ReactNode
+    /** Right of the toolbar — the primary buttons. */
+    primaryActions?: ReactNode
+    className?: string
+}
+
+const CELL = "px-3 py-2 text-xs align-middle"
+
+/**
+ * THE antd-free table for fully-materialized lists — settings, and anything else whose rows are
+ * already in memory.
+ *
+ * Deliberately not virtualized: `InfiniteVirtualTable` exists for large, paged, server-driven
+ * datasets and is antd-backed. Settings tables are small, single-page and fully loaded, so they
+ * pay none of that cost — and, crucially, can render in a host that forbids antd.
+ */
+export function DataTable<T>({
+    columns,
+    rows,
+    rowKey,
+    actions,
+    empty,
+    loading = false,
+    skeletonRows = 5,
+    filters,
+    primaryActions,
+    className,
+}: DataTableProps<T>) {
+    const showSkeleton = loading && rows.length === 0
+    const showEmpty = !loading && rows.length === 0
+
+    return (
+        <div className={clsx("flex min-w-0 flex-col gap-2", className)}>
+            {filters || primaryActions ? (
+                <div className="flex flex-wrap items-center gap-2">
+                    {filters}
+                    <div className="ml-auto flex items-center gap-2">{primaryActions}</div>
+                </div>
+            ) : null}
+
+            <div className="overflow-x-auto rounded-lg border border-solid border-colorBorderSecondary">
+                <table className="w-full border-collapse text-left">
+                    <thead>
+                        <tr className="border-0 border-b border-solid border-colorBorderSecondary bg-colorFillQuaternary">
+                            {columns.map((column) => (
+                                <th
+                                    key={column.key}
+                                    scope="col"
+                                    style={column.width ? {width: column.width} : undefined}
+                                    className={clsx(
+                                        CELL,
+                                        "font-medium text-colorTextSecondary",
+                                        column.align === "right" && "text-right",
+                                        column.align === "center" && "text-center",
+                                    )}
+                                >
+                                    {column.title}
+                                </th>
+                            ))}
+                            {actions ? <th className={clsx(CELL, "w-12")} /> : null}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {showSkeleton
+                            ? Array.from({length: skeletonRows}, (_, index) => (
+                                  <tr
+                                      key={`skeleton-${index}`}
+                                      className="border-0 border-b border-solid border-colorBorderSecondary last:border-b-0"
+                                  >
+                                      {columns.map((column) => (
+                                          <td key={column.key} className={CELL}>
+                                              <SkeletonBlock active className="h-4 w-3/4" />
+                                          </td>
+                                      ))}
+                                      {actions ? <td className={CELL} /> : null}
+                                  </tr>
+                              ))
+                            : rows.map((record) => (
+                                  <tr
+                                      key={rowKey(record)}
+                                      className="border-0 border-b border-solid border-colorBorderSecondary last:border-b-0 hover:bg-colorFillQuaternary"
+                                  >
+                                      {columns.map((column) => (
+                                          <td
+                                              key={column.key}
+                                              className={clsx(
+                                                  CELL,
+                                                  "text-colorText",
+                                                  column.mono && "font-mono tabular-nums",
+                                                  column.align === "right" && "text-right",
+                                                  column.align === "center" && "text-center",
+                                                  column.className,
+                                              )}
+                                          >
+                                              {column.render(record)}
+                                          </td>
+                                      ))}
+                                      {actions ? (
+                                          <td className={clsx(CELL, "text-right")}>
+                                              <RowActions
+                                                  items={actions(record)}
+                                                  record={record}
+                                              />
+                                          </td>
+                                      ) : null}
+                                  </tr>
+                              ))}
+                    </tbody>
+                </table>
+
+                {showEmpty ? <div className="px-3 py-8">{empty}</div> : null}
+            </div>
+        </div>
+    )
+}
+
+const RowActions = <T,>({
+    items,
+    record,
+}: {
+    items: (DataTableAction<T> | {type: "divider"})[]
+    record: T
+}) => {
+    if (items.length === 0) return null
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <button
+                    type="button"
+                    aria-label="Row actions"
+                    className="flex size-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-colorTextSecondary hover:bg-colorFillTertiary hover:text-colorText"
+                >
+                    <DotsThreeVertical size={16} weight="bold" />
+                </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-[180px]">
+                {items.map((item, index) =>
+                    "type" in item ? (
+                        <DropdownMenuSeparator key={`divider-${index}`} />
+                    ) : (
+                        <DropdownMenuItem
+                            key={item.key}
+                            className={clsx(item.danger && "!text-colorError")}
+                            onSelect={() => item.onClick(record)}
+                        >
+                            {item.icon}
+                            {item.label}
+                        </DropdownMenuItem>
+                    ),
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}

--- a/web/packages/agenta-ui/src/components/ui/index.ts
+++ b/web/packages/agenta-ui/src/components/ui/index.ts
@@ -174,3 +174,9 @@ export {
     BreadcrumbEllipsis,
 } from "./breadcrumb"
 export {cn} from "./utils"
+export {
+    DataTable,
+    type DataTableProps,
+    type DataTableColumn,
+    type DataTableAction,
+} from "./data-table"


### PR DESCRIPTION
The settings pages moved into packages in the lane below, but their tables were still antd. `/m`
cannot take antd, so the tables could not follow.

`DataTable` in `@agenta/ui` is the replacement, and the settings tables now render on it on every
host. Also here: `/m` settings shows every tab it has a page for instead of only Preferences, and
the settings tables carry their own `TooltipProvider` rather than assuming an ancestor supplies one.
Not run in a browser — static gates only (`pnpm lint-fix` 24/24, `tsc --noEmit` clean
for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`).

Stacked on `pkg/settings-spine`; review only this lane's diff.