### PR TITLE
feat(frontend): Members, Organizations, Access Controls, Domains and SSO extracted

### DIFF
--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -1,6 +1,11 @@
 import {useMemo, useState} from "react"
 
-import {fetchAllOrgsList, fetchSingleOrg} from "@agenta/entities/organization"
+import {
+    fetchAllOrgsList,
+    fetchSingleOrg,
+    updateOrganization,
+    type OrganizationFlags,
+} from "@agenta/entities/organization"
 import {useProfile} from "@agenta/entities/profile"
 import {fetchAllProjects} from "@agenta/entities/project"
 import {
@@ -12,8 +17,10 @@ import {
 } from "@agenta/settings"
 import {useApiKeys, type SettingsAccess} from "@agenta/settings"
 import {
+    AccessControlsSection,
     AccountPage,
     ApiKeysPage,
+    type AuthFlagKey,
     MembersPage,
     NamedSecretTable,
     OrganizationsPage,
@@ -53,6 +60,7 @@ const AVAILABLE: SettingsTabKey[] = [
     "webhooks",
     "organizationGeneral",
     "workspace",
+    "organization",
     "projects",
     "account",
     "preferences",
@@ -87,7 +95,8 @@ const TabBody = ({
     const projects = useQuery({
         queryKey: ["projects", workspaceId],
         queryFn: () => fetchAllProjects(workspaceId),
-        enabled: tab === "projects" || tab === "workspace" || tab === "organizationGeneral",
+        // Every organization-scoped tab resolves its org id from this list.
+        enabled: tab !== "preferences" && tab !== "account",
     })
 
     // A project carries its organization, which saves resolving one from the workspace id.
@@ -99,7 +108,7 @@ const TabBody = ({
     const org = useQuery({
         queryKey: ["selectedOrg", organizationId],
         queryFn: () => fetchSingleOrg({organizationId: organizationId!}),
-        enabled: tab === "workspace" && Boolean(organizationId),
+        enabled: (tab === "workspace" || tab === "organization") && Boolean(organizationId),
     })
     const organizations = useQuery({
         queryKey: ["orgs"],
@@ -108,6 +117,20 @@ const TabBody = ({
     })
     const [memberSearch, setMemberSearch] = useState("")
     const [orgSearch, setOrgSearch] = useState("")
+
+    const [savingFlag, setSavingFlag] = useState<AuthFlagKey | null>(null)
+    const [lastSavedFlag, setLastSavedFlag] = useState<AuthFlagKey | null>(null)
+    const setFlag = async (flag: AuthFlagKey, value: boolean) => {
+        if (!organizationId) return
+        setSavingFlag(flag)
+        try {
+            await updateOrganization(organizationId, {flags: {[flag]: value}})
+            await org.refetch()
+            setLastSavedFlag(flag)
+        } finally {
+            setSavingFlag(null)
+        }
+    }
 
     switch (tab) {
         case "preferences":
@@ -168,6 +191,22 @@ const TabBody = ({
                     currentUserId={user?.id}
                 />
             )
+        case "organization": {
+            const flags = org.data?.flags as OrganizationFlags | undefined
+            if (!flags) return null
+            return (
+                <AccessControlsSection
+                    flags={flags}
+                    onFlagChange={(flag, value) => void setFlag(flag, value)}
+                    updating={Boolean(savingFlag)}
+                    lastSavedFlag={lastSavedFlag}
+                    // Domains and SSO providers are configured on the desktop, so these two
+                    // gates read from the flags already in effect rather than from those lists.
+                    hasActiveVerifiedProvider={flags.allow_sso}
+                    hasVerifiedDomain={flags.auto_join || flags.domains_only}
+                />
+            )
+        }
         default:
             return null
     }

--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -1,10 +1,6 @@
 import {useMemo, useState} from "react"
 
-import {
-    fetchAllOrgsList,
-    fetchSingleOrg,
-    fetchWorkspaceMembers,
-} from "@agenta/entities/organization"
+import {fetchAllOrgsList, fetchSingleOrg} from "@agenta/entities/organization"
 import {useProfile} from "@agenta/entities/profile"
 import {fetchAllProjects} from "@agenta/entities/project"
 import {
@@ -20,6 +16,7 @@ import {
     ApiKeysPage,
     MembersPage,
     NamedSecretTable,
+    OrganizationsPage,
     PreferencesPage,
     ProjectsPage,
     SecretProviderTable,
@@ -54,6 +51,7 @@ const AVAILABLE: SettingsTabKey[] = [
     "llms",
     "secrets",
     "webhooks",
+    "organizationGeneral",
     "workspace",
     "projects",
     "account",
@@ -74,7 +72,7 @@ const TabBody = ({
 }: {
     tab: SettingsTabKey
     access: SettingsAccess
-    user: {username?: string | null; email?: string | null} | null
+    user: {id?: string | null; username?: string | null; email?: string | null} | null
     theme: {options: {mode: string; label: string}[]; mode: string; onSelect: (m: string) => void}
     workspaceId: string
 }) => {
@@ -89,25 +87,27 @@ const TabBody = ({
     const projects = useQuery({
         queryKey: ["projects", workspaceId],
         queryFn: () => fetchAllProjects(workspaceId),
-        enabled: tab === "projects",
+        enabled: tab === "projects" || tab === "workspace" || tab === "organizationGeneral",
     })
 
-    const members = useQuery({
-        queryKey: ["workspace", workspaceId, "members"],
-        queryFn: () => fetchWorkspaceMembers(workspaceId, true),
-        enabled: tab === "workspace" && Boolean(workspaceId),
-    })
-    // The roster names its owner, and only the org response carries `owner_id`.
+    // A project carries its organization, which saves resolving one from the workspace id.
+    const organizationId = projects.data?.find(
+        (project) => project.organization_id,
+    )?.organization_id
+    // The roster lives on the org's default workspace, not behind a members endpoint — same
+    // source the desktop reads, so the two surfaces cannot disagree.
     const org = useQuery({
-        queryKey: ["selectedOrg", "forMembers"],
-        queryFn: async () => {
-            const orgs = await fetchAllOrgsList()
-            const first = orgs[0]
-            return first ? await fetchSingleOrg({organizationId: first.id}) : null
-        },
-        enabled: tab === "workspace",
+        queryKey: ["selectedOrg", organizationId],
+        queryFn: () => fetchSingleOrg({organizationId: organizationId!}),
+        enabled: tab === "workspace" && Boolean(organizationId),
+    })
+    const organizations = useQuery({
+        queryKey: ["orgs"],
+        queryFn: () => fetchAllOrgsList(),
+        enabled: tab === "organizationGeneral",
     })
     const [memberSearch, setMemberSearch] = useState("")
+    const [orgSearch, setOrgSearch] = useState("")
 
     switch (tab) {
         case "preferences":
@@ -149,18 +149,23 @@ const TabBody = ({
         case "workspace":
             return (
                 <MembersPage
-                    members={(members.data ?? []).filter((member) => {
-                        const term = memberSearch.trim().toLowerCase()
-                        if (!term) return true
-                        return [member.user?.username, member.user?.email].some((value) =>
-                            value?.toLowerCase().includes(term),
-                        )
-                    })}
-                    loading={members.isPending}
+                    members={org.data?.default_workspace?.members ?? []}
+                    loading={projects.isPending || org.isPending}
                     searchTerm={memberSearch}
                     onSearchChange={setMemberSearch}
                     signedInUser={user}
                     ownerId={org.data?.owner_id}
+                />
+            )
+        case "organizationGeneral":
+            return (
+                <OrganizationsPage
+                    organizations={organizations.data ?? []}
+                    loading={organizations.isPending}
+                    searchTerm={orgSearch}
+                    onSearchChange={setOrgSearch}
+                    selectedOrgId={organizationId}
+                    currentUserId={user?.id}
                 />
             )
         default:

--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -1,5 +1,10 @@
-import {useMemo} from "react"
+import {useMemo, useState} from "react"
 
+import {
+    fetchAllOrgsList,
+    fetchSingleOrg,
+    fetchWorkspaceMembers,
+} from "@agenta/entities/organization"
 import {useProfile} from "@agenta/entities/profile"
 import {fetchAllProjects} from "@agenta/entities/project"
 import {
@@ -13,6 +18,7 @@ import {useApiKeys, type SettingsAccess} from "@agenta/settings"
 import {
     AccountPage,
     ApiKeysPage,
+    MembersPage,
     NamedSecretTable,
     PreferencesPage,
     ProjectsPage,
@@ -48,6 +54,7 @@ const AVAILABLE: SettingsTabKey[] = [
     "llms",
     "secrets",
     "webhooks",
+    "workspace",
     "projects",
     "account",
     "preferences",
@@ -85,6 +92,23 @@ const TabBody = ({
         enabled: tab === "projects",
     })
 
+    const members = useQuery({
+        queryKey: ["workspace", workspaceId, "members"],
+        queryFn: () => fetchWorkspaceMembers(workspaceId, true),
+        enabled: tab === "workspace" && Boolean(workspaceId),
+    })
+    // The roster names its owner, and only the org response carries `owner_id`.
+    const org = useQuery({
+        queryKey: ["selectedOrg", "forMembers"],
+        queryFn: async () => {
+            const orgs = await fetchAllOrgsList()
+            const first = orgs[0]
+            return first ? await fetchSingleOrg({organizationId: first.id}) : null
+        },
+        enabled: tab === "workspace",
+    })
+    const [memberSearch, setMemberSearch] = useState("")
+
     switch (tab) {
         case "preferences":
             return <PreferencesPage theme={theme} />
@@ -120,6 +144,23 @@ const TabBody = ({
                     projects={projects.data ?? []}
                     isLoading={projects.isPending}
                     workspaceId={workspaceId}
+                />
+            )
+        case "workspace":
+            return (
+                <MembersPage
+                    members={(members.data ?? []).filter((member) => {
+                        const term = memberSearch.trim().toLowerCase()
+                        if (!term) return true
+                        return [member.user?.username, member.user?.email].some((value) =>
+                            value?.toLowerCase().includes(term),
+                        )
+                    })}
+                    loading={members.isPending}
+                    searchTerm={memberSearch}
+                    onSearchChange={setMemberSearch}
+                    signedInUser={user}
+                    ownerId={org.data?.owner_id}
                 />
             )
         default:

--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -92,7 +92,7 @@ const TabBody = ({
 
     // A project carries its organization, which saves resolving one from the workspace id.
     const organizationId = projects.data?.find(
-        (project) => project.organization_id,
+        (project) => project.organization_id && project.workspace_id === workspaceId,
     )?.organization_id
     // The roster lives on the org's default workspace, not behind a members endpoint — same
     // source the desktop reads, so the two surfaces cannot disagree.

--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from "react"
+import {useEffect, useMemo, useState} from "react"
 
 import {
     fetchAllOrgsList,
@@ -50,6 +50,8 @@ import {useBindProjectContext} from "../context/useBindProjectContext"
 import {useCurrentProject} from "../context/useCurrentProject"
 import {AppShell} from "../nav/AppShell"
 import {NavDrawer} from "../nav/NavDrawer"
+
+import {SettingsLoadError, SettingsSectionSkeleton} from "./states/SettingsStates"
 
 const THEME_OPTIONS = [
     {mode: "light", label: "Light"},
@@ -135,17 +137,35 @@ const TabBody = ({
 
     const [savingFlag, setSavingFlag] = useState<AuthFlagKey | null>(null)
     const [lastSavedFlag, setLastSavedFlag] = useState<AuthFlagKey | null>(null)
+    const [flagError, setFlagError] = useState<string | null>(null)
     const setFlag = async (flag: AuthFlagKey, value: boolean) => {
         if (!organizationId) return
         setSavingFlag(flag)
+        setFlagError(null)
+        setLastSavedFlag(null)
         try {
             await updateOrganization(organizationId, {flags: {[flag]: value}})
             await org.refetch()
             setLastSavedFlag(flag)
+        } catch (error) {
+            // The switches are driven by the server's flags, never by local state, so a failed
+            // write needs no revert — the row simply stays where it was. Which reads as a dead
+            // toggle unless we say why.
+            setFlagError(
+                error instanceof Error && error.message
+                    ? error.message
+                    : "Could not save that setting. Try again.",
+            )
         } finally {
             setSavingFlag(null)
         }
     }
+    // "Saved" is a transient marker; without this it sits on the row for the rest of the session.
+    useEffect(() => {
+        if (!lastSavedFlag) return
+        const timer = window.setTimeout(() => setLastSavedFlag(null), 3000)
+        return () => window.clearTimeout(timer)
+    }, [lastSavedFlag])
 
     switch (tab) {
         case "preferences":
@@ -207,6 +227,20 @@ const TabBody = ({
                 />
             )
         case "organization": {
+            // This tab's org id comes from the projects list, so both queries are its loading
+            // state — and a disabled query stays `pending` forever, hence the explicit id check.
+            if (projects.isPending || (organizationId && org.isPending))
+                return <SettingsSectionSkeleton />
+            if (projects.isError || org.isError)
+                return (
+                    <SettingsLoadError
+                        text="Could not load this organization's settings."
+                        onRetry={() => {
+                            void projects.refetch()
+                            void org.refetch()
+                        }}
+                    />
+                )
             const flags = org.data?.flags as OrganizationFlags | undefined
             if (!flags) return null
             const domainList = domains.data ?? []
@@ -214,16 +248,27 @@ const TabBody = ({
             const orgSlug = org.data?.slug
             return (
                 <div className="flex flex-col gap-8">
-                    <AccessControlsSection
-                        flags={flags}
-                        onFlagChange={(flag, value) => void setFlag(flag, value)}
-                        updating={Boolean(savingFlag)}
-                        lastSavedFlag={lastSavedFlag}
-                        hasActiveVerifiedProvider={providerList.some(
-                            (provider) => provider.flags?.is_active && provider.flags?.is_valid,
-                        )}
-                        hasVerifiedDomain={domainList.some((domain) => domain.flags?.is_verified)}
-                    />
+                    <div className="flex flex-col gap-2">
+                        <AccessControlsSection
+                            flags={flags}
+                            onFlagChange={(flag, value) => void setFlag(flag, value)}
+                            updating={Boolean(savingFlag)}
+                            lastSavedFlag={lastSavedFlag}
+                            hasActiveVerifiedProvider={providerList.some(
+                                (provider) => provider.flags?.is_active && provider.flags?.is_valid,
+                            )}
+                            hasVerifiedDomain={domainList.some(
+                                (domain) => domain.flags?.is_verified,
+                            )}
+                        />
+                        {/* A failed save leaves the switch where it was, so the reason has to be
+                            visible or the toggle just looks broken. */}
+                        {flagError ? (
+                            <p className="text-destructive m-0 text-xs" role="alert">
+                                {flagError}
+                            </p>
+                        ) : null}
+                    </div>
                     {/* Read-only here: adding a domain or provider means DNS records and IdP
                         setup, which belong on the desktop. */}
                     <DomainsSection domains={domainList} loading={domains.isPending} />

--- a/web/mobile/src/features/settings/SettingsScreen.tsx
+++ b/web/mobile/src/features/settings/SettingsScreen.tsx
@@ -2,9 +2,12 @@ import {useMemo, useState} from "react"
 
 import {
     fetchAllOrgsList,
+    fetchOrganizationDomains,
+    fetchOrganizationProviders,
     fetchSingleOrg,
     updateOrganization,
     type OrganizationFlags,
+    type OrganizationProvider,
 } from "@agenta/entities/organization"
 import {useProfile} from "@agenta/entities/profile"
 import {fetchAllProjects} from "@agenta/entities/project"
@@ -19,12 +22,14 @@ import {useApiKeys, type SettingsAccess} from "@agenta/settings"
 import {
     AccessControlsSection,
     AccountPage,
+    DomainsSection,
     ApiKeysPage,
     type AuthFlagKey,
     MembersPage,
     NamedSecretTable,
     OrganizationsPage,
     PreferencesPage,
+    SsoProvidersSection,
     ProjectsPage,
     SecretProviderTable,
     SettingsPageShell,
@@ -115,6 +120,16 @@ const TabBody = ({
         queryFn: () => fetchAllOrgsList(),
         enabled: tab === "organizationGeneral",
     })
+    const domains = useQuery({
+        queryKey: ["organization-domains", organizationId],
+        queryFn: () => fetchOrganizationDomains(),
+        enabled: tab === "organization" && Boolean(organizationId),
+    })
+    const providers = useQuery({
+        queryKey: ["organization-providers", organizationId],
+        queryFn: () => fetchOrganizationProviders(),
+        enabled: tab === "organization" && Boolean(organizationId),
+    })
     const [memberSearch, setMemberSearch] = useState("")
     const [orgSearch, setOrgSearch] = useState("")
 
@@ -194,17 +209,34 @@ const TabBody = ({
         case "organization": {
             const flags = org.data?.flags as OrganizationFlags | undefined
             if (!flags) return null
+            const domainList = domains.data ?? []
+            const providerList = providers.data ?? []
+            const orgSlug = org.data?.slug
             return (
-                <AccessControlsSection
-                    flags={flags}
-                    onFlagChange={(flag, value) => void setFlag(flag, value)}
-                    updating={Boolean(savingFlag)}
-                    lastSavedFlag={lastSavedFlag}
-                    // Domains and SSO providers are configured on the desktop, so these two
-                    // gates read from the flags already in effect rather than from those lists.
-                    hasActiveVerifiedProvider={flags.allow_sso}
-                    hasVerifiedDomain={flags.auto_join || flags.domains_only}
-                />
+                <div className="flex flex-col gap-8">
+                    <AccessControlsSection
+                        flags={flags}
+                        onFlagChange={(flag, value) => void setFlag(flag, value)}
+                        updating={Boolean(savingFlag)}
+                        lastSavedFlag={lastSavedFlag}
+                        hasActiveVerifiedProvider={providerList.some(
+                            (provider) => provider.flags?.is_active && provider.flags?.is_valid,
+                        )}
+                        hasVerifiedDomain={domainList.some((domain) => domain.flags?.is_verified)}
+                    />
+                    {/* Read-only here: adding a domain or provider means DNS records and IdP
+                        setup, which belong on the desktop. */}
+                    <DomainsSection domains={domainList} loading={domains.isPending} />
+                    <SsoProvidersSection
+                        providers={providerList}
+                        loading={providers.isPending}
+                        callbackUrlFor={(provider: OrganizationProvider) =>
+                            orgSlug
+                                ? `${window.location.origin}/auth/callback/sso:${orgSlug}:${provider.slug}`
+                                : null
+                        }
+                    />
+                </div>
             )
         }
         default:

--- a/web/mobile/src/features/settings/states/SettingsStates.tsx
+++ b/web/mobile/src/features/settings/states/SettingsStates.tsx
@@ -1,0 +1,28 @@
+import {Skeleton} from "@/components/ui/skeleton"
+
+/**
+ * The waiting state for a tab whose body is not a shared page with its own `loading` prop —
+ * a stack of section-sized bars, so the switch to real content does not jump.
+ */
+export const SettingsSectionSkeleton = () => (
+    <div className="flex flex-col gap-3 py-2" aria-hidden>
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-4 w-1/4" />
+        <Skeleton className="h-20 w-full" />
+    </div>
+)
+
+/** A failed load says so and offers the retry — silence reads as "this org has no settings". */
+export const SettingsLoadError = ({text, onRetry}: {text: string; onRetry: () => void}) => (
+    <div className="flex flex-col items-start gap-2 py-2">
+        <p className="text-destructive m-0 text-xs">{text}</p>
+        <button
+            type="button"
+            onClick={onRetry}
+            className="border-border hover:bg-accent cursor-pointer rounded-md border border-solid bg-transparent px-3 py-1.5 text-xs"
+        >
+            Try again
+        </button>
+    </div>
+)

--- a/web/oss/src/components/pages/settings/Organization/General.tsx
+++ b/web/oss/src/components/pages/settings/Organization/General.tsx
@@ -7,18 +7,12 @@ import {
     transferOrganizationOwnership,
     updateOrganization,
 } from "@agenta/entities/organization"
-import {useStaticTable} from "@agenta/settings"
+import {OrganizationsPage} from "@agenta/settings-ui"
 import {InitialsAvatar} from "@agenta/ui"
 import {EnhancedModal} from "@agenta/ui/components/modal"
-import {
-    createStandardColumns,
-    InfiniteVirtualTableFeatureShell,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {EmptyState} from "@agenta/ui/ui"
-import {ArrowsLeftRight, PencilSimpleLine, Plus, SignOut, Trash} from "@phosphor-icons/react"
+import {Trash} from "@phosphor-icons/react"
 import {useMutation} from "@tanstack/react-query"
-import {App, Button, Form, Input, Select, Typography} from "antd"
+import {App, Form, Input, Select, Typography} from "antd"
 import clsx from "clsx"
 
 import {getUsernameFromEmail} from "@/oss/lib/helpers/utils"
@@ -37,11 +31,7 @@ const formatErrorMessage = (detail: unknown, fallback: string) => {
     return fallback
 }
 
-interface OrgRow extends Org {
-    key: string
-    [extra: string]: unknown
-}
-
+/** OSS binding: the shared organizations table with this app's antd dialogs. */
 const OrganizationGeneral = () => {
     const {message} = App.useApp()
     const {orgs, selectedOrg, changeSelectedOrg, refetch, loading} = useOrgData()
@@ -62,15 +52,6 @@ const OrganizationGeneral = () => {
 
     const isDeleteNameMatch =
         Boolean(activeOrg?.name) && deleteConfirmInput === (activeOrg?.name ?? "")
-
-    const rows = useMemo<OrgRow[]>(() => {
-        const all = (orgs ?? []).map((org) => ({...org, key: org.id}))
-        const term = searchTerm.trim().toLowerCase()
-        if (!term) return all
-        return all.filter((org) =>
-            [org.name, org.id].some((value) => value?.toLowerCase().includes(term)),
-        )
-    }, [orgs, searchTerm])
 
     const transferOwnerOptions = useMemo(
         () =>
@@ -199,161 +180,33 @@ const OrganizationGeneral = () => {
         selectedOrg,
     ])
 
-    const columns = useMemo(
-        () =>
-            createStandardColumns<OrgRow>([
-                {
-                    type: "entity",
-                    key: "name",
-                    title: "Organization",
-                    width: 280,
-                    fixed: "left",
-                    getName: (record) => record.name ?? record.slug ?? record.id,
-                    getChips: (record) =>
-                        record.id === selectedOrg?.id ? [{label: "Current", tone: "info"}] : [],
-                },
-                // Its own copyable column, not a tag beside the page title.
-                {type: "slug", key: "id", title: "Organization ID", width: 330},
-                {
-                    type: "text",
-                    key: "owner_id",
-                    title: "Your role",
-                    width: 140,
-                    render: (_value, record) => (record.owner_id === user?.id ? "Owner" : "Member"),
-                },
-                {
-                    type: "actions",
-                    showCopyId: false,
-                    items: [
-                        {
-                            key: "switch",
-                            label: "Switch to this organization",
-                            icon: <ArrowsLeftRight size={16} />,
-                            hidden: (record: OrgRow) => record.id === selectedOrg?.id,
-                            onClick: (record: OrgRow) => changeSelectedOrg(record.id),
-                        },
-                        {
-                            key: "rename",
-                            label: "Rename",
-                            icon: <PencilSimpleLine size={16} />,
-                            hidden: (record: OrgRow) => record.owner_id !== user?.id,
-                            onClick: (record: OrgRow) => {
-                                setActiveOrg(record)
-                                renameForm.setFieldsValue({name: record.name ?? ""})
-                                setRenameModalOpen(true)
-                            },
-                        },
-                        {
-                            key: "transfer",
-                            label: "Transfer ownership",
-                            icon: <ArrowsLeftRight size={16} />,
-                            // The member list is scoped to the current organization.
-                            hidden: (record: OrgRow) =>
-                                record.owner_id !== user?.id || record.id !== selectedOrg?.id,
-                            onClick: (record: OrgRow) => {
-                                setActiveOrg(record)
-                                setNewOwnerId(null)
-                                setTransferModalOpen(true)
-                            },
-                        },
-                        {type: "divider"},
-                        {
-                            key: "leave",
-                            label: "Leave organization",
-                            icon: <SignOut size={16} />,
-                            danger: true,
-                            hidden: (record: OrgRow) => record.owner_id === user?.id,
-                            onClick: () =>
-                                message.info(
-                                    "Ask an organization owner to remove you from Members.",
-                                ),
-                        },
-                        {
-                            key: "delete",
-                            label: "Delete organization",
-                            icon: <Trash size={16} />,
-                            danger: true,
-                            hidden: (record: OrgRow) => record.owner_id !== user?.id,
-                            onClick: (record: OrgRow) => {
-                                setActiveOrg(record)
-                                setDeleteConfirmInput("")
-                                setDeleteModalOpen(true)
-                            },
-                        },
-                    ],
-                } satisfies StandardColumnDef<OrgRow>,
-            ]),
-        [changeSelectedOrg, message, renameForm, selectedOrg?.id, user?.id],
-    )
-
-    const {tableScope, pagination} = useStaticTable<OrgRow>("settings-organizations", rows, {
-        loading,
-    })
     return (
-        <div className="flex flex-col gap-2">
-            <InfiniteVirtualTableFeatureShell<OrgRow>
-                tableScope={tableScope}
-                autoHeight={false}
-                columns={columns}
-                rowKey="key"
-                filters={
-                    <Input.Search
-                        placeholder="Search organizations"
-                        className="w-[260px]"
-                        allowClear
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                        disabled={loading}
-                    />
-                }
-                primaryActions={
-                    <Button
-                        type="primary"
-                        icon={<Plus size={14} />}
-                        onClick={() => setCreateModalOpen(true)}
-                        disabled={loading}
-                    >
-                        New organization
-                    </Button>
-                }
-                pagination={pagination}
-                tableProps={{
-                    size: "small",
-                    bordered: true,
-                    tableLayout: "fixed",
-                    locale: {
-                        emptyText: searchTerm.trim() ? (
-                            <EmptyState
-                                image="simple"
-                                description={`No organizations match “${searchTerm.trim()}”`}
-                            />
-                        ) : (
-                            <EmptyState
-                                image="simple"
-                                description={
-                                    <div className="flex flex-col gap-1">
-                                        <span className="text-xs font-medium text-colorText">
-                                            No organizations yet
-                                        </span>
-                                        <span>
-                                            Create an organization to group your workspaces,
-                                            members, and billing.
-                                        </span>
-                                    </div>
-                                }
-                            >
-                                <Button
-                                    icon={<Plus size={14} />}
-                                    onClick={() => setCreateModalOpen(true)}
-                                >
-                                    New organization
-                                </Button>
-                            </EmptyState>
-                        ),
-                    },
-                }}
-            />
-
+        <OrganizationsPage
+            organizations={orgs ?? []}
+            loading={loading}
+            searchTerm={searchTerm}
+            onSearchChange={setSearchTerm}
+            selectedOrgId={selectedOrg?.id}
+            currentUserId={user?.id}
+            onSwitch={(org) => changeSelectedOrg(org.id)}
+            onCreate={() => setCreateModalOpen(true)}
+            onRename={(org) => {
+                setActiveOrg(org)
+                renameForm.setFieldsValue({name: org.name ?? ""})
+                setRenameModalOpen(true)
+            }}
+            onTransferOwnership={(org) => {
+                setActiveOrg(org)
+                setNewOwnerId(null)
+                setTransferModalOpen(true)
+            }}
+            onLeave={() => message.info("Ask an organization owner to remove you from Members.")}
+            onDelete={(org) => {
+                setActiveOrg(org)
+                setDeleteConfirmInput("")
+                setDeleteModalOpen(true)
+            }}
+        >
             <EnhancedModal
                 title="New organization"
                 open={isCreateModalOpen}
@@ -546,7 +399,7 @@ const OrganizationGeneral = () => {
                     </div>
                 </div>
             </EnhancedModal>
-        </div>
+        </OrganizationsPage>
     )
 }
 

--- a/web/oss/src/components/pages/settings/Organization/index.tsx
+++ b/web/oss/src/components/pages/settings/Organization/index.tsx
@@ -15,7 +15,7 @@ import {
     deleteOrganizationProvider,
     type OrganizationProvider,
 } from "@agenta/entities/organization"
-import {AccessControlsSection, type AuthFlagKey} from "@agenta/settings-ui"
+import {AccessControlsSection, DomainsSection, type AuthFlagKey} from "@agenta/settings-ui"
 import {CopyTooltip as TooltipWithCopyAction} from "@agenta/ui/copy-tooltip"
 import {
     PlusOutlined,
@@ -24,7 +24,6 @@ import {
     DeleteOutlined,
     EditOutlined,
     InfoCircleOutlined,
-    ReloadOutlined,
 } from "@ant-design/icons"
 import {useQueryClient, useQuery, useMutation} from "@tanstack/react-query"
 import {
@@ -105,7 +104,11 @@ const Organization: FC = () => {
     )
 
     // Domain Verification queries and mutations
-    const {data: domains = [], refetch: refetchDomains} = useQuery({
+    const {
+        data: domains = [],
+        refetch: refetchDomains,
+        isPending: domainsLoading,
+    } = useQuery({
         queryKey: ["organization-domains", selectedOrg?.id],
         queryFn: fetchOrganizationDomains,
         enabled: !!selectedOrg?.id,
@@ -177,96 +180,65 @@ const Organization: FC = () => {
         })
     }, [domainForm, createDomainMutation])
 
-    const domainColumns = [
-        {
-            title: "Domain",
-            dataIndex: "slug",
-            key: "slug",
-            ellipsis: true,
-        },
-        {
-            title: "Expiration",
-            key: "expires_at",
-            render: (_: any, record: OrganizationDomain) => {
-                if (record.flags?.is_verified) {
-                    return <Text type="secondary">-</Text>
+    /** The DNS record to publish, and what to do after. Slotted under each pending domain. */
+    const renderDomainInstructions = useCallback((record: OrganizationDomain) => {
+        const txtRecordName = `_agenta-verification.${record.slug}`
+        const txtRecordValue = `_agenta-verification=${record.token}`
+        const mono = {fontFamily: "monospace", fontSize: "12px"} as const
+
+        return (
+            <Alert
+                type="info"
+                showIcon
+                icon={<InfoCircleOutlined />}
+                message={
+                    <span style={{fontSize: "15px", fontWeight: 500}}>
+                        Verification Instructions
+                    </span>
                 }
-                // Calculate expiration: created_at + 48 hours
-                const createdAt = new Date(record.created_at)
-                const expiresAt = new Date(createdAt.getTime() + 48 * 60 * 60 * 1000)
-                const now = new Date()
-                const isExpired = now > expiresAt
-
-                return (
-                    <Text type={isExpired ? "danger" : "secondary"}>
-                        {expiresAt.toLocaleString()}
-                        {isExpired && " (Expired)"}
-                    </Text>
-                )
-            },
-        },
-        {
-            title: "Status",
-            dataIndex: ["flags", "is_verified"],
-            key: "is_verified",
-            render: (_: any, record: OrganizationDomain) => {
-                const isVerified = record.flags?.is_verified || false
-                return isVerified ? (
-                    <Tag icon={<CheckCircleOutlined />} color="success">
-                        Verified
-                    </Tag>
-                ) : (
-                    <Tag icon={<ClockCircleOutlined />} color="warning">
-                        Pending
-                    </Tag>
-                )
-            },
-        },
-        {
-            title: "Actions",
-            key: "actions",
-            render: (_: any, record: OrganizationDomain) => (
-                <div className="flex items-center gap-2">
-                    {!record.flags?.is_verified && (
-                        <Button
-                            type="primary"
-                            size="small"
-                            onClick={() => verifyDomainMutation.mutate(record.id)}
-                            loading={verifyDomainMutation.isPending}
-                        >
-                            Verify
-                        </Button>
-                    )}
-                    <Button
-                        icon={<ReloadOutlined />}
-                        size="small"
-                        onClick={() => refreshDomainTokenMutation.mutate(record.id)}
-                        loading={refreshDomainTokenMutation.isPending}
-                        title="Refresh token"
-                    />
-                    <Popconfirm
-                        title="Delete domain"
-                        description="Are you sure you want to delete this domain?"
-                        onConfirm={() => deleteDomainMutation.mutate(record.id)}
-                        okText="Delete"
-                        okType="danger"
-                        cancelText="Cancel"
-                    >
-                        <Button
-                            danger
-                            size="small"
-                            icon={<DeleteOutlined />}
-                            loading={deleteDomainMutation.isPending}
-                        />
-                    </Popconfirm>
-                </div>
-            ),
-        },
-    ]
-
-    const pendingDomainRowKeys = domains
-        .filter((domain) => !domain.flags?.is_verified && !!domain.token)
-        .map((domain) => domain.id)
+                description={
+                    <div className="flex w-full flex-col gap-4">
+                        <Text style={{fontSize: "14px"}}>1. Add the following DNS TXT record:</Text>
+                        <Descriptions bordered size="small" column={1} className="org-instructions">
+                            <Descriptions.Item label={<span style={mono}>Type</span>}>
+                                <span style={mono}>TXT</span>
+                            </Descriptions.Item>
+                            <Descriptions.Item label={<span style={mono}>Host</span>}>
+                                <div>
+                                    <TooltipWithCopyAction
+                                        copyText={txtRecordName}
+                                        title="Copy host"
+                                    >
+                                        <span style={mono}>{txtRecordName}</span>
+                                    </TooltipWithCopyAction>
+                                    <div style={{marginTop: 4}}>
+                                        <Text type="secondary" style={{fontSize: "11px"}}>
+                                            Some DNS providers (e.g. Namecheap, GoDaddy, Cloudflare)
+                                            automatically append your domain. If so, enter only:{" "}
+                                            <Text code style={{fontSize: "11px"}}>
+                                                _agenta-verification
+                                            </Text>
+                                        </Text>
+                                    </div>
+                                </div>
+                            </Descriptions.Item>
+                            <Descriptions.Item label={<span style={mono}>Value</span>}>
+                                <TooltipWithCopyAction copyText={txtRecordValue} title="Copy value">
+                                    <span style={mono}>{txtRecordValue}</span>
+                                </TooltipWithCopyAction>
+                            </Descriptions.Item>
+                        </Descriptions>
+                        <Text style={{fontSize: "14px"}}>
+                            2. Wait a few minutes for DNS propagation.
+                        </Text>
+                        <Text style={{fontSize: "14px"}}>
+                            3. Click the &quot;Verify&quot; button.
+                        </Text>
+                    </div>
+                }
+            />
+        )
+    }, [])
 
     // SSO Provider queries and mutations
     const {data: providers = [], refetch: refetchProviders} = useQuery({
@@ -585,185 +557,24 @@ const Organization: FC = () => {
 
             {hasDomains ? (
                 <section>
-                    <div className="flex w-full flex-col gap-3">
-                        <div
-                            style={{
-                                display: "flex",
-                                justifyContent: "space-between",
-                                alignItems: "flex-start",
-                            }}
-                        >
-                            <div>
-                                <Title level={5} className="!mb-1">
-                                    Verified Domains
-                                </Title>
-                                <Text type="secondary">
-                                    Domains that belong to your organization
-                                </Text>
-                            </div>
-                            <Button
-                                type="primary"
-                                icon={<PlusOutlined />}
-                                onClick={() => setDomainModalVisible(true)}
-                            >
-                                Add Domain
-                            </Button>
-                        </div>
-
-                        <Table
-                            columns={domainColumns}
-                            dataSource={domains}
-                            rowKey="id"
-                            pagination={false}
-                            size="small"
-                            tableLayout="fixed"
-                            className="no-expand-indent no-expand-col org-domains-table"
-                            expandable={{
-                                expandedRowKeys: pendingDomainRowKeys,
-                                expandedRowRender: (record: OrganizationDomain) => {
-                                    // Only show DNS instructions for unverified domains with a token
-                                    if (record.flags?.is_verified || !record.token) {
-                                        return null
-                                    }
-
-                                    const txtRecordName = `_agenta-verification.${record.slug}`
-                                    const txtRecordValue = `_agenta-verification=${record.token}`
-
-                                    return (
-                                        <Alert
-                                            message={
-                                                <span style={{fontSize: "15px", fontWeight: 500}}>
-                                                    Verification Instructions
-                                                </span>
-                                            }
-                                            description={
-                                                <div className="flex w-full flex-col gap-4">
-                                                    <Text style={{fontSize: "14px"}}>
-                                                        1. Add the following DNS TXT record:
-                                                    </Text>
-                                                    <Descriptions
-                                                        bordered
-                                                        size="small"
-                                                        column={1}
-                                                        className="org-instructions"
-                                                    >
-                                                        <Descriptions.Item
-                                                            label={
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    Type
-                                                                </span>
-                                                            }
-                                                        >
-                                                            <span
-                                                                style={{
-                                                                    fontFamily: "monospace",
-                                                                    fontSize: "12px",
-                                                                }}
-                                                            >
-                                                                TXT
-                                                            </span>
-                                                        </Descriptions.Item>
-                                                        <Descriptions.Item
-                                                            label={
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    Host
-                                                                </span>
-                                                            }
-                                                        >
-                                                            <div>
-                                                                <TooltipWithCopyAction
-                                                                    copyText={txtRecordName}
-                                                                    title="Copy host"
-                                                                >
-                                                                    <span
-                                                                        style={{
-                                                                            fontFamily: "monospace",
-                                                                            fontSize: "12px",
-                                                                        }}
-                                                                    >
-                                                                        {txtRecordName}
-                                                                    </span>
-                                                                </TooltipWithCopyAction>
-                                                                <div style={{marginTop: 4}}>
-                                                                    <Text
-                                                                        type="secondary"
-                                                                        style={{fontSize: "11px"}}
-                                                                    >
-                                                                        Some DNS providers (e.g.
-                                                                        Namecheap, GoDaddy,
-                                                                        Cloudflare) automatically
-                                                                        append your domain. If so,
-                                                                        enter only:{" "}
-                                                                        <Text
-                                                                            code
-                                                                            style={{
-                                                                                fontSize: "11px",
-                                                                            }}
-                                                                        >
-                                                                            _agenta-verification
-                                                                        </Text>
-                                                                    </Text>
-                                                                </div>
-                                                            </div>
-                                                        </Descriptions.Item>
-                                                        <Descriptions.Item
-                                                            label={
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    Value
-                                                                </span>
-                                                            }
-                                                        >
-                                                            <TooltipWithCopyAction
-                                                                copyText={txtRecordValue}
-                                                                title="Copy value"
-                                                            >
-                                                                <span
-                                                                    className="break-all"
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    {txtRecordValue}
-                                                                </span>
-                                                            </TooltipWithCopyAction>
-                                                        </Descriptions.Item>
-                                                    </Descriptions>
-                                                    <Text style={{fontSize: "14px"}}>
-                                                        2. Wait a few minutes for DNS propagation.
-                                                    </Text>
-                                                    <Text style={{fontSize: "14px"}}>
-                                                        3. Click the "Verify" button.
-                                                    </Text>
-                                                </div>
-                                            }
-                                            type="info"
-                                            icon={<InfoCircleOutlined />}
-                                            showIcon
-                                        />
-                                    )
-                                },
-                                rowExpandable: (record: OrganizationDomain) =>
-                                    !record.flags?.is_verified && !!record.token,
-                                expandIcon: () => null,
-                            }}
-                        />
-                    </div>
+                    <DomainsSection
+                        domains={domains ?? []}
+                        loading={domainsLoading}
+                        onAdd={() => setDomainModalVisible(true)}
+                        onVerify={(domain: OrganizationDomain) =>
+                            verifyDomainMutation.mutate(domain.id)
+                        }
+                        onRefreshToken={(domain: OrganizationDomain) =>
+                            refreshDomainTokenMutation.mutate(domain.id)
+                        }
+                        onDelete={(domain: OrganizationDomain) =>
+                            deleteDomainMutation.mutate(domain.id)
+                        }
+                        verifying={verifyDomainMutation.isPending}
+                        refreshing={refreshDomainTokenMutation.isPending}
+                        deleting={deleteDomainMutation.isPending}
+                        renderInstructions={renderDomainInstructions}
+                    />
 
                     <Modal
                         title="Add Domain"

--- a/web/oss/src/components/pages/settings/Organization/index.tsx
+++ b/web/oss/src/components/pages/settings/Organization/index.tsx
@@ -15,6 +15,7 @@ import {
     deleteOrganizationProvider,
     type OrganizationProvider,
 } from "@agenta/entities/organization"
+import {AccessControlsSection, type AuthFlagKey} from "@agenta/settings-ui"
 import {CopyTooltip as TooltipWithCopyAction} from "@agenta/ui/copy-tooltip"
 import {
     PlusOutlined,
@@ -25,14 +26,12 @@ import {
     InfoCircleOutlined,
     ReloadOutlined,
 } from "@ant-design/icons"
-import {Info, Lock} from "@phosphor-icons/react"
 import {useQueryClient, useQuery, useMutation} from "@tanstack/react-query"
 import {
     Descriptions,
     Input,
     Modal,
     Skeleton,
-    Switch,
     Typography,
     message,
     Table,
@@ -41,7 +40,6 @@ import {
     Tag,
     Popconfirm,
     Alert,
-    Tooltip,
 } from "antd"
 
 import {getAgentaWebUrl} from "@/oss/lib/helpers/api"
@@ -51,75 +49,6 @@ import {useOrgData} from "@/oss/state/org"
 import {UpgradePrompt} from "./UpgradePrompt"
 
 const {Title, Text} = Typography
-
-interface SettingRowProps {
-    title: string
-    description: string
-    enabled: boolean
-    onChange: (checked: boolean) => void
-    disabled?: boolean
-    disabledReason?: string
-    tooltip?: string
-    loading?: boolean
-    showSuccess?: boolean
-}
-
-const SettingRow: FC<SettingRowProps> = ({
-    title,
-    description,
-    enabled,
-    onChange,
-    disabled,
-    disabledReason,
-    tooltip,
-    loading,
-    showSuccess,
-}) => (
-    <div
-        className={`flex items-start justify-between py-4 border-0 border-b border-solid border-[var(--ant-color-border-secondary)] last:border-0 ${disabled ? "opacity-60" : ""}`}
-    >
-        <div className="pr-8 flex-1">
-            <div className="flex items-center gap-2">
-                <Typography.Text strong>{title}</Typography.Text>
-                {tooltip && (
-                    <Tooltip title={tooltip}>
-                        <Info
-                            size={16}
-                            className="text-[var(--ant-color-text-tertiary)] cursor-help"
-                        />
-                    </Tooltip>
-                )}
-                {showSuccess && (
-                    <span className="inline-flex items-center gap-1 text-xs text-green-600">
-                        <CheckCircleOutlined />
-                        Saved
-                    </span>
-                )}
-            </div>
-            <Typography.Paragraph type="secondary" className="!mb-0 !mt-0.5">
-                {description}
-            </Typography.Paragraph>
-            {disabled && disabledReason && (
-                <p className="text-xs text-amber-600 mt-1 mb-0 flex items-center gap-1">
-                    <Lock size={14} />
-                    {disabledReason}
-                </p>
-            )}
-        </div>
-        <Switch
-            checked={enabled}
-            onChange={onChange}
-            disabled={disabled || loading}
-            loading={loading}
-        />
-    </div>
-)
-
-const SectionLabel: FC<{children: React.ReactNode}> = ({children}) => (
-    <div className="pt-4 pb-2 text-xs font-medium uppercase tracking-wider text-colorTextTertiary">
-        {children}
-    </div>
-)
 
 const Organization: FC = () => {
     const {selectedOrg, loading, refetch} = useOrgData()
@@ -460,14 +389,6 @@ const Organization: FC = () => {
         () => providers.some((provider) => provider.flags?.is_active && provider.flags?.is_valid),
         [providers],
     )
-    const allAuthMethodsDisabled = useMemo(
-        () =>
-            !selectedOrg?.flags?.allow_email &&
-            !selectedOrg?.flags?.allow_social &&
-            !selectedOrg?.flags?.allow_sso,
-        [selectedOrg?.flags],
-    )
-
     const handleFlagChange = useCallback(
         (flag: string, value: boolean) => {
             if (!selectedOrg?.id) return
@@ -647,84 +568,14 @@ const Organization: FC = () => {
     return (
         <div className="flex w-full flex-col gap-8">
             {hasAccessControl ? (
-                <section>
-                    <div className="px-1">
-                        <div className="border-0 border-b border-solid border-[var(--ant-color-border-secondary)] pb-4">
-                            <Title level={5} className="!mb-1">
-                                Access Controls
-                            </Title>
-                            <Text type="secondary">
-                                Configure how users authenticate and join your organization
-                            </Text>
-                        </div>
-
-                        {/* Sign-in methods */}
-                        <SectionLabel>Sign-in methods</SectionLabel>
-                        <SettingRow
-                            title="Email & password"
-                            description="Members can sign in with their email and a password"
-                            enabled={selectedOrg.flags.allow_email}
-                            onChange={(checked) => handleFlagChange("allow_email", checked)}
-                            loading={updating}
-                            showSuccess={lastSavedFlag === "allow_email"}
-                        />
-                        <SettingRow
-                            title="Social login"
-                            description="Allow sign-in with Google, GitHub, or other OAuth providers"
-                            enabled={selectedOrg.flags.allow_social}
-                            onChange={(checked) => handleFlagChange("allow_social", checked)}
-                            loading={updating}
-                            showSuccess={lastSavedFlag === "allow_social"}
-                        />
-                        <SettingRow
-                            title="SSO authentication"
-                            description="Enable single sign-on through your identity provider"
-                            enabled={selectedOrg.flags.allow_sso}
-                            onChange={(checked) => handleFlagChange("allow_sso", checked)}
-                            disabled={!hasActiveVerifiedProvider}
-                            disabledReason="Add an SSO provider below to enable"
-                            tooltip="OIDC supported. Configure your IdP in the SSO Providers section below."
-                            loading={updating}
-                            showSuccess={lastSavedFlag === "allow_sso"}
-                        />
-
-                        {/* Membership */}
-                        <SectionLabel>Membership</SectionLabel>
-                        <SettingRow
-                            title="Auto-join from verified domains"
-                            description="Users with a verified domain email are automatically added to this organization"
-                            enabled={selectedOrg.flags.auto_join}
-                            onChange={(checked) => handleFlagChange("auto_join", checked)}
-                            disabled={!hasVerifiedDomain}
-                            disabledReason="Verify at least one domain first"
-                            loading={updating}
-                            showSuccess={lastSavedFlag === "auto_join"}
-                        />
-                        <SettingRow
-                            title="Restrict invites to verified domains"
-                            description="Only allow inviting users whose email matches a verified domain"
-                            enabled={selectedOrg.flags.domains_only}
-                            onChange={(checked) => handleFlagChange("domains_only", checked)}
-                            disabled={!hasVerifiedDomain}
-                            disabledReason="Verify at least one domain first"
-                            loading={updating}
-                            showSuccess={lastSavedFlag === "domains_only"}
-                        />
-                        {/* Admin */}
-                        <SectionLabel>Admin</SectionLabel>
-                        <SettingRow
-                            title="Owners bypass restrictions"
-                            description="Owners can sign in and invite members regardless of the restrictions above"
-                            enabled={selectedOrg.flags.allow_root}
-                            onChange={(checked) => handleFlagChange("allow_root", checked)}
-                            disabled={allAuthMethodsDisabled && selectedOrg.flags.allow_root}
-                            disabledReason="Enable at least one sign-in method first"
-                            tooltip="Prevents account lockout. Keep enabled if all sign-in methods are disabled."
-                            loading={updating}
-                            showSuccess={lastSavedFlag === "allow_root"}
-                        />
-                    </div>
-                </section>
+                <AccessControlsSection
+                    flags={selectedOrg.flags}
+                    onFlagChange={handleFlagChange}
+                    updating={updating}
+                    lastSavedFlag={lastSavedFlag as AuthFlagKey | null}
+                    hasActiveVerifiedProvider={hasActiveVerifiedProvider}
+                    hasVerifiedDomain={hasVerifiedDomain}
+                />
             ) : (
                 <UpgradePrompt
                     title="Access Controls"

--- a/web/oss/src/components/pages/settings/Organization/index.tsx
+++ b/web/oss/src/components/pages/settings/Organization/index.tsx
@@ -15,31 +15,16 @@ import {
     deleteOrganizationProvider,
     type OrganizationProvider,
 } from "@agenta/entities/organization"
-import {AccessControlsSection, DomainsSection, type AuthFlagKey} from "@agenta/settings-ui"
+import {
+    AccessControlsSection,
+    DomainsSection,
+    SsoProvidersSection,
+    type AuthFlagKey,
+} from "@agenta/settings-ui"
 import {CopyTooltip as TooltipWithCopyAction} from "@agenta/ui/copy-tooltip"
-import {
-    PlusOutlined,
-    CheckCircleOutlined,
-    ClockCircleOutlined,
-    DeleteOutlined,
-    EditOutlined,
-    InfoCircleOutlined,
-} from "@ant-design/icons"
+import {InfoCircleOutlined} from "@ant-design/icons"
 import {useQueryClient, useQuery, useMutation} from "@tanstack/react-query"
-import {
-    Descriptions,
-    Input,
-    Modal,
-    Skeleton,
-    Typography,
-    message,
-    Table,
-    Button,
-    Form,
-    Tag,
-    Popconfirm,
-    Alert,
-} from "antd"
+import {Descriptions, Input, Modal, Skeleton, Typography, message, Form, Alert} from "antd"
 
 import {getAgentaWebUrl} from "@/oss/lib/helpers/api"
 import {useEntitlements} from "@/oss/lib/helpers/useEntitlements"
@@ -47,7 +32,7 @@ import {useOrgData} from "@/oss/state/org"
 
 import {UpgradePrompt} from "./UpgradePrompt"
 
-const {Title, Text} = Typography
+const {Text} = Typography
 
 const Organization: FC = () => {
     const {selectedOrg, loading, refetch} = useOrgData()
@@ -180,6 +165,75 @@ const Organization: FC = () => {
         })
     }, [domainForm, createDomainMutation])
 
+    const callbackUrlForProvider = useCallback(
+        (provider: OrganizationProvider) =>
+            selectedOrg?.slug
+                ? `${getAgentaWebUrl()}/auth/callback/sso:${selectedOrg.slug}:${provider.slug}`
+                : null,
+        [selectedOrg?.slug],
+    )
+
+    /** What to put in the IdP. Slotted under each provider that is not yet valid. */
+    const renderProviderInstructions = useCallback(
+        (record: OrganizationProvider) => {
+            const callbackUrl = callbackUrlForProvider(record)
+            if (!callbackUrl) return null
+            const expectedScopes = "openid email profile"
+            const mono = {fontFamily: "monospace", fontSize: "12px"} as const
+
+            return (
+                <Alert
+                    type="info"
+                    showIcon
+                    icon={<InfoCircleOutlined />}
+                    message={
+                        <span style={{fontSize: "15px", fontWeight: 500}}>
+                            Configuration Instructions
+                        </span>
+                    }
+                    description={
+                        <div className="flex w-full flex-col gap-4">
+                            <Text style={{fontSize: "14px"}}>
+                                1. Edit your IdP with the following details:
+                            </Text>
+                            <Descriptions
+                                bordered
+                                size="small"
+                                column={1}
+                                className="org-instructions"
+                            >
+                                <Descriptions.Item label={<span style={mono}>Callback URL</span>}>
+                                    <TooltipWithCopyAction
+                                        copyText={callbackUrl}
+                                        title="Copy callback URL"
+                                    >
+                                        <span style={mono}>{callbackUrl}</span>
+                                    </TooltipWithCopyAction>
+                                </Descriptions.Item>
+                                <Descriptions.Item label={<span style={mono}>Scopes</span>}>
+                                    <TooltipWithCopyAction
+                                        copyText={expectedScopes}
+                                        title="Copy scopes"
+                                    >
+                                        <span style={mono}>{expectedScopes}</span>
+                                    </TooltipWithCopyAction>
+                                </Descriptions.Item>
+                            </Descriptions>
+                            <Text style={{fontSize: "14px"}}>
+                                2. Ensure your SSO provider&apos;s OIDC discovery endpoint is
+                                accessible.
+                            </Text>
+                            <Text style={{fontSize: "14px"}}>
+                                3. Click the &quot;Enable&quot; button.
+                            </Text>
+                        </div>
+                    }
+                />
+            )
+        },
+        [callbackUrlForProvider],
+    )
+
     /** The DNS record to publish, and what to do after. Slotted under each pending domain. */
     const renderDomainInstructions = useCallback((record: OrganizationDomain) => {
         const txtRecordName = `_agenta-verification.${record.slug}`
@@ -241,7 +295,11 @@ const Organization: FC = () => {
     }, [])
 
     // SSO Provider queries and mutations
-    const {data: providers = [], refetch: refetchProviders} = useQuery({
+    const {
+        data: providers = [],
+        refetch: refetchProviders,
+        isPending: providersLoading,
+    } = useQuery({
         queryKey: ["organization-providers", selectedOrg?.id],
         queryFn: fetchOrganizationProviders,
         enabled: !!selectedOrg?.id,
@@ -354,9 +412,6 @@ const Organization: FC = () => {
         [providerForm],
     )
 
-    const pendingProviderRowKeys = providers
-        .filter((provider) => provider.flags?.is_valid === false)
-        .map((provider) => provider.id)
     const hasActiveVerifiedProvider = useMemo(
         () => providers.some((provider) => provider.flags?.is_active && provider.flags?.is_valid),
         [providers],
@@ -428,97 +483,6 @@ const Organization: FC = () => {
         },
         [handleUpdateOrganization, hasActiveVerifiedProvider, hasVerifiedDomain, selectedOrg],
     )
-
-    const providerColumns = [
-        {
-            title: "Provider",
-            dataIndex: "slug",
-            key: "slug",
-            ellipsis: true,
-        },
-        {
-            title: "Callback URL",
-            key: "callback_url",
-            render: (_: any, record: OrganizationProvider) => {
-                if (!selectedOrg?.slug) {
-                    return <Text type="secondary">Set org slug</Text>
-                }
-                const callbackUrl = `${getAgentaWebUrl()}/auth/callback/sso:${selectedOrg.slug}:${record.slug}`
-                return (
-                    <Text ellipsis style={{maxWidth: 300}}>
-                        {callbackUrl}
-                    </Text>
-                )
-            },
-        },
-        {
-            title: "Status",
-            key: "status",
-            render: (_: any, record: OrganizationProvider) => {
-                const isEnabled = record.flags?.is_enabled !== false
-                const isValid = record.flags?.is_valid !== false
-
-                if (!isEnabled) {
-                    return <Tag color="default">Disabled</Tag>
-                }
-                if (isValid) {
-                    return (
-                        <Tag icon={<CheckCircleOutlined />} color="success">
-                            Active
-                        </Tag>
-                    )
-                }
-                return (
-                    <Tag icon={<ClockCircleOutlined />} color="warning">
-                        Pending
-                    </Tag>
-                )
-            },
-        },
-        {
-            title: "Actions",
-            key: "actions",
-            render: (_: any, record: OrganizationProvider) => {
-                const isEnabled = record.flags?.is_enabled !== false
-                const isValid = record.flags?.is_valid !== false
-                return (
-                    <div className="flex items-center gap-2">
-                        {(!isEnabled || !isValid) && (
-                            <Button
-                                type="primary"
-                                size="small"
-                                onClick={() => testProviderMutation.mutate(record.id)}
-                                loading={testProviderMutation.isPending}
-                            >
-                                Enable
-                            </Button>
-                        )}
-                        <Button
-                            size="small"
-                            icon={<EditOutlined />}
-                            aria-label="Edit provider"
-                            onClick={() => handleEditProvider(record)}
-                        ></Button>
-                        <Popconfirm
-                            title="Delete SSO provider"
-                            description="Are you sure you want to delete this SSO provider?"
-                            onConfirm={() => deleteProviderMutation.mutate(record.id)}
-                            okText="Delete"
-                            okType="danger"
-                            cancelText="Cancel"
-                        >
-                            <Button
-                                danger
-                                size="small"
-                                icon={<DeleteOutlined />}
-                                loading={deleteProviderMutation.isPending}
-                            />
-                        </Popconfirm>
-                    </div>
-                )
-            },
-        },
-    ]
 
     if (loading || entitlementsLoading) {
         return (
@@ -619,37 +583,30 @@ const Organization: FC = () => {
 
             {hasSSO ? (
                 <section>
-                    <div className="flex w-full flex-col gap-3">
-                        <div
-                            style={{
-                                display: "flex",
-                                justifyContent: "space-between",
-                                alignItems: "flex-start",
-                            }}
-                        >
-                            <div>
-                                <Title level={5} className="!mb-1">
-                                    SSO Providers
-                                </Title>
-                                <Text type="secondary">
-                                    Configure identity providers for single sign-on
-                                </Text>
-                            </div>
-                            <Button
-                                type="primary"
-                                icon={<PlusOutlined />}
-                                onClick={() => {
-                                    if (!selectedOrg?.slug) {
-                                        setSlugValue("")
-                                        setSlugModalVisible(true)
-                                        return
-                                    }
-                                    setProviderModalVisible(true)
-                                }}
-                            >
-                                {selectedOrg?.slug ? "Add Provider" : "Set Slug"}
-                            </Button>
-                        </div>
+                    <SsoProvidersSection
+                        providers={providers ?? []}
+                        loading={providersLoading}
+                        callbackUrlFor={callbackUrlForProvider}
+                        addLabel={selectedOrg?.slug ? "Add Provider" : "Set Slug"}
+                        onAdd={() => {
+                            if (!selectedOrg?.slug) {
+                                setSlugValue("")
+                                setSlugModalVisible(true)
+                                return
+                            }
+                            setProviderModalVisible(true)
+                        }}
+                        onEdit={handleEditProvider}
+                        onEnable={(provider: OrganizationProvider) =>
+                            testProviderMutation.mutate(provider.id)
+                        }
+                        onDelete={(provider: OrganizationProvider) =>
+                            deleteProviderMutation.mutate(provider.id)
+                        }
+                        enabling={testProviderMutation.isPending}
+                        deleting={deleteProviderMutation.isPending}
+                        renderInstructions={renderProviderInstructions}
+                    >
                         <Descriptions
                             size="small"
                             column={1}
@@ -692,122 +649,7 @@ const Organization: FC = () => {
                                 showIcon
                             />
                         )}
-
-                        <Table
-                            columns={providerColumns}
-                            dataSource={providers}
-                            rowKey="id"
-                            pagination={false}
-                            size="small"
-                            tableLayout="fixed"
-                            className="no-expand-indent no-expand-col org-providers-table"
-                            expandable={{
-                                expandedRowKeys: pendingProviderRowKeys,
-                                expandedRowRender: (record: OrganizationProvider) => {
-                                    // Only show configuration instructions for providers that are not valid
-                                    if (record.flags?.is_valid !== false) {
-                                        return null
-                                    }
-
-                                    if (!selectedOrg?.slug) {
-                                        return null
-                                    }
-
-                                    const callbackUrl = `${getAgentaWebUrl()}/auth/callback/sso:${selectedOrg.slug}:${record.slug}`
-                                    const expectedScopes = "openid email profile"
-
-                                    return (
-                                        <Alert
-                                            message={
-                                                <span style={{fontSize: "15px", fontWeight: 500}}>
-                                                    Configuration Instructions
-                                                </span>
-                                            }
-                                            description={
-                                                <div className="flex w-full flex-col gap-4">
-                                                    <Text style={{fontSize: "14px"}}>
-                                                        1. Edit your IdP with the following details:
-                                                    </Text>
-                                                    <Descriptions
-                                                        bordered
-                                                        size="small"
-                                                        column={1}
-                                                        className="org-instructions"
-                                                    >
-                                                        <Descriptions.Item
-                                                            label={
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    Callback URL
-                                                                </span>
-                                                            }
-                                                        >
-                                                            <TooltipWithCopyAction
-                                                                copyText={callbackUrl}
-                                                                title="Copy callback URL"
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    {callbackUrl}
-                                                                </span>
-                                                            </TooltipWithCopyAction>
-                                                        </Descriptions.Item>
-                                                        <Descriptions.Item
-                                                            label={
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    Scopes
-                                                                </span>
-                                                            }
-                                                        >
-                                                            <TooltipWithCopyAction
-                                                                copyText={expectedScopes}
-                                                                title="Copy scopes"
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        fontFamily: "monospace",
-                                                                        fontSize: "12px",
-                                                                    }}
-                                                                >
-                                                                    {expectedScopes}
-                                                                </span>
-                                                            </TooltipWithCopyAction>
-                                                        </Descriptions.Item>
-                                                    </Descriptions>
-                                                    <Text style={{fontSize: "14px"}}>
-                                                        2. Ensure your SSO provider's OIDC discovery
-                                                        endpoint is accessible.
-                                                    </Text>
-                                                    <Text style={{fontSize: "14px"}}>
-                                                        3. Click the "Enable" button.
-                                                    </Text>
-                                                </div>
-                                            }
-                                            type="info"
-                                            icon={<InfoCircleOutlined />}
-                                            showIcon
-                                        />
-                                    )
-                                },
-                                rowExpandable: (record: OrganizationProvider) =>
-                                    record.flags?.is_valid === false,
-                                expandIcon: () => null,
-                            }}
-                        />
-                    </div>
+                    </SsoProvidersSection>
 
                     <Modal
                         title={editingProvider ? "Edit SSO Provider" : "Add SSO Provider"}

--- a/web/oss/src/components/pages/settings/WorkspaceManage/WorkspaceManage.tsx
+++ b/web/oss/src/components/pages/settings/WorkspaceManage/WorkspaceManage.tsx
@@ -26,7 +26,7 @@ const InviteUsersModal = dynamic(() => import("./Modals/InviteUsersModal"), {ssr
 const WorkspaceManage: FC = () => {
     const {user: signedInUser, refetch: refetchProfile} = useProfileData()
     const {selectedOrg, loading, refetch} = useOrgData()
-    const {filteredMembers, searchTerm, setSearchTerm} = useWorkspaceMembers()
+    const {members, searchTerm, setSearchTerm} = useWorkspaceMembers()
     const {hasRBAC} = useEntitlements()
     const {canInviteMembers, canRemoveMembers} = useWorkspacePermissions()
     const [isInviteModalOpen, setIsInviteModalOpen] = useState(false)
@@ -104,7 +104,7 @@ const WorkspaceManage: FC = () => {
 
     return (
         <MembersPage
-            members={filteredMembers}
+            members={members}
             loading={loading}
             searchTerm={searchTerm}
             onSearchChange={setSearchTerm}

--- a/web/oss/src/components/pages/settings/WorkspaceManage/WorkspaceManage.tsx
+++ b/web/oss/src/components/pages/settings/WorkspaceManage/WorkspaceManage.tsx
@@ -1,20 +1,10 @@
-import {useCallback, useMemo, useState, type FC} from "react"
+import {useCallback, useState, type FC} from "react"
 
 import type {WorkspaceMember} from "@agenta/entities/organization"
 import {removeFromWorkspace, resendInviteToWorkspace} from "@agenta/entities/organization"
-import {useStaticTable} from "@agenta/settings"
-import {formatDay} from "@agenta/shared/utils/dateTime"
+import {MembersPage} from "@agenta/settings-ui"
 import {message} from "@agenta/ui/app-message"
-import {
-    createStandardColumns,
-    InfiniteVirtualTableFeatureShell,
-    type EntityChip,
-    type StandardColumnDef,
-} from "@agenta/ui/table"
-import {EmptyState} from "@agenta/ui/ui"
-import {EditOutlined} from "@ant-design/icons"
-import {ArrowClockwise, Plus, Trash} from "@phosphor-icons/react"
-import {Button, Input, Modal} from "antd"
+import {Input, Modal} from "antd"
 import dynamic from "next/dynamic"
 
 import AlertPopup from "@/oss/components/AlertPopup/AlertPopup"
@@ -22,7 +12,6 @@ import {useQueryParam} from "@/oss/hooks/useQuery"
 import {useWorkspacePermissions} from "@/oss/hooks/useWorkspacePermissions"
 import {isEE, isEmailInvitationsEnabled} from "@/oss/lib/helpers/isEE"
 import {useEntitlements} from "@/oss/lib/helpers/useEntitlements"
-import {getUsernameFromEmail} from "@/oss/lib/helpers/utils"
 import {updateUsername} from "@/oss/services/profile"
 import {useOrgData} from "@/oss/state/org"
 import {useProfileData} from "@/oss/state/profile"
@@ -30,33 +19,10 @@ import {useWorkspaceMembers} from "@/oss/state/workspace"
 
 import {Roles} from "./cellRenderers"
 
-interface MemberRow extends WorkspaceMember {
-    key: string
-    [extra: string]: unknown
-}
-
-/**
- * Invitation state belongs beside the person, not stacked under a date. Members that have
- * accepted carry no chip at all.
- */
-const memberChips = (member: WorkspaceMember, isSelf: boolean): EntityChip[] => {
-    const chips: EntityChip[] = []
-    if (isSelf) chips.push({label: "You", tone: "info"})
-
-    const status = member.user?.status
-    if (status && status !== "member") {
-        chips.push(
-            status === "expired"
-                ? {label: "Expired", tone: "error", variant: "status"}
-                : {label: "Pending", tone: "warning", variant: "status"},
-        )
-    }
-    return chips
-}
-
 const InvitedUserLinkModal = dynamic(() => import("./Modals/InvitedUserLinkModal"), {ssr: false})
 const InviteUsersModal = dynamic(() => import("./Modals/InviteUsersModal"), {ssr: false})
 
+/** OSS binding: the shared members table with this app's antd dialogs and its role editor. */
 const WorkspaceManage: FC = () => {
     const {user: signedInUser, refetch: refetchProfile} = useProfileData()
     const {selectedOrg, loading, refetch} = useOrgData()
@@ -77,23 +43,8 @@ const WorkspaceManage: FC = () => {
     const organizationId = selectedOrg?.id
     const workspaceId = selectedOrg?.default_workspace?.id
 
-    const rows = useMemo<MemberRow[]>(
-        () => filteredMembers.map((member) => ({...member, key: member.user.id})),
-        [filteredMembers],
-    )
-
-    const isSelfMember = useCallback(
-        (record: MemberRow) =>
-            record.user?.id === signedInUser?.id || record.user?.email === signedInUser?.email,
-        [signedInUser?.id, signedInUser?.email],
-    )
-    const isOwnerMember = useCallback(
-        (record: MemberRow) => record.user?.id === selectedOrg?.owner_id,
-        [selectedOrg?.owner_id],
-    )
-
     const handleResendInvite = useCallback(
-        (record: MemberRow) => {
+        (record: WorkspaceMember) => {
             const {user} = record
             if (!organizationId || !user.email || !workspaceId) return
             setResendingEmail(user.email)
@@ -114,7 +65,7 @@ const WorkspaceManage: FC = () => {
     )
 
     const handleRemove = useCallback(
-        (record: MemberRow) => {
+        (record: WorkspaceMember) => {
             const {user} = record
             if (!organizationId || !user.email || !workspaceId) return
             AlertPopup({
@@ -142,185 +93,47 @@ const WorkspaceManage: FC = () => {
             await Promise.all([refetchProfile(), refetch()])
             message.success("Username updated")
             setRenameOpen(false)
-        } catch (error: any) {
-            const detail =
-                error?.response?.data?.detail || error?.message || "Unable to update username"
-            message.error(detail)
+        } catch (error) {
+            const detail = (error as {response?: {data?: {detail?: string}}; message?: string})
+                ?.response?.data?.detail
+            message.error(
+                detail || (error as {message?: string})?.message || "Unable to update username",
+            )
         }
     }, [renameValue, refetchProfile, refetch])
 
-    const columns = useMemo(
-        () =>
-            createStandardColumns<MemberRow>([
-                {
-                    type: "entity",
-                    key: "member",
-                    title: "Member",
-                    width: 280,
-                    fixed: "left",
-                    getName: (record) =>
-                        record.user.username || getUsernameFromEmail(record.user.email),
-                    getChips: (record) =>
-                        memberChips(record, record.user?.email === signedInUser?.email),
-                },
-                {
-                    type: "slug",
-                    key: "email",
-                    title: "Email",
-                    width: 290,
-                    getValue: (record) => record.user?.email,
-                },
-                ...(!isEE() || hasRBAC
-                    ? [
-                          {
-                              type: "text",
-                              key: "roles",
-                              title: "Role",
-                              width: 160,
-                              render: (_value: unknown, record: MemberRow) => (
-                                  <Roles
-                                      member={record}
-                                      signedInUser={signedInUser!}
-                                      organizationId={organizationId!}
-                                      workspaceId={workspaceId!}
-                                  />
-                              ),
-                          } satisfies StandardColumnDef<MemberRow>,
-                      ]
-                    : []),
-                {
-                    type: "text",
-                    key: "created_at",
-                    title: "Added",
-                    width: 160,
-                    render: (_value, record) => formatDay({date: record.user.created_at}),
-                },
-                {
-                    type: "actions",
-                    showCopyId: false,
-                    items: [
-                        {
-                            key: "rename",
-                            label: "Rename",
-                            icon: <EditOutlined />,
-                            hidden: (record) => !isSelfMember(record),
-                            onClick: (record) => {
-                                setRenameValue(record.user.username || "")
-                                setRenameOpen(true)
-                            },
-                        },
-                        {
-                            key: "resend_invite",
-                            label: "Resend invitation",
-                            icon: <ArrowClockwise size={16} />,
-                            hidden: (record) =>
-                                isSelfMember(record) ||
-                                record.user.status === "member" ||
-                                !canInviteMembers,
-                            disabled: (record) => resendingEmail === record.user.email,
-                            onClick: (record) => handleResendInvite(record),
-                        },
-                        {
-                            key: "remove",
-                            label: "Remove",
-                            icon: <Trash size={16} />,
-                            danger: true,
-                            hidden: (record) =>
-                                isSelfMember(record) || isOwnerMember(record) || !canRemoveMembers,
-                            onClick: (record) => handleRemove(record),
-                        },
-                    ],
-                } satisfies StandardColumnDef<MemberRow>,
-            ] as StandardColumnDef<MemberRow>[]),
-        [
-            hasRBAC,
-            organizationId,
-            selectedOrg?.owner_id,
-            signedInUser,
-            workspaceId,
-            isSelfMember,
-            isOwnerMember,
-            canInviteMembers,
-            canRemoveMembers,
-            resendingEmail,
-            handleResendInvite,
-            handleRemove,
-        ],
-    )
-
-    const {tableScope, pagination} = useStaticTable<MemberRow>("settings-members", rows, {
-        loading,
-    })
     return (
-        <div className="flex flex-col gap-2">
-            <InfiniteVirtualTableFeatureShell<MemberRow>
-                tableScope={tableScope}
-                autoHeight={false}
-                columns={columns}
-                rowKey="key"
-                filters={
-                    <Input.Search
-                        placeholder="Search members"
-                        className="w-[260px]"
-                        allowClear
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                        disabled={loading}
-                    />
-                }
-                primaryActions={
-                    canInviteMembers ? (
-                        <Button
-                            type="primary"
-                            icon={<Plus size={14} />}
-                            onClick={() => setIsInviteModalOpen(true)}
-                            disabled={loading}
-                        >
-                            Invite members
-                        </Button>
-                    ) : null
-                }
-                pagination={pagination}
-                tableProps={{
-                    size: "small",
-                    bordered: true,
-                    tableLayout: "fixed",
-                    locale: {
-                        emptyText: searchTerm.trim() ? (
-                            <EmptyState
-                                image="simple"
-                                description={`No members match “${searchTerm.trim()}”`}
-                            />
-                        ) : (
-                            <EmptyState
-                                image="simple"
-                                description={
-                                    <div className="flex flex-col gap-1">
-                                        <span className="text-xs font-medium text-colorText">
-                                            No members yet
-                                        </span>
-                                        <span>
-                                            Invite people to collaborate in this organization.
-                                            Invitations appear here until they are accepted or
-                                            expire.
-                                        </span>
-                                    </div>
-                                }
-                            >
-                                {canInviteMembers ? (
-                                    <Button
-                                        icon={<Plus size={14} />}
-                                        onClick={() => setIsInviteModalOpen(true)}
-                                    >
-                                        Invite members
-                                    </Button>
-                                ) : null}
-                            </EmptyState>
-                        ),
-                    },
-                }}
-            />
-
+        <MembersPage
+            members={filteredMembers}
+            loading={loading}
+            searchTerm={searchTerm}
+            onSearchChange={setSearchTerm}
+            signedInUser={signedInUser}
+            ownerId={selectedOrg?.owner_id}
+            canInviteMembers={canInviteMembers}
+            canRemoveMembers={canRemoveMembers}
+            resendingEmail={resendingEmail}
+            // The role editor writes through antd's Select, so it stays with this host.
+            renderRoleCell={
+                !isEE() || hasRBAC
+                    ? (member) => (
+                          <Roles
+                              member={member}
+                              signedInUser={signedInUser!}
+                              organizationId={organizationId!}
+                              workspaceId={workspaceId!}
+                          />
+                      )
+                    : undefined
+            }
+            onInvite={() => setIsInviteModalOpen(true)}
+            onResendInvite={handleResendInvite}
+            onRemove={handleRemove}
+            onRenameSelf={(member) => {
+                setRenameValue(member.user.username || "")
+                setRenameOpen(true)
+            }}
+        >
             <Modal
                 title="Rename your username"
                 open={renameOpen}
@@ -360,7 +173,7 @@ const WorkspaceManage: FC = () => {
                     invitedUserData={invitedUserData}
                 />
             )}
-        </div>
+        </MembersPage>
     )
 }
 

--- a/web/packages/agenta-entities/src/organization/types.ts
+++ b/web/packages/agenta-entities/src/organization/types.ts
@@ -82,11 +82,12 @@ export interface OrganizationProvider {
     organization_id: string
     name?: string | null
     description?: string | null
-    // Backend serves free-form dicts (OrganizationProviderResponse.flags/settings)
+    // Backend serves free-form dicts (OrganizationProviderResponse.flags/settings).
+    // `is_valid` = the test call authenticated; `is_active` = the provider is live. Both are
+    // stamped false on create and rewritten on every test.
     flags: {
         is_valid?: boolean
         is_active?: boolean
-        is_enabled?: boolean
     }
     settings: OrganizationProviderSettings
     created_at: string

--- a/web/packages/agenta-settings-ui/src/access/AccessControlsSection.tsx
+++ b/web/packages/agenta-settings-ui/src/access/AccessControlsSection.tsx
@@ -1,0 +1,114 @@
+import type {OrganizationFlags} from "@agenta/entities/organization"
+
+import {SettingToggleRow} from "./SettingToggleRow"
+
+export type AuthFlagKey = keyof Pick<
+    OrganizationFlags,
+    "allow_email" | "allow_social" | "allow_sso" | "auto_join" | "domains_only" | "allow_root"
+>
+
+export interface AccessControlsSectionProps {
+    flags: OrganizationFlags
+    onFlagChange: (flag: AuthFlagKey, value: boolean) => void
+    updating?: boolean
+    /** The flag that just saved — drives the transient "Saved" marker. */
+    lastSavedFlag?: AuthFlagKey | null
+    /** SSO cannot be switched on before a provider exists and is verified. */
+    hasActiveVerifiedProvider?: boolean
+    /** Domain-scoped membership rules need at least one verified domain. */
+    hasVerifiedDomain?: boolean
+}
+
+const SectionLabel = ({children}: {children: React.ReactNode}) => (
+    <div className="pb-2 pt-4 text-xs font-medium uppercase tracking-wider text-colorTextTertiary">
+        {children}
+    </div>
+)
+
+/** How members sign in, and who is allowed to join. */
+export const AccessControlsSection = ({
+    flags,
+    onFlagChange,
+    updating,
+    lastSavedFlag,
+    hasActiveVerifiedProvider = false,
+    hasVerifiedDomain = false,
+}: AccessControlsSectionProps) => {
+    // Turning off the last sign-in method would lock everyone out, so owner bypass is pinned on.
+    const allAuthMethodsDisabled = !flags.allow_email && !flags.allow_social && !flags.allow_sso
+
+    return (
+        <section className="flex flex-col">
+            <div className="pb-2">
+                <h2 className="m-0 text-lg font-medium text-colorText">Access Controls</h2>
+                <p className="m-0 mt-1 text-xs text-colorTextSecondary">
+                    Configure how users authenticate and join your organization
+                </p>
+            </div>
+
+            <SectionLabel>Sign-in methods</SectionLabel>
+            <SettingToggleRow
+                title="Email & password"
+                description="Members can sign in with their email and a password"
+                enabled={flags.allow_email}
+                onChange={(checked) => onFlagChange("allow_email", checked)}
+                loading={updating}
+                showSuccess={lastSavedFlag === "allow_email"}
+            />
+            <SettingToggleRow
+                title="Social login"
+                description="Allow sign-in with Google, GitHub, or other OAuth providers"
+                enabled={flags.allow_social}
+                onChange={(checked) => onFlagChange("allow_social", checked)}
+                loading={updating}
+                showSuccess={lastSavedFlag === "allow_social"}
+            />
+            <SettingToggleRow
+                title="SSO authentication"
+                description="Enable single sign-on through your identity provider"
+                enabled={flags.allow_sso}
+                onChange={(checked) => onFlagChange("allow_sso", checked)}
+                disabled={!hasActiveVerifiedProvider}
+                disabledReason="Add an SSO provider below to enable"
+                tooltip="OIDC supported. Configure your IdP in the SSO Providers section below."
+                loading={updating}
+                showSuccess={lastSavedFlag === "allow_sso"}
+            />
+
+            <SectionLabel>Membership</SectionLabel>
+            <SettingToggleRow
+                title="Auto-join from verified domains"
+                description="Users with a verified domain email are automatically added to this organization"
+                enabled={flags.auto_join}
+                onChange={(checked) => onFlagChange("auto_join", checked)}
+                disabled={!hasVerifiedDomain}
+                disabledReason="Verify at least one domain first"
+                loading={updating}
+                showSuccess={lastSavedFlag === "auto_join"}
+            />
+            <SettingToggleRow
+                title="Restrict invites to verified domains"
+                description="Only allow inviting users whose email matches a verified domain"
+                enabled={flags.domains_only}
+                onChange={(checked) => onFlagChange("domains_only", checked)}
+                disabled={!hasVerifiedDomain}
+                disabledReason="Verify at least one domain first"
+                loading={updating}
+                showSuccess={lastSavedFlag === "domains_only"}
+            />
+
+            <SectionLabel>Admin</SectionLabel>
+            <SettingToggleRow
+                title="Owners bypass restrictions"
+                description="Owners can sign in and invite members regardless of the restrictions above"
+                enabled={flags.allow_root}
+                onChange={(checked) => onFlagChange("allow_root", checked)}
+                disabled={allAuthMethodsDisabled && flags.allow_root}
+                disabledReason="Enable at least one sign-in method first"
+                tooltip="Prevents account lockout. Keep enabled if all sign-in methods are disabled."
+                loading={updating}
+                showSuccess={lastSavedFlag === "allow_root"}
+            />
+        </section>
+    )
+}

--- a/web/packages/agenta-settings-ui/src/access/DomainsSection.tsx
+++ b/web/packages/agenta-settings-ui/src/access/DomainsSection.tsx
@@ -1,0 +1,161 @@
+import type {ReactNode} from "react"
+import {useMemo} from "react"
+
+import type {OrganizationDomain} from "@agenta/entities/organization"
+import {StatusIndicator} from "@agenta/ui/components/presentational"
+import {Button, DataTable, EmptyState, type DataTableColumn} from "@agenta/ui/ui"
+import {ArrowClockwise, Plus, Trash} from "@phosphor-icons/react"
+
+/** An unverified domain's token stops being usable 48 hours after it was issued. */
+const TOKEN_LIFETIME_MS = 48 * 60 * 60 * 1000
+
+export interface DomainsSectionProps {
+    domains: OrganizationDomain[]
+    loading?: boolean
+    onAdd?: () => void
+    onVerify?: (domain: OrganizationDomain) => void
+    onRefreshToken?: (domain: OrganizationDomain) => void
+    onDelete?: (domain: OrganizationDomain) => void
+    verifying?: boolean
+    refreshing?: boolean
+    deleting?: boolean
+    /** Copy affordances differ per host, so the DNS rows are rendered by the caller. */
+    renderInstructions?: (domain: OrganizationDomain) => ReactNode
+}
+
+/** Domains you have proven you own, and what is left to do for the ones you have not. */
+export const DomainsSection = ({
+    domains,
+    loading = false,
+    onAdd,
+    onVerify,
+    onRefreshToken,
+    onDelete,
+    verifying,
+    refreshing,
+    deleting,
+    renderInstructions,
+}: DomainsSectionProps) => {
+    const columns = useMemo<DataTableColumn<OrganizationDomain>[]>(
+        () => [
+            {key: "slug", title: "Domain", width: 260, render: (record) => record.slug},
+            {
+                key: "expires_at",
+                title: "Expiration",
+                width: 220,
+                render: (record) => {
+                    if (record.flags?.is_verified) return "-"
+                    const expiresAt = new Date(
+                        new Date(record.created_at).getTime() + TOKEN_LIFETIME_MS,
+                    )
+                    const expired = new Date() > expiresAt
+                    return (
+                        <span className={expired ? "text-colorError" : "text-colorTextSecondary"}>
+                            {expiresAt.toLocaleString()}
+                            {expired ? " (Expired)" : ""}
+                        </span>
+                    )
+                },
+            },
+            {
+                key: "is_verified",
+                title: "Status",
+                width: 140,
+                render: (record) =>
+                    record.flags?.is_verified ? (
+                        <StatusIndicator tone="success" label="Verified" />
+                    ) : (
+                        <StatusIndicator tone="warning" label="Pending" />
+                    ),
+            },
+            {
+                key: "verify",
+                title: "",
+                width: 100,
+                render: (record) =>
+                    !record.flags?.is_verified && onVerify ? (
+                        <Button size="sm" disabled={verifying} onClick={() => onVerify(record)}>
+                            Verify
+                        </Button>
+                    ) : null,
+            },
+        ],
+        [onVerify, verifying],
+    )
+
+    return (
+        <section className="flex flex-col gap-2">
+            <div>
+                <h2 className="m-0 text-lg font-medium text-colorText">Verified Domains</h2>
+                <p className="m-0 mt-1 text-xs text-colorTextSecondary">
+                    Prove you own a domain to auto-join its members and restrict invitations to it.
+                </p>
+            </div>
+
+            <DataTable<OrganizationDomain>
+                columns={columns}
+                rows={domains}
+                rowKey={(record) => record.id}
+                loading={loading}
+                expandedContent={
+                    renderInstructions
+                        ? (record) =>
+                              record.flags?.is_verified || !record.token
+                                  ? null
+                                  : renderInstructions(record)
+                        : undefined
+                }
+                actions={(record) => [
+                    {
+                        key: "refresh",
+                        label: "Refresh token",
+                        icon: <ArrowClockwise size={16} />,
+                        hidden: Boolean(record.flags?.is_verified) || !onRefreshToken,
+                        disabled: refreshing,
+                        onClick: () => onRefreshToken?.(record),
+                    },
+                    {
+                        key: "delete",
+                        label: "Delete domain",
+                        icon: <Trash size={16} />,
+                        danger: true,
+                        hidden: !onDelete,
+                        disabled: deleting,
+                        onClick: () => onDelete?.(record),
+                    },
+                ]}
+                primaryActions={
+                    onAdd ? (
+                        <Button onClick={onAdd} disabled={loading}>
+                            <Plus size={14} />
+                            Add domain
+                        </Button>
+                    ) : null
+                }
+                empty={
+                    <EmptyState
+                        image="simple"
+                        description={
+                            <div className="flex flex-col gap-1">
+                                <span className="text-xs font-medium text-colorText">
+                                    No domains yet
+                                </span>
+                                <span>
+                                    Add a domain and publish its DNS record to verify that you own
+                                    it.
+                                </span>
+                            </div>
+                        }
+                    >
+                        {onAdd ? (
+                            <Button variant="outline" onClick={onAdd}>
+                                <Plus size={14} />
+                                Add domain
+                            </Button>
+                        ) : null}
+                    </EmptyState>
+                }
+            />
+        </section>
+    )
+}

--- a/web/packages/agenta-settings-ui/src/access/DomainsSection.tsx
+++ b/web/packages/agenta-settings-ui/src/access/DomainsSection.tsx
@@ -6,7 +6,13 @@ import {StatusIndicator} from "@agenta/ui/components/presentational"
 import {Button, DataTable, EmptyState, type DataTableColumn} from "@agenta/ui/ui"
 import {ArrowClockwise, Plus, Trash} from "@phosphor-icons/react"
 
-/** An unverified domain's token stops being usable 48 hours after it was issued. */
+/**
+ * An unverified domain's token stops being usable 48 hours after it was issued.
+ *
+ * The API serves no expiry field — `DomainVerificationService` rejects a verify whose
+ * `created_at` is older than its own `TOKEN_EXPIRY_HOURS = 48`, so the client mirrors that
+ * arithmetic rather than inventing a deadline of its own. Keep the two in step.
+ */
 const TOKEN_LIFETIME_MS = 48 * 60 * 60 * 1000
 
 export interface DomainsSectionProps {
@@ -45,10 +51,12 @@ export const DomainsSection = ({
                 width: 220,
                 render: (record) => {
                     if (record.flags?.is_verified) return "-"
-                    const expiresAt = new Date(
-                        new Date(record.created_at).getTime() + TOKEN_LIFETIME_MS,
-                    )
-                    const expired = new Date() > expiresAt
+                    const createdAt = record.created_at ? new Date(record.created_at) : null
+                    // No date, no deadline — better than "Invalid Date (Expired)".
+                    if (!createdAt || Number.isNaN(createdAt.getTime()))
+                        return <span className="text-colorTextSecondary">Unknown</span>
+                    const expiresAt = new Date(createdAt.getTime() + TOKEN_LIFETIME_MS)
+                    const expired = Date.now() > expiresAt.getTime()
                     return (
                         <span className={expired ? "text-colorError" : "text-colorTextSecondary"}>
                             {expiresAt.toLocaleString()}

--- a/web/packages/agenta-settings-ui/src/access/SettingToggleRow.tsx
+++ b/web/packages/agenta-settings-ui/src/access/SettingToggleRow.tsx
@@ -1,0 +1,68 @@
+import type {ReactNode} from "react"
+
+import {Spinner, Switch, Tooltip, TooltipContent, TooltipTrigger} from "@agenta/ui/ui"
+import {CheckCircle, Info, Lock} from "@phosphor-icons/react"
+
+export interface SettingToggleRowProps {
+    title: string
+    description: ReactNode
+    enabled: boolean
+    onChange: (checked: boolean) => void
+    disabled?: boolean
+    /** Shown under the row with a lock — say why it is off, not just that it is. */
+    disabledReason?: string
+    tooltip?: string
+    loading?: boolean
+    showSuccess?: boolean
+}
+
+/** One switchable policy: what it does, whether you may change it, and whether it just saved. */
+export const SettingToggleRow = ({
+    title,
+    description,
+    enabled,
+    onChange,
+    disabled,
+    disabledReason,
+    tooltip,
+    loading,
+    showSuccess,
+}: SettingToggleRowProps) => (
+    <div
+        className={`flex items-start justify-between border-0 border-b border-solid border-colorBorderSecondary py-4 last:border-0 ${
+            disabled ? "opacity-60" : ""
+        }`}
+    >
+        <div className="flex-1 pr-8">
+            <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-colorText">{title}</span>
+                {tooltip ? (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="cursor-help text-colorTextTertiary">
+                                <Info size={16} />
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>{tooltip}</TooltipContent>
+                    </Tooltip>
+                ) : null}
+                {showSuccess ? (
+                    <span className="inline-flex items-center gap-1 text-xs text-colorSuccess">
+                        <CheckCircle size={14} />
+                        Saved
+                    </span>
+                ) : null}
+                {/* antd's Switch drew its own loading spinner; the Radix one does not. */}
+                {loading ? <Spinner size="small" aria-label="Saving" /> : null}
+            </div>
+            <p className="m-0 mt-0.5 text-xs text-colorTextSecondary">{description}</p>
+            {disabled && disabledReason ? (
+                <p className="m-0 mt-1 flex items-center gap-1 text-xs text-colorWarning">
+                    <Lock size={14} />
+                    {disabledReason}
+                </p>
+            ) : null}
+        </div>
+        <Switch checked={enabled} onCheckedChange={onChange} disabled={disabled || loading} />
+    </div>
+)

--- a/web/packages/agenta-settings-ui/src/access/SettingToggleRow.tsx
+++ b/web/packages/agenta-settings-ui/src/access/SettingToggleRow.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from "react"
 
-import {Spinner, Switch, Tooltip, TooltipContent, TooltipTrigger} from "@agenta/ui/ui"
+import {SimpleTooltip, Spinner, Switch} from "@agenta/ui/ui"
 import {CheckCircle, Info, Lock} from "@phosphor-icons/react"
 
 export interface SettingToggleRowProps {
@@ -36,15 +36,19 @@ export const SettingToggleRow = ({
         <div className="flex-1 pr-8">
             <div className="flex items-center gap-2">
                 <span className="text-xs font-medium text-colorText">{title}</span>
+                {/* SimpleTooltip carries its own TooltipProvider — the convention in @agenta/ui,
+                    which mounts one per tooltip rather than a single app-level provider. The
+                    trigger is a button so it opens on focus and closes on Escape, not hover only. */}
                 {tooltip ? (
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span className="cursor-help text-colorTextTertiary">
-                                <Info size={16} />
-                            </span>
-                        </TooltipTrigger>
-                        <TooltipContent>{tooltip}</TooltipContent>
-                    </Tooltip>
+                    <SimpleTooltip title={tooltip}>
+                        <button
+                            type="button"
+                            aria-label={`About ${title}`}
+                            className="inline-flex cursor-help items-center justify-center border-0 bg-transparent p-0 text-colorTextTertiary"
+                        >
+                            <Info size={16} />
+                        </button>
+                    </SimpleTooltip>
                 ) : null}
                 {showSuccess ? (
                     <span className="inline-flex items-center gap-1 text-xs text-colorSuccess">

--- a/web/packages/agenta-settings-ui/src/access/SsoProvidersSection.tsx
+++ b/web/packages/agenta-settings-ui/src/access/SsoProvidersSection.tsx
@@ -25,8 +25,14 @@ export interface SsoProvidersSectionProps {
     children?: ReactNode
 }
 
-const isEnabled = (provider: OrganizationProvider) => provider.flags?.is_enabled !== false
-const isValid = (provider: OrganizationProvider) => provider.flags?.is_valid !== false
+/**
+ * A provider carries two flags and the API stamps both: `is_valid` is "authenticated" (the test
+ * call succeeded), `is_active` is "live". Creating one sets both to false; testing sets both from
+ * the result. The desktop read a third, `is_enabled`, that the API never serves — so its
+ * "Disabled" branch was dead. An absent flag means not-yet-validated, hence fail-closed.
+ */
+const isActive = (provider: OrganizationProvider) => provider.flags?.is_active === true
+const isValid = (provider: OrganizationProvider) => provider.flags?.is_valid === true
 
 /** The identity providers members can sign in through. */
 export const SsoProvidersSection = ({
@@ -66,11 +72,13 @@ export const SsoProvidersSection = ({
                 title: "Status",
                 width: 140,
                 render: (record) => {
-                    if (!isEnabled(record)) return <StatusIndicator label="Disabled" />
-                    return isValid(record) ? (
+                    // Not yet authenticated reads as Pending — the setup detail below the row
+                    // says what is left to do. Authenticated but not live is Disabled.
+                    if (!isValid(record)) return <StatusIndicator tone="warning" label="Pending" />
+                    return isActive(record) ? (
                         <StatusIndicator tone="success" label="Active" />
                     ) : (
-                        <StatusIndicator tone="warning" label="Pending" />
+                        <StatusIndicator label="Disabled" />
                     )
                 },
             },
@@ -79,7 +87,7 @@ export const SsoProvidersSection = ({
                 title: "",
                 width: 100,
                 render: (record) =>
-                    (!isEnabled(record) || !isValid(record)) && onEnable ? (
+                    (!isActive(record) || !isValid(record)) && onEnable ? (
                         <Button size="sm" disabled={enabling} onClick={() => onEnable(record)}>
                             Enable
                         </Button>

--- a/web/packages/agenta-settings-ui/src/access/SsoProvidersSection.tsx
+++ b/web/packages/agenta-settings-ui/src/access/SsoProvidersSection.tsx
@@ -1,0 +1,163 @@
+import type {ReactNode} from "react"
+import {useMemo} from "react"
+
+import type {OrganizationProvider} from "@agenta/entities/organization"
+import {StatusIndicator} from "@agenta/ui/components/presentational"
+import {Button, DataTable, EmptyState, type DataTableColumn} from "@agenta/ui/ui"
+import {PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
+
+export interface SsoProvidersSectionProps {
+    providers: OrganizationProvider[]
+    loading?: boolean
+    /** Builds the IdP redirect URI; it needs the org slug, so the host owns it. */
+    callbackUrlFor?: (provider: OrganizationProvider) => string | null
+    onAdd?: () => void
+    /** SSO needs an org slug first, so the host may be offering to set that instead. */
+    addLabel?: string
+    onEdit?: (provider: OrganizationProvider) => void
+    onEnable?: (provider: OrganizationProvider) => void
+    onDelete?: (provider: OrganizationProvider) => void
+    enabling?: boolean
+    deleting?: boolean
+    /** Setup detail under a provider that is not yet valid; copy affordances are the host's. */
+    renderInstructions?: (provider: OrganizationProvider) => ReactNode
+    /** The org-slug field and its warning sit between the heading and the table. */
+    children?: ReactNode
+}
+
+const isEnabled = (provider: OrganizationProvider) => provider.flags?.is_enabled !== false
+const isValid = (provider: OrganizationProvider) => provider.flags?.is_valid !== false
+
+/** The identity providers members can sign in through. */
+export const SsoProvidersSection = ({
+    providers,
+    loading = false,
+    callbackUrlFor,
+    onAdd,
+    addLabel = "Add provider",
+    onEdit,
+    onEnable,
+    onDelete,
+    enabling,
+    deleting,
+    renderInstructions,
+    children,
+}: SsoProvidersSectionProps) => {
+    const columns = useMemo<DataTableColumn<OrganizationProvider>[]>(
+        () => [
+            {key: "slug", title: "Provider", width: 200, render: (record) => record.slug},
+            {
+                key: "callback_url",
+                title: "Callback URL",
+                width: 320,
+                mono: true,
+                render: (record) => {
+                    const url = callbackUrlFor?.(record)
+                    if (!url) return <span className="text-colorTextSecondary">Set org slug</span>
+                    return (
+                        <span className="block truncate" title={url}>
+                            {url}
+                        </span>
+                    )
+                },
+            },
+            {
+                key: "status",
+                title: "Status",
+                width: 140,
+                render: (record) => {
+                    if (!isEnabled(record)) return <StatusIndicator label="Disabled" />
+                    return isValid(record) ? (
+                        <StatusIndicator tone="success" label="Active" />
+                    ) : (
+                        <StatusIndicator tone="warning" label="Pending" />
+                    )
+                },
+            },
+            {
+                key: "enable",
+                title: "",
+                width: 100,
+                render: (record) =>
+                    (!isEnabled(record) || !isValid(record)) && onEnable ? (
+                        <Button size="sm" disabled={enabling} onClick={() => onEnable(record)}>
+                            Enable
+                        </Button>
+                    ) : null,
+            },
+        ],
+        [callbackUrlFor, onEnable, enabling],
+    )
+
+    const addButton = (variant?: "outline") =>
+        onAdd ? (
+            <Button variant={variant} onClick={onAdd} disabled={loading}>
+                <Plus size={14} />
+                {addLabel}
+            </Button>
+        ) : null
+
+    return (
+        <section className="flex flex-col gap-3">
+            <div className="flex items-start justify-between">
+                <div>
+                    <h2 className="m-0 text-lg font-medium text-colorText">SSO Providers</h2>
+                    <p className="m-0 mt-1 text-xs text-colorTextSecondary">
+                        Configure identity providers for single sign-on
+                    </p>
+                </div>
+                {addButton()}
+            </div>
+
+            {children}
+
+            <DataTable<OrganizationProvider>
+                columns={columns}
+                rows={providers}
+                rowKey={(record) => record.id}
+                loading={loading}
+                expandedContent={
+                    renderInstructions
+                        ? (record) => (isValid(record) ? null : renderInstructions(record))
+                        : undefined
+                }
+                actions={(record) => [
+                    {
+                        key: "edit",
+                        label: "Edit provider",
+                        icon: <PencilSimpleLine size={16} />,
+                        hidden: !onEdit,
+                        onClick: () => onEdit?.(record),
+                    },
+                    {
+                        key: "delete",
+                        label: "Delete provider",
+                        icon: <Trash size={16} />,
+                        danger: true,
+                        hidden: !onDelete,
+                        disabled: deleting,
+                        onClick: () => onDelete?.(record),
+                    },
+                ]}
+                empty={
+                    <EmptyState
+                        image="simple"
+                        description={
+                            <div className="flex flex-col gap-1">
+                                <span className="text-xs font-medium text-colorText">
+                                    No SSO providers yet
+                                </span>
+                                <span>
+                                    Add an OIDC provider to let members sign in with your identity
+                                    provider.
+                                </span>
+                            </div>
+                        }
+                    >
+                        {addButton("outline")}
+                    </EmptyState>
+                }
+            />
+        </section>
+    )
+}

--- a/web/packages/agenta-settings-ui/src/access/UpgradeNotice.tsx
+++ b/web/packages/agenta-settings-ui/src/access/UpgradeNotice.tsx
@@ -1,0 +1,27 @@
+import type {ReactNode} from "react"
+
+import {Lock} from "@phosphor-icons/react"
+
+export interface UpgradeNoticeProps {
+    title: string
+    description: string
+    /** The upgrade link — routing and billing availability are the host's to decide. */
+    action?: ReactNode
+}
+
+/** Stands in for a section the current plan does not include. */
+export const UpgradeNotice = ({title, description, action}: UpgradeNoticeProps) => (
+    <div className="rounded-lg border border-solid border-colorBorderSecondary bg-colorBgContainer">
+        <div className="flex flex-col items-center justify-center px-6 py-12 text-center">
+            <div className="mb-4 rounded-full bg-colorFillQuaternary p-4">
+                <Lock size={32} className="text-colorTextTertiary" />
+            </div>
+            <h2 className="m-0 mb-2 text-lg font-medium text-colorText">{title}</h2>
+            <p className="m-0 mb-4 block max-w-md text-xs text-colorTextSecondary">{description}</p>
+            <p className="m-0 text-xs text-colorTextSecondary">
+                Available on <strong>Business</strong> and <strong>Enterprise</strong> plans.{" "}
+                {action}
+            </p>
+        </div>
+    </div>
+)

--- a/web/packages/agenta-settings-ui/src/index.ts
+++ b/web/packages/agenta-settings-ui/src/index.ts
@@ -25,3 +25,4 @@ export {
 export {SettingToggleRow, type SettingToggleRowProps} from "./access/SettingToggleRow"
 export {UpgradeNotice, type UpgradeNoticeProps} from "./access/UpgradeNotice"
 export {DomainsSection, type DomainsSectionProps} from "./access/DomainsSection"
+export {SsoProvidersSection, type SsoProvidersSectionProps} from "./access/SsoProvidersSection"

--- a/web/packages/agenta-settings-ui/src/index.ts
+++ b/web/packages/agenta-settings-ui/src/index.ts
@@ -16,3 +16,4 @@ export {
     type ProjectDialogState,
 } from "./projects/ProjectsPage"
 export {MembersPage, type MembersPageProps} from "./members/MembersPage"
+export {OrganizationsPage, type OrganizationsPageProps} from "./organizations/OrganizationsPage"

--- a/web/packages/agenta-settings-ui/src/index.ts
+++ b/web/packages/agenta-settings-ui/src/index.ts
@@ -15,3 +15,4 @@ export {
     type ProjectsPageProps,
     type ProjectDialogState,
 } from "./projects/ProjectsPage"
+export {MembersPage, type MembersPageProps} from "./members/MembersPage"

--- a/web/packages/agenta-settings-ui/src/index.ts
+++ b/web/packages/agenta-settings-ui/src/index.ts
@@ -17,3 +17,10 @@ export {
 } from "./projects/ProjectsPage"
 export {MembersPage, type MembersPageProps} from "./members/MembersPage"
 export {OrganizationsPage, type OrganizationsPageProps} from "./organizations/OrganizationsPage"
+export {
+    AccessControlsSection,
+    type AccessControlsSectionProps,
+    type AuthFlagKey,
+} from "./access/AccessControlsSection"
+export {SettingToggleRow, type SettingToggleRowProps} from "./access/SettingToggleRow"
+export {UpgradeNotice, type UpgradeNoticeProps} from "./access/UpgradeNotice"

--- a/web/packages/agenta-settings-ui/src/index.ts
+++ b/web/packages/agenta-settings-ui/src/index.ts
@@ -24,3 +24,4 @@ export {
 } from "./access/AccessControlsSection"
 export {SettingToggleRow, type SettingToggleRowProps} from "./access/SettingToggleRow"
 export {UpgradeNotice, type UpgradeNoticeProps} from "./access/UpgradeNotice"
+export {DomainsSection, type DomainsSectionProps} from "./access/DomainsSection"

--- a/web/packages/agenta-settings-ui/src/members/MembersPage.tsx
+++ b/web/packages/agenta-settings-ui/src/members/MembersPage.tsx
@@ -1,0 +1,195 @@
+import type {ReactNode} from "react"
+import {useMemo} from "react"
+
+import type {WorkspaceMember} from "@agenta/entities/organization"
+import {formatDay} from "@agenta/shared/utils/dateTime"
+import {Tag} from "@agenta/ui/components/presentational"
+import {Button, DataTable, EmptyState, Input, type DataTableColumn} from "@agenta/ui/ui"
+import {ArrowClockwise, PencilSimpleLine, Plus, Trash} from "@phosphor-icons/react"
+
+interface MemberRow extends WorkspaceMember {
+    key: string
+}
+
+const usernameFromEmail = (email?: string | null) => (email ? email.split("@")[0] : "")
+
+export interface MembersPageProps {
+    members: WorkspaceMember[]
+    loading?: boolean
+    searchTerm: string
+    onSearchChange: (value: string) => void
+    /** Identifies "You" and hides the destructive actions on your own row. */
+    signedInUser?: {id?: string | null; email?: string | null} | null
+    /** The owner cannot be removed. */
+    ownerId?: string | null
+    /** Roles are an EE/RBAC concern, and the cell itself is the host's (it writes). */
+    renderRoleCell?: (member: WorkspaceMember) => ReactNode
+    canInviteMembers?: boolean
+    canRemoveMembers?: boolean
+    /** Email currently being re-invited — disables that row's action. */
+    resendingEmail?: string | null
+    onInvite?: () => void
+    onResendInvite?: (member: WorkspaceMember) => void
+    onRemove?: (member: WorkspaceMember) => void
+    onRenameSelf?: (member: WorkspaceMember) => void
+    /** Invite / rename / invited-link dialogs — the host's. */
+    children?: ReactNode
+}
+
+/**
+ * The organization's members: who they are, their role, and where their invitation stands.
+ *
+ * A view only — the list, the search term and every verb come from the host, so a surface without
+ * invite dialogs still renders the roster and its empty state.
+ */
+export const MembersPage = ({
+    members,
+    loading = false,
+    searchTerm,
+    onSearchChange,
+    signedInUser,
+    ownerId,
+    renderRoleCell,
+    canInviteMembers = false,
+    canRemoveMembers = false,
+    resendingEmail,
+    onInvite,
+    onResendInvite,
+    onRemove,
+    onRenameSelf,
+    children,
+}: MembersPageProps) => {
+    const rows = useMemo<MemberRow[]>(
+        () => members.map((member) => ({...member, key: member.user.id})),
+        [members],
+    )
+
+    const isSelf = (member: WorkspaceMember) =>
+        member.user?.id === signedInUser?.id || member.user?.email === signedInUser?.email
+    const isOwner = (member: WorkspaceMember) => Boolean(ownerId) && member.user?.id === ownerId
+
+    const columns = useMemo<DataTableColumn<MemberRow>[]>(
+        () => [
+            {
+                key: "member",
+                title: "Member",
+                width: 280,
+                render: (record) => (
+                    <div className="flex min-w-0 items-center gap-2">
+                        <span className="truncate font-medium">
+                            {record.user.username || usernameFromEmail(record.user.email)}
+                        </span>
+                        {isSelf(record) ? <Tag>You</Tag> : null}
+                        {/* Invitation state belongs beside the person; accepted members carry none. */}
+                        {record.user?.status === "expired" ? <Tag>Expired</Tag> : null}
+                        {record.user?.status === "pending" ? <Tag>Pending</Tag> : null}
+                    </div>
+                ),
+            },
+            {key: "email", title: "Email", width: 290, mono: true, render: (r) => r.user?.email},
+            ...(renderRoleCell
+                ? [
+                      {
+                          key: "roles",
+                          title: "Role",
+                          width: 160,
+                          render: (record: MemberRow) => renderRoleCell(record),
+                      } satisfies DataTableColumn<MemberRow>,
+                  ]
+                : []),
+            {
+                key: "created_at",
+                title: "Added",
+                width: 160,
+                render: (record) =>
+                    record.user.created_at ? formatDay({date: record.user.created_at}) : "-",
+            },
+        ],
+        [renderRoleCell, signedInUser?.id, signedInUser?.email],
+    )
+
+    const inviteButton = (variant?: "outline") =>
+        canInviteMembers && onInvite ? (
+            <Button variant={variant} onClick={onInvite} disabled={loading}>
+                <Plus size={14} />
+                Invite members
+            </Button>
+        ) : null
+
+    return (
+        <div className="flex flex-col gap-2">
+            <DataTable<MemberRow>
+                columns={columns}
+                rows={rows}
+                rowKey={(record) => record.key}
+                loading={loading}
+                actions={(record) => [
+                    {
+                        key: "rename",
+                        label: "Rename",
+                        icon: <PencilSimpleLine size={16} />,
+                        hidden: !isSelf(record) || !onRenameSelf,
+                        onClick: () => onRenameSelf?.(record),
+                    },
+                    {
+                        key: "resend_invite",
+                        label: "Resend invitation",
+                        icon: <ArrowClockwise size={16} />,
+                        hidden:
+                            isSelf(record) ||
+                            record.user.status === "member" ||
+                            !canInviteMembers ||
+                            !onResendInvite,
+                        disabled: resendingEmail === record.user.email,
+                        onClick: () => onResendInvite?.(record),
+                    },
+                    {
+                        key: "remove",
+                        label: "Remove",
+                        icon: <Trash size={16} />,
+                        danger: true,
+                        hidden: isSelf(record) || isOwner(record) || !canRemoveMembers || !onRemove,
+                        onClick: () => onRemove?.(record),
+                    },
+                ]}
+                filters={
+                    <Input
+                        placeholder="Search members"
+                        className="w-[260px]"
+                        value={searchTerm}
+                        onChange={(event) => onSearchChange(event.target.value)}
+                        disabled={loading}
+                    />
+                }
+                primaryActions={inviteButton()}
+                empty={
+                    searchTerm.trim() ? (
+                        <EmptyState
+                            image="simple"
+                            description={`No members match “${searchTerm.trim()}”`}
+                        />
+                    ) : (
+                        <EmptyState
+                            image="simple"
+                            description={
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-xs font-medium text-colorText">
+                                        No members yet
+                                    </span>
+                                    <span>
+                                        Invite people to collaborate in this organization.
+                                        Invitations appear here until they are accepted or expire.
+                                    </span>
+                                </div>
+                            }
+                        >
+                            {inviteButton("outline")}
+                        </EmptyState>
+                    )
+                }
+            />
+
+            {children}
+        </div>
+    )
+}

--- a/web/packages/agenta-settings-ui/src/members/MembersPage.tsx
+++ b/web/packages/agenta-settings-ui/src/members/MembersPage.tsx
@@ -14,6 +14,7 @@ interface MemberRow extends WorkspaceMember {
 const usernameFromEmail = (email?: string | null) => (email ? email.split("@")[0] : "")
 
 export interface MembersPageProps {
+    /** The full roster — this page owns the search filter so hosts cannot drift on it. */
     members: WorkspaceMember[]
     loading?: boolean
     searchTerm: string
@@ -59,10 +60,17 @@ export const MembersPage = ({
     onRenameSelf,
     children,
 }: MembersPageProps) => {
-    const rows = useMemo<MemberRow[]>(
-        () => members.map((member) => ({...member, key: member.user.id})),
-        [members],
-    )
+    const rows = useMemo<MemberRow[]>(() => {
+        const term = searchTerm.trim().toLowerCase()
+        const matching = term
+            ? members.filter((member) =>
+                  [member.user?.email, member.user?.username].some((value) =>
+                      value?.toLowerCase().includes(term),
+                  ),
+              )
+            : members
+        return matching.map((member) => ({...member, key: member.user.id}))
+    }, [members, searchTerm])
 
     const isSelf = (member: WorkspaceMember) =>
         member.user?.id === signedInUser?.id || member.user?.email === signedInUser?.email

--- a/web/packages/agenta-settings-ui/src/organizations/OrganizationsPage.tsx
+++ b/web/packages/agenta-settings-ui/src/organizations/OrganizationsPage.tsx
@@ -1,0 +1,189 @@
+import type {ReactNode} from "react"
+import {useMemo} from "react"
+
+import type {Org} from "@agenta/entities/organization"
+import {Tag} from "@agenta/ui/components/presentational"
+import {Button, DataTable, EmptyState, Input, type DataTableColumn} from "@agenta/ui/ui"
+import {ArrowsLeftRight, PencilSimpleLine, Plus, SignOut, Trash} from "@phosphor-icons/react"
+
+interface OrgRow extends Org {
+    key: string
+}
+
+export interface OrganizationsPageProps {
+    /** Every organization you belong to; this page owns the search filter. */
+    organizations: Org[]
+    loading?: boolean
+    searchTerm: string
+    onSearchChange: (value: string) => void
+    /** Marks the "Current" row and scopes the ownership transfer. */
+    selectedOrgId?: string | null
+    currentUserId?: string | null
+    onSwitch?: (org: Org) => void
+    onCreate?: () => void
+    onRename?: (org: Org) => void
+    onTransferOwnership?: (org: Org) => void
+    onLeave?: (org: Org) => void
+    onDelete?: (org: Org) => void
+    /** Create / rename / transfer / delete dialogs — the host's. */
+    children?: ReactNode
+}
+
+/**
+ * The organizations you belong to, which one you are in, and what you can do to each.
+ *
+ * A view only: the list and every verb come from the host, so a surface that brings no dialogs
+ * still renders the list and its empty state.
+ */
+export const OrganizationsPage = ({
+    organizations,
+    loading = false,
+    searchTerm,
+    onSearchChange,
+    selectedOrgId,
+    currentUserId,
+    onSwitch,
+    onCreate,
+    onRename,
+    onTransferOwnership,
+    onLeave,
+    onDelete,
+    children,
+}: OrganizationsPageProps) => {
+    const rows = useMemo<OrgRow[]>(() => {
+        const term = searchTerm.trim().toLowerCase()
+        const matching = term
+            ? organizations.filter((org) =>
+                  [org.name, org.id].some((value) => value?.toLowerCase().includes(term)),
+              )
+            : organizations
+        return matching.map((org) => ({...org, key: org.id}))
+    }, [organizations, searchTerm])
+
+    const isOwner = (org: Org) => Boolean(currentUserId) && org.owner_id === currentUserId
+
+    const columns = useMemo<DataTableColumn<OrgRow>[]>(
+        () => [
+            {
+                key: "name",
+                title: "Organization",
+                width: 280,
+                render: (record) => (
+                    <div className="flex min-w-0 items-center gap-2">
+                        <span className="truncate font-medium">
+                            {record.name ?? record.slug ?? record.id}
+                        </span>
+                        {record.id === selectedOrgId ? <Tag>Current</Tag> : null}
+                    </div>
+                ),
+            },
+            // Its own copyable column, not a tag beside the page title.
+            {key: "id", title: "Organization ID", width: 330, mono: true, render: (r) => r.id},
+            {
+                key: "owner_id",
+                title: "Your role",
+                width: 140,
+                render: (record) => (isOwner(record) ? "Owner" : "Member"),
+            },
+        ],
+        [selectedOrgId, currentUserId],
+    )
+
+    const createButton = (variant?: "outline") =>
+        onCreate ? (
+            <Button variant={variant} onClick={onCreate} disabled={loading}>
+                <Plus size={14} />
+                New organization
+            </Button>
+        ) : null
+
+    return (
+        <div className="flex flex-col gap-2">
+            <DataTable<OrgRow>
+                columns={columns}
+                rows={rows}
+                rowKey={(record) => record.key}
+                loading={loading}
+                actions={(record) => [
+                    {
+                        key: "switch",
+                        label: "Switch to this organization",
+                        icon: <ArrowsLeftRight size={16} />,
+                        hidden: record.id === selectedOrgId || !onSwitch,
+                        onClick: () => onSwitch?.(record),
+                    },
+                    {
+                        key: "rename",
+                        label: "Rename",
+                        icon: <PencilSimpleLine size={16} />,
+                        hidden: !isOwner(record) || !onRename,
+                        onClick: () => onRename?.(record),
+                    },
+                    {
+                        key: "transfer",
+                        label: "Transfer ownership",
+                        icon: <ArrowsLeftRight size={16} />,
+                        // The member list is scoped to the current organization.
+                        hidden:
+                            !isOwner(record) || record.id !== selectedOrgId || !onTransferOwnership,
+                        onClick: () => onTransferOwnership?.(record),
+                    },
+                    {type: "divider"},
+                    {
+                        key: "leave",
+                        label: "Leave organization",
+                        icon: <SignOut size={16} />,
+                        danger: true,
+                        hidden: isOwner(record) || !onLeave,
+                        onClick: () => onLeave?.(record),
+                    },
+                    {
+                        key: "delete",
+                        label: "Delete organization",
+                        icon: <Trash size={16} />,
+                        danger: true,
+                        hidden: !isOwner(record) || !onDelete,
+                        onClick: () => onDelete?.(record),
+                    },
+                ]}
+                filters={
+                    <Input
+                        placeholder="Search organizations"
+                        className="w-[260px]"
+                        value={searchTerm}
+                        onChange={(event) => onSearchChange(event.target.value)}
+                        disabled={loading}
+                    />
+                }
+                primaryActions={createButton()}
+                empty={
+                    searchTerm.trim() ? (
+                        <EmptyState
+                            image="simple"
+                            description={`No organizations match “${searchTerm.trim()}”`}
+                        />
+                    ) : (
+                        <EmptyState
+                            image="simple"
+                            description={
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-xs font-medium text-colorText">
+                                        No organizations yet
+                                    </span>
+                                    <span>
+                                        An organization groups your workspaces, projects and the
+                                        people who work in them.
+                                    </span>
+                                </div>
+                            }
+                        >
+                            {createButton("outline")}
+                        </EmptyState>
+                    )
+                }
+            />
+
+            {children}
+        </div>
+    )
+}

--- a/web/packages/agenta-ui/src/components/ui/data-table.tsx
+++ b/web/packages/agenta-ui/src/components/ui/data-table.tsx
@@ -39,7 +39,11 @@ export interface DataTableProps<T> {
     columns: DataTableColumn<T>[]
     rows: T[]
     rowKey: (record: T) => string
-    /** Per-row overflow menu, rendered as a trailing column. */
+    /**
+     * Per-row overflow menu, rendered as a trailing column. The column appears only when at
+     * least one row has a visible item, so a host that supplies no verbs gets no gutter and no
+     * kebab — callers can pass the full list and lean on `hidden`.
+     */
     actions?: (record: T) => (DataTableAction<T> | {type: "divider"})[]
     /** Shown instead of rows when there are none and nothing is loading. */
     empty?: ReactNode
@@ -62,6 +66,25 @@ export interface DataTableProps<T> {
 }
 
 const CELL = "px-3 py-2 text-xs align-middle"
+
+type ActionItem<T> = DataTableAction<T> | {type: "divider"}
+
+/**
+ * The items a row will actually show: `hidden` ones are dropped, and a divider only survives
+ * with a real item on both sides. Returns an empty list when nothing is left — a read-only host
+ * hides every verb, and an empty menu is worse than no menu.
+ */
+const visibleActions = <T,>(items: ActionItem<T>[]): ActionItem<T>[] => {
+    const visible = items.filter((item) => "type" in item || !item.hidden)
+    // Hiding every action can leave a divider stranded at either end.
+    const trimmed = visible.filter(
+        (item, index) =>
+            !("type" in item) ||
+            (visible.slice(0, index).some((prior) => !("type" in prior)) &&
+                visible.slice(index + 1).some((next) => !("type" in next))),
+    )
+    return trimmed.some((item) => !("type" in item)) ? trimmed : []
+}
 
 /**
  * THE antd-free table for fully-materialized lists — settings, and anything else whose rows are
@@ -88,6 +111,11 @@ export function DataTable<T>({
 }: DataTableProps<T>) {
     const showSkeleton = loading && rows.length === 0
     const showEmpty = !loading && rows.length === 0
+    // Resolve every row's menu up front. A host that brings no verbs hides every item, and the
+    // trailing column would then be a permanent empty gutter — so the column itself is a
+    // function of what the rows actually offer, not of `actions` merely being defined.
+    const rowActions = actions ? rows.map((record) => visibleActions(actions(record))) : null
+    const showActions = Boolean(rowActions?.some((items) => items.length > 0))
 
     return (
         <div className={clsx("flex min-w-0 flex-col gap-2", className)}>
@@ -119,7 +147,7 @@ export function DataTable<T>({
                                     {column.title}
                                 </th>
                             ))}
-                            {actions ? <th className={clsx(CELL, "w-12")} /> : null}
+                            {showActions ? <th className={clsx(CELL, "w-12")} /> : null}
                         </tr>
                     </thead>
                     <tbody>
@@ -134,11 +162,12 @@ export function DataTable<T>({
                                               <SkeletonBlock active className="h-4 w-3/4" />
                                           </td>
                                       ))}
-                                      {actions ? <td className={CELL} /> : null}
+                                      {showActions ? <td className={CELL} /> : null}
                                   </tr>
                               ))
-                            : rows.map((record) => {
+                            : rows.map((record, rowIndex) => {
                                   const detail = expandedContent?.(record)
+                                  const items = rowActions?.[rowIndex] ?? []
                                   return (
                                       <Fragment key={rowKey(record)}>
                                           <tr
@@ -196,22 +225,21 @@ export function DataTable<T>({
                                                       {column.render(record)}
                                                   </td>
                                               ))}
-                                              {actions ? (
+                                              {showActions ? (
                                                   <td
                                                       className={clsx(CELL, "text-right")}
                                                       onClick={(event) => event.stopPropagation()}
                                                   >
-                                                      <RowActions
-                                                          items={actions(record)}
-                                                          record={record}
-                                                      />
+                                                      <RowActions items={items} record={record} />
                                                   </td>
                                               ) : null}
                                           </tr>
                                           {detail ? (
                                               <tr className="border-0 border-b border-solid border-colorBorderSecondary last:border-b-0">
                                                   <td
-                                                      colSpan={columns.length + (actions ? 1 : 0)}
+                                                      colSpan={
+                                                          columns.length + (showActions ? 1 : 0)
+                                                      }
                                                       className="px-3 pb-3 pt-0"
                                                   >
                                                       {detail}
@@ -230,22 +258,9 @@ export function DataTable<T>({
     )
 }
 
-const RowActions = <T,>({
-    items,
-    record,
-}: {
-    items: (DataTableAction<T> | {type: "divider"})[]
-    record: T
-}) => {
-    const visible = items.filter((item) => "type" in item || !item.hidden)
-    // Hiding every action can leave a divider stranded at either end.
-    const trimmed = visible.filter(
-        (item, index) =>
-            !("type" in item) ||
-            (visible.slice(0, index).some((prior) => !("type" in prior)) &&
-                visible.slice(index + 1).some((next) => !("type" in next))),
-    )
-    if (!trimmed.some((item) => !("type" in item))) return null
+/** Already narrowed by `visibleActions` — one row of a table that has actions may still have none. */
+const RowActions = <T,>({items, record}: {items: ActionItem<T>[]; record: T}) => {
+    if (items.length === 0) return null
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -258,7 +273,7 @@ const RowActions = <T,>({
                 </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-[180px]">
-                {trimmed.map((item, index) =>
+                {items.map((item, index) =>
                     "type" in item ? (
                         <DropdownMenuSeparator key={`divider-${index}`} />
                     ) : (

--- a/web/packages/agenta-ui/src/components/ui/data-table.tsx
+++ b/web/packages/agenta-ui/src/components/ui/data-table.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from "react"
+import {Fragment, type ReactNode} from "react"
 
 import {DotsThreeVertical} from "@phosphor-icons/react"
 import clsx from "clsx"
@@ -52,6 +52,12 @@ export interface DataTableProps<T> {
     /** Above the toolbar — a heading for the table itself. */
     title?: ReactNode
     onRowClick?: (record: T) => void
+    /**
+     * Detail rendered in a full-width row beneath the record. Return null for rows that have
+     * none — there is no expand/collapse control, so use this for detail that should always
+     * show (setup instructions, a pending state), not for optional drill-down.
+     */
+    expandedContent?: (record: T) => ReactNode
     className?: string
 }
 
@@ -77,6 +83,7 @@ export function DataTable<T>({
     primaryActions,
     title,
     onRowClick,
+    expandedContent,
     className,
 }: DataTableProps<T>) {
     const showSkeleton = loading && rows.length === 0
@@ -130,61 +137,90 @@ export function DataTable<T>({
                                       {actions ? <td className={CELL} /> : null}
                                   </tr>
                               ))
-                            : rows.map((record) => (
-                                  <tr
-                                      key={rowKey(record)}
-                                      onClick={onRowClick ? () => onRowClick(record) : undefined}
-                                      // A clickable row is a control, so it takes focus and answers
-                                      // Enter/Space like one. Rows without `onRowClick` stay plain
-                                      // markup — they must not become focus stops.
-                                      role={onRowClick ? "button" : undefined}
-                                      tabIndex={onRowClick ? 0 : undefined}
-                                      onKeyDown={
-                                          onRowClick
-                                              ? (event) => {
-                                                    // Only the row itself: controls inside a cell
-                                                    // handle their own keys, and Space on a
-                                                    // container that does not preventDefault also
-                                                    // scrolls the page.
-                                                    if (event.target !== event.currentTarget) return
-                                                    if (event.key !== "Enter" && event.key !== " ")
-                                                        return
-                                                    event.preventDefault()
-                                                    onRowClick(record)
-                                                }
-                                              : undefined
-                                      }
-                                      className={clsx(
-                                          "border-0 border-b border-solid border-colorBorderSecondary last:border-b-0 hover:bg-colorFillQuaternary",
-                                          onRowClick &&
-                                              "cursor-pointer outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring",
-                                      )}
-                                  >
-                                      {columns.map((column) => (
-                                          <td
-                                              key={column.key}
+                            : rows.map((record) => {
+                                  const detail = expandedContent?.(record)
+                                  return (
+                                      <Fragment key={rowKey(record)}>
+                                          <tr
+                                              onClick={
+                                                  onRowClick ? () => onRowClick(record) : undefined
+                                              }
+                                              // A clickable row is a control, so it takes focus and
+                                              // answers Enter/Space like one. Rows without
+                                              // `onRowClick` stay plain markup — they must not
+                                              // become focus stops.
+                                              role={onRowClick ? "button" : undefined}
+                                              tabIndex={onRowClick ? 0 : undefined}
+                                              onKeyDown={
+                                                  onRowClick
+                                                      ? (event) => {
+                                                            // Only the row itself: controls inside
+                                                            // a cell handle their own keys, and
+                                                            // Space on a container that does not
+                                                            // preventDefault also scrolls the page.
+                                                            if (
+                                                                event.target !== event.currentTarget
+                                                            )
+                                                                return
+                                                            if (
+                                                                event.key !== "Enter" &&
+                                                                event.key !== " "
+                                                            )
+                                                                return
+                                                            event.preventDefault()
+                                                            onRowClick(record)
+                                                        }
+                                                      : undefined
+                                              }
                                               className={clsx(
-                                                  CELL,
-                                                  "text-colorText",
-                                                  column.mono && "font-mono tabular-nums",
-                                                  column.align === "right" && "text-right",
-                                                  column.align === "center" && "text-center",
-                                                  column.className,
+                                                  "border-0 border-b border-solid border-colorBorderSecondary last:border-b-0 hover:bg-colorFillQuaternary",
+                                                  onRowClick &&
+                                                      "cursor-pointer outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring",
+                                                  // The detail row carries the boundary instead.
+                                                  detail && "border-b-0",
                                               )}
                                           >
-                                              {column.render(record)}
-                                          </td>
-                                      ))}
-                                      {actions ? (
-                                          <td
-                                              className={clsx(CELL, "text-right")}
-                                              onClick={(event) => event.stopPropagation()}
-                                          >
-                                              <RowActions items={actions(record)} record={record} />
-                                          </td>
-                                      ) : null}
-                                  </tr>
-                              ))}
+                                              {columns.map((column) => (
+                                                  <td
+                                                      key={column.key}
+                                                      className={clsx(
+                                                          CELL,
+                                                          "text-colorText",
+                                                          column.mono && "font-mono tabular-nums",
+                                                          column.align === "right" && "text-right",
+                                                          column.align === "center" &&
+                                                              "text-center",
+                                                          column.className,
+                                                      )}
+                                                  >
+                                                      {column.render(record)}
+                                                  </td>
+                                              ))}
+                                              {actions ? (
+                                                  <td
+                                                      className={clsx(CELL, "text-right")}
+                                                      onClick={(event) => event.stopPropagation()}
+                                                  >
+                                                      <RowActions
+                                                          items={actions(record)}
+                                                          record={record}
+                                                      />
+                                                  </td>
+                                              ) : null}
+                                          </tr>
+                                          {detail ? (
+                                              <tr className="border-0 border-b border-solid border-colorBorderSecondary last:border-b-0">
+                                                  <td
+                                                      colSpan={columns.length + (actions ? 1 : 0)}
+                                                      className="px-3 pb-3 pt-0"
+                                                  >
+                                                      {detail}
+                                                  </td>
+                                              </tr>
+                                          ) : null}
+                                      </Fragment>
+                                  )
+                              })}
                     </tbody>
                 </table>
 


### PR DESCRIPTION
Five org-level settings pages move into `@agenta/settings-ui`, and `/m` gains the Access &
Security tab that shows them.

`DataTable` gains per-row detail here, because Verified Domains and SSO Providers need an expanded
row and building them on antd would have re-introduced the dependency the lane below removed.

Two fixes worth calling out: members now read the same roster the desktop reads, and `/m` resolves
the organization from the project in *this* workspace rather than from the first project it finds.

`fd30503`'s successor (`428201410e`/`37945e49a9`) adds the Domains and SSO sections to the package
*and* wires them into `/m`. That commit is not split — a package change riding with its only
consumer is honest; a half-applied commit is not.
Not run in a browser — static gates only (`pnpm lint-fix` 24/24, `tsc --noEmit` clean
for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`).

Stacked on `pkg/entities-organization`; review only this lane's diff.