### PR TITLE
fix(runner): answered approvals close before a carried sibling re-parks the turn

### DIFF
--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -345,6 +345,15 @@ class Turn:
         return {"id": str(uuid.uuid4()), "role": "assistant", "parts": parts}
 
 
+def _upsert_gate(approvals: list, gate: dict) -> None:
+    """Refresh a re-raised gate in place; append only a newly raised toolCallId."""
+    for i, g in enumerate(approvals):
+        if g["toolCallId"] == gate["toolCallId"]:
+            approvals[i] = gate
+            return
+    approvals.append(gate)
+
+
 def invoke(
     session_id: str,
     messages: list[dict],
@@ -423,9 +432,7 @@ def invoke(
                     }
                     # Collect every raised gate; a re-raise for the same call refreshes
                     # its approval id in place without changing the raise order.
-                    t.approvals = [
-                        g for g in t.approvals if g["toolCallId"] != gate["toolCallId"]
-                    ] + [gate]
+                    _upsert_gate(t.approvals, gate)
                     if log:
                         print(
                             f"  !! approval-request: {json.dumps(f)[:400]}",

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -277,7 +277,11 @@ class Turn:
         self.tool_calls: list[dict] = []
         self.tool_outcomes: dict[str, str] = {}
         self.tool_payloads: dict[str, dict] = {}
-        self.approval: dict | None = None
+        # EVERY gate this turn raised, in raise order (a multi-gate turn raises one
+        # `tool-approval-request` frame per call). The old single `approval` dict was
+        # overwritten per frame, so only the LAST gate ever got answered and the rest
+        # sat pending until their TTL.
+        self.approvals: list[dict] = []
         self.finish_reason: str | None = None
         self.errors: list[str] = []
         self.committed_revision = None
@@ -287,6 +291,14 @@ class Turn:
     @property
     def reply(self) -> str:
         return "".join(self.text_parts)
+
+    @property
+    def approval(self) -> dict | None:
+        """The most recent raised gate — the back-compat single-gate view of `approvals`.
+
+        Every existing caller reads truthiness plus `toolCallId`/`approvalId`; none assigns.
+        """
+        return self.approvals[-1] if self.approvals else None
 
     def assistant_message(self) -> dict:
         parts = []
@@ -316,9 +328,17 @@ class Turn:
                     part["errorText"] = self.tool_payloads.get(
                         call["toolCallId"], {}
                     ).get("errorText")
-                if self.approval and self.approval["toolCallId"] == call["toolCallId"]:
+                gate = next(
+                    (
+                        g
+                        for g in self.approvals
+                        if g["toolCallId"] == call["toolCallId"]
+                    ),
+                    None,
+                )
+                if gate:
                     part["state"] = "approval-requested"
-                    part["approval"] = {"id": self.approval["approvalId"]}
+                    part["approval"] = {"id": gate["approvalId"]}
                 parts.append(part)
         if text_buf:
             parts.append({"type": "text", "text": "".join(text_buf)})
@@ -397,10 +417,15 @@ def invoke(
                     if is_new:
                         t._segments.append({"kind": "tool", "id": call["toolCallId"]})
                 elif ftype == "tool-approval-request":
-                    t.approval = {
+                    gate = {
                         "approvalId": f.get("approvalId"),
                         "toolCallId": f.get("toolCallId"),
                     }
+                    # Collect every raised gate; a re-raise for the same call refreshes
+                    # its approval id in place without changing the raise order.
+                    t.approvals = [
+                        g for g in t.approvals if g["toolCallId"] != gate["toolCallId"]
+                    ] + [gate]
                     if log:
                         print(
                             f"  !! approval-request: {json.dumps(f)[:400]}",
@@ -448,13 +473,27 @@ def invoke(
 
 
 def approval_reply(turn: Turn, approved: bool) -> dict:
+    """One assistant message answering EVERY gate the turn raised.
+
+    A multi-gate turn (a parallel batch) raises one `tool-approval-request` frame per
+    call; answering only one leaves the rest pending until their TTL. Each raised gate
+    gets the same `approved` value. A single-gate turn produces the exact message this
+    always produced."""
+    if not turn.approvals:
+        raise ValueError("turn raised no approval gate")
     message = turn.assistant_message()
+    by_tool_call = {g["toolCallId"]: g for g in turn.approvals}
+    answered = 0
     for part in message["parts"]:
-        if part.get("toolCallId") == turn.approval["toolCallId"]:
-            part["state"] = "approval-responded"
-            part["approval"] = {"id": turn.approval["approvalId"], "approved": approved}
-            return message
-    raise ValueError("gated tool call missing from assistant message")
+        gate = by_tool_call.get(part.get("toolCallId"))
+        if gate is None:
+            continue
+        part["state"] = "approval-responded"
+        part["approval"] = {"id": gate["approvalId"], "approved": approved}
+        answered += 1
+    if answered != len(by_tool_call):
+        raise ValueError("gated tool call missing from assistant message")
+    return message
 
 
 def turn_ledger(session_id: str, limit: int = 20) -> list[dict]:

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_approvals.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_approvals.py
@@ -1,0 +1,79 @@
+"""Unit test for multi-gate approval collection (run like the api_call test:
+`uv run --no-sync pytest` from `api/`, or any interpreter with pytest + httpx).
+
+The trap this pins: `Turn.approval` was a single dict overwritten by each
+`tool-approval-request` frame, so a turn that raised TWO gates (a parallel batch)
+only ever answered the LAST one — the first sat pending until its TTL, and every
+"future gated scenario" silently exercised half its gates. `approvals` now collects
+every raised gate and `approval_reply` answers each; single-gate turns produce the
+exact message they always did.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _lib(monkeypatch):
+    monkeypatch.setenv("AGENTA_BASE", "https://qa.example")
+    monkeypatch.setenv("AGENTA_PROJECT_ID", "proj-1")
+    monkeypatch.setenv("AGENTA_API_KEY", "test-key")
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    sys.modules.pop("qa_matrix_lib", None)
+    return importlib.import_module("qa_matrix_lib")
+
+
+def _turn_with_gates(lib, gates):
+    turn = lib.Turn()
+    for tool_call_id, name in gates:
+        turn.tool_calls.append(
+            {"toolCallId": tool_call_id, "toolName": name, "input": {}}
+        )
+        turn._segments.append({"kind": "tool", "id": tool_call_id})
+        turn.approvals = [
+            g for g in turn.approvals if g["toolCallId"] != tool_call_id
+        ] + [{"approvalId": f"approval-{tool_call_id}", "toolCallId": tool_call_id}]
+    return turn
+
+
+def test_single_gate_reply_is_unchanged(monkeypatch):
+    lib = _lib(monkeypatch)
+    turn = _turn_with_gates(lib, [("tc-1", "commit_revision")])
+
+    assert turn.approval == {"approvalId": "approval-tc-1", "toolCallId": "tc-1"}
+    message = lib.approval_reply(turn, approved=True)
+    (part,) = [p for p in message["parts"] if p.get("toolCallId") == "tc-1"]
+    assert part["state"] == "approval-responded"
+    assert part["approval"] == {"id": "approval-tc-1", "approved": True}
+
+
+def test_every_raised_gate_is_answered(monkeypatch):
+    lib = _lib(monkeypatch)
+    turn = _turn_with_gates(lib, [("tc-1", "rename_session"), ("tc-2", "rename_agent")])
+
+    # Back-compat single view stays the LAST raised gate.
+    assert turn.approval["toolCallId"] == "tc-2"
+
+    message = lib.approval_reply(turn, approved=True)
+    answered = {
+        p["toolCallId"]: p["approval"]
+        for p in message["parts"]
+        if p.get("state") == "approval-responded"
+    }
+    assert answered == {
+        "tc-1": {"id": "approval-tc-1", "approved": True},
+        "tc-2": {"id": "approval-tc-2", "approved": True},
+    }
+
+
+def test_a_reraise_refreshes_the_gate_in_place(monkeypatch):
+    lib = _lib(monkeypatch)
+    turn = _turn_with_gates(lib, [("tc-1", "commit_revision")])
+    turn.approvals = [g for g in turn.approvals if g["toolCallId"] != "tc-1"] + [
+        {"approvalId": "approval-fresh", "toolCallId": "tc-1"}
+    ]
+
+    assert len(turn.approvals) == 1
+    message = lib.approval_reply(turn, approved=False)
+    (part,) = [p for p in message["parts"] if p.get("toolCallId") == "tc-1"]
+    assert part["approval"] == {"id": "approval-fresh", "approved": False}

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_approvals.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_approvals.py
@@ -77,3 +77,16 @@ def test_a_reraise_refreshes_the_gate_in_place(monkeypatch):
     message = lib.approval_reply(turn, approved=False)
     (part,) = [p for p in message["parts"] if p.get("toolCallId") == "tc-1"]
     assert part["approval"] == {"id": "approval-fresh", "approved": False}
+
+
+def test_re_raise_preserves_first_raise_order(monkeypatch):
+    lib = _lib(monkeypatch)
+    approvals = [
+        {"approvalId": "a1", "toolCallId": "tc-1"},
+        {"approvalId": "a2", "toolCallId": "tc-2"},
+    ]
+    lib._upsert_gate(approvals, {"approvalId": "a1-new", "toolCallId": "tc-1"})
+    assert [g["toolCallId"] for g in approvals] == ["tc-1", "tc-2"]
+    assert approvals[0]["approvalId"] == "a1-new"
+    lib._upsert_gate(approvals, {"approvalId": "a3", "toolCallId": "tc-3"})
+    assert [g["toolCallId"] for g in approvals] == ["tc-1", "tc-2", "tc-3"]

--- a/benchmarks/agent-config-editing/scenarios/09-self-naming.json
+++ b/benchmarks/agent-config-editing/scenarios/09-self-naming.json
@@ -4,7 +4,8 @@
     "Naming sessions and agents after the model has enough context to choose a useful label.",
     "The verdict comes from the stored session or workflow header, never from the reply.",
     "name-05 seeds the VERBATIM product-default persona (_DEFAULT_AGENTS_MD in sdks/python/agenta/sdk/utils/types.py, drift-locked by the SDK unit test test_default_persona_self_naming.py): live QA showed task-shaped personas self-name while the bare default persona did not, so this scenario is the regression guard for the real new-user experience.",
-    "name-06 mirrors the composer path (workflow created with the raw request as its name, session auto-titled from the first message) and expects rename_session AND rename_agent in the same first-task turn — the pairing the persona now instructs, after a live session showed the standalone rename_agent trigger being forgotten. max_rename_calls is a SINGLE combined counter across both rename tools (run_benchmark sums them), so 2 here plus the two min-1 tool checks pins exactly one call each."
+    "name-06 mirrors the composer path (workflow created with the raw request as its name, session auto-titled from the first message) and expects rename_session AND rename_agent in the same first-task turn — the pairing the persona now instructs, after a live session showed the standalone rename_agent trigger being forgotten. max_rename_calls is a SINGLE combined counter across both rename tools (run_benchmark sums them), so 2 here plus the two min-1 tool checks pins exactly one call each.",
+    "name-06 mounts both rename ops with permission: allow, mirroring the shipped build-kit overlay — in the product these calls never raise a gate, so the scenario measures naming behavior, not approval mechanics. The approval-race regression (issue #5907, two gates with one answered on resume) is guarded at the runner unit layer (services/runner/tests/unit/session-keepalive-approval.test.ts), not here."
   ],
   "scenarios": [
     {
@@ -253,11 +254,13 @@
       "tools": [
         {
           "type": "platform",
-          "op": "rename_session"
+          "op": "rename_session",
+          "permission": "allow"
         },
         {
           "type": "platform",
-          "op": "rename_agent"
+          "op": "rename_agent",
+          "permission": "allow"
         }
       ],
       "budget": {

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -993,9 +993,28 @@ export async function runTurn(
           `[keepalive] resume answered gate reply=${decision.reply} tool=${decision.toolName ?? "?"}`,
         );
       }
-      // The harness still holds carried gates inside the original prompt, so re-arm the pause after
-      // this answer batch and let the normal park path refresh their approval TTL.
-      if (opts.resume.carriedForward.length > 0) pause.pause();
+      // The harness still holds carried gates inside the original prompt, so the turn must end
+      // paused again — but pause() both destroys the live session and settles the race signal
+      // below, so pausing here would kill a freshly-approved execution mid-flight and the
+      // paused-settle would replace its REAL result with the UNKNOWN sentinel (issue #5907).
+      // Give each answered/allowed execution its closure window FIRST, on the same per-call
+      // bound the paused-settle uses, then re-arm the pause and let the normal park path
+      // refresh the carried gates' approval TTL. Pi is exempt on purpose: it prepares the whole
+      // batch before executing any call, so while a carried sibling gate is pending closure is
+      // impossible and the paused-settle's park-and-carry branch owns those spans.
+      if (opts.resume.carriedForward.length > 0) {
+        if (!plan.isPi) {
+          const answeredAllowedIds = decisions
+            .filter((decision) => decision.reply === "once")
+            .map((decision) => decision.toolCallId);
+          await Promise.all(
+            answeredAllowedIds.map((toolCallId) =>
+              waitForToolCallClosure(toolCallId, resolvedRunLimits.toolCallMs),
+            ),
+          );
+        }
+        pause.pause();
+      }
     } else {
       promptPromise = Promise.resolve(
         env.session.prompt(promptBlocks),

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -2428,10 +2428,20 @@ describe("runTurn: real approval park + respondPermission resume", () => {
         carriedForward: [carried],
       },
     });
-    for (let i = 0; i < 5 && !env.currentTurn?.pause.active; i += 1) {
-      await Promise.resolve();
+    // The resume holds the pause OPEN until the freshly-approved execution closes (issue
+    // #5907): answer lands first, then the harness streams the real completion, and only
+    // then does the carried sibling re-arm the pause. Deliver the frames in that order.
+    for (let i = 0; i < 20 && calls.permissionReplies.length === 0; i += 1) {
+      await flush();
     }
-    assert.equal(env.currentTurn?.pause.active, true);
+    assert.deepEqual(calls.permissionReplies, [
+      { id: "perm-1", reply: "once" },
+    ]);
+    assert.equal(
+      env.currentTurn?.pause.active,
+      false,
+      "the carried sibling must not re-park before the answered execution's closure window",
+    );
     captured.onEvent!(
       updateEvent({
         sessionUpdate: "tool_call_update",
@@ -2448,6 +2458,10 @@ describe("runTurn: real approval park + respondPermission resume", () => {
         content: "answered result",
       }),
     );
+    for (let i = 0; i < 20 && !env.currentTurn?.pause.active; i += 1) {
+      await flush();
+    }
+    assert.equal(env.currentTurn?.pause.active, true);
     const result = await resumeTurn;
 
     assert.equal(result.stopReason, "paused");
@@ -2457,6 +2471,24 @@ describe("runTurn: real approval park + respondPermission resume", () => {
     assert.deepEqual([...env.parkedApprovals.keys()], ["tc-g2"]);
     assert.equal(env.approvalGateCount, 1);
     const run = calls.runs[1];
+    // The answered gate's REAL result must survive the carried sibling's re-park — the
+    // assertion issue #5907 found missing: before the ordering fix the pause destroyed the
+    // session first and this frame was replaced with APPROVED_EXECUTION_RESULT_UNKNOWN.
+    assert.equal(
+      run.handled.some(
+        (update) =>
+          update.toolCallId === "tc-g1" &&
+          update.status === "completed" &&
+          update.content === "answered result",
+      ),
+      true,
+      "the answered gate's real completion must reach the tracer",
+    );
+    assert.equal(
+      run.settled.some((entry) => entry.id === "tc-g1"),
+      false,
+      "no sentinel may replace the answered gate's real result",
+    );
     assert.equal(
       run.handled.some((update) => update.toolCallId === "tc-g2"),
       false,
@@ -2471,6 +2503,127 @@ describe("runTurn: real approval park + respondPermission resume", () => {
       run.settled.some((entry) => entry.id === "tc-g2"),
       false,
       "the carried gate receives no sentinel",
+    );
+
+    await env.destroy();
+  });
+
+  it("holds the carried sibling's re-park open until the approved execution reports its result", async () => {
+    // The live shape of issue #5907: the freshly-approved execution reports its result a few
+    // ticks after the answer, and it only gets OBSERVED while the turn's closure window is
+    // open. Before the ordering fix, the carried sibling's re-park fired synchronously after
+    // the answer batch — before the race, before any window — and the settle replaced the
+    // real result with APPROVED_EXECUTION_RESULT_UNKNOWN. This test delivers the completion
+    // only while the pause has not yet re-armed — red before the fix, green after.
+    const { calls, deps, captured } = pausableHarness();
+    // A short per-call closure bound so the red state fails fast instead of hanging.
+    deps.resolveRunLimits = () => ({
+      totalMs: 1_000_000,
+      idleMs: 500_000,
+      ttfbMs: 500_000,
+      toolCallMs: 50,
+    });
+    deps.createRunLimits = () => ({
+      onTrip() {},
+      noteToolCallStart() {},
+      noteToolCallEnd() {},
+      wrapEmit: (emit: (event: any) => void) => emit,
+      notePaused() {},
+      dispose() {},
+    });
+    const acquired = await acquireEnvironment(engineReq, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const env = acquired.env;
+
+    const firstTurn = runTurn(env, engineReq, undefined, undefined, {
+      approvalParkMode: true,
+    });
+    await flush();
+    for (const [toolCallId, title] of [
+      ["tc-g1", "commit"],
+      ["tc-g2", "deploy"],
+    ]) {
+      captured.onEvent!(
+        updateEvent({ sessionUpdate: "tool_call", toolCallId, title }),
+      );
+    }
+    captured.onPermissionRequest!({
+      id: "perm-1",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tc-g1", name: "commit", rawInput: {} },
+    });
+    captured.onPermissionRequest!({
+      id: "perm-2",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tc-g2", name: "deploy", rawInput: {} },
+    });
+    await firstTurn;
+
+    const answered = env.parkedApprovals.get("tc-g1")!;
+    const carried = env.parkedApprovals.get("tc-g2")!;
+    env.clearTurn();
+    const resumeTurn = runTurn(env, approveResume(true), undefined, undefined, {
+      approvalParkMode: true,
+      resume: {
+        decisions: [
+          {
+            permissionId: answered.permissionId,
+            reply: "once",
+            toolCallId: answered.toolCallId,
+            toolName: answered.toolName,
+            args: answered.args,
+            interactionToken: answered.interactionToken,
+            promptPromise: answered.promptPromise,
+          },
+        ],
+        carriedForward: [carried],
+      },
+    });
+    for (let i = 0; i < 20 && calls.permissionReplies.length === 0; i += 1) {
+      await flush();
+    }
+    assert.deepEqual(calls.permissionReplies, [
+      { id: "perm-1", reply: "once" },
+    ]);
+    // The approved execution takes two ticks to report — and its report is only
+    // observed while the re-park has not yet fired (the closure window the fix opens).
+    setImmediate(() => {
+      setImmediate(() => {
+        if (env.currentTurn?.pause.active) return;
+        captured.onEvent!(
+          updateEvent({
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tc-g1",
+            status: "completed",
+            content: "real output",
+          }),
+        );
+      });
+    });
+    const result = await resumeTurn;
+
+    assert.equal(result.stopReason, "paused");
+    const run = calls.runs[1];
+    assert.equal(
+      run.handled.some(
+        (update) =>
+          update.toolCallId === "tc-g1" &&
+          update.status === "completed" &&
+          update.content === "real output",
+      ),
+      true,
+      "the approved execution's real completion must land inside the pre-park closure window",
+    );
+    assert.equal(
+      run.settled.some((entry) => entry.id === "tc-g1"),
+      false,
+      "the deferred sentinel must not replace the approved execution's result",
+    );
+    assert.deepEqual(
+      [...env.parkedApprovals.keys()],
+      ["tc-g2"],
+      "the carried gate still re-parks",
     );
 
     await env.destroy();


### PR DESCRIPTION
## Context

When one turn raises two approval gates and the resume answers only one, the answered call executed but its result was replaced with the synthetic `APPROVED_EXECUTION_RESULT_UNKNOWN`: the carried (unanswered) sibling triggered the pause synchronously, before the race that should observe the answered call's real completion. Full characterization with runner-log and DB evidence: [#5907](https://github.com/Agenta-AI/agenta/issues/5907). Live evidence includes a production-path shape (an auto-allowed rename racing a client-tool park).

## Changes

- The resume block re-parks the carried sibling only AFTER each answered/allowed execution gets its `waitForToolCallClosure` window, on the same per-call bound the paused-settle path uses. Pi is exempt by design: its batch semantics make a pending sibling during closure impossible, so the park-and-carry branch keeps owning those spans. Carried-gate re-park semantics are unchanged.
- The existing carry test (which reproduced the exact topology but asserted nothing about the answered gate) now asserts the closure window is open when the answer lands and the real completion reaches the tracer; a new sibling test delivers the completion only while the re-park has not fired.
- Benchmark corrections: name-06 mounts the rename ops with `permission: allow`, mirroring the shipped overlay (the product never gates these; the approval-race regression lives at the runner unit layer). The QA harness now collects and answers EVERY raised gate in a turn instead of only the last (back-compatible for single-gate flows; all consumers audited).

## Tests

Red/green proven by stashing the fix: before, 2 failed with `APPROVED_EXECUTION_RESULT_UNKNOWN` written into the settle; after, 48/48 in the file, 2145/2145 across the runner suite, tsc clean. Scenario JSON validated, persona drift locks green, CI-pinned ruff clean.

## Known follow-up (not this PR)

A carried gate is re-parked server-side but every later frame for it is suppressed, so the client is never re-told it owes an answer and the gate expires at the 10-minute TTL. Needs its own issue: re-emit carried gates on resume or re-render from the durable interaction rows.