### PR TITLE
[fix] Stop creating the chat bootstrap row from inside an atom read

### DIFF
--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -3,9 +3,11 @@ import {memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode}
 import {workflowMolecule} from "@agenta/entities/workflow"
 import type {ConfigViewMode} from "@agenta/entity-ui"
 import {
+    ensureChatBootstrapRowAtom,
     executionController,
     executionItemController,
     isAgentModeAtomFamily,
+    needsChatBootstrapRowAtom,
     playgroundController,
 } from "@agenta/playground"
 import {EmptyState, ExecutionHeader, useEntitySelector} from "@agenta/playground-ui/components"
@@ -119,6 +121,28 @@ const GenerationComparisonRenderer = memo(() => {
             </div>
         </div>
     ))
+})
+
+/**
+ * Creates chat mode's blank first user message. Renders nothing.
+ *
+ * `generationRowIdsAtom` used to create that row from inside its own read (#5344). This lives here
+ * rather than in `ExecutionItems` because comparison-mode chat never goes through that component —
+ * this layout renders `GenerationComparisonRenderer` instead, which reads the row ids directly, so
+ * hosting the effect there would silently cost comparison chat its blank first turn. `MainLayout`
+ * is the single shared entry for every playground surface, so one instance covers the single and
+ * comparison views exactly once. Kept as its own child so the row-count subscription re-renders
+ * this null component rather than the whole layout.
+ */
+const ChatRowBootstrap = memo(() => {
+    const needsRow = useAtomValue(needsChatBootstrapRowAtom)
+    const ensureRow = useSetAtom(ensureChatBootstrapRowAtom)
+
+    useEffect(() => {
+        if (needsRow) ensureRow()
+    }, [needsRow, ensureRow])
+
+    return null
 })
 
 const RunDisabledPlaceholder = memo(({children}: {children?: ReactNode}) => (
@@ -558,6 +582,7 @@ const PlaygroundMainView = ({
                     </SplitterPanel>
                 </Splitter>
                 <PlaygroundFocusDrawer />
+                <ChatRowBootstrap />
             </div>
         </main>
     )

--- a/web/packages/agenta-playground/src/index.ts
+++ b/web/packages/agenta-playground/src/index.ts
@@ -78,6 +78,9 @@ export {
     createNegotiatingFetch,
 } from "./state"
 export type {AgentRequest, AgentChannelMode, NegotiatingFetch} from "./state"
+// Chat blank-first-row bootstrap — driven by a null-rendering child of `MainLayout`, the single
+// shared entry that covers both the single and comparison surfaces (#5344).
+export {needsChatBootstrapRowAtom, ensureChatBootstrapRowAtom} from "./state"
 // HITL resume predicate for `useChat`'s `sendAutomaticallyWhen` (approve AND deny resume).
 export {
     agentShouldResumeAfterApproval,

--- a/web/packages/agenta-playground/src/state/execution/index.ts
+++ b/web/packages/agenta-playground/src/state/execution/index.ts
@@ -264,6 +264,9 @@ export {
     isChatModeAtom,
     // Per-entity agent-mode flag
     isAgentModeAtomFamily,
+    // Chat blank-first-row bootstrap (#5344)
+    needsChatBootstrapRowAtom,
+    ensureChatBootstrapRowAtom,
     appTypeAtom,
     type AppType,
     // Row run status

--- a/web/packages/agenta-playground/src/state/execution/selectors.ts
+++ b/web/packages/agenta-playground/src/state/execution/selectors.ts
@@ -21,7 +21,7 @@ import {selectAtom} from "jotai/utils"
 import {atomFamily} from "jotai-family"
 
 import {playgroundIsChatBehaviorAtom} from "../atoms/modeOverride"
-import {entityIdsAtom, playgroundNodesAtom, playgroundStoreAtom} from "../atoms/playground"
+import {entityIdsAtom, playgroundNodesAtom, primaryEntityIdAtom} from "../atoms/playground"
 import {addUserMessageAtom} from "../chat"
 import {sharedMessageIdsAtomFamily} from "../chat/messageSelectors"
 
@@ -963,15 +963,9 @@ export const generationRowIdsAtom = atom<string[]>((get) => {
     const loadableId = get(derivedLoadableIdAtom)
     if (!loadableId) return []
     const isChat = get(isChatModeAtom)
-    if (isChat) {
-        const rowIds = get(sharedMessageIdsAtomFamily(loadableId))
-        if (rowIds.length === 0) {
-            // Bootstrap first blank user message for chat mode
-            get(playgroundStoreAtom).set(addUserMessageAtom, {loadableId, userMessage: null})
-            return get(sharedMessageIdsAtomFamily(loadableId))
-        }
-        return rowIds
-    }
+    // Reports rows, never creates one. The blank-first-message bootstrap used to live here and
+    // wrote to the store from inside this read — see `ensureChatBootstrapRowAtom` (#5344).
+    if (isChat) return get(sharedMessageIdsAtomFamily(loadableId))
     if (isChat === undefined) return []
 
     // Read directly from the molecule's displayRowIds (global atom) and apply
@@ -1256,6 +1250,47 @@ export const isAgentModeAtomFamily = atomFamily((entityId: string) =>
         return get(workflowMolecule.selectors.workflowType(entityId)) === "agent"
     }),
 )
+
+// ============================================================================
+// CHAT BOOTSTRAP ROW (#5344)
+// ============================================================================
+
+/**
+ * Whether chat mode is missing its blank first user message.
+ *
+ * Pure — this only answers the question. `generationRowIdsAtom` used to answer it AND create the
+ * row from inside its own read, which jotai flags (`Detected store mutation during atom read`) and
+ * which is worse than a warning: `cancelTestsMutationAtom` reads the row ids from inside a write,
+ * so cancelling on an empty chat could re-entrantly create the row mid-write.
+ *
+ * Excludes agents. They carry `is_chat` too (`createEphemeralAppFromTemplate` seeds
+ * `is_chat: type === "chat" || type === "agent"`), so the chat branch runs for them — but the agent
+ * surface renders `AgentGenerationPanel` and never reads `sharedMessageIdsAtomFamily`, so the row
+ * would be write-only cost. Stays `false` while `isChatMode` is undefined (entity still loading),
+ * which is also what keeps this from racing the flags: both come off the same payload.
+ */
+export const needsChatBootstrapRowAtom = atom<boolean>((get) => {
+    const loadableId = get(derivedLoadableIdAtom)
+    if (!loadableId) return false
+    if (get(isChatModeAtom) !== true) return false
+    const primaryEntityId = get(primaryEntityIdAtom)
+    if (primaryEntityId && get(isAgentModeAtomFamily(primaryEntityId))) return false
+    return get(sharedMessageIdsAtomFamily(loadableId)).length === 0
+})
+
+/**
+ * Create chat mode's blank first user message if it is missing.
+ *
+ * Idempotent by construction: the condition is re-checked HERE, inside the write, rather than
+ * trusted from the caller. Jotai writes are synchronous, so a second caller in the same tick
+ * already observes the first one's message and no-ops — which is what makes it safe to drive from
+ * a component that can mount more than once.
+ */
+export const ensureChatBootstrapRowAtom = atom(null, (get, set) => {
+    if (!get(needsChatBootstrapRowAtom)) return
+    const loadableId = get(derivedLoadableIdAtom)
+    set(addUserMessageAtom, {loadableId, userMessage: null})
+})
 
 /**
  * App-level type derived from chat mode.

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -175,6 +175,8 @@ export {inputVariableNamesAtom} from "./execution"
 // App-level mode selectors
 export {appTypeAtom, isChatModeAtom, type AppType} from "./execution"
 export {isAgentModeAtomFamily} from "./execution"
+// Chat blank-first-row bootstrap (#5344)
+export {needsChatBootstrapRowAtom, ensureChatBootstrapRowAtom} from "./execution"
 export {
     applyBuildKitOverlay,
     buildAgentRequest,

--- a/web/packages/agenta-playground/tests/unit/chatBootstrapRow.test.ts
+++ b/web/packages/agenta-playground/tests/unit/chatBootstrapRow.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for chat mode's blank first user message (#5344).
+ *
+ * That row used to be created from inside `generationRowIdsAtom`'s READ function. Jotai flags a
+ * store write during a read, and it is not only a warning: `cancelTestsMutationAtom` reads the row
+ * ids from inside a write, so cancelling on an empty chat could re-entrantly create the row
+ * mid-write. The read is now pure and the creation moved to `ensureChatBootstrapRowAtom`.
+ *
+ * Contract under test:
+ * - reading `generationRowIdsAtom` never creates a row (the regression this issue is about)
+ * - `ensureChatBootstrapRowAtom` creates exactly one row for an empty chat playground
+ * - it is idempotent — repeated calls in the same store still yield one row
+ * - it no-ops for agents, which carry `is_chat` but never render the row
+ * - it no-ops for completion apps and while the entity is still loading
+ *
+ * The workflow molecule is mocked with writable data atoms: `executionMode` drives chat capability
+ * (as in `modeOverride.test.ts`) and `workflowType` drives agent detection (as in `agentMode.test.ts`).
+ */
+import type {PlaygroundNode} from "@agenta/entities/runnable"
+import {createStore, type PrimitiveAtom} from "jotai"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entities/workflow", async (importOriginal) => {
+    const actual = (await importOriginal()) as any
+    const {atom} = await import("jotai")
+    const modeAtoms = new Map<string, unknown>()
+    const typeAtoms = new Map<string, unknown>()
+    const dataAtoms = new Map<string, unknown>()
+    const memo = (map: Map<string, unknown>, id: string, make: () => unknown) => {
+        if (!map.has(id)) map.set(id, make())
+        return map.get(id)
+    }
+    return {
+        ...actual,
+        workflowMolecule: {
+            ...actual.workflowMolecule,
+            selectors: {
+                ...actual.workflowMolecule.selectors,
+                data: (id: string) => memo(dataAtoms, id, () => atom<unknown>(null)),
+                executionMode: (id: string) =>
+                    memo(modeAtoms, id, () => atom<string>("completion")),
+                workflowType: (id: string) => memo(typeAtoms, id, () => atom<string>("completion")),
+            },
+        },
+    }
+})
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+
+import {playgroundNodesAtom, playgroundStoreAtom} from "../../src/state/atoms/playground"
+import {sharedMessageIdsAtomFamily} from "../../src/state/chat/messageSelectors"
+import {
+    ensureChatBootstrapRowAtom,
+    generationRowIdsAtom,
+    needsChatBootstrapRowAtom,
+} from "../../src/state/execution/selectors"
+
+type Store = ReturnType<typeof createStore>
+
+/** `derivedLoadableIdAtom` builds this from the depth-0 node. */
+const loadableIdFor = (entityId: string) => `testset:revision:${entityId}`
+
+const node = (entityId: string): PlaygroundNode => ({
+    id: `node-${entityId}`,
+    entityType: "revision",
+    entityId,
+    depth: 0,
+})
+
+/**
+ * Point a store's playground at one entity of the given kind.
+ * `chat` and `agent` are both chat-capable — that overlap is the reason the agent guard exists.
+ */
+const mountEntity = (store: Store, entityId: string, kind: "chat" | "agent" | "completion") => {
+    store.set(
+        workflowMolecule.selectors.executionMode(entityId) as PrimitiveAtom<string>,
+        kind === "completion" ? "completion" : "chat",
+    )
+    store.set(workflowMolecule.selectors.workflowType(entityId) as PrimitiveAtom<string>, kind)
+    store.set(playgroundNodesAtom, [node(entityId)])
+    return loadableIdFor(entityId)
+}
+
+const rowCount = (store: Store, loadableId: string) =>
+    store.get(sharedMessageIdsAtomFamily(loadableId)).length
+
+describe("chat bootstrap row", () => {
+    let store: Store
+    beforeEach(() => {
+        store = createStore()
+        // `playgroundStoreAtom` defaults to jotai's GLOBAL store, and the impure read wrote through
+        // it. Without this the write would land in the default store while the assertions read an
+        // isolated one, and the purity test below would pass whether or not the bug is present.
+        store.set(playgroundStoreAtom, store)
+    })
+
+    describe("generationRowIdsAtom (read purity)", () => {
+        it("does not create a row when read on an empty chat playground", () => {
+            const loadableId = mountEntity(store, "read-pure", "chat")
+
+            expect(store.get(generationRowIdsAtom)).toEqual([])
+            expect(store.get(generationRowIdsAtom)).toEqual([])
+
+            expect(rowCount(store, loadableId)).toBe(0)
+        })
+    })
+
+    describe("ensureChatBootstrapRowAtom", () => {
+        it("creates the blank row for an empty chat playground", () => {
+            const loadableId = mountEntity(store, "chat-1", "chat")
+            expect(store.get(needsChatBootstrapRowAtom)).toBe(true)
+
+            store.set(ensureChatBootstrapRowAtom)
+
+            expect(rowCount(store, loadableId)).toBe(1)
+            expect(store.get(generationRowIdsAtom)).toHaveLength(1)
+            expect(store.get(needsChatBootstrapRowAtom)).toBe(false)
+        })
+
+        it("is idempotent — repeated calls still yield exactly one row", () => {
+            const loadableId = mountEntity(store, "chat-2", "chat")
+
+            store.set(ensureChatBootstrapRowAtom)
+            store.set(ensureChatBootstrapRowAtom)
+            store.set(ensureChatBootstrapRowAtom)
+
+            expect(rowCount(store, loadableId)).toBe(1)
+        })
+
+        it("no-ops for an agent — it is chat-capable but never renders the row", () => {
+            const loadableId = mountEntity(store, "agent-1", "agent")
+            expect(store.get(needsChatBootstrapRowAtom)).toBe(false)
+
+            store.set(ensureChatBootstrapRowAtom)
+
+            expect(rowCount(store, loadableId)).toBe(0)
+        })
+
+        it("no-ops for a completion app", () => {
+            const loadableId = mountEntity(store, "completion-1", "completion")
+            expect(store.get(needsChatBootstrapRowAtom)).toBe(false)
+
+            store.set(ensureChatBootstrapRowAtom)
+
+            expect(rowCount(store, loadableId)).toBe(0)
+        })
+
+        it("no-ops while the playground has no node yet", () => {
+            expect(store.get(needsChatBootstrapRowAtom)).toBe(false)
+            expect(() => store.set(ensureChatBootstrapRowAtom)).not.toThrow()
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Fixes #5344 — `Detected store mutation during atom read` in the agent playground.

Thanks @ardaerzin for walking the graph on the issue; this follows the shape you laid out there, including the host correction.

**Root cause.** `generationRowIdsAtom` answered "which rows exist" *and* created chat mode's blank first user message when there were none, writing to the store from inside its own read:

```ts
if (rowIds.length === 0) {
    get(playgroundStoreAtom).set(addUserMessageAtom, {loadableId, userMessage: null})
    return get(sharedMessageIdsAtomFamily(loadableId))
}
```

**It isn't only a console warning.** `cancelTestsMutationAtom` reads the row ids from inside a write (`execution/generationSelectors.ts:207`), so cancelling on an empty chat could re-entrantly create the blank row mid-write. The "once per onboarding page load, silent everywhere else" pattern is a mount-timing artifact — the trailing `get` on line 971 clears jotai's dev flag when that atom recomputes and doesn't when the `set`'s own flush already did. The impurity is present on every chat surface; it is just silent on most of them.

**Fix.**

1. `generationRowIdsAtom`'s read is now pure — chat mode returns `sharedMessageIdsAtomFamily(loadableId)`, nothing else.
2. `needsChatBootstrapRowAtom` (pure) answers the condition; `ensureChatBootstrapRowAtom` performs the write and **re-checks every condition inside the write**, so repeated callers in one tick still yield exactly one row.
3. A null-rendering `<ChatRowBootstrap />` child of `MainLayout` drives it from an effect.

**Why `MainLayout` and not `ExecutionItems`.** Comparison-mode chat never goes through `ExecutionItems` — the layout renders `GenerationComparisonRenderer`, and `GenerationComparisonChatOutput` reads `generationRowIds` directly (`ExecutionItemComparisonView/GenerationComparisonChatOutput/index.tsx:46`). Hosting the effect in `ExecutionItems` would have silently cost comparison chat its blank first turn, and `ExecutionItems` also mounts once per column. `MainLayout` is the single shared entry for every playground surface, so one instance covers single + comparison exactly once. It is a separate child so the row-count subscription re-renders a null component rather than the whole layout.

**Agents are excluded** (`isChat && !isAgent`, root entity via `isAgentModeAtomFamily`). Agents carry `is_chat` — `createEphemeralAppFromTemplate` seeds `is_chat: type === "chat" || type === "agent"` — so the chat branch ran for them, but the agent surface renders `AgentGenerationPanel` and never reads `sharedMessageIdsAtomFamily`. The row was write-only cost there. Nothing outside `execution/selectors.ts` reads that family, so this removes work rather than changing behaviour anyone observes.

No new dependency — `jotai-effect` is not in the tree and this does not add it.

## Testing

### Verified locally

`pnpm vitest run` in `packages/agenta-playground`: **17 test files, 221 tests passed**. `tsc --noEmit` clean for both the package and `web/oss`. `eslint` and `prettier` clean on the changed `src` files.

Not verified in a browser by me — worth confirming on a fresh onboarding load that the warning is gone and the blank composer row still appears in single **and** comparison chat.

### Added or updated tests

`packages/agenta-playground/tests/unit/chatBootstrapRow.test.ts` — 6 tests, the directory had no coverage for the bootstrap:

- reading `generationRowIdsAtom` never creates a row (the regression itself)
- `ensureChatBootstrapRowAtom` creates exactly one row for an empty chat playground
- idempotency — three calls still yield one row
- agent-mode no-op
- completion-mode no-op, and no-op while the playground has no node

One detail worth flagging for review: the tests set `playgroundStoreAtom` to the test store in `beforeEach`. My first version did not, and the purity test **passed with the bug re-introduced** — `playgroundStoreAtom` defaults to jotai's global store, so the impure write landed there while the assertions read an isolated `createStore()`. With the wiring in place, re-introducing the old read fails it correctly:

```
× does not create a row when read on an empty chat playground
  AssertionError: expected [ Array(1) ] to deeply equal []
```

The comment in `beforeEach` records why that line is load-bearing.

### QA follow-up

- Confirm the blank first turn still appears in **comparison** chat (two chat revisions side by side) — that is the legacy path this PR deliberately moved the host to cover.
- Confirm a chat app whose entity is still loading (`isChatMode === undefined`) settles into a blank row once the flags arrive.
- Confirm the drawer surfaces that mount `MainLayout` (`WorkflowRevisionDrawerWrapper`, `ConfigureEvaluator`, `CreateEvaluatorDrawer`) still get the row.
- Cancel-on-empty-chat: previously this could create the row re-entrantly mid-write via `cancelTestsMutationAtom`; worth a manual pass.

## Demo

N/A — no visible UI change. The blank first row behaves exactly as before; the fix is where it is created from.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
