### PR TITLE
[fix] Transcript replay respects a cancelled interaction's terminal status

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
@@ -1,4 +1,4 @@
-import {fetchSessionRecordsAtom} from "@agenta/entities/session"
+import {fetchCancelledClientToolTokensAtom, fetchSessionRecordsAtom} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 import {getDefaultStore} from "jotai"
 
@@ -41,18 +41,24 @@ export const loadSessionMessages = async (
     // (the documented "request failed" contract) so the caller shows the history-unavailable
     // notice instead of leaking an unhandled rejection.
     try {
-        const {records, refreshed} = await getDefaultStore().set(fetchSessionRecordsAtom, sessionId)
+        const store = getDefaultStore()
+        // Best-effort join (never throws, see the atom's doc) — a resurrected cancelled part
+        // is cosmetic, so it must never gate whether the transcript loads at all.
+        const [{records, refreshed}, cancelledClientToolTokens] = await Promise.all([
+            store.set(fetchSessionRecordsAtom, sessionId),
+            store.set(fetchCancelledClientToolTokensAtom, sessionId),
+        ])
         if (refreshed && onRefreshed) {
             void refreshed.then((fresh) => {
                 if (!fresh || fresh.length === 0) return
-                const freshMsgs = transcriptToMessages(fresh)
+                const freshMsgs = transcriptToMessages(fresh, {cancelledClientToolTokens})
                 if (freshMsgs && freshMsgs.length > 0) {
                     onRefreshed({messages: freshMsgs, recordCount: fresh.length})
                 }
             })
         }
         if (!records || records.length === 0) return null
-        const messages = transcriptToMessages(records)
+        const messages = transcriptToMessages(records, {cancelledClientToolTokens})
         return messages ? {messages, recordCount: records.length} : null
     } catch (err) {
         console.warn("[loadSessionMessages] hydration fetch failed:", err)

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -733,3 +733,142 @@ describe("transcriptToMessages parked client tool", () => {
         expect(parts[0]).toMatchObject({type: "tool-request_input", state: "output-available"})
     })
 })
