### PR TITLE
docs(frontend): the sessions-UX stack — plan, restack and execution record

### DIFF
--- a/docs/design/sessions-ux-stack/execute-stacked-prs.md
+++ b/docs/design/sessions-ux-stack/execute-stacked-prs.md
@@ -278,6 +278,11 @@ being deprecated (`repository.pullRequest.projectCards`), and it fails the same 
 `docs/design/sessions-ux-stack/` is untracked. That is how these docs got swept into a
 `git stash -u` and nearly lost once already. Commit them — probably on the bottom lane.
 
+(In the event they went on their own lane at the **top** of the stack, `docs/sessions-ux-stack`
+= PR **#5894**, based on `pkg/ui-data-table-responsive`. A docs-only lane at the top touches no
+code file and so cannot conflict with any lane below it, which turned out to be the better
+placement.)
+
 ---
 
 ## Outcome (executed 2026-08-10)
@@ -305,10 +310,16 @@ lanes. The branches won; the table in that doc is superseded by the list below.
 
 ### The stack as opened
 
-29 draft PRs, `#5865`–`#5893`, bottom to top. Bottom's base is `release/v0.112.0`; every other
-lane's base is the lane directly below it. Verified on GitHub: every PR's base is correct, every
-PR's changed-file count equals `git diff --name-only <below>..<lane>`, all 29 are drafts, and
-`@coderabbitai review` is requested on each.
+29 draft PRs, `#5865`–`#5893`, bottom to top, plus `#5894` for these docs on top of them. Bottom's
+base is `release/v0.112.0`; every other lane's base is the lane directly below it. Verified on
+GitHub: every PR's base is correct, every PR's changed-file count equals
+`git diff --name-only <below>..<lane>`, all are drafts, and `@coderabbitai review` is requested on
+each.
+
+The counts below are **as opened**. Review fixes land on the lanes afterwards, so a lane's live
+commit and file counts will drift above these numbers — that is the cascade working, not a broken
+stack. Re-derive rather than compare against this table:
+`git rev-list --count <below>..<lane>` and `git diff --name-only <below>..<lane> | wc -l`.
 
 | PR | lane | commits | files |
 |---|---|---|---|

--- a/docs/design/sessions-ux-stack/execute-stacked-prs.md
+++ b/docs/design/sessions-ux-stack/execute-stacked-prs.md
@@ -3,6 +3,11 @@
 Read this whole file before running anything. Read the root `AGENTS.md` section
 **"Spreading a pile of edits back across an existing stack"** too — its warnings are load-bearing.
 
+Every shell block below opens with `set -euo pipefail` so a failing command stops the block instead
+of letting the next step run on a half-built state. **Save each block to a file and run it with
+`bash <file>`** — pasting `set -e` into an interactive shell means the first failure closes your
+session.
+
 ## Verified state (2026-08-10, re-verify before you start)
 
 | fact | value |
@@ -31,12 +36,16 @@ and CodeRabbit will review the duplicates. Phase 1 exists to rebuild that table 
 ## Phase 0 — confirm nothing moved
 
 ```bash
+set -euo pipefail
 cd .claude/worktrees/sessions-ux
 git fetch origin release/v0.112.0 main
-git rev-parse backup/pre-stack-112                      # must exist
+git rev-parse --verify "backup/pre-stack-112^{commit}"  # must exist; aborts here if it doesn't
 git status --porcelain                                  # only the untracked docs dir
-git log --oneline origin/release/v0.112.0..HEAD | wc -l # 83, or re-derive everything
+git rev-list --count origin/release/v0.112.0..HEAD      # 83, or re-derive everything
 ```
+
+`git rev-list --count`, not `git log | wc -l`: a pipeline reports `wc`'s status, so a `git log`
+that fails still prints a plausible number and the check reads as passing.
 
 If the count differs from 83, more has landed; redo Phase 1 from scratch rather than adjusting.
 
@@ -45,13 +54,17 @@ If the count differs from 83, more has landed; redo Phase 1 from scratch rather 
 For every local lane branch, find what it still contributes:
 
 ```bash
+set -euo pipefail
 for b in pkg/auth pkg/navigation pkg/navigation-ui pkg/ui-primitives pkg/session-surfaces \
          pkg/chat-engine oss/chat-on-shared-engine mobile/chat-and-shell playground/de-antd \
          pkg/ui-styles pkg/observability pkg/entities-drive pkg/entity-ui-drive \
          pkg/navigation-shell pkg/sessions-tabs pkg/home-ui oss/wire-up \
          mobile/agents-templates-settings pkg/agent-overview-layout pkg/agent-overview-body; do
-  n=$(git rev-list --count origin/release/v0.112.0..$b 2>/dev/null)
-  printf "%-38s %s\n" "$b" "$n"
+  if git rev-parse --verify -q "refs/heads/$b" >/dev/null; then
+    printf "%-38s %s\n" "$b" "$(git rev-list --count "origin/release/v0.112.0..$b")"
+  else
+    printf "%-38s %s\n" "$b" "ABSENT"        # a missing branch is a finding, not a zero
+  fi
 done
 ```
 
@@ -99,13 +112,21 @@ the PR body — a package change riding with its consumer is honest; a half-appl
 ## Phase 3 — gates, before anything is pushed
 
 ```bash
+set -euo pipefail
 cd web
 pnpm lint-fix                                   # 24/24
 for p in @agenta/shared @agenta/ui @agenta/entities @agenta/entity-ui @agenta/settings-ui \
          @agenta/oss @agenta/ee @agenta/mobile; do
-  echo "$p: $(pnpm --filter $p exec tsc --noEmit 2>&1 | grep -c 'error TS')"
-done                                            # all 0
+  echo "== $p"
+  pnpm --filter "$p" exec tsc --noEmit          # non-zero exit aborts the whole gate
+done
+echo "typecheck clean for all 8 packages"
 ```
+
+**Run `tsc` directly; never `$(… | grep -c 'error TS')`.** Inside a command substitution the
+pipeline's status is `grep`'s, so `pnpm` failing for any reason that isn't a type error — bad
+filter, missing package, OOM, a crashed compiler — prints `0` and the gate reads as green. The
+`echo "== $p"` before each run is there so a failure tells you *which* package stopped it.
 
 Run `lint-fix` **before** staging, not after committing. Prettier reflows imports once a
 specifier changes length, and a stray reformat on a lower lane shows up in every lane above it.

