### PR TITLE
[fix] Retire stale Radix selectors in acceptance tests, unhang the app-overview networkidle wait

### DIFF
--- a/.github/workflows/44-railway-tests.yml
+++ b/.github/workflows/44-railway-tests.yml
@@ -610,7 +610,9 @@ jobs:
       checks: write
       pull-requests: write
       contents: read
-    timeout-minutes: 30
+    # 30 min was too tight: retries on slow tests (e.g. the 7-minute trace test x3
+    # attempts) plus real fixes need headroom before the job gets cut off mid-run.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/web/oss/tests/playwright/acceptance/app/app-management.ts
+++ b/web/oss/tests/playwright/acceptance/app/app-management.ts
@@ -162,7 +162,10 @@ const tests = () => {
                     waitUntil: "domcontentloaded",
                 })
                 await uiHelpers.expectPath(`/apps/${appId}/overview`)
-                await page.waitForLoadState("networkidle")
+                // Not `waitForLoadState("networkidle")`: the layout keeps a live SSE
+                // connection open (ProjectWatch), so the network never goes idle and this
+                // would hang for the full test timeout. The heading assertions below
+                // already wait for the page to be ready.
             })
 
             await scenarios.when("the user opens an existing app", async () => {

--- a/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
@@ -498,16 +498,20 @@ const waitAndClickDeleteForRun = async (
 
     await page.getByRole("menuitem", {name: AUTO_EVAL_DELETE_MENU_LABEL}).click()
 
+    // DeleteEvaluationModal renders through EnhancedModal, a facade over the @agenta/ui
+    // (Radix) Dialog, so the panel is `[data-slot="dialog-content"]`, not an antd `.ant-modal`.
     const deleteModal = page
-        .locator(".ant-modal")
+        .locator('[data-slot="dialog-content"]')
         .filter({hasText: AUTO_EVAL_DELETE_CONFIRM_TEXT})
         .first()
     await expect(deleteModal).toBeVisible({timeout: 10000})
     await deleteModal.getByRole("button", {name: AUTO_EVAL_DELETE_OK_BUTTON}).click()
 
-    await expect(
-        page.locator(".ant-message").getByText(AUTO_EVAL_DELETE_SUCCESS).first(),
-    ).toBeVisible({timeout: 15000})
+    // The success message toasts through @agenta/ui's app-message facade (role="status"),
+    // not an antd `.ant-message` node.
+    await expect(page.getByRole("status").getByText(AUTO_EVAL_DELETE_SUCCESS).first()).toBeVisible({
+        timeout: 15000,
+    })
 }
 
 export {

--- a/web/oss/tests/playwright/acceptance/observability/index.ts
+++ b/web/oss/tests/playwright/acceptance/observability/index.ts
@@ -190,7 +190,10 @@ const observabilityTests = () => {
                 })
 
                 await scenarios.then("the trace detail drawer opens", async () => {
-                    const drawer = page.locator(".ant-drawer-content-wrapper")
+                    // TraceDrawer renders through EnhancedDrawer, a facade over the @agenta/ui
+                    // (Radix) Sheet, so the panel is `[data-slot="sheet-content"]`, not an antd
+                    // `.ant-drawer-content-wrapper`.
+                    const drawer = page.locator('[data-slot="sheet-content"]')
                     await expect(drawer).toBeVisible({timeout: 10000})
                 })
             },
@@ -299,7 +302,10 @@ const observabilityTests = () => {
                 // users rely on.
                 await clickFirstTraceRow(page)
 
-                const drawer = page.locator(".ant-drawer-content-wrapper")
+                // TraceDrawer renders through EnhancedDrawer, a facade over the @agenta/ui
+                // (Radix) Sheet, so the panel is `[data-slot="sheet-content"]`, not an antd
+                // `.ant-drawer-content-wrapper`.
+                const drawer = page.locator('[data-slot="sheet-content"]')
                 await expect(drawer).toBeVisible({timeout: 10000})
 
                 // The trace tree panel (CustomTreeComponent, not AntD Tree) renders a


### PR DESCRIPTION
## Context

The 0.112.0 acceptance gate run ([job](https://github.com/Agenta-AI/agenta/actions/runs/31378845895/job/93427148152)) reported 12 failures before hitting the 30-minute job cap. Most turned out to already be fixed on `release/v0.112.0` by earlier repair rounds; I verified each failing test live against the EE dev stack (`144.76.237.122:8180`, which hot-reloads the release tip) and only touched code where I could reproduce a real failure.

## Changes

**Observability trace drawer (2 tests).** `TraceDrawer` now renders through `EnhancedDrawer`, a facade over the `@agenta/ui` (Radix) `Sheet`. The tests still matched the old antd class:

```
page.locator(".ant-drawer-content-wrapper")   // never matches — 0 elements
```

Fixed to the Sheet's own slot:

```
page.locator('[data-slot="sheet-content"]')
```

**Auto-eval delete-run confirm modal + toast.** Same story: `DeleteEvaluationModal` renders through `EnhancedModal` (Radix `Dialog`), and the success message goes through `@agenta/ui`'s app-message facade (`role="status"`), not antd's `.ant-message`. Fixed both selectors in `waitAndClickDeleteForRun`.

**App overview test: hanging `networkidle` wait.** The layout now keeps a live SSE connection open (`ProjectWatch`, part of the in-flight rename-tools work), so `page.waitForLoadState("networkidle")` never resolves — Playwright waits for 500ms of zero network activity, which an open SSE connection prevents forever. Reproduced the 120s hang 1:1 with the wait in place; the fix removes it since the heading assertions right after already gate on the page being ready.

**CI job timeout: 30 → 45 minutes.** The app-overview hang alone burned ~6 minutes (3 attempts × 120s test timeout) before this fix landed; combined with the observability suite's 7-minute trace test × up to 3 retries, 30 minutes leaves no headroom.

## What I found working already (no change needed)

- **Provider fixture (`navigateToModels` / the "LLMs" settings tab)** — ran the exact failing chain live (`playground/run-variant.spec.ts` → provider ensure → LLMs tab → run) three times; passed every time. The settings IA code (`SettingsPageShell`, `navigation.ts`) is internally consistent — the "LLMs" heading is an unconditional `<h1>`. The original gate run most likely predates a fix that has since landed on `release/v0.112.0` (the branch moved ~2 hours past the gate run's tested commit before I started).
- **Deployment test** ("deploy to staging and production") — failed once with `waitForMatchingResponses` timing out on `/workflows` POST, passed cleanly on retry (13.9s). No selector issue; looked like a one-off cold-start/account-state hiccup on the dev stack (see below).

## Auto-eval "should delete an evaluation run" — selector fixed, but still blocked live

After fixing the selectors above, this test still fails, reproducibly, on a **live product bug** unrelated to selectors:

```
[Immer] The plugin for 'MapSet' has not been loaded into Immer. To enable the plugin,
import and call `enableMapSet()` when initializing your application.
  at web/packages/agenta-ui/src/InfiniteVirtualTable/atoms/columnVisibility.ts:69
```

`enableMapSet()` is called at module scope in `web/oss/src/components/pages/_app/index.tsx:28`, but on a fresh browser session landing directly on the Evaluations Runs list (which uses `InfiniteVirtualTable`'s Map-based column-visibility atom), the atom's own immer producer can run before that registration completes, crashing the whole app to Next's error overlay. Reproduced 3/3 times in fresh Playwright contexts against the dev stack. I drafted a one-line, idempotent `enableMapSet()` call directly in `columnVisibility.ts` to close the race at its source, but reverted it: this repo's dev stack is read-only for me (I can't deploy my worktree there to verify a product-code fix), and per the task's own precedent for out-of-scope product bugs (see agent-chat below), I diagnosed instead of guessing at an unverified fix. Filing this as a product bug is the next step, not a test change.

## Agent-chat diagnosis (no fix, per instructions)

`attach-send-render-reload.spec.ts:38` — the original gate failure showed the seeded agent app's playground navigation ending on a bare `/playground` path (missing `/apps/<id>`). I re-seeded an `is_agent` app via the API exactly as `seedAgentChatApp()` does and replayed `navigateToAgentPlayground`'s exact two-step navigation (`/apps` → `/apps/<id>/playground?revisions=<id>`) live, twice. Both times it landed correctly on the app-scoped playground URL — no redirect to a bare path. The test's URL construction (`${scopedPrefix}/apps/${appId}/playground`) is correct and matches the real route (`/apps/[app_id]/playground/index.tsx`, distinct from the bare `/playground/index.tsx`). I could not reproduce the reported redirect against current code, and this spec has no `test.setTimeout()` override (unlike siblings that bump to 120s+) for a flow with API seeding + 2 navigations + file upload + SSE-mocked run + reload — consistent with a timing/environment issue rather than a routing defect. Left the test unchanged, per instructions to not touch product code and leave the test as-is when the bug can't be pinned to the test layer.

## Live verification summary

| Test | Result |
|---|---|
| Provider fixture → playground run ("Should run single view variant for chat") | Passed live, 3 runs |
| Observability: "should create a trace after a Playground run" | Passed live |
| Observability: "view traces" (drawer) | Reproduced failure pre-fix (3/3), passed post-fix |
| Observability: "should open a span and drill into its attributes" | Passed live post-fix |
| App overview ("environment cards and variant list") | Reproduced 120s hang pre-fix, passed live post-fix (7.6s) |
| Auto-eval: mismatched testset error | Passed live, unchanged |
| Auto-eval: delete an evaluation run | Selector fixed and verified past the modal/toast step; test still fails on the live Immer/MapSet product bug above (diagnosed, not fixed) |
| Deployment: staging + production | Passed live (after one cold-start retry) |
| Agent-chat: attach/send/render/reload | Not reproducible against current code; diagnosed, left as-is |

## Notes for reviewers

- `web/oss/tests/playwright/acceptance/use-api/index.ts` has the same `waitForLoadState("networkidle")` pattern and will hit the same SSE-related hang; out of scope here but worth a follow-up.
- The Immer/MapSet crash above is worth its own issue; I have the exact repro (fresh session → Evaluations Runs list) and a candidate one-line fix, just unverified against a real deployment.