+
+/**
+ * Regression: a `session_interactions` row that reached a TERMINAL status (cancelled — e.g. the
+ * stale-interaction sweep) server-side, with no corresponding `tool_result` ever landing in the
+ * transcript, previously replayed as still fully pending — an interactive, answerable form
+ * stacked above the real live interaction (live evidence, session
+ * 3975e362-f64c-4e2d-8f4f-4f36c584bd91 on the 8180 dev stack). `cancelledClientToolTokens` (keyed
+ * by `session_interactions.token`, which equals the record's `toolCallId`) is the join that fixes
+ * it — each client-tool kind renders inert exactly like its own live cancel.
+ */
+describe("transcriptToMessages cancelled client-tool interactions", () => {
+    const elicitationToolCallId = "call_4ySJBKMeiDq4u3hUNGJidwkX|fc_05786f8fb9f28034"
+    const elicitationInput = {
+        message: "To configure the PR reviewer, tell me which repository to monitor.",
+        requestedSchema: {
+            type: "object",
+            required: ["repository"],
+            properties: {repository: {type: "string", title: "Repository"}},
+        },
+    }
+    const elicitationRequest = (): SessionRecord =>
+        record("record-interaction", {
+            type: "interaction_request",
+            id: elicitationToolCallId,
+            kind: "client_tool",
+            payload: {
+                toolCallId: elicitationToolCallId,
+                toolName: "request_input",
+                input: elicitationInput,
+                render: {kind: "elicitation"},
+            },
+        })
+
+    const connectToolCallId = "call_qTG2js6FcMv5thyd5UfpqCsM|fc_0e0b88283f978225"
+    const connectInput = {mode: "oauth", slug: "telegram", integration: "telegram"}
+    const connectRequest = (): SessionRecord =>
+        record("record-interaction", {
+            type: "interaction_request",
+            id: connectToolCallId,
+            kind: "client_tool",
+            payload: {
+                toolCallId: connectToolCallId,
+                toolName: "request_connection",
+                input: connectInput,
+                render: {kind: "connect"},
+            },
+        })
+
+    it("cancelled: an elicitation replays inert (output-available, action:cancel), not as a form", () => {
+        const messages = transcriptToMessages([elicitationRequest()], {
+            cancelledClientToolTokens: new Set([elicitationToolCallId]),
+        })
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId: elicitationToolCallId,
+            state: "output-available",
+            output: {action: "cancel"},
+            // The original request payload is untouched — the widget still needs it to render
+            // its (now inert) chip, e.g. for a submitted-answers style summary.
+            input: elicitationInput,
+        })
+    })
+
+    it("cancelled: a connect request replays inert (connected:false, reason:cancelled)", () => {
+        const messages = transcriptToMessages([connectRequest()], {
+            cancelledClientToolTokens: new Set([connectToolCallId]),
+        })
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_connection",
+            toolCallId: connectToolCallId,
+            state: "output-available",
+            output: {connected: false, reason: "cancelled"},
+        })
+    })
+
+    it("pending: a token NOT in the cancelled set still replays fully interactive (existing behavior)", () => {
+        const messages = transcriptToMessages([elicitationRequest()], {
+            cancelledClientToolTokens: new Set(["some-other-token"]),
+        })
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId: elicitationToolCallId,
+            state: "input-available",
+        })
+    })
+
+    it("pending: omitting the option entirely is a no-op (callers with no interaction join unaffected)", () => {
+        const messages = transcriptToMessages([elicitationRequest()])
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({state: "input-available"})
+    })
+
+    it("settled: a real tool_result still wins over a stale cancelled-token entry", () => {
+        // Belt-and-suspenders: even if the interactions join is stale (says cancelled) but the
+        // transcript itself shows a later real settle, the real settle must not be downgraded.
+        const messages = transcriptToMessages(
+            [
+                elicitationRequest(),
+                record("record-result", {
+                    type: "tool_result",
+                    id: elicitationToolCallId,
+                    output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+                }),
+            ],
+            {cancelledClientToolTokens: new Set([elicitationToolCallId])},
+        )
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            state: "output-available",
+            output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+        })
+    })
+
+    it("cancelled: an unregistered client-tool kind still settles (empty output, no crash)", () => {
+        const toolCallId = "call_unknownKind"
+        const messages = transcriptToMessages(
+            [
+                record("record-interaction", {
+                    type: "interaction_request",
+                    id: toolCallId,
+                    kind: "client_tool",
+                    payload: {toolCallId, toolName: "some_future_client_tool", input: {}},
+                }),
+            ],
+            {cancelledClientToolTokens: new Set([toolCallId])},
+        )
+        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({state: "output-available", output: {}})
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -104,6 +104,44 @@ const isRunnerSentinelError = (part: Part): boolean => {
     )
 }
 
+/** Tool name from a replayed part's `type`/`toolName` — mirrors clientTools/meta.ts's
+ * `clientToolName`, kept local since this file has no dependency on the app's client-tool layer. */
+const partToolName = (part: Part): string => {
+    if (part.type === "dynamic-tool") return typeof part.toolName === "string" ? part.toolName : ""
+    return typeof part.type === "string" ? part.type.replace(/^tool-/, "") : ""
+}
+
+/**
+ * The settled output to synthesize for a client-tool interaction the backend already cancelled
+ * (`session_interactions.status === "cancelled"`) whose transcript never got a settling
+ * `tool_result` — see `fetchCancelledClientToolTokensAtom`'s doc for why the record log alone
+ * can't tell. Mirrors each widget's OWN cancelled-terminal shape (`ConnectOutput.reason` /
+ * `ElicitationResult.action`) so a resurrected part renders exactly like a live cancel — an inert
+ * chip, never an interactive, answerable form. Keyed by the same tool name the client-tool
+ * registry dispatches on (`registry.tsx`'s `BY_TOOL_NAME`); an unregistered kind falls back to a
+ * bare empty output, which still settles (out of `input-available`) even with no dedicated chip.
+ */
+const CANCELLED_CLIENT_TOOL_OUTPUT: Record<string, Part> = {
+    request_connection: {connected: false, reason: "cancelled"},
+    request_input: {action: "cancel"},
+}
+
+/** Apply the cancelled-interaction override to every still-`input-available` client-tool part
+ * whose token the interactions join marked cancelled. Runs once, after the full record sweep, so
+ * a LATER `tool_result` for the same toolCallId (a real settle) always wins over this fallback. */
+function applyCancelledInteractions(
+    index: TranscriptIndex,
+    cancelledClientToolTokens: ReadonlySet<string> | undefined,
+): void {
+    if (!cancelledClientToolTokens || cancelledClientToolTokens.size === 0) return
+    for (const [toolCallId, part] of index.tools) {
+        if (part.state !== "input-available") continue
+        if (!cancelledClientToolTokens.has(toolCallId)) continue
+        part.state = "output-available"
+        part.output = CANCELLED_CLIENT_TOOL_OUTPUT[partToolName(part)] ?? {}
+    }
+}
+
 /**
  * Replay a parked CLIENT TOOL (`interaction_request` `kind: "client_tool"`): its unsettled tool
  * part plus the sibling `data-render` part that carries `render.kind` — the ONLY thing that tells
@@ -365,12 +403,23 @@ function applyEvent(
     }
 }
 
+export interface TranscriptToMessagesOptions {
+    /** Tokens (== toolCallId) of this session's CANCELLED `client_tool` interactions — see
+     * `fetchCancelledClientToolTokensAtom`. A resurrected part for one of these replays inert
+     * instead of as a live, answerable form. Omit when the caller has no interaction-status join
+     * available; every part then replays exactly as before (unaffected, not a regression). */
+    cancelledClientToolTokens?: ReadonlySet<string>
+}
+
 /**
  * Convert a session's ordered transcript rows into v6 `UIMessage[]`. Returns `null` when
  * there is nothing renderable (empty transcript or only metadata events) so the caller can
  * fall back to local history.
  */
