### PR TITLE
[docs] Document session rewind and branching design

### DIFF
--- a/docs/design/session-rewind-branching/README.md
+++ b/docs/design/session-rewind-branching/README.md
@@ -1,0 +1,42 @@
+# Session rewind and branching
+
+This workspace explains how rewind works in pull request 5860, why the current implementation
+still has correctness gaps, what should change before that pull request merges, and how Agenta can
+support durable branches later without making records mutable.
+
+## Reading order
+
+1. [context.md](context.md) starts with the user story and the behavior users see today.
+2. [research.md](research.md) traces the current frontend, API, record, and runner behavior.
+3. [data-model.md](data-model.md) compares the storage options and recommends session lineage.
+4. [api-design.md](api-design.md) defines the proposed contracts and frontend state.
+5. [performance-and-migration.md](performance-and-migration.md) counts requests and describes
+   migrations, storage growth, and read costs.
+6. [plan.md](plan.md) separates the requested PR changes from later backend work.
+7. [status.md](status.md) records settled decisions, open decisions, and implementation status.
+
+## Terms
+
+- **Session:** The user-visible conversation identity. The runner also uses its ID to find native
+  harness continuity.
+- **Turn:** One user input and the agent execution it starts. A session contains ordered turns.
+- **Record:** One append-only event inside a turn, such as user text, assistant text, a tool call,
+  or a tool result.
+- **Runner:** The service that executes one agent turn and persists its events.
+- **Harness:** The underlying agent runtime, such as Pi, Claude Code, or Codex.
+- **Hydration:** Rebuilding the browser transcript from durable server records.
+- **Fork:** A new session that continues from a selected point in an older session.
+- **Lineage:** Durable data saying which parent session a fork came from and how much of the parent
+  transcript it inherits.
+- **Effective transcript:** The ordered conversation a branch sees, including inherited parent
+  turns and turns written directly to the branch.
+
+## Recommendation in one paragraph
+
+Pull request 5860 should remain a focused frontend bug fix. Before merge, it should persist the
+complete fork bootstrap across reloads, including edit or rerun mode, restored draft, and history
+replay state. It should clear that state only after a successful first request, preserve the source
+title, and add the missing tests. It should state that the
+inherited prefix is browser-local and therefore not a complete cross-device branch. A separate
+backend project should add one lineage row per fork and a lineage-aware transcript read. Records
+remain append-only and linear within each session. No parent field is needed on every record.

