### PR TITLE
feat(sessions): record card answers first and give replay one rule

### DIFF
--- a/.agents/skills/agent-release-gate/resources/coverage.md
+++ b/.agents/skills/agent-release-gate/resources/coverage.md
@@ -162,6 +162,21 @@ unset it for a genuine cold 2.
 | Subscription sidecar — ChatGPT/Codex login mounted read-write with `CODEX_HOME` naming it | S2 |
 | Operator hook that SIGKILLs the runner (`--cold2-replace-cmd`) | `cold2` in every cell |
 
+## Standalone interaction-card lifecycle cells
+
+These cells run beside the harness matrix because they pin durable interaction-row composition,
+not a harness, sandbox, or provider model axis.
+
+| Cell | Tier | What it pins | Extra requirement |
+|---|---|---|---|
+| `matrix_i1_settlement.py` | coached, mechanism-level | The 3 card kinds x complete/decline/walk-away table against the live API. Answered form/connect rows must be `responded` with their exact resolution; approvals must be `resolved` with a strict verdict; abandoned rows must be swept from `pending` to `cancelled` without an invented answer; non-approval `resolved` attempts must return 409. The script sends the atomic transition itself because that write belongs to the browser. | none beyond the three gate environment variables |
+| `matrix_i2_card_journeys.py` | coached, mechanism-level | The six scripted journeys from `docs/design/client-tool-interaction-lifecycle/qa.md`: compound form/reload/connect-decline/schedule, form then connect, two connects, close/reopen, real Telegram create/remove/re-create, and decline/retry. Reload and reopen are fresh row/record reads, not browser automation; each journey names its wire-level limit. The Telegram journey validates a real bot against Telegram's own API and drives Agenta's connection lifecycle, but STOPS before entering the credential on the provider's hosted page — that step is browser-only, so the connection never reaches `is_valid` and the journey reports the gap in `not_covered`. Run qa.md journey 5 by hand in exploratory QA. | a funded model connection for the two same-session/record probes; `TELEGRAM_BOT_TOKEN` for the real Telegram journey |
+
+I2 reports an unset `TELEGRAM_BOT_TOKEN` as a loud journey `SKIP` and makes the aggregate cell
+`SKIP`. Five passing wire-level journeys must never make the untested real-provider claim look
+green. The token is read from the process environment only and is never printed or stored in the
+result.
+
 ## Optional probes (`qa_longctx.py`)
 
 Separate from the gate, these need live **Gmail and GitHub Composio connections** in the target

--- a/.agents/skills/agent-release-gate/resources/matrix_i1_settlement.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_i1_settlement.py
@@ -24,7 +24,8 @@ resolution together. A purely in-band tool-output resume would correctly leave t
 until the sweep cancelled it; that would test abandonment, not answer recording.
 
 The cell also proves `resolved` remains approval-only by requiring HTTP 409 for both non-approval
-kinds. It deliberately does not assert rendering, replay, popup behaviour, or model discovery.
+kinds, in both transition shapes: with a resolution payload and with none at all. It deliberately
+does not assert rendering, replay, popup behaviour, or model discovery.
 
   uv run matrix_i1_settlement.py
 """
@@ -75,17 +76,21 @@ def fetch_row(interaction_id: str) -> dict:
 
 
 def answer(
-    *, session_id: str, token: str, status: str, resolution: dict
+    *, session_id: str, token: str, status: str, resolution: dict | None = None
 ) -> tuple[int, dict | None, str]:
+    payload = {
+        "session_id": session_id,
+        "token": token,
+        "status": status,
+    }
+    # A bare transition omits the key entirely: the approval-only guard must hold without
+    # an answer riding along, not only when one does.
+    if resolution is not None:
+        payload["resolution"] = resolution
     response = api_call(
         "POST",
         "/sessions/interactions/transition",
-        json={
-            "session_id": session_id,
-            "token": token,
-            "status": status,
-            "resolution": resolution,
-        },
+        json=payload,
     )
     interaction = None
     if response.status_code == 200:
@@ -222,15 +227,35 @@ def resolved_refusal(kind: str) -> dict:
         status="resolved",
         resolution=resolution,
     )
+
+    bare_session_id = str(uuid.uuid4())
+    bare_token = f"i1-resolved-refusal-bare-{kind}-{uuid.uuid4().hex[:8]}"
+    create_row(
+        session_id=bare_session_id,
+        turn_id="turn-1",
+        token=bare_token,
+        kind=kind,
+    )
+    bare_status, _, bare_detail = answer(
+        session_id=bare_session_id,
+        token=bare_token,
+        status="resolved",
+    )
+
+    ok = http_status == 409 and bare_status == 409
     return {
         "kind": kind,
-        "status": "PASS" if http_status == 409 else "FAIL",
+        "status": "PASS" if ok else "FAIL",
         "why": (
-            "the API refused non-approval `resolved` with HTTP 409"
-            if http_status == 409
-            else f"expected HTTP 409, got {http_status}: {detail}"
+            "the API refused non-approval `resolved` with HTTP 409, with and without a resolution"
+            if ok
+            else (
+                f"expected HTTP 409 on both probes, got with_resolution={http_status} "
+                f"({detail}), without_resolution={bare_status} ({bare_detail})"
+            )
         ),
         "http_status": http_status,
+        "bare_http_status": bare_status,
     }
 
 

--- a/.agents/skills/agent-release-gate/resources/matrix_i1_settlement.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_i1_settlement.py
@@ -1,0 +1,270 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached, mechanism-level. No model behaviour is asserted.
+
+I1: the interaction-card settlement table against a live API.
+
+This cell creates rows directly through `POST /sessions/interactions/` because it pins the ROW
+lifecycle contract, not whether a model chooses to raise a particular card. Driving nine real
+agent turns would add cost and model variance without exercising a different persistence path.
+
+For every card kind it covers complete, decline, and walk away:
+
+  - `user_approval` complete/decline -> `resolved` with a strict verdict.
+  - `user_input` complete/decline -> `responded` with the browser's open resolution envelope.
+  - `client_tool` complete/decline -> `responded` with the browser's open resolution envelope.
+  - every walk-away row stays `pending` until a later-turn `cancel-stale` call moves it to
+    `cancelled`, without inventing a resolution.
+
+WIRE-LEVEL CAVEAT. This script has no browser. Recording a form or client-tool answer is the
+CLIENT's job, so the cell itself sends the browser's ONE atomic `/transition` call with status and
+resolution together. A purely in-band tool-output resume would correctly leave the row pending
+until the sweep cancelled it; that would test abandonment, not answer recording.
+
+The cell also proves `resolved` remains approval-only by requiring HTTP 409 for both non-approval
+kinds. It deliberately does not assert rendering, replay, popup behaviour, or model discovery.
+
+  uv run matrix_i1_settlement.py
+"""
+
+import json
+import pathlib
+import sys
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import api_call  # noqa: E402
+
+
+def create_row(*, session_id: str, turn_id: str, token: str, kind: str) -> dict:
+    tool_name = "request_input" if kind == "user_input" else "request_connection"
+    if kind == "user_approval":
+        tool_name = "create_schedule"
+    response = api_call(
+        "POST",
+        "/sessions/interactions/",
+        json={
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "token": token,
+            "kind": kind,
+            "data": {
+                "request": {
+                    "tool": tool_name,
+                    "tool_call_id": f"call-{token}",
+                }
+            },
+        },
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"create {kind} row HTTP {response.status_code}: {response.text[:300]}"
+        )
+    return response.json()["interaction"]
+
+
+def fetch_row(interaction_id: str) -> dict:
+    response = api_call("GET", f"/sessions/interactions/{interaction_id}")
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"fetch interaction HTTP {response.status_code}: {response.text[:300]}"
+        )
+    return response.json()["interaction"]
+
+
+def answer(
+    *, session_id: str, token: str, status: str, resolution: dict
+) -> tuple[int, dict | None, str]:
+    response = api_call(
+        "POST",
+        "/sessions/interactions/transition",
+        json={
+            "session_id": session_id,
+            "token": token,
+            "status": status,
+            "resolution": resolution,
+        },
+    )
+    interaction = None
+    if response.status_code == 200:
+        interaction = response.json().get("interaction")
+    return response.status_code, interaction, response.text[:300]
+
+
+def resolution_for(kind: str, outcome: str, token: str) -> tuple[str, dict]:
+    tool_call_id = f"call-{token}"
+    if kind == "user_approval":
+        return "resolved", {
+            "verdict": "approved" if outcome == "complete" else "denied",
+            "tool_call_id": tool_call_id,
+        }
+    if kind == "user_input":
+        output = (
+            {"action": "accept", "content": {"timezone": "UTC"}}
+            if outcome == "complete"
+            else {"action": "decline"}
+        )
+        return "responded", {
+            "tool_call_id": tool_call_id,
+            "tool_name": "request_input",
+            "outcome": "completed",
+            "output": output,
+        }
+    output = (
+        {"connected": True, "integration": "telegram", "slug": "telegram"}
+        if outcome == "complete"
+        else {
+            "connected": False,
+            "integration": "telegram",
+            "slug": "telegram",
+            "reason": "declined",
+        }
+    )
+    return "responded", {
+        "tool_call_id": tool_call_id,
+        "tool_name": "request_connection",
+        "outcome": "completed",
+        "output": output,
+    }
+
+
+def run_case(kind: str, outcome: str) -> dict:
+    session_id = str(uuid.uuid4())
+    token = f"i1-{kind}-{outcome}-{uuid.uuid4().hex[:8]}"
+    row = create_row(
+        session_id=session_id,
+        turn_id="turn-1",
+        token=token,
+        kind=kind,
+    )
+
+    if outcome == "walk_away":
+        sweep = api_call(
+            "POST",
+            "/sessions/interactions/cancel-stale",
+            json={"session_id": session_id, "turn_id": "turn-2"},
+        )
+        final = fetch_row(row["id"])
+        resolution = (final.get("data") or {}).get("resolution")
+        ok = (
+            sweep.status_code == 200
+            and sweep.json().get("cancelled") == 1
+            and final.get("status") == "cancelled"
+            and resolution is None
+        )
+        return {
+            "kind": kind,
+            "outcome": outcome,
+            "status": "PASS" if ok else "FAIL",
+            "why": (
+                "the later-turn sweep cancelled the still-pending row without inventing an answer"
+                if ok
+                else (
+                    f"sweep_http={sweep.status_code}, cancelled="
+                    f"{sweep.json().get('cancelled') if sweep.status_code == 200 else None}, "
+                    f"final_status={final.get('status')!r}, resolution={resolution!r}"
+                )
+            ),
+            "interaction_id": row["id"],
+            "final_status": final.get("status"),
+            "saved_resolution": resolution,
+        }
+
+    expected_status, resolution = resolution_for(kind, outcome, token)
+    http_status, transitioned, detail = answer(
+        session_id=session_id,
+        token=token,
+        status=expected_status,
+        resolution=resolution,
+    )
+    final = fetch_row(row["id"])
+    saved = (final.get("data") or {}).get("resolution")
+    ok = (
+        http_status == 200
+        and transitioned is not None
+        and final.get("status") == expected_status
+        and saved == resolution
+    )
+    return {
+        "kind": kind,
+        "outcome": outcome,
+        "status": "PASS" if ok else "FAIL",
+        "why": (
+            f"the answer settled as {expected_status} with its exact resolution"
+            if ok
+            else (
+                f"transition_http={http_status}, expected_status={expected_status!r}, "
+                f"final_status={final.get('status')!r}, expected_resolution={resolution!r}, "
+                f"saved_resolution={saved!r}, detail={detail!r}"
+            )
+        ),
+        "interaction_id": row["id"],
+        "final_status": final.get("status"),
+        "saved_resolution": saved,
+    }
+
+
+def resolved_refusal(kind: str) -> dict:
+    session_id = str(uuid.uuid4())
+    token = f"i1-resolved-refusal-{kind}-{uuid.uuid4().hex[:8]}"
+    create_row(
+        session_id=session_id,
+        turn_id="turn-1",
+        token=token,
+        kind=kind,
+    )
+    _, resolution = resolution_for(kind, "complete", token)
+    http_status, _, detail = answer(
+        session_id=session_id,
+        token=token,
+        status="resolved",
+        resolution=resolution,
+    )
+    return {
+        "kind": kind,
+        "status": "PASS" if http_status == 409 else "FAIL",
+        "why": (
+            "the API refused non-approval `resolved` with HTTP 409"
+            if http_status == 409
+            else f"expected HTTP 409, got {http_status}: {detail}"
+        ),
+        "http_status": http_status,
+    }
+
+
+def i1() -> dict:
+    cases = [
+        run_case(kind, outcome)
+        for kind in ("user_approval", "user_input", "client_tool")
+        for outcome in ("complete", "decline", "walk_away")
+    ]
+    refusals = [resolved_refusal(kind) for kind in ("user_input", "client_tool")]
+    failures = [r for r in cases + refusals if r["status"] != "PASS"]
+    return {
+        "status": "PASS" if not failures else "FAIL",
+        "why": (
+            "all nine settlement cases and both approval-only guards matched the contract"
+            if not failures
+            else " | ".join(
+                f"{r.get('kind')}/{r.get('outcome', 'resolved')}: {r['why']}"
+                for r in failures
+            )
+        ),
+        "cases": cases,
+        "non_approval_resolved_refusals": refusals,
+    }
+
+
+if __name__ == "__main__":
+    try:
+        result = i1()
+    except Exception as error:  # noqa: BLE001
+        result = {
+            "status": "FAIL",
+            "why": f"unhandled exception: {type(error).__name__}: {error}",
+        }
+    print("\n=== I1 RESULT ===")
+    print(json.dumps(result, indent=2, default=str))
+    sys.exit(0 if result["status"] == "PASS" else 1)

