### PR TITLE
fix(frontend): dropdown menus never unmount after close (scroll-fade vs Radix Presence)

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/PromptSchemaControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/PromptSchemaControl.tsx
@@ -498,11 +498,13 @@ export const PromptSchemaControl = memo(function PromptSchemaControl({
     )
 
     if (!hasMessagesField) {
-        return <div className={cn("min-h-[260px]", className)} />
+        return (
+            <div className={cn("min-h-[260px]", className)} data-testid="prompt-schema-control" />
+        )
     }
 
     return (
-        <div className={cn("flex flex-col gap-3", className)}>
+        <div className={cn("flex flex-col gap-3", className)} data-testid="prompt-schema-control">
             {/* Messages list */}
             <ChatMessageList
                 messages={messages}

--- a/web/packages/agenta-ui/src/components/ui/dropdown-menu.tsx
+++ b/web/packages/agenta-ui/src/components/ui/dropdown-menu.tsx
@@ -67,6 +67,11 @@ function DropdownMenuContent({
                     // portals to <body>, escaping the app font scope. box-border: preflight is off.
                     "relative z-50 box-border max-h-96 overflow-y-auto overflow-x-hidden bg-popover text-popover-foreground shadow-overlay font-portal",
                     "rounded-control-lg p-1",
+                    // `.overflow-y-auto` matches the global scroll-fade rule (globals.css), whose
+                    // scroll-driven animation never fires `animationend` — Radix Presence then
+                    // waits forever and the closed content stays mounted, aria-hiding the page.
+                    // `animate-none` outranks the `:where()` rule; no other animation exists here.
+                    "animate-none",
                     className,
                 )}
                 {...props}
@@ -234,6 +239,8 @@ function DropdownMenuSubContent({
                     // Same overlay chrome as DropdownMenuContent / SelectContent.
                     "relative z-50 box-border max-h-96 overflow-y-auto overflow-x-hidden bg-popover text-popover-foreground shadow-overlay font-portal",
                     "rounded-control-lg p-1",
+                    // See DropdownMenuContent: the scroll-fade animation deadlocks Presence unmount.
+                    "animate-none",
                     className,
                 )}
                 {...props}


### PR DESCRIPTION
## What

After [#5837](https://github.com/Agenta-AI/agenta/pull/5837) landed the scroll-aware scrollbar fade, every Radix dropdown menu stopped unmounting when closed. The closed menu stays fully visible and interactive in the DOM, and it keeps the rest of the page `aria-hidden`. Users hit this in the Playground role selector and anywhere else `DropdownMenuContent` renders a scrollable list.

## Why

The scroll-fade rule in `globals.css` targets `.overflow-y-auto` and attaches a scroll-driven animation (`animation-timeline: scroll(self block)`). Radix's `Presence` component reads the Content node's computed `animation-name` to decide whether to wait for `animationend` before unmounting on close. A scroll-driven timeline never fires `animationend`, so Presence waits forever.

## Fix

One utility class: `animate-none` on `DropdownMenuContent` and `DropdownMenuSubContent`. It has higher specificity than the zero-specificity `:where()` scroll-fade rule, and these nodes carry no other animation to preserve. Combobox and cascader are unaffected: their `overflow-y-auto` sits on an inner child div, which Presence never inspects.

Also adds `data-testid="prompt-schema-control"` to `PromptSchemaControl` for the acceptance-suite selector rewrite (tests-only PR follows and depends on this).

## Verification

- Root cause reproduced live on the dev stack (stuck `data-state="closed"` portal confirmed via DOM inspection).
- CSS override verified in isolation: `.animate-none` resolves computed `animationName` to `none` against the real scroll-fade rule.
- Fix is live on the hot-reloading dev stack for the acceptance test re-run.

Found by the webtest agent while fixing the playground acceptance tests.