### PR TITLE
fix(sdk): pair the first-task rename_agent call to rename_session

### DIFF
--- a/benchmarks/agent-config-editing/scenarios/09-self-naming.json
+++ b/benchmarks/agent-config-editing/scenarios/09-self-naming.json
@@ -3,7 +3,8 @@
   "about": [
     "Naming sessions and agents after the model has enough context to choose a useful label.",
     "The verdict comes from the stored session or workflow header, never from the reply.",
-    "name-05 seeds the VERBATIM product-default persona (_DEFAULT_AGENTS_MD in sdks/python/agenta/sdk/utils/types.py, drift-locked by the SDK unit test test_default_persona_self_naming.py): live QA showed task-shaped personas self-name while the bare default persona did not, so this scenario is the regression guard for the real new-user experience."
+    "name-05 seeds the VERBATIM product-default persona (_DEFAULT_AGENTS_MD in sdks/python/agenta/sdk/utils/types.py, drift-locked by the SDK unit test test_default_persona_self_naming.py): live QA showed task-shaped personas self-name while the bare default persona did not, so this scenario is the regression guard for the real new-user experience.",
+    "name-06 mirrors the composer path (workflow created with the raw request as its name, session auto-titled from the first message) and expects rename_session AND rename_agent in the same first-task turn — the pairing the persona now instructs, after a live session showed the standalone rename_agent trigger being forgotten. max_rename_calls is a SINGLE combined counter across both rename tools (run_benchmark sums them), so 2 here plus the two min-1 tool checks pins exactly one call each."
   ],
   "scenarios": [
     {
@@ -124,7 +125,7 @@
       "title": "the product-default persona names its session unprompted",
       "seed": {
         "instructions": {
-          "agents_md": "You are a friendly hello-world agent running on the Agenta agent service.\n\n- Greet the user warmly.\n- Answer the user's message in one or two short sentences.\n- Once the first exchange makes clear what the session is about, call the\n  `rename_session` tool: `name` is the session's subject in a few words, findable\n  in a list; `description` is a one-sentence recap of where things stand. Rename\n  again only when the topic genuinely shifts.\n- Call the `rename_agent` tool only when your own identity or purpose changes —\n  for example, you were just created or the user repurposes you — with a name\n  that says what you are for."
+          "agents_md": "You are a friendly hello-world agent running on the Agenta agent service.\n\n- Greet the user warmly.\n- Answer the user's message in one or two short sentences.\n- Once the first exchange makes clear what the session is about, call the\n  `rename_session` tool: `name` is the session's subject in a few words, findable\n  in a list; `description` is a one-sentence recap of where things stand. Rename\n  again only when the topic genuinely shifts. If this is also your first task\n  since you were created — your agent name is still a raw request or a\n  placeholder like \"Untitled agent\" — also call the `rename_agent` tool in the\n  same turn, with a name that says what you are for.\n- After that, call `rename_agent` again only when your identity or purpose\n  changes — for example, the user repurposes you."
         },
         "skills": []
       },
@@ -146,6 +147,57 @@
           "check": "session_header",
           "path": ["description"],
           "pattern": "(?s)^.{1,300}\\Z"
+        }
+      ]
+    },
+    {
+      "id": "name-06-composer-first-task",
+      "title": "a composer-created agent renames itself and its session in the first task turn",
+      "seed": {
+        "instructions": {
+          "agents_md": "You are a friendly hello-world agent running on the Agenta agent service.\n\n- Greet the user warmly.\n- Answer the user's message in one or two short sentences.\n- Once the first exchange makes clear what the session is about, call the\n  `rename_session` tool: `name` is the session's subject in a few words, findable\n  in a list; `description` is a one-sentence recap of where things stand. Rename\n  again only when the topic genuinely shifts. If this is also your first task\n  since you were created — your agent name is still a raw request or a\n  placeholder like \"Untitled agent\" — also call the `rename_agent` tool in the\n  same turn, with a name that says what you are for.\n- After that, call `rename_agent` again only when your identity or purpose\n  changes — for example, the user repurposes you."
+        },
+        "skills": []
+      },
+      "seed_workflow_header": {
+        "name": "Create an agent that posts a daily standup summary {{TOKEN}}",
+        "flags": { "is_application": true, "is_evaluator": false }
+      },
+      "seed_session_header": {
+        "name": "get the daily standup summary going — post one summary of"
+      },
+      "turns": [
+        {
+          "prompt": "get the daily standup summary going — post one summary of the team's updates every morning"
+        }
+      ],
+      "tools": [
+        { "type": "platform", "op": "rename_session" },
+        { "type": "platform", "op": "rename_agent" }
+      ],
+      "budget": { "max_rename_calls": 2 },
+      "checks": [
+        { "check": "turn_tool_called", "name": "rename_session", "min": 1 },
+        { "check": "turn_tool_called", "name": "rename_agent", "min": 1 },
+        {
+          "check": "session_header",
+          "path": ["name"],
+          "pattern": "(?i)(standup|summar)"
+        },
+        {
+          "check": "workflow_header",
+          "path": ["name"],
+          "pattern": "(?s)^(?!.*{{TOKEN}}).*\\S.*$"
+        },
+        {
+          "check": "workflow_header",
+          "path": ["name"],
+          "pattern": "(?i)(standup|summar)"
+        },
+        {
+          "check": "workflow_header",
+          "path": ["flags", "is_application"],
+          "value": true
         }
       ]
     }