--- a/.agents/skills/agent-release-gate/resources/matrix_i2_card_journeys.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_i2_card_journeys.py
@@ -1,0 +1,842 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""TIER: coached, mechanism-level. No model discovery claim may cite this cell.
+
+I2: six scripted interaction-card journeys against a live deployment.
+
+This is a wire-level release cell, not a browser test. It cannot click, reload a tab, preserve
+component memory, inspect card geometry, or observe the "running somewhere else" strip. Each
+journey's own docstring names the browser action it represents and the browser-only claim it
+cannot cover. A reload or reopen is represented by fresh reads of stored interaction rows and
+session records. A browser answer is represented by the same ONE atomic `/transition` call the
+browser sends before it resumes.
+
+Rows that would be expensive or flaky to raise through model behaviour are created directly via
+`POST /sessions/interactions/`. This cell pins lifecycle composition across several cards; the
+separate L cells pin model/runner gate production and in-band resume mechanics.
+
+The Telegram journey goes furthest: when `TELEGRAM_BOT_TOKEN` is set it validates the real bot
+against Telegram's own API and drives Agenta's real `/tools/connections/` create, remove and
+re-create. It stops at the one step a wire client must not take — entering the credential on the
+provider's hosted page. Agenta never accepts a provider key in its own payload, so the only
+headless route would be scraping that third-party page and posting a live secret into a guessed
+field. The journey reports that gap in `not_covered` rather than faking it; the "connected for
+real" half of qa.md journey 5 stays a human exploratory-QA step. The token is read only from the
+process environment, never printed, never returned as evidence, and never read from a file. When
+it is unset the journey returns `SKIP`, prints a loud warning, and makes the whole cell `SKIP`
+rather than letting five passing stand-ins look like full coverage.
+
+  uv run matrix_i2_card_journeys.py
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+import uuid
+
+import httpx
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from qa_matrix_lib import (  # noqa: E402
+    agent_config,
+    api_call,
+    archive,
+    create_workflow,
+    interactions,
+    invoke,
+    refs,
+    seed_and_baseline,
+    user_msg,
+)
+
+
+class JourneyError(RuntimeError):
+    pass
+
+
+def apply_model_override(config: dict) -> dict:
+    """Let a deployment without Anthropic subscription auth still run this cell.
+
+    `agent_config` hardcodes the claude harness on subscription auth, which fails outright on a
+    stack with no sidecar and no Anthropic vault key. Setting QA_HARNESS_KIND / QA_MODEL /
+    QA_PROVIDER / QA_CONNECTION_MODE swaps in any other harness (e.g. codex + gpt-5.6-luna on a
+    vault-managed OpenAI key). Unset, the config is returned untouched.
+    """
+    harness = os.environ.get("QA_HARNESS_KIND")
+    model = os.environ.get("QA_MODEL")
+    provider = os.environ.get("QA_PROVIDER")
+    mode = os.environ.get("QA_CONNECTION_MODE")
+    if harness:
+        config["harness"] = {"kind": harness}
+    if model:
+        config["llm"]["model"] = model
+    if provider:
+        config["llm"]["provider"] = provider
+    if mode:
+        config["llm"]["connection"] = {"mode": mode, "slug": None}
+    return config
+
+
+def create_interaction(
+    *, session_id: str, turn_id: str, token: str, kind: str, tool_name: str
+) -> dict:
+    response = api_call(
+        "POST",
+        "/sessions/interactions/",
+        json={
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "token": token,
+            "kind": kind,
+            "data": {
+                "request": {
+                    "tool": tool_name,
+                    "tool_call_id": f"call-{token}",
+                }
+            },
+        },
+    )
+    if response.status_code != 200:
+        raise JourneyError(
+            f"create {kind} interaction HTTP {response.status_code}: {response.text[:240]}"
+        )
+    return response.json()["interaction"]
+
+
+def transition(*, session_id: str, token: str, status: str, resolution: dict) -> dict:
+    response = api_call(
+        "POST",
+        "/sessions/interactions/transition",
+        json={
+            "session_id": session_id,
+            "token": token,
+            "status": status,
+            "resolution": resolution,
+        },
+    )
+    if response.status_code != 200:
+        raise JourneyError(
+            f"transition interaction HTTP {response.status_code}: {response.text[:240]}"
+        )
+    return response.json()["interaction"]
+
+
+def form_resolution(token: str, *, declined: bool = False) -> dict:
+    return {
+        "tool_call_id": f"call-{token}",
+        "tool_name": "request_input",
+        "outcome": "completed",
+        "output": (
+            {"action": "decline"}
+            if declined
+            else {"action": "accept", "content": {"timezone": "UTC"}}
+        ),
+    }
+
+
+def connect_resolution(
+    token: str, *, connected: bool, reason: str | None = None, slug: str = "telegram"
+) -> dict:
+    output = {"connected": connected, "integration": "telegram", "slug": slug}
+    if reason is not None:
+        output["reason"] = reason
+    return {
+        "tool_call_id": f"call-{token}",
+        "tool_name": "request_connection",
+        "outcome": "completed",
+        "output": output,
+    }
+
+
+def approval_resolution(token: str, *, approved: bool) -> dict:
+    return {
+        "verdict": "approved" if approved else "denied",
+        "tool_call_id": f"call-{token}",
+    }
+
+
+def row_by_token(rows: list[dict], token: str) -> dict | None:
+    return next((row for row in rows if row.get("token") == token), None)
+
+
+def saved_resolution(row: dict | None) -> dict | None:
+    return ((row or {}).get("data") or {}).get("resolution")
+
+
+def query_records(session_id: str) -> list[dict]:
+    response = api_call(
+        "POST",
+        "/sessions/records/query",
+        json={"session_id": session_id},
+    )
+    if response.status_code != 200:
+        raise JourneyError(
+            f"query session records HTTP {response.status_code}: {response.text[:240]}"
+        )
+    return response.json().get("records") or []
+
+
+def await_records(session_id: str, seconds: float = 20.0) -> list[dict]:
+    deadline = time.time() + seconds
+    records = query_records(session_id)
+    while not records and time.time() < deadline:
+        time.sleep(1.0)
+        records = query_records(session_id)
+    return records
+
+
+def journey_compound(parameters: dict, references: dict) -> dict:
+    """Stand-in for form -> browser reload -> connect decline -> resume -> schedule approval ->
+    reload. Fresh row/record queries represent reloads, and a same-session live turn proves the
+    session remains usable after decline. It cannot assert widget rendering, automatic browser
+    resume composition, card multiplicity on screen, or the ownership warning strip."""
+    session_id = str(uuid.uuid4())
+    form_token = f"i2-compound-form-{uuid.uuid4().hex[:8]}"
+    connect_token = f"i2-compound-connect-{uuid.uuid4().hex[:8]}"
+    approval_token = f"i2-compound-approval-{uuid.uuid4().hex[:8]}"
+
+    messages = [user_msg("Reply with exactly: AGENT_READY")]
+    first_turn = invoke(session_id, messages, parameters, references, log=False)
+    if first_turn.errors:
+        return {
+            "status": "FAIL",
+            "why": f"agent creation turn errored: {first_turn.errors[:1]}",
+            "session_id": session_id,
+        }
+
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-form",
+        token=form_token,
+        kind="user_input",
+        tool_name="request_input",
+    )
+    form_answer = form_resolution(form_token)
+    transition(
+        session_id=session_id,
+        token=form_token,
+        status="responded",
+        resolution=form_answer,
+    )
+    first_reload_rows = interactions(session_id)
+    first_reload_records = await_records(session_id)
+
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-connect",
+        token=connect_token,
+        kind="client_tool",
+        tool_name="request_connection",
+    )
+    connect_decline = connect_resolution(
+        connect_token, connected=False, reason="declined"
+    )
+    transition(
+        session_id=session_id,
+        token=connect_token,
+        status="responded",
+        resolution=connect_decline,
+    )
+
+    resumed_messages = messages + [
+        first_turn.assistant_message(),
+        user_msg("Reply with exactly: RESUMED"),
+    ]
+    resumed_turn = invoke(
+        session_id,
+        resumed_messages,
+        parameters,
+        references,
+        log=False,
+    )
+
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-schedule",
+        token=approval_token,
+        kind="user_approval",
+        tool_name="create_schedule",
+    )
+    schedule_approval = approval_resolution(approval_token, approved=True)
+    transition(
+        session_id=session_id,
+        token=approval_token,
+        status="resolved",
+        resolution=schedule_approval,
+    )
+    final_rows = interactions(session_id)
+    final_records = await_records(session_id)
+
+    first_form = row_by_token(first_reload_rows, form_token)
+    form = row_by_token(final_rows, form_token)
+    connect = row_by_token(final_rows, connect_token)
+    approval = row_by_token(final_rows, approval_token)
+    checks = {
+        "first_reload_form_responded": (
+            (first_form or {}).get("status") == "responded"
+            and saved_resolution(first_form) == form_answer
+        ),
+        "form_remained_responded": (
+            (form or {}).get("status") == "responded"
+            and saved_resolution(form) == form_answer
+        ),
+        "connect_decline_saved": (
+            (connect or {}).get("status") == "responded"
+            and saved_resolution(connect) == connect_decline
+        ),
+        "schedule_approval_saved": (
+            (approval or {}).get("status") == "resolved"
+            and saved_resolution(approval) == schedule_approval
+        ),
+        "run_resumed": not resumed_turn.errors
+        and "RESUMED" in resumed_turn.reply.upper(),
+        "records_survived_both_reads": bool(first_reload_records and final_records),
+    }
+    ok = all(checks.values())
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "why": (
+            "form, connect decline, and schedule approval survived both durable rereads and the "
+            "same session completed a later turn"
+            if ok
+            else f"compound journey checks failed: {checks}"
+        ),
+        "session_id": session_id,
+        "checks": checks,
+        "final_states": {
+            form_token: (form or {}).get("status"),
+            connect_token: (connect or {}).get("status"),
+            approval_token: (approval or {}).get("status"),
+        },
+        "record_counts": [len(first_reload_records), len(final_records)],
+        "resume_errors": resumed_turn.errors,
+    }
+
+
+def journey_form_then_connect() -> dict:
+    """Stand-in for two back-to-back rendered cards. Direct row creation represents each card,
+    and a fresh query represents the browser rebuilding its state. It cannot assert that the form
+    fields or connect widget render correctly or that the queue blocks the composer."""
+    session_id = str(uuid.uuid4())
+    form_token = f"i2-back-form-{uuid.uuid4().hex[:8]}"
+    connect_token = f"i2-back-connect-{uuid.uuid4().hex[:8]}"
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-form",
+        token=form_token,
+        kind="user_input",
+        tool_name="request_input",
+    )
+    form_answer = form_resolution(form_token)
+    transition(
+        session_id=session_id,
+        token=form_token,
+        status="responded",
+        resolution=form_answer,
+    )
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-connect",
+        token=connect_token,
+        kind="client_tool",
+        tool_name="request_connection",
+    )
+    rows = interactions(session_id)
+    form = row_by_token(rows, form_token)
+    connect = row_by_token(rows, connect_token)
+    pending = [row.get("token") for row in rows if row.get("status") == "pending"]
+    ok = (
+        (form or {}).get("status") == "responded"
+        and saved_resolution(form) == form_answer
+        and (connect or {}).get("status") == "pending"
+        and pending == [connect_token]
+    )
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "why": (
+            "the answered form stayed answered and only the following connect row remained live"
+            if ok
+            else (
+                f"form_status={(form or {}).get('status')!r}, "
+                f"form_resolution={saved_resolution(form)!r}, "
+                f"connect_status={(connect or {}).get('status')!r}, pending={pending}"
+            )
+        ),
+        "session_id": session_id,
+        "pending_tokens": pending,
+    }
+
+
+def journey_two_connects() -> dict:
+    """Stand-in for two connect widgets in one conversation. Independent row tokens represent
+    the two visible cards; reads after each transition represent UI reconciliation. It cannot
+    assert popup isolation, component-local double-settle guards, or visual card identity."""
+    session_id = str(uuid.uuid4())
+    first_token = f"i2-connect-a-{uuid.uuid4().hex[:8]}"
+    second_token = f"i2-connect-b-{uuid.uuid4().hex[:8]}"
+    for turn_id, token in (("turn-a", first_token), ("turn-b", second_token)):
+        create_interaction(
+            session_id=session_id,
+            turn_id=turn_id,
+            token=token,
+            kind="client_tool",
+            tool_name="request_connection",
+        )
+    first_answer = connect_resolution(first_token, connected=True, slug="telegram-a")
+    second_answer = connect_resolution(second_token, connected=True, slug="telegram-b")
+    transition(
+        session_id=session_id,
+        token=first_token,
+        status="responded",
+        resolution=first_answer,
+    )
+    after_first = interactions(session_id)
+    transition(
+        session_id=session_id,
+        token=second_token,
+        status="responded",
+        resolution=second_answer,
+    )
+    after_both = interactions(session_id)
+
+    first_mid = row_by_token(after_first, first_token)
+    second_mid = row_by_token(after_first, second_token)
+    first_final = row_by_token(after_both, first_token)
+    second_final = row_by_token(after_both, second_token)
+    checks = {
+        "first_settled_alone": (
+            (first_mid or {}).get("status") == "responded"
+            and saved_resolution(first_mid) == first_answer
+        ),
+        "second_untouched_until_answered": (second_mid or {}).get("status")
+        == "pending",
+        "first_never_reverted": (
+            (first_final or {}).get("status") == "responded"
+            and saved_resolution(first_final) == first_answer
+        ),
+        "second_settled_independently": (
+            (second_final or {}).get("status") == "responded"
+            and saved_resolution(second_final) == second_answer
+        ),
+    }
+    ok = all(checks.values())
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "why": (
+            "each connect row settled independently and neither answer touched or reverted the other"
+            if ok
+            else f"two-connect checks failed: {checks}"
+        ),
+        "session_id": session_id,
+        "checks": checks,
+    }
+
+
+def journey_close_and_reopen(parameters: dict, references: dict) -> dict:
+    """Stand-in for closing and reopening the browser tab. Two fresh row and record queries
+    represent new-tab hydration after one answered card and one parked card. It cannot prove the
+    parked widget is clickable, drafts survive local storage, or a real tab discarded memory."""
+    session_id = str(uuid.uuid4())
+    answered_token = f"i2-reopen-answered-{uuid.uuid4().hex[:8]}"
+    parked_token = f"i2-reopen-parked-{uuid.uuid4().hex[:8]}"
+
+    turn = invoke(
+        session_id,
+        [user_msg("Reply with exactly: DURABLE")],
+        parameters,
+        references,
+        log=False,
+    )
+    if turn.errors:
+        return {
+            "status": "FAIL",
+            "why": f"record-producing turn errored: {turn.errors[:1]}",
+            "session_id": session_id,
+        }
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-answered",
+        token=answered_token,
+        kind="client_tool",
+        tool_name="request_connection",
+    )
+    answered_resolution = connect_resolution(answered_token, connected=True)
+    transition(
+        session_id=session_id,
+        token=answered_token,
+        status="responded",
+        resolution=answered_resolution,
+    )
+    rows_after_answer = interactions(session_id)
+    records_after_answer = await_records(session_id)
+
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-parked",
+        token=parked_token,
+        kind="client_tool",
+        tool_name="request_connection",
+    )
+    rows_after_reopen = interactions(session_id)
+    records_after_reopen = query_records(session_id)
+    answered = row_by_token(rows_after_reopen, answered_token)
+    parked = row_by_token(rows_after_reopen, parked_token)
+    checks = {
+        "answered_before_close": (
+            (row_by_token(rows_after_answer, answered_token) or {}).get("status")
+            == "responded"
+        ),
+        "answered_after_reopen": (
+            (answered or {}).get("status") == "responded"
+            and saved_resolution(answered) == answered_resolution
+        ),
+        "parked_after_reopen": (
+            (parked or {}).get("status") == "pending"
+            and saved_resolution(parked) is None
+        ),
+        "records_reread": bool(records_after_answer and records_after_reopen),
+    }
+    ok = all(checks.values())
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "why": (
+            "fresh reads kept the answered card dead and the parked card live"
+            if ok
+            else f"close/reopen checks failed: {checks}"
+        ),
+        "session_id": session_id,
+        "checks": checks,
+        "record_counts": [len(records_after_answer), len(records_after_reopen)],
+    }
+
+
+def validate_telegram_bot(token: str) -> dict:
+    try:
+        response = httpx.get(
+            f"https://api.telegram.org/bot{token}/getMe",
+            timeout=20.0,
+        )
+    except Exception as error:  # noqa: BLE001
+        raise JourneyError(
+            f"Telegram Bot API request failed ({type(error).__name__}); token was not printed"
+        ) from None
+    payload = response.json() if response.status_code == 200 else {}
+    if response.status_code != 200 or not payload.get("ok"):
+        raise JourneyError(
+            f"Telegram rejected TELEGRAM_BOT_TOKEN with HTTP {response.status_code}"
+        )
+    bot = payload.get("result") or {}
+    return {"id": bot.get("id"), "username": bot.get("username")}
+
+
+def create_real_telegram_connection(slug: str) -> dict:
+    """Drive the product's real connection-create call and return the pending connection.
+
+    The credential itself is deliberately NOT sent from here. Agenta never accepts a provider
+    API key in this payload — the service comment is explicit that the key is entered on the
+    provider's hosted redirect UI — so a wire client could only deliver it by scraping that
+    third-party page and guessing which field to post a live secret into. This cell refuses to
+    do that; see the journey's `not_covered` field."""
+    response = api_call(
+        "POST",
+        "/tools/connections/",
+        json={
+            "connection": {
+                "slug": slug,
+                "name": slug,
+                "provider_key": "composio",
+                "integration_key": "telegram",
+                "data": {"auth_scheme": "api_key"},
+            }
+        },
+    )
+    if response.status_code != 200:
+        raise JourneyError(
+            f"create Telegram connection HTTP {response.status_code}; response omitted to avoid "
+            "leaking provider context"
+        )
+    connection = response.json()["connection"]
+    if not (connection.get("data") or {}).get("redirect_url"):
+        delete_connection(connection["id"])
+        raise JourneyError(
+            "the Telegram connection came back with no hosted credential URL, so the browser "
+            "step a user would take does not exist"
+        )
+    return connection
+
+
+def delete_connection(connection_id: str) -> int:
+    response = api_call("DELETE", f"/tools/connections/{connection_id}")
+    return response.status_code
+
+
+def journey_real_telegram() -> dict:
+    """Wire-level stand-in for: click Connect, enter a real Telegram bot token, remove the
+    connection, ask again.
+
+    What it really covers: the bot token is validated against Telegram's own API (proving the
+    credential is real and live), Agenta's real `/tools/connections/` create returns a pending
+    connection with a hosted credential URL, the connection is removed, a second one is created,
+    and both client-tool rows settle through the same atomic `/transition` the browser sends.
+
+    What it CANNOT cover, by design: entering the credential on the provider's hosted page. That
+    is a browser step — Agenta never accepts the key in its own payload — and the only headless
+    route would be scraping a third-party form and posting a live secret into a guessed field.
+    So the connection never reaches `is_valid`, and the "connected for real" half of qa.md
+    journey 5 stays a human exploratory-QA step. The journey reports that gap in `not_covered`
+    instead of pretending to cover it.
+
+    The token is read only from the process environment, never printed, never returned as
+    evidence, and never read from a file."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    if not token:
+        warning = (
+            "WARNING: I2 TELEGRAM JOURNEY SKIPPED. TELEGRAM_BOT_TOKEN is unset, so real "
+            "connect / remove / reconnect DID NOT RUN. This is untested coverage, not a pass."
+        )
+        print(f"\n{'!' * 88}\n{warning}\n{'!' * 88}\n", file=sys.stderr)
+        return {"status": "SKIP", "why": warning}
+
+    session_id = str(uuid.uuid4())
+    created_ids: list[str] = []
+    try:
+        bot = validate_telegram_bot(token)
+        first_token = f"i2-telegram-first-{uuid.uuid4().hex[:8]}"
+        create_interaction(
+            session_id=session_id,
+            turn_id="turn-telegram-first",
+            token=first_token,
+            kind="client_tool",
+            tool_name="request_connection",
+        )
+        first = create_real_telegram_connection(f"qa-telegram-{uuid.uuid4().hex[:8]}")
+        created_ids.append(first["id"])
+        # The browser would settle the card with the connection it just completed; here the
+        # recorded outcome names the connection that WAS created, credential entry aside.
+        first_answer = connect_resolution(
+            first_token,
+            connected=True,
+            slug=first["slug"],
+        )
+        transition(
+            session_id=session_id,
+            token=first_token,
+            status="responded",
+            resolution=first_answer,
+        )
+        first_delete = delete_connection(first["id"])
+        if first_delete == 204:
+            created_ids.remove(first["id"])
+
+        second_token = f"i2-telegram-second-{uuid.uuid4().hex[:8]}"
+        create_interaction(
+            session_id=session_id,
+            turn_id="turn-telegram-second",
+            token=second_token,
+            kind="client_tool",
+            tool_name="request_connection",
+        )
+        second = create_real_telegram_connection(f"qa-telegram-{uuid.uuid4().hex[:8]}")
+        created_ids.append(second["id"])
+        second_answer = connect_resolution(
+            second_token,
+            connected=True,
+            slug=second["slug"],
+        )
+        transition(
+            session_id=session_id,
+            token=second_token,
+            status="responded",
+            resolution=second_answer,
+        )
+        rows = interactions(session_id)
+        first_row = row_by_token(rows, first_token)
+        second_row = row_by_token(rows, second_token)
+        checks = {
+            "real_bot_validated": bool(bot.get("id")),
+            "first_connection_created": bool(first.get("id")),
+            "first_removed": first_delete == 204,
+            "second_connection_created": bool(second.get("id")),
+            "reconnect_is_a_fresh_connection": first.get("id") != second.get("id"),
+            "first_row_settled": (
+                (first_row or {}).get("status") == "responded"
+                and saved_resolution(first_row) == first_answer
+            ),
+            "second_row_settled": (
+                (second_row or {}).get("status") == "responded"
+                and saved_resolution(second_row) == second_answer
+            ),
+        }
+        ok = all(checks.values())
+        return {
+            "status": "PASS" if ok else "FAIL",
+            "why": (
+                "a real Telegram bot was validated, a connection was created, removed and "
+                "recreated, and both card outcomes are stored"
+                if ok
+                else f"real Telegram checks failed: {checks}"
+            ),
+            "session_id": session_id,
+            "bot_id": bot.get("id"),
+            "bot_username": bot.get("username"),
+            "checks": checks,
+            "not_covered": (
+                "entering the bot token on the provider's hosted page, and therefore the "
+                "connection reaching is_valid. That is a browser step; run qa.md journey 5 by "
+                "hand during exploratory QA."
+            ),
+        }
+    except JourneyError as error:
+        return {
+            "status": "FAIL",
+            "why": str(error),
+            "session_id": session_id,
+        }
+    except Exception as error:  # noqa: BLE001
+        return {
+            "status": "FAIL",
+            "why": (
+                f"unexpected Telegram journey error ({type(error).__name__}); details omitted "
+                "so TELEGRAM_BOT_TOKEN cannot appear in output"
+            ),
+            "session_id": session_id,
+        }
+    finally:
+        for connection_id in created_ids:
+            delete_connection(connection_id)
+
+
+def journey_decline_then_retry() -> dict:
+    """Stand-in for clicking Not now and then Retry. The retry is represented by creation of one
+    fresh row after the decline settles; fresh queries prove the old row stays dead. It cannot
+    assert the Retry button is visible/clickable or that a model re-asked at the right time."""
+    session_id = str(uuid.uuid4())
+    declined_token = f"i2-decline-{uuid.uuid4().hex[:8]}"
+    retry_token = f"i2-retry-{uuid.uuid4().hex[:8]}"
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-decline",
+        token=declined_token,
+        kind="client_tool",
+        tool_name="request_connection",
+    )
+    decline = connect_resolution(declined_token, connected=False, reason="declined")
+    transition(
+        session_id=session_id,
+        token=declined_token,
+        status="responded",
+        resolution=decline,
+    )
+    create_interaction(
+        session_id=session_id,
+        turn_id="turn-retry",
+        token=retry_token,
+        kind="client_tool",
+        tool_name="request_connection",
+    )
+    rows = interactions(session_id)
+    declined = row_by_token(rows, declined_token)
+    retry = row_by_token(rows, retry_token)
+    live = [row.get("token") for row in rows if row.get("status") == "pending"]
+    ok = (
+        (declined or {}).get("status") == "responded"
+        and saved_resolution(declined) == decline
+        and (retry or {}).get("status") == "pending"
+        and live == [retry_token]
+    )
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "why": (
+            "the decline stayed settled and retry created exactly one new live row"
+            if ok
+            else (
+                f"declined_status={(declined or {}).get('status')!r}, "
+                f"declined_resolution={saved_resolution(declined)!r}, "
+                f"retry_status={(retry or {}).get('status')!r}, live={live}"
+            )
+        ),
+        "session_id": session_id,
+        "live_tokens": live,
+    }
+
+
+def capture_journey(function, *args) -> dict:
+    try:
+        return function(*args)
+    except Exception as error:  # noqa: BLE001
+        return {
+            "status": "FAIL",
+            "why": f"unhandled {function.__name__} error: {type(error).__name__}: {error}",
+        }
+
+
+def i2() -> dict:
+    hexid = uuid.uuid4().hex[:8]
+    workflow_id, variant_id = create_workflow(hexid, "qa-i2")
+    try:
+        config = agent_config(
+            instructions="Be terse. Reply with exactly what is requested."
+        )
+        config = apply_model_override(config)
+        revision_id, _ = seed_and_baseline(workflow_id, variant_id, config, hexid)
+        parameters = {"agent": config}
+        references = refs(workflow_id, variant_id, revision_id)
+        journeys = {
+            "compound": capture_journey(journey_compound, parameters, references),
+            "form_then_connect": capture_journey(journey_form_then_connect),
+            "two_connects": capture_journey(journey_two_connects),
+            "close_and_reopen": capture_journey(
+                journey_close_and_reopen, parameters, references
+            ),
+            "real_telegram": capture_journey(journey_real_telegram),
+            "decline_then_retry": capture_journey(journey_decline_then_retry),
+        }
+        failures = [
+            name for name, result in journeys.items() if result["status"] == "FAIL"
+        ]
+        skips = [
+            name for name, result in journeys.items() if result["status"] == "SKIP"
+        ]
+        passes = [
+            name for name, result in journeys.items() if result["status"] == "PASS"
+        ]
+        status = "FAIL" if failures else "SKIP" if skips else "PASS"
+        if failures:
+            why = " | ".join(f"{name}: {journeys[name]['why']}" for name in failures)
+        elif skips:
+            why = (
+                f"{len(passes)} journeys passed; {len(skips)} SKIPPED AND UNTESTED: "
+                + ", ".join(skips)
+            )
+        else:
+            why = "all six card journeys matched their stored-row and record contracts"
+        return {
+            "status": status,
+            "why": why,
+            "workflow_id": workflow_id,
+            "summary": {
+                "passed": passes,
+                "failed": failures,
+                "skipped_untested": skips,
+            },
+            "journeys": journeys,
+        }
+    finally:
+        archive(workflow_id)
+
+
+if __name__ == "__main__":
+    try:
+        result = i2()
+    except Exception as error:  # noqa: BLE001
+        result = {
+            "status": "FAIL",
+            "why": f"unhandled exception: {type(error).__name__}: {error}",
+        }
+    print("\n=== I2 RESULT ===")
+    print(json.dumps(result, indent=2, default=str))
+    sys.exit(0 if result["status"] in ("PASS", "SKIP") else 1)

--- a/.agents/skills/agent-release-gate/resources/matrix_l4_client_tool_lifecycle.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l4_client_tool_lifecycle.py
@@ -34,14 +34,17 @@ The correctness half is what blocks: the browser's result must actually reach th
 `client_tool` interaction must be STORED (a row in `/sessions/interactions/`), not merely
 streamed.
 
-OBSERVED NUANCE, recorded but not asserted (2026-08-06): a client-tool row that was FULFILLED
-successfully still ends up stored as `cancelled`, not `responded`/`resolved`. The browser answers
-in-band through the messages plane, and the next turn's `cancelStaleInteractions` sweep spares
-only the tokens it recognises as in-band answers -- which covers approval replies, not client-tool
-outputs -- so the row is swept as though it had been abandoned. The round trip itself works, so
-this cell asserts only that no row is left `pending`. It is the durable RECORD that lies: anything
-reading the stored interactions later (a reconnecting client, an audit) cannot tell a fulfilled
-client tool from an abandoned one. Worth fixing, not worth blocking a release on.
+FIXED CONTRACT (2026-08-10): the browser records a client-tool answer with ONE
+`POST /sessions/interactions/transition` call that writes `status=responded` and
+`data.resolution` together, before it sends the resume turn. The later stale sweep filters on
+`pending`, so the answered row is invisible to it and must remain `responded`; `resolved` stays
+approval-only.
+
+WIRE-LEVEL CAVEAT. This script has no browser, so the server cannot perform that client-owned
+write on its behalf. The cell therefore makes the same transition call itself, keyed by the
+stored row's token, BEFORE it sends the in-band tool output. Fulfilling only through the assistant
+message would correctly leave the row `pending` for the next-turn sweep to cancel. Do not remove
+the explicit transition or mistake it for server-side behaviour.
 
 FIRST-RUN NOTE. If turn 1 ends without a recognizable paused client-tool call, this cell FAILS
 and prints the frames it did see. That is deliberate: a SKIP here would be an untested claim, and
@@ -58,6 +61,7 @@ import uuid
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
     agent_config,
+    api_call,
     archive,
     create_workflow,
     interactions,
@@ -152,6 +156,57 @@ def l4():
             r for r in interactions(session_id) if r.get("kind") == "client_tool"
         ]
 
+        row = next(
+            (
+                r
+                for r in rows_paused
+                if ((r.get("data") or {}).get("request") or {}).get("tool_call_id")
+                == call_id
+                or r.get("token") == call_id
+            ),
+            None,
+        )
+        if row is None:
+            return {
+                "status": "FAIL",
+                "why": (
+                    "the paused client-tool call has no stored row keyed by its tool_call_id, so "
+                    "the browser-equivalent answer transition cannot be sent"
+                ),
+                "workflow_id": wf,
+                "session_id": session_id,
+                "tool_call_id": call_id,
+                "client_tool_rows_while_paused": rows_paused,
+            }
+
+        resolution = {
+            "tool_call_id": call_id,
+            "tool_name": TOOL_NAME,
+            "outcome": "completed",
+            "output": marker,
+        }
+        transition = api_call(
+            "POST",
+            "/sessions/interactions/transition",
+            json={
+                "session_id": session_id,
+                "token": row["token"],
+                "status": "responded",
+                "resolution": resolution,
+            },
+        )
+        if transition.status_code != 200:
+            return {
+                "status": "FAIL",
+                "why": (
+                    "the browser-equivalent atomic answer transition failed: "
+                    f"HTTP {transition.status_code} {transition.text[:300]}"
+                ),
+                "workflow_id": wf,
+                "session_id": session_id,
+                "interaction_id": row.get("id"),
+            }
+
         # Turn 2: the browser answers. No new user message -- the result belongs to this turn.
         msgs2 = msgs + [fulfil(t1, call_id, marker)]
         t2 = invoke(session_id, msgs2, params, references, log=False)
@@ -163,9 +218,17 @@ def l4():
         ]
         statuses = [r.get("status") for r in rows_after]
         stored = bool(rows_after)
-        no_orphan_pending = all(s != "pending" for s in statuses)
+        settled_row = next(
+            (r for r in rows_after if r.get("id") == row.get("id")), None
+        )
+        settled_resolution = ((settled_row or {}).get("data") or {}).get("resolution")
+        stored_answer = (
+            settled_row is not None
+            and settled_row.get("status") == "responded"
+            and settled_resolution == resolution
+        )
 
-        ok = delivered and stored and no_orphan_pending and not t2.errors
+        ok = delivered and stored and stored_answer and not t2.errors
 
         why_parts = []
         if not delivered:
@@ -178,9 +241,11 @@ def l4():
                 "no `client_tool` interaction row was stored, so the call existed only on the "
                 "stream -- nothing durable for a reconnecting client to render"
             )
-        elif not no_orphan_pending:
+        elif not stored_answer:
             why_parts.append(
-                f"a `client_tool` row is still `pending` after the round trip completed: {statuses}"
+                "the answered `client_tool` row did not remain `responded` with its exact "
+                f"resolution after resume: status={(settled_row or {}).get('status')!r}, "
+                f"resolution={settled_resolution!r}"
             )
         if t2.errors:
             why_parts.append(f"the resumed turn errored: {t2.errors[:1]}")
@@ -189,7 +254,7 @@ def l4():
             "status": "PASS" if ok else "FAIL",
             "why": (
                 "the client-tool round trip completes, the result reaches the model, and the "
-                "interaction is stored"
+                "interaction remains `responded` with its answer stored"
                 if ok
                 else " | ".join(why_parts)
             ),
@@ -198,6 +263,9 @@ def l4():
             "result_reached_model": delivered,
             "client_tool_rows_while_paused": [r.get("status") for r in rows_paused],
             "client_tool_rows_after": statuses,
+            "answered_interaction_id": row.get("id"),
+            "answered_interaction_status": (settled_row or {}).get("status"),
+            "answered_interaction_resolution": settled_resolution,
             # RECORDED, NOT ASSERTED. Two ids is today's expected cost: a client-tool pause is
             # not parkable, so the environment is destroyed and the resume rebuilds. If this ever
             # reads 1, the warm hold (#5384) landed and this cell's docstring needs updating --

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -139,16 +139,19 @@ class SessionInteractionTransitionRequest(BaseModel):
     session_id: str
     token: str
     status: SessionInteractionStatus
-    resolution: Optional[SessionInteractionResolution] = None
+    # The router owns kind-specific validation because the row kind is not known here.
+    resolution: Optional[Dict[str, Any]] = None
 
     @model_validator(mode="after")
     def validate_resolution_status(self) -> "SessionInteractionTransitionRequest":
-        # Resolution is answer data, so it is valid only on the resolved lifecycle edge.
-        if (
-            self.resolution is not None
-            and self.status != SessionInteractionStatus.resolved
+        # Resolution is valid only on lifecycle edges that settle an answer.
+        if self.resolution is not None and self.status not in (
+            SessionInteractionStatus.responded,
+            SessionInteractionStatus.resolved,
         ):
-            raise ValueError("resolution is only valid when status is resolved")
+            raise ValueError(
+                "resolution is only valid when status is responded or resolved"
+            )
         return self
 
 

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -29,6 +29,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import ValidationError
 
 # FastAPI route params need fastapi.UploadFile; request.form() yields starlette's base class.
 from fastapi import UploadFile as FastAPIUploadFile
@@ -132,6 +133,7 @@ from oss.src.apis.fastapi.sessions.models import (
     SessionInteractionCreateRequest,
     SessionInteractionQueryRequest,
     SessionInteractionRespondRequest,
+    SessionInteractionResolution,
     SessionInteractionResponse,
     SessionInteractionsResponse,
     SessionInteractionTransitionRequest,
@@ -867,9 +869,7 @@ class InteractionsRouter:
         ):
             raise FORBIDDEN_EXCEPTION
 
-        resolution = (
-            body.resolution.model_dump() if body.resolution is not None else None
-        )
+        resolution = body.resolution
         if resolution is not None:
             interactions = await self.interactions_service.query_interactions(
                 project_id=project_id,
@@ -888,11 +888,22 @@ class InteractionsRouter:
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Interaction not found or already terminal",
                 )
-            if source.kind != SessionInteractionKind.user_approval:
+            if (
+                body.status == SessionInteractionStatus.resolved
+                and source.kind != SessionInteractionKind.user_approval
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
-                    detail="Resolution is only valid for user approval interactions",
+                    detail=f"Resolved status is not valid for {source.kind.value} interactions",
                 )
+            if source.kind == SessionInteractionKind.user_approval:
+                try:
+                    SessionInteractionResolution.model_validate(resolution)
+                except ValidationError as e:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=e.errors(include_context=False),
+                    ) from e
 
         try:
             interaction = await self.interactions_service.transition_interaction(

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -870,7 +870,9 @@ class InteractionsRouter:
             raise FORBIDDEN_EXCEPTION
 
         resolution = body.resolution
-        if resolution is not None:
+        # `resolved` is approval-only whether or not an answer rides along, so the row lookup
+        # runs for a bare `resolved` transition too.
+        if resolution is not None or body.status == SessionInteractionStatus.resolved:
             interactions = await self.interactions_service.query_interactions(
                 project_id=project_id,
                 query=SessionInteractionQuery(session_id=body.session_id),
@@ -896,7 +898,10 @@ class InteractionsRouter:
                     status_code=status.HTTP_409_CONFLICT,
                     detail=f"Resolved status is not valid for {source.kind.value} interactions",
                 )
-            if source.kind == SessionInteractionKind.user_approval:
+            if (
+                resolution is not None
+                and source.kind == SessionInteractionKind.user_approval
+            ):
                 try:
                     SessionInteractionResolution.model_validate(resolution)
                 except ValidationError as e:

--- a/api/oss/tests/pytest/acceptance/sessions/test_interaction_sweep_race.py
+++ b/api/oss/tests/pytest/acceptance/sessions/test_interaction_sweep_race.py
@@ -87,4 +87,4 @@ class TestInteractionSweepRace:
         assert answered_after["status"] == "responded"
         assert answered_after["data"]["resolution"] == resolution
         assert pending_after["status"] == "cancelled"
-        assert pending_after.get("data", {}).get("resolution") is None
+        assert (pending_after.get("data") or {}).get("resolution") is None

--- a/api/oss/tests/pytest/acceptance/sessions/test_interaction_sweep_race.py
+++ b/api/oss/tests/pytest/acceptance/sessions/test_interaction_sweep_race.py
@@ -1,0 +1,90 @@
+"""Acceptance coverage for the atomic interaction-answer ordering guarantee.
+
+Requires a live stack through the shared ``authed_api`` fixture. The answered row and an
+unanswered control share one stale sweep so the test proves both that the sweep ran and that its
+``pending`` filter protects an answer recorded as ``responded``.
+"""
+
+from uuid import uuid4
+
+
+def _create_client_tool(authed_api, *, session_id: str, turn_id: str, token: str):
+    response = authed_api(
+        "POST",
+        "/sessions/interactions/",
+        json={
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "token": token,
+            "kind": "client_tool",
+            "data": {
+                "request": {
+                    "tool": "request_connection",
+                    "tool_call_id": f"call-{token}",
+                }
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["interaction"]
+
+
+def _fetch(authed_api, interaction_id: str):
+    response = authed_api("GET", f"/sessions/interactions/{interaction_id}")
+    assert response.status_code == 200, response.text
+    return response.json()["interaction"]
+
+
+class TestInteractionSweepRace:
+    def test_answered_row_is_invisible_to_later_turn_sweep(self, authed_api):
+        session_id = str(uuid4())
+        answered_token = f"answered-{uuid4().hex}"
+        pending_token = f"pending-{uuid4().hex}"
+        answered = _create_client_tool(
+            authed_api,
+            session_id=session_id,
+            turn_id="turn-1",
+            token=answered_token,
+        )
+        pending = _create_client_tool(
+            authed_api,
+            session_id=session_id,
+            turn_id="turn-2",
+            token=pending_token,
+        )
+        resolution = {
+            "tool_call_id": f"call-{answered_token}",
+            "tool_name": "request_connection",
+            "outcome": "completed",
+            "output": {"connected": True, "integration": "telegram"},
+        }
+
+        transition = authed_api(
+            "POST",
+            "/sessions/interactions/transition",
+            json={
+                "session_id": session_id,
+                "token": answered_token,
+                "status": "responded",
+                "resolution": resolution,
+            },
+        )
+        assert transition.status_code == 200, transition.text
+        transitioned = transition.json()["interaction"]
+        assert transitioned["status"] == "responded"
+        assert transitioned["data"]["resolution"] == resolution
+
+        sweep = authed_api(
+            "POST",
+            "/sessions/interactions/cancel-stale",
+            json={"session_id": session_id, "turn_id": "turn-3"},
+        )
+        assert sweep.status_code == 200, sweep.text
+        assert sweep.json()["cancelled"] == 1
+
+        answered_after = _fetch(authed_api, answered["id"])
+        pending_after = _fetch(authed_api, pending["id"])
+        assert answered_after["status"] == "responded"
+        assert answered_after["data"]["resolution"] == resolution
+        assert pending_after["status"] == "cancelled"
+        assert pending_after.get("data", {}).get("resolution") is None

--- a/api/oss/tests/pytest/unit/sessions/test_transition_interaction_resolution.py
+++ b/api/oss/tests/pytest/unit/sessions/test_transition_interaction_resolution.py
@@ -30,22 +30,85 @@ def _make_authed_request(app: FastAPI, project_id, user_id) -> Request:
     return request
 
 
-async def test_transition_route_passes_resolution_to_the_domain_transition():
+# Walk-away needs the sweep, so it is pinned by the acceptance test and the I1 gate cell, not here.
+@pytest.mark.parametrize(
+    ("kind", "outcome", "target_status", "resolution"),
+    [
+        (
+            SessionInteractionKind.user_approval,
+            "complete",
+            SessionInteractionStatus.resolved,
+            {"verdict": "approved", "tool_call_id": "tool-1"},
+        ),
+        (
+            SessionInteractionKind.user_approval,
+            "decline",
+            SessionInteractionStatus.resolved,
+            {"verdict": "denied", "tool_call_id": "tool-1"},
+        ),
+        (
+            SessionInteractionKind.user_input,
+            "complete",
+            SessionInteractionStatus.responded,
+            {
+                "tool_call_id": "tool-1",
+                "tool_name": "request_input",
+                "outcome": "completed",
+                "output": {"action": "accept", "content": {"timezone": "UTC"}},
+            },
+        ),
+        (
+            SessionInteractionKind.user_input,
+            "decline",
+            SessionInteractionStatus.responded,
+            {
+                "tool_call_id": "tool-1",
+                "tool_name": "request_input",
+                "outcome": "completed",
+                "output": {"action": "decline"},
+            },
+        ),
+        (
+            SessionInteractionKind.client_tool,
+            "complete",
+            SessionInteractionStatus.responded,
+            {
+                "tool_call_id": "tool-1",
+                "tool_name": "request_connection",
+                "outcome": "completed",
+                "output": {"connected": True, "integration": "telegram"},
+            },
+        ),
+        (
+            SessionInteractionKind.client_tool,
+            "decline",
+            SessionInteractionStatus.responded,
+            {
+                "tool_call_id": "tool-1",
+                "tool_name": "request_connection",
+                "outcome": "completed",
+                "output": {"connected": False, "reason": "declined"},
+            },
+        ),
+    ],
+)
+async def test_transition_route_settlement_matrix(
+    kind, outcome, target_status, resolution
+):
     project_id = uuid4()
     user_id = uuid4()
     captured = []
+    source = SessionInteraction(
+        project_id=project_id,
+        session_id="session-1",
+        token=f"{kind.value}-{outcome}",
+        kind=kind,
+        status=SessionInteractionStatus.pending,
+    )
 
     class _InteractionsService:
         async def query_interactions(self, *, project_id, query):
-            return [
-                SessionInteraction(
-                    project_id=project_id,
-                    session_id=query.session_id,
-                    token="approval-token",
-                    kind=SessionInteractionKind.user_approval,
-                    status=SessionInteractionStatus.pending,
-                )
-            ]
+            return [source]
 
         async def transition_interaction(self, *, transition):
             captured.append(transition)
@@ -53,7 +116,7 @@ async def test_transition_route_passes_resolution_to_the_domain_transition():
                 project_id=transition.project_id,
                 session_id=transition.session_id,
                 token=transition.token,
-                kind=SessionInteractionKind.user_approval,
+                kind=kind,
                 status=transition.status,
                 data=SessionInteractionData(resolution=transition.resolution),
             )
@@ -65,9 +128,9 @@ async def test_transition_route_passes_resolution_to_the_domain_transition():
     )
     body = SessionInteractionTransitionRequest(
         session_id="session-1",
-        token="approval-token",
-        status=SessionInteractionStatus.resolved,
-        resolution={"verdict": "denied", "tool_call_id": "tool-1"},
+        token=source.token,
+        status=target_status,
+        resolution=resolution,
     )
 
     with patch(
@@ -81,13 +144,12 @@ async def test_transition_route_passes_resolution_to_the_domain_transition():
         )
 
     assert len(captured) == 1
-    assert captured[0].resolution == {
-        "verdict": "denied",
-        "tool_call_id": "tool-1",
-    }
+    assert captured[0].status == target_status
+    assert captured[0].resolution == resolution
     assert response.interaction is not None
+    assert response.interaction.status == target_status
     assert response.interaction.data is not None
-    assert response.interaction.data.resolution == captured[0].resolution
+    assert response.interaction.data.resolution == resolution
 
 
 @pytest.mark.parametrize(
@@ -114,20 +176,95 @@ async def test_transition_route_passes_resolution_to_the_domain_transition():
     ],
 )
 def test_transition_route_rejects_invalid_approval_resolution_with_422(payload):
+    interactions_service = AsyncMock()
+    interactions_service.query_interactions.return_value = [
+        SessionInteraction(
+            project_id=uuid4(),
+            session_id="session-1",
+            token="approval-token",
+            kind=SessionInteractionKind.user_approval,
+            status=SessionInteractionStatus.pending,
+        )
+    ]
     router = InteractionsRouter(
-        interactions_service=AsyncMock(),
+        interactions_service=interactions_service,
         workflows_service=AsyncMock(),
         respond_task=AsyncMock(),
     )
     app = FastAPI()
     app.include_router(router.router)
 
-    response = TestClient(app).post("/transition", json=payload)
+    @app.middleware("http")
+    async def add_request_scope(request, call_next):
+        request.state.project_id = uuid4()
+        request.state.user_id = uuid4()
+        return await call_next(request)
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        response = TestClient(app).post("/transition", json=payload)
 
     assert response.status_code == 422
 
 
-async def test_transition_route_rejects_resolution_for_client_tool_with_409():
+async def test_transition_route_accepts_open_resolution_for_client_tool_on_responded():
+    project_id = uuid4()
+    user_id = uuid4()
+    interactions_service = AsyncMock()
+    interactions_service.query_interactions.return_value = [
+        SessionInteraction(
+            project_id=project_id,
+            session_id="session-1",
+            token="client-tool-token",
+            kind=SessionInteractionKind.client_tool,
+            status=SessionInteractionStatus.pending,
+        )
+    ]
+    interactions_service.transition_interaction.return_value = SessionInteraction(
+        project_id=project_id,
+        session_id="session-1",
+        token="client-tool-token",
+        kind=SessionInteractionKind.client_tool,
+        status=SessionInteractionStatus.responded,
+    )
+    router = InteractionsRouter(
+        interactions_service=interactions_service,
+        workflows_service=AsyncMock(),
+        respond_task=AsyncMock(),
+    )
+    body = SessionInteractionTransitionRequest(
+        session_id="session-1",
+        token="client-tool-token",
+        status=SessionInteractionStatus.responded,
+        resolution={
+            "tool_call_id": "tool-1",
+            "tool_name": "request_connection",
+            "outcome": "completed",
+            "output": {"connected": True},
+        },
+    )
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        await router.transition_interaction(
+            request=_make_authed_request(FastAPI(), project_id, user_id),
+            body=body,
+        )
+
+    transition = interactions_service.transition_interaction.await_args.kwargs[
+        "transition"
+    ]
+    assert transition.status == SessionInteractionStatus.responded
+    assert transition.resolution == body.resolution
+
+
+async def test_transition_route_rejects_resolved_client_tool_with_409():
     project_id = uuid4()
     user_id = uuid4()
     interactions_service = AsyncMock()
@@ -149,7 +286,7 @@ async def test_transition_route_rejects_resolution_for_client_tool_with_409():
         session_id="session-1",
         token="client-tool-token",
         status=SessionInteractionStatus.resolved,
-        resolution={"verdict": "approved", "tool_call_id": "tool-1"},
+        resolution={"tool_call_id": "tool-1", "outcome": "completed"},
     )
 
     with patch(

--- a/api/oss/tests/pytest/unit/sessions/test_transition_interaction_resolution.py
+++ b/api/oss/tests/pytest/unit/sessions/test_transition_interaction_resolution.py
@@ -302,3 +302,42 @@ async def test_transition_route_rejects_resolved_client_tool_with_409():
 
     assert caught.value.status_code == 409
     interactions_service.transition_interaction.assert_not_awaited()
+
+
+async def test_transition_route_rejects_resolved_client_tool_without_resolution_with_409():
+    project_id = uuid4()
+    user_id = uuid4()
+    interactions_service = AsyncMock()
+    interactions_service.query_interactions.return_value = [
+        SessionInteraction(
+            project_id=project_id,
+            session_id="session-1",
+            token="client-tool-token",
+            kind=SessionInteractionKind.client_tool,
+            status=SessionInteractionStatus.pending,
+        )
+    ]
+    router = InteractionsRouter(
+        interactions_service=interactions_service,
+        workflows_service=AsyncMock(),
+        respond_task=AsyncMock(),
+    )
+    body = SessionInteractionTransitionRequest(
+        session_id="session-1",
+        token="client-tool-token",
+        status=SessionInteractionStatus.resolved,
+    )
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        with pytest.raises(HTTPException) as caught:
+            await router.transition_interaction(
+                request=_make_authed_request(FastAPI(), project_id, user_id),
+                body=body,
+            )
+
+    assert caught.value.status_code == 409
+    interactions_service.transition_interaction.assert_not_awaited()

--- a/services/runner/src/engines/sandbox_agent/client-tools.ts
+++ b/services/runner/src/engines/sandbox_agent/client-tools.ts
@@ -223,6 +223,7 @@ export interface BuildClientToolRelayInput {
     toolName: string | undefined,
     toolArgs: unknown,
     kind: "user_approval" | "client_tool",
+    toolCallId?: string,
   ) => void;
   /** Non-Pi harness (Claude): maps the call to its real ACP tool-call id. Omit for Pi (the
    *  relay-minted id is already exact). The relay resolves the id ONCE per pending call and
@@ -300,6 +301,7 @@ export function buildClientToolRelay({
         request.toolName,
         request.input,
         "client_tool",
+        correlatedId,
       );
       return "pendingApproval";
     },

--- a/services/runner/tests/unit/client-tools.test.ts
+++ b/services/runner/tests/unit/client-tools.test.ts
@@ -58,7 +58,12 @@ function responderReturning(verdict: ClientToolVerdict): Responder {
 function seam(verdict: ClientToolVerdict, opts: { index?: boolean } = {}) {
   const events: AgentEvent[] = [];
   const pausedToolCalls: string[] = [];
-  const recorded: Array<{ token: string; toolName?: string; kind: string }> = [];
+  const recorded: Array<{
+    token: string;
+    toolName?: string;
+    kind: string;
+    toolCallId?: string;
+  }> = [];
   let pauses = 0;
   const index = opts.index ? createToolCallCorrelationIndex() : undefined;
   const relay = buildClientToolRelay({
@@ -70,8 +75,8 @@ function seam(verdict: ClientToolVerdict, opts: { index?: boolean } = {}) {
         pauses += 1;
       },
     },
-    recordPendingInteraction: (token, toolName, _args, kind) => {
-      recorded.push({ token, toolName, kind });
+    recordPendingInteraction: (token, toolName, _args, kind, toolCallId) => {
+      recorded.push({ token, toolName, kind, toolCallId });
     },
     toolCallIndex: index,
   });
@@ -255,7 +260,12 @@ describe("buildClientToolRelay", () => {
     assert.deepEqual(ev.payload.render, { kind: "connect" });
     assert.deepEqual(s.pausedToolCalls, ["tc-1"], "the tool call is marked paused");
     assert.deepEqual(s.recorded, [
-      { token: "i-1", toolName: "request_connection", kind: "client_tool" },
+      {
+        token: "i-1",
+        toolName: "request_connection",
+        kind: "client_tool",
+        toolCallId: "tc-1",
+      },
     ]);
     // onPause is the consumer's responsibility to call after a pendingApproval outcome
     // (relay loop / MCP handler); it delegates to the pause controller (the turn-ender).
@@ -280,6 +290,7 @@ describe("buildClientToolRelay", () => {
     );
     assert.equal((s.events[0] as any).payload.toolCallId, "acp-real");
     assert.equal((s.events[0] as any).payload.toolCall.id, "acp-real");
+    assert.equal(s.recorded[0]?.toolCallId, "acp-real");
   });
 
   it("emits a widget for EACH pending client tool (several connections in one turn)", async () => {

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -6,7 +6,7 @@ import {
     modalitiesForModel,
     workflowMolecule,
 } from "@agenta/entities/workflow"
-import {buildRenderMap, isPendingClientToolInteraction} from "@agenta/playground"
+import {messageHasPendingHitl} from "@agenta/playground"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {UploadSimple} from "@phosphor-icons/react"
@@ -344,12 +344,10 @@ const AgentConversation = ({
     // opens the paused turn's own trace drawer.
     const openTraceDrawer = useSetAtom(openTraceDrawerAtom)
     const pendingApprovals = useMemo(() => getPendingApprovals(messages), [messages])
-    // Parked connect interaction on the paused turn → the InteractionDock owns its actions (the
-    // inline row is a passive marker). Gated off while busy (`input-streaming` isn't parked yet)
-    // and after a user stop (the run is dead, nothing to settle — matches the queue's stop void).
+    // The connect dock stays visible for the newest parked card unless the run was stopped.
     const pendingInteraction = useMemo(
-        () => (busy || stopped ? null : getPendingConnectInteraction(messages)),
-        [messages, busy, stopped],
+        () => (stopped ? null : getPendingConnectInteraction(messages)),
+        [messages, stopped],
     )
     const openPausedTurnTrace = useMemo(() => {
         const last = messages[messages.length - 1]
@@ -361,32 +359,20 @@ const AgentConversation = ({
     // AND the Session inspector's live-watcher signal, which derives "streaming" from `running`).
     // Precedence error > awaiting approval > running > idle. Reset to idle on unmount so a closed
     // tab keeps no stale dot and stops claiming it's the live watcher.
-    // `hitlPending` reads only the LAST assistant message, so the moment a new turn starts
-    // streaming (or hydration reshapes the transcript) a still-pending interaction in an
-    // EARLIER message stops counting — status collapses to idle, the settle stamp lands, and
-    // the running-elsewhere strip flickers in the very tab that owns the parked widget
-    // (Mahmoud's session e627d80a). Scan the whole transcript: any pending interaction this
-    // tab renders means this tab owns the run.
-    const anyPendingInteraction = useMemo(
-        () =>
-            messages.some((message) => {
-                if (message.role !== "assistant") return false
-                const parts = message.parts ?? []
-                const renderMap = buildRenderMap(parts)
-                return parts.some((part) => isPendingClientToolInteraction(part, renderMap))
-            }),
-        [messages],
-    )
+    // A still-pending interaction in an EARLIER message must keep the status at `awaiting`, or the
+    // status collapses to idle, the settle stamp lands, and the running-elsewhere strip flickers in
+    // the very tab that owns the parked widget (Mahmoud's session e627d80a). `hitlPending` scans
+    // the whole transcript for exactly that, approvals included.
     useEffect(() => {
         const status: SessionRunStatus = error
             ? "error"
-            : hitlPending || anyPendingInteraction
+            : hitlPending
               ? "awaiting"
               : busy
                 ? "running"
                 : "idle"
         setSessionStatus({id: sessionId, status})
-    }, [error, hitlPending, anyPendingInteraction, busy, sessionId, setSessionStatus])
+    }, [error, hitlPending, busy, sessionId, setSessionStatus])
     useEffect(
         () => () => setSessionStatus({id: sessionId, status: "idle"}),
         [sessionId, setSessionStatus],
@@ -584,9 +570,9 @@ const AgentConversation = ({
                 showWorking={
                     isLast && busy && (!isAssistantTurn || message.parts.some(isVisiblePart))
                 }
-                // Paused on the user (never concurrently with showWorking — hitlPending implies not
-                // busy): keeps the turn from reading as finished while the queue holds sends.
-                showWaiting={isLast && isAssistantTurn && !busy && hitlPending}
+                // Paused on the user: painted on the turn that actually HOLDS the gate, not the
+                // newest one, so a card parked several turns up marks its own turn.
+                showWaiting={isAssistantTurn && !busy && !stopped && messageHasPendingHitl(message)}
                 showStopped={stopped && isLast && isAssistantTurn}
                 resendDisabled={busy}
                 onResend={handleResend}
@@ -713,7 +699,6 @@ const AgentConversation = ({
                                 onApprovalResponse={handleApprovalResponse}
                                 onViewTrace={openPausedTurnTrace}
                                 pendingInteraction={pendingInteraction}
-                                onClientToolOutput={handleClientToolOutput}
                                 onSubmit={handleSubmit}
                                 onStop={handleStop}
                                 richInputRef={richInputRef}

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/abandonedFormSession.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/abandonedFormSession.json
@@ -1,0 +1,845 @@
+[
+  {
+    "id": "3ac1e196-9d0c-4137-84d5-5b187bfe07fa",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "I want to create an agent that sends me … <91 chars elided>",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-10T14:11:51.213Z"
+  },
+  {
+    "id": "e84f5a4c-de6b-50b6-baa0-fc4d51dd5efc",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_6Ev3NNVyPlFdRIoDRF4RKN3w|fc_0127887… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <195 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:00.250Z"
+  },
+  {
+    "id": "79419f2e-dc56-5fad-8c26-c1e1a4141efa",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_6Ev3NNVyPlFdRIoDRF4RKN3w|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "---\nname: \"build-an-agent\"\ndescription: … <12820 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:00.250Z"
+  },
+  {
+    "id": "e5298ef8-e9ec-5f4b-be19-b29c42530216",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_9TZhCpuETAWXy0ruPgYnC8v7|fc_0127887… <83 chars elided>",
+      "name": "find",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <171 chars elided>",
+        "pattern": "references/agent-templates/index.md"
+      }
+    },
+    "created_at": "2026-08-10T14:12:03.568Z"
+  },
+  {
+    "id": "73479402-304b-59b6-a5bc-6513e88587ec",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_9TZhCpuETAWXy0ruPgYnC8v7|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "error: Found argument '--no-require-git'… <248 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:12:03.568Z"
+  },
+  {
+    "id": "ee4ad8c7-26c9-57f3-b031-f61ccb997694",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_F4rCCLQOVRBsIyguLveYaXqs|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <171 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:08.479Z"
+  },
+  {
+    "id": "05dd224f-ab2a-543b-a29c-626c1369618c",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_F4rCCLQOVRBsIyguLveYaXqs|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": ".agenta-skill-set.json\nbuild-an-agent/",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:08.479Z"
+  },
+  {
+    "id": "8ab7d51a-cc84-5717-98cc-ef4574171ef8",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_CgCsnin4iSnw6I6orMZ0bBxV|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <186 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:13.783Z"
+  },
+  {
+    "id": "5834b100-6263-5b08-b736-619ee43ba8e5",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_CgCsnin4iSnw6I6orMZ0bBxV|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "references/\nSKILL.md",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:13.783Z"
+  },
+  {
+    "id": "993c66a9-88b5-5ed7-94dc-7c525b5a90c4",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_07YbzYFCW64e3ZGooV6NQ2ze|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <197 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:16.713Z"
+  },
+  {
+    "id": "59c17422-16c7-5f73-830d-f6371858c49a",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_07YbzYFCW64e3ZGooV6NQ2ze|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "Path not found: /tmp/agenta/mounts/019fe… <213 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:12:16.713Z"
+  },
+  {
+    "id": "cb8df4c3-0f3b-53b9-84df-085dd77fec5e",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_QdfzWu4Fit44c3RZPp0mhpmx|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <197 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:20.808Z"
+  },
+  {
+    "id": "51d28fd7-369d-5c56-be06-4076d0180327",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_QdfzWu4Fit44c3RZPp0mhpmx|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "agent-templates/\nconfig-schema.md\ntrigger-inputs.md",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:20.808Z"
+  },
+  {
+    "id": "be6802e8-1542-4450-b4c7-c01258befc17",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "d137b4d128625070c9eebad694a71953"
+    },
+    "created_at": "2026-08-10T14:12:21.338Z"
+  },
+  {
+    "id": "3f1d20ed-1b65-4c73-ac3c-c20096ccbbdc",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "I want to create an agent that sends me … <91 chars elided>",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-10T14:14:26.788Z"
+  },
+  {
+    "id": "a2eceda2-906a-4122-924b-1c9edd512a6b",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Inspecting playbook index**\n\nI need to… <408 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "ee4b58b0-6a1d-5b4e-9d0c-6e54309f9c84",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_cos65iPtQcwoSeCo274tHxpu|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <222 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "576070fa-22a9-51f3-a551-6147266fe841",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_36OO60wY2e9UxrP0QmiATv3K|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c20-8d… <174 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "c501dd36-8025-579e-9ac8-ff8d6a101524",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_OaTDsWsrPzndHArJ2NYK6zaZ|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <212 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "08e4ac6e-9613-5a96-84e2-96962a5b8b77",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_36OO60wY2e9UxrP0QmiATv3K|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "ENOENT: no such file or directory, acces… <218 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "e76810df-57c4-530f-b570-2e7d6ef68f91",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_OaTDsWsrPzndHArJ2NYK6zaZ|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "ENOENT: no such file or directory, acces… <256 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "9c081ac3-5ad4-599d-9033-00953a19c0c2",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_cos65iPtQcwoSeCo274tHxpu|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "# Agent template playbooks\n\nMatch the us… <4532 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "3d60f877-2509-4e9d-9d72-3da71d4f8dc4",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Correcting path typo**\n\nI need to ensu… <370 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "59a87425-5a4b-5fba-88f2-c9e8abf00f89",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_y3gX69Fmcfs71YOv3iBQQ0mS|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <214 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "6cdbefee-cd0a-5295-9fdc-e28fe9885ee3",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_5gXdoIef4ScubRAhB2KCD3Ig|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <212 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "8a056135-afc4-55ef-8723-d9493ed9f9ef",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_tIalLuExYiDMiSN8Otvoaz1a|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <195 chars elided>",
+        "limit": 220,
+        "offset": 1
+      }
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "29be8628-0dc3-5e31-b339-aeb3e7688c85",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_5gXdoIef4ScubRAhB2KCD3Ig|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "ENOENT: no such file or directory, acces… <256 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "a7020368-b0e0-528d-b756-5adfbb6c939d",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_tIalLuExYiDMiSN8Otvoaz1a|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "---\nname: \"build-an-agent\"\ndescription: … <12820 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "68816998-c664-580b-9067-010ed834cc77",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 14,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_y3gX69Fmcfs71YOv3iBQQ0mS|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "# The agent config, field by field\n\nRead… <17820 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "c1291959-a913-49a9-850f-8f2457578368",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 15,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Clarifying user details**\n\nI need to c… <485 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:14:45.386Z"
+  },
+  {
+    "id": "e4c0cfd3-b9d3-5abc-9875-824f571ac42d",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 16,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_oKZiZXfG0lf35KE3WNAOIDws|fc_0b9b71f… <83 chars elided>",
+      "name": "discover_tools",
+      "type": "tool_call",
+      "input": {
+        "provider": "composio",
+        "use_cases": [
+          "send a Telegram message"
+        ],
+        "limit_alternatives": 5
+      }
+    },
+    "created_at": "2026-08-10T14:14:45.386Z"
+  },
+  {
+    "id": "1d3449e5-3595-5e2a-bf8e-f74abde84fcc",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 17,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+      "name": "request_input",
+      "type": "tool_call",
+      "input": {
+        "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+        "requestedSchema": {
+          "type": "object",
+          "required": [
+            "time_of_day",
+            "timezone",
+            "telegram_chat"
+          ],
+          "properties": {
+            "timezone": {
+              "type": "string",
+              "title": "Timezone",
+              "default": "Asia/Riyadh",
+              "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+            },
+            "time_of_day": {
+              "type": "string",
+              "title": "Morning delivery time",
+              "format": "time",
+              "default": "08:00"
+            },
+            "poetry_style": {
+              "type": "string",
+              "title": "Poetry preference",
+              "format": "multiline",
+              "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+              "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+            },
+            "telegram_chat": {
+              "type": "string",
+              "title": "Telegram chat ID or @username"
+            }
+          },
+          "x-ag-stepper": true
+        }
+      }
+    },
+    "created_at": "2026-08-10T14:14:45.984Z"
+  },
+  {
+    "id": "bfb8bee4-a8bf-5edb-a5b0-b90136a1c532",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 18,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "time_of_day",
+              "timezone",
+              "telegram_chat"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Timezone",
+                "default": "Asia/Riyadh",
+                "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+              },
+              "time_of_day": {
+                "type": "string",
+                "title": "Morning delivery time",
+                "format": "time",
+                "default": "08:00"
+              },
+              "poetry_style": {
+                "type": "string",
+                "title": "Poetry preference",
+                "format": "multiline",
+                "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+                "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+              },
+              "telegram_chat": {
+                "type": "string",
+                "title": "Telegram chat ID or @username"
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "render": {
+          "kind": "elicitation"
+        },
+        "toolCall": {
+          "id": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+          "kind": "client",
+          "name": "request_input",
+          "input": {
+            "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "time_of_day",
+                "timezone",
+                "telegram_chat"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Timezone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+                },
+                "time_of_day": {
+                  "type": "string",
+                  "title": "Morning delivery time",
+                  "format": "time",
+                  "default": "08:00"
+                },
+                "poetry_style": {
+                  "type": "string",
+                  "title": "Poetry preference",
+                  "format": "multiline",
+                  "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+                  "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+                },
+                "telegram_chat": {
+                  "type": "string",
+                  "title": "Telegram chat ID or @username"
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "rawInput": {
+            "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "time_of_day",
+                "timezone",
+                "telegram_chat"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Timezone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+                },
+                "time_of_day": {
+                  "type": "string",
+                  "title": "Morning delivery time",
+                  "format": "time",
+                  "default": "08:00"
+                },
+                "poetry_style": {
+                  "type": "string",
+                  "title": "Poetry preference",
+                  "format": "multiline",
+                  "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+                  "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+                },
+                "telegram_chat": {
+                  "type": "string",
+                  "title": "Telegram chat ID or @username"
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6"
+        },
+        "toolName": "request_input",
+        "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6"
+      }
+    },
+    "created_at": "2026-08-10T14:14:45.984Z"
+  },
+  {
+    "id": "2086d496-82a7-5b11-969d-4a1f6fc0f000",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 19,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_oKZiZXfG0lf35KE3WNAOIDws|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "aborted",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:45.984Z"
+  },
+  {
+    "id": "b204d7dd-2daf-44b9-8a51-6e46723b37ca",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 20,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0.043811699999999995,
+      "type": "usage",
+      "input": 9,
+      "total": 63654,
+      "output": 1119
+    },
+    "created_at": "2026-08-10T14:14:48.282Z"
+  },
+  {
+    "id": "e96de44b-ef83-4323-a3f6-d7520f0282ca",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 21,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "aeb7c12a4619a3254805c080f76b59f2",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-10T14:14:48.282Z"
+  },
+  {
+    "id": "99df840c-a4f0-4f9c-ba77-855ac6f1d037",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Responding to cancellation**\n\nI need t… <367 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:16:13.079Z"
+  },
+  {
+    "id": "ca72d92d-f2c3-56d8-83c5-6d703e17c214",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_iLvfcJo0QEc2TmNlKZrFyeD6|fc_0a6f77e… <83 chars elided>",
+      "name": "rename_session",
+      "type": "tool_call",
+      "input": {
+        "name": "Daily Arabic Poetry",
+        "description": "Setting up a Telegram agent to send Arab… <128 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:16:13.079Z"
+  },
+  {
+    "id": "aac33e87-9647-5341-afcf-4528dde3d6b1",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_QKleioohKPLZ8UoK09ayHOIX|fc_0a6f77e… <83 chars elided>",
+      "name": "rename_agent",
+      "type": "tool_call",
+      "input": {
+        "name": "Arabic Poetry Scheduler",
+        "description": "Configures and schedules daily Arabic poetry messages to Telegram."
+      }
+    },
+    "created_at": "2026-08-10T14:16:14.787Z"
+  },
+  {
+    "id": "c40ab7cc-837a-5151-b8a6-1e8194a9cbc9",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_iLvfcJo0QEc2TmNlKZrFyeD6|fc_0a6f77e… <83 chars elided>",
+      "type": "tool_result",
+      "output": "{\"stream\":{\"created_at\":\"2026-08-10T14:0… <725 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:16:14.787Z"
+  },
+  {
+    "id": "57ae39da-d135-54ab-bd3c-3d342ff52c9a",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_QKleioohKPLZ8UoK09ayHOIX|fc_0a6f77e… <83 chars elided>",
+      "type": "tool_result",
+      "output": "{\"count\":1,\"workflow\":{\"flags\":{\"is_appl… <482 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:16:14.787Z"
+  },
+  {
+    "id": "f6e7b701-fa76-4845-9931-b067e321a98e",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0.030453400000000002,
+      "type": "usage",
+      "input": 6,
+      "total": 43212,
+      "output": 176
+    },
+    "created_at": "2026-08-10T14:16:16.788Z"
+  },
+  {
+    "id": "db7c3e26-3870-4c36-8f43-eb80c027d2b8",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "No problem. When you’re ready, send the … <165 chars elided>",
+      "type": "message"
+    },
+    "created_at": "2026-08-10T14:16:16.788Z"
+  },
+  {
+    "id": "f0f14d71-ada0-42d8-93b3-df02e530ace0",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "f9a838ce54c84ee28f0b51555e82b03f"
+    },
+    "created_at": "2026-08-10T14:16:16.788Z"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/clientToolAnswer.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/clientToolAnswer.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pins the ordering guarantee behind the interaction-lifecycle fix: the durable row is recorded
+ * BEFORE the resume is dispatched, because the resume starts a turn whose stale sweep cancels
+ * every still-`pending` row. Review round 1 caught this racing instead of ordering.
+ */
+import {describe, expect, it, vi} from "vitest"
+
+import {RECORD_ANSWER_TIMEOUT_MS, recordAnswerThenResume} from "./clientToolAnswer"
+
+const deferred = () => {
+    let resolve!: () => void
+    const promise = new Promise<void>((r) => {
+        resolve = r
+    })
+    return {promise, resolve}
+}
+
+describe("recordAnswerThenResume", () => {
+    it("does not dispatch the resume until the record settles", async () => {
+        const gate = deferred()
+        const order: string[] = []
+        const resume = vi.fn(() => order.push("resume"))
+
+        const done = recordAnswerThenResume({
+            record: async () => {
+                await gate.promise
+                order.push("record")
+            },
+            resume,
+        })
+
+        await Promise.resolve()
+        expect(resume).not.toHaveBeenCalled()
+
+        gate.resolve()
+        await done
+        expect(order).toEqual(["record", "resume"])
+    })
+
+    it("dispatches the resume once the record fails", async () => {
+        const resume = vi.fn()
+        await recordAnswerThenResume({
+            record: async () => {
+                throw new Error("interactions API is down")
+            },
+            resume,
+        })
+        expect(resume).toHaveBeenCalledTimes(1)
+    })
+
+    it("dispatches the resume when the record never settles, so a wedged API cannot block it", async () => {
+        vi.useFakeTimers()
+        try {
+            const resume = vi.fn()
+            const done = recordAnswerThenResume({
+                record: () => new Promise<void>(() => undefined),
+                resume,
+                timeoutMs: 50,
+            })
+            await vi.advanceTimersByTimeAsync(49)
+            expect(resume).not.toHaveBeenCalled()
+            await vi.advanceTimersByTimeAsync(1)
+            await done
+            expect(resume).toHaveBeenCalledTimes(1)
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it("keeps the cap short enough to cost one beat, not the turn", () => {
+        expect(RECORD_ANSWER_TIMEOUT_MS).toBeLessThanOrEqual(2_000)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/clientToolAnswer.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/clientToolAnswer.ts
@@ -1,0 +1,42 @@
+/**
+ * Ordering for a client-tool answer: record the durable row, THEN dispatch the resume.
+ *
+ * The resume starts a new turn, and a new turn's `cancelStaleInteractions` sweep cancels every
+ * row still `pending`. Racing the two loses that race often enough to matter — the record can
+ * need three round trips (cache miss, invalidate, refetch, POST) against the resume's one — and
+ * a lost race stores an answered card as abandoned, which is the whole bug this project fixes.
+ *
+ * The wait is capped: a wedged API must never strand the user's answer. On timeout the resume
+ * goes out exactly as it did before, and a late record still lands if the sweep has not won.
+ */
+
+/** Long enough for the record's worst case (cache miss + refetch + POST), short enough that a
+ * dead API costs the user one beat rather than the turn. */
+export const RECORD_ANSWER_TIMEOUT_MS = 2_000
+
+export const recordAnswerThenResume = async ({
+    record,
+    resume,
+    timeoutMs = RECORD_ANSWER_TIMEOUT_MS,
+}: {
+    record: () => Promise<unknown>
+    resume: () => void
+    timeoutMs?: number
+}): Promise<void> => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+        await Promise.race([
+            // `record` is best-effort and documented never to reject; the catch is belt and braces
+            // so a future change there can never swallow the resume.
+            Promise.resolve()
+                .then(record)
+                .catch(() => undefined),
+            new Promise<void>((resolve) => {
+                timer = setTimeout(resolve, timeoutMs)
+            }),
+        ])
+    } finally {
+        if (timer !== undefined) clearTimeout(timer)
+    }
+    resume()
+}

--- a/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
@@ -1,4 +1,4 @@
-import {fetchCancelledClientToolTokensAtom, fetchSessionRecordsAtom} from "@agenta/entities/session"
+import {fetchSessionInteractionStatesAtom, fetchSessionRecordsAtom} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 import {getDefaultStore} from "jotai"
 
@@ -42,23 +42,22 @@ export const loadSessionMessages = async (
     // notice instead of leaking an unhandled rejection.
     try {
         const store = getDefaultStore()
-        // Best-effort join (never throws, see the atom's doc) — a resurrected cancelled part
-        // is cosmetic, so it must never gate whether the transcript loads at all.
-        const [{records, refreshed}, cancelledClientToolTokens] = await Promise.all([
+        // The best-effort lifecycle join must never gate transcript loading.
+        const [{records, refreshed}, interactionRowStates] = await Promise.all([
             store.set(fetchSessionRecordsAtom, sessionId),
-            store.set(fetchCancelledClientToolTokensAtom, sessionId),
+            store.set(fetchSessionInteractionStatesAtom, sessionId),
         ])
         if (refreshed && onRefreshed) {
             void refreshed.then((fresh) => {
                 if (!fresh || fresh.length === 0) return
-                const freshMsgs = transcriptToMessages(fresh, {cancelledClientToolTokens})
+                const freshMsgs = transcriptToMessages(fresh, {interactionRowStates})
                 if (freshMsgs && freshMsgs.length > 0) {
                     onRefreshed({messages: freshMsgs, recordCount: fresh.length})
                 }
             })
         }
         if (!records || records.length === 0) return null
-        const messages = transcriptToMessages(records, {cancelledClientToolTokens})
+        const messages = transcriptToMessages(records, {interactionRowStates})
         return messages ? {messages, recordCount: records.length} : null
     } catch (err) {
         console.warn("[loadSessionMessages] hydration fetch failed:", err)

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -1,6 +1,12 @@
-import type {SessionRecord} from "@agenta/entities/session"
+import type {
+    SessionInteractionRowState,
+    SessionInteractionRowStates,
+    SessionRecord,
+} from "@agenta/entities/session"
+import {CLIENT_TOOL_INTERACTION_ENDED_OUTPUT} from "@agenta/shared/clientTools"
 import {describe, expect, it} from "vitest"
 
+import abandonedFormSession from "./__fixtures__/abandonedFormSession.json"
 import {APPROVED_EXECUTION_RESULT_UNKNOWN, transcriptToMessages} from "./transcriptToMessages"
 
 const record = (id: string, payload: Record<string, unknown>, sender = "agent"): SessionRecord => ({
@@ -734,16 +740,7 @@ describe("transcriptToMessages parked client tool", () => {
     })
 })
 
-/**
- * Regression: a `session_interactions` row that reached a TERMINAL status (cancelled — e.g. the
- * stale-interaction sweep) server-side, with no corresponding `tool_result` ever landing in the
- * transcript, previously replayed as still fully pending — an interactive, answerable form
- * stacked above the real live interaction (live evidence, session
- * 3975e362-f64c-4e2d-8f4f-4f36c584bd91 on the 8180 dev stack). `cancelledClientToolTokens` (keyed
- * by `session_interactions.token`, which equals the record's `toolCallId`) is the join that fixes
- * it — each client-tool kind renders inert exactly like its own live cancel.
- */
-describe("transcriptToMessages cancelled client-tool interactions", () => {
+describe("transcriptToMessages interaction-row precedence", () => {
     const elicitationToolCallId = "call_4ySJBKMeiDq4u3hUNGJidwkX|fc_05786f8fb9f28034"
     const elicitationInput = {
         message: "To configure the PR reviewer, tell me which repository to monitor.",
@@ -781,94 +778,300 @@ describe("transcriptToMessages cancelled client-tool interactions", () => {
             },
         })
 
-    it("cancelled: an elicitation replays inert (output-available, action:cancel), not as a form", () => {
-        const messages = transcriptToMessages([elicitationRequest()], {
-            cancelledClientToolTokens: new Set([elicitationToolCallId]),
-        })
-        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({
-            type: "tool-request_input",
-            toolCallId: elicitationToolCallId,
-            state: "output-available",
-            output: {action: "cancel"},
-            // The original request payload is untouched — the widget still needs it to render
-            // its (now inert) chip, e.g. for a submitted-answers style summary.
-            input: elicitationInput,
-        })
+    const rowState = (
+        token: string,
+        overrides: Partial<SessionInteractionRowState> = {},
+    ): SessionInteractionRowState => ({
+        token,
+        status: "cancelled",
+        kind: "client_tool",
+        ...overrides,
     })
+    const rowStates = (...rows: SessionInteractionRowState[]): SessionInteractionRowStates =>
+        new Map(rows.map((row) => [row.token, row]))
+    const toolParts = (
+        records: SessionRecord[],
+        interactionRowStates?: SessionInteractionRowStates,
+    ): Record<string, unknown>[] =>
+        (
+            (transcriptToMessages(records, {interactionRowStates})?.[0].parts ??
+                []) as unknown as Record<string, unknown>[]
+        ).filter((part) => typeof part.toolCallId === "string")
 
-    it("cancelled: a connect request replays inert (connected:false, reason:cancelled)", () => {
-        const messages = transcriptToMessages([connectRequest()], {
-            cancelledClientToolTokens: new Set([connectToolCallId]),
-        })
-        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({
-            type: "tool-request_connection",
-            toolCallId: connectToolCallId,
-            state: "output-available",
-            output: {connected: false, reason: "cancelled"},
-        })
-    })
-
-    it("pending: a token NOT in the cancelled set still replays fully interactive (existing behavior)", () => {
-        const messages = transcriptToMessages([elicitationRequest()], {
-            cancelledClientToolTokens: new Set(["some-other-token"]),
-        })
-        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({
-            type: "tool-request_input",
-            toolCallId: elicitationToolCallId,
-            state: "input-available",
-        })
-    })
-
-    it("pending: omitting the option entirely is a no-op (callers with no interaction join unaffected)", () => {
-        const messages = transcriptToMessages([elicitationRequest()])
-        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({state: "input-available"})
-    })
-
-    it("settled: a real tool_result still wins over a stale cancelled-token entry", () => {
-        // Belt-and-suspenders: even if the interactions join is stale (says cancelled) but the
-        // transcript itself shows a later real settle, the real settle must not be downgraded.
-        const messages = transcriptToMessages(
+    it("keeps a recorded tool result ahead of row state", () => {
+        const output = {action: "accept", content: {repository: "octocat/Hello-World"}}
+        const parts = toolParts(
             [
                 elicitationRequest(),
                 record("record-result", {
                     type: "tool_result",
                     id: elicitationToolCallId,
-                    output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+                    output,
                 }),
             ],
-            {cancelledClientToolTokens: new Set([elicitationToolCallId])},
+            rowStates(
+                rowState(elicitationToolCallId, {
+                    status: "responded",
+                    resolution: {outcome: "error", error: "stale error"},
+                }),
+            ),
         )
-        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+
+        expect(parts[0]).toMatchObject({state: "output-available", output})
+    })
+
+    it("renders a completed saved resolution", () => {
+        const output = {action: "accept", content: {repository: "octocat/Hello-World"}}
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(
+                rowState(elicitationToolCallId, {
+                    status: "responded",
+                    resolution: {
+                        tool_call_id: elicitationToolCallId,
+                        tool_name: "request_input",
+                        outcome: "completed",
+                        output,
+                    },
+                }),
+            ),
+        )
+
+        expect(parts[0]).toMatchObject({state: "output-available", output})
+    })
+
+    it("uses neutral output when a completed resolution has no object output", () => {
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(
+                rowState(elicitationToolCallId, {
+                    status: "responded",
+                    resolution: {outcome: "completed", output: "invalid"},
+                }),
+            ),
+        )
 
         expect(parts[0]).toMatchObject({
             state: "output-available",
-            output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
         })
     })
 
-    it("cancelled: an unregistered client-tool kind still settles (empty output, no crash)", () => {
-        const toolCallId = "call_unknownKind"
-        const messages = transcriptToMessages(
-            [
-                record("record-interaction", {
-                    type: "interaction_request",
-                    id: toolCallId,
-                    kind: "client_tool",
-                    payload: {toolCallId, toolName: "some_future_client_tool", input: {}},
+    it("renders an error saved resolution", () => {
+        const parts = toolParts(
+            [connectRequest()],
+            rowStates(
+                rowState(connectToolCallId, {
+                    status: "responded",
+                    resolution: {
+                        tool_call_id: connectToolCallId,
+                        tool_name: "request_connection",
+                        outcome: "error",
+                        error: "OAuth popup failed",
+                    },
                 }),
-            ],
-            {cancelledClientToolTokens: new Set([toolCallId])},
+            ),
         )
-        const parts = (messages?.[0].parts ?? []) as unknown as Record<string, unknown>[]
 
-        expect(parts[0]).toMatchObject({state: "output-available", output: {}})
+        expect(parts[0]).toMatchObject({state: "output-error", errorText: "OAuth popup failed"})
+    })
+
+    it("renders neutral output for terminal rows without saved answers", () => {
+        const parts = toolParts(
+            [elicitationRequest(), connectRequest()],
+            rowStates(rowState(elicitationToolCallId), rowState(connectToolCallId)),
+        )
+        const elicitation = parts.find((part) => part.toolCallId === elicitationToolCallId)
+        const connect = parts.find((part) => part.toolCallId === connectToolCallId)
+
+        expect(elicitation).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+        expect(connect).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+        expect(elicitation?.output).not.toEqual({action: "cancel"})
+        expect(connect?.output).not.toEqual({connected: false, reason: "cancelled"})
+    })
+
+    it("leaves a pending row live", () => {
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(rowState(elicitationToolCallId, {status: "pending"})),
+        )
+
+        expect(parts[0]).toMatchObject({state: "input-available"})
+    })
+
+    it("joins through a stamped tool-call id before the row token", () => {
+        const output = {connected: true, integration: "telegram"}
+        const parts = toolParts(
+            [connectRequest()],
+            rowStates(
+                rowState("interaction-token", {
+                    status: "responded",
+                    toolCallId: connectToolCallId,
+                    resolution: {outcome: "completed", output},
+                }),
+            ),
+        )
+
+        expect(parts[0]).toMatchObject({state: "output-available", output})
+    })
+
+    it("joins legacy rows through token equality", () => {
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(rowState(elicitationToolCallId, {kind: "user_input", status: "resolved"})),
+        )
+
+        expect(parts[0]).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+    })
+
+    it("never settles a client-tool part from a user-approval row", () => {
+        const parts = toolParts(
+            [connectRequest()],
+            rowStates(rowState(connectToolCallId, {kind: "user_approval", status: "cancelled"})),
+        )
+
+        expect(parts[0]).toMatchObject({state: "input-available"})
+    })
+
+    // The gate is on a turn that never resumed, so no other pass settles it. Left
+    // `approval-requested`, the whole-chat queue scan holds every typed message behind a gate
+    // whose turn is long dead (review round 1, finding 2).
+    const abandonedApprovalRecords = (): SessionRecord[] => [
+        record("r-user-1", {type: "message", text: "delete the file"}, "user"),
+        record("r-call", {
+            type: "tool_call",
+            id: "tool-1",
+            name: "bash",
+            input: {command: "rm notes.md"},
+        }),
+        record("r-req", {
+            type: "interaction_request",
+            id: "approval-1",
+            kind: "user_approval",
+            payload: {toolCallId: "tool-1"},
+        }),
+        record("r-done-paused", {type: "done", stopReason: "paused"}),
+        record("r-user-2", {type: "message", text: "never mind, just say hi"}, "user"),
+        record("r-msg", {type: "message", text: "hi"}),
+        record("r-done", {type: "done"}),
+    ]
+    const allParts = (
+        records: SessionRecord[],
+        interactionRowStates?: SessionInteractionRowStates,
+    ): Record<string, unknown>[] =>
+        (transcriptToMessages(records, {interactionRowStates}) ?? []).flatMap(
+            (message) => message.parts as unknown as Record<string, unknown>[],
+        )
+
+    it("leaves an abandoned approval gate pending when no row says otherwise", () => {
+        const parts = allParts(abandonedApprovalRecords())
+
+        expect(parts.some((part) => part.state === "approval-requested")).toBe(true)
+    })
+
+    it("settles an abandoned approval gate from its swept row", () => {
+        const parts = allParts(
+            abandonedApprovalRecords(),
+            rowStates(rowState("approval-1", {kind: "user_approval", status: "cancelled"})),
+        )
+
+        expect(parts.some((part) => part.state === "approval-requested")).toBe(false)
+        // Denied, not approved: the sweep proves only that the gate died unanswered, and the
+        // gated tool never ran.
+        expect(parts.find((part) => part.toolCallId === "tool-1")).toMatchObject({
+            state: "output-denied",
+        })
+    })
+
+    it("replays an answered approval row with its verdict", () => {
+        const parts = allParts(
+            abandonedApprovalRecords(),
+            rowStates(
+                rowState("approval-1", {
+                    kind: "user_approval",
+                    status: "resolved",
+                    resolution: {verdict: "denied", tool_call_id: "tool-1"},
+                }),
+            ),
+        )
+
+        expect(parts.find((part) => part.toolCallId === "tool-1")).toMatchObject({
+            state: "approval-responded",
+            approval: {id: "approval-1", approved: false},
+        })
+    })
+
+    it("keeps an answered approval row's approved verdict", () => {
+        const parts = allParts(
+            abandonedApprovalRecords(),
+            rowStates(
+                rowState("approval-1", {
+                    kind: "user_approval",
+                    status: "resolved",
+                    resolution: {verdict: "approved", tool_call_id: "tool-1"},
+                }),
+            ),
+        )
+
+        expect(parts.find((part) => part.toolCallId === "tool-1")).toMatchObject({
+            state: "approval-responded",
+            approval: {id: "approval-1", approved: true},
+        })
+    })
+
+    it("preserves record-only replay when row states are omitted", () => {
+        expect(toolParts([elicitationRequest()])[0]).toMatchObject({state: "input-available"})
+    })
+})
+
+/**
+ * Golden replay of a REAL pre-fix session (live QA, 2026-08-10): dev stack session
+ * `0b6a8c44-a975-4431-90e7-adbcab87c8e8`, whose single interaction row is
+ * `client_tool` / `request_input` / `cancelled` with no resolution and no
+ * `data.request.tool_call_id`. Its 44 records are the fixture, structurally untouched — only long
+ * unrelated `read`/`ls` payloads are elided, never the form's own records.
+ *
+ * The shape that makes it interesting: the form's turn ends `done{stopReason:"paused"}` and the
+ * NEXT turn starts with no user message between, so the two fold into one `resumed` draft. The
+ * resumed-draft pass settles approval gates only, so nothing but the row can settle this card.
+ */
+describe("golden: an abandoned form card from a real pre-fix session", () => {
+    const FORM_TOOL_CALL_ID =
+        "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6"
+    const goldenRecords = abandonedFormSession as unknown as SessionRecord[]
+    const formPart = (interactionRowStates?: SessionInteractionRowStates) =>
+        (transcriptToMessages(goldenRecords, {interactionRowStates}) ?? [])
+            .flatMap((message) => message.parts as unknown as Record<string, unknown>[])
+            .find((part) => part.toolCallId === FORM_TOOL_CALL_ID)
+
+    it("replays the form live when no row state is available", () => {
+        expect(formPart()).toMatchObject({type: "tool-request_input", state: "input-available"})
+    })
+
+    it("settles the form to the neutral ended state from its cancelled row", () => {
+        const part = formPart(
+            new Map([
+                [
+                    FORM_TOOL_CALL_ID,
+                    {token: FORM_TOOL_CALL_ID, status: "cancelled", kind: "client_tool"},
+                ],
+            ]) as SessionInteractionRowStates,
+        )
+
+        expect(part).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+        // Never the pre-fix guesses that made an answered form read as dismissed.
+        expect(part?.output).not.toEqual({action: "cancel"})
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -1,4 +1,9 @@
-import type {SessionRecord} from "@agenta/entities/session"
+import type {
+    SessionInteractionRowState,
+    SessionInteractionRowStates,
+    SessionRecord,
+} from "@agenta/entities/session"
+import {CLIENT_TOOL_INTERACTION_ENDED_OUTPUT} from "@agenta/shared/clientTools"
 import type {UIMessage} from "ai"
 
 import {attachmentContentUrl} from "./attachmentMedia"
@@ -104,41 +109,71 @@ const isRunnerSentinelError = (part: Part): boolean => {
     )
 }
 
-/** Tool name from a replayed part's `type`/`toolName` — mirrors clientTools/meta.ts's
- * `clientToolName`, kept local since this file has no dependency on the app's client-tool layer. */
-const partToolName = (part: Part): string => {
-    if (part.type === "dynamic-tool") return typeof part.toolName === "string" ? part.toolName : ""
-    return typeof part.type === "string" ? part.type.replace(/^tool-/, "") : ""
+function settleClientToolPart(part: Part, row: SessionInteractionRowState): void {
+    if (part.state !== "input-available") return
+
+    if (row.resolution) {
+        if (row.resolution.outcome === "error") {
+            const error = row.resolution.error
+            part.state = "output-error"
+            part.errorText =
+                typeof error === "string" && error ? error : "The request ended without a result."
+        } else {
+            const output = row.resolution.output
+            part.state = "output-available"
+            part.output =
+                typeof output === "object" && output !== null && !Array.isArray(output)
+                    ? output
+                    : {...CLIENT_TOOL_INTERACTION_ENDED_OUTPUT}
+        }
+        return
+    }
+
+    if (row.status === "cancelled" || row.status === "responded" || row.status === "resolved") {
+        part.state = "output-available"
+        part.output = {...CLIENT_TOOL_INTERACTION_ENDED_OUTPUT}
+    }
 }
 
 /**
- * The settled output to synthesize for a client-tool interaction the backend already cancelled
- * (`session_interactions.status === "cancelled"`) whose transcript never got a settling
- * `tool_result` — see `fetchCancelledClientToolTokensAtom`'s doc for why the record log alone
- * can't tell. Mirrors each widget's OWN cancelled-terminal shape (`ConnectOutput.reason` /
- * `ElicitationResult.action`) so a resurrected part renders exactly like a live cancel — an inert
- * chip, never an interactive, answerable form. Keyed by the same tool name the client-tool
- * registry dispatches on (`registry.tsx`'s `BY_TOOL_NAME`); an unregistered kind falls back to a
- * bare empty output, which still settles (out of `input-available`) even with no dedicated chip.
+ * An approval gate whose row is terminal. Approval rows always recorded their outcome correctly,
+ * so they are trustworthy here. A verdict replays the real answer. A swept row proves only that
+ * the gate died unanswered — and that the gated tool never ran — so it settles denied rather than
+ * claiming an approval nobody gave. Either way the gate stops reading as still awaiting the user:
+ * a dead gate left `approval-requested` holds the message queue forever once the scans that read
+ * it cover the whole transcript.
  */
-const CANCELLED_CLIENT_TOOL_OUTPUT: Record<string, Part> = {
-    request_connection: {connected: false, reason: "cancelled"},
-    request_input: {action: "cancel"},
+function settleApprovalPart(part: Part, row: SessionInteractionRowState): void {
+    if (part.state !== "approval-requested") return
+
+    const verdict = row.resolution?.verdict
+    if (verdict === "approved" || verdict === "denied") {
+        part.state = "approval-responded"
+        part.approval = {id: row.token, approved: verdict === "approved"}
+        return
+    }
+    if (row.status === "cancelled") {
+        part.state = "output-denied"
+        return
+    }
+    if (row.status === "responded" || row.status === "resolved") part.state = "approval-responded"
 }
 
-/** Apply the cancelled-interaction override to every still-`input-available` client-tool part
- * whose token the interactions join marked cancelled. Runs once, after the full record sweep, so
- * a LATER `tool_result` for the same toolCallId (a real settle) always wins over this fallback. */
-function applyCancelledInteractions(
+function applyInteractionRowStates(
     index: TranscriptIndex,
-    cancelledClientToolTokens: ReadonlySet<string> | undefined,
+    interactionRowStates: SessionInteractionRowStates | undefined,
 ): void {
-    if (!cancelledClientToolTokens || cancelledClientToolTokens.size === 0) return
-    for (const [toolCallId, part] of index.tools) {
-        if (part.state !== "input-available") continue
-        if (!cancelledClientToolTokens.has(toolCallId)) continue
-        part.state = "output-available"
-        part.output = CANCELLED_CLIENT_TOOL_OUTPUT[partToolName(part)] ?? {}
+    if (!interactionRowStates || interactionRowStates.size === 0) return
+    for (const row of interactionRowStates.values()) {
+        // Token equality supports rows written before the runner stamped the tool-call id; an
+        // approval gate is also indexed under its interaction id, which IS the row token.
+        const toolCallId = row.toolCallId ?? row.token
+        const part = index.tools.get(toolCallId) ?? index.approvals.get(row.token)
+        if (!part) continue
+
+        if (row.kind === "user_approval") settleApprovalPart(part, row)
+        else if (row.kind === "client_tool" || row.kind === "user_input")
+            settleClientToolPart(part, row)
     }
 }
 
@@ -404,11 +439,8 @@ function applyEvent(
 }
 
 export interface TranscriptToMessagesOptions {
-    /** Tokens (== toolCallId) of this session's CANCELLED `client_tool` interactions — see
-     * `fetchCancelledClientToolTokensAtom`. A resurrected part for one of these replays inert
-     * instead of as a live, answerable form. Omit when the caller has no interaction-status join
-     * available; every part then replays exactly as before (unaffected, not a regression). */
-    cancelledClientToolTokens?: ReadonlySet<string>
+    /** Row lifecycle settles replayed interactions; omit it to preserve record-only replay. */
+    interactionRowStates?: SessionInteractionRowStates
 }
 
 /**
@@ -476,11 +508,8 @@ export function transcriptToMessages(
         }
     }
 
-    // Same "settle whatever the record log alone left parked" idea as the resumed-approval pass
-    // above, for client tools: a token the caller's interaction-status join says is CANCELLED
-    // never got its own `tool_result` (a real settle would have), so it replays parked forever
-    // without this.
-    applyCancelledInteractions(index, options?.cancelledClientToolTokens)
+    // Recorded results win; otherwise saved answers, neutral terminal state, then pending.
+    applyInteractionRowStates(index, options?.interactionRowStates)
 
     const messages = drafts
         .filter((d) => d.parts.length > 0)

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -23,7 +23,6 @@ import {type useVoiceComposer} from "../hooks/useVoiceComposer"
 
 import {ComposerSkeleton} from "./AgentChatSkeleton"
 import ApprovalDock, {type getPendingApprovals} from "./ApprovalDock"
-import type {ClientToolOutputHandler} from "./clientTools"
 import ComposerAttachments from "./ComposerAttachments"
 import ConnectModelBanner from "./ConnectModelBanner"
 import ContextBudgetIndicator from "./ContextBudgetIndicator"
@@ -65,7 +64,6 @@ const AgentComposerDock = ({
     onApprovalResponse,
     onViewTrace,
     pendingInteraction,
-    onClientToolOutput,
     onSubmit,
     onStop,
     richInputRef,
@@ -98,7 +96,6 @@ const AgentComposerDock = ({
     onApprovalResponse: (args: {id: string; approved: boolean; message?: string}) => void
     onViewTrace?: () => void
     pendingInteraction: ReturnType<typeof getPendingConnectInteraction>
-    onClientToolOutput: ClientToolOutputHandler
     onSubmit: (text: string) => void | Promise<void>
     onStop: () => void
     richInputRef: RefObject<RichChatInputHandle | null>
@@ -217,14 +214,8 @@ const AgentComposerDock = ({
                     onViewTrace={onViewTrace}
                     entityId={entityId}
                 />
-                {/* Parked client-tool interactions (connect): same placement contract as the
-                    approval dock — the paused gate can't scroll out of reach, and "Not now"
-                    is the escape hatch that resumes the run without connecting. */}
-                <InteractionDock
-                    className={CHAT_COLUMN}
-                    pending={pendingInteraction}
-                    onOutput={onClientToolOutput}
-                />
+                {/* The connect dock is a shortcut to the actionable transcript card. */}
+                <InteractionDock className={CHAT_COLUMN} pending={pendingInteraction} />
                 {/* Owner call: a template pick must not shift the composer, so no chip renders here
                     (unlike the home surface) — the strip card's own selected state is the
                     "which template" indicator; the composer text is the only other feedback. */}

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -46,26 +46,23 @@ const manifestsByToolCallId = (parts: UIMessage["parts"] = []): Map<string, unkn
     return found
 }
 
-/**
- * Approvals the run is currently blocked on. HITL only ever pauses the LAST assistant turn (see
- * `isHitlPending`), so we read pending tool gates off that turn — a turn can request several at
- * once (parallel tool calls), so this returns all of them in order.
- */
+/** Pending approval gates across assistant messages, in transcript order. */
 export const getPendingApprovals = (messages: UIMessage[]): PendingApproval[] => {
-    const last = messages[messages.length - 1]
-    if (!last || last.role !== "assistant") return []
     const out: PendingApproval[] = []
-    const manifests = manifestsByToolCallId(last.parts)
-    for (const part of last.parts ?? []) {
-        const p = part as ToolUIPart
-        const approval = (p as {approval?: ApprovalRef}).approval
-        if (isToolPart(part) && p.state === "approval-requested" && approval?.id) {
-            out.push({
-                approvalId: approval.id,
-                toolName: partToolName(p),
-                input: p.input,
-                manifest: manifests.get(p.toolCallId),
-            })
+    for (const message of messages) {
+        if (message.role !== "assistant") continue
+        const manifests = manifestsByToolCallId(message.parts)
+        for (const part of message.parts ?? []) {
+            const p = part as ToolUIPart
+            const approval = (p as {approval?: ApprovalRef}).approval
+            if (isToolPart(part) && p.state === "approval-requested" && approval?.id) {
+                out.push({
+                    approvalId: approval.id,
+                    toolName: partToolName(p),
+                    input: p.input,
+                    manifest: manifests.get(p.toolCallId),
+                })
+            }
         }
     }
     return out

--- a/web/oss/src/components/AgentChatSlice/components/InteractionDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/InteractionDock.tsx
@@ -1,160 +1,65 @@
-/**
- * Persistent "the agent is waiting for you" band for parked CLIENT-TOOL interactions — the sibling
- * of ApprovalDock with the same placement contract: it lives in the composer region (between the
- * transcript and the input) so a paused run can't scroll out of reach, and it OWNS the actions
- * while the inline transcript row is just a marker.
- *
- * Why it exists (UX): when the runner parks a `request_connection`, the stream genuinely ends —
- * `useChat` reads "ready", so nothing busy-derived (working dots, stop button) signals the pause,
- * while the message queue silently holds every send (`isHitlPending`). This dock makes the paused
- * state visible where the user is typing AND provides the escape hatch a parked connection
- * previously lacked: "Not now" settles the call as a structured decline, so the run resumes and
- * the conversation unfreezes.
- *
- * v1 covers the connect interaction (`request_connection` / render.kind "connect"). Elicitation
- * stays inline — it's a form the user fills in the transcript, and it carries its own
- * Decline/Dismiss actions; the composer's waiting state covers its visibility.
- */
+/** Persistent shortcut from the composer to a parked connect card in the transcript. */
 import {memo, useCallback, useRef} from "react"
 
 import {buildRenderMap, isPendingClientToolInteraction} from "@agenta/playground"
-import {Plugs, Spinner} from "@phosphor-icons/react"
+import {CLIENT_TOOL_DESCRIPTORS} from "@agenta/shared/clientTools"
+import {ArrowUp, Plugs} from "@phosphor-icons/react"
 import type {ToolUIPart, UIMessage} from "ai"
-import {Button, Typography} from "antd"
+import {Typography} from "antd"
 
-import {clientToolMeta, type ClientToolMeta, type ClientToolOutputHandler} from "./clientTools"
-import type {SettleClientTool} from "./clientTools/types"
-import {useConnectFlow} from "./clientTools/useConnectFlow"
+import {clientToolMeta, type ClientToolMeta} from "./clientTools"
 
 const {Text} = Typography
 
 /** Whether this client-tool meta is the connect interaction (registry's two dispatch axes). */
 const isConnectInteraction = (meta: ClientToolMeta): boolean =>
-    meta.renderKind === "connect" || meta.toolName === "request_connection"
+    meta.renderKind === CLIENT_TOOL_DESCRIPTORS.connection.renderKind ||
+    meta.toolName === CLIENT_TOOL_DESCRIPTORS.connection.toolName
 
-/**
- * The parked connect interaction the run is currently blocked on, or null. Like
- * `getPendingApprovals`, HITL only ever pauses the LAST assistant turn (see `isHitlPending`), so
- * only that turn is read. The runner parks one interaction per turn — first match wins.
- */
+/** The newest parked connect interaction across the transcript, or null. */
 export const getPendingConnectInteraction = (messages: UIMessage[]): ClientToolMeta | null => {
-    const last = messages[messages.length - 1]
-    if (!last || last.role !== "assistant") return null
-    const parts = last.parts ?? []
-    const renderMap = buildRenderMap(parts as {type?: string; data?: unknown}[])
-    for (const part of parts) {
-        if (!isPendingClientToolInteraction(part as {type?: string; state?: string}, renderMap))
-            continue
-        const meta = clientToolMeta(part as ToolUIPart, renderMap)
-        if (isConnectInteraction(meta)) return meta
+    // The shortcut points to the most recent pending connect card.
+    for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex--) {
+        const message = messages[messageIndex]
+        if (message.role !== "assistant") continue
+        const parts = message.parts ?? []
+        const renderMap = buildRenderMap(parts as {type?: string; data?: unknown}[])
+        for (let partIndex = parts.length - 1; partIndex >= 0; partIndex--) {
+            const part = parts[partIndex]
+            if (!isPendingClientToolInteraction(part as {type?: string; state?: string}, renderMap))
+                continue
+            const meta = clientToolMeta(part as ToolUIPart, renderMap)
+            if (isConnectInteraction(meta)) return meta
+        }
     }
     return null
-}
-
-/** The dock's connect card: header + per-phase body + actions, driven by the shared OAuth flow. */
-const ConnectCard = ({
-    meta,
-    onOutput,
-    active,
-}: {
-    meta: ClientToolMeta
-    onOutput: ClientToolOutputHandler
-    active: boolean
-}) => {
-    // Same settle mapping as ClientToolPart — the dock is a second dispatch site for this part.
-    const settle = useCallback<SettleClientTool>(
-        (args: {output: Record<string, unknown>} | {errorText: string}) => {
-            if ("errorText" in args) {
-                onOutput({
-                    toolName: meta.toolName,
-                    toolCallId: meta.toolCallId,
-                    errorText: args.errorText,
-                })
-            } else {
-                onOutput({
-                    toolName: meta.toolName,
-                    toolCallId: meta.toolCallId,
-                    output: args.output,
-                })
-            }
-        },
-        [onOutput, meta.toolName, meta.toolCallId],
-    )
-    const {label, phase, errorText, modeResolving, runConnect, cancel, decline} = useConnectFlow(
-        meta,
-        settle,
-        active,
-    )
-
-    return (
-        <div className="ag-surface-chat mb-2 flex flex-col gap-2.5 rounded-lg p-3">
-            {/* Header: a quiet primary cue, same visual language as the approval dock's header. */}
-            <div className="flex items-center gap-2">
-                <Plugs size={15} weight="fill" className="shrink-0 text-colorPrimary" />
-                <Text className="!text-xs !font-medium">The agent is waiting for you</Text>
-            </div>
-
-            {phase === "connecting" ? (
-                <div className="flex items-center gap-2">
-                    <Spinner size={13} className="shrink-0 animate-spin text-colorPrimary" />
-                    <Text type="secondary" className="!text-xs">
-                        Connecting {label}… finish signing in from the popup window.
-                    </Text>
-                </div>
-            ) : phase === "error" ? (
-                <Text type="danger" className="!text-xs" title={errorText ?? undefined}>
-                    {errorText ?? "Connection failed."}
-                </Text>
-            ) : (
-                <Text type="secondary" className="!text-xs">
-                    Connect <span className="font-medium text-colorText">{label}</span> to let the
-                    agent continue, or continue without the connection.
-                </Text>
-            )}
-
-            <div className="flex items-center justify-end gap-1.5">
-                {phase === "connecting" ? (
-                    <Button onClick={cancel}>Cancel</Button>
-                ) : (
-                    <>
-                        <Button onClick={decline}>Not now</Button>
-                        <Button
-                            type="primary"
-                            disabled={modeResolving}
-                            title={
-                                modeResolving ? "Checking how this toolkit connects…" : undefined
-                            }
-                            onClick={() => runConnect(true)}
-                        >
-                            {phase === "error" ? "Retry" : `Connect ${label}`}
-                        </Button>
-                    </>
-                )}
-            </div>
-        </div>
-    )
 }
 
 interface InteractionDockProps {
     /** The parked connect interaction the run is blocked on (from `getPendingConnectInteraction`). */
     pending: ClientToolMeta | null
-    /** Settle channel — the panel maps this onto `addToolOutput` (marks the resume as live). */
-    onOutput: ClientToolOutputHandler
     className?: string
 }
 
 /**
  * Always mounted; enter + leave animate via the grid-rows 0fr↔1fr height collapse (+ opacity), the
  * same idiom as ApprovalDock. `inert` while closed drops the (clipped, latched) card from tab order
- * + a11y so a keyboard user can't reach hidden buttons.
+ * + a11y so a keyboard user can't reach the hidden shortcut.
  */
-const InteractionDock = ({pending, onOutput, className}: InteractionDockProps) => {
+const InteractionDock = ({pending, className}: InteractionDockProps) => {
     const open = !!pending
     // Latch the last pending interaction so the card persists through the height collapse.
     const shownRef = useRef(pending)
     if (pending) shownRef.current = pending
     const shown = shownRef.current
-    const shownIsActive = !!pending && shown?.toolCallId === pending.toolCallId
+    const toolCallId = shown?.toolCallId
+    const scrollToCard = useCallback(() => {
+        if (!toolCallId) return
+        // Virtualized transcript cards may not be mounted.
+        document
+            .querySelector(`[data-client-tool-call-id="${CSS.escape(toolCallId)}"]`)
+            ?.scrollIntoView({behavior: "smooth", block: "center"})
+    }, [toolCallId])
 
     return (
         <div
@@ -165,13 +70,22 @@ const InteractionDock = ({pending, onOutput, className}: InteractionDockProps) =
         >
             <div className="min-h-0 overflow-hidden">
                 {shown ? (
-                    // Keyed by call id so flow state (phase/popup) resets per parked call.
-                    <ConnectCard
-                        key={shown.toolCallId}
-                        meta={shown}
-                        onOutput={onOutput}
-                        active={shownIsActive}
-                    />
+                    <button
+                        type="button"
+                        onClick={scrollToCard}
+                        className="ag-surface-chat mb-2 flex w-full cursor-pointer items-center gap-2 rounded-lg border-0 p-3 text-left transition-colors hover:bg-colorFillTertiary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-colorPrimary"
+                    >
+                        <Plugs size={15} weight="fill" className="shrink-0 text-colorPrimary" />
+                        <span className="flex min-w-0 flex-col">
+                            <Text className="!text-xs !font-medium">
+                                The run is waiting for you
+                            </Text>
+                            <Text type="secondary" className="!text-xs">
+                                Go to the connection card above
+                            </Text>
+                        </span>
+                        <ArrowUp size={14} className="ml-auto shrink-0 text-colorTextTertiary" />
+                    </button>
                 ) : null}
             </div>
         </div>

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
@@ -59,7 +59,11 @@ const ClientToolPart = ({
         [onOutput, meta.toolName, meta.toolCallId],
     )
 
-    return createElement(handler, {meta, settle, degradedEarlierInTurn})
+    return (
+        <div data-client-tool-call-id={meta.toolCallId}>
+            {createElement(handler, {meta, settle, degradedEarlierInTurn})}
+        </div>
+    )
 }
 
 export default memo(ClientToolPart)

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
@@ -2,15 +2,14 @@
  * Connect widget — the `request_connection` / `render.kind: "connect"` client tool (#4920).
  *
  * The agent asked for a connection it lacks (e.g. GitHub). While the call is PARKED, this inline
- * row is a passive marker only — the actions (Connect / Not now / Cancel) live in the
- * InteractionDock in the composer region, mirroring ApprovalDock's "dock acts, inline marks"
- * contract, so the paused run can never scroll out of reach and always has an escape hatch.
+ * row owns the Connect / Not now actions. The InteractionDock remains a shortcut back to it.
  *
  * After the call settles this row owns the result UX (U1) — an inline status chip in the same
  * visual language as approve/deny: "GitHub connected" ✓, or "Connection not completed" + Retry
  * (which re-runs the OAuth via the shared `useConnectFlow`, priming the vault for the agent's
  * re-ask — the settled part itself can't be re-resolved).
  */
+import {isInteractionEndedOutput} from "@agenta/shared/clientTools"
 import {
     ArrowClockwise,
     CheckCircle,
@@ -22,7 +21,7 @@ import {
 import {Button, Typography} from "antd"
 
 import type {ClientToolHandlerProps} from "./types"
-import {useConnectFlow, type ConnectOutput} from "./useConnectFlow"
+import {settledFailureChip, useConnectFlow, type ConnectOutput} from "./useConnectFlow"
 
 const {Text} = Typography
 
@@ -34,14 +33,19 @@ const {Text} = Typography
  */
 const DEFERRED_SENTINEL = "DEFERRED_NOT_EXECUTED"
 
-/** Non-error terminal reasons (see `ConnectOutput.reason`): render generic wording for
- * these; any other `reason` is a real failure message and must be shown verbatim — a
- * create failure was previously settling silently with no error surfaced at all. */
-const KNOWN_CONNECT_REASONS = new Set(["declined", "cancelled", "timeout"])
-
 const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
-    const {label, phase, errorText, outcome, manuallyConnected, modeResolving, runConnect, cancel} =
-        useConnectFlow(meta, settle)
+    const {
+        label,
+        phase,
+        errorText,
+        errorRetryable,
+        outcome,
+        manuallyConnected,
+        modeResolving,
+        runConnect,
+        cancel,
+        decline,
+    } = useConnectFlow(meta, settle)
 
     // A runner-deferred sibling settles as an error carrying the deferral sentinel (not a real
     // connection failure); see DEFERRED_SENTINEL.
@@ -68,6 +72,15 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
     // ── Settled: the result chip (U1). `outcome` covers the render before `meta.settled` flips. ──
     if (meta.settled || outcome) {
         const output = (meta.output ?? {}) as ConnectOutput
+        if (isInteractionEndedOutput(meta.output)) {
+            return (
+                <ChipRow icon={<Plugs size={13} className="text-colorTextTertiary" />}>
+                    <Text type="secondary" className="!text-xs !text-colorTextTertiary">
+                        Connection request ended
+                    </Text>
+                </ChipRow>
+            )
+        }
         if (manuallyConnected || output.connected === true || outcome?.connected === true) {
             return (
                 <ChipRow
@@ -88,14 +101,10 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
                 </ChipRow>
             )
         }
-        // Declined / cancelled / timeout: quiet generic wording — these are expected, not
-        // errors. Any other reason is the create call's own failure message and must be
-        // shown, not swallowed behind the same generic text (it previously was).
-        const reason = outcome?.reason ?? output.reason
-        const failureDetail =
-            typeof reason === "string" && reason && !KNOWN_CONNECT_REASONS.has(reason)
-                ? reason
-                : undefined
+        // Declined / cancelled / timeout get quiet generic wording; any other reason is the create
+        // call's own failure message and is shown verbatim. This branch is the one a parked card
+        // takes, the only one that survives a reload, and the only one a post-settle retry reaches.
+        const {failureDetail, retryable: settledRetryable} = settledFailureChip(outcome, output)
         return (
             <ChipRow
                 icon={
@@ -113,7 +122,11 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
                 >
                     {failureDetail ?? "Connection not completed"}
                 </Text>
-                <RetryButton onClick={() => runConnect(false)} disabled={modeResolving} />
+                {/* No Retry for a duplicate: repeating the create can only 409 again, and the call
+                    is already settled so there is nothing else to act on. */}
+                {settledRetryable ? (
+                    <RetryButton onClick={() => runConnect(false)} disabled={modeResolving} />
+                ) : null}
             </ChipRow>
         )
     }
@@ -125,18 +138,36 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
                 <Text type="danger" className="!text-xs truncate" title={errorText ?? undefined}>
                     {errorText ?? "Connection failed."}
                 </Text>
-                <RetryButton onClick={() => runConnect(false)} disabled={modeResolving} />
+                <div className="ml-auto flex items-center gap-1.5">
+                    <Button type="text" size="small" onClick={decline}>
+                        Not now
+                    </Button>
+                    {/* A duplicate-connection failure can only repeat, so Retry is not offered. */}
+                    {errorRetryable ? (
+                        <RetryButton onClick={() => runConnect(false)} disabled={modeResolving} />
+                    ) : null}
+                </div>
             </ChipRow>
         )
     }
 
-    // ── Pending: passive marker — the InteractionDock (above the composer) owns the actions ──────
     return (
         <ChipRow icon={<Plugs size={13} className="text-colorPrimary" />}>
             <Text className="!text-xs">Connect {label}</Text>
-            <Text type="secondary" className="!text-xs !text-colorTextTertiary">
-                waiting for your response below
-            </Text>
+            <div className="ml-auto flex items-center gap-1.5">
+                <Button type="text" size="small" onClick={decline}>
+                    Not now
+                </Button>
+                <Button
+                    type="primary"
+                    size="small"
+                    disabled={modeResolving}
+                    title={modeResolving ? "Checking how this toolkit connects…" : undefined}
+                    onClick={() => runConnect(true)}
+                >
+                    Connect {label}
+                </Button>
+            </div>
         </ChipRow>
     )
 }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.settleOnce.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.settleOnce.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * One settle per elicitation card.
+ *
+ * `meta.settled` only flips after an awaited record write, so between an Accept click and that
+ * write the card is still showing live Decline/Dismiss buttons. Without a latch the second click
+ * sends a competing answer for the same `toolCallId`, and the runner resumes on whichever lands
+ * last. These tests pin the latch: the first settle wins and later clicks are inert.
+ *
+ * The chrome (antd, SchemaForm, icons) is mocked — this is about the settle channel, not layout.
+ */
+import {act} from "react"
+
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entity-ui/gatewayTool", () => ({
+    SchemaForm: () => <div />,
+    formatReviewValue: (_field: unknown, value: unknown) => String(value),
+}))
+
+vi.mock("@agenta/shared/clientTools", () => ({
+    isInteractionEndedOutput: () => false,
+}))
+
+vi.mock("@agenta/shared/hooks", () => ({
+    useModifierKey: () => "⌘",
+}))
+
+vi.mock("@agenta/shared/utils", () => ({
+    buildAcceptResult: (content: unknown, message: string) => ({
+        action: "accept",
+        content,
+        message,
+    }),
+    buildCancelResult: (message: string) => ({action: "cancel", message}),
+    buildDeclineResult: (message: string) => ({action: "decline", message}),
+    buildDegradationErrorText: (reason: string) => reason,
+    buildFormFieldsFromSchema: () => [],
+    // "pending" is the live form — the only state that renders these buttons.
+    deriveElicitationPartState: () => "pending",
+    parseElicitationPayload: () => ({
+        ok: true,
+        payload: {message: "Pick a timezone", requestedSchema: {}},
+    }),
+    partitionElicitationDraft: () => ({known: {}, unknown: {}}),
+    serializeElicitationContent: (_payload: unknown, values: unknown) => values,
+}))
+
+vi.mock("@agenta/ui", () => ({
+    HeightCollapse: ({children}: {children?: React.ReactNode}) => <div>{children}</div>,
+}))
+
+vi.mock("@agenta/ui/rich-chat-input", () => ({
+    ShortcutHint: () => <span />,
+}))
+
+vi.mock("@phosphor-icons/react", () => ({
+    CaretRight: () => <i />,
+    CheckCircle: () => <i />,
+    Prohibit: () => <i />,
+    Question: () => <i />,
+    Warning: () => <i />,
+    XCircle: () => <i />,
+}))
+
+vi.mock("antd", () => {
+    const Button = ({
+        children,
+        onClick,
+        disabled,
+    }: {
+        children?: React.ReactNode
+        onClick?: () => void
+        disabled?: boolean
+    }) => (
+        <button type="button" onClick={onClick} disabled={disabled}>
+            {children}
+        </button>
+    )
+    return {
+        Button,
+        Form: {
+            useForm: () => [{validateFields: () => Promise.resolve({timezone: "UTC"})}],
+            useWatch: () => ({}),
+        },
+        Typography: {Text: ({children}: {children?: React.ReactNode}) => <span>{children}</span>},
+    }
+})
+
+vi.mock("../../assets/toolDisplay", () => ({
+    resolveToolDisplay: () => ({label: "Elicitation"}),
+}))
+
+import ElicitationWidget from "./ElicitationWidget"
+import type {ClientToolMeta, SettleClientTool} from "./types"
+
+const META = {
+    toolCallId: "call-1",
+    toolName: "ag_elicit",
+    renderKind: "elicitation",
+    state: "input-available",
+    input: {message: "Pick a timezone", requestedSchema: {}},
+    output: undefined,
+    settled: false,
+    part: {} as ClientToolMeta["part"],
+} satisfies ClientToolMeta
+
+let container: HTMLDivElement
+let root: Root
+
+const buttonNamed = (label: string) =>
+    Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === label,
+    ) as HTMLButtonElement | undefined
+
+const render = async (settle: SettleClientTool) => {
+    await act(async () => {
+        root.render(<ElicitationWidget meta={META} settle={settle} />)
+    })
+}
+
+beforeEach(() => {
+    ;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(async () => {
+    await act(async () => {
+        root.unmount()
+    })
+    container.remove()
+    vi.clearAllMocks()
+})
+
+describe("ElicitationWidget — one settle per card", () => {
+    it("ignores a Decline that lands on an in-flight Accept", async () => {
+        const settle = vi.fn()
+        await render(settle)
+
+        await act(async () => {
+            buttonNamed("Accept")?.click()
+        })
+        // The record write has not returned, so `meta.settled` is still false here.
+        await act(async () => {
+            buttonNamed("Decline")?.click()
+        })
+
+        expect(settle).toHaveBeenCalledTimes(1)
+        expect(settle.mock.calls[0][0]).toMatchObject({output: {action: "accept"}})
+    })
+
+    it("ignores a Dismiss that lands on an in-flight Decline", async () => {
+        const settle = vi.fn()
+        await render(settle)
+
+        await act(async () => {
+            buttonNamed("Decline")?.click()
+        })
+        await act(async () => {
+            buttonNamed("Dismiss")?.click()
+        })
+
+        expect(settle).toHaveBeenCalledTimes(1)
+        expect(settle.mock.calls[0][0]).toMatchObject({output: {action: "decline"}})
+    })
+
+    it("disables the secondary actions once a settle is in flight", async () => {
+        const settle = vi.fn()
+        await render(settle)
+
+        await act(async () => {
+            buttonNamed("Decline")?.click()
+        })
+
+        expect(buttonNamed("Decline")?.disabled).toBe(true)
+        expect(buttonNamed("Dismiss")?.disabled).toBe(true)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
@@ -132,7 +132,7 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
 
     // Accept stays disabled until every required question has an answer — a dominant, always-
     // enabled primary invites submitting unfinished forms. Defaults count, so a fully-prefilled
-    // form is born ready (one-click accept). Decline/Dismiss stay always-available.
+    // form is born ready (one-click accept). Decline/Dismiss stay available until a settle starts.
     const watchedValues = Form.useWatch([], form) as Record<string, unknown> | undefined
     const requiredNames = parsed.ok ? (parsed.payload.requestedSchema.required ?? []) : []
     const missingRequired = requiredNames.filter((name) => {
@@ -167,10 +167,17 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
             // storage unavailable — drafts are best-effort
         }
     }
+    // One settle per card: `meta.settled` only flips after an awaited record write, so without this
+    // latch a Decline landing on an in-flight Accept sends a second answer for the same tool call.
+    const settlingRef = useRef(false)
     const settleAndClear: typeof settle = (
         args: {output: Record<string, unknown>} | {errorText: string},
     ) => {
+        if (settlingRef.current) return
+        settlingRef.current = true
+        setSubmitting(true)
         clearDraft()
+        // Split by shape: `settle` is overloaded, so the union has to be narrowed to pick one.
         if ("errorText" in args) {
             settle(args)
         } else {
@@ -399,6 +406,7 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
                 )}
                 <Button
                     type="text"
+                    disabled={submitting}
                     onClick={() =>
                         settleAndClear({
                             output: toOutput(buildDeclineResult("Declined the request.")),
@@ -410,6 +418,7 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
                 <Button
                     type="text"
                     className="ml-auto opacity-60"
+                    disabled={submitting}
                     onClick={() =>
                         settleAndClear({
                             output: toOutput(buildCancelResult("Dismissed the request.")),

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
@@ -14,6 +14,7 @@ import {
     type StepInfo,
     formatReviewValue,
 } from "@agenta/entity-ui/gatewayTool"
+import {isInteractionEndedOutput} from "@agenta/shared/clientTools"
 import {useModifierKey} from "@agenta/shared/hooks"
 import {
     type ElicitationResult,
@@ -205,6 +206,13 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
 
     // Settled replays: chip copy comes from the envelope (`humanFriendlyMessage`), never re-resolved.
     if (partState !== "pending") {
+        if (isInteractionEndedOutput(meta.output)) {
+            return (
+                <Chip icon={<Question size={13} className="shrink-0 text-colorTextTertiary" />}>
+                    Request ended
+                </Chip>
+            )
+        }
         const envelopeMessage =
             meta.output &&
             typeof (meta.output as {humanFriendlyMessage?: unknown}).humanFriendlyMessage ===
@@ -291,11 +299,13 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
             settleAndClear({
                 output: toOutput(buildAcceptResult(content, "Provided the requested input.")),
             })
+            // Deliberately still submitting: the settle is fire-and-forget behind an awaited record
+            // write, so re-enabling here lets a second click fire a second settle.
         } catch (err) {
             // antd surfaces inline field errors; in stepper mode, jump to the failing question.
             const first = (err as {errorFields?: {name: (string | number)[]}[]})?.errorFields?.[0]
             if (first?.name) formRef.current?.goToField?.(first.name)
-        } finally {
+            // The form is still open and answerable, so the button has to come back.
             setSubmitting(false)
         }
     }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
@@ -6,9 +6,12 @@
  * `{approved: false}` envelope. Reading it as a parked client tool made the fallback overwrite that
  * envelope with `{status: "not_handled"}`, so the model saw a failed tool and retried the same call.
  */
-import type {RenderHintLike} from "@agenta/playground"
-import type {ToolUIPart} from "ai"
+import {isHitlPending, type RenderHintLike} from "@agenta/playground"
+import type {ToolUIPart, UIMessage} from "ai"
 import {describe, expect, it} from "vitest"
+
+import {getPendingApprovals} from "../ApprovalDock"
+import {getPendingConnectInteraction} from "../InteractionDock"
 
 import ConnectToolWidget from "./ConnectToolWidget"
 import ElicitationWidget from "./ElicitationWidget"
@@ -24,6 +27,63 @@ const toolPart = (part: Record<string, unknown>): ToolUIPart =>
         input: {path: "/x"},
         ...part,
     }) as unknown as ToolUIPart
+
+const EARLIER_PENDING_MESSAGES = [
+    {
+        id: "assistant-pending",
+        role: "assistant",
+        parts: [
+            {
+                type: "tool-browser_connection",
+                toolCallId: "call-connect",
+                state: "input-available",
+                input: {integration: "github"},
+            },
+            {
+                type: "data-render",
+                data: {toolCallId: "call-connect", render: {kind: "connect"}},
+            },
+            {
+                type: "tool-delete_file",
+                toolCallId: "call-approval",
+                state: "approval-requested",
+                input: {path: "notes.txt"},
+                approval: {id: "approval-earlier"},
+            },
+            {
+                type: "data-approval-manifest",
+                data: {toolCallId: "call-approval", manifest: {files: ["notes.txt"]}},
+            },
+        ],
+    },
+    {
+        id: "user-next",
+        role: "user",
+        parts: [{type: "text", text: "continue"}],
+    },
+    {
+        id: "assistant-last",
+        role: "assistant",
+        parts: [{type: "text", text: "Starting the next turn"}],
+    },
+] as unknown as UIMessage[]
+
+describe("pending interaction geometry", () => {
+    it("keeps earlier cards discoverable after a later message", () => {
+        expect(isHitlPending(EARLIER_PENDING_MESSAGES)).toBe(true)
+        expect(getPendingConnectInteraction(EARLIER_PENDING_MESSAGES)?.toolCallId).toBe(
+            "call-connect",
+        )
+        expect(getPendingApprovals(EARLIER_PENDING_MESSAGES)).toEqual([
+            {
+                approvalId: "approval-earlier",
+                toolName: "delete_file",
+                input: {path: "notes.txt"},
+                manifest: {files: ["notes.txt"]},
+            },
+        ])
+    })
+})
 
 describe("isClientToolPart", () => {
     it("does NOT claim a denied approval part (output-denied)", () => {
@@ -83,9 +143,11 @@ describe("resolveClientToolHandler", () => {
         expect(resolveClientToolHandler(clientToolMeta(part))).toBe(ElicitationWidget)
     })
 
-    it("does not reinterpret an explicit unknown render kind by tool name", () => {
+    it("falls back to tool name when the render kind is unknown", () => {
         const part = toolPart({type: "tool-request_input", state: "input-available"})
-        expect(resolveClientToolHandler(clientToolMeta(part, renderMapFor("display")))).toBeNull()
+        expect(resolveClientToolHandler(clientToolMeta(part, renderMapFor("display")))).toBe(
+            ElicitationWidget,
+        )
     })
 
     it("still resolves the connect widget on both axes", () => {

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.ts
@@ -66,7 +66,7 @@ export const isClientToolPart = (
     const meta = clientToolMeta(part, renderMap)
     if (hasClientToolHandler(meta)) return true
 
-    // Parked unknown client tool: the run ended with this part still unsettled.
+    // Keep this last-message-only so old parked parts are not auto-settled.
     const parkedUnsettled = !ctx.isStreaming && ctx.isLastMessage && !meta.settled
     return parkedUnsettled
 }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
@@ -5,8 +5,8 @@
  * REQUIRED wire field for interaction kinds — it arrives as a sibling `data-render` part (AI SDK
  * tool chunks are strict), resolved into `meta.renderKind` via the message-scoped render map
  * (@agenta/playground `buildRenderMap`). The `toolName` axis is the safety net for a hint that
- * never arrived — the connect widget's v1 wire predates the guarantee, and a transcript persisted
- * before the replay path carried the sibling part has none. Each later kind is one added entry,
+ * is missing or unknown — the connect widget's v1 wire predates the guarantee, and a transcript
+ * persisted before the replay path carried the sibling part has none. Each later kind is one added entry,
  * not a protocol change. Contract: docs/design/agent-chat-interaction-kinds/decisions.md
  *
  *   runner interaction_request ──▶ tool part (+ sibling data-render part)
@@ -27,6 +27,8 @@
  */
 import type {ComponentType} from "react"
 
+import {CLIENT_TOOL_DESCRIPTORS} from "@agenta/shared/clientTools"
+
 import ConnectToolWidget from "./ConnectToolWidget"
 import ElicitationWidget from "./ElicitationWidget"
 import type {ClientToolHandlerProps, ClientToolMeta} from "./types"
@@ -35,24 +37,23 @@ type ClientToolHandler = ComponentType<ClientToolHandlerProps>
 
 /** Handlers keyed by `render.kind` (checked first — the finer dispatch axis). */
 const BY_RENDER_KIND: Record<string, ClientToolHandler> = {
-    connect: ConnectToolWidget,
-    elicitation: ElicitationWidget,
+    [CLIENT_TOOL_DESCRIPTORS.connection.renderKind]: ConnectToolWidget,
+    [CLIENT_TOOL_DESCRIPTORS.elicitation.renderKind]: ElicitationWidget,
 }
 
 /** Handlers keyed by `toolName` (checked when no render hint matched). Both entries are
  * platform-reserved static tools, so the name is a safe second axis when the hint is missing —
  * an old persisted transcript, or any replay path that didn't carry the sibling part. */
 const BY_TOOL_NAME: Record<string, ClientToolHandler> = {
-    request_connection: ConnectToolWidget,
-    request_input: ElicitationWidget,
+    [CLIENT_TOOL_DESCRIPTORS.connection.toolName]: ConnectToolWidget,
+    [CLIENT_TOOL_DESCRIPTORS.elicitation.toolName]: ElicitationWidget,
 }
 
 /** Resolve the widget for a client tool, or `null` when none is registered. */
-export const resolveClientToolHandler = (meta: ClientToolMeta): ClientToolHandler | null => {
-    if (meta.renderKind !== undefined) return BY_RENDER_KIND[meta.renderKind] ?? null
-    if (BY_TOOL_NAME[meta.toolName]) return BY_TOOL_NAME[meta.toolName]
-    return null
-}
+export const resolveClientToolHandler = (meta: ClientToolMeta): ClientToolHandler | null =>
+    (meta.renderKind ? BY_RENDER_KIND[meta.renderKind] : undefined) ??
+    BY_TOOL_NAME[meta.toolName] ??
+    null
 
 /** Whether this client tool has a dedicated widget (used to route known tools in every state). */
 export const hasClientToolHandler = (meta: ClientToolMeta): boolean =>

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
@@ -11,8 +11,11 @@
 import {describe, expect, it} from "vitest"
 
 import {
+    connectFailureFrom,
     extractConnectErrorMessage,
     isConnectModeResolving,
+    isConnectionAlreadyExists,
+    settledFailureChip,
     resolveConnectMode,
 } from "./useConnectFlow"
 
@@ -100,5 +103,163 @@ describe("extractConnectErrorMessage", () => {
             "Connection failed. Please try again.",
         )
         expect(extractConnectErrorMessage(null)).toBe("Connection failed. Please try again.")
+    })
+})
+
+/**
+ * The duplicate-connection dead end found in live QA (2026-08-10): when the project already holds a
+ * connection for the toolkit, `POST /tools/connections/` answers 409 whose `detail` is the platform
+ * CONFLICT ENVELOPE — an object, not a string. The extractor only read the string form, so the card
+ * showed "Connection failed. Please try again.", the settle reason carried that same non-reason to
+ * the agent, and Retry re-fired the identical doomed create forever.
+ */
+describe("a duplicate connection (409)", () => {
+    const conflictError = (conflict?: Record<string, unknown>) => ({
+        statusCode: 409,
+        body: {
+            detail: {
+                message: "A resource with slug 'telegram' already exists in this project.",
+                ...(conflict ? {conflict} : {}),
+            },
+        },
+    })
+
+    it("names the integration from the conflict envelope", () => {
+        expect(
+            extractConnectErrorMessage(
+                conflictError({
+                    provider_key: "composio",
+                    integration_key: "telegram",
+                    slug: "telegram",
+                }),
+            ),
+        ).toBe("A connection for telegram already exists in this project.")
+    })
+
+    it("falls back to the server's own message when the conflict names no integration", () => {
+        expect(extractConnectErrorMessage(conflictError())).toBe(
+            "A resource with slug 'telegram' already exists in this project.",
+        )
+    })
+
+    it("still says what happened when the 409 carries no usable body at all", () => {
+        expect(extractConnectErrorMessage({statusCode: 409, body: {}})).toBe(
+            "A connection for this integration already exists in this project.",
+        )
+    })
+
+    it("never reports the generic failure for a 409", () => {
+        for (const err of [
+            conflictError(),
+            conflictError({integration_key: "gmail"}),
+            {statusCode: 409},
+        ]) {
+            expect(extractConnectErrorMessage(err)).not.toBe("Connection failed. Please try again.")
+        }
+    })
+
+    it("is the one failure Retry cannot fix", () => {
+        expect(isConnectionAlreadyExists(conflictError())).toBe(true)
+        expect(isConnectionAlreadyExists({statusCode: 422, body: {detail: "nope"}})).toBe(false)
+        expect(isConnectionAlreadyExists(new Error("network down"))).toBe(false)
+    })
+
+    it("gives the card and the settle reason the SAME message, and drops Retry", () => {
+        // The catch block feeds `setErrorText` and the settle `reason` from this one value, so the
+        // agent reads exactly what the user reads.
+        const failure = connectFailureFrom(
+            conflictError({integration_key: "telegram", slug: "telegram"}),
+        )
+
+        expect(failure.message).toBe("A connection for telegram already exists in this project.")
+        expect(failure.retryable).toBe(false)
+    })
+
+    it("keeps Retry for failures a retry could actually fix", () => {
+        expect(connectFailureFrom({statusCode: 422, body: {detail: "popup blocked"}})).toEqual({
+            message: "popup blocked",
+            retryable: true,
+        })
+        expect(connectFailureFrom(new Error("network down")).retryable).toBe(true)
+    })
+
+    it("reads an object detail on other 4xx codes too", () => {
+        expect(
+            extractConnectErrorMessage({
+                statusCode: 422,
+                body: {detail: {message: "custom OAuth credentials are required."}},
+            }),
+        ).toBe("custom OAuth credentials are required.")
+    })
+})
+
+/**
+ * Review round 3 finding 2: the PARKED card's 409 goes through `finish()`, so the render takes the
+ * SETTLED branch — `phase` is back to `idle` and `errorRetryable` is never read there. The settled
+ * branch has to make its own decision, and it must survive a reload, where only the stored output
+ * is left.
+ */
+/**
+ * Review round 3 finding 2 and the round-5 defect both land here: the PARKED card's failure goes
+ * through `finish()`, so the render takes the SETTLED branch — which returns before the
+ * `phase === "error"` branch, making that branch unreachable once settled. Everything the chip
+ * shows after a settle, including a post-settle retry's result, has to come through here.
+ */
+describe("settledFailureChip", () => {
+    it("drops Retry when the live outcome says the failure cannot be retried", () => {
+        expect(settledFailureChip({retryable: false}, {}).retryable).toBe(false)
+    })
+
+    it("drops Retry after a reload, from the stored output alone", () => {
+        expect(settledFailureChip(null, {retryable: false}).retryable).toBe(false)
+    })
+
+    it("keeps Retry for an ordinary failure", () => {
+        expect(settledFailureChip({retryable: true}, {retryable: true}).retryable).toBe(true)
+        expect(settledFailureChip(null, {}).retryable).toBe(true)
+        expect(settledFailureChip(undefined, undefined).retryable).toBe(true)
+    })
+
+    it("keeps Retry for outputs written before the flag existed", () => {
+        expect(settledFailureChip(null, {reason: "cancelled"}).retryable).toBe(true)
+    })
+
+    it("renders generic wording for the three expected non-error reasons", () => {
+        for (const reason of ["declined", "cancelled", "timeout"]) {
+            expect(settledFailureChip(null, {reason}).failureDetail).toBeUndefined()
+        }
+    })
+
+    it("renders any other reason verbatim", () => {
+        expect(
+            settledFailureChip(null, {
+                reason: "A connection for gmail already exists in this project.",
+            }).failureDetail,
+        ).toBe("A connection for gmail already exists in this project.")
+    })
+
+    it("the round-5 repro: a doomed retry from an abandoned-OAuth card stops offering Retry", () => {
+        // The stored output is the abandoned connect: reason "cancelled", no flag — so before the
+        // fix the chip kept its generic wording and a Retry that 409'd forever (QA reqid 4913/4919).
+        const abandoned = {connected: false, reason: "cancelled"}
+        expect(settledFailureChip(null, abandoned)).toEqual({
+            failureDetail: undefined,
+            retryable: true,
+        })
+
+        // After the failed retry refreshes the live outcome, the chip tells the truth and drops Retry.
+        const afterDoomedRetry = {
+            connected: false,
+            reason: "A connection for gmail already exists in this project.",
+            retryable: false,
+        }
+        expect(settledFailureChip(afterDoomedRetry, abandoned)).toEqual({
+            failureDetail: "A connection for gmail already exists in this project.",
+            retryable: false,
+        })
+    })
+
+    it("lets the live outcome override a stale stored output", () => {
+        expect(settledFailureChip({retryable: false}, {retryable: true}).retryable).toBe(false)
     })
 })

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
@@ -1,10 +1,6 @@
 /**
- * The Agenta OAuth connect flow for a `request_connection` client tool (#4920), extracted from
- * ConnectToolWidget so two surfaces share ONE implementation without double-settling:
- *  - the InteractionDock card (composer region) owns the LIVE parked call's actions — Connect,
- *    "Not now" (decline), Cancel — mirroring ApprovalDock's "dock acts, inline marks" contract;
- *  - the inline transcript chip keeps the post-settle states (result chip + Retry, which re-runs
- *    the OAuth with `settleParkedCall=false` to prime the vault for the agent's re-ask).
+ * The Agenta OAuth connect flow for a `request_connection` client tool (#4920). The inline card
+ * owns the parked call's actions and settled Retry, which can prime the vault for the agent's re-ask.
  *
  * It runs the existing connection machinery (`useToolsConnections` → `POST /tools/connections/`,
  * then a popup on the returned `redirect_url`) and settles the parked call with a **reference,
@@ -21,9 +17,8 @@
  *   · cancel/abandon → {connected:false, reason:"cancelled"} · timeout → {connected:false,
  *   reason:"timeout"} · failure → errorText.
  *
- * Two instances can be mounted for the SAME parked call (dock + inline marker). `meta.settled`
- * guards every live-settle path in addition to the per-instance `settledRef`, so an instance that
- * didn't perform the settle can never fire a second `addToolOutput` for it.
+ * `meta.settled` guards every live-settle path in addition to the per-instance `settledRef`, so a
+ * rerendered or remounted flow cannot fire a second `addToolOutput` for the same call.
  */
 import {useCallback, useEffect, useRef, useState} from "react"
 
@@ -56,9 +51,12 @@ export interface ConnectOutput {
     /**
      * `"declined" | "cancelled" | "timeout"` for the three expected non-error terminal
      * states, or the actual failure message when the create call itself errored (see
-     * `KNOWN_CONNECT_REASONS` in ConnectToolWidget, which renders the latter verbatim).
+     * `KNOWN_CONNECT_REASONS` below, whose members render as generic wording instead).
      */
     reason?: string
+    /** False only when repeating the create cannot work (a duplicate connection). Stored WITH the
+     * settled output so the card still knows after a reload, when only this output survives. */
+    retryable?: boolean
 }
 
 export type ConnectPhase = "idle" | "connecting" | "error"
@@ -91,27 +89,75 @@ export const resolveConnectMode = (
     return hintedMode
 }
 
+/** A create that collided with an existing connection for this toolkit. Retrying can only collide
+ * again, so the card drops Retry and the settle reason names the real obstacle. */
+export const isConnectionAlreadyExists = (err: unknown): boolean =>
+    (err as {statusCode?: unknown} | null)?.statusCode === 409
+
 /**
  * Prefer the backend's own `detail` on a 4xx (e.g. "telegram has no managed OAuth
  * configuration…") — Fern's default `Error.message` bundles a multi-line dump
  * (`message\nStatus code: 422\nBody: {...}`) that is not fit to show a user. Any other
  * failure (network error, 5xx) falls back to a generic message.
+ *
+ * `detail` is a STRING on the hand-written 4xx paths and an OBJECT (`{message, conflict}`) on the
+ * platform's conflict envelope. Reading only the string form is what left every duplicate-connection
+ * failure showing "Connection failed. Please try again." with no way to learn why.
  */
 export const extractConnectErrorMessage = (err: unknown): string => {
     const statusCode = (err as {statusCode?: unknown} | null)?.statusCode
     const body = (err as {body?: unknown} | null)?.body
     const detail =
         body && typeof body === "object" ? (body as {detail?: unknown}).detail : undefined
-    if (
-        typeof statusCode === "number" &&
-        statusCode >= 400 &&
-        statusCode < 500 &&
-        typeof detail === "string" &&
-        detail
-    ) {
-        return detail
+    const detailObject =
+        detail && typeof detail === "object" ? (detail as Record<string, unknown>) : undefined
+    const detailMessage =
+        typeof detailObject?.message === "string" ? detailObject.message : undefined
+    const integration = (detailObject?.conflict as {integration_key?: unknown} | undefined)
+        ?.integration_key
+
+    if (isConnectionAlreadyExists(err)) {
+        // The server's own wording says "resource" and quotes a slug; name the integration instead.
+        if (typeof integration === "string" && integration)
+            return `A connection for ${integration} already exists in this project.`
+        return detailMessage ?? "A connection for this integration already exists in this project."
+    }
+    if (typeof statusCode === "number" && statusCode >= 400 && statusCode < 500) {
+        if (typeof detail === "string" && detail) return detail
+        if (detailMessage) return detailMessage
     }
     return "Connection failed. Please try again."
+}
+
+/** One derivation for both halves of a failed create: what the card shows, what the settle reason
+ * tells the agent, and whether Retry is worth offering. They are one value so they cannot drift. */
+export const connectFailureFrom = (err: unknown): {message: string; retryable: boolean} => ({
+    message: extractConnectErrorMessage(err),
+    retryable: !isConnectionAlreadyExists(err),
+})
+
+/** Non-error terminal reasons: render generic wording for these; any other `reason` is a real
+ * failure message and must be shown verbatim (a create failure once settled silently). */
+const KNOWN_CONNECT_REASONS = new Set(["declined", "cancelled", "timeout"])
+
+/**
+ * What the SETTLED failure chip shows. The live outcome wins over the stored output on both halves:
+ * a manual retry from an already-settled card cannot settle anything, so refreshing that outcome is
+ * the only way its result reaches the chip — the settled block returns before the error branch.
+ * After a reload only the stored output survives, and a pre-flag output keeps Retry.
+ */
+export const settledFailureChip = (
+    outcome: {reason?: string; retryable?: boolean} | null | undefined,
+    output: {reason?: string; retryable?: boolean} | undefined,
+): {failureDetail?: string; retryable: boolean} => {
+    const reason = outcome?.reason ?? output?.reason
+    return {
+        failureDetail:
+            typeof reason === "string" && reason && !KNOWN_CONNECT_REASONS.has(reason)
+                ? reason
+                : undefined,
+        retryable: outcome?.retryable ?? output?.retryable ?? true,
+    }
 }
 
 /** Read the API origin the OAuth callback page posts from; null if it can't be resolved. */
@@ -147,7 +193,7 @@ export const isConnectModeResolving = ({
     timedOut: boolean
 }): boolean => hasIntegrationKey && queryIsLoading && !timedOut
 
-export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, active = true) => {
+export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool) => {
     const input = (meta.input ?? {}) as Record<string, unknown>
     const integration = typeof input.integration === "string" ? input.integration : ""
     // Connection slug: the call may pin one; default to the integration key. The output carries it
@@ -195,6 +241,8 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
 
     const [phase, setPhase] = useState<ConnectPhase>("idle")
     const [errorText, setErrorText] = useState<string | null>(null)
+    // A duplicate-connection create can only fail the same way again, so Retry is hidden for it.
+    const [errorRetryable, setErrorRetryable] = useState(true)
     // A retry started AFTER the parked call already settled (as a failure) succeeded. The settled
     // part can't be re-resolved, but the connection now exists in the vault, so we flip the chip to
     // "connected" — the agent's re-ask resolves cleanly on its next turn.
@@ -203,13 +251,15 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // `meta.settled` only flips a render later (after `addToolOutput` propagates), and without this
     // the surface would stay on "Connecting…" until then. `reason` mirrors `ConnectOutput.reason`
     // so a failure's message renders on that same first frame instead of one render late.
-    const [outcome, setOutcome] = useState<{connected: boolean; reason?: string} | null>(null)
+    const [outcome, setOutcome] = useState<{
+        connected: boolean
+        reason?: string
+        retryable?: boolean
+    } | null>(null)
 
-    // One-shot guard so THIS instance settles the parked call at most once, plus shared cleanup for
-    // the running popup's listener/poll/timeout. `meta.settled` covers the OTHER instance's settle.
+    // One-shot guard so this instance settles the parked call at most once, plus shared cleanup for
+    // the running popup's listener/poll/timeout. `meta.settled` covers a remount mid-flow.
     const settledRef = useRef(false)
-    const activeRef = useRef(active)
-    activeRef.current = active
     const popupRef = useRef<Window | null>(null)
     const cleanupRef = useRef<(() => void) | null>(null)
 
@@ -231,20 +281,18 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
                 setOutcome({connected: false, reason: result.errorText})
                 settle({errorText: result.errorText})
             } else {
-                setOutcome({connected: result.connected === true, reason: result.reason})
+                setOutcome({
+                    connected: result.connected === true,
+                    reason: result.reason,
+                    retryable: result.retryable,
+                })
                 settle({output: result as Record<string, unknown>})
             }
         },
         [settle, teardown],
     )
 
-    useEffect(() => {
-        if (!active) {
-            teardown()
-            setPhase("idle")
-        }
-        return () => teardown()
-    }, [active, teardown])
+    useEffect(() => teardown, [teardown])
 
     /**
      * Run the Agenta OAuth flow: create the connection, open the popup, and watch its three terminal
@@ -259,25 +307,23 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     const runConnect = useCallback(
         async (settleParkedCall: boolean) => {
             if (phase === "connecting") return
-            if (settleParkedCall && (!activeRef.current || settledRef.current || meta.settled))
-                return
+            if (settleParkedCall && (settledRef.current || meta.settled)) return
             // The integration-detail lookup that picks the real auth mode hasn't resolved yet —
             // proceeding here would send the agent's raw (possibly wrong, e.g. "oauth" for a
             // toolkit that only supports api_key) hint. The button is disabled for this same
             // window; this is the defense-in-depth backstop for a click that raced it.
             if (modeResolvingRef.current) return
             setErrorText(null)
+            setErrorRetryable(true)
             setPhase("connecting")
             try {
                 const result = await handleCreate({slug, name: slug, mode})
-                if (settleParkedCall && !activeRef.current) return
                 const redirectUrl =
                     typeof result.connection?.data?.redirect_url === "string"
                         ? result.connection.data.redirect_url
                         : undefined
 
                 const onSuccess = () => {
-                    if (settleParkedCall && !activeRef.current) return
                     invalidate()
                     if (settleParkedCall) finish({connected: true, integration, slug})
                     else {
@@ -338,7 +384,6 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
                     if (!popupRef.current?.closed || succeeded) return
                     // Abandon: closed without a success message.
                     teardown()
-                    if (settleParkedCall && !activeRef.current) return
                     if (settleParkedCall)
                         finish({connected: false, integration, slug, reason: "cancelled"})
                     else setPhase("idle")
@@ -347,7 +392,6 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
                 const timeout = window.setTimeout(() => {
                     if (succeeded) return
                     teardown()
-                    if (settleParkedCall && !activeRef.current) return
                     if (settleParkedCall)
                         finish({connected: false, integration, slug, reason: "timeout"})
                     else setPhase("idle")
@@ -364,13 +408,19 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
                     }
                 }
             } catch (err) {
-                if (settleParkedCall && !activeRef.current) return
-                const message = extractConnectErrorMessage(err)
+                const {message, retryable} = connectFailureFrom(err)
                 // A create failure is terminal for the parked call: settle so the run resumes; for a
                 // manual retry just surface the reason with another Retry.
                 setPhase("error")
                 setErrorText(message)
-                if (settleParkedCall) finish({connected: false, integration, slug, reason: message})
+                setErrorRetryable(retryable)
+                if (settleParkedCall)
+                    finish({connected: false, integration, slug, reason: message, retryable})
+                // A retry from an ALREADY-settled card settles nothing, and the settled chip returns
+                // before the error branch — so refresh the outcome IT renders from, or it keeps
+                // showing the original reason and a Retry that can only fail the same way.
+                else if (settledRef.current || meta.settled)
+                    setOutcome({connected: false, reason: message, retryable})
             }
         },
         [
@@ -410,6 +460,7 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
         label,
         phase,
         errorText,
+        errorRetryable,
         outcome,
         manuallyConnected,
         // True while the toolkit's real auth mode is still being looked up — callers should

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -3,6 +3,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {
     commandSessionStream,
     killSession,
+    recordInteractionAnswerAtom,
     revalidateSessionMountsAtom,
     revalidateSessionRecordsAtom,
 } from "@agenta/entities/session"
@@ -25,6 +26,7 @@ import {useAtomValue, useSetAtom, useStore} from "jotai"
 import {projectIdAtom} from "@/oss/state/project"
 
 import {AgentChatTransport} from "../assets/AgentChatTransport"
+import {recordAnswerThenResume} from "../assets/clientToolAnswer"
 import {doesAgentChatStopKillSession} from "../assets/constants"
 import {ignoreStreamRejection, parseAgentRunError} from "../assets/runError"
 import {getMessageTraceId} from "../assets/trace"
@@ -128,6 +130,7 @@ export const useAgentChatSession = ({
 
     const revalidateSessionMounts = useSetAtom(revalidateSessionMountsAtom)
     const revalidateSessionRecords = useSetAtom(revalidateSessionRecordsAtom)
+    const recordInteractionAnswer = useSetAtom(recordInteractionAnswerAtom)
     const queryClient = useQueryClient()
     // Only a gate settled in this mount may trigger an automatic resume; hydrated answers stay inert.
     const liveGateInteractionRef = useRef<LiveAgentInteraction | null>(null)
@@ -224,23 +227,42 @@ export const useAgentChatSession = ({
     // is by id — so a cast onto the untyped UIMessage tool map is safe.
     const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
         ({toolName, toolCallId, output, errorText}) => {
+            // Set synchronously: it holds off transcript adoption for the whole ordered window.
             liveGateInteractionRef.current = {kind: "client_tool", id: toolCallId}
-            if (errorText !== undefined) {
-                addToolOutput({
-                    state: "output-error",
-                    tool: toolName as never,
-                    toolCallId,
-                    errorText,
-                }).catch(ignoreStreamRejection)
-            } else {
-                addToolOutput({
-                    tool: toolName as never,
-                    toolCallId,
-                    output: (output ?? {}) as never,
-                }).catch(ignoreStreamRejection)
-            }
+            // Ordered, not raced — the resume starts a turn whose sweep cancels every `pending`
+            // row, so the answer has to be durable first. Capped inside the helper.
+            void recordAnswerThenResume({
+                record: () =>
+                    recordInteractionAnswer({
+                        sessionId,
+                        toolCallId,
+                        resolution: {
+                            tool_call_id: toolCallId,
+                            tool_name: toolName,
+                            ...(errorText !== undefined
+                                ? {outcome: "error", error: errorText}
+                                : {outcome: "completed", output: output ?? {}}),
+                        },
+                    }),
+                resume: () => {
+                    if (errorText !== undefined) {
+                        addToolOutput({
+                            state: "output-error",
+                            tool: toolName as never,
+                            toolCallId,
+                            errorText,
+                        }).catch(ignoreStreamRejection)
+                    } else {
+                        addToolOutput({
+                            tool: toolName as never,
+                            toolCallId,
+                            output: (output ?? {}) as never,
+                        }).catch(ignoreStreamRejection)
+                    }
+                },
+            })
         },
-        [addToolOutput],
+        [addToolOutput, recordInteractionAnswer, sessionId],
     )
 
     // Orphan detection for the queue's pre-resume hold: the tail is a RESTORED message (this

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -178,6 +178,9 @@ export const useAgentChatSession = ({
             void queryClient.invalidateQueries({queryKey: ["session-liveness"]})
         },
         onError: (err) => {
+            // A failed stream never dispatches the pending resume, so drop the marker: leaving it
+            // set freezes records adoption for this mount and can resume a stale gate much later.
+            liveGateInteractionRef.current = null
             // Render the error in-chat (the `error` alert below); swallow it here so an
             // aborted/errored stream doesn't bubble unhandled to the Next.js dev overlay (F-033).
             console.warn("[AgentChatPanel] useChat error (rendered in-chat):", err)
@@ -396,6 +399,9 @@ export const useAgentChatSession = ({
 
     const handleStop = useCallback(() => {
         markStopped()
+        // A stop voids the pending gate (same rule the queue applies), so the marker must go too —
+        // otherwise it outlives the abandoned resume and blocks this mount's records adoption.
+        liveGateInteractionRef.current = null
         stop() // abort the client stream immediately
         if (!projectId || !sessionId) return
         // Opt-in hard kill (NEXT_PUBLIC_AGENT_CHAT_STOP_KILLS_SESSION): tear the whole session down.

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
@@ -11,9 +11,48 @@
  * local `addToolOutput` settle is still waiting for `sendAutomaticallyWhen` to fire — the adopted
  * transcript predates the settle and silently discards it.
  */
+import type {UIMessage} from "ai"
 import {describe, expect, it} from "vitest"
 
-import {shouldSkipRecordsRefresh} from "./useSessionHydration"
+import {shouldAdoptTranscript, shouldSkipRecordsRefresh} from "./useSessionHydration"
+
+type ToolState = "input-available" | "output-available"
+
+const toolMessage = ({
+    id,
+    toolCallId,
+    state,
+    type = "tool-request_input",
+}: {
+    id: string
+    toolCallId: string
+    state: ToolState
+    type?: "tool-request_input" | "dynamic-tool"
+}): UIMessage => ({
+    id,
+    role: "assistant",
+    parts: [
+        {
+            type,
+            ...(type === "dynamic-tool" ? {toolName: "request_input"} : {}),
+            toolCallId,
+            state,
+            input: {},
+            ...(state === "output-available" ? {output: {submitted: true}} : {}),
+        },
+        // A dynamic-tool part carries its client-tool identity only in this sibling, exactly as
+        // replay emits it — the tool name is not readable off `type` there.
+        ...(type === "dynamic-tool"
+            ? [{type: "data-render", data: {toolCallId, render: {kind: "elicitation"}}}]
+            : []),
+    ] as UIMessage["parts"],
+})
+
+const textMessage = (id: string): UIMessage => ({
+    id,
+    role: "user",
+    parts: [{type: "text", text: "hello"}],
+})
 
 describe("shouldSkipRecordsRefresh", () => {
     it("does not skip when idle and no settle is pending a resume", () => {
@@ -31,5 +70,220 @@ describe("shouldSkipRecordsRefresh", () => {
 
     it("skips when both are true", () => {
         expect(shouldSkipRecordsRefresh({busy: true, pendingResume: true})).toBe(true)
+    })
+})
+
+/**
+ * The composed decision, where the card predicates meet the watermark and the floors. Review round 3
+ * finding 1: the settled-card path is meant to bypass ONLY the growth test. Bypassing the
+ * anti-truncation floor too would let a lagging snapshot replace the screen and localStorage, regress
+ * the watermark, and release the composer against a truncated history.
+ */
+describe("shouldAdoptTranscript", () => {
+    const waiting = (id: string) =>
+        toolMessage({id: `local-${id}`, toolCallId: id, state: "input-available"})
+    const settledCard = (id: string) =>
+        toolMessage({id: `server-${id}`, toolCallId: id, state: "output-available"})
+
+    const base = {
+        serverRecordCount: 44,
+        watermark: 44,
+        busy: false,
+        pendingResume: false,
+    }
+
+    it("adopts the zombie case: equal counts, equal records, card settled server-side", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                localMessages: [waiting("call-1")],
+                serverMessages: [settledCard("call-1")],
+            }),
+        ).toBe(true)
+    })
+
+    it("REFUSES a lagging snapshot that settles the card but drops the newest turn", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                serverRecordCount: 40,
+                localMessages: [waiting("call-1"), textMessage("newest-turn")],
+                serverMessages: [settledCard("call-1")],
+            }),
+        ).toBe(false)
+    })
+
+    it("refuses a shorter snapshot even when the record count has not regressed", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                localMessages: [waiting("call-1"), textMessage("newest-turn")],
+                serverMessages: [settledCard("call-1")],
+            }),
+        ).toBe(false)
+    })
+
+    it("refuses while a recorded answer is still waiting on its resume dispatch", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                pendingResume: true,
+                localMessages: [waiting("call-1")],
+                serverMessages: [settledCard("call-1")],
+            }),
+        ).toBe(false)
+    })
+
+    it("refuses while this tab is streaming", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                busy: true,
+                localMessages: [waiting("call-1")],
+                serverMessages: [settledCard("call-1")],
+            }),
+        ).toBe(false)
+    })
+
+    it("refuses when the server copy still shows the card waiting", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                serverRecordCount: 99,
+                localMessages: [waiting("call-1")],
+                serverMessages: [waiting("call-1")],
+            }),
+        ).toBe(false)
+    })
+
+    it("still adopts on plain record growth when nothing is waiting", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                serverRecordCount: 50,
+                localMessages: [textMessage("local")],
+                serverMessages: [textMessage("server"), textMessage("server-2")],
+            }),
+        ).toBe(true)
+    })
+
+    it("does not adopt an unchanged log when nothing is waiting", () => {
+        expect(
+            shouldAdoptTranscript({
+                ...base,
+                localMessages: [textMessage("local")],
+                serverMessages: [textMessage("server")],
+            }),
+        ).toBe(false)
+    })
+})
+
+/**
+ * The waiting-card semantics, asserted through the decision the user actually gets. Counts are held
+ * at equality so ONLY the card logic decides: a card the server copy does not settle must never be
+ * overwritten (the user may be mid-answer), and a card it does settle is what lets a dead session's
+ * stale copy be replaced at all.
+ */
+describe("shouldAdoptTranscript: waiting cards", () => {
+    const at = (localMessages: UIMessage[], serverMessages: UIMessage[]) =>
+        shouldAdoptTranscript({
+            serverRecordCount: 44,
+            watermark: 44,
+            busy: false,
+            pendingResume: false,
+            localMessages,
+            serverMessages,
+        })
+    const waiting = (id: string, key = "local") =>
+        toolMessage({id: `${key}-${id}`, toolCallId: id, state: "input-available"})
+    const settledCard = (id: string, key = "server") =>
+        toolMessage({id: `${key}-${id}`, toolCallId: id, state: "output-available"})
+
+    it("does not adopt an unchanged log when no card is waiting", () => {
+        expect(at([settledCard("call-1", "local")], [settledCard("call-1")])).toBe(false)
+    })
+
+    it("refuses when the waiting card is absent from the server copy", () => {
+        expect(at([waiting("call-1")], [textMessage("server")])).toBe(false)
+    })
+
+    it("refuses when the server copy still shows the card waiting", () => {
+        expect(at([waiting("call-1")], [waiting("call-1", "server")])).toBe(false)
+    })
+
+    it("adopts when the server copy settles the card", () => {
+        expect(at([waiting("call-1")], [settledCard("call-1")])).toBe(true)
+    })
+
+    it("refuses when only one of two waiting cards is settled", () => {
+        expect(
+            at(
+                [waiting("call-1"), waiting("call-2")],
+                [settledCard("call-1"), waiting("call-2", "server")],
+            ),
+        ).toBe(false)
+    })
+
+    it("ignores an ordinary server tool stuck at input-available", () => {
+        // An interrupted turn leaves one behind forever; treating it as a card would both freeze
+        // adoption and, worse, let the settled-card path fire on a tool nobody is waiting on.
+        // Both assertions below FLIP if `pendingClientToolCallIds` ever counts it as a card —
+        // an equal-counts case alone cannot tell the two apart (both refuse), so it is not enough.
+        const stuck: UIMessage = {
+            id: "local",
+            role: "assistant",
+            parts: [
+                {type: "tool-read_file", toolCallId: "call-9", state: "input-available", input: {}},
+            ] as UIMessage["parts"],
+        }
+        // Freeze check: the log grew, so a stuck server tool must not hold adoption back.
+        expect(
+            shouldAdoptTranscript({
+                serverRecordCount: 50,
+                watermark: 44,
+                busy: false,
+                pendingResume: false,
+                localMessages: [stuck],
+                serverMessages: [textMessage("server")],
+            }),
+        ).toBe(true)
+        // Settled-card check: nothing is WAITING, so an unchanged log must not adopt just because
+        // the server copy shows that same tool settled.
+        expect(
+            at(
+                [stuck],
+                [
+                    {
+                        id: "server",
+                        role: "assistant",
+                        parts: [
+                            {
+                                type: "tool-read_file",
+                                toolCallId: "call-9",
+                                state: "output-available",
+                                input: {},
+                                output: {ok: true},
+                            },
+                        ] as UIMessage["parts"],
+                    },
+                ],
+            ),
+        ).toBe(false)
+    })
+
+    it("finds a waiting dynamic-tool card before the last message", () => {
+        const card = toolMessage({
+            id: "local-card",
+            toolCallId: "call-1",
+            state: "input-available",
+            type: "dynamic-tool",
+        })
+        expect(at([card, textMessage("local-tail")], [textMessage("server")])).toBe(false)
+        expect(
+            at(
+                [card, textMessage("local-tail")],
+                [settledCard("call-1"), textMessage("server-tail")],
+            ),
+        ).toBe(true)
     })
 })

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -1,6 +1,11 @@
 import {type MutableRefObject, useCallback, useEffect, useRef, useState} from "react"
 
-import {revalidateSessionRecordsAtom, shouldAdoptServerTranscript} from "@agenta/entities/session"
+import {
+    revalidateSessionInteractionsAtom,
+    revalidateSessionRecordsAtom,
+    shouldAdoptServerTranscript,
+} from "@agenta/entities/session"
+import {buildRenderMap, isPendingClientToolInteraction} from "@agenta/playground"
 import {type UIMessage} from "ai"
 import {useAtomValue, useSetAtom} from "jotai"
 
@@ -44,6 +49,101 @@ export const shouldSkipRecordsRefresh = ({
     busy: boolean
     pendingResume: boolean
 }): boolean => busy || pendingResume
+
+/** Waiting CLIENT-TOOL cards anywhere in the chat — the same whole-chat scan the tab status uses.
+ * Narrow to client tools on purpose: an interrupted turn can leave an ordinary server tool part at
+ * `input-available` forever, and that must not freeze adoption. */
+const pendingClientToolCallIds = (messages: UIMessage[]): Set<string> => {
+    const pending = new Set<string>()
+    for (const message of messages) {
+        if (message.role !== "assistant") continue
+        const parts = message.parts ?? []
+        // Message-scoped: the render hint rides a sibling part in the SAME message.
+        const renderMap = buildRenderMap(parts)
+        for (const part of parts) {
+            if (!isPendingClientToolInteraction(part, renderMap)) continue
+            const {toolCallId} = part as {toolCallId?: unknown}
+            if (typeof toolCallId === "string") pending.add(toolCallId)
+        }
+    }
+    return pending
+}
+
+/** Locally-waiting cards the server copy shows as settled. A card the server does not carry at all
+ * is NOT settled — the server has not caught up. */
+const settledLocallyWaitingIds = (
+    localMessages: UIMessage[],
+    serverMessages: UIMessage[],
+): {pending: Set<string>; settled: Set<string>} => {
+    const pending = pendingClientToolCallIds(localMessages)
+    const settled = new Set<string>()
+    if (pending.size === 0) return {pending, settled}
+    for (const message of serverMessages) {
+        if (message.role !== "assistant") continue
+        const parts = message.parts ?? []
+        const renderMap = buildRenderMap(parts)
+        for (const part of parts) {
+            const {toolCallId} = part as {toolCallId?: unknown}
+            if (typeof toolCallId !== "string" || !pending.has(toolCallId)) continue
+            if (!isPendingClientToolInteraction(part, renderMap)) settled.add(toolCallId)
+        }
+    }
+    return {pending, settled}
+}
+
+/**
+ * The whole adoption decision: the shared growth test, the waiting-card guards, and the floors the
+ * settled-card path must still respect.
+ *
+ * That last part is the subtle one. `shouldAdoptServerTranscript` carries THREE refusals, and the
+ * settled-card path is meant to bypass exactly one of them — the growth test, which a dead session
+ * can never satisfy — a session cached before the interaction-lifecycle fix renders its abandoned
+ * card live and its watermark already equals the server's record count, so nothing else can ever
+ * trigger. Bypassing the anti-truncation floor as well would let a lagging snapshot (same
+ * card, same terminal row, minus the newest turn) replace the screen AND localStorage, regress the
+ * watermark, and release the composer against a truncated history. The zombie case clears both
+ * floors with equality, so requiring them costs nothing.
+ */
+export const shouldAdoptTranscript = ({
+    serverRecordCount,
+    serverMessages,
+    localMessages,
+    watermark,
+    busy,
+    pendingResume,
+}: {
+    serverRecordCount: number
+    serverMessages: UIMessage[]
+    localMessages: UIMessage[]
+    watermark: number | undefined
+    busy: boolean
+    /** A client-tool answer is recorded but its resume has not dispatched — see `pendingResumeRef`. */
+    pendingResume: boolean
+}): boolean => {
+    const {pending, settled} = settledLocallyWaitingIds(localMessages, serverMessages)
+    // A waiting card the server copy does not settle must never be overwritten: the user may be
+    // mid-answer, and adopting would discard it.
+    if (pending.size > 0 && settled.size !== pending.size) return false
+
+    if (
+        shouldAdoptServerTranscript({
+            serverRecordCount,
+            serverMessageCount: serverMessages.length,
+            localMessageCount: localMessages.length,
+            watermark,
+            busy,
+        })
+    )
+        return true
+
+    return (
+        pending.size > 0 &&
+        !busy &&
+        !pendingResume &&
+        serverRecordCount >= (watermark ?? 0) &&
+        serverMessages.length >= localMessages.length
+    )
+}
 
 /**
  * Hybrid history for one session tab. localStorage holds only the session INDEX; the durable
@@ -112,14 +212,17 @@ export const useSessionHydration = ({
         (transcript: SessionTranscript | null, {armJump = true} = {}): boolean => {
             if (!transcript) return false
             const {messages: serverMsgs, recordCount} = transcript
-            const adopt = shouldAdoptServerTranscript({
-                serverRecordCount: recordCount,
-                serverMessageCount: serverMsgs.length,
-                localMessageCount: messagesRef.current.length,
-                watermark: recordWatermarkRef.current,
-                busy: busyRef.current,
-            })
-            if (!adopt) return false
+            if (
+                !shouldAdoptTranscript({
+                    serverRecordCount: recordCount,
+                    serverMessages: serverMsgs,
+                    localMessages: messagesRef.current,
+                    watermark: recordWatermarkRef.current,
+                    busy: busyRef.current,
+                    pendingResume: !!pendingResumeRef.current,
+                })
+            )
+                return false
             // Restored history renders settled (no live fade-in) and pinned to the bottom.
             serverMsgs.forEach((m) => {
                 seenIdsRef.current.add(m.id)
@@ -147,6 +250,7 @@ export const useSessionHydration = ({
             sessionId,
             messagesRef,
             busyRef,
+            pendingResumeRef,
             seenIdsRef,
             restoredIdsRef,
             recordWatermarkRef,
@@ -289,6 +393,7 @@ export const useSessionHydration = ({
     const activeSessionId = useAtomValue(activeSessionIdAtomFamily(scopeKey))
     const projectId = useAtomValue(projectIdAtom)
     const revalidateSessionRecords = useSetAtom(revalidateSessionRecordsAtom)
+    const revalidateSessionInteractions = useSetAtom(revalidateSessionInteractionsAtom)
     const refreshFromRecords = useCallback(() => {
         // Entry check: skip while THIS tab streams (already the live truth, `onFinish`
         // revalidates) OR a client-tool settle is already waiting on its resume dispatch — see
@@ -320,11 +425,16 @@ export const useSessionHydration = ({
             adoptServerTranscriptRef.current(transcript, {armJump: false})
         })
     }, [sessionId, busyRef, pendingResumeRef, revalidateSessionRecords])
+    const refreshFromInteractions = useCallback(() => {
+        revalidateSessionInteractions(sessionId)
+        refreshFromRecords()
+    }, [sessionId, revalidateSessionInteractions, refreshFromRecords])
     useSessionRecordsWatch({
         sessionId,
         projectId,
         enabled: activeSessionId === sessionId,
         onRecordsChanged: refreshFromRecords,
+        onInteractionChanged: refreshFromInteractions,
     })
 
     return {isHydrating, hydratedEmpty, runningElsewhere}

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
@@ -8,7 +8,7 @@ const sessionWatchUrl = (sessionId: string, projectId: string): string =>
     )}&project_id=${encodeURIComponent(projectId)}`
 
 /**
- * Live records relay for the active desktop conversation.
+ * Live records and interaction-row relay for the active desktop conversation.
  *
  * The shared watch lifecycle keeps the foreground-only connection, bounded jittered retries,
  * token refresh on fatal close, ready revalidation, and throttled trailing refresh.
@@ -18,11 +18,13 @@ export const useSessionRecordsWatch = ({
     projectId,
     enabled,
     onRecordsChanged,
+    onInteractionChanged,
 }: {
     sessionId: string
     projectId?: string | null
     enabled: boolean
     onRecordsChanged: () => void
+    onInteractionChanged: () => void
 }): void => {
     const url = sessionId && projectId ? sessionWatchUrl(sessionId, projectId) : null
     useWatchEventSource({
@@ -31,6 +33,7 @@ export const useSessionRecordsWatch = ({
         on: {
             ready: onRecordsChanged,
             "records-changed": onRecordsChanged,
+            interaction: onInteractionChanged,
         },
     })
 }

--- a/web/packages/agenta-chat/src/assets/loadSession.ts
+++ b/web/packages/agenta-chat/src/assets/loadSession.ts
@@ -1,12 +1,11 @@
 // Copied verbatim from web/oss/src/components/AgentChatSlice/assets/loadSession.ts (2026-07-25);
 // the OSS original remains authoritative for the desktop chat until the re-plumb PR deletes it.
 // Keep byte-parity if either side changes.
-// Adaptations: none — `fetchSessionRecordsAtom`/`fetchCancelledClientToolTokensAtom` already read
+// Adaptations: none — `fetchSessionRecordsAtom`/`fetchSessionInteractionStatesAtom` already read
 // `projectIdAtom` internally from `@agenta/entities/session` (an allowed package dep), so no
 // OSS-app-only import is involved and no signature change was needed.
-// Re-synced 2026-08-10: the cancelled-client-tool-tokens join (transcript replay respecting a
-// terminal `session_interactions` status — a resurrected parked form must not replay interactive).
-import {fetchCancelledClientToolTokensAtom, fetchSessionRecordsAtom} from "@agenta/entities/session"
+// Re-synced 2026-08-10: interaction rows now provide replay lifecycle and saved outcomes.
+import {fetchSessionInteractionStatesAtom, fetchSessionRecordsAtom} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 import {getDefaultStore} from "jotai"
 
@@ -50,17 +49,16 @@ export const loadSessionMessages = async (
     // notice instead of leaking an unhandled rejection.
     try {
         const store = getDefaultStore()
-        // Best-effort join (never throws, see the atom's doc) — a resurrected cancelled part
-        // is cosmetic, so it must never gate whether the transcript loads at all.
-        const [{records, refreshed}, cancelledClientToolTokens] = await Promise.all([
+        // The best-effort lifecycle join must never gate transcript loading.
+        const [{records, refreshed}, interactionRowStates] = await Promise.all([
             store.set(fetchSessionRecordsAtom, sessionId),
-            store.set(fetchCancelledClientToolTokensAtom, sessionId),
+            store.set(fetchSessionInteractionStatesAtom, sessionId),
         ])
         if (refreshed && onRefreshed) {
             void refreshed
                 .then((fresh) => {
                     if (!fresh || fresh.length === 0) return
-                    const freshMsgs = transcriptToMessages(fresh, {cancelledClientToolTokens})
+                    const freshMsgs = transcriptToMessages(fresh, {interactionRowStates})
                     if (freshMsgs && freshMsgs.length > 0) {
                         onRefreshed({messages: freshMsgs, recordCount: fresh.length})
                     }
@@ -73,7 +71,7 @@ export const loadSessionMessages = async (
                 })
         }
         if (!records || records.length === 0) return null
-        const messages = transcriptToMessages(records, {cancelledClientToolTokens})
+        const messages = transcriptToMessages(records, {interactionRowStates})
         return messages ? {messages, recordCount: records.length} : null
     } catch (err) {
         console.warn("[loadSessionMessages] hydration fetch failed:", err)

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -9,8 +9,13 @@
 //
 // `attachmentContentUrl` is the package's own copy of the original's `attachmentMedia.ts`
 // builder, on `@agenta/shared/api` rather than the OSS app layer.
-import type {SessionRecord} from "@agenta/entities/session"
+import type {
+    SessionInteractionRowState,
+    SessionInteractionRowStates,
+    SessionRecord,
+} from "@agenta/entities/session"
 import {getAgentaApiUrl} from "@agenta/shared/api"
+import {CLIENT_TOOL_INTERACTION_ENDED_OUTPUT} from "@agenta/shared/clientTools"
 import type {UIMessage} from "ai"
 
 /**
@@ -125,41 +130,71 @@ const isRunnerSentinelError = (part: Part): boolean => {
     )
 }
 
-/** Tool name from a replayed part's `type`/`toolName` — mirrors clientTools/meta.ts's
- * `clientToolName`, kept local since this file has no dependency on the app's client-tool layer. */
-const partToolName = (part: Part): string => {
-    if (part.type === "dynamic-tool") return typeof part.toolName === "string" ? part.toolName : ""
-    return typeof part.type === "string" ? part.type.replace(/^tool-/, "") : ""
+function settleClientToolPart(part: Part, row: SessionInteractionRowState): void {
+    if (part.state !== "input-available") return
+
+    if (row.resolution) {
+        if (row.resolution.outcome === "error") {
+            const error = row.resolution.error
+            part.state = "output-error"
+            part.errorText =
+                typeof error === "string" && error ? error : "The request ended without a result."
+        } else {
+            const output = row.resolution.output
+            part.state = "output-available"
+            part.output =
+                typeof output === "object" && output !== null && !Array.isArray(output)
+                    ? output
+                    : {...CLIENT_TOOL_INTERACTION_ENDED_OUTPUT}
+        }
+        return
+    }
+
+    if (row.status === "cancelled" || row.status === "responded" || row.status === "resolved") {
+        part.state = "output-available"
+        part.output = {...CLIENT_TOOL_INTERACTION_ENDED_OUTPUT}
+    }
 }
 
 /**
- * The settled output to synthesize for a client-tool interaction the backend already cancelled
- * (`session_interactions.status === "cancelled"`) whose transcript never got a settling
- * `tool_result` — see `fetchCancelledClientToolTokensAtom`'s doc for why the record log alone
- * can't tell. Mirrors each widget's OWN cancelled-terminal shape (`ConnectOutput.reason` /
- * `ElicitationResult.action`) so a resurrected part renders exactly like a live cancel — an inert
- * chip, never an interactive, answerable form. Keyed by the same tool name the client-tool
- * registry dispatches on; an unregistered kind falls back to a bare empty output, which still
- * settles (out of `input-available`) even with no dedicated chip.
+ * An approval gate whose row is terminal. Approval rows always recorded their outcome correctly,
+ * so they are trustworthy here. A verdict replays the real answer. A swept row proves only that
+ * the gate died unanswered — and that the gated tool never ran — so it settles denied rather than
+ * claiming an approval nobody gave. Either way the gate stops reading as still awaiting the user:
+ * a dead gate left `approval-requested` holds the message queue forever once the scans that read
+ * it cover the whole transcript.
  */
-const CANCELLED_CLIENT_TOOL_OUTPUT: Record<string, Part> = {
-    request_connection: {connected: false, reason: "cancelled"},
-    request_input: {action: "cancel"},
+function settleApprovalPart(part: Part, row: SessionInteractionRowState): void {
+    if (part.state !== "approval-requested") return
+
+    const verdict = row.resolution?.verdict
+    if (verdict === "approved" || verdict === "denied") {
+        part.state = "approval-responded"
+        part.approval = {id: row.token, approved: verdict === "approved"}
+        return
+    }
+    if (row.status === "cancelled") {
+        part.state = "output-denied"
+        return
+    }
+    if (row.status === "responded" || row.status === "resolved") part.state = "approval-responded"
 }
 
-/** Apply the cancelled-interaction override to every still-`input-available` client-tool part
- * whose token the interactions join marked cancelled. Runs once, after the full record sweep, so
- * a LATER `tool_result` for the same toolCallId (a real settle) always wins over this fallback. */
-function applyCancelledInteractions(
+function applyInteractionRowStates(
     index: TranscriptIndex,
-    cancelledClientToolTokens: ReadonlySet<string> | undefined,
+    interactionRowStates: SessionInteractionRowStates | undefined,
 ): void {
-    if (!cancelledClientToolTokens || cancelledClientToolTokens.size === 0) return
-    for (const [toolCallId, part] of index.tools) {
-        if (part.state !== "input-available") continue
-        if (!cancelledClientToolTokens.has(toolCallId)) continue
-        part.state = "output-available"
-        part.output = CANCELLED_CLIENT_TOOL_OUTPUT[partToolName(part)] ?? {}
+    if (!interactionRowStates || interactionRowStates.size === 0) return
+    for (const row of interactionRowStates.values()) {
+        // Token equality supports rows written before the runner stamped the tool-call id; an
+        // approval gate is also indexed under its interaction id, which IS the row token.
+        const toolCallId = row.toolCallId ?? row.token
+        const part = index.tools.get(toolCallId) ?? index.approvals.get(row.token)
+        if (!part) continue
+
+        if (row.kind === "user_approval") settleApprovalPart(part, row)
+        else if (row.kind === "client_tool" || row.kind === "user_input")
+            settleClientToolPart(part, row)
     }
 }
 
@@ -412,11 +447,8 @@ function applyEvent(
 }
 
 export interface TranscriptToMessagesOptions {
-    /** Tokens (== toolCallId) of this session's CANCELLED `client_tool` interactions — see
-     * `fetchCancelledClientToolTokensAtom`. A resurrected part for one of these replays inert
-     * instead of as a live, answerable form. Omit when the caller has no interaction-status join
-     * available; every part then replays exactly as before (unaffected, not a regression). */
-    cancelledClientToolTokens?: ReadonlySet<string>
+    /** Row lifecycle settles replayed interactions; omit it to preserve record-only replay. */
+    interactionRowStates?: SessionInteractionRowStates
 }
 
 /**
@@ -484,11 +516,8 @@ export function transcriptToMessages(
         }
     }
 
-    // Same "settle whatever the record log alone left parked" idea as the resumed-approval pass
-    // above, for client tools: a token the caller's interaction-status join says is CANCELLED
-    // never got its own `tool_result` (a real settle would have), so it replays parked forever
-    // without this.
-    applyCancelledInteractions(index, options?.cancelledClientToolTokens)
+    // Recorded results win; otherwise saved answers, neutral terminal state, then pending.
+    applyInteractionRowStates(index, options?.interactionRowStates)
 
     const messages = drafts
         .filter((d) => d.parts.length > 0)

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -226,6 +226,9 @@ export const useAgentConversation = ({
             revalidateSessionRecords(sessionId)
         },
         onError: (err) => {
+            // A failed stream never dispatches the pending resume, so drop the marker: leaving it
+            // set freezes records adoption for this mount and can resume a stale gate much later.
+            liveGateInteractionRef.current = null
             // The error is stamped in-chat (effect below); swallow it here so an aborted/errored
             // stream doesn't bubble unhandled to a dev overlay (F-033).
             console.warn("[useAgentConversation] useChat error (rendered in-chat):", err)
@@ -480,6 +483,9 @@ export const useAgentConversation = ({
     const handleStop = useCallback(() => {
         const last = messagesRef.current[messagesRef.current.length - 1]
         if (last && last.role === "assistant") setStopped(true)
+        // A stop voids the pending gate (same rule the queue applies), so the marker must go too —
+        // otherwise it outlives the abandoned resume and blocks this mount's records adoption.
+        liveGateInteractionRef.current = null
         stop()
     }, [stop])
 

--- a/web/packages/agenta-chat/src/model/approvals.ts
+++ b/web/packages/agenta-chat/src/model/approvals.ts
@@ -21,20 +21,17 @@ interface ApprovalRef {
 // Copied verbatim from web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
 // (2026-07-25); the OSS original remains authoritative for the desktop chat until the re-plumb
 // PR deletes it. Keep byte-parity if either side changes.
-/**
- * Approvals the run is currently blocked on. HITL only ever pauses the LAST assistant turn (see
- * `isHitlPending`), so we read pending tool gates off that turn — a turn can request several at
- * once (parallel tool calls), so this returns all of them in order.
- */
+/** Pending approval gates across assistant messages, in transcript order. */
 export const getPendingApprovals = (messages: UIMessage[]): PendingApproval[] => {
-    const last = messages[messages.length - 1]
-    if (!last || last.role !== "assistant") return []
     const out: PendingApproval[] = []
-    for (const part of last.parts ?? []) {
-        const p = part as ToolUIPart
-        const approval = (p as {approval?: ApprovalRef}).approval
-        if (isToolPart(p.type as string) && p.state === "approval-requested" && approval?.id) {
-            out.push({approvalId: approval.id, toolName: partToolName(p), input: p.input})
+    for (const message of messages) {
+        if (message.role !== "assistant") continue
+        for (const part of message.parts ?? []) {
+            const p = part as ToolUIPart
+            const approval = (p as {approval?: ApprovalRef}).approval
+            if (isToolPart(p.type as string) && p.state === "approval-requested" && approval?.id) {
+                out.push({approvalId: approval.id, toolName: partToolName(p), input: p.input})
+            }
         }
     }
     return out

--- a/web/packages/agenta-chat/tests/unit/assets/__fixtures__/abandonedFormSession.json
+++ b/web/packages/agenta-chat/tests/unit/assets/__fixtures__/abandonedFormSession.json
@@ -1,0 +1,845 @@
+[
+  {
+    "id": "3ac1e196-9d0c-4137-84d5-5b187bfe07fa",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "I want to create an agent that sends me … <91 chars elided>",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-10T14:11:51.213Z"
+  },
+  {
+    "id": "e84f5a4c-de6b-50b6-baa0-fc4d51dd5efc",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_6Ev3NNVyPlFdRIoDRF4RKN3w|fc_0127887… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <195 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:00.250Z"
+  },
+  {
+    "id": "79419f2e-dc56-5fad-8c26-c1e1a4141efa",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_6Ev3NNVyPlFdRIoDRF4RKN3w|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "---\nname: \"build-an-agent\"\ndescription: … <12820 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:00.250Z"
+  },
+  {
+    "id": "e5298ef8-e9ec-5f4b-be19-b29c42530216",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_9TZhCpuETAWXy0ruPgYnC8v7|fc_0127887… <83 chars elided>",
+      "name": "find",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <171 chars elided>",
+        "pattern": "references/agent-templates/index.md"
+      }
+    },
+    "created_at": "2026-08-10T14:12:03.568Z"
+  },
+  {
+    "id": "73479402-304b-59b6-a5bc-6513e88587ec",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_9TZhCpuETAWXy0ruPgYnC8v7|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "error: Found argument '--no-require-git'… <248 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:12:03.568Z"
+  },
+  {
+    "id": "ee4ad8c7-26c9-57f3-b031-f61ccb997694",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_F4rCCLQOVRBsIyguLveYaXqs|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <171 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:08.479Z"
+  },
+  {
+    "id": "05dd224f-ab2a-543b-a29c-626c1369618c",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_F4rCCLQOVRBsIyguLveYaXqs|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": ".agenta-skill-set.json\nbuild-an-agent/",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:08.479Z"
+  },
+  {
+    "id": "8ab7d51a-cc84-5717-98cc-ef4574171ef8",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_CgCsnin4iSnw6I6orMZ0bBxV|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <186 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:13.783Z"
+  },
+  {
+    "id": "5834b100-6263-5b08-b736-619ee43ba8e5",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_CgCsnin4iSnw6I6orMZ0bBxV|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "references/\nSKILL.md",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:13.783Z"
+  },
+  {
+    "id": "993c66a9-88b5-5ed7-94dc-7c525b5a90c4",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_07YbzYFCW64e3ZGooV6NQ2ze|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <197 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:16.713Z"
+  },
+  {
+    "id": "59c17422-16c7-5f73-830d-f6371858c49a",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_07YbzYFCW64e3ZGooV6NQ2ze|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "Path not found: /tmp/agenta/mounts/019fe… <213 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:12:16.713Z"
+  },
+  {
+    "id": "cb8df4c3-0f3b-53b9-84df-085dd77fec5e",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_QdfzWu4Fit44c3RZPp0mhpmx|fc_0127887… <83 chars elided>",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <197 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:12:20.808Z"
+  },
+  {
+    "id": "51d28fd7-369d-5c56-be06-4076d0180327",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_QdfzWu4Fit44c3RZPp0mhpmx|fc_0127887… <83 chars elided>",
+      "type": "tool_result",
+      "output": "agent-templates/\nconfig-schema.md\ntrigger-inputs.md",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:12:20.808Z"
+  },
+  {
+    "id": "be6802e8-1542-4450-b4c7-c01258befc17",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "d137b4d128625070c9eebad694a71953"
+    },
+    "created_at": "2026-08-10T14:12:21.338Z"
+  },
+  {
+    "id": "3f1d20ed-1b65-4c73-ac3c-c20096ccbbdc",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "I want to create an agent that sends me … <91 chars elided>",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-10T14:14:26.788Z"
+  },
+  {
+    "id": "a2eceda2-906a-4122-924b-1c9edd512a6b",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Inspecting playbook index**\n\nI need to… <408 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "ee4b58b0-6a1d-5b4e-9d0c-6e54309f9c84",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_cos65iPtQcwoSeCo274tHxpu|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <222 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "576070fa-22a9-51f3-a551-6147266fe841",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_36OO60wY2e9UxrP0QmiATv3K|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c20-8d… <174 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "c501dd36-8025-579e-9ac8-ff8d6a101524",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_OaTDsWsrPzndHArJ2NYK6zaZ|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <212 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "08e4ac6e-9613-5a96-84e2-96962a5b8b77",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_36OO60wY2e9UxrP0QmiATv3K|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "ENOENT: no such file or directory, acces… <218 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "e76810df-57c4-530f-b570-2e7d6ef68f91",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_OaTDsWsrPzndHArJ2NYK6zaZ|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "ENOENT: no such file or directory, acces… <256 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "9c081ac3-5ad4-599d-9033-00953a19c0c2",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_cos65iPtQcwoSeCo274tHxpu|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "# Agent template playbooks\n\nMatch the us… <4532 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:14:36.716Z"
+  },
+  {
+    "id": "3d60f877-2509-4e9d-9d72-3da71d4f8dc4",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Correcting path typo**\n\nI need to ensu… <370 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "59a87425-5a4b-5fba-88f2-c9e8abf00f89",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_y3gX69Fmcfs71YOv3iBQQ0mS|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <214 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "6cdbefee-cd0a-5295-9fdc-e28fe9885ee3",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_5gXdoIef4ScubRAhB2KCD3Ig|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <212 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "8a056135-afc4-55ef-8723-d9493ed9f9ef",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_tIalLuExYiDMiSN8Otvoaz1a|fc_0b9b71f… <83 chars elided>",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <195 chars elided>",
+        "limit": 220,
+        "offset": 1
+      }
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "29be8628-0dc3-5e31-b339-aeb3e7688c85",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_5gXdoIef4ScubRAhB2KCD3Ig|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "ENOENT: no such file or directory, acces… <256 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "a7020368-b0e0-528d-b756-5adfbb6c939d",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_tIalLuExYiDMiSN8Otvoaz1a|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "---\nname: \"build-an-agent\"\ndescription: … <12820 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "68816998-c664-580b-9067-010ed834cc77",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 14,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_y3gX69Fmcfs71YOv3iBQQ0mS|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "# The agent config, field by field\n\nRead… <17820 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:14:40.072Z"
+  },
+  {
+    "id": "c1291959-a913-49a9-850f-8f2457578368",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 15,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Clarifying user details**\n\nI need to c… <485 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:14:45.386Z"
+  },
+  {
+    "id": "e4c0cfd3-b9d3-5abc-9875-824f571ac42d",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 16,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_oKZiZXfG0lf35KE3WNAOIDws|fc_0b9b71f… <83 chars elided>",
+      "name": "discover_tools",
+      "type": "tool_call",
+      "input": {
+        "provider": "composio",
+        "use_cases": [
+          "send a Telegram message"
+        ],
+        "limit_alternatives": 5
+      }
+    },
+    "created_at": "2026-08-10T14:14:45.386Z"
+  },
+  {
+    "id": "1d3449e5-3595-5e2a-bf8e-f74abde84fcc",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 17,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+      "name": "request_input",
+      "type": "tool_call",
+      "input": {
+        "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+        "requestedSchema": {
+          "type": "object",
+          "required": [
+            "time_of_day",
+            "timezone",
+            "telegram_chat"
+          ],
+          "properties": {
+            "timezone": {
+              "type": "string",
+              "title": "Timezone",
+              "default": "Asia/Riyadh",
+              "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+            },
+            "time_of_day": {
+              "type": "string",
+              "title": "Morning delivery time",
+              "format": "time",
+              "default": "08:00"
+            },
+            "poetry_style": {
+              "type": "string",
+              "title": "Poetry preference",
+              "format": "multiline",
+              "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+              "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+            },
+            "telegram_chat": {
+              "type": "string",
+              "title": "Telegram chat ID or @username"
+            }
+          },
+          "x-ag-stepper": true
+        }
+      }
+    },
+    "created_at": "2026-08-10T14:14:45.984Z"
+  },
+  {
+    "id": "bfb8bee4-a8bf-5edb-a5b0-b90136a1c532",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 18,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "time_of_day",
+              "timezone",
+              "telegram_chat"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Timezone",
+                "default": "Asia/Riyadh",
+                "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+              },
+              "time_of_day": {
+                "type": "string",
+                "title": "Morning delivery time",
+                "format": "time",
+                "default": "08:00"
+              },
+              "poetry_style": {
+                "type": "string",
+                "title": "Poetry preference",
+                "format": "multiline",
+                "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+                "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+              },
+              "telegram_chat": {
+                "type": "string",
+                "title": "Telegram chat ID or @username"
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "render": {
+          "kind": "elicitation"
+        },
+        "toolCall": {
+          "id": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+          "kind": "client",
+          "name": "request_input",
+          "input": {
+            "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "time_of_day",
+                "timezone",
+                "telegram_chat"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Timezone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+                },
+                "time_of_day": {
+                  "type": "string",
+                  "title": "Morning delivery time",
+                  "format": "time",
+                  "default": "08:00"
+                },
+                "poetry_style": {
+                  "type": "string",
+                  "title": "Poetry preference",
+                  "format": "multiline",
+                  "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+                  "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+                },
+                "telegram_chat": {
+                  "type": "string",
+                  "title": "Telegram chat ID or @username"
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "rawInput": {
+            "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "time_of_day",
+                "timezone",
+                "telegram_chat"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Timezone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+                },
+                "time_of_day": {
+                  "type": "string",
+                  "title": "Morning delivery time",
+                  "format": "time",
+                  "default": "08:00"
+                },
+                "poetry_style": {
+                  "type": "string",
+                  "title": "Poetry preference",
+                  "format": "multiline",
+                  "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+                  "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+                },
+                "telegram_chat": {
+                  "type": "string",
+                  "title": "Telegram chat ID or @username"
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6"
+        },
+        "toolName": "request_input",
+        "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6"
+      }
+    },
+    "created_at": "2026-08-10T14:14:45.984Z"
+  },
+  {
+    "id": "2086d496-82a7-5b11-969d-4a1f6fc0f000",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 19,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_oKZiZXfG0lf35KE3WNAOIDws|fc_0b9b71f… <83 chars elided>",
+      "type": "tool_result",
+      "output": "aborted",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:14:45.984Z"
+  },
+  {
+    "id": "b204d7dd-2daf-44b9-8a51-6e46723b37ca",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 20,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0.043811699999999995,
+      "type": "usage",
+      "input": 9,
+      "total": 63654,
+      "output": 1119
+    },
+    "created_at": "2026-08-10T14:14:48.282Z"
+  },
+  {
+    "id": "e96de44b-ef83-4323-a3f6-d7520f0282ca",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 21,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "aeb7c12a4619a3254805c080f76b59f2",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-10T14:14:48.282Z"
+  },
+  {
+    "id": "99df840c-a4f0-4f9c-ba77-855ac6f1d037",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Responding to cancellation**\n\nI need t… <367 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:16:13.079Z"
+  },
+  {
+    "id": "ca72d92d-f2c3-56d8-83c5-6d703e17c214",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_iLvfcJo0QEc2TmNlKZrFyeD6|fc_0a6f77e… <83 chars elided>",
+      "name": "rename_session",
+      "type": "tool_call",
+      "input": {
+        "name": "Daily Arabic Poetry",
+        "description": "Setting up a Telegram agent to send Arab… <128 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:16:13.079Z"
+  },
+  {
+    "id": "aac33e87-9647-5341-afcf-4528dde3d6b1",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_QKleioohKPLZ8UoK09ayHOIX|fc_0a6f77e… <83 chars elided>",
+      "name": "rename_agent",
+      "type": "tool_call",
+      "input": {
+        "name": "Arabic Poetry Scheduler",
+        "description": "Configures and schedules daily Arabic poetry messages to Telegram."
+      }
+    },
+    "created_at": "2026-08-10T14:16:14.787Z"
+  },
+  {
+    "id": "c40ab7cc-837a-5151-b8a6-1e8194a9cbc9",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_iLvfcJo0QEc2TmNlKZrFyeD6|fc_0a6f77e… <83 chars elided>",
+      "type": "tool_result",
+      "output": "{\"stream\":{\"created_at\":\"2026-08-10T14:0… <725 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:16:14.787Z"
+  },
+  {
+    "id": "57ae39da-d135-54ab-bd3c-3d342ff52c9a",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_QKleioohKPLZ8UoK09ayHOIX|fc_0a6f77e… <83 chars elided>",
+      "type": "tool_result",
+      "output": "{\"count\":1,\"workflow\":{\"flags\":{\"is_appl… <482 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:16:14.787Z"
+  },
+  {
+    "id": "f6e7b701-fa76-4845-9931-b067e321a98e",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0.030453400000000002,
+      "type": "usage",
+      "input": 6,
+      "total": 43212,
+      "output": 176
+    },
+    "created_at": "2026-08-10T14:16:16.788Z"
+  },
+  {
+    "id": "db7c3e26-3870-4c36-8f43-eb80c027d2b8",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "No problem. When you’re ready, send the … <165 chars elided>",
+      "type": "message"
+    },
+    "created_at": "2026-08-10T14:16:16.788Z"
+  },
+  {
+    "id": "f0f14d71-ada0-42d8-93b3-df02e530ace0",
+    "session_id": "0b6a8c44-a975-4431-90e7-adbcab87c8e8",
+    "project_id": "019fe7de-5e28-7c70-b374-e855b88410a9",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "f9a838ce54c84ee28f0b51555e82b03f"
+    },
+    "created_at": "2026-08-10T14:16:16.788Z"
+  }
+]

--- a/web/packages/agenta-chat/tests/unit/assets/loadSession.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/loadSession.test.ts
@@ -1,17 +1,17 @@
-import type {SessionRecord} from "@agenta/entities/session"
+import type {SessionInteractionRowState, SessionRecord} from "@agenta/entities/session"
 import {atom} from "jotai"
 import {beforeEach, describe, expect, it, vi} from "vitest"
 
-// `fetchSessionRecordsAtom`/`fetchCancelledClientToolTokensAtom` (real impls in @agenta/entities)
+// `fetchSessionRecordsAtom`/`fetchSessionInteractionStatesAtom` (real impls in @agenta/entities)
 // hit the network via jotai-tanstack-query; loadSessionMessages only needs their resolved-value
 // contracts, so both are replaced with controllable stubs rather than standing up a query client +
-// fetch mock. The cancelled-tokens set defaults empty — irrelevant to this file's own assertions,
+// fetch mock. The interaction-state map defaults empty — irrelevant to this file's own assertions,
 // which only cover the records half; transcriptToMessages.test.ts covers the join itself.
 let fetchResult: {records: SessionRecord[] | null; refreshed?: Promise<SessionRecord[] | null>}
-let cancelledClientToolTokens = new Set<string>()
+let interactionRowStates = new Map<string, SessionInteractionRowState>()
 vi.mock("@agenta/entities/session", () => ({
     fetchSessionRecordsAtom: atom(null, async () => fetchResult),
-    fetchCancelledClientToolTokensAtom: atom(null, async () => cancelledClientToolTokens),
+    fetchSessionInteractionStatesAtom: atom(null, async () => interactionRowStates),
 }))
 
 const {loadSessionMessages} = await import("../../../src/assets/loadSession")
@@ -30,7 +30,7 @@ const record = (id: string, payload: Record<string, unknown>, sender = "agent"):
 describe("loadSessionMessages", () => {
     beforeEach(() => {
         fetchResult = {records: null}
-        cancelledClientToolTokens = new Set()
+        interactionRowStates = new Map()
     })
 
     it("returns null when there are no records", async () => {

--- a/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
@@ -1,7 +1,14 @@
-import type {SessionRecord} from "@agenta/entities/session"
+import type {
+    SessionInteractionRowState,
+    SessionInteractionRowStates,
+    SessionRecord,
+} from "@agenta/entities/session"
+import {CLIENT_TOOL_INTERACTION_ENDED_OUTPUT} from "@agenta/shared/clientTools"
 import {describe, expect, it} from "vitest"
 
 import {transcriptToMessages} from "../../../src/assets/transcriptToMessages"
+
+import abandonedFormSession from "./__fixtures__/abandonedFormSession.json"
 
 const record = (id: string, payload: Record<string, unknown>, sender = "agent"): SessionRecord => ({
     id,
@@ -469,15 +476,7 @@ describe("transcriptToMessages parked client tool", () => {
     })
 })
 
-/**
- * Regression: a `session_interactions` row that reached a TERMINAL status (cancelled) server-side
- * with no corresponding `tool_result` in the transcript previously replayed as still fully
- * pending — an interactive, answerable form stacked above the real live interaction (live
- * evidence, session 3975e362-f64c-4e2d-8f4f-4f36c584bd91 on the 8180 dev stack).
- * `cancelledClientToolTokens` (keyed by `session_interactions.token` == the record's `toolCallId`)
- * is the join that fixes it — byte-parity with the OSS original's suite.
- */
-describe("transcriptToMessages cancelled client-tool interactions", () => {
+describe("transcriptToMessages interaction-row precedence", () => {
     const elicitationToolCallId = "call_1|fc_1"
     const elicitationInput = {
         message: "Which repository?",
@@ -511,85 +510,300 @@ describe("transcriptToMessages cancelled client-tool interactions", () => {
             },
         })
 
-    it("cancelled: an elicitation replays inert (output-available, action:cancel), not as a form", () => {
-        const parts = (transcriptToMessages([elicitationRequest()], {
-            cancelledClientToolTokens: new Set([elicitationToolCallId]),
-        })?.[0].parts ?? []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({
-            type: "tool-request_input",
-            toolCallId: elicitationToolCallId,
-            state: "output-available",
-            output: {action: "cancel"},
-            input: elicitationInput,
-        })
+    const rowState = (
+        token: string,
+        overrides: Partial<SessionInteractionRowState> = {},
+    ): SessionInteractionRowState => ({
+        token,
+        status: "cancelled",
+        kind: "client_tool",
+        ...overrides,
     })
+    const rowStates = (...rows: SessionInteractionRowState[]): SessionInteractionRowStates =>
+        new Map(rows.map((row) => [row.token, row]))
+    const toolParts = (
+        records: SessionRecord[],
+        interactionRowStates?: SessionInteractionRowStates,
+    ): Record<string, unknown>[] =>
+        (
+            (transcriptToMessages(records, {interactionRowStates})?.[0].parts ??
+                []) as unknown as Record<string, unknown>[]
+        ).filter((part) => typeof part.toolCallId === "string")
 
-    it("cancelled: a connect request replays inert (connected:false, reason:cancelled)", () => {
-        const parts = (transcriptToMessages([connectRequest()], {
-            cancelledClientToolTokens: new Set([connectToolCallId]),
-        })?.[0].parts ?? []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({
-            type: "tool-request_connection",
-            toolCallId: connectToolCallId,
-            state: "output-available",
-            output: {connected: false, reason: "cancelled"},
-        })
-    })
-
-    it("pending: a token NOT in the cancelled set still replays fully interactive (existing behavior)", () => {
-        const parts = (transcriptToMessages([elicitationRequest()], {
-            cancelledClientToolTokens: new Set(["some-other-token"]),
-        })?.[0].parts ?? []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({
-            type: "tool-request_input",
-            toolCallId: elicitationToolCallId,
-            state: "input-available",
-        })
-    })
-
-    it("pending: omitting the option entirely is a no-op (callers with no interaction join unaffected)", () => {
-        const parts = (transcriptToMessages([elicitationRequest()])?.[0].parts ??
-            []) as unknown as Record<string, unknown>[]
-
-        expect(parts[0]).toMatchObject({state: "input-available"})
-    })
-
-    it("settled: a real tool_result still wins over a stale cancelled-token entry", () => {
-        const parts = (transcriptToMessages(
+    it("keeps a recorded tool result ahead of row state", () => {
+        const output = {action: "accept", content: {repository: "octocat/Hello-World"}}
+        const parts = toolParts(
             [
                 elicitationRequest(),
                 record("r-result", {
                     type: "tool_result",
                     id: elicitationToolCallId,
-                    output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+                    output,
                 }),
             ],
-            {cancelledClientToolTokens: new Set([elicitationToolCallId])},
-        )?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+            rowStates(
+                rowState(elicitationToolCallId, {
+                    status: "responded",
+                    resolution: {outcome: "error", error: "stale error"},
+                }),
+            ),
+        )
+
+        expect(parts[0]).toMatchObject({state: "output-available", output})
+    })
+
+    it("renders a completed saved resolution", () => {
+        const output = {action: "accept", content: {repository: "octocat/Hello-World"}}
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(
+                rowState(elicitationToolCallId, {
+                    status: "responded",
+                    resolution: {
+                        tool_call_id: elicitationToolCallId,
+                        tool_name: "request_input",
+                        outcome: "completed",
+                        output,
+                    },
+                }),
+            ),
+        )
+
+        expect(parts[0]).toMatchObject({state: "output-available", output})
+    })
+
+    it("uses neutral output when a completed resolution has no object output", () => {
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(
+                rowState(elicitationToolCallId, {
+                    status: "responded",
+                    resolution: {outcome: "completed", output: "invalid"},
+                }),
+            ),
+        )
 
         expect(parts[0]).toMatchObject({
             state: "output-available",
-            output: {action: "accept", content: {repository: "octocat/Hello-World"}},
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
         })
     })
 
-    it("cancelled: an unregistered client-tool kind still settles (empty output, no crash)", () => {
-        const toolCallId = "call_unknownKind"
-        const parts = (transcriptToMessages(
-            [
-                record("r-interaction", {
-                    type: "interaction_request",
-                    id: toolCallId,
-                    kind: "client_tool",
-                    payload: {toolCallId, toolName: "some_future_client_tool", input: {}},
+    it("renders an error saved resolution", () => {
+        const parts = toolParts(
+            [connectRequest()],
+            rowStates(
+                rowState(connectToolCallId, {
+                    status: "responded",
+                    resolution: {
+                        tool_call_id: connectToolCallId,
+                        tool_name: "request_connection",
+                        outcome: "error",
+                        error: "OAuth popup failed",
+                    },
                 }),
-            ],
-            {cancelledClientToolTokens: new Set([toolCallId])},
-        )?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+            ),
+        )
 
-        expect(parts[0]).toMatchObject({state: "output-available", output: {}})
+        expect(parts[0]).toMatchObject({state: "output-error", errorText: "OAuth popup failed"})
+    })
+
+    it("renders neutral output for terminal rows without saved answers", () => {
+        const parts = toolParts(
+            [elicitationRequest(), connectRequest()],
+            rowStates(rowState(elicitationToolCallId), rowState(connectToolCallId)),
+        )
+        const elicitation = parts.find((part) => part.toolCallId === elicitationToolCallId)
+        const connect = parts.find((part) => part.toolCallId === connectToolCallId)
+
+        expect(elicitation).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+        expect(connect).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+        expect(elicitation?.output).not.toEqual({action: "cancel"})
+        expect(connect?.output).not.toEqual({connected: false, reason: "cancelled"})
+    })
+
+    it("leaves a pending row live", () => {
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(rowState(elicitationToolCallId, {status: "pending"})),
+        )
+
+        expect(parts[0]).toMatchObject({state: "input-available"})
+    })
+
+    it("joins through a stamped tool-call id before the row token", () => {
+        const output = {connected: true, integration: "telegram"}
+        const parts = toolParts(
+            [connectRequest()],
+            rowStates(
+                rowState("interaction-token", {
+                    status: "responded",
+                    toolCallId: connectToolCallId,
+                    resolution: {outcome: "completed", output},
+                }),
+            ),
+        )
+
+        expect(parts[0]).toMatchObject({state: "output-available", output})
+    })
+
+    it("joins legacy rows through token equality", () => {
+        const parts = toolParts(
+            [elicitationRequest()],
+            rowStates(rowState(elicitationToolCallId, {kind: "user_input", status: "resolved"})),
+        )
+
+        expect(parts[0]).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+    })
+
+    it("never settles a client-tool part from a user-approval row", () => {
+        const parts = toolParts(
+            [connectRequest()],
+            rowStates(rowState(connectToolCallId, {kind: "user_approval", status: "cancelled"})),
+        )
+
+        expect(parts[0]).toMatchObject({state: "input-available"})
+    })
+
+    // The gate is on a turn that never resumed, so no other pass settles it. Left
+    // `approval-requested`, the whole-chat queue scan holds every typed message behind a gate
+    // whose turn is long dead (review round 1, finding 2).
+    const abandonedApprovalRecords = (): SessionRecord[] => [
+        record("r-user-1", {type: "message", text: "delete the file"}, "user"),
+        record("r-call", {
+            type: "tool_call",
+            id: "tool-1",
+            name: "bash",
+            input: {command: "rm notes.md"},
+        }),
+        record("r-req", {
+            type: "interaction_request",
+            id: "approval-1",
+            kind: "user_approval",
+            payload: {toolCallId: "tool-1"},
+        }),
+        record("r-done-paused", {type: "done", stopReason: "paused"}),
+        record("r-user-2", {type: "message", text: "never mind, just say hi"}, "user"),
+        record("r-msg", {type: "message", text: "hi"}),
+        record("r-done", {type: "done"}),
+    ]
+    const allParts = (
+        records: SessionRecord[],
+        interactionRowStates?: SessionInteractionRowStates,
+    ): Record<string, unknown>[] =>
+        (transcriptToMessages(records, {interactionRowStates}) ?? []).flatMap(
+            (message) => message.parts as unknown as Record<string, unknown>[],
+        )
+
+    it("leaves an abandoned approval gate pending when no row says otherwise", () => {
+        const parts = allParts(abandonedApprovalRecords())
+
+        expect(parts.some((part) => part.state === "approval-requested")).toBe(true)
+    })
+
+    it("settles an abandoned approval gate from its swept row", () => {
+        const parts = allParts(
+            abandonedApprovalRecords(),
+            rowStates(rowState("approval-1", {kind: "user_approval", status: "cancelled"})),
+        )
+
+        expect(parts.some((part) => part.state === "approval-requested")).toBe(false)
+        // Denied, not approved: the sweep proves only that the gate died unanswered, and the
+        // gated tool never ran.
+        expect(parts.find((part) => part.toolCallId === "tool-1")).toMatchObject({
+            state: "output-denied",
+        })
+    })
+
+    it("replays an answered approval row with its verdict", () => {
+        const parts = allParts(
+            abandonedApprovalRecords(),
+            rowStates(
+                rowState("approval-1", {
+                    kind: "user_approval",
+                    status: "resolved",
+                    resolution: {verdict: "denied", tool_call_id: "tool-1"},
+                }),
+            ),
+        )
+
+        expect(parts.find((part) => part.toolCallId === "tool-1")).toMatchObject({
+            state: "approval-responded",
+            approval: {id: "approval-1", approved: false},
+        })
+    })
+
+    it("keeps an answered approval row's approved verdict", () => {
+        const parts = allParts(
+            abandonedApprovalRecords(),
+            rowStates(
+                rowState("approval-1", {
+                    kind: "user_approval",
+                    status: "resolved",
+                    resolution: {verdict: "approved", tool_call_id: "tool-1"},
+                }),
+            ),
+        )
+
+        expect(parts.find((part) => part.toolCallId === "tool-1")).toMatchObject({
+            state: "approval-responded",
+            approval: {id: "approval-1", approved: true},
+        })
+    })
+
+    it("preserves record-only replay when row states are omitted", () => {
+        expect(toolParts([elicitationRequest()])[0]).toMatchObject({state: "input-available"})
+    })
+})
+
+/**
+ * Golden replay of a REAL pre-fix session (live QA, 2026-08-10): dev stack session
+ * `0b6a8c44-a975-4431-90e7-adbcab87c8e8`, whose single interaction row is
+ * `client_tool` / `request_input` / `cancelled` with no resolution and no
+ * `data.request.tool_call_id`. Its 44 records are the fixture, structurally untouched — only long
+ * unrelated `read`/`ls` payloads are elided, never the form's own records.
+ *
+ * The shape that makes it interesting: the form's turn ends `done{stopReason:"paused"}` and the
+ * NEXT turn starts with no user message between, so the two fold into one `resumed` draft. The
+ * resumed-draft pass settles approval gates only, so nothing but the row can settle this card.
+ */
+describe("golden: an abandoned form card from a real pre-fix session", () => {
+    const FORM_TOOL_CALL_ID =
+        "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6"
+    const goldenRecords = abandonedFormSession as unknown as SessionRecord[]
+    const formPart = (interactionRowStates?: SessionInteractionRowStates) =>
+        (transcriptToMessages(goldenRecords, {interactionRowStates}) ?? [])
+            .flatMap((message) => message.parts as unknown as Record<string, unknown>[])
+            .find((part) => part.toolCallId === FORM_TOOL_CALL_ID)
+
+    it("replays the form live when no row state is available", () => {
+        expect(formPart()).toMatchObject({type: "tool-request_input", state: "input-available"})
+    })
+
+    it("settles the form to the neutral ended state from its cancelled row", () => {
+        const part = formPart(
+            new Map([
+                [
+                    FORM_TOOL_CALL_ID,
+                    {token: FORM_TOOL_CALL_ID, status: "cancelled", kind: "client_tool"},
+                ],
+            ]) as SessionInteractionRowStates,
+        )
+
+        expect(part).toMatchObject({
+            state: "output-available",
+            output: CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+        })
+        // Never the pre-fix guesses that made an answered form read as dismissed.
+        expect(part?.output).not.toEqual({action: "cancel"})
     })
 })

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -8,6 +8,7 @@
 // persist-on-settle → run-status publish, plus error stamping and the rewind plan.
 import {createElement, type ReactNode} from "react"
 
+import {buildAgentRequest} from "@agenta/playground"
 import {act, renderHook, waitFor} from "@testing-library/react"
 import type {UIMessage} from "ai"
 import {createStore, Provider} from "jotai"
@@ -34,14 +35,13 @@ vi.mock("@agenta/entities/session", async () => {
         revalidateSessionRecordsAtom: atom(null, () => {}),
         // The hydration seam's records fetch: "no server history" for these tests.
         fetchSessionRecordsAtom: atom(null, () => ({records: null, refreshed: null})),
+        fetchSessionInteractionStatesAtom: atom(null, () => new Map()),
     }
 })
 
 vi.mock("@agenta/entities/trace", () => ({
     markTraceAsFresh: vi.fn(),
 }))
-
-import {buildAgentRequest} from "@agenta/playground"
 
 import {useAgentConversation} from "../../../src/hooks/useAgentConversation"
 import {markSessionFresh} from "../../../src/state/sessionEphemera"

--- a/web/packages/agenta-chat/tests/unit/model/approvals.test.ts
+++ b/web/packages/agenta-chat/tests/unit/model/approvals.test.ts
@@ -5,7 +5,7 @@ import {getPendingApprovals} from "../../../src/model/approvals"
 import approvalTurnFixture from "../fixtures/approvalTurn.json"
 
 describe("getPendingApprovals", () => {
-    it("returns the pending approvals off the last assistant turn, in order", () => {
+    it("returns pending approvals in transcript order", () => {
         const messages = approvalTurnFixture as UIMessage[]
         expect(getPendingApprovals(messages)).toEqual([
             {approvalId: "appr_1", toolName: "delete_file", input: {path: "notes.txt"}},
@@ -13,15 +13,19 @@ describe("getPendingApprovals", () => {
         ])
     })
 
-    it("is empty when the last message is from the user", () => {
-        const messages: UIMessage[] = [
+    it("finds approvals before a trailing user message", () => {
+        const messages = [
+            ...(approvalTurnFixture as UIMessage[]),
             {
-                id: "u1",
+                id: "u2",
                 role: "user",
                 parts: [{type: "text", text: "hi"}],
             } as unknown as UIMessage,
         ]
-        expect(getPendingApprovals(messages)).toEqual([])
+        expect(getPendingApprovals(messages)).toEqual([
+            {approvalId: "appr_1", toolName: "delete_file", input: {path: "notes.txt"}},
+            {approvalId: "appr_2", toolName: "send_mail", input: {to: "a@b.com"}},
+        ])
     })
 
     it("is empty for an empty message list", () => {

--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -174,6 +174,46 @@ export interface RespondInteractionParams extends InteractionScopedParams {
 export const isInteractionConflict = (error: unknown): boolean =>
     (error as {statusCode?: number} | null)?.statusCode === 409
 
+export interface TransitionInteractionParams extends SessionScopedParams {
+    token: string
+    status: SessionInteractionStatusCode
+    resolution?: Record<string, unknown>
+}
+
+/**
+ * Write a row lifecycle transition by `session_id` + `token`, not row id.
+ * Status and resolution stay atomic so the stale sweep cannot win between writes.
+ */
+export async function transitionInteraction({
+    sessionId,
+    token,
+    status,
+    resolution,
+    projectId,
+    appId,
+    abortSignal,
+}: TransitionInteractionParams): Promise<SessionInteraction | null> {
+    if (!projectId || !sessionId || !token) return null
+
+    const data = await getSessionsClient().transitionInteraction(
+        {
+            session_id: sessionId,
+            token,
+            status,
+            // The generated type predates the widened resolution payload.
+            resolution: resolution as AgentaApi.SessionInteractionResolution | undefined,
+        },
+        projectScopedRequest(projectId, appId, abortSignal),
+    )
+
+    const validated = safeParseWithLogging(
+        sessionInteractionResponseSchema,
+        data,
+        "[transitionInteraction]",
+    )
+    return validated?.interaction ?? null
+}
+
 /**
  * Resolve a HITL interaction (approve/deny/input) — the detached respond dispatcher.
  *

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -10,6 +10,7 @@ export {
     queryInteractions,
     fetchInteraction,
     respondInteraction,
+    transitionInteraction,
     isInteractionConflict,
     querySessionStreams,
     querySessions,
@@ -33,6 +34,7 @@ export {
     type QueryInteractionsParams,
     type InteractionScopedParams,
     type RespondInteractionParams,
+    type TransitionInteractionParams,
     type CommandSessionStreamParams,
 } from "./api/api"
 export {
@@ -90,9 +92,12 @@ export {
     type SessionRecordsFetchResult,
 } from "./state/records"
 export {
-    fetchCancelledClientToolTokensAtom,
-    cancelledClientToolTokensQueryKey,
+    fetchSessionInteractionStatesAtom,
+    revalidateSessionInteractionsAtom,
+    type SessionInteractionRowState,
+    type SessionInteractionRowStates,
 } from "./state/interactionStatus"
+export {recordInteractionAnswerAtom} from "./state/interactionAnswer"
 export {
     sessionMountsQueryFamily,
     mountFilesQueryFamily,

--- a/web/packages/agenta-entities/src/session/state/interactionAnswer.ts
+++ b/web/packages/agenta-entities/src/session/state/interactionAnswer.ts
@@ -1,0 +1,70 @@
+import {projectIdAtom} from "@agenta/shared/state"
+import {atom} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+
+import {transitionInteraction} from "../api/api"
+
+import {
+    fetchSessionInteractionStatesAtom,
+    sessionInteractionRowsQueryKey,
+    type SessionInteractionRowStates,
+} from "./interactionStatus"
+
+/** New rows join through the stamped tool-call id; legacy rows join through token equality. */
+const tokenForToolCall = (
+    states: SessionInteractionRowStates,
+    toolCallId: string,
+): string | null => {
+    for (const state of states.values()) {
+        if (state.toolCallId === toolCallId) return state.token
+    }
+    return states.has(toolCallId) ? toolCallId : null
+}
+
+/**
+ * Best-effort by design: failures preserve today's in-band resume behavior.
+ * It never blocks or rejects the client-tool resume path.
+ * Callers fire it without awaiting the result.
+ */
+export const recordInteractionAnswerAtom = atom(
+    null,
+    async (
+        get,
+        set,
+        params: {
+            sessionId: string
+            toolCallId: string
+            resolution: Record<string, unknown>
+        },
+    ): Promise<void> => {
+        const {sessionId, toolCallId, resolution} = params
+        const projectId = get(projectIdAtom) ?? ""
+        if (!projectId || !sessionId) return
+
+        const queryClient = get(queryClientAtom)
+        const rowsQueryKey = sessionInteractionRowsQueryKey(projectId, sessionId)
+        try {
+            let states = await set(fetchSessionInteractionStatesAtom, sessionId)
+            let token = tokenForToolCall(states, toolCallId)
+            if (!token) {
+                // The card can be newer than the cached rows, so refetch once before giving up.
+                await queryClient.invalidateQueries({queryKey: rowsQueryKey})
+                states = await set(fetchSessionInteractionStatesAtom, sessionId)
+                token = tokenForToolCall(states, toolCallId)
+            }
+            if (!token) return
+
+            await transitionInteraction({
+                sessionId,
+                token,
+                status: "responded",
+                resolution,
+                projectId,
+            })
+
+            await queryClient.invalidateQueries({queryKey: rowsQueryKey})
+        } catch (err) {
+            console.warn("[recordInteractionAnswerAtom] write failed:", err)
+        }
+    },
+)

--- a/web/packages/agenta-entities/src/session/state/interactionStatus.ts
+++ b/web/packages/agenta-entities/src/session/state/interactionStatus.ts
@@ -1,62 +1,86 @@
 /**
- * Terminal status join for transcript replay — the cheapest correct source for "was this parked
- * client-tool interaction already resolved server-side?"
- *
- * The durable record log (`sessionRecordsQueryFamily`) replays a `client_tool` interaction request
- * from its own `interaction_request` event alone; it never carries the interaction's later
- * lifecycle (a `session_interactions` row concept, not a record). A normal live settle (connect,
- * elicitation answer) DOES leave a trace: the browser's `addToolOutput` resubmits the result, and
- * the runner re-emits it as a `tool_result` record that settles the part on replay too — no query
- * needed. But a server-side cancellation (the stale-interaction sweep, or any path that never
- * round-trips a tool_result) leaves the transcript with nothing but the original request, which
- * replays as a fully interactive, still-pending form forever.
- *
- * `session_interactions.token` is the join key: it equals the record's `toolCallId` (confirmed
- * against a live 8180 row: token `call_n7Gec...` == the `interaction_request` record's
- * `toolCallId` == its `attributes.id`). So the cheapest fix is one small, best-effort query for the
- * session's `client_tool` interactions, filtered to `cancelled`, keyed by that token.
+ * Replay joins durable records with interaction rows because records omit later row lifecycle.
+ * New rows join through `data.request.tool_call_id`; legacy rows join through token equality.
  */
 import {projectIdAtom} from "@agenta/shared/state"
 import {atom} from "jotai"
 import {queryClientAtom} from "jotai-tanstack-query"
 
 import {queryInteractions} from "../api/api"
+import type {
+    SessionInteraction,
+    SessionInteractionKind,
+    SessionInteractionStatusCode,
+} from "../core/schema"
 
-const CANCELLED_CLIENT_TOOL_TOKENS_STALE_MS = 15_000
+const SESSION_INTERACTION_ROWS_STALE_MS = 15_000
 
-export const cancelledClientToolTokensQueryKey = (projectId: string, sessionId: string) =>
-    ["session", "interactions", "cancelledClientToolTokens", projectId, sessionId] as const
+export const sessionInteractionRowsQueryKey = (projectId: string, sessionId: string) =>
+    ["session", "interactions", "rows", projectId, sessionId] as const
 
-const cancelledClientToolTokensQueryOptions = (projectId: string, sessionId: string) => ({
-    queryKey: cancelledClientToolTokensQueryKey(projectId, sessionId),
-    queryFn: async (): Promise<ReadonlySet<string>> => {
-        const interactions = await queryInteractions({sessionId, projectId, kind: "client_tool"})
-        const tokens = (interactions ?? [])
-            .filter((i) => i.status === "cancelled" && typeof i.token === "string" && i.token)
-            .map((i) => i.token as string)
-        return new Set(tokens)
-    },
-    staleTime: CANCELLED_CLIENT_TOOL_TOKENS_STALE_MS,
+const sessionInteractionRowsQueryOptions = (projectId: string, sessionId: string) => ({
+    queryKey: sessionInteractionRowsQueryKey(projectId, sessionId),
+    queryFn: async (): Promise<SessionInteraction[]> =>
+        (await queryInteractions({sessionId, projectId})) ?? [],
+    staleTime: SESSION_INTERACTION_ROWS_STALE_MS,
 })
+
+export interface SessionInteractionRowState {
+    token: string
+    status: SessionInteractionStatusCode
+    kind: SessionInteractionKind
+    resolution?: Record<string, unknown>
+    toolCallId?: string
+}
+
+export type SessionInteractionRowStates = ReadonlyMap<string, SessionInteractionRowState>
+
+function interactionStatesFromRows(rows: SessionInteraction[]): SessionInteractionRowStates {
+    const states = new Map<string, SessionInteractionRowState>()
+    for (const row of rows) {
+        if (typeof row.token !== "string" || !row.token) continue
+
+        const toolCallId = row.data?.request?.tool_call_id
+        states.set(row.token, {
+            token: row.token,
+            status: row.status as SessionInteractionStatusCode,
+            kind: row.kind as SessionInteractionKind,
+            ...(row.data?.resolution ? {resolution: row.data.resolution} : {}),
+            ...(typeof toolCallId === "string" && toolCallId ? {toolCallId} : {}),
+        })
+    }
+    return states
+}
 
 /**
  * Imperative, best-effort fetch through the shared query cache. Never throws — a failure (network,
- * missing project scope) resolves to an empty set, so a resurrected-form miss degrades to today's
+ * missing project scope) resolves to an empty map, so a replay-join miss degrades to today's
  * behavior (still pending) rather than blocking the whole transcript from loading.
  */
-export const fetchCancelledClientToolTokensAtom = atom(
+export const fetchSessionInteractionStatesAtom = atom(
     null,
-    async (get, _set, sessionId: string): Promise<ReadonlySet<string>> => {
+    async (get, _set, sessionId: string): Promise<SessionInteractionRowStates> => {
         const projectId = get(projectIdAtom) ?? ""
-        if (!projectId || !sessionId) return new Set()
+        if (!projectId || !sessionId) return new Map()
         try {
             const client = get(queryClientAtom)
-            return await client.fetchQuery(
-                cancelledClientToolTokensQueryOptions(projectId, sessionId),
+            const rows = await client.fetchQuery(
+                sessionInteractionRowsQueryOptions(projectId, sessionId),
             )
+            return interactionStatesFromRows(rows)
         } catch (err) {
-            console.warn("[fetchCancelledClientToolTokensAtom] fetch failed:", err)
-            return new Set()
+            console.warn("[fetchSessionInteractionStatesAtom] fetch failed:", err)
+            return new Map()
         }
     },
 )
+
+export const revalidateSessionInteractionsAtom = atom(null, (get, _set, sessionId: string) => {
+    const projectId = get(projectIdAtom) ?? ""
+    if (!projectId || !sessionId) return
+    // Keep an initial rows fetch in flight while marking its cache entry stale.
+    void get(queryClientAtom).invalidateQueries(
+        {queryKey: sessionInteractionRowsQueryKey(projectId, sessionId)},
+        {cancelRefetch: false},
+    )
+})

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts
@@ -14,6 +14,7 @@
  * `tools__{provider}__{integration}__{action}__{connection}` (see `parseGatewayToolName`), and a
  * custom function tool arrives as its bare `function.name`.
  */
+import {CLIENT_TOOL_NAMES} from "@agenta/shared/clientTools"
 import {parseGatewayToolSlug} from "@agenta/shared/utils"
 
 import {PI_BUILTIN_RULE_NAMES} from "./piPermissions"
@@ -123,9 +124,6 @@ const PLATFORM_OPS = new Set([
     "resume_subscription",
 ])
 
-/** Browser-fulfilled client tools — they carry their own widget/decline UI; never auto-allowable. */
-const CLIENT_TOOLS = new Set(["request_connection", "request_input"])
-
 /** The seven built-ins by lower-cased name, so a gate can be written under its canonical name. */
 const PI_BUILTIN_CANONICAL_NAMES = new Map<string, string>(
     PI_BUILTIN_RULE_NAMES.map((name) => [name.toLowerCase(), name]),
@@ -139,7 +137,7 @@ const PI_BUILTIN_CANONICAL_NAMES = new Map<string, string>(
  */
 export function gateRulePattern(toolName: string): string | null {
     if (!toolName) return null
-    if (PLATFORM_OPS.has(toolName) || CLIENT_TOOLS.has(toolName)) return null
+    if (PLATFORM_OPS.has(toolName) || CLIENT_TOOL_NAMES.has(toolName)) return null
     if (toolName.startsWith("mcp__")) return null
     // A built-in reaches the card lower-cased (the run frame's part is `tool-bash`); the rule list
     // reads one way only if both writers use the canonical name.

--- a/web/packages/agenta-playground/src/index.ts
+++ b/web/packages/agenta-playground/src/index.ts
@@ -87,7 +87,7 @@ export {
 // Render-hint map for interaction kinds (sibling `data-render` parts → toolCallId lookup).
 export {buildRenderMap, renderKindFor, type RenderHintLike} from "./state"
 // Queued-message release gate for the agent chat composer (HITL-safe, one-by-one).
-export {canReleaseQueuedMessage, isHitlPending} from "./state"
+export {canReleaseQueuedMessage, isHitlPending, messageHasPendingHitl} from "./state"
 // Per-turn request capture + correlation helpers (Turn Inspector Context/Raw tabs).
 export {
     appendCapped,

--- a/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts
@@ -28,6 +28,8 @@ interface ApprovalLike {
     approved?: boolean
 }
 
+import {CLIENT_TOOL_NAMES} from "@agenta/shared/clientTools"
+
 import {buildRenderMap, renderKindFor, type RenderHintLike} from "./renderMap"
 
 export type LiveAgentInteraction =
@@ -70,14 +72,6 @@ const isRespondedToolPart = (part: ToolPartLike): boolean =>
  * resume (and stops the queue gate, which composes this predicate, from holding forever). v1 client
  * tools are never approval-gated; an approval-gated client tool would need a richer signal.
  */
-/**
- * Known browser-fulfilled client tools, mirroring the app-layer registry's `BY_TOOL_NAME`
- * (`request_connection`, `request_input`). The package cannot import that registry (layering), so
- * it tracks the same names. A part dispatches as a client tool by `render.kind` (finer axis) OR
- * this name, matching the registry's `render.kind -> toolName` precedence.
- */
-const CLIENT_TOOL_NAMES = new Set(["request_connection", "request_input"])
-
 const toolPartName = (part: ToolPartLike): string =>
     typeof part.type === "string" ? part.type.replace(/^tool-/, "") : ""
 
@@ -125,7 +119,7 @@ const isSettledToolPart = (part: ToolPartLike): boolean =>
         part.state === "approval-responded")
 
 /**
- * Resume when the last assistant turn carries a freshly-resolved parked interaction. Approval
+ * Resume when the targeted assistant turn carries a freshly-resolved parked interaction. Approval
  * responses dispatch per card; browser-fulfilled client tools retain the all-settled rule:
  *   - Approval (approve OR deny): a denied tool part is `approval-responded`, so a deny-only turn
  *     still resumes and the runner gets the denial round-trip (the deny dead-end fix).
@@ -139,10 +133,33 @@ export function agentShouldResumeAfterApproval({
     messages: MessageLike[]
     liveInteraction?: LiveAgentInteraction | null
 }): boolean {
-    const last = messages[messages.length - 1]
-    if (!last || last.role !== "assistant") return false
+    if (liveInteraction === null) return false
 
-    const parts = last.parts ?? []
+    // Live markers target their owning message; markerless orphan checks stay tail-only.
+    let message: MessageLike | undefined
+    if (liveInteraction) {
+        for (let i = messages.length - 1; i >= 0; i--) {
+            const candidate = messages[i]
+            if (candidate.role !== "assistant") continue
+            const ownsInteraction = (candidate.parts ?? []).some(
+                (part) =>
+                    isToolPart(part) &&
+                    (liveInteraction.kind === "approval"
+                        ? part.approval?.id === liveInteraction.id
+                        : part.toolCallId === liveInteraction.id),
+            )
+            if (ownsInteraction) {
+                message = candidate
+                break
+            }
+        }
+    } else {
+        const last = messages[messages.length - 1]
+        if (last?.role === "assistant") message = last
+    }
+    if (!message) return false
+
+    const parts = message.parts ?? []
     const toolParts = parts.filter((part) => isToolPart(part) && part.providerExecuted !== true)
     if (toolParts.length === 0) return false
 
@@ -151,7 +168,6 @@ export function agentShouldResumeAfterApproval({
 
     let lastResolvedIdx = -1
     let lastResolvedIsApproval = false
-    if (liveInteraction === null) return false
     if (liveInteraction) {
         lastResolvedIsApproval = liveInteraction.kind === "approval"
         lastResolvedIdx = parts.findIndex((part) =>

--- a/web/packages/agenta-playground/src/state/execution/agentMessageQueue.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentMessageQueue.ts
@@ -33,7 +33,7 @@ const isToolPart = (part: ToolPartLike): boolean => {
 }
 
 /**
- * The last assistant turn is paused awaiting the user's decision on a tool gate
+ * An assistant turn is paused awaiting the user's decision on a tool gate
  * (`approval-requested`) — the one HITL state the user can act on (via the ApprovalDock).
  *
  * Deliberately NOT `approval-responded`: that "resume is imminent" hold belongs SOLELY to
@@ -46,11 +46,14 @@ const isToolPart = (part: ToolPartLike): boolean => {
  * unblock UI can never disagree.
  */
 export function isHitlPending(messages: MessageLike[]): boolean {
-    const last = messages[messages.length - 1]
-    if (!last || last.role !== "assistant") return false
-    const parts = last.parts ?? []
-    // Parked client tools (elicitation forms, connect cards) hold the queue exactly like an
-    // approval gate: the stream reads "ready" while the run awaits the user's widget action.
+    return messages.some(messageHasPendingHitl)
+}
+
+/** The per-message half of `isHitlPending`, so a "waiting for you" marker paints on the turn that
+ * actually holds the gate instead of the newest one. Built from the same predicate on purpose. */
+export function messageHasPendingHitl(message: MessageLike): boolean {
+    if (message.role !== "assistant") return false
+    const parts = message.parts ?? []
     const renderMap = buildRenderMap(parts)
     return parts.some(
         (part) =>

--- a/web/packages/agenta-playground/src/state/execution/index.ts
+++ b/web/packages/agenta-playground/src/state/execution/index.ts
@@ -371,7 +371,7 @@ export {
 // Render-hint map: sibling `data-render` parts → toolCallId lookup (interaction kinds).
 export {buildRenderMap, renderKindFor, type RenderHintLike} from "./renderMap"
 // Agent-lane queued-message release gate (never releases mid-HITL or pre-resume).
-export {canReleaseQueuedMessage, isHitlPending} from "./agentMessageQueue"
+export {canReleaseQueuedMessage, isHitlPending, messageHasPendingHitl} from "./agentMessageQueue"
 // Per-turn request capture + correlation helpers (Turn Inspector Context/Raw tabs).
 export {
     appendCapped,

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -189,7 +189,7 @@ export {
     type LiveAgentInteraction,
 } from "./execution"
 export {buildRenderMap, renderKindFor, type RenderHintLike} from "./execution"
-export {canReleaseQueuedMessage, isHitlPending} from "./execution"
+export {canReleaseQueuedMessage, isHitlPending, messageHasPendingHitl} from "./execution"
 export {
     appendCapped,
     buildTurnCapture,

--- a/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentApprovalResume.test.ts
@@ -328,6 +328,23 @@ describe("agentShouldResumeAfterApproval", () => {
         expect(agentShouldResumeAfterApproval({messages})).toBe(true)
     })
 
+    it("resumes a named client-tool result in an earlier message only with its live marker", () => {
+        const messages = [
+            user("connect github"),
+            assistantWithClientTool("output-available", {connected: true}),
+            user("continue"),
+            {id: "a2", role: "assistant", parts: [{type: "text", text: "Starting"}]},
+        ]
+
+        expect(
+            agentShouldResumeAfterApproval({
+                messages,
+                liveInteraction: {kind: "client_tool", id: "call_c"},
+            }),
+        ).toBe(true)
+        expect(agentShouldResumeAfterApproval({messages})).toBe(false)
+    })
+
     it("does NOT resume while a client tool is still parked (input-available)", () => {
         const messages = [user("connect github"), assistantWithClientTool("input-available")]
         expect(agentShouldResumeAfterApproval({messages})).toBe(false)

--- a/web/packages/agenta-playground/tests/unit/agentMessageQueue.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentMessageQueue.test.ts
@@ -112,6 +112,25 @@ describe("isHitlPending", () => {
         expect(isHitlPending([assistantText("hello"), user("again")])).toBe(false)
     })
 
+    it("is true when an earlier assistant message still has a pending client tool", () => {
+        const messages = [
+            {
+                id: "a-pending",
+                role: "assistant",
+                parts: [
+                    {
+                        type: "tool-request_connection",
+                        toolCallId: "call-connect",
+                        state: "input-available",
+                    },
+                ],
+            },
+            user("again"),
+            assistantText("starting the next turn"),
+        ]
+        expect(isHitlPending(messages)).toBe(true)
+    })
+
     it("is false for an empty conversation", () => {
         expect(isHitlPending([])).toBe(false)
     })

--- a/web/packages/agenta-shared/package.json
+++ b/web/packages/agenta-shared/package.json
@@ -21,6 +21,7 @@
         "./api": "./src/api/index.ts",
         "./api/env": "./src/api/env.ts",
         "./api/persist": "./src/api/persist/index.ts",
+        "./clientTools": "./src/clientTools/index.ts",
         "./state": "./src/state/index.ts",
         "./utils": "./src/utils/index.ts",
         "./utils/mobileGate": "./src/utils/mobileGate/index.ts",

--- a/web/packages/agenta-shared/src/clientTools/index.ts
+++ b/web/packages/agenta-shared/src/clientTools/index.ts
@@ -1,0 +1,25 @@
+export const CLIENT_TOOL_DESCRIPTORS = {
+    connection: {toolName: "request_connection", renderKind: "connect"},
+    elicitation: {toolName: "request_input", renderKind: "elicitation"},
+} as const
+
+export const CLIENT_TOOL_NAMES: ReadonlySet<string> = new Set(
+    Object.values(CLIENT_TOOL_DESCRIPTORS).map(({toolName}) => toolName),
+)
+
+const CLIENT_TOOL_INTERACTION_ENDED_KEY = "agenta_interaction_ended"
+
+// Marks a terminal row with no saved answer, which is neither an answer nor an abandonment.
+// Frozen: replay assigns it as a part's `output`, so a mutable singleton would alias every card.
+export const CLIENT_TOOL_INTERACTION_ENDED_OUTPUT = Object.freeze({
+    [CLIENT_TOOL_INTERACTION_ENDED_KEY]: true,
+})
+
+export function isInteractionEndedOutput(output: unknown): boolean {
+    return (
+        typeof output === "object" &&
+        output !== null &&
+        !Array.isArray(output) &&
+        (output as Record<string, unknown>)[CLIENT_TOOL_INTERACTION_ENDED_KEY] === true
+    )
+}


### PR DESCRIPTION
## Context

An agent can stop in the middle of a run and ask the user for something. The chat then shows a card: a form to fill in, a service to connect, or a tool call to approve.

In production the user answered those cards and the system never wrote the answer down. The row that holds a card's state stayed `pending`. At the start of the next turn, a cleanup job closed every old `pending` row and marked it `cancelled`. In the database an answered card and an abandoned card then looked the same.

Everything the user saw followed from that. After a reload, an answered form came back empty and asked to be filled again. A finished connect card came back dead, with buttons that did nothing, and it held the composer so no new message could be sent. A warning strip said the run was going on somewhere else, in the same tab that owned the run.

The full story, with the evidence for each claim, is in the design docs PR [#5916](https://github.com/Agenta-AI/agenta/pull/5916).

The base of this PR is [#5860](https://github.com/Agenta-AI/agenta/pull/5860), because both branches edit the same chat files. GitHub therefore shows only this PR's own diff.

## Changes

### 1. Record the answer first, then resume

When the user answers a card, the browser now makes one API call before it sends the resume. That call tells the server "this card is answered, and here is the answer". It writes the status and the answer together, so the row is never half written.

The order is what closes the race. The cleanup job only closes rows that are still `pending`. A row that already says `responded` is invisible to it. The cleanup job itself needed no change at all.

`responded` plus a saved answer is the settled state for form and connect cards. `resolved` stays approval-only.

Before this PR:

| Card kind | User completes it | User declines it | User walks away |
|---|---|---|---|
| Approval | `resolved`, verdict saved | `resolved`, verdict saved | `pending`, later `cancelled` |
| Form | `cancelled`, nothing saved | `cancelled`, nothing saved | `pending`, later `cancelled` |
| Connect | `cancelled`, nothing saved | `pending`, never touched | `pending`, never touched |

After this PR:

| Card kind | User completes it | User declines it | User walks away |
|---|---|---|---|
| Approval | `resolved`, verdict saved | `resolved`, verdict saved | `pending`, later `cancelled` |
| Form | `responded`, answer saved | `responded`, decline saved | `pending`, later `cancelled` |
| Connect | `responded`, result saved | `responded`, decline saved | `pending`, later `cancelled` |

Only the approval card was ever right. Now all three record what happened, and `cancelled` means one thing again: nobody answered.

### 2. One rule for what replay shows

When the browser rebuilds a chat from the server's history, each card takes the first state that applies:

1. A real recorded answer in the conversation. Show the answered card.
2. An answer saved on the row. Show that answer.
3. An old row that is closed with no saved answer. Show a neutral, dead "request ended" card. Never guess whether the user answered or walked away.
4. Nothing above applies. The card is still open, so show it live and clickable.

The old code guessed. It turned every closed row into "Dismissed the request." or "Connection not completed" with a Retry button, which is why answered cards came back looking abandoned.

There are two copies of the replay code, one in the app and one in the `@agenta/chat` package. The precedence block is identical in both, byte for byte.

### 3. The browser listens, and stops overwriting

The server already publishes an event when a card's row changes. Only the mobile app listened to it. The desktop chat now listens too, re-reads the rows, and repaints the cards.

The browser also refuses to adopt the server's copy of the chat while a card is waiting, unless that copy settles the same card. This protects an answer the user has typed but not yet sent.

One extra case fixed the oldest sessions. The browser used to adopt a server copy only when the history had grown. A dead session never grows, so a chat cached before this fix kept showing its live card forever. A server copy that settles every waiting card is now adopted even with no growth. Two floors keep that path safe: the server copy may not carry fewer records than the browser's watermark, and it may not carry fewer messages than the screen.

### 4. Cards act where they appear

The Connect and Not-now buttons now live on the card itself, wherever the card sits in the chat. The dock at the bottom of the composer stays, but only as a shortcut that scrolls to the card. That kills the dead-card bug at its root, because a card no longer loses its buttons when a new turn pushes it up the page.

The scans that decide the tab status, the message queue hold, and which approvals are open now read the whole chat instead of only the last message.

A connect create that fails now shows the server's real reason. A duplicate reads "A connection for telegram already exists in this project." instead of "Connection failed. Please try again." The card and the reason the agent reads come from one value, so they cannot drift apart. Retry is hidden when a retry cannot work.

### Three things this PR does not change

After a reload, a settled failed connect card offers one more Retry click. That click re-derives the truthful state and the buttons go away. The refresh is live-only on purpose, because writing it down would mean settling a part that is already settled, which the double-settle guards exist to prevent. One wasted click per reload, never a loop.

Reusing a connection that already exists stays out of scope. It is issue [#5911](https://github.com/Agenta-AI/agenta/issues/5911). This PR only makes the real reason visible.

Answering form and connect cards from mobile never existed. It stays its own ticket.

## Tests

- A settlement matrix unit test in the API: three card kinds against three outcomes, asserting the final status and the saved answer, plus the two guards that keep `resolved` approval-only.
- An acceptance test for the race: record an answer, then run the cleanup job for a later turn, and assert the row is still `responded` with its answer intact.
- Golden replay tests in both replay copies, covering every line of the rule. One fixture is a real broken session pulled from the dev stack, with all 44 of its records.
- The geometry test: one chat whose waiting card is not the last message. It asserts at once that the tab reports "awaiting", the message queue holds, and the card is clickable.
- Adoption safety tests over hostile orderings: refresh during an answer, adoption while parked, and a lagging server copy that must not truncate the screen.
- Connect flow tests: the duplicate message, the settle reason and the card text coming from one value, and Retry surviving for ordinary failures.
- Two new release gate cells, `matrix_i1_settlement` and `matrix_i2_card_journeys`. `matrix_l4_client_tool_lifecycle` was tightened, because its docstring recorded the defect this PR removes.

Live QA ran on the dev stack against the full journey list: answer and reload, decline and reload, close the tab and open it again, two connects in one conversation, old pre-fix sessions with and without a warm cache, and a real Telegram bot token through create, remove, and create again.

## What to QA

1. Ask an agent for something that needs a form. Answer the form. Reload the page. The form still shows your answers and stays answered.
2. Ask for a service connection and click "Not now". The run resumes. Reload. The card still shows the decline.
3. Open a session from before this fix that has a dead card. The card reads "Request ended", it has no buttons, and the composer is free.
4. Ask to connect a service that this project already has. The card names the real reason and offers no Retry.
5. Start a turn while a connect card is still waiting further up the chat. The card's own Connect and Not-now buttons still work.
6. Regression: run a normal tool approval. Allow it, then deny one. Both still work and the run continues.