-export function transcriptToMessages(records: SessionRecord[]): UIMessage[] | null {
+export function transcriptToMessages(
+    records: SessionRecord[],
+    options?: TranscriptToMessagesOptions,
+): UIMessage[] | null {
     const drafts: DraftMessage[] = []
     let current: DraftMessage | null = null
     // Paused resumes close the draft, but later answers and results still target its tool part.
@@ -426,6 +475,12 @@ export function transcriptToMessages(records: SessionRecord[]): UIMessage[] | nu
             if (part.state === "approval-requested") part.state = "approval-responded"
         }
     }
+
+    // Same "settle whatever the record log alone left parked" idea as the resumed-approval pass
+    // above, for client tools: a token the caller's interaction-status join says is CANCELLED
+    // never got its own `tool_result` (a real settle would have), so it replays parked forever
+    // without this.
+    applyCancelledInteractions(index, options?.cancelledClientToolTokens)
 
     const messages = drafts
         .filter((d) => d.parts.length > 0)

--- a/web/packages/agenta-chat/src/assets/loadSession.ts
+++ b/web/packages/agenta-chat/src/assets/loadSession.ts
@@ -1,10 +1,12 @@
 // Copied verbatim from web/oss/src/components/AgentChatSlice/assets/loadSession.ts (2026-07-25);
 // the OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it.
 // Keep byte-parity if either side changes.
-// Adaptations: none — `fetchSessionRecordsAtom` already reads `projectIdAtom` internally from
-// `@agenta/entities/session` (an allowed package dep), so no OSS-app-only import is involved and
-// no signature change was needed.
-import {fetchSessionRecordsAtom} from "@agenta/entities/session"
+// Adaptations: none — `fetchSessionRecordsAtom`/`fetchCancelledClientToolTokensAtom` already read
+// `projectIdAtom` internally from `@agenta/entities/session` (an allowed package dep), so no
+// OSS-app-only import is involved and no signature change was needed.
+// Re-synced 2026-08-10: the cancelled-client-tool-tokens join (transcript replay respecting a
+// terminal `session_interactions` status — a resurrected parked form must not replay interactive).
+import {fetchCancelledClientToolTokensAtom, fetchSessionRecordsAtom} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 import {getDefaultStore} from "jotai"
 
