### PR TITLE
[feat] Agents name their own sessions and themselves

### DIFF
--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import sys
 import uuid
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 import httpx
 
@@ -35,10 +36,24 @@ PI_CORE_HAIKU_MODEL = "claude-haiku-4-5"
 
 
 def api_call(method: str, path: str, timeout: float = 60.0, **kwargs) -> httpx.Response:
+    # httpx REPLACES an URL-embedded query string entirely when `params=` is also given,
+    # so a path like "/sessions/streams/?session_id=..." used to silently lose its query
+    # to the hardcoded project_id (the endpoint then 422s with "Field required"). Merge
+    # the path's query into the params dict instead — explicit `params=` kwargs win,
+    # then project_id — so both spellings are safe for every caller. A path WITHOUT a
+    # query and no extra params builds the exact same request as before.
+    params = {"project_id": PROJECT, **(kwargs.pop("params", None) or {})}
+    parsed = urlsplit(f"{BASE}/api{path}")
+    url = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", parsed.fragment))
+    if parsed.query:
+        params = {
+            **dict(parse_qsl(parsed.query, keep_blank_values=True)),
+            **params,
+        }
     return httpx.request(
         method,
-        f"{BASE}/api{path}",
-        params={"project_id": PROJECT},
+        url,
+        params=params,
         headers={"Authorization": f"ApiKey {KEY}", "Content-Type": "application/json"},
         timeout=timeout,
         **kwargs,

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -42,14 +42,15 @@ def api_call(method: str, path: str, timeout: float = 60.0, **kwargs) -> httpx.R
     # the path's query into the params dict instead — explicit `params=` kwargs win,
     # then project_id — so both spellings are safe for every caller. A path WITHOUT a
     # query and no extra params builds the exact same request as before.
-    params = {"project_id": PROJECT, **(kwargs.pop("params", None) or {})}
+    explicit = {"project_id": PROJECT, **(kwargs.pop("params", None) or {})}
     parsed = urlsplit(f"{BASE}/api{path}")
     url = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", parsed.fragment))
-    if parsed.query:
-        params = {
-            **dict(parse_qsl(parsed.query, keep_blank_values=True)),
-            **params,
-        }
+    # Keep the path's query as PAIRS (a dict would collapse repeated keys like
+    # ?workflow_refs=a&workflow_refs=b); explicit params override any same-named pair.
+    path_pairs = parse_qsl(parsed.query, keep_blank_values=True) if parsed.query else []
+    params = [(k, v) for k, v in path_pairs if k not in explicit] + list(
+        explicit.items()
+    )
     return httpx.request(
         method,
         url,

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_api_call.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_api_call.py
@@ -1,0 +1,62 @@
+"""Unit test for `api_call`'s query merging (run: `uv run --no-sync pytest` from `api/`,
+or any interpreter with pytest + httpx: `pytest test_qa_matrix_lib_api_call.py`).
+
+The trap this pins: httpx REPLACES an URL-embedded query string entirely when
+`params=` is also passed. `api_call` hardcodes `params={"project_id": ...}`, so a
+caller writing `api_call("GET", "/sessions/streams/?session_id=...")` silently lost
+`session_id` and the endpoint 422ed with "Field required" — observed live as
+benchmark scenarios failing at seed/verify while direct curls worked.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _lib(monkeypatch):
+    monkeypatch.setenv("AGENTA_BASE", "https://qa.example")
+    monkeypatch.setenv("AGENTA_PROJECT_ID", "proj-1")
+    monkeypatch.setenv("AGENTA_API_KEY", "test-key")
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    sys.modules.pop("qa_matrix_lib", None)
+    return importlib.import_module("qa_matrix_lib")
+
+
+def _sent_url(lib, method, path, **kwargs):
+    import httpx
+
+    captured = {}
+
+    def fake_request(method_, url, *, params=None, **kw):
+        request = httpx.Request(method_, url, params=params)
+        captured["url"] = str(request.url)
+        return httpx.Response(200, request=request)
+
+    with patch.object(lib, "httpx") as fake:
+        fake.request = fake_request
+        lib.api_call(method, path, **kwargs)
+    return captured["url"]
+
+
+def test_path_without_query_builds_the_same_request_as_before(monkeypatch):
+    lib = _lib(monkeypatch)
+    url = _sent_url(lib, "GET", "/workflows/abc")
+    assert url == "https://qa.example/api/workflows/abc?project_id=proj-1"
+
+
+def test_path_embedded_query_survives_the_project_id_params(monkeypatch):
+    lib = _lib(monkeypatch)
+    url = _sent_url(lib, "GET", "/sessions/streams/?session_id=sess-1")
+    assert "session_id=sess-1" in url
+    assert "project_id=proj-1" in url
+
+
+def test_explicit_params_kwarg_merges_and_wins_over_the_path_query(monkeypatch):
+    lib = _lib(monkeypatch)
+    url = _sent_url(
+        lib, "GET", "/sessions/streams/?session_id=old", params={"session_id": "new"}
+    )
+    assert "session_id=new" in url
+    assert "session_id=old" not in url
+    assert "project_id=proj-1" in url

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_api_call.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_api_call.py
@@ -60,3 +60,11 @@ def test_explicit_params_kwarg_merges_and_wins_over_the_path_query(monkeypatch):
     assert "session_id=new" in url
     assert "session_id=old" not in url
     assert "project_id=proj-1" in url
+
+
+def test_repeated_query_keys_are_preserved(monkeypatch):
+    lib = _lib(monkeypatch)
+    url = _sent_url(lib, "GET", "/workflows/query?workflow_refs=a&workflow_refs=b")
+    assert "workflow_refs=a" in url
+    assert "workflow_refs=b" in url
+    assert "project_id=proj-1" in url

--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -660,6 +660,7 @@ session_turns_service = SessionTurnsService(
 workflows_service = WorkflowsService(
     workflows_dao=workflows_dao,
     static_catalog=StaticWorkflowCatalog(),
+    watch_publisher=_sessions_watch_publisher,
 )
 
 environments_service = EnvironmentsService(

--- a/api/entrypoints/worker_queues.py
+++ b/api/entrypoints/worker_queues.py
@@ -170,7 +170,10 @@ def _build_triggers_broker() -> tuple[AsyncBroker, int]:
         VariantDBE=EnvironmentVariantDBE,
         RevisionDBE=EnvironmentRevisionDBE,
     )
-    workflows_service = WorkflowsService(workflows_dao=workflows_dao)
+    workflows_service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        watch_publisher=SessionsWatchPublisher(),
+    )
     environments_service = EnvironmentsService(environments_dao=environments_dao)
     embeds_service = EmbedsService(
         workflows_service=workflows_service,
@@ -222,7 +225,10 @@ def _build_interactions_broker() -> tuple[AsyncBroker, int]:
         VariantDBE=EnvironmentVariantDBE,
         RevisionDBE=EnvironmentRevisionDBE,
     )
-    workflows_service = WorkflowsService(workflows_dao=workflows_dao)
+    workflows_service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        watch_publisher=SessionsWatchPublisher(),
+    )
     environments_service = EnvironmentsService(environments_dao=environments_dao)
     embeds_service = EmbedsService(
         workflows_service=workflows_service,
@@ -291,7 +297,10 @@ def _build_evaluations_broker() -> tuple[AsyncBroker, int]:
         testsets_dao=testsets_dao, testcases_service=testcases_service
     )
     SimpleTestsetsService(testsets_service=testsets_service)
-    workflows_service = WorkflowsService(workflows_dao=workflows_dao)
+    workflows_service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        watch_publisher=SessionsWatchPublisher(),
+    )
     evaluators_service = EvaluatorsService(workflows_service=workflows_service)
     simple_evaluators_service = SimpleEvaluatorsService(
         evaluators_service=evaluators_service

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -39,7 +39,7 @@ from oss.src.utils.env import env
 from oss.src.utils.exceptions import intercept_exceptions
 from oss.src.utils.logging import get_module_logger
 
-from oss.src.dbs.redis.sessions.contract import watch_channel
+from oss.src.dbs.redis.sessions.contract import project_watch_channel, watch_channel
 from oss.src.dbs.redis.shared.engine import get_streams_engine
 from oss.src.apis.fastapi.sessions.watch import watch_event_stream
 
@@ -348,6 +348,14 @@ class SessionStreamsRouter:
             tags=["Sessions"],
             response_model=None,
         )
+        self.router.add_api_route(
+            "/sessions/watch",
+            self.watch_project,
+            methods=["GET"],
+            operation_id="watch_project",
+            tags=["Sessions"],
+            response_model=None,
+        )
 
     @intercept_exceptions()
     @_handle_session_exceptions()
@@ -595,6 +603,49 @@ class SessionStreamsRouter:
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
                 # Disable proxy buffering so frames flush immediately.
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @intercept_exceptions()
+    async def watch_project(
+        self,
+        request: Request,
+        project_id: UUID = Query(...),
+    ) -> StreamingResponse:
+        """Relay low-frequency entity changes for the authorized project.
+
+        A caller with only one required view permission cannot open this stream and falls back to
+        the lists' polling behavior.
+        """
+        user_id = request.state.user_id
+        authorized_project_id = request.state.project_id
+
+        can_view_sessions = await check_action_access(
+            user_uid=str(user_id),
+            project_id=str(authorized_project_id),
+            permission=Permission.VIEW_SESSIONS,
+        )
+        can_view_workflows = await check_action_access(
+            user_uid=str(user_id),
+            project_id=str(authorized_project_id),
+            permission=Permission.VIEW_WORKFLOWS,
+        )
+        if not (can_view_sessions and can_view_workflows):
+            raise FORBIDDEN_EXCEPTION
+
+        stream = watch_event_stream(
+            channel=project_watch_channel(str(authorized_project_id)),
+            pubsub_factory=lambda: get_streams_engine().get_redis().pubsub(),
+            heartbeat_seconds=env.sessions.watch_heartbeat_seconds,
+            retry_milliseconds=env.sessions.watch_retry_milliseconds,
+        )
+        return StreamingResponse(
+            stream,
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
                 "X-Accel-Buffering": "no",
             },
         )

--- a/api/oss/src/apis/fastapi/sessions/watch.py
+++ b/api/oss/src/apis/fastapi/sessions/watch.py
@@ -37,7 +37,10 @@ _KNOWN_EVENTS = {
     WATCH_EVENT_RECORDS_CHANGED,
     WATCH_EVENT_LIFECYCLE,
     WATCH_EVENT_INTERACTION,
+    "session-changed",
+    "workflow-changed",
 }
+# Each project event family also needs its view permission in the project route's conjunction.
 
 
 def format_watch_frame(raw: Any) -> Optional[str]:

--- a/api/oss/src/apis/fastapi/sessions/watch.py
+++ b/api/oss/src/apis/fastapi/sessions/watch.py
@@ -8,6 +8,8 @@ clients never see a silent connection.
 """
 
 import json
+import math
+import threading
 from typing import Any, AsyncIterator, Callable, Optional
 
 from oss.src.dbs.redis.sessions.contract import (
@@ -21,6 +23,53 @@ from oss.src.utils.logging import get_module_logger
 log = get_module_logger(__name__)
 
 HEARTBEAT_FRAME = ": heartbeat\n\n"
+
+# ---------------------------------------------------------------------------
+# Server-shutdown release.
+#
+# Uvicorn's graceful shutdown drains in-flight responses BEFORE it runs lifespan
+# shutdown, and an SSE response never completes on its own — so without a release
+# every reload/stop waits on these generators forever (live symptom: the dev
+# stack's `uvicorn --reload` logs "Reloading..." and the API stays dead until a
+# hard container restart, since any open browser tab holds a watch stream).
+# `Server.handle_exit` is the first thing uvicorn does on SIGINT/SIGTERM — before
+# the drain — so hooking it (the sse-starlette approach) releases every stream
+# within one poll interval and lets the drain complete. A client disconnect
+# already releases a stream by cancelling the generator; this covers the server
+# side. A `threading.Event` because the hook may run from a signal frame: no
+# event-loop affinity, and polling it is cheap.
+# ---------------------------------------------------------------------------
+
+_shutdown = threading.Event()
+
+# Upper bound on how long a stream keeps waiting on Redis before it re-checks the
+# shutdown flag, so a reload never waits a full heartbeat interval (15s default).
+_SHUTDOWN_POLL_SECONDS = 1.0
+
+
+def request_shutdown() -> None:
+    """Release every open watch stream (idempotent; wired into uvicorn's exit path)."""
+    _shutdown.set()
+
+
+def _install_uvicorn_exit_hook() -> None:
+    try:
+        from uvicorn.server import Server  # noqa: PLC0415 — optional dependency
+    except Exception:  # pragma: no cover — no uvicorn (workers, bare test runs)
+        return
+    if getattr(Server.handle_exit, "_agenta_watch_hook", False):  # pragma: no cover
+        return
+    original = Server.handle_exit
+
+    def handle_exit(self: Any, sig: Any, frame: Any) -> Any:
+        request_shutdown()
+        return original(self, sig, frame)
+
+    handle_exit._agenta_watch_hook = True  # type: ignore[attr-defined]
+    Server.handle_exit = handle_exit  # type: ignore[method-assign]
+
+
+_install_uvicorn_exit_hook()
 
 
 def retry_frame(retry_milliseconds: int) -> str:
@@ -83,21 +132,37 @@ async def watch_event_stream(
 
     The subscription is torn down in ``finally`` — a client disconnect cancels
     the generator (GeneratorExit/CancelledError), which is exactly the cleanup
-    path, so no Redis subscription outlives its SSE connection.
+    path, so no Redis subscription outlives its SSE connection. CancelledError is
+    never swallowed here: the ``finally`` guards only the best-effort teardown.
+
+    Server shutdown is the OTHER release path: the loop re-checks the module
+    shutdown flag at least every ``_SHUTDOWN_POLL_SECONDS``, and returns as soon
+    as it is set — uvicorn's drain would otherwise wait on this generator forever
+    (see the module comment). The heartbeat cadence is preserved by counting idle
+    polls rather than lengthening the wait.
     """
     pubsub = pubsub_factory()
     try:
         await pubsub.subscribe(channel)
         yield retry_frame(retry_milliseconds)
         yield ready_frame()
-        while True:
+        poll_seconds = min(heartbeat_seconds, _SHUTDOWN_POLL_SECONDS)
+        idle_polls_per_heartbeat = max(1, math.ceil(heartbeat_seconds / poll_seconds))
+        idle_polls = 0
+        while not _shutdown.is_set():
             message = await pubsub.get_message(
                 ignore_subscribe_messages=True,
-                timeout=heartbeat_seconds,
+                timeout=poll_seconds,
             )
+            if _shutdown.is_set():
+                break
             if message is None:
-                yield HEARTBEAT_FRAME
+                idle_polls += 1
+                if idle_polls >= idle_polls_per_heartbeat:
+                    idle_polls = 0
+                    yield HEARTBEAT_FRAME
                 continue
+            idle_polls = 0
             if message.get("type") != "message":
                 continue
             frame = format_watch_frame(message.get("data"))

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -778,7 +778,10 @@ class WorkflowsRouter:
             raise FORBIDDEN_EXCEPTION  # type: ignore
 
         if str(workflow_id) != str(workflow_edit_request.workflow.id):
-            return WorkflowResponse()
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Workflow ID in path does not match workflow ID in request body.",
+            )
 
         workflow = await self.workflows_service.edit_workflow(
             project_id=UUID(request.state.project_id),
@@ -787,8 +790,14 @@ class WorkflowsRouter:
             workflow_edit=workflow_edit_request.workflow,
         )
 
+        if not workflow:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Workflow not found.",
+            )
+
         workflow_response = WorkflowResponse(
-            count=1 if workflow else 0,
+            count=1,
             workflow=workflow,
         )
 

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -783,6 +783,17 @@ class WorkflowsRouter:
                 detail="Workflow ID in path does not match workflow ID in request body.",
             )
 
+        # A present name must not be empty or whitespace-only: a blank artifact name renders as an
+        # unreadable row in every list, and the shared ArtifactEdit shape carries no constraint (an
+        # omitted name still means "no change"). The LLM-facing rename_agent schema already rejects
+        # this; the check closes the direct-API hole.
+        edit_name = workflow_edit_request.workflow.name
+        if edit_name is not None and not edit_name.strip():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="workflow.name must contain a non-whitespace character.",
+            )
+
         workflow = await self.workflows_service.edit_workflow(
             project_id=UUID(request.state.project_id),
             user_id=UUID(request.state.user_id),

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from agenta.sdk.models.workflows import WorkflowServiceRequestData
 
@@ -59,7 +59,23 @@ class SessionStreamHeaderEdit(Header):
 
     Distinct from SessionStreamEdit (used by the flag-mirror/heartbeat paths) so the
     liveness-only writes can never carry name/description, and vice versa.
+
+    ``name`` may be omitted/``None`` (no change) or an empty string (the explicit
+    clear-title action the chat rail's rename path uses), but a NON-empty name must
+    contain a non-whitespace character: storing ``"   "`` clears the visible title
+    while the row still holds a value, a state no caller ever means. The LLM-facing
+    ``rename_session`` schema already rejects both; this closes the direct-API hole.
     """
+
+    @field_validator("name")
+    @classmethod
+    def _non_empty_name_must_not_be_blank(cls, value: Optional[str]) -> Optional[str]:
+        if value and not value.strip():
+            raise ValueError(
+                "name must contain a non-whitespace character"
+                " (send an empty string to clear the title)"
+            )
+        return value
 
 
 class SessionStreamQuery(BaseModel):

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -159,6 +159,22 @@ class SessionStreamsService:
                 state=state,
             )
 
+    async def _publish_changed(self, *, project_id: UUID, session_id: str) -> None:
+        if self._watch is None:
+            return
+        try:
+            await self._watch.changed(
+                project_id=str(project_id),
+                entity="session",
+                id=session_id,
+            )
+        except Exception:
+            log.warning(
+                "[WATCH] session change publish failed",
+                project_id=str(project_id),
+                session_id=session_id,
+            )
+
     async def command(
         self,
         *,
@@ -648,8 +664,8 @@ class SessionStreamsService:
     ) -> Optional[SessionStream]:
         """The rename edit: full-PUT {name, description} onto the merged stream row.
 
-        Pure DB write — no Redis nest interaction, no flags/turn_id touched. Off the
-        runner's write path. Creates the row if the session has never heartbeat/run
+        Header-only durable write — no Redis nest interaction, no flags/turn_id touched. Off
+        the runner's write path. Creates the row if the session has never heartbeat/run
         yet (a caller may name a session before its first turn), mirroring
         `_start_turn`'s create-or-update pattern.
         """
@@ -660,27 +676,30 @@ class SessionStreamsService:
             session_id=session_id,
             header=header,
         )
-        if updated is not None:
-            return updated
-        try:
-            return await self._dao.create(
-                project_id=project_id,
-                user_id=user_id,
-                stream=SessionStreamCreate(
+        if updated is None:
+            try:
+                updated = await self._dao.create(
+                    project_id=project_id,
+                    user_id=user_id,
+                    stream=SessionStreamCreate(
+                        session_id=session_id,
+                        name=header.name,
+                        description=header.description,
+                    ),
+                )
+            except SessionStreamAlreadyExists:
+                # A concurrent first touch (heartbeat/rename) won the race; the row now
+                # exists — apply the header edit onto it.
+                updated = await self._dao.update_header(
+                    project_id=project_id,
+                    user_id=user_id,
                     session_id=session_id,
-                    name=header.name,
-                    description=header.description,
-                ),
-            )
-        except SessionStreamAlreadyExists:
-            # A concurrent first touch (heartbeat/rename) won the race; the row now
-            # exists — apply the header edit onto it.
-            return await self._dao.update_header(
-                project_id=project_id,
-                user_id=user_id,
-                session_id=session_id,
-                header=header,
-            )
+                    header=header,
+                )
+
+        if updated is not None:
+            await self._publish_changed(project_id=project_id, session_id=session_id)
+        return updated
 
     async def set_origin(
         self,

--- a/api/oss/src/core/sessions/watch/interfaces.py
+++ b/api/oss/src/core/sessions/watch/interfaces.py
@@ -26,3 +26,7 @@ class SessionsWatchPublisherInterface(Protocol):
     ) -> None:
         """A gate became actionable or was answered (`pending` | `resolved`)."""
         ...
+
+    async def changed(self, *, project_id: str, entity: str, id: str) -> None:
+        """A project-scoped entity changed."""
+        ...

--- a/api/oss/src/core/workflows/build_kit.py
+++ b/api/oss/src/core/workflows/build_kit.py
@@ -32,6 +32,8 @@ _READ_CONFIG_OPS: tuple[str, ...] = (
     ("read_config",) if "read_config" in PLATFORM_OPS else ()
 )
 
+_AUTO_ALLOWED_BUILD_KIT_OPS = frozenset({"rename_session", "rename_agent"})
+
 # Cut ops stay catalog opt-ins.
 DEFAULT_BUILD_KIT_OPS: tuple[str, ...] = (
     "discover_tools",
@@ -40,6 +42,7 @@ DEFAULT_BUILD_KIT_OPS: tuple[str, ...] = (
     "annotate_trace",
     "query_spans",
     "test_run",
+    "rename_session",
     "discover_triggers",
     "create_schedule",
     "create_subscription",
@@ -86,7 +89,18 @@ def build_agent_template_overlay() -> Dict[str, Any]:
     """Build the playground-only agent-template overlay from platform-owned sources."""
     return {
         "tools": [
-            *[{"type": "platform", "op": op_name} for op_name in DEFAULT_BUILD_KIT_OPS],
+            *[
+                {
+                    "type": "platform",
+                    "op": op_name,
+                    **(
+                        {"permission": "allow"}
+                        if op_name in _AUTO_ALLOWED_BUILD_KIT_OPS
+                        else {}
+                    ),
+                }
+                for op_name in DEFAULT_BUILD_KIT_OPS
+            ],
             *_reserved_static_tool_embeds(),
         ],
         "skills": [

--- a/api/oss/src/core/workflows/build_kit.py
+++ b/api/oss/src/core/workflows/build_kit.py
@@ -43,6 +43,7 @@ DEFAULT_BUILD_KIT_OPS: tuple[str, ...] = (
     "query_spans",
     "test_run",
     "rename_session",
+    "rename_agent",
     "discover_triggers",
     "create_schedule",
     "create_subscription",

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -943,15 +943,28 @@ class WorkflowsService:
         #
         workflow_edit: WorkflowEdit,
     ) -> Optional[Workflow]:
-        artifact_flags = self._artifact_flags_from_any(workflow_edit.flags)
-        artifact_edit = ArtifactEdit(
-            **workflow_edit.model_dump(
-                mode="json",
-                exclude_none=True,
-                exclude={"flags"},
-            ),
-            flags=self._dump_stored_flags(artifact_flags) or None,
+        current_artifact = await self.workflows_dao.fetch_artifact(
+            project_id=project_id,
+            #
+            artifact_ref=Reference(id=workflow_edit.id),
+            #
+            include_archived=False,
         )
+        if not current_artifact:
+            return None
+
+        artifact_edit_kwargs = workflow_edit.model_dump(
+            mode="json",
+            exclude_none=True,
+            exclude={"flags"},
+        )
+        if "flags" in workflow_edit.model_fields_set:
+            artifact_flags = self._artifact_flags_from_any(workflow_edit.flags)
+            artifact_edit_kwargs["flags"] = (
+                self._dump_stored_flags(artifact_flags) or None
+            )
+
+        artifact_edit = ArtifactEdit(**artifact_edit_kwargs)
 
         artifact = await self.workflows_dao.edit_artifact(
             project_id=project_id,

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -25,6 +25,7 @@ from agenta.sdk.engines.running.utils import (
 from agenta.sdk.engines.tracing.propagation import inject
 
 from oss.src.core.git.interfaces import GitDAOInterface
+from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
 from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.git.dtos import (
     ArtifactCreate,
@@ -239,11 +240,13 @@ class WorkflowsService:
         environments_service: Optional["EnvironmentsService"] = None,  # type: ignore
         embeds_service: Optional["EmbedsService"] = None,  # type: ignore
         static_catalog: Optional[StaticWorkflowProvider] = None,
+        watch_publisher: Optional[SessionsWatchPublisherInterface] = None,
     ):
         self.workflows_dao = workflows_dao
         self.environments_service = environments_service
         self.embeds_service = embeds_service
         self.static_catalog = static_catalog
+        self._watch = watch_publisher
 
     @staticmethod
     def _artifact_cache_key(artifact_id: UUID) -> str:
@@ -982,6 +985,20 @@ class WorkflowsService:
             project_id=project_id,
             workflow=workflow,
         )
+
+        if self._watch is not None:
+            try:
+                await self._watch.changed(
+                    project_id=str(project_id),
+                    entity="workflow",
+                    id=str(workflow_edit.id),
+                )
+            except Exception:
+                log.warning(
+                    "[WATCH] workflow change publish failed",
+                    project_id=str(project_id),
+                    workflow_id=str(workflow_edit.id),
+                )
 
         return workflow
 

--- a/api/oss/src/dbs/redis/sessions/contract.py
+++ b/api/oss/src/dbs/redis/sessions/contract.py
@@ -87,14 +87,17 @@ def make_displacement_payload(*, by: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Watch channel (M3 live relay) — change notifications, never record payloads.
+# Watch channels — change notifications, never record payloads.
 # Published on the DURABLE Redis plane (the SSE endpoint subscribes there via
 # get_streams_engine(); publisher and subscriber must share one plane — the
 # displaced channel above lives on the volatile plane instead).
+# Per-session channels carry high-frequency in-session traffic; the project
+# channel carries low-frequency entity changes for list pages.
 # Payload shapes:
 #   {"type": "records-changed", "session_id": s}
 #   {"type": "lifecycle",       "session_id": s, "state": "running"|"ended"}
 #   {"type": "interaction",     "session_id": s, "status": "pending"|"resolved"}
+#   {"type": "<entity>-changed", "entity": entity, "id": id}
 # ---------------------------------------------------------------------------
 
 WATCH_EVENT_RECORDS_CHANGED = "records-changed"
@@ -116,6 +119,10 @@ def watch_channel(project_id: str, session_id: str) -> str:
     return f"watch:{project_id}:session:{session_id}"
 
 
+def project_watch_channel(project_id: str) -> str:
+    return f"watch:{project_id}:project"
+
+
 def make_watch_records_changed_payload(*, session_id: str) -> dict:
     return {"type": WATCH_EVENT_RECORDS_CHANGED, "session_id": session_id}
 
@@ -126,6 +133,10 @@ def make_watch_lifecycle_payload(*, session_id: str, state: str) -> dict:
 
 def make_watch_interaction_payload(*, session_id: str, status: str) -> dict:
     return {"type": WATCH_EVENT_INTERACTION, "session_id": session_id, "status": status}
+
+
+def make_watch_entity_changed_payload(*, entity: str, id: str) -> dict:
+    return {"type": f"{entity}-changed", "entity": entity, "id": id}
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/src/dbs/redis/sessions/watch.py
+++ b/api/oss/src/dbs/redis/sessions/watch.py
@@ -1,6 +1,6 @@
-"""Per-session watch channel — fire-and-forget publishers (M3 live relay).
+"""Session and project watch channels — fire-and-forget publishers.
 
-Publish side of ``GET /sessions/streams/watch``. Every publish is best-effort:
+Publish side of the session and project SSE endpoints. Every publish is best-effort:
 a failure is logged and swallowed so the write path that triggered it (records
 append, turn lifecycle, interaction create/resolve) never fails or re-drives
 because of the relay. PUBLISH to zero subscribers is an O(1) Redis no-op.
@@ -14,9 +14,11 @@ import json
 from typing import TYPE_CHECKING, Optional
 
 from oss.src.dbs.redis.sessions.contract import (
+    make_watch_entity_changed_payload,
     make_watch_interaction_payload,
     make_watch_lifecycle_payload,
     make_watch_records_changed_payload,
+    project_watch_channel,
     watch_channel,
 )
 from oss.src.dbs.redis.shared.engine import get_streams_engine
@@ -44,8 +46,8 @@ class SessionsWatchPublisher:
     async def _publish(
         self,
         *,
+        channel: str,
         project_id: str,
-        session_id: str,
         payload: dict,
     ) -> None:
         try:
@@ -54,7 +56,7 @@ class SessionsWatchPublisher:
             # cost at most 1s, never a TCP timeout.
             await asyncio.wait_for(
                 self._client().publish(
-                    watch_channel(project_id, session_id),
+                    channel,
                     json.dumps(payload).encode(),
                 ),
                 timeout=1.0,
@@ -64,14 +66,14 @@ class SessionsWatchPublisher:
             log.warning(
                 "[WATCH] publish failed",
                 project_id=project_id,
-                session_id=session_id,
+                session_id=payload.get("session_id"),
                 event_type=payload.get("type"),
             )
 
     async def records_changed(self, *, project_id: str, session_id: str) -> None:
         await self._publish(
+            channel=watch_channel(project_id, session_id),
             project_id=project_id,
-            session_id=session_id,
             payload=make_watch_records_changed_payload(session_id=session_id),
         )
 
@@ -83,8 +85,8 @@ class SessionsWatchPublisher:
         state: str,
     ) -> None:
         await self._publish(
+            channel=watch_channel(project_id, session_id),
             project_id=project_id,
-            session_id=session_id,
             payload=make_watch_lifecycle_payload(session_id=session_id, state=state),
         )
 
@@ -96,9 +98,16 @@ class SessionsWatchPublisher:
         status: str,
     ) -> None:
         await self._publish(
+            channel=watch_channel(project_id, session_id),
             project_id=project_id,
-            session_id=session_id,
             payload=make_watch_interaction_payload(
                 session_id=session_id, status=status
             ),
+        )
+
+    async def changed(self, *, project_id: str, entity: str, id: str) -> None:
+        await self._publish(
+            channel=project_watch_channel(project_id),
+            project_id=project_id,
+            payload=make_watch_entity_changed_payload(entity=entity, id=id),
         )

--- a/api/oss/tests/pytest/acceptance/sessions/test_stream_header_basics.py
+++ b/api/oss/tests/pytest/acceptance/sessions/test_stream_header_basics.py
@@ -104,3 +104,48 @@ class TestSessionStreamHeaderBasics:
             "GET", "/sessions/streams/", params={"session_id": "foo bar"}
         )
         assert response.status_code == 422
+
+    def test_whitespace_only_name_rejected(self, authed_api):
+        # A non-empty name must contain a non-whitespace character: "   " would clear the
+        # visible title while the row still holds a value. The LLM-facing rename_session
+        # schema already rejects this; the endpoint must too.
+        session_id = str(uuid.uuid4())
+        authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={"name": "Real Name"},
+        )
+
+        response = authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={"name": "   "},
+        )
+        assert response.status_code == 422
+
+        response = authed_api(
+            "GET", "/sessions/streams/", params={"session_id": session_id}
+        )
+        assert response.json()["stream"]["name"] == "Real Name"
+
+    def test_empty_name_still_clears_the_title(self, authed_api):
+        # The empty string is the explicit clear-title action the chat rail sends;
+        # it must stay accepted (only whitespace-only garbage is rejected).
+        session_id = str(uuid.uuid4())
+        authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={"name": "To Be Cleared"},
+        )
+
+        response = authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={"name": ""},
+        )
+        assert response.status_code == 200
+        assert response.json()["stream"]["name"] == ""

--- a/api/oss/tests/pytest/acceptance/workflows/test_workflows_basics.py
+++ b/api/oss/tests/pytest/acceptance/workflows/test_workflows_basics.py
@@ -231,6 +231,34 @@ class TestWorkflowsBasics:
         assert body["count"] == 1
         assert body["workflow"]["flags"] == original_flags
 
+    def test_edit_workflow_rejects_blank_name(
+        self,
+        authed_api,
+    ):
+        # A present name must not be empty or whitespace-only: a blank artifact name
+        # renders as an unreadable row in every list. The LLM-facing rename_agent
+        # schema already rejects this; the endpoint must too.
+        workflow = _create_workflow(authed_api, flags={"is_application": True})
+        workflow_id = workflow["id"]
+        original_name = workflow["name"]
+
+        for blank in ("   ", ""):
+            response = authed_api(
+                "PUT",
+                f"/workflows/{workflow_id}",
+                json={
+                    "workflow": {
+                        "id": workflow_id,
+                        "name": blank,
+                    }
+                },
+            )
+            assert response.status_code == 422
+
+        response = authed_api("GET", f"/workflows/{workflow_id}")
+        assert response.status_code == 200
+        assert response.json()["workflow"]["name"] == original_name
+
     def test_edit_workflow_rejects_id_mismatch(
         self,
         authed_api,

--- a/api/oss/tests/pytest/acceptance/workflows/test_workflows_basics.py
+++ b/api/oss/tests/pytest/acceptance/workflows/test_workflows_basics.py
@@ -1,6 +1,27 @@
 from uuid import uuid4
 
 
+def _create_workflow(authed_api, *, flags):
+    workflow_slug = uuid4()
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={
+            "workflow": {
+                "slug": f"workflow-{workflow_slug}",
+                "name": f"Workflow {workflow_slug}",
+                "description": "Workflow Description",
+                "flags": flags,
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    return body["workflow"]
+
+
 class TestWorkflowsBasics:
     def test_create_workflow(
         self,
@@ -113,9 +134,9 @@ class TestWorkflowsBasics:
                     "name": f"Workflow {workflow_slug}",
                     "description": "Workflow Description",
                     "flags": {
-                        "is_custom": False,
+                        "is_application": True,
                         "is_evaluator": False,
-                        "is_feedback": False,
+                        "is_snippet": False,
                     },
                     "tags": {
                         "tag1": "value1",
@@ -149,9 +170,9 @@ class TestWorkflowsBasics:
                     "name": "Another Workflow Name",
                     "description": "Another Workflow Description",
                     "flags": {
-                        "is_custom": False,
-                        "is_evaluator": False,
-                        "is_feedback": False,
+                        "is_application": False,
+                        "is_evaluator": True,
+                        "is_snippet": False,
                     },
                     "tags": {
                         "tag1": "value3",
@@ -172,7 +193,107 @@ class TestWorkflowsBasics:
         assert response.status_code == 200
         response = response.json()
         assert response["count"] == 1
+        assert response["workflow"]["flags"] == {
+            "is_application": False,
+            "is_evaluator": True,
+            "is_snippet": False,
+        }
         # ----------------------------------------------------------------------
+
+    def test_edit_workflow_preserves_omitted_flags(
+        self,
+        authed_api,
+    ):
+        workflow = _create_workflow(
+            authed_api,
+            flags={
+                "is_application": True,
+                "is_evaluator": False,
+                "is_snippet": False,
+            },
+        )
+        original_flags = workflow["flags"]
+        workflow_id = workflow["id"]
+
+        response = authed_api(
+            "PUT",
+            f"/workflows/{workflow_id}",
+            json={
+                "workflow": {
+                    "id": workflow_id,
+                    "name": "Renamed Workflow",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert body["workflow"]["flags"] == original_flags
+
+    def test_edit_workflow_rejects_id_mismatch(
+        self,
+        authed_api,
+    ):
+        workflow = _create_workflow(authed_api, flags={"is_application": True})
+        workflow_id = workflow["id"]
+
+        response = authed_api(
+            "PUT",
+            f"/workflows/{workflow_id}",
+            json={
+                "workflow": {
+                    "id": str(uuid4()),
+                    "name": "Renamed Workflow",
+                }
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_edit_workflow_returns_not_found_for_missing_workflow(
+        self,
+        authed_api,
+    ):
+        workflow_id = str(uuid4())
+
+        response = authed_api(
+            "PUT",
+            f"/workflows/{workflow_id}",
+            json={
+                "workflow": {
+                    "id": workflow_id,
+                    "name": "Renamed Workflow",
+                }
+            },
+        )
+
+        assert response.status_code == 404
+
+    def test_edit_workflow_returns_not_found_for_archived_workflow(
+        self,
+        authed_api,
+    ):
+        workflow = _create_workflow(authed_api, flags={"is_application": True})
+        workflow_id = workflow["id"]
+        archive_response = authed_api(
+            "POST",
+            f"/workflows/{workflow_id}/archive",
+        )
+        assert archive_response.status_code == 200
+
+        response = authed_api(
+            "PUT",
+            f"/workflows/{workflow_id}",
+            json={
+                "workflow": {
+                    "id": workflow_id,
+                    "name": "Renamed Workflow",
+                }
+            },
+        )
+
+        assert response.status_code == 404
 
     def test_archive_workflow(
         self,

--- a/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
+++ b/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
@@ -43,6 +43,7 @@ EXPECTED_BUILD_KIT_OPS_WITHOUT_READ_CONFIG = (
     "annotate_trace",
     "query_spans",
     "test_run",
+    "rename_session",
     "discover_triggers",
     "create_schedule",
     "create_subscription",
@@ -60,6 +61,7 @@ EXPECTED_BUILD_KIT_OPS_WITH_READ_CONFIG = (
     "annotate_trace",
     "query_spans",
     "test_run",
+    "rename_session",
     "discover_triggers",
     "create_schedule",
     "create_subscription",
@@ -128,7 +130,14 @@ def test_agent_template_overlay_tools_list_is_pinned():
     request_input = catalog.retrieve_revision(slug=REQUEST_INPUT_WORKFLOW_SLUG)
 
     assert overlay["tools"] == [
-        *[{"type": "platform", "op": op_name} for op_name in DEFAULT_BUILD_KIT_OPS],
+        *[
+            {
+                "type": "platform",
+                "op": op_name,
+                **({"permission": "allow"} if op_name == "rename_session" else {}),
+            }
+            for op_name in DEFAULT_BUILD_KIT_OPS
+        ],
         {
             "@ag.embed": {
                 "@ag.references": {
@@ -160,8 +169,21 @@ def test_agent_template_overlay_contains_platform_ops_playbook_skill_and_permiss
     assert set(DEFAULT_BUILD_KIT_OPS) <= set(PLATFORM_OPS)
     assert set(DEFAULT_BUILD_KIT_OPS).isdisjoint(CUT_BUILD_KIT_OPS)
     assert platform_tools == [
-        {"type": "platform", "op": op_name} for op_name in DEFAULT_BUILD_KIT_OPS
+        {
+            "type": "platform",
+            "op": op_name,
+            **({"permission": "allow"} if op_name == "rename_session" else {}),
+        }
+        for op_name in DEFAULT_BUILD_KIT_OPS
     ]
+    assert [
+        tool["op"] for tool in platform_tools if tool.get("permission") == "allow"
+    ] == ["rename_session"]
+    assert all(
+        "permission" not in tool
+        for tool in platform_tools
+        if tool["op"] != "rename_session"
+    )
 
     authoring_skill = StaticWorkflowCatalog().retrieve_revision(
         slug=BUILD_AN_AGENT_SLUG

--- a/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
+++ b/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
@@ -44,6 +44,7 @@ EXPECTED_BUILD_KIT_OPS_WITHOUT_READ_CONFIG = (
     "query_spans",
     "test_run",
     "rename_session",
+    "rename_agent",
     "discover_triggers",
     "create_schedule",
     "create_subscription",
@@ -62,6 +63,7 @@ EXPECTED_BUILD_KIT_OPS_WITH_READ_CONFIG = (
     "query_spans",
     "test_run",
     "rename_session",
+    "rename_agent",
     "discover_triggers",
     "create_schedule",
     "create_subscription",
@@ -134,7 +136,11 @@ def test_agent_template_overlay_tools_list_is_pinned():
             {
                 "type": "platform",
                 "op": op_name,
-                **({"permission": "allow"} if op_name == "rename_session" else {}),
+                **(
+                    {"permission": "allow"}
+                    if op_name in {"rename_session", "rename_agent"}
+                    else {}
+                ),
             }
             for op_name in DEFAULT_BUILD_KIT_OPS
         ],
@@ -172,17 +178,21 @@ def test_agent_template_overlay_contains_platform_ops_playbook_skill_and_permiss
         {
             "type": "platform",
             "op": op_name,
-            **({"permission": "allow"} if op_name == "rename_session" else {}),
+            **(
+                {"permission": "allow"}
+                if op_name in {"rename_session", "rename_agent"}
+                else {}
+            ),
         }
         for op_name in DEFAULT_BUILD_KIT_OPS
     ]
     assert [
         tool["op"] for tool in platform_tools if tool.get("permission") == "allow"
-    ] == ["rename_session"]
+    ] == ["rename_session", "rename_agent"]
     assert all(
         "permission" not in tool
         for tool in platform_tools
-        if tool["op"] != "rename_session"
+        if tool["op"] not in {"rename_session", "rename_agent"}
     )
 
     authoring_skill = StaticWorkflowCatalog().retrieve_revision(

--- a/api/oss/tests/pytest/unit/sessions/test_stream_header_merge.py
+++ b/api/oss/tests/pytest/unit/sessions/test_stream_header_merge.py
@@ -381,3 +381,33 @@ async def test_rename_race_falls_back_to_header_update_on_concurrent_create(
 
     assert stream.name == "Won The Retry"
     assert dao.header_updates == 1
+
+
+# ---------------------------------------------------------------------------
+# Name validation on the header edit (the direct-API hole behind rename_session):
+# the LLM-facing schema requires a non-whitespace name, but a direct PUT used to
+# persist "   " — clearing the visible title while the row still held a value.
+# The empty string stays allowed: it is the explicit clear-title action the chat
+# rail's rename path sends, and None/omitted still means "no change".
+# ---------------------------------------------------------------------------
+
+
+def test_whitespace_only_name_is_rejected_at_validation():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="non-whitespace"):
+        SessionStreamHeaderEdit(name="   ")
+
+
+def test_empty_name_stays_the_explicit_clear():
+    assert SessionStreamHeaderEdit(name="").name == ""
+
+
+def test_omitted_and_none_name_still_mean_no_change():
+    assert SessionStreamHeaderEdit().name is None
+    assert SessionStreamHeaderEdit(name=None).name is None
+
+
+def test_a_normal_rename_validates():
+    edit = SessionStreamHeaderEdit(name="Billing migration", description="recap")
+    assert edit.name == "Billing migration"

--- a/api/oss/tests/pytest/unit/sessions/test_watch_endpoint.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watch_endpoint.py
@@ -97,6 +97,59 @@ async def test_stream_yields_event_frames_then_heartbeats():
 
 
 @pytest.mark.asyncio
+async def test_stream_terminates_on_server_shutdown_signal():
+    # Uvicorn drains in-flight responses BEFORE lifespan shutdown, so an SSE
+    # generator that never ends wedges every reload/stop (the live symptom:
+    # `--reload` logs "Reloading..." and the API is dead until a hard restart).
+    # The stream must return promptly once the shutdown flag is set.
+    from oss.src.apis.fastapi.sessions import watch as watch_module
+
+    pubsub = _FakePubSub([])
+    stream = watch_event_stream(
+        channel="watch:p:session:s1",
+        pubsub_factory=lambda: pubsub,
+        heartbeat_seconds=0.01,
+        retry_milliseconds=5000,
+    )
+    assert await stream.__anext__() == retry_frame(5000)
+    assert await stream.__anext__() == ready_frame()
+
+    watch_module.request_shutdown()
+    try:
+        with pytest.raises(StopAsyncIteration):
+            await stream.__anext__()
+    finally:
+        watch_module._shutdown.clear()
+
+    # The shutdown path runs the same teardown a client disconnect does.
+    assert pubsub.unsubscribed == ["watch:p:session:s1"]
+    assert pubsub.closed is True
+
+
+def test_uvicorn_exit_hook_is_installed_and_requests_shutdown():
+    # The release only works if uvicorn's handle_exit actually reaches
+    # request_shutdown — pin both the installation and the effect.
+    uvicorn_server = pytest.importorskip("uvicorn.server")
+    from oss.src.apis.fastapi.sessions import watch as watch_module
+
+    assert getattr(uvicorn_server.Server.handle_exit, "_agenta_watch_hook", False)
+
+    class _FakeServer:
+        handle_exit = uvicorn_server.Server.handle_exit
+
+        def __init__(self):
+            self.should_exit = False
+            self.force_exit = False
+            self._captured_signals = []
+
+    try:
+        _FakeServer().handle_exit(None, None)
+        assert watch_module._shutdown.is_set()
+    finally:
+        watch_module._shutdown.clear()
+
+
+@pytest.mark.asyncio
 async def test_stream_cleans_up_subscription_on_close():
     pubsub = _FakePubSub([])
     stream = watch_event_stream(

--- a/api/oss/tests/pytest/unit/sessions/test_watch_endpoint.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watch_endpoint.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import FastAPI, HTTPException, Request
 
 from oss.src.apis.fastapi.sessions.router import SessionStreamsRouter
+from oss.src.core.access.permissions.types import Permission
 from oss.src.apis.fastapi.sessions.watch import (
     HEARTBEAT_FRAME,
     format_watch_frame,
@@ -22,7 +23,7 @@ from oss.src.apis.fastapi.sessions.watch import (
     retry_frame,
     watch_event_stream,
 )
-from oss.src.dbs.redis.sessions.contract import watch_channel
+from oss.src.dbs.redis.sessions.contract import project_watch_channel, watch_channel
 from oss.src.dbs.redis.sessions.watch import SessionsWatchPublisher
 from oss.src.utils.env import env
 
@@ -212,11 +213,17 @@ async def test_stream_delivers_publisher_events_end_to_end():
     assert json.loads(frame.split("data: ")[1])["session_id"] == "sess-e2e"
 
 
-def _make_authed_request(app: FastAPI, project_id, user_id) -> Request:
+def _make_authed_request(
+    app: FastAPI,
+    project_id,
+    user_id,
+    *,
+    path: str = "/sessions/streams/watch",
+) -> Request:
     scope = {
         "type": "http",
         "method": "GET",
-        "path": "/sessions/streams/watch",
+        "path": path,
         "headers": [],
         "app": app,
     }
@@ -324,3 +331,74 @@ async def test_ready_is_not_emitted_before_the_subscription_is_live():
     )
 
     await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_project_watch_endpoint_streams_known_events_and_skips_unknown():
+    router = _router()
+    project_id = uuid4()
+    request = _make_authed_request(
+        FastAPI(),
+        project_id,
+        uuid4(),
+        path="/sessions/watch",
+    )
+    pubsub = _FakePubSub(
+        [
+            _msg({"type": "session-changed", "entity": "session", "id": "session-1"}),
+            _msg({"type": "unknown-changed", "entity": "unknown", "id": "unknown-1"}),
+            _msg(
+                {"type": "workflow-changed", "entity": "workflow", "id": "workflow-1"}
+            ),
+        ]
+    )
+
+    with (
+        patch(
+            "oss.src.apis.fastapi.sessions.router.check_action_access",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "oss.src.apis.fastapi.sessions.router.get_streams_engine"
+        ) as streams_engine,
+    ):
+        streams_engine.return_value.get_redis.return_value.pubsub.return_value = pubsub
+        response = await router.watch_project(request=request, project_id=project_id)
+
+        frames = [await response.body_iterator.__anext__() for _ in range(5)]
+        await response.body_iterator.aclose()
+
+    assert frames[0] == retry_frame(env.sessions.watch_retry_milliseconds)
+    assert frames[1] == ready_frame()
+    assert frames[2].startswith("event: session-changed\n")
+    assert frames[3].startswith("event: workflow-changed\n")
+    assert frames[4] == HEARTBEAT_FRAME
+    assert pubsub.subscribed == [project_watch_channel(str(project_id))]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permissions", [(True, False), (False, True)])
+async def test_project_watch_endpoint_requires_both_view_permissions(permissions):
+    router = _router()
+    project_id = uuid4()
+    request = _make_authed_request(
+        FastAPI(),
+        project_id,
+        uuid4(),
+        path="/sessions/watch",
+    )
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        side_effect=permissions,
+    ) as check_access:
+        with pytest.raises(HTTPException) as exc_info:
+            await router.watch_project(request=request, project_id=project_id)
+
+    assert exc_info.value.status_code == 403
+    assert [call.kwargs["permission"] for call in check_access.await_args_list] == [
+        Permission.VIEW_SESSIONS,
+        Permission.VIEW_WORKFLOWS,
+    ]

--- a/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
@@ -9,6 +9,7 @@ DB write is already committed and must not be re-driven by relay errors).
 
 import json
 import zlib
+from inspect import Parameter, signature
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -16,8 +17,13 @@ import pytest
 from orjson import dumps
 
 from oss.src.core.sessions.records.service import RecordsService
+from oss.src.core.sessions.streams.dtos import SessionStreamHeaderEdit
+from oss.src.core.sessions.streams.service import SessionStreamsService
+from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
 from oss.src.core.sessions.records.dtos import SessionRecord
-from oss.src.dbs.redis.sessions.contract import watch_channel
+from oss.src.core.workflows.dtos import Workflow, WorkflowEdit
+from oss.src.core.workflows.service import WorkflowsService
+from oss.src.dbs.redis.sessions.contract import project_watch_channel, watch_channel
 from oss.src.dbs.redis.sessions.watch import SessionsWatchPublisher
 from oss.src.tasks.asyncio.sessions.records_worker import RecordsWorker
 
@@ -40,6 +46,7 @@ class _RecordingPublisher:
 
     def __init__(self, *, fail: bool = False, journal=None):
         self.calls: list[tuple[str, str]] = []
+        self.changed_calls: list[tuple[str, str, str]] = []
         self.fail = fail
         self.journal = journal
 
@@ -49,6 +56,11 @@ class _RecordingPublisher:
         self.calls.append((project_id, session_id))
         if self.journal is not None:
             self.journal.append(("publish", session_id))
+
+    async def changed(self, *, project_id: str, entity: str, id: str) -> None:
+        if self.fail:
+            raise RuntimeError("relay down")
+        self.changed_calls.append((project_id, entity, id))
 
 
 def _worker(records_dao, publisher):
@@ -181,3 +193,146 @@ async def test_publisher_swallows_redis_failure():
     await publisher.lifecycle(project_id="p", session_id="s", state="running")
     await publisher.interaction(project_id="p", session_id="s", status="pending")
     assert broken.publish.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_publisher_publishes_entity_change_on_project_channel():
+    import fakeredis
+
+    redis = fakeredis.FakeAsyncRedis()
+    pubsub = redis.pubsub()
+    project_id = str(uuid4())
+    channel = project_watch_channel(project_id)
+    await pubsub.subscribe(channel)
+    await pubsub.get_message(timeout=1)
+
+    publisher = SessionsWatchPublisher(redis_client=redis)
+    await publisher.changed(project_id=project_id, entity="session", id="session-1")
+
+    message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1)
+    assert message is not None
+    assert json.loads(message["data"]) == {
+        "type": "session-changed",
+        "entity": "session",
+        "id": "session-1",
+    }
+
+
+def test_changed_signature_is_keyword_only_on_protocol_and_publisher():
+    protocol_parameters = list(
+        signature(SessionsWatchPublisherInterface.changed).parameters.values()
+    )
+    assert [parameter.name for parameter in protocol_parameters] == [
+        "self",
+        "project_id",
+        "entity",
+        "id",
+    ]
+    assert all(
+        parameter.kind is Parameter.KEYWORD_ONLY
+        for parameter in protocol_parameters[1:]
+    )
+
+    publisher = SessionsWatchPublisher(redis_client=AsyncMock())
+    with pytest.raises(TypeError):
+        publisher.changed("project-1", "session", "session-1")
+
+
+@pytest.mark.asyncio
+async def test_set_header_publishes_session_change_with_explicit_project_id():
+    project_id = uuid4()
+    updated = object()
+    streams_dao = AsyncMock()
+    streams_dao.update_header.return_value = updated
+    publisher = _RecordingPublisher()
+    service = SessionStreamsService(
+        streams_dao=streams_dao,
+        lock_engine=None,
+        watch_publisher=publisher,
+    )
+
+    result = await service.set_header(
+        project_id=project_id,
+        user_id=uuid4(),
+        session_id="session-1",
+        header=SessionStreamHeaderEdit(name="Renamed"),
+    )
+
+    assert result is updated
+    assert publisher.changed_calls == [
+        (str(project_id), "session", "session-1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_edit_workflow_publishes_workflow_change_with_explicit_project_id(
+    monkeypatch,
+):
+    from oss.src.core.workflows import service as workflows_service_module
+
+    project_id = uuid4()
+    workflow_id = uuid4()
+    workflow = Workflow(id=workflow_id, slug="workflow")
+    workflows_dao = AsyncMock()
+    workflows_dao.fetch_artifact.return_value = workflow
+    workflows_dao.edit_artifact.return_value = workflow
+    publisher = _RecordingPublisher()
+    service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        watch_publisher=publisher,
+    )
+    monkeypatch.setattr(workflows_service_module, "invalidate_cache", AsyncMock())
+    monkeypatch.setattr(workflows_service_module, "set_cache", AsyncMock())
+
+    result = await service.edit_workflow(
+        project_id=project_id,
+        user_id=uuid4(),
+        workflow_edit=WorkflowEdit(id=workflow_id, name="Renamed"),
+    )
+
+    assert result is not None
+    assert publisher.changed_calls == [
+        (str(project_id), "workflow", str(workflow_id)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_change_publisher_failure_does_not_fail_either_write(monkeypatch):
+    from oss.src.core.workflows import service as workflows_service_module
+
+    project_id = uuid4()
+    publisher = _RecordingPublisher(fail=True)
+
+    streams_dao = AsyncMock()
+    streams_dao.update_header.return_value = object()
+    streams_service = SessionStreamsService(
+        streams_dao=streams_dao,
+        lock_engine=None,
+        watch_publisher=publisher,
+    )
+    session_result = await streams_service.set_header(
+        project_id=project_id,
+        user_id=uuid4(),
+        session_id="session-1",
+        header=SessionStreamHeaderEdit(name="Renamed"),
+    )
+
+    workflow_id = uuid4()
+    workflow = Workflow(id=workflow_id, slug="workflow")
+    workflows_dao = AsyncMock()
+    workflows_dao.fetch_artifact.return_value = workflow
+    workflows_dao.edit_artifact.return_value = workflow
+    workflows_service = WorkflowsService(
+        workflows_dao=workflows_dao,
+        watch_publisher=publisher,
+    )
+    monkeypatch.setattr(workflows_service_module, "invalidate_cache", AsyncMock())
+    monkeypatch.setattr(workflows_service_module, "set_cache", AsyncMock())
+    workflow_result = await workflows_service.edit_workflow(
+        project_id=project_id,
+        user_id=uuid4(),
+        workflow_edit=WorkflowEdit(id=workflow_id, name="Renamed"),
+    )
+
+    assert session_result is not None
+    assert workflow_result is not None

--- a/api/oss/tests/pytest/unit/workflows/test_edit_endpoint_name_validation.py
+++ b/api/oss/tests/pytest/unit/workflows/test_edit_endpoint_name_validation.py
@@ -1,0 +1,108 @@
+"""The edit endpoint rejects a blank workflow name at the API boundary.
+
+The LLM-facing `rename_agent` schema requires a non-whitespace name, but that schema
+gates only the tool: a direct PUT used to persist `"   "` as the artifact name, which
+renders as an unreadable row in every list. The shared `ArtifactEdit` shape carries no
+constraint (other git entities reuse it), so the check lives in the handler: a PRESENT
+name must contain a non-whitespace character, while an omitted name still means
+"no change".
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+WORKFLOW_ID = uuid4()
+
+
+def _request():
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            project_id=str(uuid4()),
+            user_id=str(uuid4()),
+        )
+    )
+
+
+def _edit_request(**workflow):
+    from oss.src.apis.fastapi.workflows.models import WorkflowEditRequest
+
+    return WorkflowEditRequest.model_validate(
+        {"workflow": {"id": str(WORKFLOW_ID), **workflow}}
+    )
+
+
+@pytest.fixture
+def router():
+    from oss.src.apis.fastapi.workflows.router import WorkflowsRouter
+
+    return WorkflowsRouter(
+        workflows_service=AsyncMock(),
+        environments_service=AsyncMock(),
+    )
+
+
+@pytest.fixture
+def allow_access():
+    with patch(
+        "oss.src.apis.fastapi.workflows.router.check_action_access",
+        AsyncMock(return_value=True),
+    ):
+        yield
+
+
+async def _edit(router, **workflow):
+    return await router.edit_workflow(
+        _request(),
+        workflow_id=WORKFLOW_ID,
+        workflow_edit_request=_edit_request(**workflow),
+    )
+
+
+class TestEditWorkflowNameValidation:
+    async def test_whitespace_only_name_is_a_422_and_never_reaches_the_service(
+        self, router, allow_access
+    ):
+        with pytest.raises(HTTPException) as caught:
+            await _edit(router, name="   ")
+
+        assert caught.value.status_code == 422
+        router.workflows_service.edit_workflow.assert_not_awaited()
+
+    async def test_empty_name_is_a_422_and_never_reaches_the_service(
+        self, router, allow_access
+    ):
+        with pytest.raises(HTTPException) as caught:
+            await _edit(router, name="")
+
+        assert caught.value.status_code == 422
+        router.workflows_service.edit_workflow.assert_not_awaited()
+
+    async def test_omitted_name_still_means_no_change_and_passes_through(
+        self, router, allow_access
+    ):
+        from oss.src.core.workflows.dtos import Workflow
+
+        router.workflows_service.edit_workflow.return_value = Workflow(
+            id=WORKFLOW_ID, slug="workflow"
+        )
+
+        response = await _edit(router, description="New description")
+
+        assert response.count == 1
+        router.workflows_service.edit_workflow.assert_awaited_once()
+
+    async def test_a_normal_rename_passes_through(self, router, allow_access):
+        from oss.src.core.workflows.dtos import Workflow
+
+        router.workflows_service.edit_workflow.return_value = Workflow(
+            id=WORKFLOW_ID, slug="workflow", name="Support triage"
+        )
+
+        response = await _edit(router, name="Support triage")
+
+        assert response.count == 1
+        router.workflows_service.edit_workflow.assert_awaited_once()

--- a/benchmarks/agent-config-editing/bench_lib.py
+++ b/benchmarks/agent-config-editing/bench_lib.py
@@ -544,6 +544,8 @@ class Ctx:
         token: str,
         baseline_version: int,
         final_version: int | None,
+        session_id: str,
+        workflow_id: str,
     ) -> None:
         self.stored = stored  # parameters.agent of the newest revision
         self.seeded = seeded  # parameters.agent as this trial seeded it
@@ -556,6 +558,8 @@ class Ctx:
         self.token = token
         self.baseline_version = baseline_version
         self.final_version = final_version
+        self.session_id = session_id
+        self.workflow_id = workflow_id
 
     @property
     def replies(self) -> str:
@@ -621,6 +625,55 @@ def _stored_matches(ctx: Ctx, spec: dict) -> str | None:
     if not re.search(pattern, got):
         return f"{_p(spec['path'])} does not match /{pattern}/"
     return None
+
+
+def _header_assertion(ctx: Ctx, spec: dict, row: dict, label: str) -> str | None:
+    """Apply the stored-row assertion grammar to a session or workflow header."""
+    path = spec.get("path") or [spec["field"]]
+    got = resolve(row, path)
+    rendered_path = f"{label}.{_p(path)}"
+
+    if "pattern" in spec:
+        if not isinstance(got, str):
+            return f"{rendered_path} is not a string ({type(got).__name__})"
+        pattern = substitute_token(spec["pattern"], ctx.token)
+        if not re.search(pattern, got):
+            return f"{rendered_path} does not match /{pattern}/"
+
+    if "text" in spec:
+        if not isinstance(got, str):
+            return f"{rendered_path} is not a string ({type(got).__name__})"
+        text = substitute_token(spec["text"], ctx.token)
+        if text not in got:
+            return f"{rendered_path} does not contain {text!r}"
+
+    if "value" in spec and got != spec["value"]:
+        return f"{rendered_path} is {got!r}, expected {spec['value']!r}"
+    return None
+
+
+@check("session_header")
+def _session_header(ctx: Ctx, spec: dict) -> str | None:
+    path = f"/sessions/streams/?session_id={ctx.session_id}"
+    response = wire().api_call("GET", path)
+    if response.status_code != 200:
+        return f"GET {path} returned HTTP {response.status_code}: {response.text[:300]}"
+    stream = response.json().get("stream")
+    if not isinstance(stream, dict):
+        return f"GET {path} returned no session stream"
+    return _header_assertion(ctx, spec, stream, "session")
+
+
+@check("workflow_header")
+def _workflow_header(ctx: Ctx, spec: dict) -> str | None:
+    path = f"/workflows/{ctx.workflow_id}"
+    response = wire().api_call("GET", path)
+    if response.status_code != 200:
+        return f"GET {path} returned HTTP {response.status_code}: {response.text[:300]}"
+    workflow = response.json().get("workflow")
+    if not isinstance(workflow, dict):
+        return f"GET {path} returned no workflow"
+    return _header_assertion(ctx, spec, workflow, "workflow")
 
 
 @check("stored_count")
@@ -1268,6 +1321,11 @@ def create_trial_agent(cell: dict, scenario: dict, token: str, label: str) -> di
     w = wire()
     hexid = uuid.uuid4().hex[:8]
     workflow_id, variant_id = create_workflow_named(hexid, label)
+    if scenario.get("seed_workflow_header"):
+        seed_workflow_header(
+            workflow_id,
+            substitute_token(scenario["seed_workflow_header"], token),
+        )
     agent = agent_config(cell, scenario.get("seed"), token)
     revision_id, version = w.seed_and_baseline(workflow_id, variant_id, agent, hexid)
     trial = {
@@ -1286,6 +1344,30 @@ def create_workflow_named(hexid: str, label: str) -> tuple[str, str]:
     """`qa_matrix_lib.create_workflow` with a benchmark-shaped slug, so an abandoned run's leftovers
     are identifiable in a project by name alone."""
     return wire().create_workflow(hexid, f"bench-{label}"[:40])
+
+
+def seed_workflow_header(workflow_id: str, header: dict) -> None:
+    """Give a trial workflow a known header before the model sees its first task."""
+    path = f"/workflows/{workflow_id}"
+    response = wire().api_call(
+        "PUT",
+        path,
+        json={"workflow": {"id": workflow_id, **header}},
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"seed workflow header HTTP {response.status_code}: {response.text[:300]}"
+        )
+
+
+def seed_session_header(session_id: str, header: dict) -> None:
+    """Create or update a trial's session header before its first turn."""
+    path = f"/sessions/streams/header?session_id={session_id}"
+    response = wire().api_call("PUT", path, json=header)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"seed session header HTTP {response.status_code}: {response.text[:300]}"
+        )
 
 
 def write_agent_mount_file(workflow_id: str, path: str, content: str) -> None:
@@ -1505,7 +1587,12 @@ def connected_integrations() -> set | None:
 # Scenario loading
 # ---------------------------------------------------------------------------
 
-DEFAULT_BUDGET = {"max_tool_errors": 0, "max_commit_calls": 1, "max_rounds": 8}
+DEFAULT_BUDGET = {
+    "max_tool_errors": 0,
+    "max_commit_calls": 1,
+    "max_rename_calls": 0,
+    "max_rounds": 8,
+}
 
 
 def load_scenarios(only: list | None = None, classes: list | None = None) -> list:

--- a/benchmarks/agent-config-editing/bench_lib.py
+++ b/benchmarks/agent-config-editing/bench_lib.py
@@ -1176,7 +1176,7 @@ def error_kind(error: dict) -> str:
 
 
 def blocked_only_by_harness(
-    trial_errors: list, commit_calls: int, budget: dict
+    trial_errors: list, commit_calls: int, budget: dict, rename_calls: int = 0
 ) -> bool:
     """True when a trial would have been one-shot except for harness errors.
 
@@ -1186,6 +1186,8 @@ def blocked_only_by_harness(
     if not trial_errors:
         return False
     if commit_calls > budget["max_commit_calls"]:
+        return False
+    if rename_calls > budget.get("max_rename_calls", 0):
         return False
     return all(error_kind(e) == "harness" for e in trial_errors)
 

--- a/benchmarks/agent-config-editing/run_benchmark.py
+++ b/benchmarks/agent-config-editing/run_benchmark.py
@@ -163,6 +163,11 @@ def run_trial(cell_id: str, cell: dict, scenario: dict, index: int) -> dict:
 
         session_id = str(__import__("uuid").uuid4())
         record["session_id"] = session_id
+        if scenario.get("seed_session_header"):
+            B.seed_session_header(
+                session_id,
+                B.substitute_token(scenario["seed_session_header"], token),
+            )
         msgs: list = []
         groups: list = []
         gates_total = 0
@@ -221,12 +226,17 @@ def run_trial(cell_id: str, cell: dict, scenario: dict, index: int) -> dict:
             token=token,
             baseline_version=trial["baseline_version"],
             final_version=version,
+            session_id=session_id,
+            workflow_id=trial["workflow_id"],
         )
         checks = B.evaluate_checks(scenario["checks"], ctx)
         flat = ctx.turns
         errors = B.tool_error_details(flat)
         repeats = B.identical_repeat_after_refusal(flat)
         commit_calls = B.count_calls(flat, "commit_revision")
+        rename_calls = sum(
+            B.count_calls(flat, name) for name in ("rename_session", "rename_agent")
+        )
         budget = scenario["budget"]
 
         failures = [c for c in checks if c["failure"]]
@@ -235,6 +245,7 @@ def run_trial(cell_id: str, cell: dict, scenario: dict, index: int) -> dict:
             settled.get("settled", False)
             and len(errors) <= budget["max_tool_errors"]
             and commit_calls <= budget["max_commit_calls"]
+            and rename_calls <= budget["max_rename_calls"]
         )
         # The global instrument. A model that re-sends a refused call verbatim has read `retryable`
         # and ignored `next_step`, and that is a hard fail wherever it happens — including in a
@@ -274,6 +285,7 @@ def run_trial(cell_id: str, cell: dict, scenario: dict, index: int) -> dict:
                     ],
                     "tool_errors": errors,
                     "commit_calls": commit_calls,
+                    "rename_calls": rename_calls,
                     "approval_gates": gates_total,
                     "wire_turns": len(flat),
                     "finish_reasons": [t.finish_reason for t in flat],

--- a/benchmarks/agent-config-editing/run_benchmark.py
+++ b/benchmarks/agent-config-editing/run_benchmark.py
@@ -268,7 +268,7 @@ def run_trial(cell_id: str, cell: dict, scenario: dict, index: int) -> dict:
                 "outcome": outcome,
                 "infra_signature": B.infra_signature(flat),
                 "blocked_only_by_harness": B.blocked_only_by_harness(
-                    errors, commit_calls, budget
+                    errors, commit_calls, budget, rename_calls
                 ),
                 "one_shot": bool(functional and within_budget and not hard_fails),
                 "eventual": bool(functional and not hard_fails),

--- a/benchmarks/agent-config-editing/scenarios/09-self-naming.json
+++ b/benchmarks/agent-config-editing/scenarios/09-self-naming.json
@@ -1,0 +1,122 @@
+{
+  "class": "self_naming",
+  "about": [
+    "Naming sessions and agents after the model has enough context to choose a useful label.",
+    "The verdict comes from the stored session or workflow header, never from the reply."
+  ],
+  "scenarios": [
+    {
+      "id": "name-01-session-after-task",
+      "title": "name a session after understanding its task",
+      "turns": [
+        {
+          "prompt": "help me put together a smoke-test plan for the billing migration we're shipping on friday"
+        }
+      ],
+      "tools": [{ "type": "platform", "op": "rename_session" }],
+      "budget": { "max_rename_calls": 1 },
+      "checks": [
+        { "check": "turn_tool_called", "name": "rename_session", "min": 1 },
+        {
+          "check": "session_header",
+          "path": ["name"],
+          "pattern": "(?i)(billing|migration)"
+        },
+        {
+          "check": "session_header",
+          "path": ["description"],
+          "pattern": "(?s)^.{1,300}\\Z"
+        }
+      ]
+    },
+    {
+      "id": "name-02-session-update",
+      "title": "update the session name when the subject changes",
+      "seed_session_header": {
+        "name": "Mobile checkout release",
+        "description": "Planning the release checks for mobile checkout."
+      },
+      "turns": [
+        {
+          "prompt": "outline the release checks we should run for the mobile checkout"
+        },
+        {
+          "prompt": "actually let's switch gears — draft an incident response checklist for a database outage"
+        }
+      ],
+      "tools": [{ "type": "platform", "op": "rename_session" }],
+      "budget": { "max_rename_calls": 1 },
+      "checks": [
+        {
+          "check": "turn_tool_called",
+          "name": "rename_session",
+          "min": 1,
+          "turn": 1
+        },
+        {
+          "check": "session_header",
+          "path": ["name"],
+          "pattern": "(?i)(incident|database|outage)"
+        }
+      ]
+    },
+    {
+      "id": "name-03-agent-first-task",
+      "title": "name a placeholder agent after its first task",
+      "seed_workflow_header": {
+        "name": "Untitled agent",
+        "description": "Waiting for a first task.",
+        "flags": { "is_application": true, "is_evaluator": false }
+      },
+      "turns": [
+        {
+          "prompt": "make me a pre-release checklist for the billing portal and call out what should block the deploy"
+        }
+      ],
+      "tools": [{ "type": "platform", "op": "rename_agent" }],
+      "budget": { "max_rename_calls": 1 },
+      "checks": [
+        { "check": "turn_tool_called", "name": "rename_agent", "min": 1 },
+        {
+          "check": "workflow_header",
+          "path": ["name"],
+          "pattern": "(?i)^(?!untitled agent$).*\\S.*$"
+        },
+        {
+          "check": "workflow_header",
+          "path": ["description"],
+          "pattern": "(?s)^.{1,300}\\Z"
+        },
+        {
+          "check": "workflow_header",
+          "path": ["flags", "is_application"],
+          "value": true
+        },
+        {
+          "check": "workflow_header",
+          "path": ["flags", "is_evaluator"],
+          "value": false
+        }
+      ]
+    },
+    {
+      "id": "name-04-no-spurious-rename",
+      "title": "leave a useful session name alone for a trivial request",
+      "seed_session_header": {
+        "name": "Release notes {{TOKEN}}",
+        "description": "Finishing the release notes for this build."
+      },
+      "turns": [{ "prompt": "thanks — just reply with noted" }],
+      "tools": [{ "type": "platform", "op": "rename_session" }],
+      "budget": { "max_rename_calls": 0 },
+      "checks": [
+        {
+          "check": "session_header",
+          "path": ["name"],
+          "pattern": "(?i)^release notes QA-[A-Z0-9]{8}$",
+          "text": "{{TOKEN}}"
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/agent-config-editing/scenarios/09-self-naming.json
+++ b/benchmarks/agent-config-editing/scenarios/09-self-naming.json
@@ -2,7 +2,8 @@
   "class": "self_naming",
   "about": [
     "Naming sessions and agents after the model has enough context to choose a useful label.",
-    "The verdict comes from the stored session or workflow header, never from the reply."
+    "The verdict comes from the stored session or workflow header, never from the reply.",
+    "name-05 seeds the VERBATIM product-default persona (_DEFAULT_AGENTS_MD in sdks/python/agenta/sdk/utils/types.py, drift-locked by the SDK unit test test_default_persona_self_naming.py): live QA showed task-shaped personas self-name while the bare default persona did not, so this scenario is the regression guard for the real new-user experience."
   ],
   "scenarios": [
     {
@@ -115,6 +116,36 @@
           "path": ["name"],
           "pattern": "(?i)^release notes QA-[A-Z0-9]{8}$",
           "text": "{{TOKEN}}"
+        }
+      ]
+    },
+    {
+      "id": "name-05-default-persona-session",
+      "title": "the product-default persona names its session unprompted",
+      "seed": {
+        "instructions": {
+          "agents_md": "You are a friendly hello-world agent running on the Agenta agent service.\n\n- Greet the user warmly.\n- Answer the user's message in one or two short sentences.\n- Once the first exchange makes clear what the session is about, call the\n  `rename_session` tool: `name` is the session's subject in a few words, findable\n  in a list; `description` is a one-sentence recap of where things stand. Rename\n  again only when the topic genuinely shifts.\n- Call the `rename_agent` tool only when your own identity or purpose changes —\n  for example, you were just created or the user repurposes you — with a name\n  that says what you are for."
+        },
+        "skills": []
+      },
+      "turns": [
+        {
+          "prompt": "help me plan the onboarding schedule for the two support engineers starting next month — what should their first two weeks look like?"
+        }
+      ],
+      "tools": [{ "type": "platform", "op": "rename_session" }],
+      "budget": { "max_rename_calls": 1 },
+      "checks": [
+        { "check": "turn_tool_called", "name": "rename_session", "min": 1 },
+        {
+          "check": "session_header",
+          "path": ["name"],
+          "pattern": "(?i)(onboarding|support|engineer)"
+        },
+        {
+          "check": "session_header",
+          "path": ["description"],
+          "pattern": "(?s)^.{1,300}\\Z"
         }
       ]
     }

--- a/docs/design/agent-self-naming-tools/README.md
+++ b/docs/design/agent-self-naming-tools/README.md
@@ -1,0 +1,44 @@
+# Agent self-naming tools
+
+Two new platform tools that let an agent name and describe the session it is running in
+(`rename_session`) and name and describe itself (`rename_agent`), plus the live-refresh
+mechanism that makes those renames show up in an open browser tab.
+
+## Reading order
+
+| File | The question it answers |
+| --- | --- |
+| [context.md](context.md) | Why this work exists, what counts as done, what is out of scope, and which decisions are already made. |
+| [research.md](research.md) | How agent tools, sessions, workflow artifacts, and the live-update relay work in the code today, and the two hazards found while reading them. |
+| [api-design.md](api-design.md) | The exact contract of both tools, the tool descriptions the model reads, and the watch-event payload. |
+| [plan.md](plan.md) | The implementation steps, in dependency order, with files per step. |
+| [qa.md](qa.md) | Tests, the one-shot benchmark scenarios, and the live verification script. |
+| [status.md](status.md) | Current progress, open decisions, and history. |
+
+## Glossary
+
+Terms used across these files, defined once here.
+
+- **Agent**: what a user builds and talks to in the product. It is stored as a **workflow
+  artifact** (the row the agents list reads) with variants and revisions under it. Its display
+  name lives on the artifact.
+- **Session**: one conversation. Stored as a `session_streams` row carrying `name` and
+  `description`. `name` is the session title; there is no separate title column.
+- **Runner**: the Node service that drives a turn, dispatches tool calls from the host, and holds
+  the run's credential. The sandbox never holds a credential.
+- **Sandbox**: the isolated process the harness runs in. It sends a tool name plus arguments and
+  nothing else.
+- **Harness**: the coding-agent program the runner drives (Claude Code, Pi, Codex).
+- **Platform tool**: an Agenta endpoint exposed to the model as a tool. The author writes
+  `{"type": "platform", "op": "<op>"}`; the description, schema, endpoint, and hidden bindings all
+  come from a code-defined catalog.
+- **Run context**: a blob of the run's own identity (project, workflow, trace) delivered on the
+  `/run` request. A tool binds a field from it server-side so the model never sees or sets that
+  field.
+- **Context binding**: a map from a request-body path to a `$ctx.<dotted.path>` token. The runner
+  fills it at dispatch, after the model's arguments, so a bound field always wins.
+- **Build kit**: the tool set injected into every playground agent by default
+  (`DEFAULT_BUILD_KIT_OPS`).
+- **Watch relay**: a server-to-browser notification path. The server publishes a small frame on
+  Redis, an endpoint streams it as Server-Sent Events, and the browser refetches through its
+  normal endpoints. The frame carries ids only, never entity data.

--- a/docs/design/agent-self-naming-tools/api-design.md
+++ b/docs/design/agent-self-naming-tools/api-design.md
@@ -79,8 +79,9 @@ argument the runner strips before sending, and this op has a real `description` 
   in.
 - **Permission.** `EDIT_SESSIONS`, checked against the run's own credential. `read_only=False` means
   the call prompts for approval under the default `allow_reads` policy unless the agent's config
-  sets `permission: "allow"` on the tool. Whether the default build kit ships it as `allow` is
-  settled in [status.md](status.md) open question 1.
+  sets `permission: "allow"` on the tool. As implemented, the default build-kit overlay ships BOTH
+  rename ops with `permission: "allow"`, so no approval card appears; server-side RBAC still gates
+  every call.
 - **Empty or blank name.** `minLength: 1` plus the `\S` pattern rejects both an empty string and a
   whitespace-only one, so the tool cannot clear a title.
 - **Description omitted.** The DAO applies only non-`None` fields, so an existing description

--- a/docs/design/agent-self-naming-tools/api-design.md
+++ b/docs/design/agent-self-naming-tools/api-design.md
@@ -1,0 +1,283 @@
+# Contracts
+
+Three contracts change or get added: the `rename_session` catalog op, the `rename_agent` catalog
+op, and the project watch event. Nothing else on the wire moves.
+
+## Field roles
+
+Every field below is classified by what it **is**, not by the feature it serves. The classification
+decides who owns it and whether the model may ever see it.
+
+| Field | Role | Owner | Model sees it |
+| --- | --- | --- | --- |
+| `name` | Data. Human-readable content the model authors. | Model | Yes |
+| `description` | Data. Human-readable content the model authors. | Model | Yes |
+| `session_id` | Routing identity. Which row the write lands on. | Platform, bound from run context | No |
+| `workflow_id`, `workflow.id` | Routing identity. Same value in the path and the body. | Platform, bound from run context | No |
+| `flags` | Metadata classification of the artifact. | Platform | No, and it must not be written by a rename |
+| `Authorization` | Credential. The run's propagated caller credential. | Runner, per request | No |
+| `read_only`, `permission` | Policy. Decides whether the call prompts for approval. | Catalog and the agent's config | No |
+
+Two consequences worth stating, because both are easy to get wrong:
+
+- **`name` and `description` are the platform's existing `Header` shape.** Do not invent `title` or
+  `summary`. The session list's `search` filter matches `name`, so a `title` field would be a second
+  name that nothing searches.
+- **`flags` is platform metadata, and a rename is not a classification change.** A rename request
+  that carries flags is a request that can misclassify the row. The tool must send none, which
+  requires the service fix described in [research.md](research.md).
+
+## `rename_session`
+
+Endpoint mode. The write endpoint already exists.
+
+```python
+PlatformOp(
+    op="rename_session",
+    description=_RENAME_SESSION_DESCRIPTION,
+    method="POST",
+    path="/api/sessions/streams/header?session_id={session_id}",
+    input_schema=_RENAME_SESSION_INPUT_SCHEMA,
+    context_bindings={"session_id": "$ctx.session.id"},
+    read_only=False,
+)
+```
+
+Model-visible input schema, after `resolved_input_schema()` strips the bound field:
+
+```jsonc
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name":        {"type": "string", "minLength": 1, "maxLength": 120, "pattern": "\\S"},
+    "description": {"type": "string", "maxLength": 300}
+  },
+  "required": ["name"]
+}
+```
+
+`minLength: 1` alone is not enough. A name of `"   "` passes it, and the header write stores it, so
+the visible title clears while the row still holds a value. JSON Schema patterns are unanchored, so
+`"\\S"` requires at least one non-whitespace character anywhere in the string. Both ops use the same
+`name` schema.
+
+**The query parameter rides in the path as a substitution token** because `ToolCall` has no `query`
+field. This reuses machinery that already exists: `substitutePathParams` (`direct.ts:184`) runs on
+the whole path string and URL-encodes the value, `pathParamNames` then deletes `session_id` from the
+body (`relay.ts:471`) so only `{name, description}` is sent, and `directCallUrl`'s host lock and
+mount check both operate on `resolved.pathname`, so the query string weakens neither. Adding a
+`query` map to `ToolCall` would touch the wire contract, the SDK model, the runner, and the golden
+wire test for one op. Revisit if a second op needs it.
+
+`accepts_description` stays absent (false). That flag adds an ephemeral per-call `description`
+argument the runner strips before sending, and this op has a real `description` field.
+
+### Behavior
+
+- **Scoping.** `session_id` is bound and stripped, so the agent can only rename the session it runs
+  in.
+- **Permission.** `EDIT_SESSIONS`, checked against the run's own credential. `read_only=False` means
+  the call prompts for approval under the default `allow_reads` policy unless the agent's config
+  sets `permission: "allow"` on the tool. Whether the default build kit ships it as `allow` is
+  settled in [status.md](status.md) open question 1.
+- **Empty or blank name.** `minLength: 1` plus the `\S` pattern rejects both an empty string and a
+  whitespace-only one, so the tool cannot clear a title.
+- **Description omitted.** The DAO applies only non-`None` fields, so an existing description
+  survives.
+- **Concurrent rename.** Last write wins. There is no version column on `session_streams` and the
+  update is a single-row transaction.
+- **No session.** A headless invoke or an evaluation run carries no `sessionId`, so
+  `$ctx.session.id` does not resolve and `assembleBody` throws. That is the correct fail-closed
+  behavior. The thrown message must name the tool so the model can read it.
+
+### Carrying the session id into run context
+
+Add `session?: { id?: string }` to `RunContext` in `services/runner/src/protocol.ts`, documented as
+runner-filled and never service-filled, mirroring how `project.id` is documented as service-filled.
+In `run-turn.ts`, pass an augmented blob to `startToolRelay`:
+
+```ts
+env.sessionId ? { ...request.runContext, session: { id: env.sessionId } } : request.runContext
+```
+
+computed once beside the existing `sessionId` binding at line 108.
+
+This keeps the documented invariant intact. The service still does not put a conversation id in
+`runContext`, and the value the tool binds is the live id the runner owns for this turn. The SDK's
+`RunContext` model needs no new field, since nothing on the SDK side reads or emits it; add one line
+to its docstring naming `$ctx.session.id` as a runner-provided token so the next reader does not
+conclude the namespace is closed.
+
+## `rename_agent`
+
+Endpoint mode against the artifact edit route. Requires `PUT` on the direct-call allowlist and the
+`flags` fix, both in [plan.md](plan.md).
+
+```python
+PlatformOp(
+    op="rename_agent",
+    description=_RENAME_AGENT_DESCRIPTION,
+    method="PUT",
+    path="/api/workflows/{workflow_id}",
+    input_schema=_RENAME_AGENT_INPUT_SCHEMA,
+    args_into="workflow",
+    context_bindings={
+        "workflow_id": "$ctx.workflow.artifact.id",
+        "workflow.id": "$ctx.workflow.artifact.id",
+    },
+    read_only=False,
+)
+```
+
+The model-visible schema is identical to `rename_session`'s: `name` required, 1 to 120 characters
+with the `\S` pattern; `description` optional, up to 300.
+
+**Two bindings resolve the same token** because the route needs the id twice: once in the path and
+once in the body, where the handler compares them. `pathParamNames` deletes only the top-level
+`workflow_id` key from the body after substitution, so the nested `workflow.id` survives into the
+payload. Both come from one run-context value, so they can never disagree, and the handler's
+id-mismatch branch is unreachable through this tool.
+
+### The route must stop reporting a missing target as success
+
+`edit_workflow` returns HTTP 200 with `count: 0` in two cases: when the body's `workflow.id` does
+not match the path, and when the service finds no artifact (a deleted or archived workflow). The
+runner treats any 2xx as a successful tool call (`direct.ts:643` raises only on a non-ok status), so
+a rename against a workflow that no longer exists returns success to the model, which then reports
+to the user that it renamed itself. Nothing was written.
+
+Correct the route rather than papering over it at the tool: when `WorkflowsService.edit_workflow`
+returns `None`, raise `HTTPException(status_code=status.HTTP_404_NOT_FOUND, ...)`, the pattern
+`api/oss/src/apis/fastapi/applications/router.py:1146` already uses. Do the same for the id-mismatch
+branch, which is a client error and not an empty result. The tool then fails closed with a message
+the model can act on.
+
+This is a correctness fix to an existing public endpoint, not new surface. Any caller currently
+reading `count` to detect the failure keeps working, because a 404 is what it was already checking
+for in effect.
+
+The assembled body is:
+
+```jsonc
+{"workflow": {"name": "...", "description": "...", "id": "<bound>"}}
+```
+
+which is exactly `WorkflowEditRequest`. No `flags`, no `tags`, no `meta`.
+
+### Behavior
+
+- **Scoping.** `workflow_id` is bound and stripped, so the agent can only rename itself.
+- **Permission.** `EDIT_WORKFLOWS`, checked against the run's own credential.
+- **No workflow identity.** A run with no resolved workflow reference (an inline config with no
+  stored artifact) cannot resolve the token, and the call fails closed with a message naming the
+  tool.
+- **Evaluators and other workflow-backed entities.** The run-context builder normalizes
+  `application*` and `evaluator*` reference families into `workflow.artifact`, so the op would work
+  on those too. It ships only in the build kit, which mounts on agents, so that path is not
+  exercised. The op description says "the agent you are running as", which stays true either way.
+
+## The tool descriptions the model reads
+
+These carry the whole instruction. Keep them in the catalog next to the op, as `_RENAME_*_DESCRIPTION`
+constants.
+
+### `rename_session`
+
+> Name and describe the session you are running in, so a person scanning a long list of sessions can
+> tell what this one is. Call it once you understand what the session is about, which is usually
+> after the first exchange. Call it again later whenever the session has moved on and the name or
+> the recap no longer fits.
+>
+> `name` is the general subject: what this session is about, as a short label a person can scan in a
+> list. A few words. Not the latest step, and not a sentence.
+>
+> `description` is the current state: a short recap of what has happened and what is open, one to
+> one and a half sentences, short enough to read inside a table cell.
+>
+> This renames the session you are in and no other one. It works only inside a session.
+
+### `rename_agent`
+
+> Name and describe yourself, so a person browsing the list of agents can tell what you are for.
+> Call it once you understand your own purpose, which is usually right after your first task. Call
+> it again if your purpose changes.
+>
+> `name` is what you are for, as a short label a person can scan in a list. A few words.
+>
+> `description` is what you do and where you currently stand, one to one and a half sentences, short
+> enough to read inside a table cell.
+>
+> This renames the agent you are running as and no other one. It changes only your name and your
+> description, never your configuration.
+
+## The project watch event
+
+A second channel scope beside the existing per-session one, chosen by traffic volume. Keep
+`watch:{project}:session:{session}` for high-frequency in-session traffic; a browser not in that
+session must not pay for it. Add `watch:{project}:project` for low-frequency entity-changed
+notifications a list page needs.
+
+- **Contract** (`api/oss/src/dbs/redis/sessions/contract.py`, beside the existing helpers):
+  `project_watch_channel(project_id)` and `make_watch_entity_changed_payload(entity, id)` returning
+  `{"type": f"{entity}-changed", "entity": entity, "id": id}`.
+- **Event names**: `session-changed` and `workflow-changed`. The entity goes in the SSE event
+  **name**, not only in the data, because `EventSource` dispatches per name: a subscriber pays
+  nothing for events it did not register for, and the browser ignores an unrecognized name for free.
+  Keep the closed `_KNOWN_EVENTS` allowlist.
+- **Why `workflow-changed` and not `agent-changed`.** The frame names the platform entity that
+  changed. The agents list is one view of workflow artifacts, and an evaluator is another; a frame
+  named after the view would be wrong for every other view of the same row.
+- **Publisher**: a keyword-only `changed(*, project_id, entity, id)` method on
+  `SessionsWatchPublisher` and on the Protocol in
+  `api/oss/src/core/sessions/watch/interfaces.py`, with the same best-effort, one-second-bounded,
+  never-raises contract as the three existing methods.
+- **Endpoint**: `GET /watch?project_id=...`, reusing `watch_event_stream` unchanged against
+  `project_watch_channel(request.state.project_id)`. The `project_id` query parameter is the
+  standard one every Agenta endpoint carries and the existing session watch client already sends it
+  (`useSessionRecordsWatch.ts:20`). What this route does not take is an **entity-specific**
+  parameter: there is no `session_id` and no `workflow_id`, because the channel is the whole
+  project.
+- **Permission**: there is no generic project-view permission, and this one stream carries frames
+  for two entity families. Require **every** view permission whose entity appears on the channel, as
+  a conjunction: today `VIEW_SESSIONS` and `VIEW_WORKFLOWS`. Check them with the same
+  `check_action_access` calls the two existing routes use, and return `FORBIDDEN_EXCEPTION` when
+  either fails. Write the permission list next to `_KNOWN_EVENTS` with a comment stating that adding
+  an event to the allowlist means adding its view permission here.
+- **Why a conjunction and not per-frame filtering**: the frames carry no entity data, so the only
+  thing a subscriber learns is that something in a category changed, and the refetch each frame
+  provokes is authorized normally by its own endpoint. Filtering frames per permission would add a
+  second authorization model for zero protected information. The cost of the conjunction is that a
+  role holding only one of the two permissions cannot open the stream at all and falls back to the
+  30 second refetch, which is acceptable and must be stated in the route docstring.
+- **Client**: one hook in a package, `useProjectWatch({on: {"session-changed": handler, ...}})`,
+  holding the connection lifecycle the two existing hooks already implement. Extract it from
+  `useSessionRecordsWatch` rather than writing a third copy. Mount it once per project scope so
+  every page under it shares one connection; the in-session hook keeps its own connection for the
+  high-frequency channel.
+
+**How a later feature reuses this.** Publish
+`changed(project_id=..., entity="<entity>", id=...)` from the service method that
+committed the write, next to the write. Add the event name to `_KNOWN_EVENTS` **and** its view
+permission to the endpoint's conjunction. On the client, add one entry to the `on` map whose handler
+invalidates that page's existing query key. Two rules stay fixed: the frame carries no entity data,
+and the handler only invalidates, never applies a change read out of the frame.
+
+**Known cost.** One SSE connection and one Redis pubsub connection per open tab. That is the order
+the session relay already costs per open chat, and `router.py:585` already flags the revisit ("one
+pubsub connection per SSE connection (v1); revisit with a shared listener if counts grow"). The
+project channel does not change the order of magnitude and the same note applies.
+
+## Chat title precedence after this change
+
+Decision 2 in [context.md](context.md) removes the title-provenance idea. The rule becomes: **a
+non-empty server name wins.** In `reconcileServerSessionsAtomFamily`
+(`web/oss/src/components/AgentChatSlice/state/sessions.ts:431`), `title: s.title?.trim() ? s.title :
+remote.title` becomes `title: remote.title?.trim() ? remote.title : s.title`.
+
+This is safe because every locally set title is also written to the server: both the auto-title and
+the manual rename call `setSessionHeader`. The one visible cost is a brief flicker when a list
+refetch that started **before** a local rename's write landed resolves **after** it, showing the old
+name for one render. It corrects itself on the next reconcile. Accept it rather than reintroducing
+provenance tracking; if it proves annoying in practice, the fix is to invalidate the session list
+right after a local rename resolves, not a new field.

--- a/docs/design/agent-self-naming-tools/context.md
+++ b/docs/design/agent-self-naming-tools/context.md
@@ -1,0 +1,70 @@
+# Why this work exists
+
+## What a user sees today
+
+**Sessions carry a truncated first message as their name.** When someone sends a first message in
+the desktop chat, the browser takes that message, cuts it at 60 code points, and writes it to the
+session's durable name. A list of sessions therefore reads as a column of half-sentences. Nothing
+ever improves that name later, because nothing else writes it except a manual rename in the session
+rail.
+
+**Agents carry whatever name the creation flow gave them.** An agent created from a template gets
+the template's name. An agent created blank gets a placeholder. The description is usually empty. A
+person browsing the agents list sees rows that do not say what the agents do, and the only way to
+fix that is to type a name by hand in the playground header.
+
+In both cases the party that knows the answer is the agent itself, and it has no way to say it.
+
+## What we are building
+
+Two platform tools, both in the default build kit so every playground agent has them without the
+author opting in.
+
+- `rename_session` lets the agent name and describe the session it is running in, once it
+  understands what the session is about, and update both later when the session moves on.
+- `rename_agent` lets the agent name and describe itself, typically right after its first task,
+  once it understands its own purpose.
+
+Plus the piece that makes either one visible: a project-scoped watch relay, so a rename written by
+a server-side actor reaches an open browser tab without a reload.
+
+## Decisions already made
+
+These are settled. Do not re-open them during implementation.
+
+1. **Both tools go into `DEFAULT_BUILD_KIT_OPS`.** They are default build-kit behavior, not an
+   author opt-in. Wherever the build kit is present, both tools are present, including
+   trigger-minted runs. There is no special case for automation runs: the presence of the build kit
+   decides.
+2. **The agent may overwrite a name a human typed.** The server records no title provenance and we
+   are not adding any. A server-side rename simply shows in the browser. The chat's local title
+   must stop beating the server's.
+3. **The client-side auto-title stays, and fires only on the first message.** It labels sessions
+   the user never opens and sessions on other devices. The agent's better name arrives later and
+   supersedes it.
+4. **The name and the description have distinct jobs.** The name is the general subject: what the
+   session is about, or what the agent is for, short enough to scan in a long list. The description
+   is the current state: a recap of one to one and a half sentences that fits a table cell.
+5. **Tool descriptions carry the whole instruction.** The model learns when to call, what each
+   field means, and that it may call again later, from the catalog description alone. There is no
+   prompt-side companion instruction.
+
+## Done means
+
+- An agent in a fresh playground session calls `rename_session` after understanding the task, and
+  the `session_streams` row holds the new name and description.
+- A fresh agent calls `rename_agent` after its first task, and the workflow artifact row holds the
+  new name and description, with its flags intact.
+- Both renames appear in an open sessions list and an open agents list without a reload, in a tab
+  that did not make the change.
+- Both tools appear in the one-shot benchmark and hold the 95% target on the small-model cells.
+
+## Out of scope
+
+- Server-side arbitration between a human name and an agent name. Decision 2 rules it out.
+- Renaming any session or agent other than the one the run belongs to. Both targets are bound from
+  run context and stripped from the model's schema.
+- Clearing a name. `minLength: 1` plus a non-whitespace pattern on the schema means the tool cannot
+  blank a title, by an empty string or by spaces; that stays a human action.
+- Widening the watch relay beyond the two entities these tools touch. The mechanism generalizes,
+  but each later entity adds its own publish call and its own client handler.

--- a/docs/design/agent-self-naming-tools/plan.md
+++ b/docs/design/agent-self-naming-tools/plan.md
@@ -1,0 +1,284 @@
+# Implementation plan
+
+Fourteen steps in four tracks plus verification. Each step is one commit. The tracks are
+independent of one another; within a track the order holds.
+
+- **Session tool** (S1 to S3): `rename_session` end to end.
+- **Agent tool** (A1 to A4): `rename_agent` end to end, including the two blockers it needs first.
+- **Chat title** (T1): make a server rename visible in the desktop chat.
+- **Live refresh** (W1 to W3): the project watch channel, serving both tools.
+- **Verification** (V1 to V4): tests, benchmark, docs, live QA.
+
+The tools work without the live refresh; the refresh is a shared mechanism that stands on its own.
+Both tools are worth landing before the refresh, because a rename that only shows after a 30 second
+refetch is still a working rename.
+
+## Session tool
+
+### S1. Carry the live session id in run context, and name the tool when a binding fails
+
+Files:
+
+- `services/runner/src/protocol.ts`: add `session?: {id?: string}` to `RunContext`, documented as
+  runner-filled and never service-filled.
+- `services/runner/src/engines/sandbox_agent/run-turn.ts`: at the `startToolRelay` call (line 897),
+  pass `env.sessionId ? {...request.runContext, session: {id: env.sessionId}} : request.runContext`.
+  Compute it once beside the existing `sessionId` binding at line 108.
+- `services/runner/src/tools/direct.ts` (`assembleBody`) and `services/runner/src/tools/relay.ts`
+  (pass `spec.name`): include the tool name in the "missing run-context value for direct-call
+  binding" error.
+- `sdks/python/agenta/sdk/agents/dtos.py`: one docstring line on `RunContext` naming
+  `$ctx.session.id` as a runner-provided token, so the next reader does not conclude the namespace
+  is closed.
+
+Tests: extend `services/runner/tests/unit/tool-direct.test.ts` with a case that resolves
+`$ctx.session.id`, a case that throws when the id is absent, and an assertion on the message text.
+
+### S2. Add the `rename_session` catalog op and put it in the default build kit
+
+Files:
+
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py`: the `_RENAME_SESSION_DESCRIPTION`
+  constant (verbatim from [api-design.md](api-design.md)), the `_RENAME_SESSION_INPUT_SCHEMA`
+  constant, and the `PlatformOp` entry.
+- `api/oss/src/core/workflows/build_kit.py`: add `"rename_session"` to `DEFAULT_BUILD_KIT_OPS`.
+
+Tests: `sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py` for the op resolving,
+`session_id` being absent from `resolved_input_schema()`, and the emitted `ToolCall` carrying the
+path token and the binding. Add a case in `services/runner/tests/unit/tool-direct.test.ts`
+asserting `directCallUrl` produces `<origin>/api/sessions/streams/header?session_id=<id>`. Extend
+whatever test pins `DEFAULT_BUILD_KIT_OPS` or the build-kit overlay shape.
+
+### S3. Decide and encode the approval behavior
+
+Both ops are `read_only=False`, so under the default `allow_reads` policy each call prompts the user
+for approval unless the tool's config sets `permission: "allow"`. A prompt on the first turn defeats
+the feature: the point is that the agent labels the session and itself without being asked.
+
+**Recommended:** the build-kit overlay emits both ops with `permission: "allow"`.
+
+File: `api/oss/src/core/workflows/build_kit.py`. `build_agent_template_overlay` currently emits
+`{"type": "platform", "op": op_name}` for every op in `DEFAULT_BUILD_KIT_OPS`. Add a small set of
+auto-allowed op names and emit `permission: "allow"` for those two. Do **not** add them to
+`web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts`'s `PLATFORM_OPS`,
+which exists to stop a user from permanently auto-allowing an op whose gate must survive; these two
+are deliberately ungated.
+
+Test: extend the build-kit overlay test to assert both ops carry `permission: "allow"` and that no
+other op does.
+
+**Fallback if the decision goes the other way** (see [status.md](status.md) open question 1): leave
+the overlay alone and instead add both op names to `toolPermission.ts`'s `PLATFORM_OPS`, with a case
+in `web/packages/agenta-entity-ui/tests/unit/toolPermission.test.ts`. Note that this branch also
+changes the benchmark: a gated call is not a one-shot rename, so the benchmark cells would need the
+tool explicitly allowed in their seeded config.
+
+Land this once for both ops rather than splitting it.
+
+## Agent tool
+
+### A1. Allow PUT on direct-call dispatch
+
+Files:
+
+- `sdks/python/agenta/sdk/agents/tools/models.py`: `ToolCall.method` becomes
+  `Literal["GET", "POST", "PUT", "DELETE"]`, and the docstring line that says GET/POST/DELETE only.
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py`: `PlatformOp.method` gains `"PUT"`
+  (line 167).
+- `services/runner/src/protocol.ts`: `DirectCall.method` gains `"PUT"` (line 150).
+- `services/runner/src/tools/direct.ts`: `DIRECT_CALL_METHODS` (line 33), the error text at line
+  478, the `callDirect` signature (line 595), and the body-serialization condition at line 620,
+  which must serialize for `PUT` as well as `POST`.
+
+Tests: `services/runner/tests/unit/tool-direct.test.ts` for a PUT dispatch carrying a JSON body, and
+for an unlisted method still being rejected. Add an SDK test that a catalog op may declare `PUT`.
+
+The dispatcher stays constrained: four explicit methods, an origin lock, and a mount-path check, all
+unchanged.
+
+### A2. Make the workflow edit route correct for a rename
+
+Two fixes to the same request path, one commit.
+
+**Stop nulling flags the edit does not carry.** File: `api/oss/src/core/workflows/service.py`
+(`edit_workflow`, line 938). Build the `ArtifactEdit` so `flags` is passed only when `workflow_edit`
+actually set it, for example by assembling the keyword arguments in a dict and adding `flags` under
+`if "flags" in workflow_edit.model_fields_set`. The DAO already writes a column only when its name
+is in `model_fields_set`; this restores the intent its own comment states.
+
+**Stop reporting a missing target as success.** File:
+`api/oss/src/apis/fastapi/workflows/router.py` (`edit_workflow`, line 755). Raise
+`HTTPException(status_code=status.HTTP_404_NOT_FOUND, ...)` when the service returns `None`, and a
+client error on the id-mismatch branch, instead of returning 200 with `count: 0`. The runner treats
+any 2xx as a successful tool call, so without this a rename against a deleted or archived agent
+tells the model it succeeded. Reasoning in [api-design.md](api-design.md).
+
+Tests: `api/oss/tests/pytest/` coverage for workflows, asserting that a PUT with only `{id, name}`
+leaves `flags` unchanged, that a PUT carrying flags still replaces them, and that a PUT naming a
+workflow id that does not exist or has been archived returns a non-2xx rather than `count: 0`.
+
+This fixes a latent bug on its own. Every caller that renames a workflow without resending flags
+currently NULLs them, and the frontend only avoids it by hard-coding `{is_application: true}` on
+every rename.
+
+### A3. Add the `rename_agent` catalog op and put it in the default build kit
+
+Files:
+
+- `sdks/python/agenta/sdk/agents/platform/op_catalog.py`: the `_RENAME_AGENT_DESCRIPTION` constant,
+  the `_RENAME_AGENT_INPUT_SCHEMA` constant, and the `PlatformOp` entry with `args_into="workflow"`
+  and the two context bindings.
+- `api/oss/src/core/workflows/build_kit.py`: add `"rename_agent"` to `DEFAULT_BUILD_KIT_OPS`.
+
+Tests: catalog tests as in S2, plus a runner test asserting the assembled body is
+`{"workflow": {"name", "description", "id"}}` with the top-level `workflow_id` stripped after path
+substitution, and that the URL is `<origin>/api/workflows/<id>`.
+
+Depends on A1. Do not land before A2, or the first live call wipes an agent's flags.
+
+### A4. Frontend rename surfaces adopt the fixed contract
+
+File: `web/oss/src/components/EntityIdentity/useRenameApp.ts`: drop the hard-coded
+`flags: {is_application: true}` now that A2 makes it unnecessary and it is wrong for any
+non-application workflow the hook is reused on.
+
+Test: whatever unit coverage exists for the hook, or none if the change is a deletion covered by
+A2's API test.
+
+Optional. It removes a workaround rather than adding behavior, so it can be dropped if it grows.
+
+## Chat title
+
+### T1. A non-empty server session name wins in the chat reconcile
+
+File: `web/oss/src/components/AgentChatSlice/state/sessions.ts`
+(`reconcileServerSessionsAtomFamily`, line 431): `title: remote.title?.trim() ? remote.title :
+s.title`. Update the function docstring, which currently states the opposite rule.
+
+Tests: extend `web/oss/src/components/AgentChatSlice/state/sessions.pageTitle.test.ts` with a
+server name replacing a local one, an empty server name leaving the local one alone, and a session
+absent locally still adopting the server name.
+
+No change to `autoTitleSessionAtomFamily`. It already fires at most once, on the first user message,
+and returns early when a title exists.
+
+## Live refresh
+
+### W1. The project watch channel and its endpoint
+
+Files:
+
+- `api/oss/src/dbs/redis/sessions/contract.py`: `project_watch_channel(project_id)`,
+  `make_watch_entity_changed_payload(entity, id)`, and the module comment block at line 90 extended
+  to document the second scope.
+- `api/oss/src/dbs/redis/sessions/watch.py`: a `changed(*, project_id, entity, id)` method with the
+  same best-effort, one-second-bounded, never-raises contract as the three existing methods. The
+  signature takes `project_id` explicitly, exactly as `records_changed`, `lifecycle`, and
+  `interaction` already do (`watch.py:71`, `:78`, `:91`). The publisher holds a Redis client and
+  cannot derive the project channel on its own, so a caller that omits `project_id` would publish
+  nowhere.
+- `api/oss/src/core/sessions/watch/interfaces.py`: pin the same keyword-only signature on the
+  Protocol.
+- `api/oss/src/apis/fastapi/sessions/watch.py`: add `session-changed` and `workflow-changed` to
+  `_KNOWN_EVENTS`, emit the entity as the SSE event name, and record the required view permissions
+  beside the allowlist.
+- `api/oss/src/apis/fastapi/sessions/router.py`: a `GET /watch?project_id=...` route reusing
+  `watch_event_stream` against `project_watch_channel(request.state.project_id)`, gated on
+  `VIEW_SESSIONS` **and** `VIEW_WORKFLOWS`.
+
+Tests: `api/oss/tests/pytest/unit/sessions/test_watch_endpoint.py` already asserts the frame
+sequence for the session route; add the project route beside it, plus a case that a caller missing
+either view permission gets a forbidden response rather than a stream. Pin the `changed` signature
+in the Protocol test so a positional call fails at type-check time.
+
+This ships no user-visible behavior on its own, which is the point. It is the shared piece and it
+reviews cleanly without either tool attached.
+
+### W2. Publish on both writes
+
+Files:
+
+- `api/oss/src/core/sessions/streams/service.py`: publish
+  `changed(project_id=..., entity="session", id=session_id)` at the end of `set_header` (line 641),
+  through the injected publisher, matching `_publish_lifecycle`'s shape. `set_header` already
+  receives the project id; pass it explicitly.
+- `api/oss/src/core/workflows/service.py`: publish
+  `changed(project_id=..., entity="workflow", id=workflow_id)` at the end of `edit_workflow`,
+  through the same Protocol. `edit_workflow` already takes `project_id` as a keyword argument. This
+  means the workflows service gains an optional publisher dependency; construct it in the entrypoints
+  beside the sessions one (`api/entrypoints/routers.py:648`).
+
+Test: `api/oss/tests/pytest/unit/sessions/test_watch_publish.py` for one `session-changed` frame per
+`set_header` on the project channel, one `workflow-changed` frame per `edit_workflow`, and a failing
+publisher not failing either write.
+
+If threading a publisher into `WorkflowsService` turns out to be a large change, publish from the
+API router handler instead and say so in [status.md](status.md). The rule that matters is that the
+publish sits next to the committed write and cannot fail it.
+
+### W3. Subscribe once per project and refresh both lists
+
+Files:
+
+- Extract the connection lifecycle from
+  `web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts` into a package hook
+  `useProjectWatch({on})`, keeping the `visibilitychange` open and close, the jittered backoff with
+  a token refresh, the revalidation on `ready`, and the minimum interval between revalidations.
+- Mount it once per project scope.
+- `session-changed` invalidates the **prefix** `["session-list", projectId]`. The rail's session
+  query is keyed per agent, `["session-list", projectId, appId]`
+  (`web/oss/src/components/AgentChatSlice/state/projectSessions.ts:30`), and a watch frame carries a
+  session id, not an agent id, so the handler cannot name the exact key. A prefix invalidation
+  refetches every mounted scope's list, which is what a rename in an unknown scope needs.
+- The handler does **not** call `reconcileServerSessionsAtomFamily` itself. That atom takes a scope
+  key and the full server array, neither of which a frame carries. The already-mounted
+  `useReconcileServerSessions(scope)` hooks (`projectSessions.ts:93`, wired at
+  `AgentChatPanel.tsx:81`) reconcile on their own once the refetch lands. The handler's whole job is
+  the invalidation.
+- `workflow-changed` calls `invalidateAgentsWorkflowQueries()`
+  (`web/oss/src/components/pages/agents/store.ts:84`) and invalidates
+  `["workflows", "artifact", id]`.
+- Run the same two invalidations on the `ready` event, which covers changes missed while the
+  connection was down. This mirrors what `useSessionRecordsWatch` already does on `ready`.
+
+Tests: drive the hook with a fake `EventSource` and assert the event-to-handler mapping and the
+`ready` revalidation. The rest is verified live.
+
+## Verification
+
+### V1. API tests
+
+See [qa.md](qa.md) for the list. Land them with the step they cover rather than as a batch.
+
+### V2. Benchmark scenarios
+
+See [qa.md](qa.md). One commit adding the two check kinds, one adding the scenario file, one
+widening `LIVE_TOOLS` per scenario.
+
+### V3. Documentation
+
+Files:
+
+- `docs/design/agent-workflows/documentation/tools.md`: add both ops to the op table around line
+  547, note that both are in the default build kit, and correct the catalog-field prose at line 521
+  which currently says endpoint mode is `GET`/`POST` only.
+- The watch pattern documents itself in the contract module comment block from W1, which is where
+  the existing channel and payload shapes are already described.
+
+Run the `keep-docs-in-sync` skill after the last code step so nothing else drifted.
+
+### V4. Live QA
+
+See [qa.md](qa.md).
+
+## Branch layout
+
+The four tracks touch disjoint files except for `op_catalog.py` (S2 and A3) and
+`build_kit.py` (S2 and A3). Put the session tool below the agent tool in one linear stack so the
+catalog file has a single owner per lane, and set each pull request's base to the branch below it.
+The chat-title and live-refresh tracks touch no file the tool tracks touch and can sit anywhere in
+the line.
+
+Put each test file on the lane whose tip first contains every symbol the test touches. The
+`tool-direct.test.ts` cases from S1, S2, A1, and A3 all live in one file, so that file lands on the
+highest of those lanes.

--- a/docs/design/agent-self-naming-tools/qa.md
+++ b/docs/design/agent-self-naming-tools/qa.md
@@ -1,0 +1,163 @@
+# Verification
+
+Three layers, each answering a different question. Unit and API tests answer "does the contract hold
+in isolation". The benchmark answers "do small models actually call these tools correctly, one
+shot". Live QA answers "does a person see the rename".
+
+## Unit and API tests
+
+Land each with the step it covers, listed in [plan.md](plan.md).
+
+### Runner (`services/runner/tests/unit/tool-direct.test.ts`)
+
+- `$ctx.session.id` resolves from the augmented run-context blob.
+- A run with no session id makes the binding throw, and the message names the tool.
+- `directCallUrl` produces `<origin>/api/sessions/streams/header?session_id=<id>` and the query
+  string does not defeat the host lock or the mount check.
+- A `PUT` dispatch carries a JSON body; a method outside the four-item allowlist is still rejected.
+- `rename_agent`'s assembled body is `{"workflow": {"name", "description", "id"}}`, with the
+  top-level `workflow_id` stripped after path substitution, and the URL is `<origin>/api/workflows/<id>`.
+
+### SDK catalog (`sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py`)
+
+- Both ops resolve to a `CallbackToolSpec` with a direct `call`.
+- `session_id`, `workflow_id`, and `workflow.id` are all absent from `resolved_input_schema()`.
+- The emitted `ToolCall` carries the path token, the bindings, and `args_into` where declared.
+- A whitespace-only `name` fails schema validation on both ops.
+- A catalog op may declare `PUT`.
+- Both ops are in `DEFAULT_BUILD_KIT_OPS` and therefore in the build-kit overlay.
+
+### API (`api/oss/tests/pytest/`)
+
+- **Session header write**: covered already by
+  `acceptance/sessions/test_stream_header_basics.py` and `test_stream_header_roundtrip.py`. Add one
+  case only if the query-parameter-in-path form exposes something those miss.
+- **Workflow edit preserves flags**: a PUT carrying only `{id, name}` leaves `flags` unchanged; a
+  PUT carrying flags still replaces them. This is the regression test for the bug A2 fixes and it
+  must exist before `rename_agent` ships.
+- **Workflow edit fails loudly on a missing target**: a PUT naming a workflow id that does not exist
+  or has been archived returns a non-2xx, not 200 with `count: 0`. Drive the concurrent-deletion
+  case directly: archive or delete the workflow, then issue the edit.
+- **Watch endpoint** (`unit/sessions/test_watch_endpoint.py`): the project route emits the same
+  frame sequence the session route does (a `retry:` preamble, one `ready`, one frame per publish),
+  a payload whose type is outside the allowlist loses its own frame without dropping the connection,
+  and a caller holding only one of `VIEW_SESSIONS` / `VIEW_WORKFLOWS` gets a forbidden response
+  instead of a stream.
+- **Watch publish** (`unit/sessions/test_watch_publish.py`): `set_header` publishes exactly one
+  `session-changed` frame on the project channel; `edit_workflow` publishes exactly one
+  `workflow-changed` frame; both pass `project_id` explicitly; a publisher that raises does not fail
+  either write.
+
+### Frontend
+
+- The build-kit overlay test: both ops carry `permission: "allow"` and no other op does. If open
+  question 1 in [status.md](status.md) is answered the other way, this becomes a
+  `web/packages/agenta-entity-ui/tests/unit/toolPermission.test.ts` case instead, asserting neither
+  op is auto-allowable from the approval card.
+- `web/oss/src/components/AgentChatSlice/state/sessions.pageTitle.test.ts`: a non-empty server name
+  replaces a local one; an empty server name leaves the local one alone; a session absent locally
+  adopts the server name.
+- The project watch hook, driven by a fake `EventSource`: the event-to-handler mapping and the
+  revalidation on `ready`.
+
+## One-shot benchmark
+
+`benchmarks/agent-config-editing/` measures whether a small model completes a configuration action
+one-shot, against a 95% target. Both tools belong in it, because both are exactly the shape it
+measures: a user types in prose, the model must reach for the right tool with the right arguments on
+the first try, and the verdict is read from a stored row.
+
+Two facts about the harness shape this work (details in [research.md](research.md)): every verdict
+is currently read from `parameters.agent` of the newest revision, and `LIVE_TOOLS` mounts only
+`read_config` and `commit_revision`.
+
+### New check kinds (`bench_lib.py`)
+
+Register two checks behind the existing `@check("<name>")` decorator, each reading a row the current
+`Ctx` does not carry:
+
+- `session_header`: fetches `GET /sessions/streams/?session_id=<the trial's session id>` and
+  asserts on `name` or `description`. The trial already mints its own session id
+  (`bench_lib.py:1402`); carry it onto `Ctx` so the check can read it back.
+- `workflow_header`: fetches the trial's workflow artifact and asserts on `name`, `description`,
+  and that `flags` survived.
+
+Both take the same `pattern` form `stored_matches` uses rather than a literal, because the wording
+is the model's to choose and a literal check would score a correct rename a miss. Assert the shape,
+not the bytes. Where a token must appear verbatim, use a `{{TOKEN}}` substring check.
+
+### New scenario file (`scenarios/09-self-naming.json`)
+
+Class `self_naming`. Suggested scenarios, each a single turn written the way a person types:
+
+| Id | Prompt shape | What it checks |
+| --- | --- | --- |
+| `name-01-session-after-task` | A real task with a clear subject, no mention of naming | The model calls `rename_session` unprompted, the stored `name` describes the subject, the `description` is non-empty and under 300 characters |
+| `name-02-session-update` | Two turns: a task, then a clear change of subject | A second `rename_session` call, with the stored name reflecting the new subject |
+| `name-03-agent-first-task` | A first task for a freshly seeded agent with a placeholder name | The model calls `rename_agent`, the stored artifact `name` is no longer the placeholder, and `flags` are intact |
+| `name-04-no-spurious-rename` | A trivial one-line request in an already well-named session | Neither tool is called, enforced by `max_rename_calls: 0`; the stored name still matches the seeded one |
+
+`name-04` matters as much as the other three. A tool that fires on every turn produces churn in the
+list, and only a scenario that scores a call as a failure can catch it.
+
+Both `flags` assertions on `name-03` are the benchmark's guard against the bug A2 fixes regressing.
+
+### Harness plumbing
+
+- **Mounting the tools needs no new plumbing.** `run_benchmark.py:158` already computes
+  `run_agent["tools"] = B.LIVE_TOOLS + (scenario.get("tools") or [])`, so a scenario adds its own
+  ops by declaring a `tools` list. Each of the four scenarios declares the one op it measures.
+- Carry the trial's `session_id` and `workflow_id` onto `Ctx` so the two new checks can read the
+  rows back.
+- **Add and enforce a rename-call budget.** The budget block today is `max_rounds`,
+  `max_tool_errors`, and `max_commit_calls`, and `within_budget` (`run_benchmark.py:230`) counts
+  only tool errors and `commit_revision` calls. A rename budget that is only declared in the JSON
+  changes nothing. Add `max_rename_calls`, count calls to `rename_session` and `rename_agent` the
+  same way `commit_calls` is counted, and add the comparison to the `within_budget` conjunction.
+  Set it to 1 for `name-01` through `name-03` and **0** for `name-04`, which is the only way that
+  scenario can fail on a spurious rename.
+
+### Reporting
+
+No change. Both `one_shot` and `excl. harness` still apply, and the outcome labels
+(`bench_lib.classify_outcome`) already distinguish "used the surface and got the details wrong" from
+"described the mechanism and made zero calls", which is the distinction that tells us whether to
+change a description or fix a bug.
+
+## Live QA
+
+Deploy an OSS dev stack: `load-env hosting/docker-compose/oss/.env.oss.dev` then
+`bash ./hosting/docker-compose/run.sh --oss --dev --build`.
+
+**The scenario.** Create a fresh agent, from a template or blank. Do not rename it by hand. Open a
+new session in the playground chat and give it a real task with a clear subject. Then open a second,
+separate session with the same agent and give it a different task.
+
+**What to confirm, in order:**
+
+1. The model calls `rename_session` with a `name` that reads as a subject and a `description` that
+   reads as a recap of one to one and a half sentences. Read the arguments in the approval card or
+   the tool-call display, not just the reply.
+2. The model calls `rename_agent` after its first task, with a name that says what the agent is for.
+3. `GET /sessions/streams/?session_id=...` returns the new `name` and `description`.
+4. The agents list shows the new agent name **and the agent is still in the list**, which is the
+   flags check. If it vanished, A2 did not land or did not work.
+5. The `GET /watch` stream in the network tab carries one `session-changed` frame and one
+   `workflow-changed` frame, each at the moment of its call.
+6. The sessions list, the chat rail, and the agents list all show the new names without a reload.
+   Watch them in a **second tab that never touched the session**, which is the case client-side
+   mutation invalidation cannot serve.
+7. The second session gets its own distinct name, and renaming it does not disturb the first.
+8. Rename a session by hand in the rail, then send another message. The agent may overwrite it; that
+   is decision 2 and it is expected. What must not happen is the name reverting on its own between
+   refetches.
+
+**Then check the stored rows in Postgres**, so the assertion is on stored state and not on model
+prose:
+
+```sql
+select name, description from session_streams where session_id = '...';
+select name, description, flags from workflow_artifacts where id = '...';
+```
+
+Confirm the exact table and column names against the DBA modules before running the second query.

--- a/docs/design/agent-self-naming-tools/qa.md
+++ b/docs/design/agent-self-naming-tools/qa.md
@@ -31,7 +31,7 @@ Land each with the step it covers, listed in [plan.md](plan.md).
 
 - **Session header write**: covered already by
   `acceptance/sessions/test_stream_header_basics.py` and `test_stream_header_roundtrip.py`. Add one
-  case only if the query-parameter-in-path form exposes something those miss.
+  case only if the query-parameter-in-path form exposes a behavior those tests do not cover.
 - **Workflow edit preserves flags**: a PUT carrying only `{id, name}` leaves `flags` unchanged; a
   PUT carrying flags still replaces them. This is the regression test for the bug A2 fixes and it
   must exist before `rename_agent` ships.

--- a/docs/design/agent-self-naming-tools/research.md
+++ b/docs/design/agent-self-naming-tools/research.md
@@ -1,0 +1,244 @@
+# How the code works today
+
+Everything below was read in the tree at `main` as of 2026-08-09. Line numbers are a reading aid,
+not a contract.
+
+## Where agent tools come from
+
+An agent's tools are declared in its config and discriminated on `type`
+(`sdks/python/agenta/sdk/agents/tools/models.py:230`): `builtin`, `gateway`, `code`, `client`,
+`reference`, `platform`.
+
+A **platform tool** wraps an existing Agenta endpoint. The author writes only
+`{"type": "platform", "op": "<op>"}`. Everything else lives in a code-defined catalog.
+
+- **Catalog**: `sdks/python/agenta/sdk/agents/platform/op_catalog.py`. `PLATFORM_OPS` (line 1475)
+  maps an op key to a `PlatformOp` (line 152), validated at import. A `PlatformOp` carries the
+  model-facing `description`, either `method` + `path` (endpoint mode) or `handler` (server-side
+  handler mode), an `input_schema`, `context_bindings`, `args_into`, `read_only`, `timeout_ms`,
+  and `accepts_description`.
+- **Resolver**: `platform/platform_tools.py:60` turns each config entry into a `CallbackToolSpec`
+  carrying a `ToolCall` descriptor plus the base URL and the per-request credential. It makes no
+  HTTP call.
+- **Dispatch**: the runner. `services/runner/src/tools/relay.ts:466` builds the body with
+  `assembleBody`, resolves the URL with `directCallUrl`, and posts it from the host. The sandbox
+  never holds a credential.
+- **Self-targeting**: `context_bindings` maps a dotted body path to a `"$ctx.<dotted.path>"` token.
+  The runner resolves it against the run's `runContext` at dispatch
+  (`services/runner/src/tools/direct.ts:139`), after the model's arguments and after the static
+  body, so a bound field always wins. `PlatformOp.resolved_input_schema()` (`op_catalog.py:262`)
+  strips every bound field from the schema the model reads. A token that does not resolve throws
+  rather than silently dropping the field.
+
+Two registration points sit outside the catalog and are easy to miss:
+
+- `api/oss/src/core/workflows/build_kit.py:36` `DEFAULT_BUILD_KIT_OPS`: the ops injected into every
+  playground agent. Everything not listed there is an author opt-in.
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts:103`
+  `PLATFORM_OPS`: a hardcoded set of op names the approval card must never offer to auto-allow. An
+  op missing from this set becomes auto-allowable from the card.
+
+Reference example end to end: `annotate_trace` (`op_catalog.py:1531`) is `POST /api/annotations/`
+with `args_into="annotation"` and
+`context_bindings={"annotation.links.invocation.trace_id": "$ctx.trace.trace_id", ...}`. The model
+can only ever annotate its own trace.
+
+## The session write path already exists
+
+The session entity is the `session_streams` row (`api/oss/src/core/sessions/streams/dtos.py:30`).
+Its `Header` (`sdks/python/agenta/sdk/models/shared.py:150`) is exactly `{name, description}`, both
+optional strings on unconstrained `String` columns. `name` is the session title, and
+`/sessions/query`'s `search` filter matches against it.
+
+`PUT` and `POST /sessions/streams/header` (`api/oss/src/apis/fastapi/sessions/router.py:513`,
+permission `EDIT_SESSIONS`) take `session_id` as a query parameter and a body that is `Header` and
+nothing else. It calls `SessionStreamsService.set_header`
+(`core/sessions/streams/service.py:641`), which updates the row or creates it if the session has
+not run yet. The DAO write (`dbs/postgres/sessions/streams/dao.py:263` via `mappings.py:80`) applies
+only fields that are not `None`, so an omitted `description` is preserved and an empty-string `name`
+clears the title. **No API or SDK work is needed for the session write.** Acceptance coverage exists
+at `api/oss/tests/pytest/acceptance/sessions/test_stream_header_basics.py` and
+`test_stream_header_roundtrip.py`.
+
+## How a run knows which session it is in
+
+The session id arrives as the top-level `sessionId` on the `/run` request. It is deliberately
+**not** in `runContext`: both the SDK docstring (`sdks/python/agenta/sdk/agents/dtos.py:520`) and
+the runner's (`services/runner/src/protocol.ts:202`) state that the runner owns the live id across
+turns and that duplicating it in run context would let it go stale.
+
+Inside the runner the live id is `env.sessionId`, set from `resolveRunSessionId(request, "")`
+(`protocol.ts:865`). It is in scope exactly where tool dispatch is wired: `startToolRelay` is called
+at `services/runner/src/engines/sandbox_agent/run-turn.ts:897` with `request.runContext` as its
+fifth argument, and `const sessionId = env.sessionId` sits on line 108 of the same file.
+
+There is precedent for a runner-visible-only run-context field: `RunContext.project.id`
+(`protocol.ts:222`) is stamped by the service from its own request state.
+
+## How a run knows which agent it is
+
+`RunContext.workflow` already carries the three workflow entities as `{id, slug, version}`
+references: `artifact`, `variant`, `revision`, plus `is_draft`
+(`services/runner/src/protocol.ts:227`, `sdks/python/agenta/sdk/agents/dtos.py:469`). The SDK fills
+them best-effort from the resolved tracing references in
+`sdks/python/agenta/sdk/agents/tracing.py:136`, normalizing `application*` and `evaluator*`
+reference families into the same workflow shape because those entities are workflow-backed.
+
+So **`$ctx.workflow.artifact.id` is the agent's own id** and it already reaches the runner. No new
+run-context field is needed for `rename_agent`. Existing ops bind `$ctx.workflow.variant.id`
+(`commit_revision`, `create_schedule`, `test_run`); the artifact reference has no consumer yet but
+is populated by the same code path.
+
+## The endpoint that renames an agent
+
+`PUT /api/workflows/{workflow_id}` (`api/oss/src/apis/fastapi/workflows/router.py:755`, registered
+at line 233, permission `EDIT_WORKFLOWS`). Body is
+`WorkflowEditRequest{workflow: WorkflowEdit}`, where `WorkflowEdit` extends `ArtifactEdit`
+(`api/oss/src/core/git/dtos.py:32`): `id`, `name`, `description`, `tags`, `meta`, `folder_id`,
+plus `flags`. The handler compares the body's `workflow.id` against the path parameter and returns
+an **empty response with `count: 0`** when they disagree, rather than an error.
+
+### Hazard 1: the direct-call dispatcher does not allow PUT
+
+`ToolCall.method` is `Literal["GET", "POST", "DELETE"]`
+(`sdks/python/agenta/sdk/agents/tools/models.py:329`), `PlatformOp.method` mirrors it
+(`op_catalog.py:167`), and the runner enforces the same allowlist in three places:
+`DIRECT_CALL_METHODS` (`services/runner/src/tools/direct.ts:33`), the `callDirect` signature
+(`direct.ts:595`), and `DirectCall.method` (`services/runner/src/protocol.ts:150`). `callDirect`
+also serializes a body only when the method is `POST` (`direct.ts:620`).
+
+The workflow edit route is registered with `methods=["PUT"]` only. **Adding `POST` to that route
+would break `POST /api/workflows/query`**: `/{workflow_id}` is registered at line 233 and `/query`
+at line 263, and FastAPI matches in registration order, so a POST to `/workflows/query` would bind
+`workflow_id="query"` and fail UUID validation with a 422.
+
+Three ways out, and the recommendation:
+
+| Option | Cost | Verdict |
+| --- | --- | --- |
+| Allow `PUT` in the direct-call allowlist | Four small edits (two SDK literals, the runner type plus the body-serialization condition) and one doc line | **Recommended.** The dispatcher stays constrained (an explicit four-method allowlist), and every future artifact-edit op works, since the platform uses PUT for all of them. |
+| Register a second POST route for the same handler, after `/query` | A duplicate URL for one operation in the public OpenAPI spec, which flows into Fern codegen and the API docs | Rejected. It hides a method restriction behind public API surface. |
+| Handler mode (`tools.agenta.rename_agent`) | A registration in `api/oss/src/core/tools/platform_handlers.py`, service wiring at the API boundary, and an elevation policy | Rejected for this feature. Handler mode exists to enforce confinement the endpoint cannot (see `commit_revision`); a closed two-field schema needs none. |
+
+### Hazard 2: an edit that omits `flags` sets them to NULL
+
+`WorkflowsService.edit_workflow` (`api/oss/src/core/workflows/service.py:938`) rebuilds an
+`ArtifactEdit` and always passes `flags=` as an explicit keyword:
+
+```python
+artifact_edit = ArtifactEdit(
+    **workflow_edit.model_dump(mode="json", exclude_none=True, exclude={"flags"}),
+    flags=self._dump_stored_flags(artifact_flags) or None,
+)
+```
+
+The DAO (`api/oss/src/dbs/postgres/git/dao.py:233`) writes a column only when its name is in
+`model_fields_set`, with the comment "prevents partial edits from wiping unrelated fields (flags,
+name, etc.)". Passing `flags=` as a keyword defeats that for `flags` alone: an edit that carries no
+flags resolves to `None` and **NULLs the column**. Wiping `is_application` removes the row from the
+agents list, whose query filters on flags.
+
+The frontend already works around this. `useRenameApp`
+(`web/oss/src/components/EntityIdentity/useRenameApp.ts`) sends `flags: {is_application: true}` on
+every rename, and `updateWorkflow` (`web/packages/agenta-entities/src/workflow/api/api.ts:1038`)
+forwards it. A tool that hard-coded the same flag would mislabel any non-application workflow it
+was mounted on, so the fix belongs in the service: pass `flags` only when the edit set it.
+
+## The client-side auto-title, and why the chat hides a server rename
+
+- **Auto-title**: `autoTitleSessionAtomFamily`
+  (`web/oss/src/components/AgentChatSlice/state/sessions.ts:609`) takes the first user message,
+  truncates it to 60 code points, writes it to local state, and persists it with `setSessionHeader`.
+  It returns early when the session already has any local title, so it fires **at most once per
+  session**. `AgentConversation.tsx:176` drives it from `firstUserText(messages)`. Decision 3 in
+  [context.md](context.md) is therefore already satisfied by the current code and needs no change.
+- **Manual rename**: `renameSessionAtomFamily` (`sessions.ts:583`) writes local state and persists
+  through the same `setSessionHeader`. So every locally set title is also on the server.
+- **The blocker**: `reconcileServerSessionsAtomFamily` (`sessions.ts:431`) folds the server list
+  over the local cache with `title: s.title?.trim() ? s.title : remote.title`. A local title always
+  wins, so an agent rename would be stored in the database and never shown in the chat.
+- **The sessions list needs no change.** `sessionRowTitle`
+  (`web/packages/agenta-sessions/src/row/sessionRowTitle.ts`) reads the server row directly, and
+  `useSessionList` (`.../state/useSessionList.ts:93`) is an infinite query with
+  `staleTime: 30_000`. A server rename appears there on the next refetch.
+
+## What the agents list reads, and what to invalidate
+
+- The agents list is `web/oss/src/components/pages/agents/store.ts`. Query key
+  `["agents-workflows", projectId, searchTerm]`, `staleTime: 30_000`,
+  `refetchOnWindowFocus: false`. It queries workflow artifacts and classifies them. The file
+  already exports `invalidateAgentsWorkflowQueries()`.
+- The playground header's agent name comes from `workflowMolecule.selectors.artifactName`
+  (`web/packages/agenta-entities/src/workflow/state/molecule.ts:460`), which reads the artifact
+  query keyed `["workflows", "artifact", workflowId, projectId]`
+  (`.../workflow/state/store.ts:1101`).
+
+So an agent rename needs two invalidations on the client: the agents list key and the artifact key
+for that id.
+
+## The live-update relay that exists, and what is missing
+
+**Publish.** `SessionsWatchPublisher` (`api/oss/src/dbs/redis/sessions/watch.py`) has three methods,
+`records_changed`, `lifecycle`, `interaction`. Each builds a payload from
+`api/oss/src/dbs/redis/sessions/contract.py:119` and PUBLISHes it on the durable Redis plane to
+`watch_channel(project_id, session_id)`, which is `watch:{project_id}:session:{session_id}`
+(`contract.py:115`). Every publish is best-effort and bounded to one second: a failure is logged and
+swallowed, because the write it announces is already committed.
+
+**Layering.** Core services never import Redis. They take a `SessionsWatchPublisherInterface`
+Protocol (`api/oss/src/core/sessions/watch/interfaces.py`) and call it through a small private
+helper (`_publish_lifecycle` at `core/sessions/streams/service.py:151`). The concrete publisher is
+constructed in the entrypoints (`api/entrypoints/routers.py:648`, `worker_streams.py:84`,
+`worker_queues.py:189`).
+
+**Transport.** `GET /sessions/streams/watch?session_id=`
+(`api/oss/src/apis/fastapi/sessions/router.py:539`, `VIEW_SESSIONS`) returns a `StreamingResponse`
+over `watch_event_stream` (`.../sessions/watch.py:60`). That generator subscribes one Redis pubsub
+connection to one channel and yields SSE frames: a `retry:` preamble, a `ready` frame once the
+subscription is live, one frame per publish, and `: heartbeat` comments while idle.
+`format_watch_frame` drops any payload whose `type` is not in the closed `_KNOWN_EVENTS` allowlist,
+so a malformed publish loses its own frame and never the connection.
+
+**The frames carry no entity data.** A frame is an event type plus the ids needed to route it, and
+the client revalidates through its normal authorized endpoints. That is the property that makes the
+relay cheap to extend: it never authorizes a payload, because there is no payload.
+
+**Consume.** Two copies of one hook: `useSessionRecordsWatch`
+(`web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts`, wired at
+`useSessionHydration.ts:272`) and `useSessionWatch` (`web/mobile/src/features/chat/useSessionWatch.ts`).
+Both own a native `EventSource` with `withCredentials`, open and close on `visibilitychange`, use a
+jittered 1s-to-30s backoff after a fatal `CLOSED` that first attempts a token refresh, revalidate on
+`ready` to cover events missed while disconnected, and enforce a minimum interval between
+revalidations.
+
+**What is missing for this feature.** The channel and the endpoint are keyed on a session id, so a
+project-level page has nothing to subscribe to. The sessions list and the agents list are exactly
+such pages. The server half of `watch_event_stream` is already generic: it takes a channel name and
+a pubsub factory and knows nothing about sessions.
+
+**What trigger creation does is not this pattern and does not generalize.** `useTriggerSchedule`
+(`web/packages/agenta-entities/src/gatewayTrigger/hooks/useTriggerSchedule.ts:24`) invalidates its
+own query key after its own mutation resolves. The list updates instantly for the tab that made the
+change and for nobody else. When an agent creates a schedule server-side through `create_schedule`,
+no trigger query is invalidated anywhere.
+
+## The one-shot benchmark
+
+`benchmarks/agent-config-editing/` measures whether a small model completes a configuration action
+one-shot, with a 95% target. It is wire-level: every trial drives `/services/agent/v0/invoke`, the
+endpoint the playground drives, and every verdict is read from a stored row, never from the reply.
+
+- `run_benchmark.py` runs cells (harness times model times sandbox) against a deployment described
+  by three environment variables.
+- Scenarios are JSON under `scenarios/`, each with `turns`, `checks`, a `seed` patch, and a
+  `budget` that defines what "one-shot" means for that scenario.
+- Checks are registered in `bench_lib.py` behind a `@check("<name>")` decorator and read
+  `ctx.stored`, which is **`parameters.agent` of the newest revision** (`bench_lib.stored_agent`).
+- `LIVE_TOOLS` (`bench_lib.py:392`) mounts exactly `read_config` and `commit_revision` and nothing
+  else, so a trial can never pass through some other route.
+- Every trial already mints its own session id (`bench_lib.py:1402`) and invokes with it.
+- Per-trial random tokens (`{{TOKEN}}`) keep a check from passing on the model's priors.
+
+Two gaps for these tools: the verdict source is the revision's `parameters.agent`, and neither the
+`session_streams` row nor the workflow artifact row is reachable from `ctx`; and `LIVE_TOOLS` mounts
+neither new op. Both are additive changes, covered in [qa.md](qa.md).

--- a/docs/design/agent-self-naming-tools/status.md
+++ b/docs/design/agent-self-naming-tools/status.md
@@ -1,17 +1,41 @@
 # Status
 
-**Phase:** plan finalized, implementation not started.
+**Phase:** implemented on `feat/agent-self-naming-tools`; live QA (V4) and a benchmark run remain.
 **Last updated:** 2026-08-10.
 
 ## Progress
 
 | Track | Steps | State |
 | --- | --- | --- |
-| Session tool | S1 to S3 | Not started |
-| Agent tool | A1 to A4 | Not started |
-| Chat title | T1 | Not started |
-| Live refresh | W1 to W3 | Not started |
-| Verification | V1 to V4 | Not started |
+| Session tool | S1 to S3 | Done. Unit-tested (runner, SDK catalog, build-kit overlay). |
+| Agent tool | A1 to A4 | Done. A2's regression tests are acceptance tests and need a live stack. |
+| Chat title | T1 | Done, with reconcile-precedence tests. |
+| Live refresh | W1 to W3 | Done. Watch endpoint/publish unit-tested; browser behavior needs live QA. |
+| Verification | V1 to V3 | Done (tests landed with their steps; benchmark scenarios + budget; docs synced). |
+| Verification | V4 | Not started — live QA runs outside this branch. |
+
+## Implementation deviations (all small, each justified)
+
+- S2+S3 landed as one commit (shared files), as the plan itself allowed for S3.
+- A1+A3 landed as one commit: the PUT-allowlist tests and the `rename_agent` tests share
+  `tool-direct.test.ts` and `test_op_catalog.py`, and the plan's own branch-layout note says a
+  shared test file lands with the highest step. A2 is committed **before** them so `rename_agent`
+  never exists in history ahead of the flags fix.
+- A2 gained a `fetch_artifact(include_archived=False)` pre-check in `edit_workflow` — the DAO edit
+  alone cannot distinguish archived from missing, and the plan requires 404 for both.
+- A2's test file (`acceptance/workflows/test_workflows_basics.py`) also corrects pre-existing test
+  data that used variant-level flag keys (`is_custom`, `is_feedback`) where artifact flags belong.
+- One stale runner test (`sandbox-agent-orchestration.test.ts`) asserted the relay gets no run
+  context when the request carries none; S1's augmentation makes that `{session: {id}}`, and the
+  assertion now pins the new shape.
+- W3's shared hook lives at `web/oss/src/hooks/useProjectWatch.ts` (app layer, not a package): only
+  `web/oss` consumes it today, matching the package-placement heuristic. `useSessionRecordsWatch`
+  was mechanically refolded onto it.
+- The project watch route is `GET /sessions/watch?project_id=...` (the sessions root router), the
+  natural reading of the plan's `GET /watch` under that router.
+- V3 also refreshed the stale `DEFAULT_BUILD_KIT_OPS` enumeration in `tools.md` (it predated
+  `test_run`/`read_config`) and synced the interface inventory (four-method allowlist, fail-closed
+  binding errors naming the tool, the runner-filled `session.id`).
 
 ## Open questions
 

--- a/docs/design/agent-self-naming-tools/status.md
+++ b/docs/design/agent-self-naming-tools/status.md
@@ -1,0 +1,79 @@
+# Status
+
+**Phase:** plan finalized, implementation not started.
+**Last updated:** 2026-08-10.
+
+## Progress
+
+| Track | Steps | State |
+| --- | --- | --- |
+| Session tool | S1 to S3 | Not started |
+| Agent tool | A1 to A4 | Not started |
+| Chat title | T1 | Not started |
+| Live refresh | W1 to W3 | Not started |
+| Verification | V1 to V4 | Not started |
+
+## Open questions
+
+None. The one question this plan carried is resolved below.
+
+### Resolved: the rename tools do not prompt for approval
+
+Both ops write, so `read_only=False`, and under the default `allow_reads` policy every call would
+raise an approval card, because the build-kit overlay emits no `permission` for any op today.
+
+**Resolution: both ship with `permission: "allow"` in the build-kit overlay.** The write is
+self-scoped (the target is bound from run context and cannot be redirected), non-destructive (the
+schema cannot produce an empty or blank name), and reversible by the user in one click from the rail
+or the playground header. A prompt on turn one, before the user has read anything the agent
+produced, is a worse interruption than any outcome it prevents. `commit_revision` prompting is right
+because it changes what the agent is; a rename changes only a label.
+
+This unblocks S3 and the benchmark scenarios, which can now assume an ungated call. The fallback
+branch documented in [plan.md](plan.md) step S3 stays there as the record of what the other answer
+would have cost, and is not the path to implement.
+
+## Known risks
+
+### A trigger-minted run may lack the write permission
+
+Automation sessions are the ones that most need a good name, and their credential is server-minted
+rather than the user's. If that credential lacks `EDIT_SESSIONS` or `EDIT_WORKFLOWS`, both tools
+fail closed on triggered runs. Decision 4 in [context.md](context.md) rules out special-casing, so
+this is a verification item, not a design question: check it with one triggered run during live QA,
+and if the scope is missing, treat it as separate work on the trigger dispatch path.
+
+### The flags fix has callers we have not enumerated
+
+Step A2 changes `edit_workflow` so an edit that omits `flags` no longer NULLs the column. The DAO's
+own comment states that this is the intended behavior, and the frontend already compensates by
+sending `flags: {is_application: true}` on every rename, so no caller should depend on the null-out.
+Confirm by grepping for `edit_workflow` and `updateWorkflow` callers before landing, and keep A4
+(removing the frontend workaround) in the same stack so the two stay consistent.
+
+### One SSE connection per open tab
+
+The project watch channel adds one Server-Sent-Events connection and one Redis pubsub connection per
+open tab, on top of the per-session one an open chat already costs. That is the same order of
+magnitude, and `api/oss/src/apis/fastapi/sessions/router.py:585` already carries the revisit note
+("revisit with a shared listener if counts grow"). No action now; do not let the project channel be
+the reason the note is finally acted on without measurement.
+
+## Decisions and their history
+
+| Date | Decision | Who |
+| --- | --- | --- |
+| 2026-08-09 | Both ops go into `DEFAULT_BUILD_KIT_OPS` rather than staying author opt-ins. The earlier research recommended opt-in; this reverses it. | Mahmoud |
+| 2026-08-09 | The agent may overwrite a human-typed session name. The client-side title-provenance idea from the earlier research is dropped; the chat reconcile lets a non-empty server name win instead. | Mahmoud |
+| 2026-08-09 | The client-side auto-title stays and fires only on the first message. Reading the code showed this already holds, so no change is needed. | Mahmoud |
+| 2026-08-09 | Trigger-minted runs get no special case; the presence of the build kit decides. | Mahmoud |
+| 2026-08-09 | `rename_agent` added as a second tool with the same shape. | Mahmoud |
+| 2026-08-09 | `rename_agent` uses endpoint mode with `PUT`, which means widening the direct-call method allowlist from three methods to four. The two alternatives (a duplicate POST route, or handler mode) were rejected; see [research.md](research.md). | Plan |
+| 2026-08-09 | The watch event is named `workflow-changed`, not `agent-changed`, because it names the platform entity that changed rather than one view of it. | Plan |
+| 2026-08-10 | Approval behavior settled: both ops carry `permission: "allow"` in the build-kit overlay. | Orchestrator, flagged to Mahmoud and unvetoed |
+| 2026-08-10 | Both `name` schemas gain a `\S` pattern. `minLength: 1` alone admits a whitespace-only name, which clears the visible title while the row still holds a value. | Plan review |
+| 2026-08-10 | `edit_workflow` raises a 404 for a missing or archived target instead of returning 200 with `count: 0`. The runner treats any 2xx as success, so the old shape reported a silent no-op as a completed rename. | Plan review |
+| 2026-08-10 | `changed` takes `project_id` explicitly, keyword-only, matching the three existing publisher methods. A Redis client alone cannot derive the project channel. | Plan review |
+| 2026-08-10 | `GET /watch` takes the standard `project_id` query parameter and requires `VIEW_SESSIONS` and `VIEW_WORKFLOWS` together. There is no generic project-view permission, and one stream carries both entity families. | Plan review |
+| 2026-08-10 | The `session-changed` handler invalidates the `["session-list", projectId]` prefix and lets the mounted `useReconcileServerSessions` hooks reconcile. `reconcileServerSessionsAtomFamily` needs a scope key and the full server array, neither of which a frame carries. | Plan review |
+| 2026-08-10 | The benchmark needs no tool-mounting plumbing (`run_benchmark.py:158` already appends a scenario's `tools`), but it does need `max_rename_calls` counted and enforced in `within_budget`, since a declared-only budget changes nothing. | Plan review |

--- a/docs/design/agent-workflows/documentation/tools.md
+++ b/docs/design/agent-workflows/documentation/tools.md
@@ -518,7 +518,7 @@ Each catalog entry (`PlatformOp`, a typed model validated at import) maps an `op
 | Field | Meaning |
 | --- | --- |
 | `description` | The model-facing description (SDK-owned). |
-| `method`, `path` | The existing endpoint to call: `GET`/`POST` and a relative `/api/...` path. Endpoint-mode ops set these; a handler-mode op sets `handler` instead (exactly one of the two targets). |
+| `method`, `path` | The existing endpoint to call: one of `GET`/`POST`/`PUT`/`DELETE` (the runner's explicit direct-call allowlist) and a relative `/api/...` path. Endpoint-mode ops set these; a handler-mode op sets `handler` instead (exactly one of the two targets). |
 | `handler` | A reserved `tools.agenta.<op>` call-ref for a server-side handler (see [server-handled ops](#server-handled-ops-handler-mode)). Mutually exclusive with `method`+`path`. |
 | `input_schema` / `input_schema_ref` | The request input schema — inline JSON Schema, or a `CATALOG_TYPES` key (expanded via `x-ag-type-ref`). Exactly one. |
 | `context_bindings` | Self-targeting fields: an endpoint body path → a `$ctx.<key>` run-context token. Stripped from the model schema; emitted as `call.context` (endpoint mode) or spec-level `contextBindings` (handler mode). |
@@ -534,10 +534,13 @@ once per project and merges it as an overlay onto any agent-typed entity; it is 
 but not embeddable/committable, and the legacy per-application `additional_context` rider
 remains one release as a fallback. It embeds an explicit default subset,
 `DEFAULT_BUILD_KIT_OPS` in `api/oss/src/core/workflows/build_kit.py`: `discover_tools`,
-`commit_revision`, `annotate_trace`, `query_spans`, `discover_triggers`, `create_schedule`,
-`create_subscription`, `list_schedules`, `list_deliveries`, `test_subscription`,
-`remove_schedule`, and `remove_subscription` (12 ops, plus the `request_connection` client
-tool and the build-an-agent playbook skill). Every other catalog op (the pause/resume
+`commit_revision`, `annotate_trace`, `query_spans`, `test_run`, `rename_session`,
+`rename_agent`, `discover_triggers`, `create_schedule`, `create_subscription`,
+`list_schedules`, `list_deliveries`, `test_subscription`, `remove_schedule`, and
+`remove_subscription` (15 ops — 16 with `read_config`, which joins the kit whenever ordered
+operations put it in the catalog — plus the `request_connection` client tool and the
+build-an-agent playbook skill). The overlay emits `permission: "allow"` for the two rename
+ops so the self-scoped, reversible label writes never raise an approval card. Every other catalog op (the pause/resume
 lifecycle, `query_workflows`, `list_connections`, `list_subscriptions`) stays a catalog
 opt-in: an author adds `{type:"platform", op}` explicitly. The rationale for the cut list
 lives in the [build-kit-tools-cleanup workspace](../projects/build-kit-tools-cleanup/research.md).
@@ -552,6 +555,8 @@ A few ops worth naming:
 | `commit_revision` | handler `tools.agenta.commit_revision` via `POST /tools/call` | mutating (approval) | "Update yourself": binds `workflow_revision.workflow_variant_id` ← `$ctx.workflow.variant.id`, so the agent can only ever commit a revision to its own variant. The handler hard-applies the agent scope policy (no writes to `harness.kind`, `harness.permissions`, `runner.permissions`, `sandbox.kind`, `sandbox.permissions`) and refuses full-data commits. Enforcement design: `docs/design/agent-config-editing/contracts/read-config.md` §11.2. |
 | `read_config` | handler `tools.agenta.read_config` via `POST /tools/call` | read (auto-allow) | Read the agent's own stored configuration, whole or a named part, so an edit can anchor on real current text. Binds the variant id and draft state from run context. In the catalog by default; setting `AGENTA_WORKFLOWS_ORDERED_OPERATIONS_ENABLED` falsy takes the deployment back to the legacy surface and removes it. Contract: `docs/design/agent-config-editing/contracts/read-config.md`. |
 | `test_run` | handler `tools.agenta.test_run` | mutating (approval) | Run the agent's own variant once and return a digest + verdict. Handler mode, flag-gated off, not in the overlay yet (see below). |
+| `rename_session` | `POST /api/sessions/streams/header?session_id={session_id}` | mutating (auto-allow via overlay) | Name and describe the session the agent is running in. The session id is bound from `$ctx.session.id` (runner-filled) and stripped from the model schema, so the agent can only rename its own session. The `name` schema requires a non-whitespace character, so the tool cannot blank a title. In the default build kit. Design: `docs/design/agent-self-naming-tools/`. |
+| `rename_agent` | `PUT /api/workflows/{workflow_id}` | mutating (auto-allow via overlay) | Name and describe the agent itself. The artifact id is bound twice from `$ctx.workflow.artifact.id` (path and body) and stripped from the model schema; the body carries only `{workflow: {name, description, id}}`, never flags. In the default build kit. Design: `docs/design/agent-self-naming-tools/`. |
 
 This mirrors the evaluators catalog pattern (`api/oss/src/resources/evaluators/evaluators.py`,
 a code-defined table of named ops). Multi-step operations (e.g. create-then-commit) are composed

--- a/docs/design/agent-workflows/interfaces/cross-service/runner-to-tool-callback.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/runner-to-tool-callback.md
@@ -82,16 +82,20 @@ A resolved callback spec can carry an optional `call` descriptor instead of a `c
 mirrored in `wire_models.py` and pinned by the golden `/run` fixtures). When present it tells the
 runner to call an Agenta endpoint **directly** — reusing the run's `toolCallback.authorization`,
 with `path` an absolute path from the Agenta origin (derived from `toolCallback.endpoint`) — rather
-than posting back through `/tools/call`. Shape: `{ method: "GET"|"POST", path, body?, context?,
-args_into? }`. A spec carries `call` XOR `call_ref`.
+than posting back through `/tools/call`. Shape: `{ method: "GET"|"POST"|"PUT"|"DELETE", path,
+body?, context?, args_into? }` (the runner's explicit method allowlist; `POST` and `PUT` carry
+the assembled JSON body). A spec carries `call` XOR `call_ref`.
 
 The runner assembles the request body (`tools/direct.ts` `assembleBody`) in three layers, later
 wins: the model's args (at `args_into`, else the root) → the static `body` → the `context`
 binding. `context` maps a body path to a `"$ctx.<dotted.path>"` token, which the runner resolves
 against the per-turn `runContext` blob on the `/run` request (`service-to-agent-runner.md`) and
 deep-sets LAST — so a self-targeting tool's own trace/variant is filled server-side and the model
-can never set or override a bound field. A token that does not resolve is skipped (the field stays
-unset); deep-set is prototype-pollution-safe.
+can never set or override a bound field. A token that does not resolve fails the call with an
+error naming the binding and the tool (fail-closed — e.g. `rename_session` outside a session);
+deep-set is prototype-pollution-safe. Before binding, the runner augments its dispatch copy of
+the blob with `session.id` (the live session id it owns), the one runner-filled key in the
+namespace — see `service-to-agent-runner.md`.
 
 **Status (direct-call tools):** wired end to end for endpoint-mode platform ops. The SDK
 platform-op resolver emits `call` (and `call.context` for self-targeting ops such as

--- a/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
+++ b/docs/design/agent-workflows/interfaces/cross-service/service-to-agent-runner.md
@@ -92,7 +92,10 @@ tool's `call.context` binding at dispatch: the runner fills the bound request fi
 server-side, hidden from the model (see `runner-to-tool-callback.md`). `workflow` mirrors the
 platform's three workflow entities — `artifact` / `variant` / `revision`, each an `{id, slug,
 version}` reference — and `is_draft` says whether the run targets a committed revision or a
-playground draft. The conversation id is NOT carried here; it rides the top-level `sessionId`. The
+playground draft. The conversation id is NOT carried here on the wire; it rides the top-level
+`sessionId`, and the runner — which owns the live id across turns — augments its internal dispatch
+copy of this blob with `session.id` so `$ctx.session.id` bindings resolve (`RunContext.session` in
+`protocol.ts` is runner-filled, never service-filled). The
 inner keys are deliberately snake_case — they are the binding namespace a `call.context` value
 (`"$ctx.<dotted.path>"`, e.g. `"$ctx.workflow.variant.id"`) addresses, not the wire's usual
 camelCase. Omitted when there is no identity to bind, so a run that needs no binding stays

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -516,9 +516,9 @@ class RunContext(BaseModel):
 
     The inner keys are deliberately snake_case (``workflow.variant.id``, ``trace.trace_id``): they
     are the binding NAMESPACE that a catalog entry's ``$ctx.<dotted.path>`` token addresses, so
-    they match those tokens exactly rather than the wire's camelCase convention. The conversation
-    id is NOT carried here — it rides the top-level ``sessionId`` field, and the runner owns the
-    live id across turns; duplicating it in run context would only let it go stale. ``to_wire``
+    they match those tokens exactly rather than the wire's camelCase convention. The service sends
+    the conversation id through the top-level ``sessionId`` field; the runner adds the live
+    ``$ctx.session.id`` token to its internal dispatch blob, never through this model. ``to_wire``
     emits only the sub-objects/fields that are set, so a run with no identity yields an empty blob
     (and the serializer omits the key entirely)."""
 

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -1432,6 +1432,32 @@ _TEST_RUN_INPUT_SCHEMA: Dict[str, Any] = {
     "required": ["target", "inputs"],
 }
 
+_RENAME_SESSION_DESCRIPTION = """Name and describe the session you are running in, so a person scanning a long list of sessions can tell what this one is. Call it once you understand what the session is about, which is usually after the first exchange. Call it again later whenever the session has moved on and the name or the recap no longer fits.
+
+`name` is the general subject: what this session is about, as a short label a person can scan in a list. A few words. Not the latest step, and not a sentence.
+
+`description` is the current state: a short recap of what has happened and what is open, one to one and a half sentences, short enough to read inside a table cell.
+
+This renames the session you are in and no other one. It works only inside a session."""
+
+_RENAME_SESSION_INPUT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120,
+            "pattern": r"\S",
+        },
+        "description": {
+            "type": "string",
+            "maxLength": 300,
+        },
+    },
+    "required": ["name"],
+}
+
 _EMPTY_INPUT_SCHEMA: Dict[str, Any] = {"type": "object", "properties": {}}
 _TRIGGER_ID_INPUT_SCHEMA: Dict[str, Any] = {
     "type": "object",
@@ -1499,6 +1525,15 @@ PLATFORM_OPS: Dict[str, PlatformOp] = {
             path="/api/spans/query",
             input_schema=_QUERY_SPANS_INPUT_SCHEMA,
             read_only=True,
+        ),
+        PlatformOp(
+            op="rename_session",
+            description=_RENAME_SESSION_DESCRIPTION,
+            method="POST",
+            path="/api/sessions/streams/header?session_id={session_id}",
+            input_schema=_RENAME_SESSION_INPUT_SCHEMA,
+            context_bindings={"session_id": "$ctx.session.id"},
+            read_only=False,
         ),
         PlatformOp(
             op="test_run",

--- a/sdks/python/agenta/sdk/agents/platform/op_catalog.py
+++ b/sdks/python/agenta/sdk/agents/platform/op_catalog.py
@@ -164,7 +164,7 @@ class PlatformOp(BaseModel):
     description: str = Field(
         min_length=1, description="Model-facing description (SDK-owned)."
     )
-    method: Optional[Literal["GET", "POST", "DELETE"]] = None
+    method: Optional[Literal["GET", "POST", "PUT", "DELETE"]] = None
     # An EXISTING Agenta endpoint, as a path relative to the API origin (e.g. ``/api/tools/discover``).
     # The runner binds the origin to the run's own Agenta and confines the path to the API mount.
     path: Optional[str] = Field(default=None, min_length=1)
@@ -1458,6 +1458,32 @@ _RENAME_SESSION_INPUT_SCHEMA: Dict[str, Any] = {
     "required": ["name"],
 }
 
+_RENAME_AGENT_DESCRIPTION = """Name and describe yourself, so a person browsing the list of agents can tell what you are for. Call it once you understand your own purpose, which is usually right after your first task. Call it again if your purpose changes.
+
+`name` is what you are for, as a short label a person can scan in a list. A few words.
+
+`description` is what you do and where you currently stand, one to one and a half sentences, short enough to read inside a table cell.
+
+This renames the agent you are running as and no other one. It changes only your name and your description, never your configuration."""
+
+_RENAME_AGENT_INPUT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120,
+            "pattern": r"\S",
+        },
+        "description": {
+            "type": "string",
+            "maxLength": 300,
+        },
+    },
+    "required": ["name"],
+}
+
 _EMPTY_INPUT_SCHEMA: Dict[str, Any] = {"type": "object", "properties": {}}
 _TRIGGER_ID_INPUT_SCHEMA: Dict[str, Any] = {
     "type": "object",
@@ -1533,6 +1559,19 @@ PLATFORM_OPS: Dict[str, PlatformOp] = {
             path="/api/sessions/streams/header?session_id={session_id}",
             input_schema=_RENAME_SESSION_INPUT_SCHEMA,
             context_bindings={"session_id": "$ctx.session.id"},
+            read_only=False,
+        ),
+        PlatformOp(
+            op="rename_agent",
+            description=_RENAME_AGENT_DESCRIPTION,
+            method="PUT",
+            path="/api/workflows/{workflow_id}",
+            input_schema=_RENAME_AGENT_INPUT_SCHEMA,
+            args_into="workflow",
+            context_bindings={
+                "workflow_id": "$ctx.workflow.artifact.id",
+                "workflow.id": "$ctx.workflow.artifact.id",
+            },
             read_only=False,
         ),
         PlatformOp(

--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -308,8 +308,8 @@ class ToolCall(BaseModel):
     instead of routing through the shared ``/tools/call`` gateway. A spec carries ``call`` (direct)
     XOR ``call_ref`` (gateway), never both.
 
-    - ``method`` is restricted to ``GET`` / ``POST`` / ``DELETE`` (the runner is a constrained dispatcher,
-      never an arbitrary HTTP client).
+    - ``method`` is restricted to ``GET`` / ``POST`` / ``PUT`` / ``DELETE`` (the runner is a
+      constrained dispatcher, never an arbitrary HTTP client).
     - ``path`` is an absolute path from the Agenta ORIGIN; the runner derives that origin from the
       run's ``toolCallback.endpoint``, so a tool can never reach a non-Agenta host.
     - ``body`` holds static, server-fixed fields baked at resolve time (e.g. a reference tool's
@@ -326,7 +326,7 @@ class ToolCall(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
-    method: Literal["GET", "POST", "DELETE"]
+    method: Literal["GET", "POST", "PUT", "DELETE"]
     path: str = Field(min_length=1)
     body: Optional[Dict[str, Any]] = None
     context: Optional[Dict[str, str]] = None

--- a/sdks/python/agenta/sdk/utils/types.py
+++ b/sdks/python/agenta/sdk/utils/types.py
@@ -1057,10 +1057,22 @@ def _model_catalog_type() -> dict:
 
 
 _DEFAULT_AGENT_MODEL = "gpt-5.6-luna"
+# The self-naming guidance is load-bearing, not flavor: with the bare default persona
+# the model reliably answers and stops — it never reaches for `rename_session` on its
+# own, while task-shaped personas do (live QA, 2026-08-10; benchmark class
+# `self_naming`, scenario name-05 pins this persona verbatim). The tool descriptions
+# alone lose to "answer the question", so the standing instruction rides here.
 _DEFAULT_AGENTS_MD = (
     "You are a friendly hello-world agent running on the Agenta agent service.\n\n"
     "- Greet the user warmly.\n"
-    "- Answer the user's message in one or two short sentences."
+    "- Answer the user's message in one or two short sentences.\n"
+    "- Once the first exchange makes clear what the session is about, call the\n"
+    "  `rename_session` tool: `name` is the session's subject in a few words, findable\n"
+    "  in a list; `description` is a one-sentence recap of where things stand. Rename\n"
+    "  again only when the topic genuinely shifts.\n"
+    "- Call the `rename_agent` tool only when your own identity or purpose changes —\n"
+    "  for example, you were just created or the user repurposes you — with a name\n"
+    "  that says what you are for."
 )
 
 # The single source of the run-selection defaults. The SDK builtin interface

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
@@ -66,6 +66,7 @@ def test_catalog_ships_platform_builder_ops():
         "query_workflows",
         "query_spans",
         "rename_session",
+        "rename_agent",
         "test_run",
         "commit_revision",
         "annotate_trace",
@@ -105,6 +106,17 @@ def test_op_requires_exactly_one_schema_source():
             input_schema={"type": "object"},
             input_schema_ref="messages",
         )
+
+
+def test_catalog_op_may_declare_put():
+    op = PlatformOp(
+        op="x",
+        description="d",
+        method="PUT",
+        path="/api/x",
+        input_schema={"type": "object"},
+    )
+    assert op.method == "PUT"
 
 
 def test_op_input_schema_ref_must_be_a_known_catalog_key():
@@ -283,6 +295,45 @@ async def test_rename_session_emits_a_bound_direct_call(connection):
 
 def test_rename_session_rejects_whitespace_only_name():
     schema = get_platform_op("rename_session").resolved_input_schema()
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"name": "   "}, schema)
+
+
+async def test_rename_agent_emits_a_bound_direct_call(connection):
+    resolution = await _resolver(connection).resolve(
+        [PlatformToolConfig(op="rename_agent")]
+    )
+    spec = resolution.tool_specs[0]
+
+    assert isinstance(spec, CallbackToolSpec)
+    assert spec.kind == "callback"
+    assert spec.name == "rename_agent"
+    assert spec.call_ref is None
+    assert isinstance(spec.call, ToolCall)
+    assert spec.call.method == "PUT"
+    assert spec.call.path == "/api/workflows/{workflow_id}"
+    assert spec.call.context == {
+        "workflow_id": "$ctx.workflow.artifact.id",
+        "workflow.id": "$ctx.workflow.artifact.id",
+    }
+    assert spec.call.args_into == "workflow"
+    assert spec.read_only is False
+
+    schema = get_platform_op("rename_agent").resolved_input_schema()
+    assert set(schema["properties"]) == {"name", "description"}
+    assert "workflow_id" not in schema["properties"]
+    assert "workflow" not in schema["properties"]
+    assert schema["required"] == ["name"]
+    assert spec.input_schema == schema
+
+    wire = spec.to_wire()
+    assert wire["call"]["path"] == spec.call.path
+    assert wire["call"]["context"] == spec.call.context
+    assert wire["call"]["args_into"] == "workflow"
+
+
+def test_rename_agent_rejects_whitespace_only_name():
+    schema = get_platform_op("rename_agent").resolved_input_schema()
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate({"name": "   "}, schema)
 

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_op_catalog.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 
+import jsonschema
 import pytest
 from pydantic import ValidationError
 
@@ -28,7 +29,12 @@ from agenta.sdk.agents.platform import (
     PlatformOp,
     get_platform_op,
 )
-from agenta.sdk.agents.tools import GatewayToolResolutionError, UnknownPlatformOpError
+from agenta.sdk.agents.tools import (
+    CallbackToolSpec,
+    GatewayToolResolutionError,
+    ToolCall,
+    UnknownPlatformOpError,
+)
 
 
 def _ordered_operations_enabled() -> bool:
@@ -59,6 +65,7 @@ def test_catalog_ships_platform_builder_ops():
         "discover_tools",
         "query_workflows",
         "query_spans",
+        "rename_session",
         "test_run",
         "commit_revision",
         "annotate_trace",
@@ -246,6 +253,38 @@ async def test_discover_tools_wire_carries_call_not_call_ref(connection):
     assert wire["kind"] == "callback"
     assert "callRef" not in wire
     assert wire["call"]["path"] == "/api/tools/discover"
+
+
+async def test_rename_session_emits_a_bound_direct_call(connection):
+    resolution = await _resolver(connection).resolve(
+        [PlatformToolConfig(op="rename_session")]
+    )
+    spec = resolution.tool_specs[0]
+
+    assert isinstance(spec, CallbackToolSpec)
+    assert spec.kind == "callback"
+    assert spec.name == "rename_session"
+    assert spec.call_ref is None
+    assert isinstance(spec.call, ToolCall)
+    assert spec.call.method == "POST"
+    assert spec.call.path == "/api/sessions/streams/header?session_id={session_id}"
+    assert spec.call.context == {"session_id": "$ctx.session.id"}
+    assert spec.read_only is False
+
+    schema = get_platform_op("rename_session").resolved_input_schema()
+    assert set(schema["properties"]) == {"name", "description"}
+    assert schema["required"] == ["name"]
+    assert spec.input_schema == schema
+
+    wire = spec.to_wire()
+    assert wire["call"]["path"] == spec.call.path
+    assert wire["call"]["context"] == {"session_id": "$ctx.session.id"}
+
+
+def test_rename_session_rejects_whitespace_only_name():
+    schema = get_platform_op("rename_session").resolved_input_schema()
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"name": "   "}, schema)
 
 
 async def test_test_run_emits_handler_call_ref_with_bindings_and_timeout_by_default(

--- a/sdks/python/oss/tests/pytest/unit/agents/test_default_persona_self_naming.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_default_persona_self_naming.py
@@ -1,0 +1,52 @@
+"""The default persona's self-naming guidance, and its benchmark mirror.
+
+Live QA (2026-08-10) showed the split this guards: agents with task-shaped personas
+call `rename_session` unprompted, while the bare product-default persona answers and
+stops — the tool description alone loses to "answer the question". The standing
+guidance therefore rides `_DEFAULT_AGENTS_MD`, and the benchmark scenario
+`name-05-default-persona-session` measures exactly that persona. This test locks the
+two together: a change to the shipped default that forgets the benchmark mirror (or
+vice versa) fails here instead of silently measuring a stale persona.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agenta.sdk.utils.types import build_agent_v0_default
+
+_SCENARIO_FILE = (
+    Path(__file__).resolve().parents[7]
+    / "benchmarks"
+    / "agent-config-editing"
+    / "scenarios"
+    / "09-self-naming.json"
+)
+
+
+def _default_agents_md() -> str:
+    return build_agent_v0_default()["instructions"]["agents_md"]
+
+
+def test_default_persona_carries_the_self_naming_guidance():
+    text = _default_agents_md()
+    assert "`rename_session`" in text
+    assert "`rename_agent`" in text
+    # The guards against churn ride along with the guidance itself.
+    assert "only when the topic genuinely shifts" in text
+    assert "only when your own identity or purpose changes" in text
+
+
+@pytest.mark.skipif(
+    not _SCENARIO_FILE.exists(),
+    reason="benchmarks/ not present in this checkout",
+)
+def test_benchmark_name_05_seeds_the_default_persona_verbatim():
+    doc = json.loads(_SCENARIO_FILE.read_text())
+    scenario = next(
+        s for s in doc["scenarios"] if s["id"] == "name-05-default-persona-session"
+    )
+    assert scenario["seed"]["instructions"]["agents_md"] == _default_agents_md()

--- a/services/oss/src/agent/config.py
+++ b/services/oss/src/agent/config.py
@@ -29,7 +29,14 @@ DEFAULT_TOOLS: List[Any] = []
 DEFAULT_AGENTS_MD = (
     "You are a friendly hello-world agent running on the Agenta agent service.\n\n"
     "- Greet the user warmly.\n"
-    "- Answer the user's message in one or two short sentences."
+    "- Answer the user's message in one or two short sentences.\n"
+    "- Once the first exchange makes clear what the session is about, call the\n"
+    "  `rename_session` tool: `name` is the session's subject in a few words, findable\n"
+    "  in a list; `description` is a one-sentence recap of where things stand. Rename\n"
+    "  again only when the topic genuinely shifts.\n"
+    "- Call the `rename_agent` tool only when your own identity or purpose changes —\n"
+    "  for example, you were just created or the user repurposes you — with a name\n"
+    "  that says what you are for."
 )
 
 

--- a/services/oss/tests/pytest/unit/agent/test_default_agent_template.py
+++ b/services/oss/tests/pytest/unit/agent/test_default_agent_template.py
@@ -40,6 +40,16 @@ def test_service_default_is_the_bare_builder():
     assert _inspect_agent_default() == build_agent_v0_default()
 
 
+def test_config_fallback_agents_md_matches_the_platform_default():
+    # `agent/config.py` keeps a fallback copy of the default persona for runs where the
+    # editable files are missing; it must not drift from the SDK's single source (the
+    # persona now carries the self-naming guidance, so a stale copy would silently
+    # reintroduce the never-renames behavior live QA caught).
+    from oss.src.agent.config import DEFAULT_AGENTS_MD  # noqa: PLC0415
+
+    assert DEFAULT_AGENTS_MD == build_agent_v0_default()["instructions"]["agents_md"]
+
+
 def test_inspect_default_parses_into_the_runtime_selection():
     # The default the playground pre-fills on `/inspect` must parse cleanly into the same runtime
     # values `AgentTemplate.from_params` produces, so what the user sees is what the agent runs.

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -106,6 +106,9 @@ export async function runTurn(
   const { plan, logger, deps } = env;
   const credential = opts.credential ?? (() => runCredential(request));
   const sessionId = env.sessionId;
+  const toolRunContext = env.sessionId
+    ? { ...request.runContext, session: { id: env.sessionId } }
+    : request.runContext;
   // Race marker for a user Stop (the control-plane `cancel`/`steer` command drops the alive lock, the
   // heartbeat aborts `signal`). Distinct from PAUSED/RUN_LIMIT_TRIPPED so the turn ends CLEANLY
   // (honest interrupted transcript, keep-warm) instead of falling through to the error catch.
@@ -903,7 +906,7 @@ export async function runTurn(
         plan.workspace.relayDir,
         plan.tools.toolSpecs,
         request.toolCallback as ToolCallbackContext | undefined,
-        request.runContext,
+        toolRunContext,
         env.clientToolRelayRef.current,
         relayGuard,
         {

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -199,8 +199,8 @@ export interface RunContextReference {
  * `workflow` mirrors the platform's three workflow entities — the `artifact` (the workflow), the
  * `variant`, and the `revision` — so the run's identity reads the same way the rest of the platform
  * names a workflow; `is_draft` says whether the run targets a committed revision (`false`) or an
- * uncommitted playground draft (`true`). The conversation id is NOT carried here — it rides the
- * top-level `sessionId` field, and the runner owns the live id across turns.
+ * uncommitted playground draft (`true`). The service does not carry the conversation id here — it
+ * rides the top-level `sessionId` field, and the runner augments its dispatch copy with the live id.
  *
  * The inner keys are deliberately snake_case (`workflow.variant.id`, `trace.trace_id`): they are
  * the binding NAMESPACE a `call.context` value (`"$ctx.<dotted.path>"`) addresses, so they match
@@ -220,6 +220,13 @@ export interface RunContext {
    * over the mount-derived project scope when keying its parked-session pool (`poolKeyFor`).
    */
   project?: {
+    id?: string;
+  };
+  /**
+   * The live session id, filled by the runner from its session environment for tool dispatch and
+   * never filled by the service's `/run` request context.
+   */
+  session?: {
     id?: string;
   };
   workflow?: {

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -147,7 +147,7 @@ export interface ResolvedToolSpec {
    * `call` XOR `callRef`. Plumbing only here: nothing emits or dispatches it yet.
    */
   call?: {
-    method: "GET" | "POST" | "DELETE";
+    method: "GET" | "POST" | "PUT" | "DELETE";
     path: string;
     body?: Record<string, unknown>;
     context?: Record<string, string>;

--- a/services/runner/src/tools/direct.ts
+++ b/services/runner/src/tools/direct.ts
@@ -225,6 +225,7 @@ export function assembleBody(
   call: DirectCall,
   params: unknown,
   runContext?: RunContext,
+  toolName?: string,
 ): Record<string, unknown> {
   // 1. Model args, at args_into (deep-set) or the root.
   let body: Record<string, unknown> = {};
@@ -248,7 +249,8 @@ export function assembleBody(
       const value = resolveCtxToken(runContext, token);
       if (value === undefined) {
         throw new Error(
-          `missing run-context value for direct-call binding '${bodyPath}'`,
+          `missing run-context value for direct-call binding '${bodyPath}'` +
+            (toolName ? ` for tool '${toolName}'` : ""),
         );
       }
       deepSet(body, bodyPath, value);

--- a/services/runner/src/tools/direct.ts
+++ b/services/runner/src/tools/direct.ts
@@ -30,7 +30,7 @@ export type DirectCall = NonNullable<ResolvedToolSpec["call"]>;
 const CTX_TOKEN_PREFIX = "$ctx.";
 
 /** Methods a direct call may use. The descriptor is untrusted, so this is an allowlist. */
-const DIRECT_CALL_METHODS = new Set(["GET", "POST", "DELETE"]);
+const DIRECT_CALL_METHODS = new Set(["GET", "POST", "PUT", "DELETE"]);
 
 /**
  * Object keys that must never be written through a dotted path or a merge: assigning to them
@@ -455,7 +455,7 @@ export function applyContextBindings(
 /**
  * Validate the descriptor and build the absolute URL to call. The `call` is untrusted input, so
  * this is the SSRF guard, and it makes NO assumption about where the Agenta API is mounted:
- *  - `method` must be on the allowlist (GET/POST/DELETE);
+ *  - `method` must be on the allowlist (GET/POST/PUT/DELETE);
  *  - `path` must be a single absolute-path reference — a string starting with exactly one `/`
  *    (no scheme, no protocol-relative `//host`, no backslashes, no whitespace/CRLF, no literal
  *    `..` traversal);
@@ -477,7 +477,7 @@ export function directCallUrl(
 ): string {
   if (!DIRECT_CALL_METHODS.has(call.method)) {
     throw new Error(
-      `direct-call method '${call.method}' is not allowed (GET/POST/DELETE only)`,
+      `direct-call method '${call.method}' is not allowed (GET/POST/PUT/DELETE only)`,
     );
   }
   const path = substitutePathParams(call.path, params);
@@ -594,7 +594,7 @@ export function agentaErrorDetail(bodyText: string): string | undefined {
  * starts emitting `call`.
  */
 export async function callDirect(
-  method: "GET" | "POST" | "DELETE",
+  method: "GET" | "POST" | "PUT" | "DELETE",
   url: string,
   authorization: string | undefined,
   body: Record<string, unknown>,
@@ -618,8 +618,11 @@ export async function callDirect(
     response = await fetch(url, {
       method,
       headers,
-      // GET and DELETE carry no body; POST sends the assembled JSON body.
-      body: method === "POST" ? JSON.stringify(body) : undefined,
+      // GET and DELETE carry no body; POST and PUT send the assembled JSON body.
+      body:
+        method === "POST" || method === "PUT"
+          ? JSON.stringify(body)
+          : undefined,
       signal: combined,
       // Do not auto-follow redirects: a 3xx to another host would defeat the origin lock in
       // directCallUrl (SSRF-via-redirect). A 3xx surfaces here as a non-ok response and fails

--- a/services/runner/src/tools/relay.ts
+++ b/services/runner/src/tools/relay.ts
@@ -464,7 +464,7 @@ async function executeAllowedRelayedTool(
   // `callRef`, so this is checked before the gateway fallback. `runContext` fills the
   // `call.context` bindings server-side (direct-call tools, Phase 3a), hidden from the model.
   if (spec.call) {
-    const body = assembleBody(spec.call, dispatchArgs, runContext);
+    const body = assembleBody(spec.call, dispatchArgs, runContext, spec.name);
     const url = directCallUrl(callback.endpoint, spec.call, body);
     // Path params were just substituted into the URL from this same body; strip them so a
     // POST handler whose request model expects the identifier only in the route (e.g.

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -1731,8 +1731,10 @@ describe("runSandboxAgent orchestration", () => {
       [{ name: "server_tool", kind: "callback" }],
       undefined,
     ]);
-    // The relay carries execution only (no permissions argument): no runContext here.
-    assert.equal(calls.toolRelayArgs?.[4], undefined);
+    // The relay carries execution only (no permissions argument). The request sent no
+    // runContext, but the runner augments its dispatch copy with the live session id so
+    // $ctx.session.id bindings resolve (RunContext.session is runner-filled).
+    assert.deepEqual(calls.toolRelayArgs?.[4], { session: { id: "session-1" } });
     // Trailing arg is the relay callbacks object (client-tool + park handlers).
     assert.deepEqual(
       Object.keys((calls.toolRelayArgs?.[5] ?? {}) as object).sort(),

--- a/services/runner/tests/unit/tool-direct.test.ts
+++ b/services/runner/tests/unit/tool-direct.test.ts
@@ -51,6 +51,7 @@ import type { ResolvedToolSpec, RunContext } from "../../src/protocol.ts";
 // A fake run context (direct-call tools, Phase 3a). The keys are the snake_case binding namespace
 // a `call.context` value (`"$ctx.<dotted.path>"`) addresses.
 const RUN_CONTEXT: RunContext = {
+  session: { id: "session-self" },
   workflow: {
     variant: { id: "own-variant" },
     revision: { id: "rev_self" },
@@ -184,6 +185,43 @@ describe("assembleBody", () => {
 // ---------------------------------------------------------------------------
 
 describe("assembleBody context binding", () => {
+  it("binds the runner-augmented $ctx.session.id", () => {
+    const call: DirectCall = {
+      method: "POST",
+      path: "/api/sessions/streams/header?session_id={session_id}",
+      context: { session_id: "$ctx.session.id" },
+    };
+    const body = assembleBody(
+      call,
+      { name: "Agent naming" },
+      RUN_CONTEXT,
+      "rename_session",
+    );
+    assert.deepEqual(body, {
+      name: "Agent naming",
+      session_id: "session-self",
+    });
+  });
+
+  it("names the tool when its session binding is missing", () => {
+    const call: DirectCall = {
+      method: "POST",
+      path: "/api/sessions/streams/header?session_id={session_id}",
+      context: { session_id: "$ctx.session.id" },
+    };
+    const { session: _session, ...runContextWithoutSession } = RUN_CONTEXT;
+    assert.throws(
+      () =>
+        assembleBody(
+          call,
+          { name: "Agent naming" },
+          runContextWithoutSession,
+          "rename_session",
+        ),
+      /missing run-context value for direct-call binding 'session_id' for tool 'rename_session'/,
+    );
+  });
+
   it("binds a $ctx value from the run context, deep-set at the mapped path", () => {
     const call: DirectCall = {
       method: "POST",
@@ -413,6 +451,46 @@ describe("directCallUrl", () => {
     assert.equal(
       url,
       "https://agenta.example/api/tools/catalog/integrations?search=github",
+    );
+  });
+
+  it("substitutes rename_session's bound id without weakening URL confinement", () => {
+    const call: DirectCall = {
+      method: "POST",
+      path: "/api/sessions/streams/header?session_id={session_id}",
+    };
+    const url = directCallUrl(ENDPOINT, call, {
+      session_id: "session/1?next=https://evil.example",
+    });
+    assert.equal(
+      url,
+      "https://agenta.example/api/sessions/streams/header?session_id=session%2F1%3Fnext%3Dhttps%3A%2F%2Fevil.example",
+    );
+    assert.equal(new URL(url).origin, "https://agenta.example");
+    assert.equal(new URL(url).pathname, "/api/sessions/streams/header");
+
+    for (const unsafePath of [
+      "https://evil.example/api/sessions/streams/header?session_id={session_id}",
+      "//evil.example/api/sessions/streams/header?session_id={session_id}",
+    ]) {
+      assert.throws(
+        () =>
+          directCallUrl(
+            ENDPOINT,
+            { ...call, path: unsafePath },
+            { session_id: "self" },
+          ),
+        /must be an absolute path starting with a single '\/'/,
+      );
+    }
+    assert.throws(
+      () =>
+        directCallUrl(
+          ENDPOINT,
+          { ...call, path: "/admin?session_id={session_id}" },
+          { session_id: "self" },
+        ),
+      /is outside the Agenta API mount '\/api'/,
     );
   });
 
@@ -655,6 +733,31 @@ describe("startToolRelay direct branch (host makes the call for the sandbox)", (
       workflow_variant_id: "own-variant", // bound to the run's own variant, not the model's
       parameters: { temperature: 0.2 },
     });
+  });
+
+  it("passes the tool name through a missing direct-call context error", async () => {
+    const selfSpec: ResolvedToolSpec = {
+      name: "rename_session",
+      kind: "callback",
+      call: {
+        method: "POST",
+        path: "/api/sessions/streams/header?session_id={session_id}",
+        context: { session_id: "$ctx.session.id" },
+      },
+    };
+    const { session: _session, ...runContextWithoutSession } = RUN_CONTEXT;
+    const res = await relayOnce(
+      selfSpec,
+      { endpoint: ENDPOINT, authorization: "ApiKey secret" },
+      { name: "Agent naming" },
+      runContextWithoutSession,
+    );
+
+    assert.equal(res.ok, false);
+    assert.match(
+      res.error ?? "",
+      /missing run-context value for direct-call binding 'session_id' for tool 'rename_session'/,
+    );
   });
 
   it("strips substituted path params out of the POST body", async () => {

--- a/services/runner/tests/unit/tool-direct.test.ts
+++ b/services/runner/tests/unit/tool-direct.test.ts
@@ -53,6 +53,7 @@ import type { ResolvedToolSpec, RunContext } from "../../src/protocol.ts";
 const RUN_CONTEXT: RunContext = {
   session: { id: "session-self" },
   workflow: {
+    artifact: { id: "agent-self" },
     variant: { id: "own-variant" },
     revision: { id: "rev_self" },
     is_draft: false,
@@ -533,10 +534,10 @@ describe("directCallUrl", () => {
     );
   });
 
-  it("rejects a disallowed method", () => {
+  it("rejects a method outside the four-item allowlist", () => {
     assert.throws(
       () => directCallUrl(ENDPOINT, { method: "PATCH" as any, path: "/api/x" }),
-      /method 'PATCH' is not allowed/,
+      /GET\/POST\/PUT\/DELETE only/,
     );
   });
 
@@ -758,6 +759,44 @@ describe("startToolRelay direct branch (host makes the call for the sandbox)", (
       res.error ?? "",
       /missing run-context value for direct-call binding 'session_id' for tool 'rename_session'/,
     );
+  });
+
+  it("dispatches rename_agent with a PUT JSON body and bound URL", async () => {
+    const calls = stubFetch("renamed");
+    const renameAgentSpec: ResolvedToolSpec = {
+      name: "rename_agent",
+      kind: "callback",
+      call: {
+        method: "PUT",
+        path: "/api/workflows/{workflow_id}",
+        args_into: "workflow",
+        context: {
+          workflow_id: "$ctx.workflow.artifact.id",
+          "workflow.id": "$ctx.workflow.artifact.id",
+        },
+      },
+    };
+    const res = await relayOnce(
+      renameAgentSpec,
+      { endpoint: ENDPOINT, authorization: "ApiKey secret" },
+      {
+        name: "Support triage",
+        description: "Routes and summarizes incoming support requests.",
+      },
+      RUN_CONTEXT,
+    );
+
+    assert.equal(res.ok, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].init.method, "PUT");
+    assert.equal(calls[0].url, "https://agenta.example/api/workflows/agent-self");
+    assert.deepEqual(JSON.parse(calls[0].init.body as string), {
+      workflow: {
+        name: "Support triage",
+        description: "Routes and summarizes incoming support requests.",
+        id: "agent-self",
+      },
+    });
   });
 
   it("strips substituted path params out of the POST body", async () => {

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
@@ -1,19 +1,5 @@
-import {useEffect, useRef} from "react"
-
-import Session from "supertokens-auth-react/recipe/session"
-
+import {useWatchEventSource} from "@/oss/hooks/useProjectWatch"
 import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
-
-/** Fatal-close backoff (EventSource does NOT auto-retry from CLOSED): exponential from 1s to
- * a 30s ceiling, jittered 50–100% so a fleet of tabs doesn't reconnect in lockstep. */
-const RETRY_BASE_MS = 1_000
-const RETRY_MAX_MS = 30_000
-const retryDelayMs = (attempt: number): number =>
-    Math.round(Math.min(RETRY_BASE_MS * 2 ** attempt, RETRY_MAX_MS) * (0.5 + Math.random() / 2))
-
-/** Minimum spacing between two revalidations, so a streaming turn's record batches can't fan out
- * into one full record-log refetch per event. */
-const MIN_INTERVAL_MS = 3_000
 
 /** Watch endpoint URL — same-origin `/api` + cookie auth, consumed via native EventSource. */
 const sessionWatchUrl = (sessionId: string, projectId: string): string =>
@@ -22,20 +8,10 @@ const sessionWatchUrl = (sessionId: string, projectId: string): string =>
     )}&project_id=${encodeURIComponent(projectId)}`
 
 /**
- * Live records relay (M3) for the desktop chat: one EventSource per ACTIVE conversation, so a turn
- * that advances anywhere else (an approval answered on mobile, a run on another device) converges
- * here within seconds instead of only on reload.
+ * Live records relay for the active desktop conversation.
  *
- * Events carry no payload — `records-changed` (and every `open`, for missed-event coverage) just
- * calls back into the caller's existing revalidate + guarded-adopt path. Foreground-only: the
- * source closes on `visibilitychange → hidden` and reopens on visible. Transient errors ride
- * EventSource's built-in reconnect (the server pins its delay with an SSE `retry:` preamble); a
- * fatal CLOSED reopens on a jittered backoff, after first attempting a session refresh — the usual
- * fatal cause is a 401 at the access-token refresh boundary, and a stream has no interceptor to
- * refresh-and-retry the way axios does. The reload/open revalidation stays the fallback either way.
- *
- * Mirrors `web/mobile/src/features/chat/useSessionWatch.ts` (same endpoint, same contract) minus
- * the mobile-only badge invalidations.
+ * The shared watch lifecycle keeps the foreground-only connection, bounded jittered retries,
+ * token refresh on fatal close, ready revalidation, and throttled trailing refresh.
  */
 export const useSessionRecordsWatch = ({
     sessionId,
@@ -45,101 +21,16 @@ export const useSessionRecordsWatch = ({
 }: {
     sessionId: string
     projectId?: string | null
-    /** Only the visible/active conversation subscribes — inactive tabs stay mounted in antd Tabs. */
     enabled: boolean
     onRecordsChanged: () => void
 }): void => {
-    const onRecordsChangedRef = useRef(onRecordsChanged)
-    onRecordsChangedRef.current = onRecordsChanged
-
-    useEffect(() => {
-        if (!enabled || !sessionId || !projectId) return
-        if (typeof window === "undefined" || typeof window.EventSource === "undefined") return
-
-        let source: EventSource | null = null
-        let retryHandle: number | undefined
-        let disposed = false
-        let lastNotifiedAt = 0
-        let trailingHandle: number | undefined
-        let attempt = 0
-
-        // Leading edge plus a TRAILING one. Dropping everything inside the window loses the
-        // batch that arrives last, and on a resumed turn that is the `done` batch which settles
-        // the approval — a parked session has no `runningElsewhere` poll to correct it, so the
-        // transcript would stay stale until the user reloads. One trailing call is enough
-        // however many notifications land in the window: the refresh refetches everything.
-        const notify = () => {
-            const now = Date.now()
-            const elapsed = now - lastNotifiedAt
-            if (elapsed >= MIN_INTERVAL_MS) {
-                lastNotifiedAt = now
-                onRecordsChangedRef.current()
-                return
-            }
-            if (trailingHandle !== undefined) return
-            trailingHandle = window.setTimeout(() => {
-                trailingHandle = undefined
-                lastNotifiedAt = Date.now()
-                onRecordsChangedRef.current()
-            }, MIN_INTERVAL_MS - elapsed)
-        }
-
-        const close = () => {
-            source?.close()
-            source = null
-        }
-
-        const scheduleRetry = () => {
-            if (disposed || retryHandle !== undefined) return
-            const delay = retryDelayMs(attempt)
-            attempt += 1
-            retryHandle = window.setTimeout(() => {
-                retryHandle = undefined
-                // Refresh first or every attempt 401s again; reopen either way, since a
-                // network failure is not a reason to stop watching.
-                void Session.attemptRefreshingSession()
-                    .catch(() => false)
-                    .finally(open)
-            }, delay)
-        }
-
-        const open = () => {
-            if (disposed || source !== null || document.visibilityState !== "visible") return
-            const es = new EventSource(sessionWatchUrl(sessionId, projectId), {
-                withCredentials: true,
-            })
-            source = es
-            es.onopen = () => {
-                attempt = 0
-            }
-            // One revalidation per (re)connect covers events missed while disconnected — the
-            // server has no replay/cursor semantics. Keyed on `ready` rather than `onopen`:
-            // headers arrive before the server's Redis subscription is live, so a change
-            // landing in that window would miss both this refetch and the stream.
-            es.addEventListener("ready", notify)
-            es.addEventListener("records-changed", notify)
-            es.onerror = () => {
-                // CONNECTING = built-in auto-reconnect; only a fatal CLOSED needs us.
-                if (es.readyState === EventSource.CLOSED) {
-                    close()
-                    scheduleRetry()
-                }
-            }
-        }
-
-        const onVisibility = () => {
-            if (document.visibilityState === "visible") open()
-            else close()
-        }
-
-        document.addEventListener("visibilitychange", onVisibility)
-        open()
-        return () => {
-            disposed = true
-            document.removeEventListener("visibilitychange", onVisibility)
-            if (retryHandle !== undefined) window.clearTimeout(retryHandle)
-            if (trailingHandle !== undefined) window.clearTimeout(trailingHandle)
-            close()
-        }
-    }, [sessionId, projectId, enabled])
+    const url = sessionId && projectId ? sessionWatchUrl(sessionId, projectId) : null
+    useWatchEventSource({
+        url,
+        enabled,
+        on: {
+            ready: onRecordsChanged,
+            "records-changed": onRecordsChanged,
+        },
+    })
 }

--- a/web/oss/src/components/AgentChatSlice/state/sessions.pageTitle.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.pageTitle.test.ts
@@ -4,7 +4,9 @@ import {describe, expect, it} from "vitest"
 import {
     activeSessionTitleAtomFamily,
     adoptSessionAtomFamily,
+    reconcileServerSessionsAtomFamily,
     renameSessionAtomFamily,
+    sessionHistoryAtomFamily,
     setActiveSessionAtomFamily,
 } from "./sessions"
 
@@ -23,5 +25,45 @@ describe("activeSessionTitleAtomFamily", () => {
 
         store.set(renameSessionAtomFamily(scope), {id: "one", title: "Renamed"})
         expect(store.get(activeSessionTitleAtomFamily(scope)).title).toBe("Renamed")
+    })
+})
+
+describe("reconcileServerSessionsAtomFamily title precedence", () => {
+    const titleOf = (store: ReturnType<typeof createStore>, scope: string, id: string) =>
+        store.get(sessionHistoryAtomFamily(scope)).find((s) => s.id === id)?.title
+
+    it("lets a non-empty server name replace a local one", () => {
+        const scope = `reconcile-server-wins-${Date.now()}`
+        const store = createStore()
+
+        store.set(adoptSessionAtomFamily(scope), {id: "one", title: "Local title"})
+        store.set(reconcileServerSessionsAtomFamily(scope), [
+            {id: "one", title: "Agent-chosen title"},
+        ])
+
+        expect(titleOf(store, scope, "one")).toBe("Agent-chosen title")
+    })
+
+    it("keeps the local name when the server one is empty or blank", () => {
+        const scope = `reconcile-local-kept-${Date.now()}`
+        const store = createStore()
+
+        store.set(adoptSessionAtomFamily(scope), {id: "one", title: "Local title"})
+        store.set(reconcileServerSessionsAtomFamily(scope), [{id: "one", title: "   "}])
+        expect(titleOf(store, scope, "one")).toBe("Local title")
+
+        store.set(reconcileServerSessionsAtomFamily(scope), [{id: "one"}])
+        expect(titleOf(store, scope, "one")).toBe("Local title")
+    })
+
+    it("adopts the server name for a session absent locally", () => {
+        const scope = `reconcile-adopt-${Date.now()}`
+        const store = createStore()
+
+        store.set(reconcileServerSessionsAtomFamily(scope), [
+            {id: "new-one", title: "Server-only title"},
+        ])
+
+        expect(titleOf(store, scope, "new-one")).toBe("Server-only title")
     })
 })

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -420,7 +420,9 @@ export interface ServerSessionSummary {
 /**
  * Fold the server's durable session list for a scope over the localStorage cache:
  *  - adopt sessions the server knows and we don't (cross-device / post-localStorage-wipe),
- *  - enrich `title`/`createdAt` from the server (a local user title always wins),
+ *  - enrich `title`/`createdAt` from the server (a non-empty server title wins: every local
+ *    title is also persisted server-side, and a server-side rename — e.g. the agent's own
+ *    `rename_session` tool — must show without a reload),
  *  - drop a session the server DROPPED — present-before, gone-now = hard-deleted elsewhere —
  *    but never a purely-local optimistic session (one the server never confirmed).
  * Open tabs / active stay per-device. Idempotent: a no-op when already reconciled.
@@ -442,7 +444,7 @@ export const reconcileServerSessionsAtomFamily = atomFamily((key: string) =>
                 merged.push({
                     ...s,
                     serverKnown: true,
-                    title: s.title?.trim() ? s.title : remote.title,
+                    title: remote.title?.trim() ? remote.title : s.title,
                     createdAt: s.createdAt ?? remote.createdAt,
                     // Keep the freshest activity time: a local turn just settled may lead the
                     // server heartbeat, and vice-versa across devices.

--- a/web/oss/src/components/EntityIdentity/useRenameApp.ts
+++ b/web/oss/src/components/EntityIdentity/useRenameApp.ts
@@ -50,7 +50,6 @@ export const useRenameApp = () => {
                     id,
                     name,
                     description,
-                    flags: {is_application: true},
                 })
                 invalidateWorkflowsListCache()
                 invalidateWorkflowCache(id)

--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -32,6 +32,7 @@ import {useStyles} from "./assets/styles"
 import AuthUpgradeHost from "./AuthUpgradeHost"
 import ErrorFallback from "./ErrorFallback"
 import PostHogThemeCapture from "./PostHogThemeCapture"
+import ProjectWatch from "./ProjectWatch"
 import {SidebarIsland} from "./SidebarIsland"
 import {useAppTheme} from "./ThemeContextProvider"
 
@@ -423,6 +424,7 @@ const App: React.FC<LayoutProps> = ({children}) => {
                 </Layout>
             ) : (
                 <ProtectedRoute shell="app">
+                    <ProjectWatch />
                     <AppWithVariants
                         isAppRoute={isAppRoute}
                         classes={classes}

--- a/web/oss/src/components/Layout/ProjectWatch.test.tsx
+++ b/web/oss/src/components/Layout/ProjectWatch.test.tsx
@@ -1,0 +1,162 @@
+import {act} from "react"
+
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+const mocks = vi.hoisted(() => ({
+    invalidateAgentsWorkflowQueries: vi.fn(() => Promise.resolve()),
+    invalidateQueries: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock("@agenta/shared/api", () => ({
+    queryClient: {invalidateQueries: mocks.invalidateQueries},
+}))
+
+vi.mock("@/oss/components/pages/agents/store", () => ({
+    invalidateAgentsWorkflowQueries: mocks.invalidateAgentsWorkflowQueries,
+}))
+
+vi.mock("@/oss/lib/helpers/api", () => ({
+    getAgentaApiUrl: () => "/api",
+}))
+
+vi.mock("@/oss/state/project", () => ({
+    projectIdAtom: {},
+}))
+
+vi.mock("jotai", () => ({
+    useAtomValue: () => "project-1",
+}))
+
+vi.mock("supertokens-auth-react/recipe/session", () => ({
+    default: {attemptRefreshingSession: vi.fn(() => Promise.resolve(true))},
+}))
+
+const sources: FakeEventSource[] = []
+
+class FakeEventSource {
+    static readonly CLOSED = 2
+
+    readonly url: string
+    readonly withCredentials: boolean
+    readyState = 1
+    onopen: ((event: Event) => void) | null = null
+    onerror: ((event: Event) => void) | null = null
+    private listeners = new Map<string, Set<(event: MessageEvent<string>) => void>>()
+
+    constructor(url: string | URL, options?: EventSourceInit) {
+        this.url = String(url)
+        this.withCredentials = options?.withCredentials ?? false
+        sources.push(this)
+    }
+
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null) {
+        if (typeof listener !== "function") return
+        const listeners = this.listeners.get(type) ?? new Set()
+        listeners.add(listener as (event: MessageEvent<string>) => void)
+        this.listeners.set(type, listeners)
+    }
+
+    close() {
+        this.readyState = FakeEventSource.CLOSED
+    }
+
+    emit(type: string, data = "{}") {
+        const event = new MessageEvent<string>(type, {data})
+        for (const listener of this.listeners.get(type) ?? []) listener(event)
+    }
+}
+
+const originalEventSource = globalThis.EventSource
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+const mountProjectWatch = async () => {
+    const {default: ProjectWatch} = await import("./ProjectWatch")
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    await act(async () => {
+        root?.render(<ProjectWatch />)
+    })
+    return sources.at(-1)
+}
+
+beforeEach(() => {
+    ;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+    globalThis.EventSource = FakeEventSource as unknown as typeof EventSource
+    sources.length = 0
+    mocks.invalidateAgentsWorkflowQueries.mockClear()
+    mocks.invalidateQueries.mockClear()
+})
+
+afterEach(async () => {
+    await act(async () => {
+        root?.unmount()
+    })
+    root = null
+    container?.remove()
+    container = null
+    globalThis.EventSource = originalEventSource
+})
+
+describe("ProjectWatch", () => {
+    it("maps session changes to the project session-list prefix", async () => {
+        const source = await mountProjectWatch()
+
+        expect(source?.url).toBe("/api/sessions/watch?project_id=project-1")
+        expect(source?.withCredentials).toBe(true)
+
+        act(() => {
+            source?.emit(
+                "session-changed",
+                JSON.stringify({type: "session-changed", entity: "session", id: "session-1"}),
+            )
+        })
+
+        expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: ["session-list", "project-1"],
+            exact: false,
+        })
+        expect(mocks.invalidateAgentsWorkflowQueries).not.toHaveBeenCalled()
+    })
+
+    it("maps workflow changes to the agents list and workflow artifact", async () => {
+        const source = await mountProjectWatch()
+
+        act(() => {
+            source?.emit(
+                "workflow-changed",
+                JSON.stringify({
+                    type: "workflow-changed",
+                    entity: "workflow",
+                    id: "workflow-1",
+                }),
+            )
+        })
+
+        expect(mocks.invalidateAgentsWorkflowQueries).toHaveBeenCalledOnce()
+        expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: ["workflows", "artifact", "workflow-1"],
+            exact: false,
+        })
+    })
+
+    it("revalidates both list families when the stream is ready", async () => {
+        const source = await mountProjectWatch()
+
+        act(() => {
+            source?.emit("ready")
+        })
+
+        expect(mocks.invalidateAgentsWorkflowQueries).toHaveBeenCalledOnce()
+        expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: ["session-list", "project-1"],
+            exact: false,
+        })
+        expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: ["workflows", "artifact"],
+            exact: false,
+        })
+    })
+})

--- a/web/oss/src/components/Layout/ProjectWatch.tsx
+++ b/web/oss/src/components/Layout/ProjectWatch.tsx
@@ -1,0 +1,63 @@
+import {useCallback, useMemo} from "react"
+
+import {queryClient} from "@agenta/shared/api"
+import {useAtomValue} from "jotai"
+
+import {invalidateAgentsWorkflowQueries} from "@/oss/components/pages/agents/store"
+import {useProjectWatch, type ProjectWatchHandlers} from "@/oss/hooks/useProjectWatch"
+import {projectIdAtom} from "@/oss/state/project"
+
+const workflowIdFromEvent = (event: MessageEvent<string>): string | null => {
+    try {
+        const payload: unknown = JSON.parse(event.data)
+        if (!payload || typeof payload !== "object" || !("id" in payload)) return null
+        return typeof payload.id === "string" ? payload.id : null
+    } catch {
+        return null
+    }
+}
+
+const ProjectWatch = () => {
+    const projectId = useAtomValue(projectIdAtom)
+
+    const invalidateSessions = useCallback(() => {
+        if (!projectId) return
+        void queryClient.invalidateQueries({
+            queryKey: ["session-list", projectId],
+            exact: false,
+        })
+    }, [projectId])
+
+    const invalidateWorkflow = useCallback((event: MessageEvent<string>) => {
+        void invalidateAgentsWorkflowQueries()
+        const workflowId = workflowIdFromEvent(event)
+        if (!workflowId) return
+        void queryClient.invalidateQueries({
+            queryKey: ["workflows", "artifact", workflowId],
+            exact: false,
+        })
+    }, [])
+
+    const revalidateProjectLists = useCallback(() => {
+        invalidateSessions()
+        void invalidateAgentsWorkflowQueries()
+        void queryClient.invalidateQueries({
+            queryKey: ["workflows", "artifact"],
+            exact: false,
+        })
+    }, [invalidateSessions])
+
+    const handlers = useMemo(
+        (): ProjectWatchHandlers => ({
+            ready: revalidateProjectLists,
+            "session-changed": invalidateSessions,
+            "workflow-changed": invalidateWorkflow,
+        }),
+        [invalidateSessions, invalidateWorkflow, revalidateProjectLists],
+    )
+
+    useProjectWatch({on: handlers})
+    return null
+}
+
+export default ProjectWatch

--- a/web/oss/src/hooks/useProjectWatch.ts
+++ b/web/oss/src/hooks/useProjectWatch.ts
@@ -1,0 +1,131 @@
+import {useEffect, useRef} from "react"
+
+import {useAtomValue} from "jotai"
+import Session from "supertokens-auth-react/recipe/session"
+
+import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
+import {projectIdAtom} from "@/oss/state/project"
+
+const RETRY_BASE_MS = 1_000
+const RETRY_MAX_MS = 30_000
+const MIN_INTERVAL_MS = 3_000
+
+const retryDelayMs = (attempt: number): number =>
+    Math.round(Math.min(RETRY_BASE_MS * 2 ** attempt, RETRY_MAX_MS) * (0.5 + Math.random() / 2))
+
+export type WatchEventHandler = (event: MessageEvent<string>) => void
+export type WatchEventHandlers = Record<string, WatchEventHandler>
+
+export const useWatchEventSource = ({
+    url,
+    enabled = true,
+    on,
+}: {
+    url: string | null
+    enabled?: boolean
+    on: WatchEventHandlers
+}): void => {
+    const onRef = useRef(on)
+    onRef.current = on
+    const eventNamesKey = Object.keys(on).sort().join("|")
+
+    useEffect(() => {
+        if (!enabled || !url) return
+        if (typeof window === "undefined" || typeof window.EventSource === "undefined") return
+
+        const eventNames = eventNamesKey ? eventNamesKey.split("|") : []
+        let source: EventSource | null = null
+        let retryHandle: number | undefined
+        let trailingHandle: number | undefined
+        let disposed = false
+        let lastNotifiedAt: number | null = null
+        let attempt = 0
+        const pendingEvents = new Map<string, MessageEvent<string>>()
+
+        const flushPending = () => {
+            const pending = [...pendingEvents.entries()]
+            pendingEvents.clear()
+            for (const [eventName, event] of pending) {
+                onRef.current[eventName]?.(event)
+            }
+        }
+
+        const notify = (eventName: string, event: MessageEvent<string>) => {
+            pendingEvents.set(eventName, event)
+            const now = Date.now()
+            const elapsed = lastNotifiedAt === null ? MIN_INTERVAL_MS : now - lastNotifiedAt
+            if (elapsed >= MIN_INTERVAL_MS) {
+                if (trailingHandle !== undefined) window.clearTimeout(trailingHandle)
+                trailingHandle = undefined
+                lastNotifiedAt = now
+                flushPending()
+                return
+            }
+            if (trailingHandle !== undefined) return
+            trailingHandle = window.setTimeout(() => {
+                trailingHandle = undefined
+                lastNotifiedAt = Date.now()
+                flushPending()
+            }, MIN_INTERVAL_MS - elapsed)
+        }
+
+        const close = () => {
+            source?.close()
+            source = null
+        }
+
+        const open = () => {
+            if (disposed || source !== null || document.visibilityState !== "visible") return
+            const eventSource = new EventSource(url, {withCredentials: true})
+            source = eventSource
+            eventSource.onopen = () => {
+                attempt = 0
+            }
+            for (const eventName of eventNames) {
+                eventSource.addEventListener(eventName, (event) => {
+                    notify(eventName, event as MessageEvent<string>)
+                })
+            }
+            eventSource.onerror = () => {
+                if (eventSource.readyState !== EventSource.CLOSED) return
+                close()
+                if (disposed || retryHandle !== undefined) return
+                const delay = retryDelayMs(attempt)
+                attempt += 1
+                retryHandle = window.setTimeout(() => {
+                    retryHandle = undefined
+                    void Session.attemptRefreshingSession()
+                        .catch(() => false)
+                        .finally(open)
+                }, delay)
+            }
+        }
+
+        const onVisibility = () => {
+            if (document.visibilityState === "visible") open()
+            else close()
+        }
+
+        document.addEventListener("visibilitychange", onVisibility)
+        open()
+        return () => {
+            disposed = true
+            document.removeEventListener("visibilitychange", onVisibility)
+            if (retryHandle !== undefined) window.clearTimeout(retryHandle)
+            if (trailingHandle !== undefined) window.clearTimeout(trailingHandle)
+            close()
+        }
+    }, [enabled, eventNamesKey, url])
+}
+
+export type ProjectWatchEvent = "ready" | "session-changed" | "workflow-changed"
+export type ProjectWatchHandlers = Record<ProjectWatchEvent, WatchEventHandler>
+
+export const useProjectWatch = ({on}: {on: ProjectWatchHandlers}): void => {
+    const projectId = useAtomValue(projectIdAtom)
+    const url = projectId
+        ? `${getAgentaApiUrl()}/sessions/watch?project_id=${encodeURIComponent(projectId)}`
+        : null
+
+    useWatchEventSource({url, on})
+}


### PR DESCRIPTION
## Context

Sessions in the chat rail keep whatever truncated auto-title the client cut from the first message, and a new agent stays "Untitled agent" until a human renames it. The agent itself is the one participant that actually knows what a session is about, but it had no way to say so.

## Changes

Two platform tools that every build-kit agent now carries, auto-allowed so no approval card interrupts the conversation:

- `rename_session` sets the current session's name (what the session is about, findable in a list) and description (a one-sentence state recap). The session id is bound server-side from the run context; the model only passes name and description.
- `rename_agent` renames the agent itself over `PUT /api/workflows/{id}`, with the artifact id bound server-side.

What had to change underneath, layer by layer:

- The runner now carries the live session id in the tool-dispatch run context, so `rename_session` can bind it.
- `PUT` joins the direct-call method allowlist (was GET/POST/DELETE), with the body serialized like POST.
- Two prerequisite backend fixes: `edit_workflow` no longer nulls flags the caller omitted, and a missing or archived target now returns 404 instead of a success with `count: 0` (a deleted agent can no longer be "renamed" successfully).
- Names update live without a reload: a new project-scoped watch channel publishes `session-changed` / `workflow-changed` beside the committed writes, streamed to the browser over `GET /api/sessions/watch?project_id=` (SSE). One `ProjectWatch` mount in the layout invalidates the session list and workflow queries on each event, and a non-empty server-set name wins over the client's auto-title in the rail.
- Server-side validation: whitespace-only names return 422 on both endpoints. The empty string stays accepted on sessions because the chat rail sends `name: ""` as the explicit clear-title action; workflows reject empty and whitespace-only alike.

### Making the model actually use it

Live QA showed the plumbing is not the hard part: task-oriented agent personas call the tools reliably, but the bare default persona a brand-new agent ships with never did (0/3 organic trials). The tool description alone does not drive behavior. The fix is three tight bullets in the default agent persona (the exact surface the failing population gets, drift-locked between the SDK and the services fallback by unit tests): name the session after the first exchange, rename only on a genuine topic shift, rename the agent only when its identity or purpose changes.

Measured by the new `self_naming` benchmark class (5 scenarios, 3 trials each, with enforced rename-call budgets):

| Scenario | Result |
|---|---|
| name-05 default persona names its first session | 3/3 one-shot (was 0/3 before the persona change) |
| name-04 no spurious rename on a trivial request | 3/3 one-shot, zero rename calls (guard holds) |
| name-01 session named after a task | 3/3 eventual (renames first, then over-explores past the one-shot budget) |
| name-02 re-rename on a topic shift | 2/3 eventual, 1 miss |
| name-03 agent names itself on its first task | 2/3 eventual, 1 miss |

The two scenarios that define the product experience (05 and 04) pass fully. The residual misses are a general explore-before-acting habit, now permanently measured for future tuning.

### Also in this branch

- The shared watch SSE stream releases on server shutdown. Before, an infinite stream held uvicorn's graceful reload forever, so any file edit on a dev stack killed the API until a hard container restart.
- The QA harness `api_call()` merges a path-embedded query string into params instead of letting httpx silently drop it (this bug corrupted half of the first benchmark run).

The full design workspace (research, API design, plan, QA notes) rides in this branch under `docs/design/agent-self-naming-tools/`.

## Tests

- Runner 2143/2143, SDK 2022, API sessions+workflows+applications 905 passed, web 143/143, CI-pinned ruff and prettier clean.
- Acceptance against the live stack: workflow basics 9/9, plus the whitespace/clear-title cases on both endpoints.
- Benchmark run above; raw results committed under `benchmarks/agent-config-editing`.

## What to QA

- Create a fresh agent, send one substantive first message. The session renames itself in the rail during the turn, with no reload and no approval card.
- Open a second session on the same agent about a different topic. It gets its own name; the first session's name stays.
- Rename a session yourself in the rail. Your name sticks (the agent may later overwrite it only on a real topic shift).
- Regression: on a dev stack, edit any API file while a chat tab is open. The API reloads and comes back on its own instead of hanging until a container restart.

<details>
<summary>Full live-QA report (mechanism, scope, model behavior, permissions)</summary>

Live QA against `agenta-ee-dev-rel112`, driving both the UI and the wire API directly.

**Tool mechanism, verified solid.** Both endpoints persist correctly to Postgres (verified by direct row reads). Both ops are correctly auto-allowed: no approval frame ever appears in the SSE stream, on organic or explicit calls. `GET /api/sessions/watch` delivers real `session-changed` / `workflow-changed` events on every rename, and the sessions and agents lists live-update without a reload. Whitespace validation verified in all four cases plus a sanity check that normal renames still work.

**Overlay scope, confirmed.** A normal Chat-tab session on an already-created agent carries the full build-kit overlay including both rename ops with `permission: "allow"`, byte-identical in shape to the onboarding composer's request. Every regular chat session gets the tools.

**Trigger credentials, not a gap.** Trigger-minted tokens carry the creating user's full RBAC role; `EDIT_SESSIONS` / `EDIT_WORKFLOWS` gate both endpoints identically for trigger and interactive auth. The build-kit `permission: "allow"` only skips the client-side approval UI, never server-side RBAC.

**Model behavior.** Organic trials with the literal default hello-world persona: 0/3 spontaneous renames before the persona change; the benchmark's task-oriented personas: 6/6 across both tools; explicit-instruction control: 1/1. After the persona change: the table above.

Found and fixed along the way: the server-side whitespace validation gap, a misleading `AmbiguousConnectionError` on an empty vault ([#5902](https://github.com/Agenta-AI/agenta/pull/5902)), the uvicorn reload wedge, and the harness query-drop bug.

</details>