--- a/docs/design/sessions-ux-stack/execute-stacked-prs.md
+++ b/docs/design/sessions-ux-stack/execute-stacked-prs.md
@@ -1,0 +1,260 @@
+# Execute: stacked draft PRs for the sessions-UX work onto `release/v0.112.0`
+
+Read this whole file before running anything. Read the root `AGENTS.md` section
+**"Spreading a pile of edits back across an existing stack"** too — its warnings are load-bearing.
+
+## Verified state (2026-08-10, re-verify before you start)
+
+| fact | value |
+|---|---|
+| worktree | `.claude/worktrees/sessions-ux`, branch `pkg/settings-spine` |
+| backup ref | **`backup/pre-stack-112`** already exists at the current tip — do not delete |
+| target | `origin/release/v0.112.0` = PR **#5827**, OPEN, → `main` |
+| tip merged into 112 | **zero conflicts** (`git merge-tree` clean) |
+| commits not yet in 112 | **83** |
+| working tree | clean except untracked `docs/design/sessions-ux-stack/` |
+
+### The thing that invalidates the old lane table
+
+Four lanes are **already merged into `release/v0.112.0`** under names that differ from the local
+branches:
+
+`pkg/ui-surfaces` · `pkg/sessions` · `pkg/sessions-ui` · `pkg/entity-ui-agent`
+
+All four are ancestors of 112 and 0 commits ahead. That is why `pkg/auth` shrank from 11 commits
+to 1 the moment origin was refetched — most of its content is already in.
+
+**So the lane table in `restack-onto-112.md` is stale.** Do not cherry-pick from it blind: you
+will open PRs whose diffs are already merged, on a release branch other people are assembling,
+and CodeRabbit will review the duplicates. Phase 1 exists to rebuild that table from fact.
+
+## Phase 0 — confirm nothing moved
+
+```bash
+cd .claude/worktrees/sessions-ux
+git fetch origin release/v0.112.0 main
+git rev-parse backup/pre-stack-112                      # must exist
+git status --porcelain                                  # only the untracked docs dir
+git log --oneline origin/release/v0.112.0..HEAD | wc -l # 83, or re-derive everything
+```
+
+If the count differs from 83, more has landed; redo Phase 1 from scratch rather than adjusting.
+
+## Phase 1 — rebuild the lane table from fact
+
+For every local lane branch, find what it still contributes:
+
+```bash
+for b in pkg/auth pkg/navigation pkg/navigation-ui pkg/ui-primitives pkg/session-surfaces \
+         pkg/chat-engine oss/chat-on-shared-engine mobile/chat-and-shell playground/de-antd \
+         pkg/ui-styles pkg/observability pkg/entities-drive pkg/entity-ui-drive \
+         pkg/navigation-shell pkg/sessions-tabs pkg/home-ui oss/wire-up \
+         mobile/agents-templates-settings pkg/agent-overview-layout pkg/agent-overview-body; do
+  n=$(git rev-list --count origin/release/v0.112.0..$b 2>/dev/null)
+  printf "%-38s %s\n" "$b" "$n"
+done
+```
+
+Drop every lane with 0. For the rest, list the surviving commits
+(`git log --oneline origin/release/v0.112.0..<lane>`) and record which files each touches
+(`git show --stat`). **Trust the file lists, not the commit subjects** — the previous mapping was
+built from subjects and that is exactly where it went wrong.
+
+Then map this session's 50 commits (`git log --oneline origin/release/v0.112.0..HEAD`, the newest
+50) onto lanes. `restack-onto-112.md` has a proposed grouping; treat it as a hypothesis to check
+per commit, not as truth.
+
+**Their commits are not contiguous.** You cannot cut this history at branch points; you must
+cherry-pick per lane.
+
+## Phase 2 — build the lanes
+
+One linear line, each lane on top of the one below:
+
+```bash
+base=origin/release/v0.112.0
+git checkout -b <lane-1> $base
+git cherry-pick <its commits, oldest first>
+# verify, then
+git checkout -b <lane-2> <lane-1>
+...
+```
+
+After **every** lane, before moving on:
+
+```bash
+git diff --name-only <lane-below>..<lane>   # exactly this lane's files, nothing from below
+```
+
+If a lower lane's file appears, the order is wrong. Fix it there and then — it compounds upward.
+
+### Commits that span two lanes
+
+Some commits touch a package **and** `web/mobile` (`fd30503` adds the Domains and SSO sections
+*and* wires them into `/m`). Do not split hunks. Use sequential working-tree states: make the file
+the lower lane's version and commit that; then edit to add the upper lane's delta and commit it
+there. If a split is not worth the effort, put the whole commit in the **upper** lane and say so in
+the PR body — a package change riding with its consumer is honest; a half-applied commit is not.
+
+## Phase 3 — gates, before anything is pushed
+
+```bash
+cd web
+pnpm lint-fix                                   # 24/24
+for p in @agenta/shared @agenta/ui @agenta/entities @agenta/entity-ui @agenta/settings-ui \
+         @agenta/oss @agenta/ee @agenta/mobile; do
+  echo "$p: $(pnpm --filter $p exec tsc --noEmit 2>&1 | grep -c 'error TS')"
+done                                            # all 0
+```
+
+Run `lint-fix` **before** staging, not after committing. Prettier reflows imports once a
+specifier changes length, and a stray reformat on a lower lane shows up in every lane above it.
+
+## Phase 4 — push and open the PRs, bottom-up
+
+Do the bottom lane end-to-end first and check it on GitHub before doing the rest.
+
+```bash
+git push -u origin <lane>
+
+gh pr create --draft \
+  --base <lane-below-or-release/v0.112.0> \
+  --head <lane> \
+  --title "<type>(<area>): <what changed>" \
+  --body-file <(cat <<'BODY'
+<what this lane does, and why it is its own lane>
+
+Stacked on `<lane-below>`; review only this lane's diff.
+BODY
+)
+
+gh pr comment <number> --body "@coderabbitai review"
+```
+
+- **Every PR is a draft.** `--draft` on create; do not mark ready.
+- **Bottom lane's base is `release/v0.112.0`**, every other lane's base is the lane directly
+  below it. Wrong bases turn each PR into a diff of the whole stack.
+- **Comment `@coderabbitai review` under each** after creating it.
+- Title convention is in the root `AGENTS.md`; the `write-pr-description` skill has the body
+  format. Never put "Claude", "Anthropic" or `Co-Authored-By` in a commit or PR.
+
+## Phase 5 — verify the stack on GitHub
+
+For each PR, the **Files changed** tab must show only that lane's files. If it shows the lane
+below's too, the base is wrong — fix with `gh pr edit <n> --base <correct>`, no need to re-push.
+
+## Known traps from the session that produced this
+
+- **`git checkout <stash> -- <path>` applies the stash's whole tree, not its diff.** That stash
+  sits on a divergent parent; doing this reverted 276 files and deleted a directory another agent
+  had just added. To apply a stash's changes, use `git diff <stash>^ <stash> -- <paths>` and
+  `git apply --3way`.
+- **`rebase -i` / `add -i` are unavailable here.** To fold a change into a non-tip commit:
+  `git reset --soft HEAD~1`, unstage what does not belong, `git add` what does,
+  `git commit --amend --no-edit`, then recreate the dropped commit.
+- **`but rub` / `but absorb` mis-route against a live working tree** — new files go to the topmost
+  lane, unattributable hunks go to the docs lane, multi-hunk files commit partially with a warning
+  that is easy to miss. Use stash isolation.
+- **A green `tsc` does not mean an edit landed.** A string-replace that matches nothing is a
+  silent no-op and the gates still pass. Grep the file back after scripted edits.
+
+## Two things that are not verified
+
+1. **Nothing in this stack has been run in a browser.** The `@rc-component/form` migration
+   (`e2db4ba`) touches the elicitation form the chat runtime drives; the `/m` write sheets call
+   real mutation endpoints. Static gates only. Say so in the PR bodies.
+2. `web/packages/agenta-sessions/test-results/junit.xml` is **tracked**, so every test run dirties
+   the tree. It should be untracked and gitignored — worth a separate small PR, not smuggled into
+   a lane.
+
+## Housekeeping
+
+`docs/design/sessions-ux-stack/` is untracked. That is how these docs got swept into a
+`git stash -u` and nearly lost once already. Commit them — probably on the bottom lane.
+
+---
+
+## Outcome (executed 2026-08-10)
+
+### What Phase 1 actually found
+
+The premise of Phases 2 and 3 was wrong in our favour: **the stack was already built.** All 83
+commits sat on a single linear chain (no merge commits) with `origin/release/v0.112.0` as an
+*ancestor* of the tip, and 29 local lane branches already pointed at the right cut points. Nothing
+needed cherry-picking; Phase 2 collapsed into "verify the chain".
+
+Two claims in the doc above were re-checked and corrected:
+
+- **`pkg/ui-surfaces` · `pkg/sessions` · `pkg/sessions-ui` · `pkg/entity-ui-agent` are merged into
+  112 — but only on `origin`.** The remote refs are 0 ahead of 112. The *local* branches of the
+  same name are stale, diverged, and not ancestors of the tip. They are dead; ignore them.
+- **No commit in the 83 duplicates 112.** `git cherry origin/release/v0.112.0 HEAD` returns 83 `+`
+  and 0 `-`. The "PRs whose diffs are already merged" hazard did not materialise.
+
+The lane order that was already in the branches differs from `restack-onto-112.md`'s proposal —
+`pkg/settings-spine` sits *below* `pkg/ui-data-table`, not above it, and four proposed lanes
+(`pkg/shared-edition-gates`, `pkg/entity-ui-drillin-bridge`, `mobile/settings`,
+`mobile/drillin-bridge`) do not exist as branches; their commits were folded into neighbouring
+lanes. The branches won; the table in that doc is superseded by the list below.
+
+### The stack as opened
+
+29 draft PRs, `#5865`–`#5893`, bottom to top. Bottom's base is `release/v0.112.0`; every other
+lane's base is the lane directly below it. Verified on GitHub: every PR's base is correct, every
+PR's changed-file count equals `git diff --name-only <below>..<lane>`, all 29 are drafts, and
+`@coderabbitai review` is requested on each.
+
+| PR | lane | commits | files |
+|---|---|---|---|
+| 5865 | `pkg/auth` | 1 | 49 |
+| 5866 | `pkg/navigation` | 1 | 25 |
+| 5867 | `pkg/navigation-ui` | 1 | 39 |
+| 5868 | `pkg/ui-primitives` | 1 | 10 |
+| 5869 | `pkg/session-surfaces` | 1 | 42 |
+| 5870 | `pkg/chat-engine` | 1 | 45 |
+| 5871 | `oss/chat-on-shared-engine` | 1 | 100 |
+| 5872 | `mobile/chat-and-shell` | 1 | 40 |
+| 5873 | `playground/de-antd` | 1 | 15 |
+| 5874 | `pkg/ui-styles` | 2 | 21 |
+| 5875 | `pkg/observability` | 1 | 14 |
+| 5876 | `pkg/entities-drive` | 1 | 31 |
+| 5877 | `pkg/entity-ui-drive` | 1 | 44 |
+| 5878 | `pkg/navigation-shell` | 1 | 20 |
+| 5879 | `pkg/sessions-tabs` | 2 | 48 |
+| 5880 | `pkg/home-ui` | 1 | 65 |
+| 5881 | `oss/wire-up` | 1 | 18 |
+| 5882 | `mobile/agents-templates-settings` | 1 | 30 |
+| 5883 | `pkg/agent-overview-layout` | 1 | 4 |
+| 5884 | `pkg/agent-overview-body` | 8 | 24 |
+| 5885 | `pkg/settings-spine` | 12 | 73 |
+| 5886 | `pkg/ui-data-table` | 4 | 9 |
+| 5887 | `oss/drop-reexport-shims` | 1 | 108 |
+| 5888 | `pkg/entities-organization` | 1 | 42 |
+| 5889 | `pkg/settings-org-pages` | 8 | 13 |
+| 5890 | `pkg/settings-tools-triggers` | 5 | 64 |
+| 5891 | `pkg/entity-ui-form-engine` | 1 | 5 |
+| 5892 | `pkg/settings-ee-pages` | 12 | 95 |
+| 5893 | `pkg/ui-data-table-responsive` | 10 | 88 |
+
+Gates before pushing: `pnpm lint-fix` 24/24 with a clean tree afterwards, and `tsc --noEmit` = 0
+errors for `@agenta/shared`, `ui`, `entities`, `entity-ui`, `settings-ui`, `oss`, `ee`, `mobile`.
+(`restack-onto-112.md` warned that `@agenta/mobile` had 17 errors from another agent's in-flight
+work — that has since settled.)
+
+### New traps found while executing
+
+- **A batch `git push origin <28 refs>` is rejected wholesale with `GH013: Repository rule
+  violations`**, with no indication of which rule. The same refs push fine one at a time. Push
+  lanes sequentially and verify each with `git ls-remote` before moving on.
+- **`gh pr edit` fails on this repo** with a GraphQL error about Projects (classic) being
+  deprecated (`repository.pullRequest.projectCards`). To change a PR's base, title or body, use
+  the REST route instead: `gh api -X PATCH repos/<owner>/<repo>/pulls/<n> -f base=... -f title=...`.
+
+### Still open
+
+- Nothing here has been run in a browser. `#5891` (`SchemaForm`/`SubscriptionForm` onto
+  `@rc-component/form`) sits under the elicitation form the chat runtime drives, and `#5892`'s `/m`
+  write paths call real mutation endpoints. Both PR bodies say so.
+- `web/oss/test-results/junit.xml` and `web/packages/agenta-sessions/test-results/junit.xml` are
+  still tracked. Left alone deliberately — untracking them is an independent change and does not
+  belong in any of these lanes.

--- a/docs/design/sessions-ux-stack/execute-stacked-prs.md
+++ b/docs/design/sessions-ux-stack/execute-stacked-prs.md
@@ -73,29 +73,71 @@ Drop every lane with 0. For the rest, list the surviving commits
 (`git show --stat`). **Trust the file lists, not the commit subjects** — the previous mapping was
 built from subjects and that is exactly where it went wrong.
 
-Then map this session's 50 commits (`git log --oneline origin/release/v0.112.0..HEAD`, the newest
-50) onto lanes. `restack-onto-112.md` has a proposed grouping; treat it as a hypothesis to check
-per commit, not as truth.
+Then map this session's commits onto lanes. **Never select them by count or offset** ("the newest
+50"): one commit added, amended or reordered by another agent shifts every index, and the range
+silently picks up unrelated commits while dropping session ones.
+
+Pin the boundary by SHA instead, once, before anything moves. The previous carve stopped at the
+highest lane branch that already exists, so that ref *is* the boundary:
+
+```bash
+set -euo pipefail
+base=$(git rev-parse origin/release/v0.112.0)
+tip=$(git rev-parse HEAD)                      # write these two SHAs down; they are the contract
+boundary=$(git rev-parse pkg/agent-overview-body)   # highest pre-existing lane from Phase 1
+git merge-base --is-ancestor "$boundary" "$tip"     # fails loudly if it is not on this line
+git merge-base --is-ancestor "$base" "$boundary"    # …and that the line starts at 112
+
+git log --oneline "$boundary..$tip"            # this session's commits — stable under reordering
+git rev-list --count "$boundary..$tip"
+```
+
+Cross-check that list against the SHA table in `restack-onto-112.md` (validate each with
+`git rev-parse --verify '<sha>^{commit}'` — one entry there was malformed). Treat the grouping in
+that doc as a hypothesis to check per commit, not as truth.
 
 **Their commits are not contiguous.** You cannot cut this history at branch points; you must
-cherry-pick per lane.
+cherry-pick per lane. If a subject-based selection is unavoidable, use `git log --grep` with an
+anchored pattern and print the resulting SHAs — never a positional slice.
 
 ## Phase 2 — build the lanes
 
 One linear line, each lane on top of the one below:
 
+Most of these lane names **already exist locally** (Phase 1 will show you which). `git checkout -b`
+fails on an existing name and `-B` silently discards whatever it pointed at — so neither is safe on
+its own. The semantics chosen here are **refuse, never reset**: an existing lane branch is a signal
+that the lane may already be built, and re-deriving it blind is how work gets lost.
+
 ```bash
+set -euo pipefail
 base=origin/release/v0.112.0
-git checkout -b <lane-1> $base
+
+new_lane () {                       # refuse to clobber; the operator decides what to do
+  local lane=$1 start=$2
+  if git rev-parse --verify -q "refs/heads/$lane" >/dev/null; then
+    echo "refusing: $lane already exists at $(git rev-parse --short "$lane")." >&2
+    echo "  inspect it first — the lane may already be correct." >&2
+    echo "  to rebuild deliberately: git branch backup/$lane $lane && git branch -D $lane" >&2
+    return 1
+  fi
+  git checkout -b "$lane" "$start"
+}
+
+new_lane <lane-1> "$base"
 git cherry-pick <its commits, oldest first>
 # verify, then
-git checkout -b <lane-2> <lane-1>
+new_lane <lane-2> <lane-1>
 ...
 ```
+
+Every deletion goes through a `backup/<lane>` ref first. That is what made this session recoverable
+(see `backup/pre-stack-112` in Phase 0) and it costs nothing.
 
 After **every** lane, before moving on:
 
 ```bash
+set -euo pipefail
 git diff --name-only <lane-below>..<lane>   # exactly this lane's files, nothing from below
 ```
 