--- a/docs/design/session-rewind-branching/api-design.md
+++ b/docs/design/session-rewind-branching/api-design.md
@@ -1,0 +1,274 @@
+# API and frontend contracts
+
+## Immediate pull request 5860 contract
+
+The immediate fix remains frontend-owned and adds no HTTP contract.
+
+### Persisted frontend execution state
+
+Reload safety requires the complete action that bootstraps the child, not only a replay marker.
+This is execution state, not lineage metadata. Store it separately from the session header:
+
+```typescript
+type ForkBootstrap =
+    | {
+          mode: "edit"
+          draft: string
+          requestState: "pending" | "in-flight"
+      }
+    | {
+          mode: "rerun"
+          requestState: "pending" | "in-flight"
+      }
+
+type ForkBootstrapBySession = Record<string, ForkBootstrap>
+```
+
+Use a local storage-backed Jotai atom with a new storage key, for example:
+
+```text
+agenta:agent-chat:fork-bootstrap:v1
+```
+
+The retained messages remain in the existing local message store. The write rules are:
+
+- Store edit or rerun mode when `rewindForkAtomFamily` creates the child.
+- Store the restored user draft for edit mode.
+- Restore the draft or automatic rerun behavior when the child mounts after reload.
+- Read it when `buildAgentRequest` decides whether to disable last-message-only optimization.
+- Mark it `in-flight` only when transport dispatch begins.
+- Treat an `in-flight` bootstrap restored after page reload as `pending`, because the browser stream
+  that owned it no longer exists.
+- Keep it through error, abort, and disconnect.
+- Clear it only when the first request completes successfully.
+- Delete it when the child session is permanently deleted.
+
+Do not store this bootstrap inside `AgentChatSession.lineage`. It controls one request and has a
+shorter lifecycle than descriptive session relationships.
+
+### Frontend session header
+
+For this pull request, extend the session creation writer so a new local session may receive a
+title:
+
+```typescript
+interface AddSessionInput {
+    title?: string
+}
+```
+
+`rewindForkAtomFamily` reads the source session and creates the child with:
+
+```text
+<source title> (branch)
+```
+
+If the source has no title, existing auto-title behavior remains. If the source has a title, persist
+the child title through the existing session-header API. This is one header request, not a second
+request in addition to auto-title. The current frontend session type does not carry description, so
+description support stays in the durable backend project.
+
+### First-request completion
+
+The AI SDK completion callback exposes abort, disconnect, and error flags. The bootstrap is cleared
+only when all are false. The exact callback shape must follow the pinned AI SDK version.
+
+## Durable fork endpoint
+
+The durable project should create the child session and lineage atomically in the core database.
+
+```http
+POST /sessions/{source_session_id}/fork
+```
+
+Request:
+
+```json
+{
+  "target_session_id": "session-B",
+  "inherited_turn_count": 2,
+  "header": {
+    "name": "Customer investigation (branch)",
+    "description": "Investigating the failed checkout"
+  }
+}
+```
+
+Field roles:
+
+| Field | Role | Owner | Lifecycle |
+|---|---|---|---|
+| `source_session_id` | Source identity in the path | Caller | One fork operation |
+| `target_session_id` | Idempotent target identity | Caller | Lifetime of child session |
+| `inherited_turn_count` | Data cursor over complete effective turns | Caller | Immutable lineage |
+| `header` | Descriptive metadata override | Caller and product UI | Editable after creation |
+
+The server copies the source header when `header` is absent. When fields are supplied, they override
+the copied values. Omission means copy; an explicit empty string means clear.
+
+Before opening the core database transaction, the service resolves `inherited_turn_count` against
+the source's effective transcript and identifies the final inherited physical record. The public
+request stays turn-based; `cutoff_session_id` and `cutoff_record_id` are internal lineage fields.
+
+Response:
+
+```json
+{
+  "session": {
+    "session_id": "session-B",
+    "name": "Customer investigation (branch)",
+    "description": "Investigating the failed checkout"
+  },
+  "lineage": {
+    "root_session_id": "session-A",
+    "parent_session_id": "session-A",
+    "inherited_turn_count": 2
+  }
+}
+```
+
+Validation:
+
+- Source and target IDs pass existing session ID validation.
+- Source exists in the caller's project.
+- Target does not identify an unrelated existing session.
+- The source effective transcript contains the requested number of complete turns.
+- A nonzero inherited prefix resolves to a physical cutoff record.
+- The target cannot be its own ancestor.
+- The lineage depth stays below a configured safety ceiling.
+- A running source is rejected unless the selected cutoff is already complete and the product
+  explicitly accepts snapshotting a stable prefix.
+
+Idempotency:
+
+- Repeating the same source, target, and cutoff returns the existing fork.
+- Reusing the target with different lineage returns a conflict.
+
+## Effective transcript endpoint
+
+Keep the existing records endpoint physical:
+
+```http
+POST /sessions/records/query
+```
+
+It continues to return only records written under the requested session ID. Inspector and
+observability consumers may need that exact provenance.
+
+Add a logical transcript endpoint:
+
+```http
+POST /sessions/transcript/query
+```
+
+Request:
+
+```json
+{
+  "session_id": "session-B"
+}
+```
+
+Response:
+
+```json
+{
+  "session_id": "session-B",
+  "count": 42,
+  "records": [
+    {"session_id": "session-A", "turn_id": "A1", "record_index": 0},
+    {"session_id": "session-A", "turn_id": "A2", "record_index": 0},
+    {"session_id": "session-B", "turn_id": "B1", "record_index": 0}
+  ]
+}
+```
+
+Existing `SessionRecord.session_id` already identifies provenance. The response does not rewrite
+source IDs or add a misleading `inherited` field. A consumer can compare each record's session ID
+with the requested session ID.
+
+The frontend hydration and runner reconstruction switch from physical records to this effective
+transcript. The Inspector may expose both effective conversation context and child-only physical
+events as distinct views.
+
+## Session list contract
+
+Add optional lineage to `SessionListItem` so the existing sessions query can render branch labels
+without another frontend request:
+
+```json
+{
+  "session_id": "session-B",
+  "name": "Customer investigation (branch)",
+  "lineage": {
+    "root_session_id": "session-A",
+    "parent_session_id": "session-A",
+    "inherited_turn_count": 2
+  }
+}
+```
+
+The API must batch this lookup for the complete page. It must not fetch lineage once per session.
+
+## Branch-family query
+
+A branch tree UI may later need all descendants:
+
+```http
+POST /sessions/lineage/query
+```
+
+```json
+{
+  "root_session_id": "session-A"
+}
+```
+
+This endpoint is not required for the first durable fork if the UI continues to show each branch as
+an independent History row. Add it only when a branch-family UI has a caller.
+
+## Durable frontend model
+
+The server summary maps to:
+
+```typescript
+interface AgentChatSession {
+    id: string
+    title?: string
+    description?: string
+    createdAt?: number
+    lastMessageAt?: number
+    lineage?: {
+        rootSessionId: string
+        parentSessionId: string
+        inheritedTurnCount: number
+    }
+}
+```
+
+Durable fork flow:
+
+1. Count the complete visible turns before the selected UI turn.
+2. Call the fork endpoint.
+3. Add the returned child summary to local state and make it active.
+4. Optimistically show the retained local prefix while transcript hydration resolves.
+5. Send the edited or copied user prompt as the child's first turn.
+6. Let the runner load the effective transcript from the server.
+
+The durable flow removes `replayHistory` and the persisted bootstrap because the runner no
+longer depends on a browser-supplied prefix.
+
+## Fork transaction ownership
+
+The stream and lineage rows live in the same core Postgres database, but existing DAOs open and
+commit their own sessions. The fork service must not call two independent create methods and claim
+atomicity.
+
+Add a composite database operation, behind a core DAO interface, that owns one SQLAlchemy session
+and transaction. It inserts the child `session_streams` row, the `session_lineage` row, and any
+`session_attachment_access` rows. Unique constraints make an identical target retry idempotent; a
+conflicting target causes the entire transaction to roll back.
+
+The tracing-store cutoff lookup happens before this core transaction because the two stores cannot
+share a SQL transaction. If cutoff resolution fails, do not start the core transaction. Once
+resolved, the source log is append-only and the selected cutoff remains stable.

