### PR TITLE
[DO NOT MERGE] ci: full acceptance gate run for 0.112.0

### DIFF
--- a/web/oss/tests/playwright/README.md
+++ b/web/oss/tests/playwright/README.md
@@ -1,0 +1,2 @@
+
+<!-- Release 0.112.0 acceptance gate run, 2026-08-10: no functional change; this PR exists to trigger the full preview pipeline on the merged release tip. -->


### PR DESCRIPTION
## Purpose

This PR exists only to run the full preview pipeline (build, Railway preview deploy, full test suite including web acceptance) against the merged tip of `release/v0.112.0`, now that the test-suite repairs are in:

- [#5895](https://github.com/Agenta-AI/agenta/pull/5895) dropdown unmount fix + `prompt-schema-control` test id
- [#5896](https://github.com/Agenta-AI/agenta/pull/5896) playground selector rewrite, apiBase fallback fix, retry-eligibility for 5 nondeterministic tests

The only diff is a comment line in the Playwright README. **Close without merging once the verdict is read.**