@@ -136,21 +178,35 @@ specifier changes length, and a stray reformat on a lower lane shows up in every
 Do the bottom lane end-to-end first and check it on GitHub before doing the rest.
 
 ```bash
+set -euo pipefail
 git push -u origin <lane>
+# `git push` prints nothing useful on success — prove it landed before opening the PR.
+# Compare SHAs against ls-remote; never against the remote-tracking ref, which goes stale.
+local_sha=$(git rev-parse <lane>)
+remote_sha=$(git ls-remote --heads origin <lane> | awk '{print $1}')
+test -n "$remote_sha" && test "$local_sha" = "$remote_sha"
+
+body=$(mktemp)
+trap 'rm -f "$body"' EXIT
+cat > "$body" <<'BODY'
+<what this lane does, and why it is its own lane>
+
+Stacked on `<lane-below>`; review only this lane's diff.
+BODY
 
 gh pr create --draft \
   --base <lane-below-or-release/v0.112.0> \
   --head <lane> \
   --title "<type>(<area>): <what changed>" \
-  --body-file <(cat <<'BODY'
-<what this lane does, and why it is its own lane>
-
-Stacked on `<lane-below>`; review only this lane's diff.
-BODY
-)
+  --body-file "$body"
 
 gh pr comment <number> --body "@coderabbitai review"
 ```
+
+The body goes through a temp file, not `--body-file <(cat <<'BODY' … )`. A heredoc inside a
+process substitution **does not parse under bash 3.2**, which is what `/bin/bash` still is on
+macOS — `unexpected EOF while looking for matching`. The `mktemp` form parses under bash 3.2,
+bash 5 and zsh alike.
 
 - **Every PR is a draft.** `--draft` on create; do not mark ready.
 - **Bottom lane's base is `release/v0.112.0`**, every other lane's base is the lane directly
@@ -162,7 +218,17 @@ gh pr comment <number> --body "@coderabbitai review"
 ## Phase 5 — verify the stack on GitHub
 
 For each PR, the **Files changed** tab must show only that lane's files. If it shows the lane
-below's too, the base is wrong — fix with `gh pr edit <n> --base <correct>`, no need to re-push.
+below's too, the base is wrong — no need to re-push, just repoint the PR:
+
+```bash
+set -euo pipefail
+gh api -X PATCH repos/:owner/:repo/pulls/<n> -f base=<correct-lane-below>
+```
+
+**Do not use `gh pr edit`.** It fails on this repo with a GraphQL error about Projects (classic)
+being deprecated (`repository.pullRequest.projectCards`), and it fails the same way for `--base`,
+`--title` and `--body`. The REST route above is the working path for all three (`-f title=…`,
+`-f body=…`). This is recorded repo knowledge, not a preference.
 
 ## Known traps from the session that produced this
 
@@ -170,6 +236,25 @@ below's too, the base is wrong — fix with `gh pr edit <n> --base <correct>`, n
   sits on a divergent parent; doing this reverted 276 files and deleted a directory another agent
   had just added. To apply a stash's changes, use `git diff <stash>^ <stash> -- <paths>` and
   `git apply --3way`.
+- **That diff covers tracked files only — untracked files live in the stash's *third parent*.**
+  `git stash push -u` builds a commit with up to three parents: `^1` = HEAD, `^2` = the index,
+  `^3` = the untracked files. `git diff <stash>^ <stash>` and `git checkout <stash> -- <paths>`
+  both miss `^3` entirely, so anything that was untracked comes back silently absent — which is
+  exactly how `docs/design/sessions-ux-stack/` was nearly lost. Restore in two steps:
+
+  ```bash
+  set -euo pipefail
+  stash=stash@{0}
+  git diff "$stash^" "$stash" -- <tracked-paths> | git apply --3way   # tracked
+  if git rev-parse --verify -q "$stash^3" >/dev/null; then            # untracked, if any
+    git checkout "$stash^3" -- <untracked-paths>
+  fi
+  git status --porcelain -- <all-paths>                               # eyeball the result
+  ```
+
+  `git rev-parse --verify "$stash^3"` failing is meaningful: it means the stash was taken without
+  `-u`, so there are no untracked files to recover. Never assume — check. Same trap, same fix, in
+  the root `AGENTS.md` §"Spreading a pile of edits back across an existing stack".
 - **`rebase -i` / `add -i` are unavailable here.** To fold a change into a non-tip commit:
   `git reset --soft HEAD~1`, unstage what does not belong, `git add` what does,
   `git commit --amend --no-edit`, then recreate the dropped commit.

--- a/docs/design/sessions-ux-stack/handoff-audit-log-billing.md
+++ b/docs/design/sessions-ux-stack/handoff-audit-log-billing.md
@@ -126,14 +126,38 @@ imports, one component per file, semantic tokens only.
 
 ## Verification (run all of it before each commit)
 
+Save this as a file and run it with `bash` — `set -e` pasted into an interactive shell closes the
+session on the first failure.
+
 ```bash
+set -euo pipefail
 cd web
 pnpm lint-fix                                   # must be 24/24
+
 for p in @agenta/settings-ui @agenta/oss @agenta/ee @agenta/mobile; do
-  echo "$p: $(pnpm --filter $p exec tsc --noEmit 2>&1 | grep -c 'error TS')"
-done                                            # all must be 0
-grep -rn 'from "antd"\|@ant-design' packages/agenta-settings-ui/src   # must be empty
+  echo "== $p"
+  pnpm --filter "$p" exec tsc --noEmit          # non-zero exit aborts the gate
+done
+
+# no antd anywhere in the package — both quote styles, and the subpath imports
+if grep -rnE "from ['\"]antd|from ['\"]@ant-design" packages/agenta-settings-ui/src; then
+  echo "antd import found in @agenta/settings-ui" >&2
+  exit 1
+fi
+
+echo "gates green"
 ```
+
+Two things this block deliberately does *not* do:
+
+- **It never wraps `tsc` in `$(… | grep -c 'error TS')`.** A command substitution reports the
+  pipeline's last status, i.e. `grep`'s — so `pnpm` failing for a reason that isn't a type error
+  (bad filter, missing package, OOM, a compiler crash) prints `0` and the gate reads as green.
+  Run `tsc` directly under `set -e` and let a failure stop the script.
+- **It does not leave the antd `grep` bare.** `grep` exits 1 when it finds nothing, which under
+  `set -e` would abort on the *success* case; and the old pattern only matched double quotes, so a
+  single-quoted `from 'antd'` slipped through. The `if` form inverts it correctly: a hit is the
+  failure.
 
 **None of this session's work has been run in a browser** — every gate has been lint + tsc
 only. If you can get the app up, that's worth more than another green typecheck. There is a

--- a/docs/design/sessions-ux-stack/handoff-audit-log-billing.md
+++ b/docs/design/sessions-ux-stack/handoff-audit-log-billing.md
@@ -1,0 +1,143 @@
+# Handoff: extract Audit Log and Usage & Billing into `@agenta/settings-ui`
+
+## Where you are
+
+Worktree: `.claude/worktrees/sessions-ux`, branch `pkg/settings-spine`.
+Run everything from `web/`.
+
+The tree is **green right now** — `pnpm lint-fix` passes 24/24 and `tsc` is 0 errors across
+`@agenta/settings-ui`, `@agenta/oss`, `@agenta/ee`, `@agenta/mobile`. Keep it that way at
+every commit.
+
+## Target architecture (this is why the task is worth doing)
+
+Today there are three web apps: `web/oss`, `web/ee`, `web/mobile`. The goal is **only
+`web/mobile`** — it replaces both. OSS vs EE becomes an **env-var gate inside that one app**,
+not two codebases.
+
+So the `@agenta/*` packages are the real shipping layer, and `oss/`/`ee/` are transitional
+hosts on the way out. **Moving EE-only code into `@agenta/settings-ui` is correct**, even
+though that package is currently a dependency of `web/oss`. Gate EE features at runtime on
+`SettingsAccess.isEE` (from `getEnv("NEXT_PUBLIC_AGENTA_LICENSE") === "ee"`), never by which
+package a file lives in. If you find yourself worrying "but this ships to OSS" — that concern
+is void here. Don't re-raise it.
+
+## The task
+
+1. **Audit Log** — `web/ee/src/components/pages/settings/AuditLog/` (7 files, ~706 loc)
+2. **Usage & Billing** — `web/ee/src/components/pages/settings/Billing/` (~769 loc) plus
+   `web/oss/src/components/pages/settings/Billing`
+3. Wire both into `/m`'s settings rail behind `access.isEE`
+   (`web/mobile/src/features/settings/SettingsScreen.tsx`)
+
+Do Audit Log first and commit it before starting Billing.
+
+## The extraction pattern this codebase already uses
+
+Nine settings pages have been extracted this way. **Follow it exactly** — do not invent a
+new shape. Read one of these first as a reference; `MembersPage` is the clearest:
+
+- `web/packages/agenta-settings-ui/src/members/MembersPage.tsx` (view + host slots)
+- `web/oss/src/components/pages/settings/WorkspaceManage/WorkspaceManage.tsx` (OSS binding)
+- `web/mobile/src/features/settings/MembersTab.tsx` (mobile binding, bottom sheets)
+
+The rules:
+
+- The extracted component is a **view fed by props**. It owns layout, columns, empty states
+  and the search filter. It owns no app state and no dialogs.
+- Anything host-specific arrives as a **render slot** (`renderUser`, `renderInstructions`,
+  `renderRoleCell`) or a **verb prop** (`onDelete`, `confirm`).
+- An action whose slot is absent **hides itself** (`hidden: !confirm`) rather than rendering
+  a control that does nothing.
+- Tables use `DataTable` from `@agenta/ui/ui` — **never** `InfiniteVirtualTable` /
+  `createStandardColumns` / `useStaticTable`. Those are antd-backed. `DataTable` supports
+  `columns`, `rows`, `rowKey`, `actions`, `filters`, `primaryActions`, `title`, `empty`,
+  `loading`, `onRowClick`, `expandedContent`.
+- OSS keeps a thin binding file at the old path so its pages don't change.
+
+## What I already learned attempting Audit Log (I reverted; don't repeat this)
+
+I moved the files, rewrote the shell, converted `AuditEventCells`, then ran out of room and
+reverted rather than leave a package that doesn't compile. These findings are solid:
+
+**Its two app-layer dependencies should become slots, not moves.**
+- `AuditEventCells.tsx:21` and `AuditEventDrawer.tsx:15` import `UserReference` from
+  `@/oss/components/References/UserReference`. It's *nearly* portable (only antd
+  `Typography` + `@agenta/entities`), but a `renderUser?: (userId, className?) => ReactNode`
+  slot is cleaner and matches the pattern.
+- `AuditLogFilters.tsx:26` imports `QuickDateRangePicker`, which pulls in
+  `@/oss/components/Filters/Sort` — a whole OSS filter component. Definitely a slot:
+  `renderDateRange?: (state: {value, onChange}) => ReactNode`.
+
+**`useEntitlements` becomes props.** `AuditLog.tsx` calls `useEntitlements()` for
+`hasAudit`/`isLoading`. Take `hasAudit?: boolean` and `entitlementsLoading?: boolean`; the
+host resolves entitlements. Note the two-gate model in that file's header comment — tab
+visibility is `canViewEvents` (already handled by the sidebar), page content is `Flag.AUDIT`.
+
+**`UpgradePrompt` is already replaced.** Use `UpgradeNotice` from
+`packages/agenta-settings-ui/src/access/UpgradeNotice.tsx`. It takes its upgrade link as an
+`action` slot because routing and billing availability are the host's.
+
+**The antd surface is light and every piece has an equivalent.** No form engine involved:
+
+| file | antd | replacement |
+|---|---|---|
+| `AuditLog.tsx` | `Spin` | `Spinner` |
+| `AuditEventCells.tsx` | `Tag`, `Tooltip` | `Tag` from `@agenta/ui/components/presentational`; a `title` attribute for the per-cell hover |
+| `AuditEventDrawer.tsx` | `Descriptions`, `Empty`, `Tag`, `Typography` | `EmptyState`, `Tag`, plain elements — **`Descriptions` has no equivalent**, write a small definition list |
+| `AuditLogFilters.tsx` | `Input` | `Input` from `@agenta/ui/ui` |
+| `AuditLogTable.tsx` | `Skeleton` | `DataTable`'s built-in `loading` |
+
+**The bit that stopped me:** `ActorCell` (and the drawer) currently take only `eventId` and
+reach for `UserReference` directly. `renderUser` has to be threaded from `AuditLog` →
+`AuditLogTable` → its column renderers → `ActorCell`. Plan that threading before you start
+editing, or you'll half-convert like I did.
+
+## Gotchas that cost me time this session
+
+- **Never do string/regex surgery on JSX.** I corrupted a file with a brace-matching script
+  and had to restore from git. Use the `Edit` tool for anything inside a component body.
+  Batched `python` replacements are fine for imports and whole-block swaps you've read first.
+- **Check `@agenta/ui` signatures before writing call sites.** I guessed wrong repeatedly.
+  `Button` has no `icon` prop (children instead), sizes are `sm` not `small`;
+  `Select` is composed (`SelectTrigger`/`SelectContent`/`SelectItem`), not `options`-based;
+  `Alert` takes `type`/`message`; `Tag` takes children; `Spinner` takes `size="small"`.
+- **A disabled button fires no pointer events.** antd's Tooltip handled that; Radix doesn't.
+  Wrap in a `span` if the tooltip on a disabled control matters.
+- **OSS lint forbids re-export stubs from `@agenta/*`.** Don't leave
+  `export {default} from "@agenta/settings-ui/..."` at an old path — import the package
+  directly at the consuming site.
+- **`fixed: "left"` and `restField`/`fieldKey` are antd table concerns.** Drop them; they're
+  inert on `DataTable`.
+- **Registry components need a prettier pass.** `pnpm dlx shadcn@latest add <x>` in
+  `web/mobile/` writes upstream formatting; run `npx prettier --write` on the file and check
+  its import grouping.
+
+## Wiring `/m` afterwards
+
+In `web/mobile/src/features/settings/SettingsScreen.tsx`:
+- add `"auditLog"` / `"billing"` to `AVAILABLE`
+- the access object currently hardcodes `billingEnabled: false` and `canViewEvents: false` —
+  these gate tab visibility via `isSettingsTabVisible` in `@agenta/settings/navigation`
+- render behind `access.isEE`
+
+Mobile hard rules (`web/mobile/CLAUDE.md`): **no antd ever**, no `@/oss` or `@agenta/ee`
+imports, one component per file, semantic tokens only.
+
+## Verification (run all of it before each commit)
+
+```bash
+cd web
+pnpm lint-fix                                   # must be 24/24
+for p in @agenta/settings-ui @agenta/oss @agenta/ee @agenta/mobile; do
+  echo "$p: $(pnpm --filter $p exec tsc --noEmit 2>&1 | grep -c 'error TS')"
+done                                            # all must be 0
+grep -rn 'from "antd"\|@ant-design' packages/agenta-settings-ui/src   # must be empty
+```
+
+**None of this session's work has been run in a browser** — every gate has been lint + tsc
+only. If you can get the app up, that's worth more than another green typecheck. There is a
+standing verification backlog: the `@rc-component/form` migration of `SchemaForm` (it drives
+chat elicitation), and the new `/m` write sheets for Projects and Members.
+
+Commit messages: no "Claude"/"Anthropic"/"Co-Authored-By" lines.

