### PR TITLE
test: fix vacuous built-ins SDK tests (#5662)

### DIFF
--- a/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
@@ -10,9 +10,10 @@ is not mirrored in the doc fails CI instead of shipping a stale reference to the
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
-from typing import get_args
+from typing import Any, get_args
 
 import pytest
 
@@ -165,13 +166,26 @@ def test_config_schema_names_every_tool_type_discriminator():
     assert not missing, f"config-schema.md does not document tool type(s): {missing}"
 
 
+def _contains_builtin_type(value: Any) -> bool:
+    """Recursively detect any object with ``type == "builtin"`` (whitespace-safe)."""
+    if isinstance(value, dict):
+        if value.get("type") == "builtin":
+            return True
+        return any(_contains_builtin_type(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_builtin_type(item) for item in value)
+    return False
+
+
 def test_no_json_example_writes_a_builtin_tool_entry():
     # The `builtin` arm survives only as legacy dual-read. The authoring agent copies these
     # examples verbatim, so an example that still writes one would keep producing configs the
     # resolver has to ignore.
+    # Parse each fenced JSON block so whitespace variants like `"type":"builtin"` still fail.
     content = _file("references/config-schema.md").content
     for block in re.findall(r"```json\n(.*?)```", content, flags=re.DOTALL):
-        assert '"type": "builtin"' not in block, (
+        data = json.loads(block)
+        assert not _contains_builtin_type(data), (
             "a JSON example in config-schema.md still writes a builtin tool entry"
         )
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agenta_builtins_reference_files.py
@@ -182,8 +182,15 @@ def test_no_json_example_writes_a_builtin_tool_entry():
     # examples verbatim, so an example that still writes one would keep producing configs the
     # resolver has to ignore.
     # Parse each fenced JSON block so whitespace variants like `"type":"builtin"` still fail.
+    # Match indented / spaced fences and require at least one block so the test cannot pass vacuously.
     content = _file("references/config-schema.md").content
-    for block in re.findall(r"```json\n(.*?)```", content, flags=re.DOTALL):
+    blocks = re.findall(
+        r"^[ \t]*```json[ \t]*\r?\n(.*?)^[ \t]*```",
+        content,
+        flags=re.DOTALL | re.IGNORECASE | re.MULTILINE,
+    )
+    assert blocks, "config-schema.md must contain a fenced JSON example"
+    for block in blocks:
         data = json.loads(block)
         assert not _contains_builtin_type(data), (
             "a JSON example in config-schema.md still writes a builtin tool entry"

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_resolver.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_resolver.py
@@ -295,8 +295,15 @@ async def test_reserved_gateway_name_fails_before_adapter_call():
 
 
 async def test_a_bare_tool_name_string_is_ignored_too():
-    # `coerce_tool_config` turns a bare string into a BuiltinToolConfig.
-    resolved = await ToolResolver().resolve(coerce_tool_configs(["read"]))
+    # `coerce_tool_configs` turns a bare string into a BuiltinToolConfig.
+    # Pass `.tool_configs` — the parse result itself is not a sequence of configs
+    # (iterating the pydantic model yields field tuples, so resolve would not see
+    # the coerced BuiltinToolConfig and would pass for the wrong reason).
+    parsed = coerce_tool_configs(["read"])
+    assert len(parsed.tool_configs) == 1
+    assert isinstance(parsed.tool_configs[0], BuiltinToolConfig)
+
+    resolved = await ToolResolver().resolve(parsed.tool_configs)
 
     assert resolved.tool_specs == []
 


### PR DESCRIPTION
## Summary
Fixes two SDK unit tests that currently pass without exercising what they claim to check (follow-up from #5651 review / #5662).

### 1. Vacuous resolver test (`test_a_bare_tool_name_string_is_ignored_too`)
`coerce_tool_configs([\"read\"])` returns a pydantic `ToolConfigParseResult`, not a sequence of tool configs. Passing the parse result into `ToolResolver().resolve()` meant iteration never saw the coerced `BuiltinToolConfig`, so the empty-spec assertion could pass for the wrong reason.

**Change:** assert the parse result contains a single `BuiltinToolConfig`, then pass `parsed.tool_configs` into `resolve()`.

### 2. Substring-only JSON check (`test_no_json_example_writes_a_builtin_tool_entry`)
The old check looked for the literal substring `"type": "builtin"`, so whitespace variants like `"type":"builtin"` could slip through.

**Change:** parse each fenced JSON block and recursively reject any object with `type == "builtin"`.

## Test plan
- [x] Targeted test logic updated as described in #5662
- [ ] CI unit tests for `sdks/python/oss/tests/pytest/unit/agents/`

Closes #5662