--- a/docs/design/session-rewind-branching/context.md
+++ b/docs/design/session-rewind-branching/context.md
@@ -1,0 +1,86 @@
+# User experience and scope
+
+## What the user sees today
+
+The playground lets a user rewind from an earlier user or assistant message. Before pull request
+5860, rewind changed only the browser transcript. The session ID stayed the same.
+
+That produced a visible failure:
+
+1. The browser removed the later messages.
+2. The durable record log still held those messages under the same session ID.
+3. A later hydration fetched the complete record log.
+4. The removed messages reappeared.
+
+The runner created a second, less visible failure. A warm harness session, or a cold harness session
+restored through native continuity, still remembered the later turns. Even if the browser hid those
+turns successfully, the agent could answer using information the user believed they had removed.
+
+## User story
+
+As an agent playground user, I want to rewind to a selected turn and continue in another direction
+without later turns reappearing or influencing the new response. I also want the original
+conversation to remain available, so rewind never destroys prior work.
+
+For a durable product experience, the same branch should reopen correctly after a page reload, a
+local storage clear, or a switch to another browser or device.
+
+## Pull request 5860 behavior
+
+Pull request 5860 changes rewind into a new-session fork:
+
+```text
+Original session A
+Turn 1 -> Turn 2 -> Turn 3 -> Turn 4
+
+Rewind before Turn 3
+
+Original session A
+Turn 1 -> Turn 2 -> Turn 3 -> Turn 4
+
+Fork session B
+Turn 1 -> Turn 2 -> new Turn 3
+```
+
+The browser closes session A's tab but keeps A in History. It creates session B, copies the retained
+messages into browser storage, and makes B active. The first request for B sends the full retained
+history because B has no records or native harness continuity. Later requests send only the newest
+user message.
+
+## Goals for pull request 5860
+
+- Stop removed messages from returning in the same browser.
+- Ensure the new runner session receives the retained context on its first request.
+- Preserve the complete original session in History.
+- Survive a reload between rewind and the first send.
+- Retry correctly when the first branch request fails or is aborted.
+- Restore whether the fork should reopen an editable prompt or rerun a prompt automatically.
+- Preserve a meaningful session title.
+- Add no backend schema migration.
+
+## Non-goals for pull request 5860
+
+- Durable branch lineage across devices.
+- A branch tree UI.
+- Copying or snapshotting a sandbox filesystem.
+- Undoing external tool side effects.
+- Changing append-only record persistence.
+- Adding parent fields to every record.
+- Fixing the package-level rewind implementation in `@agenta/chat`.
+
+## Goals for the later durable branching project
+
+- Store the parent session and inherited effective-turn count on the server.
+- Reconstruct a branch from parent records plus its own records.
+- Let the frontend and runner use one server-owned effective transcript.
+- Preserve titles, descriptions, and branch provenance across devices.
+- Avoid copying parent records into every child branch.
+- Keep one frontend transcript request per opened session.
+
+## Separate client-tool replay defect
+
+The `request_input` replay defect discussed during this review is valid but independent. A preceding
+ACP tool call may carry `{}` before the interaction request carries the real form input. Both
+transcript mapper copies retain `{}` because they update only an `undefined` input. That causes the
+elicitation form parser to degrade. It should be fixed in a separate commit or pull request with
+parity tests in the OSS and `@agenta/chat` copies. It does not change the rewind data model.

