### PR TITLE
fix(frontend): analytics range bounds keep their UTC designator

### DIFF
--- a/web/oss/src/components/Filters/Sort.tsx
+++ b/web/oss/src/components/Filters/Sort.tsx
@@ -6,6 +6,7 @@ import {Button, DatePicker, Divider, Popover, Typography} from "antd"
 import dayjs, {Dayjs} from "dayjs"
 import {createUseStyles} from "react-jss"
 
+import {utcRangeStamp} from "@/oss/lib/helpers/dateTimeHelper"
 import {JSSTheme} from "@/oss/lib/Types"
 
 const useStyles = createUseStyles((theme: JSSTheme) => ({
@@ -125,22 +126,16 @@ const Sort: React.FC<Props> = ({
         if (preset?.amount && preset.unit) {
             const now = dayjs().utc()
 
-            sortedTime = now.subtract(preset.amount, preset.unit).toISOString().split(".")[0]
+            sortedTime = utcRangeStamp(now.subtract(preset.amount, preset.unit))
         } else if (sortData === "custom" && (customRange?.startTime || customRange?.endTime)) {
             if (customRange.startTime) {
-                customRangeTime.startTime = dayjs(customRange.startTime)
-                    .utc()
-                    .toISOString()
-                    .split(".")[0]
+                customRangeTime.startTime = utcRangeStamp(customRange.startTime)
             }
             if (customRange.endTime) {
-                customRangeTime.endTime = dayjs(customRange.endTime)
-                    .utc()
-                    .toISOString()
-                    .split(".")[0]
+                customRangeTime.endTime = utcRangeStamp(customRange.endTime)
             }
         } else if (sortData === "all time") {
-            sortedTime = "1970-01-01T00:00:00"
+            sortedTime = "1970-01-01T00:00:00Z"
         }
 
         onSortApply({

--- a/web/oss/src/lib/helpers/dateTimeHelper/index.ts
+++ b/web/oss/src/lib/helpers/dateTimeHelper/index.ts
@@ -54,3 +54,14 @@ export const formatDay = ({
     const direct = dayjs.utc(date)
     return direct.isValid() ? direct.format(outputFormat) : ""
 }
+
+/**
+ * A UTC range bound for the analytics/trace queries, truncated to seconds.
+ *
+ * The trailing `Z` is not cosmetic: these strings are re-parsed client-side with `dayjs(value)`,
+ * and a designator-less stamp is read as LOCAL time. West of UTC that pushes the window start
+ * into the future and the query throws `endTime must be greater than or equal to startTime`
+ * instead of rendering.
+ */
+export const utcRangeStamp = (date: dayjs.ConfigType): string =>
+    `${dayjs(date).utc().toISOString().split(".")[0]}Z`

--- a/web/oss/src/state/newObservability/atoms/controls.ts
+++ b/web/oss/src/state/newObservability/atoms/controls.ts
@@ -8,6 +8,7 @@ import {atomFamily, atomWithStorage} from "jotai/utils"
 
 import type {SortResult} from "@/oss/components/Filters/Sort"
 import type {TestsetTraceData} from "@/oss/components/SharedDrawers/AddToTestsetDrawer/assets/types"
+import {utcRangeStamp} from "@/oss/lib/helpers/dateTimeHelper"
 import {onboardingStorageUserIdAtom} from "@/oss/lib/onboarding/atoms"
 import type {Filter} from "@/oss/lib/Types"
 import {currentWorkflowContextAtom} from "@/oss/state/workflow"
@@ -20,7 +21,7 @@ export type ObservabilityTabInfo = "traces" | "sessions"
 
 export const DEFAULT_SORT: SortResult = {
     type: "standard",
-    sorted: dayjs().utc().subtract(24, "hours").toISOString().split(".")[0],
+    sorted: utcRangeStamp(dayjs().subtract(24, "hours")),
 }
 
 const HAS_RECEIVED_TRACES_STORAGE_KEY = "agenta:observability:has-received-traces"

--- a/web/oss/src/state/observability/dashboard.ts
+++ b/web/oss/src/state/observability/dashboard.ts
@@ -5,6 +5,7 @@ import {eagerAtom} from "jotai-eager"
 import {atomWithQuery} from "jotai-tanstack-query"
 
 import {SortResult} from "@/oss/components/Filters/Sort"
+import {utcRangeStamp} from "@/oss/lib/helpers/dateTimeHelper"
 import {GenerationDashboardData} from "@/oss/lib/types_ee"
 import {fetchGenerationsDashboardData} from "@/oss/services/tracing/api"
 import {routerAppIdAtom} from "@/oss/state/app/atoms/fetcher"
@@ -14,7 +15,7 @@ dayjs.extend(utc)
 
 export const observabilityDashboardTimeRangeAtom = atom<SortResult>({
     type: "standard",
-    sorted: dayjs().utc().subtract(30, "days").toISOString().split(".")[0],
+    sorted: utcRangeStamp(dayjs().subtract(30, "days")),
     customRange: {},
     label: "1 month",
 })


### PR DESCRIPTION
## Context

Observability dashboards misbehave for anyone whose machine is not on UTC. West of UTC they fail outright: pick the 30 minutes range in New York and the query asks for a window that ends before it starts, so `fetchDashboardAnalytics` throws "endTime must be greater than or equal to startTime" and no chart renders. East of UTC there is no error at all, just a silently wider window than the one you picked.

The range bounds lose their UTC designator on the way out. `toISOString().split(".")[0]` trims the milliseconds and the trailing `Z`, and the value is read a second time with `dayjs(startTime)`, which treats a stamp with no designator as local time. The offset is then applied twice.

## Changes

`utcRangeStamp()` joins the other helpers in `dateTimeHelper` and keeps the designator. It replaces the hand-rolled truncation at every site that feeds a query: the preset branch and both custom range bounds in `Sort.tsx`, plus the two dashboard defaults in `newObservability/atoms/controls.ts` and `observability/dashboard.ts`. The "all time" literal gets the same treatment.

Before:

```
2026-08-11T05:24:59
```

After:

```
2026-08-11T05:24:59Z
```

Nothing changes on the wire. The API parses both forms with `datetime.fromisoformat`, and `parse_windowing` stamps a naive datetime as UTC, so the server already resolved these to the same instant. The defect was entirely client side, in the second parse.

## Tests

Measured a 30 minute preset in four zones, comparing the duration the client computes and whether the window end lands before its start:

| Timezone | Before | After |
| --- | --- | --- |
| UTC | 30 min | 30 min |
| Europe/Istanbul (+3) | 210 min | 30 min |
| America/New_York (-4) | -209 min, query throws | 30 min |
| America/Los_Angeles (-7) | -389 min, query throws | 30 min |

`packages/agenta-entities/tests/integration/trace-migration.integration.test.ts` still builds designator-less bounds on purpose. Those assert the API accepts that form, which it still does, so they are left alone.

## What to QA

- Set your machine to a US timezone, open Observability and pick the 30 minutes range. The chart renders instead of showing the start/end error.
- Set your machine to a positive offset (for example Europe/Istanbul), pick 30 minutes, and check the x-axis covers half an hour rather than several hours.
- Regression: a custom start/end range and the "all time" preset both still return data.
- Regression: the traces list on `/observability` uses the same sort control. Its 24 hour default still returns the last day.