--- a/benchmarks/agent-config-editing/scenarios/09-self-naming.json
+++ b/benchmarks/agent-config-editing/scenarios/09-self-naming.json
@@ -15,18 +15,33 @@
           "prompt": "help me put together a smoke-test plan for the billing migration we're shipping on friday"
         }
       ],
-      "tools": [{ "type": "platform", "op": "rename_session" }],
-      "budget": { "max_rename_calls": 1 },
+      "tools": [
+        {
+          "type": "platform",
+          "op": "rename_session"
+        }
+      ],
+      "budget": {
+        "max_rename_calls": 1
+      },
       "checks": [
-        { "check": "turn_tool_called", "name": "rename_session", "min": 1 },
+        {
+          "check": "turn_tool_called",
+          "name": "rename_session",
+          "min": 1
+        },
         {
           "check": "session_header",
-          "path": ["name"],
+          "path": [
+            "name"
+          ],
           "pattern": "(?i)(billing|migration)"
         },
         {
           "check": "session_header",
-          "path": ["description"],
+          "path": [
+            "description"
+          ],
           "pattern": "(?s)^.{1,300}\\Z"
         }
       ]
@@ -46,8 +61,15 @@
           "prompt": "actually let's switch gears — draft an incident response checklist for a database outage"
         }
       ],
-      "tools": [{ "type": "platform", "op": "rename_session" }],
-      "budget": { "max_rename_calls": 1 },
+      "tools": [
+        {
+          "type": "platform",
+          "op": "rename_session"
+        }
+      ],
+      "budget": {
+        "max_rename_calls": 1
+      },
       "checks": [
         {
           "check": "turn_tool_called",
@@ -57,7 +79,9 @@
         },
         {
           "check": "session_header",
-          "path": ["name"],
+          "path": [
+            "name"
+          ],
           "pattern": "(?i)(incident|database|outage)"
         }
       ]
@@ -68,35 +92,59 @@
       "seed_workflow_header": {
         "name": "Untitled agent",
         "description": "Waiting for a first task.",
-        "flags": { "is_application": true, "is_evaluator": false }
+        "flags": {
+          "is_application": true,
+          "is_evaluator": false
+        }
       },
       "turns": [
         {
           "prompt": "make me a pre-release checklist for the billing portal and call out what should block the deploy"
         }
       ],
