### PR TITLE
fix(runner): tell the model its rendered-skills path so it stops guessing

### DIFF
--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -31,6 +31,7 @@
  * span. stdout is reserved for the JSON result (see cli.ts); logs go to stderr.
  */
 import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 
 import { apiBase } from "../../apiBase.ts";
 
@@ -771,6 +772,13 @@ export async function acquireEnvironment(
       isPi: plan.isPi,
       agentMountedPath: environment.agentMountedPath,
       agentMountSkipped: !!agentMountSkipped,
+      // Mirrors prepareWorkspace's materialization split: Pi reads an immutable
+      // `agents/skills/<digest>` snapshot; other harnesses read `.{acpAgent}/skills/<name>`.
+      skillsPath: plan.workspace.skillDirs.length
+        ? plan.isPi
+          ? join(plan.workspace.cwd, "agents", "skills")
+          : join(plan.workspace.cwd, `.${plan.acpAgent}`, "skills")
+        : undefined,
       toolNames: plan.tools.toolSpecs.map((spec) => spec.name),
     });
     const guidedPlan = guidance
@@ -921,9 +929,8 @@ export async function acquireEnvironment(
                 : undefined,
           ])
         : undefined;
-    const claudeAppendixMeta: ClaudeSystemPromptMeta | undefined = claudeAppendix
-      ? claudeSystemPromptMeta(claudeAppendix)
-      : undefined;
+    const claudeAppendixMeta: ClaudeSystemPromptMeta | undefined =
+      claudeAppendix ? claudeSystemPromptMeta(claudeAppendix) : undefined;
     // Claude-only: request visible ("summarized") extended-thinking display so the model's
     // reasoning reaches the runner (and the playground). Without it, recent Claude models
     // return signature-only thinking and no reasoning surfaces. See `claude-thinking.ts`.

--- a/services/runner/src/engines/sandbox_agent/platform-guidance.ts
+++ b/services/runner/src/engines/sandbox_agent/platform-guidance.ts
@@ -65,6 +65,26 @@ export function skillLocationAppendix(): SystemPromptAppendix {
 }
 
 /**
+ * The READ side of the skills folder: its real absolute path.
+ *
+ * THE OBSERVED FAILURE (live session 2026-08-10): asked about its own skills, a model emitted a
+ * fully-formed absolute path from pattern memory as its FIRST move — structurally wrong (one id
+ * segment where the mount has two) — got ENOENT, and only then listed its real cwd to find the
+ * true path, a self-correction that cost a failed call and an approval interruption. Nothing
+ * told it where the rendered skills live; the mount paragraph covers only `agent-files/`.
+ */
+export function skillsReadPathAppendix(
+  skillsPath: string,
+): SystemPromptAppendix {
+  return {
+    id: "skills-read-path",
+    text:
+      `Your rendered skill files live at \`${skillsPath}\` (one folder per skill, each with ` +
+      "its SKILL.md). To read a skill, list that directory; never construct the path from memory.",
+  };
+}
+
+/**
  * The tool that changes a configuration. BOTH config sentences name it, so both apply only to a
  * run that HAS it.
  *
@@ -163,6 +183,8 @@ export interface PlatformGuidanceInput {
   readonly isPi: boolean;
   /** The resolved absolute mount path, when the durable agent folder is live. */
   readonly agentMountedPath: string | undefined;
+  /** The absolute rendered-skills directory, when this run materialized any skills. */
+  readonly skillsPath?: string | undefined;
   /** True when a durable agent folder was ATTEMPTED for this run and refused. */
   readonly agentMountSkipped: boolean;
   /** The names of the tools this run offers the model. */
@@ -217,6 +239,11 @@ export function platformGuidanceAppendix(
   const hasCommitTool = input.toolNames.includes(CONFIG_COMMIT_TOOL);
   const instructions = hasCommitTool ? instructionsSourceAppendix() : undefined;
   const skills = hasCommitTool ? skillLocationAppendix() : undefined;
+  // Gated only on materialized skills, not on the commit tool: the read path is true for any
+  // run that has skills, and stating it prevents the guessed-absolute-path failure above.
+  const skillsReadPath = input.skillsPath
+    ? skillsReadPathAppendix(input.skillsPath)
+    : undefined;
   const mount = mountGuidanceServedElsewhere(input)
     ? undefined
     : input.agentMountedPath
@@ -231,5 +258,11 @@ export function platformGuidanceAppendix(
     hasCommitTool && input.acpAgent === "codex"
       ? codexBundledSkillsAppendix()
       : undefined;
-  return composeSystemPromptAppendix([instructions, skills, codexSkills, mount]);
+  return composeSystemPromptAppendix([
+    instructions,
+    skills,
+    skillsReadPath,
+    codexSkills,
+    mount,
+  ]);
 }

--- a/services/runner/tests/unit/platform-guidance.test.ts
+++ b/services/runner/tests/unit/platform-guidance.test.ts
@@ -53,6 +53,18 @@ describe("what every harness is told", () => {
     }
   });
 