--- a/docs/design/session-rewind-branching/data-model.md
+++ b/docs/design/session-rewind-branching/data-model.md
@@ -1,0 +1,255 @@
+# Data model options
+
+## Required information
+
+A durable fork needs to answer four questions:
+
+1. Which session is the child?
+2. Which session is its direct parent?
+3. How many complete turns from the parent's effective transcript does the child inherit?
+4. Which root session groups the complete branch family?
+
+The first durable model does not need a record-level parent pointer. Rewind and rerun happen at turn
+boundaries. To rerun a selected turn, the child inherits through the previous complete turn and
+writes the copied or edited user prompt as its own first turn.
+
+The canonical cursor is an effective-turn count rather than a turn ID. Hydrated `UIMessage` objects
+do not currently retain `turn_id`, old records may have a null `turn_id`, and a child can be forked
+from a turn it already inherited from an ancestor. The visible transcript always has a stable
+ordered turn count, so the frontend can supply it without guessing a database identifier.
+
+## Recommended durable model: session lineage
+
+Add one row for every non-root branch:
+
+```text
+session_lineage
+
+project_id             UUID, required
+session_id             string, required, child session
+root_session_id        string, required
+parent_session_id      string, required
+inherited_turn_count   integer, required, minimum 0
+cutoff_session_id      string, nullable, internal physical cursor
+cutoff_record_id       UUID, nullable, internal physical cursor
+created_at             timestamp, required
+created_by_id          UUID, nullable by existing lifecycle conventions
+```
+
+Recommended constraints and indexes:
+
+```text
+PRIMARY KEY (project_id, session_id)
+INDEX (project_id, root_session_id)
+INDEX (project_id, parent_session_id)
+```
+
+`inherited_turn_count = 0` means the child inherits no completed parent turn. This represents a
+fork before the first turn.
+
+The service validates that the parent effective transcript contains at least the requested number
+of complete turns. Session IDs remain bare string correlators because sessions may be external and
+the current model does not enforce session IDs as foreign keys.
+
+`inherited_turn_count` is the semantic cursor exposed to clients. At fork creation, the backend
+also resolves the final inherited record and stores its real source session and record ID. Those two
+internal fields let the records database stop at the inherited boundary instead of loading a large
+discarded parent tail. Both are null when the inherited turn count is zero.
+
+The cutoff record ID is not itself an ordering key. The records DAO resolves that row and applies a
+null-safe total order:
+
+```text
+(timestamp IS NULL, COALESCE(timestamp, created_at), created_at,
+ COALESCE(record_index, -1), record_id)
+```
+
+The leading boolean preserves `timestamp ASC NULLS LAST`. `COALESCE(timestamp, created_at)` gives
+the null-timestamp group a comparable value, after which `created_at` and `record_index` preserve
+their current precedence. Non-null `record_id` is the deterministic tiebreaker. The tracing database
+needs a matching composite expression index prefixed by `project_id` and `session_id`. Normal
+records reads and cutoff reads must use the same order. The source session is stored because the
+last inherited record may belong to an ancestor rather than the direct parent.
+
+### Example
+
+```text
+Session A turns: A1, A2, A3
+
+Lineage for B:
+session_id = B
+root_session_id = A
+parent_session_id = A
+inherited_turn_count = 2
+cutoff_session_id = A
+cutoff_record_id = <last record of A2>
+
+Session B turns: B1, B2
+
+Effective transcript for B:
+A1 + A2 + B1 + B2
+```
+
+If C forks from B through B1:
+
+```text
+Lineage for C:
+session_id = C
+root_session_id = A
+parent_session_id = B
+inherited_turn_count = 3
+cutoff_session_id = B
+cutoff_record_id = <last record of B1>
+
+Effective transcript for C:
+A1 + A2 + B1 + C's turns
+```
+
+The count is over B's effective transcript, not only turns physically written under B. This allows
+a child to fork at an inherited ancestor turn without adding another cursor type.
+
+Lineage traversal combines the physical cutoff on each ancestry edge into a bounded segment plan.
+For the example above, C reads A only through A2 and B only through B1. It never scans A3 or later B
+turns merely to discard them in application code.
+
+## Why lineage is not stored in tags or general metadata
+
+Tags describe filterable labels such as session origin. General metadata holds optional extension
+data. Lineage changes transcript reconstruction and must be validated, indexed, and queried as a
+core relationship. A dedicated table gives it a typed lifecycle and prevents unrelated metadata
+writes from replacing it.
+
+Using `session_streams.meta` is acceptable for a disposable spike, but not for the production read
+path.
+
+## Option comparison
+
+### Option A: frontend-only copied prefix
+
+This is pull request 5860.
+
+```text
+Child local messages = retained parent messages
+Child durable records = new turns only
+```
+
+Advantages:
+
+- No backend work.
+- No migration.
+- No extra rewind request.
+- Smallest fix for the original resurrection bug.
+
+Costs:
+
+- Not cross-device.
+- Local storage loss removes inherited context from the visible transcript.
+- Requires special first-request replay state.
+- Duplicates the prefix in browser storage.
+
+Use this only as the immediate bug fix.
+
+### Option B: copy parent records into the child
+
+The backend could physically duplicate every inherited record under the child session ID.
+
+Advantages:
+
+- Existing records queries and runner reconstruction need little change.
+- A child is self-contained.
+
+Costs:
+
+- Fork writes grow with transcript length.
+- Every branch duplicates records and large event attributes.
+- Record identity, trace identity, tool-call identity, and attachment provenance become ambiguous.
+- A large branch family multiplies storage.
+- Copying while the parent is running needs snapshot rules.
+
+This option is not recommended.
+
+### Option C: session lineage with read-time transcript resolution
+
+The child stores only new turns. One lineage row points to the inherited parent prefix.
+
+Advantages:
+
+- Records stay immutable and append-only.
+- Fork creation is constant-size.
+- No record duplication.
+- The relationship supports a branch tree naturally.
+- Parent and child provenance remain visible.
+
+Costs:
+
+- Transcript reads must resolve ancestry.
+- The runner and frontend must use the effective transcript endpoint.
+- Attachments and session files need an explicit inheritance policy.
+- Deep branch chains need a depth limit and cycle protection.
+
+This is the recommended durable model.
+
+### Option D: parent pointers on messages or records
+
+LobeChat and Open WebUI store message trees because their durable unit is a message. Agenta's
+durable unit is a lower-level event record. A single assistant message may span many records.
+
+Adding `parent_record_id` would force message semantics into event fragments and would still not
+solve native runner continuity. A new first-class message table could support true message trees,
+but it is a larger redesign than session branching requires.
+
+Do not choose this option for rewind.
+
+### Option E: truncate or supersede records in place
+
+Records already carry lifecycle fields, so the API could hide later records. The runner would also
+need to invalidate its warm pool, discard native harness continuity, and start from the retained
+prefix. This destroys or hides the old branch unless a second lineage model preserves it.
+
+This option is harder than a fork and gives users less recoverability. It is not recommended.
+
+## Header and related data
+
+The fork operation should copy or derive:
+
+- `name`: copy a user-defined name and append `(branch)`; auto-generated naming may be recalculated.
+- `description`: copy unchanged by default.
+- workflow references: the child turn supplies these through the normal invocation path.
+- native `agent_session_id`: never copy; the child must establish separate harness continuity.
+- liveness flags: start false.
+- archive and ended state: do not copy.
+
+## Attachments, files, and side effects
+
+### Attachments
+
+Inherited messages may contain session-scoped attachment IDs. The current `session_attachments` row
+is the owner and has one `session_id`; its `referenced_at` field is only a timestamp, not a reusable
+reference relation.
+
+The recommended model adds an access table:
+
+```text
+session_attachment_access
+
+project_id
+session_id             child allowed to use the attachment
+attachment_id          existing parent-owned attachment
+source_session_id      owning parent session
+created_at
+```
+
+The fork transaction inserts access rows for attachments reachable from the inherited prefix. Read
+and reference APIs accept either direct ownership or an access row. File bytes and attachment IDs
+remain unchanged.
+
+### Session files and sandbox state
+
+A transcript branch does not automatically clone files created in the parent sandbox. The first
+durable version should state that it inherits conversation context and attachment access, not
+arbitrary filesystem or process state. Sandbox snapshotting is a separate capability.
+
+### External tool side effects
+
+Forking never undoes sent emails, commits, API mutations, or other external actions. The existing
+warning for side-effecting tools remains required.

