### PR TITLE
refactor(frontend): SchemaForm and SubscriptionForm off antd Form

### DIFF
--- a/web/packages/agenta-entity-ui/package.json
+++ b/web/packages/agenta-entity-ui/package.json
@@ -39,6 +39,7 @@
         "@agenta/shared": "workspace:../agenta-shared",
         "@agenta/ui": "workspace:../agenta-ui",
         "@phosphor-icons/react": "^2.1.10",
+        "@rc-component/form": "^1.8.1",
         "clsx": "^2.1.1",
         "fflate": "0.4.8",
         "js-yaml": "^4.3.0",

--- a/web/packages/agenta-entity-ui/src/gatewayTool/components/FormItem.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTool/components/FormItem.tsx
@@ -1,0 +1,62 @@
+import {cloneElement, isValidElement, type ReactElement, type ReactNode} from "react"
+
+import {Field as FieldChrome} from "@agenta/ui/ui"
+import {Field} from "@rc-component/form"
+import type {NamePath, Rule} from "@rc-component/form/lib/interface"
+
+export interface FormItemProps {
+    name?: NamePath
+    label?: ReactNode
+    rules?: Rule[]
+    initialValue?: unknown
+    /** `checked` for toggles, matching antd's Form.Item. */
+    valuePropName?: string
+    /** Renders the control without label chrome — the caller draws its own. */
+    hideLabel?: boolean
+    className?: string
+    children: ReactElement
+}
+
+/**
+ * antd's Form.Item, minus antd.
+ *
+ * The binding is @rc-component/form's Field — the same engine antd wraps, so name paths,
+ * rules, initialValue and valuePropName behave identically. Only the label and error chrome
+ * differ: those come from @agenta/ui's Field, which carries no antd and needs no
+ * ConfigProvider, so these forms render correctly on a host that forbids antd.
+ */
+export function FormItem({
+    name,
+    label,
+    rules,
+    initialValue,
+    valuePropName,
+    hideLabel,
+    className,
+    children,
+}: FormItemProps) {
+    const required = rules?.some((rule) => typeof rule === "object" && rule.required)
+
+    return (
+        <Field name={name} rules={rules} initialValue={initialValue} valuePropName={valuePropName}>
+            {(control, meta) => {
+                const error = meta.errors?.[0]
+                // rc hands back the value/onChange pair under the configured prop names.
+                const bound = isValidElement(children) ? cloneElement(children, control) : children
+
+                if (hideLabel && !error) return bound
+
+                return (
+                    <FieldChrome
+                        label={hideLabel ? undefined : label}
+                        required={required}
+                        error={error}
+                        className={className}
+                    >
+                        {bound}
+                    </FieldChrome>
+                )
+            }}
+        </Field>
+    )
+}