@@ -47,12 +49,18 @@ export const loadSessionMessages = async (
     // (the documented "request failed" contract) so the caller shows the history-unavailable
     // notice instead of leaking an unhandled rejection.
     try {
-        const {records, refreshed} = await getDefaultStore().set(fetchSessionRecordsAtom, sessionId)
+        const store = getDefaultStore()
+        // Best-effort join (never throws, see the atom's doc) — a resurrected cancelled part
+        // is cosmetic, so it must never gate whether the transcript loads at all.
+        const [{records, refreshed}, cancelledClientToolTokens] = await Promise.all([
+            store.set(fetchSessionRecordsAtom, sessionId),
+            store.set(fetchCancelledClientToolTokensAtom, sessionId),
+        ])
         if (refreshed && onRefreshed) {
             void refreshed
                 .then((fresh) => {
                     if (!fresh || fresh.length === 0) return
-                    const freshMsgs = transcriptToMessages(fresh)
+                    const freshMsgs = transcriptToMessages(fresh, {cancelledClientToolTokens})
                     if (freshMsgs && freshMsgs.length > 0) {
                         onRefreshed({messages: freshMsgs, recordCount: fresh.length})
                     }
@@ -65,7 +73,7 @@ export const loadSessionMessages = async (
                 })
         }
         if (!records || records.length === 0) return null
-        const messages = transcriptToMessages(records)
+        const messages = transcriptToMessages(records, {cancelledClientToolTokens})
         return messages ? {messages, recordCount: records.length} : null
     } catch (err) {
         console.warn("[loadSessionMessages] hydration fetch failed:", err)

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -125,6 +125,44 @@ const isRunnerSentinelError = (part: Part): boolean => {
     )
 }
 
+/** Tool name from a replayed part's `type`/`toolName` — mirrors clientTools/meta.ts's
+ * `clientToolName`, kept local since this file has no dependency on the app's client-tool layer. */
+const partToolName = (part: Part): string => {
+    if (part.type === "dynamic-tool") return typeof part.toolName === "string" ? part.toolName : ""
+    return typeof part.type === "string" ? part.type.replace(/^tool-/, "") : ""
+}
+
+/**
+ * The settled output to synthesize for a client-tool interaction the backend already cancelled
+ * (`session_interactions.status === "cancelled"`) whose transcript never got a settling
+ * `tool_result` — see `fetchCancelledClientToolTokensAtom`'s doc for why the record log alone
+ * can't tell. Mirrors each widget's OWN cancelled-terminal shape (`ConnectOutput.reason` /
+ * `ElicitationResult.action`) so a resurrected part renders exactly like a live cancel — an inert
+ * chip, never an interactive, answerable form. Keyed by the same tool name the client-tool
+ * registry dispatches on; an unregistered kind falls back to a bare empty output, which still
+ * settles (out of `input-available`) even with no dedicated chip.
+ */
+const CANCELLED_CLIENT_TOOL_OUTPUT: Record<string, Part> = {
+    request_connection: {connected: false, reason: "cancelled"},
+    request_input: {action: "cancel"},
+}
+
+/** Apply the cancelled-interaction override to every still-`input-available` client-tool part
+ * whose token the interactions join marked cancelled. Runs once, after the full record sweep, so
+ * a LATER `tool_result` for the same toolCallId (a real settle) always wins over this fallback. */
+function applyCancelledInteractions(
+    index: TranscriptIndex,
+    cancelledClientToolTokens: ReadonlySet<string> | undefined,
+): void {
+    if (!cancelledClientToolTokens || cancelledClientToolTokens.size === 0) return
+    for (const [toolCallId, part] of index.tools) {
+        if (part.state !== "input-available") continue
+        if (!cancelledClientToolTokens.has(toolCallId)) continue
+        part.state = "output-available"
+        part.output = CANCELLED_CLIENT_TOOL_OUTPUT[partToolName(part)] ?? {}
+    }
+}
+
 /**
  * Replay a parked CLIENT TOOL (`interaction_request` `kind: "client_tool"`): its unsettled tool
  * part plus the sibling `data-render` part that carries `render.kind` — the ONLY thing that tells
@@ -373,12 +411,23 @@ function applyEvent(
     }
 }
 
+export interface TranscriptToMessagesOptions {
+    /** Tokens (== toolCallId) of this session's CANCELLED `client_tool` interactions — see
+     * `fetchCancelledClientToolTokensAtom`. A resurrected part for one of these replays inert
+     * instead of as a live, answerable form. Omit when the caller has no interaction-status join
+     * available; every part then replays exactly as before (unaffected, not a regression). */
+    cancelledClientToolTokens?: ReadonlySet<string>
+}
+
 /**
  * Convert a session's ordered transcript rows into v6 `UIMessage[]`. Returns `null` when
  * there is nothing renderable (empty transcript or only metadata events) so the caller can
  * fall back to local history.
  */
-export function transcriptToMessages(records: SessionRecord[]): UIMessage[] | null {
+export function transcriptToMessages(
+    records: SessionRecord[],
+    options?: TranscriptToMessagesOptions,
+): UIMessage[] | null {
     const drafts: DraftMessage[] = []
     let current: DraftMessage | null = null
     // Paused resumes close the draft, but later answers and results still target its tool part.
@@ -434,6 +483,12 @@ export function transcriptToMessages(records: SessionRecord[]): UIMessage[] | nu
             if (part.state === "approval-requested") part.state = "approval-responded"
         }
     }
+
+    // Same "settle whatever the record log alone left parked" idea as the resumed-approval pass
+    // above, for client tools: a token the caller's interaction-status join says is CANCELLED
+    // never got its own `tool_result` (a real settle would have), so it replays parked forever
+    // without this.
+    applyCancelledInteractions(index, options?.cancelledClientToolTokens)
 
     const messages = drafts
         .filter((d) => d.parts.length > 0)

--- a/web/packages/agenta-chat/tests/unit/assets/loadSession.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/loadSession.test.ts
@@ -2,12 +2,16 @@ import type {SessionRecord} from "@agenta/entities/session"
 import {atom} from "jotai"
 import {beforeEach, describe, expect, it, vi} from "vitest"
 
-// `fetchSessionRecordsAtom` (real impl in @agenta/entities) hits the network via
-// jotai-tanstack-query; loadSessionMessages only needs its {records, refreshed} contract, so the
-// atom is replaced with a controllable stub rather than standing up a query client + fetch mock.
+// `fetchSessionRecordsAtom`/`fetchCancelledClientToolTokensAtom` (real impls in @agenta/entities)
+// hit the network via jotai-tanstack-query; loadSessionMessages only needs their resolved-value
+// contracts, so both are replaced with controllable stubs rather than standing up a query client +
+// fetch mock. The cancelled-tokens set defaults empty — irrelevant to this file's own assertions,
+// which only cover the records half; transcriptToMessages.test.ts covers the join itself.
 let fetchResult: {records: SessionRecord[] | null; refreshed?: Promise<SessionRecord[] | null>}
+let cancelledClientToolTokens = new Set<string>()
 vi.mock("@agenta/entities/session", () => ({
     fetchSessionRecordsAtom: atom(null, async () => fetchResult),
+    fetchCancelledClientToolTokensAtom: atom(null, async () => cancelledClientToolTokens),
 }))
 
 const {loadSessionMessages} = await import("../../../src/assets/loadSession")
@@ -26,6 +30,7 @@ const record = (id: string, payload: Record<string, unknown>, sender = "agent"):
 describe("loadSessionMessages", () => {
     beforeEach(() => {
         fetchResult = {records: null}
+        cancelledClientToolTokens = new Set()
     })
 
     it("returns null when there are no records", async () => {

--- a/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
@@ -468,3 +468,128 @@ describe("transcriptToMessages parked client tool", () => {
         expect(parts[0]).toMatchObject({type: "tool-request_input", state: "output-available"})
     })
 })
+
+/**
+ * Regression: a `session_interactions` row that reached a TERMINAL status (cancelled) server-side
+ * with no corresponding `tool_result` in the transcript previously replayed as still fully
+ * pending — an interactive, answerable form stacked above the real live interaction (live
+ * evidence, session 3975e362-f64c-4e2d-8f4f-4f36c584bd91 on the 8180 dev stack).
+ * `cancelledClientToolTokens` (keyed by `session_interactions.token` == the record's `toolCallId`)
+ * is the join that fixes it — byte-parity with the OSS original's suite.
+ */
+describe("transcriptToMessages cancelled client-tool interactions", () => {
+    const elicitationToolCallId = "call_1|fc_1"
+    const elicitationInput = {
+        message: "Which repository?",
+        requestedSchema: {type: "object", properties: {}},
+    }
+    const elicitationRequest = (): SessionRecord =>
+        record("r-interaction", {
+            type: "interaction_request",
+            id: elicitationToolCallId,
+            kind: "client_tool",
+            payload: {
+                toolCallId: elicitationToolCallId,
+                toolName: "request_input",
+                input: elicitationInput,
+                render: {kind: "elicitation"},
+            },
+        })
+
+    const connectToolCallId = "call_2|fc_2"
+    const connectInput = {mode: "oauth", slug: "telegram", integration: "telegram"}
+    const connectRequest = (): SessionRecord =>
+        record("r-interaction", {
+            type: "interaction_request",
+            id: connectToolCallId,
+            kind: "client_tool",
+            payload: {
+                toolCallId: connectToolCallId,
+                toolName: "request_connection",
+                input: connectInput,
+                render: {kind: "connect"},
+            },
+        })
+
+    it("cancelled: an elicitation replays inert (output-available, action:cancel), not as a form", () => {
+        const parts = (transcriptToMessages([elicitationRequest()], {
+            cancelledClientToolTokens: new Set([elicitationToolCallId]),
+        })?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId: elicitationToolCallId,
+            state: "output-available",
+            output: {action: "cancel"},
+            input: elicitationInput,
+        })
+    })
+
+    it("cancelled: a connect request replays inert (connected:false, reason:cancelled)", () => {
+        const parts = (transcriptToMessages([connectRequest()], {
+            cancelledClientToolTokens: new Set([connectToolCallId]),
+        })?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_connection",
+            toolCallId: connectToolCallId,
+            state: "output-available",
+            output: {connected: false, reason: "cancelled"},
+        })
+    })
+
+    it("pending: a token NOT in the cancelled set still replays fully interactive (existing behavior)", () => {
+        const parts = (transcriptToMessages([elicitationRequest()], {
+            cancelledClientToolTokens: new Set(["some-other-token"]),
+        })?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            type: "tool-request_input",
+            toolCallId: elicitationToolCallId,
+            state: "input-available",
+        })
+    })
+
+    it("pending: omitting the option entirely is a no-op (callers with no interaction join unaffected)", () => {
+        const parts = (transcriptToMessages([elicitationRequest()])?.[0].parts ??
+            []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({state: "input-available"})
+    })
+
+    it("settled: a real tool_result still wins over a stale cancelled-token entry", () => {
+        const parts = (transcriptToMessages(
+            [
+                elicitationRequest(),
+                record("r-result", {
+                    type: "tool_result",
+                    id: elicitationToolCallId,
+                    output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+                }),
+            ],
+            {cancelledClientToolTokens: new Set([elicitationToolCallId])},
+        )?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({
+            state: "output-available",
+            output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+        })
+    })
+
+    it("cancelled: an unregistered client-tool kind still settles (empty output, no crash)", () => {
+        const toolCallId = "call_unknownKind"
+        const parts = (transcriptToMessages(
+            [
+                record("r-interaction", {
+                    type: "interaction_request",
+                    id: toolCallId,
+                    kind: "client_tool",
+                    payload: {toolCallId, toolName: "some_future_client_tool", input: {}},
+                }),
+            ],
+            {cancelledClientToolTokens: new Set([toolCallId])},
+        )?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({state: "output-available", output: {}})
+    })
+})

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -90,6 +90,10 @@ export {
     type SessionRecordsFetchResult,
 } from "./state/records"
 export {
+    fetchCancelledClientToolTokensAtom,
+    cancelledClientToolTokensQueryKey,
+} from "./state/interactionStatus"
+export {
     sessionMountsQueryFamily,
     mountFilesQueryFamily,
     latestMountFilesQueryFamily,

--- a/web/packages/agenta-entities/src/session/state/interactionStatus.ts
+++ b/web/packages/agenta-entities/src/session/state/interactionStatus.ts
@@ -1,0 +1,62 @@
+/**
+ * Terminal status join for transcript replay — the cheapest correct source for "was this parked
+ * client-tool interaction already resolved server-side?"
+ *
+ * The durable record log (`sessionRecordsQueryFamily`) replays a `client_tool` interaction request
+ * from its own `interaction_request` event alone; it never carries the interaction's later
+ * lifecycle (a `session_interactions` row concept, not a record). A normal live settle (connect,
+ * elicitation answer) DOES leave a trace: the browser's `addToolOutput` resubmits the result, and
+ * the runner re-emits it as a `tool_result` record that settles the part on replay too — no query
+ * needed. But a server-side cancellation (the stale-interaction sweep, or any path that never
+ * round-trips a tool_result) leaves the transcript with nothing but the original request, which
+ * replays as a fully interactive, still-pending form forever.
+ *
+ * `session_interactions.token` is the join key: it equals the record's `toolCallId` (confirmed
+ * against a live 8180 row: token `call_n7Gec...` == the `interaction_request` record's
+ * `toolCallId` == its `attributes.id`). So the cheapest fix is one small, best-effort query for the
+ * session's `client_tool` interactions, filtered to `cancelled`, keyed by that token.
+ */
+import {projectIdAtom} from "@agenta/shared/state"
+import {atom} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+
+import {queryInteractions} from "../api/api"
+
+const CANCELLED_CLIENT_TOOL_TOKENS_STALE_MS = 15_000
+
+export const cancelledClientToolTokensQueryKey = (projectId: string, sessionId: string) =>
+    ["session", "interactions", "cancelledClientToolTokens", projectId, sessionId] as const
+
+const cancelledClientToolTokensQueryOptions = (projectId: string, sessionId: string) => ({
+    queryKey: cancelledClientToolTokensQueryKey(projectId, sessionId),
+    queryFn: async (): Promise<ReadonlySet<string>> => {
+        const interactions = await queryInteractions({sessionId, projectId, kind: "client_tool"})
+        const tokens = (interactions ?? [])
+            .filter((i) => i.status === "cancelled" && typeof i.token === "string" && i.token)
+            .map((i) => i.token as string)
+        return new Set(tokens)
+    },
+    staleTime: CANCELLED_CLIENT_TOOL_TOKENS_STALE_MS,
+})
+
+/**
+ * Imperative, best-effort fetch through the shared query cache. Never throws — a failure (network,
+ * missing project scope) resolves to an empty set, so a resurrected-form miss degrades to today's
+ * behavior (still pending) rather than blocking the whole transcript from loading.
+ */
+export const fetchCancelledClientToolTokensAtom = atom(
+    null,
+    async (get, _set, sessionId: string): Promise<ReadonlySet<string>> => {
+        const projectId = get(projectIdAtom) ?? ""
+        if (!projectId || !sessionId) return new Set()
+        try {
+            const client = get(queryClientAtom)
+            return await client.fetchQuery(
+                cancelledClientToolTokensQueryOptions(projectId, sessionId),
+            )
+        } catch (err) {
+            console.warn("[fetchCancelledClientToolTokensAtom] fetch failed:", err)
+            return new Set()
+        }
+    },
+)


### PR DESCRIPTION
## Context

Live evidence, session `3975e362-f64c-4e2d-8f4f-4f36c584bd91` on the 8180 dev stack: after a hard reload, a client-tool interaction whose `session_interactions` row was already terminally `cancelled` (e.g. the stale-interaction sweep) re-rendered as fully PENDING. The elicitation form came back at question 1, blank, with live Accept/Decline/Dismiss buttons, stacked above the real, current pending interaction. This is very plausibly what was actually seen as "no UI showed up" in the connect-flow investigation (#5909): the dead earlier form rendered prominently and hid the real one below it.

Live-verified the extent of the bug before this fix: clicking "Decline" on the resurrected form is a pure client-side cosmetic no-op. The chip flips to "Declined the request.", but the network log shows zero mutating requests and the `session_interactions` row stays byte-identical (`status=cancelled`, original `updated_at`). The real pending interaction beside it is untouched. So the UI lies twice (a dead form renders live, then a click on it pretends to work), but there is no backend gap to close for this symptom. The fix is entirely in transcript replay.

## Changes

`replayClientTool` (in `transcriptToMessages.ts`) rebuilds a parked client tool's part straight from its own `interaction_request` record. That record has no way to know the interaction's later lifecycle — that lives in `session_interactions`, a separate table, not the record log. A normal live settle (a successful connect, an answered elicitation) does leave a trace: the browser's `addToolOutput` resubmits the result, and the runner re-emits it as a `tool_result` record that settles the part on replay too, so no join is needed for that path. But a server-side cancellation leaves the transcript with nothing but the original request, forever.

`transcriptToMessages` now takes an optional `cancelledClientToolTokens: ReadonlySet<string>` and, after the full record sweep completes (so a real, later `tool_result` always wins over this fallback), settles any part still stuck at `input-available` whose token is in that set. The synthesized output mirrors each widget's OWN cancelled-terminal shape, so a resurrected part renders exactly like a live cancel:

```
request_connection -> {connected: false, reason: "cancelled"}   (ConnectToolWidget's generic
                                                                   "Connection not completed" chip)
request_input       -> {action: "cancel"}                        (ElicitationWidget's "Dismissed
                                                                   the request." chip)
```

The join key is `session_interactions.token`, which equals the record's `toolCallId` — confirmed live against an 8180 row (token `call_n7Gec...` == the `interaction_request` record's `toolCallId`). New `fetchCancelledClientToolTokensAtom` in `@agenta/entities/session` (mirrors `fetchSessionRecordsAtom`'s "imperative fetch through the shared query cache" pattern) queries the session's `client_tool` interactions and reduces them to the cancelled tokens. It's best-effort: any failure resolves to an empty set rather than throwing, so a resurrected-form miss just degrades to today's behavior instead of blocking the whole transcript from loading. `loadSessionMessages` fetches it alongside records and threads it through.

Same treatment for the `agenta-chat` package's byte-parity copy of both files (per that pair's own "keep byte-parity if either side changes" convention).

## Tests / notes

- 7 new unit tests per copy (14 total) in the `transcriptToMessages` test family: cancelled -> inert for both known client-tool kinds, pending -> unaffected (both "token not in the set" and "option omitted entirely" — the existing behavior, unchanged), a real `tool_result` still overriding a stale cancelled-token entry, and an unregistered client-tool kind still settling (empty output) instead of crashing.
- Updated `loadSession.test.ts`'s `@agenta/entities/session` mock to stub the new atom.
- `tsc --noEmit` clean across `oss`, `@agenta/entities`, `@agenta/chat`. `pnpm turbo run build --filter=@agenta/entities --filter=@agenta/chat` clean. `pnpm turbo run lint --filter=@agenta/oss --filter=@agenta/chat --filter=@agenta/entities` clean (no new warnings).
- Full suites green: `@agenta/oss` AgentChatSlice (167 tests), `@agenta/chat` (252 tests), `@agenta/entities` (954 tests).
- Live-verified the before-state (the resurrected-form bug, and that "Decline" on it is a cosmetic no-op) on the 8180 dev stack per the evidence above. This worktree's actual fix could not be re-verified live the same way (the 8180 stack runs whatever checkout is deployed to it, not this branch directly) — verified by unit test + code trace instead.

## What to QA

- Open a session with a client-tool interaction (connect or elicitation) that got cancelled server-side (the stale-interaction sweep, or any other path that never round-trips a settle) while this browser wasn't watching, then hard-reload. The interaction should render as an inert, already-resolved chip ("Connection not completed" / "Dismissed the request."), not as a live form.
- Regression: a session with a genuinely still-pending client-tool interaction reloads exactly as before — the interactive form/dock still appears and still works.
- Regression: a session with a SUCCESSFULLY completed client-tool interaction (one that has a `tool_result` in its transcript) still replays as connected/submitted, not as cancelled.