--- a/docs/design/session-rewind-branching/performance-and-migration.md
+++ b/docs/design/session-rewind-branching/performance-and-migration.md
@@ -1,0 +1,173 @@
+# Performance, queries, and migration
+
+## Frontend network requests today
+
+The numbers below count browser-to-API requests, not cache reads.
+
+### Opening the playground
+
+- Session list: one `/sessions/query` request per agent scope.
+- Refresh behavior: stale after 30 seconds, refresh every 60 seconds, and refresh on window focus.
+- Transcript: zero requests for a fresh empty session.
+- Transcript: one records request for a cache miss or stale cached session.
+- Records consumers share one TanStack Query key, so hydration and Inspector do not intentionally
+  issue parallel duplicate requests within the stale window.
+
+### Rewind in pull request 5860
+
+- Creating the child: local storage only.
+- Typical rewind with a retained user message: one session-header request from auto-title after the
+  child mounts.
+- Rewind before the first user message: zero requests until the edited prompt is sent.
+- First send: one normal invocation request. Its body is larger because it carries the retained
+  transcript.
+- Opening the original again: one records request if its shared cache is stale or absent.
+
+## Frontend requests after the immediate PR hardening
+
+The requested hardening does not add a network request:
+
+| Action | PR 5860 now | Hardened PR |
+|---|---:|---:|
+| Click rewind with a copied title | Usually 1 header request | 1 header request |
+| Click rewind without a title | 0 until auto-title | 0 until auto-title |
+| First child send | 1 invocation | 1 invocation |
+| Open stale child | 1 records query | 1 records query |
+| Session list refresh | 1 sessions query | 1 sessions query |
+
+Persisting the complete bootstrap adds one small local storage entry per pending fork. The editable
+draft dominates its size and is bounded by the existing composer input. Copying the source title
+uses the existing header endpoint and suppresses a duplicate auto-title write.
+
+The retained prefix is already duplicated in the browser's local message cache. Storage growth is
+linear in the number and length of retained messages for each fork. This remains a known limitation.
+
+## Frontend requests with durable lineage
+
+Durable lineage adds one request at fork creation and preserves existing read counts:
+
+| Action | Frontend requests |
+|---|---:|
+| Click durable fork | 1 fork request |
+| First child send | 1 invocation |
+| Open stale child | 1 effective transcript query |
+| Session list refresh | 1 sessions query including batched lineage |
+| Open branch-family UI | 0 extra if list data is enough; otherwise 1 lineage query on demand |
+
+The effective transcript request replaces the physical records request for conversation hydration.
+It must not run in addition to it. Inspector views that explicitly request physical records may
+share a separate cached query because they answer a different question.
+
+The first invocation body becomes smaller because the browser sends only the new user message. The
+runner resolves inherited context server-side.
+
+## Backend query cost with durable lineage
+
+Current transcript reconstruction needs one records database query for one session.
+
+A naive lineage implementation would execute one lineage query and one records query per ancestor.
+Do not implement that pattern.
+
+The target implementation uses:
+
+1. One core database query to resolve the lineage chain and inherited-turn counts. A recursive CTE
+   or bounded iterative query can do this.
+2. One tracing database query that fetches records for every session segment in the resolved chain,
+   bounded by the physical cutoff stored on each lineage edge.
+
+Expected backend database round trips per transcript cache miss:
+
+```text
+Current root session:     1 records query
+Durable root session:     1 lineage lookup + 1 records query
+Durable branch, depth N:  1 lineage-chain query + 1 batched records query
+```
+
+Branch depth must not produce N frontend requests or N records queries. Add indexes on child, root,
+and parent session IDs. Set a lineage depth limit to bound malformed or adversarial chains.
+
+The records query must apply cutoffs in SQL. It must not fetch a complete 100,000-turn parent and
+trim it to two turns in application code. `cutoff_record_id` identifies the boundary row. The query
+uses the null-safe total order `(timestamp IS NULL, COALESCE(timestamp, created_at), created_at,
+COALESCE(record_index, -1), record_id)`. A matching tracing-database composite expression index,
+prefixed by project and session, makes each segment a bounded range scan. One batched query can
+express the resolved session segments as bounded predicates.
+
+### Session-list backend cost
+
+The current session-list service performs three batched database operations after any reference-ID
+resolution: one stream query, one latest-turn query, and one tracing-store last-message query. A
+separate lineage enrichment query would raise that to four.
+
+Prefer a left join from the stream query to `session_lineage`, since both tables live in the core
+database and each child has at most one lineage row. This keeps the list at three database
+operations while widening the stream result. If DAO layering makes the join impractical, use one
+batched lineage query for the page and explicitly accept the fourth operation. Never query lineage
+once per row.
+
+## Response size and latency
+
+An effective transcript returns the same conversation context that the browser or runner needs to
+reconstruct. Its response size is approximately the size of the visible inherited prefix plus child
+records. Lineage avoids duplicate storage but does not avoid transmitting inherited context on a
+cold read.
+
+Existing IndexedDB persistence and TanStack Query deduplication can cache the effective transcript
+under a key such as:
+
+```text
+["session", "transcript", projectId, sessionId]
+```
+
+Append-only child growth keeps cache invalidation simple. Parent sessions are immutable before the
+stored cutoff for completed turns, so an inherited prefix does not need repeated parent polling.
+
+## Database migration
+
+### Immediate PR hardening
+
+- No backend migration.
+- Add a new local storage atom key for complete fork bootstrap state.
+- Optional TypeScript fields do not require transforming existing browser session entries.
+- Deleting a child must clean the new local storage entry.
+
+### Durable lineage
+
+Use an additive migration that creates `session_lineage`, `session_attachment_access`, and their
+indexes.
+
+- Do not rewrite records.
+- Add the tracing-database composite expression index for bounded record-prefix reads.
+- Add `record_id` as the final ordering key in ordinary records queries so all readers use the same
+  total order. This only resolves previously undefined ties.
+- Do not backfill existing sessions.
+- Treat an absent lineage row as a root session.
+- Keep new lineage fields optional in API responses during rollout.
+- Deploy backend read compatibility before switching frontend hydration.
+- Rollback is safe while no client requires lineage-only transcripts; child records remain intact,
+  but inherited prefixes become unavailable without the lineage reader.
+
+## Data retention and deletion
+
+Parent deletion affects descendants. The durable project must choose a policy before implementation:
+
+- Prevent hard deletion while descendants exist.
+- Soft-delete the parent but retain its records while descendants reference them.
+- Materialize descendants before permanent parent purge.
+
+The recommended first policy is to retain soft-deleted ancestors until every descendant expires or
+is deleted. Archive remains a visibility operation and does not affect lineage reads.
+
+## Performance verification
+
+Measure and pin:
+
+- Frontend request count for rewind, first send, branch open, and original open.
+- Backend database round trips for lineage depth 0, 1, 5, and the configured maximum.
+- Transcript latency and payload size at 10, 100, and 1,000 records.
+- Transcript rows scanned when a branch inherits 2 turns from a 100,000-turn parent.
+- Correct cutoff behavior for equal timestamps, null timestamps, null record indexes, and tied
+  ingest timestamps.
+- Session-list latency and database operation count for a page with 50 sessions and mixed lineage.
+- Storage growth for 10 branches from a 100-turn parent under copy and lineage models.
+- Cache behavior when an effective transcript and Inspector physical records are both open.

