### PR TITLE
[docs] Record session UX implementation and QA

### DIFF
--- a/docs/design/session-ux-interface-review.md
+++ b/docs/design/session-ux-interface-review.md
@@ -1,0 +1,1868 @@
+# Sessions UX interface review
+
+Status: implementation complete; residual verification recorded
+
+Date: 2026-08-10
+
+Primary baseline reviewed: [PR #5767](https://github.com/Agenta-AI/agenta/pull/5767)
+
+Related release set: PRs #5766 through #5776 and #5793.
+
+## Review outcome
+
+The product need is valid. The new sessions surfaces need the server to decide which sessions
+belong in each list before pagination, and they need enough data to render useful rows.
+
+The implemented revision resolves the interface findings from the PR baseline. It adds atomic
+claim and session attribution, typed queries and expansions, retained trigger history, generated
+clients, typed frontend policies and actions, exact delivery mode, and reserved-tag sanitization.
+
+The implementation follows these decisions:
+
+1. Keep tags as the short-term storage for session origin and trigger identity.
+2. Do not expose reserved tag keys as the frontend's public contract. Expose typed session fields
+   and compile them to tag predicates internally.
+3. Store stable filterable attribution values in tags. Resolve the current trigger name at read
+   time; do not snapshot it in tags or meta.
+4. Use the repository's resource-nested query pattern and return the pagination cursor.
+5. Make latest-message hydration an explicit list expansion and treat it as best effort.
+6. Expose the exact delivery ID on automation session rows. Do not add event, run, or trace data
+   without a concrete user story.
+7. Do not introduce a new provenance table or index without a demonstrated need.
+
+Automated API, Postgres, generated-client, and frontend verification passed. Schedule live
+acceptance passed. Browser QA, subscription live acceptance, and the representative performance
+benchmark remain incomplete. Section 15 records the exact evidence and residual risk.
+
+## 1. Product story
+
+The original sessions UX problem is described in the
+[`agenta-sessions-ux` plan](https://github.com/Agenta-AI/agenta/blob/oss/home-overview/docs/design/agenta-sessions-ux/plan.md)
+on the frontend stack:
+
+> Sessions are the user's daily work, but there is no project-wide place to find, filter,
+> organize, and reopen them.
+
+The sessions and Home redesign turns that into five core user stories.
+
+### Story 1: Find human-started sessions
+
+As a user, I want the default sessions list to show the work I started, without frequent
+automation runs burying it.
+
+The frontend needs:
+
+- A way to identify trigger-started sessions.
+- A server-side way to exclude them before ordering and pagination.
+
+### Story 2: Inspect automation runs
+
+As a user, I want to switch to automation runs and understand which automation started each one.
+
+The frontend needs:
+
+- A way to request trigger-started sessions only.
+- The stable ID of the schedule or subscription that started the session.
+- Optionally, the automation kind for an icon or label.
+- Optionally, a display name for the row.
+
+The stable ID is required if a row links to the automation. The kind and name are presentation
+requirements and should be justified by the actual row design.
+
+### Story 3: Find sessions needing attention
+
+As a user, I want to filter to sessions that are live or waiting for me.
+
+The frontend needs:
+
+- Liveness filtering from session flags.
+- The complete set of session IDs with actionable interactions.
+- A server-side ID-set filter so the waiting set is intersected with agent, origin, lifecycle,
+  ordering, and pagination constraints.
+
+Waiting is not a liveness value. It comes from the interactions domain. The frontend currently
+resolves the small waiting ID set and pushes those IDs into the sessions query.
+
+### Story 4: Pin sessions without duplicates
+
+As a user, I want pinned sessions at the top and recent sessions below them.
+
+The frontend needs:
+
+- A query that includes an explicit session-ID set for the pinned group.
+- A query that excludes those IDs from the recent group.
+
+Pins are currently local to the browser. The server does not need to own pin persistence for this
+iteration, but it must apply the ID predicates before pagination.
+
+### Story 5: Decide whether to reopen a session
+
+As a user, I want each row to say what happened, rather than opening every session to inspect its
+transcript.
+
+The frontend needs a short preview. PR #5767 defines that preview as the newest message when that
+message contains nonblank text, including its source and timestamp. It does not fall back to an
+older textual message when the newest message has no text.
+
+## 2. Stories implemented by the PR set
+
+The release set is broader than the sessions API. It combines one backend lane, one frontend
+package stack, and two independent changes.
+
+| Story | Backend/API | Frontend policy | UI surface |
+| --- | --- | --- | --- |
+| Separate human and automation sessions | #5767 | #5769 | #5770, #5772, #5775 |
+| Identify the automation | #5767 | #5769 | #5770, #5772, #5775 |
+| Preview the latest message | #5767 | #5769 | #5770, #5772, #5775 |
+| Filter live sessions | #5767 | #5769 | #5770, #5775 |
+| Filter waiting sessions | Existing interactions API plus #5767 ID filter | #5769 | #5770, #5775 |
+| Pin and deduplicate sessions | #5767 ID filters | #5769 | #5770, #5772, #5775 |
+| Browse project and agent sessions | Existing agent references plus #5767 intersections | #5769 | #5775 |
+| Rework Home and agent overview | Supporting session API | #5769, #5771 | #5772 |
+| Browse agents as cards | None | #5771 | #5773 |
+| Inspect templates | None | #5772 data | #5774 |
+| Start sessions with seeded files | None | #5772 seed | #5776 consumption |
+| Reveal filtered uploads | None | None | #5793, independent |
+
+## 3. Historical PR stack
+
+### Independent lanes
+
+| PR | Branch and base | Purpose |
+| --- | --- | --- |
+| [#5766](https://github.com/Agenta-AI/agenta/pull/5766) | `entities/trigger-helpers` -> `main` | Shared frontend trigger-to-agent and cron helpers |
+| [#5767](https://github.com/Agenta-AI/agenta/pull/5767) | `api/session-trigger-stamp` -> `feat/mobile-parity-and-consolidation` | Sessions query, origin stamp, delivery link, preview |
+| [#5793](https://github.com/Agenta-AI/agenta/pull/5793) | `fe-fix/drive-upload-reveal` -> `main` | Independent Drive upload fix |
+
+### Linear frontend stack
+
+```text
+feat/mobile-parity-and-consolidation
+  -> #5768 pkg/ui-surfaces
+  -> #5769 pkg/sessions
+  -> #5770 pkg/sessions-ui
+  -> #5771 pkg/entity-ui-agent
+  -> #5772 oss/home-overview
+  -> #5773 oss/agents-page
+  -> #5774 oss/templates
+  -> #5775 oss/sessions-page
+  -> #5776 oss/seed-attachments
+```
+
+#5766 is outside this Git stack but is still a release prerequisite: #5771 imports its
+`triggerBoundAgentId` helper, so #5766 must reach the frontend stack's base before #5771 builds.
+
+| PR | Purpose |
+| --- | --- |
+| #5768 | Shared panel layout primitives |
+| #5769 | Headless sessions query, filters, pins, grouping, and row view models |
+| #5770 | Portable sessions rows and filter controls |
+| #5771 | Portable agent cards and next-trigger sections |
+| #5772 | Home and agent-overview redesign |
+| #5773 | Agents page |
+| #5774 | Template gallery and detail page |
+| #5775 | Project and agent sessions pages |
+| #5776 | Seeded attachment handoff to the first message |
+
+The implementation used `origin/release/v0.112.0` at `965851e15d`, which contained the required
+session and trigger surfaces. No GitButler stacks were applied at the start.
+
+## 4. Interface-first view
+
+Before discussing storage or services, the interface review starts with what the frontend must
+ask and what it must receive.
+
+### 4.1 Information required by each frontend decision
+
+| Frontend decision | Required information | Implemented source |
+| --- | --- | --- |
+| Show normal sessions | Exclude trigger origin | `exclude.origins: ["trigger"]` |
+| Show automation runs | Include trigger origin | `session.origins: ["trigger"]` |
+| Name an automation row | Current trigger name | Typed `trigger.name` expansion |
+| Link to an automation | Trigger ID and kind | Typed `trigger.id` and `trigger.kind` |
+| Show schedule/subscription icon | Trigger kind | Typed `trigger.kind` |
+| Filter by agent | A matching turn workflow reference | `turn_references` query predicate |
+| Filter live sessions | Liveness flags | `session.liveness.is_alive` |
+| Filter waiting sessions | Actionable interaction session IDs | `session_ids` |
+| Fetch pinned group | Local pinned IDs | `session_ids` |
+| Avoid duplicates | Local pinned IDs | `exclude.session_ids` |
+| Show row preview | Newest message when it has text | Typed `last_message` expansion |
+| Open exact delivery | Delivery ID | Typed `delivery.id` and exact delivery mode |
+| Order and paginate | Terminal cursor object | Response `windowing` |
+
+Agent filtering and row enrichment use related but different turn semantics. The filter matches a
+session when any turn contains the requested reference. The returned row displays the highest
+`turn_index` turn's references. A multi-agent session can therefore match an older turn while its
+row exposes a newer turn's agent.
+
+### 4.2 Information not required by the current sessions list
+
+The list does not currently need:
+
+- Provider event ID.
+- Detached workflow run ID.
+- Turn ID.
+- Trace ID.
+- Trigger configuration such as cron or provider-specific options.
+- Full transcript records.
+
+The exact trigger delivery ID is required for the confirmed `View delivery` action. The remaining
+values may be useful for an automation-run details page or an observability link, but are not
+required to separate sessions, name the automation, or render the preview.
+
+## 5. Trigger terms
+
+The previous review used several terms without enough specificity. This section defines each one
+through one example.
+
+Assume an automation named `Support triage` starts an agent whenever a Gmail message arrives.
+
+### 5.1 Trigger configuration
+
+The trigger configuration is the reusable automation definition.
+
+For an event subscription it includes information such as:
+
+- The provider event type, such as `GMAIL_NEW_MESSAGE`.
+- The connected account.
+- Provider-specific filters.
+- Input mappings.
+- The workflow or agent to invoke.
+
+For a schedule it includes:
+
+- The cron expression.
+- Optional start and end times.
+- Input mappings.
+- The workflow or agent to invoke.
+
+The sessions list does not need this configuration. If the user opens the automation, the
+frontend can retrieve it using the trigger ID.
+
+### 5.2 Schedule and subscription
+
+A schedule fires because a clock reaches a configured time.
+
+A subscription fires because an external event arrives, such as a Gmail message or GitHub pull
+request.
+
+PR #5767 writes this distinction as:
+
+```json
+{"ag.trigger.kind": "schedule"}
+```
+
+or:
+
+```json
+{"ag.trigger.kind": "subscription"}
+```
+
+The kind is useful only if the UI presents these differently or needs to choose the correct
+destination when opening the automation.
+
+### 5.3 Initiating event
+
+The initiating event is one concrete occurrence that causes the automation to run.
+
+Examples:
+
+- One Gmail message arriving.
+- One GitHub pull request being opened.
+- The 02:00 schedule tick on August 10.
+
+It is not the reusable trigger configuration. The same schedule can produce hundreds of initiating
+events over time.
+
+The sessions list does not need this event ID for its current design. An audit or retry screen may
+need it.
+
+### 5.4 Trigger delivery
+
+A trigger delivery is Agenta's audit row for one attempt to process one initiating event.
+
+It records which subscription or schedule fired, the event identity, dispatch status, inputs, and
+the result or error. It has a `delivery_id`. The successful claimant creates the row. A duplicate
+claimant skips invocation; the delivery row does not record each duplicate claim attempt.
+
+The distinction is:
+
+```text
+Schedule "Nightly digest"       reusable configuration
+Delivery on August 10 at 02:00  one exact firing
+Delivery on August 11 at 02:00  another exact firing
+```
+
+PR #5767 adds `session_id` to the delivery data. This gives the system:
+
+```text
+delivery -> session
+```
+
+The confirmed row menu includes `View delivery`, so automation session rows require this exact
+delivery ID. The action opens the delivery payload, mapping result, dispatch status, or
+pre-execution error.
+
+### 5.5 Workflow run
+
+A workflow run is one execution of the selected workflow. The detached invocation path has a
+`run_id`, but this path does not currently have one canonical persisted workflow-run entity that
+connects all execution identifiers. Detached deliveries store `result.run_id`; synchronous
+deliveries instead store trace, span, and output information.
+
+The sessions list does not need the run ID. A session can contain multiple turns and executions,
+so a run ID is not the session's user-facing identity.
+
+### 5.6 Session and turn
+
+A session is the durable conversation or work container shown in the sessions list.
+
+A turn is one execution within that session. For example:
+
+```text
+Session: Investigate refund request
+  Turn 1: inspect order
+  Turn 2: ask user for approval
+  Turn 3: issue refund
+```
+
+Trigger dispatch creates a fresh session in the current implementation. That is a product choice:
+each automation firing is represented as a new session. The list therefore treats automation runs
+as sessions even though one session can technically contain several turns.
+
+### 5.7 Trace and records
+
+A trace is observability data for one execution. It contains timing and nested model/tool spans.
+
+Records are the transcript and execution events associated with a session and turn. They include
+messages, thoughts, tool calls, tool results, usage, errors, and completion events.
+
+The list needs only a preview derived from records. It does not need the trace ID unless the row
+offers an `Open trace` action.
+
+### 5.8 Identity chain for this UX
+
+The minimum current chain is:
+
+```text
+subscription or schedule ID
+  -> stamped onto session
+  -> session groups turns and records
+```
+
+The fuller operational chain is:
+
+```text
+subscription or schedule
+  -> initiating event
+  -> delivery
+  -> workflow invocation
+  -> session
+  -> turn
+  -> trace and records
+```
+
+The full chain is useful for debugging. It does not need to appear in every sessions-list row.
+
+## 6. Frontend interface changes
+
+### 6.1 Before #5769
+
+The list-filter and pagination subset of the frontend `querySessions` wrapper supported:
+
+```ts
+interface QuerySessionsParams {
+    projectId: string
+    references?: Reference[]
+    includeEnded?: boolean
+    includeArchived?: boolean
+    search?: string
+    limit?: number
+    next?: string
+    newest?: string
+}
+```
+
+The complete wrapper also carried transport/context options such as `appId`, `abortSignal`, and
+`lowPriority`; those are unchanged by the sessions-list work.
+
+The session row already included stream fields and latest-turn references. It did not parse tags
+or a message preview.
+
+### 6.2 Reviewed #5769 baseline
+
+PR #5769 extends that list-filter and pagination subset with:
+
+```ts
+interface QuerySessionsParams {
+    projectId: string
+    references?: Reference[]
+    includeEnded?: boolean
+    includeArchived?: boolean
+    search?: string
+    flags?: {
+        is_alive?: boolean
+        is_running?: boolean
+        is_attached?: boolean
+    }
+    sessionIds?: string[]
+    excludeSessionIds?: string[]
+    origin?: string
+    excludeOrigin?: string
+    limit?: number
+    next?: string
+    newest?: string
+}
+```
+
+The parsed session row gains:
+
+```ts
+interface SessionStream {
+    // Existing stream fields...
+    tags?: Record<string, unknown> | null
+    references?: Reference[] | null
+    last_message?: {
+        text: string
+        source?: string | null
+        timestamp?: string | null
+    } | null
+}
+```
+
+The frontend then reads backend storage keys directly:
+
+```ts
+const SESSION_ORIGIN_TAG = "ag.origin"
+const SESSION_TRIGGER_NAME_TAG = "ag.trigger.name"
+const SESSION_TRIGGER_KIND_TAG = "ag.trigger.kind"
+```
+
+This direct dependency was the main interface concern. The implemented frontend now depends on
+typed domain fields and does not parse reserved storage keys.
+
+### 6.3 Baseline frontend-stack calls
+
+These are representative calls from PR #5769's stack, not the current `main` checkout. The wrapper
+also sends `include_ended: true` by default.
+
+Default sessions mode:
+
+```json
+{
+  "include_ended": true,
+  "include_archived": false,
+  "exclude_origin": "trigger",
+  "windowing": {"limit": 30}
+}
+```
+
+Automation mode:
+
+```json
+{
+  "origin": "trigger",
+  "include_ended": true,
+  "include_archived": false,
+  "windowing": {"limit": 30}
+}
+```
+
+Agent-scoped live sessions:
+
+```json
+{
+  "references": [{"id": "019d952f-0000-0000-0000-000000000000"}],
+  "flags": {"is_alive": true},
+  "exclude_origin": "trigger",
+  "windowing": {"limit": 30}
+}
+```
+
+Waiting sessions:
+
+```json
+{
+  "session_ids": ["session-a", "session-b"],
+  "include_ended": true,
+  "exclude_origin": "trigger",
+  "windowing": {"limit": 30}
+}
+```
+
+Pinned group:
+
+```json
+{
+  "session_ids": ["session-pinned-a", "session-pinned-b"],
+  "include_ended": true,
+  "windowing": {"limit": 30}
+}
+```
+
+The actual pinned query also carries the active search, agent, status/waiting, and archive filters.
+It deliberately suppresses the default trigger exclusion so a pinned automation session remains
+visible in its pinned group.
+
+Recent group without duplicate pins:
+
+```json
+{
+  "exclude_session_ids": ["session-pinned-a", "session-pinned-b"],
+  "exclude_origin": "trigger",
+  "include_ended": true,
+  "windowing": {"limit": 30}
+}
+```
+
+## 7. Public API review
+
+### 7.1 API before #5767
+
+`POST /sessions/query` accepted a flat request:
+
+```json
+{
+  "references": [{"id": "..."}],
+  "windowing": {"limit": 30},
+  "include_ended": true,
+  "include_archived": false,
+  "search": "refund"
+}
+```
+
+It returned:
+
+```json
+{
+  "count": 1,
+  "sessions": [
+    {
+      "id": "...",
+      "session_id": "...",
+      "name": "Refund request",
+      "flags": {"is_alive": false},
+      "references": [{"id": "..."}],
+      "created_at": "...",
+      "updated_at": "..."
+    }
+  ]
+}
+```
+
+### 7.2 Reviewed #5767 baseline
+
+The request gains:
+
+```json
+{
+  "flags": {"is_alive": true},
+  "session_ids": ["..."],
+  "exclude_session_ids": ["..."],
+  "include_total": true,
+  "origin": "trigger",
+  "exclude_origin": "trigger"
+}
+```
+
+The response structurally gains `total` and `last_message`. `SessionStream` already exposed optional
+`tags` and `meta`; #5767 starts populating reserved `ag.*` tag keys.
+
+#5769 does not expose `includeTotal` from its frontend wrapper and does not parse `total` from the
+response, so this capability is implemented by #5767 but unused by the sessions UI in this stack.
+
+```json
+{
+  "count": 1,
+  "total": 37,
+  "sessions": [
+    {
+      "session_id": "...",
+      "tags": {
+        "ag.origin": "trigger",
+        "ag.trigger.id": "...",
+        "ag.trigger.name": "Nightly digest",
+        "ag.trigger.kind": "schedule"
+      },
+      "last_message": {
+        "session_id": "...",
+        "text": "Digest delivered.",
+        "source": "agent",
+        "timestamp": "..."
+      }
+    }
+  ]
+}
+```
+
+### 7.3 What is good
+
+- Filters execute before pagination.
+- Positive filters are intersected.
+- `session_ids=[]` means no matches instead of no restriction.
+- Exclusions execute before pagination.
+- Legacy rows without origin tags survive `exclude_origin="trigger"`.
+- Query and count use the same SQL predicate.
+- `count` remains the number of rows in the page.
+- `total` is optional and ignores pagination.
+- Latest messages are fetched in one batch instead of one call per row.
+
+### 7.4 Findings resolved by the implementation
+
+The following subsections describe defects in the reviewed PR baseline. The completed revision
+resolves each defect through the typed contract shown in Section 8.
+
+#### The request was a flat collection of different roles
+
+The request mixes:
+
+- Resource predicates: search, flags, origin.
+- Cross-resource constraints: references.
+- Explicit set constraints: session IDs.
+- Lifecycle policy: include ended/archived.
+- Response options: include total.
+- Pagination: windowing.
+
+The repository's stronger query APIs group resource predicates under the resource name. Examples:
+
+- `WorkflowQueryRequest.workflow` in
+  `api/oss/src/apis/fastapi/workflows/models.py:69`.
+- `TestsetQueryRequest.testset` in
+  `api/oss/src/apis/fastapi/testsets/models.py:70`.
+- `EvaluationRunQueryRequest.run` in
+  `api/oss/src/apis/fastapi/evaluations/models.py:144`.
+
+#### `include_total` was mixed into filtering
+
+It changes response cost and shape. It should remain at the API/options layer, not inside the core
+session predicate DTO.
+
+#### Origin was untyped and singular
+
+`origin: string` accepts typos and supports only one inclusion value. `origin` and
+`exclude_origin` can also contradict each other.
+
+#### The response did not return its next cursor
+
+The request accepts `windowing`, but `SessionsResponse` does not return the next cursor. Session
+pagination needs both the last row's internal `id` (`next`) and activity timestamp (`newest`). The
+frontend reconstructs both from the row. Workflows and testsets return cursor data explicitly,
+although their shared cursor helper would need extension for the session query's coalesced activity
+timestamp.
+
+#### The response exposed storage rather than domain fields
+
+The frontend must know that `ag.trigger.name` means trigger name. If storage later changes from
+tags to columns, every frontend consumer must change.
+
+#### ID lists were unbounded
+
+The API should bound and validate inclusion and exclusion lists. A query containing thousands of
+arbitrary strings should not produce an unbounded `IN` predicate.
+
+#### Total repeated reference resolution
+
+When `include_total=true`, the router calls `query_sessions()` and `count_sessions()` separately.
+Both resolve turn references to session IDs. This adds a duplicate query and allows the page and
+total to observe different intermediate sets.
+
+## 8. Implemented public API
+
+This shape follows the repository's resource-query pattern while preserving the useful behavior
+from #5767.
+
+### 8.1 Request
+
+```json
+{
+  "session": {
+    "search": "refund",
+    "liveness": {"is_alive": true},
+    "tags": {"team": "support"}
+  },
+  "session_ids": ["session-a", "session-b"],
+  "turn_references": [
+    {"id": "019d952f-0000-0000-0000-000000000000"}
+  ],
+  "exclude": {
+    "session_ids": ["session-pinned"],
+    "origins": ["trigger"]
+  },
+  "include_ended": true,
+  "include_archived": false,
+  "include_total": true,
+  "expand": ["last_message"],
+  "windowing": {
+    "limit": 30,
+    "next": "...",
+    "newest": "2026-08-10T12:03:14Z"
+  }
+}
+```
+
+The compatibility boundary is:
+
+- Session predicates under `session`.
+- Turn references named as turn references.
+- Exclusions grouped rather than one new `exclude_*` field per predicate.
+- Response options outside the predicate.
+- Cursor pagination kept under `windowing`.
+
+The liveness object preserves the current boolean predicate semantics, including future false
+predicates. If origin selection later includes `unknown`, the backend must define it as a
+null/missing-tag predicate; it cannot compile `unknown` to ordinary JSONB containment.
+
+### 8.2 Response
+
+```json
+{
+  "count": 1,
+  "total": 37,
+  "sessions": [
+    {
+      "id": "...",
+      "session_id": "...",
+      "name": null,
+      "origin": "trigger",
+      "trigger": {
+        "id": "019d952f-0000-0000-0000-000000000000",
+        "kind": "schedule",
+        "name": "Nightly digest"
+      },
+      "delivery": {
+        "id": "019d952f-0000-0000-0000-000000000001"
+      },
+      "references": [{"id": "..."}],
+      "last_message": {
+        "text": "Digest delivered.",
+        "source": "agent",
+        "timestamp": "..."
+      }
+    }
+  ],
+  "windowing": {
+    "next": "...",
+    "newest": "2026-08-10T12:03:14Z",
+    "limit": 30
+  }
+}
+```
+
+The API stores origin, trigger, and delivery IDs in tags internally. The response adapter translates
+storage into explicit fields and removes reserved attribution keys from the public tags map. This
+implementation does not use session meta.
+
+For an unstamped row, the implementation models `origin` as null. With the API's current
+`response_model_exclude_none` policy the field may be omitted on the wire. It does not report
+`manual`, because absence cannot distinguish a manual session from legacy data or a failed trigger
+stamp.
+
+### 8.3 Should the API expose only generic tag filters?
+
+A generic tag filter would work mechanically:
+
+```json
+{
+  "session": {
+    "tags": {"ag.origin": "trigger"}
+  }
+}
+```
+
+It is not the preferred public interface for system-owned origin because:
+
+- It exposes a reserved storage key.
+- It provides no enum validation.
+- It makes the frontend responsible for null/unknown compatibility semantics.
+- It makes a later storage migration a public breaking change.
+
+The implemented boundary is:
+
+```text
+Public API: session.origins = ["trigger"]
+Internal query: tags @> {"ag.origin": "trigger"}
+```
+
+Generic user tags can still be supported separately through `session.tags`.
+
+## 9. Reviewed baseline model and internal interfaces
+
+This section records the #5767 baseline that produced the findings. The completed implementation
+separates query predicates from response options, uses typed attribution projections, and keeps
+reserved storage keys behind the API adapter.
+
+### 9.1 API models
+
+`SessionQueryRequest` gains:
+
+- `flags`
+- `session_ids`
+- `exclude_session_ids`
+- `include_total`
+- `origin`
+- `exclude_origin`
+
+`SessionsResponse` gains optional `total`.
+
+### 9.2 Core session models
+
+`SessionListItem` gains `last_message`.
+
+`SessionQuery` gains the new request fields, including `include_total` even though it is not a row
+predicate.
+
+The sessions core also gains trigger-specific constants and `SessionTriggerRef`.
+
+Feedback:
+
+- `SessionListItem.last_message` is a reasonable response projection.
+- `include_total` should not live in the core predicate model.
+- Trigger attribution should be exposed through a typed session field, but sessions core should
+  not need constants for every trigger storage key.
+- `origin` and `kind` should be enums at the public boundary.
+
+### 9.3 Stream query models
+
+`SessionStreamQuery` gains generic `tags` and `exclude_tags` predicates.
+
+Feedback:
+
+- JSONB containment is a reasonable persistence adapter.
+- A public `exclude_tags` API is not established elsewhere and needs clear null semantics.
+- The session-origin API should compile into these internal predicates rather than expose them.
+
+### 9.4 Stream DAO interface
+
+The stream DAO query gains `exclude_session_ids`, and the interface gains a separate `count()`.
+
+Feedback:
+
+- Applying exclusions before windowing is correct.
+- Sharing one predicate builder between list and count is correct.
+- ID sets should be bounded at the public boundary.
+- A single service query result should resolve references once and then perform list/count.
+
+### 9.5 Records interface
+
+The records DAO and service gain:
+
+```python
+latest_message_per_session(
+    project_id: UUID,
+    session_ids: List[str],
+) -> Dict[str, SessionMessagePreview]
+```
+
+Feedback:
+
+- The batch interface is correct for a list expansion.
+- It belongs to the records domain.
+- The sessions service should call it only when the expansion is requested.
+- A records failure should not fail the base sessions list.
+
+### 9.6 Trigger dispatcher interface
+
+The dispatcher gains an optional concrete `SessionStreamsService` dependency. It now:
+
+1. Mints `session_id`.
+2. Writes trigger attribution to the session stream.
+3. Passes `session_id` to the workflow request.
+4. Stores `session_id` in delivery data.
+
+Feedback:
+
+- Minting the session ID before invocation is reasonable.
+- The dispatcher is the correct place to know which schedule/subscription fired.
+- The dependency should be a narrow session-attribution interface, not the concrete stream
+  service.
+- Correlation should be persisted to the claimed delivery before invocation so a crash does not
+  lose it.
+- The best-effort attribution write means origin is a UI convenience, not a guaranteed invariant.
+
+## 10. Tags, meta, and provenance
+
+### 10.1 Repository meaning
+
+Agenta's shared metadata model has three categories:
+
+| Field | PostgreSQL storage | Meaning |
+| --- | --- | --- |
+| `flags` | JSONB | System state used by behavior and filters |
+| `tags` | JSONB | Small labels used for categorization and containment filtering |
+| `meta` | JSON | Rich descriptive context, usually not queried |
+
+JSONB supports containment operators and GIN indexes. JSON preserves a JSON document but is not
+the repository's normal indexed-filter path.
+
+JSONB does not create an index automatically.
+
+This tags-as-labels distinction is a shared-model convention, not currently enforced by session
+DTOs. `SessionStream.tags` is typed as `Dict[str, Any]`, so session tags can technically contain
+arbitrary JSON until that contract is tightened.
+
+### 10.2 GIN, not chain
+
+The index is a GIN index, pronounced like `gin`. GIN means Generalized Inverted Index.
+
+For JSONB it lets PostgreSQL efficiently answer containment queries such as:
+
+```sql
+flags @> '{"is_alive": true}'
+```
+
+or:
+
+```sql
+tags @> '{"ag.origin": "trigger"}'
+```
+
+`session_streams.flags` has a GIN index. `session_streams.tags` does not. The implemented origin
+query is valid, but representative query-plan verification was not run. No tags index was added.
+
+### 10.3 What belongs in tags
+
+For the current UX, these values are plausible tags because the list filters by them:
+
+```json
+{
+  "ag.origin": "trigger",
+  "ag.trigger.id": "...",
+  "ag.trigger.kind": "schedule",
+  "ag.trigger.delivery_id": "..."
+}
+```
+
+`ag.trigger.id` is higher-cardinality than a typical label. It would be useful if the API needed
+all sessions from one automation, but #5767 does not expose a trigger-ID or generic-tag predicate.
+That reverse query would require an additional public filter.
+
+### 10.4 Why this implementation does not use meta
+
+The confirmed product behavior is to show the current automation name. The implementation resolves
+the schedule/subscription by stable ID and does not store a name snapshot in tags or meta.
+
+No other current field needs a rich non-queryable document. Delivery details remain on the delivery
+resource, while future usage and cost values require typed numeric summaries. Adding session meta
+would create a second storage convention without serving the current interface.
+
+### 10.5 Why not require typed provenance now?
+
+A dedicated provenance object or table is not required for the two current questions:
+
+1. Was this session started by a trigger?
+2. Which schedule or subscription started it?
+
+Tags answer both because the implementation provides:
+
+- Atomic merge semantics.
+- Reserved `ag.*` ownership.
+- Typed API translation.
+- A clear meaning for missing origin.
+
+A GIN index is a performance optimization, not a semantic requirement. The representative query
+plan was not measured, so no index was added. Add one only when measured origin filtering cost
+justifies it.
+
+Typed storage becomes valuable when one or more of these become true:
+
+- Origin affects authorization, billing, retention, or lifecycle.
+- Attribution needs database-level referential integrity or repair guarantees beyond the atomic
+  claim transaction.
+- More origin types appear and have different required fields.
+- Referential integrity to a source entity is required.
+- Reverse queries by exact delivery become common.
+- Users can edit arbitrary session tags.
+- Migrations or repair jobs need a versioned attribution schema.
+
+Until then, a new provenance table would add complexity without improving the current user story.
+The public interface should still be typed because public contracts and storage have different
+lifetimes.
+
+### 10.6 Atomic reserved-tag merge
+
+The implemented attribution write atomically merges reserved keys into the existing tags
+dictionary. It preserves unrelated user tags and concurrent liveness updates.
+
+The write follows this behavior conceptually:
+
+```sql
+tags = coalesce(tags, '{}'::jsonb) || :origin_patch
+```
+
+Real-Postgres tests cover claim, history, and concurrent attribution behavior.
+
+### 10.7 Reserved namespace
+
+`ag.*` remains the private storage namespace. The API sanitizer removes reserved keys from every
+public session `tags` map while preserving typed attribution fields and user-visible tags. Future
+generic tag writes must continue to reject reserved keys.
+
+### 10.8 Manual versus unknown
+
+PR #5767 defines `manual` and `trigger`, but production code stamps only `trigger`.
+
+Therefore:
+
+| Stored state | Safe interpretation |
+| --- | --- |
+| `ag.origin = "trigger"` | Trigger dispatcher successfully stamped this session |
+| `ag.origin = "manual"` | Supported by the model, but not written by this PR's production path |
+| Missing `ag.origin` | Unknown: manual, legacy, another source, or failed trigger stamp |
+
+The implemented frontend uses:
+
+```json
+{"exclude": {"origins": ["trigger"]}}
+```
+
+instead of:
+
+```json
+{"session": {"origins": ["manual"]}}
+```
+
+The first means `show everything not known to be triggered`. The second would hide almost every
+unstamped historical and manual session.
+
+The public API should not claim that missing means manual. It should either expose `unknown` as a
+read classification or document that origin may be absent.
+
+## 11. Last-message enrichment
+
+### 11.1 Interface before the PR
+
+A session list row described the stream and latest turn:
+
+```json
+{
+  "session_id": "...",
+  "name": "Refund request",
+  "flags": {"is_alive": false},
+  "references": [{"id": "agent-id"}],
+  "updated_at": "..."
+}
+```
+
+To display transcript content, the frontend queried session records after opening a session.
+
+### 11.2 Interface in the reviewed PR baseline
+
+Every row from `/sessions/query` may include:
+
+```json
+{
+  "last_message": {
+    "session_id": "...",
+    "text": "Refund approved.",
+    "source": "agent",
+    "timestamp": "..."
+  }
+}
+```
+
+This does not add a `last_message` column to `session_streams`, and it does not write message text
+into the stream row. `SessionListItem` inherits the stream fields and adds a read-time response
+field. The service fetches the preview from records each time the expansion is built.
+
+The frontend uses this field in title precedence:
+
+```text
+explicit session name
+  else trigger name
+  else last message
+  else "Untitled session"
+```
+
+When a named row exists, the message becomes its subtitle.
+
+### 11.3 Implemented backend behavior
+
+When the caller requests the message expansion, the sessions service performs:
+
+```text
+1. Query session streams in the transactional database.
+2. Query latest turns in the transactional database.
+3. Query latest message records in the analytics/tracing database.
+4. Merge the three results by session_id.
+```
+
+The records query is batched with PostgreSQL `DISTINCT ON (session_id)`. This avoids one records
+request for every row.
+
+### 11.4 Different lifecycles
+
+Session streams and records are not written or retained in the same way.
+
+| Session stream | Records |
+| --- | --- |
+| Transactional/core database | Analytics/tracing database |
+| One durable row per session | Many append-only events per session |
+| Updated by heartbeat and lifecycle actions | Written asynchronously from runner events |
+| Used for liveness and list membership | Used for transcript and observability |
+| Session lifecycle ownership | Independent tracing retention |
+
+Consequences:
+
+- A stream can exist before its first message record arrives.
+- A session can be current while its preview is temporarily old.
+- A record write can fail while the stream remains valid.
+- The analytics database can be unavailable while the transactional session list is healthy.
+- Deleting or archiving a session does not imply identical record retention.
+
+`last_message` is therefore a best-effort preview, not authoritative session state.
+
+### 11.5 Baseline problem with unconditional enrichment
+
+In the reviewed baseline, the records query ran for every `/sessions/query` call whenever
+`RecordsService` was wired. This included callers that did not render previews.
+
+That baseline also allowed a records exception to fail the complete sessions list even though its
+base stream data was available.
+
+### 11.6 Implemented expansion
+
+The implementation uses an explicit expansion:
+
+```json
+{
+  "expand": ["last_message"]
+}
+```
+
+Home and Sessions request it explicitly. Other clients avoid the cross-database query.
+
+When requested, the implementation does the following:
+
+- Fetches the latest turn and latest message concurrently after stream IDs are known.
+- Bounds the page size.
+- Catches records failures and returns the base rows without previews.
+- Uses `newest message if textual` semantics.
+
+The implementation preserves the baseline semantic: it selects the newest message and then omits
+the preview if that message has no text. It does not fall back to the preceding textual message.
+
+The response does not need `last_message.session_id` because the preview is already nested under a
+specific session row.
+
+### 11.7 Long-term options
+
+There are two valid long-term designs.
+
+#### Query-time expansion
+
+Keep records authoritative and batch-load the preview when requested.
+
+Use this while list volume and latency remain acceptable. It avoids duplicated preview state.
+
+#### Materialized session summary
+
+Maintain an eventually consistent read projection with fields such as:
+
+```text
+latest_message_text
+latest_message_source
+latest_message_at
+latest_turn_reference
+origin
+```
+
+Use this only if the sessions list becomes hot enough that repeated cross-database expansions are
+measurably expensive. The projection is a cache for list rendering, not the transcript source of
+truth.
+
+## 12. Trigger execution and session association
+
+### 12.1 Behavior before the PR
+
+A triggered workflow eventually received or created a session ID, but the dispatcher did not know
+which session the detached run produced. A delivery stored a detached `run_id`, not the session ID.
+
+Consequences:
+
+- A session row could not say that a trigger started it.
+- The default sessions list could not exclude automation sessions.
+- A delivery could not directly link to the resulting session.
+
+### 12.2 Behavior in the reviewed PR baseline
+
+After claiming a delivery, the dispatcher:
+
+```text
+1. Generates session_id.
+2. Adds session_id to delivery data in memory.
+3. Stamps the session stream with trigger tags.
+4. Sends the same session_id in the workflow request.
+5. Completes the delivery with session_id and invocation result.
+```
+
+This ensures the runner, stream, turns, and records use the same session ID.
+
+### 12.3 Why generating the session ID early makes sense
+
+The dispatcher is the only point that knows both sides at once:
+
+- Which subscription or schedule fired.
+- Which new workflow invocation is about to start.
+
+If the runner generated the ID later, the dispatcher would need to recover it from a detached
+response that currently does not return the session ID. Preallocation gives the dispatcher a
+stable correlation value before execution starts.
+
+### 12.4 Implemented atomic claim
+
+The current UX requires only:
+
+```text
+session -> trigger configuration ID/kind
+delivery -> session ID
+```
+
+The completed implementation provides both relationships in one Postgres claim transaction. It
+claims the delivery with `data.session_id` and creates or merges the attributed session before
+workflow invocation. A failed claim or attribution rolls back both writes and invokes nothing.
+Completion merges result or error data without removing the claimed session ID.
+
+### 12.5 Is delivery ID required on the session?
+
+Yes. The confirmed product behavior includes this reverse action:
+
+> Open the exact automation delivery that created this session.
+
+The public response exposes delivery ID as an explicit typed relationship. The storage adapter
+keeps it in a reserved tag, and the frontend does not parse that key.
+
+### 12.6 Do we need run and trace IDs?
+
+Not for the current list.
+
+Add a trace link only when the row or details view offers observability navigation. Add a run ID
+only when a persisted run resource exists and users can do something with it.
+
+The earlier recommendation mentioned them to describe the complete execution chain, not to propose
+putting all of them in the current session model.
+
+## 13. Implementation disposition
+
+### Completed
+
+1. Aligned `POST /sessions/query` with the resource-nested query pattern.
+2. Separated response options from row predicates.
+3. Returned pagination windowing instead of reconstructing it in the frontend.
+4. Exposed typed `origin`, `trigger`, and `delivery` response fields.
+5. Kept reserved tag keys private to the backend adapter.
+6. Bounded and validated ID sets.
+7. Corrected the false claim that session tags already have a GIN index.
+8. Merged reserved tags instead of replacing the whole dictionary.
+9. Defined missing origin as unknown, not manual.
+10. Made latest-message enrichment explicit and best effort.
+11. Persisted delivery-to-session correlation before invocation.
+12. Exposed the exact delivery ID as a typed relationship on attributed automation sessions.
+13. Preserved configurations and deliveries after normal automation deletion.
+
+### Deferred follow-up
+
+- Protect `ag.*` from future user tag writes.
+- Add a materialized session summary only after measuring list-query cost.
+- Introduce typed provenance storage only when provenance becomes a protected domain invariant.
+- Run the representative 10,000-session and 200,000-record benchmark before deciding whether to add
+  an index.
+- Address gateway connection hard deletion if product history must survive that broader operation.
+
+### Not required for this release story
+
+- A new workflow-run table.
+- Provider event IDs on session rows.
+- Run IDs on session rows.
+- Trace IDs on session rows.
+- Full trigger configuration on session rows.
+- A new provenance table.
+
+## 14. Confirmed product decisions
+
+1. Automation rows display the current schedule/subscription name, not an execution-time snapshot.
+2. Clicking an automation row opens the session.
+3. Secondary row actions open the automation configuration and exact delivery.
+4. Schedule versus subscription is visible in the row.
+5. Every claimed trigger firing creates a new session.
+6. Message previews appear on Home and project/agent Sessions pages only.
+7. Sidebar, agent overview, mobile, reconciliation, and internal callers do not request previews.
+8. The base API returns all origins. Each frontend surface chooses whether to exclude trigger
+   sessions.
+9. Normal automation deletion preserves configuration and delivery history.
+10. This implementation does not use session meta.
+11. Authenticated exact-by-ID schedule and subscription reads include soft-deleted configurations
+    as read-only. Normal lists and mutations remain live-only.
+
+Normal automation deletion does not cover gateway connection hard deletion. Hard-deleting a
+gateway connection can still cascade through subscription and delivery history. This remains a
+deferred risk.
+
+## 15. Implementation verification
+
+### Environment
+
+- GitButler target at start: `origin/release/v0.112.0` at `965851e15d`.
+- Applied stacks at start: none.
+- Deployment: `http://144.76.237.122:8280`.
+- Compose project: `agenta-ee-dev-wp-b2-rendering`.
+- Postgres published port: 5434.
+
+The implementation is packaged as the stacked review set described in
+`session-ux-interface/implementation.md`.
+
+### Automated evidence
+
+- 559 non-integration session and trigger API tests passed.
+- Eight core Postgres claim and history tests passed in the deployed container.
+- Phase 5 trigger join, cursor, and origin Postgres tests passed in the deployed container.
+- Three generated Python client tests passed.
+- Frontend builds, type checks, lint, and relevant package suites passed.
+- Final reviews found no P0 or P1 findings.
+
+### Live evidence
+
+- Schedule acceptance passed and produced linked delivery and session IDs.
+- An authenticated canonical query returned the typed current trigger name and kind, typed
+  delivery, terminal windowing, and only user tags.
+- Exact delivery mode returned the linked session and result.
+
+### Residual verification
+
+- Browser QA did not run because host Chromium sandboxing is disabled. The run did not bypass the
+  sandbox with `--no-sandbox`.
+- Subscription live acceptance did not run because `COMPOSIO_TEST_CONNECTED_ACCOUNT` was missing.
+- The representative 10,000-session and 200,000-record benchmark did not run. No index was added,
+  and this review makes no representative performance claim.
+
+## Appendix A: Future tag filtering and grouping
+
+This appendix records a known future story. It is not in scope for PR #5767, but the current
+interface should not make it difficult to add later.
+
+### A.1 User story
+
+As a user, I want to organize sessions with tags and use those tags to filter or group the complete
+session set.
+
+Tags may come from different owners:
+
+- Users may add labels such as `customer=acme`, `topic=billing`, or `priority=high`.
+- Agenta may add labels with stable product semantics.
+- An agent may eventually organize its own sessions through an Agenta-controlled tool.
+
+One important product-defined classification is the session's work status:
+
+```text
+todo
+in_progress
+done
+blocked
+parked
+```
+
+This is the status of the work represented by the session. It is not whether an agent is currently
+running or waiting for a person.
+
+### A.2 Status vocabulary
+
+The current session stack already uses the word `status` for several unrelated concepts.
+
+| Concept | Examples | Owner | Meaning |
+| --- | --- | --- | --- |
+| Work status | todo, in progress, done, blocked, parked | User-managed, Agenta-defined vocabulary | How the user organizes the work |
+| Runtime liveness | alive, running, attached | Agenta runtime | Whether execution infrastructure is active |
+| Interaction state | waiting for approval, waiting for input | Agenta runtime and user interaction | Whether the agent needs a human response |
+| Lifecycle | ended, archived | User and session service | Whether the session remains active or visible |
+| Generic tags | customer=acme, topic=billing | User, agent, or Agenta | Open-ended classification |
+
+A session can be all of the following at once:
+
+```text
+work_status = blocked
+is_alive = false
+waiting_for_input = false
+archived = false
+```
+
+Calling all of these fields `status` would make filters and row labels ambiguous. This appendix
+uses `work_status` for `todo`, `in_progress`, `done`, `blocked`, and `parked`.
+
+### A.3 Does this change the interface decision?
+
+It changes the decision from `only domain-specific filters` to a hybrid interface.
+
+The API should support both:
+
+1. Generic tags when tags themselves are the product feature.
+2. Typed fields for stable domain concepts whose semantics matter outside generic labeling.
+
+This means the public interface can expose:
+
+```json
+{
+  "session": {
+    "tags": {"customer": "acme", "topic": "billing"},
+    "work_statuses": ["blocked", "parked"],
+    "origins": ["trigger"]
+  }
+}
+```
+
+All three may compile to JSONB tag predicates internally. They are still different public
+concepts:
+
+- `tags` means caller-selected labels with generic containment semantics.
+- `work_statuses` means a validated product vocabulary.
+- `origins` means who or what initiated the session, including null/unknown compatibility rules.
+
+The existence of generic tag filtering does not require callers to write:
+
+```json
+{
+  "session": {
+    "tags": {
+      "ag.origin": "trigger",
+      "ag.work_status": "blocked"
+    }
+  }
+}
+```
+
+That shape would expose storage keys and make callers reproduce domain rules. It would also allow
+typos and invalid values to bypass validation.
+
+### A.4 Public tags versus storage tags
+
+Once users can intentionally create and filter tags, tags are no longer only a backend
+implementation detail. They become part of the public session resource.
+
+The boundary should distinguish two things:
+
+| Concept | Public? | Example |
+| --- | --- | --- |
+| Public generic tag | Yes | `customer=acme` |
+| Documented Agenta tag intended for generic use | Yes | A future stable classification explicitly documented as a tag |
+| Private storage tag behind a typed field | No | `ag.origin=trigger` behind `origin` |
+| Internal implementation marker | No | Migration or repair bookkeeping |
+
+The physical database may store all four in one JSONB column. The response adapter does not have to
+return every physical key through the public `tags` map.
+
+This preserves storage flexibility:
+
+```text
+Public session.origin       -> stored temporarily as tags["ag.origin"]
+Public session.work_status  -> may be stored as tags["ag.work_status"]
+Public session.tags         -> stored as user-visible tag entries
+```
+
+### A.5 Namespace and ownership
+
+A namespace needs both semantic ownership and write policy.
+
+One workable policy is:
+
+| Namespace | Meaning | Generic user write |
+| --- | --- | --- |
+| `ag.*` | Agenta-defined semantics | Rejected |
+| Unprefixed or a future custom namespace | User-defined labels | Allowed with validation |
+
+`ag.*` does not have to mean that only background services can ever change the value. It means
+Agenta owns the field's definition and validation.
+
+For example, `work_status` is selected by a user but follows an Agenta-defined vocabulary. A
+dedicated work-status operation may write `ag.work_status` internally. The generic tag-edit API
+still rejects direct writes to `ag.*`.
+
+This prevents a generic tag update from changing origin or bypassing work-status validation.
+
+The exact custom-tag namespace should be decided after checking existing SDK and API conventions.
+The important rule is that custom and reserved keys cannot overwrite each other.
+
+### A.6 Work status as a typed field
+
+Work status deserves a typed public field if Agenta standardizes:
+
+- Its allowed values.
+- Its filter behavior.
+- Its display labels and ordering.
+- Its grouping behavior.
+- Which users or agents may change it.
+
+A possible response is:
+
+```json
+{
+  "session_id": "session-a",
+  "work_status": "blocked",
+  "tags": {
+    "customer": "acme",
+    "topic": "billing"
+  }
+}
+```
+
+A possible update operation is:
+
+```http
+POST /sessions/session-a/work-status
+Content-Type: application/json
+
+{"work_status": "blocked"}
+```
+
+The endpoint shape is illustrative. The important distinction is that it validates the work-status
+vocabulary instead of treating the value as an arbitrary tag.
+
+If the product does not standardize this vocabulary, `status=blocked` can remain a generic
+user-created tag. In that case Agenta should not attach special behavior or UI assumptions to it.
+
+### A.7 Generic tag updates
+
+The generic tag interface should patch keys rather than replace the complete dictionary.
+
+An illustrative request is:
+
+```json
+{
+  "set": {
+    "customer": "acme",
+    "topic": "billing",
+    "priority": "high"
+  },
+  "unset": ["old-label"]
+}
+```
+
+Required semantics:
+
+- `set` changes only the named custom keys.
+- `unset` removes only the named custom keys.
+- Reserved keys cannot be changed through this interface.
+- Concurrent system attribution writes are preserved.
+- Keys and values follow bounded label types rather than arbitrary unbounded JSON.
+
+This future story makes #5767's whole-tag replacement more clearly unsafe. Origin stamping must not
+erase user tags, and user edits must not erase origin stamping.
+
+### A.8 Generic tag filters
+
+The smallest useful generic filter follows the repository's existing containment convention:
+
+```json
+{
+  "session": {
+    "tags": {
+      "customer": "acme",
+      "priority": "high"
+    }
+  }
+}
+```
+
+Its documented meaning should be:
+
+```text
+customer = acme AND priority = high
+```
+
+This is a good first version because it maps directly to JSONB containment and matches established
+Agenta resource queries.
+
+More expressive requirements should not be guessed in advance. If the product later needs `OR`,
+key existence, value sets, or negative matches, extend the contract deliberately. For example:
+
+```json
+{
+  "session": {
+    "tag_filter": {
+      "all": [
+        {"key": "customer", "operator": "eq", "value": "acme"},
+        {"key": "priority", "operator": "in", "value": ["high", "urgent"]}
+      ]
+    }
+  }
+}
+```
+
+There is no reason to introduce this expression language before a real story needs it.
+
+### A.9 Grouping and pagination
+
+Tag filtering fits naturally into `/sessions/query`. Grouping is a separate concern because the
+list is cursor-paginated.
+
+The frontend cannot fetch one page, group those rows, and claim to have grouped the complete set.
+Later pages may contain more values or may change every group's count and ordering.
+
+There are two practical designs.
+
+#### Known finite groups
+
+For work status, the frontend knows the complete vocabulary. It can issue one filtered query per
+visible group:
+
+```json
+{"session": {"work_statuses": ["todo"]}, "windowing": {"limit": 30}}
+```
+
+```json
+{"session": {"work_statuses": ["blocked"]}, "windowing": {"limit": 30}}
+```
+
+Each group owns its own cursor. This works well for a board with a small fixed set of columns.
+
+If column counts are required, the API also needs a count or facets operation that applies the
+same base filters.
+
+#### Arbitrary tag groups
+
+For `group by customer`, the frontend may not know all values in advance. It first needs facets:
+
+```json
+{
+  "field": {"tag": "customer"},
+  "base_filter": {
+    "include_archived": false
+  }
+}
+```
+
+Conceptual response:
+
+```json
+{
+  "facets": [
+    {"value": "acme", "count": 42},
+    {"value": "globex", "count": 17},
+    {"value": null, "count": 8}
+  ]
+}
+```
+
+The frontend can then query each selected group through `/sessions/query`, with an independent
+cursor per group.
+
+A single endpoint that returns every group and every group's rows would need nested pagination
+cursors and is unnecessary for the first iteration.
+
+### A.10 Indexing impact
+
+Origin alone may not justify a new tags index at current cardinality. A product feature offering
+arbitrary tag filtering and grouping changes the expected query load.
+
+Before shipping generic tag filtering:
+
+- Define bounded tag key and value types.
+- Measure representative project cardinality.
+- Inspect containment and facet query plans.
+- Add the appropriate GIN index for containment queries when needed.
+- Consider targeted expression indexes for a very hot standardized field such as work status.
+
+An index supports a query shape; it should follow the documented filter and grouping contract.
+
+### A.11 Effect on the provenance decision
+
+This future story does not require a dedicated provenance table.
+
+It strengthens four short-term requirements:
+
+1. Origin writes must merge instead of replacing tags.
+2. Reserved namespaces need enforced ownership.
+3. Session tag values need bounded public types.
+4. The response must distinguish public tags from private storage markers.
+
+It also clarifies why the API should not choose between `all typed fields` and `all raw tags`.
+
+The durable interface is hybrid:
+
+```text
+Generic labels       -> public tags interface
+Stable domain fields -> typed origin and work_status interfaces
+Physical storage     -> may use one JSONB tags column initially
+```
+
+This gives users open-ended organization without making every caller understand Agenta's internal
+tag keys.
+
+### A.12 Decisions for future tag implementation
+
+1. Is work status an Agenta-defined vocabulary or an arbitrary custom tag?
+2. Can agents change work status and user tags, or only human users?
+3. Are Agenta-created public tags visible in the same map as user-created tags?
+4. Which tag keys are reserved, and how does the API report a rejected reserved-key write?
+5. Does the first grouping UI use fixed work-status columns or arbitrary tag keys?
+6. Are facet counts required, and must they be exact?
+7. What are the maximum number of tags, key length, value length, and allowed value types?
+
+### A.13 Usage, cost, and models
+
+Future session rows may also show:
+
+- Total input and output tokens.
+- Total cost.
+- The model or models used in the session.
+
+These values do not have the same semantic role as tags.
+
+| Information | Role | Source of truth | Suitable session representation |
+| --- | --- | --- | --- |
+| Token counts | Numeric usage aggregate | Per-turn usage records or traces | Typed summary field |
+| Cost | Numeric monetary aggregate | Per-turn usage/cost records | Typed summary field |
+| Model used | Execution/configuration identity | Turn, trace, or effective run configuration | Typed model list or summary |
+| `customer=acme` | Classification label | Session tags | Generic tag |
+
+#### Tokens and cost are not tags
+
+Tags are designed for label equality and containment:
+
+```json
+{"customer": "acme", "priority": "high"}
+```
+
+Token and cost queries need numeric semantics:
+
+```text
+total_tokens > 100000
+total_cost between 1.00 and 10.00
+sum cost by project
+order sessions by cost
+```
+
+Encoding numeric values as tags would lose numeric ordering and aggregation semantics. It would
+also produce high-cardinality GIN entries that change after every turn.
+
+Meta can hold a usage snapshot, but meta is not a good authoritative query surface. A snapshot can
+be useful for debugging or compatibility, but consumers should not parse an arbitrary meta path to
+calculate billing or sort sessions.
+
+The public response should use typed fields, for example:
+
+```json
+{
+  "session_id": "session-a",
+  "usage": {
+    "input_tokens": 12400,
+    "output_tokens": 3100,
+    "total_tokens": 15500,
+    "cost": {
+      "amount": "0.0842",
+      "currency": "USD"
+    }
+  }
+}
+```
+
+Money should not use a binary floating-point value. The contract should use a decimal string or
+minor units, include currency, and state whether the value is estimated or charged.
+
+#### A session may use several models
+
+A session can contain several turns. Different turns may use different workflow revisions or model
+configurations. One turn may also call more than one model.
+
+A singular field such as:
+
+```json
+{"model": "gpt-5"}
+```
+
+is ambiguous unless the product defines it as one of:
+
+- Model used by the latest turn.
+- Primary model configured for the latest workflow revision.
+- Model responsible for most token usage.
+- Only model used across the entire session.
+
+A safer summary is explicit:
+
+```json
+{
+  "models": [
+    {
+      "provider": "openai",
+      "model": "gpt-5",
+      "input_tokens": 12000,
+      "output_tokens": 3000
+    },
+    {
+      "provider": "openai",
+      "model": "text-embedding-3-small",
+      "input_tokens": 400,
+      "output_tokens": 0
+    }
+  ],
+  "latest_model": {
+    "provider": "openai",
+    "model": "gpt-5"
+  }
+}
+```
+
+The interface should include only the summary the UI actually uses. A model breakdown can remain
+an expansion or details endpoint until the product needs it.
+
+#### Read-time expansion versus materialized summary
+
+Usage, cost, and model information can follow the same two designs as last-message previews.
+
+Query-time expansion:
+
+```json
+{
+  "expand": ["usage", "models"]
+}
+```
+
+The API aggregates records or traces for only the sessions in the current page. This avoids
+duplicating state but adds cross-domain query cost.
+
+Materialized summary:
+
+```text
+session_usage_summary
+  input_tokens
+  output_tokens
+  total_tokens
+  cost_amount
+  cost_currency
+  latest_model
+  models_used
+  updated_at
+```
+
+This makes list sorting, filtering, and grouping cheaper, but it is an eventually consistent read
+model. Usage records remain the source of truth.
+
+Choose based on the user story:
+
+- Display usage on a small page: query-time expansion may be enough.
+- Sort or filter every session by cost/tokens: materialize indexed numeric fields.
+- Aggregate billing: use the authoritative usage/billing domain, not session tags or previews.
+- Group by model: define model identity and multi-model grouping semantics first, then use a typed
+  model filter or a deliberately maintained projection.
+
+#### Can model identity also be a tag?
+
+A model label can be denormalized into a tag for a narrow equality filter, but only after defining
+which model the tag represents. For example, `ag.latest_model` and `ag.models_used` have different
+meanings and cardinality.
+
+If the public API offers `models`, callers should filter through a typed model field. The backend
+may compile that filter to an indexed projection or tags internally. Callers should not need to
+know the projection key.
+
+#### Effect on the interface decision
+
+This story strengthens the hybrid design:
+
+```text
+Tags                  -> categorical labels
+Meta                  -> rich non-queryable context and snapshots
+Typed session summary -> usage, cost, model summaries, work status, origin
+Records and traces    -> per-execution source of truth
+```
+
+It does not justify putting every summary directly on the stored session stream. It justifies a
+clear public session-summary interface whose fields may be read-time expansions or materialized
+projections depending on measured query needs.

--- a/docs/design/session-ux-interface/README.md
+++ b/docs/design/session-ux-interface/README.md
@@ -1,0 +1,39 @@
+# Session UX interface redesign
+
+This workspace records the completed revision of the session-list interfaces introduced by the
+v0.112 sessions UX stack.
+
+## Reading order
+
+1. [`context.md`](context.md) explains the user experience, goals, decisions, and non-goals.
+2. [`implementation.md`](implementation.md) gives reviewers a concise code and runtime handoff.
+3. [`qa-handoff.md`](qa-handoff.md) records verification evidence and remaining QA work.
+4. [`research.md`](research.md) compares the proposed design with PR #5767 and records costs and
+   regression risks.
+5. [`plan.md`](plan.md) records the implementation phases, files, tests, and rollout order.
+6. [`status.md`](status.md) records the implementation outcome and residual verification work.
+
+The detailed interface review remains at
+[`../session-ux-interface-review.md`](../session-ux-interface-review.md).
+
+## Terms
+
+- **Session:** The conversation or work container shown in session lists.
+- **Turn:** One agent execution inside a session.
+- **Automation:** A schedule or event subscription that invokes an agent.
+- **Delivery:** The audit record for one automation firing. Every successful claim has a unique
+  delivery ID.
+- **Origin:** Who or what created a session. The current automated value is `trigger`; an absent
+  value means unknown, not manual.
+- **Expansion:** Optional response data that the caller requests because it costs another lookup,
+  such as a message preview or current automation name.
+- **Session attribution:** The stable relationship from a session to its origin, automation, and
+  exact delivery.
+
+## Implementation record
+
+Implementation started from GitButler target `origin/release/v0.112.0` at `965851e15d`. No stacks
+were applied at the start.
+
+The implementation is complete and organized as a stacked review set. See `implementation.md` for
+the review split and `qa-handoff.md` for verification evidence and residual risks.

--- a/docs/design/session-ux-interface/context.md
+++ b/docs/design/session-ux-interface/context.md
@@ -1,0 +1,108 @@
+# Context
+
+## User experience
+
+The new Home and Sessions surfaces organize sessions as daily work. They separate sessions started
+by a person from sessions started by an automation, show useful row context, and let users reopen a
+session.
+
+The initial implementation added the required backend capability in PR #5767 and consumed it in
+the frontend package stack beginning with PR #5769. It exposed storage keys, enriched every list
+with transcript data, and did not retain the exact delivery relationship needed for historical
+inspection. The completed revision replaces those interfaces with typed queries, expansions,
+attribution, and row actions.
+
+## Goals
+
+1. Keep every trigger firing as a distinct session.
+2. Let the API return all origins unless the caller filters them.
+3. Let each frontend surface choose whether to show automation sessions.
+4. Expose typed session origin, automation, and delivery relationships.
+5. Keep JSONB tags as the initial private storage mechanism.
+6. Show the current automation name and its schedule/subscription kind.
+7. Keep the primary row action opening the session.
+8. Add secondary actions for the automation configuration and exact delivery.
+9. Preserve automation configurations and deliveries after deletion.
+10. Load message previews only on Home and dedicated Sessions pages.
+11. Follow the repository's resource-nested query shape and cursor response conventions.
+12. Avoid data migrations and unnecessary database schema changes before production.
+
+## Confirmed product decisions
+
+| Question | Decision |
+| --- | --- |
+| Which automation name appears? | The current automation name, resolved from the configuration. |
+| What does a row click do? | It opens the session. |
+| What additional actions exist? | Open automation configuration and view exact delivery. |
+| Is automation kind visible? | Yes. The row distinguishes schedule from subscription. |
+| Does each firing create a session? | Yes. Each claimed firing receives a fresh session ID. |
+| Where are previews shown? | Home and project/agent Sessions pages only. |
+| What does an unfiltered API query return? | All origins. Frontends opt into exclusions. |
+| What happens after automation deletion? | Normal deletion soft-deletes the configuration and preserves delivery history. Authenticated exact-by-ID reads include the deleted configuration as read-only. |
+| Is trigger name snapshotted? | No. Resolve the current name. |
+| Does this work use session meta? | No. |
+
+## Storage decision
+
+The first implementation stores stable attribution values in the existing session tags JSONB
+column. The storage adapter owns the reserved keys.
+
+```json
+{
+  "ag.origin": "trigger",
+  "ag.trigger.id": "019d952f-0000-0000-0000-000000000000",
+  "ag.trigger.kind": "schedule",
+  "ag.trigger.delivery_id": "019d952f-0000-0000-0000-000000000001"
+}
+```
+
+The public response exposes typed fields instead of these keys.
+
+The attribution write merges reserved keys into existing tags. It never replaces the complete
+tags object.
+
+## Why meta is not used
+
+PR #5767 used a name snapshot to avoid resolving the automation. The confirmed product behavior
+requires the current name instead, so a stored name snapshot would be stale after a rename.
+
+No other field in this scope needs a rich non-queryable document:
+
+- IDs and kind are compact filterable attribution values.
+- Delivery details remain on the delivery resource.
+- Usage, cost, and models are future typed summaries.
+- Generic user tags are a future public tag capability.
+
+Using meta would add a second storage convention without serving a current requirement.
+
+## Public interface boundary
+
+The public interface is hybrid:
+
+- Stable domain concepts use typed fields, such as origin, trigger kind, and delivery ID.
+- Generic user labels will use a public tags interface in future work.
+- The backend may store typed fields in tags initially.
+- Frontends never need to know reserved storage keys.
+
+The API sanitizer removes reserved attribution keys from public `tags` maps. Typed origin, trigger,
+and delivery fields remain available. Exact authenticated schedule and subscription reads include
+soft-deleted configurations for historical display. Normal lists and mutations remain live-only.
+
+## Deferred risk
+
+Normal automation deletion preserves configuration and delivery history. Hard deletion of a
+gateway connection can still cascade through subscriptions and deliveries. That path is outside
+the direct automation-deletion scope and remains a deferred history-retention risk.
+
+## Non-goals
+
+- Generic tag editing, filtering, grouping, or facets.
+- Work-status implementation.
+- Token, cost, or model summaries.
+- A provenance table or new attribution columns.
+- A workflow-run table.
+- Trigger-name snapshots.
+- Provider event, run, or trace IDs on session rows.
+- Message previews on sidebar, agent overview, mobile, reconciliation, or internal callers.
+- Changing duplicate-delivery idempotency.
+- Changing the primary row action.

--- a/docs/design/session-ux-interface/implementation.md
+++ b/docs/design/session-ux-interface/implementation.md
@@ -38,8 +38,15 @@ not store a trigger-name snapshot or session meta.
 cursor windowing. It returns typed `origin`, `trigger`, `delivery`, `last_message`, and `windowing`
 fields.
 
-The API adapter removes reserved `ag.*` attribution keys from every public session `tags` map.
-Frontend code reads typed relationships only.
+The endpoint enforces: a windowing `limit` between 1 and 200, returning 422 outside that range; 422
+when a cursor is supplied without its companion bound; and 422 when a request both includes and
+excludes the same origin. A session with no recorded origin reports `origin: "manual"`, and origin
+filters treat a missing value the same way. Message previews are truncated to 240 characters
+server-side; the generated clients carry no length constraint on that field, since the client
+generator maps no string-length rules for this project.
+
+The API adapter reserves the entire `ag.` tag prefix and removes every key in that namespace from
+public session `tags` maps. Frontend code reads typed relationships only.
 
 Message previews and current trigger names are optional expansions:
 
@@ -53,8 +60,10 @@ Normal schedule and subscription deletion now uses lifecycle soft deletion. Norm
 mutations, dispatch, and provider lookup remain live-only. Authenticated exact-by-ID reads can
 retrieve a deleted configuration for historical display, and delivery history remains available.
 
-Hard deletion of a gateway connection can still cascade through subscription and delivery
-history. That broader operation is deferred.
+Hard deletion of a gateway connection cascades through its subscriptions' history: their
+tombstones and delivery records are removed with the connection. History for a subscription
+survives only while its connection exists. This is accepted product behavior for this release, not
+a planned follow-up.
 
 ## Frontend behavior
 
@@ -67,13 +76,32 @@ policy:
 | Home automation sessions | Trigger only | `last_message`, `trigger` |
 | Sessions default mode | Exclude trigger | `last_message` |
 | Sessions automation mode | Trigger only | `last_message`, `trigger` |
+| Agent overview automation | Trigger only | `trigger` |
 | Sidebar | Exclude trigger | None |
 | Mobile | Preserve its explicit existing policy | None |
 | Internal callers | All origins unless specified | None |
 
+Agent overview automation requests the `trigger` expansion so it can resolve the current schedule
+or subscription name, but it does not request `last_message`.
+
+A separate `sidebarPinned` policy applies only to pinned-session queries: it always uses origin
+`all`, regardless of the surface's own origin policy, so a pinned automation session stays visible
+in the sidebar instead of being filtered out.
+
 Clicking a row still opens the session. Automation rows add `Open automation` and `View delivery`
 secondary actions. Exact delivery mode fetches one delivery by ID and does not start the owner-wide
 delivery list query.
+
+## Known behavior
+
+The session list sorts by last activity and pages with a keyset cursor built from that ordering.
+When a session's activity changes while a caller is paging past its old position, the session can
+move across the cursor boundary and be skipped for that scroll pass. The gap is temporary: the
+session reappears on the next list refresh. This is accepted behavior for this release.
+
+The agent roster's "last active" value counts every session, including automation-created ones. A
+schedule or subscription firing on an agent with no human activity marks that agent as recently
+active. This is a declared product choice, not an oversight.
 
 ## Review stack
 

--- a/docs/design/session-ux-interface/implementation.md
+++ b/docs/design/session-ux-interface/implementation.md
@@ -1,0 +1,88 @@
+# Implementation handoff
+
+Date: 2026-08-11
+
+## Outcome
+
+The session UX now separates human-started and automation-started sessions without exposing
+private storage keys to frontend callers. Automation rows can show the current schedule or
+subscription name, identify the automation kind, and open the exact delivery that created the
+session.
+
+The implementation uses the existing session tags and trigger lifecycle columns. It adds no data
+migration, backfill, or database index.
+
+## Runtime flow
+
+For each trigger firing, the dispatcher generates one delivery ID and one session ID. A single
+Postgres transaction claims the delivery and creates or updates the attributed session. A failed
+claim or attribution rolls back both writes and invokes no workflow.
+
+The session stores private attribution values in reserved tags:
+
+```json
+{
+  "ag.origin": "trigger",
+  "ag.trigger.id": "019d952f-0000-0000-0000-000000000000",
+  "ag.trigger.kind": "schedule",
+  "ag.trigger.delivery_id": "019d952f-0000-0000-0000-000000000001"
+}
+```
+
+The write merges these keys into the existing tags object. It does not replace user tags and does
+not store a trigger-name snapshot or session meta.
+
+## Public contract
+
+`POST /sessions/query` accepts resource-nested predicates, exclusions, optional expansions, and
+cursor windowing. It returns typed `origin`, `trigger`, `delivery`, `last_message`, and `windowing`
+fields.
+
+The API adapter removes reserved `ag.*` attribution keys from every public session `tags` map.
+Frontend code reads typed relationships only.
+
+Message previews and current trigger names are optional expansions:
+
+- Home and Sessions request message previews.
+- Automation modes also request current trigger details.
+- Sidebar, agent overview, mobile, and internal callers do not request previews.
+
+## History behavior
+
+Normal schedule and subscription deletion now uses lifecycle soft deletion. Normal lists,
+mutations, dispatch, and provider lookup remain live-only. Authenticated exact-by-ID reads can
+retrieve a deleted configuration for historical display, and delivery history remains available.
+
+Hard deletion of a gateway connection can still cascade through subscription and delivery
+history. That broader operation is deferred.
+
+## Frontend behavior
+
+The API returns all origins when no origin predicate is present. Each frontend surface sets its own
+policy:
+
+| Surface | Policy | Expansions |
+| --- | --- | --- |
+| Home human sessions | Exclude trigger | `last_message` |
+| Home automation sessions | Trigger only | `last_message`, `trigger` |
+| Sessions default mode | Exclude trigger | `last_message` |
+| Sessions automation mode | Trigger only | `last_message`, `trigger` |
+| Sidebar | Exclude trigger | None |
+| Mobile | Preserve its explicit existing policy | None |
+| Internal callers | All origins unless specified | None |
+
+Clicking a row still opens the session. Automation rows add `Open automation` and `View delivery`
+secondary actions. Exact delivery mode fetches one delivery by ID and does not start the owner-wide
+delivery list query.
+
+## Review stack
+
+The implementation is split from `origin/release/v0.112.0` in dependency order:
+
+1. API attribution, lifecycle, query, expansion, and sanitization.
+2. Generated Python and TypeScript clients plus their consuming UV lockfiles.
+3. Session entity contracts, frontend list policies, row models, actions, and historical drawers.
+4. Design record and QA handoff.
+
+See [`qa-handoff.md`](qa-handoff.md) for verification evidence and remaining checks. See
+[`plan.md`](plan.md) for the detailed file and behavior map.

--- a/docs/design/session-ux-interface/plan.md
+++ b/docs/design/session-ux-interface/plan.md
@@ -1,0 +1,811 @@
+# Session UX interface implementation plan
+
+Status: implemented, with residual verification listed in `status.md`.
+
+Phases 1 through 9 are complete. The representative performance benchmark in Phase 10 was not run,
+and no index was added. Phase 11 completed automated API, Postgres, generated-client, and frontend
+checks. Browser QA and subscription live acceptance remain incomplete for the reasons recorded in
+`status.md`.
+
+## Outcome
+
+The revision gives callers a stable typed contract, lets users inspect the exact automation
+delivery behind a session, and runs expensive enrichments only where the UI displays them.
+
+The implementation keeps existing JSONB and lifecycle columns. It requires no data backfill and no
+mandatory database schema migration.
+
+## Change summary
+
+| Area | Change | Reason |
+| --- | --- | --- |
+| Attribution storage | Merge origin, trigger ID/kind, and delivery ID into JSONB tags | Preserve existing and future user tags without adding columns |
+| Trigger name | Resolve current name through an optional API expansion | Confirmed product behavior; avoids stale snapshots and meta |
+| Delivery history | Soft-delete configurations and retain deliveries | Sessions must open the exact historical delivery |
+| Session query | Add resource-nested filters and typed response fields | Match repository conventions and hide storage keys |
+| Origin default | Return all origins when no filter is supplied | Keep API neutral; frontend owns presentation policy |
+| Pagination | Return `next` and `newest` | Stop clients rebuilding an internal cursor |
+| Message preview | Make it an optional expansion | Avoid records queries on callers that do not display previews |
+| Row actions | Keep session open as primary; add configuration and delivery actions | Preserve current behavior while exposing history |
+| Meta | Do not use it | No current requirement needs a rich non-queryable snapshot |
+
+## Data and performance impact
+
+### Data migration
+
+There is no data migration or backfill.
+
+The feature is pre-production. Tests create new attributed sessions through the revised write path.
+The implementation does not attempt to repair rows created by earlier branches.
+
+If the v0.112 branch creates test sessions before the revised writer lands, those rows may lack an
+exact delivery ID. The typed response returns `delivery: null`, and the frontend hides `View
+delivery` for those rows. Treat that data as disposable pre-production data; do not add a repair
+path.
+
+Do not release the session UX to production between the #5827 merge and the revised attribution
+writer. The production release unit must include the writer before users can create durable
+automation sessions.
+
+### Database schema
+
+No mandatory database schema migration is planned.
+
+The existing schema already provides:
+
+- JSONB `session_streams.tags`.
+- JSON `trigger_deliveries.data`.
+- Lifecycle fields on trigger subscriptions and schedules.
+- Exact delivery IDs and retrieval.
+
+The implementation changes application behavior and query predicates, not columns or constraints.
+
+Indexes are a measured follow-up. Do not add a migration for an index until a representative query
+plan demonstrates the need.
+
+### Frontend network requests
+
+The session-list request count does not increase compared with PR #5767.
+
+- Current automation names are hydrated by the sessions API when requested.
+- The frontend does not issue one trigger request per row.
+- The delivery endpoint is called once after the user selects `View delivery`.
+- Opening an automation uses the existing trigger entity/drawer fetch and cache.
+
+### Backend queries
+
+PR #5767 always queries streams, latest turns, and latest messages.
+
+The revised implementation runs only requested enrichments:
+
+| Surface | Message expansion | Current automation expansion |
+| --- | ---: | ---: |
+| Home human sessions | Yes | No |
+| Home automation sessions | Yes | Yes |
+| Project Sessions default mode | Yes | No |
+| Project Sessions automation mode | Yes | Yes |
+| Agent-scoped Sessions default mode | Yes | No |
+| Agent-scoped Sessions automation mode | Yes | Yes |
+| Sidebar | No | No |
+| Agent overview | No | No |
+| Mobile | No | No |
+| Internal/reconciliation callers | No | No |
+
+Current automation hydration uses a conditional read-model join from session streams to schedules
+and subscriptions. It adds no database roundtrip and no frontend request. The join runs only when
+the caller requests the trigger expansion.
+
+Home cards may mount waiting, pinned, and recent queries. The Sessions page may mount pinned and
+recent queries. Performance verification must measure the complete group pattern, not one isolated
+request.
+
+Worst-case request totals (waiting and pinned groups both present, no total count):
+
+| Surface | HTTP requests | SQL roundtrips | PR #5767 SQL roundtrips |
+| --- | ---: | ---: | ---: |
+| Home human + automation cards | 7 | 19 | 19 |
+| Project Sessions | 3 | 7 | 7 |
+| Agent-scoped Sessions | 3 | 9 | 9 |
+| Sidebar pinned + recent | 2 | 4 | 6 |
+
+Home and Sessions totals include one shared actionable-interactions request. The conditional trigger
+join does not add a roundtrip.
+
+## Target interface
+
+### Request
+
+```json
+{
+  "session": {
+    "search": "refund",
+    "liveness": {
+      "is_alive": true
+    },
+    "origins": ["trigger"]
+  },
+  "session_ids": ["session-a"],
+  "turn_references": [
+    {"id": "019d952f-0000-0000-0000-000000000000"}
+  ],
+  "exclude": {
+    "session_ids": ["session-pinned"],
+    "origins": ["trigger"]
+  },
+  "include_ended": true,
+  "include_archived": false,
+  "include_total": false,
+  "expand": ["last_message", "trigger"],
+  "windowing": {
+    "limit": 30,
+    "next": "...",
+    "newest": "2026-08-10T12:03:14Z"
+  }
+}
+```
+
+### Request semantics
+
+- Missing origin filters return every origin.
+- `session.origins=["trigger"]` selects attributed automation sessions.
+- `exclude.origins=["trigger"]` excludes attributed automation sessions and preserves unknown
+  rows.
+- Missing attribution means unknown. It does not mean manual.
+- Positive predicates intersect.
+- Exclusions apply before ordering and pagination.
+- An explicit empty inclusion ID list matches nothing.
+- Each inclusion or exclusion ID set accepts at most 500 validated session IDs.
+- `include_total` changes response work, not row membership.
+- `expand` selects optional response work.
+
+### Response
+
+```json
+{
+  "count": 1,
+  "sessions": [
+    {
+      "id": "019d952f-0000-0000-0000-000000000010",
+      "session_id": "session-a",
+      "name": null,
+      "origin": "trigger",
+      "trigger": {
+        "id": "019d952f-0000-0000-0000-000000000000",
+        "kind": "schedule",
+        "name": "Nightly digest"
+      },
+      "delivery": {
+        "id": "019d952f-0000-0000-0000-000000000001"
+      },
+      "references": [{"id": "019d952f-0000-0000-0000-000000000020"}],
+      "last_message": {
+        "text": "Digest delivered.",
+        "source": "agent",
+        "timestamp": "2026-08-10T12:03:14Z"
+      }
+    }
+  ],
+  "windowing": {
+    "next": "019d952f-0000-0000-0000-000000000010",
+    "newest": "2026-08-10T12:03:14Z",
+    "limit": 30
+  }
+}
+```
+
+`trigger.name` appears only when the caller requests the trigger expansion and the current
+configuration can be resolved. The typed trigger and delivery IDs remain available without the
+name.
+
+## Phase 1: Update planning sources
+
+### Work
+
+1. Replace the open product questions in `../session-ux-interface-review.md` with the confirmed
+   decisions in `context.md`.
+2. Correct the previous statement that delivery IDs are unnecessary on session rows.
+3. Record that deleted automation history is preserved.
+4. Record that current names replace snapshots.
+5. Record that this implementation uses no meta.
+
+### Reason
+
+The implementation plan and research document must describe one contract. Leaving old questions
+open would send implementers toward incompatible choices.
+
+## Phase 2: Make attribution merge-safe and delivery-aware
+
+### Work
+
+1. Define typed core values for:
+   - Session origin.
+   - Trigger kind (`schedule` or `subscription`).
+   - Trigger configuration ID.
+   - Delivery ID.
+2. Introduce a narrow transactional delivery/session-claim interface for trigger dispatch.
+3. Keep reserved tag keys inside the sessions persistence adapter.
+4. Replace whole-object tag writes with an atomic JSONB merge of owned keys.
+5. Store:
+
+   ```json
+   {
+     "ag.origin": "trigger",
+     "ag.trigger.id": "...",
+     "ag.trigger.kind": "schedule",
+     "ag.trigger.delivery_id": "..."
+   }
+   ```
+
+6. Stop writing `ag.trigger.name`.
+7. Do not write session meta.
+
+### Dispatch sequence
+
+1. Resolve the schedule/subscription and delivery event identity.
+2. Generate delivery and session IDs.
+3. In one Postgres transaction, atomically claim the delivery with `data.session_id` and create or
+   merge the attributed session stream.
+4. Commit both rows together. If the event conflict loses or attribution fails, roll back both.
+5. Stop when another worker already claimed the event. The unused generated IDs have no persisted
+   effect.
+6. Validate references and map inputs.
+7. Invoke the workflow with the same session ID.
+8. Complete the delivery by merging result/error data without removing `session_id`.
+
+The delivery and session tables use the same transactional Postgres engine. One unit-of-work
+adapter preserves the invariant without a schema change or committed intermediate state. Including
+`session_id` in the initial claim also avoids an additional database update compared with PR #5767.
+
+### Failure behavior
+
+- A failed atomic claim creates no session and invokes nothing.
+- A failed attribution rolls back the delivery claim, creates no session, and invokes nothing.
+- A validation failure keeps the attributed session, completes the claimed delivery as failed,
+  and invokes nothing.
+- An invocation failure keeps the attributed session and failed delivery for inspection.
+- Duplicate provider delivery remains idempotent.
+
+### Primary files
+
+- `api/oss/src/core/sessions/dtos.py`
+- `api/oss/src/core/sessions/streams/interfaces.py`
+- `api/oss/src/core/sessions/streams/service.py`
+- `api/oss/src/dbs/postgres/sessions/streams/dao.py`
+- `api/oss/src/tasks/asyncio/triggers/dispatcher.py`
+- `api/oss/src/core/triggers/dtos.py`
+- `api/oss/src/core/triggers/interfaces.py`
+- `api/oss/src/dbs/postgres/triggers/dao.py`
+- `api/entrypoints/routers.py`
+- `api/entrypoints/worker_queues.py`
+
+### Tests
+
+- The delivery claim, session attribution, and workflow request use the same session ID.
+- The attribution stores the exact delivery ID.
+- Different event IDs create different sessions.
+- Duplicate event claims create no second session.
+- Schedule and subscription kinds are correct.
+- Existing custom tags survive attribution.
+- A concurrent heartbeat does not erase attribution or liveness.
+- No name or meta is written.
+- Completion preserves the claimed `session_id`.
+- Attribution failure rolls back both delivery and session writes and permits a safe retry.
+- A validation failure still leaves one attributed session linked to its failed delivery.
+
+### Integration coverage
+
+Add real-Postgres integration tests for the two behaviors fake DAOs cannot prove:
+
+- Concurrent heartbeat and attribution SQL preserve flags and tags without a lost update.
+- Normal automation deletion retains configuration and delivery rows through the real foreign-key
+  graph.
+
+## Phase 3: Preserve deleted automation history
+
+### Work
+
+1. Change schedule deletion from physical deletion to lifecycle soft deletion.
+2. Change subscription deletion from physical deletion to lifecycle soft deletion after provider
+   cleanup.
+3. Add `deleted_at IS NULL` to normal schedule and subscription list queries.
+4. Exclude deleted configurations from dispatch and provider-trigger lookup paths.
+5. Reject edits and activation changes on deleted configurations.
+6. Allow authenticated exact-by-ID retrieval of a deleted configuration for historical display.
+7. Preserve physical purge as an explicit administrative/test operation, not normal deletion.
+8. Keep delivery rows unchanged and retrievable.
+9. Change the temporary `test_subscription(... finally: delete_subscription(...))` cleanup path to
+   use a service-level test cleanup operation. That operation deletes the provider-side trigger
+   first, then physically purges the local test configuration and deliveries.
+10. Re-resolve schedules from live persistence when queued work executes. Do not trust a serialized
+    schedule after it may have been deleted or disabled. Accept the existing queued payload shape
+    during the v0.112 rollout.
+
+### Schema impact
+
+None. Trigger subscriptions and schedules already inherit `LifecycleDBA` and already have
+`deleted_at` indexes.
+
+### Reason
+
+Current DAO deletion calls `session.delete()`. Delivery foreign keys use `ON DELETE CASCADE`, so
+physical deletion removes the delivery that a session needs to inspect. Soft deletion preserves
+the existing foreign-key graph.
+
+### Primary files
+
+- `api/oss/src/core/triggers/service.py`
+- `api/oss/src/core/triggers/interfaces.py`
+- `api/oss/src/dbs/postgres/triggers/dao.py`
+- `api/oss/src/apis/fastapi/triggers/models.py`
+- `api/oss/src/apis/fastapi/triggers/router.py`
+- `api/oss/src/tasks/taskiq/triggers/worker.py`
+
+### Tests
+
+- Normal deletion sets lifecycle fields and retains the row.
+- Provider-side subscription cleanup still runs.
+- Normal list and dispatch queries exclude deleted configurations.
+- Exact historical retrieval can read a deleted configuration.
+- Delivery retrieval still works after configuration deletion.
+- Deleted schedules cannot fire.
+- Deleted subscriptions cannot process provider events.
+- Temporary subscription tests physically purge their test configuration and deliveries.
+- Temporary subscription cleanup removes the provider trigger before local purge.
+- A real-Postgres integration test proves normal deletion does not activate delivery cascades.
+
+## Phase 4: Revise the sessions query contract
+
+### Work
+
+1. Add API request models for:
+   - Nested `session` predicates.
+   - `exclude` predicates.
+   - `expand` options.
+   - Typed plural origins.
+2. Keep existing flat fields as compatibility inputs for already released session clients.
+3. Normalize both shapes in `apis/fastapi/sessions/utils.py`.
+4. Reject contradictory duplicate values with a 422 response.
+5. Separate row predicates from lifecycle, response options, and pagination.
+6. Bound and validate session-ID lists.
+7. Resolve turn references once and reuse the ID set for page and total.
+8. Decode private attribution tags into typed response fields.
+9. Keep reserved attribution keys in the legacy raw `tags` response during the API/client
+   transition so the existing #5769 frontend continues to work.
+10. Prepare one API-boundary sanitizer that removes reserved keys while preserving non-reserved
+   user-visible tags. Enable it only in the final cleanup phase after all frontend reads are typed.
+11. Audit plain stream fetch/query responses as well as root session-list responses so the final
+   cleanup covers every public session endpoint.
+12. Keep an empty request neutral about origin.
+13. Return response windowing with `next` and `newest`.
+14. Keep `include_total` outside the core predicate DTO.
+
+### Compatibility policy
+
+The endpoint predates PR #5767. Do not break existing references, search, lifecycle, or windowing
+callers.
+
+During the v0.112 stack rollout:
+
+- Backend accepts old and new shapes.
+- New frontend sends the new shape.
+- Response additions remain optional and additive.
+- Generated clients replace the temporary type widening.
+
+### Primary files
+
+- `api/oss/src/apis/fastapi/sessions/models.py`
+- `api/oss/src/apis/fastapi/sessions/router.py`
+- `api/oss/src/apis/fastapi/sessions/utils.py` (new)
+- `api/oss/src/core/sessions/dtos.py`
+- `api/oss/src/core/sessions/service.py`
+- `api/oss/src/core/sessions/streams/dtos.py`
+- `api/oss/src/core/sessions/streams/interfaces.py`
+- `api/oss/src/core/sessions/streams/service.py`
+- `api/oss/src/dbs/postgres/sessions/streams/dao.py`
+- `api/oss/src/apis/fastapi/shared/utils.py`
+
+### Tests
+
+- Empty request returns trigger and unknown-origin sessions.
+- Trigger inclusion and exclusion work before pagination.
+- Excluding trigger retains null/unstamped tags.
+- Existing flat payloads remain valid.
+- Nested and equivalent flat payloads produce the same predicate.
+- Contradictory fields fail validation.
+- Empty inclusion IDs match nothing.
+- Inclusion and reference filters intersect.
+- Exclusion values win on overlap.
+- ID list bounds are enforced.
+- Page and total share one reference resolution.
+- Returned cursor matches coalesced session activity ordering.
+- Typed attribution is present while legacy raw tags remain during compatibility.
+
+## Phase 5: Add optional response expansions
+
+### Last-message expansion
+
+1. Run the records query only for `expand=["last_message"]`.
+2. Remove `session_id` from the nested public preview.
+3. Fetch latest turns and messages concurrently after stream IDs are known.
+4. Catch records lookup failures and return the base list without previews.
+5. Preserve PR #5767 semantics: select the newest message and omit the preview when that message
+   has no text.
+
+### Current-trigger expansion
+
+1. Add `expand=["trigger"]`.
+2. Extend the existing `SessionStreamsDAOInterface.query()` with a typed
+   `include_trigger_details` read option and return a typed stream-list projection.
+3. Keep query ownership in `dbs/postgres/sessions/streams/dao.py`. Implement conditional left joins
+   to schedules and subscriptions by project, kind, and ID in the same stream statement.
+4. Include soft-deleted configurations in this historical join so their last persisted name
+   remains available.
+5. Skip both trigger-table joins when the expansion is absent.
+6. Include the current or last persisted name in the typed trigger response.
+7. Include typed trigger ID/kind and delivery ID even when name lookup fails.
+8. Return a null name only when the referenced configuration is genuinely missing.
+9. Compare the UUID columns as text to the reserved tag values. A malformed legacy trigger ID
+   produces no PostgreSQL cast error and yields `trigger: null`; it is not actionable. Parse
+   delivery ID independently, yielding `delivery: null` when malformed.
+10. Treat a database failure in the joined stream statement like any stream-query failure. Only
+    records hydration is best effort because it uses a separate analytics database.
+
+### Reason
+
+This design avoids additional frontend list-time requests and database roundtrips. It adds indexed
+join work only when the caller asks for the current automation name.
+
+### Primary files
+
+- `api/oss/src/core/sessions/service.py`
+- `api/oss/src/core/sessions/records/dtos.py`
+- `api/oss/src/core/sessions/records/interfaces.py`
+- `api/oss/src/core/sessions/records/service.py`
+- `api/oss/src/dbs/postgres/sessions/records/dao.py`
+- `api/oss/src/core/sessions/streams/interfaces.py`
+- `api/oss/src/dbs/postgres/sessions/streams/dao.py`
+- `api/entrypoints/routers.py`
+
+### Tests
+
+- No expansion performs no records lookup or trigger-table join.
+- Message expansion makes one batch records call.
+- Trigger expansion remains one stream SQL roundtrip with conditional indexed joins.
+- Trigger rename is visible without changing the session.
+- Soft-deleted configurations retain their last persisted name.
+- A malformed trigger ID tag returns `trigger: null` without failing the query.
+- A database failure in the joined trigger stream query fails the request like any stream query and
+  does not issue fallback SQL.
+- Message expansion failure does not fail the list.
+
+## Phase 6: Regenerate clients and update entity contracts
+
+### Work
+
+1. Regenerate TypeScript and Python clients from the revised OpenAPI.
+2. Rebuild the generated TypeScript package.
+3. Remove the temporary Fern type assertion in `querySessions`.
+4. Add `querySessionsPage()` returning sessions, total, and windowing.
+5. Keep a temporary list-only wrapper for callers that do not need envelope fields.
+6. Extend the frontend Zod boundary with typed origin, trigger, delivery, preview, and windowing.
+7. Include expansions in query keys.
+8. Prefer response cursor data instead of reconstructing it from rows.
+9. Keep a temporary row-cursor fallback while old and new API versions can coexist.
+
+### Primary files
+
+- `web/packages/agenta-api-client/src/generated/`
+- `clients/python/agenta_client/`
+- `web/packages/agenta-sdk/src/resources.ts`
+- `web/packages/agenta-entities/src/session/api/api.ts`
+- `web/packages/agenta-entities/src/session/core/schema.ts`
+- `web/packages/agenta-entities/src/session/state/listOptions.ts`
+
+### Tests
+
+- The Fern client receives the nested request shape.
+- The response boundary accepts typed attribution.
+- Expansion values participate in query keys.
+- Returned windowing takes precedence over fallback reconstruction.
+- Old responses without typed fields degrade safely during rollout.
+
+## Phase 7: Update headless session policy
+
+### Work
+
+1. Remove direct reads of `ag.origin`, `ag.trigger.name`, and `ag.trigger.kind`.
+2. Build the row view model from typed attribution.
+3. Expose automation data:
+
+   ```ts
+   interface SessionAutomationVm {
+       id: string
+       kind: "schedule" | "subscription"
+       name: string | null
+        deliveryId: string | null
+   }
+   ```
+
+4. Preserve row-title precedence:
+   - Explicit session name.
+   - Current automation name.
+   - Message preview.
+   - Untitled session.
+5. Use fallback labels when the current name is unavailable:
+   - `Missing schedule`
+   - `Missing event subscription`
+6. Render automation kind independently from the name.
+7. Keep every trigger firing as a separate session.
+8. Add a caller-owned expansion parameter to `useSessionCardList` and `useSessionList`. Do not
+   infer preview policy inside a shared hook.
+9. Pass expansions explicitly from Home and Sessions composition call sites. Agent overview,
+   sidebar, mobile, and internal callers pass none.
+
+### Expansion policy
+
+- Home human sessions request `last_message`.
+- Home automation sessions request `last_message` and `trigger`.
+- Sessions default mode requests `last_message`.
+- Sessions automation mode requests `last_message` and `trigger`.
+- All other consumers request neither.
+
+### Primary files
+
+- `web/packages/agenta-sessions/src/row/sessionTrigger.ts`
+- `web/packages/agenta-sessions/src/row/sessionRowTitle.ts`
+- `web/packages/agenta-sessions/src/row/viewModel.ts`
+- `web/packages/agenta-sessions/src/state/useSessionList.ts`
+- `web/packages/agenta-sessions/src/state/useSessionCardList.ts`
+- `web/packages/agenta-sessions/src/state/useSessionsList.ts`
+- `web/oss/src/components/pages/agent-home/components/HomeSessionsSection.tsx`
+- `web/oss/src/components/pages/agent-home/components/HomeAutomationsSection.tsx`
+- `web/oss/src/components/pages/overview/agent/AgentOverview.tsx`
+- `web/oss/src/components/pages/sessions/SessionsPage.tsx`
+- `web/oss/src/components/Sidebar/dynamic/sessionsSource.ts`
+
+### Tests
+
+- Row models use typed fields and no reserved keys.
+- Current name appears after a rename.
+- Soft-deleted configurations keep their last persisted name.
+- Kind remains visible when name is absent.
+- Delivery ID reaches row actions.
+- Every call site requests only its approved expansions.
+- Default API behavior and frontend exclusion behavior remain separate.
+
+## Phase 8: Add configuration and delivery actions
+
+### Work
+
+1. Keep row body/title click opening the session.
+2. Add neutral secondary menu entries:
+   - `Open automation`
+   - `View delivery`
+3. Stop event propagation from secondary actions.
+4. Open the schedule or subscription drawer using typed kind and ID.
+5. Extend the delivery drawer state to focus one exact delivery ID.
+6. Add an exact-only drawer mode. In this mode, suppress the existing owner-scoped paginated
+   delivery-list query.
+7. Fetch exact delivery with `GET /triggers/deliveries/{delivery_id}` as the only delivery request.
+8. Show delivery ID, event ID, status, inputs, result/error, timestamps, and linked session.
+9. Hide or disable only the unavailable secondary action when IDs or permissions are missing.
+10. Keep the session action available without `VIEW_TRIGGERS`.
+
+### Package placement
+
+- Neutral row action contracts remain in `@agenta/sessions-ui`.
+- Trigger entity state and fetches remain in `@agenta/entities/gatewayTrigger`.
+- Trigger-specific drawers remain in `@agenta/entity-ui`.
+- App composition and routing remain in `web/oss`.
+
+### Primary files
+
+- `web/packages/agenta-sessions-ui/src/SessionRow.tsx`
+- `web/packages/agenta-entities/src/gatewayTrigger/api/api.ts`
+- `web/packages/agenta-entities/src/gatewayTrigger/state/`
+- `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerDeliveriesDrawer.tsx`
+- `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerScheduleDrawer.tsx`
+- `web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerSubscriptionDrawer.tsx`
+- `web/oss/src/components/pages/sessions/SessionsPage.tsx`
+- `web/oss/src/components/pages/sessions/components/SessionListCard.tsx`
+
+### Tests
+
+- Primary click opens the session.
+- Secondary actions do not open the session.
+- Correct configuration drawer opens for each kind.
+- Delivery fetch uses the exact ID and project scope.
+- Exact-only delivery mode does not mount the owner delivery-list query.
+- Deleted configuration does not block delivery inspection.
+- Missing trigger permission affects only trigger actions.
+
+## Phase 9: Apply explicit frontend origin policies
+
+### Policy matrix
+
+| Caller | Origin policy |
+| --- | --- |
+| Home human sessions | Exclude trigger |
+| Home automation sessions | Trigger only |
+| Sessions default mode | Exclude trigger |
+| Sessions automation mode | Trigger only |
+| Sidebar | Exclude trigger |
+| Agent overview | Explicitly choose based on its list purpose; no inherited default |
+| Mobile | Preserve its current product behavior explicitly |
+| Internal/reconciliation | All origins unless its specific job requires otherwise |
+
+### Work
+
+1. Remove any backend default exclusion.
+2. Require every list factory to pass or deliberately omit origin policy.
+3. Include origin policy in query keys.
+4. Add request-shape tests for each consumer class.
+5. After every frontend consumer reads typed attribution, enable the API sanitizer that removes
+   reserved attribution keys from all public session `tags` maps.
+6. Deploy the sanitizer atomically with the typed frontend or in a top stacked lane that includes
+   the frontend migration. Never deploy it before the frontend stops reading `ag.*`.
+7. Add final-cleanup tests proving typed attribution remains present while every public session
+   response omits reserved attribution keys.
+
+### Reason
+
+Origin filtering is presentation policy. A neutral API prevents one frontend's default from
+silently affecting another consumer.
+
+## Phase 10: Deferred performance benchmark
+
+This benchmark was not run. The implementation added no index and makes no representative latency
+claim.
+
+### Work
+
+1. Seed representative project session and records volume in the normal test/development
+   environment:
+   - 10,000 session streams in one project.
+   - 1,000 trigger-attributed sessions split across schedules and subscriptions.
+   - 20 records per session (200,000 records total).
+   - 100 pinned IDs and 100 waiting IDs.
+   - Page size 30.
+2. Capture `EXPLAIN (ANALYZE, BUFFERS)` for:
+   - Origin containment with project scope.
+   - Latest-message expansion for one normal page.
+   - Conditional current-trigger stream joins.
+3. Record query latency and rows scanned.
+4. Benchmark full Home and Sessions behavior with waiting, pinned, and recent groups active.
+5. Add no index when existing project/lifecycle indexes satisfy the budget below.
+6. If evidence requires an index, write a separate schema-migration task and document its write and
+   storage cost before implementation.
+
+### Initial acceptance budget
+
+Use the original PR as the comparison baseline:
+
+- Non-preview callers must perform less backend work than PR #5767.
+- Human-session preview pages must not add trigger lookups.
+- Automation preview requests keep the same SQL roundtrip count as PR #5767.
+- The conditional joined stream statement stays within 20 percent of the original stream-query
+  latency at representative volume.
+- Complete automation-page latency with all active groups stays within 20 percent of PR #5767.
+- No frontend request may scale with row count.
+- Exact delivery retrieval occurs only after user action.
+
+## Phase 11: Verification
+
+### API tests
+
+Run focused session and trigger suites throughout implementation, then the standard API suite:
+
+```text
+cd api && py-run-tests
+```
+
+Add real-Postgres acceptance coverage under the existing API acceptance suites for:
+
+- Concurrent attribution and heartbeat updates.
+- Soft deletion with retained delivery/configuration rows.
+- Exact delivery retrieval after deletion.
+
+Before committing API work:
+
+```text
+ruff format
+ruff check --fix
+```
+
+### Frontend checks
+
+```text
+cd web && pnpm lint-fix
+cd web && pnpm turbo run build --filter=@agenta/entities --filter=@agenta/sessions --filter=@agenta/sessions-ui --filter=@agenta/entity-ui
+cd web && pnpm turbo run test:unit --filter=@agenta/entities --filter=@agenta/sessions --filter=@agenta/sessions-ui --filter=@agenta/entity-ui
+cd web && pnpm --filter @agenta/oss types:check
+cd web/tests && pnpm test:acceptance --grep "session automation actions"
+```
+
+Add a Vitest setup to `@agenta/sessions-ui` if the merged v0.112 package does not contain one. Add
+component tests for primary click and secondary-action propagation. Add a browser acceptance test
+under `web/tests/` for permission behavior and the configuration/delivery drawers.
+
+### Generated Python client
+
+Add `clients/python/tests/test_session_query_models.py` as a real generated-contract test. It must:
+
+- Import the generated nested request and expanded response models.
+- Serialize a nested origin/exclusion/expansion request.
+- Parse a response containing trigger, delivery, preview, and windowing fields.
+- Parse an unknown-origin row with no delivery.
+
+After client generation, run:
+
+```text
+uv build --directory clients/python
+uv run --directory clients/python pytest
+```
+
+Add pytest as a development dependency if the generated client package does not already provide
+it. The build and model round-trip tests must pass.
+
+### Live QA checklist
+
+1. Empty API query returns unknown and trigger-origin sessions.
+2. Default Sessions UI hides automation sessions.
+3. Automation mode shows only automation sessions.
+4. Repeated firings create distinct sessions and deliveries.
+5. Row kind distinguishes schedules and subscriptions.
+6. Renaming an automation changes existing session-row labels.
+7. Deleting an automation removes it from normal lists but preserves configuration and delivery
+   history.
+8. Primary click opens the session.
+9. Secondary actions open the current configuration and exact delivery.
+10. Home and Sessions display previews.
+11. Sidebar and internal callers make no preview query.
+12. Records lookup failure does not fail the list.
+13. Existing custom tags survive attribution.
+14. No session-list flow issues one frontend request per row.
+
+## GitButler implementation structure
+
+The final review set uses four lanes rather than the original seven-lane proposal. The smaller
+split keeps each public contract with its implementation while preserving dependency order.
+
+Create these lanes from the configured `origin/release/v0.112.0` target.
+
+Use one linear stack because generated clients and frontend packages depend on the API contract
+below them:
+
+```text
+v0.112 implementation base
+  -> api/session-ux-contract
+  -> clients/session-ux-contract
+  -> frontend/session-ux
+  -> docs/session-ux-handoff
+```
+
+### Lane ownership
+
+1. `api/session-ux-contract` owns claim integrity, retained trigger history, the nested query,
+   optional expansions, typed responses, and reserved-tag sanitization.
+2. `clients/session-ux-contract` owns generated Python and TypeScript clients and the API, SDK, and
+   services lockfile metadata required by the editable Python client.
+3. `frontend/session-ux` owns SDK accessors, the typed session entity boundary, caller policies,
+   row view models, secondary actions, exact delivery mode, historical drawers, and app
+   composition.
+4. `docs/session-ux-handoff` owns this design record and QA handoff.
+
+Set each PR base to the branch directly below it. Before every GitButler write, follow the
+coordination lock protocol in `docs/design/agent-workflows/scratch/agent-coordination.md`.
+
+## Implementation base used
+
+Implementation started with these conditions:
+
+1. GitButler targets `origin/release/v0.112.0`.
+2. `but pull` first established the implementation base at `965851e15d`; the final refresh moved
+   the target to `4af155162b` with no conflicts.
+3. The old `main` target branch is not applied above the release.
+4. The #5767/#5769 session and trigger surfaces are present.
+5. No GitButler stacks were applied.
+6. The user approved implementation from this plan.
+7. The standalone EE dev deployment for this checkout is healthy at
+   `http://144.76.237.122:8280`.
+8. The compose project is `agenta-ee-dev-wp-b2-rendering`, with Postgres published on port 5434.

--- a/docs/design/session-ux-interface/plan.md
+++ b/docs/design/session-ux-interface/plan.md
@@ -87,7 +87,7 @@ The revised implementation runs only requested enrichments:
 | Agent-scoped Sessions default mode | Yes | No |
 | Agent-scoped Sessions automation mode | Yes | Yes |
 | Sidebar | No | No |
-| Agent overview | No | No |
+| Agent overview | No | Yes |
 | Mobile | No | No |
 | Internal/reconciliation callers | No | No |
 
@@ -652,10 +652,14 @@ join work only when the caller asks for the current automation name.
 Origin filtering is presentation policy. A neutral API prevents one frontend's default from
 silently affecting another consumer.
 
-## Phase 10: Deferred performance benchmark
+## Phase 10: Performance benchmark
 
-This benchmark was not run. The implementation added no index and makes no representative latency
-claim.
+The benchmark ran on 2026-08-11 at the volume specified below. No index is required at this
+volume: human-surface queries measured 15 to 19 ms p50, automation-surface queries (trigger join
+plus message preview) measured 24 to 25 ms p50, and deep cursor pages added roughly 10 ms
+regardless of depth. An optional partial index on the project scope and origin tag roughly halves
+trigger-side query cost and is documented as a follow-up option, not a requirement for this
+release.
 
 ### Work
 
@@ -806,6 +810,5 @@ Implementation started with these conditions:
 4. The #5767/#5769 session and trigger surfaces are present.
 5. No GitButler stacks were applied.
 6. The user approved implementation from this plan.
-7. The standalone EE dev deployment for this checkout is healthy at
-   `http://144.76.237.122:8280`.
-8. The compose project is `agenta-ee-dev-wp-b2-rendering`, with Postgres published on port 5434.
+7. The standalone EE development deployment for this checkout is healthy. See the
+   `debug-local-deployment` skill for how to locate and reach it.

--- a/docs/design/session-ux-interface/qa-handoff.md
+++ b/docs/design/session-ux-interface/qa-handoff.md
@@ -1,0 +1,104 @@
+# QA handoff
+
+Date: 2026-08-11
+
+## Release state
+
+Implementation and automated verification are complete. Schedule acceptance and authenticated API
+wire checks passed. Browser QA, live subscription acceptance, and the representative performance
+benchmark remain open for the reasons below.
+
+The active EE development deployment is:
+
+- URL: `http://144.76.237.122:8280`
+- Compose project: `agenta-ee-dev-wp-b2-rendering`
+- API health: `GET /api/health` returns `200`
+- Web root: redirects to `/w`
+- Postgres host port: `5434`
+
+## Verified
+
+### API and database
+
+- 565 non-integration session and trigger tests passed after updating to release commit
+  `4af155162b`.
+- Real-Postgres tests passed for atomic delivery/session claims, rollback, merge-safe attribution,
+  trigger joins, origin filtering, cursor behavior, soft deletion, and retained history.
+- Final code review found no P0 or P1 findings.
+
+### Generated clients
+
+- The generated Python package builds.
+- Three Python contract tests passed for nested queries, typed attribution, expansions, and
+  windowing.
+- The generated TypeScript client and consuming session entity contracts build and type-check.
+
+### Frontend
+
+- Relevant frontend package builds passed.
+- Relevant package type checks and lint passed.
+- Focused and full package tests passed for origin policies, query shapes, row view models,
+  automation actions, exact delivery mode, and historical drawer behavior.
+
+### Live checks
+
+- A schedule firing created one linked delivery and session.
+- An authenticated canonical session query returned the current trigger name and kind, typed
+  delivery data, terminal windowing, and only public user tags.
+- Exact delivery retrieval returned the linked session and execution result.
+- A clean web-container restart reaches Next.js ready state. The root redirects to `/w`, and the
+  API health endpoint remains available.
+
+## Manual QA
+
+Run these checks against the deployment above:
+
+1. Open project Sessions in default mode. Automation-created sessions do not appear.
+2. Switch to automation mode. Only automation-created sessions appear.
+3. Open a schedule row. The primary click opens the session.
+4. Use `Open automation`. The matching schedule or subscription drawer opens.
+5. Use `View delivery`. The drawer shows only the exact delivery and linked session.
+6. Rename an automation. Existing session rows show the current name.
+7. Delete an automation. It disappears from normal lists, but its historical configuration and
+   delivery remain readable from the session row.
+8. Confirm Home and Sessions show previews. Sidebar, agent overview, and mobile must not issue
+   preview expansions.
+9. Test a user without trigger-view permission. The session remains openable while unavailable
+   automation actions remain hidden or disabled.
+10. Repeat the flow in light and dark themes and at desktop and mobile widths.
+
+## Open verification
+
+### Browser QA
+
+Automated Chromium QA did not run because the host disables the Chromium sandbox. The test did not
+bypass that protection with `--no-sandbox`. Run the manual checklist from a browser environment
+with working sandbox support.
+
+### Subscription acceptance
+
+Live subscription acceptance requires `COMPOSIO_TEST_CONNECTED_ACCOUNT`. It was not available in
+the test environment. Run one real provider event and verify that it creates a distinct session and
+delivery with `kind: subscription`.
+
+### Performance benchmark
+
+The planned 10,000-session and 200,000-record benchmark did not run. No index was added, and no
+representative latency claim is made.
+
+Seed the volume described in [`plan.md`](plan.md#phase-10-deferred-performance-benchmark), then
+capture `EXPLAIN (ANALYZE, BUFFERS)` for origin filtering, message expansion, and current-trigger
+joins. Measure complete Home and Sessions group behavior, not one isolated query.
+
+## Deferred risk
+
+Normal automation deletion retains history. Hard deletion of a gateway connection can still
+cascade through subscriptions and deliveries. Do not treat gateway connection deletion as covered
+by the retained-history acceptance checks.
+
+## Deployment note
+
+The web container previously restarted because bind-mounted dependency and generated-client output
+was owned by host UID `1000`, while the container runs as UID `10001`. The local ignored
+`node_modules` and `dist` trees were made writable to match the existing development deployment.
+No source change was required.

--- a/docs/design/session-ux-interface/qa-handoff.md
+++ b/docs/design/session-ux-interface/qa-handoff.md
@@ -4,17 +4,15 @@ Date: 2026-08-11
 
 ## Release state
 
-Implementation and automated verification are complete. Schedule acceptance and authenticated API
-wire checks passed. Browser QA, live subscription acceptance, and the representative performance
-benchmark remain open for the reasons below.
+Implementation and verification are complete. Schedule acceptance, authenticated API wire checks,
+browser QA, live subscription acceptance, and the representative performance benchmark all passed.
+Details below.
 
-The active EE development deployment is:
+Checks ran against the active EE development deployment. See the `debug-local-deployment` skill
+for how to locate and reach it. Observed at verification time:
 
-- URL: `http://144.76.237.122:8280`
-- Compose project: `agenta-ee-dev-wp-b2-rendering`
 - API health: `GET /api/health` returns `200`
 - Web root: redirects to `/w`
-- Postgres host port: `5434`
 
 ## Verified
 
@@ -51,50 +49,62 @@ The active EE development deployment is:
 
 ## Manual QA
 
-Run these checks against the deployment above:
+Checklist for the deployment above. Coverage from the most recent browser QA session is noted per
+item.
 
-1. Open project Sessions in default mode. Automation-created sessions do not appear.
-2. Switch to automation mode. Only automation-created sessions appear.
-3. Open a schedule row. The primary click opens the session.
-4. Use `Open automation`. The matching schedule or subscription drawer opens.
-5. Use `View delivery`. The drawer shows only the exact delivery and linked session.
-6. Rename an automation. Existing session rows show the current name.
+1. Open project Sessions in default mode. Automation-created sessions do not appear. — Covered, pass.
+2. Switch to automation mode. Only automation-created sessions appear. — Covered, pass.
+3. Open a schedule row. The primary click opens the session. — Covered, pass.
+4. Use `Open automation`. The matching schedule or subscription drawer opens. — Covered, pass.
+5. Use `View delivery`. The drawer shows only the exact delivery and linked session. — Covered, pass.
+6. Rename an automation. Existing session rows show the current name. — Covered, pass.
 7. Delete an automation. It disappears from normal lists, but its historical configuration and
-   delivery remain readable from the session row.
+   delivery remain readable from the session row. — Covered, pass.
 8. Confirm Home and Sessions show previews. Sidebar, agent overview, and mobile must not issue
-   preview expansions.
+   preview expansions. — Covered, pass (verified via request bodies).
 9. Test a user without trigger-view permission. The session remains openable while unavailable
-   automation actions remain hidden or disabled.
-10. Repeat the flow in light and dark themes and at desktop and mobile widths.
+   automation actions remain hidden or disabled. — Blocked: every stock role includes trigger
+   visibility, so this needs a deployment configured with a custom access role.
+10. Repeat the flow in light and dark themes and at desktop and mobile widths. — Dark theme
+    covered, pass. The mobile-width portion is blocked by a pre-existing desktop-only dashboard
+    gate, unrelated to this change.
 
-## Open verification
+## Verification completed since this handoff was written
+
+A verification and fix wave closed the three items below.
 
 ### Browser QA
 
-Automated Chromium QA did not run because the host disables the Chromium sandbox. The test did not
-bypass that protection with `--no-sandbox`. Run the manual checklist from a browser environment
-with working sandbox support.
+Manual QA ran in a browser environment with working sandbox support. Eight of ten checklist items
+passed, covering mode filtering, row actions, the delivery dialog, rename propagation,
+deleted-automation read-only history, expansion scoping (verified via request bodies), and dark
+theme rendering. The permission-restricted step is blocked: every stock role includes trigger
+visibility, so testing a role without it needs a deployment configured with a custom access role.
+The mobile-width step is blocked by a pre-existing desktop-only dashboard gate, unrelated to this
+change.
 
 ### Subscription acceptance
 
-Live subscription acceptance requires `COMPOSIO_TEST_CONNECTED_ACCOUNT`. It was not available in
-the test environment. Run one real provider event and verify that it creates a distinct session and
-delivery with `kind: subscription`.
+Live subscription acceptance ran twice against a real provider event. The first run used a real
+GitHub star event through a temporary connection. The second repeated the flow through a
+connection the user created directly in the product, with no manual database writes. Both runs
+produced exactly one delivery and one session with `kind: subscription`, correct typed
+attribution, and no `ag.*` tag leakage in the public response.
 
 ### Performance benchmark
 
-The planned 10,000-session and 200,000-record benchmark did not run. No index was added, and no
-representative latency claim is made.
-
-Seed the volume described in [`plan.md`](plan.md#phase-10-deferred-performance-benchmark), then
-capture `EXPLAIN (ANALYZE, BUFFERS)` for origin filtering, message expansion, and current-trigger
-joins. Measure complete Home and Sessions group behavior, not one isolated query.
+The representative benchmark ran at the planned volume: 10,000 sessions and 200,000 records. No
+index is required for production at this volume. Human-surface queries measured 15 to 19 ms;
+automation-surface queries, which add the trigger join and message preview, measured 24 to 25 ms.
+An optional partial index for automation-heavy queries at larger volume is documented, with its
+DDL and full measurements, alongside `plan.md`'s benchmark section.
 
 ## Deferred risk
 
-Normal automation deletion retains history. Hard deletion of a gateway connection can still
-cascade through subscriptions and deliveries. Do not treat gateway connection deletion as covered
-by the retained-history acceptance checks.
+Normal automation deletion retains history. Hard deletion of a gateway connection cascades through
+its subscriptions' tombstones and delivery history; do not treat connection deletion as covered by
+the retained-history acceptance checks. This is accepted product behavior for this release; no
+follow-up code change is planned.
 
 ## Deployment note
 

--- a/docs/design/session-ux-interface/research.md
+++ b/docs/design/session-ux-interface/research.md
@@ -1,0 +1,202 @@
+# Research findings
+
+The complete investigation is in
+[`../session-ux-interface-review.md`](../session-ux-interface-review.md). This file records the
+implementation facts and outcomes for this revision.
+
+## Baseline
+
+PR #5767 adds:
+
+- Trigger origin and trigger identity in session tags.
+- A generated session ID in trigger dispatch.
+- `session_id` in delivery data.
+- Flat origin, liveness, and ID-set query fields.
+- An optional total count.
+- An unconditional latest-message lookup for session-list rows.
+
+PR #5769 adds:
+
+- Frontend support for those flat query fields.
+- Direct parsing of reserved `ag.*` keys.
+- Session list grouping, pinning, waiting-ID pushdown, and row view models.
+- Client-side reconstruction of pagination cursors.
+
+## Existing schema capabilities
+
+No attribution schema migration is required.
+
+- `session_streams.tags` is already JSONB.
+- Trigger subscriptions and schedules already include lifecycle columns such as `deleted_at`.
+- Trigger deliveries already include JSON data that can carry `session_id`.
+- Trigger deliveries already have an exact project-scoped retrieval endpoint.
+
+Before this revision, schedule and subscription DAO deletion physically deleted rows. Delivery
+foreign keys use `ON DELETE CASCADE`, so those physical deletes removed delivery history. Normal
+application deletion now uses lifecycle soft deletion and preserves the existing rows without a new
+column.
+
+Authenticated exact-by-ID schedule and subscription reads include soft-deleted configurations as
+read-only history. Normal lists, edits, activation changes, dispatch, and provider-trigger lookup
+remain live-only.
+
+Hard deletion of a gateway connection can still cascade through its subscriptions and deliveries.
+This path is outside direct automation deletion and remains a deferred risk.
+
+## Existing retrieval interfaces
+
+The backend already supports:
+
+- `GET /triggers/deliveries/{delivery_id}` for one exact delivery.
+- Fetching one schedule by ID.
+- Fetching one subscription by ID.
+- Querying schedules and subscriptions.
+
+The frontend already has trigger entities and delivery/configuration drawer components. The new row
+actions should extend those surfaces instead of introducing another details implementation.
+
+## No data migration
+
+This work was pre-production. The implementation does not backfill old session attribution,
+delivery IDs, or trigger names.
+
+Verification covers data created through the revised write path.
+
+Rows created on the pre-production v0.112 branch before the revised writer may have no exact
+delivery attribution. They degrade to `delivery: null`, and the UI hides the delivery action. This
+test data is disposable. The production release must include the revised writer; no repair path or
+backfill is planned.
+
+## Database schema impact
+
+The planned functional work requires no database schema migration:
+
+- Attribution stays in JSONB tags.
+- Session ID stays in delivery JSON data.
+- Soft deletion uses existing lifecycle columns.
+- Typed API fields are response projections.
+
+Indexes are the only possible schema change. They are not part of the initial implementation. Add
+an index only after a representative `EXPLAIN (ANALYZE, BUFFERS)` demonstrates that the query needs
+it.
+
+Candidate indexes, if measurements require them:
+
+- A GIN index on `session_streams.tags` for origin containment.
+- A partial records index for latest-message lookups.
+
+## Request comparison with PR #5767
+
+| Concern | PR #5767 | Implemented revision |
+| --- | --- | --- |
+| Session query HTTP calls | One per list group/page | Same |
+| Message preview | Every session query | Explicit expansion on Home/Sessions only |
+| Automation name | Snapshot in session tags | Optional conditional read-model join for current names |
+| Trigger list requests from frontend | None | None |
+| Exact delivery request | Not available from row | One request after user selects `View delivery` |
+| Pagination | Frontend rebuilds cursor | API returns cursor |
+| Origin default | API returns all | Same, documented explicitly |
+| Storage write | Replaces all tags | Merges reserved keys |
+
+## Backend query cost
+
+The original PR performs these lookups for every non-empty session page:
+
+1. Session streams.
+2. Latest turns.
+3. Latest messages.
+
+The implemented behavior is caller-specific:
+
+| Caller | Streams | Latest turns | Latest message | Current automation |
+| --- | ---: | ---: | ---: | ---: |
+| Sidebar/internal | 1 | 1 | 0 | 0 |
+| Home human sessions | 1 | 1 | 1 | 0 |
+| Home automation sessions | 1 joined query | 1 | 1 | Included in stream query |
+| Sessions default mode | 1 | 1 | 1 | 0 |
+| Sessions automation mode | 1 joined query | 1 | 1 | Included in stream query |
+
+When the caller requests trigger details, the session read-model query conditionally joins schedule
+and subscription rows by project, typed kind, and ID. The primary-key joins add work to the stream
+statement but do not add database roundtrips. The join includes soft-deleted configurations so
+historical rows retain their last persisted name.
+
+The frontend can mount more than one list query per surface. A card may query waiting, pinned, and
+recent groups. The Sessions page may query pinned and recent groups. The revised design keeps the
+same group-level HTTP query count as PR #5767.
+
+Per group, a preview request remains three SQL roundtrips (joined streams, latest turns, latest
+messages). A non-preview request drops to two. Agent-reference resolution may add one existing turn
+query per group.
+
+### Complete surface counts
+
+These worst cases assume waiting and pinned groups are both non-empty, previews are enabled where
+approved, and `include_total` is false.
+
+| Surface | Session HTTP requests | Other HTTP requests | SQL roundtrips | PR #5767 SQL roundtrips |
+| --- | ---: | ---: | ---: | ---: |
+| Home with human and automation cards | 6 (3 per card) | 1 actionable-interactions request | 19 | 19 |
+| Project Sessions page | 2 (pinned, recent) | 1 actionable-interactions request | 7 | 7 |
+| Agent-scoped Sessions page | 2 (pinned, recent) | 1 actionable-interactions request | 9 | 9 |
+| Sidebar with pinned and recent | 2 | 0 | 4 | 6 |
+
+SQL totals include one actionable-interactions query where shown. Agent-scoped totals include one
+turn-reference resolution per session query. Conditional trigger-name joins remain inside the
+stream roundtrip. Empty waiting/pinned groups reduce these counts.
+
+## Frontend request cost
+
+The implementation adds no list-time frontend requests compared with PR #5767:
+
+- Current automation names are hydrated by a conditional sessions read-model join, not by frontend
+  requests.
+- Exact delivery fetch happens only after the user selects `View delivery`.
+- Opening a configuration uses the existing trigger entity/drawer cache and fetch path.
+
+The typed frontend policy does not issue one schedule/subscription request per row.
+
+## Regression risks
+
+### Query compatibility
+
+The sessions query predates PR #5767. Existing clients use flat references, lifecycle, search, and
+windowing fields. The backend should accept existing fields while introducing the nested request.
+Normalize both shapes at the API boundary.
+
+### Deleted trigger visibility
+
+Soft-deleted schedules and subscriptions must disappear from normal lists and dispatch loops.
+Exact historical reads must continue to work. Missing `deleted_at IS NULL` predicates can either
+resurrect deleted automations or keep dispatching them.
+
+### Provider cleanup
+
+Deleting a subscription must still remove or disable its provider-side trigger. Soft deletion
+changes local persistence only.
+
+### Attribution races
+
+The dispatcher and first runner heartbeat can create the same session stream concurrently. The
+merge path must preserve liveness flags and attribution tags regardless of write order.
+
+### Optional expansions
+
+An unavailable records lookup must not fail the base session list because records use a separate
+analytics database. Trigger-name hydration is a conditional join in the transactional stream query;
+it follows normal stream-query failure behavior. Missing or malformed attribution yields a null
+typed relationship and no action. Valid trigger and delivery IDs remain available when only name
+resolution is missing.
+
+### Frontend origin policy
+
+The API default returns every origin. Each frontend caller must set its policy explicitly so a new
+caller does not accidentally inherit Home or Sessions behavior.
+
+## Performance verification status
+
+Structural gates passed for explicit expansions, conditional trigger joins, bounded session-ID
+filters, concurrent enrichments, and no per-row trigger or delivery requests.
+
+The planned benchmark with 10,000 sessions and 200,000 records was not run. No query-plan or
+latency claim is recorded, and no index was added.

--- a/docs/design/session-ux-interface/status.md
+++ b/docs/design/session-ux-interface/status.md
@@ -4,7 +4,8 @@ Date: 2026-08-10
 
 ## Current phase
 
-Implementation complete. Residual verification and one deferred history-retention risk remain.
+Implementation, review, and verification are complete. The stack is ready for final review. See
+the closing update at the end of this file.
 
 ## Completed
 
@@ -20,8 +21,8 @@ Implementation complete. Residual verification and one deferred history-retentio
 - Pulled release commit `965851e15d` and removed the old `main` target from the applied workspace.
 - Pulled nine later release commits after implementation; the final target is `4af155162b`.
 - Verified no implementation stack is applied and unrelated local changes remain untouched.
-- Verified the existing standalone EE deployment for this checkout at
-  `http://144.76.237.122:8280`.
+- Verified the existing standalone EE development deployment for this checkout (see the
+  `debug-local-deployment` skill for how to reach it).
 - Implemented atomic delivery claim and session attribution with one linked delivery/session ID.
 - Implemented typed session queries, response expansions, windowing, and generated TypeScript and
   Python clients.
@@ -44,9 +45,9 @@ Recorded start state:
 - Target version: v0.112 release branch.
 - Applied stacks: none.
 - Existing unrelated uncommitted changes: present and untouched.
-- Deployment: `agenta-ee-dev-wp-b2-rendering` on port 8280, with this checkout bind-mounted into
-  API, workers, web, generated clients, and frontend packages.
-- Database: `agenta_ee_core` on the stack Postgres container, published on port 5434.
+- Deployment: the standalone EE development deployment, with this checkout bind-mounted into API,
+  workers, web, generated clients, and frontend packages.
+- Database: the deployment's stack Postgres container.
 
 The implementation is being packaged as the stacked review set described in `implementation.md`.
 
@@ -62,19 +63,38 @@ The implementation is being packaged as the stacked review set described in `imp
 - Restored the EE development web service after bind-mounted host-owned package outputs blocked
   the container's UID from completing dependency preparation.
 
-## Residual verification
+## Later verification (2026-08-11)
 
-- Browser QA did not run because host Chromium sandboxing is disabled. The run did not bypass the
-  sandbox with `--no-sandbox`.
-- Subscription live acceptance did not run because `COMPOSIO_TEST_CONNECTED_ACCOUNT` was missing.
-- The representative benchmark with 10,000 sessions and 200,000 records did not run. No index was
-  added, and no representative performance claim is made.
+- Browser QA ran in a browser environment with working sandbox support. Eight of ten checklist
+  items passed. The permission-restricted step is blocked pending a deployment configured with a
+  custom access role; the mobile-width step is blocked by a pre-existing desktop-only dashboard
+  gate, unrelated to this change.
+- Subscription live acceptance ran twice against a real provider event, producing one delivery and
+  one session with `kind: subscription` each time, correct typed attribution, and no `ag.*` tag
+  leakage.
+- The representative benchmark ran at 10,000 sessions and 200,000 records. No index is required at
+  this volume. Human-surface queries measured 15 to 19 ms p50; automation-surface queries measured
+  24 to 25 ms p50. An optional partial index for automation-heavy queries at larger volume is
+  documented as a follow-up option, not a requirement for this release.
 
-## Deferred risk
+## Known limitation: connection deletion and history
 
-Hard deletion of a gateway connection can still cascade through subscription and delivery history.
-This path is outside direct automation deletion and remains deferred.
+Hard deletion of a gateway connection cascades through its subscriptions' tombstones and delivery
+history; history for a subscription survives only while its connection exists. This is accepted
+product behavior for this release. The docs are corrected to state this bound; no follow-up code
+change is planned.
 
 ## Decisions remaining
 
 Generic tags, work status, usage, cost, and models remain separately scoped future work.
+
+## Closing update — 2026-08-11
+
+Implementation, review, and fix waves are complete. The stack is ready for final review: PR #5929
+(API attribution, lifecycle, query, expansion, sanitization), PR #5928 (generated Python and
+TypeScript clients), PR #5927 (frontend entity contracts, list policies, row models, actions,
+drawers), and PR #5926 (this design record). PR #5930 (subscription reference validation fix) and
+PR #5931 (schedule cron per-row error isolation) merged separately during the same effort.
+
+Follow-up issues filed for out-of-scope findings: #5933 (unbounded reconciliation fetch), #5934
+(delivery-upsert builder dedup), and #5935 (worker UUID guards).

--- a/docs/design/session-ux-interface/status.md
+++ b/docs/design/session-ux-interface/status.md
@@ -1,0 +1,80 @@
+# Status
+
+Date: 2026-08-10
+
+## Current phase
+
+Implementation complete. Residual verification and one deferred history-retention risk remain.
+
+## Completed
+
+- Reviewed PR #5767 backend changes.
+- Mapped the v0.112 frontend PR stack.
+- Recorded the public interface and storage recommendations.
+- Confirmed product behavior for names, row actions, delivery history, kinds, sessions, previews,
+  and origin defaults.
+- Confirmed no session meta use.
+- Confirmed no data backfill is required before production.
+- Created the implementation plan.
+- Retargeted GitButler to `origin/release/v0.112.0`.
+- Pulled release commit `965851e15d` and removed the old `main` target from the applied workspace.
+- Pulled nine later release commits after implementation; the final target is `4af155162b`.
+- Verified no implementation stack is applied and unrelated local changes remain untouched.
+- Verified the existing standalone EE deployment for this checkout at
+  `http://144.76.237.122:8280`.
+- Implemented atomic delivery claim and session attribution with one linked delivery/session ID.
+- Implemented typed session queries, response expansions, windowing, and generated TypeScript and
+  Python clients.
+- Implemented trigger soft deletion, retained history, and live-only normal lists and mutations.
+- Implemented authenticated exact-by-ID schedule and subscription reads that include soft-deleted
+  configurations as read-only.
+- Implemented typed frontend origin policies, row actions, and exact-only delivery mode.
+- Implemented reserved-tag sanitization so public tags contain only user-visible keys.
+- Verified a scheduled run with linked delivery and session IDs.
+- Verified an authenticated canonical session query with the current trigger name and kind, typed
+  delivery, terminal windowing, and only user tags.
+- Verified exact delivery retrieval with the linked session and result.
+
+## Implementation start state
+
+Recorded start state:
+
+- Current branch: `gitbutler/workspace`.
+- GitButler target: `origin/release/v0.112.0` at `4af155162b`.
+- Target version: v0.112 release branch.
+- Applied stacks: none.
+- Existing unrelated uncommitted changes: present and untouched.
+- Deployment: `agenta-ee-dev-wp-b2-rendering` on port 8280, with this checkout bind-mounted into
+  API, workers, web, generated clients, and frontend packages.
+- Database: `agenta_ee_core` on the stack Postgres container, published on port 5434.
+
+The implementation is being packaged as the stacked review set described in `implementation.md`.
+
+## Verification
+
+- 565 non-integration session and trigger API tests passed after the final release pull.
+- Eight core Postgres claim and history tests passed in the deployed container.
+- Phase 5 trigger join, cursor, and origin Postgres tests passed in the deployed container.
+- Three generated Python client tests passed.
+- Frontend builds, type checks, lint, and relevant package suites passed.
+- Schedule live acceptance passed.
+- Final reviews found no P0 or P1 findings.
+- Restored the EE development web service after bind-mounted host-owned package outputs blocked
+  the container's UID from completing dependency preparation.
+
+## Residual verification
+
+- Browser QA did not run because host Chromium sandboxing is disabled. The run did not bypass the
+  sandbox with `--no-sandbox`.
+- Subscription live acceptance did not run because `COMPOSIO_TEST_CONNECTED_ACCOUNT` was missing.
+- The representative benchmark with 10,000 sessions and 200,000 records did not run. No index was
+  added, and no representative performance claim is made.
+
+## Deferred risk
+
+Hard deletion of a gateway connection can still cascade through subscription and delivery history.
+This path is outside direct automation deletion and remains deferred.
+
+## Decisions remaining
+
+Generic tags, work status, usage, cost, and models remain separately scoped future work.


### PR DESCRIPTION
## Context
The session UX change spans trigger dispatch, session queries, generated clients, frontend list policy, historical drawers, and deployment QA. Reviewers and release testers need one durable account of the final behavior and the checks that remain open.

## Changes
This PR records the confirmed product decisions, runtime flow, public contract, storage choice, review-stack boundaries, and retained-history behavior. It adds a concise implementation handoff and a separate QA handoff with live deployment details, manual checks, verified evidence, and residual risks.

## Tests / notes
- The documents were checked against the implemented stack and final verification record.
- No runtime code changes are included.
- Browser QA, live subscription acceptance, and the representative 10,000-session/200,000-record benchmark remain explicitly open.

Stack: 4 of 4. Base: `frontend/session-ux`.