--- a/docs/design/sessions-ux-stack/plan-settings-nav-takeover.md
+++ b/docs/design/sessions-ux-stack/plan-settings-nav-takeover.md
@@ -1,0 +1,140 @@
+# Plan: make `/m` settings navigation match OSS, and put the nested rail behind a flag
+
+## Why
+
+The nested settings side-panel on `/m` is contested inside the team. Rather than keep arguing
+it or throw the work away, **make the OSS pattern the default and keep the nested one alive
+behind an env var.** Nobody has to relitigate, and the code stays.
+
+## The two patterns
+
+**OSS — takeover (this becomes the default).** The main sidebar *is* the settings nav.
+Its header turns into `← Back`, its sections become Project / Organization / Personal with an
+icon per row, and the footer keeps Invite Teammate / Help & Docs / the project switcher. There
+is **no in-page top bar** — the content pane starts directly with the tab title
+("Members" / "Manage members, invitations, and access."). Second screenshot in the thread.
+
+**`/m` — nested (this goes behind the flag).** The main rail (Home / Sessions / Agents) stays
+put, a *second* rail appears next to it with the settings groups, and a "Settings" top bar sits
+above the content. Three levels of chrome for one page. First screenshot.
+
+## Requested outcome
+
+1. Default `/m` behaviour == OSS takeover: settings replaces the main sidebar, top bar removed.
+2. Nested rail stays reachable behind `NEXT_PUBLIC_SETTINGS_NESTED_NAV=true`.
+3. OSS/EE unchanged — they already do the takeover.
+
+## Where the pieces are
+
+Everything is in the `sessions-ux` worktree, branch `pkg/settings-spine`. Run from `web/`.
+
+**OSS already implements the takeover you are copying — read it first, don't redesign it:**
+- `oss/src/components/Sidebar/scopes/settingsScope.tsx` — builds a `SidebarScope` with
+  `SETTINGS_SIDEBAR_SCOPE_ID`, groups from `SETTINGS_SCOPES`, one Phosphor icon per tab, and
+  the tabs from `getSettingsSidebarTabs(access)`. **The icon map lives here** — it is the one
+  thing `/m` is missing and should be shared rather than copied (see step 2).
+- `oss/src/pages/w/[workspace_id]/p/[project_id]/settings/index.tsx` — the page. Note it
+  renders `SettingsPageShell` with a title/description and no top bar.
+
+**`/m` currently hand-rolls its nested rail:**
+- `mobile/src/features/settings/SettingsScreen.tsx` — the `<nav>` block (~line 230) renders
+  the groups; above it, `ScreenScaffold`'s `header` renders the `NavDrawer` + an `<h1>Settings</h1>`.
+  Both come out under the flag.
+- `mobile/src/features/nav/mobileNavScope.tsx` — mobile's `SidebarScope` for the shared
+  `SidebarShell`. This is where a settings scope belongs, mirroring `settingsScope.tsx`.
+- `mobile/src/features/nav/{AppShell,NavDrawer,NavRail}.tsx` — the shell that would host it.
+
+**Shared contracts:** `@agenta/navigation` (`SidebarScope`, `SidebarSection`,
+`SidebarSelection`, `SETTINGS_SIDEBAR_SCOPE_ID`) and `@agenta/settings`
+(`SETTINGS_SCOPES`, `getSettingsSidebarTabs`, `resolveSettingsTab`, `isSettingsTabKey`).
+
+## Steps
+
+### 1. Add the flag
+
+Follow the existing idiom exactly — `mobile/src/features/chat/steer.ts` is the model:
+
+```ts
+// mobile/src/features/settings/nestedNav.ts
+import {getEnv} from "@/lib/env"
+
+/** Nested settings rail (a second rail beside the main one). OFF: settings takes over the
+ *  main sidebar, matching oss/ee. */
+export const isNestedSettingsNavEnabled = (): boolean =>
+    (getEnv("NEXT_PUBLIC_SETTINGS_NESTED_NAV") || "").toLowerCase() === "true"
+```
+
+Register it wherever mobile's other `NEXT_PUBLIC_*` flags are declared for the runtime env
+(check `mobile/src/lib/env.ts` and the docker-compose env files under
+`hosting/docker-compose/`; `NEXT_PUBLIC_AGENT_CHAT_STEER` shows the full path a flag takes).
+
+### 2. Share the settings scope instead of copying it
+
+**Do not duplicate `settingsScope.tsx` into mobile.** That is the mistake this codebase has a
+hard rule against — extract, never hand-roll a second version.
+
+Move the reusable core into `@agenta/settings` (it is headless — icons, groups, tab list) and
+leave the app-coupled parts (`useSettingsAccess`, `useQueryParam`, `settingsTabAtom`) in each
+host. Concretely:
+
+- `packages/agenta-settings/src/sidebar.ts` (new): the tab→icon map and a
+  `buildSettingsSidebarSections(tabs, activeTab)` returning `SidebarSection[]`.
+- `oss/.../settingsScope.tsx` keeps its hooks and calls the shared builder.
+- `mobile/src/features/settings/settingsNavScope.tsx` (new): same builder, mobile's routing.
+
+`SETTINGS_SCOPES` and `getSettingsSidebarTabs(access)` are already shared — the grouping and
+labels must keep coming from there so the two rails cannot drift.
+
+### 3. Takeover on `/m` (the default path)
+
+When the flag is off:
+- The sidebar renders the settings scope instead of `mobileNavScope` — header becomes
+  `← Back` (returns to the last non-settings route), footer unchanged.
+- `ScreenScaffold` gets **no** `header` — drop the `NavDrawer` + `<h1>Settings</h1>` row.
+- The content pane renders `SettingsPageShell` alone, exactly as OSS does.
+- On a phone the sidebar is a drawer, so "takeover" means the *drawer's* contents change; the
+  content pane is full-width either way. Check both breakpoints — `lg:` is where OSS's rail
+  becomes persistent.
+
+When the flag is on: today's nested rail, unchanged.
+
+### 4. Keep the nested path working
+
+Do not delete the `<nav>` block — move it behind the flag so both render paths compile and
+are exercisable. A reviewer should be able to flip one env var and see the other pattern.
+
+## Constraints
+
+- **Mobile hard rules** (`web/mobile/CLAUDE.md`): no antd ever, no `@/oss` or `@agenta/ee`
+  imports, one component per file, semantic tokens only (`bg-background`,
+  `text-muted-foreground`), motion via `useMotionPresets()`.
+- **OSS/EE must not change behaviour.** They already do the takeover; step 2 refactors where
+  the icon map lives, nothing user-visible. Diff the OSS settings page before/after.
+- The settings tab list, grouping and labels stay driven by `@agenta/settings` for both hosts.
+
+## Verification
+
+```bash
+cd web
+pnpm lint-fix                                   # must be 24/24
+for p in @agenta/settings @agenta/navigation @agenta/oss @agenta/ee @agenta/mobile; do
+  echo "$p: $(pnpm --filter $p exec tsc --noEmit 2>&1 | grep -c 'error TS')"
+done                                            # all must be 0
+```
+
+Then **actually look at it** — this is a layout change and static gates say nothing about it:
+- `/m` settings with the flag unset → sidebar is the settings nav, no top bar, matches OSS.
+- `/m` settings with `NEXT_PUBLIC_SETTINGS_NESTED_NAV=true` → today's nested rail.
+- Both at phone and `lg` widths.
+- OSS settings unchanged.
+
+Arda runs the dev servers — ask for a URL rather than starting one.
+
+## Context worth having
+
+The target architecture is that **`web/mobile` replaces `web/oss` and `web/ee`**, with edition
+as an env-var gate inside one app. That is why this flag is the right shape: `/m` has to be
+able to present the same navigation OSS does, because it will *be* OSS. It is also why
+anything still living in `oss/` or `ee/` counts as debt.
+
+Commit messages: no "Claude"/"Anthropic"/"Co-Authored-By" lines.

--- a/docs/design/sessions-ux-stack/plan-settings-nav-takeover.md
+++ b/docs/design/sessions-ux-stack/plan-settings-nav-takeover.md
@@ -114,18 +114,31 @@ are exercisable. A reviewer should be able to flip one env var and see the other
 
 ## Verification
 
