### PR TITLE
fix(frontend): playground error-state Try again button actually retries

### DIFF
--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -315,7 +315,7 @@ const PlaygroundMainView = ({
                     <Typography.Text className="mb-3 text-[14px]">
                         Playground is unable to communicate with the service
                     </Typography.Text>
-                    <Button>Try again</Button>
+                    <Button onClick={() => window.location.reload()}>Try again</Button>
                 </div>
             </main>
         )


### PR DESCRIPTION
## Context

The playground's "Something went wrong / Playground is unable to communicate with the service" error state renders a Try again button with no click handler. It does nothing, and a user who hits the error state (reproducible 3/3 when a just-committed revision races the playground's entity resolution, per the diagnosis in [#5905](https://github.com/Agenta-AI/agenta/pull/5905)) is stuck.

## Changes

One line: the button reloads the page, which is what recovery requires in that state (the racing revision resolves on a fresh load).

## Tests

Prettier clean; the dev stack hot-reloaded and serves 200. The error state needs the race to render, so the practical check is in the What to QA line.

## What to QA

- If you ever land on the playground's "Something went wrong" screen, Try again now reloads and recovers instead of doing nothing.