### PR TITLE
fix(tests): playground role-select selectors, apiBase pre-nav bug, mark 5 flaky tests retry-eligible

### DIFF
--- a/web/oss/tests/playwright/acceptance/agent-chat/tests.ts
+++ b/web/oss/tests/playwright/acceptance/agent-chat/tests.ts
@@ -29,9 +29,17 @@ const seededRevisionByApp = new Map<string, string>()
 
 const apiBase = (page: Page): string => {
     if (process.env.AGENTA_API_URL) return process.env.AGENTA_API_URL
-    const origin = new URL(page.url() || process.env.AGENTA_WEB_URL || "http://localhost:3000")
-        .origin
-    return `${origin}/api`
+    // seedAgentChatApp() runs before the test navigates anywhere, so page.url() is still
+    // "about:blank" — a non-empty string that defeats `page.url() || fallback`, and whose
+    // origin serializes to the literal string "null" (a bogus `/null/api/...` request).
+    // Treat about:blank as "no real page yet" and fall back to the configured web URL,
+    // same as the test config's own baseURL (playwright.config.ts).
+    const currentUrl = page.url()
+    const base =
+        currentUrl && currentUrl !== "about:blank"
+            ? currentUrl
+            : process.env.AGENTA_WEB_URL || "http://localhost:3000"
+    return `${new URL(base).origin}/api`
 }
 
 const testWithAgentChatFixtures = baseTest.extend<AgentChatFixtures>({

--- a/web/oss/tests/playwright/acceptance/auto-evaluation/index.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/index.ts
@@ -26,64 +26,74 @@ const getRequiredVariantName = (name: string | null | undefined) => {
 }
 
 const testAutoEval = () => {
-    baseAutoEvalTest(
-        "should run a single evaluation",
-        {
-            tag: [
-                createTagString("scope", TestScope.EVALUATIONS),
-                createTagString("coverage", TestCoverage.SMOKE),
-                createTagString("coverage", TestCoverage.LIGHT),
-                createTagString("coverage", TestCoverage.FULL),
-                createTagString("path", TestPath.HAPPY),
-            ],
-        },
-        async ({page, apiHelpers, runAutoEvaluation, navigateToEvaluation}) => {
-            // getApp() may create the app through the UI; that does not fit the 60s default (#5695).
-            baseAutoEvalTest.setTimeout(120000)
+    // Retry-eligible (Mahmoud, see AGENTS.md/session notes): read-only flow that neither
+    // mutates state nor destroys data. openAutoEvaluationRunFromList's search-input step has
+    // a low-confidence toHaveValue race (a typing/re-render timing issue, not a stale
+    // selector), so a retry is safe here. Narrowest scope: this one test only.
+    baseAutoEvalTest.describe("Should run a single evaluation (retry-eligible)", () => {
+        baseAutoEvalTest.describe.configure({retries: 2})
 
-            const app = await apiHelpers.getApp("completion")
-            const appId = app.id
-
-            const variants = await apiHelpers.getVariants(appId)
-            const variantName = getRequiredVariantName(variants[0]?.name)
-            const evaluationName = `e2e-auto-results-${Date.now()}`
-
-            await navigateToEvaluation(appId)
-            const testset = await apiHelpers.createTestset({
-                name: `e2e auto eval completion ${Date.now()}`,
-                rows: [
-                    {
-                        input: "Say hello",
-                        correct_answer: "Hello",
-                    },
-                    {
-                        input: "Say goodbye",
-                        correct_answer: "Goodbye",
-                    },
+        baseAutoEvalTest(
+            "should run a single evaluation",
+            {
+                tag: [
+                    createTagString("scope", TestScope.EVALUATIONS),
+                    createTagString("coverage", TestCoverage.SMOKE),
+                    createTagString("coverage", TestCoverage.LIGHT),
+                    createTagString("coverage", TestCoverage.FULL),
+                    createTagString("path", TestPath.HAPPY),
                 ],
-            })
+            },
+            async ({page, apiHelpers, runAutoEvaluation, navigateToEvaluation}) => {
+                // getApp() may create the app through the UI; that does not fit the 60s default (#5695).
+                baseAutoEvalTest.setTimeout(120000)
 
-            const {name: createdEvaluationName, runId} = await runAutoEvaluation({
-                name: evaluationName,
-                evaluators: ["Exact Match"],
-                testset: testset.name,
-                variants: [variantName],
-            })
+                const app = await apiHelpers.getApp("completion")
+                const appId = app.id
 
-            await expect(page.locator(".ant-modal").first()).toHaveCount(0)
+                const variants = await apiHelpers.getVariants(appId)
+                const variantName = getRequiredVariantName(variants[0]?.name)
+                const evaluationName = `e2e-auto-results-${Date.now()}`
 
-            await openAutoEvaluationRunFromList({
-                page,
-                evaluationName: createdEvaluationName,
-                runId,
-            })
+                await navigateToEvaluation(appId)
+                const testset = await apiHelpers.createTestset({
+                    name: `e2e auto eval completion ${Date.now()}`,
+                    rows: [
+                        {
+                            input: "Say hello",
+                            correct_answer: "Hello",
+                        },
+                        {
+                            input: "Say goodbye",
+                            correct_answer: "Goodbye",
+                        },
+                    ],
+                })
 
-            await expect
-                .poll(() => new URL(page.url()).pathname)
-                .toContain(`${getProjectScopedBasePath(page)}/apps/${appId}/evaluations/results/`)
-            await expect.poll(() => new URL(page.url()).searchParams.get("type")).toBe("auto")
-        },
-    )
+                const {name: createdEvaluationName, runId} = await runAutoEvaluation({
+                    name: evaluationName,
+                    evaluators: ["Exact Match"],
+                    testset: testset.name,
+                    variants: [variantName],
+                })
+
+                await expect(page.locator(".ant-modal").first()).toHaveCount(0)
+
+                await openAutoEvaluationRunFromList({
+                    page,
+                    evaluationName: createdEvaluationName,
+                    runId,
+                })
+
+                await expect
+                    .poll(() => new URL(page.url()).pathname)
+                    .toContain(
+                        `${getProjectScopedBasePath(page)}/apps/${appId}/evaluations/results/`,
+                    )
+                await expect.poll(() => new URL(page.url()).searchParams.get("type")).toBe("auto")
+            },
+        )
+    })
 
     baseAutoEvalTest(
         "should show an error when attempting to create an evaluation with a mismatched testset",

--- a/web/oss/tests/playwright/acceptance/evaluators/index.ts
+++ b/web/oss/tests/playwright/acceptance/evaluators/index.ts
@@ -50,62 +50,74 @@ import {
 } from "./tests"
 
 const testEvaluators = () => {
-    test(
-        "should navigate to the evaluators page and display both automatic and human evaluator tabs",
-        {
-            tag: [
-                createTagString("scope", TestScope.EVALUATIONS),
-                createTagString("coverage", TestCoverage.SMOKE),
-                createTagString("coverage", TestCoverage.LIGHT),
-                createTagString("coverage", TestCoverage.FULL),
-                createTagString("path", TestPath.HAPPY),
-            ],
-        },
-        async ({page, navigateToEvaluators}) => {
-            // Navigate to the evaluators page and verify the initial state
-            await navigateToEvaluators()
+    // Retry-eligible (Mahmoud, see AGENTS.md/session notes): read-only navigation flow that
+    // neither mutates state nor destroys data. waitForEvaluatorsQuery (tests.ts) has a
+    // low-confidence timeout, not a stale selector, so a retry is safe here. Narrowest scope:
+    // this one test only.
+    test.describe("Should navigate to the evaluators page and display both automatic and human evaluator tabs (retry-eligible)", () => {
+        test.describe.configure({retries: 2})
 
-            // Verify page title is visible
-            await expect(page.getByTitle(EVALUATORS_PAGE_TITLE).first()).toBeVisible()
+        test(
+            "should navigate to the evaluators page and display both automatic and human evaluator tabs",
+            {
+                tag: [
+                    createTagString("scope", TestScope.EVALUATIONS),
+                    createTagString("coverage", TestCoverage.SMOKE),
+                    createTagString("coverage", TestCoverage.LIGHT),
+                    createTagString("coverage", TestCoverage.FULL),
+                    createTagString("path", TestPath.HAPPY),
+                ],
+            },
+            async ({page, navigateToEvaluators}) => {
+                // Navigate to the evaluators page and verify the initial state
+                await navigateToEvaluators()
 
-            // Verify the Automatic Evaluators tab is visible and selected by default
-            const automaticTab = page.getByRole("tab", {name: EVALUATOR_TAB_AUTOMATIC}).first()
-            await expect(automaticTab).toBeVisible()
-            await expect(automaticTab).toHaveAttribute("aria-selected", "true")
-            // Note: on initial load the URL param may be absent (null) — the tab atom defaults
-            // to "automatic" without writing to the URL. Once a tab is explicitly clicked the
-            // param is set, which is what the later assertions verify.
+                // Verify page title is visible
+                await expect(page.getByTitle(EVALUATORS_PAGE_TITLE).first()).toBeVisible()
 
-            // Verify the Human Evaluators tab is visible but not selected
-            const humanTab = page.getByRole("tab", {name: EVALUATOR_TAB_HUMAN}).first()
-            await expect(humanTab).toBeVisible()
-            await expect(humanTab).toHaveAttribute("aria-selected", "false")
+                // Verify the Automatic Evaluators tab is visible and selected by default
+                const automaticTab = page.getByRole("tab", {name: EVALUATOR_TAB_AUTOMATIC}).first()
+                await expect(automaticTab).toBeVisible()
+                await expect(automaticTab).toHaveAttribute("aria-selected", "true")
+                // Note: on initial load the URL param may be absent (null) — the tab atom defaults
+                // to "automatic" without writing to the URL. Once a tab is explicitly clicked the
+                // param is set, which is what the later assertions verify.
 
-            // Verify the Create new button is visible on the Automatic tab
-            await expect(
-                page.getByRole("button", {name: EVALUATOR_CREATE_BUTTON_LABEL}).first(),
-            ).toBeVisible()
+                // Verify the Human Evaluators tab is visible but not selected
+                const humanTab = page.getByRole("tab", {name: EVALUATOR_TAB_HUMAN}).first()
+                await expect(humanTab).toBeVisible()
+                await expect(humanTab).toHaveAttribute("aria-selected", "false")
 
-            // Switch to the Human Evaluators tab
-            await ensureEvaluatorTab(page, EVALUATOR_TAB_HUMAN, EVALUATOR_TAB_PARAM_HUMAN)
+                // Verify the Create new button is visible on the Automatic tab
+                await expect(
+                    page.getByRole("button", {name: EVALUATOR_CREATE_BUTTON_LABEL}).first(),
+                ).toBeVisible()
 
-            // Verify Human tab is now selected and URL updated
-            await expect(humanTab).toHaveAttribute("aria-selected", "true")
-            await expect(automaticTab).toHaveAttribute("aria-selected", "false")
-            await expect
-                .poll(() => new URL(page.url()).searchParams.get("tab"))
-                .toBe(EVALUATOR_TAB_PARAM_HUMAN)
+                // Switch to the Human Evaluators tab
+                await ensureEvaluatorTab(page, EVALUATOR_TAB_HUMAN, EVALUATOR_TAB_PARAM_HUMAN)
 
-            // Verify the Create new button is still visible on the Human tab
-            await expect(
-                page.getByRole("button", {name: EVALUATOR_CREATE_BUTTON_LABEL}).first(),
-            ).toBeVisible()
+                // Verify Human tab is now selected and URL updated
+                await expect(humanTab).toHaveAttribute("aria-selected", "true")
+                await expect(automaticTab).toHaveAttribute("aria-selected", "false")
+                await expect
+                    .poll(() => new URL(page.url()).searchParams.get("tab"))
+                    .toBe(EVALUATOR_TAB_PARAM_HUMAN)
 
-            // Switch back to Automatic tab and verify
-            await ensureEvaluatorTab(page, EVALUATOR_TAB_AUTOMATIC, EVALUATOR_TAB_PARAM_AUTOMATIC)
-            await expect(automaticTab).toHaveAttribute("aria-selected", "true")
-        },
-    )
+                // Verify the Create new button is still visible on the Human tab
+                await expect(
+                    page.getByRole("button", {name: EVALUATOR_CREATE_BUTTON_LABEL}).first(),
+                ).toBeVisible()
+
+                // Switch back to Automatic tab and verify
+                await ensureEvaluatorTab(
+                    page,
+                    EVALUATOR_TAB_AUTOMATIC,
+                    EVALUATOR_TAB_PARAM_AUTOMATIC,
+                )
+                await expect(automaticTab).toHaveAttribute("aria-selected", "true")
+            },
+        )
+    })
 
     test(
         "should create an Exact Match evaluator from the template dropdown",

--- a/web/oss/tests/playwright/acceptance/human-annotation/index.ts
+++ b/web/oss/tests/playwright/acceptance/human-annotation/index.ts
@@ -208,72 +208,91 @@ const humanAnnotationTests = () => {
     )
 
     // WEB-ACC-HUMAN-004
-    baseHumanTest(
-        "should create a new evaluator inline and annotate a scenario from the annotate tab",
-        {
-            tag: [
-                createTagString("scope", TestScope.EVALUATIONS),
-                createTagString("coverage", TestCoverage.LIGHT),
-                createTagString("coverage", TestCoverage.FULL),
-                createTagString("path", TestPath.HAPPY),
-                createTagString("license", "oss"),
-                createTagString("speed", TestSpeedType.SLOW),
-            ],
-        },
-        async (
-            {
-                page,
-                apiHelpers,
-                navigateToHumanEvaluation,
-                createHumanEvaluationRun,
-                annotateCurrentHumanScenario,
-            },
-            testInfo,
-        ) => {
-            // Skipped in CI: annotateCurrentHumanScenario waits on an LLM auto-run
-            // against the external mockgpt.wiremockapi.cloud provider, which
-            // consistently times out from the CI-deployed backend (fails all
-            // retries, not just intermittently) but works locally. Needs
-            // diagnosis with CI trace access before re-enabling.
-            testInfo.skip(!!process.env.CI, "Depends on external mock-LLM reachability from CI")
+    // Retry-eligible (Mahmoud, see AGENTS.md/session notes): each run uses a fresh
+    // Date.now()-suffixed app/testset/evaluator name, so a retry never collides with or
+    // destroys a prior attempt's data. annotateCurrentHumanScenario's annotation-form
+    // predicate (tests.ts) has a low-confidence timeout, not a stale selector. Narrowest
+    // scope: this one test only.
+    baseHumanTest.describe(
+        "Should create a new evaluator inline and annotate a scenario from the annotate tab (retry-eligible)",
+        () => {
+            baseHumanTest.describe.configure({retries: 2})
 
-            testInfo.setTimeout(120000)
+            baseHumanTest(
+                "should create a new evaluator inline and annotate a scenario from the annotate tab",
+                {
+                    tag: [
+                        createTagString("scope", TestScope.EVALUATIONS),
+                        createTagString("coverage", TestCoverage.LIGHT),
+                        createTagString("coverage", TestCoverage.FULL),
+                        createTagString("path", TestPath.HAPPY),
+                        createTagString("license", "oss"),
+                        createTagString("speed", TestSpeedType.SLOW),
+                    ],
+                },
+                async (
+                    {
+                        page,
+                        apiHelpers,
+                        navigateToHumanEvaluation,
+                        createHumanEvaluationRun,
+                        annotateCurrentHumanScenario,
+                    },
+                    testInfo,
+                ) => {
+                    // Skipped in CI: annotateCurrentHumanScenario waits on an LLM auto-run
+                    // against the external mockgpt.wiremockapi.cloud provider, which
+                    // consistently times out from the CI-deployed backend (fails all
+                    // retries, not just intermittently) but works locally. Needs
+                    // diagnosis with CI trace access before re-enabling.
+                    testInfo.skip(
+                        !!process.env.CI,
+                        "Depends on external mock-LLM reachability from CI",
+                    )
 
-            const app = await apiHelpers.createApp("completion")
-            const appId = app.id
+                    testInfo.setTimeout(120000)
 
-            const variants = await apiHelpers.getVariants(appId)
-            const variantName = getRequiredVariantName(variants[0]?.name)
+                    const app = await apiHelpers.createApp("completion")
+                    const appId = app.id
 
-            await navigateToHumanEvaluation(appId)
+                    const variants = await apiHelpers.getVariants(appId)
+                    const variantName = getRequiredVariantName(variants[0]?.name)
 
-            const testset = await apiHelpers.createTestset({
-                name: `e2e human annotation inline eval ${Date.now()}`,
-                rows: [
-                    {country: "Say hello"},
-                    {country: "Say goodbye"},
-                    {country: "Tell me a joke"},
-                ],
-            })
+                    await navigateToHumanEvaluation(appId)
 
-            await createHumanEvaluationRun({
-                variants: variantName,
-                testset: testset.name,
-                name: `e2e-human-inline-${Date.now()}`,
-                skipEvaluatorCreation: false,
-                evaluatorMetricName: INLINE_EVALUATOR_METRIC_NAME,
-            })
+                    const testset = await apiHelpers.createTestset({
+                        name: `e2e human annotation inline eval ${Date.now()}`,
+                        rows: [
+                            {country: "Say hello"},
+                            {country: "Say goodbye"},
+                            {country: "Tell me a joke"},
+                        ],
+                    })
 
-            await expect(humanEvaluationModal(page)).toHaveCount(0)
-            await expect
-                .poll(() => new URL(page.url()).pathname)
-                .toContain(`${getProjectScopedBasePath(page)}/apps/${appId}/evaluations/results/`)
-            await expect.poll(() => new URL(page.url()).searchParams.get("type")).toBe("human")
+                    await createHumanEvaluationRun({
+                        variants: variantName,
+                        testset: testset.name,
+                        name: `e2e-human-inline-${Date.now()}`,
+                        skipEvaluatorCreation: false,
+                        evaluatorMetricName: INLINE_EVALUATOR_METRIC_NAME,
+                    })
 
-            await annotateCurrentHumanScenario({
-                metricLabel: INLINE_EVALUATOR_METRIC_NAME,
-                valueLabel: "True",
-            })
+                    await expect(humanEvaluationModal(page)).toHaveCount(0)
+                    await expect
+                        .poll(() => new URL(page.url()).pathname)
+                        .toContain(
+                            `${getProjectScopedBasePath(page)}/apps/${appId}/evaluations/results/`,
+                        )
+                    await expect
+                        .poll(() => new URL(page.url()).searchParams.get("type"))
+                        .toBe("human")
+
+                    await annotateCurrentHumanScenario({
+                        metricLabel: INLINE_EVALUATOR_METRIC_NAME,
+                        valueLabel: "True",
+                    })
+                },
+            )
         },
     )
 

--- a/web/oss/tests/playwright/acceptance/observability/index.ts
+++ b/web/oss/tests/playwright/acceptance/observability/index.ts
@@ -149,45 +149,53 @@ const runPlaygroundAndGoToObservability = async (
 
 const observabilityTests = () => {
     // WEB-ACC-OBS-001
-    test(
-        "view traces",
-        {tag: smokeTags},
-        async ({page, uiHelpers, apiHelpers, testProviderHelpers}) => {
-            // 7 minutes: setup (provider + app creation + playground run) ~60-90 s,
-            // trace indexing up to ~150 s, polling 16×15 s = 240 s; total ≈ 390 s.
-            test.setTimeout(420000)
+    // Retry-eligible (Mahmoud, see AGENTS.md/session notes): read-only flow (views traces),
+    // no state mutation. Trace indexing can lag past the polling window, a stack-timing
+    // issue rather than a stale selector, so a retry is safe here. Narrowest scope: this
+    // one test only.
+    test.describe("View traces (retry-eligible)", () => {
+        test.describe.configure({retries: 2})
 
-            await scenarios.given("the user is authenticated", async () => {
-                await expectAuthenticatedSession(page)
-            })
+        test(
+            "view traces",
+            {tag: smokeTags},
+            async ({page, uiHelpers, apiHelpers, testProviderHelpers}) => {
+                // 7 minutes: setup (provider + app creation + playground run) ~60-90 s,
+                // trace indexing up to ~150 s, polling 16×15 s = 240 s; total ≈ 390 s.
+                test.setTimeout(420000)
 
-            await scenarios.and(
-                "a completion app with a configured test provider exists",
-                async () => {
-                    // Run a playground variant to seed a trace, then navigate to observability
-                    // and wait for the trace row to appear (with Refresh retries for async indexing).
-                    await runPlaygroundAndGoToObservability(
-                        page,
-                        apiHelpers,
-                        uiHelpers,
-                        testProviderHelpers,
-                    )
-                },
-            )
+                await scenarios.given("the user is authenticated", async () => {
+                    await expectAuthenticatedSession(page)
+                })
 
-            await scenarios.when("the user opens the traces table", async () => {
-                // runPlaygroundAndGoToObservability already confirmed this row is visible;
-                // click the row itself because virtualized Ant tables do not guarantee
-                // stable cell tags or ARIA roles in the body.
-                await clickFirstTraceRow(page)
-            })
+                await scenarios.and(
+                    "a completion app with a configured test provider exists",
+                    async () => {
+                        // Run a playground variant to seed a trace, then navigate to observability
+                        // and wait for the trace row to appear (with Refresh retries for async indexing).
+                        await runPlaygroundAndGoToObservability(
+                            page,
+                            apiHelpers,
+                            uiHelpers,
+                            testProviderHelpers,
+                        )
+                    },
+                )
 
-            await scenarios.then("the trace detail drawer opens", async () => {
-                const drawer = page.locator(".ant-drawer-content-wrapper")
-                await expect(drawer).toBeVisible({timeout: 10000})
-            })
-        },
-    )
+                await scenarios.when("the user opens the traces table", async () => {
+                    // runPlaygroundAndGoToObservability already confirmed this row is visible;
+                    // click the row itself because virtualized Ant tables do not guarantee
+                    // stable cell tags or ARIA roles in the body.
+                    await clickFirstTraceRow(page)
+                })
+
+                await scenarios.then("the trace detail drawer opens", async () => {
+                    const drawer = page.locator(".ant-drawer-content-wrapper")
+                    await expect(drawer).toBeVisible({timeout: 10000})
+                })
+            },
+        )
+    })
 
     // WEB-ACC-OBS-002
     test(
@@ -268,37 +276,44 @@ const observabilityTests = () => {
     )
 
     // WEB-ACC-OBS-004
-    test(
-        "should open a span and drill into its attributes",
-        {tag: lightSlowTags},
-        async ({page, apiHelpers, uiHelpers, testProviderHelpers}) => {
-            test.setTimeout(420000)
-            await runPlaygroundAndGoToObservability(
-                page,
-                apiHelpers,
-                uiHelpers,
-                testProviderHelpers,
-            )
+    // Retry-eligible (Mahmoud, see AGENTS.md/session notes): read-only flow (drills into a
+    // trace's attributes), no state mutation. Same trace-indexing lag as "view traces", a
+    // stack-timing issue rather than a stale selector. Narrowest scope: this one test only.
+    test.describe("Should open a span and drill into its attributes (retry-eligible)", () => {
+        test.describe.configure({retries: 2})
 
-            // Click the first data row to open the trace drawer. The virtual table body
-            // does not expose stable cell tags, but the row click handler is the behavior
-            // users rely on.
-            await clickFirstTraceRow(page)
+        test(
+            "should open a span and drill into its attributes",
+            {tag: lightSlowTags},
+            async ({page, apiHelpers, uiHelpers, testProviderHelpers}) => {
+                test.setTimeout(420000)
+                await runPlaygroundAndGoToObservability(
+                    page,
+                    apiHelpers,
+                    uiHelpers,
+                    testProviderHelpers,
+                )
 
-            const drawer = page.locator(".ant-drawer-content-wrapper")
-            await expect(drawer).toBeVisible({timeout: 10000})
+                // Click the first data row to open the trace drawer. The virtual table body
+                // does not expose stable cell tags, but the row click handler is the behavior
+                // users rely on.
+                await clickFirstTraceRow(page)
 
-            // The trace tree panel (CustomTreeComponent, not AntD Tree) renders a
-            // "Search in tree" input when loaded. Verify the panel mounted with content.
-            const treeSearchInput = drawer.getByPlaceholder("Search in tree")
-            await expect(treeSearchInput).toBeVisible({timeout: 10000})
+                const drawer = page.locator(".ant-drawer-content-wrapper")
+                await expect(drawer).toBeVisible({timeout: 10000})
 
-            // Each span in the tree renders a square avatar (AvatarTreeContent → antd Avatar
-            // shape="square"). At least one confirms the tree has nodes.
-            const spanAvatar = drawer.locator(".ant-avatar-square").first()
-            await expect(spanAvatar).toBeVisible({timeout: 10000})
-        },
-    )
+                // The trace tree panel (CustomTreeComponent, not AntD Tree) renders a
+                // "Search in tree" input when loaded. Verify the panel mounted with content.
+                const treeSearchInput = drawer.getByPlaceholder("Search in tree")
+                await expect(treeSearchInput).toBeVisible({timeout: 10000})
+
+                // Each span in the tree renders a square avatar (AvatarTreeContent → antd Avatar
+                // shape="square"). At least one confirms the tree has nodes.
+                const spanAvatar = drawer.locator(".ant-avatar-square").first()
+                await expect(spanAvatar).toBeVisible({timeout: 10000})
+            },
+        )
+    })
 
     // WEB-ACC-OBS-005
     test(

--- a/web/oss/tests/playwright/acceptance/playground/tests.ts
+++ b/web/oss/tests/playwright/acceptance/playground/tests.ts
@@ -244,17 +244,21 @@ const testWithVariantFixtures = baseTest.extend<VariantFixtures>({
                 expect(typeof role).toBe("string")
 
                 // 2. Click on the message button to create a new prompt slot.
-                // Scope role-selector lookup to the prompt editor that owns the clicked
-                // Message button. The chat-turn controls also have a Message button and
-                // .message-user-select controls, and some are intentionally disabled; a global
-                // nth() can land on those instead of the newly-added prompt-template message.
-                const roleButtonSelector = ".message-user-select"
-                const messageButton = page.getByRole("button", {name: "Message"}).first()
-                const promptToolbar = messageButton.locator(
-                    'xpath=ancestor::*[.//*[contains(normalize-space(.), "Prompt Syntax")]][1]',
-                )
-                const promptEditor = promptToolbar.locator("xpath=..")
-                const roleButtons = promptEditor.locator(roleButtonSelector)
+                // Scope everything to the prompt template's own PromptSchemaControl
+                // instance (data-testid="prompt-schema-control") rather than chaining
+                // ancestor:: xpath hops off the "Message" button — the chat-turn controls
+                // also render a "Message" button and .message-user-select role selectors,
+                // and a global nth() can land on those instead of the prompt template.
+                const promptControl = page.locator('[data-testid="prompt-schema-control"]').first()
+                const messageButton = promptControl.getByRole("button", {
+                    name: "Message",
+                    exact: true,
+                })
+                const roleButtons = promptControl.locator(".message-user-select")
+                // Each ChatMessageItem renders exactly one role selector and one editor
+                // in the same order as the messages array, so the Nth role button and the
+                // Nth editor input always belong to the same message row.
+                const editorInputs = promptControl.locator('.editor-input[role="textbox"]')
                 const msgCountBefore = await roleButtons.count()
 
                 await messageButton.click()
@@ -264,22 +268,13 @@ const testWithVariantFixtures = baseTest.extend<VariantFixtures>({
                     .poll(async () => roleButtons.count(), {timeout: 15000})
                     .toBeGreaterThan(msgCountBefore)
 
-                // The new role button is always appended last in the template section.
+                // The new role button/editor are always appended last in the template.
                 const roleButton = roleButtons.nth(msgCountBefore)
+                const emptyEditorLocator = editorInputs.nth(msgCountBefore)
 
                 // Wait for the role button to be enabled (may be briefly disabled while the
                 // ChatMessageList state settles after inserting the new message).
                 await expect(roleButton).toBeEnabled({timeout: 15000})
-
-                // Locate the text editor inside the same agenta-shared-editor container as
-                // the role button so typing lands in the correct slot.
-                const editorContainer = roleButton.locator(
-                    'xpath=ancestor::div[contains(@class, "agenta-shared-editor")]',
-                )
-                const emptyEditorLocator = editorContainer
-                    .locator('.editor-input[role="textbox"]')
-                    .first()
-
                 await expect(emptyEditorLocator).toBeVisible({timeout: 10000})
 
                 // 4. Select the role
@@ -290,6 +285,12 @@ const testWithVariantFixtures = baseTest.extend<VariantFixtures>({
                 await expect(menuItem).toBeVisible()
                 await menuItem.scrollIntoViewIfNeeded()
                 await menuItem.click()
+
+                // Wait for the role dropdown to fully unmount before continuing — while open
+                // (or mid-close) its portal marks the rest of the page aria-hidden, which
+                // blinds every getByRole()-based lookup below (see PR #5895 for the underlying
+                // Presence/animation fix; this is a plain readiness wait, not a workaround).
+                await expect(page.locator('[data-slot="dropdown-menu-content"]')).toHaveCount(0)
 
                 // 5. Add the prompt
                 await emptyEditorLocator.scrollIntoViewIfNeeded()


### PR DESCRIPTION
## Summary

Three independent fixes to the web acceptance suite, continuing the repair from #5854/#5855.

### 1. Playground prompt-message XPath fragility (confirmed real)

`playground/index.ts:178` ("Should update the prompt and save the changes") and `:219`
("should save the current changes as a new variant") both failed at
`scrollIntoViewIfNeeded` timing out on `addNewPrompt()`'s 5-hop
`xpath=ancestor::.../locator('..')` chain, which no longer matches the current DOM (the
prompt editor now renders through `PromptSchemaControl`, shared with the evaluator
DrillInView, not the structure the chain assumed).

**Fix:** replaced the chain with a scoped, index-correlated lookup:
- Added `data-testid="prompt-schema-control"` to `PromptSchemaControl.tsx`'s root — this
  ships in **#5895**, not here (see Dependency below).
- `addNewPrompt()` now scopes the "Message" button and `.message-user-select` role
  buttons to that testid, and pairs the Nth role button with the Nth
  `.editor-input[role="textbox"]` — each `ChatMessageItem` renders exactly one of each,
  in message order, so no ancestor traversal is needed.

**A second, real bug surfaced during investigation** (live-debugged against
`144.76.237.122:8180`, not a test artifact): selecting a role from the dropdown updated
the value correctly but its Radix portal never unmounted — `data-state` flipped to
`"closed"` but the node stayed mounted and interactive forever, permanently
`aria-hiding` the rest of the page (confirmed via `getComputedStyle` + manual repro).
Root cause: `DropdownMenuContent`'s `overflow-y-auto` class collides with `globals.css`'s
scroll-fade animation, which Radix's `Presence` waits on before unmounting — a
scroll-timeline animation never fires the `animationend` it's waiting for. Fixed with a
one-class `animate-none` override, verified via isolated CSS-specificity test. **This
fix also ships in #5895**, and is a prerequisite for these two tests to pass — a selector
rewrite alone can't work around a permanently-open, aria-hiding overlay.

**Verified live:** both tests pass (16.0s and 14.0s) against `144.76.237.122:8180` once
#5895's changes were live on that stack.

### 2. `apiBase()` about:blank bug (confirmed real, fixed)

`agent-chat/attach-send-render-reload.spec.ts` failed in ~300ms:
`seedAgentChatApp()` calls `apiBase(page)` *before* the test navigates anywhere, so
`page.url()` is still `"about:blank"` — a non-empty string that defeats
`page.url() || fallback`, and whose `.origin` serializes to the literal string `"null"`
(a bogus `/null/api/...` request).

**Fix:** treat `about:blank` explicitly as "no real page yet" and fall back to
`AGENTA_WEB_URL`, matching the test config's own `baseURL`.

**Verified live:** the test now runs past seeding and into `navigateToAgentPlayground()`
(60s+ instead of ~300ms). It then fails on a **separate, real, downstream issue** —
`expectPath` times out waiting for `/apps/<id>/playground`; the seeded `is_agent` app's
playground URL instead resolves to a bare `/playground` path with no `/apps/<id>`
segment, suggesting agent-type workflows have moved under a different route in the
current IA. Not chased, per scope — flagging as a follow-up.

### 3. Mark 5 nondeterministic tests retry-eligible (not skipped)

Per Mahmoud's call: three low-confidence timeouts (two evaluator-area: a `toHaveValue`
race in `openAutoEvaluationRunFromList`, and a `waitForEvaluatorsQuery` timeout; one
human-annotation predicate timeout) and two observability trace-indexing tests are
read-only or use uniquely-named fixtures, so a retry is safe — never skipped.

**Implementation:** each test wrapped in its own nested `test.describe(...)` with
`test.describe.configure({retries: 2})` — the narrowest scope covering exactly one test,
leaving every sibling test in the same file at the suite's global default (0 retries
locally, 2 in CI; `playwright.config.ts` has no per-project override, confirmed no
existing retry pattern in the suite to conflict with).

- `auto-evaluation/index.ts`: "should run a single evaluation"
- `evaluators/index.ts`: "should navigate to the evaluators page and display both
  automatic and human evaluator tabs"
- `human-annotation/index.ts`: "should create a new evaluator inline and annotate a
  scenario from the annotate tab"
- `observability/index.ts`: "view traces" and "should open a span and drill into its
  attributes"

**Verified live:** `--list` collects all 80 tests with no errors; the evaluators test
passes cleanly under the new describe scope; the auto-evaluation test genuinely retried
twice (3 total attempts visible in the run log) before failing on unrelated flakiness,
confirming `configure({retries: 2})` is wired up correctly and doesn't break test
loading. Pass/fail of these five stays nondeterministic by design.

## Dependency

**Requires #5895 to merge first.** This branch's playground selectors use the
`data-testid="prompt-schema-control"` that PR adds, and rely on its `animate-none` fix
for the role dropdown to close at all. Verification above was run against the live dev
stack after #5895's changes were applied there directly (not yet merged) — CI here won't
go green until #5895 lands on `release/v0.112.0`.

## Test plan

- [x] Playground: both tests pass live (16.0s, 14.0s) against `144.76.237.122:8180`
- [x] apiBase: confirmed past the `about:blank`/`null` bug; downstream `/apps/<id>`
      routing failure reported separately, not fixed here
- [x] Retry-marking: `--list` clean (80 tests, 21 files); one test passed under the new
      scope, one genuinely retried twice as configured
- [x] `pnpm turbo run lint --filter=@agenta/oss` — clean (pre-existing warnings only,
      unrelated files)
- [x] `prettier --write` on all touched files