### PR TITLE
fix(frontend): Immer MapSet race crashes fresh sessions on virtual-table pages

### DIFF
--- a/web/packages/agenta-ui/package.json
+++ b/web/packages/agenta-ui/package.json
@@ -104,6 +104,7 @@
         "clsx": "^2.1.1",
         "dompurify": "^3.4.12",
         "fast-deep-equal": "^3.1.3",
+        "immer": "^10.1.3",
         "jotai": "^2.16.1",
         "jotai-family": "^1.0.1",
         "jotai-immer": "^0.4.3",

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/atoms/columnVisibility.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/atoms/columnVisibility.ts
@@ -1,9 +1,14 @@
+import {enableMapSet} from "immer"
 import {atom} from "jotai"
 import {selectAtom} from "jotai/utils"
 import {atomFamily} from "jotai-family"
 import {atomWithImmer} from "jotai-immer"
 
 import type {ColumnViewportVisibilityEvent} from "../types"
+
+// This module's producers mutate Maps; registering here (idempotent) closes the race
+// where a fresh session reaches this atom before _app's module-scope enableMapSet().
+enableMapSet()
 
 const DEFAULT_SCOPE = "__default__"
 const resolveScopeKey = (scopeId: string | null) => scopeId ?? DEFAULT_SCOPE

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1690,6 +1690,9 @@ importers:
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
+      immer:
+        specifier: ^10.1.3
+        version: 10.2.0
       jotai:
         specifier: ^2.16.1
         version: 2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6)
@@ -1698,7 +1701,7 @@ importers:
         version: 1.0.1(jotai@2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6))
       jotai-immer:
         specifier: ^0.4.3
-        version: 0.4.3(immer@11.1.7)(jotai@2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6))
+        version: 0.4.3(immer@10.2.0)(jotai@2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6))
       jotai-scheduler:
         specifier: ^0.0.5
         version: 0.0.5(jotai@2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -17980,11 +17983,6 @@ snapshots:
   jotai-immer@0.4.3(immer@10.2.0)(jotai@2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6)):
     dependencies:
       immer: 10.2.0
-      jotai: 2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6)
-
-  jotai-immer@0.4.3(immer@11.1.7)(jotai@2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6)):
-    dependencies:
-      immer: 11.1.7
       jotai: 2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6)
 
   jotai-scheduler@0.0.5(jotai@2.20.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):


### PR DESCRIPTION
## What

A fresh browser session that lands directly on a page using `InfiniteVirtualTable` (for example the Evaluation Runs list) can crash the whole app to Next's error overlay with:

```
[Immer] The plugin for 'MapSet' has not been loaded into Immer.
```

Reproduced 3 out of 3 times in fresh Playwright contexts by the acceptance-backlog agent while repairing the delete-evaluation-run test (diagnosis documented in [#5900](https://github.com/Agenta-AI/agenta/pull/5900)).

## Why

`enableMapSet()` is only called at module scope in `_app`, and the table's Map-based column-visibility atom (`web/packages/agenta-ui/src/InfiniteVirtualTable/atoms/columnVisibility.ts`) can execute its immer producer before that registration runs on a cold load.

## Fix

Register the plugin (an idempotent call) directly in the module whose producers mutate Maps, and declare `immer` as a direct dependency of `@agenta/ui` (it was previously reachable only through the app packages, and the direct import surfaced that gap as a module-resolution failure).

## Verification

Live on the dev stack after a web-container dependency install and restart: the page loads clean, no module-resolution or MapSet errors in the container log. The blocked delete-evaluation-run acceptance test can be confirmed on the gate re-run once this and [#5900](https://github.com/Agenta-AI/agenta/pull/5900) merge.