+Save as a file and run with `bash` — `set -e` in an interactive shell exits it on the first failure.
+
 ```bash
+set -euo pipefail
 cd web
 pnpm lint-fix                                   # must be 24/24
 for p in @agenta/settings @agenta/navigation @agenta/oss @agenta/ee @agenta/mobile; do
-  echo "$p: $(pnpm --filter $p exec tsc --noEmit 2>&1 | grep -c 'error TS')"
-done                                            # all must be 0
+  echo "== $p"
+  pnpm --filter "$p" exec tsc --noEmit          # a failure here aborts the gate
+done
+echo "typecheck clean"
 ```
 
+`tsc` runs directly, never as `$(… | grep -c 'error TS')`: inside a command substitution the
+status is `grep`'s, so a `pnpm` that dies for any non-type reason prints `0` and the gate passes
+on a broken build.
+
 Then **actually look at it** — this is a layout change and static gates say nothing about it:
-- `/m` settings with the flag unset → sidebar is the settings nav, no top bar, matches OSS.
-- `/m` settings with `NEXT_PUBLIC_SETTINGS_NESTED_NAV=true` → today's nested rail.
-- Both at phone and `lg` widths.
+
+- `/m` settings with the flag unset, **at `lg`+** → sidebar is the settings nav, no top bar,
+  matches OSS.
+- `/m` settings with the flag unset, **on a phone** → the `lg:hidden` header is there, its button
+  opens the drawer, and the drawer shows the *settings* nav. This is the case the takeover is
+  most likely to break; check it first.
+- `/m` settings with `NEXT_PUBLIC_SETTINGS_NESTED_NAV=true` → today's nested rail, both widths.
 - OSS settings unchanged.
 
 Arda runs the dev servers — ask for a URL rather than starting one.

--- a/docs/design/sessions-ux-stack/plan-settings-nav-takeover.md
+++ b/docs/design/sessions-ux-stack/plan-settings-nav-takeover.md
@@ -10,9 +10,12 @@ behind an env var.** Nobody has to relitigate, and the code stays.
 
 **OSS — takeover (this becomes the default).** The main sidebar *is* the settings nav.
 Its header turns into `← Back`, its sections become Project / Organization / Personal with an
-icon per row, and the footer keeps Invite Teammate / Help & Docs / the project switcher. There
-is **no in-page top bar** — the content pane starts directly with the tab title
+icon per row, and the footer keeps Invite Teammate / Help & Docs / the project switcher. At `lg`
+and up there is **no in-page top bar** — the content pane starts directly with the tab title
 ("Members" / "Manage members, invitations, and access."). Second screenshot in the thread.
+
+Below `lg` the sidebar is a **drawer**, so "no top bar" cannot apply there: the top bar is what
+holds the drawer trigger. See step 3.
 
 **`/m` — nested (this goes behind the flag).** The main rail (Home / Sessions / Agents) stays
 put, a *second* rail appears next to it with the settings groups, and a "Settings" top bar sits
@@ -20,9 +23,26 @@ above the content. Three levels of chrome for one page. First screenshot.
 
 ## Requested outcome
 
-1. Default `/m` behaviour == OSS takeover: settings replaces the main sidebar, top bar removed.
+1. Default `/m` behaviour == OSS takeover: settings replaces the main sidebar, and the in-page top
+   bar is removed **at `lg` and up**. Below `lg` a minimal header stays, carrying the `NavDrawer`
+   trigger — without it the drawer has nothing to open it and phone users lose the settings nav
+   entirely.
 2. Nested rail stays reachable behind `NEXT_PUBLIC_SETTINGS_NESTED_NAV=true`.
 3. OSS/EE unchanged — they already do the takeover.