--- a/docs/design/session-rewind-branching/plan.md
+++ b/docs/design/session-rewind-branching/plan.md
@@ -1,0 +1,204 @@
+# Implementation plan
+
+## Recommended sequence
+
+Do not combine frontend hardening, durable lineage, and branch-tree UI into one pull request. The
+current production bug needs a small correction. Durable cross-device branches need backend design
+and migration work. A grouped branch UI should follow only after the durable contract exists.
+
+## Pull request 5860 changes requested before merge
+
+### Persist the complete fork bootstrap
+
+Replace `unloggedHistorySessionIds`, the rewind draft handoff, and the pending automatic rerun atom
+with one local storage-backed bootstrap keyed by child session ID.
+
+Reason:
+
+- The retained messages already survive reload.
+- Edit or rerun mode, restored draft, and the instruction to replay history must survive the same
+  reload.
+- User-side rewind has an unbounded edit window before the first request.
+
+Implementation surfaces:
+
+- `web/oss/src/components/AgentChatSlice/state/sessions.ts` or a focused persisted state module.
+- `web/oss/src/components/AgentChatSlice/state/rewindFork.ts`.
+- `web/oss/src/components/AgentChatSlice/hooks/useComposerDraft.ts`.
+- `web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts`.
+- Session deletion and reset cleanup paths.
+
+### Clear replay state only after success
+
+Read the pinned AI SDK completion flags. Keep the bootstrap after abort, disconnect, or error. Clear it
+only when the runner has successfully completed the first child turn.
+
+Reason:
+
+- `onFinish` is a lifecycle callback, not a success guarantee.
+- Clearing early turns a recoverable network failure into silent context loss.
+
+### Preserve the source title
+
+Let `addSessionAtomFamily` accept an optional title. `rewindForkAtomFamily` copies the current source
+title with a `(branch)` suffix and persists it through the existing header API. Untitled sessions
+continue through auto-title.
+
+Reason:
+
+- A user-defined session name is descriptive metadata and should survive duplication.
+- Auto-title from the first retained prompt can discard a deliberate rename.
+
+Description remains out of scope because the frontend session model does not currently carry it.
+
+### Add regression tests
+
+Add tests for:
+
+- User rewind, restore persisted state and draft, then send the complete retained history.
+- Assistant rewind, restore persisted state, then perform the automatic rerun once.
+- Abort first child request, retry, and replay again.
+- Error first child request, retry, and replay again.
+- Successful first child request clears bootstrap state.
+- Deleting or resetting a child removes bootstrap state.
+- A custom title is copied with a branch suffix.
+- The original session remains complete and in History.
+
+### State the durability limitation
+
+Update the pull request description and comments to say that the parent prefix remains browser-local
+under the child ID. Do not describe the fork as cross-device durable.
+
+Reason:
+
+- The child record log begins with the newly sent turn.
+- Another browser cannot reconstruct inherited parent turns.
+- The hydration count floor preserves a local copy but does not create a server copy.
+
+### Fix the client-tool replay defect separately
+
+In both transcript mapper copies, replace any existing tool input with a defined interaction input.
+Add the `{}` placeholder followed by authoritative payload regression test in both test suites.
+
+Reason:
+
+- ACP explicitly uses `{}` as a possible early placeholder.
+- The interaction request carries the real form payload.
+- This defect is independent of rewind and should not obscure the fork review.
+
+## Verification for pull request 5860
+
+Run the existing focused suites plus the new tests:
+
+- AgentChatSlice unit tests.
+- `@agenta/playground` request-builder unit tests.
+- `@agenta/entities` transcript-adoption tests.
+- TypeScript checks and frontend lint-fix required by repository guidance.
+
+Manual scenarios:
+
+1. Rewind a user turn, reload before sending, edit, and send.
+2. Rewind an assistant turn and let the automatic rerun start.
+3. Abort the first child run and retry.
+4. Disconnect the network during the first child run and retry.
+5. Open the original from History and confirm it is complete.
+6. Rewind a custom-named session and inspect both History rows.
+7. Confirm the side-effect warning still appears when required.
+
+## Durable branching project
+
+### Add the lineage domain
+
+Create core DTOs, DAO interfaces, Postgres entities, mappings, and services for `session_lineage`.
+Keep router, service, interface, implementation, and database layers in the repository's required
+dependency order.
+
+Acceptance conditions:
+
+- One immutable lineage row per child session.
+- Inherited-turn count validation against the parent's effective transcript.
+- A physical source-session and record cutoff resolved at fork creation.
+- Cycle and depth protection.
+- Batched root and parent queries.
+- No record copy.
+
+### Add the fork endpoint
+
+Create the child stream, lineage row, and attachment access rows through one composite DAO operation
+that owns one core database transaction. Copy source header fields unless the caller overrides them.
+Make target session ID reuse idempotent for an identical request.
+
+Acceptance conditions:
+
+- Repeated identical request returns the same child.
+- Conflicting target reuse returns a domain conflict.
+- A missing or foreign-project source is not exposed.
+- An inherited-turn count beyond the source effective transcript is rejected.
+
+### Add effective transcript resolution
+
+Resolve the ancestor chain and fetch every physical record segment in order. Preserve each record's
+source session ID. Keep the physical records endpoint's session-local semantics unchanged.
+
+First make physical record ordering total and indexable. Add `record_id` as the final tiebreaker,
+normalize nullable ordering fields as specified in `data-model.md`, and create the matching tracing
+database expression index. Use the identical ordering for physical and effective transcript reads.
+
+Acceptance conditions:
+
+- Root transcript equals the current records transcript.
+- Child transcript contains only the permitted parent prefix plus child records.
+- Grandchild traversal works.
+- Depth does not create one database query per ancestor.
+- Parent records after the cutoff never appear.
+- A two-turn fork from a large parent does not scan the discarded parent tail.
+- Equal or null ordering fields cannot move a record across the inclusive cutoff.
+
+### Switch runner reconstruction
+
+Change the runner from physical records query to effective transcript query. A child starts a new
+native harness session but receives inherited conversation context from the server.
+
+Acceptance conditions:
+
+- The frontend sends only the new user message.
+- The runner sees inherited context before the first child turn.
+- Native `agent_session_id` is new for the child.
+- Warm and cold child turns agree.
+
+### Switch frontend hydration
+
+Add a transcript query state family and change `loadSessionMessages` to use it. Keep one shared
+network flight and IndexedDB persistence. Include optional lineage in session-list reconciliation.
+
+Acceptance conditions:
+
+- Another browser opens the complete child transcript.
+- Clearing local storage does not remove inherited context.
+- Session list still uses one frontend request.
+- Opening a branch still uses one transcript request.
+
+### Add attachment access and define deletion policy
+
+Add `session_attachment_access` rows for attachments in the inherited prefix. Update attachment read
+and reference authorization to accept direct ownership or child access. Retain soft-deleted
+ancestor records while descendants depend on them. Do not claim sandbox filesystem inheritance.
+
+### Remove the frontend bootstrap compatibility path
+
+After every supported backend exposes effective transcripts, remove `replayHistory` and the
+persisted bootstrap. Keep a short rollout window if frontend and backend versions can differ.
+
+## Later branch navigation
+
+Keep each branch as a separate History row initially. Add grouped navigation only when user research
+shows that branch families need one sidebar entry.
+
+Possible UI additions:
+
+- `Branch of <title>` subtitle.
+- `View original` action.
+- Branch point label such as `Branched before Turn 3`.
+- A branch switcher inside one conversation surface.
+
+These additions consume lineage. They do not require record parent pointers or mutable history.