+  it("states the rendered-skills read path when skills are materialized, and stays silent otherwise", () => {
+    // The fix for an observed failure: with no stated path, a model guessed a structurally-wrong
+    // absolute skills path from memory as its first move (ENOENT + an approval interruption).
+    const withSkills = platformGuidanceAppendix(
+      run({ skillsPath: "/tmp/agenta/mounts/p/s/agents/skills" }),
+    );
+    assert.ok(withSkills?.includes("/tmp/agenta/mounts/p/s/agents/skills"));
+    assert.ok(withSkills?.includes("never construct the path from memory"));
+    const withoutSkills = platformGuidanceAppendix(run({}));
+    assert.ok(!withoutSkills?.includes("rendered skill files"));
+  });
+
   it("names the configuration path and denies the working-directory copy", () => {
     // Both halves are load-bearing. Naming the real place without denying the wrong one leaves the
     // model with two plausible targets, which is the state it was already in when it failed.
@@ -70,9 +82,7 @@ describe("what every harness is told", () => {
     // DELIBERATE EDIT: this asserted the SKILL sentence opened the block. The instructions
     // sentence now leads (see the ordering comment on `platformGuidanceAppendix`), so the property
     // worth keeping is that a config sentence comes first and the mount paragraph comes last.
-    const guidance = platformGuidanceAppendix(
-      run({ agentMountedPath: MOUNT }),
-    );
+    const guidance = platformGuidanceAppendix(run({ agentMountedPath: MOUNT }));
     assert.ok(guidance?.startsWith(instructionsSourceAppendix().text));
     assert.ok(guidance?.endsWith(agentMountGuidance(MOUNT)));
   });
@@ -114,9 +124,7 @@ describe("the mount paragraph is delivered exactly once", () => {
     // The three-state arm, matching Claude's. Silence here is not neutral: the conversation's
     // history may show an earlier session that read files from the folder, and only a statement in
     // this turn can stop the model reporting the user's saved work as lost.
-    const guidance = platformGuidanceAppendix(
-      run({ agentMountSkipped: true }),
-    );
+    const guidance = platformGuidanceAppendix(run({ agentMountSkipped: true }));
     assert.ok(guidance?.includes(agentMountUnavailableGuidance()));
   });
 
@@ -203,7 +211,11 @@ describe("the skill sentence follows the TOOL, not the flag", () => {
     // tool it does not have. The block is guidance about this environment, so naming a
     // capability the run lacks is the confusion it exists to remove.
     const guidance = platformGuidanceAppendix(run({ toolNames: [] }));
-    assert.equal(guidance, undefined, "and with nothing else to say, the block is silent");
+    assert.equal(
+      guidance,
+      undefined,
+      "and with nothing else to say, the block is silent",
+    );
   });
 
   it("is present for a run that offers it, alongside unrelated tools", async () => {
@@ -232,8 +244,13 @@ describe("the skill sentence follows the TOOL, not the flag", () => {
     // send the whole list), so gating on the flag would delete correct guidance from the
     // release-default configuration. Presence also catches what a flag check cannot: a flag-ON
     // agent that simply has no config tools.
-    assert.ok(platformGuidanceAppendix(run({ toolNames: ["commit_revision"] })));
-    assert.equal(platformGuidanceAppendix(run({ toolNames: ["read_config"] })), undefined);
+    assert.ok(
+      platformGuidanceAppendix(run({ toolNames: ["commit_revision"] })),
+    );
+    assert.equal(
+      platformGuidanceAppendix(run({ toolNames: ["read_config"] })),
+      undefined,
+    );
   });
 });
 
@@ -246,7 +263,11 @@ describe("the instructions-location sentence", () => {
     const text = instructionsSourceAppendix().text;
     assert.ok(text.includes("`parameters.agent.instructions.agents_md`"));
     assert.match(text, /is a copy of your configuration/, "names it a copy");
-    assert.match(text, /does NOT change your instructions/, "closes the WRITE direction");
+    assert.match(
+      text,
+      /does NOT change your instructions/,
+      "closes the WRITE direction",
+    );
     assert.match(text, /may not appear here/, "closes the READ direction");
     assert.equal(instructionsSourceAppendix().id, "instructions-source");
   });
@@ -275,7 +296,10 @@ describe("the instructions-location sentence", () => {
     // It says "This file" rather than naming CLAUDE.md or AGENTS.md, because the block is rendered
     // INSIDE the file it describes. A per-harness path would be one more thing to keep in sync and
     // one more thing to get wrong.
-    assert.match(instructionsSourceAppendix().text, /^This file is a copy of your configuration/);
+    assert.match(
+      instructionsSourceAppendix().text,
+      /^This file is a copy of your configuration/,
+    );
     for (const name of ["CLAUDE.md", "AGENTS.md"]) {
       assert.ok(!instructionsSourceAppendix().text.includes(name));
     }
@@ -285,7 +309,9 @@ describe("the instructions-location sentence", () => {
     // The ordering decision, pinned so it cannot drift silently: by measured failure rate the
     // instructions mistake dominates, and the sentence describes the document being read, so it
     // belongs at the top of that document. Swapping this is a deliberate experiment, not a tidy-up.
-    const guidance = platformGuidanceAppendix(run({ toolNames: ["commit_revision"] }));
+    const guidance = platformGuidanceAppendix(
+      run({ toolNames: ["commit_revision"] }),
+    );
     assert.ok(guidance);
     const iAt = guidance.indexOf(instructionsSourceAppendix().text);
     const sAt = guidance.indexOf(skillLocationAppendix().text);
@@ -295,12 +321,18 @@ describe("the instructions-location sentence", () => {
 
   it("rides the SAME tool gate as the skill sentence, in both arms", () => {
     // One gate for both, so they can never disagree about whether this run can commit.
-    const withTool = platformGuidanceAppendix(run({ toolNames: ["commit_revision"] }));
+    const withTool = platformGuidanceAppendix(
+      run({ toolNames: ["commit_revision"] }),
+    );
     assert.ok(withTool?.includes("agents_md"));
     assert.ok(withTool?.includes("parameters.agent.skills"));
 
     const withoutTool = platformGuidanceAppendix(run({ toolNames: ["bash"] }));
-    assert.equal(withoutTool, undefined, "neither sentence applies without the tool");
+    assert.equal(
+      withoutTool,
+      undefined,
+      "neither sentence applies without the tool",
+    );
   });
 
   it("still yields the mount paragraph alone when there is no config tool", () => {
@@ -330,7 +362,10 @@ describe("the codex bundled-skills rebuttal", () => {
     ]) {
       const g = platformGuidanceAppendix(other);
       assert.ok(g, other.acpAgent);
-      assert.ok(!g.includes("skill-installer"), `${other.acpAgent} must not see it`);
+      assert.ok(
+        !g.includes("skill-installer"),
+        `${other.acpAgent} must not see it`,
+      );
     }
   });
 


### PR DESCRIPTION
## Context

In a live session ([debugged today](https://github.com/Agenta-AI/agenta/pull/5903)), an agent asked about its own skills emitted a fully-formed absolute skills path from pattern memory as its very first tool call. The guess was structurally wrong (one id segment where the real mount path has two), so the read failed with ENOENT; the model then self-corrected by listing its actual working directory, which cost a failed call plus an approval interruption before it found the skill exactly where it had been correctly materialized all along.

The gap: the platform guidance names the durable `agent-files/` folder with its real absolute path, but nothing states where the rendered skills live, so the model is left to infer that path and sometimes guesses.

## Changes

A new `skills-read-path` appendix in the platform guidance states the harness-correct absolute skills directory and says to list it rather than construct paths from memory. The path mirrors `prepareWorkspace`'s materialization split: Pi reads the immutable `agents/skills/<digest>` snapshot; other harnesses read `.{acpAgent}/skills/<name>`. The appendix only appears when the run actually materialized skills.

## Tests

- New unit case in `platform-guidance.test.ts`: the path appears when skills are materialized and is absent otherwise. File passes; full runner suite 2117 passed; `tsc --noEmit` clean.
- The dev runner picks this up via tsx watch. NOT yet verified in a live run; the What to QA step below is the live check.

## What to QA

- Create an agent with a skill attached, ask it something that makes it consult the skill. Its first read should hit the real path directly, with no ENOENT retry loop in the transcript.