### PR TITLE
[fix] Round 2: fix agent-chat playground navigation, app-overview app pollution, use-api selectors

### DIFF
--- a/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
+++ b/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
@@ -39,6 +39,9 @@ test(
     "an uploaded attachment renders after send and after reload",
     {tag: tags},
     async ({page, seedAgentChatApp, navigateToAgentPlayground}) => {
+        // API seeding + 2 navigations + file upload + SSE-mocked run + reload is heavier
+        // than the 60s default (siblings that do less than this already bump to 120s+, #5695).
+        test.setTimeout(120000)
         await expectAuthenticatedSession(page)
         const appId = await seedAgentChatApp()
         await navigateToAgentPlayground(appId)
@@ -85,12 +88,15 @@ test(
 
         const runRequest = await runRequestPromise
         expect(runRequest.postData() ?? "").not.toContain("data:")
-        await expect(page.getByText(IMAGE_NAME, {exact: true}).last()).toBeVisible()
+        // FileCard (@ant-design/x) renders an image attachment as just an <img>, with the
+        // filename only in `alt` — there is no separate visible text caption for images
+        // (unlike the file/audio/video card types, which do render a name label).
+        await expect(page.getByAltText(IMAGE_NAME).last()).toBeVisible()
         await expect.poll(() => contentReads).toBeGreaterThanOrEqual(1)
 
         await page.reload({waitUntil: "domcontentloaded"})
 
-        await expect(page.getByText(IMAGE_NAME, {exact: true}).last()).toBeVisible()
+        await expect(page.getByAltText(IMAGE_NAME).last()).toBeVisible()
         await expect.poll(() => contentReads).toBeGreaterThanOrEqual(2)
     },
 )

--- a/web/oss/tests/playwright/acceptance/agent-chat/tests.ts
+++ b/web/oss/tests/playwright/acceptance/agent-chat/tests.ts
@@ -130,24 +130,48 @@ const testWithAgentChatFixtures = baseTest.extend<AgentChatFixtures>({
 
     navigateToAgentPlayground: async ({page, uiHelpers}, use) => {
         await use(async (appId: string) => {
-            const scopedPrefix =
-                new URL(page.url() || "http://localhost").pathname.match(
-                    /^(\/w\/[^/]+\/p\/[^/]+)/,
-                )?.[1] ?? ""
-            const playgroundUrl = `${scopedPrefix}/apps/${appId}/playground`
-            const revisionId = seededRevisionByApp.get(appId)
+            const scopedPrefixFrom = (url: string) =>
+                new URL(url || "http://localhost").pathname.match(/^(\/w\/[^/]+\/p\/[^/]+)/)?.[1] ??
+                ""
 
-            await page.goto(scopedPrefix ? `${scopedPrefix}/apps` : "/apps", {
+            // seedAgentChatApp() only makes API calls, so on a fresh test page.url() is
+            // still "about:blank" here — scopedPrefix would be permanently empty if read
+            // now. Navigate to the unscoped /apps first (the server resolves it to the
+            // workspace/project-scoped URL), THEN read the prefix from the page's new,
+            // resolved URL. Reading it before this goto sent every later navigation
+            // (playground included) to an unscoped path, which the app doesn't route to
+            // the seeded app — it falls through to the bare onboarding playground instead.
+            const initialScopedPrefix = scopedPrefixFrom(page.url())
+            await page.goto(initialScopedPrefix ? `${initialScopedPrefix}/apps` : "/apps", {
                 waitUntil: "domcontentloaded",
             })
             await uiHelpers.expectPath("/apps")
+
+            const scopedPrefix = scopedPrefixFrom(page.url())
+            const playgroundUrl = `${scopedPrefix}/apps/${appId}/playground`
+            const revisionId = seededRevisionByApp.get(appId)
             const target = revisionId ? `${playgroundUrl}?revisions=${revisionId}` : playgroundUrl
             await page.goto(target, {waitUntil: "domcontentloaded"})
             await uiHelpers.expectPath(`/apps/${appId}/playground`)
 
             // The agent chat panel is interactive once the composer textbox is mounted.
             // (First-run: confirm this selector against the live RichChatInput composer.)
-            await expect(page.getByRole("textbox").last()).toBeVisible({timeout: 30000})
+            const composer = page.getByRole("textbox").last()
+            // A revision committed moments earlier via direct API calls can race the
+            // playground's entity resolution (read-your-writes lag against the
+            // just-created revision), landing on MainLayout's "Playground is unable to
+            // communicate with the service" error state instead of the composer. That
+            // panel's own "Try again" button has no onClick (dead), so recover with a
+            // real reload instead, which re-runs entity resolution from scratch.
+            const errorState = page.getByText(
+                "Playground is unable to communicate with the service",
+            )
+            await expect(composer.or(errorState).first()).toBeVisible({timeout: 30000})
+            for (let attempt = 0; attempt < 3 && !(await composer.isVisible()); attempt += 1) {
+                await page.reload({waitUntil: "domcontentloaded"})
+                await expect(composer.or(errorState).first()).toBeVisible({timeout: 20000})
+            }
+            await expect(composer).toBeVisible({timeout: 30000})
         })
     },
 

--- a/web/oss/tests/playwright/acceptance/app/app-management.ts
+++ b/web/oss/tests/playwright/acceptance/app/app-management.ts
@@ -152,8 +152,15 @@ const tests = () => {
                 await expectAuthenticatedSession(page)
             })
 
-            await scenarios.and("at least one prompt app exists in the project", async () => {
-                const app = await apiHelpers.getApp()
+            await scenarios.and("a fresh completion app exists in the project", async () => {
+                // createApp(), not getApp(): the workflow list has no field that tells a
+                // completion app from an agent app (both carry the same
+                // {is_application, is_evaluator, is_snippet} flags), so getApp()'s loose
+                // "completion" matcher can pick up an agent app seeded by another test in
+                // the same shared ephemeral project (e.g. agent-chat). An agent app has no
+                // "Deployment" section, so this test hung waiting for a heading that would
+                // never render. Always minting a fresh app sidesteps the ambiguity.
+                const app = await apiHelpers.createApp("completion")
                 appId = app.id
             })
 

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -117,6 +117,11 @@ const deployFirstVariantToDevelopment = async (
  * wait for the page (and its Jotai atoms) to be ready.
  */
 const openVariantUseApiDrawer = async (page: any) => {
+    // The Use API button is NOT disabled while no revision is selected (it captures
+    // selectedRevisionId at click time), so wait for the registry's auto-selection to
+    // settle (an antd row checkbox turns checked) before clicking — clicking early
+    // opens the drawer with an undefined revision and empty snippets.
+    await expect(page.locator(".ant-checkbox-checked").first()).toBeVisible({timeout: 15000})
     const useApiButton = page.locator('[data-tour="api-code-button"]')
     await expect(useApiButton).toBeVisible({timeout: 15000})
     await expect(useApiButton).toBeEnabled({timeout: 5000})

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -111,16 +111,21 @@ const deployFirstVariantToDevelopment = async (
  * Opens the "How to use API" drawer from the Variants tab.
  * Uses the data-tour attribute so we target exactly this button even if other
  * "Use API" buttons exist elsewhere in the page.
- * Waits for networkidle first so Jotai atoms are settled before the click.
+ * Not `waitForLoadState("networkidle")`: the layout keeps a live SSE connection
+ * open (ProjectWatch), so the network never goes idle and this would hang for
+ * the full test timeout. The button visibility/enabled checks below already
+ * wait for the page (and its Jotai atoms) to be ready.
  */
 const openVariantUseApiDrawer = async (page: any) => {
-    await page.waitForLoadState("networkidle")
     const useApiButton = page.locator('[data-tour="api-code-button"]')
     await expect(useApiButton).toBeVisible({timeout: 15000})
     await expect(useApiButton).toBeEnabled({timeout: 5000})
     await useApiButton.click()
 
-    const drawer = page.locator(".ant-drawer-content-wrapper").filter({
+    // The drawer renders through EnhancedDrawer, a facade over the @agenta/ui
+    // (Radix) Sheet, so the panel is `[data-slot="sheet-content"]`, not an antd
+    // `.ant-drawer-content-wrapper`.
+    const drawer = page.locator('[data-slot="sheet-content"]').filter({
         hasText: "How to use API",
     })
     await expect(drawer).toBeVisible({timeout: 20000})
@@ -130,17 +135,18 @@ const openVariantUseApiDrawer = async (page: any) => {
 /**
  * Opens the "How to use API" drawer from the Deployments tab.
  * Uses the generic primary "Use API" button (no data-tour on the deployments one).
- * Waits for networkidle first — DeploymentsDashboard is a dynamic() import whose
- * onClick setter may not be wired yet if clicked too early.
+ * Not `waitForLoadState("networkidle")` — see openVariantUseApiDrawer above. The
+ * button visibility/enabled checks below wait out the DeploymentsDashboard
+ * dynamic() import instead.
  */
 const openDeploymentUseApiDrawer = async (page: any) => {
-    await page.waitForLoadState("networkidle")
     const useApiButton = page.getByRole("button", {name: "Use API"}).first()
     await expect(useApiButton).toBeVisible({timeout: 15000})
     await expect(useApiButton).toBeEnabled({timeout: 5000})
     await useApiButton.click()
 
-    const drawer = page.locator(".ant-drawer-content-wrapper").filter({
+    // Same Radix Sheet facade as openVariantUseApiDrawer above.
+    const drawer = page.locator('[data-slot="sheet-content"]').filter({
         hasText: "How to use API",
     })
     await expect(drawer).toBeVisible({timeout: 20000})
@@ -192,7 +198,7 @@ const useApiTests = () => {
 
             await scenarios.when("the user opens the Use API drawer", async () => {
                 // data-tour="api-code-button" uniquely identifies the variants-tab "Use API"
-                // button. networkidle ensures Jotai atoms are settled before the click.
+                // button.
                 useApiDrawer = await openVariantUseApiDrawer(page)
             })
 


### PR DESCRIPTION
## Context

Round 2 of the 0.112.0 acceptance gate cleanup, following #5900/#5901. The gate re-ran with those fixes: 43 passed, 4 flaky-recovered, 4 failed. Two of the four were the follow-up already flagged in #5900 (`use-api`'s same stale selector / hanging wait). The other two needed fresh diagnosis: the app-overview test still failed after its round-1 fix, and agent-chat was still unreproducible locally until this round found the actual bug. All four are fixed here and verified live against the dev stack (`144.76.237.122:8180`).

## Changes

**`use-api` drawer tests.** Same two issues as #5900, on a file that wasn't in scope for round 1: `.ant-drawer-content-wrapper` never matches (the drawer is `[data-slot="sheet-content"]`, an `@agenta/ui` Sheet), and `waitForLoadState("networkidle")` hangs forever because the layout keeps a live SSE connection open (`ProjectWatch`). Both fixed the same way as the round-1 overview test.

**App overview test — the real root cause.** #5900 removed the hanging `networkidle` wait, but CI kept failing at the same spot ("waiting for getByRole('heading', {name: 'Deployment'})", 120s × 3). The test called `apiHelpers.getApp()`, whose "completion" matcher only excludes `is_chat`/`is_custom`/`is_evaluator` — but the `/workflows/query` list API returns **no field that distinguishes a completion app from an agent app**; both carry identical `{is_application, is_evaluator, is_snippet}` flags. In CI's single shared ephemeral project (one project for all 80 tests), `agent-chat`'s test runs immediately before this one and leaves behind an agent app. `getApp()` picked that up instead of creating a real completion app. An agent app renders `AgentOverview`, not `DeploymentOverview` — no "Deployment" heading ever appears, hence the deterministic 120s hang.

Fix: `apiHelpers.createApp("completion")` instead of `getApp()` — always mints a fresh app, sidestepping the classification ambiguity. Verified by reproducing the exact CI scenario: seed an agent app via `agent-chat`'s fixture in one ephemeral project, then run this test right after in the same project. Failed before the fix, passed after.

**Agent-chat: the actual bug behind "unreproducible locally."** Round 1 replayed the seed+navigate flow live and it worked, so I couldn't reproduce the CI failure and left the test alone (documented in #5900). This round's gate log gave the missing piece: the CI navigation chain shows `/w?revisions=...` → workspace → `/apps` → a **bare** `/playground` (missing `/apps/<id>`). Root cause:

```js
// before
const scopedPrefix = new URL(page.url() || "http://localhost").pathname
    .match(/^(\/w\/[^/]+\/p\/[^/]+)/)?.[1] ?? ""
```

`seedAgentChatApp()` only makes API calls (no navigation), so on a fresh test `page.url()` is still `"about:blank"` when this line runs — `scopedPrefix` is permanently `""`. Both the first `goto("/apps")` and, critically, the **second** `goto` (to the actual playground) use this same stale empty prefix, so the playground navigation targets an unscoped `/apps/<id>/playground` — a URL the app doesn't route to the seeded app; it falls through to the bare onboarding playground ("What do you want to build?"), which has no composer, hanging `expectPath` for the full timeout.

Fix: recompute `scopedPrefix` from `page.url()` again *after* the first navigation resolves it to the real workspace/project-scoped URL.

That got the test past navigation, but exposed a second, real issue: a revision committed moments earlier via direct API calls can race the playground's entity resolution, landing on `MainLayout`'s "Playground is unable to communicate with the service" error state instead of the composer (3/3 reproduction rate in fresh browser contexts). That panel's own "Try again" button has **no `onClick` handler** (`web/oss/src/components/Playground/Components/MainLayout/index.tsx:318` — `<Button>Try again</Button>`, literally does nothing), so I added a real `page.reload()` retry in the test instead, which re-runs entity resolution from scratch. 3/3 clean after that.

Finally, the test's own assertions were stale: `FileCard` (`@ant-design/x`) renders an image attachment as a bare `<img>` with the filename only in `alt`, not as visible text (only file/audio/video card types get a name caption). `getByText(IMAGE_NAME)` never matched post-send; switched to `getByAltText`, matching the pre-send assertion on the same page that already used it correctly. Also bumped the timeout to 120s (siblings doing less already use 120s+, per #5695) since this flow is API seed + 2 navigations + upload + SSE-mocked run + reload.

## Live verification summary

| Test | Result |
|---|---|
| `use-api`: variant TypeScript snippet | Passed live (13.7s) |
| `use-api`: deployment TypeScript snippet | Passed live (9.2s) |
| App overview (fresh, isolated) | Passed live (14.8s) |
| App overview (reproducing CI: agent-chat seeds an agent app first, same ephemeral project) | Failed before fix (confirmed root cause), passed after (18.8s / 9.1s across repeats) |
| Agent-chat attach/send/render/reload (isolated) | Reproduced the exact CI redirect chain before the fix; passed 3/3 after (9.4–12.1s each) |
| Agent-chat + app-overview together (CI order, shared ephemeral project) | Passed 2/2 clean runs; one run hit a transient full-navigation hang unrelated to any of these changes (health check was 200 immediately before and after — looked like shared-stack load, not a code issue), self-recovered on immediate retry |

## Notes for reviewers

- The dead "Try again" button (`MainLayout/index.tsx:318`) is a separate, minor product bug (button exists but does nothing) — not fixed here since I have no way to verify a product-code change against this dev stack without deploying to it, which I was asked not to do. Flagging for a follow-up.
- Verified read-only against `144.76.237.122:8180` throughout; made no product-code changes, no stack deploys/restarts. One accidental cross-navigation into another agent's live session during manual diagnosis (read-only, no clicks) — caught and backed out immediately.