--- a/docs/design/session-rewind-branching/research.md
+++ b/docs/design/session-rewind-branching/research.md
@@ -1,0 +1,161 @@
+# Current implementation and failure analysis
+
+## Current storage layers
+
+Agenta stores session information at three levels.
+
+### Session stream
+
+`session_streams` has one row per session and project. It stores:
+
+- `session_id`
+- `name` and `description`
+- liveness flags
+- the current `turn_id`
+- tags and general metadata
+- lifecycle timestamps
+
+Relevant code:
+
+- `api/oss/src/dbs/postgres/sessions/streams/dbes.py`
+- `api/oss/src/core/sessions/streams/dtos.py`
+
+### Session turn
+
+`session_turns` has one row per execution. Its unique ordering key is
+`(project_id, session_id, turn_index)`. It also stores the harness kind, native agent session ID,
+sandbox ID, workflow references, and trace identifiers.
+
+Relevant code:
+
+- `api/oss/src/dbs/postgres/sessions/turns/dbes.py`
+- `api/oss/src/dbs/postgres/sessions/turns/dbas.py`
+- `api/oss/src/core/sessions/turns/dtos.py`
+
+### Session record
+
+`records` stores append-only events. A record has `session_id`, `turn_id`, `record_index`, event
+time, source, type, and opaque event attributes. `record_index` restarts for each turn, so reads
+order first by producer timestamp, then ingest time, then record index.
+
+Relevant code:
+
+- `api/oss/src/dbs/postgres/sessions/records/dbes.py`
+- `api/oss/src/dbs/postgres/sessions/records/dbas.py`
+- `api/oss/src/dbs/postgres/sessions/records/dao.py`
+
+Records are event fragments, not message rows. Assistant text, tool calls, tool results, and finish
+events may all be separate records inside one turn. This is why adding `parent_record_id` to every
+record would model the wrong abstraction for session branching.
+
+## How the browser loads a transcript
+
+`loadSessionMessages(sessionId)` performs one logical records fetch through the shared TanStack
+Query cache. The cache is persisted to IndexedDB and revalidated when stale. The returned records
+are folded into Vercel `UIMessage` objects by `transcriptToMessages`.
+
+The browser keeps a second transcript cache in local storage. On mount:
+
+- A local cache hit paints immediately and starts one background records revalidation.
+- A local cache miss performs one records query and shows a skeleton until it resolves.
+- A brand-new session skips the guaranteed-empty records query.
+
+Relevant code:
+
+- `web/oss/src/components/AgentChatSlice/assets/loadSession.ts`
+- `web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts`
+- `web/packages/agenta-entities/src/session/state/records.ts`
+
+## How the runner reconstructs context
+
+The runner fetches `/sessions/records/query` using only the current session ID. It folds those
+ordered records into neutral chat messages. This lets the browser send only the newest user message
+for an established session.
+
+Relevant code:
+
+- `services/runner/src/sessions/records-query.ts`
+- `services/runner/src/sessions/reconstruct.ts`
+- `services/runner/src/sessions/persist.ts`
+
+The current query cannot inherit records from another session because it accepts only `session_id`.
+
+## What pull request 5860 adds
+
+The pull request adds `rewindForkAtomFamily` in the OSS playground:
+
+1. Mint a new session ID through the existing `addSessionAtomFamily` writer.
+2. Copy the retained `UIMessage[]` prefix into the new session's local message cache.
+3. Mark the new session in the module-level `unloggedHistorySessionIds` set.
+4. Optionally save an editable draft or schedule an automatic assistant rerun.
+5. Close the original tab without deleting the original session.
+6. Send the complete local transcript on the fork's first request.
+7. Clear the replay marker in `onFinish`.
+
+The pull request does not modify the API, database, or runner record reconstruction.
+
+## What works
+
+- The original session remains complete in local and server History.
+- The new session gets a different native runner continuity identity.
+- Same-browser hydration under the old session ID can no longer resurrect the removed tail.
+- The first branch request can provide the retained context to an empty runner session.
+- User-side rewind restores the selected user text to the composer.
+- Assistant-side rewind automatically reruns the preceding user turn.
+- Existing side-effect warnings remain in place.
+
+## What does not work
+
+### Reload before first send loses replay intent
+
+`unloggedHistorySessionIds` is a module-level `Set`. The retained messages survive in local storage,
+but the instruction to replay them does not. After reload, last-message-only optimization sends the
+new prompt without the retained prefix.
+
+The same reload also loses the action that created the fork. User-side rewind stores the editable
+draft in `composerDraftBySession`, an in-memory `Map`. Assistant-side rewind stores its automatic
+rerun request in `pendingRewindRerunAtom`, an in-memory atom. A correct reload-safe fix must persist
+the complete bootstrap, not only the replay boolean.
+
+### Failed or aborted first request consumes replay intent
+
+The pull request clears the marker in `onFinish` without inspecting the AI SDK completion flags.
+The callback also runs for abort, disconnect, and error outcomes. A retry can therefore omit the
+retained prefix even though runner continuity was never established.
+
+### The retained prefix is not durable under the child session
+
+The runner persists the new inbound user turn and new agent events under the child session. It does
+not copy the retained parent records. The prefix remains only in this browser's local message cache.
+
+After local storage loss or on another device, opening the child shows only records written directly
+under the child. The agent response may refer to context the UI cannot display.
+
+### A custom title is not copied
+
+The new session is created as `{id, createdAt}`. Auto-title later derives a title from the first
+retained user message. A user-defined title is lost. The frontend session model also omits the
+backend's existing description field.
+
+### The hydration test protects the local cache rather than durability
+
+The new `shouldAdoptServerTranscript` test correctly prevents a shorter child record log from
+overwriting a longer local transcript. That preserves same-browser display. It does not make the
+prefix available to another browser or the runner's future server reconstruction.
+
+### The package copy still rewinds in place
+
+`web/packages/agenta-chat/src/hooks/useAgentConversation.ts` still truncates user-side rewind under
+the same session and regenerates assistant-side rewind under the same session. It is currently not
+the shipped OSS playground path, but it must be resolved before that package surface is used.
+
+## Why append-only records are not the problem
+
+Append-only storage is compatible with branching. The missing concept is a read-time relationship:
+
+```text
+child session B inherits the first two effective turns of parent session A
+```
+
+Each session can keep writing a linear event log. A lineage-aware reader concatenates the permitted
+prefixes. No existing record changes or deletion are required.