+
+## Status
+
+Steps 1–4 are **implemented**, on the `pkg/settings-ee-pages` lane (PR **#5892**):
+
+| step | landed as |
+|---|---|
+| 1. the flag | `web/mobile/src/features/settings/nestedNav.ts` |
+| 2. shared scope | `web/packages/agenta-settings/src/sidebar.tsx` + `mobile/src/features/settings/settingsNavScope.tsx` |
+| 3. takeover | `SettingsScreen.tsx` — `AppShell scope={nestedNav ? undefined : settingsScope}`, `lg:hidden` header keeps the `NavDrawer` trigger |
+| 4. nested path | `SettingsTabRail` still renders, behind the flag |
+
+What remains is the browser pass under **Verification** — none of it has been looked at at either
+breakpoint. Read the rest as the rationale for what is there, not as work to do.
 
 ## Where the pieces are
 
@@ -39,7 +59,8 @@ Everything is in the `sessions-ux` worktree, branch `pkg/settings-spine`. Run fr
 **`/m` currently hand-rolls its nested rail:**
 - `mobile/src/features/settings/SettingsScreen.tsx` — the `<nav>` block (~line 230) renders
   the groups; above it, `ScreenScaffold`'s `header` renders the `NavDrawer` + an `<h1>Settings</h1>`.
-  Both come out under the flag.
+  The `<nav>` block goes behind the flag; the header becomes `lg:hidden` rather than disappearing,
+  because it carries the drawer trigger (see step 3).
 - `mobile/src/features/nav/mobileNavScope.tsx` — mobile's `SidebarScope` for the shared
   `SidebarShell`. This is where a settings scope belongs, mirroring `settingsScope.tsx`.
 - `mobile/src/features/nav/{AppShell,NavDrawer,NavRail}.tsx` — the shell that would host it.
@@ -77,8 +98,9 @@ Move the reusable core into `@agenta/settings` (it is headless — icons, groups
 leave the app-coupled parts (`useSettingsAccess`, `useQueryParam`, `settingsTabAtom`) in each
 host. Concretely:
 
-- `packages/agenta-settings/src/sidebar.ts` (new): the tab→icon map and a
-  `buildSettingsSidebarSections(tabs, activeTab)` returning `SidebarSection[]`.
+- `packages/agenta-settings/src/sidebar.tsx` (new): the tab→icon map and a
+  `buildSettingsSidebarSections(tabs, activeTab)` returning `SidebarSection[]`. (`.tsx`, not
+  `.ts` — the icon map holds JSX elements.)
 - `oss/.../settingsScope.tsx` keeps its hooks and calls the shared builder.
 - `mobile/src/features/settings/settingsNavScope.tsx` (new): same builder, mobile's routing.
 
@@ -88,13 +110,23 @@ labels must keep coming from there so the two rails cannot drift.
 ### 3. Takeover on `/m` (the default path)
 
 When the flag is off:
+
 - The sidebar renders the settings scope instead of `mobileNavScope` — header becomes
   `← Back` (returns to the last non-settings route), footer unchanged.
-- `ScreenScaffold` gets **no** `header` — drop the `NavDrawer` + `<h1>Settings</h1>` row.
-- The content pane renders `SettingsPageShell` alone, exactly as OSS does.
-- On a phone the sidebar is a drawer, so "takeover" means the *drawer's* contents change; the
-  content pane is full-width either way. Check both breakpoints — `lg:` is where OSS's rail
-  becomes persistent.
+- **At `lg` and up**, `ScreenScaffold` gets **no** `header` — the `NavDrawer` +
+  `<h1>Settings</h1>` row goes away and the content pane renders `SettingsPageShell` alone,
+  exactly as OSS does.
+- **Below `lg` the header survives.** The sidebar is a drawer at phone widths, and the header is
+  the only thing that opens it: removing it unconditionally strands a phone user on whichever
+  settings tab they landed on, with no way back to the nav. Keep an `lg:hidden` header rendering
+  the `NavDrawer` trigger — passing it the *settings* scope, so the drawer opens the settings nav
+  and not the app nav — with "Settings" beside it (a lone icon button reads as stray chrome; the
+  tab's own title is the page heading directly underneath). In JSX terms this header is
+  conditional on the **breakpoint**, not on the flag.
+- So "takeover" means: **at `lg`+** the persistent rail's *contents* become the settings nav and
+  the top bar disappears; **below `lg`** the *drawer's* contents become the settings nav and a
+  trigger-only header remains. The content pane is full-width either way. Check both breakpoints
+  — `lg:` is where OSS's rail becomes persistent.
 
 When the flag is on: today's nested rail, unchanged.
 

--- a/docs/design/sessions-ux-stack/plan.md
+++ b/docs/design/sessions-ux-stack/plan.md
@@ -1,0 +1,236 @@
+# Committing the working-tree web changes as a stack
+
+## 1. Where we actually are
+
+`feat/sessions-ux-polish` is a **scratch integration branch**, not a PR branch. PRs are
+carved out of it into clean lanes (the git-stash isolation technique in `AGENTS.md`).
+
+Already carved and open:
+
+```
+main
+ ├─ entities/trigger-helpers            #5766
+ ├─ fe-fix/drive-upload-reveal          #5793
+ └─ feat/mobile-parity-and-consolidation
+     └─ pkg/ui-surfaces                 #5768
+         └─ pkg/sessions                #5769
+             └─ pkg/sessions-ui         #5770
+                 └─ pkg/entity-ui-agent #5771
+                     └─ oss/home-overview   #5772
+                         └─ oss/agents-page #5773
+                             └─ oss/templates    #5774
+                                 └─ oss/sessions-page   #5775
+                                     └─ oss/seed-attachments  #5776   ← published top
+```
+
+Local `HEAD` vs that top: **+211 / −11**. Concretely:
+
+| | |
+|---|---|
+| commits on `HEAD` not yet pushed anywhere | **85** |
+| tree delta `origin/oss/seed-attachments` → `HEAD`, `web/` only | **365 files** |
+| uncommitted `web/` paths | **261** |
+
+## 2. The base problem
+
+`merge-base(HEAD, oss/seed-attachments)` = `e6b4ff5143`. From there:
+
+```
+carve point → HEAD                    211 commits
+carve point → oss/seed-attachments     11 commits
+carve point → feat/mobile-parity        2 commits
+```
+
+So the published stack was **not cherry-picked** — 211 integration commits were
+re-authored into 11 clean ones across 10 lanes, covering only the
+sessions / home / agents / templates theme. Everything else in those 211 is uncarved:
+
+- `@agenta/auth` + `@agenta/auth-ui` (shared sign-in for oss/ee/mobile)
+- `@agenta/navigation` + `@agenta/navigation-ui` (sidebar model + antd-free renderers)
+- desktop chat re-plumb waves 1–5 (OSS onto `@agenta/chat`), chat slice off antd waves
+  1–6, `@ant-design/x` → Streamdown, streaming pacing
+- mobile live chat, ONE composer, ONE ApprovalCard, responsive layouts
+- agent-path playground chrome off antd waves 1–3
+- `perf`: lean cross-package subpaths
+
+**Tier 1 is therefore a 365-file tree delta to carve by content, not 85 commits to
+replay.** Per-area divergence on the ground the new work touches:
+
+```
+AgentChatSlice  74   agenta-chat  40   oss/pages  25   Sidebar  20
+navigation  15   agenta-auth  15   Playground  15   auth-ui  14
+navigation-ui  11   sessions  10   entity-ui  10   mobile  53
+```
+
+The uncommitted work sits **on top of** that. `@agenta/home-ui` depends on `@agenta/chat`
+and `@agenta/sessions-ui`; the new mobile screens depend on mobile live chat; the
+playground-ui extraction depends on the playground antd waves.
+
+> **So `oss/seed-attachments` is NOT a valid base for the new lanes.** Carving them
+> straight onto it produces branches that don't compile.
+
+## 3. Tier 1 — carve the 365-file delta (extends the published stack)
+
+Appended above `oss/seed-attachments`, in dependency order. Lanes are split **by path**,
+because hunk-level splitting is unreliable (`AGENTS.md`) — which is why the three chat
+themes (re-plumb / de-antd / Streamdown) collapse into one lane: they rewrite the same
+74 `AgentChatSlice` files.
+
+| # | branch | paths |
+|---|---|---|
+| T1 | `pkg/auth` | `packages/agenta-auth/**`, `packages/agenta-auth-ui/**`, `oss/src/components/pages/auth/**`, `mobile/src/features/auth/**`, `mobile/src/lib/auth`, `mobile/src/middleware.ts` + test |
+| T2 | `pkg/navigation` | `packages/agenta-navigation/**`, `oss/src/components/Sidebar/{dynamic,engine/types,engine/visibility,scopes/constants}`, `oss/src/lib/atoms/sidebar.ts` |
+| T3 | `pkg/navigation-ui` | `packages/agenta-navigation-ui/**`, `oss/src/components/Sidebar/{components,engine/SidebarMenu,engine/SidebarShell,hooks}`, `mobile/src/features/{nav,context}/**`, `mobile/src/components/{AgentaLogo,ContentRail,ui/sheet}` |
+| T4 | `pkg/ui-primitives` | `packages/agenta-ui/**` (context-menu, split-pane, tooltip-composed, PanelSection, presentational/chat), `packages/agenta-shared/src/utils/timeAgo.ts` |
+| T5 | `pkg/session-surfaces` | `packages/agenta-sessions/**`, `packages/agenta-sessions-ui/**`, `packages/agenta-entity-ui/**`, `packages/agenta-entities/src/gatewayTrigger/**`, `oss/src/components/pages/{agent-home,agents,sessions,overview,settings}/**`, `oss/src/components/TemplateStrip` |
+| T6 | `pkg/chat-engine` | `packages/agenta-chat/**` (40), `packages/agenta-playground/**` |
+| T7 | `oss/chat-on-shared-engine` | `oss/src/components/AgentChatSlice/**` (74), `oss/src/components/{Drives,SessionInspector,Layout}`, `oss/src/hooks/useAlwaysAllowTool`, `oss/src/pages/**`, `oss/src/styles/globals.css`, `ee/**` |
+| T8 | `mobile/chat-and-shell` | `mobile/src/features/{chat,home,sessions,agents}/**`, `mobile/src/components/ScreenScaffold`, `mobile/src/{styles,pages}/**`, `mobile/{next.config,package.json,scripts}`, `mobile/tests/**` |
+| T9 | `playground/de-antd` | `oss/src/components/Playground/**` (15) |
+
+`pnpm-lock.yaml`: never carve the file directly — after each lane's `package.json`
+changes, regenerate with `pnpm install --lockfile-only` and commit the result in
+that lane.
+
+## 4. Tier 2 — the 261 uncommitted `web/` paths
+
+Stacked above T8. Ordered so each lane's diff is self-contained.
+
+### L1 `pkg/ui-styles` — global stylesheets into `@agenta/ui`
+`web/packages/agenta-ui/src/styles/{theme-variables,code-editor-styles,editor-theme,custom-resize-handle,surfaces}.css` (new)
+· delete `oss/src/styles/{theme-variables,code-editor-styles,editor-theme}.css`, `oss/src/assets/custom-resize-handle.css`
+· `oss|mobile/src/styles/globals.css`, `oss|ee|mobile/src/pages/_app.tsx`
+· `web/scripts/generate-tailwind-tokens.ts`, `mobile/scripts/generate-shadcn-tokens.ts`,
+`oss/tailwind.config.ts`, `mobile/src/styles/theme.generated.css`, both `next.config.ts`
+
+Generator output path moves — regenerate, don't hand-edit (`AGENTS.md`).
+
+### L2 `pkg/observability` — `@agenta/observability`
+new `web/packages/agenta-observability/**`
+· `oss/src/state/observability/dashboard.ts` (now re-exports)
+· delete `oss/src/services/tracing/api/index.ts`; `services/tracing/{lib/helpers,types/index}.ts`
+· `oss/src/components/UsageSummary/index.tsx` (−48 lines, consumes the package)
+· `pnpm-lock.yaml`
+
+### L3 `pkg/entities-drive` — headless drive layer
+new `web/packages/agenta-entities/src/drive/**` (29 modules) + `tests/unit/dropEntries.test.ts`
+· `agenta-entities/package.json`: `./drive` export, `+motion`, `+pdfjs-dist`
+· delete the corresponding headless files under `oss/src/components/Drives/`
+
+### L4 `pkg/entity-ui-drive` — drive UI
+new `web/packages/agenta-entity-ui/src/drive/**` (39 modules) + `tests/unit/useUploadReveal.test.ts`
+· delete the remaining `oss/src/components/Drives/*` (66 paths total across L3+L4)
+· survivors rewired: `chatFileRefs.tsx`, `DriveFileLinkProvider.tsx`, new `useChatScopeSessionId.ts`
+· consumers: `pages/overview/agent/AgentFilesCard.tsx`, `AgentChatSlice/components/AttachmentViewerDrawer.tsx`
+
+Biggest lane. Split L3/L4 keeps each reviewable.
+
+### L5 `pkg/navigation-ui-shell` — `SidebarShell` + `SidebarLogo`
+new `agenta-navigation-ui/src/{SidebarShell,SidebarLogo}.tsx`, `agenta-navigation/src/supportLinks.ts`
+· delete `oss/src/components/Sidebar/engine/SidebarShell.tsx`, `components/SidebarLogo.tsx`
+· `oss/src/components/Sidebar/{Sidebar,hooks/useWorkflowSwitcher,scopes/*}`
+· `agenta-navigation/src/{index,types,dynamic/registry,dynamic/useSidebarDynamicChildren}`
+· `agenta-navigation-ui/{package.json,src/index,src/NavMenu}`
+· mobile nav: `NavDrawer`, `NavRail`, `useMobileNavItems`, new `mobileNavScope.tsx`, delete `NavPanel.tsx`
+
+### L6 `pkg/playground-ui-agent-chrome`
+new `agenta-playground-ui/src/components/{AgentBuildPanel,AgentConfigHeader,PlaygroundModeSwitch}.tsx`, `AgentPageHeader/`, `CommitVariantChanges/`
+· delete `oss/.../CommitVariantChangesModal/{index.tsx,assets/types.d.ts}`
+· `oss/.../{AgentRevisionSelector,PlaygroundHeader,PlaygroundVariantConfig,PlaygroundVariantConfigHeader,CommitVariantChangesButton}`
+· `agenta-playground-ui/package.json`
+
+### L7 `pkg/sessions-tabs` — tab rail, list panel, filters bar
+new `agenta-sessions-ui/src/{SessionTab,SessionTabStrip,SessionTabRail,SessionTabDragItem,SessionListPanel,SessionRowContextMenu,SessionFiltersBar,useSessionActions}`
+· new `agenta-sessions/src/state/{tabOrder,waitingByAgent}.ts`; `state/index.ts`
+· new `agenta-chat/src/state/panelLayout.ts`; `state/{index,sessionEphemera}.ts`
+· new `agenta-ui/.../layout/FilterRailLayout.tsx` + `layout/index.tsx`
+· `oss/.../AgentChatSlice/{state/panelLayout,state/sessions,hooks/useSessionActions,components/SessionTagBar}`
+· `oss/src/components/pages/sessions/SessionsPage.tsx`
+· `agenta-sessions-ui/{package.json,src/index,SessionCardList,SessionFiltersPanel,controls/SessionFilterControls}`
+
+### L8 `pkg/home-ui` — `@agenta/home-ui` + oss agent-home rewire
+new `web/packages/agenta-home-ui/**` (incl. renames `TemplatesSection/TemplateCard.tsx` →
+`TemplateCard.tsx`, `ProviderMarks.tsx` → `TemplateProviderMarks.tsx`)
+· new `agenta-entities/src/workflow/agentTemplates.ts` + test, `workflow/state/agentRoster.ts`, `session/core/freshSessions.ts`
+· new `agenta-entity-ui/src/agent/AgentRosterGrid.tsx`; `agent/{AgentCard,index}`
+· delete `oss/.../agent-home/assets/templates.ts` + test, `components/{HomeAutomationsSection,HomeSessionsSection}`, `TemplatesGallery/TemplateSection.tsx`
+· `oss/.../agent-home/**` (index, StripHome, PlaygroundOnboarding, TemplateDetail, TemplateSetupDrawer, TemplatesGallery, TemplatesSection, YourAgentsTable, hooks)
+· `oss/src/components/TemplateStrip/**` (7), `NewAgentButton`, `pages/agents/{AgentsGrid,AgentsPage,store}`
+· `oss/src/state/url/template.ts` + test
+
+### L9 `oss/wire-up` — leftovers
+`agenta-shared/src/api/{axios,index}.ts`, `utils/mobileGate` + test
+· `agenta-ui/src/{RichChatInput/RichChatInput,components/presentational/attachments/ImagePreview,components/ui/split-pane}`
+· `oss/src/lib/helpers/auth/AuthProvider.tsx`, `components/Layout/assets/Breadcrumbs.tsx`
+· `AgentChatSlice/{AgentConversation,assets/markdown,components/Inspector/lenses/RuntimeLens,components/ToolActivity,hooks/useOnboardingChat}`
+
+### L10 `mobile/agents-templates-settings`
+new `mobile/src/features/agents/{AgentListScreen,AgentTemplatesScreen,AgentTemplateDetailScreen,NewAgentAction,useNewAgentAction}`
+· new `features/settings/SettingsScreen.tsx`; new pages `agents/index`, `settings/index`, `templates/{index,[template_key]}`
+· new `features/chat/{SessionWorkspace,SessionTabs,SessionsPane,ConfigPane,SessionTopBar,selectedRevision}`; delete `ChatHeader.tsx`
+· new `features/home/{HomeComposer,pendingTask}`; delete `features/home/AgentListRow.tsx`
+· new `features/sessions/useSessionRowMenu.ts`
+· `ChatScreen`, `LiveConversation`, `useAgentEntity`, `ScreenScaffold`, `SessionListScreen`, `AgentOverviewScreen`, `pages/_app`, `sessions/[session_id].tsx`, `package.json`
+
+## 5. Two ways to run this
+
+**A. Full carve (correct, expensive).** Tier 1 then Tier 2 — 18 lanes, PR bases chained
+bottom-to-top, each diff clean against main's line. Use git-stash isolation per
+`AGENTS.md`; verify each lane's *tip tree*, not its diff.
+
+**B. Staging base (fast, deferred cost).** Push `feat/sessions-ux-polish` as-is and open
+only the Tier-2 lanes L1…L10 with `--base feat/sessions-ux-polish`. Per-PR diffs are
+clean immediately; the 85 stay unreviewed and nothing can merge until Tier 1 lands later.
+
+**C. Hybrid.** Tier 2 lanes L1–L4 (ui-styles, observability, both drive lanes) have the
+weakest dependency on the 85 — they could be verified against the published top and
+carved now, with L5–L10 deferred behind Tier 1. Needs a per-lane compile check to
+confirm.
+
+## 6. Excluded / flagged
+
+- `web/oss/test-results/junit.xml` — build artifact, **do not commit**; gitignore it.
+- `web/pnpm-lock.yaml` — split per lane that adds a dep (L2 observability, L3 motion +
+  pdfjs-dist, L8 home-ui, L10 mobile). Never commit whole.
+- Non-`web/` dirty paths stay out of this stack, on their own parallel lane:
+  `hosting/docker-compose/**`, `services/runner/**` (+ untracked
+  `build_snapshot_dind.py`), `docs/design/agenta-mobile/README.md`.
+- Gates before each commit: `pnpm lint-fix` in `web/`,
+  `pnpm --filter @agenta/oss exec tsc` gated on **error-signature diff**, not count.
+
+## 7. Executed (commit only, nothing pushed)
+
+20 lanes committed on top of `origin/oss/seed-attachments`, in this order:
+
+```
+oss/seed-attachments (#5776)
+ → pkg/auth 49 · pkg/navigation 25 · pkg/navigation-ui 39 · pkg/ui-primitives 9
+ → pkg/session-surfaces 49 · pkg/chat-engine 45 · oss/chat-on-shared-engine 102
+ → mobile/chat-and-shell 40 · playground/de-antd 15 · chore/app-wiring 5      [Tier 1]
+ → pkg/ui-styles 18 · pkg/observability 14 · pkg/entities-drive 31
+ → pkg/entity-ui-drive 44 · pkg/navigation-shell 20 · pkg/playground-agent-chrome 17
+ → pkg/sessions-tabs 31 · pkg/home-ui 57 · oss/wire-up 12
+ → mobile/agents-templates-settings 30                                        [Tier 2]
+```
+
+Verified: Tier-1 top `web/` tree == `sux/pre-carve` `web/` tree (empty diff); Tier-2 top
+`web/` tree == the original working tree (150-file gap fully accounted for by the stash's
+untracked parent, `git status -- web` empty); every one of the 365 + 346 paths lands in
+exactly one lane, zero double-placement.
+
+Recovery points: tag `sux/pre-carve` (= old `feat/sessions-ux-polish` tip) and
+`stash@{0}` (the pre-carve working tree). Neither has been dropped.
+
+### Known debt before these become PRs
+
+- Committed with `--no-verify`. Tier-1 content is verbatim from already-hooked commits;
+  **Tier-2 content has not been through `pnpm lint-fix`** — run it per lane and amend.
+- `pnpm-lock.yaml` was carried whole into `chore/app-wiring` and `oss/wire-up` rather
+  than regenerated per lane. Lanes between them can fail `--frozen-lockfile`. Fix by
+  running `pnpm install --lockfile-only` on each lane that changes a `package.json`.
+- Lanes are split by **path**, so a file whose working-tree delta mixes concerns lands
+  whole in one lane (e.g. `mobile/src/pages/_app.tsx` → `pkg/ui-styles`). Per-lane
+  compilation is not guaranteed; verify with `pnpm --filter @agenta/oss exec tsc` before
+  opening each PR.
+- PR bases: bottom lane `--base oss/seed-attachments`, every other lane `--base
+  <branch-below-it>`.

--- a/docs/design/sessions-ux-stack/plan.md
+++ b/docs/design/sessions-ux-stack/plan.md
@@ -76,6 +76,14 @@ because hunk-level splitting is unreliable (`AGENTS.md`) — which is why the th
 themes (re-plumb / de-antd / Streamdown) collapse into one lane: they rewrite the same
 74 `AgentChatSlice` files.
 
+**The path selectors are per-tier, and the two tiers carve different things.** Tier 1 carves the
+365-file *committed* tree delta; Tier 2 carves the 261 *uncommitted* paths that sit on top of it.
+So a path may legitimately appear in a T-lane and again in an L-lane (`mobile/src/features/nav/**`
+in T3 and L5; `Drives/**` in T7 and L4; `AgentChatSlice/**` in T7 and L9; the mobile styles/pages
+in T8, L1 and L10) — those are two different deltas to the same file, landing in sequence. The
+no-double-placement claim in §7 is **within** a tier, which is where it matters: two lanes in the
+same tier must never claim the same path, or the lower one's diff leaks upward.
+
 | # | branch | paths |
 |---|---|---|
 | T1 | `pkg/auth` | `packages/agenta-auth/**`, `packages/agenta-auth-ui/**`, `oss/src/components/pages/auth/**`, `mobile/src/features/auth/**`, `mobile/src/lib/auth`, `mobile/src/middleware.ts` + test |
@@ -174,7 +182,7 @@ new `mobile/src/features/agents/{AgentListScreen,AgentTemplatesScreen,AgentTempl
 
 ## 5. Two ways to run this
 
-**A. Full carve (correct, expensive).** Tier 1 then Tier 2 — 18 lanes, PR bases chained
+**A. Full carve (correct, expensive).** Tier 1 then Tier 2 — 19 lanes (T1–T9 + L1–L10), PR bases chained
 bottom-to-top, each diff clean against main's line. Use git-stash isolation per
 `AGENTS.md`; verify each lane's *tip tree*, not its diff.
 
@@ -200,7 +208,10 @@ confirm.
 
 ## 7. Executed (commit only, nothing pushed)
 
-20 lanes committed on top of `origin/oss/seed-attachments`, in this order:
+20 lanes committed on top of `origin/oss/seed-attachments`, in this order — 19 planned plus
+`chore/app-wiring`, which the carve needed for the cross-cutting `_app`/lockfile leftovers. Two
+planned names changed on the way: `pkg/navigation-ui-shell` → `pkg/navigation-shell` and
+`pkg/playground-ui-agent-chrome` → `pkg/playground-agent-chrome`.
 
 ```
 oss/seed-attachments (#5776)
@@ -215,8 +226,14 @@ oss/seed-attachments (#5776)
 
 Verified: Tier-1 top `web/` tree == `sux/pre-carve` `web/` tree (empty diff); Tier-2 top
 `web/` tree == the original working tree (150-file gap fully accounted for by the stash's
-untracked parent, `git status -- web` empty); every one of the 365 + 346 paths lands in
-exactly one lane, zero double-placement.
+untracked parent, `git status -- web` empty); every path lands in exactly one lane **within its
+tier**, zero double-placement.
+
+The per-lane numbers above are what to trust; the tier totals in this doc do not reconcile and
+should not be quoted. Tier 2's lane counts sum to 274, against 261 uncommitted paths in §1 and a
+"346" that appeared in an earlier draft of this paragraph — the three were counted at different
+moments and by different rules (paths vs files-changed, before vs after the lockfile splits). The
+tree equality above is the real verification; it holds regardless of which total is right.
 
 Recovery points: tag `sux/pre-carve` (= old `feat/sessions-ux-polish` tip) and
 `stash@{0}` (the pre-carve working tree). Neither has been dropped.

--- a/docs/design/sessions-ux-stack/restack-onto-112.md
+++ b/docs/design/sessions-ux-stack/restack-onto-112.md
@@ -112,8 +112,12 @@ tree** (`git show <lane>:<file>`), then the next.
 ## Before pushing
 
 - `pnpm lint-fix` from `web/` — 24/24.
-- `tsc --noEmit` = 0 for `@agenta/ui`, `@agenta/settings-ui`, `@agenta/entities`, `@agenta/oss`,
-  `@agenta/ee`, `@agenta/mobile`.
+- `tsc --noEmit` = 0 for **all eight** packages the stack touches: `@agenta/shared`, `@agenta/ui`,
+  `@agenta/entities`, `@agenta/entity-ui`, `@agenta/settings-ui`, `@agenta/oss`, `@agenta/ee`,
+  `@agenta/mobile`. (An earlier version of this list omitted `@agenta/shared` and
+  `@agenta/entity-ui`, so the gate could pass with two packages never compiled. Use the loop in
+  `execute-stacked-prs.md` Phase 3 — it runs `tsc` directly under `set -euo pipefail` rather than
+  counting `error TS` lines, so a failed `pnpm` cannot read as zero errors.)
 - Per lane, `git diff --name-only <lane-below>..<lane>` must list exactly that lane's files.
 - PR bases: bottom = `release/v0.112.0`, each other = the lane below.
 

--- a/docs/design/sessions-ux-stack/restack-onto-112.md
+++ b/docs/design/sessions-ux-stack/restack-onto-112.md
@@ -1,6 +1,18 @@
 # Restack the sessions-UX work onto `release/v0.112.0`
 
-## State of the world (verified, 2026-08-10)
+> **Superseded — historical. Do not execute this file.**
+> `execute-stacked-prs.md` is the live runbook and the record of what actually happened. This
+> document is the earlier snapshot from the same day, taken *before* the stack was built, and its
+> state table is now wrong in every row: it reports 88 commits, no lane branches and no PRs, while
+> the stack that exists is 83 commits across 29 lane branches with PRs `#5865`–`#5893` open (plus
+> `#5894` for these docs). Its `@agenta/mobile` TypeScript warning has also settled.
+>
+> Kept for two things that are still useful and are not repeated elsewhere: the reasoning for
+> basing on 112 rather than `main`, and the per-commit lane hypothesis below — which
+> `execute-stacked-prs.md` checked against the branches and partly overturned. Read it as a
+> proposal, never as instructions: running it now would rebuild lanes that already have open PRs.
+
+## State of the world (verified 2026-08-10, superseded — see the banner above)
 
 | fact | value |
 |---|---|
@@ -54,7 +66,7 @@ In dependency order — each depends only on lanes below it.
 | `pkg/ui-data-table` | `DataTable` in `@agenta/ui` + per-row detail + the responsive header fixes | `82aa890`, `550f58d`, `81e8f13`, `710d401`, `5897dfc` |
 | `pkg/shared-edition-gates` | `isEE`/`isToolsEnabled`/`isBillingEnabled` into `@agenta/shared/api`; 15 call sites repointed | `998a53e`, `edf8952` |
 | `pkg/entities-organization` | org + workspace API and types into `@agenta/entities/organization` | `76b9531` |
-| `pkg/settings-spine` | `@agenta/settings` + `@agenta/settings-ui`; Preferences, Account, API keys, secrets, vault, webhooks, projects | `eb45a4e`, `6fa6d45`, `e9733a8`, `51892a4`, `e5d02b2`, `f87c2c7`, `f84d10f`, `ff5e9f0`, `675003 3`, `7d5b56f`, `88de93a`, `babcb59`, `190f7e6` |
+| `pkg/settings-spine` | `@agenta/settings` + `@agenta/settings-ui`; Preferences, Account, API keys, secrets, vault, webhooks, projects | `eb45a4e`, `6fa6d45`, `e9733a8`, `51892a4`, `e5d02b2`, `f87c2c7`, `f84d10f`, `ff5e9f0`, `6750033`, `7d5b56f`, `88de93a`, `babcb59`, `190f7e6` |
 | `oss/drop-reexport-shims` | removes 24 app-layer re-export stubs; repoints ~60 call sites | `102a320` |
 | `pkg/settings-org-pages` | Members, Organizations, Access Controls, Domains, SSO | `06e67c0`, `8d5c308`, `714884a`, `e5de1cd`, `bd3cc1a`, `45896f2`, `fd30503`, `a7ff686`, `5ef55f9` |
 | `pkg/entity-ui-form-engine` | `SchemaForm` + `SubscriptionForm` off antd `Form` onto `@rc-component/form` | `e2db4ba` |

--- a/docs/design/sessions-ux-stack/restack-onto-112.md
+++ b/docs/design/sessions-ux-stack/restack-onto-112.md
@@ -1,0 +1,135 @@
+# Restack the sessions-UX work onto `release/v0.112.0`
+
+## State of the world (verified, 2026-08-10)
+
+| fact | value |
+|---|---|
+| `main` | has v0.111.0 merged |
+| `release/v0.112.0` | PR **#5827** → `main`, OPEN, mergeable, 93 commits |
+| our work | **88 commits, all on local `pkg/settings-spine`** |
+| our lane branches on `origin` | **none** — `pkg/auth`, `pkg/navigation`, … exist only locally |
+| open PRs for our lanes | **none** |
+| `release/v0.112.0` has that we don't | 105 commits |
+| merge base | `f85c5ac5e1`, an ancestor of both `main` and 112 |
+
+**There is no PR stack to update.** The plan doc's §7 said "commit only, nothing pushed",
+and that is still literally true: nothing from this effort has been pushed under any name, and
+no PR references it. The three PRs currently targeting `release/v0.112.0` (#5857, #5859, #5860)
+are someone else's session fixes.
+
+So the task is to **create** the stack, based on today's `release/v0.112.0` — not to rebase an
+existing one.
+
+One thing checked because it would have been nasty: `web/packages/agenta-chat` exists on 112 and
+on our branch, but both inherit it from the same ancestor commit `ff8acd5427` (the scaffold). So
+there is no duplicate-creation conflict — our chat commits are additive on top of it.
+
+## Base
+
+Stack on **`release/v0.112.0`**, not `main`. 112 is still open, it is where the release is being
+assembled, and our work was always meant for it. Bottom lane's PR base = `release/v0.112.0`;
+every other lane's base = the lane below it.
+
+## Proposed lanes
+
+Two groups. The first 40 commits are the original carve (the plan doc's Tier 1 + Tier 2, already
+committed on lane branches locally). The next 50 are this session's settings work, which has no
+lanes yet.
+
+### Already have local branches — rebase these onto 112, in this order
+
+`pkg/auth` → `pkg/navigation` → `pkg/navigation-ui` → `pkg/ui-primitives` →
+`pkg/session-surfaces` → `pkg/chat-engine` → `oss/chat-on-shared-engine` →
+`mobile/chat-and-shell` → `playground/de-antd` → `pkg/ui-styles` → `pkg/observability` →
+`pkg/entities-drive` → `pkg/entity-ui-drive` → `pkg/navigation-shell` → `pkg/sessions-tabs` →
+`pkg/home-ui` → `oss/wire-up` → `mobile/agents-templates-settings` →
+`pkg/agent-overview-layout` → `pkg/agent-overview-body`
+
+### New lanes for this session's 50 commits
+
+In dependency order — each depends only on lanes below it.
+
+| lane | what | commits |
+|---|---|---|
+| `pkg/ui-data-table` | `DataTable` in `@agenta/ui` + per-row detail + the responsive header fixes | `82aa890`, `550f58d`, `81e8f13`, `710d401`, `5897dfc` |
+| `pkg/shared-edition-gates` | `isEE`/`isToolsEnabled`/`isBillingEnabled` into `@agenta/shared/api`; 15 call sites repointed | `998a53e`, `edf8952` |
+| `pkg/entities-organization` | org + workspace API and types into `@agenta/entities/organization` | `76b9531` |
+| `pkg/settings-spine` | `@agenta/settings` + `@agenta/settings-ui`; Preferences, Account, API keys, secrets, vault, webhooks, projects | `eb45a4e`, `6fa6d45`, `e9733a8`, `51892a4`, `e5d02b2`, `f87c2c7`, `f84d10f`, `ff5e9f0`, `675003 3`, `7d5b56f`, `88de93a`, `babcb59`, `190f7e6` |
+| `oss/drop-reexport-shims` | removes 24 app-layer re-export stubs; repoints ~60 call sites | `102a320` |
+| `pkg/settings-org-pages` | Members, Organizations, Access Controls, Domains, SSO | `06e67c0`, `8d5c308`, `714884a`, `e5de1cd`, `bd3cc1a`, `45896f2`, `fd30503`, `a7ff686`, `5ef55f9` |
+| `pkg/entity-ui-form-engine` | `SchemaForm` + `SubscriptionForm` off antd `Form` onto `@rc-component/form` | `e2db4ba` |
+| `pkg/settings-tools-triggers` | Tools (7 files) and the three Triggers sections | `5b1abd3`, `cffe819`, `9357251`, `1d01adb` |
+| `pkg/settings-ee-pages` | Audit Log, Usage & Billing, entitlements | `13ba738`, `6ba7fcf`, `7f78cef`, `03434c1`, `0cb74c3`, `cac44e3` |
+| `pkg/entity-ui-drillin-bridge` | `useWorkflowReferenceBridge` out of OSS's drill-in provider into `@agenta/entity-ui` | `984b94e` |
+| `mobile/settings` | the `/m` settings screen, its tabs, the write sheets, the nav takeover | `783af5d`, `440b457`, `c245b69`, `4c04fd3`, `a29b5a3`, `118c04c` |
+| `mobile/drillin-bridge` | `/m`'s config pane onto the shared bridge — depends on `pkg/entity-ui-drillin-bridge` | `ca5be47` |
+
+`pkg/entity-ui-form-engine` must land **before** `mobile/settings` — the mobile Tools/Triggers
+tabs are only writable because that migration removed antd from the drawers.
+
+## Mechanics
+
+Do **not** try to assign files lane-by-lane against the live working tree. The root `AGENTS.md`
+documents why that mis-routes (new files land in the topmost lane, `absorb` sends anything it
+cannot attribute to the docs lane, multi-hunk files commit partially). Use the **git-stash
+isolation** technique from `AGENTS.md` §"Spreading a pile of edits back across an existing stack":
+snapshot, stash everything, restore one lane's files at a time into a clean tree, land, verify the
+lane's **tip tree** (not its diff), then move on.
+
+Several commits touch both a package and `web/mobile` (for example `fd30503` adds the domains and
+SSO sections *and* wires them into `/m`). Those need splitting across two lanes — the sequential
+working-tree technique in the same section, not hunk assignment.
+
+## How to run it
+
+Work in this order. Commit nothing to a lane until the lane below it is verified.
+
+1. **Snapshot first.** `but oplog snapshot -m "pre-restack"` if the repo is in GitButler
+   workspace mode; otherwise `git branch backup/pre-restack-112 pkg/settings-spine`. This is
+   the only safe recovery point and you will want it.
+2. **Confirm the base.** `git fetch origin release/v0.112.0`. Everything stacks on that ref,
+   not on `main`.
+3. **Rebase the 20 existing lanes** onto it, bottom-up, in the listed order. After each:
+   `git diff --name-only <lane-below>..<lane>` must list exactly that lane's files and nothing
+   from a lower lane. If a lower lane's files appear, the order is wrong — fix it before
+   continuing, not after.
+4. **Build the 12 new lanes** from the 50 commits, using git-stash isolation (below). Same
+   per-lane diff check.
+5. **Split the commits that touch two lanes.** `fd30503` is the clearest: it adds the Domains
+   and SSO sections to the package *and* wires them into `/m`. Make the tree the package
+   lane's version, commit that, then edit to add the mobile delta and amend it into the
+   mobile lane. Do not try to assign hunks.
+6. **Gates, then push.** Only after every lane's diff is clean.
+7. **Open PRs** bottom-up, each based on the lane below.
+
+Do not attempt this with `but rub` / `but absorb` against the live working tree. The root
+`AGENTS.md` documents exactly how that mis-routes: new files land in the topmost lane,
+`absorb` sends anything it cannot attribute to the docs lane, and a multi-hunk file commits
+partially with a warning that is easy to miss. Use the stash-isolation technique instead —
+stash everything, restore one lane's files into a clean tree, land, verify the lane's **tip
+tree** (`git show <lane>:<file>`), then the next.
+
+## Before pushing
+
+- `pnpm lint-fix` from `web/` — 24/24.
+- `tsc --noEmit` = 0 for `@agenta/ui`, `@agenta/settings-ui`, `@agenta/entities`, `@agenta/oss`,
+  `@agenta/ee`, `@agenta/mobile`.
+- Per lane, `git diff --name-only <lane-below>..<lane>` must list exactly that lane's files.
+- PR bases: bottom = `release/v0.112.0`, each other = the lane below.
+
+## Two things that are not ready to push
+
+1. **Nothing here has been run in a browser.** The `@rc-component/form` migration touches the
+   elicitation form the chat runtime drives; the `/m` write sheets call real mutation endpoints.
+   Static gates only.
+2. **`@agenta/mobile` currently fails `tsc`** with 17 errors that belong to another agent's
+   in-flight work (`jotai-family` resolution, `useMobileNavItems`, `PreferencesTab`,
+   `useVoiceComposer`). That has to settle before `mobile/settings` can be verified.
+
+Commit messages: no "Claude"/"Anthropic"/"Co-Authored-By" lines.
+
+## Note on these docs
+
+They live untracked in `docs/design/sessions-ux-stack/`, which means a `git stash -u` sweeps
+them up and a restore that misses `stash^3` loses them. That already happened once — they were
+recovered from `stash@{0}^3`. Commit them, or keep them outside the worktree.

--- a/docs/design/sessions-ux-stack/restack-onto-112.md
+++ b/docs/design/sessions-ux-stack/restack-onto-112.md
@@ -67,6 +67,19 @@ In dependency order — each depends only on lanes below it.
 `pkg/entity-ui-form-engine` must land **before** `mobile/settings` — the mobile Tools/Triggers
 tabs are only writable because that migration removed antd from the drawers.
 
+Every SHA above is abbreviated; validate before use, because at least one was mistyped here
+(`6750033` was written as two tokens). Under `set -euo pipefail`:
+
+```bash
+set -euo pipefail
+for s in <the SHAs for one lane>; do git rev-parse --verify "$s^{commit}" >/dev/null; done
+echo "all SHAs resolve"
+```
+
+The `pkg/settings-spine` row lists 13 commits; the lane as built holds 12
+(`execute-stacked-prs.md`). The branches won that disagreement — one commit was folded into a
+neighbouring lane. Another reason to treat this table as a hypothesis.
+
 ## Mechanics
 
 Do **not** try to assign files lane-by-lane against the live working tree. The root `AGENTS.md`
@@ -85,8 +98,11 @@ working-tree technique in the same section, not hunk assignment.
 Work in this order. Commit nothing to a lane until the lane below it is verified.
 
 1. **Snapshot first.** `but oplog snapshot -m "pre-restack"` if the repo is in GitButler
-   workspace mode; otherwise `git branch backup/pre-restack-112 pkg/settings-spine`. This is
-   the only safe recovery point and you will want it.
+   workspace mode; otherwise `git branch backup/pre-stack-112 pkg/settings-spine`. This is
+   the only safe recovery point and you will want it. **`backup/pre-stack-112` is the one
+   canonical name** — `execute-stacked-prs.md` Phase 0 verifies exactly that ref, and an earlier
+   draft of this file called it `backup/pre-restack-112`, so a recovery point created under the
+   old name satisfies neither runbook's check.
 2. **Confirm the base.** `git fetch origin release/v0.112.0`. Everything stacks on that ref,
    not on `main`.
 3. **Rebase the 20 existing lanes** onto it, bottom-up, in the listed order. After each:
@@ -96,9 +112,25 @@ Work in this order. Commit nothing to a lane until the lane below it is verified
 4. **Build the 12 new lanes** from the 50 commits, using git-stash isolation (below). Same
    per-lane diff check.
 5. **Split the commits that touch two lanes.** `fd30503` is the clearest: it adds the Domains
-   and SSO sections to the package *and* wires them into `/m`. Make the tree the package
-   lane's version, commit that, then edit to add the mobile delta and amend it into the
-   mobile lane. Do not try to assign hunks.
+   and SSO sections to the package *and* wires them into `/m`. Do not try to assign hunks. Use
+   sequential working-tree states, and note that the second half is a **new commit on the upper
+   lane**, not an amend:
+
+   ```bash
+   set -euo pipefail
+   git checkout <package-lane>
+   # make the tree the package lane's version of the file, then
+   git commit -m "<package half>"
+   git checkout -b <mobile-lane> <package-lane>       # upper lane branches off the lower one
+   # edit the same file to add the /m delta, then
+   git commit -m "<mobile half>"
+   ```
+
+   **Never `git commit --amend` here.** Amend rewrites *the commit you are standing on* — on the
+   package lane that folds the mobile delta into the lower lane (so the upper lane's PR shows an
+   empty diff and the lower lane's shows mobile files it should not own), and it rewrites a
+   commit every lane above has already built on. `execute-stacked-prs.md` §"Commits that span two
+   lanes" says the same thing.
 6. **Gates, then push.** Only after every lane's diff is clean.
 7. **Open PRs** bottom-up, each based on the lane below.
 


### PR DESCRIPTION
These five documents drove the 29-lane stack below and were living untracked in the worktree,
which is how they were nearly lost to a `git stash -u` once already. Committing them.

- `plan.md` — the original carve: what leaves the app, in what order, and why.
- `plan-settings-nav-takeover.md` — the settings and navigation half of that plan.
- `handoff-audit-log-billing.md` — the state of the EE Audit Log and Usage & Billing work.
- `restack-onto-112.md` — the analysis that chose `release/v0.112.0` as the base.
- `execute-stacked-prs.md` — the runbook, plus an **Outcome** section recording what the
  execution actually found: the stack was already built, four lanes were merged only on `origin`
  (their local branches are stale), no commit duplicated 112, and two new traps — batch ref
  pushes are rejected wholesale with `GH013`, and `gh pr edit` fails on this repo with a
  Projects-classic GraphQL error, so base/title edits need `gh api -X PATCH`.

Docs only — no code. Kept off the code lanes deliberately so none of them carries unrelated files.

Stacked on `pkg/ui-data-table-responsive`; review only this lane's diff.