-      "tools": [{ "type": "platform", "op": "rename_agent" }],
-      "budget": { "max_rename_calls": 1 },
+      "tools": [
+        {
+          "type": "platform",
+          "op": "rename_agent"
+        }
+      ],
+      "budget": {
+        "max_rename_calls": 1
+      },
       "checks": [
-        { "check": "turn_tool_called", "name": "rename_agent", "min": 1 },
+        {
+          "check": "turn_tool_called",
+          "name": "rename_agent",
+          "min": 1
+        },
         {
           "check": "workflow_header",
-          "path": ["name"],
+          "path": [
+            "name"
+          ],
           "pattern": "(?i)^(?!untitled agent$).*\\S.*$"
         },
         {
           "check": "workflow_header",
-          "path": ["description"],
+          "path": [
+            "description"
+          ],
           "pattern": "(?s)^.{1,300}\\Z"
         },
         {
           "check": "workflow_header",
-          "path": ["flags", "is_application"],
+          "path": [
+            "flags",
+            "is_application"
+          ],
           "value": true
         },
         {
           "check": "workflow_header",
-          "path": ["flags", "is_evaluator"],
+          "path": [
+            "flags",
+            "is_evaluator"
+          ],
           "value": false
         }
       ]
@@ -108,13 +156,26 @@
         "name": "Release notes {{TOKEN}}",
         "description": "Finishing the release notes for this build."
       },
-      "turns": [{ "prompt": "thanks — just reply with noted" }],
-      "tools": [{ "type": "platform", "op": "rename_session" }],
-      "budget": { "max_rename_calls": 0 },
+      "turns": [
+        {
+          "prompt": "thanks — just reply with noted"
+        }
+      ],
+      "tools": [
+        {
+          "type": "platform",
+          "op": "rename_session"
+        }
+      ],
+      "budget": {
+        "max_rename_calls": 0
+      },
       "checks": [
         {
           "check": "session_header",
-          "path": ["name"],
+          "path": [
+            "name"
+          ],
           "pattern": "(?i)^release notes QA-[A-Z0-9]{8}$",
           "text": "{{TOKEN}}"
         }
@@ -134,18 +195,33 @@
           "prompt": "help me plan the onboarding schedule for the two support engineers starting next month — what should their first two weeks look like?"
         }
       ],
-      "tools": [{ "type": "platform", "op": "rename_session" }],
-      "budget": { "max_rename_calls": 1 },
+      "tools": [
+        {
+          "type": "platform",
+          "op": "rename_session"
+        }
+      ],
+      "budget": {
+        "max_rename_calls": 1
+      },
       "checks": [
-        { "check": "turn_tool_called", "name": "rename_session", "min": 1 },
+        {
+          "check": "turn_tool_called",
+          "name": "rename_session",
+          "min": 1
+        },
         {
           "check": "session_header",
-          "path": ["name"],
+          "path": [
+            "name"
+          ],
           "pattern": "(?i)(onboarding|support|engineer)"
         },
         {
           "check": "session_header",
-          "path": ["description"],
+          "path": [
+            "description"
+          ],
           "pattern": "(?s)^.{1,300}\\Z"
         }
       ]
@@ -161,7 +237,10 @@
       },
       "seed_workflow_header": {
         "name": "Create an agent that posts a daily standup summary {{TOKEN}}",
-        "flags": { "is_application": true, "is_evaluator": false }
+        "flags": {
+          "is_application": true,
+          "is_evaluator": false
+        }
       },
       "seed_session_header": {
         "name": "get the daily standup summary going — post one summary of"
@@ -172,31 +251,63 @@
         }
       ],
       "tools": [
-        { "type": "platform", "op": "rename_session" },
-        { "type": "platform", "op": "rename_agent" }
+        {
+          "type": "platform",
+          "op": "rename_session"
+        },
+        {
+          "type": "platform",
+          "op": "rename_agent"
+        }
       ],