--- a/docs/design/session-rewind-branching/status.md
+++ b/docs/design/session-rewind-branching/status.md
@@ -1,0 +1,75 @@
+# Status and decisions
+
+## Current status
+
+Planning complete. No implementation changes were made in this workspace.
+
+Pull request under review:
+
+- `https://github.com/Agenta-AI/agenta/pull/5860`
+- Head commit reviewed: `c17d5541288cb5e3f8f5bac645ca48f38175a7a6`
+- Base branch: `release/v0.112.0`
+
+## Settled recommendations
+
+- Rewind creates a new runtime session. It does not truncate the existing session in place.
+- The original session remains complete in History.
+- Pull request 5860 stays frontend-only and does not introduce backend lineage.
+- The pull request must persist edit or rerun mode, restored draft, and replay state, then clear the
+  bootstrap only after success.
+- The pull request should preserve custom titles.
+- The pull request must describe its same-browser durability limitation.
+- Durable branching uses session lineage, not parent pointers on every record.
+- Records remain append-only.
+- A durable child stores how many complete turns it inherits from the parent's effective transcript.
+- The backend also stores an internal physical record cutoff so transcript reads do not scan
+  discarded parent tails.
+- Physical records use one null-safe total order ending in `record_id`, backed by a matching tracing
+  database index.
+- The effective transcript endpoint replaces the frontend's records hydration request rather than
+  adding another request.
+- The client-tool `{}` input replay defect is valid and should be fixed separately.
+
+## Open decisions for durable branching
+
+### Parent deletion
+
+Recommended default: retain soft-deleted ancestor records while descendants reference them. The
+team must define permanent purge behavior and retention accounting.
+
+### Attachment access
+
+Recommended default: add `session_attachment_access` rows that grant the child access to existing
+parent-owned attachments without copying bytes or changing attachment IDs.
+
+### Running-parent forks
+
+Recommended default: reject a fork when the selected turn is incomplete. Decide whether a completed
+prefix of a currently running parent may be forked safely.
+
+### Header naming
+
+Recommended default: copy a custom title with `(branch)` and copy description unchanged. Decide how
+the API distinguishes a custom title from an auto-generated title if auto-title should be
+recalculated.
+
+### Branch depth
+
+Choose a maximum after measuring realistic usage. The implementation must have a finite ceiling and
+cycle protection even if the UI rarely creates deep chains.
+
+### Session files
+
+Recommended first contract: transcript and attachment-access inheritance only. Do not inherit
+arbitrary sandbox files or processes until a snapshot capability exists.
+
+## Known implementation risks
+
+- Frontend and backend may deploy at different times. Removing `replayHistory` requires a capability
+  or rollout gate.
+- Session turns live in the core database while records may live in the tracing database. Effective
+  transcript resolution needs a bounded two-store read rather than a relational cross-database join.
+- Existing comments in older agent-workflows session documentation describe a cold-only system and
+  are stale relative to current warm and durable behavior. Treat current code as authoritative.
+- The package-level `@agenta/chat` rewind remains in-place and can reintroduce the original bug when
+  that surface becomes active.


### PR DESCRIPTION
## Context
PR #5860 fixes rewind resurrection by moving the user onto a new session, but the implementation still leaves open questions about reload safety, cross-device durability, metadata, and future branch storage. Reviewers lacked one place that separated the immediate frontend fix from the longer-term backend model.

## Changes
Adds a self-contained design workspace for session rewind and branching. It documents the user story, current frontend and runner behavior, known failure modes, and the requested changes before PR #5860 merges.

The durable proposal keeps records append-only. A child session stores lineage to its parent, an effective-turn count, and an indexed physical cutoff. A lineage-aware transcript read reconstructs inherited context without copying parent records or adding frontend request fan-out. Separate documents cover API contracts, frontend state, attachment access, migrations, query counts, storage growth, and rollout phases.

## Tests / notes
- Documentation-only change.
- `git diff --check -- docs/design/session-rewind-branching` passes.
- The workspace was independently reviewed for reload state, cutoff ordering, attachment ownership, transaction boundaries, migrations, and bounded query performance.
- Start with `docs/design/session-rewind-branching/README.md` for the reading order.