### PR TITLE
fix(sdk): empty vault reports a missing credential, not 'multiple connections'

### DIFF
--- a/sdks/python/agenta/sdk/agents/platform/connections.py
+++ b/sdks/python/agenta/sdk/agents/platform/connections.py
@@ -448,6 +448,11 @@ def _choose_default(
         raise MissingProviderError(
             model=model.model, hint_provider=_harness_default_provider(harness)
         )
+    if not pool:
+        # Zero candidates with a known provider is a MISSING credential, not an ambiguous
+        # one — falling through to AmbiguousConnectionError told users with an empty vault
+        # "multiple connections for provider 'X'" and sent them hunting phantom secrets.
+        raise MissingCredentialError(provider=model.provider or "")
     if len(pool) == 1:
         return pool[0]
     default_named = [candidate for candidate in pool if candidate.slug == "default"]

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
@@ -126,6 +126,14 @@ async def test_managed_connection_with_empty_key_fails_closed(fake_http, connect
         )
 
 
+async def test_empty_vault_reports_missing_not_ambiguous(fake_http, connection):
+    fake_http(connections, payload=[])
+    with pytest.raises(MissingCredentialError):
+        await VaultConnectionResolver(connection).resolve(
+            model=_model(slug=None), context=_context()
+        )
+
+
 async def test_default_connection_ambiguous(fake_http, connection):
     fake_http(
         connections,


### PR DESCRIPTION
## What

An agent run in a project whose vault holds NO provider key failed with:

```
multiple connections for provider 'openai'; name one in the config
```

which is the opposite of the truth and sends the user hunting for phantom connections. Found during rename-tools live QA, where it burned real hours across two zero-secret projects.

## Why

`_choose_default` in `sdks/python/agenta/sdk/agents/platform/connections.py` handles the empty candidate pool only for a bare model id with no provider. With a known provider and zero candidates it fell through the single-match and default-named checks straight to `AmbiguousConnectionError`.

## Fix

An explicit empty-pool branch raising `MissingCredentialError` (HTTP 422): "provider 'openai' connection has no usable credential; configure a credential or select self_managed authentication."

## Verification

- New unit test `test_empty_vault_reports_missing_not_ambiguous` (31/31 pass in the file).
- Live on the dev stack: the release-gate baseline probe against a freshly minted zero-secret project now returns the 422 with the honest message (was: 500 "multiple connections"); a one-key project still resolves and completes (PONG).