### PR TITLE
fix(frontend): a pending interaction anywhere in the tab counts as awaiting

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -6,6 +6,7 @@ import {
     modalitiesForModel,
     workflowMolecule,
 } from "@agenta/entities/workflow"
+import {buildRenderMap, isPendingClientToolInteraction} from "@agenta/playground"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {UploadSimple} from "@phosphor-icons/react"
@@ -360,16 +361,32 @@ const AgentConversation = ({
     // AND the Session inspector's live-watcher signal, which derives "streaming" from `running`).
     // Precedence error > awaiting approval > running > idle. Reset to idle on unmount so a closed
     // tab keeps no stale dot and stops claiming it's the live watcher.
+    // `hitlPending` reads only the LAST assistant message, so the moment a new turn starts
+    // streaming (or hydration reshapes the transcript) a still-pending interaction in an
+    // EARLIER message stops counting — status collapses to idle, the settle stamp lands, and
+    // the running-elsewhere strip flickers in the very tab that owns the parked widget
+    // (Mahmoud's session e627d80a). Scan the whole transcript: any pending interaction this
+    // tab renders means this tab owns the run.
+    const anyPendingInteraction = useMemo(
+        () =>
+            messages.some((message) => {
+                if (message.role !== "assistant") return false
+                const parts = message.parts ?? []
+                const renderMap = buildRenderMap(parts)
+                return parts.some((part) => isPendingClientToolInteraction(part, renderMap))
+            }),
+        [messages],
+    )
     useEffect(() => {
         const status: SessionRunStatus = error
             ? "error"
-            : hitlPending
+            : hitlPending || anyPendingInteraction
               ? "awaiting"
               : busy
                 ? "running"
                 : "idle"
         setSessionStatus({id: sessionId, status})
-    }, [error, hitlPending, busy, sessionId, setSessionStatus])
+    }, [error, hitlPending, anyPendingInteraction, busy, sessionId, setSessionStatus])
     useEffect(
         () => () => setSessionStatus({id: sessionId, status: "idle"}),
         [sessionId, setSessionStatus],


### PR DESCRIPTION
## Context

In [session e627d80a](https://github.com/Agenta-AI/agenta/pull/5857) territory: the "running somewhere else" strip flickered in the very tab that owned a parked connect card whenever a new turn started. The status publisher derives "awaiting" from `hitlPending`, which reads only the LAST assistant message; the moment a new turn begins streaming (or hydration reshapes the transcript), a still-pending interaction in an earlier message stops counting, status collapses toward idle, the settle stamp lands, and the [#5857](https://github.com/Agenta-AI/agenta/pull/5857) strip logic sees "settled locally, running remotely" — the exact signature of another tab.

## Changes

The status publisher scans the whole transcript: any pending client-tool interaction this tab renders means this tab owns the run, so the session publishes "awaiting" and the strip stays suppressed. One memo plus one condition; the strip's own derivation is untouched.

## Tests

Type-check clean; the AgentChatSlice suite runs in CI. Live behavior is part of the compound-flow QA below.

## What to QA

- Drive an agent through form → connect → schedule in one conversation. The "running somewhere else" strip must never appear in the driving tab at any point, including the moments new turns begin.
- Regression: a second tab watching the same session must still show the strip within ~15s.