### PR TITLE
[fix] Connect-flow feedback: actionable errors, correct auth mode, working decline

### DIFF
--- a/api/oss/src/apis/fastapi/tools/router.py
+++ b/api/oss/src/apis/fastapi/tools/router.py
@@ -63,6 +63,9 @@ from oss.src.core.tools.exceptions import (
 from oss.src.core.tools.service import (
     ToolsService,
 )
+from oss.src.core.gateway.connections.exceptions import (
+    AdapterError as ConnectionAdapterError,
+)
 from oss.src.core.gateway.connections.utils import decode_oauth_state
 from oss.src.core.workflows.service import WorkflowsService
 from oss.src.core.tracing.service import TracingService
@@ -770,12 +773,32 @@ class ToolsRouter:
                 },
             )
 
-        connection = await self.tools_service.create_connection(
-            project_id=UUID(request.state.project_id),
-            user_id=UUID(request.state.user_id),
-            #
-            connection_create=body.connection,
-        )
+        try:
+            connection = await self.tools_service.create_connection(
+                project_id=UUID(request.state.project_id),
+                user_id=UUID(request.state.user_id),
+                #
+                connection_create=body.connection,
+            )
+        except ConnectionAdapterError as e:
+            # Composio has no managed ("use_composio_managed_auth") auth config for
+            # this toolkit in this environment — it only offers use_custom_auth.
+            # Surface an actionable 422 instead of letting this fall through to
+            # @intercept_exceptions' bare 500.
+            if e.operation == "initiate_connection.create_auth_config":
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"The '{body.connection.integration_key}' integration has no "
+                        "managed OAuth configuration available in this environment. "
+                        "It requires custom OAuth credentials (use_custom_auth) to "
+                        "be configured for this provider before it can be connected."
+                    ),
+                ) from e
+            raise HTTPException(
+                status_code=422,
+                detail=e.detail or e.message,
+            ) from e
 
         return ToolConnectionResponse(
             count=1,

--- a/api/oss/src/core/gateway/catalog/providers/composio/adapter.py
+++ b/api/oss/src/core/gateway/catalog/providers/composio/adapter.py
@@ -274,6 +274,25 @@ def _parse_integration_detail(item: Dict[str, Any]) -> CatalogIntegration:
         if mapped and mapped not in auth_schemes:
             auth_schemes.append(mapped)
 
+    # Some toolkits (e.g. telegram) have NO Composio-managed auth config at all —
+    # `composio_managed_auth_schemes` comes back empty even though the toolkit is
+    # connectable via `use_custom_auth`. Fall back to `auth_config_details` (the
+    # same field the connections adapter reads to pick `use_custom_auth`'s
+    # authScheme) so the client learns a real supported mode instead of a caller
+    # defaulting to oauth against a toolkit that has none.
+    if not auth_schemes:
+        for detail in item.get("auth_config_details") or []:
+            mode = (detail.get("mode") or "").lower()
+            if not mode or mode == "no_auth":
+                continue
+            mapped = (
+                CatalogAuthScheme.OAUTH
+                if "oauth" in mode
+                else CatalogAuthScheme.API_KEY
+            )
+            if mapped not in auth_schemes:
+                auth_schemes.append(mapped)
+
     raw_cats = meta.get("categories") or []
     categories = [c["name"] if isinstance(c, dict) else str(c) for c in raw_cats if c]
 

--- a/api/oss/tests/pytest/unit/tools/test_catalog_auth_schemes_fallback.py
+++ b/api/oss/tests/pytest/unit/tools/test_catalog_auth_schemes_fallback.py
@@ -1,0 +1,78 @@
+"""Regression: `GET /toolkits/{slug}` auth-scheme parsing for toolkits with no Composio-
+managed auth config.
+
+Live evidence: telegram has NO `composio_managed_auth_schemes` at all (Composio only
+offers `use_custom_auth` for it — see the connections adapter's identical 404, "Default
+auth config not found for toolkit telegram... Use type use_custom_auth with your own
+credentials instead"). Before this fix, `_parse_integration_detail` read only
+`composio_managed_auth_schemes`, so ``integration.auth_schemes`` came back ``None`` for
+telegram — every caller that picks a connect mode from that field (the settings
+ConnectModal's `resolveAvailableModes`, and any future caller doing the same for the
+agent connect widget) falls back to "oauth", which Composio then 404s on. Falling back to
+`auth_config_details` (the same field the connections adapter already reads to choose
+`use_custom_auth`'s authScheme) fixes the signal at the source.
+"""
+
+from __future__ import annotations
+
+from oss.src.core.gateway.catalog.dtos import CatalogAuthScheme
+from oss.src.core.gateway.catalog.providers.composio.adapter import (
+    _parse_integration_detail,
+)
+
+
+def test_no_managed_auth_falls_back_to_auth_config_details():
+    """telegram-shaped payload: empty managed schemes, a real custom auth_config_details."""
+    item = {
+        "slug": "telegram",
+        "name": "Telegram",
+        "meta": {"description": "d", "categories": []},
+        "composio_managed_auth_schemes": [],
+        "auth_config_details": [{"name": "Telegram", "mode": "API_KEY"}],
+    }
+    integration = _parse_integration_detail(item)
+    assert integration.auth_schemes == [CatalogAuthScheme.API_KEY]
+
+
+def test_no_managed_auth_bearer_token_mode_maps_to_api_key():
+    """Any non-oauth custom mode (not just the literal 'API_KEY') counts as api_key —
+    mirrors the connections adapter's own `"oauth" not in mode.lower()` heuristic."""
+    item = {
+        "slug": "telegram",
+        "name": "Telegram",
+        "meta": {},
+        "auth_config_details": [{"name": "Telegram", "mode": "BEARER_TOKEN"}],
+    }
+    integration = _parse_integration_detail(item)
+    assert integration.auth_schemes == [CatalogAuthScheme.API_KEY]
+
+
+def test_no_auth_toolkit_reports_no_auth_schemes():
+    """A NO_AUTH-only toolkit (e.g. codeinterpreter) must not be reported as api_key —
+    it needs no auth_scheme selection at all."""
+    item = {
+        "slug": "codeinterpreter",
+        "name": "Code Interpreter",
+        "meta": {},
+        "auth_config_details": [{"mode": "NO_AUTH"}],
+    }
+    integration = _parse_integration_detail(item)
+    assert integration.auth_schemes is None
+
+
+def test_managed_auth_schemes_present_skips_fallback():
+    """Regression guard: an integration WITH managed auth (e.g. github) keeps reading
+    from `composio_managed_auth_schemes` and never touches the fallback."""
+    item = {
+        "slug": "github",
+        "name": "GitHub",
+        "meta": {},
+        "composio_managed_auth_schemes": [{"name": "oauth2"}],
+        # If the fallback fired here it would ALSO report api_key — assert it doesn't.
+        "auth_config_details": [
+            {"name": "OAuth", "mode": "OAUTH2"},
+            {"name": "API Key", "mode": "API_KEY"},
+        ],
+    }
+    integration = _parse_integration_detail(item)
+    assert integration.auth_schemes == [CatalogAuthScheme.OAUTH]

--- a/api/oss/tests/pytest/unit/tools/test_create_connection_errors.py
+++ b/api/oss/tests/pytest/unit/tools/test_create_connection_errors.py
@@ -1,0 +1,129 @@
+"""Unit tests for POST /tools/connections/ adapter-error mapping.
+
+Regression for a live 500: Composio has no managed ("use_composio_managed_auth")
+auth config for some toolkits (e.g. telegram) and rejects auth-config creation
+with a 404 telling the caller to use ``use_custom_auth`` instead. The gateway
+adapter wraps that as a ``ConnectionAdapterError``
+(``oss.src.core.gateway.connections.exceptions.AdapterError``), which the
+router previously let fall through to the generic ``@intercept_exceptions``
+handler -> a bare, unactionable 500. It must now surface as a 422 with a
+message telling the user this toolkit needs custom OAuth credentials in this
+environment.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from oss.src.apis.fastapi.tools.models import ToolConnectionCreateRequest
+from oss.src.apis.fastapi.tools.router import ToolsRouter
+from oss.src.core.gateway.connections.exceptions import (
+    AdapterError as ConnectionAdapterError,
+)
+from oss.src.core.tools.dtos import ToolConnectionCreate, ToolProviderKind
+
+
+def _router(*, create_connection):
+    tools_service = SimpleNamespace(create_connection=create_connection)
+    return ToolsRouter(tools_service=tools_service)
+
+
+def _request():
+    return SimpleNamespace(
+        state=SimpleNamespace(project_id=str(uuid4()), user_id=str(uuid4())),
+        headers={},
+    )
+
+
+def _body(integration_key: str = "telegram") -> ToolConnectionCreateRequest:
+    return ToolConnectionCreateRequest(
+        connection=ToolConnectionCreate(
+            slug=f"conn-{uuid4().hex[:8]}",
+            provider_key=ToolProviderKind.COMPOSIO,
+            integration_key=integration_key,
+        )
+    )
+
+
+async def test_create_connection_no_managed_auth_config_returns_422(monkeypatch):
+    async def _allow(**_kwargs):
+        return True
+
+    monkeypatch.setattr("oss.src.apis.fastapi.tools.router.check_action_access", _allow)
+
+    async def _create_connection(**_kwargs):
+        raise ConnectionAdapterError(
+            provider_key="composio",
+            operation="initiate_connection.create_auth_config",
+            detail=(
+                'Default auth config not found for toolkit "telegram" and no '
+                "input auth config id found. Use type use_custom_auth with "
+                "your own credentials instead."
+            ),
+        )
+
+    router = _router(create_connection=_create_connection)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await router.create_connection(_request(), body=_body("telegram"))
+
+    assert exc_info.value.status_code == 422
+    detail = exc_info.value.detail
+    assert "telegram" in detail
+    assert "custom OAuth credentials" in detail
+    # The old opaque generic-500 message must not leak through.
+    assert "unexpected error" not in detail.lower()
+
+
+async def test_create_connection_other_adapter_error_returns_422_with_upstream_detail(
+    monkeypatch,
+):
+    async def _allow(**_kwargs):
+        return True
+
+    monkeypatch.setattr("oss.src.apis.fastapi.tools.router.check_action_access", _allow)
+
+    async def _create_connection(**_kwargs):
+        raise ConnectionAdapterError(
+            provider_key="composio",
+            operation="initiate_connection.link_account",
+            detail="mutually exclusive fields: auth_config_id, integration_id",
+        )
+
+    router = _router(create_connection=_create_connection)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await router.create_connection(_request(), body=_body("github"))
+
+    assert exc_info.value.status_code == 422
+    assert "mutually exclusive fields" in exc_info.value.detail
+
+
+async def test_create_connection_success_returns_connection(monkeypatch):
+    async def _allow(**_kwargs):
+        return True
+
+    monkeypatch.setattr("oss.src.apis.fastapi.tools.router.check_action_access", _allow)
+
+    from oss.src.core.tools.dtos import ToolConnection
+
+    expected = ToolConnection(
+        id=uuid4(),
+        slug="conn-github",
+        provider_key=ToolProviderKind.COMPOSIO,
+        integration_key="github",
+    )
+
+    async def _create_connection(**_kwargs):
+        return expected
+
+    router = _router(create_connection=_create_connection)
+
+    response = await router.create_connection(_request(), body=_body("github"))
+
+    assert response.count == 1
+    assert response.connection == expected

--- a/web/oss/src/components/AgentChatSlice/components/InteractionDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/InteractionDock.tsx
@@ -80,7 +80,7 @@ const ConnectCard = ({
         },
         [onOutput, meta.toolName, meta.toolCallId],
     )
-    const {label, phase, errorText, runConnect, cancel, decline} = useConnectFlow(
+    const {label, phase, errorText, modeResolving, runConnect, cancel, decline} = useConnectFlow(
         meta,
         settle,
         active,
@@ -118,7 +118,14 @@ const ConnectCard = ({
                 ) : (
                     <>
                         <Button onClick={decline}>Not now</Button>
-                        <Button type="primary" onClick={() => runConnect(true)}>
+                        <Button
+                            type="primary"
+                            disabled={modeResolving}
+                            title={
+                                modeResolving ? "Checking how this toolkit connects…" : undefined
+                            }
+                            onClick={() => runConnect(true)}
+                        >
                             {phase === "error" ? "Retry" : `Connect ${label}`}
                         </Button>
                     </>

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
@@ -40,7 +40,7 @@ const DEFERRED_SENTINEL = "DEFERRED_NOT_EXECUTED"
 const KNOWN_CONNECT_REASONS = new Set(["declined", "cancelled", "timeout"])
 
 const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
-    const {label, phase, errorText, outcome, manuallyConnected, runConnect, cancel} =
+    const {label, phase, errorText, outcome, manuallyConnected, modeResolving, runConnect, cancel} =
         useConnectFlow(meta, settle)
 
     // A runner-deferred sibling settles as an error carrying the deferral sentinel (not a real
@@ -113,7 +113,7 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
                 >
                     {failureDetail ?? "Connection not completed"}
                 </Text>
-                <RetryButton onClick={() => runConnect(false)} />
+                <RetryButton onClick={() => runConnect(false)} disabled={modeResolving} />
             </ChipRow>
         )
     }
@@ -125,7 +125,7 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
                 <Text type="danger" className="!text-xs truncate" title={errorText ?? undefined}>
                     {errorText ?? "Connection failed."}
                 </Text>
-                <RetryButton onClick={() => runConnect(false)} />
+                <RetryButton onClick={() => runConnect(false)} disabled={modeResolving} />
             </ChipRow>
         )
     }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
@@ -34,6 +34,11 @@ const {Text} = Typography
  */
 const DEFERRED_SENTINEL = "DEFERRED_NOT_EXECUTED"
 
+/** Non-error terminal reasons (see `ConnectOutput.reason`): render generic wording for
+ * these; any other `reason` is a real failure message and must be shown verbatim — a
+ * create failure was previously settling silently with no error surfaced at all. */
+const KNOWN_CONNECT_REASONS = new Set(["declined", "cancelled", "timeout"])
+
 const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
     const {label, phase, errorText, outcome, manuallyConnected, runConnect, cancel} =
         useConnectFlow(meta, settle)
@@ -83,12 +88,30 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
                 </ChipRow>
             )
         }
-        // Declined / cancelled / timeout / failed: a Retry re-runs the OAuth fresh (the parked call
-        // already resolved, so this primes the vault and flips the chip on success).
+        // Declined / cancelled / timeout: quiet generic wording — these are expected, not
+        // errors. Any other reason is the create call's own failure message and must be
+        // shown, not swallowed behind the same generic text (it previously was).
+        const reason = outcome?.reason ?? output.reason
+        const failureDetail =
+            typeof reason === "string" && reason && !KNOWN_CONNECT_REASONS.has(reason)
+                ? reason
+                : undefined
         return (
-            <ChipRow icon={<Warning size={13} weight="fill" className="text-colorWarning" />}>
-                <Text type="secondary" className="!text-xs">
-                    Connection not completed
+            <ChipRow
+                icon={
+                    <Warning
+                        size={13}
+                        weight="fill"
+                        className={failureDetail ? "text-colorError" : "text-colorWarning"}
+                    />
+                }
+            >
+                <Text
+                    type={failureDetail ? "danger" : "secondary"}
+                    className="!text-xs truncate"
+                    title={failureDetail}
+                >
+                    {failureDetail ?? "Connection not completed"}
                 </Text>
                 <RetryButton onClick={() => runConnect(false)} />
             </ChipRow>

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the pure helpers in `useConnectFlow` — the connect-mode resolver (bug: a
+ * toolkit with no Composio-managed OAuth, e.g. telegram, was always attempted as "oauth"
+ * and 404'd) and the error-message extractor (bug: a create failure settled the parked
+ * call silently, with no error surfaced anywhere — see ConnectToolWidget.test / the
+ * ConnectToolWidget KNOWN_CONNECT_REASONS branch this message feeds).
+ */
+import {describe, expect, it} from "vitest"
+
+import {extractConnectErrorMessage, resolveConnectMode} from "./useConnectFlow"
+
+describe("resolveConnectMode", () => {
+    it("keeps the hint when the catalog has no auth_schemes yet (loading, or backend reported none)", () => {
+        expect(resolveConnectMode("oauth", undefined)).toBe("oauth")
+        expect(resolveConnectMode("oauth", null)).toBe("oauth")
+        expect(resolveConnectMode("api_key", [])).toBe("api_key")
+    })
+
+    it("keeps the hint when the toolkit actually supports it", () => {
+        expect(resolveConnectMode("oauth", ["oauth"])).toBe("oauth")
+        expect(resolveConnectMode("api_key", ["api_key"])).toBe("api_key")
+        expect(resolveConnectMode("oauth", ["oauth", "api_key"])).toBe("oauth")
+    })
+
+    it("telegram case: an 'oauth' hint against a toolkit with only api_key falls back to api_key", () => {
+        expect(resolveConnectMode("oauth", ["api_key"])).toBe("api_key")
+    })
+
+    it("the reverse: an 'api_key' hint against an oauth-only toolkit falls back to oauth", () => {
+        expect(resolveConnectMode("api_key", ["oauth"])).toBe("oauth")
+    })
+})
+
+describe("extractConnectErrorMessage", () => {
+    it("prefers the backend's detail string on a 4xx", () => {
+        const err = {
+            statusCode: 422,
+            body: {detail: "telegram requires custom OAuth credentials in this environment."},
+        }
+        expect(extractConnectErrorMessage(err)).toBe(
+            "telegram requires custom OAuth credentials in this environment.",
+        )
+    })
+
+    it("falls back to a generic message on a 5xx even with a detail present", () => {
+        const err = {statusCode: 502, body: {detail: "upstream exploded"}}
+        expect(extractConnectErrorMessage(err)).toBe("Connection failed. Please try again.")
+    })
+
+    it("falls back to a generic message when there is no parseable body/detail", () => {
+        expect(extractConnectErrorMessage(new Error("network down"))).toBe(
+            "Connection failed. Please try again.",
+        )
+        expect(extractConnectErrorMessage({statusCode: 422, body: {}})).toBe(
+            "Connection failed. Please try again.",
+        )
+        expect(extractConnectErrorMessage(null)).toBe("Connection failed. Please try again.")
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
@@ -1,16 +1,23 @@
 /**
  * Unit tests for the pure helpers in `useConnectFlow` — the connect-mode resolver (bug: a
  * toolkit with no Composio-managed OAuth, e.g. telegram, was always attempted as "oauth"
- * and 404'd) and the error-message extractor (bug: a create failure settled the parked
- * call silently, with no error surfaced anywhere — see ConnectToolWidget.test / the
- * ConnectToolWidget KNOWN_CONNECT_REASONS branch this message feeds).
+ * and 404'd), the mode-resolving guard (CodeRabbit finding on #5909: `resolveConnectMode`'s
+ * "keep the hint while loading" fallback is fine for the RENDER, but a click landing in that
+ * same window must not be allowed to fire a request with the raw, unverified hint), and the
+ * error-message extractor (bug: a create failure settled the parked call silently, with no
+ * error surfaced anywhere — see ConnectToolWidget.test / the ConnectToolWidget
+ * KNOWN_CONNECT_REASONS branch this message feeds).
  */
 import {describe, expect, it} from "vitest"
 
-import {extractConnectErrorMessage, resolveConnectMode} from "./useConnectFlow"
+import {
+    extractConnectErrorMessage,
+    isConnectModeResolving,
+    resolveConnectMode,
+} from "./useConnectFlow"
 
 describe("resolveConnectMode", () => {
-    it("keeps the hint when the catalog has no auth_schemes yet (loading, or backend reported none)", () => {
+    it("RENDER fallback: keeps the hint when the catalog has no auth_schemes yet (loading, or backend reported none) — `isConnectModeResolving` below is what stops a click from acting on this before it's verified", () => {
         expect(resolveConnectMode("oauth", undefined)).toBe("oauth")
         expect(resolveConnectMode("oauth", null)).toBe("oauth")
         expect(resolveConnectMode("api_key", [])).toBe("api_key")
@@ -28,6 +35,44 @@ describe("resolveConnectMode", () => {
 
     it("the reverse: an 'api_key' hint against an oauth-only toolkit falls back to oauth", () => {
         expect(resolveConnectMode("api_key", ["oauth"])).toBe("oauth")
+    })
+})
+
+describe("isConnectModeResolving", () => {
+    it("blocks: a real integration key, the catalog lookup in flight, not timed out — the exact window a click must not act in", () => {
+        expect(
+            isConnectModeResolving({
+                hasIntegrationKey: true,
+                queryIsLoading: true,
+                timedOut: false,
+            }),
+        ).toBe(true)
+    })
+
+    it("unblocks once the lookup settles (success or error) — queryIsLoading flips false", () => {
+        expect(
+            isConnectModeResolving({
+                hasIntegrationKey: true,
+                queryIsLoading: false,
+                timedOut: false,
+            }),
+        ).toBe(false)
+    })
+
+    it("unblocks for a malformed call with no integration key, even mid-'loading' — a disabled TanStack Query reports isLoading:true forever, which must not permanently disable Connect", () => {
+        expect(
+            isConnectModeResolving({
+                hasIntegrationKey: false,
+                queryIsLoading: true,
+                timedOut: false,
+            }),
+        ).toBe(false)
+    })
+
+    it("unblocks once timed out, even if the query is still loading — a stuck lookup (dead network) cannot latch the button disabled forever", () => {
+        expect(
+            isConnectModeResolving({hasIntegrationKey: true, queryIsLoading: true, timedOut: true}),
+        ).toBe(false)
     })
 })
 

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
@@ -27,6 +27,8 @@
  */
 import {useCallback, useEffect, useRef, useState} from "react"
 
+import {useToolIntegrationDetail} from "@agenta/entities/gatewayTool"
+
 import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
 
 import {useToolsConnections} from "../../../pages/settings/Tools/hooks/useToolsConnections"
@@ -47,6 +49,11 @@ export interface ConnectOutput {
     connected?: boolean
     integration?: string
     slug?: string
+    /**
+     * `"declined" | "cancelled" | "timeout"` for the three expected non-error terminal
+     * states, or the actual failure message when the create call itself errored (see
+     * `KNOWN_CONNECT_REASONS` in ConnectToolWidget, which renders the latter verbatim).
+     */
     reason?: string
 }
 
@@ -55,6 +62,53 @@ export type ConnectPhase = "idle" | "connecting" | "error"
 /** `github` → `GitHub`-ish: a readable label without a provider catalog lookup. */
 const prettyIntegration = (key: string): string =>
     key ? key.charAt(0).toUpperCase() + key.slice(1) : "the service"
+
+/**
+ * Resolve the actual connect mode to use, the same way the settings ConnectModal's
+ * `resolveAvailableModes` does — the toolkit's own catalog data is the source of truth for
+ * which modes it supports, not the agent's `mode` hint. A toolkit with no Composio-managed
+ * OAuth (e.g. telegram — Composio 404s "Default auth config not found... Use type
+ * use_custom_auth instead") reports no `"oauth"` scheme, so blindly trusting a hint of
+ * `"oauth"` 404s every time. `authSchemes` undefined/empty (catalog still loading, or the
+ * backend reported none) keeps the hint as-is rather than blocking the flow.
+ */
+export const resolveConnectMode = (
+    hintedMode: "oauth" | "api_key",
+    authSchemes: string[] | null | undefined,
+): "oauth" | "api_key" => {
+    if (!authSchemes || authSchemes.length === 0) return hintedMode
+    const supportsOauth = authSchemes.includes("oauth")
+    const supportsApiKey = authSchemes.includes("api_key")
+    if (hintedMode === "oauth" && supportsOauth) return "oauth"
+    if (hintedMode === "api_key" && supportsApiKey) return "api_key"
+    // The hint isn't actually supported: use whatever the toolkit does support instead.
+    if (supportsOauth) return "oauth"
+    if (supportsApiKey) return "api_key"
+    return hintedMode
+}
+
+/**
+ * Prefer the backend's own `detail` on a 4xx (e.g. "telegram has no managed OAuth
+ * configuration…") — Fern's default `Error.message` bundles a multi-line dump
+ * (`message\nStatus code: 422\nBody: {...}`) that is not fit to show a user. Any other
+ * failure (network error, 5xx) falls back to a generic message.
+ */
+export const extractConnectErrorMessage = (err: unknown): string => {
+    const statusCode = (err as {statusCode?: unknown} | null)?.statusCode
+    const body = (err as {body?: unknown} | null)?.body
+    const detail =
+        body && typeof body === "object" ? (body as {detail?: unknown}).detail : undefined
+    if (
+        typeof statusCode === "number" &&
+        statusCode >= 400 &&
+        statusCode < 500 &&
+        typeof detail === "string" &&
+        detail
+    ) {
+        return detail
+    }
+    return "Connection failed. Please try again."
+}
 
 /** Read the API origin the OAuth callback page posts from; null if it can't be resolved. */
 const agentaApiOrigin = (): string | null => {
@@ -74,7 +128,11 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // back as the reference the runner re-resolves.
     const slug =
         typeof input.slug === "string" && input.slug ? input.slug : integration || "default"
-    const mode = input.mode === "api_key" ? "api_key" : "oauth"
+    const hintedMode = input.mode === "api_key" ? "api_key" : "oauth"
+    // The toolkit's real supported schemes override a hint the toolkit doesn't actually
+    // support (see `resolveConnectMode`) — a stale/loading catalog just keeps the hint.
+    const {integration: integrationDetail} = useToolIntegrationDetail(integration)
+    const mode = resolveConnectMode(hintedMode, integrationDetail?.auth_schemes)
     const label = prettyIntegration(integration)
     // A window name UNIQUE to this parked call. Several connect flows can be live at once; a shared
     // name makes the second `window.open` reuse the first's popup, so the second flow's
@@ -92,8 +150,9 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     const [manuallyConnected, setManuallyConnected] = useState(false)
     // The live flow's terminal result, held locally so the chip paints the instant we settle —
     // `meta.settled` only flips a render later (after `addToolOutput` propagates), and without this
-    // the surface would stay on "Connecting…" until then.
-    const [outcome, setOutcome] = useState<{connected: boolean} | null>(null)
+    // the surface would stay on "Connecting…" until then. `reason` mirrors `ConnectOutput.reason`
+    // so a failure's message renders on that same first frame instead of one render late.
+    const [outcome, setOutcome] = useState<{connected: boolean; reason?: string} | null>(null)
 
     // One-shot guard so THIS instance settles the parked call at most once, plus shared cleanup for
     // the running popup's listener/poll/timeout. `meta.settled` covers the OTHER instance's settle.
@@ -118,10 +177,10 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
             // Leave "connecting" and record the terminal result so the chip paints now.
             setPhase("idle")
             if ("errorText" in result) {
-                setOutcome({connected: false})
+                setOutcome({connected: false, reason: result.errorText})
                 settle({errorText: result.errorText})
             } else {
-                setOutcome({connected: result.connected === true})
+                setOutcome({connected: result.connected === true, reason: result.reason})
                 settle({output: result as Record<string, unknown>})
             }
         },
@@ -250,7 +309,7 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
                 }
             } catch (err) {
                 if (settleParkedCall && !activeRef.current) return
-                const message = err instanceof Error ? err.message : "Connection failed."
+                const message = extractConnectErrorMessage(err)
                 // A create failure is terminal for the parked call: settle so the run resumes; for a
                 // manual retry just surface the reason with another Retry.
                 setPhase("error")

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
@@ -43,6 +43,10 @@ import type {ClientToolMeta, SettleClientTool} from "./types"
 const CONNECT_TIMEOUT_MS = 180_000
 /** Popup-closed poll cadence, matching the existing ConnectModal. */
 const POPUP_POLL_MS = 1000
+/** Ceiling on how long Connect/Retry stays disabled waiting for the toolkit's real auth mode —
+ * see `modeResolving` below. Generous for a normal catalog fetch, short enough that a genuinely
+ * stuck lookup doesn't read as a dead button. */
+const MODE_RESOLVE_TIMEOUT_MS = 8_000
 
 /** The settled call's reference shape (what the runner re-resolves against). */
 export interface ConnectOutput {
@@ -121,6 +125,28 @@ const agentaApiOrigin = (): string | null => {
     }
 }
 
+/**
+ * Whether Connect/Retry must stay disabled and `runConnect` must refuse to fire: the toolkit's
+ * real auth mode isn't known yet, so proceeding could send the agent's raw hint (e.g. "oauth" for
+ * a toolkit that only supports "api_key" — the exact telegram 404 this whole flow exists to
+ * avoid). Extracted as a pure predicate so this specific guard — "don't fire an unsupported
+ * request before the catalog lookup resolves" — has direct unit coverage, not just the render's
+ * fallback behavior in `resolveConnectMode`.
+ *
+ * `hasIntegrationKey` false (a malformed call) and `timedOut` true (the bounded wait in
+ * `useConnectFlow` elapsed — a dead network must not disable Connect forever) both force this to
+ * `false`: either says "stop waiting", not "keep waiting".
+ */
+export const isConnectModeResolving = ({
+    hasIntegrationKey,
+    queryIsLoading,
+    timedOut,
+}: {
+    hasIntegrationKey: boolean
+    queryIsLoading: boolean
+    timedOut: boolean
+}): boolean => hasIntegrationKey && queryIsLoading && !timedOut
+
 export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, active = true) => {
     const input = (meta.input ?? {}) as Record<string, unknown>
     const integration = typeof input.integration === "string" ? input.integration : ""
@@ -130,8 +156,33 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
         typeof input.slug === "string" && input.slug ? input.slug : integration || "default"
     const hintedMode = input.mode === "api_key" ? "api_key" : "oauth"
     // The toolkit's real supported schemes override a hint the toolkit doesn't actually
-    // support (see `resolveConnectMode`) — a stale/loading catalog just keeps the hint.
-    const {integration: integrationDetail} = useToolIntegrationDetail(integration)
+    // support (see `resolveConnectMode`). While the catalog lookup is still in flight,
+    // `resolveConnectMode` falls back to the hint — fine for the RENDER, but `runConnect`
+    // below must not let a click land inside that window and fire the (possibly wrong) hinted
+    // mode: `modeResolving`/`modeResolvingRef` gate it shut until the lookup settles.
+    const {integration: integrationDetail, isLoading: integrationDetailLoading} =
+        useToolIntegrationDetail(integration)
+    // Bounded: a stuck/never-resolving lookup (dead network, an endpoint outage) must NOT
+    // permanently disable Connect — past this bound, fall back to the agent's hinted mode same
+    // as `resolveConnectMode` already does for "no schemes reported" (a wrong-but-triable guess
+    // beats a dead button forever). Armed only while genuinely waiting (see
+    // `isConnectModeResolving`'s own bail-outs), so it never fires needlessly.
+    const [modeResolveTimedOut, setModeResolveTimedOut] = useState(false)
+    useEffect(() => {
+        if (!integration || !integrationDetailLoading) {
+            setModeResolveTimedOut(false)
+            return
+        }
+        const timer = window.setTimeout(() => setModeResolveTimedOut(true), MODE_RESOLVE_TIMEOUT_MS)
+        return () => window.clearTimeout(timer)
+    }, [integration, integrationDetailLoading])
+    const modeResolving = isConnectModeResolving({
+        hasIntegrationKey: !!integration,
+        queryIsLoading: integrationDetailLoading,
+        timedOut: modeResolveTimedOut,
+    })
+    const modeResolvingRef = useRef(modeResolving)
+    modeResolvingRef.current = modeResolving
     const mode = resolveConnectMode(hintedMode, integrationDetail?.auth_schemes)
     const label = prettyIntegration(integration)
     // A window name UNIQUE to this parked call. Several connect flows can be live at once; a shared
@@ -210,6 +261,11 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
             if (phase === "connecting") return
             if (settleParkedCall && (!activeRef.current || settledRef.current || meta.settled))
                 return
+            // The integration-detail lookup that picks the real auth mode hasn't resolved yet —
+            // proceeding here would send the agent's raw (possibly wrong, e.g. "oauth" for a
+            // toolkit that only supports api_key) hint. The button is disabled for this same
+            // window; this is the defense-in-depth backstop for a click that raced it.
+            if (modeResolvingRef.current) return
             setErrorText(null)
             setPhase("connecting")
             try {
@@ -356,6 +412,9 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
         errorText,
         outcome,
         manuallyConnected,
+        // True while the toolkit's real auth mode is still being looked up — callers should
+        // disable Connect/Retry for this window (see the `runConnect` guard above).
+        modeResolving,
         runConnect,
         cancel,
         decline,

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -199,6 +199,7 @@ export const useAgentChatSession = ({
         setMessages,
         persistMessages,
         intent,
+        pendingResumeRef: liveGateInteractionRef,
     })
 
     // A decision made in THIS mount marks the resume as live — a restored approval-requested tail

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit test for `shouldSkipRecordsRefresh` — the guard that stops the records-changed relay from
+ * clobbering a client-tool settle that hasn't resumed yet.
+ *
+ * Regression: clicking "Not now" on a parked connect request fired zero network requests and the
+ * interaction stayed `pending` forever (live evidence: sessions e8c3b72a-0fb0-4895-a77d-3f073672da8a
+ * and 9d4e0324-344c-42f0-ab72-a7afe0246b72 on the 8180 dev stack — reproduced live: clicking "Not
+ * now" produced no new `/services/agent/v0/invoke` request, and the transcript visibly reverted to
+ * an earlier turn). Root cause: `useSessionRecordsWatch`'s relay can tick and adopt a server
+ * transcript while the run is idle (`busy=false`, since the resume hasn't been dispatched yet) but a
+ * local `addToolOutput` settle is still waiting for `sendAutomaticallyWhen` to fire — the adopted
+ * transcript predates the settle and silently discards it.
+ */
+import {describe, expect, it} from "vitest"
+
+import {shouldSkipRecordsRefresh} from "./useSessionHydration"
+
+describe("shouldSkipRecordsRefresh", () => {
+    it("does not skip when idle and no settle is pending a resume", () => {
+        expect(shouldSkipRecordsRefresh({busy: false, pendingResume: false})).toBe(false)
+    })
+
+    it("skips while this tab is streaming (existing busy guard)", () => {
+        expect(shouldSkipRecordsRefresh({busy: true, pendingResume: false})).toBe(true)
+    })
+
+    it("skips while a client-tool settle awaits its resume dispatch, even though busy=false", () => {
+        // This is the exact gap the bug lived in: not busy yet, but not safe to adopt either.
+        expect(shouldSkipRecordsRefresh({busy: false, pendingResume: true})).toBe(true)
+    })
+
+    it("skips when both are true", () => {
+        expect(shouldSkipRecordsRefresh({busy: true, pendingResume: true})).toBe(true)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -27,6 +27,25 @@ const REMOTE_RUN_POLL_MS = 15_000
 const REMOTE_RUN_POLL_MAX_MS = 60_000
 
 /**
+ * Whether the records-changed relay's catch-up refetch must skip this tick.
+ *
+ * `busy` is the existing guard (a live local stream outranks the log). `pendingResume` is new:
+ * a client-tool settle (connect Not-now/Connect, an elicitation answer) writes
+ * `liveGateInteractionRef` synchronously and clears it only once `sendAutomaticallyWhen`
+ * actually dispatches the resume — `busy` doesn't flip true until THAT dispatch lands, so
+ * there is a real gap where the settle is local-only and not yet durable. A relay tick in that
+ * gap previously adopted a server transcript that predates the settle, silently discarding it —
+ * the parked interaction then never resumes (bug: "Not now" firing zero network requests).
+ */
+export const shouldSkipRecordsRefresh = ({
+    busy,
+    pendingResume,
+}: {
+    busy: boolean
+    pendingResume: boolean
+}): boolean => busy || pendingResume
+
+/**
  * Hybrid history for one session tab. localStorage holds only the session INDEX; the durable
  * conversation CONTENT lives in the backend record log — so a tab either paints from cache and
  * revalidates (SWR), or hydrates from the server once (cache miss). Both paths adopt the server
@@ -45,6 +64,7 @@ export const useSessionHydration = ({
     setMessages,
     persistMessages,
     intent,
+    pendingResumeRef,
 }: {
     sessionId: string
     initialMessages: UIMessage[]
@@ -59,6 +79,15 @@ export const useSessionHydration = ({
     setMessages: (messages: UIMessage[]) => void
     persistMessages: (args: {id: string; messages: UIMessage[]; recordCount?: number}) => void
     intent: ScrollIntent
+    /**
+     * Non-null while a client-tool settle (connect Not-now/Connect, an elicitation answer) has
+     * fired locally and is waiting for `sendAutomaticallyWhen` to dispatch its resume — see
+     * `liveGateInteractionRef` in `useAgentChatSession`. The settle is NOT durable until that
+     * dispatch lands (`busy` flips true); a records-changed relay tick landing in that gap must
+     * not adopt a server transcript that predates it, or the local settle is silently discarded
+     * and the parked interaction never resumes (bug: "Not now" firing zero network requests).
+     */
+    pendingResumeRef: MutableRefObject<unknown>
 }) => {
     // Cache-first — when this tab opens with no locally-cached messages (a session this browser
     // never ran, or after a storage clear), hydrate once from the server (`queryRecords` → v6
@@ -259,8 +288,15 @@ export const useSessionHydration = ({
     const projectId = useAtomValue(projectIdAtom)
     const revalidateSessionRecords = useSetAtom(revalidateSessionRecordsAtom)
     const refreshFromRecords = useCallback(() => {
-        // Skipped while THIS tab streams — it is already the live truth, and `onFinish` revalidates.
-        if (busyRef.current) return
+        // Skipped while THIS tab streams (already the live truth, `onFinish` revalidates) OR a
+        // client-tool settle is waiting on its resume dispatch — see `shouldSkipRecordsRefresh`.
+        if (
+            shouldSkipRecordsRefresh({
+                busy: busyRef.current,
+                pendingResume: !!pendingResumeRef.current,
+            })
+        )
+            return
         // A tick usually lands inside the records query's stale window, so the shared cache would
         // resolve unchanged; invalidate first, then adopt through the SAME guard as every other path.
         revalidateSessionRecords(sessionId)
@@ -268,7 +304,7 @@ export const useSessionHydration = ({
             // A background catch-up must not yank a reader who scrolled up — as with the poll.
             adoptServerTranscriptRef.current(transcript, {armJump: false}),
         )
-    }, [sessionId, busyRef, revalidateSessionRecords])
+    }, [sessionId, busyRef, pendingResumeRef, revalidateSessionRecords])
     useSessionRecordsWatch({
         sessionId,
         projectId,

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -288,8 +288,9 @@ export const useSessionHydration = ({
     const projectId = useAtomValue(projectIdAtom)
     const revalidateSessionRecords = useSetAtom(revalidateSessionRecordsAtom)
     const refreshFromRecords = useCallback(() => {
-        // Skipped while THIS tab streams (already the live truth, `onFinish` revalidates) OR a
-        // client-tool settle is waiting on its resume dispatch — see `shouldSkipRecordsRefresh`.
+        // Entry check: skip while THIS tab streams (already the live truth, `onFinish`
+        // revalidates) OR a client-tool settle is already waiting on its resume dispatch — see
+        // `shouldSkipRecordsRefresh`.
         if (
             shouldSkipRecordsRefresh({
                 busy: busyRef.current,
@@ -300,10 +301,22 @@ export const useSessionHydration = ({
         // A tick usually lands inside the records query's stale window, so the shared cache would
         // resolve unchanged; invalidate first, then adopt through the SAME guard as every other path.
         revalidateSessionRecords(sessionId)
-        void loadSessionMessages(sessionId).then((transcript) =>
+        void loadSessionMessages(sessionId).then((transcript) => {
+            // Adoption-point recheck: the entry check above only covers the window BEFORE this
+            // fetch started. `loadSessionMessages` is a real network round trip, and a client-tool
+            // settle can land while it's in flight — without re-checking here, that settle arrives
+            // busy=false/pendingResume=true, passes nothing, and this `.then` still clobbers it
+            // with the (now stale) transcript it fetched before the settle happened.
+            if (
+                shouldSkipRecordsRefresh({
+                    busy: busyRef.current,
+                    pendingResume: !!pendingResumeRef.current,
+                })
+            )
+                return
             // A background catch-up must not yank a reader who scrolled up — as with the poll.
-            adoptServerTranscriptRef.current(transcript, {armJump: false}),
-        )
+            adoptServerTranscriptRef.current(transcript, {armJump: false})
+        })
     }, [sessionId, busyRef, pendingResumeRef, revalidateSessionRecords])
     useSessionRecordsWatch({
         sessionId,


### PR DESCRIPTION
## Context

Mahmoud hit a dead end trying to connect a Telegram agent to Composio (live sessions `e8c3b72a-0fb0-4895-a77d-3f073672da8a` and `9d4e0324-344c-42f0-ab72-a7afe0246b72` on the 8180 dev stack, `session_interactions` rows stuck `pending`). Four bugs compounded into that dead end; a fifth (found mid-fix, on the coordinator's steer) is the actual root cause that made the flow unusable for telegram in the first place. This PR fixes four of the five. The fifth, the dock's `stopped` gate silently hiding a re-parked interaction, is being isolated by a separate instrumented capture and will land as its own small follow-up (see "Known remaining issue" below).

## Changes

**1. Backend 500 -> actionable 422.** Composio has no managed OAuth config for some toolkits (telegram is one; it only supports `use_custom_auth`). `POST /api/tools/connections/` raised `AdapterError` from the gateway `connections` domain, a different class from the one `@handle_adapter_exceptions` catches (`core/tools/exceptions`), so it fell through to the generic `@intercept_exceptions` handler and returned a bare 500. `create_connection` now catches the gateway `AdapterError` directly and returns 422 with a message telling the user the toolkit needs custom OAuth credentials in this environment.

**2. The real root cause: wrong auth mode, not a Composio outage.** While reproducing bug 1 live, the coordinator caught that the telegram POST always sent `auth_scheme: "oauth"`, and traced it to `useConnectFlow`'s `mode` blindly trusting the agent's `input.mode` hint (which defaults to oauth). Telegram's real scheme is a bot token (api_key-style), and the adapter already supports `use_custom_auth` for it (`adapter.py:162-175`) - the flow just never asked for it. Live proof this works: `POST /tools/connections/` for telegram with `auth_scheme: "api_key"` on a minted 8180 account returns **200** with a `redirect_url` (`https://connect.composio.dev/link/...`), identical in shape to the OAuth path - Composio's own hosted page collects the bot token, so **no new widget UI is needed**.

  I first checked whether the settings page's `ConnectModal` already picks the right mode (it looked like it should) - it doesn't. Its `resolveAvailableModes` reads `integration.auth_schemes`, which the backend built only from Composio's `composio_managed_auth_schemes` field. For telegram that field is empty (confirmed live: `GET .../tools/catalog/providers/composio/integrations/telegram` returns no `auth_schemes` at all), so `resolveAvailableModes` falls through its own `length === 0 -> oauth` default. Same latent bug, just unhit because most toolkits do have managed oauth. Fixed at the shared source: `_parse_integration_detail` now falls back to `auth_config_details` (the same field the connections adapter reads) when the managed list is empty, so both the settings modal and the agent widget see the toolkit's real scheme.

  `useConnectFlow` now cross-checks the agent's `mode` hint against the toolkit's real `auth_schemes` (fetched via `useToolIntegrationDetail`) and overrides it when the toolkit doesn't actually support the hinted mode.

**3. Silent failure on the widget.** When the create POST failed, `useConnectFlow` settled it through the exact same path as decline/cancel/timeout (`finish()` -> a `ConnectOutput`, not `{errorText}`). `ConnectToolWidget`'s render order checks `meta.settled`/`outcome` before `phase === "error"`, so a real failure always fell through to a generic "Connection not completed" chip - Retry looked completely dead, no error anywhere. The failure reason is now carried through `settle()`'s output and rendered verbatim unless it's one of the three expected non-error terminal states (declined/cancelled/timeout). Error messages prefer the backend's own 4xx `detail` over Fern's default `Error.message`, which bundles a multi-line status/body dump not fit to show a user.

**4. "Not now" fired zero network requests.** Reproduced live: clicking "Not now" on a parked connect request produced no new `/services/agent/v0/invoke` call, and the transcript visibly reverted to an earlier turn. Root cause: `useSessionRecordsWatch`'s SSE relay can tick and adopt a fresh server transcript while the run is idle (`busy=false` - the resume hasn't been dispatched yet) but a local `addToolOutput` settle is still waiting for `sendAutomaticallyWhen` to actually fire it. `liveGateInteractionRef` is written synchronously the instant the settle happens and only cleared once dispatch lands, so it's non-null for exactly that gap. A relay tick landing in that window adopted a transcript that predated the settle, silently discarding it before the resume could ever be sent. `useSessionHydration` now takes that same ref (`pendingResumeRef`, no new signal invented) and skips the relay's adoption while it's set.

## Known remaining issue (not in this PR)

`AgentConversation.tsx:351` gates the connect dock on `busy || stopped ? null : ...`. `stopped` only clears on a new submit/regenerate, but the server-side run can continue past a client Stop and park a NEW interaction, which the latched `stopped` then hides forever. A separate instrumented capture is isolating this (two competing theories for why the widget never rendered in one observed case); it'll land as its own small follow-up once the evidence picks the winner.

## Tests / notes

- **Backend:** `ruff format` + `ruff check` clean. New unit tests: `api/oss/tests/pytest/unit/tools/test_create_connection_errors.py` (3 tests, router-level, exercises the actual `ToolsRouter.create_connection` handler with a faked service raising the real exception), `api/oss/tests/pytest/unit/tools/test_catalog_auth_schemes_fallback.py` (4 tests, the `auth_config_details` fallback and a regression guard that managed-auth toolkits are untouched). All pass.
- **Frontend:** `tsc --noEmit` clean, `pnpm turbo run lint --filter=@agenta/oss` clean (no new warnings). New unit tests: `useConnectFlow.test.ts` (7 tests, `resolveConnectMode` + `extractConnectErrorMessage`), `useSessionHydration.test.ts` (4 tests, the new `shouldSkipRecordsRefresh` guard). Full `AgentChatSlice` vitest suite (162 tests, 21 files) passes with no regressions.
- **Live-verified on the 8180 dev stack** (minted ephemeral accounts, real Composio calls), before this branch's fix:
  - Bug 1 before-state: `POST /tools/connections/` for telegram -> 500, traceback matching `adapter.py:188` / `router.py:773` exactly.
  - Bug 5 before-state: `GET .../catalog/providers/composio/integrations/telegram` -> no `auth_schemes`; `POST /tools/connections/` with `auth_scheme: "api_key"` -> 200 + `redirect_url` (proves the fix's target shape works today, api key just isn't being requested).
  - Bug 4 before-state / bug 3 reproduction: drove a real agent conversation through the elicitation form to the connect ask, clicked "Not now", confirmed zero new `/services/agent/v0/invoke` requests and the transcript reverting to an earlier turn (matches the `session_interactions` rows for Mahmoud's two sessions, still `pending` with no `updated_at`).
  - This worktree's actual code changes could **not** be re-verified live: the 8180 stack hot-reloads the `main` checkout, not this branch. Verified by unit test + code trace instead, per the repo's verification convention for this situation.

## What to QA

- Request a telegram connection through an agent (or any toolkit with no Composio-managed OAuth). The widget should ask for `api_key`-mode custom auth and open a redirect popup, not 404.
- Force a connect failure (e.g. a toolkit slug Composio doesn't recognize) and confirm the widget shows the real error text, not a silent "Connection not completed".
- Click "Not now" on a parked connect request. Confirm a `/services/agent/v0/invoke` request fires and the agent's next turn acknowledges the decline.
- Regression: a normal successful OAuth connect (e.g. github) still opens its popup and settles "connected" as before.