--- a/web/packages/agenta-entity-ui/src/gatewayTool/components/SchemaForm.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTool/components/SchemaForm.tsx
@@ -24,14 +24,15 @@ import {
 import {CaretLeft, CaretRight, Check, MinusCircle, Plus} from "@phosphor-icons/react"
 // DELIBERATE RESIDUE — antd `Form` stays as the state engine (registration, rules,
 // validateFields, useWatch). The `form: FormInstance` prop is cross-package public API:
-// web/oss ElicitationWidget drives it with `Form.useWatch`/`validateFields`/`setFieldsValue`,
+// web/oss ElicitationWidget drives it with `useWatch`/`validateFields`/`setFieldsValue`,
 // and gatewayTrigger's SubscriptionForm prefills it via `setFieldsValue`. Removing the engine
 // here would break those hosts; it needs its own coordinated chunk that owns them.
-import {Form} from "antd"
-import type {FormInstance} from "antd"
+import Form, {List, useForm, useWatch} from "@rc-component/form"
+import type {FormInstance} from "@rc-component/form"
 
 import {ScheduleBuilderField} from "../../gatewayTrigger/drawers/ScheduleBuilderField"
 
+import {FormItem} from "./FormItem"
 import {
     ChipsInput,
     Chip,
@@ -120,7 +121,7 @@ const SchemaForm = forwardRef<SchemaFormHandle, Props>(
         },
         ref,
     ) => {
-        const [form] = Form.useForm(formProp)
+        const [form] = useForm(formProp)
         const fields = useMemo(
             () =>
                 buildFormFieldsFromSchema(schema, "", {
@@ -162,7 +163,7 @@ const SchemaForm = forwardRef<SchemaFormHandle, Props>(
                 pickable: stepperOn && !!current && wantsChoiceCards(current),
             })
         }, [step, fields, onReview, stepperOn, onStepChange])
-        Form.useWatch([], form) // review rows re-render as answers change
+        useWatch([], form) // review rows re-render as answers change
         const optionalFields = useMemo(() => fields.filter((f) => !f.required), [fields])
 
         // JSON editor state
@@ -261,17 +262,10 @@ const SchemaForm = forwardRef<SchemaFormHandle, Props>(
         return (
             <Form
                 form={form}
-                layout="vertical"
-                disabled={disabled}
-                requiredMark={false}
                 // Raw values on purpose: cleanFormValues would recurse into (and destroy) dayjs
                 // objects and JSON.parse typed strings — wrong for a draft snapshot.
                 onValuesChange={onValuesChange ? (_, all) => onValuesChange(all) : undefined}
-                className={
-                    flat
-                        ? "[&_.ant-form-item]:!mb-3 [&_.ant-form-item-label]:!pb-1 [&_.ant-form-item-label>label]:!h-auto [&_.ant-form-item-label>label]:!text-xs"
-                        : "[&_.ant-form-item]:!mb-3"
-                }
+                component={false}
             >
                 {/* No Enter-advance in the stepper: in chat, Enter means "send" (the composer
                     says ↵ Send) — overloading it to page a form is a conflicting affordance. */}
@@ -1014,7 +1008,7 @@ function SchemaFormField({
     // Free-form object or array → JSON editor
     if ((field.type === "object" || field.type === "array") && field.freeform) {
         return (
-            <Form.Item
+            <FormItem
                 name={field.name.split(".")}
                 label={label}
                 rules={[
@@ -1035,7 +1029,7 @@ function SchemaFormField({
                     disabled={disabled}
                     placeholder={field.type === "object" ? '{"key": "value"}' : '[{"item": 1}]'}
                 />
-            </Form.Item>
+            </FormItem>
         )
     }
 
@@ -1043,7 +1037,7 @@ function SchemaFormField({
     // upgraded to checkbox choice cards when the options carry descriptions.
     if (field.type === "array" && field.multiple) {
         return (
-            <Form.Item
+            <FormItem
                 name={field.name.split(".")}
                 label={label}
                 rules={rules}
@@ -1058,7 +1052,7 @@ function SchemaFormField({
                         disabled={disabled}
                     />
                 )}
-            </Form.Item>
+            </FormItem>
         )
     }
 
@@ -1078,31 +1072,31 @@ function SchemaFormField({
     switch (field.type) {
         case "boolean":
             return (
-                <Form.Item
+                <FormItem
                     name={field.name.split(".")}
                     label={label}
                     valuePropName="checked"
                     initialValue={field.default ?? false}
                 >
                     <FormSwitch size="sm" disabled={disabled} />
-                </Form.Item>
+                </FormItem>
             )
 
         case "number":
             return (
-                <Form.Item
+                <FormItem
                     name={field.name.split(".")}
                     label={label}
                     rules={rules}
                     initialValue={field.default}
                 >
                     <InputNumber className="w-full" placeholder={field.label} disabled={disabled} />
-                </Form.Item>
+                </FormItem>
             )
 
         case "enum":
             return (
-                <Form.Item
+                <FormItem
                     name={field.name.split(".")}
                     label={label}
                     rules={rules}
@@ -1129,7 +1123,7 @@ function SchemaFormField({
                             options={(field.enumValues ?? []).map((v) => ({value: v, label: v}))}
                         />
                     )}
-                </Form.Item>
+                </FormItem>
             )
 
         default:
@@ -1138,42 +1132,42 @@ function SchemaFormField({
                 // Seed the displayed schedule as the value — the builder has no empty state,
                 // so an unseeded required field would look answered while Accept stays disabled.
                 return (
-                    <Form.Item
+                    <FormItem
                         name={field.name.split(".")}
                         label={label}
                         rules={rules}
                         initialValue={cronInitialValue(field.default)}
                     >
                         <CronField />
-                    </Form.Item>
+                    </FormItem>
                 )
             }
             if (field.format === "date" || field.format === "date-time") {
                 // No initialValue: a wire default is an ISO STRING and the control emits dayjs —
                 // date fields render empty; other types prefill.
                 return (
-                    <Form.Item name={field.name.split(".")} label={label} rules={rules}>
+                    <FormItem name={field.name.split(".")} label={label} rules={rules}>
                         <DateTimeInput
                             showTime={field.format === "date-time"}
                             disabled={disabled}
                         />
-                    </Form.Item>
+                    </FormItem>
                 )
             }
             if (field.format === "multiline") {
                 return (
-                    <Form.Item
+                    <FormItem
                         name={field.name.split(".")}
                         label={label}
                         rules={rules}
                         initialValue={field.default}
                     >
                         <Textarea rows={3} placeholder={field.label} disabled={disabled} />
-                    </Form.Item>
+                    </FormItem>
                 )
             }
             return (
-                <Form.Item
+                <FormItem
                     name={field.name.split(".")}
                     label={label}
                     rules={[
@@ -1184,7 +1178,7 @@ function SchemaFormField({
                     initialValue={field.default}
                 >
                     <Input placeholder={field.label} disabled={disabled} />
-                </Form.Item>
+                </FormItem>
             )
     }
 }
@@ -1228,7 +1222,7 @@ function ArrayField({
                 </div>
             )}
 
-            <Form.List
+            <List
                 name={namePath}
                 rules={
                     rules.length > 0
@@ -1252,23 +1246,18 @@ function ArrayField({
                             </span>
                         )}
 
-                        {fields.map(({key, name, ...restField}) =>
+                        {fields.map(({key, name}) =>
                             hasObjectItems ? (
                                 <ArrayObjectItem
                                     key={key}
                                     name={name}
-                                    restField={restField}
                                     itemChildren={field.itemChildren!}
                                     onRemove={() => remove(name)}
                                     disabled={disabled}
                                 />
                             ) : (
                                 <div key={key} className="flex items-start gap-2">
-                                    <Form.Item
-                                        {...restField}
-                                        name={[name]}
-                                        className="!mb-0 flex-1"
-                                    >
+                                    <FormItem name={[name]} className="!mb-0 flex-1">
                                         {primitiveItemType === "number" ||
                                         primitiveItemType === "integer" ? (
                                             <InputNumber
@@ -1282,7 +1271,7 @@ function ArrayField({
                                                 disabled={disabled}
                                             />
                                         )}
-                                    </Form.Item>
+                                    </FormItem>
                                     <Button
                                         variant="ghost"
                                         size="icon"
@@ -1309,7 +1298,7 @@ function ArrayField({
                         </Button>
                     </div>
                 )}
-            </Form.List>
+            </List>
         </div>
     )
 }
@@ -1320,13 +1309,11 @@ function ArrayField({
 
 function ArrayObjectItem({
     name,
-    restField,
     itemChildren,
     onRemove,
     disabled,
 }: {
     name: number
-    restField: {fieldKey?: number}
     itemChildren: FormFieldDescriptor[]
     onRemove: () => void
     disabled?: boolean
@@ -1386,9 +1373,8 @@ function ArrayObjectItem({
                                             className="data-[state=closed]:hidden"
                                         >
                                             {child.children.map((gc) => (
-                                                <Form.Item
+                                                <FormItem
                                                     key={gc.name}
-                                                    {...restField}
                                                     name={[name, ...gc.name.split(".")]}
                                                     label={<FieldLabel field={gc} />}
                                                     rules={
@@ -1406,7 +1392,7 @@ function ArrayObjectItem({
                                                         placeholder={gc.label}
                                                         disabled={disabled}
                                                     />
-                                                </Form.Item>
+                                                </FormItem>
                                             ))}
                                         </AccordionContent>
                                     </AccordionItem>
@@ -1416,24 +1402,22 @@ function ArrayObjectItem({
 
                         if (child.type === "boolean") {
                             return (
-                                <Form.Item
+                                <FormItem
                                     key={child.name}
-                                    {...restField}
                                     name={[name, child.name]}
                                     label={childLabel}
                                     valuePropName="checked"
                                     initialValue={child.default ?? false}
                                 >
                                     <FormSwitch size="sm" disabled={disabled} />
-                                </Form.Item>
+                                </FormItem>
                             )
                         }
 
                         if (child.type === "number") {
                             return (
-                                <Form.Item
+                                <FormItem
                                     key={child.name}
-                                    {...restField}
                                     name={[name, child.name]}
                                     label={childLabel}
                                     rules={childRules}
@@ -1444,15 +1428,14 @@ function ArrayObjectItem({
                                         placeholder={child.label}
                                         disabled={disabled}
                                     />
-                                </Form.Item>
+                                </FormItem>
                             )
                         }
 
                         if (child.type === "enum") {
                             return (
-                                <Form.Item
+                                <FormItem
                                     key={child.name}
-                                    {...restField}
                                     name={[name, child.name]}
                                     label={childLabel}
                                     rules={childRules}
@@ -1466,22 +1449,21 @@ function ArrayObjectItem({
                                             label: v,
                                         }))}
                                     />
-                                </Form.Item>
+                                </FormItem>
                             )
                         }
 
                         // Default: string input
                         return (
-                            <Form.Item
+                            <FormItem
                                 key={child.name}
-                                {...restField}
                                 name={[name, child.name]}
                                 label={childLabel}
                                 rules={childRules}
                                 initialValue={child.default}
                             >
                                 <Input placeholder={child.label} disabled={disabled} />
-                            </Form.Item>
+                            </FormItem>
                         )
                     })}
                 </AccordionContent>

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/subscription/SubscriptionForm.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/subscription/SubscriptionForm.tsx
@@ -31,8 +31,8 @@ import {message} from "@agenta/ui"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {Input, Spinner} from "@agenta/ui/ui"
 import {FlowArrow, GitBranch, Lightning, Tag} from "@phosphor-icons/react"
-// The SchemaForm bridge: SchemaForm (gatewayTool) still requires an antd FormInstance.
-import {Form} from "antd"
+// SchemaForm takes a form instance; this one only exists to prefill trigger_config.
+import {useForm} from "@rc-component/form"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
 
 import {DrawerFooter} from "../../../drawers/shared/DrawerFooter"
@@ -193,7 +193,7 @@ export function SubscriptionForm({
         [subscriptions, connectionId, eventKey, subscriptionId],
     )
 
-    const [configForm] = Form.useForm()
+    const [configForm] = useForm()
     const configFormRef = useRef<SchemaFormHandle>(null)
 
     // Prefill from the freshly-fetched subscription (edit mode). Hydrate once per id: any

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1328,6 +1328,9 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@rc-component/form':
+        specifier: ^1.8.1
+        version: 1.8.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query':
         specifier: '>=5.0.0'
         version: 5.100.9(react@19.2.6)


### PR DESCRIPTION
`SchemaForm` and `SubscriptionForm` move from antd's `Form` onto `@rc-component/form` — the same
engine antd itself uses, without the antd component layer. That is what makes the Tools and
Triggers drawers renderable on `/m`, which the lane two above depends on.

**Read this one carefully.** `SchemaForm` is the form the chat runtime drives for elicitation, and
nothing in this stack has been run in a browser. Five files, but the blast radius is the
elicitation path.
Not run in a browser — static gates only (`pnpm lint-fix` 24/24, `tsc --noEmit` clean
for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`).

Stacked on `pkg/settings-tools-triggers`; review only this lane's diff.