### PR TITLE
[docs] Client-tool interaction lifecycle: research, blame timeline, plan v2

### DIFF
--- a/docs/design/client-tool-interaction-lifecycle/README.md
+++ b/docs/design/client-tool-interaction-lifecycle/README.md
@@ -1,0 +1,55 @@
+# Client-tool interaction lifecycle
+
+Planning workspace for one coherent model of when interaction cards (questionnaire forms,
+connect cards, approval gates) render in the agent chat, and how their outcomes reach both
+the UI and the model. Born from a day of recurring resurrection/duplication bugs
+(2026-08-10); the thesis and symptoms live in [context.md](context.md).
+
+## Reading order
+
+| Question | File |
+|---|---|
+| Why does this project exist, what did the user see? | [context.md](context.md) |
+| How does the system actually behave today (code truth + live evidence)? | [research.md](research.md) |
+| What do we change, in what order? | [plan.md](plan.md) |
+| Where does the work stand right now? | [status.md](status.md) |
+
+## Glossary (shared by every file here)
+
+- **Interaction**: a request the agent parks the run on, awaiting a user action in the
+  chat UI. Kinds today: `request_input` (a questionnaire form, also called elicitation),
+  `request_connection` (a connect card for a provider integration), and tool approval
+  gates (allow/deny a tool call).
+- **Card**: the rendered widget for one interaction.
+- **Park**: the runner suspending a turn until the interaction is answered; the stream
+  ends while the server-side run stays alive waiting.
+- **Interaction row**: the `session_interactions` database row that tracks one
+  interaction's status (`pending`, `cancelled`, resolved states).
+- **Records / transcript**: the persisted per-session record stream (tracing-backed) the
+  server keeps of everything said and done; the frontend can rebuild a conversation from
+  it (**replay**) via `transcriptToMessages`.
+- **Adoption**: the frontend replacing its in-memory messages with a replay built from
+  the server records (on reload, on the records relay ticking, or on hydration).
+- **Records relay**: the SSE stream that tells an open tab the session's records changed,
+  triggering a refresh that can end in adoption.
+- **Runner**: the Node sidecar that executes agent turns against a harness (Pi, Claude,
+  Codex). **Harness**: the coding-agent engine the runner drives.
+- **Resume**: the follow-up run the client dispatches after answering an interaction, so
+  the parked turn continues with the answer.
+
+## Today's landed fixes this project builds on (all 2026-08-10)
+
+- [#5857](https://github.com/Agenta-AI/agenta/pull/5857) strip derivation trusts local
+  settles; [#5913](https://github.com/Agenta-AI/agenta/pull/5913) extends "awaiting" to a
+  pending interaction anywhere in the tab's transcript.
+- [#5859](https://github.com/Agenta-AI/agenta/pull/5859) replay renders parked client
+  tools at all (the render-hint mechanism).
+- [#5909](https://github.com/Agenta-AI/agenta/pull/5909) connect flow: correct auth
+  scheme, visible errors, decline reaches the server, adoption guarded against clobbering
+  a just-settled answer.
+- [#5912](https://github.com/Agenta-AI/agenta/pull/5912) replay renders server-cancelled
+  interactions inert instead of resurrecting them.
+- [#5910](https://github.com/Agenta-AI/agenta/pull/5910) runner: an answered approval's
+  result is observed before a carried sibling re-parks the turn.
+- Issues: [#5907](https://github.com/Agenta-AI/agenta/issues/5907) (ordering race),
+  [#5911](https://github.com/Agenta-AI/agenta/issues/5911) (connection reuse).

--- a/docs/design/client-tool-interaction-lifecycle/README.md
+++ b/docs/design/client-tool-interaction-lifecycle/README.md
@@ -1,55 +1,55 @@
-# Client-tool interaction lifecycle
+# Interaction cards: research and fix plan
 
-Planning workspace for one coherent model of when interaction cards (questionnaire forms,
-connect cards, approval gates) render in the agent chat, and how their outcomes reach both
-the UI and the model. Born from a day of recurring resurrection/duplication bugs
-(2026-08-10); the thesis and symptoms live in [context.md](context.md).
+An agent can ask the user for something in the middle of a run. The chat then shows a
+card. The user acts on the card. The run continues.
 
-## Reading order
+We have three kinds of cards:
 
-| Question | File |
-|---|---|
-| Why does this project exist, what did the user see? | [context.md](context.md) |
-| How does the system actually behave today (code truth + live evidence)? | [research.md](research.md) |
-| What do we change, in what order? | [plan.md](plan.md) |
-| Where does the work stand right now? | [status.md](status.md) |
+| Card | What it asks | Example |
+|---|---|---|
+| Form card | Fill in some fields | "Pick a time and a timezone" |
+| Connect card | Connect an external account | "Connect Telegram" |
+| Approval card | Allow or deny a tool call | "Allow the agent to create a schedule?" |
 
-## Glossary (shared by every file here)
+On 2026-08-10, Mahmoud hit many bugs with these cards in one session. Cards came back
+after he answered them. Dead cards blocked the screen. A warning strip accused his own
+tab. This folder explains why, and what we will change.
 
-- **Interaction**: a request the agent parks the run on, awaiting a user action in the
-  chat UI. Kinds today: `request_input` (a questionnaire form, also called elicitation),
-  `request_connection` (a connect card for a provider integration), and tool approval
-  gates (allow/deny a tool call).
-- **Card**: the rendered widget for one interaction.
-- **Park**: the runner suspending a turn until the interaction is answered; the stream
-  ends while the server-side run stays alive waiting.
-- **Interaction row**: the `session_interactions` database row that tracks one
-  interaction's status (`pending`, `cancelled`, resolved states).
-- **Records / transcript**: the persisted per-session record stream (tracing-backed) the
-  server keeps of everything said and done; the frontend can rebuild a conversation from
-  it (**replay**) via `transcriptToMessages`.
-- **Adoption**: the frontend replacing its in-memory messages with a replay built from
-  the server records (on reload, on the records relay ticking, or on hydration).
-- **Records relay**: the SSE stream that tells an open tab the session's records changed,
-  triggering a refresh that can end in adoption.
-- **Runner**: the Node sidecar that executes agent turns against a harness (Pi, Claude,
-  Codex). **Harness**: the coding-agent engine the runner drives.
-- **Resume**: the follow-up run the client dispatches after answering an interaction, so
-  the parked turn continues with the answer.
+## Read in this order
 
-## Today's landed fixes this project builds on (all 2026-08-10)
+1. [context.md](context.md) — what the user saw, in his words.
+2. [research.md](research.md) — how the system really works, and where it lies.
+3. [plan.md](plan.md) — the four changes we will make.
+4. [qa.md](qa.md) — the tests that will catch this class of bug forever.
+5. [status.md](status.md) — where the work stands.
 
-- [#5857](https://github.com/Agenta-AI/agenta/pull/5857) strip derivation trusts local
-  settles; [#5913](https://github.com/Agenta-AI/agenta/pull/5913) extends "awaiting" to a
-  pending interaction anywhere in the tab's transcript.
-- [#5859](https://github.com/Agenta-AI/agenta/pull/5859) replay renders parked client
-  tools at all (the render-hint mechanism).
-- [#5909](https://github.com/Agenta-AI/agenta/pull/5909) connect flow: correct auth
-  scheme, visible errors, decline reaches the server, adoption guarded against clobbering
-  a just-settled answer.
-- [#5912](https://github.com/Agenta-AI/agenta/pull/5912) replay renders server-cancelled
-  interactions inert instead of resurrecting them.
-- [#5910](https://github.com/Agenta-AI/agenta/pull/5910) runner: an answered approval's
-  result is observed before a carried sibling re-parks the turn.
-- Issues: [#5907](https://github.com/Agenta-AI/agenta/issues/5907) (ordering race),
-  [#5911](https://github.com/Agenta-AI/agenta/issues/5911) (connection reuse).
+## The words we use (same words in every file)
+
+- **Card**: the widget the user sees and acts on.
+- **Interaction row**: one database row per card. It stores the card's state:
+  `pending` (waiting), `resolved` (answered), or `cancelled` (closed without an answer).
+- **Record list**: the server's saved history of the conversation. The browser can
+  rebuild the whole chat from it. We call that rebuild **replay**.
+- **Adoption**: the browser throws away its own copy of the chat and takes the server's
+  replay instead.
+- **The sweep**: a cleanup job. At the start of each new turn, it closes old `pending`
+  rows by setting them to `cancelled`.
+- **Park**: the run stops and waits for the user to act on a card.
+- **Resume**: the run continues after the user acted.
+- **Runner**: the service that runs the agent.
+
+## Fixes already merged on 2026-08-10 (before this plan)
+
+- [#5904](https://github.com/Agenta-AI/agenta/pull/5904): the agent no longer guesses
+  file paths for its skills.
+- [#5909](https://github.com/Agenta-AI/agenta/pull/5909): Telegram connect uses the
+  right login type, errors show on screen, and "Not now" really declines.
+- [#5910](https://github.com/Agenta-AI/agenta/pull/5910): the runner no longer loses
+  the result of an approved tool call.
+- [#5912](https://github.com/Agenta-AI/agenta/pull/5912): cancelled cards come back
+  dead, not alive.
+- [#5913](https://github.com/Agenta-AI/agenta/pull/5913): the "running somewhere else"
+  strip no longer shows in the tab that owns the run.
+
+Open issues: [#5907](https://github.com/Agenta-AI/agenta/issues/5907) (runner race),
+[#5911](https://github.com/Agenta-AI/agenta/issues/5911) (reuse an existing connection).

--- a/docs/design/client-tool-interaction-lifecycle/context.md
+++ b/docs/design/client-tool-interaction-lifecycle/context.md
@@ -1,54 +1,44 @@
-# Why this work exists
+# What happened, and why we started this project
 
-## What the user experiences today
+## What Mahmoud saw (2026-08-10, on the release stack)
 
-Mahmoud drove one conversation on the release stack (sessions 6609cd91 and e627d80a,
-2026-08-10): create an agent that sends Arabic poetry to Telegram every morning. The agent
-asks a questionnaire, then asks to connect Telegram, then asks to approve a schedule. Every
-step that should show exactly one card showed the wrong set:
+He asked for an agent that sends Arabic poetry to Telegram every morning. The agent
+asked him a form, then asked to connect Telegram, then asked to approve a schedule.
+Each step should show one card. Instead:
 
-1. The "running somewhere else" strip appeared in the tab that was itself driving the run.
-2. When the connect card appeared, the already-answered questionnaire reappeared with it,
-   blank and interactive, and the answer he had given was ignored.
-3. After connecting successfully, he had to scroll back and answer the questionnaire again.
-4. At the schedule step, the connect card came back (dead: no click worked, not even
-   "Not now"), the strip flashed again, and the original questionnaire showed again.
-5. In a later run where the connection fully succeeded, the agent asked him to connect
-   Telegram again as if nothing had happened.
+1. The "running somewhere else" strip showed in his own tab. His tab WAS the run.
+2. When the connect card appeared, the form he had already answered appeared again,
+   empty. His answer was lost.
+3. After he connected, he had to answer the form a second time.
+4. At the schedule step, the old connect card came back. It was dead. No button worked,
+   not even "Not now". The strip flashed again. The form showed a third time.
+5. In a later run, the connection worked. The agent still asked him to connect again.
 
-His summary, which this project adopts as the thesis: whenever there is one new thing to
-show, the UI shows everything instead of that thing.
+His summary: when there is one new thing to show, the UI shows everything instead of
+that thing. That summary became the thesis of this project.
 
-## Why it keeps happening
+## Why the bugs kept coming back
 
-Fixes so far treated each symptom where it surfaced: the strip's derivation, one replay
-branch, one adoption race, one scheme default. Each fix was real, verified, and correct,
-and the class keeps returning because the underlying model is fragmented. Interaction
-state lives in four places that do not agree on ownership or lifecycle:
+We fixed each symptom where it appeared. Each fix was real. The class survived, because
+the state of a card lives in four places, and the four places do not agree:
 
-- the live stream's in-memory messages (what this tab saw happen),
-- the persisted transcript records (what the server remembers being said),
-- the `session_interactions` rows (what the server considers pending or settled),
-- the localStorage message cache (what this tab saved last time it settled).
+1. The chat the browser tab holds in memory.
+2. The record list on the server.
+3. The interaction row in the database.
+4. A saved copy of the chat in the browser's local storage.
 
-Different render paths read different subsets of these, at different moments, with
-different staleness, and several server-side transitions (cancellation sweeps, the
-one-interaction-per-turn rule, TTL expiry) happen with no signal to the client at all.
-The model, meanwhile, sometimes never learns the outcome of an interaction it requested,
-so it asks again even when the thing it asked for succeeded.
+Different screens read different places, at different moments. Some server actions
+change a card's state and tell nobody. And the deepest problem: when the user answers a
+card, the system never writes "answered" anywhere durable. See research.md.
 
 ## Goal
 
-One documented, enforced lifecycle for client-tool interactions: a single answer to "what
-may render right now, in what state, from which source of truth", and a guaranteed path
-for interaction outcomes to reach both the UI and the model. The plan in this workspace
-sequences the changes that get there, building on today's landed fixes rather than
-replacing them.
+One clear rule for what a card may show, from one agreed source of truth. And a
+guarantee: when the user answers a card, the system records the answer, the screen
+shows it, and the agent learns it.
 
-## Non-goals
+## Not in this project
 
-- Redesigning the approval-gate UX or the widgets' visual design.
-- The connection-reuse product feature (tracked as issue #5911); this project only
-  guarantees the model learns outcomes, which #5911 then builds on.
-- The runner's approval-ordering race (PR #5910) and its suppressed-carried-gate
-  follow-up; they are adjacent, tracked, and referenced, not re-planned here.
+- New card designs.
+- Reusing an existing connection instead of asking again (issue #5911).
+- Letting the mobile app answer form and connect cards (it never could; own ticket).

--- a/docs/design/client-tool-interaction-lifecycle/context.md
+++ b/docs/design/client-tool-interaction-lifecycle/context.md
@@ -1,0 +1,54 @@
+# Why this work exists
+
+## What the user experiences today
+
+Mahmoud drove one conversation on the release stack (sessions 6609cd91 and e627d80a,
+2026-08-10): create an agent that sends Arabic poetry to Telegram every morning. The agent
+asks a questionnaire, then asks to connect Telegram, then asks to approve a schedule. Every
+step that should show exactly one card showed the wrong set:
+
+1. The "running somewhere else" strip appeared in the tab that was itself driving the run.
+2. When the connect card appeared, the already-answered questionnaire reappeared with it,
+   blank and interactive, and the answer he had given was ignored.
+3. After connecting successfully, he had to scroll back and answer the questionnaire again.
+4. At the schedule step, the connect card came back (dead: no click worked, not even
+   "Not now"), the strip flashed again, and the original questionnaire showed again.
+5. In a later run where the connection fully succeeded, the agent asked him to connect
+   Telegram again as if nothing had happened.
+
+His summary, which this project adopts as the thesis: whenever there is one new thing to
+show, the UI shows everything instead of that thing.
+
+## Why it keeps happening
+
+Fixes so far treated each symptom where it surfaced: the strip's derivation, one replay
+branch, one adoption race, one scheme default. Each fix was real, verified, and correct,
+and the class keeps returning because the underlying model is fragmented. Interaction
+state lives in four places that do not agree on ownership or lifecycle:
+
+- the live stream's in-memory messages (what this tab saw happen),
+- the persisted transcript records (what the server remembers being said),
+- the `session_interactions` rows (what the server considers pending or settled),
+- the localStorage message cache (what this tab saved last time it settled).
+
+Different render paths read different subsets of these, at different moments, with
+different staleness, and several server-side transitions (cancellation sweeps, the
+one-interaction-per-turn rule, TTL expiry) happen with no signal to the client at all.
+The model, meanwhile, sometimes never learns the outcome of an interaction it requested,
+so it asks again even when the thing it asked for succeeded.
+
+## Goal
+
+One documented, enforced lifecycle for client-tool interactions: a single answer to "what
+may render right now, in what state, from which source of truth", and a guaranteed path
+for interaction outcomes to reach both the UI and the model. The plan in this workspace
+sequences the changes that get there, building on today's landed fixes rather than
+replacing them.
+
+## Non-goals
+
+- Redesigning the approval-gate UX or the widgets' visual design.
+- The connection-reuse product feature (tracked as issue #5911); this project only
+  guarantees the model learns outcomes, which #5911 then builds on.
+- The runner's approval-ordering race (PR #5910) and its suppressed-carried-gate
+  follow-up; they are adjacent, tracked, and referenced, not re-planned here.

--- a/docs/design/client-tool-interaction-lifecycle/implementation.md
+++ b/docs/design/client-tool-interaction-lifecycle/implementation.md
@@ -5,8 +5,8 @@ plain language. This file says which files change, in which order, and what will
 
 Everything below was checked against the working tree on 2026-08-10, on top of the tip of
 release/v0.112.0. Where the plan or the research no longer matches the code, the correction is
-recorded here and repeated in [Plan corrections](#plan-corrections). Neither plan.md nor
-research.md is edited.
+recorded here and repeated in [Plan corrections](#plan-corrections). plan.md and research.md
+keep their own wording; they carry only small factual fixes, never the detail below.
 
 ## Code reality check
 
@@ -433,8 +433,11 @@ Change 1. Everything else reads the state this creates.
   over the existing generated route, in the style of `respondInteraction` at line 189.
 - `web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts:225-240`
   (`handleClientToolOutput`): before `addToolOutput`, fire the transition to `responded` with
-  the outcome. It must not block the resume: on failure, log and continue, which is exactly
-  today's behavior.
+  the outcome, and wait for it before dispatching the resume, under a short cap. The resume
+  starts the new turn whose sweep cancels the row, so the two must not race. On failure or on
+  the cap, log and resume anyway, which is exactly today's behavior. Shipped as the pure helper
+  `recordAnswerThenResume` (2 s cap) in
+  `web/oss/src/components/AgentChatSlice/assets/clientToolAnswer.ts`.
 - The card widgets need the row token to name what they are answering. Resolve it from the
   rows the browser already fetches (see Slice B's map), matching on
   `data.request.tool_call_id` first and falling back to `token == toolCallId` for legacy rows.

--- a/docs/design/client-tool-interaction-lifecycle/implementation.md
+++ b/docs/design/client-tool-interaction-lifecycle/implementation.md
@@ -1,0 +1,655 @@
+# Implementation: slices, anchors, and traps
+
+This is the technical companion to [plan.md](plan.md). The plan says what changes and why in
+plain language. This file says which files change, in which order, and what will bite.
+
+Everything below was checked against the working tree on 2026-08-10, on top of the tip of
+release/v0.112.0. Where the plan or the research no longer matches the code, the correction is
+recorded here and repeated in [Plan corrections](#plan-corrections). Neither plan.md nor
+research.md is edited.
+
+## Code reality check
+
+### 1. The interaction row. Confirmed, and no migration is needed
+
+The table is `session_interactions`, declared at
+`api/oss/src/dbs/postgres/sessions/interactions/dbes.py:14`. The kinds and statuses in the plan
+are exact: `api/oss/src/core/sessions/interactions/dtos.py:10-22` declares
+`user_approval | user_input | client_tool` and `pending | responded | resolved | cancelled`.
+
+The outcome column already exists. It is not a column of its own. It is the `resolution` key
+inside the JSON `data` blob, declared at `dtos.py:48` (`SessionInteractionData.resolution`) and
+written by a JSONB merge at
+`api/oss/src/dbs/postgres/sessions/interactions/dao.py:105-118`, which preserves the rest of
+`data` while adding the answer. The web side already declares the same key at
+`web/packages/agenta-entities/src/session/core/schema.ts:69`, and nothing in the repo reads it
+yet. So the plan's "no database migration" constraint holds with room to spare.
+
+One useful side fact: `actionable_only` filters on `status == "pending"` only
+(`dao.py:213-217`). A row that goes to `responded` therefore drops out of the mobile inbox and
+the desktop activity badge for free, with no extra work.
+
+### 2. The sweep. Confirmed, and it is two sweeps, not one
+
+The one the plan means is the turn-start sweep. The runner calls it at
+`services/runner/src/sessions/interactions.ts:188` (`cancelStaleInteractions`), fired from
+`services/runner/src/server.ts:494`. It reaches
+`api/oss/src/apis/fastapi/sessions/router.py:915`, then
+`api/oss/src/core/sessions/interactions/service.py:97`, then the SQL at
+`api/oss/src/dbs/postgres/sessions/interactions/dao.py:151-172`.
+
+The SQL filters on `SessionInteractionDBE.status == "pending"` at `dao.py:157`. Nothing else.
+A row already at `responded` is invisible to it. Change 1 is therefore race-safe by ordering
+exactly as the plan claims, and the sweep needs zero edits.
+
+There is a second, narrower sweep the plan does not mention: the orphaned-gate reconciliation in
+the records worker at `api/oss/src/tasks/asyncio/sessions/records_worker.py:96-148`. It calls the
+same DAO function but scoped with `only_turn_id`, so it only closes gates of a turn that already
+reached its terminal record. It also filters on `pending` (same line, `dao.py:157`), so it is
+equally harmless to a `responded` row. Worth knowing because it is the sweep that can fire
+milliseconds after a turn ends, and it is the one the runner's own comment at
+`services/runner/src/engines/sandbox_agent/run-turn.ts:665-672` is racing.
+
+### 3. The interactions API. Corrected: there are three guards, not one
+
+The guard the brief points at is real and is at
+`api/oss/src/apis/fastapi/sessions/router.py:891-895`:
+
+```python
+if source.kind != SessionInteractionKind.user_approval:
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Resolution is only valid for user approval interactions",
+    )
+```
+
+But two more guards block Change 1, and both are in the request model, not the router.
+
+`api/oss/src/apis/fastapi/sessions/models.py:130-134` declares the resolution payload as
+approval-shaped and closed:
+
+```python
+class SessionInteractionResolution(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    verdict: Literal["approved", "denied"]
+    tool_call_id: str
+```
+
+A form answer or a connection result cannot be expressed in that shape, and `extra="forbid"`
+rejects anything else.
+
+`api/oss/src/apis/fastapi/sessions/models.py:144-152` then refuses a resolution on any status
+except `resolved`:
+
+```python
+if self.resolution is not None and self.status != SessionInteractionStatus.resolved:
+    raise ValueError("resolution is only valid when status is resolved")
+```
+
+Change 1 wants one call that writes `responded` and the outcome together. Two calls would
+reopen the exact race the plan closes, because the row sits at `pending` between them. So this
+validator has to accept a resolution on the `responded` edge as well.
+
+Below the router, nothing blocks. The service passes the transition through unchanged
+(`api/oss/src/core/sessions/interactions/service.py:78-95`) and the DAO already allows the
+`pending -> responded` and `responded -> resolved` edges through the CAS at
+`api/oss/src/dbs/postgres/sessions/interactions/dao.py:125`
+(`status.in_(("pending", "responded"))`). The JSONB merge at `dao.py:105-118` writes the
+resolution regardless of which status accompanies it.
+
+The existing behavior is pinned by
+`api/oss/tests/pytest/unit/sessions/test_transition_interaction_resolution.py`, which builds an
+approval row and asserts the resolution reaches the domain transition. That test stays valid;
+it needs siblings for the other two kinds.
+
+### 4. Corrected: the browser has no write path to the interactions API at all
+
+This is the biggest correction in the file, and it changes how Change 1 has to be built.
+
+The plan says "the approval card already works this way. We extend its pattern; we invent
+nothing." That is true of the mobile app and false of the desktop web app.
+
+- Mobile answers approvals through the interactions plane:
+  `web/mobile/src/features/chat/useApprovalActions.ts:111` calls `respondInteraction`, which
+  reaches `api/oss/src/apis/fastapi/sessions/router.py:992`. That endpoint flips the row to
+  `responded` at `router.py:1035-1043` and then dispatches the resume server-side.
+- Desktop answers approvals in band, through the message stream. It never calls the
+  interactions API to write anything. `web/packages/agenta-entities/src/session/api/api.ts`
+  exports `queryInteractions` (line 108), `fetchInteraction` (line 143) and `respondInteraction`
+  (line 189), and the desktop chat uses only `queryInteractions`, from
+  `web/packages/agenta-entities/src/session/state/interactionStatus.ts:33`. There is no
+  `transitionInteraction` wrapper in the entities layer at all, although the generated Fern
+  client has the route at
+  `web/packages/agenta-api-client/src/generated/api/resources/sessions/client/Client.ts:715`.
+
+What actually moves the desktop's approval rows off `pending` is the runner. It calls
+`resolveInteraction` (`services/runner/src/sessions/interactions.ts:153`) from
+`run-turn.ts:642` and `run-turn.ts:683`, keyed by the interaction token that the browser echoes
+back inside the approval envelope. The SDK stamps that token at
+`sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:239` (from `part.approval.id`) and
+`messages.py:277`, and the runner reads it back through
+`services/runner/src/responder.ts:405` (`extractInBandApprovalAnswers`) and
+`services/runner/src/permission-plan.ts:62`.
+
+So Change 1's web half is new construction, not an extension: a `transitionInteraction` wrapper
+in `web/packages/agenta-entities/src/session/api/api.ts`, called from the desktop chat before
+the resume goes out. The server half is small because the endpoint exists.
+
+### 5. Client-tool delivery. Confirmed never resolved, and "resolve on consume" costs more than the plan assumes
+
+`services/runner/src/engines/sandbox_agent/client-tools.ts` creates the row and never settles
+it. The create is `recordPendingInteraction(request.id, request.toolName, request.input,
+"client_tool")` at `client-tools.ts:298-303`, inside `buildClientToolRelay` (declared at
+`client-tools.ts:242`). Grep confirms `resolveInteraction` has exactly three call sites
+(`run-turn.ts:642`, `run-turn.ts:683`, and its own declaration), all on the approval path.
+No client-tool row is ever transitioned by anyone. The release gate already records this: the
+docstring of `.agents/skills/agent-release-gate/resources/matrix_l4_client_tool_lifecycle.py`
+observes that a fulfilled client tool still stores as `cancelled` and deliberately asserts only
+that no row is left `pending`.
+
+The natural place to resolve on consume is `client-tools.ts:266`, where the responder returns
+`verdict.kind === "fulfilled"`. That is the exact moment the browser's answer reaches the
+harness, and `resolveInteraction` already exists one import away.
+
+The problem is the key. The row's token is `request.id`, the relay's interaction id
+(`services/runner/src/tools/client-tool-relay.ts:13-16`). On the resume turn the stored output
+is looked up by `approvedCallKey(name, args)`, not by token
+(`services/runner/src/responder.ts:440`, `extractClientToolOutputs`), and the relay mints a fresh
+`request.id` for the re-raised call. So at the consume point the runner does not know which row
+it just satisfied. Approvals dodge this only because the token rides inside the approval
+envelope, and the SDK stamps that token onto approval envelopes only. The client-tool branch at
+`sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:200-209` carries no token.
+
+Making resolve-on-consume work therefore means a new field through three layers: the browser
+stamps the token into the client-tool output, `messages.py` passes it through, and
+`client-tools.ts` reads and strips it before handing the output to the model. The API cannot do
+it instead, because the API never parses tool result blocks; the resume reaches the runner as an
+opaque message list.
+
+**Recommendation: do not build resolve-on-consume in this project.** Treat `responded` plus a
+saved resolution as the durable settled state for `user_input` and `client_tool`, and leave
+`resolved` as the approval-only edge. Nothing user visible depends on the distinction: Change 2
+reads the resolution payload, not the status name, and `actionable_only` already excludes
+`responded`. The cost is three layers of new plumbing for a status word nobody renders. If a
+reviewer insists, the build is specified above and is a self-contained follow-on slice.
+
+One small runner change is still worth doing, and it belongs in Slice A. Today client-tool rows
+carry no `data.request.tool_call_id`, because `recordPendingInteraction` is called with four
+arguments at `client-tools.ts:298-303` while the underlying builder accepts a fifth
+(`buildInteractionData(request, tool, args, toolCallId)` at
+`services/runner/src/sessions/interactions.ts:71`, and the run-turn closure at
+`run-turn.ts:598-604` takes `toolCallId`). Passing `correlatedId` there, and widening the
+callback type at `client-tools.ts:221-226`, gives the browser a deterministic way to match a row
+to a rendered card. Without it the only join key is the empirical claim documented at
+`web/packages/agenta-entities/src/session/state/interactionStatus.ts:14-17`, that the row token
+equals the record's `toolCallId`. That claim was verified once against one live row. It is
+structurally true only when `toolCallIndex.lookup` misses and `correlatedId` falls back to
+`request.toolCallId`, and `request.id` happens to equal `request.toolCallId`. It is not a
+contract. Legacy rows still need the fallback, so keep both.
+
+### 6. Replay. Corrected: the two copies are already NOT byte-identical
+
+Both files exist:
+
+- `web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts`, 504 lines,
+  md5 `bfa18c1b008ebd8aa9074d7987919ed7`.
+- `web/packages/agenta-chat/src/assets/transcriptToMessages.ts`, 512 lines,
+  md5 `547dd832b3defdb664ba0e1eeb964af8`.
+
+`diff` reports 58 changed lines, and three of the differences are behavioral, not cosmetic:
+
+1. The approval sentinel is matched by equality in the OSS copy
+   (`transcriptToMessages.ts:101-104`) and by prefix in the package copy
+   (`agenta-chat/src/assets/transcriptToMessages.ts:118-124`).
+2. The OSS copy emits a `data-approval-manifest` sibling part at
+   `transcriptToMessages.ts:323-335`. The package copy has no equivalent, so a replayed
+   approval card there loses its manifest body.
+3. The OSS default branch covers `attachment_delivery`
+   (`transcriptToMessages.ts:400`); the package copy does not
+   (`agenta-chat/.../transcriptToMessages.ts:408`).
+
+Their `loadSession.ts` siblings have drifted too
+(`web/oss/src/components/AgentChatSlice/assets/loadSession.ts` md5 `77ec1fcf…` against
+`web/packages/agenta-chat/src/assets/loadSession.ts` md5 `209e1ea1…`).
+
+So the instruction "keep them byte-identical" cannot be honored, because they never were. The
+workable rule is narrower and is what Slice B adopts: **the precedence logic must be identical
+in both copies, and the pre-existing divergences above must be left untouched.**
+
+The precedence rule has exactly one landing site in each copy, and it is already the only place
+row data touches the transcript. `applyCancelledInteractions` is at
+`transcriptToMessages.ts:132-143` in OSS, called at line 483, and at
+`agenta-chat/.../transcriptToMessages.ts:153-164`, called at line 491. Its body already encodes
+rule 1 implicitly:
+
+```ts
+if (part.state !== "input-available") continue          // a tool_result already settled it
+if (!cancelledClientToolTokens.has(toolCallId)) continue
+part.state = "output-available"
+part.output = CANCELLED_CLIENT_TOOL_OUTPUT[partToolName(part)] ?? {}
+```
+
+Rule 3 is the bug: `CANCELLED_CLIENT_TOOL_OUTPUT` (OSS lines 124-127) synthesizes
+`{connected: false, reason: "cancelled"}` and `{action: "cancel"}`, which is what produces
+"Dismissed the request." at
+`web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx:254-259`
+and "Connection not completed" with a Retry button at
+`web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx:99-118`.
+That is the code that guesses abandonment. It must become a neutral terminal state instead.
+
+The row fetch that feeds it is `fetchCancelledClientToolTokensAtom` at
+`web/packages/agenta-entities/src/session/state/interactionStatus.ts:47`, which today returns a
+`Set` of cancelled tokens only (`interactionStatus.ts:32-38`). Rule 2 needs the resolution
+payload and the status, so this atom must return a map keyed by token, not a set. Its two
+callers are `web/oss/src/components/AgentChatSlice/assets/loadSession.ts:47-61` and
+`web/packages/agenta-chat/src/assets/loadSession.ts:55-76`.
+
+### 7. Adoption. Confirmed, with a precise landing site
+
+`web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts` has four adoption paths and
+one adoption function: `adoptServerTranscript` at line 111. The decision is
+`shouldAdoptServerTranscript({...})` at lines 115-122, and the replacement is
+`setMessages(serverMsgs)` at lines 137-139. The four triggers are the cache-miss effect
+(line 166), the revalidate-on-open effect (line 220), the remote-run poll (line 249), and the
+push relay `refreshFromRecords` (line 292).
+
+There is already a guard of exactly the right shape: `shouldSkipRecordsRefresh` at line 40,
+which is `busy || pendingResume`, applied both before the fetch (lines 296-302) and again after
+it (lines 312-318) because a settle can land mid-flight. `pendingResume` is the caller's
+`liveGateInteractionRef`, set in
+`web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts:217` and `:227` and cleared
+at `:158`. Change 3's rule is the same idea widened from "an answer is in flight" to "a card is
+waiting".
+
+Put the rule in `useSessionHydration.ts`, not in the shared
+`web/packages/agenta-entities/src/session/core/transcriptAdoption.ts`. The shared
+`shouldAdoptServerTranscript` (line 28) is also called by
+`web/mobile/src/features/chat/transcriptAdoption.ts:28` with `busy: false` hardcoded, and mobile
+cannot answer form or connect cards at all, so a rule about pending cards would be dead weight
+there and would need mobile-side inputs it does not have.
+
+The row-change event exists and the desktop does not listen to it. The contract is at
+`api/oss/src/dbs/redis/sessions/contract.py:99` and `:105`
+(`WATCH_EVENT_INTERACTION = "interaction"`), the publisher is
+`api/oss/src/dbs/redis/sessions/watch.py:93`, and it fires from
+`api/oss/src/core/sessions/interactions/service.py:56-60` (create, `pending`), `:90-94`
+(transition, `resolved`) and `:113-118` (cancel sweep, `resolved`). The SSE endpoint is
+`api/oss/src/apis/fastapi/sessions/router.py:547` and the frame is formatted at
+`api/oss/src/apis/fastapi/sessions/watch.py:96`. Mobile subscribes at
+`web/mobile/src/features/chat/useSessionWatch.ts:110`.
+
+The desktop's subscription belongs in the handler map at
+`web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts:31-34`, which currently
+registers `ready` and `records-changed` only. The generic transport underneath
+(`web/oss/src/hooks/useProjectWatch.ts:19`, `useWatchEventSource`) already fans out arbitrary
+named events, so this is a one-key addition plus a handler. Note the effect dependency
+`eventNamesKey` at `useProjectWatch.ts:30`: adding an event key recreates the EventSource, which
+is fine once at mount but must not be computed from changing data.
+
+The payload carries only `{type, session_id, status}`, so the handler cannot know which card
+changed. That matches the plan: refetch the rows, do not try to patch one card.
+
+### 8. The dock. Confirmed last-message-only, and the connect card has no buttons of its own
+
+`web/oss/src/components/AgentChatSlice/components/InteractionDock.tsx:40-52`:
+
+```ts
+export const getPendingConnectInteraction = (messages: UIMessage[]): ClientToolMeta | null => {
+    const last = messages[messages.length - 1]
+    if (!last || last.role !== "assistant") return null
+```
+
+It is gated again by the caller at
+`web/oss/src/components/AgentChatSlice/AgentConversation.tsx:351-354`. The buttons it owns are
+Cancel (line 117), Not now (line 120) and Connect/Retry (lines 121-130), all driven by
+`useConnectFlow(meta, settle, active)` at line 83.
+
+The inline connect card renders no buttons at all. Its pending branch at
+`web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx:133-141` is a
+passive "waiting for your response below" marker. That single fact is the dead-card bug.
+
+The move is cheap because the machinery is already shared. `useConnectFlow`
+(`web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts`) is a
+standalone hook whose module docstring at lines 1-27 already states the two-surface contract,
+and double settling is guarded by `settledRef` plus `meta.settled` at lines 210 and 264. The
+dock's settle mapping at `InteractionDock.tsx:65-82` is a copy of the canonical one at
+`web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx:43-60`, with a
+comment saying so. The form card is the working precedent: `ElicitationWidget.tsx` already owns
+its own Accept, Decline and Dismiss buttons at lines 370-409.
+
+The whole-chat scan model to follow is `AgentConversation.tsx:371-390` (`anyPendingInteraction`,
+from PR #5913). The remaining last-message-only scans, in the order they matter:
+
+| Where | What it decides |
+|---|---|
+| `InteractionDock.tsx:41` | whether the connect dock renders, and on which tool call |
+| `web/packages/agenta-playground/src/state/execution/agentMessageQueue.ts:48-49` (`isHitlPending`) | the message-queue hold, the composer waiting state, and `AgentConversation.tsx:620` |
+| `web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx:55` (`getPendingApprovals`) | which approval gates the approval dock shows |
+| `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts:134-141` | whether the resume is dispatched after a settle |
+| `AgentConversation.tsx:620` | the per-turn "waiting for you" affordance |
+| `web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts:70` | whether an unregistered parked client tool renders its auto-settling fallback |
+
+The package mirrors the same logic and would keep the defect if only `web/oss` is fixed:
+`web/packages/agenta-chat/src/model/approvals.ts:30`,
+`web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts:80`,
+`web/packages/agenta-chat/src/hooks/useAgentConversation.ts:360`.
+
+The `meta.ts:70` case is deliberately left alone: it guards the auto-settling "not handled"
+fallback, and widening it to the whole chat would auto-settle old parked parts. It is listed so
+the next reader knows it was considered.
+
+### 9. The registry fallthrough. Confirmed, one line, plus one test to invert
+
+`web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx:52`:
+
+```ts
+if (meta.renderKind !== undefined) return BY_RENDER_KIND[meta.renderKind] ?? null
+```
+
+The `?? null` makes the `toolName` fallback on line 53 unreachable whenever any render kind
+string is present, including an unknown one. The consequence chain is
+`registry.tsx:58-59` (`hasClientToolHandler` false) to `meta.ts:67-71` to
+`ClientToolPart.tsx:41` falling back to `UnhandledClientTool`, which auto-settles the run as
+`not_handled` at `UnhandledClientTool.tsx:20`.
+
+Two things the research does not mention. First, the current behavior is pinned by a test that
+must be inverted, not just updated:
+`web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts:86-89`, named "does
+not reinterpret an explicit unknown render kind by tool name". Second, the package copy never
+took this change and is still correct
+(`web/packages/agenta-chat/src/skin/registry.ts:58-65`), so the fix restores parity rather than
+creating it.
+
+### 10. Corrected: the tool-name list exists four times, not twice
+
+| Where | Symbol | Purpose |
+|---|---|---|
+| `web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx:45-48` | `BY_TOOL_NAME` | name to React widget |
+| `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts:79` | `CLIENT_TOOL_NAMES` | queue hold and auto-resume policy |
+| `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts:127` | `CLIENT_TOOLS` | never auto-allowable in the permission gate |
+| `transcriptToMessages.ts:124-127` in both copies | `CANCELLED_CLIENT_TOOL_OUTPUT` | replay's synthesized terminal output |
+
+Two more single-name hardcodes sit on the same axis: `InteractionDock.tsx:33`
+(`meta.renderKind === "connect" || meta.toolName === "request_connection"`) and the render-kind
+keys at `registry.tsx:37-40`.
+
+The import hierarchy is `shared <- ui <- entities <- entity-ui <- playground <- playground-ui`
+(`web/AGENTS.md:444-447` and `.agents/skills/agenta-package-practices/SKILL.md:38-41`). The only
+node all four consumers can reach is `@agenta/shared`, and all four already depend on it. So the
+shared source is a React-free descriptor in `web/packages/agenta-shared`, exporting the tool
+names and their render kinds. The widget map at `registry.tsx:45-48` stays in the app layer and
+keys off the shared constants, because it holds React components.
+
+### 11. Tests and gates. Confirmed
+
+API tests are split into `api/oss/tests/pytest/unit/`, `.../integration/` and
+`.../acceptance/`. The interaction unit tests live in `api/oss/tests/pytest/unit/sessions/`
+(`test_transition_interaction_resolution.py`, `test_respond_interaction_enqueue.py`,
+`test_interactions_transition_update.py`, `test_orphaned_gate_reconciliation.py`). Acceptance
+tests that hit a live stack live in `api/oss/tests/pytest/acceptance/sessions/`, and they mint
+accounts through the fixtures in `api/oss/tests/pytest/utils/accounts.py`.
+
+Gate scripts are standalone `uv run` scripts under
+`.agents/skills/agent-release-gate/resources/`, each with a PEP 723 header, a long docstring
+that states the tier and what it pins, and imports from `qa_matrix_lib`
+(`agent_config`, `create_workflow`, `interactions`, `invoke`, `refs`, `seed_and_baseline`,
+`user_msg`). `matrix_l4_client_tool_lifecycle.py` is the closest model and already contains the
+defect statement this project fixes, so it must be updated in the same slice.
+
+Replay tests already exist in both copies:
+`web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts` and
+`web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts`. The adoption guard
+has `web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts`.
+
+## The slice map
+
+Build order is dependency order. Each slice ships on its own and leaves the product working.
+
+### Slice A: record the answer first
+
+Change 1. Everything else reads the state this creates.
+
+**API**
+
+- `api/oss/src/apis/fastapi/sessions/models.py:130-134`: widen the resolution payload so a form
+  answer and a connection result fit. Keep the approval shape valid and keep it strict for
+  `user_approval`; the other kinds need an open dictionary.
+- `api/oss/src/apis/fastapi/sessions/models.py:144-152`: allow a resolution on the `responded`
+  edge as well as `resolved`, so one call records both.
+- `api/oss/src/apis/fastapi/sessions/router.py:891-895`: replace the approval-only kind guard
+  with a per-kind check that accepts `user_input` and `client_tool`.
+- No service, DAO, migration, or sweep change. `service.py:78-95` and `dao.py:92-135` already
+  do the right thing.
+
+**Runner**
+
+- `services/runner/src/engines/sandbox_agent/client-tools.ts:298-303`: pass `correlatedId` as
+  the tool-call id, and widen the callback type at `client-tools.ts:221-226` to accept it, so
+  new `client_tool` rows carry `data.request.tool_call_id`.
+
+**Web**
+
+- `web/packages/agenta-entities/src/session/api/api.ts`: add a `transitionInteraction` wrapper
+  over the existing generated route, in the style of `respondInteraction` at line 189.
+- `web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts:225-240`
+  (`handleClientToolOutput`): before `addToolOutput`, fire the transition to `responded` with
+  the outcome. It must not block the resume: on failure, log and continue, which is exactly
+  today's behavior.
+- The card widgets need the row token to name what they are answering. Resolve it from the
+  rows the browser already fetches (see Slice B's map), matching on
+  `data.request.tool_call_id` first and falling back to `token == toolCallId` for legacy rows.
+
+**Acceptance check.** On a live stack, answer a form card and a connect card, then let a new
+turn start. Query `/sessions/interactions/query` for the session. Both rows read `responded`
+with the answer under `data.resolution`, and neither reads `cancelled`.
+
+**Traps.** The API container's hot reload wedges on edits of this shape; when the endpoint stops
+responding, hard restart the container rather than waiting for the reloader. The runner change
+means the services container needs a restart. Do not split the transition into two calls
+(status, then resolution): the row sits at `pending` between them and the sweep can win.
+`ruff format` then `ruff check --fix` in `api/` before committing, and `pnpm lint-fix` in
+`web/`.
+
+### Slice B: one rule for what replay shows
+
+Change 2. Depends on Slice A only for rule 2 to have data; the other three rules are
+implementable and testable immediately.
+
+- `web/packages/agenta-entities/src/session/state/interactionStatus.ts:27-62`: return a map from
+  token to `{status, kind, resolution, toolCallId}` instead of a set of cancelled tokens. Keep
+  the best-effort contract, including the empty-result-on-failure behavior at lines 57-60, and
+  keep the 15 second stale time.
+- `web/oss/src/components/AgentChatSlice/assets/loadSession.ts:47-61` and
+  `web/packages/agenta-chat/src/assets/loadSession.ts:55-76`: thread the map through.
+- `web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts:132-143` and
+  `web/packages/agenta-chat/src/assets/transcriptToMessages.ts:153-164`: rewrite
+  `applyCancelledInteractions` into the four-rule precedence. Rule 1 is the existing
+  `part.state !== "input-available"` skip and stays. Rule 2 renders the saved outcome. Rule 3
+  replaces `CANCELLED_CLIENT_TOOL_OUTPUT` (lines 124-127 in both) with a neutral terminal
+  marker. Rule 4 is doing nothing.
+- `web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx:99-118`
+  and `.../ElicitationWidget.tsx:254-259`: render the neutral "interaction ended" state without
+  a Retry button and without the word "Dismissed", and render the rule 2 outcome when one
+  exists.
+
+**Acceptance check.** Load a session whose form row is `cancelled` with no resolution. The card
+renders as an inert "interaction ended" chip with no buttons, and the same session rendered from
+a warm cache and from a cold cache produces identical output. Load a session whose row is
+`responded` with an outcome and the card renders the answer.
+
+**Traps.** The two replay copies are not byte-identical and never were (see anchor 6). Copy the
+precedence logic verbatim into both and leave the three known divergences alone. Do not try to
+reconcile the files in this slice. Every behavior change here must be added to both
+`transcriptToMessages.test.ts` files in the same commit, or the package copy silently rots.
+
+### Slice C: the browser listens, and stops overwriting
+
+Change 3. Independent of A and B; ordered here because its value is visible only once B renders
+row state correctly.
+
+- `web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts:31-34`: add
+  `interaction` to the handler map, wired to the same refresh the other two events use, plus an
+  invalidation of the interaction-rows query key from
+  `interactionStatus.ts:27`.
+- `web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts:111-139`: extend the
+  adoption guard so a waiting card blocks adoption unless the incoming transcript settles that
+  same card. Follow the existing double-check shape at lines 296-318: check before the fetch and
+  again after it.
+- Do not touch `web/packages/agenta-entities/src/session/core/transcriptAdoption.ts`. Mobile
+  shares it and cannot answer these cards.
+
+**Acceptance check.** With a form card waiting, force a records refresh (or let the poll fire).
+The card stays on screen and any typed draft survives. When the server copy contains the
+answered form, adoption proceeds and the card renders answered.
+
+**Traps.** `useProjectWatch.ts:30` uses `eventNamesKey` as an effect dependency, so the event
+name list must be a stable constant or the EventSource reconnects on every render. The
+throttle at `useProjectWatch.ts` is 3 seconds with a trailing flush, so a test that asserts
+immediacy will flake.
+
+### Slice D: cards work where they appear
+
+Change 4. Depends on nothing, but lands after C so the live QA journey exercises one coherent
+build.
+
+- `web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx:133-141`:
+  replace the passive marker with the real actions, driven by `useConnectFlow`. The double
+  settle guard at `useConnectFlow.ts:210` and `:264` already makes two mounted surfaces safe.
+- `web/oss/src/components/AgentChatSlice/components/InteractionDock.tsx`: keep the dock, drop
+  the buttons, make it scroll to the card. Mahmoud's decision, recorded in plan.md.
+- Whole-chat scans, following `AgentConversation.tsx:371-390`: fix
+  `InteractionDock.tsx:41`, `agentMessageQueue.ts:48-49` (`isHitlPending`),
+  `ApprovalDock.tsx:55` (`getPendingApprovals`), and
+  `agentApprovalResume.ts:134-141`. Mirror each into
+  `web/packages/agenta-chat/src/model/approvals.ts:30`,
+  `web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts:80` and
+  `web/packages/agenta-chat/src/hooks/useAgentConversation.ts:360`. Leave `meta.ts:70` alone and
+  say why in the commit.
+- `registry.tsx:52`: restore the `toolName` fallback, and invert
+  `meta.test.ts:86-89` to assert the fallback instead of forbidding it.
+- New React-free descriptor in `web/packages/agenta-shared` holding the client-tool names and
+  render kinds. Point `registry.tsx:37-48`, `agentApprovalResume.ts:79`,
+  `toolPermission.ts:127`, the two `CANCELLED_CLIENT_TOOL_OUTPUT` maps and
+  `InteractionDock.tsx:33` at it.
+
+**Acceptance check.** Park a connect card, then start a new turn so the card is no longer the
+last message. The card's own Connect and Not now buttons still work, the dock shows and scrolls
+to it, the composer still holds the queue, and answering it resumes the run.
+
+**Traps.** `agentApprovalResume.ts` and `agentMessageQueue.ts` are in `@agenta/playground` and
+are consumed by both the desktop chat and `@agenta/chat`. A change there that assumes desktop
+data shapes breaks mobile. Widening `agentApprovalResume.ts:134-141` to the whole chat can
+re-dispatch a resume for an old settled card; scope the scan to unsettled parts only.
+The shared descriptor must not import React or antd, or it violates the `@agenta/shared`
+placement rule.
+
+### Slice E: tests and gates
+
+- `api/oss/tests/pytest/unit/sessions/`: a settlement matrix test alongside
+  `test_transition_interaction_resolution.py`, covering all three kinds against all three
+  outcomes (complete, decline, walk away), asserting the final status and the saved outcome.
+- `api/oss/tests/pytest/acceptance/sessions/`: the sweep race test. Create a row, transition it
+  to `responded`, run `cancel-stale` for a later turn, and assert the row is still `responded`
+  with its outcome intact.
+- `web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts` and
+  `web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts`: golden fixtures for
+  every line of the Slice B rule, including pre-fix `cancelled` rows with no resolution, run
+  against both copies.
+- The geometry test: one fixture whose waiting card is not in the last message, asserting at
+  once that the session status is `awaiting`, the message queue holds, and the card is
+  clickable. This is the test that makes the Slice D scans stay fixed.
+- `web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts`: the adoption safety
+  cases, over refresh-during-answer, adoption-during-park, and reload-mid-answer.
+- `.agents/skills/agent-release-gate/resources/matrix_i1_settlement.py`: the settlement table
+  against a live API, in the shape of `matrix_l4_client_tool_lifecycle.py`.
+- `.agents/skills/agent-release-gate/resources/matrix_i2_card_journeys.py`: the six scripted
+  journeys from qa.md.
+- Update `matrix_l4_client_tool_lifecycle.py`. Its docstring records the "fulfilled client tool
+  stores as cancelled" defect as observed-but-not-asserted, and its assertion is only that no row
+  is left `pending`. After Slice A both must change, or the gate keeps documenting a bug that no
+  longer exists.
+- `.agents/skills/agent-release-gate/resources/coverage.md` and the release-conductor Stage 4
+  list gain the two new cells.
+
+**Acceptance check.** `cd api && py-run-tests` and the web unit suites pass, and both new gate
+scripts run green against the dev stack with a cheap model.
+
+**Traps.** Gate scripts are `uv run` scripts with PEP 723 headers, not pytest. CI pins ruff
+0.15.12 while local environments may run older versions, and the styling job covers `.agents/`
+and `docs/` as well as `api/`, so judge formatting with `uvx ruff@0.15.12`. Gate run artifacts
+contain probe tokens that trip secret scanners; they are not credentials.
+
+## Plan corrections
+
+None of these change the plan's four changes. They change what the changes cost.
+
+1. **The desktop browser has no write path to the interactions API.** plan.md Change 1 says the
+   approval card already works this way and that we invent nothing. That is true of mobile
+   (`web/mobile/src/features/chat/useApprovalActions.ts:111`) and false of the desktop chat,
+   which answers approvals in band and lets the runner resolve the row
+   (`services/runner/src/engines/sandbox_agent/run-turn.ts:642`). Slice A adds a new
+   `transitionInteraction` wrapper and a new call site. It is still small, but it is new
+   construction.
+
+2. **Three guards block Change 1, not one.** Besides the kind check at
+   `api/oss/src/apis/fastapi/sessions/router.py:891-895`, the resolution payload model is
+   approval-shaped and closed (`models.py:130-134`) and a validator forbids a resolution on any
+   status except `resolved` (`models.py:144-152`). Both must change, or the single-call write
+   that makes the ordering race-safe is impossible.
+
+3. **"Resolve on consume" is not cheap and is recommended out of scope.** The consume point is
+   `services/runner/src/engines/sandbox_agent/client-tools.ts:266`, but the runner does not know
+   which row it satisfied, because client-tool outputs are keyed by name and arguments
+   (`services/runner/src/responder.ts:440`) and carry no interaction token
+   (`sdks/python/agenta/sdk/agents/adapters/vercel/messages.py:200-209`). Building it means a new
+   field through the browser, the SDK and the runner, for a status word that nothing renders.
+   `responded` plus a saved outcome is the durable settled state this project needs.
+
+4. **The two replay copies are already not byte-identical.** md5 `bfa18c1b…` against
+   `547dd832…`, 58 differing lines, three of them behavioral (anchor 6). The instruction to keep
+   them byte-identical cannot be met. The rule Slice B follows is that the precedence logic is
+   identical and the pre-existing divergences stay.
+
+5. **The tool-name list exists four times, not twice**, plus two single-name hardcodes
+   (anchor 10). research.md Finding 4 undercounts.
+
+6. **The registry one-liner also needs a test inverted.** research.md Finding 3 says one line
+   fixes it. The line is `registry.tsx:52`, and
+   `web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts:86-89` currently
+   asserts the broken behavior on purpose. Also, the package copy at
+   `web/packages/agenta-chat/src/skin/registry.ts:58-65` never took the change, so the fix
+   restores parity.
+
+7. **There are two sweeps.** research.md describes the turn-start sweep only. The records
+   worker's orphaned-gate reconciliation
+   (`api/oss/src/tasks/asyncio/sessions/records_worker.py:96-148`) is a second one. It also
+   filters on `pending`, so it is harmless to the plan, but it is the one that can fire
+   milliseconds after a turn ends, and any future work on this area must account for it.
+
+8. **The row-to-card join key is empirical, not contractual.**
+   `web/packages/agenta-entities/src/session/state/interactionStatus.ts:14-17` documents that the
+   row token equals the record's `toolCallId`, verified once against one live row. For
+   `client_tool` rows the token is the relay interaction id and the tool-call id can be a
+   correlated ACP id (`client-tools.ts:283-290`). Slice A stamps
+   `data.request.tool_call_id` on new rows so the join is deterministic, and keeps the equality
+   as a legacy fallback.
+
+9. **The pending TTL is 7 days, not absent and not 10 minutes.**
+   `api/oss/src/dbs/postgres/sessions/interactions/dao.py:31` sets
+   `PENDING_INTERACTION_TTL = timedelta(days=7)`, applied only to `actionable_only` queries at
+   `dao.py:213-217`. research.md Finding 4 is right that no timeout changes a card's state; the
+   constant exists but only hides old rows from inbox queries.
+
+10. **The release gate already documents the defect.**
+    `.agents/skills/agent-release-gate/resources/matrix_l4_client_tool_lifecycle.py` records that
+    a fulfilled client tool stores as `cancelled` and deliberately asserts only that no row is
+    left `pending`. That cell must be tightened in Slice E, or the gate will keep passing on the
+    old contract.
+
+## Nothing blocks implementation
+
+Every anchor resolved to real code. No migration is needed, no new event payload is needed, and
+no endpoint has to be created. The only design decision this file makes on its own is
+recommendation 3, that resolve-on-consume stays out of scope. If a reviewer overrules it, the
+build is specified in anchor 5 and is a self-contained follow-on slice that changes nothing
+already shipped.

--- a/docs/design/client-tool-interaction-lifecycle/plan.md
+++ b/docs/design/client-tool-interaction-lifecycle/plan.md
@@ -1,0 +1,82 @@
+# Plan: one lifecycle contract for interaction cards (v2, post-review)
+
+Prerequisite reading: [research.md](research.md). Terms: [README.md](README.md).
+This is the reshaped plan after an adversarial review found v1 unsound (the review's
+findings and their adoption are recorded in status.md). It is deliberately smaller.
+
+## The contract, in one sentence
+
+Answering an interaction flips its row FIRST, before anything else can touch it; replay
+reads outcomes by a fixed precedence; a tab that renders a pending card neither adopts
+over it nor strands it.
+
+## The four changes
+
+### C1. The answer is the authoritative first transition (the whole settlement fix)
+
+When the user acts on a client-tool card, desktop first flips the row `pending ->
+responded` through the existing interactions API (the same first step mobile approvals
+already take), THEN dispatches the message-borne resume exactly as today. The runner
+resolves the row (`responded -> resolved`, with the outcome payload) when it consumes
+the answer. No sweep changes at all: the sweep only cancels `pending` rows, so a
+responded row survives it by existing semantics. If the respond call fails, the flow
+degrades to today's behavior (message-borne only), never blocks the user.
+
+Why this shape: it wins the sweep-vs-resolve race by ordering, not by exemption lists;
+it reuses the transition machinery approvals already exercise; and the API change is
+small (accept the respond transition and, on resolve, an outcome payload for
+`client_tool` rows; lift the approval-only guard exactly that far).
+
+Explicit limitation, stated not hidden: mobile cannot fulfill client tools today (its
+dispatcher builds resume history for approvals only). This plan does not change that;
+it documents it and keeps the contract desktop-first.
+
+### C2. One replay precedence rule (no new record kind)
+
+The closing conversational fact for a client tool already exists: the `tool_result`
+record. Replay (both copies) reads outcomes in fixed precedence:
+1. a real `tool_result` (wins always, preserves the actual answer),
+2. else a post-contract row resolution,
+3. else, for a legacy cancelled row with no result: a neutral, inert "interaction
+   ended" state — never inferred success or decline,
+4. else (still pending): the live, actionable card.
+The v1 idea of emitting `interaction_response` records for client tools is dropped: it
+duplicated an existing fact and created ordering disagreements.
+
+### C3. Desktop stops being deaf and stops clobbering
+
+Subscribe the desktop records-watch hook to the EXISTING generic interaction event (no
+payload enrichment; it already fires on every transition): on receipt, refetch the
+interaction rows and rederive. Plus one adoption rule: never adopt the server transcript
+while this tab renders a pending card, unless the incoming state settles that same card.
+Payload enrichment and in-place part patching are explicitly deferred until a measured
+refetch cost justifies them.
+
+### C4. Cards act where they render
+
+A pending client-tool card is actionable inline wherever it renders (the dock, if kept,
+becomes a convenience pointer, not the owner of the actions; its duplicate settle site
+is removed). The small pending-predicates (`isHitlPending`, the dock's scan) read the
+whole transcript like the session-status scan already does. The registry's
+unknown-render-kind dispatch falls through to the tool name (a one-line repair of a
+hazard introduced 2026-08-10; lands immediately, independent of this project).
+
+## Filed separately, deliberately out of this project
+
+- Mobile client-tool fulfillment (documented limitation above).
+- Model-visibility improvements (uniform outcome framing, connection-validity checks,
+  naming newly available tools) — adjacent defects with their own tickets.
+- Draft-key pruning, the package-loader rejection parity, the null-turn-id sweep gap.
+- Connection reuse (issue #5911).
+
+## Validation
+
+- The settlement matrix from research section 5 as tests: after C1, completion and
+  decline produce `responded/resolved` with outcomes on desktop; abandonment still
+  sweep-cancels; the race case (sweep firing between answer and resume) is pinned by a
+  test that answers, delays the resume, runs the sweep, and asserts the row survived.
+- Replay goldens per precedence tier, identical across both copies, including legacy
+  rows with and without `tool_result`.
+- The live acceptance scenario: form, connect, schedule in one conversation with
+  reloads between steps; every card appears once, acts where it is, and nothing
+  resurrects.

--- a/docs/design/client-tool-interaction-lifecycle/plan.md
+++ b/docs/design/client-tool-interaction-lifecycle/plan.md
@@ -29,7 +29,10 @@ Why this order wins: the sweep only closes `pending` rows. A row that is already
 plan tried to record the answer at delivery time; the review proved the sweep runs
 before delivery, so that shape loses the race. Recording first cannot lose it.
 
-If the "answered" call fails, nothing blocks: the flow falls back to today's behavior.
+The resume waits for the "answered" call, but not forever: the wait is capped at two
+seconds. If the call fails, or the cap runs out, the resume goes out exactly as today,
+and a late "answered" call still lands if the sweep has not run yet. So a broken call
+costs at most today's behavior, never the turn.
 
 The approval card already works this way. We extend its pattern; we invent nothing.
 
@@ -43,8 +46,9 @@ wins:
 
 1. A real recorded answer in the conversation. Show the answered card.
 2. An outcome saved on the row (exists only after Change 1). Show that outcome.
-3. An old row that says `cancelled` with no saved answer. Show a neutral, dead
-   "interaction ended" card. Never guess whether it was answered or abandoned.
+3. A row that ended (`cancelled`, `responded` or `resolved`) with no saved answer. Show
+   a neutral, dead "interaction ended" card. Never guess whether it was answered or
+   abandoned.
 4. Nothing above applies: the card is still open. Show it live and clickable.
 
 Version 1 wanted a new record type for answers. The review showed the conversation
@@ -80,7 +84,13 @@ slow one day, we can enrich it then.
 
 - Mobile answering of form and connect cards.
 - Making the agent's "am I connected?" check verify the connection is valid.
-- Reusing an existing connection (issue #5911).
+- Reusing an existing connection
+  ([#5911](https://github.com/Agenta-AI/agenta/issues/5911)).
+- Announcing a carried approval gate again. When one turn raises two gates and the
+  resume answers one, the other is parked again but never announced, so the user is
+  never asked and its row waits forever. The ordering half was fixed in
+  [#5910](https://github.com/Agenta-AI/agenta/pull/5910); the rest sits with the open
+  runner race, [#5907](https://github.com/Agenta-AI/agenta/issues/5907).
 - Small cleanups: stale form drafts, one missing error catch, one unreachable sweep
   edge case.
 

--- a/docs/design/client-tool-interaction-lifecycle/plan.md
+++ b/docs/design/client-tool-interaction-lifecycle/plan.md
@@ -15,10 +15,14 @@ Today: the user answers, the resume goes out, the row stays `pending`, the sweep
 marks it `cancelled`. The truth is lost (research Finding 1).
 
 New behavior: when the user answers a card, the browser FIRST tells the server
-"answered" (one small API call that flips the row from `pending` to `responded`). Then
-it sends the resume exactly as today. When the runner consumes the answer, the server
-sets the row to `resolved` and saves the outcome (the form values, or the connection
-result).
+"answered" (one small API call that flips the row from `pending` to `responded` and
+saves the outcome: the form values, or the connection result). Then it sends the
+resume exactly as today. `responded` with a saved outcome IS the settled state for
+form and connect cards; `resolved` stays the approval-only end state. We checked
+whether the runner could later confirm consumption and mark the row `resolved`: it
+cannot know which row it consumed without new plumbing through three layers, for a
+status word nothing displays. So we do not build that. Details are in
+[implementation.md](implementation.md).
 
 Why this order wins: the sweep only closes `pending` rows. A row that is already
 `responded` survives the sweep, with no changes to the sweep at all. Version 1 of the
@@ -63,6 +67,9 @@ slow one day, we can enrich it then.
 - The buttons live ON the card, wherever it is in the chat. The bottom dock becomes a
   pointer to the card, not the owner of the buttons. This kills the dead-card bug at
   its root.
+- Decided (Mahmoud, 2026-08-10): the dock STAYS, as a shortcut. It still appears while
+  a card waits, and clicking it scrolls to the card. This keeps the visible UI change
+  as small as possible.
 - The three code paths that only looked at the last message now scan the whole chat,
   like the status fix (#5913) already does.
 - The one-line dispatch repair from research Finding 3 lands immediately, outside this

--- a/docs/design/client-tool-interaction-lifecycle/plan.md
+++ b/docs/design/client-tool-interaction-lifecycle/plan.md
@@ -1,82 +1,90 @@
-# Plan: one lifecycle contract for interaction cards (v2, post-review)
+# Plan: four changes
 
-Prerequisite reading: [research.md](research.md). Terms: [README.md](README.md).
-This is the reshaped plan after an adversarial review found v1 unsound (the review's
-findings and their adoption are recorded in status.md). It is deliberately smaller.
+Read [research.md](research.md) first. This is version 2 of the plan. An adversarial
+review rejected version 1, mostly for being too big and for one real design error. The
+review history is in [status.md](status.md).
 
-## The contract, in one sentence
+## The idea in one sentence
 
-Answering an interaction flips its row FIRST, before anything else can touch it; replay
-reads outcomes by a fixed precedence; a tab that renders a pending card neither adopts
-over it nor strands it.
+Record the answer first, read it by one rule, listen for changes, and let every card
+work where it appears.
 
-## The four changes
+## Change 1: record the answer before anything else
 
-### C1. The answer is the authoritative first transition (the whole settlement fix)
+Today: the user answers, the resume goes out, the row stays `pending`, the sweep later
+marks it `cancelled`. The truth is lost (research Finding 1).
 
-When the user acts on a client-tool card, desktop first flips the row `pending ->
-responded` through the existing interactions API (the same first step mobile approvals
-already take), THEN dispatches the message-borne resume exactly as today. The runner
-resolves the row (`responded -> resolved`, with the outcome payload) when it consumes
-the answer. No sweep changes at all: the sweep only cancels `pending` rows, so a
-responded row survives it by existing semantics. If the respond call fails, the flow
-degrades to today's behavior (message-borne only), never blocks the user.
+New behavior: when the user answers a card, the browser FIRST tells the server
+"answered" (one small API call that flips the row from `pending` to `responded`). Then
+it sends the resume exactly as today. When the runner consumes the answer, the server
+sets the row to `resolved` and saves the outcome (the form values, or the connection
+result).
 
-Why this shape: it wins the sweep-vs-resolve race by ordering, not by exemption lists;
-it reuses the transition machinery approvals already exercise; and the API change is
-small (accept the respond transition and, on resolve, an outcome payload for
-`client_tool` rows; lift the approval-only guard exactly that far).
+Why this order wins: the sweep only closes `pending` rows. A row that is already
+`responded` survives the sweep, with no changes to the sweep at all. Version 1 of the
+plan tried to record the answer at delivery time; the review proved the sweep runs
+before delivery, so that shape loses the race. Recording first cannot lose it.
 
-Explicit limitation, stated not hidden: mobile cannot fulfill client tools today (its
-dispatcher builds resume history for approvals only). This plan does not change that;
-it documents it and keeps the contract desktop-first.
+If the "answered" call fails, nothing blocks: the flow falls back to today's behavior.
 
-### C2. One replay precedence rule (no new record kind)
+The approval card already works this way. We extend its pattern; we invent nothing.
 
-The closing conversational fact for a client tool already exists: the `tool_result`
-record. Replay (both copies) reads outcomes in fixed precedence:
-1. a real `tool_result` (wins always, preserves the actual answer),
-2. else a post-contract row resolution,
-3. else, for a legacy cancelled row with no result: a neutral, inert "interaction
-   ended" state — never inferred success or decline,
-4. else (still pending): the live, actionable card.
-The v1 idea of emitting `interaction_response` records for client tools is dropped: it
-duplicated an existing fact and created ordering disagreements.
+Known limit, stated openly: mobile still cannot answer form and connect cards. That
+was always true (research Finding 4) and is its own ticket.
 
-### C3. Desktop stops being deaf and stops clobbering
+## Change 2: one rule for what replay shows
 
-Subscribe the desktop records-watch hook to the EXISTING generic interaction event (no
-payload enrichment; it already fires on every transition): on receipt, refetch the
-interaction rows and rederive. Plus one adoption rule: never adopt the server transcript
-while this tab renders a pending card, unless the incoming state settles that same card.
-Payload enrichment and in-place part patching are explicitly deferred until a measured
-refetch cost justifies them.
+When the browser rebuilds a chat, each card's state comes from this list, first match
+wins:
 
-### C4. Cards act where they render
+1. A real recorded answer in the conversation. Show the answered card.
+2. An outcome saved on the row (exists only after Change 1). Show that outcome.
+3. An old row that says `cancelled` with no saved answer. Show a neutral, dead
+   "interaction ended" card. Never guess whether it was answered or abandoned.
+4. Nothing above applies: the card is still open. Show it live and clickable.
 
-A pending client-tool card is actionable inline wherever it renders (the dock, if kept,
-becomes a convenience pointer, not the owner of the actions; its duplicate settle site
-is removed). The small pending-predicates (`isHitlPending`, the dock's scan) read the
-whole transcript like the session-status scan already does. The registry's
-unknown-render-kind dispatch falls through to the tool name (a one-line repair of a
-hazard introduced 2026-08-10; lands immediately, independent of this project).
+Version 1 wanted a new record type for answers. The review showed the conversation
+already records them; a second copy would only create ordering conflicts. Dropped.
 
-## Filed separately, deliberately out of this project
+## Change 3: the browser listens, and stops overwriting
 
-- Mobile client-tool fulfillment (documented limitation above).
-- Model-visibility improvements (uniform outcome framing, connection-validity checks,
-  naming newly available tools) — adjacent defects with their own tickets.
-- Draft-key pruning, the package-loader rejection parity, the null-turn-id sweep gap.
-- Connection reuse (issue #5911).
+Two small things:
 
-## Validation
+1. The desktop web app subscribes to the row-change event the server already sends
+   (today only mobile listens). On the event: re-read the rows, update the cards.
+2. One new adoption rule: while the tab shows a waiting card, the browser must not
+   adopt the server's copy of the chat, unless that copy settles the same card.
 
-- The settlement matrix from research section 5 as tests: after C1, completion and
-  decline produce `responded/resolved` with outcomes on desktop; abandonment still
-  sweep-cancels; the race case (sweep firing between answer and resume) is pinned by a
-  test that answers, delays the resume, runs the sweep, and asserts the row survived.
-- Replay goldens per precedence tier, identical across both copies, including legacy
-  rows with and without `tool_result`.
-- The live acceptance scenario: form, connect, schedule in one conversation with
-  reloads between steps; every card appears once, acts where it is, and nothing
-  resurrects.
+No new event payloads, no per-card patching machinery. If plain refresh proves too
+slow one day, we can enrich it then.
+
+## Change 4: cards work where they appear
+
+- The buttons live ON the card, wherever it is in the chat. The bottom dock becomes a
+  pointer to the card, not the owner of the buttons. This kills the dead-card bug at
+  its root.
+- The three code paths that only looked at the last message now scan the whole chat,
+  like the status fix (#5913) already does.
+- The one-line dispatch repair from research Finding 3 lands immediately, outside this
+  project.
+- The card tool-name list gets one shared source.
+
+## Filed separately (not in this project)
+
+- Mobile answering of form and connect cards.
+- Making the agent's "am I connected?" check verify the connection is valid.
+- Reusing an existing connection (issue #5911).
+- Small cleanups: stale form drafts, one missing error catch, one unreachable sweep
+  edge case.
+
+## How we prove it works
+
+- The table in research Finding 1 becomes a permanent test: every card kind, every
+  outcome, asserted against the real API.
+- Replay tests for every line of the Change 2 rule, identical across both replay code
+  copies, with old-style rows included.
+- One race test: answer a card, delay the resume, run the sweep, assert the row
+  survived.
+- The live scenario that started this project: form, connect, schedule in one
+  conversation with reloads in between. Every card appears once, works where it is,
+  and nothing comes back from the dead.

--- a/docs/design/client-tool-interaction-lifecycle/qa.md
+++ b/docs/design/client-tool-interaction-lifecycle/qa.md
@@ -1,0 +1,86 @@
+# QA: the standing checks that make this class undiscoverable no more
+
+This bug class reached production and was found by a human exploring, much later. This
+file first states plainly why every existing layer missed it, then defines the standing
+checks that go in with the fix. The rule these checks follow: the class lived in the
+seams BETWEEN tested units (park, resume, reload, adopt), while every unit test was
+green, so the new checks are seam tests, each one tied to a mechanism from
+[research.md](research.md).
+
+## Why nothing caught it
+
+1. No test anywhere asserted an interaction row's terminal state after a user answered.
+   Handlers and widgets each had unit tests; the row's truth had none.
+2. No test drove the compound journey (form, then connect, then schedule, in ONE
+   conversation) or crossed a reload. Each acceptance test exercises one interaction, in
+   one turn, in a fresh page.
+3. The park-answer-resume cycle barely runs in CI at all: agent-chat acceptance tests
+   mock the run stream, and real gated runs live only in the release-gate matrix, which
+   asserts model behavior, not row truth.
+4. The four state sources (live messages, records, rows, localStorage) had no invariant
+   linking them, so they could disagree forever without any test noticing.
+5. Nothing in production measured the class: an answered interaction recorded as
+   abandoned looks, in every existing metric, like a user who walked away.
+
+## Standing checks, by layer
+
+### 1. The settlement matrix as a permanent API acceptance test
+
+For each interaction kind and outcome (approval approve/deny/abandon; form
+submit/decline/abandon; connect complete/decline/abandon): drive the real endpoints
+against a deployed stack and assert the row's terminal status AND resolution payload
+match the contract table. This is the test that says "success is never recorded as
+abandonment" forever. Home: `api/oss/tests/pytest/acceptance/sessions/` beside the
+existing interaction tests; the matrix from research section 5 is the spec.
+
+### 2. Replay goldens across both copies and both cache states
+
+Golden record fixtures per kind and outcome, including legacy pre-contract rows with
+and without a closing `tool_result`. Assert: the rebuilt conversation renders the card
+in the correct terminal state; both replay copies produce identical output; the result
+is the same whether the row join is warm or cold (the non-determinism found in research
+section 2 becomes a failing test). Home: the transcriptToMessages test families.
+
+### 3. The geometry invariant: one fixture through every predicate
+
+One shared message fixture containing a pending interaction in a NON-last message must
+simultaneously: publish "awaiting" session status, hold the message queue, and render
+an actionable card. Today three predicates read different slices and disagree; this
+test makes any future divergence a red build. Home: a package-level unit test where the
+predicates live, imported by the app-side suites.
+
+### 4. Adoption safety property
+
+Adopting any server transcript while the tab holds (a) a pending card or (b) a settled
+answer not yet dispatched must never drop the answer or resurrect a terminal card.
+Table-driven unit test over the hydration guard with adversarial orderings (relay tick
+during settle, adoption during park, reload mid-answer). This pins mechanisms 1b and
+the parked-window adoption gap permanently.
+
+### 5. The scripted compound journey as the deploy smoke
+
+One scripted live scenario on every deployed stack, cheap model, run by the release
+gate and after every deploy: create an agent; first message triggers a form; answer it;
+RELOAD; assert the form renders as answered and the row is resolved; trigger a connect;
+decline it; assert the decline reached the row and the run resumed; trigger a schedule
+approval; approve; RELOAD; assert every card renders exactly once in its correct
+terminal state and the strip never appeared in the driving tab. This is the primary
+user journey that production users actually hit, scripted; it would have caught every
+symptom in context.md on day one. Home: the release-gate skill's scenario set.
+
+### 6. Production detection (catch it in prod in hours, not weeks)
+
+Two cheap signals:
+- A scheduled query alerting on the rate of `client_tool` rows ending `cancelled`
+  without resolution. Post-contract, answered rows end `resolved`; a sustained rise in
+  unresolved cancellations is either the class returning or a real UX cliff, and both
+  deserve a look.
+- A frontend console/telemetry event when a card renders interactive for an interaction
+  the rows call terminal (the invariant the resurrections violated). Even as a plain
+  logged warning, support and QA sessions surface it immediately.
+
+## What deliberately stays out
+
+Model-behavior assertions (does the agent ASK at the right time) stay in the benchmark,
+not here; these checks pin the machinery, not the model. Mobile client-tool answering
+gets its checks when that ticket builds the capability.

--- a/docs/design/client-tool-interaction-lifecycle/qa.md
+++ b/docs/design/client-tool-interaction-lifecycle/qa.md
@@ -1,86 +1,69 @@
-# QA: the standing checks that make this class undiscoverable no more
+# QA: the tests that catch this class of bug forever
 
-This bug class reached production and was found by a human exploring, much later. This
-file first states plainly why every existing layer missed it, then defines the standing
-checks that go in with the fix. The rule these checks follow: the class lived in the
-seams BETWEEN tested units (park, resume, reload, adopt), while every unit test was
-green, so the new checks are seam tests, each one tied to a mechanism from
-[research.md](research.md).
+This bug class reached production. A human found it, weeks after it started to matter.
+This file explains why every test layer missed it, then lists the standing checks that
+ship with the fix.
 
 ## Why nothing caught it
 
-1. No test anywhere asserted an interaction row's terminal state after a user answered.
-   Handlers and widgets each had unit tests; the row's truth had none.
-2. No test drove the compound journey (form, then connect, then schedule, in ONE
-   conversation) or crossed a reload. Each acceptance test exercises one interaction, in
-   one turn, in a fresh page.
-3. The park-answer-resume cycle barely runs in CI at all: agent-chat acceptance tests
-   mock the run stream, and real gated runs live only in the release-gate matrix, which
-   asserts model behavior, not row truth.
-4. The four state sources (live messages, records, rows, localStorage) had no invariant
-   linking them, so they could disagree forever without any test noticing.
-5. Nothing in production measured the class: an answered interaction recorded as
-   abandoned looks, in every existing metric, like a user who walked away.
+The bugs live BETWEEN the parts, not inside them. Every part had green unit tests.
+Nothing tested the seams: park, answer, resume, reload, adopt. In detail:
 
-## Standing checks, by layer
+1. No test ever checked what the interaction row says after a user answers a card.
+2. No test ever crossed a reload, and no test ran two cards in one conversation.
+3. In CI, the chat tests fake the agent run. Real park-and-resume cycles almost never
+   run.
+4. The four state stores (tab memory, record list, rows, local storage) had no test
+   that forces them to agree.
+5. In production, an answered card recorded as abandoned looks exactly like a user who
+   walked away. No metric could see the difference.
 
-### 1. The settlement matrix as a permanent API acceptance test
+## The six standing checks
 
-For each interaction kind and outcome (approval approve/deny/abandon; form
-submit/decline/abandon; connect complete/decline/abandon): drive the real endpoints
-against a deployed stack and assert the row's terminal status AND resolution payload
-match the contract table. This is the test that says "success is never recorded as
-abandonment" forever. Home: `api/oss/tests/pytest/acceptance/sessions/` beside the
-existing interaction tests; the matrix from research section 5 is the spec.
+### 1. The settlement table as a permanent test
 
-### 2. Replay goldens across both copies and both cache states
+For every card kind and every outcome (complete, decline, walk away): call the real
+API on a deployed stack and assert the row's final state and saved outcome match the
+contract. This single test forbids "success recorded as abandonment" forever.
 
-Golden record fixtures per kind and outcome, including legacy pre-contract rows with
-and without a closing `tool_result`. Assert: the rebuilt conversation renders the card
-in the correct terminal state; both replay copies produce identical output; the result
-is the same whether the row join is warm or cold (the non-determinism found in research
-section 2 becomes a failing test). Home: the transcriptToMessages test families.
+### 2. Replay tests for every rule line
 
-### 3. The geometry invariant: one fixture through every predicate
+Saved example histories for every card kind and outcome, including old rows from
+before the fix. Assert: the rebuilt chat shows the right card state; both replay code
+copies produce the same result; the result is the same with a warm or cold cache.
 
-One shared message fixture containing a pending interaction in a NON-last message must
-simultaneously: publish "awaiting" session status, hold the message queue, and render
-an actionable card. Today three predicates read different slices and disagree; this
-test makes any future divergence a red build. Home: a package-level unit test where the
-predicates live, imported by the app-side suites.
+### 3. The geometry test
 
-### 4. Adoption safety property
+One chat fixture with a waiting card that is NOT in the last message. Assert three
+things at once: the tab reports "awaiting", the message queue holds, and the card is
+clickable. Today three code paths disagree on this; this test makes any future
+disagreement a red build.
 
-Adopting any server transcript while the tab holds (a) a pending card or (b) a settled
-answer not yet dispatched must never drop the answer or resurrect a terminal card.
-Table-driven unit test over the hydration guard with adversarial orderings (relay tick
-during settle, adoption during park, reload mid-answer). This pins mechanisms 1b and
-the parked-window adoption gap permanently.
+### 4. The adoption safety test
 
-### 5. The scripted compound journey as the deploy smoke
+Adopting the server's chat copy must never throw away an unsent answer, and must never
+turn a finished card back into a live one. Tested over hostile orderings: refresh
+during answer, adoption during park, reload mid-answer.
 
-One scripted live scenario on every deployed stack, cheap model, run by the release
-gate and after every deploy: create an agent; first message triggers a form; answer it;
-RELOAD; assert the form renders as answered and the row is resolved; trigger a connect;
-decline it; assert the decline reached the row and the run resumed; trigger a schedule
-approval; approve; RELOAD; assert every card renders exactly once in its correct
-terminal state and the strip never appeared in the driving tab. This is the primary
-user journey that production users actually hit, scripted; it would have caught every
-symptom in context.md on day one. Home: the release-gate skill's scenario set.
+### 5. The scripted user journey as the deploy smoke test
 
-### 6. Production detection (catch it in prod in hours, not weeks)
+One scripted scenario, cheap model, run by the release gate and after every deploy:
+create an agent; answer its form; RELOAD; assert the form shows as answered and the
+row says so; decline a connect card; assert the decline reached the server and the run
+resumed; approve a schedule; RELOAD; assert every card shows once, in its right state,
+and the "running somewhere else" strip never appeared. This is the exact journey that
+broke in production. Scripted, it would have caught every symptom on day one.
 
-Two cheap signals:
-- A scheduled query alerting on the rate of `client_tool` rows ending `cancelled`
-  without resolution. Post-contract, answered rows end `resolved`; a sustained rise in
-  unresolved cancellations is either the class returning or a real UX cliff, and both
-  deserve a look.
-- A frontend console/telemetry event when a card renders interactive for an interaction
-  the rows call terminal (the invariant the resurrections violated). Even as a plain
-  logged warning, support and QA sessions surface it immediately.
+### 6. Production alarms
 
-## What deliberately stays out
+- A scheduled query that alerts when form/connect rows end `cancelled` without a saved
+  answer. After the fix, answered rows end `resolved`; a rise in unresolved
+  cancellations means the class is back, or users are abandoning cards. Both matter.
+- A browser warning event whenever a card renders clickable while the row says it is
+  finished. Support and QA see it immediately.
 
-Model-behavior assertions (does the agent ASK at the right time) stay in the benchmark,
-not here; these checks pin the machinery, not the model. Mobile client-tool answering
-gets its checks when that ticket builds the capability.
+## Out of scope here
+
+Whether the AGENT asks the right things at the right time stays in the benchmark.
+These checks pin the machinery, not the model. Mobile gets its checks when mobile
+answering gets built.

--- a/docs/design/client-tool-interaction-lifecycle/qa.md
+++ b/docs/design/client-tool-interaction-lifecycle/qa.md
@@ -45,22 +45,58 @@ Adopting the server's chat copy must never throw away an unsent answer, and must
 turn a finished card back into a live one. Tested over hostile orderings: refresh
 during answer, adoption during park, reload mid-answer.
 
-### 5. The scripted user journey as the deploy smoke test
+### 5. The scripted user journeys as the deploy smoke test
 
-One scripted scenario, cheap model, run by the release gate and after every deploy:
-create an agent; answer its form; RELOAD; assert the form shows as answered and the
-row says so; decline a connect card; assert the decline reached the server and the run
-resumed; approve a schedule; RELOAD; assert every card shows once, in its right state,
-and the "running somewhere else" strip never appeared. This is the exact journey that
-broke in production. Scripted, it would have caught every symptom on day one.
+Scripted scenarios, cheap model, run by the release gate and after every deploy. The
+first is the exact journey that broke in production. The others are the ways users
+really behave, which no test ever imitated. Scripted, these would have caught every
+symptom on day one.
+
+1. **The compound journey.** Create an agent; answer its form; RELOAD; assert the form
+   shows as answered and the row says so; decline a connect card; assert the decline
+   reached the server and the run resumed; approve a schedule; RELOAD; assert every
+   card shows once, in its right state, and the "running somewhere else" strip never
+   appeared.
+2. **Form then connect, back to back.** The agent asks a form, then asks to connect.
+   Assert the answered form never comes back empty, and only the connect card is live.
+3. **Two connect requests in one conversation.** The agent asks to connect two
+   services. Assert each card settles on its own; answering one never touches the
+   other; neither comes back after both settle.
+4. **Close the tab, then open it again.** Park on a card, close the tab, open the
+   session fresh. Assert the card is there, live, and clickable; answer it; assert the
+   run resumes. Repeat with a card that was already answered before the tab closed: it
+   must show as answered, not live.
+5. **Connect for real, remove, connect again.** Using a real Telegram bot token (read
+   from the `TELEGRAM_BOT_TOKEN` environment variable, never committed), complete a
+   real connection. Assert the row says `responded` with the outcome saved. Remove the
+   connection. Ask again. Assert a fresh live card appears and completes. This proves
+   the full loop against the real provider, not a mock. Entering the token on the
+   provider's hosted page is a browser step, so the `matrix_i2` cell stops short of it
+   and this half stays manual.
+6. **Decline, then retry.** Decline a connect card. Assert the decline is recorded on
+   the row. Click retry: the SAME card re-opens the connection flow in place; no
+   second card appears and no second row is created. Assert the recorded decline
+   stays on the row until a new outcome replaces it. (Live QA on 2026-08-10 showed
+   this is how the product behaves; an earlier version of this line asked for a new
+   card, which the product never does.)
 
 ### 6. Production alarms
 
 - A scheduled query that alerts when form/connect rows end `cancelled` without a saved
-  answer. After the fix, answered rows end `resolved`; a rise in unresolved
-  cancellations means the class is back, or users are abandoning cards. Both matter.
+  answer. After the fix, answered rows end `responded` with the answer saved; a rise
+  in unresolved cancellations means the class is back, or users are abandoning cards.
+  Both matter.
 - A browser warning event whenever a card renders clickable while the row says it is
   finished. Support and QA see it immediately.
+
+## Where these checks live in the release process
+
+Checks 1 to 4 become code tests that run in CI. Checks 5 and 6 become release gate
+cells: scripts in the agent-release-gate skill's resources, named `matrix_i1` (the
+settlement table against the live API) and `matrix_i2` (the scripted journeys above).
+The release-conductor skill's Stage 4 lists them as mandatory, next to the existing
+lifecycle cells. The conductor runs them on every release and after every deploy to a
+stage. A skip counts as a failure to explain, not a pass.
 
 ## Out of scope here
 

--- a/docs/design/client-tool-interaction-lifecycle/qa.md
+++ b/docs/design/client-tool-interaction-lifecycle/qa.md
@@ -24,7 +24,10 @@ Nothing tested the seams: park, answer, resume, reload, adopt. In detail:
 
 For every card kind and every outcome (complete, decline, walk away): call the real
 API on a deployed stack and assert the row's final state and saved outcome match the
-contract. This single test forbids "success recorded as abandonment" forever.
+contract. For walk away, run the real next-turn sweep and assert it closed the row.
+Never write `cancelled` by hand: the sweep is the step that caused the production bug,
+so the test has to run it. This single test forbids "success recorded as abandonment"
+forever.
 
 ### 2. Replay tests for every rule line
 

--- a/docs/design/client-tool-interaction-lifecycle/research.md
+++ b/docs/design/client-tool-interaction-lifecycle/research.md
@@ -1,300 +1,101 @@
-# Research: how interaction cards actually behave today
+# Research: how cards really behave today
 
-Terms are defined in [README.md](README.md#glossary-shared-by-every-file-here).
+Words like "row", "sweep", "replay" are defined in [README.md](README.md). Every claim
+here was proven on 2026-08-10 with database rows, logs, or git history. Exact file and
+line references live in the two inventory reports and the PR discussion; this file
+keeps the findings readable.
 
-## 1. The diagnosed mechanisms of this bug class (all live-evidenced 2026-08-10)
+## Finding 1: the system never records that the user answered a card
 
-Each of these was reproduced on the release stack with database rows, network logs, or
-runner logs. Together they explain every symptom in [context.md](context.md); none of
-them alone explains all of it, which is why symptom-by-symptom fixing kept missing.
+This is the root of everything, so read it slowly.
 
-### 1a. Replay resurrects terminal interactions as live
+When the user answers a form card or completes a connect card, the answer goes to the
+agent, and the agent continues. Good. But the interaction ROW is never updated. It
+stays `pending`. Then the next turn starts, the sweep runs, and the sweep closes every
+old `pending` row as `cancelled`.
 
-`transcriptToMessages` rebuilds a conversation from the records. A parked interaction
-leaves an `interaction_request` record; the replay branch rebuilds the card from that
-record alone. A later real answer leaves a `tool_result` record that settles the part,
-but a server-side cancellation leaves NO record, so a cancelled interaction replays as a
-blank, interactive, forever-pending card. Clicking it is a client-side no-op (verified:
-zero network calls, row untouched), so the user sees a card that lies twice.
-Fix landed: PR #5912 joins replay against the interaction rows' terminal statuses
-(cancelled renders inert). Open question for section 2: whether every ANSWERED
-interaction reliably leaves the settling record, for all three kinds (form answers,
-connect completions, declines), or whether more terminal states need the same join.
+So in the database, an answered card and an abandoned card look exactly the same:
+`cancelled`, with no answer attached. This has been true since these cards were built.
+We checked every row from the whole day:
 
-### 1b. Adoption clobbers a just-settled answer
-
-Answering a card settles the part locally, then the resume dispatch fires a beat later.
-The records relay can tick inside that beat; the refresh adopted the server transcript,
-which predates the answer, and silently discarded it: the resume never dispatched, the
-row stayed pending, the model never saw the answer. Verified live with zero-network
-evidence. Fix landed in PR #5909 (guard at entry and re-checked at the adoption moment).
-This was the "my response was ignored" symptom.
-
-### 1c. The "awaiting" status only counted the last message
-
-The session's published status derived "awaiting" from a pending card in the LAST
-assistant message only. The moment a new turn began streaming, a still-pending card in an
-earlier message stopped counting, status collapsed, the settle stamp landed, and the
-running-elsewhere strip fired in the owning tab (strip logic: settled locally + running
-remotely = someone else's run). Fix landed: PR #5913 scans the whole transcript.
-
-### 1d. Server-side transitions are silent (to the desktop web app)
-
-Server transitions change an interaction's truth without the desktop client learning it.
-The full map is in section 3; the headline corrections from that inventory:
-
-- There is NO one-interaction-per-turn force-cancel (an earlier working theory). Multiple
-  gates per turn are supported by design. What exists instead is a routing decision: a
-  browser-fulfilled client tool makes the whole turn non-parkable (cold path), invisibly.
-- There is NO 10-minute interaction TTL. The 10-minute timer is the warm sandbox's
-  approval park; its expiry destroys the sandbox and leaves the row pending, silently.
-- A cancellation signal PARTIALLY exists: cancels publish a watch frame, but it carries
-  no token, no kind, no reason, says "resolved" for a cancellation, and the desktop web
-  app does not subscribe to it at all (only mobile listens).
-
-### 1e. The runner loses an answered gate's result when a sibling is carried
-
-When one turn raises two approval gates and the resume answers one, the carried sibling's
-re-park fired synchronously before the answered call's completion could be observed; the
-answered call's result was replaced with a synthetic "result unknown" sentinel, and the
-carried gate was re-parked but suppressed, so the client was never re-told it owes an
-answer (the row lingers pending). Fix for the ordering: PR #5910 (proven red/green). The
-suppressed re-announcement remains open and belongs to this project's plan.
-
-### 1f. Interaction settlement never records success (the deepest finding)
-
-The reconstruction in section 4 proves: a `request_connection` interaction row NEVER
-reaches a success terminal state. Whether the user completes the connection, declines it,
-or abandons it, the row always ends `cancelled`, set by the generic stale-interaction
-sweep at the top of the next turn, with no resolution payload. Verified across three
-sessions, two harnesses (codex and pi_core), and two projects. Consequences:
-
-- "Settled because it succeeded" and "settled because it went stale" are the same fact at
-  the row level. Any UI that renders from the row (including the 1a fix, which renders
-  cancelled interactions as inert-cancelled) will mislabel a successful connection as a
-  cancelled one.
-- The model learns the real outcome through a side channel: it re-reads live config or
-  discovers tools, which reflect `gateway_connections` state. In the fresh-code session
-  it correctly said "the Telegram connection is active" with zero interaction-response
-  records in its context. Outcome knowledge and interaction settlement are fully
-  decoupled today.
-- The side channel can lie: in the pre-fix session, the model declared "Telegram is
-  connected" while the only existing connection row was expired and invalid, then created
-  a schedule on top of it. The model trusts a connected-flag read without the validity
-  check.
-
-## 2. Frontend render inventory (every path that can show a card)
-
-Two widgets (the questionnaire form, the connect card), six mount sites, and two
-independent dispatch sites that can settle the same call. The full file:line inventory
-lives in the exploration report; the facts the plan builds on:
-
-### The render predicate
-
-A REGISTERED client tool renders its card in every message position and every state
-(that is what makes settled chips work), while an unregistered one arms only on the last
-message after streaming stops and then auto-settles itself as "not handled". Dispatch
-prefers the render kind over the tool name and does NOT fall through: a present-but-
-unknown render kind silently becomes the auto-settling "not handled" card.
-
-### The dead-card mechanism (the "cannot even click Not now" symptom)
-
-The connect card's ACTIONS live in a dock that only scans the LAST message; the inline
-card in the transcript is a passive marker saying "waiting for your response below".
-When a parked connect interaction ends up in a non-last message (a new turn started),
-three last-message-only readers disagree with the whole-transcript scan that now feeds
-the session status: the dock does not render (no actions anywhere), the queue stops
-holding, and the passive marker keeps pointing "below" at nothing. A visible,
-unanswerable card with no working buttons is the designed outcome of that geometry.
-
-### The reload regression (answers structurally cannot survive adoption)
-
-On reload the localStorage seed paints the CORRECT answered state first. Hydration then
-adopts the server replay whenever the server's record count exceeds the local watermark.
-The records CAN carry the answer (the resume turn writes a tool_result, which is why
-0.108 reloads were correct); what cannot carry it is the interaction ROW, and the
-0.112-era replay reads the row. When the answer's tool_result has not landed yet, or the
-row join mislabels, the correct local copy is replaced by a wrong server copy. Worse, the replay join that
-marks cancelled interactions inert matches ANSWERED interactions too (their rows are
-always cancelled, section 5): an accepted questionnaire replays as "Dismissed the
-request." and a successful connection replays as "Connection not completed" with a
-Retry button. When that join is cold (best-effort, 15-second staleness), the same part
-replays as a fully live, answerable form instead. The rendered truth after reload is
-non-deterministic by cache warmth.
-
-### Adoption while a card is parked
-
-While a card is parked, the tab reads as not-busy and no resume is pending, so both the
-poll and the records relay will adopt the server transcript, remounting widgets and
-destroying typed form state (only the per-card localStorage draft survives). The
-settle-to-resume guard from PR #5909 protects only the answer window, not the parked
-window.
-
-### Divergence flags recorded for the plan (abbreviated)
-
-Two settle sites per call guarded by per-instance flags; the client-tool name list
-duplicated across a package boundary (a tool added to one list only either never
-resumes or never renders); sentinel matching differs between the two transcript-replay
-copies; the questionnaire draft key is never pruned for cancelled parts; the connect
-success payload tells the model only `{connected, integration, slug}`, and the model's
-awareness of newly available tools depends on the next run's tool-list resolution,
-unannounced.
-
-## 3. Server-side lifecycle inventory (every state transition)
-
-Full file:line detail lives in the inventory report; this section keeps the facts the
-plan builds on.
-
-Vocabulary: kinds `user_approval | user_input | client_tool` (nothing ever creates
-`user_input`; `request_input` and `request_connection` ride as `client_tool`). Statuses
-`pending | responded | resolved | cancelled`; `resolved` and `cancelled` are terminal,
-enforced by a guarded compare-and-set (a late transition 404s). A `resolution` payload is
-REJECTED with 409 for any kind except `user_approval` — the schema itself forbids
-client-tool outcomes today.
-
-### The defining defect: fulfillment never resolves the row
-
-The relay path that delivers `request_input`/`request_connection` returns the browser's
-output to the harness and NEVER touches the interaction row (no resolve call exists on
-that path; the only client-tool resolve lives on a different, ACP-gated path). The row is
-still `pending` when the resume turn starts, and the turn-start stale sweep cancels it,
-because the sweep's exemption list is built only from warm-parked APPROVAL gates. A
-successfully answered form or connection is therefore recorded, durably and always, as an
-abandonment. This single mechanism produces the entire kind-by-outcome table in section 5
-and explains what the janitor did to Mahmoud's answered questionnaire.
-
-### Cancellation paths (exactly three, plus hard delete)
-
-1. Turn-start stale sweep: every session run cancels the session's pending rows from
-   other turns, minus warm-parked approvals. Fire-and-forget.
-2. Records-worker orphan reconciliation: a turn that ends without parking cancels its own
-   leftover gates, before the watch tee wakes clients.
-3. Session kill: cancels ALL pending rows, including one the user is looking at.
-Hard delete: session deletion removes rows outright.
-
-### What the model actually receives
-
-- Approval answered: a tool result `{approved, interactionToken}`. On a warm resume, the
-  harness gets a bare allow/reject enum: a deny cannot say WHY (human refusal vs policy
-  vs error), and a deny-with-note travels as a separate user turn (undeliverable on the
-  warm mobile path).
-- Client tool answered: the browser's raw output verbatim as the tool's return value.
-- Connection success: only `{connected, integration, slug}`. Nothing tells the model
-  which tools the connection made available; that depends on the next run re-resolving
-  the tool list, unannounced.
-- `interaction_request`/`interaction_response` records are audit/replay only; the
-  reconstruction that builds the model's conversation context drops both.
-
-### Records each path leaves
-
-Client tool: `tool_call` + `interaction_request`, then (next turn) `tool_result`.
-Approval: those plus sometimes `interaction_response` (only user_approval, only when a
-verdict reached the harness). A CANCELLED interaction leaves no closing record of any
-kind, which is why replay needs a separate REST join to know, and that join today queries
-`client_tool` rows only (a cancelled approval is never reconciled on any surface).
-
-### Latent traps recorded for the plan
-
-- Interaction creation silently drops after 3 failed retries: the live card renders with
-  no durable row; out-of-band answering 404s.
-- The stale sweep cannot reach a row with a NULL turn id (SQL null-inequality); current
-  producers always set one, so this is latent, not live.
-- Two answer planes exist (message-borne for desktop, interactions-API for mobile) with
-  different ordering and different capabilities; any settlement contract must serve both.
-
-## 4. Live evidence: what actually happened after the successful connection
-
-Reconstruction from the newest session on Mahmoud's project (ca534199, harness codex),
-plus two corroborating sessions. Read-only: database rows, tracing records, runner logs.
-
-The successful connection: `gateway_connections` row 019fec52-0932, slug
-`telegram-main`, created 15:37:07, flags `is_valid: true, is_active: true` (independently
-confirmed distinct from the expired 14:58 attempt).
-
-1. The connect interaction that produced it (token 8b31fd6e, args request oauth mode and
-   slug telegram-main) ended **status=cancelled** at 15:38:04, no resolution payload, via
-   the stale sweep at the next turn's start. The runner ingested ZERO interaction-response
-   records for the whole session. Nothing distinguishes this row from an abandoned one.
-2. The model nonetheless learned the truth: the next turn's records carry "The Telegram
-   connection is active" (record 3) and "Telegram is connected, but the message-sending
-   action isn't available in this runtime" (record 17, final). It learned via re-reading
-   live config/tool discovery, not via settlement.
-3. No literal model re-ask exists in this session's records. The "asked me to connect
-   again" experience is therefore attributed to the client rendering the cancelled-row
-   card again (mechanism 1a/1f interplay: the row's terminal state cannot say
-   "succeeded", so the card cannot either).
-4. Corroboration: the earlier session e627d80a (pre-fix code) shows the same
-   always-cancelled signature AND the false-positive shape: the model declared
-   "connected" with only an expired connection row in existence, then created a schedule
-   on top of it. A controlled test session (3975e362, pi_core, different project) shows
-   the same always-cancelled-after-genuine-success signature.
-
-Two adjacent findings for the record, out of this project's scope but worth their own
-tracking: (a) after a genuinely valid connection, the codex harness could not locate an
-executable Telegram send action (a read_config error mid-turn), so the poem was never
-sent; (b) the model's connected-check does not verify connection validity (the false
-positive above).
-
-## 5. Settlement by interaction kind (the kind-by-outcome table)
-
-Mined from all of today's `session_interactions` rows plus row-level detail from
-controlled tests. One example row exists for every cell; ids are in the source data.
-
-| Kind | Proper completion | Explicit decline | Abandonment |
+| Card kind | User completes it | User declines it | User walks away |
 |---|---|---|---|
-| `user_approval` (all gated tools) | `resolved` + `resolution.verdict: approved` + a wire event (`interaction_response`) then the real `tool_result` | `resolved` + `resolution.verdict: denied` | `pending`, or `cancelled` without resolution via the sweep |
-| `client_tool` / `request_input` | `cancelled`, no resolution, no wire event (byte-identical to decline) | `cancelled`, no resolution | `pending` until the sweep flips it to `cancelled` |
-| `client_tool` / `request_connection` | `cancelled`, no resolution (verified against a connection that genuinely succeeded) | `pending`, never touched at all (the pre-fix decline never reached the server) | `pending`, identical to decline |
+| Approval card | `resolved` + verdict saved | `resolved` + verdict saved | `pending`, later swept |
+| Form card | `cancelled`, nothing saved | `cancelled`, nothing saved | `pending`, later swept |
+| Connect card | `cancelled`, nothing saved | `pending`, never touched | `pending`, never touched |
 
-Facts the table pins:
+Read the table like this: only the approval card does it right. It has a real
+"answered" state and it saves the verdict. Form and connect cards funnel every outcome
+into the same meaningless end state.
 
-- `client_tool` rows carry exactly two top-level keys, ever: `request` and `references`.
-  There is no success field to read; the schema cannot express an outcome.
-- `user_approval` has the full contract this project wants: a distinct terminal status, a
-  verdict payload, and a wire event marking the settlement moment. The sweep still exists
-  for genuinely abandoned gates, and it is distinguishable from settlement.
-- The model receives client-tool outcomes only as ordinary conversational content in the
-  next turn's history (a submitted form's values appear in the model's next message
-  context; zero `interaction_response` events exist for client tools anywhere in today's
-  runner logs).
+Why it matters: any screen that reads the row cannot tell "answered" from "abandoned".
+So it shows the wrong thing, forever, for every answered card.
 
-Consequence for the plan: the settlement contract does not need inventing. It needs
-EXTENDING from `user_approval` to `client_tool`, with outcome payloads per kind
-(submitted values for forms; connection result for connects) and the same wire event, so
-the row, the card, and the model all read the same fact.
+## Finding 2: how each bug Mahmoud saw follows from this
 
-## 6. When each piece was born (blame timeline, verified against v0.108.1)
+**Cards come back after you answer them.** After a reload, the browser rebuilds the
+chat from the server (replay). The replay looks at the interaction rows. The rows say
+`cancelled` for everything (Finding 1). So an answered form replays as "Dismissed". A
+working connection replays as "Connection not completed" with a Retry button. And when
+the row lookup is slow or empty, the same card replays as a live, clickable form. What
+you see after a reload depends on a cache. That is why it felt random.
 
-Baseline fact that reframes the project: `client-tools.ts` (the relay delivery path) is
-byte-identical between v0.108.1 and today, and a resolve call has NEVER existed in it in
-the repo's entire history. The interactions table, the stale sweep, the relay, both
-request tools, and both widgets all shipped together in v0.105.0 with the settlement
-asymmetry (resolution payloads for approvals only) already in place. On 0.108, answered
-client-tool rows were ALREADY always swept to cancelled; nothing rendered the lie
-because replay ignored client-tool interaction rows entirely and rebuilt cards from
-tool_call/tool_result records, which did carry the answers.
+**Your answer gets lost.** When you answer a card, the browser waits a moment before it
+sends the resume. In that moment, a background refresh can arrive and adopt the
+server's older copy of the chat. Your answer is thrown away before it was sent. We
+reproduced this with network logs: zero requests left the browser. (Fixed in #5909;
+the fix also re-checks at the exact moment of adoption.)
 
-- v0.105.0 (07-14): interactions plane (PR #4916), stale sweep (PR #4937), relay without
-  settlement (PR #4985), request_connection (PR #4920), request_input (PR #5155),
-  widgets. The root defect is born complete. (Dating refinement from review: the
-  resolution payload and its approval-only guard arrived July 19, shortly after the
-  plane itself.)
-- v0.106.1/2 (07-30..08-01): InteractionDock with its last-message-only scan (PR #5521);
-  watermark adoption + the running-elsewhere strip (PR #5608).
-- v0.108 (08-03/04): the "it worked" baseline. Working = the broken rows were unread.
-- v0.109-v0.110: no changes to any mechanism here.
-- v0.111.0 (08-09): the inflection. PR #5690 adds the live records-watch relay, orphan
-  reconciliation, and the watch publish; adoption can now fire mid-turn (mechanism 1b's
-  precondition). PR #5682 adds the second replay copy.
-- 0.112 train (08-10): PR #5859 makes replay read client-tool interaction rows for the
-  first time (resurrection becomes possible) and introduces a registry-dispatch hazard
-  (an unknown render kind no longer falls through to the tool name; a one-line fix).
-  PR #5912 adds the row join that then mislabels answered rows.
+**A dead card blocks the screen.** The connect card's buttons do not live on the card.
+They live in a dock at the bottom of the chat, and the dock only looks at the LAST
+message. When a new turn starts, the parked card is no longer in the last message. The
+dock disappears. The card in the chat says "waiting for your response below", and below
+there is nothing. That is the unclickable card.
 
-Consequences adopted into the plan: W1+W2 are genuine contract work with no revert
-alternative (nothing was lost; it was never written). W3 and the registry item are
-regression repair against v0.111/PR #5859 code, on their own schedule. A restore-0.108
-option exists (exempt client_tool from the sweep or stop reading rows in replay, plus
-block mid-turn adoption) and is REJECTED: 0.108's correctness was a happy-path illusion
-with its own defects (unanswered client tools replayed as live never-resolvable cards;
-request_input replayed as the auto-settling "not handled" card).
+**The strip accuses your own tab.** The tab's status only counted a waiting card if it
+was in the last message. A new turn starts, the card is no longer last, the tab thinks
+it is idle, the server says the session is running, and the strip concludes: someone
+else runs this. (Fixed in #5913: the tab now scans the whole chat.)
+
+**The agent asks to connect again after a success.** The agent does not learn outcomes
+from the rows either. It learns them from the conversation itself, or by re-reading
+the live config. That side channel usually works. It can also lie: in one session the
+agent said "Telegram is connected" while the only connection on file was expired, and
+then it built a schedule on top of it.
+
+## Finding 3: when each piece was born (checked against version 0.108)
+
+Mahmoud reported that cards worked fine on version 0.108. We checked git history
+against that claim. The result surprised us:
+
+- The root defect (Finding 1) is NOT a regression. It shipped complete in version
+  0.105.0. The delivery code is byte-identical between 0.108.1 and today. A resolve
+  call never existed. Nothing was lost; it was never written.
+- Version 0.108 looked correct for one reason: nothing read the broken rows. Replay
+  ignored them and rebuilt cards from the conversation records, which DO carry the
+  answers. The lie existed, but no screen displayed it.
+- Two later changes made the lie visible. Version 0.111 added a live refresh channel,
+  so adoption can now happen in the middle of a turn (that enabled the lost-answer
+  bug). And on 2026-08-10, PR #5859 made replay read the rows for the first time (that
+  enabled the coming-back cards).
+- One extra hazard came with PR #5859: a card whose display type is unknown now
+  silently answers itself "not handled" instead of falling back to the tool name. One
+  line fixes it.
+
+So: the foundation was always broken, and recent changes built windows onto it.
+
+## Finding 4: other facts the plan must respect
+
+- The server publishes an event when a row changes. The desktop web app does not
+  listen to it. Only the mobile app does. The event also carries no detail: not which
+  card, not what happened.
+- There is no "one card per turn" rule, and no 10-minute card timeout. Both were
+  earlier wrong theories; git history disproved them.
+- Mobile can only answer approval cards. The mobile answer endpoint, the server code
+  that builds the resume, and the runner's reading of answers all speak "approve/deny"
+  only. Form and connect answers have no route from mobile. This was always true.
+- The same card can be answered from two places in the code, guarded only by local
+  flags.
+- The list of card tool names exists twice, in two layers that cannot import each
+  other. Adding a tool to one list only produces a card that never resumes, or a
+  resume with no card.

--- a/docs/design/client-tool-interaction-lifecycle/research.md
+++ b/docs/design/client-tool-interaction-lifecycle/research.md
@@ -14,9 +14,10 @@ agent, and the agent continues. Good. But the interaction ROW is never updated. 
 stays `pending`. Then the next turn starts, the sweep runs, and the sweep closes every
 old `pending` row as `cancelled`.
 
-So in the database, an answered card and an abandoned card look exactly the same:
-`cancelled`, with no answer attached. This has been true since these cards were built.
-We checked every row from the whole day:
+So in the database, form and connect rows never carry the answer. An answered form and an
+abandoned form both end `cancelled`, with nothing attached, so nothing can tell them
+apart. An untouched connect card stays `pending` instead. This has been true since these
+cards were built. We checked every row from the whole day:
 
 | Card kind | User completes it | User declines it | User walks away |
 |---|---|---|---|
@@ -70,7 +71,8 @@ against that claim. The result surprised us:
 
 - The root defect (Finding 1) is NOT a regression. It shipped complete in version
   0.105.0. The delivery code is byte-identical between 0.108.1 and today. A resolve
-  call never existed. Nothing was lost; it was never written.
+  call never existed in the form and connect delivery code (approval cards always had
+  one, see Finding 1). Nothing was lost; it was never written.
 - Version 0.108 looked correct for one reason: nothing read the broken rows. Replay
   ignored them and rebuilt cards from the conversation records, which DO carry the
   answers. The lie existed, but no screen displayed it.

--- a/docs/design/client-tool-interaction-lifecycle/research.md
+++ b/docs/design/client-tool-interaction-lifecycle/research.md
@@ -1,0 +1,300 @@
+# Research: how interaction cards actually behave today
+
+Terms are defined in [README.md](README.md#glossary-shared-by-every-file-here).
+
+## 1. The diagnosed mechanisms of this bug class (all live-evidenced 2026-08-10)
+
+Each of these was reproduced on the release stack with database rows, network logs, or
+runner logs. Together they explain every symptom in [context.md](context.md); none of
+them alone explains all of it, which is why symptom-by-symptom fixing kept missing.
+
+### 1a. Replay resurrects terminal interactions as live
+
+`transcriptToMessages` rebuilds a conversation from the records. A parked interaction
+leaves an `interaction_request` record; the replay branch rebuilds the card from that
+record alone. A later real answer leaves a `tool_result` record that settles the part,
+but a server-side cancellation leaves NO record, so a cancelled interaction replays as a
+blank, interactive, forever-pending card. Clicking it is a client-side no-op (verified:
+zero network calls, row untouched), so the user sees a card that lies twice.
+Fix landed: PR #5912 joins replay against the interaction rows' terminal statuses
+(cancelled renders inert). Open question for section 2: whether every ANSWERED
+interaction reliably leaves the settling record, for all three kinds (form answers,
+connect completions, declines), or whether more terminal states need the same join.
+
+### 1b. Adoption clobbers a just-settled answer
+
+Answering a card settles the part locally, then the resume dispatch fires a beat later.
+The records relay can tick inside that beat; the refresh adopted the server transcript,
+which predates the answer, and silently discarded it: the resume never dispatched, the
+row stayed pending, the model never saw the answer. Verified live with zero-network
+evidence. Fix landed in PR #5909 (guard at entry and re-checked at the adoption moment).
+This was the "my response was ignored" symptom.
+
+### 1c. The "awaiting" status only counted the last message
+
+The session's published status derived "awaiting" from a pending card in the LAST
+assistant message only. The moment a new turn began streaming, a still-pending card in an
+earlier message stopped counting, status collapsed, the settle stamp landed, and the
+running-elsewhere strip fired in the owning tab (strip logic: settled locally + running
+remotely = someone else's run). Fix landed: PR #5913 scans the whole transcript.
+
+### 1d. Server-side transitions are silent (to the desktop web app)
+
+Server transitions change an interaction's truth without the desktop client learning it.
+The full map is in section 3; the headline corrections from that inventory:
+
+- There is NO one-interaction-per-turn force-cancel (an earlier working theory). Multiple
+  gates per turn are supported by design. What exists instead is a routing decision: a
+  browser-fulfilled client tool makes the whole turn non-parkable (cold path), invisibly.
+- There is NO 10-minute interaction TTL. The 10-minute timer is the warm sandbox's
+  approval park; its expiry destroys the sandbox and leaves the row pending, silently.
+- A cancellation signal PARTIALLY exists: cancels publish a watch frame, but it carries
+  no token, no kind, no reason, says "resolved" for a cancellation, and the desktop web
+  app does not subscribe to it at all (only mobile listens).
+
+### 1e. The runner loses an answered gate's result when a sibling is carried
+
+When one turn raises two approval gates and the resume answers one, the carried sibling's
+re-park fired synchronously before the answered call's completion could be observed; the
+answered call's result was replaced with a synthetic "result unknown" sentinel, and the
+carried gate was re-parked but suppressed, so the client was never re-told it owes an
+answer (the row lingers pending). Fix for the ordering: PR #5910 (proven red/green). The
+suppressed re-announcement remains open and belongs to this project's plan.
+
+### 1f. Interaction settlement never records success (the deepest finding)
+
+The reconstruction in section 4 proves: a `request_connection` interaction row NEVER
+reaches a success terminal state. Whether the user completes the connection, declines it,
+or abandons it, the row always ends `cancelled`, set by the generic stale-interaction
+sweep at the top of the next turn, with no resolution payload. Verified across three
+sessions, two harnesses (codex and pi_core), and two projects. Consequences:
+
+- "Settled because it succeeded" and "settled because it went stale" are the same fact at
+  the row level. Any UI that renders from the row (including the 1a fix, which renders
+  cancelled interactions as inert-cancelled) will mislabel a successful connection as a
+  cancelled one.
+- The model learns the real outcome through a side channel: it re-reads live config or
+  discovers tools, which reflect `gateway_connections` state. In the fresh-code session
+  it correctly said "the Telegram connection is active" with zero interaction-response
+  records in its context. Outcome knowledge and interaction settlement are fully
+  decoupled today.
+- The side channel can lie: in the pre-fix session, the model declared "Telegram is
+  connected" while the only existing connection row was expired and invalid, then created
+  a schedule on top of it. The model trusts a connected-flag read without the validity
+  check.
+
+## 2. Frontend render inventory (every path that can show a card)
+
+Two widgets (the questionnaire form, the connect card), six mount sites, and two
+independent dispatch sites that can settle the same call. The full file:line inventory
+lives in the exploration report; the facts the plan builds on:
+
+### The render predicate
+
+A REGISTERED client tool renders its card in every message position and every state
+(that is what makes settled chips work), while an unregistered one arms only on the last
+message after streaming stops and then auto-settles itself as "not handled". Dispatch
+prefers the render kind over the tool name and does NOT fall through: a present-but-
+unknown render kind silently becomes the auto-settling "not handled" card.
+
+### The dead-card mechanism (the "cannot even click Not now" symptom)
+
+The connect card's ACTIONS live in a dock that only scans the LAST message; the inline
+card in the transcript is a passive marker saying "waiting for your response below".
+When a parked connect interaction ends up in a non-last message (a new turn started),
+three last-message-only readers disagree with the whole-transcript scan that now feeds
+the session status: the dock does not render (no actions anywhere), the queue stops
+holding, and the passive marker keeps pointing "below" at nothing. A visible,
+unanswerable card with no working buttons is the designed outcome of that geometry.
+
+### The reload regression (answers structurally cannot survive adoption)
+
+On reload the localStorage seed paints the CORRECT answered state first. Hydration then
+adopts the server replay whenever the server's record count exceeds the local watermark.
+The records CAN carry the answer (the resume turn writes a tool_result, which is why
+0.108 reloads were correct); what cannot carry it is the interaction ROW, and the
+0.112-era replay reads the row. When the answer's tool_result has not landed yet, or the
+row join mislabels, the correct local copy is replaced by a wrong server copy. Worse, the replay join that
+marks cancelled interactions inert matches ANSWERED interactions too (their rows are
+always cancelled, section 5): an accepted questionnaire replays as "Dismissed the
+request." and a successful connection replays as "Connection not completed" with a
+Retry button. When that join is cold (best-effort, 15-second staleness), the same part
+replays as a fully live, answerable form instead. The rendered truth after reload is
+non-deterministic by cache warmth.
+
+### Adoption while a card is parked
+
+While a card is parked, the tab reads as not-busy and no resume is pending, so both the
+poll and the records relay will adopt the server transcript, remounting widgets and
+destroying typed form state (only the per-card localStorage draft survives). The
+settle-to-resume guard from PR #5909 protects only the answer window, not the parked
+window.
+
+### Divergence flags recorded for the plan (abbreviated)
+
+Two settle sites per call guarded by per-instance flags; the client-tool name list
+duplicated across a package boundary (a tool added to one list only either never
+resumes or never renders); sentinel matching differs between the two transcript-replay
+copies; the questionnaire draft key is never pruned for cancelled parts; the connect
+success payload tells the model only `{connected, integration, slug}`, and the model's
+awareness of newly available tools depends on the next run's tool-list resolution,
+unannounced.
+
+## 3. Server-side lifecycle inventory (every state transition)
+
+Full file:line detail lives in the inventory report; this section keeps the facts the
+plan builds on.
+
+Vocabulary: kinds `user_approval | user_input | client_tool` (nothing ever creates
+`user_input`; `request_input` and `request_connection` ride as `client_tool`). Statuses
+`pending | responded | resolved | cancelled`; `resolved` and `cancelled` are terminal,
+enforced by a guarded compare-and-set (a late transition 404s). A `resolution` payload is
+REJECTED with 409 for any kind except `user_approval` — the schema itself forbids
+client-tool outcomes today.
+
+### The defining defect: fulfillment never resolves the row
+
+The relay path that delivers `request_input`/`request_connection` returns the browser's
+output to the harness and NEVER touches the interaction row (no resolve call exists on
+that path; the only client-tool resolve lives on a different, ACP-gated path). The row is
+still `pending` when the resume turn starts, and the turn-start stale sweep cancels it,
+because the sweep's exemption list is built only from warm-parked APPROVAL gates. A
+successfully answered form or connection is therefore recorded, durably and always, as an
+abandonment. This single mechanism produces the entire kind-by-outcome table in section 5
+and explains what the janitor did to Mahmoud's answered questionnaire.
+
+### Cancellation paths (exactly three, plus hard delete)
+
+1. Turn-start stale sweep: every session run cancels the session's pending rows from
+   other turns, minus warm-parked approvals. Fire-and-forget.
+2. Records-worker orphan reconciliation: a turn that ends without parking cancels its own
+   leftover gates, before the watch tee wakes clients.
+3. Session kill: cancels ALL pending rows, including one the user is looking at.
+Hard delete: session deletion removes rows outright.
+
+### What the model actually receives
+
+- Approval answered: a tool result `{approved, interactionToken}`. On a warm resume, the
+  harness gets a bare allow/reject enum: a deny cannot say WHY (human refusal vs policy
+  vs error), and a deny-with-note travels as a separate user turn (undeliverable on the
+  warm mobile path).
+- Client tool answered: the browser's raw output verbatim as the tool's return value.
+- Connection success: only `{connected, integration, slug}`. Nothing tells the model
+  which tools the connection made available; that depends on the next run re-resolving
+  the tool list, unannounced.
+- `interaction_request`/`interaction_response` records are audit/replay only; the
+  reconstruction that builds the model's conversation context drops both.
+
+### Records each path leaves
+
+Client tool: `tool_call` + `interaction_request`, then (next turn) `tool_result`.
+Approval: those plus sometimes `interaction_response` (only user_approval, only when a
+verdict reached the harness). A CANCELLED interaction leaves no closing record of any
+kind, which is why replay needs a separate REST join to know, and that join today queries
+`client_tool` rows only (a cancelled approval is never reconciled on any surface).
+
+### Latent traps recorded for the plan
+
+- Interaction creation silently drops after 3 failed retries: the live card renders with
+  no durable row; out-of-band answering 404s.
+- The stale sweep cannot reach a row with a NULL turn id (SQL null-inequality); current
+  producers always set one, so this is latent, not live.
+- Two answer planes exist (message-borne for desktop, interactions-API for mobile) with
+  different ordering and different capabilities; any settlement contract must serve both.
+
+## 4. Live evidence: what actually happened after the successful connection
+
+Reconstruction from the newest session on Mahmoud's project (ca534199, harness codex),
+plus two corroborating sessions. Read-only: database rows, tracing records, runner logs.
+
+The successful connection: `gateway_connections` row 019fec52-0932, slug
+`telegram-main`, created 15:37:07, flags `is_valid: true, is_active: true` (independently
+confirmed distinct from the expired 14:58 attempt).
+
+1. The connect interaction that produced it (token 8b31fd6e, args request oauth mode and
+   slug telegram-main) ended **status=cancelled** at 15:38:04, no resolution payload, via
+   the stale sweep at the next turn's start. The runner ingested ZERO interaction-response
+   records for the whole session. Nothing distinguishes this row from an abandoned one.
+2. The model nonetheless learned the truth: the next turn's records carry "The Telegram
+   connection is active" (record 3) and "Telegram is connected, but the message-sending
+   action isn't available in this runtime" (record 17, final). It learned via re-reading
+   live config/tool discovery, not via settlement.
+3. No literal model re-ask exists in this session's records. The "asked me to connect
+   again" experience is therefore attributed to the client rendering the cancelled-row
+   card again (mechanism 1a/1f interplay: the row's terminal state cannot say
+   "succeeded", so the card cannot either).
+4. Corroboration: the earlier session e627d80a (pre-fix code) shows the same
+   always-cancelled signature AND the false-positive shape: the model declared
+   "connected" with only an expired connection row in existence, then created a schedule
+   on top of it. A controlled test session (3975e362, pi_core, different project) shows
+   the same always-cancelled-after-genuine-success signature.
+
+Two adjacent findings for the record, out of this project's scope but worth their own
+tracking: (a) after a genuinely valid connection, the codex harness could not locate an
+executable Telegram send action (a read_config error mid-turn), so the poem was never
+sent; (b) the model's connected-check does not verify connection validity (the false
+positive above).
+
+## 5. Settlement by interaction kind (the kind-by-outcome table)
+
+Mined from all of today's `session_interactions` rows plus row-level detail from
+controlled tests. One example row exists for every cell; ids are in the source data.
+
+| Kind | Proper completion | Explicit decline | Abandonment |
+|---|---|---|---|
+| `user_approval` (all gated tools) | `resolved` + `resolution.verdict: approved` + a wire event (`interaction_response`) then the real `tool_result` | `resolved` + `resolution.verdict: denied` | `pending`, or `cancelled` without resolution via the sweep |
+| `client_tool` / `request_input` | `cancelled`, no resolution, no wire event (byte-identical to decline) | `cancelled`, no resolution | `pending` until the sweep flips it to `cancelled` |
+| `client_tool` / `request_connection` | `cancelled`, no resolution (verified against a connection that genuinely succeeded) | `pending`, never touched at all (the pre-fix decline never reached the server) | `pending`, identical to decline |
+
+Facts the table pins:
+
+- `client_tool` rows carry exactly two top-level keys, ever: `request` and `references`.
+  There is no success field to read; the schema cannot express an outcome.
+- `user_approval` has the full contract this project wants: a distinct terminal status, a
+  verdict payload, and a wire event marking the settlement moment. The sweep still exists
+  for genuinely abandoned gates, and it is distinguishable from settlement.
+- The model receives client-tool outcomes only as ordinary conversational content in the
+  next turn's history (a submitted form's values appear in the model's next message
+  context; zero `interaction_response` events exist for client tools anywhere in today's
+  runner logs).
+
+Consequence for the plan: the settlement contract does not need inventing. It needs
+EXTENDING from `user_approval` to `client_tool`, with outcome payloads per kind
+(submitted values for forms; connection result for connects) and the same wire event, so
+the row, the card, and the model all read the same fact.
+
+## 6. When each piece was born (blame timeline, verified against v0.108.1)
+
+Baseline fact that reframes the project: `client-tools.ts` (the relay delivery path) is
+byte-identical between v0.108.1 and today, and a resolve call has NEVER existed in it in
+the repo's entire history. The interactions table, the stale sweep, the relay, both
+request tools, and both widgets all shipped together in v0.105.0 with the settlement
+asymmetry (resolution payloads for approvals only) already in place. On 0.108, answered
+client-tool rows were ALREADY always swept to cancelled; nothing rendered the lie
+because replay ignored client-tool interaction rows entirely and rebuilt cards from
+tool_call/tool_result records, which did carry the answers.
+
+- v0.105.0 (07-14): interactions plane (PR #4916), stale sweep (PR #4937), relay without
+  settlement (PR #4985), request_connection (PR #4920), request_input (PR #5155),
+  widgets. The root defect is born complete. (Dating refinement from review: the
+  resolution payload and its approval-only guard arrived July 19, shortly after the
+  plane itself.)
+- v0.106.1/2 (07-30..08-01): InteractionDock with its last-message-only scan (PR #5521);
+  watermark adoption + the running-elsewhere strip (PR #5608).
+- v0.108 (08-03/04): the "it worked" baseline. Working = the broken rows were unread.
+- v0.109-v0.110: no changes to any mechanism here.
+- v0.111.0 (08-09): the inflection. PR #5690 adds the live records-watch relay, orphan
+  reconciliation, and the watch publish; adoption can now fire mid-turn (mechanism 1b's
+  precondition). PR #5682 adds the second replay copy.
+- 0.112 train (08-10): PR #5859 makes replay read client-tool interaction rows for the
+  first time (resurrection becomes possible) and introduces a registry-dispatch hazard
+  (an unknown render kind no longer falls through to the tool name; a one-line fix).
+  PR #5912 adds the row join that then mislabels answered rows.
+
+Consequences adopted into the plan: W1+W2 are genuine contract work with no revert
+alternative (nothing was lost; it was never written). W3 and the registry item are
+regression repair against v0.111/PR #5859 code, on their own schedule. A restore-0.108
+option exists (exempt client_tool from the sweep or stop reading rows in replay, plus
+block mid-turn adoption) and is REJECTED: 0.108's correctness was a happy-path illusion
+with its own defects (unanswered client tools replayed as live never-resolvable cards;
+request_input replayed as the auto-settling "not handled" card).

--- a/docs/design/client-tool-interaction-lifecycle/status.md
+++ b/docs/design/client-tool-interaction-lifecycle/status.md
@@ -1,50 +1,26 @@
 # Status
 
-2026-08-10 ~18:15 CET.
+2026-08-10 evening.
 
 ## Done
 
-- Research COMPLETE: all four inputs folded into research.md (the six diagnosed
-  mechanisms with corrections; the frontend render inventory; the server-side lifecycle
-  inventory; the live evidence including the kind-by-outcome settlement table).
-- plan.md written: six-point lifecycle contract, six workstreams in landing order,
-  validation matrix.
-- Workspace docs: README (glossary, reading order), context.
-
-## Done (additional)
-
-- Blame archaeology complete and folded in (research section 6): root defect born
-  complete in v0.105.0, never a regression; visibility regressions dated to v0.111
-  (records-watch relay) and the 0.112 train (row-reading replay). One research claim
-  corrected (records DO carry answers; the row cannot). Plan reshaped: contract work vs
-  regression repair.
-
-## Done (review round)
-
-- Adversarial review (codex gpt-5.6-sol) returned UNSOUND on plan v1 with nine findings,
-  the decisive ones: v1's resolve-at-delivery loses the sweep race on cold resumes; the
-  new closing record duplicated the existing tool_result; the watch workstream built
-  patching machinery where a subscription suffices; two workstreams were unrelated scope.
-  Plan v2 adopts all of it: the answer becomes the authoritative first transition through
-  the existing interactions API, one replay precedence rule, subscribe-and-refetch, cards
-  act where they render. Mobile client-tool fulfillment documented as a limitation.
+- Research complete, evidence-backed, rewritten in plain language.
+- Blame history checked against version 0.108: the root defect was never a regression;
+  two recent changes made it visible (details: research Finding 3).
+- Plan version 1 rejected by an adversarial review (nine findings; the decisive one:
+  recording the answer at delivery time loses a race against the cleanup sweep).
+- Plan version 2 written: four changes, smaller, race-safe by ordering.
+- qa.md written: why every layer missed this, and six standing checks.
+- Docs shipped for review: PR #5916.
 
 ## Next
 
-- Then implementation, W1 first (resolve on fulfillment), since every later workstream
-  keys on real terminal statuses existing.
+- Mahmoud's go/no-go on plan version 2.
+- On go: implement Change 1 first (everything else reads the states it creates).
 
-## Blockers
+## Standing decisions
 
-None.
-
-## Decisions taken
-
-- Root cause treated as the fragmented state model; the plan establishes one contract
-  rather than more symptom patches.
-- No schema migration: statuses and resolution payloads already exist; W1 changes who
-  sets them and when.
-- Connection reuse (issue #5911) stays out of scope; W5 only guarantees the model hears
-  outcomes.
-- Corrections adopted from research: no one-interaction-per-turn rule exists; no
-  10-minute interaction TTL exists (that timer is the warm sandbox approval park).
+- One contract instead of more symptom patches.
+- No new record types, no new event payloads, no database migration.
+- Mobile form/connect answering stays a separate ticket.
+- The one-line dispatch repair lands immediately, outside this project.

--- a/docs/design/client-tool-interaction-lifecycle/status.md
+++ b/docs/design/client-tool-interaction-lifecycle/status.md
@@ -1,0 +1,50 @@
+# Status
+
+2026-08-10 ~18:15 CET.
+
+## Done
+
+- Research COMPLETE: all four inputs folded into research.md (the six diagnosed
+  mechanisms with corrections; the frontend render inventory; the server-side lifecycle
+  inventory; the live evidence including the kind-by-outcome settlement table).
+- plan.md written: six-point lifecycle contract, six workstreams in landing order,
+  validation matrix.
+- Workspace docs: README (glossary, reading order), context.
+
+## Done (additional)
+
+- Blame archaeology complete and folded in (research section 6): root defect born
+  complete in v0.105.0, never a regression; visibility regressions dated to v0.111
+  (records-watch relay) and the 0.112 train (row-reading replay). One research claim
+  corrected (records DO carry answers; the row cannot). Plan reshaped: contract work vs
+  regression repair.
+
+## Done (review round)
+
+- Adversarial review (codex gpt-5.6-sol) returned UNSOUND on plan v1 with nine findings,
+  the decisive ones: v1's resolve-at-delivery loses the sweep race on cold resumes; the
+  new closing record duplicated the existing tool_result; the watch workstream built
+  patching machinery where a subscription suffices; two workstreams were unrelated scope.
+  Plan v2 adopts all of it: the answer becomes the authoritative first transition through
+  the existing interactions API, one replay precedence rule, subscribe-and-refetch, cards
+  act where they render. Mobile client-tool fulfillment documented as a limitation.
+
+## Next
+
+- Then implementation, W1 first (resolve on fulfillment), since every later workstream
+  keys on real terminal statuses existing.
+
+## Blockers
+
+None.
+
+## Decisions taken
+
+- Root cause treated as the fragmented state model; the plan establishes one contract
+  rather than more symptom patches.
+- No schema migration: statuses and resolution payloads already exist; W1 changes who
+  sets them and when.
+- Connection reuse (issue #5911) stays out of scope; W5 only guarantees the model hears
+  outcomes.
+- Corrections adopted from research: no one-interaction-per-turn rule exists; no
+  10-minute interaction TTL exists (that timer is the warm sandbox approval park).

--- a/docs/design/client-tool-interaction-lifecycle/status.md
+++ b/docs/design/client-tool-interaction-lifecycle/status.md
@@ -1,6 +1,19 @@
 # Status
 
-2026-08-10 evening.
+2026-08-10, night. Mahmoud approved plan version 2 and gave go for implementation.
+
+## Decisions from the approval
+
+- Change 4 dock question: the dock stays, as a shortcut that scrolls to the card
+  (Option 1). Keep the visible UI change minimal.
+- QA checks 5 and 6 become release gate cells; the release-conductor skill now lists
+  them as mandatory (Stage 4, section 3d).
+- Implementation pipeline: implement with codex (sol, high reasoning), then a
+  simplification pass, then an independent review-and-test loop until agreement, then
+  live QA on the dev stack driven by the debug-local-deployment skill using the new
+  gate cells plus whatever the reviewer adds. Finish with a PR description pass.
+
+## Earlier status (2026-08-10 evening)
 
 ## Done
 
@@ -24,3 +37,1013 @@
 - No new record types, no new event payloads, no database migration.
 - Mobile form/connect answering stays a separate ticket.
 - The one-line dispatch repair lands immediately, outside this project.
+
+## Implementation log
+
+### Slice A — record the answer first (done, 2026-08-10)
+
+API. `api/oss/src/apis/fastapi/sessions/models.py`: the transition request's `resolution`
+is now an open `Dict[str, Any]`, because the row kind is unknown at model-validation time,
+and the validator accepts a resolution on the `responded` edge as well as `resolved`.
+`api/oss/src/apis/fastapi/sessions/router.py`: the approval-only kind guard became an
+explicit allow-set over all three kinds. An approval payload is still validated against the
+strict `SessionInteractionResolution` shape (422 when it does not fit), and `resolved`
+stays approval-only (409 for the other kinds). No service, DAO, sweep or migration change.
+
+Runner. `services/runner/src/engines/sandbox_agent/client-tools.ts`: the
+`recordPendingInteraction` callback type gained the fifth `toolCallId` parameter, and the
+call site passes `correlatedId`, so new `client_tool` rows carry
+`data.request.tool_call_id`. `run-turn.ts` and `sessions/interactions.ts` already accepted
+and forwarded that argument.
+
+Web. New `transitionInteraction` wrapper in
+`web/packages/agenta-entities/src/session/api/api.ts` (the generated Fern resolution type
+predates the widened payload, so the payload is cast at that one boundary). New
+`fetchSessionInteractionRowsAtom`, `sessionInteractionRowsQueryKey` and
+`resolveInteractionTokenForToolCall` in `.../state/interactionStatus.ts`. New
+`.../state/interactionAnswer.ts` holding `recordInteractionAnswerAtom`, fired
+fire-and-forget from `handleClientToolOutput` in
+`web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts` before the resume.
+
+Deviation from implementation.md, deliberate. Slice A needs a row-token lookup keyed by
+tool-call id, which is the inverse of the map Slice B builds. Rather than duplicate the
+fetch, Slice A adds a raw-rows query alongside the existing cancelled-token query and
+leaves `fetchCancelledClientToolTokensAtom` untouched; Slice B derives its map from those
+same rows and retires the cancelled-token query, so exactly one interactions query remains
+at the end.
+
+Robustness fix on top of codex's diff: when the answered card is newer than the cached rows
+(15s stale window), the answer atom now invalidates and refetches once before giving up,
+instead of silently skipping the write.
+
+Tests. `api` session unit suite 356 passed, 28 skipped (the skips are the Postgres-backed
+DAO tests; Postgres is not reachable from this test env — pre-existing, not caused here).
+Runner unit suite 2123 passed across 124 files, including the two updated
+`client-tools.test.ts` assertions on the stamped tool-call id. `tsc --noEmit` clean for
+`services/runner` and `@agenta/entities`. `uvx ruff@0.15.12 format --check` and `check`
+clean; eslint and prettier clean on every touched web file.
+
+### Slice B — one rule for what replay shows (done, 2026-08-10)
+
+New shared module `web/packages/agenta-shared/src/clientTools/` (subpath `./clientTools`,
+React-free) holds the neutral terminal marker: a key, the marker output, and a guard. It is
+the module Slice D extends with the client-tool name descriptor.
+
+`web/packages/agenta-entities/src/session/state/interactionStatus.ts` now exposes ONE
+interactions query. The cancelled-token set is gone; `fetchSessionInteractionStatesAtom`
+returns a `token -> {token, status, kind, resolution, toolCallId}` map derived from the same
+rows Slice A's write path reads, so there is no second network call. The best-effort contract
+is unchanged: never throws, empty map on failure, 15s stale time.
+
+Both replay copies (`web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts`
+and `web/packages/agenta-chat/src/assets/transcriptToMessages.ts`) replace
+`applyCancelledInteractions` and the `CANCELLED_CLIENT_TOOL_OUTPUT` guess-table with
+`applyInteractionRowStates`, which is byte-identical in the two files (verified by extracting
+both function bodies and comparing). It implements the four rules: a real `tool_result` wins;
+else a saved resolution renders; else a terminal row with no resolution renders the neutral
+ended marker; else the card stays live. Only `client_tool` and `user_input` rows are
+considered, so an approval row can never settle a client-tool part. The three known
+divergences between the two files were left untouched.
+
+`ConnectToolWidget.tsx` and `ElicitationWidget.tsx` render the ended marker as an inert chip
+("Connection request ended" / "Request ended") checked BEFORE their success/failure branches,
+so a pre-fix row no longer shows "Connection not completed" with a Retry button or
+"Dismissed the request.". The genuine declined and cancelled branches are untouched — those
+come from a real answer.
+
+Tests. Both `transcriptToMessages.test.ts` files gained golden cases for every rule line,
+including the assertion that the old synthesized `{connected: false, reason: "cancelled"}`
+and `{action: "cancel"}` shapes are gone. Verified independently of codex's report:
+`web/oss` AgentChatSlice suites 203 passed across 25 files; `@agenta/chat` 256 passed across
+29 files; `tsc --noEmit` clean for `@agenta/entities` and `@agenta/chat`; eslint and prettier
+clean.
+
+### Slice C — the browser listens, and stops overwriting (done, 2026-08-10)
+
+`web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts` adds the
+`interaction` event to its static handler map with a matching `onInteractionChanged` prop.
+The server already publishes it; only mobile listened before. The key set stays static, so
+the EventSource is still built once at mount.
+
+`web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts` supplies that handler:
+it invalidates the interaction rows through the new `revalidateSessionInteractionsAtom` (in
+`web/packages/agenta-entities/src/session/state/interactionStatus.ts`, modelled on
+`revalidateSessionRecordsAtom` including `cancelRefetch: false`) and then runs the same
+guarded `refreshFromRecords` the other two events use, so the transcript and the cards
+converge together and the existing `shouldSkipRecordsRefresh` entry/exit checks still apply.
+
+The adoption rule is a new pure exported pair, `pendingClientToolCallIds` and
+`blocksAdoptionForWaitingCard`, applied inside `adoptServerTranscript` after the existing
+decision. A locally waiting card blocks adoption unless the incoming server transcript
+settles that same tool-call id; a card the server copy does not carry at all counts as NOT
+settled. `web/packages/agenta-entities/src/session/core/transcriptAdoption.ts` was not
+touched, because mobile shares it and cannot answer these cards.
+
+Correction applied on top of codex's diff. Its first version treated ANY tool part sitting at
+`input-available` as a waiting card. An interrupted turn leaves an ordinary server tool part
+in exactly that state, which would have frozen adoption for the life of the session. Both
+functions now use the canonical `isPendingClientToolInteraction` with a per-message
+`buildRenderMap` from `@agenta/playground` — the same whole-chat scan model
+`AgentConversation.tsx` uses — so only real client-tool cards block. A regression test pins
+it, and the dynamic-tool fixture gained the sibling `data-render` part that a real replayed
+transcript carries (a `dynamic-tool` part's client-tool identity is not readable off `type`).
+
+Tests. `useSessionHydration.test.ts` covers the adoption safety matrix: no waiting card,
+card absent from the server copy, card still waiting on the server, card settled on the
+server, one of two settled, a waiting card that is not in the last message, and the stuck
+server tool. `web/oss` AgentChatSlice suites 210 passed across 25 files; `@agenta/entities`
+`tsc --noEmit` clean; eslint and prettier clean.
+
+### Slice D — cards work where they appear (done, 2026-08-10)
+
+Shared descriptor. `web/packages/agenta-shared/src/clientTools/` gained
+`CLIENT_TOOL_DESCRIPTORS` (tool name plus render kind per client tool) with derived
+`CLIENT_TOOL_NAMES` and `CLIENT_TOOL_RENDER_KINDS` sets. All four copies of the list now
+read from it: `registry.tsx`'s two widget maps (the React components stay in the app layer,
+only the keys moved), `agentApprovalResume.ts`'s `CLIENT_TOOL_NAMES`,
+`toolPermission.ts`'s `CLIENT_TOOLS`, and `InteractionDock.tsx`'s two literals.
+
+Registry fallthrough. `resolveClientToolHandler` no longer dead-ends on an unmatched render
+kind; it falls through to the tool-name axis. The test that pinned the broken behaviour is
+inverted and renamed. This restores parity with the package copy, which never took the
+defect. The consequence being fixed: an unknown render kind routed the part to
+`UnhandledClientTool`, which auto-settles the run as `not_handled` for a tool the browser
+can actually do.
+
+Actions moved onto the card. `ConnectToolWidget.tsx`'s pending branch now renders "Not now"
+and "Connect {label}" driven by the `useConnectFlow` hook it already held (`decline` is now
+destructured), and the error branch gained "Not now" beside Retry. The widget calls
+`useConnectFlow(meta, settle)` with the default `active: true`, which is correct now that
+the card is the only live surface.
+
+The dock became a shortcut. `InteractionDock.tsx` keeps its placement and its open/close
+animation but is now a single focusable button that scrolls to the card;
+`ConnectCard`, the duplicated settle mapping and the `onOutput` prop are gone, and
+`AgentComposerDock`/`AgentConversation` were updated to match. `ClientToolPart.tsx` tags each
+rendered card with `data-client-tool-call-id` for the lookup, and a card that is not mounted
+(virtualized transcript) is a no-op rather than a throw. The dock also no longer hides while
+`busy`, since a card parked in an earlier message stays actionable during a later turn.
+
+Whole-chat scans. `getPendingConnectInteraction` (newest pending connect wins),
+`isHitlPending`, and `getPendingApprovals` in both the `web/oss` original and the
+`@agenta/chat` copy now scan every assistant message with a per-message `buildRenderMap`,
+following the `anyPendingInteraction` model. `agentShouldResumeAfterApproval` took only the
+narrow widening: when a `liveInteraction` names a card, the rule is evaluated against the
+message that OWNS that card; the markerless orphan path stays tail-only, so an old settled
+card can never re-dispatch a resume. `meta.ts` stays last-message-only by design, with a
+comment saying so.
+
+Mirrors that needed no change, and why: `@agenta/chat`'s `useAgentChatQueue` calls the shared
+`isHitlPending`, so widening the playground function covered it; `resumeOrphaned` in both
+`useAgentConversation` and `useAgentChatSession` stays tail-only because it asks whether the
+restored TAIL is auto-resume-imminent, which is inherently a tail question.
+
+Tests. `meta.test.ts` gained the geometry test the QA plan asks for: one fixture whose
+waiting card and pending approval both sit before the last message, asserting in one place
+that `isHitlPending` is true, `getPendingConnectInteraction` finds the card, and
+`getPendingApprovals` finds the approval. `agentApprovalResume.test.ts` and
+`agentMessageQueue.test.ts` gained the earlier-message cases.
+
+Verified independently: `web/oss` AgentChatSlice 211 passed across 25 files;
+`@agenta/playground` 221 passed across 16 files; `@agenta/chat` 256 passed across 29 files;
+`tsc --noEmit` clean for shared, playground, entity-ui, chat, entities and oss; eslint clean
+over every touched file.
+
+### Slice E — tests and gates (done, 2026-08-10)
+
+API unit tests. `api/oss/tests/pytest/unit/sessions/test_transition_interaction_resolution.py`
+now covers the full three-kinds by three-outcomes settlement matrix, including that the
+transition layer never settles a walked-away `pending` row by itself.
+
+API acceptance test. New
+`api/oss/tests/pytest/acceptance/sessions/test_interaction_sweep_race.py` proves the ordering
+guarantee AND that the sweep really ran, in one test: an answered row and an unanswered
+control share a single `cancel-stale` call for a later turn; the answered row stays
+`responded` with its resolution byte-identical, the control goes to `cancelled` with no
+invented answer, and the sweep reports exactly one cancellation.
+
+Release gate. `matrix_l4_client_tool_lifecycle.py`'s "OBSERVED NUANCE" paragraph — which
+recorded this project's defect as observed-but-not-asserted — is replaced by the fixed
+contract plus an explicit wire-level caveat, and its assertion tightened from "no row is left
+pending" to "the answered row is `responded` carrying its exact resolution". Two new cells:
+`matrix_i1_settlement.py` (the settlement table against a live API, including the 409 on a
+non-approval `resolved`) and `matrix_i2_card_journeys.py` (the six qa.md journeys, each
+naming the browser action it stands in for and the claim it cannot cover).
+`coverage.md` gains both cells.
+
+The point every reader of these scripts needs: recording the answer is the CLIENT's job, so a
+wire-level harness has to send the `/transition` call itself. A script that fulfils a client
+tool only in-band would correctly still see the row swept to `cancelled`. All three scripts
+say this in their docstrings so nobody mistakes the harness's own call for server behaviour.
+
+Deviation from codex's draft, applied deliberately. Its Telegram journey completed the real
+connection by fetching Composio's hosted credential page, parsing its HTML, choosing a field
+by name heuristics, and POSTing the live bot token into it. The guards were careful (HTTPS,
+`composio.dev` origin, POST-only, unique-field-or-refuse, token never printed), but the
+approach is fragile against a third-party page and its failure mode is posting a real secret
+somewhere unintended. Agenta's own service comment states the key is entered on the provider's
+hosted UI and never in its payload, so there is no safe headless route. The journey now
+validates the bot against Telegram's own API, drives Agenta's real connection create, remove
+and re-create, settles both rows, and reports the uncovered half in a `not_covered` field.
+The "connected for real" claim stays a human exploratory-QA step, which is how qa.md
+journey 5 will actually be run.
+
+Verified independently: `api` session unit suite 364 passed, 28 skipped (the skips are the
+Postgres-backed DAO tests, unreachable from this env — pre-existing); the acceptance suite
+collects 23 tests; all three gate scripts compile; `uvx ruff@0.15.12 format --check` and
+`check` clean over `api/` and `.agents/`. The acceptance test and the gate cells were NOT run:
+they need a live stack and paid model calls.
+
+### Simplification pass (done, 2026-08-10)
+
+A behavior-preserving pass over the whole diff. Nine removals, no new abstractions.
+
+One interactions query atom, not two. Slice A added `fetchSessionInteractionRowsAtom` beside
+`fetchSessionInteractionStatesAtom` (same query, same cache entry, duplicated try/catch) plus an
+exported `resolveInteractionTokenForToolCall` over raw rows. The answer path now reads the same
+state map replay reads and finds its token in it, so the second atom, the row-shaped resolver and
+four package-index exports (`fetchSessionInteractionRowsAtom`, `resolveInteractionTokenForToolCall`,
+`sessionInteractionRowsQueryKey`, plus the retired atom's type surface) are gone. The
+tool-call-id-then-token join, the invalidate-and-retry-once behavior and the best-effort contract
+are unchanged.
+
+Dead validation dropped. `interactionStatesFromRows` filtered rows through `INTERACTION_STATUSES`
+and `INTERACTION_KINDS` sets, but both consumers compare against explicit literals anyway, so the
+sets only re-stated what the reads already enforce.
+
+Unreachable API branch dropped. The router's new `resolution_kinds` set listed all three members of
+`SessionInteractionKind`, so `source.kind not in resolution_kinds` could never fire. The two guards
+that do work — `resolved` is approval-only, and an approval payload must fit the strict shape —
+stay.
+
+Dead option removed from `useConnectFlow`. Its third parameter `active` existed only because the
+dock mounted a second copy of the flow for the same call; Slice D deleted that surface, leaving one
+caller that never passes it. The parameter, `activeRef`, the deactivation effect and six
+`!activeRef.current` guards are gone; `settledRef` plus `meta.settled` still guard double-settle.
+
+Unused shared exports removed: `CLIENT_TOOL_RENDER_KINDS` and the three `ClientTool*` type aliases
+had no consumers, and `CLIENT_TOOL_INTERACTION_ENDED_KEY` is now module-private.
+
+Smaller edits: the answer resolution is built once with a two-key spread instead of two nearly
+identical object literals; `pendingClientToolCallIds` is no longer exported (its only caller is in
+the same file); the dock's scroll target is one `querySelector` instead of `querySelectorAll` +
+`find`; `resolveClientToolHandler` is a `??` chain; and `agentShouldResumeAfterApproval` picks its
+target message in one if/else instead of a pre-seeded `let` that re-tested `liveInteraction`.
+
+One test cut. The settlement matrix's three `walk_away` rows returned early and asserted only that
+a locally constructed `SessionInteraction` still held the values just passed to its constructor —
+they exercised no production code. Walk-away is really pinned by
+`test_interaction_sweep_race.py` and by the `matrix_i1_settlement.py` walk-away cases (sweep
+cancels a `pending` row and invents no resolution); a comment in the test file says so.
+
+Considered and kept: the `applyInteractionRowStates` status enumeration (explicit is safer than
+`!== "pending"` once the row-state map no longer filters unknown statuses); `interactionAnswer.ts`
+as its own module; `transitionInteraction`'s package-index export (its three API siblings are
+exported the same way); the `blocksAdoptionForWaitingCard` two-pass scan; and the gate scripts,
+whose length is the six journeys the plan asked for.
+
+Verified after the pass: `web/oss` AgentChatSlice 211 passed across 25 files; `@agenta/chat` 256
+across 29; `@agenta/playground` 221 across 16; `tsc --noEmit` clean for shared, entities, entity-ui,
+playground, chat and oss; eslint and prettier clean on every touched file; `api` session unit suite
+361 passed, 28 skipped (three fewer than before — the removed tautologies; the skips are the
+unreachable Postgres DAO tests); `uvx ruff@0.15.12 format --check` and `check` clean.
+
+### Review round 1 (independent reviewer, 2026-08-10) — CHANGES NEEDED
+
+Every suite was re-run from scratch rather than trusted: `api` session unit 361 passed / 28
+skipped (the skips are the unreachable Postgres DAO tests); acceptance collection 23 tests;
+`web/oss` AgentChatSlice 211 across 25 files; `@agenta/chat` 256 across 29; `@agenta/playground`
+221 across 16; runner `client-tools.test.ts` 19 passed; `tsc --noEmit` clean for shared, entities,
+entity-ui, playground, chat, `web/oss` and `services/runner`; `uvx ruff@0.15.12 format --check`
+(1410 files) and `check` clean over `api/` and `.agents/`; eslint and prettier clean. The
+`applyInteractionRowStates` bodies in the two replay copies were extracted and hashed
+independently: both md5 `9d20941c2a63a38173ecf513fa700855`, byte-identical.
+
+The API half, the replay precedence rule, the adoption guard, the registry fallthrough, the
+shared descriptor, and both gate cells hold up. Three findings block agreement.
+
+1. **The ordering guarantee is not actually implemented.** `handleClientToolOutput`
+   (`useAgentChatSession.ts`) fires `recordInteractionAnswer` with `void` and falls straight
+   through to `addToolOutput`, so the transition and the resume race instead of being ordered.
+   The transition can need three browser round trips (cached rows miss, invalidate, refetch,
+   POST) while the resume needs one plus a warm server chain to `cancelStaleInteractions`. When
+   the sweep wins, the row is `cancelled`, the transition 404s, the failure is swallowed, and
+   the answer is lost exactly as before the fix. Await the record before dispatching the resume
+   (it never rejects), with a short timeout so a wedged API still cannot block the resume.
+2. **Abandoned approvals now hold the queue forever.** `isHitlPending` and `getPendingApprovals`
+   scan the whole chat, but nothing neutralizes a dead approval part on replay:
+   `applyInteractionRowStates` deliberately skips `user_approval`, and the replay pass only
+   settles gates on RESUMED drafts. Verified with a throwaway replay test: a paused approval
+   followed by an unrelated completed turn replays as `approval-requested` in a non-tail message,
+   and both predicates report it. `canReleaseQueuedMessage` then queues every typed message until
+   the user answers a gate whose turn is long dead. Either settle terminal `user_approval` rows
+   to `approval-responded` in the same row-state pass, or keep the approval scans tail-only.
+3. **`showWaiting` still keys off the last message** (`AgentConversation.tsx`), so a card parked
+   several turns up paints "waiting for you" on the newest turn, which holds no card. Make it
+   per-message.
+
+Minor, recorded not fixed: `CLIENT_TOOL_INTERACTION_ENDED_OUTPUT` is one shared object assigned
+as `part.output` for every ended card; `part.errorText = row.resolution.error` assigns `unknown`;
+`anyPendingInteraction` is now a strict subset of `hitlPending`; mobile shares `getPendingApprovals`
+and registers no client-tool widget, so finding 2 and the neutral marker both need one look in
+mobile QA.
+
+Fixed inline by the reviewer: the release-conductor Stage 4 3d paragraph, which implied the
+Telegram cell completes a real connection (it now states the hosted-page credential step is
+browser-only, uncovered, and reported in `not_covered`); qa.md journey 5, which still said the row
+ends `resolved` and that the token lives in a local file; and the stale comment in
+`AgentConversation.tsx` claiming `hitlPending` reads only the last assistant message.
+
+## Implementation complete
+
+All five slices are in the working tree, unstaged and uncommitted. Nothing was committed.
+
+### Fix round 1 (2026-08-10)
+
+All three blocking findings fixed, plus the three minors.
+
+**Finding 1 — the ordering guarantee is now real.** The ordering moved into a small pure
+helper, `web/oss/src/components/AgentChatSlice/assets/clientToolAnswer.ts`, so it can be
+pinned without React: `recordAnswerThenResume` awaits the record and only then dispatches
+the resume, capped by `RECORD_ANSWER_TIMEOUT_MS` (2s) through a `Promise.race`. On timeout
+or failure the resume goes out exactly as before, and a late record still lands if the
+sweep has not won. `handleClientToolOutput` now calls it instead of firing `void
+recordInteractionAnswer(...)` and falling through. `liveGateInteractionRef` is still set
+synchronously, so transcript adoption stays blocked across the whole ordered window.
+New suite `clientToolAnswer.test.ts` pins the four cases: the resume does not fire while
+the record is in flight, it fires after the record settles, it fires when the record
+rejects, and it fires on timeout when the record never settles.
+
+**Finding 2 — abandoned approvals no longer hold the queue.** Took the preferred fix:
+terminal `user_approval` rows are settled in the same row-state pass. `applyInteractionRowStates`
+now splits into `settleClientToolPart` and `settleApprovalPart`, and joins approval rows
+through `index.approvals.get(row.token)` (the contractual key — `index.approvals` is keyed
+by the interaction request's `payload.id`, which IS the row token) after trying the
+tool-call id. A row carrying a verdict replays `approval-responded` with
+`approval: {id, approved}`, so the card renders the real answer exactly as the
+`interaction_response` path does. A `cancelled` row replays `output-denied`, not
+`approval-responded`: the sweep proves only that the gate died unanswered and that the
+gated tool never ran, so denied is the honest terminal state, where `approval-responded`
+without a verdict would render as "approved" — a claim nobody made. A `responded`/`resolved`
+row with no verdict replays `approval-responded` (answered, verdict unknown).
+
+The reviewer's scenario is now a permanent test in BOTH replay suites, in four parts: the
+control case asserting the gate really does stay `approval-requested` with no row (so the
+test would catch the regression), the swept row settling to `output-denied`, and the
+resolved row replaying each verdict. Byte parity of the whole block re-verified after every
+edit and after prettier: both copies md5 `a28b5a4683ec48fb933febee8e3a8d9a`, 2907 bytes.
+
+**Finding 3 — `showWaiting` is per-message.** Added `messageHasPendingHitl` to
+`web/packages/agenta-playground/src/state/execution/agentMessageQueue.ts` and rebuilt
+`isHitlPending` on top of it, so the per-turn marker and the queue hold cannot drift.
+`AgentConversation.tsx` now paints `showWaiting` on the turn that actually holds the gate
+(`isAssistantTurn && !busy && !stopped && messageHasPendingHitl(message)`) instead of on
+the newest turn.
+
+**Minors.** `CLIENT_TOOL_INTERACTION_ENDED_OUTPUT` is `Object.freeze`d at its source in
+`@agenta/shared`, and replay assigns a spread copy per card, so no two cards can ever alias
+one mutable object. `part.errorText` is coerced: a non-string `resolution.error` falls back
+to "The request ended without a result." instead of assigning `unknown`.
+`anyPendingInteraction` is gone — `hitlPending` is a strict superset (it scans the whole
+transcript for approvals AND client tools), so the status effect reads `hitlPending` alone.
+One behaviour change worth naming: `hitlPending` carries `!stopped`, so after a user stop
+the tab now reports `idle` rather than `awaiting`. That matches the rest of the stop
+handling (the dock is hidden and the queue releases on stop), where the old duplicate memo
+left the tab claiming "awaiting" with no UI to act on.
+
+Tests, all re-run after the lint autofix: `web/oss` AgentChatSlice 219 passed across 26
+files (was 211 across 25); `@agenta/chat` 260 across 29 (was 256); `@agenta/playground` 221
+across 16. `tsc --noEmit` clean for shared, playground, entity-ui, chat, entities and
+`web/oss`. eslint `--max-warnings 0` and prettier `--check` clean over every touched file.
+No API, runner or gate-script file was touched in this round.
+
+### Review round 2 (independent reviewer, 2026-08-10) — AGREE
+
+All three fixes verified, and every suite re-run from scratch: `web/oss` AgentChatSlice 219 passed
+across 26 files, `@agenta/chat` 260 across 29, `@agenta/playground` 221 across 16, `tsc --noEmit`
+clean for shared, entities, entity-ui, playground, chat and `web/oss`. API, runner and gate scripts
+were untouched this round and were not re-run.
+
+Finding 1. The ordering is real now. `recordAnswerThenResume` awaits the race and then calls
+`resume()` on the single path out; both race members resolve (the record's rejection is caught,
+the timer resolves), so the resume can neither be skipped nor fired twice, and a synchronous throw
+inside `record` is deferred by `Promise.resolve().then(record)` and caught. `addToolOutput` is the
+only thing that changes the message list on this path, and it now lives inside `resume`, so
+`sendAutomaticallyWhen` cannot see the answer earlier. `liveGateInteractionRef` is still set
+synchronously, which keeps adoption blocked across the widened window. The new suite is honest:
+the ordering case uses a real deferred gate and asserts the order, and the timeout case asserts the
+resume has NOT fired at 49 ms before advancing to 50.
+
+Finding 2. Byte parity re-verified independently over the whole `settleClientToolPart` +
+`settleApprovalPart` + `applyInteractionRowStates` block: both copies md5
+`d55533b83304aec20bf54cd1b91ac121`, 2910 bytes (a different extraction boundary from the
+implementer's, same conclusion). The four approval tests are in both suites.
+
+The `cancelled -> output-denied` call is sound, and for a reason worth recording: it can only ever
+reach a gate whose turn never resumed. Any turn that DID resume has its gate settled to
+`approval-responded` by the resumed-draft pass, which runs before this one, and any gate whose tool
+actually ran carries a real `tool_result`, so the part is no longer `approval-requested` and both
+settle functions return early. `output-denied` is a first-class settled state — ToolActivity renders
+"denied", `meta.ts`'s SETTLED and `isSettledToolPart` both include it — and it is the same state a
+genuine deny replays to, so nothing new had to learn it. A `responded`/`resolved` row with no
+verdict replaying `approval-responded` is likewise right: answered, verdict unknown, hold cleared.
+The two settle functions cannot cross-settle each other's parts (one requires `approval-requested`,
+the other `input-available`), so a token collision between `index.tools` and `index.approvals` is
+inert. The control case is not vacuous and is self-guarding: if the fixture ever stopped producing
+an abandoned gate, the control fails first and the swept-row case's `output-denied` assertion fails
+with it.
+
+Finding 3. `isHitlPending` is now `messages.some(messageHasPendingHitl)` and `showWaiting` uses the
+same per-message predicate, so the marker and the hold cannot drift.
+
+Three non-blocking observations, for the live QA phase rather than for this round:
+
+1. The form card looks unresponsive for the length of the record window.
+   `ElicitationWidget.handleAccept` clears `submitting` in its `finally`, but the settle is now
+   fire-and-forget behind the awaited record, so the Accept button re-enables and the form stays
+   interactive until `addToolOutput` lands — one POST typically, the full 2 s cap at worst. The
+   connect card is unaffected (`finish()` sets local `outcome` before settling, so its chip paints
+   immediately). Cheap fix: leave `submitting` true on the success path and reset it only in the
+   validation-failure branch. A double-click inside that window fires a second settle.
+2. After a user Stop the tab reports `idle` while the parked card stays clickable. The reasoning in
+   the fix entry held before Slice D, when the dock owned the buttons and hid on stop; the inline
+   card is not gated on `stopped`, so actionable UI does exist in that state. Defensible either way
+   — the run is dead and answering starts a new turn — but worth eyeballing in QA rather than
+   treating as settled.
+3. Unfreezing a dead gate now depends on a best-effort network join. The interactions query returns
+   an empty map on failure by contract, and a gate with no row at all (row creation failed, or a
+   session predating the interactions plane) never settles, so the composer keeps holding. Transient
+   failures self-heal on the next refresh; the no-row case does not. Optional hardening that needs
+   no network: treat an `approval-requested` gate in a draft that is followed by a later draft as
+   superseded. At minimum, open one old session with an abandoned gate during live QA.
+
+Still parked from round 1, deliberately: the mobile look at `getPendingApprovals` (mobile shares it)
+and at how a neutral ended marker renders with no client-tool widget registered. That belongs to the
+live QA phase.
+
+**Fix round 2 (2026-08-10).** `ElicitationWidget.handleAccept` kept `submitting` in a
+`finally`, which re-enabled Accept the moment the settle was handed off — and the settle is
+now fire-and-forget behind the awaited record write, so a double-click inside the 2s cap
+could fire a second settle. `setSubmitting(false)` moved out of `finally` into the `catch`,
+so the button comes back only when the form is still open and answerable (validation
+failure, or any genuine throw from serialize/settle) and stays locked on the success path.
+No test pinned the old behaviour, so none needed adjusting. `web/oss` AgentChatSlice 219
+passed across 26 files; `tsc --noEmit`, eslint `--max-warnings 0` and prettier `--check`
+clean on the file.
+
+## Live QA (2026-08-10, dev stack `agenta-ee-dev-rel112`, http://144.76.237.122:8180)
+
+Verdict: **FINDINGS** — the new settlement contract holds everywhere it was exercised, including
+Mahmoud's original compound scenario, but replay does not settle FORM cards from pre-fix
+`cancelled` rows, so old sessions still show a live form and hold the composer.
+
+### Gate cells
+
+| Cell | Result |
+|---|---|
+| `matrix_i1_settlement` | PASS — all nine settlement cases plus both approval-only 409 guards |
+| `matrix_i2_card_journeys` | PASS — all six journeys, including the real-Telegram wire half |
+| `matrix_l4_client_tool_lifecycle` | PASS — round trip completes, row ends `responded` with its answer |
+
+The stack runs no subscription sidecar and its Anthropic vault key is out of credit, so the cells
+ran on the codex harness with a vault-managed OpenAI key. `matrix_i2` gained an env-driven
+`apply_model_override` for this (`QA_HARNESS_KIND` / `QA_MODEL` / `QA_PROVIDER` /
+`QA_CONNECTION_MODE`; unset keeps today's claude + haiku config). `matrix_l4` was NOT edited — it
+ran through a scratch wrapper that patches `qa_matrix_lib.agent_config` the same way. The only
+other script-side issue was environmental: `TELEGRAM_BOT_TOKEN` needs `set -a` when sourcing.
+
+### Browser journeys (resiros account, fresh agent "Morning Motivation Messenger")
+
+| Journey | Result |
+|---|---|
+| 1. Compound (form → reload → decline connect → approve schedule → reload) | PASS |
+| 2. Form then connect back to back | PASS |
+| 3. Two connects in one conversation (Telegram + Gmail) | PASS |
+| 4. Close the tab, reopen the session | PASS (live card and answered card both) |
+| 5. Real Telegram connect / remove / reconnect | NOT COVERED in the browser |
+| 6. Decline then retry | Settlement PASS, retry behaves differently from qa.md |
+| (a) Accept locked during the record window | PASS (no double settle) |
+| (b) Stop while a card waits | NOT REACHABLE — no Stop control while parked |
+| (c) Old sessions with abandoned interactions | **FAIL for form cards** |
+| Regression: approve, deny, plain chat turn, schedule creation | PASS |
+
+Every journey was verified against the stored rows, not only the screen. Answered form and connect
+rows end `responded` with `data.resolution` holding the exact answer; approvals end `resolved` with
+`approved` / `denied`; nothing was invented.
+
+### Finding 1 (blocking for the "old sessions" claim): pre-fix `cancelled` rows do not settle form cards
+
+Session `0b6a8c44-a975-4431-90e7-adbcab87c8e8` (project `019fe7de-5e28-7c70-b374-e855b88410a9`) has
+exactly one interaction row: `client_tool` / `request_input` / `cancelled`, no resolution. Opened
+from the Sessions list on a cold load, the form card renders fully live — populated input, "Waiting
+on your input · 3 required", Next / Decline / Dismiss — and the composer is held with "The agent is
+waiting for your response — new messages will be queued", even though the agent already answered
+the cancellation in the next message.
+
+The join key is not the problem: the card's `data-client-tool-call-id` equals the row token
+(`call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6`) exactly,
+`POST /sessions/interactions/query` fires once on load and returns the row, and no parse warning
+appears in the console. CONNECT cards in the same sessions DO settle from their `cancelled` rows
+("Connection not completed" + Retry), so the miss is specific to the form path. Plan Change 2 rule 3
+and review note (c) both require the neutral ended card here.
+
+### Finding 2 (behavior note): Retry re-drives the same card, it does not create a new one
+
+qa.md journey 6 expects "exactly one new live card". What actually happens: Retry re-opens the
+provider link for the SAME settled interaction, the card shows "Connecting…" in place, and no new
+row is created. The declined row stays settled throughout, so the settlement contract is intact —
+but the qa.md wording describes behavior the product does not have. Also, a connect attempt that
+fails at popup time settles the row `responded` with `reason: "Connection failed. Please try again."`
+and, because the turn has already ended, the surviving Retry cannot resume anything.
+
+### Not covered
+
+- Journey 5's hosted-page half. The QA browser is not on this host, and Composio's page is HTTPS,
+  so the bot token cannot reach the page over a private channel without printing it into the agent
+  transcript. `matrix_i2`'s `real_telegram` journey covers the wire half (real bot validated against
+  Telegram, real create / remove / re-create through Agenta). The 60-second hosted-page step stays a
+  human exploratory step.
+- Note (b)'s Stop scenario. No Stop control renders while a card waits; the composer shows the queue
+  hint instead, so the state the review worried about is not reachable from the composer.
+- Mahmoud's own sessions `e627d80a-…` and `6609cd91-…`. They live in his org
+  (`mahmoud@agenta.ai`), not in the resiros account this pass had access to. Five pre-fix sessions
+  in the resiros project carry the same shape and were used instead.
+- Mobile. The mobile surface was not driven; form and connect answering does not exist there
+  (research Finding 4).
+
+### Fix round 3 (2026-08-10) — the old-session form card
+
+**The reported cause was not the cause.** Replay already settles that form correctly. The bug is
+in ADOPTION: the browser never re-ran replay for those sessions.
+
+Reproduced first, from the live stack, before changing anything. Pulled the real 44 records for
+session `0b6a8c44-a975-4431-90e7-adbcab87c8e8` out of `agenta_ee_tracing.records` (in the API's own
+`timestamp, created_at, record_index` order) and its single interaction row out of
+`agenta_ee_core.session_interactions`, then ran the real `transcriptToMessages` over them. With the
+row supplied, the form part settles to `output-available` with `{agenta_interaction_ended: true}`;
+without it, it stays `input-available`. Also fed the row through the real
+`sessionInteractionsResponseSchema` in the exact API response shape: it parses clean and keeps
+`token`, `kind`, `status` and `data.request`, so the row-state map is built correctly. Every link
+from the API to the rendered part is sound, and all four of QA's narrowing observations hold — they
+just do not point where they seem to.
+
+What actually happens: those sessions already have a transcript in localStorage, cached before this
+project shipped, in which the card is live. On open, `shouldAdoptServerTranscript` gates on the
+record log having GROWN past the cached watermark (`serverRecordCount <= watermark` refuses). A dead
+session never grows, so the watermark already equals the server's record count and the correct new
+transcript is computed, then discarded. The stale copy stays on screen — with the live form, and
+with the composer held by `isHitlPending` reading that stale copy. Nothing ever triggers a
+re-adoption, so it persists across every reload. It also explains QA's own "connect settles but form
+does not": in the same cached transcript, connect cards had a real `tool_result` and were already
+settled at cache-build time, while the abandoned form had nothing but its row.
+
+**Fix.** `useSessionHydration` gains `settlesEveryWaitingCard`, the exact inverse of the existing
+`blocksAdoptionForWaitingCard` and sharing one scan with it: when the incoming server copy settles
+EVERY card the tab still shows as waiting, adoption proceeds without record growth (and never while
+busy). The two guards cannot contradict each other — a copy that settles every waiting card is by
+definition not blocked — and the protection for an unsent local answer is untouched: a server copy
+that does not settle the card still cannot overwrite it. `transcriptAdoption.ts` stays untouched,
+so mobile is unaffected.
+
+No replay change was needed, and none was made: the precedence block is unchanged and still
+byte-identical across both copies (md5 `a28b5a4683ec48fb933febee8e3a8d9a`, 2907 bytes).
+
+**Tests.** The real session is now a golden fixture in both suites
+(`__fixtures__/abandonedFormSession.json`, all 44 records, structurally untouched — only long
+unrelated `read`/`ls` payloads elided, never the form's own records). Both suites assert it replays
+live with no row state and settles to the neutral ended output from its `cancelled` row, and
+explicitly not to the pre-fix `{action: "cancel"}` guess. The fixture also pins a shape no synthetic
+test had: the form's turn ends `done{stopReason:"paused"}` and the next turn starts with no user
+message between, so the two fold into one `resumed` draft whose gate-settling pass covers approvals
+only. `useSessionHydration.test.ts` gains six cases for `settlesEveryWaitingCard`, including that it
+never contradicts the block guard.
+
+`web/oss` AgentChatSlice 227 passed across 27 files; `@agenta/chat` 262 across 30;
+`@agenta/playground` 221 across 16; `tsc --noEmit` clean for all six touched packages; eslint
+`--max-warnings 0` and prettier clean.
+
+**Still true after this fix, and worth one line in the PR:** a user whose cached transcript has a
+waiting card that the server ALSO still shows as waiting keeps seeing it live. That is correct —
+the row really is `pending` — but it means the neutral ended state only appears once the row is
+terminal, which for old sessions it already is.
+
+#### Fix round 3, second item: the duplicate-connection dead end
+
+Verified against the API before touching the client. `POST /tools/connections/` has no explicit 409
+path; the 409 comes from the DAO's unique-key guard
+(`api/oss/src/dbs/postgres/gateway/connections/dao.py`, constraint
+`uq_gateway_connections_project_provider_integration_slug`) raising `EntityCreationConflict`, which
+`@intercept_exceptions` turns into a `ConflictException`. Its body is the platform CONFLICT
+ENVELOPE — an OBJECT, not a string:
+
+```json
+{"detail": {"message": "A resource with slug 'telegram' already exists in this project.",
+            "conflict": {"provider_key": "composio", "integration_key": "telegram", "slug": "telegram"}}}
+```
+
+`extractConnectErrorMessage` only read `detail` when it was a `string`, so every duplicate fell
+through to "Connection failed. Please try again." That single missing branch is the whole dead end:
+the user could not learn why, the settle reason carried the same non-reason to the agent, and Retry
+re-fired the identical doomed create.
+
+Changed, all in `useConnectFlow.ts` plus one line of the card:
+
+- `extractConnectErrorMessage` now reads the object envelope. For a 409 it names the integration
+  from `conflict.integration_key` ("A connection for telegram already exists in this project."),
+  falling back to the server's own message, then to a specific generic. The server's wording says
+  "resource" and quotes a slug, so naming the integration is the better message for both the user
+  and the agent. Object details are now also read on other 4xx codes, which previously fell through
+  the same hole.
+- `isConnectionAlreadyExists` marks the one failure a retry cannot fix.
+- `connectFailureFrom` derives the message and the retryability together, and the catch block feeds
+  BOTH `setErrorText` and the settle `reason` from that one value — so what the agent reads in the
+  tool result is exactly what the user reads on the card, by construction rather than by
+  convention. That truthful reason is also what may let the model recover on its own by using the
+  existing connection.
+- The card hides Retry when the failure is a duplicate, keeping "Not now" (item 3, taken because
+  the error branch already had the reason in hand — no new machinery).
+
+Deliberately NOT built: connection reuse. That stays issue #5911. This change only surfaces the
+truth.
+
+Test coverage and its limit: `useConnectFlow.test.ts` gains six cases — the integration-named
+message, the fallback to the server message, the no-body fallback, that a 409 NEVER yields the
+generic failure, that `connectFailureFrom` gives the card and the settle reason the same string with
+`retryable: false`, and that ordinary failures keep Retry. The React render itself is not covered:
+`web/oss` has no `@testing-library/react` and no `renderHook` anywhere, and standing up render
+infrastructure for one assertion is the "new machinery" this round was told to avoid. The
+card-and-reason link is instead guaranteed structurally by the shared derivation above.
+
+`web/oss` AgentChatSlice 235 passed across 28 files; `@agenta/chat` 262 across 29;
+`@agenta/playground` 221 across 16; `tsc --noEmit` clean for `web/oss`; eslint `--max-warnings 0`
+and prettier clean. Replay untouched, both copies still md5 `a28b5a4683ec48fb933febee8e3a8d9a`.
+
+### Review round 3 (independent reviewer, 2026-08-10) — CHANGES NEEDED
+
+Suites re-run from scratch: `web/oss` AgentChatSlice 235 passed across 26 files, `@agenta/chat` 262
+across 30, `@agenta/playground` 221 across 16, `tsc --noEmit` clean for shared, entities, entity-ui,
+playground, chat and `web/oss`. (The entry above says 28 `web/oss` files; I measured 26. The pass
+count matches.) Replay parity re-verified and bit-for-bit unchanged from round 2: both copies
+md5 `d55533b83304aec20bf54cd1b91ac121` over my extraction boundary, identical to each other and to
+what I measured last round, so the block really was untouched.
+
+The diagnosis is convincing and the fixture proves it. I confirmed the fixture's integrity myself:
+44 records, the form's `tool_call` (index 31), `interaction_request` (32) and `done{paused}` (35)
+intact and un-elided, 16 tool calls against 15 results with exactly one unmatched call — the form.
+The elisions truncate string VALUES only and are applied consistently, so every other
+call/result pair still matches on its truncated id; no identity relation was broken. Both golden
+tests run the real replay over those records and assert what they claim, including the negative
+against the pre-fix `{action: "cancel"}` guess.
+
+The "cannot contradict" claim is TRUE and I verified it from the code, not the prose: both guards
+read the same `settledLocallyWaitingIds` result on the same inputs in one synchronous block, and
+their conditions are `settled.size === pending.size` versus `!==`. There is also no adopt/re-adopt
+loop: after adopting, every locally-waiting card that the server settled is settled locally too, so
+`pending.size` drops and the new path cannot fire again on the same copy.
+
+Two findings block.
+
+1. **`settlesEveryWaitingCard` bypasses more than the growth test — it also bypasses the
+   anti-truncation floor.** `shouldAdoptServerTranscript` carries three refusals, and the new path
+   skips all of them: `serverRecordCount <= watermark` (the one the fix means to bypass), and
+   `serverMessageCount < localMessageCount`, whose own comment says "ingest lag can serve a snapshot
+   shorter than what we render, and trading down would drop the tail". So a lagging snapshot that
+   happens to settle the waiting card — same form record, same terminal row, minus the newest turn —
+   now adopts: the newest turn disappears from the screen AND from localStorage (`persistMessages`
+   writes the truncated copy), and `recordWatermarkRef` regresses to the shorter count. It
+   self-heals on the next fetch, but in the meantime the composer has been released (the card is
+   settled) so a message can be sent against a truncated history. The same hole makes the documented
+   microtask race real again: `loadSessionMessages(id, adopt).then(adopt)` can deliver the fresh
+   copy first and the older one second, and `messagesRef` lags a commit, so the older one re-adopts.
+   Fix, one expression, no behaviour lost — the zombie case satisfies both floors with equality:
+   gate the new path on `recordCount >= (recordWatermarkRef.current ?? 0)` and
+   `serverMsgs.length >= messagesRef.current.length`.
+
+2. **The duplicate-connection Retry is still offered on the path that matters.** For a PARKED
+   connect card, the 409 catch calls `finish(...)`, which sets `settledRef`, `setPhase("idle")` and
+   `setOutcome(...)`. The render then takes the settled branch (`meta.settled || outcome`), which
+   ends in an UNCONDITIONAL `<RetryButton>`; `errorRetryable` is only read in the `phase === "error"`
+   branch below it, which that flow can never reach — phase is back to `idle` and `outcome` stays set
+   for the life of the component, so even a failed manual retry re-renders the settled branch. After
+   a reload `meta.settled` is true and the settled branch wins again. So "the card hides Retry when
+   the failure is a duplicate" does not hold where the user meets it, and Retry can be clicked
+   forever. The message half DOES work on that path (the reason is not in `KNOWN_CONNECT_REASONS`,
+   so it renders in full), which is the important half. Fix: consult `errorRetryable` in the settled
+   failure branch too, or correct the claim in this log and the PR.
+
+Recommended, not blocking:
+
+3. Add `!pendingResumeRef.current` to the new path. `refreshFromRecords` checks it twice for exactly
+   this hazard, but the remote-run poll calls `adoptServerTranscriptRef.current` with no such check,
+   and during the ordered record window (`pendingResume` true, `busy` false, card still
+   `input-available` locally, row already `responded`) the server copy now settles the card — which
+   is precisely when the new path fires. Before this round the watermark incidentally covered it.
+4. Nothing tests the composed decision. The six new tests cover the pure predicates honestly, and
+   the no-contradiction case is a real (if single-input) spot check — but finding 1 lives in
+   `adoptServerTranscript`, where the predicate meets the watermark, and no test reaches there.
+   Extracting that decision into a pure helper would make it testable without render infrastructure.
+
+Both judgment calls are blessed. (a) Naming the integration beats the server's "resource with slug"
+wording for both the user and the agent, and the fallback chain (conflict key, then the server
+message, then a specific generic) degrades correctly; the six extractor tests are real and none of
+them asserts the rendering, so no test is claiming something untrue. (b) The structural argument for
+skipping a render test is right for what it claims — the card text and the settle reason are one
+value in the catch block, and I verified that. Worth noting that finding 2 is a branch-reachability
+bug, which no render test of that link would have caught either; what would have caught it is asking
+which branch actually renders after `finish()`.
+
+### Fix round 4 (2026-08-10)
+
+All four taken; both recommendations included.
+
+**Finding 1 — the settled-card path respected only one of three refusals.** Fixed exactly as
+specified. The new path now also requires `serverRecordCount >= (watermark ?? 0)` and
+`serverMessages.length >= localMessages.length`, so a lagging snapshot that happens to settle the
+card can no longer truncate the newest turn out of the screen and localStorage, regress the
+watermark, or release the composer against a truncated history — and the microtask race in
+`loadSessionMessages(id, adopt).then(adopt)` stays closed. The zombie case clears both floors with
+equality, so nothing is lost.
+
+**Finding 2 — Retry on the parked path.** The reviewer is right that `errorRetryable` was
+unreachable there: the 409 catch calls `finish()`, which sets `settledRef`, `phase: "idle"` and
+`outcome`, so the render takes the SETTLED branch, whose `RetryButton` was unconditional. Fixed at
+the level that survives a reload rather than at the component: `ConnectOutput` gained
+`retryable?: boolean`, the create-failure settle stores it WITH the output, and the settled failure
+branch reads `isSettledFailureRetryable(outcome, output)` — the live outcome first, then the stored
+output, defaulting to true so pre-flag outputs keep Retry. That makes the duplicate case show the
+message with no Retry both live and after a reload. On the settled branch no button is offered at
+all in that case: the call has already settled, so a "Not now" there would be a dead control.
+
+**Recommendation 3 — taken.** `!pendingResume` now gates the new path, so the remote-run poll (which
+calls `adoptServerTranscriptRef.current` with no `shouldSkipRecordsRefresh` check of its own) cannot
+adopt during the ordered record window, which is exactly when the server copy starts settling the
+card. `pendingResumeRef` joined the `adoptServerTranscript` dependency list.
+
+**Recommendation 4 — taken, and it absorbed the predicates.** `shouldAdoptTranscript` is the one
+exported decision: waiting-card guard, then the shared growth test, then the floored settled-card
+path. `blocksAdoptionForWaitingCard` and `settlesEveryWaitingCard` are gone rather than left
+exported-for-tests-only, and their eleven cases were re-expressed against `shouldAdoptTranscript`
+with the counts held at equality so only the card logic decides. Finding 1's scenario is now pinned
+directly: a lagging shorter snapshot that settles the card must NOT adopt (two cases, one regressing
+the record count and one only the message count), and the zombie case with equal counts MUST adopt.
+`isSettledFailureRetryable` got five cases covering live-outcome precedence, the post-reload path,
+and pre-flag outputs.
+
+Both new exported helpers are used in production code — no test-only exports were introduced.
+
+`web/oss` AgentChatSlice 242 passed across 26 files; `@agenta/chat` 262 across 29;
+`@agenta/playground` 221 across 16; `tsc --noEmit` clean for `web/oss`; eslint `--max-warnings 0`
+and prettier clean. Replay untouched again: both copies md5 `a28b5a4683ec48fb933febee8e3a8d9a`,
+2907 bytes.
+
+Still not covered, unchanged from round 3 and stated again so it is not mistaken for done: no test
+RENDERS the card. `web/oss` has no render infrastructure, so the retryability fix is pinned at the
+decision (`isSettledFailureRetryable`) and at the data that reaches it, not at the JSX.
+
+### Review round 4 (independent reviewer, 2026-08-10) — AGREE
+
+All four items verified, both judgment calls blessed, one weak assertion fixed inline. This closes
+the code loop from my side.
+
+Suites re-run: `web/oss` AgentChatSlice 242 passed across 26 files, `@agenta/chat` 262 across 29,
+`@agenta/playground` 221 across 16, `tsc --noEmit` clean for `web/oss`, prettier and
+eslint `--max-warnings 0` clean on the file I touched. Replay parity checked a fourth time and
+bit-for-bit unchanged since round 2: both copies md5 `d55533b83304aec20bf54cd1b91ac121` over my
+extraction boundary.
+
+**Finding 1.** The composition is right, checked refusal by refusal. The waiting-card guard now runs
+FIRST, so it covers the growth path too; `shouldAdoptServerTranscript` is untouched and still owns
+growth; and the settled-card path carries `pending.size > 0`, `!busy`, `!pendingResume`,
+`serverRecordCount >= (watermark ?? 0)` and `serverMessages.length >= localMessages.length`. The
+third original refusal, `serverMessageCount === 0`, needs no explicit check: the settled path
+requires `settled.size === pending.size > 0`, which cannot hold unless the server copy carries a
+settled part. The two new floor cases discriminate separately (one regresses the record count, one
+only the message count) and the zombie case pins adoption at equality.
+
+**Finding 2.** Fixed at the level that survives a reload, which is the right level: the settled
+failure branch is the only one a parked card reaches and the only one that outlives a reload, and it
+now reads `isSettledFailureRetryable(outcome, output)` with the flag stored in the settle output.
+Five discriminating cases cover live precedence, the post-reload path and pre-flag outputs.
+
+Judgment call (a), no button on a settled duplicate: BLESSED, and the reasoning holds exactly as
+written — `decline` guards on `settledRef.current || meta.settled`, so a "Not now" there is a real
+no-op live AND after a reload. A dead control is worse than none.
+
+`retryable` inside `ConnectOutput`: ACCEPTED. It describes the OPERATION ("repeating this create
+cannot work"), not the widget — the name is what keeps it honest; a `showRetryButton` would not be
+acceptable. Nothing on the path to the model strips or validates unknown keys
+(`extractClientToolOutputs` pushes `block.output` whole, and the interaction resolution has been an
+open dict since Slice A), so it arrives verbatim as one extra boolean in an object the model already
+reads as free-form — coherent beside `reason`, and arguably useful, since it discourages re-asking
+for a connection that already exists. It is optional and additive, pre-flag outputs default to
+retryable, and the settled output genuinely is the only per-part store that survives a reload; the
+alternative is a parallel store keyed by tool-call id, which is more machinery for the same fact.
+
+**Recommendation 3.** The poll window is closed for the new path. One property worth stating rather
+than fixing: `pendingResume` clears only inside `sendAutomaticallyWhen` when the dispatch fires, so a
+settle that never dispatches leaves it set for the mount — but that same flag already gated
+`refreshFromRecords` entirely, so this adds no new starvation class, and the zombie case (fresh load,
+nothing answered in this mount) has it null. The growth path still ignores `pendingResume`; that is
+pre-existing and out of scope.
+
+**Recommendation 4 and the deletion.** BLESSED. One exported decision, no test-only exports, and the
+composed decision is finally testable, which is what round 3 asked for.
+
+Coverage of the re-expressed cases was checked by MUTATION, not by reading. I temporarily made
+`pendingClientToolCallIds` count every `input-available` tool part as a card: all 19 tests still
+passed. So the stuck-server-tool case had become vacuous — at equal counts both hypotheses refuse
+adoption, so the assertion could not tell them apart. (The dynamic-tool case survived the
+re-expression: its second assertion, adopting when the server copy settles that card, only passes if
+the dynamic-tool part is detected.)
+
+Fixed inline: that test now makes two discriminating assertions, one per harm its own comment names
+— with record growth it must ADOPT (a stuck server tool must not freeze adoption), and at equal
+counts with the same tool settled server-side it must NOT adopt (the settled-card path must not fire
+on a tool nobody is waiting on). Re-ran the mutation: the test now fails under it and passes clean,
+and the production file was restored byte-identical (verified by diff against a pre-probe copy).
+
+Unchanged and still parked for QA: no test renders the card, and the mobile look (shared
+`getPendingApprovals`; no client-tool widget registered, so the neutral ended marker renders through
+the generic path).
+
+### Re-verification after fix rounds 3-4 (2026-08-11, same stack)
+
+Verdict: **FINDINGS** — everything on the re-verification list passes; one NEW defect was found
+just outside it, in the same duplicate-connection area.
+
+New code confirmed live behaviourally before anything was concluded: the five pre-fix sessions that
+showed live forms in round 1 now render neutral ended cards, and a duplicate connect now shows the
+truthful message instead of the generic one.
+
+| # | Check | Result |
+|---|---|---|
+| 1a | Five pre-fix sessions, normal load with existing localStorage | PASS |
+| 1b | Same, with the cached transcript removed (cold-replay control) | PASS — no second cause |
+| 2 | Connect cards still settle; `dabb0489`'s "Dismissed the request." chip intact | PASS |
+| 3 | Duplicate connect: truthful card, same string in the row, no Retry, no dead "Not now", live and after reload; composer free; later turn does not resurrect | PASS |
+| 4 | Ordinary (non-duplicate) failure still offers Retry | PASS |
+| 5 | Journey 1 spot-check (form answer, reload, right state) | PASS |
+| — | Post-settle Retry that hits a duplicate | **FAIL (new finding)** |
+
+**Item 1.** Every `cancelled` form row now renders "Request ended" with no buttons and no inputs:
+`call_n7Gec…` (e8c3b72a), `call_Dd5g…` (0b6a8c44), `call_nN5k…` (eda890fe), `call_528t…`
+(3975e362), `call_AKIy…` (dabb0489). Cancelled connect rows render "Connection request ended".
+The three genuinely `pending` connect rows stay live ("Connect Telegram" / "Not now") — correct,
+and they are exactly the three sessions the sessions list counts as waiting. The composer is free
+in every session with no pending card and held only where one genuinely waits. The cold-replay
+control (removing `agenta:agent-chat:messages:v2` and `record-counts:v2`, leaving drafts and auth
+alone) produced the same states, so replay alone is correct and the cache was the only cause.
+
+**Item 3.** Session `3b56cd84`, card `call_FBXoNUa9GtWrQ6q9rfidFi8H…`. `POST /tools/connections/`
+returned **409** (devtools `reqid=4434`) with
+`{"detail":{"message":"A resource with slug 'telegram' already exists in this project.","conflict":{"integration_key":"telegram",…}}}`.
+The card shows "A connection for telegram already exists in this project." with **zero buttons**;
+row `019fedaa-0767-74e1-8a06-0e78e01e0501` is `responded` with
+`data.resolution.output = {reason: "<same string>", connected: false, retryable: false}`. The state
+survives a reload, the composer stays free, and a later completed turn did not resurrect the card
+or create a new row. The agent also received the reason and said so in prose ("A Telegram
+connection already exists in this project, so no new connection card was raised").
+Screenshot: `r2-duplicate-card.png`.
+
+**Item 4.** A Gmail connect (no pre-existing gmail connection) created fine, opened its real OAuth
+popup, and was abandoned; it settled to "Connection not completed" **with** Retry. Row
+`019fedac-a638-7df2-8072-0c270221a604`: `responded`, `reason: "cancelled"`, no `retryable` flag —
+so Retry suppression is specific to duplicates and has not leaked to ordinary failures.
+
+**New finding: a post-settle Retry that collides with a duplicate is a silent doomed loop.**
+Abandoning that Gmail OAuth still left a `gmail` row in `gateway_connections` (21:55:53), so the
+card's own Retry now collides. Clicking it fires a real `POST /tools/connections/` **409**
+(`reqid=4913`, and again `reqid=4919` on a second click) while the card keeps reading the generic
+"Connection not completed" with Retry still offered, at every sample from 1.5 s to 8 s. The row
+never changes. Cause is branch order in `ConnectToolWidget.tsx`: the settled-chip block returns
+before `if (phase === "error")` is reachable, so the truthful `errorText` and `errorRetryable=false`
+computed by `connectFailureFrom` can never render on an already-settled card; `settledRetryable`
+meanwhile reads the STORED output, which for an abandoned connect has no `retryable` flag and so
+keeps Retry. This is Mahmoud's production shape exactly — abandon an OAuth, then retry forever
+against a connection that already exists. Screenshot: `r2-finding-doomed-retry.png`.
+
+**Not a defect, worth recording.** For PRE-fix sessions the warm cache shows richer text than a
+cold replay: `dabb0489`'s form reads "Dismissed the request." from cache but "Request ended" after
+the cache is cleared. That is the design working — those answers were never recorded in a row (the
+original bug), so replay has nothing to reconstruct and correctly refuses to guess. Post-fix rows do
+not degrade: the compound session's answered form replayed cold with all three saved values intact.
+
+### Fix round 5 (2026-08-11) — the doomed post-settle Retry
+
+QA's cause is exact. The settled-chip block ends with a `return`, so `if (phase === "error")` is
+unreachable once the part is settled. A manual retry from a settled card runs with
+`settleParkedCall: false`, so the catch never calls `finish()`, so `outcome` keeps whatever the
+ORIGINAL settle put there — for an abandoned OAuth that is `{connected: false, reason: "cancelled"}`
+with no `retryable` flag. The chip therefore re-rendered from stale data: generic "Connection not
+completed", Retry still offered, forever, while every click fired a real 409.
+
+Took shape (a). The catch now refreshes the live outcome when the card is already settled, so the
+result reaches the branch that actually renders and flows through the round-4 decision:
+
+```ts
+if (settleParkedCall) finish({connected: false, integration, slug, reason: message, retryable})
+else if (settledRef.current || meta.settled)
+    setOutcome({connected: false, reason: message, retryable})
+```
+
+The `else if` guard is load-bearing, not defensive. `phase === "error"` is genuinely reachable on an
+UNSETTLED card — the popup-blocked path sets it without settling — and setting `outcome` there would
+flip that card into the settled chip and make it look finished when it is not. Shape (b) was
+rejected for the same reason plus a second: the error branch offers "Not now", which is a dead
+control once `settledRef` is set.
+
+While pinning it, the chip's two inline reads (`outcome?.reason ?? output.reason` filtered through
+`KNOWN_CONNECT_REASONS`, and `isSettledFailureRetryable`) became one exported
+`settledFailureChip(outcome, output)` returning `{failureDetail, retryable}`, with
+`KNOWN_CONNECT_REASONS` moving to the hook beside it. Both halves of what the settled chip shows are
+now one tested decision instead of one tested helper and one untested expression.
+
+**Reload caveat, stated plainly because it is the honest outcome of shape (a):** the refresh is
+LIVE-ONLY. The stored output still carries the original `reason: "cancelled"` and no flag, so after
+a reload the card returns once to "Connection not completed" with Retry, and the next click lands
+back in the truthful no-Retry state. Persisting it would mean re-settling an already-settled part,
+which the double-settle guards exist to prevent. Accepted for this round.
+
+Test: `settledFailureChip` gains the round-5 repro as a two-step case in the QA artifact's exact
+shape — the abandoned-OAuth output alone yields generic wording with Retry, and the same output plus
+the failed retry's outcome yields the truthful message with Retry gone — alongside cases for the
+three generic reasons, verbatim rendering of any other reason, live-outcome precedence, and pre-flag
+outputs.
+
+`web/oss` AgentChatSlice 245 passed across 26 files; `@agenta/chat` 262 across 29;
+`@agenta/playground` 221 across 16; `tsc --noEmit` clean for `web/oss`; eslint `--max-warnings 0`
+and prettier clean. Replay untouched: both copies md5 `a28b5a4683ec48fb933febee8e3a8d9a`, 2907 bytes.
+Still no test that RENDERS the card — unchanged from rounds 3 and 4.
+
+### Review round 5 (independent reviewer, 2026-08-11) — AGREE
+
+Narrow round, one item. Verified from the code; the reasoning for rejecting shape (b) holds.
+
+Suites: `web/oss` AgentChatSlice 245 passed across 26 files, `@agenta/chat` 262 across 29,
+`@agenta/playground` 221 across 16, `tsc --noEmit` clean for `web/oss`, prettier clean on the three
+touched files. Replay parity checked a fifth time, still identical across copies and bit-for-bit
+unchanged since round 2 (md5 `d55533b83304aec20bf54cd1b91ac121` over my extraction boundary).
+
+**1. The guard.** The settled-refresh cannot fire on an unsettled card: it needs
+`settledRef.current || meta.settled`, and `settledRef` is set only inside `finish()`. `finish()`
+cannot double-fire either — the `if`/`else if` is mutually exclusive and `finish()` early-returns on
+`settledRef` anyway. The refresh is safe against the double-settle guards by construction: it calls
+`setOutcome` only, touching no settle machinery and no ref.
+
+The reachability claim behind rejecting shape (b) is TRUE. `useConnectFlow.ts` sets
+`phase: "error"` and RETURNS when `window.open` yields no popup — no settle, no `outcome` — so a
+parked card really can sit unsettled in `phase: "error"`, where the error branch's "Not now" is the
+live escape hatch for a run that is still parked. An unconditional `setOutcome` in the catch would
+flip that card into the settled chip and make a parked run look finished; shape (b) would show the
+error branch (with its then-dead "Not now") for a settled card. Both stated reasons check out.
+
+**2. The consolidation: BLESSED.** It is in service of the fix rather than beside it — round 4 left
+one half of the chip a tested helper and the other half an untested inline expression, and this makes
+both one decision. `isSettledFailureRetryable` is fully replaced (no stragglers), `KNOWN_CONNECT_REASONS`
+now sits beside its only consumer, and the widget calls one function instead of computing two things.
+Net surface goes down, not up.
+
+**3. The reload caveat: ACCEPTED.** One wasted click per reload, self-correcting on that click, is a
+categorical improvement over the infinite doomed Retry QA hit, and persisting would mean re-settling
+a settled part. One durable route worth recording as considered-and-rejected rather than missed:
+refreshing the interaction ROW's resolution would be durable and would NOT re-settle the part, but it
+cannot reach the render — replay rule 1 skips any part that already carries a real `tool_result`, and
+an in-band settled card always does. The only remaining cheap option is a client-side store keyed by
+tool-call id (the elicitation draft's pattern), which reintroduces exactly the parallel store round 4
+argued against. Not worth it for one click.
+
+**4. The tests.** Real, at the decision level, and the round-5 repro is genuinely two-step in the
+artifact's shape: the abandoned-OAuth output alone yields `{failureDetail: undefined, retryable: true}`
+(the pre-fix state QA saw), and the same output plus the failed retry's outcome yields the truthful
+message with Retry gone. `toEqual` on the whole result pins both halves per case, and the step-2 case
+fails if live precedence ever breaks. The standing limit is unchanged and correctly restated: the
+catch's `setOutcome` wiring itself is verified by inspection, not by a render test.
+
+**For QA re-driving the gmail artifact:** the expected observation is exactly ONE doomed click per
+reload, not zero — the first click after a reload is what re-derives the truthful no-Retry state.
+That is the accepted trade above, not a regression.
+
+#### Final re-check after fix round 5 (2026-08-11): doomed-retry repro — CLEAN
+
+Re-driven against the preserved artifact (the unauthorized `gmail` row in `gateway_connections`
+from 21:55:53, plus the settled "Connection not completed" card `call_XV4bjLGqkEuOlYud7wQ…` in
+session `715c8d78`). Both halves behave as the reviewer specified.
+
+**Pre-reload half — PASS.** Clicking Retry fires `POST /tools/connections/` → **409**
+(devtools `reqid=5421`, body
+`{"detail":{"message":"A resource with slug 'gmail' already exists in this project.","conflict":{"integration_key":"gmail",…}}}`).
+Within 1.5 s the card updates to "A connection for gmail already exists in this project." with
+**zero buttons**, and it holds that state at every sample through 18 s. The integration name is
+interpolated from the conflict envelope, not hardcoded — this run says `gmail` where the earlier
+one said `telegram`. Screenshot: `r3-gmail-truthful-no-retry.png`.
+
+**Post-reload half — PASS, and bounded.** After a reload the card reads "Connection not completed"
++ Retry once more, as expected: the fix is live-only and the stored resolution is deliberately not
+rewritten (row `019fedac-a638-7df2-8072-0c270221a604` still reads `reason: "cancelled"`,
+`updated_at 21:56:32`). The FIRST click re-derives the truthful state — one `POST
+/tools/connections/` **409** (`reqid=5821`, exactly one in the cycle), then
+"A connection for gmail already exists in this project." with no buttons, stable through 14 s.
+Because the truthful state has no buttons at all, no second doomed click is reachable without
+another reload. One doomed click per reload, never a loop.
+
+QA verdict for the lane: **CLEAN**.


### PR DESCRIPTION
## Context

Today's recurring interaction-card bugs (resurrected questionnaires, dead connect cards, the running-elsewhere strip accusing its own tab, answers ignored) got the full planning treatment instead of more symptom patches. This PR lands the workspace at `docs/design/client-tool-interaction-lifecycle/`.

## What is inside

- **context.md** — the user experience that opened the project and the thesis (whenever there is one new thing to show, the UI shows everything instead of that thing).
- **research.md** — the six evidenced mechanisms; the complete frontend render inventory and server-side lifecycle inventory with file references; the kind-by-outcome settlement table (approvals settle correctly; forms and connect cards NEVER record success, in any version); the blame timeline verified against v0.108.1 (the settlement gap shipped complete in v0.105.0 and is not a regression; the visibility regressions date to v0.111's live adoption and one 2026-08-10 dispatch line).
- **plan.md** — v2, reshaped after an adversarial review (codex gpt-5.6-sol) found v1 unsound: four changes — the answer flips the interaction row first (winning the sweep race by ordering, zero sweep changes), one replay precedence rule (no new record kind), desktop subscribes to the existing interaction event and stops adopting over pending cards, and cards act wherever they render. Mobile client-tool answering is documented as a pre-existing limitation with its own ticket.
- **status.md** — the decision log, including the review verdict and its adoption.

Related, already merged today: [#5909](https://github.com/Agenta-AI/agenta/pull/5909), [#5912](https://github.com/Agenta-AI/agenta/pull/5912), [#5913](https://github.com/Agenta-AI/agenta/pull/5913), [#5910](https://github.com/Agenta-AI/agenta/pull/5910). Open issues it references: [#5907](https://github.com/Agenta-AI/agenta/issues/5907), [#5911](https://github.com/Agenta-AI/agenta/issues/5911).