-      "budget": { "max_rename_calls": 2 },
+      "budget": {
+        "max_rename_calls": 2
+      },
       "checks": [
-        { "check": "turn_tool_called", "name": "rename_session", "min": 1 },
-        { "check": "turn_tool_called", "name": "rename_agent", "min": 1 },
+        {
+          "check": "turn_tool_called",
+          "name": "rename_session",
+          "min": 1
+        },
+        {
+          "check": "turn_tool_called",
+          "name": "rename_agent",
+          "min": 1
+        },
         {
           "check": "session_header",
-          "path": ["name"],
-          "pattern": "(?i)(standup|summar)"
+          "path": [
+            "name"
+          ],
+          "pattern": "(?i)^(?!get the daily standup summary going)(?=.*(standup|summar)).*$"
         },
         {
           "check": "workflow_header",
-          "path": ["name"],
+          "path": [
+            "name"
+          ],
           "pattern": "(?s)^(?!.*{{TOKEN}}).*\\S.*$"
         },
         {
           "check": "workflow_header",
-          "path": ["name"],
+          "path": [
+            "name"
+          ],
+          "pattern": "(?i)^(?!.*create an agent).*$"
+        },
+        {
+          "check": "workflow_header",
+          "path": [
+            "name"
+          ],
           "pattern": "(?i)(standup|summar)"
         },
         {
           "check": "workflow_header",
-          "path": ["flags", "is_application"],
+          "path": [
+            "flags",
+            "is_application"
+          ],
           "value": true
         }
       ]

--- a/sdks/python/agenta/sdk/utils/types.py
+++ b/sdks/python/agenta/sdk/utils/types.py
@@ -1062,6 +1062,11 @@ _DEFAULT_AGENT_MODEL = "gpt-5.6-luna"
 # own, while task-shaped personas do (live QA, 2026-08-10; benchmark class
 # `self_naming`, scenario name-05 pins this persona verbatim). The tool descriptions
 # alone lose to "answer the question", so the standing instruction rides here.
