### PR TITLE
fix(tests): select a registry row explicitly when none auto-selects

### DIFF
--- a/web/oss/tests/playwright/acceptance/agent-skills/skill-folder-upload.spec.ts
+++ b/web/oss/tests/playwright/acceptance/agent-skills/skill-folder-upload.spec.ts
@@ -92,7 +92,9 @@ const selectBundledFile = async (page: Page, label: string) => {
         .click()
 }
 
-test(
+// Skipped per release-gate decision (Mahmoud, 2026-08-10): rotating environment-sensitive
+// failure in CI (gate run 31401605372). Tracked for repair, not deleted.
+test.skip(
     "uploading a skill package parses the folded description and keeps bundled files isolated",
     {tag: tags},
     async ({page, uiHelpers}) => {

--- a/web/oss/tests/playwright/acceptance/auto-evaluation/index.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/index.ts
@@ -33,7 +33,9 @@ const testAutoEval = () => {
     baseAutoEvalTest.describe("Should run a single evaluation (retry-eligible)", () => {
         baseAutoEvalTest.describe.configure({retries: 2})
 
-        baseAutoEvalTest(
+        // Skipped per release-gate decision (Mahmoud, 2026-08-10): eternity-class runtime
+        // dominates the CI wall clock with retries. Tracked for repair, not deleted.
+        baseAutoEvalTest.skip(
             "should run a single evaluation",
             {
                 tag: [

--- a/web/oss/tests/playwright/acceptance/observability/index.ts
+++ b/web/oss/tests/playwright/acceptance/observability/index.ts
@@ -156,7 +156,9 @@ const observabilityTests = () => {
     test.describe("View traces (retry-eligible)", () => {
         test.describe.configure({retries: 2})
 
-        test(
+        // Skipped per release-gate decision (Mahmoud, 2026-08-10): eternity-class runtime
+        // (7-minute budget, up to 21 minutes with retries) dominates the CI wall clock.
+        test.skip(
             "view traces",
             {tag: smokeTags},
             async ({page, uiHelpers, apiHelpers, testProviderHelpers}) => {
@@ -365,7 +367,9 @@ const observabilityTests = () => {
     )
 
     // WEB-ACC-OBS-006
-    test(
+    // Skipped per release-gate decision (Mahmoud, 2026-08-10): rotating environment-sensitive
+    // failure in CI (gate run 31401605372). Tracked for repair, not deleted.
+    test.skip(
         "should create a trace after a Playground run",
         {tag: lightSlowTags},
         async ({page, apiHelpers, uiHelpers, testProviderHelpers}) => {

--- a/web/oss/tests/playwright/acceptance/settings/model-hub.ts
+++ b/web/oss/tests/playwright/acceptance/settings/model-hub.ts
@@ -222,7 +222,9 @@ const modelHubTests = () => {
         },
     )
 
-    test(
+    // Skipped per release-gate decision (Mahmoud, 2026-08-10): rotating environment-sensitive
+    // failure in CI (gate run 31401605372). Tracked for repair, not deleted.
+    test.skip(
         "should add and delete a custom provider via the UI",
         {tag: tagsLight},
         async ({page, testProviderHelpers}) => {

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -118,10 +118,17 @@ const deployFirstVariantToDevelopment = async (
  */
 const openVariantUseApiDrawer = async (page: any) => {
     // The Use API button is NOT disabled while no revision is selected (it captures
-    // selectedRevisionId at click time), so wait for the registry's auto-selection to
-    // settle (an antd row checkbox turns checked) before clicking — clicking early
-    // opens the drawer with an undefined revision and empty snippets.
-    await expect(page.locator(".ant-checkbox-checked").first()).toBeVisible({timeout: 15000})
+    // selectedRevisionId at click time), so ensure a row IS selected before clicking —
+    // clicking early opens the drawer with an undefined revision and empty snippets.
+    // Environments differ: some auto-select a row, some (CI's fresh project) do not,
+    // so select the first row explicitly when nothing is checked.
+    const checkedRow = page.locator(".ant-checkbox-checked").first()
+    if (!(await checkedRow.isVisible().catch(() => false))) {
+        const firstRowCheckbox = page.locator(".ant-checkbox-input").first()
+        await expect(firstRowCheckbox).toBeVisible({timeout: 15000})
+        await firstRowCheckbox.click()
+    }
+    await expect(checkedRow).toBeVisible({timeout: 15000})
     const useApiButton = page.locator('[data-tour="api-code-button"]')
     await expect(useApiButton).toBeVisible({timeout: 15000})
     await expect(useApiButton).toBeEnabled({timeout: 5000})

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -122,9 +122,11 @@ const openVariantUseApiDrawer = async (page: any) => {
     // clicking early opens the drawer with an undefined revision and empty snippets.
     // Environments differ: some auto-select a row, some (CI's fresh project) do not,
     // so select the first row explicitly when nothing is checked.
-    const checkedRow = page.locator(".ant-checkbox-checked").first()
+    // Scoped to the registry table's BODY rows: the header select-all and any checkbox
+    // outside the table must neither satisfy the check nor receive the click.
+    const checkedRow = page.locator(".ant-table-tbody .ant-checkbox-checked").first()
     if (!(await checkedRow.isVisible().catch(() => false))) {
-        const firstRowCheckbox = page.locator(".ant-checkbox-input").first()
+        const firstRowCheckbox = page.locator(".ant-table-tbody .ant-checkbox-input").first()
         await expect(firstRowCheckbox).toBeVisible({timeout: 15000})
         await firstRowCheckbox.click()
     }


### PR DESCRIPTION
## Context

The readiness wait added in [#5905](https://github.com/Agenta-AI/agenta/pull/5905)'s review round (wait for a checked row before opening the Use API drawer) assumed the registry auto-selects a row. CI's fresh project never checks one, so both use-api tests fail on the wait itself ([gate run](https://github.com/Agenta-AI/agenta/actions/runs/31401605372/job/93501955174)). My regression, honestly labeled.

## Changes

Keep the race protection (the drawer captures the revision at click time), but when no row is checked, click the first row's checkbox to create the selection, then require it. Works in both auto-selecting and non-selecting environments.

## Tests

Prettier clean. CI on this PR validates both use-api tests in the exact environment that failed.

## Update (release-gate decision)

Per the release-gate call, this PR now also skips five tests with tracking comments, none deleted:
- Rotating environment-sensitive failures from the final gate run: the skill-package upload test, the model-hub custom-provider test, and the observability trace-after-run test.
- Eternity-class runtimes that dominate the CI wall clock: observability "view traces" and auto-evaluation "should run a single evaluation" (7-minute budgets, up to ~21 minutes with retries).

The gate's meaning after this PR: the acceptance suite's passing set is deterministic; the skipped five are tracked repair backlog, visible as skips rather than masquerading as gate noise.