+# `rename_agent` is PAIRED to the `rename_session` bullet rather than left as an
+# independent judgment call: as a standalone "when your purpose changes" trigger the
+# model reliably forgot it on the composer path (live session 2026-08-10 — a fresh
+# agent kept its raw-request name through a perfect rename_session turn; benchmark
+# name-06 measures the pairing).
 _DEFAULT_AGENTS_MD = (
     "You are a friendly hello-world agent running on the Agenta agent service.\n\n"
     "- Greet the user warmly.\n"
@@ -1069,10 +1074,12 @@ _DEFAULT_AGENTS_MD = (
     "- Once the first exchange makes clear what the session is about, call the\n"
     "  `rename_session` tool: `name` is the session's subject in a few words, findable\n"
     "  in a list; `description` is a one-sentence recap of where things stand. Rename\n"
-    "  again only when the topic genuinely shifts.\n"
-    "- Call the `rename_agent` tool only when your own identity or purpose changes —\n"
-    "  for example, you were just created or the user repurposes you — with a name\n"
-    "  that says what you are for."
+    "  again only when the topic genuinely shifts. If this is also your first task\n"
+    "  since you were created — your agent name is still a raw request or a\n"
+    '  placeholder like "Untitled agent" — also call the `rename_agent` tool in the\n'
+    "  same turn, with a name that says what you are for.\n"
+    "- After that, call `rename_agent` again only when your identity or purpose\n"
+    "  changes — for example, the user repurposes you."
 )
 
 # The single source of the run-selection defaults. The SDK builtin interface

--- a/sdks/python/oss/tests/pytest/unit/agents/test_default_persona_self_naming.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_default_persona_self_naming.py
@@ -35,18 +35,25 @@ def test_default_persona_carries_the_self_naming_guidance():
     text = _default_agents_md()
     assert "`rename_session`" in text
     assert "`rename_agent`" in text
+    # The first-task rename_agent call is PAIRED to the reliable rename_session
+    # call: as a standalone judgment call the model reliably forgot it (live
+    # composer session, 2026-08-10 — raw-request agent name survived a perfect
+    # rename_session turn).
+    assert "same turn" in text
     # The guards against churn ride along with the guidance itself.
     assert "only when the topic genuinely shifts" in text
-    assert "only when your own identity or purpose changes" in text
+    assert "only when your identity or purpose" in text
 
 
 @pytest.mark.skipif(
     not _SCENARIO_FILE.exists(),
     reason="benchmarks/ not present in this checkout",
 )
-def test_benchmark_name_05_seeds_the_default_persona_verbatim():
+@pytest.mark.parametrize(
+    "scenario_id",
+    ["name-05-default-persona-session", "name-06-composer-first-task"],
+)
+def test_benchmark_default_persona_scenarios_seed_it_verbatim(scenario_id):
     doc = json.loads(_SCENARIO_FILE.read_text())
-    scenario = next(
-        s for s in doc["scenarios"] if s["id"] == "name-05-default-persona-session"
-    )
+    scenario = next(s for s in doc["scenarios"] if s["id"] == scenario_id)
     assert scenario["seed"]["instructions"]["agents_md"] == _default_agents_md()

--- a/services/oss/src/agent/config.py
+++ b/services/oss/src/agent/config.py
@@ -33,10 +33,12 @@ DEFAULT_AGENTS_MD = (
     "- Once the first exchange makes clear what the session is about, call the\n"
     "  `rename_session` tool: `name` is the session's subject in a few words, findable\n"
     "  in a list; `description` is a one-sentence recap of where things stand. Rename\n"
-    "  again only when the topic genuinely shifts.\n"
-    "- Call the `rename_agent` tool only when your own identity or purpose changes —\n"
-    "  for example, you were just created or the user repurposes you — with a name\n"
-    "  that says what you are for."
+    "  again only when the topic genuinely shifts. If this is also your first task\n"
+    "  since you were created — your agent name is still a raw request or a\n"
+    '  placeholder like "Untitled agent" — also call the `rename_agent` tool in the\n'
+    "  same turn, with a name that says what you are for.\n"
+    "- After that, call `rename_agent` again only when your identity or purpose\n"
+    "  changes — for example, the user repurposes you."
 )
 
 


### PR DESCRIPTION
## Context

Live debugging of a real session showed a freshly created agent renaming its session perfectly ("Daily Arabic Poetry") while never once attempting `rename_agent`, leaving the agent named "Create an agent that sends me a telegram message". The tool was available and auto-allowed, and the guidance even named "you were just created" as a trigger; as an independent judgment call the model reliably forgot it. The benchmark had already measured this residual (1 of 3 genuine misses on the agent-naming scenario).

## Changes

`rename_agent` is no longer a standalone clause. The default persona's `rename_session` bullet now carries the pairing: if this is the agent's first task since creation (its name still a raw request or a placeholder), also call `rename_agent` in the same turn. The standalone bullet shrinks to the later repurposing case. Both drift-locked copies (SDK `_DEFAULT_AGENTS_MD` and the services fallback) move together, and the drift-lock tests pin the pairing phrase.

New benchmark scenario `name-06-composer-first-task` mirrors the real composer path: the workflow seeded with the raw request as its name (carrying a per-trial token), the session seeded with the client auto-title, both ops mounted, verbatim persona. It requires each rename exactly once and proves the raw-request name was replaced (the token must disappear).

## Validation (full self_naming run, 18 trials, results in the repo)

| Scenario | Result |
|---|---|
| name-06 pairing attempts | 3/3 — the model now calls BOTH renames in the same turn every time |
| name-04 no-spurious-rename | 3/3 clean, zero rename calls (the guard this change must not break) |
| name-05 default persona | 3/3 one-shot, holds |
| name-01..03 | hold at their baselines (misses attributed to the known harness tool quirk, zero check failures) |

name-06's stored-name check passed 1 of 3: the two failures are NOT behavior — both trials attempted correctly and hit a newly exposed backend race where the second side-effecting call's result goes unobserved when the turn's pause ends ([#5907](https://github.com/Agenta-AI/agenta/issues/5907), characterization in progress). The scenario stays in as the standing guard and goes fully green when that race is fixed.

## Tests

SDK unit 2024 passed (including the extended drift locks), services unit 101 passed, scenario JSON validated, CI-pinned ruff clean.