### PR TITLE
[feat] Keep automation session history linked

### DIFF
--- a/api/ee/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
+++ b/api/ee/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
@@ -269,8 +269,14 @@ class TestTriggerSubscriptionsLifecycle:
             )
             assert delete.status_code == 204
 
+            # The shared route now returns the soft-deleted subscription for exact-ID
+            # historical display (deleted automations remain readable), not a 404 —
+            # list/query routes still omit it.
             fetch = triggers_api("GET", f"/triggers/subscriptions/{subscription_id}")
-            assert fetch.status_code == 404
+            assert fetch.status_code == 200, fetch.text
+            historical = fetch.json()["subscription"]
+            assert historical["id"] == subscription_id
+            assert historical["deleted_at"] is not None
 
             # C7: deleting the subscription must NOT delete/revoke the connection.
             conn = triggers_api("GET", f"/tools/connections/{connection_id}")

--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -885,9 +885,9 @@ _triggers_broker = ProducerOnlyRedisStreamBroker(
 
 _triggers_dispatcher = TriggersDispatcher(
     triggers_dao=triggers_dao,
+    session_claims_dao=session_streams_dao,
     workflows_service=workflows_service,
     dispatch_fn=_dispatch_detached_run,
-    streams_service=session_streams_service,
 )
 
 _triggers_worker = TriggersWorker(

--- a/api/entrypoints/worker_queues.py
+++ b/api/entrypoints/worker_queues.py
@@ -50,7 +50,6 @@ from oss.src.core.evaluators.service import EvaluatorsService, SimpleEvaluatorsS
 from oss.src.core.queries.service import QueriesService
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
 from oss.src.core.sessions.records.service import RecordsService
-from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.core.testcases.service import TestcasesService
 from oss.src.core.testsets.service import SimpleTestsetsService, TestsetsService
 from oss.src.core.tracing.service import TracingService
@@ -72,7 +71,6 @@ from oss.src.dbs.postgres.sessions.interactions.dao import SessionInteractionsDA
 from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
 from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 from oss.src.dbs.redis.sessions.watch import SessionsWatchPublisher
-from oss.src.dbs.redis.shared.engine import get_lock_engine
 from oss.src.dbs.postgres.shared.engine import (
     get_analytics_engine,
     get_transactions_engine,
@@ -159,7 +157,9 @@ def _build_triggers_broker() -> tuple[AsyncBroker, int]:
         approximate=True,
     )
 
-    triggers_dao = TriggersDAO()
+    transactions_engine = get_transactions_engine()
+    triggers_dao = TriggersDAO(engine=transactions_engine)
+    session_streams_dao = SessionStreamsDAO(engine=transactions_engine)
     workflows_dao = GitDAO(
         ArtifactDBE=WorkflowArtifactDBE,
         VariantDBE=WorkflowVariantDBE,
@@ -183,19 +183,10 @@ def _build_triggers_broker() -> tuple[AsyncBroker, int]:
     workflows_service.embeds_service = embeds_service
     environments_service.embeds_service = embeds_service
 
-    # Triggers dispatched through the queue must be stamped as automation-started too —
-    # without this composition they'd reach the sessions list indistinguishable from a
-    # person's own work, which is the whole point of the origin tag.
-    streams_service = SessionStreamsService(
-        streams_dao=SessionStreamsDAO(engine=get_transactions_engine()),
-        lock_engine=get_lock_engine(),
-        watch_publisher=SessionsWatchPublisher(),
-    )
-
     triggers_dispatcher = TriggersDispatcher(
         triggers_dao=triggers_dao,
+        session_claims_dao=session_streams_dao,
         workflows_service=workflows_service,
-        streams_service=streams_service,
     )
     TriggersWorker(
         broker=broker, dispatcher=triggers_dispatcher, triggers_dao=triggers_dao

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -1,10 +1,14 @@
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional
+from typing import Annotated, Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from oss.src.core.sessions.dtos import SessionListItem
+from oss.src.core.sessions.dtos import (
+    SessionExpansion,
+    SessionListItem,
+    SessionOrigin,
+)
 from oss.src.core.sessions.streams.dtos import (
     SessionStream,
     SessionStreamQueryFlags,
@@ -28,28 +32,56 @@ from oss.src.core.shared.dtos import OTelSpanId, Reference, Windowing
 # ---------------------------------------------------------------------------
 
 
+SessionId = Annotated[
+    str,
+    Field(min_length=1, max_length=128, pattern=r"^[a-zA-Z0-9_\-]+$"),
+]
+
+
+class SessionPredicatesRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    search: Optional[str] = None
+    liveness: Optional[SessionStreamQueryFlags] = None
+    origins: Optional[List[SessionOrigin]] = None
+
+
+class SessionExcludeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    origins: Optional[List[SessionOrigin]] = None
+    session_ids: Optional[List[SessionId]] = Field(default=None, max_length=500)
+
+
 class SessionQueryRequest(BaseModel):
-    references: Optional[List[Reference]] = None
-    windowing: Optional[Windowing] = None
+    model_config = ConfigDict(extra="forbid")
+
+    session: Optional[SessionPredicatesRequest] = None
+    # Canonical explicit set selection. It intersects with turn_references.
+    session_ids: Optional[List[SessionId]] = Field(default=None, max_length=500)
+    exclude: Optional[SessionExcludeRequest] = None
+    turn_references: Optional[List[Reference]] = None
     # Include ended (killed) sessions so the list keeps resumable history, not just live ones.
     include_ended: bool = False
     # Include archived sessions — off by default (archive hides); on for the archived view.
     include_archived: bool = False
+    # Also return `total`. Off by default — a filter chip wants it, a scroll page does not.
+    include_total: bool = False
+    expand: List[SessionExpansion] = Field(default_factory=list)
+    windowing: Optional[Windowing] = None
+
+    # Compatibility inputs for the currently released flat predicates.
+    references: Optional[List[Reference]] = None
     # Case-insensitive substring match over the session title (`session_streams.name`).
     search: Optional[str] = None
     # Liveness filter (alive ⊇ running ⊇ attached) against the row's mirrored flags.
     flags: Optional[SessionStreamQueryFlags] = None
-    # Restrict to / exclude an explicit id set — the pushdown for predicates that live outside
-    # the stream row (client-held pins, sessions named by a pending-interaction lookup), so the
-    # server still owns the intersection, the ordering and the windowing.
-    session_ids: Optional[List[str]] = None
-    exclude_session_ids: Optional[List[str]] = None
-    # Also return `total`. Off by default — a filter chip wants it, a scroll page does not.
-    include_total: bool = False
-    # Who started the session: "manual", "trigger", … Absent means every origin.
-    origin: Optional[str] = None
+    # Released flat exclusion alias for exclude.session_ids.
+    exclude_session_ids: Optional[List[SessionId]] = Field(default=None, max_length=500)
+    # Who started the session. Absent means every origin.
+    origin: Optional[SessionOrigin] = None
     # Its negation — hides one origin while still showing sessions with no stamp at all.
-    exclude_origin: Optional[str] = None
+    exclude_origin: Optional[SessionOrigin] = None
 
 
 class SessionsResponse(BaseModel):
@@ -60,6 +92,7 @@ class SessionsResponse(BaseModel):
     # `SessionListItem` = `SessionStream` + the latest turn's `references` (WP0-R3),
     # absent (excluded by response_model_exclude_none) when the session has no turns yet.
     sessions: List[SessionListItem] = Field(default_factory=list)
+    windowing: Optional[Windowing] = None
 
 
 class SessionResponse(BaseModel):

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Annotated, Any, Dict, List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from oss.src.core.sessions.dtos import (
     SessionExpansion,
@@ -25,6 +25,7 @@ from oss.src.core.sessions.interactions.dtos import (
 from oss.src.core.sessions.mounts.dtos import SessionMount, SessionMountQuery
 from oss.src.core.sessions.turns.dtos import HarnessKind, SessionTurn, SessionTurnQuery
 from oss.src.core.shared.dtos import OTelSpanId, Reference, Windowing
+from oss.src.dbs.postgres.sessions.streams.dao import MAX_SESSION_QUERY_LIMIT
 
 
 # ---------------------------------------------------------------------------
@@ -82,6 +83,20 @@ class SessionQueryRequest(BaseModel):
     origin: Optional[SessionOrigin] = None
     # Its negation — hides one origin while still showing sessions with no stamp at all.
     exclude_origin: Optional[SessionOrigin] = None
+
+    @field_validator("windowing")
+    @classmethod
+    def _bound_windowing_limit(cls, value: Optional[Windowing]) -> Optional[Windowing]:
+        # `Windowing` is the shared SDK model (also used by tracing/otel), so its
+        # `limit` carries no bound of its own. `limit: 0` compiled to no SQL LIMIT
+        # at all — an authenticated caller could dump the whole project in one
+        # request (P0-1). Bound it here, at the request model.
+        if value is not None and value.limit is not None:
+            if not (1 <= value.limit <= MAX_SESSION_QUERY_LIMIT):
+                raise ValueError(
+                    f"windowing.limit must be between 1 and {MAX_SESSION_QUERY_LIMIT}."
+                )
+        return value
 
 
 class SessionsResponse(BaseModel):

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -95,7 +95,6 @@ from oss.src.core.sessions.mounts.dtos import SessionMountQuery
 from oss.src.core.sessions.turns.dtos import SessionTurnComplete, SessionTurnCreate
 from oss.src.core.sessions.turns.service import SessionTurnsService
 from oss.src.core.sessions.turns.types import SessionTurnNotFound
-from oss.src.core.sessions.dtos import SessionQuery
 from oss.src.core.sessions.service import SessionsService
 from oss.src.core.mounts.service import MountsService
 from oss.src.apis.fastapi.mounts.router import handle_mount_exceptions
@@ -153,6 +152,11 @@ from oss.src.apis.fastapi.sessions.models import (
     SessionQueryRequest,
     SessionResponse,
     SessionsResponse,
+)
+from oss.src.apis.fastapi.sessions.utils import (
+    compute_session_response_windowing,
+    normalize_session_query_request,
+    sanitize_session_stream,
 )
 
 log = get_module_logger(__name__)
@@ -405,7 +409,7 @@ class SessionStreamsRouter:
             project_id=UUID(str(project_id)),
             session_id=session_id,
         )
-        return SessionStreamResponse(stream=stream)
+        return SessionStreamResponse(stream=sanitize_session_stream(stream))
 
     @intercept_exceptions()
     @_handle_session_exceptions()
@@ -481,9 +485,12 @@ class SessionStreamsRouter:
         if not has_permission:
             raise FORBIDDEN_EXCEPTION
 
-        return await self._service.heartbeat(
+        heartbeat = await self._service.heartbeat(
             project_id=project_id,
             request=payload,
+        )
+        return heartbeat.model_copy(
+            update={"stream": sanitize_session_stream(heartbeat.stream)}
         )
 
     @intercept_exceptions()
@@ -514,7 +521,10 @@ class SessionStreamsRouter:
                 ),
             ),
         )
-        return SessionStreamsResponse(count=len(streams), streams=streams)
+        return SessionStreamsResponse(
+            count=len(streams),
+            streams=[sanitize_session_stream(stream) for stream in streams],
+        )
 
     @intercept_exceptions()
     @_handle_session_exceptions()
@@ -540,7 +550,7 @@ class SessionStreamsRouter:
             session_id=session_id,
             header=header,
         )
-        return SessionStreamResponse(stream=stream)
+        return SessionStreamResponse(stream=sanitize_session_stream(stream))
 
     @intercept_exceptions()
     @_handle_session_exceptions()
@@ -1699,32 +1709,25 @@ class SessionsRootRouter:
         ):
             raise FORBIDDEN_EXCEPTION
 
-        query = SessionQuery(
-            references=body.references,
-            include_ended=body.include_ended,
-            include_archived=body.include_archived,
-            search=body.search,
-            flags=body.flags,
-            session_ids=body.session_ids,
-            exclude_session_ids=body.exclude_session_ids,
-            include_total=body.include_total,
-            origin=body.origin,
-            exclude_origin=body.exclude_origin,
-        )
-        sessions = await self.sessions_service.query_sessions(
+        normalized = normalize_session_query_request(body)
+        page = await self.sessions_service.query_sessions_page(
             project_id=UUID(str(project_id)),
-            query=query,
-            windowing=body.windowing,
+            query=normalized.predicates,
+            lifecycle=normalized.lifecycle,
+            options=normalized.options,
+            windowing=normalized.windowing,
         )
-        total = (
-            await self.sessions_service.count_sessions(
-                project_id=UUID(str(project_id)),
-                query=query,
-            )
-            if body.include_total
-            else None
+        response_windowing = compute_session_response_windowing(
+            sessions=page.sessions,
+            requested=normalized.windowing,
         )
-        return SessionsResponse(count=len(sessions), total=total, sessions=sessions)
+        sessions = [sanitize_session_stream(session) for session in page.sessions]
+        return SessionsResponse(
+            count=len(page.sessions),
+            total=page.total,
+            sessions=sessions,
+            windowing=response_windowing,
+        )
 
     @intercept_exceptions()
     async def delete_session(
@@ -1772,7 +1775,10 @@ class SessionsRootRouter:
             user_id=UUID(str(user_id)),
             session_id=session_id,
         )
-        return SessionResponse(count=1 if session else 0, session=session)
+        return SessionResponse(
+            count=1 if session else 0,
+            session=sanitize_session_stream(session),
+        )
 
     @intercept_exceptions()
     async def unarchive_session(
@@ -1796,7 +1802,10 @@ class SessionsRootRouter:
             user_id=UUID(str(user_id)),
             session_id=session_id,
         )
-        return SessionResponse(count=1 if session else 0, session=session)
+        return SessionResponse(
+            count=1 if session else 0,
+            session=sanitize_session_stream(session),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -95,6 +95,7 @@ from oss.src.core.sessions.mounts.dtos import SessionMountQuery
 from oss.src.core.sessions.turns.dtos import SessionTurnComplete, SessionTurnCreate
 from oss.src.core.sessions.turns.service import SessionTurnsService
 from oss.src.core.sessions.turns.types import SessionTurnNotFound
+from oss.src.core.sessions.dtos import SessionExpansion
 from oss.src.core.sessions.service import SessionsService
 from oss.src.core.mounts.service import MountsService
 from oss.src.apis.fastapi.mounts.router import handle_mount_exceptions
@@ -1708,6 +1709,26 @@ class SessionsRootRouter:
             permission=Permission.VIEW_SESSIONS,
         ):
             raise FORBIDDEN_EXCEPTION
+
+        if SessionExpansion.trigger in body.expand and not await check_action_access(
+            user_uid=str(user_id),
+            project_id=str(project_id),
+            permission=Permission.VIEW_TRIGGERS,
+        ):
+            # Every other trigger read gates on VIEW_TRIGGERS; this one only checked
+            # VIEW_SESSIONS, so a custom role with the former but not the latter could
+            # read trigger names through the expansion (P2-3). Degrade rather than 403 —
+            # drop the expansion so `trigger.name` comes back None like an unrequested
+            # expansion, and the rest of the row still renders.
+            body = body.model_copy(
+                update={
+                    "expand": [
+                        expansion
+                        for expansion in body.expand
+                        if expansion != SessionExpansion.trigger
+                    ]
+                }
+            )
 
         normalized = normalize_session_query_request(body)
         page = await self.sessions_service.query_sessions_page(

--- a/api/oss/src/apis/fastapi/sessions/utils.py
+++ b/api/oss/src/apis/fastapi/sessions/utils.py
@@ -1,0 +1,231 @@
+from json import dumps
+from typing import Any, Callable, Optional, TypeVar
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel, ConfigDict
+
+from oss.src.apis.fastapi.sessions.models import SessionQueryRequest
+from oss.src.core.sessions.dtos import (
+    SessionQuery,
+    SessionQueryLifecycle,
+    SessionQueryOptions,
+)
+from oss.src.core.sessions.streams.dtos import SessionStream
+from oss.src.core.shared.dtos import Windowing
+
+_RESERVED_ATTRIBUTION_TAGS = {
+    "ag.origin",
+    "ag.trigger.id",
+    "ag.trigger.kind",
+    "ag.trigger.delivery_id",
+    "ag.trigger.name",
+}
+
+SessionStreamT = TypeVar("SessionStreamT", bound=SessionStream)
+
+
+class NormalizedSessionQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    predicates: SessionQuery
+    lifecycle: SessionQueryLifecycle
+    options: SessionQueryOptions
+    windowing: Optional[Windowing] = None
+
+
+def _provided(model: Optional[BaseModel], field: str) -> bool:
+    return model is not None and field in model.model_fields_set
+
+
+def _canonical_list(value: Any) -> Any:
+    if value is None:
+        return None
+    canonical = []
+    for item in value:
+        if isinstance(item, BaseModel):
+            item = item.model_dump(mode="json", exclude_none=True)
+        elif hasattr(item, "value"):
+            item = item.value
+        canonical.append(dumps(item, sort_keys=True))
+    return sorted(set(canonical))
+
+
+def _merge_compatibility_value(
+    *,
+    name: str,
+    nested_value: Any,
+    nested_provided: bool,
+    flat_value: Any,
+    flat_provided: bool,
+    canonicalize: Callable[[Any], Any] = lambda value: value,
+) -> Any:
+    if (
+        nested_provided
+        and flat_provided
+        and canonicalize(nested_value) != canonicalize(flat_value)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Contradictory values supplied for {name}.",
+        )
+    if nested_provided:
+        return nested_value
+    if flat_provided:
+        return flat_value
+    return None
+
+
+def _unique_sorted(values: Any) -> Any:
+    if values is None:
+        return None
+    return sorted(
+        set(values), key=lambda value: value.value if hasattr(value, "value") else value
+    )
+
+
+def normalize_session_query_request(
+    body: SessionQueryRequest,
+) -> NormalizedSessionQuery:
+    session = body.session
+    exclude = body.exclude
+
+    search = _merge_compatibility_value(
+        name="session.search/search",
+        nested_value=session.search if session else None,
+        nested_provided=_provided(session, "search"),
+        flat_value=body.search,
+        flat_provided=_provided(body, "search"),
+        canonicalize=lambda value: (
+            value.strip() or None if isinstance(value, str) else value
+        ),
+    )
+    if isinstance(search, str):
+        search = search.strip() or None
+
+    liveness = _merge_compatibility_value(
+        name="session.liveness/flags",
+        nested_value=session.liveness if session else None,
+        nested_provided=_provided(session, "liveness"),
+        flat_value=body.flags,
+        flat_provided=_provided(body, "flags"),
+        canonicalize=lambda value: (
+            value.model_dump(exclude_none=True) or None if value is not None else None
+        ),
+    )
+    origins = _merge_compatibility_value(
+        name="session.origins/origin",
+        nested_value=session.origins if session else None,
+        nested_provided=_provided(session, "origins"),
+        flat_value=[body.origin] if body.origin is not None else None,
+        flat_provided=_provided(body, "origin"),
+        canonicalize=_canonical_list,
+    )
+    exclude_session_ids = _merge_compatibility_value(
+        name="exclude.session_ids/exclude_session_ids",
+        nested_value=exclude.session_ids if exclude else None,
+        nested_provided=_provided(exclude, "session_ids"),
+        flat_value=body.exclude_session_ids,
+        flat_provided=_provided(body, "exclude_session_ids"),
+        canonicalize=_canonical_list,
+    )
+    exclude_origins = _merge_compatibility_value(
+        name="exclude.origins/exclude_origin",
+        nested_value=exclude.origins if exclude else None,
+        nested_provided=_provided(exclude, "origins"),
+        flat_value=[body.exclude_origin] if body.exclude_origin is not None else None,
+        flat_provided=_provided(body, "exclude_origin"),
+        canonicalize=_canonical_list,
+    )
+    turn_references = _merge_compatibility_value(
+        name="turn_references/references",
+        nested_value=body.turn_references,
+        nested_provided=_provided(body, "turn_references"),
+        flat_value=body.references,
+        # The released field treated [] as no filter. Preserve that behavior even when
+        # the canonical field is also present.
+        flat_provided=_provided(body, "references") and bool(body.references),
+        canonicalize=_canonical_list,
+    )
+
+    return NormalizedSessionQuery(
+        predicates=SessionQuery(
+            turn_references=turn_references,
+            search=search,
+            flags=liveness,
+            session_ids=_unique_sorted(body.session_ids),
+            exclude_session_ids=_unique_sorted(exclude_session_ids),
+            origins=_unique_sorted(origins),
+            exclude_origins=_unique_sorted(exclude_origins),
+        ),
+        lifecycle=SessionQueryLifecycle(
+            include_ended=body.include_ended,
+            include_archived=body.include_archived,
+        ),
+        options=SessionQueryOptions(
+            include_total=body.include_total,
+            expand=body.expand,
+        ),
+        windowing=body.windowing,
+    )
+
+
+def compute_session_response_windowing(
+    *, sessions: list[Any], requested: Optional[Windowing]
+) -> Optional[Windowing]:
+    if requested is None:
+        return None
+
+    terminal = Windowing(
+        newest=requested.newest,
+        oldest=requested.oldest,
+        limit=requested.limit,
+        order=requested.order,
+        interval=requested.interval,
+        rate=requested.rate,
+    )
+    if (
+        requested.limit is None
+        or requested.limit <= 0
+        or len(sessions) < requested.limit
+        or not sessions
+    ):
+        return terminal
+
+    last = sessions[-1]
+    activity = last.updated_at or last.created_at
+    if last.id is None or activity is None:
+        return terminal
+
+    if requested.order == "ascending":
+        return Windowing(
+            next=last.id,
+            newest=requested.newest,
+            oldest=activity,
+            limit=requested.limit,
+            order=requested.order,
+        )
+    return Windowing(
+        next=last.id,
+        newest=activity,
+        oldest=requested.oldest,
+        limit=requested.limit,
+        order=requested.order,
+    )
+
+
+def sanitize_session_tags(tags: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    if tags is None:
+        return tags
+    return {
+        key: value
+        for key, value in tags.items()
+        if key not in _RESERVED_ATTRIBUTION_TAGS
+    }
+
+
+def sanitize_session_stream(
+    stream: Optional[SessionStreamT],
+) -> Optional[SessionStreamT]:
+    if stream is None:
+        return None
+    return stream.model_copy(update={"tags": sanitize_session_tags(stream.tags)})

--- a/api/oss/src/apis/fastapi/sessions/utils.py
+++ b/api/oss/src/apis/fastapi/sessions/utils.py
@@ -12,14 +12,7 @@ from oss.src.core.sessions.dtos import (
 )
 from oss.src.core.sessions.streams.dtos import SessionStream
 from oss.src.core.shared.dtos import Windowing
-
-_RESERVED_ATTRIBUTION_TAGS = {
-    "ag.origin",
-    "ag.trigger.id",
-    "ag.trigger.kind",
-    "ag.trigger.delivery_id",
-    "ag.trigger.name",
-}
+from oss.src.dbs.postgres.sessions.streams.mappings import SESSION_RESERVED_TAG_KEYS
 
 SessionStreamT = TypeVar("SessionStreamT", bound=SessionStream)
 
@@ -88,6 +81,25 @@ def normalize_session_query_request(
 ) -> NormalizedSessionQuery:
     session = body.session
     exclude = body.exclude
+    windowing = body.windowing
+
+    if windowing is not None and windowing.next is not None:
+        # `apply_windowing` nests the cursor predicate under its companion bound
+        # (`.newest` descending / `.oldest` ascending); `next` without it compiles
+        # to no WHERE clause at all — a silent "page 1 again" infinite loop rather
+        # than a diagnostic (P1-2). Contained here, not in the shared helper that
+        # tracing/otel also use.
+        ascending = (windowing.order or "descending").lower() == "ascending"
+        if ascending and windowing.oldest is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="windowing.next requires windowing.oldest when windowing.order is 'ascending'.",
+            )
+        if not ascending and windowing.newest is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="windowing.next requires windowing.newest.",
+            )
 
     search = _merge_compatibility_value(
         name="session.search/search",
@@ -203,6 +215,8 @@ def compute_session_response_windowing(
             oldest=activity,
             limit=requested.limit,
             order=requested.order,
+            interval=requested.interval,
+            rate=requested.rate,
         )
     return Windowing(
         next=last.id,
@@ -210,6 +224,8 @@ def compute_session_response_windowing(
         oldest=requested.oldest,
         limit=requested.limit,
         order=requested.order,
+        interval=requested.interval,
+        rate=requested.rate,
     )
 
 
@@ -219,7 +235,7 @@ def sanitize_session_tags(tags: Optional[dict[str, Any]]) -> Optional[dict[str, 
     return {
         key: value
         for key, value in tags.items()
-        if key not in _RESERVED_ATTRIBUTION_TAGS
+        if key not in SESSION_RESERVED_TAG_KEYS
     }
 
 

--- a/api/oss/src/apis/fastapi/sessions/utils.py
+++ b/api/oss/src/apis/fastapi/sessions/utils.py
@@ -12,7 +12,9 @@ from oss.src.core.sessions.dtos import (
 )
 from oss.src.core.sessions.streams.dtos import SessionStream
 from oss.src.core.shared.dtos import Windowing
-from oss.src.dbs.postgres.sessions.streams.mappings import SESSION_RESERVED_TAG_KEYS
+from oss.src.dbs.postgres.sessions.streams.mappings import (
+    SESSION_RESERVED_TAG_NAMESPACE,
+)
 
 SessionStreamT = TypeVar("SessionStreamT", bound=SessionStream)
 
@@ -159,6 +161,25 @@ def normalize_session_query_request(
         canonicalize=_canonical_list,
     )
 
+    final_origins = _unique_sorted(origins)
+    final_exclude_origins = _unique_sorted(exclude_origins)
+    if final_origins and final_exclude_origins:
+        # An AND of the two predicates (P2-11): an origin in both lists can never
+        # match, so the whole query silently returns zero rows instead of
+        # surfacing the caller's contradiction — the same "contained here, not in
+        # the shared helper" reasoning as the P1-2 cursor check above.
+        contradictory = sorted(
+            value.value for value in set(final_origins) & set(final_exclude_origins)
+        )
+        if contradictory:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Contradictory origin filter: {contradictory} present in both "
+                    "the include and exclude origin lists."
+                ),
+            )
+
     return NormalizedSessionQuery(
         predicates=SessionQuery(
             turn_references=turn_references,
@@ -166,8 +187,8 @@ def normalize_session_query_request(
             flags=liveness,
             session_ids=_unique_sorted(body.session_ids),
             exclude_session_ids=_unique_sorted(exclude_session_ids),
-            origins=_unique_sorted(origins),
-            exclude_origins=_unique_sorted(exclude_origins),
+            origins=final_origins,
+            exclude_origins=final_exclude_origins,
         ),
         lifecycle=SessionQueryLifecycle(
             include_ended=body.include_ended,
@@ -235,7 +256,7 @@ def sanitize_session_tags(tags: Optional[dict[str, Any]]) -> Optional[dict[str, 
     return {
         key: value
         for key, value in tags.items()
-        if key not in SESSION_RESERVED_TAG_KEYS
+        if not key.startswith(SESSION_RESERVED_TAG_NAMESPACE)
     }
 
 

--- a/api/oss/src/apis/fastapi/triggers/router.py
+++ b/api/oss/src/apis/fastapi/triggers/router.py
@@ -1091,7 +1091,7 @@ class TriggersRouter:
     ) -> TriggerSubscriptionResponse:
         await self._check(request, Permission.VIEW_TRIGGERS)
 
-        subscription = await self.triggers_service.fetch_subscription(
+        subscription = await self.triggers_service.fetch_subscription_including_deleted(
             project_id=UUID(request.state.project_id),
             #
             subscription_id=subscription_id,
@@ -1156,6 +1156,7 @@ class TriggersRouter:
 
         deleted = await self.triggers_service.delete_subscription(
             project_id=UUID(request.state.project_id),
+            user_id=UUID(str(request.state.user_id)),
             #
             subscription_id=subscription_id,
         )
@@ -1343,7 +1344,7 @@ class TriggersRouter:
     ) -> TriggerScheduleResponse:
         await self._check(request, Permission.VIEW_TRIGGERS)
 
-        schedule = await self.triggers_service.fetch_schedule(
+        schedule = await self.triggers_service.fetch_schedule_including_deleted(
             project_id=UUID(request.state.project_id),
             #
             schedule_id=schedule_id,
@@ -1409,6 +1410,7 @@ class TriggersRouter:
 
         deleted = await self.triggers_service.delete_schedule(
             project_id=UUID(request.state.project_id),
+            user_id=UUID(str(request.state.user_id)),
             #
             schedule_id=schedule_id,
         )

--- a/api/oss/src/core/sessions/dtos.py
+++ b/api/oss/src/core/sessions/dtos.py
@@ -1,10 +1,18 @@
+from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from oss.src.core.sessions.records.dtos import SessionMessagePreview
 from oss.src.core.sessions.streams.dtos import SessionStream, SessionStreamQueryFlags
 from oss.src.core.shared.dtos import Reference
+from oss.src.core.sessions.types import SessionDelivery as SessionDelivery
+from oss.src.core.sessions.types import SessionOrigin as SessionOrigin
+from oss.src.core.sessions.types import SessionTrigger as SessionTrigger
+from oss.src.core.sessions.types import (
+    SessionTriggerAttribution as SessionTriggerAttribution,
+)
+from oss.src.core.sessions.types import SessionTriggerKind as SessionTriggerKind
 
 
 class SessionListItem(SessionStream):
@@ -23,37 +31,9 @@ class SessionListItem(SessionStream):
     last_message: Optional[SessionMessagePreview] = None
 
 
-# Reserved tag naming WHO started a session. Lives in `tags` rather than a column: the sessions
-# list must be able to hide automation runs by default, and a jsonb tag with a GIN index filters
-# as well as a column would without a migration.
-SESSION_ORIGIN_TAG = "ag.origin"
-
-SESSION_ORIGIN_MANUAL = "manual"
-SESSION_ORIGIN_TRIGGER = "trigger"
-
-# WHICH automation started the session. Written by the same single writer as the origin tag
-# (`SessionStreamsService.set_origin`), so the tags stay one write and never need a merge.
-SESSION_TRIGGER_ID_TAG = "ag.trigger.id"
-SESSION_TRIGGER_NAME_TAG = "ag.trigger.name"
-SESSION_TRIGGER_KIND_TAG = "ag.trigger.kind"
-
-SESSION_TRIGGER_KIND_SCHEDULE = "schedule"
-SESSION_TRIGGER_KIND_SUBSCRIPTION = "subscription"
-
-
-class SessionTriggerRef(BaseModel):
-    """The automation that started a session.
-
-    The name is a SNAPSHOT taken at dispatch, not a live join: a row is history, and resolving
-    names at read time would make the session list depend on the triggers domain. Renaming an
-    automation therefore does not retitle its past runs — the id is stamped alongside so a
-    read-time resolve can supersede the snapshot later without a migration.
-    """
-
-    id: str
-    name: Optional[str] = None
-    # "schedule" (a cron fired) or "subscription" (an event arrived).
-    kind: Optional[str] = None
+class SessionExpansion(str, Enum):
+    last_message = "last_message"
+    trigger = "trigger"
 
 
 class SessionQuery(BaseModel):
@@ -63,12 +43,9 @@ class SessionQuery(BaseModel):
     Every predicate a list view offers must live here. A client that filters a windowed
     page filters the window, not the set — wrong counts, wrong empty states."""
 
-    references: Optional[List[Reference]] = None
-    # Include ended (killed) sessions so the durable list keeps resumable history — absence then
-    # means genuinely hard-deleted, which the frontend uses to prune a locally-cached session.
-    include_ended: bool = False
-    # Include archived sessions — off by default (archive hides); on for the archived view.
-    include_archived: bool = False
+    model_config = ConfigDict(extra="forbid")
+
+    turn_references: Optional[List[Reference]] = None
     # Case-insensitive substring match over the session title (`session_streams.name`).
     search: Optional[str] = None
     # Liveness (alive ⊇ running ⊇ attached), matched against the row's mirrored `flags`.
@@ -80,12 +57,26 @@ class SessionQuery(BaseModel):
     # Its complement: drop known ids from the list, so a group rendered separately (pins) does
     # not appear twice.
     exclude_session_ids: Optional[List[str]] = None
-    # Also return the total matching rows, ignoring windowing. Off by default: a filter chip
-    # wants it, a scroll page does not, and it costs a second query.
+    origins: Optional[List[SessionOrigin]] = None
+    exclude_origins: Optional[List[SessionOrigin]] = None
+
+
+class SessionQueryLifecycle(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    include_ended: bool = False
+    include_archived: bool = False
+
+
+class SessionQueryOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     include_total: bool = False
-    # Who started the session (`SESSION_ORIGIN_*`). A triggered run is a session like any other,
-    # so without this filter an automation's work is indistinguishable from your own in the list.
-    origin: Optional[str] = None
-    # The negation, which containment cannot express: hide automation runs while still showing
-    # every session written before origins were stamped (their tags are NULL, not "manual").
-    exclude_origin: Optional[str] = None
+    expand: List[SessionExpansion] = Field(default_factory=list)
+
+
+class SessionQueryPage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    sessions: List[SessionListItem] = Field(default_factory=list)
+    total: Optional[int] = None

--- a/api/oss/src/core/sessions/records/dtos.py
+++ b/api/oss/src/core/sessions/records/dtos.py
@@ -2,9 +2,13 @@ from datetime import datetime
 from typing import Optional, Any, Dict
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from oss.src.core.shared.dtos import Lifecycle, OTelSpanId
+
+# The DAO truncates at the SQL level (`left(attributes->>'text', ...)`) — this bound
+# just keeps the DTO honest about that contract for any other producer.
+SESSION_MESSAGE_PREVIEW_TEXT_LIMIT = 240
 
 
 class SessionRecordEvent(BaseModel):
@@ -48,7 +52,7 @@ class SessionMessagePreview(BaseModel):
     reached for rather than what it concluded.
     """
 
-    text: str
+    text: str = Field(max_length=SESSION_MESSAGE_PREVIEW_TEXT_LIMIT)
     # "user" or "agent" — the row prefixes your own messages so a preview isn't mistaken for a reply.
     source: Optional[str] = None
     timestamp: Optional[datetime] = None

--- a/api/oss/src/core/sessions/records/dtos.py
+++ b/api/oss/src/core/sessions/records/dtos.py
@@ -48,7 +48,6 @@ class SessionMessagePreview(BaseModel):
     reached for rather than what it concluded.
     """
 
-    session_id: str
     text: str
     # "user" or "agent" — the row prefixes your own messages so a preview isn't mistaken for a reply.
     source: Optional[str] = None

--- a/api/oss/src/core/sessions/service.py
+++ b/api/oss/src/core/sessions/service.py
@@ -11,33 +11,48 @@ whole surface. The front-end composes them — see `apis/fastapi/sessions/router
 module docstring for the read-walk.
 """
 
-from typing import List, Optional, Set
+import asyncio
+from typing import Dict, List, Optional, Set
 from uuid import UUID
 
 from oss.src.core.shared.dtos import Windowing
-from oss.src.core.sessions.dtos import SESSION_ORIGIN_TAG, SessionListItem, SessionQuery
-from oss.src.core.sessions.streams.dtos import SessionStream, SessionStreamQuery
+from oss.src.core.sessions.dtos import (
+    SessionExpansion,
+    SessionListItem,
+    SessionQuery,
+    SessionQueryLifecycle,
+    SessionQueryOptions,
+    SessionQueryPage,
+)
+from oss.src.core.sessions.records.dtos import SessionMessagePreview
+from oss.src.core.sessions.streams.dtos import (
+    SessionStream,
+    SessionStreamQuery,
+    SessionStreamReadOptions,
+)
 from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.core.sessions.turns.dtos import SessionTurnQuery
 from oss.src.core.sessions.turns.service import SessionTurnsService
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
 from oss.src.core.sessions.records.service import RecordsService
 from oss.src.core.mounts.service import MountsService
+from oss.src.utils.logging import get_module_logger
 
 
-def _stream_filter(query: Optional[SessionQuery]) -> SessionStreamQuery:
+log = get_module_logger(__name__)
+
+
+def _stream_filter(
+    query: Optional[SessionQuery], lifecycle: SessionQueryLifecycle
+) -> SessionStreamQuery:
     """The row predicate shared by the list and its total."""
     return SessionStreamQuery(
-        include_ended=bool(query and query.include_ended),
-        include_archived=bool(query and query.include_archived),
+        include_ended=lifecycle.include_ended,
+        include_archived=lifecycle.include_archived,
         search=query.search if query else None,
         flags=query.flags if query else None,
-        tags={SESSION_ORIGIN_TAG: query.origin} if query and query.origin else None,
-        exclude_tags=(
-            {SESSION_ORIGIN_TAG: query.exclude_origin}
-            if query and query.exclude_origin
-            else None
-        ),
+        origins=query.origins if query else None,
+        exclude_origins=query.exclude_origins if query else None,
     )
 
 
@@ -65,11 +80,13 @@ class SessionsService:
         project_id: UUID,
         #
         query: Optional[SessionQuery] = None,
+        lifecycle: Optional[SessionQueryLifecycle] = None,
+        options: Optional[SessionQueryOptions] = None,
         windowing: Optional[Windowing] = None,
     ) -> List[SessionListItem]:
         """List/filter sessions, newest -> oldest, windowed.
 
-        Reads the merged stream rows; when `references` is set, first joins the
+        Reads the merged stream rows; when `turn_references` is set, first joins the
         turns' references (WP1's GIN `.contains()`) to resolve the matching
         `session_id`s, then filters the stream query to that set. No
         denormalization onto the stream row (B3) — revisit only if the join
@@ -79,37 +96,103 @@ class SessionsService:
         turn's `references` and its last message, each via a single batch lookup keyed on
         every listed `session_id` — never one call per row (WP0-R3).
         """
+        page = await self.query_sessions_page(
+            project_id=project_id,
+            query=query,
+            lifecycle=lifecycle,
+            options=options,
+            windowing=windowing,
+        )
+        return page.sessions
+
+    async def query_sessions_page(
+        self,
+        *,
+        project_id: UUID,
+        #
+        query: Optional[SessionQuery] = None,
+        lifecycle: Optional[SessionQueryLifecycle] = None,
+        options: Optional[SessionQueryOptions] = None,
+        windowing: Optional[Windowing] = None,
+    ) -> SessionQueryPage:
+        lifecycle = lifecycle or SessionQueryLifecycle()
+        options = options or SessionQueryOptions()
         session_ids = await self._resolve_session_ids(
             project_id=project_id, query=query
         )
+
+        sessions = await self._query_sessions(
+            project_id=project_id,
+            query=query,
+            lifecycle=lifecycle,
+            options=options,
+            windowing=windowing,
+            session_ids=session_ids,
+        )
+        total = (
+            await self._count_sessions(
+                project_id=project_id,
+                query=query,
+                lifecycle=lifecycle,
+                session_ids=session_ids,
+            )
+            if options.include_total
+            else None
+        )
+        return SessionQueryPage(sessions=sessions, total=total)
+
+    async def _query_sessions(
+        self,
+        *,
+        project_id: UUID,
+        query: Optional[SessionQuery],
+        lifecycle: SessionQueryLifecycle,
+        options: SessionQueryOptions,
+        windowing: Optional[Windowing],
+        session_ids: Optional[List[str]],
+    ) -> List[SessionListItem]:
         if session_ids is not None and not session_ids:
             return []
 
-        streams = await self.streams_service.query_streams(
+        stream_kwargs = dict(
             project_id=project_id,
-            filter=_stream_filter(query),
+            filter=_stream_filter(query, lifecycle),
             windowing=windowing,
             session_ids=session_ids,
             exclude_session_ids=query.exclude_session_ids if query else None,
         )
+        if SessionExpansion.trigger in options.expand:
+            stream_kwargs["read_options"] = SessionStreamReadOptions(
+                include_trigger_details=True
+            )
+        streams = await self.streams_service.query_streams(**stream_kwargs)
 
         if not streams:
             return []
 
         listed_ids = [stream.session_id for stream in streams]
 
-        latest_turns = await self.turns_service.latest_turn_per_session(
-            project_id=project_id,
-            session_ids=listed_ids,
+        latest_turns_lookup = self.turns_service.latest_turn_per_session(
+            project_id=project_id, session_ids=listed_ids
         )
-        previews = (
-            await self.records_service.latest_message_per_session(
-                project_id=project_id,
-                session_ids=listed_ids,
+        if SessionExpansion.last_message in options.expand:
+            latest_turns_task = asyncio.create_task(latest_turns_lookup)
+            previews_task = asyncio.create_task(
+                self._latest_message_previews(
+                    project_id=project_id,
+                    session_ids=listed_ids,
+                )
             )
-            if self.records_service
-            else {}
-        )
+            try:
+                latest_turns = await latest_turns_task
+            except BaseException:
+                previews_task.cancel()
+                await asyncio.gather(previews_task, return_exceptions=True)
+                raise
+            previews = await previews_task
+        else:
+            latest_turns = await latest_turns_lookup
+            previews = {}
 
         items = []
         for stream in streams:
@@ -123,24 +206,60 @@ class SessionsService:
             )
         return items
 
+    async def _latest_message_previews(
+        self,
+        *,
+        project_id: UUID,
+        session_ids: List[str],
+    ) -> Dict[str, SessionMessagePreview]:
+        if self.records_service is None:
+            return {}
+        try:
+            return await self.records_service.latest_message_per_session(
+                project_id=project_id,
+                session_ids=session_ids,
+            )
+        except Exception:
+            log.warning(
+                "[SESSIONS] latest-message lookup failed",
+                project_id=str(project_id),
+            )
+            return {}
+
     async def count_sessions(
         self,
         *,
         project_id: UUID,
         #
         query: Optional[SessionQuery] = None,
+        lifecycle: Optional[SessionQueryLifecycle] = None,
     ) -> int:
         """Total sessions matching the filter, ignoring windowing — what a filter chip
         shows. Same predicate as `query_sessions`, so a page and its total agree."""
         session_ids = await self._resolve_session_ids(
             project_id=project_id, query=query
         )
+        return await self._count_sessions(
+            project_id=project_id,
+            query=query,
+            lifecycle=lifecycle or SessionQueryLifecycle(),
+            session_ids=session_ids,
+        )
+
+    async def _count_sessions(
+        self,
+        *,
+        project_id: UUID,
+        query: Optional[SessionQuery],
+        lifecycle: SessionQueryLifecycle,
+        session_ids: Optional[List[str]],
+    ) -> int:
         if session_ids is not None and not session_ids:
             return 0
 
         return await self.streams_service.count_streams(
             project_id=project_id,
-            filter=_stream_filter(query),
+            filter=_stream_filter(query, lifecycle),
             session_ids=session_ids,
             exclude_session_ids=query.exclude_session_ids if query else None,
         )
@@ -153,7 +272,7 @@ class SessionsService:
     ) -> Optional[List[str]]:
         """The id set to restrict the stream query to, or `None` for no restriction.
 
-        `references` resolves through the turns; `session_ids` arrives from the caller
+        `turn_references` resolves through the turns; `session_ids` arrives from the caller
         (pins, a pending-interaction lookup). Given both, the restriction is their
         INTERSECTION — each narrows, so an id must satisfy both. An empty list (as opposed
         to `None`) means the filters can match nothing, and callers short-circuit on it.
@@ -162,10 +281,12 @@ class SessionsService:
             return None
 
         from_references: Optional[Set[str]] = None
-        if query.references:
+        if query.turn_references is not None:
+            if not query.turn_references:
+                return []
             matching_turns = await self.turns_service.query_turns(
                 project_id=project_id,
-                query=SessionTurnQuery(references=query.references),
+                query=SessionTurnQuery(references=query.turn_references),
             )
             from_references = {turn.session_id for turn in matching_turns}
 

--- a/api/oss/src/core/sessions/service.py
+++ b/api/oss/src/core/sessions/service.py
@@ -31,7 +31,6 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamReadOptions,
 )
 from oss.src.core.sessions.streams.service import SessionStreamsService
-from oss.src.core.sessions.turns.dtos import SessionTurnQuery
 from oss.src.core.sessions.turns.service import SessionTurnsService
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
 from oss.src.core.sessions.records.service import RecordsService
@@ -40,6 +39,12 @@ from oss.src.utils.logging import get_module_logger
 
 
 log = get_module_logger(__name__)
+
+# Hard cap on the id set resolved from `turn_references` (P2-12): the explicit
+# `session_ids`/`exclude_session_ids` request fields are already capped at 500;
+# this derived set rode along unbounded (a full turns-table scan for a broad
+# reference filter).
+TURN_REFERENCES_SESSION_ID_CAP = 500
 
 
 def _stream_filter(
@@ -154,18 +159,16 @@ class SessionsService:
         if session_ids is not None and not session_ids:
             return []
 
-        stream_kwargs = dict(
+        streams = await self.streams_service.query_streams(
             project_id=project_id,
             filter=_stream_filter(query, lifecycle),
             windowing=windowing,
             session_ids=session_ids,
             exclude_session_ids=query.exclude_session_ids if query else None,
+            read_options=SessionStreamReadOptions(
+                include_trigger_details=SessionExpansion.trigger in options.expand
+            ),
         )
-        if SessionExpansion.trigger in options.expand:
-            stream_kwargs["read_options"] = SessionStreamReadOptions(
-                include_trigger_details=True
-            )
-        streams = await self.streams_service.query_streams(**stream_kwargs)
 
         if not streams:
             return []
@@ -223,6 +226,7 @@ class SessionsService:
             log.warning(
                 "[SESSIONS] latest-message lookup failed",
                 project_id=str(project_id),
+                exc_info=True,
             )
             return {}
 
@@ -284,11 +288,13 @@ class SessionsService:
         if query.turn_references is not None:
             if not query.turn_references:
                 return []
-            matching_turns = await self.turns_service.query_turns(
-                project_id=project_id,
-                query=SessionTurnQuery(references=query.turn_references),
+            from_references = set(
+                await self.turns_service.query_session_ids_by_references(
+                    project_id=project_id,
+                    references=query.turn_references,
+                    limit=TURN_REFERENCES_SESSION_ID_CAP,
+                )
             )
-            from_references = {turn.session_id for turn in matching_turns}
 
         explicit: Optional[Set[str]] = (
             set(query.session_ids) if query.session_ids is not None else None

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, field_validator
 from agenta.sdk.models.workflows import WorkflowServiceRequestData
 
 from oss.src.core.shared.dtos import Header, Identifier, Lifecycle
+from oss.src.core.sessions.types import SessionDelivery, SessionOrigin, SessionTrigger
 
 
 class SessionStreamFlags(BaseModel):
@@ -37,6 +38,18 @@ class SessionStream(Identifier, Header, Lifecycle):
     turn_id: Optional[str] = None
     # Set = archived (hidden but restorable); distinct from `deleted_at` (killed, still listed).
     archived_at: Optional[datetime] = None
+    origin: Optional[SessionOrigin] = None
+    trigger: Optional[SessionTrigger] = None
+    delivery: Optional[SessionDelivery] = None
+
+
+class SessionStreamReadOptions(BaseModel):
+    include_trigger_details: bool = False
+
+
+class SessionStreamQueryResult(BaseModel):
+    stream: SessionStream
+    trigger_name: Optional[str] = None
 
 
 class SessionStreamCreate(Header):
@@ -93,6 +106,8 @@ class SessionStreamQuery(BaseModel):
     tags: Optional[Dict[str, Any]] = None
     # Its negation. A row with NULL tags PASSES: absence of a stamp is not a match.
     exclude_tags: Optional[Dict[str, Any]] = None
+    origins: Optional[list[SessionOrigin]] = None
+    exclude_origins: Optional[list[SessionOrigin]] = None
 
 
 class CommandMode(str, Enum):

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -102,10 +102,6 @@ class SessionStreamQuery(BaseModel):
     include_archived: bool = False
     # Case-insensitive substring match over `name` (the session title).
     search: Optional[str] = None
-    # jsonb containment against the row's `tags` — carries the origin filter.
-    tags: Optional[Dict[str, Any]] = None
-    # Its negation. A row with NULL tags PASSES: absence of a stamp is not a match.
-    exclude_tags: Optional[Dict[str, Any]] = None
     origins: Optional[list[SessionOrigin]] = None
     exclude_origins: Optional[list[SessionOrigin]] = None
 

--- a/api/oss/src/core/sessions/streams/interfaces.py
+++ b/api/oss/src/core/sessions/streams/interfaces.py
@@ -8,7 +8,10 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamEdit,
     SessionStreamHeaderEdit,
     SessionStreamQuery,
+    SessionStreamQueryResult,
+    SessionStreamReadOptions,
 )
+from oss.src.core.sessions.types import SessionTriggerAttribution
 from oss.src.core.shared.dtos import Windowing
 
 
@@ -55,7 +58,8 @@ class SessionStreamsDAOInterface(ABC):
         windowing: Optional[Windowing] = None,
         session_ids: Optional[List[str]] = None,
         exclude_session_ids: Optional[List[str]] = None,
-    ) -> List[SessionStream]: ...
+        read_options: Optional[SessionStreamReadOptions] = None,
+    ) -> List[SessionStreamQueryResult]: ...
 
     @abstractmethod
     async def count(
@@ -136,3 +140,18 @@ class SessionStreamsDAOInterface(ABC):
         *,
         project_id: Optional[UUID] = None,
     ) -> int: ...
+
+
+class TriggerSessionClaimsDAOInterface(ABC):
+    @abstractmethod
+    async def claim_trigger_delivery(
+        self,
+        *,
+        project_id: UUID,
+        user_id: Optional[UUID],
+        event_id: str,
+        session_id: str,
+        attribution: SessionTriggerAttribution,
+    ) -> bool:
+        """Atomically claim one trigger delivery and attribute its session."""
+        ...

--- a/api/oss/src/core/sessions/streams/interfaces.py
+++ b/api/oss/src/core/sessions/streams/interfaces.py
@@ -155,3 +155,18 @@ class TriggerSessionClaimsDAOInterface(ABC):
     ) -> bool:
         """Atomically claim one trigger delivery and attribute its session."""
         ...
+
+    @abstractmethod
+    async def abandon_claimed_session(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+    ) -> bool:
+        """Soft-delete a session_streams row claimed via `claim_trigger_delivery`.
+
+        Called when dispatch fails before a turn ever starts, so the row never
+        lingers as a permanent, un-sweepable phantom session (it has `flags=NULL`
+        at claim time, which the orphan sweep can never match).
+        """
+        ...

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -13,7 +13,7 @@ Command matrix (inputs/data × force):
 """
 
 import uuid_utils.compat as uuid
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Iterable, List, Optional
 from uuid import UUID
 
 from oss.src.utils.logging import get_module_logger
@@ -59,19 +59,13 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamFlags,
     SessionStreamHeaderEdit,
     SessionStreamQuery,
+    SessionStreamReadOptions,
 )
 from oss.src.core.sessions.streams.types import (
     ConcurrencyLimitExceeded,
     SessionIdInvalid,
     SessionStreamAlreadyExists,
     SessionTurnInUse,
-)
-from oss.src.core.sessions.dtos import (
-    SESSION_ORIGIN_TAG,
-    SESSION_TRIGGER_ID_TAG,
-    SESSION_TRIGGER_KIND_TAG,
-    SESSION_TRIGGER_NAME_TAG,
-    SessionTriggerRef,
 )
 from oss.src.core.sessions.streams.interfaces import SessionStreamsDAOInterface
 from oss.src.core.sessions.streams.runner_client import kill_runner_sandbox
@@ -701,53 +695,6 @@ class SessionStreamsService:
             await self._publish_changed(project_id=project_id, session_id=session_id)
         return updated
 
-    async def set_origin(
-        self,
-        *,
-        project_id: UUID,
-        user_id: Optional[UUID],
-        session_id: str,
-        origin: str,
-        trigger: Optional[SessionTriggerRef] = None,
-    ) -> Optional[SessionStream]:
-        """Record WHO started a session, and which automation did, as reserved tags.
-
-        Written before the run, so the row usually does not exist yet — hence the same
-        create-or-update shape as `set_header`. Tags are replaced wholesale, which is safe only
-        because this is the first writer; the trigger identity is stamped HERE rather than by a
-        second writer for exactly that reason.
-        """
-        _validate_session_id(session_id)
-        tags: Dict[str, Any] = {SESSION_ORIGIN_TAG: origin}
-        if trigger is not None:
-            tags[SESSION_TRIGGER_ID_TAG] = trigger.id
-            if trigger.name:
-                tags[SESSION_TRIGGER_NAME_TAG] = trigger.name
-            if trigger.kind:
-                tags[SESSION_TRIGGER_KIND_TAG] = trigger.kind
-        updated = await self._dao.update(
-            project_id=project_id,
-            user_id=user_id,
-            session_id=session_id,
-            stream=SessionStreamEdit(tags=tags),
-        )
-        if updated is not None:
-            return updated
-        try:
-            return await self._dao.create(
-                project_id=project_id,
-                user_id=user_id,
-                stream=SessionStreamCreate(session_id=session_id, tags=tags),
-            )
-        except SessionStreamAlreadyExists:
-            # A concurrent first heartbeat won the race; the row exists now.
-            return await self._dao.update(
-                project_id=project_id,
-                user_id=user_id,
-                session_id=session_id,
-                stream=SessionStreamEdit(tags=tags),
-            )
-
     async def query_streams(
         self,
         *,
@@ -756,16 +703,35 @@ class SessionStreamsService:
         windowing: Optional[Windowing] = None,
         session_ids: Optional[List[str]] = None,
         exclude_session_ids: Optional[List[str]] = None,
+        read_options: Optional[SessionStreamReadOptions] = None,
     ) -> List[SessionStream]:
         if filter.session_id:
             _validate_session_id(filter.session_id)
-        return await self._dao.query(
+        results = await self._dao.query(
             project_id=project_id,
             filter=filter,
             windowing=windowing,
             session_ids=session_ids,
             exclude_session_ids=exclude_session_ids,
+            read_options=read_options,
         )
+        streams = []
+        for result in results:
+            stream = result.stream
+            if (
+                read_options
+                and read_options.include_trigger_details
+                and stream.trigger is not None
+            ):
+                stream = stream.model_copy(
+                    update={
+                        "trigger": stream.trigger.model_copy(
+                            update={"name": result.trigger_name}
+                        )
+                    }
+                )
+            streams.append(stream)
+        return streams
 
     async def count_streams(
         self,

--- a/api/oss/src/core/sessions/turns/interfaces.py
+++ b/api/oss/src/core/sessions/turns/interfaces.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from oss.src.core.shared.dtos import Windowing
+from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.sessions.turns.dtos import (
     HarnessKind,
     SessionTurn,
@@ -50,6 +50,21 @@ class SessionTurnsDAOInterface(ABC):
         query: Optional[SessionTurnQuery] = None,
         windowing: Optional[Windowing] = None,
     ) -> List[SessionTurn]: ...
+
+    @abstractmethod
+    async def query_session_ids_by_references(
+        self,
+        *,
+        project_id: UUID,
+        references: List[Reference],
+        limit: int,
+    ) -> List[str]:
+        """Distinct session ids whose turns match `references`, capped at `limit`.
+
+        Narrower than `query_turns` (which loads full turn rows, unbounded) — the
+        session list's turn_references filter only ever needs the id set (P2-12).
+        """
+        ...
 
     @abstractmethod
     async def latest_turn(

--- a/api/oss/src/core/sessions/turns/service.py
+++ b/api/oss/src/core/sessions/turns/service.py
@@ -8,7 +8,7 @@ turn_index DESC LIMIT 1).
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from oss.src.core.shared.dtos import Windowing
+from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.sessions.turns.dtos import (
     HarnessKind,
     SessionTurn,
@@ -81,6 +81,19 @@ class SessionTurnsService:
             project_id=project_id,
             query=query,
             windowing=windowing,
+        )
+
+    async def query_session_ids_by_references(
+        self,
+        *,
+        project_id: UUID,
+        references: List[Reference],
+        limit: int,
+    ) -> List[str]:
+        return await self._dao.query_session_ids_by_references(
+            project_id=project_id,
+            references=references,
+            limit=limit,
         )
 
     async def latest_turn(

--- a/api/oss/src/core/sessions/types.py
+++ b/api/oss/src/core/sessions/types.py
@@ -1,0 +1,31 @@
+from enum import Enum
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class SessionOrigin(str, Enum):
+    manual = "manual"
+    trigger = "trigger"
+
+
+class SessionTriggerKind(str, Enum):
+    schedule = "schedule"
+    subscription = "subscription"
+
+
+class SessionTriggerAttribution(BaseModel):
+    configuration_id: UUID
+    kind: SessionTriggerKind
+    delivery_id: UUID
+
+
+class SessionTrigger(BaseModel):
+    id: UUID
+    kind: SessionTriggerKind
+    name: Optional[str] = None
+
+
+class SessionDelivery(BaseModel):
+    id: UUID

--- a/api/oss/src/core/triggers/dtos.py
+++ b/api/oss/src/core/triggers/dtos.py
@@ -32,6 +32,12 @@ from oss.src.core.shared.dtos import (
 
 TRIGGER_MAX_RETRIES = 5
 
+# The one delivery status that a retry may re-claim (P1-8): a transient failure
+# (the runner was unreachable) rather than a permanent one (invalid config,
+# unresolvable reference). Shared by the dedup pre-check and the atomic claim so
+# they can never disagree on what counts as retryable.
+TRIGGER_DELIVERY_RETRYABLE_STATUS_CODE = "500"
+
 
 # ---------------------------------------------------------------------------
 # Trigger Enums

--- a/api/oss/src/core/triggers/interfaces.py
+++ b/api/oss/src/core/triggers/interfaces.py
@@ -117,6 +117,17 @@ class TriggersDAOInterface(ABC):
     ) -> Optional[TriggerSubscription]: ...
 
     @abstractmethod
+    async def fetch_subscription_including_deleted(
+        self,
+        *,
+        project_id: UUID,
+        #
+        subscription_id: UUID,
+    ) -> Optional[TriggerSubscription]:
+        """Retrieve an exact subscription for authenticated historical display."""
+        ...
+
+    @abstractmethod
     async def edit_subscription(
         self,
         *,
@@ -131,9 +142,21 @@ class TriggersDAOInterface(ABC):
         self,
         *,
         project_id: UUID,
+        user_id: UUID,
         #
         subscription_id: UUID,
     ) -> bool: ...
+
+    @abstractmethod
+    async def purge_subscription(
+        self,
+        *,
+        project_id: UUID,
+        #
+        subscription_id: UUID,
+    ) -> bool:
+        """Physically remove a subscription and its deliveries."""
+        ...
 
     @abstractmethod
     async def query_subscriptions(
@@ -166,8 +189,10 @@ class TriggersDAOInterface(ABC):
 
         Deliberately cross-project: an inbound Composio event carries only the
         provider ``ti_*`` and no tenant scope, so this lookup *recovers* the
-        project from the (partial-unique) ``trigger_id`` column. The only sanctioned
-        unscoped DAO read — every other read/write takes ``project_id``.
+        project from the project-scoped partial-unique ``trigger_id`` column. Returns
+        no match when multiple live projects share the id, rather than selecting a
+        tenant. The only sanctioned unscoped DAO read — every other read/write takes
+        ``project_id``.
         """
         ...
 
@@ -186,7 +211,7 @@ class TriggersDAOInterface(ABC):
         ...
 
     @abstractmethod
-    async def claim_delivery(
+    async def write_subscription_delivery_if_live(
         self,
         *,
         project_id: UUID,
@@ -194,14 +219,7 @@ class TriggersDAOInterface(ABC):
         #
         delivery: TriggerDeliveryCreate,
     ) -> Optional[TriggerDelivery]:
-        """Atomically reserve the delivery row for (subscription|schedule, event_id).
-
-        Backed by the same partial-unique index ``write_delivery`` upserts on:
-        ``INSERT ... ON CONFLICT DO NOTHING ... RETURNING``. Returns the newly
-        inserted (reserved) row, or ``None`` if a row for this event already
-        exists — meaning another caller already claimed (or completed) it and
-        this caller must NOT invoke the bound workflow.
-        """
+        """Upsert only while the subscription parent remains live and active."""
         ...
 
     @abstractmethod
@@ -216,8 +234,8 @@ class TriggersDAOInterface(ABC):
     ) -> Optional[TriggerDelivery]:
         """Complete a previously claimed delivery row to its terminal status.
 
-        Updates the row IN PLACE by id (never inserts) so a post-invoke write
-        failure cannot manifest as "no row exists" on retry.
+        Updates the row in place by id and merges data so claim-time correlation
+        fields survive terminal result or error writes.
         """
         ...
 
@@ -298,6 +316,17 @@ class TriggersDAOInterface(ABC):
     ) -> Optional[TriggerSchedule]: ...
 
     @abstractmethod
+    async def fetch_schedule_including_deleted(
+        self,
+        *,
+        project_id: UUID,
+        #
+        schedule_id: UUID,
+    ) -> Optional[TriggerSchedule]:
+        """Retrieve an exact schedule for authenticated historical display."""
+        ...
+
+    @abstractmethod
     async def edit_schedule(
         self,
         *,
@@ -312,9 +341,21 @@ class TriggersDAOInterface(ABC):
         self,
         *,
         project_id: UUID,
+        user_id: UUID,
         #
         schedule_id: UUID,
     ) -> bool: ...
+
+    @abstractmethod
+    async def purge_schedule(
+        self,
+        *,
+        project_id: UUID,
+        #
+        schedule_id: UUID,
+    ) -> bool:
+        """Physically remove a schedule and its deliveries."""
+        ...
 
     @abstractmethod
     async def query_schedules(

--- a/api/oss/src/core/triggers/interfaces.py
+++ b/api/oss/src/core/triggers/interfaces.py
@@ -159,6 +159,19 @@ class TriggersDAOInterface(ABC):
         ...
 
     @abstractmethod
+    async def mark_subscription_needs_provider_cleanup(
+        self,
+        *,
+        project_id: UUID,
+        subscription_id: UUID,
+    ) -> None:
+        """Best-effort marker for reconciliation: local state (soft-delete /
+        is_active=false) already committed, but the matching provider cleanup
+        call failed. Not scoped to `deleted_at IS NULL` — the caller may be
+        marking a row it just soft-deleted."""
+        ...
+
+    @abstractmethod
     async def query_subscriptions(
         self,
         *,

--- a/api/oss/src/core/triggers/providers/composio/adapter.py
+++ b/api/oss/src/core/triggers/providers/composio/adapter.py
@@ -238,6 +238,14 @@ class ComposioTriggersAdapter(ComposioTriggersCatalogClient, TriggersGatewayInte
     ) -> None:
         try:
             await self._delete(f"/trigger_instances/manage/{trigger_id}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return
+            raise AdapterError(
+                provider_key="composio",
+                operation="delete_subscription",
+                detail=composio_error_detail(e),
+            ) from e
         except httpx.HTTPError as e:
             raise AdapterError(
                 provider_key="composio",

--- a/api/oss/src/core/triggers/service.py
+++ b/api/oss/src/core/triggers/service.py
@@ -1084,10 +1084,17 @@ class TriggersService:
         #
         subscription_id: UUID,
     ) -> bool:
-        """Delete the provider ``ti_*``, then soft-delete the local row.
+        """Soft-delete the local row first, then best-effort delete the provider ``ti_*``.
+
+        Local state must land before the provider call: a degraded provider (a
+        rotated key, a timeout, a 5xx) must never leave a user unable to delete a
+        firing automation (P0-2) — mirrors `delete_connection`'s existing
+        tolerance in the connections domain. A provider failure is logged and
+        recorded as a `needs_provider_cleanup` marker for reconciliation instead
+        of raised.
 
         Deleting a subscription must NOT revoke the shared connection (C7): the
-        adapter call below targets only the trigger instance, never the ``ca_*``.
+        provider call targets only the trigger instance, never the ``ca_*``.
         """
         existing = await self.dao.fetch_subscription(
             project_id=project_id,
@@ -1096,16 +1103,30 @@ class TriggersService:
         if existing is None:
             return False
 
-        await self._delete_provider_subscription(
-            project_id=project_id,
-            subscription=existing,
-        )
-
-        return await self.dao.delete_subscription(
+        deleted = await self.dao.delete_subscription(
             project_id=project_id,
             user_id=user_id,
             subscription_id=subscription_id,
         )
+
+        try:
+            await self._delete_provider_subscription(
+                project_id=project_id,
+                subscription=existing,
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            log.warning(
+                "Failed to delete provider trigger for subscription %s, "
+                "local delete already applied: %s",
+                subscription_id,
+                e,
+            )
+            await self.dao.mark_subscription_needs_provider_cleanup(
+                project_id=project_id,
+                subscription_id=subscription_id,
+            )
+
+        return deleted
 
     async def _delete_provider_subscription(
         self,
@@ -1114,14 +1135,24 @@ class TriggersService:
         subscription: TriggerSubscription,
     ) -> None:
         trigger_id = subscription.trigger_id
-        if trigger_id is not None:
-            connection = await self.connections_service.get_connection(
-                project_id=project_id,
-                connection_id=subscription.connection_id,
-            )
-            if connection is not None:
-                adapter = self.adapter_registry.get(connection.provider_key.value)
-                await adapter.delete_subscription(trigger_id=trigger_id)
+        if trigger_id is None:
+            return
+        # The provider delete needs only `trigger_id` — look up the connection just
+        # for its provider_key, and fall back to the default provider when the
+        # connection row is already gone (P2-5: a soft-deleted subscription whose
+        # connection was deleted must still attempt cleanup, or the upstream
+        # `ti_*` fires into a 200-ACK void forever).
+        connection = await self.connections_service.get_connection(
+            project_id=project_id,
+            connection_id=subscription.connection_id,
+        )
+        provider_key = (
+            connection.provider_key.value
+            if connection is not None
+            else TriggerProviderKind.COMPOSIO.value
+        )
+        adapter = self.adapter_registry.get(provider_key)
+        await adapter.delete_subscription(trigger_id=trigger_id)
 
     async def cleanup_test_subscription(
         self,
@@ -1136,6 +1167,12 @@ class TriggersService:
         )
         if existing is None:
             return False
+
+        if not existing.flags.is_test:
+            # This is a physical, unrecoverable purge — refuse anything that
+            # isn't a short-lived test subscription so a wrong subscription_id
+            # can't destroy real automation history.
+            raise ValueError("cleanup_test_subscription only purges test subscriptions")
 
         await self._delete_provider_subscription(
             project_id=project_id,
@@ -1195,6 +1232,12 @@ class TriggersService:
         """Full-PUT play/pause toggle; touches only local is_active (never is_valid).
 
         Distinct from /revoke, which drives the provider ti_* / is_valid axis.
+
+        Stopping (``is_active=False``) writes local state first, then attempts the
+        provider sync best-effort: a degraded provider must never block a user
+        from stopping a firing automation (P0-2), mirroring `delete_subscription`.
+        Starting keeps the provider-first order — the enable call must actually
+        succeed before the subscription can be trusted to run again.
         """
         existing = await self.dao.fetch_subscription(
             project_id=project_id,
@@ -1202,13 +1245,6 @@ class TriggersService:
         )
         if existing is None:
             raise SubscriptionNotFoundError(subscription_id=str(subscription_id))
-
-        await self._sync_provider_enabled(
-            project_id=project_id,
-            subscription=existing,
-            is_active=is_active,
-            is_valid=existing.flags.is_valid,
-        )
 
         edit = TriggerSubscriptionEdit(
             id=existing.id,
@@ -1221,11 +1257,42 @@ class TriggersService:
             flags=existing.flags.model_copy(update={"is_active": is_active}),
         )
 
-        updated = await self.dao.edit_subscription(
-            project_id=project_id,
-            user_id=user_id,
-            subscription=edit,
-        )
+        if is_active:
+            await self._sync_provider_enabled(
+                project_id=project_id,
+                subscription=existing,
+                is_active=is_active,
+                is_valid=existing.flags.is_valid,
+            )
+            updated = await self.dao.edit_subscription(
+                project_id=project_id,
+                user_id=user_id,
+                subscription=edit,
+            )
+        else:
+            updated = await self.dao.edit_subscription(
+                project_id=project_id,
+                user_id=user_id,
+                subscription=edit,
+            )
+            try:
+                await self._sync_provider_enabled(
+                    project_id=project_id,
+                    subscription=existing,
+                    is_active=is_active,
+                    is_valid=existing.flags.is_valid,
+                )
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                log.warning(
+                    "Failed to sync provider disable for subscription %s, "
+                    "local stop already applied: %s",
+                    subscription_id,
+                    e,
+                )
+                await self.dao.mark_subscription_needs_provider_cleanup(
+                    project_id=project_id,
+                    subscription_id=subscription_id,
+                )
         if updated is None:
             raise SubscriptionNotFoundError(subscription_id=str(subscription_id))
         return updated
@@ -1293,10 +1360,20 @@ class TriggersService:
             )
         finally:
             if owns_created:
-                await self.cleanup_test_subscription(
-                    project_id=project_id,
-                    subscription_id=created.id,
-                )
+                # A transient provider failure during teardown must not mask a
+                # captured result (or a real error from the `try` block) with an
+                # unrelated AdapterError raised from `finally`.
+                try:
+                    await self.cleanup_test_subscription(
+                        project_id=project_id,
+                        subscription_id=created.id,
+                    )
+                except AdapterError as e:
+                    log.warning(
+                        "Failed to clean up test subscription %s: %s",
+                        created.id,
+                        e,
+                    )
 
     async def _set_valid(
         self,
@@ -1672,7 +1749,21 @@ class TriggersService:
         user_id: Optional[UUID] = None,
         #
         delivery: TriggerDeliveryCreate,
-    ) -> TriggerDelivery:
+    ) -> Optional[TriggerDelivery]:
+        """Write a delivery row.
+
+        A subscription-scoped delivery routes through the liveness-gated DAO path
+        (`write_subscription_delivery_if_live`) — this public service method must
+        not reopen the hole that one was added to close (P3-6). No production
+        caller today; a schedule-scoped delivery has no equivalent gate to bypass,
+        so it still goes straight to `write_delivery`.
+        """
+        if delivery.subscription_id is not None and delivery.schedule_id is None:
+            return await self.dao.write_subscription_delivery_if_live(
+                project_id=project_id,
+                user_id=user_id,
+                delivery=delivery,
+            )
         return await self.dao.write_delivery(
             project_id=project_id,
             user_id=user_id,

--- a/api/oss/src/core/triggers/service.py
+++ b/api/oss/src/core/triggers/service.py
@@ -980,6 +980,18 @@ class TriggersService:
             subscription_id=subscription_id,
         )
 
+    async def fetch_subscription_including_deleted(
+        self,
+        *,
+        project_id: UUID,
+        #
+        subscription_id: UUID,
+    ) -> Optional[TriggerSubscription]:
+        return await self.dao.fetch_subscription_including_deleted(
+            project_id=project_id,
+            subscription_id=subscription_id,
+        )
+
     async def query_subscriptions(
         self,
         *,
@@ -1068,10 +1080,11 @@ class TriggersService:
         self,
         *,
         project_id: UUID,
+        user_id: UUID,
         #
         subscription_id: UUID,
     ) -> bool:
-        """Delete the local row and the provider ``ti_*``.
+        """Delete the provider ``ti_*``, then soft-delete the local row.
 
         Deleting a subscription must NOT revoke the shared connection (C7): the
         adapter call below targets only the trigger instance, never the ``ca_*``.
@@ -1083,25 +1096,52 @@ class TriggersService:
         if existing is None:
             return False
 
-        trigger_id = existing.trigger_id
+        await self._delete_provider_subscription(
+            project_id=project_id,
+            subscription=existing,
+        )
+
+        return await self.dao.delete_subscription(
+            project_id=project_id,
+            user_id=user_id,
+            subscription_id=subscription_id,
+        )
+
+    async def _delete_provider_subscription(
+        self,
+        *,
+        project_id: UUID,
+        subscription: TriggerSubscription,
+    ) -> None:
+        trigger_id = subscription.trigger_id
         if trigger_id is not None:
             connection = await self.connections_service.get_connection(
                 project_id=project_id,
-                connection_id=existing.connection_id,
+                connection_id=subscription.connection_id,
             )
             if connection is not None:
                 adapter = self.adapter_registry.get(connection.provider_key.value)
-                try:
-                    await adapter.delete_subscription(trigger_id=trigger_id)
-                except AdapterError:
-                    # Provider-side trigger may already be gone; local delete is
-                    # the source of truth. Unexpected errors are left to surface.
-                    log.warning(
-                        "Failed to delete provider trigger %s; proceeding with local delete",
-                        trigger_id,
-                    )
+                await adapter.delete_subscription(trigger_id=trigger_id)
 
-        return await self.dao.delete_subscription(
+    async def cleanup_test_subscription(
+        self,
+        *,
+        project_id: UUID,
+        subscription_id: UUID,
+    ) -> bool:
+        """Remove a temporary provider trigger and physically purge its local history."""
+        existing = await self.dao.fetch_subscription(
+            project_id=project_id,
+            subscription_id=subscription_id,
+        )
+        if existing is None:
+            return False
+
+        await self._delete_provider_subscription(
+            project_id=project_id,
+            subscription=existing,
+        )
+        return await self.dao.purge_subscription(
             project_id=project_id,
             subscription_id=subscription_id,
         )
@@ -1186,8 +1226,9 @@ class TriggersService:
             user_id=user_id,
             subscription=edit,
         )
-
-        return updated or existing
+        if updated is None:
+            raise SubscriptionNotFoundError(subscription_id=str(subscription_id))
+        return updated
 
     async def test_subscription(
         self,
@@ -1252,7 +1293,7 @@ class TriggersService:
             )
         finally:
             if owns_created:
-                await self.delete_subscription(
+                await self.cleanup_test_subscription(
                     project_id=project_id,
                     subscription_id=created.id,
                 )
@@ -1295,8 +1336,9 @@ class TriggersService:
             user_id=user_id,
             subscription=edit,
         )
-
-        return updated or existing
+        if updated is None:
+            raise SubscriptionNotFoundError(subscription_id=str(subscription_id))
+        return updated
 
     # -----------------------------------------------------------------------
     # Schedules
@@ -1374,6 +1416,18 @@ class TriggersService:
             schedule_id=schedule_id,
         )
 
+    async def fetch_schedule_including_deleted(
+        self,
+        *,
+        project_id: UUID,
+        #
+        schedule_id: UUID,
+    ) -> Optional[TriggerSchedule]:
+        return await self.dao.fetch_schedule_including_deleted(
+            project_id=project_id,
+            schedule_id=schedule_id,
+        )
+
     async def query_schedules(
         self,
         *,
@@ -1423,11 +1477,13 @@ class TriggersService:
         self,
         *,
         project_id: UUID,
+        user_id: UUID,
         #
         schedule_id: UUID,
     ) -> bool:
         return await self.dao.delete_schedule(
             project_id=project_id,
+            user_id=user_id,
             schedule_id=schedule_id,
         )
 
@@ -1471,8 +1527,9 @@ class TriggersService:
             user_id=user_id,
             schedule=edit,
         )
-
-        return updated or existing
+        if updated is None:
+            raise ScheduleNotFoundError(schedule_id=str(schedule_id))
+        return updated
 
     async def refresh_schedules(
         self,
@@ -1555,7 +1612,7 @@ class TriggersService:
                         project_id=str(project_id),
                         event_id=event_id,
                         event=event,
-                        schedule=schedule.model_dump(mode="json"),
+                        schedule_id=str(schedule.id),
                     ),
                     timeout=_ENQUEUE_TIMEOUT_SECONDS,
                 )

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -175,7 +175,6 @@ class RecordsDAO(RecordsDAOInterface):
             if not isinstance(text, str) or not text.strip():
                 continue
             previews[row.session_id] = SessionMessagePreview(
-                session_id=row.session_id,
                 text=text.strip(),
                 source=row.record_source,
                 timestamp=row.timestamp or row.created_at,

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -1,11 +1,12 @@
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from oss.src.core.sessions.records.dtos import (
+    SESSION_MESSAGE_PREVIEW_TEXT_LIMIT,
     SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
@@ -143,11 +144,17 @@ class RecordsDAO(RecordsDAOInterface):
             return {}
 
         async with self.engine.session() as session:
+            # Select the truncated text expression, not the whole `attributes` JSONB —
+            # a 5 MB last message otherwise rides along for every row on every page
+            # (P2-1). `left(...)` truncates before the value ever leaves Postgres.
+            preview_text = func.left(
+                RecordDBE.attributes["text"].astext, SESSION_MESSAGE_PREVIEW_TEXT_LIMIT
+            ).label("text")
             stmt = (
                 select(
                     RecordDBE.session_id,
                     RecordDBE.record_source,
-                    RecordDBE.attributes,
+                    preview_text,
                     RecordDBE.timestamp,
                     RecordDBE.created_at,
                 )
@@ -170,7 +177,7 @@ class RecordsDAO(RecordsDAOInterface):
 
         previews: Dict[str, SessionMessagePreview] = {}
         for row in rows:
-            text = (row.attributes or {}).get("text")
+            text = row.text
             # A message whose payload carries no text (attachment-only) has nothing to preview.
             if not isinstance(text, str) or not text.strip():
                 continue

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -3,11 +3,12 @@ from typing import List, Optional
 from uuid import UUID
 
 import uuid_utils.compat as uuid
-from sqlalchemy import case, cast, delete as sa_delete, func, literal, not_, or_, select
+from sqlalchemy import case, cast, delete as sa_delete, func, literal, or_, select
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID, insert
 from sqlalchemy.exc import IntegrityError
 
 from oss.src.core.sessions.dtos import (
+    SessionOrigin,
     SessionTriggerAttribution,
     SessionTriggerKind,
 )
@@ -55,6 +56,12 @@ _UUID_PATTERN = (
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
     r"[0-9a-f]{4}-[0-9a-f]{12}$"
 )
+
+# Defense-in-depth clamp (P0-1): the API request model already bounds
+# `windowing.limit` to [1, 200] with a 422, but this DAO is also reachable from
+# internal callers that build a `Windowing` directly — never let one of those
+# reach Postgres with an unbounded or negative `LIMIT`.
+MAX_SESSION_QUERY_LIMIT = 200
 
 
 class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInterface):
@@ -188,6 +195,17 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
 
         return claimed
 
+    async def abandon_claimed_session(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+    ) -> bool:
+        return await self.delete_by_session_id(
+            project_id=project_id,
+            session_id=session_id,
+        )
+
     async def get_by_session_id(
         self,
         *,
@@ -272,20 +290,19 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
             )
             if flags_filter:
                 stmt = stmt.where(SessionStreamDBE.flags.contains(flags_filter))
-        if filter.tags:
-            stmt = stmt.where(SessionStreamDBE.tags.contains(filter.tags))
-        if filter.exclude_tags:
-            # `NOT (tags @> …)` is NULL — not true — for a row with no tags, which would drop
-            # every session written before origins were stamped. Admit those explicitly.
-            stmt = stmt.where(
-                or_(
-                    SessionStreamDBE.tags.is_(None),
-                    not_(SessionStreamDBE.tags.contains(filter.exclude_tags)),
-                )
-            )
         origin = SessionStreamDBE.tags[SESSION_ORIGIN_TAG_KEY].astext
         if filter.origins is not None:
-            stmt = stmt.where(origin.in_([value.value for value in filter.origins]))
+            origin_values = [value.value for value in filter.origins]
+            if SessionOrigin.manual.value in origin_values:
+                # Nothing has ever stamped "manual" — every human session has a NULL
+                # origin (only `trigger_attribution_tags` writes the tag, and only
+                # ever "trigger"). Admit NULL when "manual" is requested, or
+                # `origins: ["manual"]` matches zero rows and
+                # `origins: ["manual", "trigger"]` silently drops every human
+                # session (P1-1).
+                stmt = stmt.where(or_(origin.in_(origin_values), origin.is_(None)))
+            else:
+                stmt = stmt.where(origin.in_(origin_values))
         if filter.exclude_origins:
             stmt = stmt.where(
                 or_(
@@ -344,6 +361,14 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
                 exclude_session_ids=exclude_session_ids,
             )
             if windowing:
+                if windowing.limit is not None:
+                    windowing = windowing.model_copy(
+                        update={
+                            "limit": min(
+                                max(windowing.limit, 1), MAX_SESSION_QUERY_LIMIT
+                            )
+                        }
+                    )
                 stmt = apply_windowing(
                     stmt=stmt,
                     DBE=SessionStreamDBE,

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -2,19 +2,30 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy import delete as sa_delete, func, not_, or_, select
+import uuid_utils.compat as uuid
+from sqlalchemy import case, cast, delete as sa_delete, func, literal, not_, or_, select
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID, insert
 from sqlalchemy.exc import IntegrityError
 
+from oss.src.core.sessions.dtos import (
+    SessionTriggerAttribution,
+    SessionTriggerKind,
+)
 from oss.src.core.sessions.streams.dtos import (
     SessionStream,
     SessionStreamCreate,
     SessionStreamEdit,
     SessionStreamHeaderEdit,
     SessionStreamQuery,
+    SessionStreamQueryResult,
+    SessionStreamReadOptions,
 )
-from oss.src.core.sessions.streams.interfaces import SessionStreamsDAOInterface
+from oss.src.core.sessions.streams.interfaces import (
+    SessionStreamsDAOInterface,
+    TriggerSessionClaimsDAOInterface,
+)
 from oss.src.core.sessions.streams.types import SessionStreamAlreadyExists
-from oss.src.core.shared.dtos import Windowing
+from oss.src.core.shared.dtos import Status, Windowing
 
 from oss.src.dbs.postgres.shared.engine import (
     TransactionsEngine,
@@ -23,14 +34,30 @@ from oss.src.dbs.postgres.shared.engine import (
 from oss.src.dbs.postgres.shared.utils import apply_windowing
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.dbs.postgres.sessions.streams.mappings import (
+    SESSION_ORIGIN_TAG_KEY,
+    SESSION_TRIGGER_ID_TAG_KEY,
+    SESSION_TRIGGER_KIND_TAG_KEY,
+    trigger_attribution_tags,
     map_stream_dbe_to_dto,
+    map_stream_query_result,
     map_stream_dto_to_dbe_create,
     map_stream_dto_to_dbe_edit,
     map_stream_dto_to_dbe_header_edit,
 )
+from oss.src.dbs.postgres.triggers.dbes import (
+    TriggerDeliveryDBE,
+    TriggerScheduleDBE,
+    TriggerSubscriptionDBE,
+)
 
 
-class SessionStreamsDAO(SessionStreamsDAOInterface):
+_UUID_PATTERN = (
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInterface):
     def __init__(self, engine: TransactionsEngine = None):
         if engine is None:
             engine = get_transactions_engine()
@@ -59,6 +86,107 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
                 raise SessionStreamAlreadyExists(session_id=stream.session_id) from e
             raise
         return map_stream_dbe_to_dto(stream_dbe=dbe)
+
+    async def claim_trigger_delivery(
+        self,
+        *,
+        project_id: UUID,
+        user_id: Optional[UUID],
+        event_id: str,
+        session_id: str,
+        attribution: SessionTriggerAttribution,
+    ) -> bool:
+        by_schedule = attribution.kind == SessionTriggerKind.schedule
+        claim_status = Status(code="102", message="claimed")
+        delivery_values = {
+            "id": attribution.delivery_id,
+            "project_id": project_id,
+            "created_by_id": user_id,
+            "subscription_id": None if by_schedule else attribution.configuration_id,
+            "schedule_id": attribution.configuration_id if by_schedule else None,
+            "event_id": event_id,
+            "status": claim_status.model_dump(mode="json", exclude_none=True),
+            "data": {"session_id": session_id},
+        }
+        index_elements = (
+            ["project_id", "schedule_id", "event_id"]
+            if by_schedule
+            else ["project_id", "subscription_id", "event_id"]
+        )
+        index_where = (
+            TriggerDeliveryDBE.schedule_id.isnot(None)
+            if by_schedule
+            else TriggerDeliveryDBE.subscription_id.isnot(None)
+        )
+        parent_dbe = TriggerScheduleDBE if by_schedule else TriggerSubscriptionDBE
+        active_flags = (
+            {"is_active": True}
+            if by_schedule
+            else {"is_active": True, "is_valid": True}
+        )
+        live_parent = (
+            select(parent_dbe.id)
+            .where(
+                parent_dbe.project_id == project_id,
+                parent_dbe.id == attribution.configuration_id,
+                parent_dbe.deleted_at.is_(None),
+                parent_dbe.flags.contains(active_flags),
+            )
+            .with_for_update()
+            .cte("live_trigger_configuration")
+        )
+        delivery_columns = list(delivery_values)
+        claimed_delivery = (
+            insert(TriggerDeliveryDBE)
+            .from_select(
+                delivery_columns,
+                select(
+                    *(
+                        literal(
+                            delivery_values[column],
+                            type_=TriggerDeliveryDBE.__table__.c[column].type,
+                        )
+                        for column in delivery_columns
+                    )
+                ).select_from(live_parent),
+            )
+            .on_conflict_do_nothing(
+                index_elements=index_elements,
+                index_where=index_where,
+            )
+            .returning(TriggerDeliveryDBE.id)
+            .cte("claimed_trigger_delivery")
+        )
+
+        tags = trigger_attribution_tags(attribution)
+        stream_insert = insert(SessionStreamDBE).from_select(
+            ["id", "project_id", "created_by_id", "session_id", "tags"],
+            select(
+                literal(uuid.uuid7()),
+                literal(project_id),
+                literal(user_id),
+                literal(session_id),
+                cast(tags, JSONB),
+            ).select_from(claimed_delivery),
+        )
+        merged_tags = func.coalesce(SessionStreamDBE.tags, cast({}, JSONB)).op("||")(
+            stream_insert.excluded.tags
+        )
+        statement = stream_insert.on_conflict_do_update(
+            index_elements=["project_id", "session_id"],
+            set_={"tags": merged_tags},
+        ).returning(SessionStreamDBE.id)
+
+        async with self.engine.session() as session:
+            try:
+                result = await session.execute(statement)
+                claimed = result.scalar_one_or_none() is not None
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+        return claimed
 
     async def get_by_session_id(
         self,
@@ -155,6 +283,16 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
                     not_(SessionStreamDBE.tags.contains(filter.exclude_tags)),
                 )
             )
+        origin = SessionStreamDBE.tags[SESSION_ORIGIN_TAG_KEY].astext
+        if filter.origins is not None:
+            stmt = stmt.where(origin.in_([value.value for value in filter.origins]))
+        if filter.exclude_origins:
+            stmt = stmt.where(
+                or_(
+                    origin.is_(None),
+                    origin.not_in([value.value for value in filter.exclude_origins]),
+                )
+            )
         term = filter.search.strip() if filter.search else ""
         if term:
             # Escape LIKE metacharacters so a literal `%`/`_` in the search term
@@ -193,10 +331,13 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
         windowing: Optional[Windowing] = None,
         session_ids: Optional[List[str]] = None,
         exclude_session_ids: Optional[List[str]] = None,
-    ) -> List[SessionStream]:
+        read_options: Optional[SessionStreamReadOptions] = None,
+    ) -> List[SessionStreamQueryResult]:
+        read_options = read_options or SessionStreamReadOptions()
         async with self.engine.session() as session:
+            stmt = self._query_select(read_options=read_options)
             stmt = self._apply_filters(
-                select(SessionStreamDBE),
+                stmt,
                 project_id=project_id,
                 filter=filter,
                 session_ids=session_ids,
@@ -229,8 +370,58 @@ class SessionStreamsDAO(SessionStreamsDAOInterface):
                     SessionStreamDBE.id.desc(),
                 )
             result = await session.execute(stmt)
+            if read_options.include_trigger_details:
+                rows = result.all()
+                return [
+                    map_stream_query_result(
+                        stream_dbe=row[0], trigger_name=row.trigger_name
+                    )
+                    for row in rows
+                ]
             dbes = result.scalars().all()
-        return [map_stream_dbe_to_dto(stream_dbe=dbe) for dbe in dbes]
+            return [map_stream_query_result(stream_dbe=dbe) for dbe in dbes]
+
+    @staticmethod
+    def _query_select(*, read_options: SessionStreamReadOptions):
+        if not read_options.include_trigger_details:
+            return select(SessionStreamDBE)
+
+        trigger_id_text = SessionStreamDBE.tags[SESSION_TRIGGER_ID_TAG_KEY].astext
+        trigger_kind = SessionStreamDBE.tags[SESSION_TRIGGER_KIND_TAG_KEY].astext
+        trigger_id = case(
+            (
+                trigger_id_text.op("~*")(_UUID_PATTERN),
+                cast(trigger_id_text, PG_UUID(as_uuid=True)),
+            ),
+            else_=None,
+        )
+        trigger_name = case(
+            (
+                trigger_kind == SessionTriggerKind.schedule.value,
+                TriggerScheduleDBE.name,
+            ),
+            (
+                trigger_kind == SessionTriggerKind.subscription.value,
+                TriggerSubscriptionDBE.name,
+            ),
+            else_=None,
+        ).label("trigger_name")
+
+        return (
+            select(SessionStreamDBE, trigger_name)
+            .outerjoin(
+                TriggerScheduleDBE,
+                (TriggerScheduleDBE.project_id == SessionStreamDBE.project_id)
+                & (trigger_kind == SessionTriggerKind.schedule.value)
+                & (TriggerScheduleDBE.id == trigger_id),
+            )
+            .outerjoin(
+                TriggerSubscriptionDBE,
+                (TriggerSubscriptionDBE.project_id == SessionStreamDBE.project_id)
+                & (trigger_kind == SessionTriggerKind.subscription.value)
+                & (TriggerSubscriptionDBE.id == trigger_id),
+            )
+        )
 
     async def update(
         self,

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -27,6 +27,7 @@ from oss.src.core.sessions.streams.interfaces import (
 )
 from oss.src.core.sessions.streams.types import SessionStreamAlreadyExists
 from oss.src.core.shared.dtos import Status, Windowing
+from oss.src.core.triggers.dtos import TRIGGER_DELIVERY_RETRYABLE_STATUS_CODE
 
 from oss.src.dbs.postgres.shared.engine import (
     TransactionsEngine,
@@ -45,6 +46,13 @@ from oss.src.dbs.postgres.sessions.streams.mappings import (
     map_stream_dto_to_dbe_edit,
     map_stream_dto_to_dbe_header_edit,
 )
+
+# The trigger claim lives in the sessions DAO, not triggers/dao.py (P2-13,
+# accepted + documented per the ruling): the delivery INSERT and the session's
+# attribution INSERT must land in one statement for atomicity — one committed
+# session_streams row is what proves a delivery was claimed. Splitting them
+# across two DAOs would need a second round-trip and reopen the race this
+# claim exists to close. See claim_trigger_delivery below.
 from oss.src.dbs.postgres.triggers.dbes import (
     TriggerDeliveryDBE,
     TriggerScheduleDBE,
@@ -143,23 +151,40 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
             .cte("live_trigger_configuration")
         )
         delivery_columns = list(delivery_values)
-        claimed_delivery = (
-            insert(TriggerDeliveryDBE)
-            .from_select(
-                delivery_columns,
-                select(
-                    *(
-                        literal(
-                            delivery_values[column],
-                            type_=TriggerDeliveryDBE.__table__.c[column].type,
-                        )
-                        for column in delivery_columns
+        delivery_insert = insert(TriggerDeliveryDBE).from_select(
+            delivery_columns,
+            select(
+                *(
+                    literal(
+                        delivery_values[column],
+                        type_=TriggerDeliveryDBE.__table__.c[column].type,
                     )
-                ).select_from(live_parent),
-            )
-            .on_conflict_do_nothing(
+                    for column in delivery_columns
+                )
+            ).select_from(live_parent),
+        )
+        claimed_delivery = (
+            delivery_insert.on_conflict_do_update(
                 index_elements=index_elements,
                 index_where=index_where,
+                # Retry re-claim (P1-8): a delivery stuck in the one retryable
+                # terminal state (500 — the runner was unreachable, not a
+                # permanent rejection) can be re-claimed by a fresh attempt.
+                # Any other existing row (still claimed, or a terminal
+                # non-retryable status) fails this WHERE and the row is left
+                # untouched — the same outcome DO NOTHING gave for every case
+                # except this one. `dedup_seen` gates on the identical status
+                # check so a retry actually reaches this claim instead of
+                # short-circuiting before it.
+                where=TriggerDeliveryDBE.status["code"].astext
+                == TRIGGER_DELIVERY_RETRYABLE_STATUS_CODE,
+                set_={
+                    "id": delivery_insert.excluded.id,
+                    "created_by_id": delivery_insert.excluded.created_by_id,
+                    "status": delivery_insert.excluded.status,
+                    "data": delivery_insert.excluded.data,
+                    "updated_at": datetime.now(timezone.utc),
+                },
             )
             .returning(TriggerDeliveryDBE.id)
             .cte("claimed_trigger_delivery")

--- a/api/oss/src/dbs/postgres/sessions/streams/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/mappings.py
@@ -24,6 +24,21 @@ SESSION_ORIGIN_TAG_KEY = "ag.origin"
 SESSION_TRIGGER_ID_TAG_KEY = "ag.trigger.id"
 SESSION_TRIGGER_KIND_TAG_KEY = "ag.trigger.kind"
 SESSION_TRIGGER_DELIVERY_ID_TAG_KEY = "ag.trigger.delivery_id"
+# Legacy: no current writer, but rows stamped before this diff may still carry it.
+SESSION_TRIGGER_NAME_TAG_KEY = "ag.trigger.name"
+
+# Single source of truth for "which tag keys are system attribution, never
+# caller-owned" — the writer (`trigger_attribution_tags`) and every sanitizer
+# import this instead of hand-copying the key list (P1-7: it had already drifted).
+SESSION_RESERVED_TAG_KEYS = frozenset(
+    {
+        SESSION_ORIGIN_TAG_KEY,
+        SESSION_TRIGGER_ID_TAG_KEY,
+        SESSION_TRIGGER_KIND_TAG_KEY,
+        SESSION_TRIGGER_DELIVERY_ID_TAG_KEY,
+        SESSION_TRIGGER_NAME_TAG_KEY,
+    }
+)
 
 
 def trigger_attribution_tags(
@@ -37,16 +52,44 @@ def trigger_attribution_tags(
     }
 
 
+def _strip_reserved_tags(
+    tags: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """The sanitization chokepoint (P1-6): every read path constructs its
+    `SessionStream` through `map_stream_dbe_to_dto`, so stripping here — rather
+    than in each of the API's seven hand-copied router call sites — is the one
+    place a future eighth read path automatically inherits the guarantee."""
+    if not tags:
+        return None
+    sanitized = {
+        key: value
+        for key, value in tags.items()
+        if key not in SESSION_RESERVED_TAG_KEYS
+    }
+    # All-reserved tags must read back as absent, not `{}` (P3-8).
+    return sanitized or None
+
+
 def decode_session_attribution(
     tags: Optional[Dict[str, Any]],
 ) -> tuple[
     Optional[SessionOrigin], Optional[SessionTrigger], Optional[SessionDelivery]
 ]:
-    tags = tags or {}
-    try:
-        origin = SessionOrigin(tags.get(SESSION_ORIGIN_TAG_KEY))
-    except (TypeError, ValueError):
-        origin = None
+    # A malformed JSONB value (e.g. a list) must not 500 every list containing the
+    # row (P3-10) — treat anything but a dict as untagged.
+    tags = tags if isinstance(tags, dict) else {}
+
+    origin_value = tags.get(SESSION_ORIGIN_TAG_KEY)
+    if origin_value is None:
+        # No stamp at all means a human session — every writer of `ag.origin` sets
+        # "trigger"; nothing ever stamped "manual" (P1-1). Default it here so a
+        # human session reports an origin instead of null.
+        origin = SessionOrigin.manual
+    else:
+        try:
+            origin = SessionOrigin(origin_value)
+        except (TypeError, ValueError):
+            origin = None
 
     try:
         trigger = SessionTrigger(
@@ -105,7 +148,7 @@ def map_stream_dbe_to_dto(
         flags=SessionStreamFlags.model_validate(stream_dbe.flags)
         if stream_dbe.flags
         else SessionStreamFlags(),
-        tags=stream_dbe.tags,
+        tags=_strip_reserved_tags(stream_dbe.tags),
         meta=stream_dbe.meta,
         origin=origin,
         trigger=trigger,

--- a/api/oss/src/dbs/postgres/sessions/streams/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/mappings.py
@@ -27,9 +27,9 @@ SESSION_TRIGGER_DELIVERY_ID_TAG_KEY = "ag.trigger.delivery_id"
 # Legacy: no current writer, but rows stamped before this diff may still carry it.
 SESSION_TRIGGER_NAME_TAG_KEY = "ag.trigger.name"
 
-# Single source of truth for "which tag keys are system attribution, never
-# caller-owned" — the writer (`trigger_attribution_tags`) and every sanitizer
-# import this instead of hand-copying the key list (P1-7: it had already drifted).
+# Single source of truth for "which exact tag keys the writer stamps" — used by
+# the writer-side subset assert (P1-7's test) so a future fifth attribution key
+# is caught if it isn't inside the reserved namespace below.
 SESSION_RESERVED_TAG_KEYS = frozenset(
     {
         SESSION_ORIGIN_TAG_KEY,
@@ -39,6 +39,14 @@ SESSION_RESERVED_TAG_KEYS = frozenset(
         SESSION_TRIGGER_NAME_TAG_KEY,
     }
 )
+
+# The reserved namespace (P3-7): the whole "ag." prefix is reserved, not just
+# these five exact names — a future "ag.custom" read as caller-owned today,
+# which contradicts what the names promise. There is no tag write path yet, so
+# this closes the door before one exists rather than patching a live hole.
+# Exact semantics, deliberately simple: `key.startswith("ag.")` — no case
+# folding, no whitespace trimming.
+SESSION_RESERVED_TAG_NAMESPACE = "ag."
 
 
 def trigger_attribution_tags(
@@ -64,7 +72,7 @@ def _strip_reserved_tags(
     sanitized = {
         key: value
         for key, value in tags.items()
-        if key not in SESSION_RESERVED_TAG_KEYS
+        if not key.startswith(SESSION_RESERVED_TAG_NAMESPACE)
     }
     # All-reserved tags must read back as absent, not `{}` (P3-8).
     return sanitized or None

--- a/api/oss/src/dbs/postgres/sessions/streams/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/mappings.py
@@ -1,14 +1,67 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 
+from pydantic import ValidationError
+
+from oss.src.core.sessions.types import (
+    SessionDelivery,
+    SessionOrigin,
+    SessionTrigger,
+    SessionTriggerAttribution,
+)
 from oss.src.core.sessions.streams.dtos import (
     SessionStream,
     SessionStreamCreate,
     SessionStreamEdit,
     SessionStreamFlags,
     SessionStreamHeaderEdit,
+    SessionStreamQueryResult,
 )
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
+
+
+SESSION_ORIGIN_TAG_KEY = "ag.origin"
+SESSION_TRIGGER_ID_TAG_KEY = "ag.trigger.id"
+SESSION_TRIGGER_KIND_TAG_KEY = "ag.trigger.kind"
+SESSION_TRIGGER_DELIVERY_ID_TAG_KEY = "ag.trigger.delivery_id"
+
+
+def trigger_attribution_tags(
+    attribution: SessionTriggerAttribution,
+) -> Dict[str, str]:
+    return {
+        SESSION_ORIGIN_TAG_KEY: SessionOrigin.trigger.value,
+        SESSION_TRIGGER_ID_TAG_KEY: str(attribution.configuration_id),
+        SESSION_TRIGGER_KIND_TAG_KEY: attribution.kind.value,
+        SESSION_TRIGGER_DELIVERY_ID_TAG_KEY: str(attribution.delivery_id),
+    }
+
+
+def decode_session_attribution(
+    tags: Optional[Dict[str, Any]],
+) -> tuple[
+    Optional[SessionOrigin], Optional[SessionTrigger], Optional[SessionDelivery]
+]:
+    tags = tags or {}
+    try:
+        origin = SessionOrigin(tags.get(SESSION_ORIGIN_TAG_KEY))
+    except (TypeError, ValueError):
+        origin = None
+
+    try:
+        trigger = SessionTrigger(
+            id=tags.get(SESSION_TRIGGER_ID_TAG_KEY),
+            kind=tags.get(SESSION_TRIGGER_KIND_TAG_KEY),
+        )
+    except ValidationError:
+        trigger = None
+
+    try:
+        delivery = SessionDelivery(id=tags.get(SESSION_TRIGGER_DELIVERY_ID_TAG_KEY))
+    except ValidationError:
+        delivery = None
+
+    return origin, trigger, delivery
 
 
 def map_stream_dto_to_dbe_create(
@@ -34,6 +87,7 @@ def map_stream_dbe_to_dto(
     *,
     stream_dbe: SessionStreamDBE,
 ) -> SessionStream:
+    origin, trigger, delivery = decode_session_attribution(stream_dbe.tags)
     return SessionStream(
         id=stream_dbe.id,
         created_at=stream_dbe.created_at,
@@ -53,6 +107,20 @@ def map_stream_dbe_to_dto(
         else SessionStreamFlags(),
         tags=stream_dbe.tags,
         meta=stream_dbe.meta,
+        origin=origin,
+        trigger=trigger,
+        delivery=delivery,
+    )
+
+
+def map_stream_query_result(
+    *,
+    stream_dbe: SessionStreamDBE,
+    trigger_name: Optional[str] = None,
+) -> SessionStreamQueryResult:
+    return SessionStreamQueryResult(
+        stream=map_stream_dbe_to_dto(stream_dbe=stream_dbe),
+        trigger_name=trigger_name,
     )
 
 

--- a/api/oss/src/dbs/postgres/sessions/turns/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/turns/dao.py
@@ -13,7 +13,7 @@ from oss.src.core.sessions.turns.dtos import (
     SessionTurnQuery,
 )
 from oss.src.core.sessions.turns.interfaces import SessionTurnsDAOInterface
-from oss.src.core.shared.dtos import Windowing
+from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.core.shared.exceptions import EntityCreationConflict
 from oss.src.dbs.postgres.sessions.turns.dbes import SessionTurnDBE
 from oss.src.dbs.postgres.sessions.turns.mappings import (
@@ -128,6 +128,29 @@ class SessionTurnsDAO(SessionTurnsDAOInterface):
         if dbe is None:
             return None
         return map_turn_dbe_to_dto(turn_dbe=dbe)
+
+    async def query_session_ids_by_references(
+        self,
+        *,
+        project_id: UUID,
+        references: List[Reference],
+        limit: int,
+    ) -> List[str]:
+        turn_references = query_turn_references(SessionTurnQuery(references=references))
+        if turn_references is None:
+            return []
+        async with self.engine.session() as session:
+            stmt = (
+                select(SessionTurnDBE.session_id)
+                .where(
+                    SessionTurnDBE.project_id == project_id,
+                    SessionTurnDBE.references.contains(turn_references),
+                )
+                .distinct()
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            return [row[0] for row in result.all()]
 
     async def query_turns(
         self,

--- a/api/oss/src/dbs/postgres/shared/utils.py
+++ b/api/oss/src/dbs/postgres/shared/utils.py
@@ -117,7 +117,11 @@ def apply_windowing(
         )
         stmt = stmt.order_by(windowing_order, id_tiebreak)
 
-    if windowing.limit:
-        stmt = stmt.limit(windowing.limit)
+    if windowing.limit is not None:
+        # `if windowing.limit:` was falsy for `0`, which skipped the `.limit(...)`
+        # call entirely and returned every row; a negative value reached Postgres
+        # as a literal `LIMIT -1` and 500'd. Clamp to at least 1 instead — the safe
+        # direction is "too few rows", never "unbounded" or "malformed SQL".
+        stmt = stmt.limit(max(windowing.limit, 1))
 
     return stmt

--- a/api/oss/src/dbs/postgres/triggers/dao.py
+++ b/api/oss/src/dbs/postgres/triggers/dao.py
@@ -3,8 +3,8 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 from uuid import UUID
 
-from sqlalchemy import select, update
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import cast, delete, func, literal, select, update
+from sqlalchemy.dialects.postgresql import JSON, JSONB, insert
 from sqlalchemy.exc import IntegrityError
 
 from oss.src.core.shared.dtos import Status, Windowing
@@ -125,6 +125,7 @@ class TriggersDAO(TriggersDAOInterface):
             stmt = select(TriggerSubscriptionDBE).where(
                 TriggerSubscriptionDBE.project_id == project_id,
                 TriggerSubscriptionDBE.id == subscription_id,
+                TriggerSubscriptionDBE.deleted_at.is_(None),
             )
 
             result = await session.execute(stmt)
@@ -138,6 +139,23 @@ class TriggersDAO(TriggersDAOInterface):
                 subscription_dbe=subscription_dbe,
             )
 
+    async def fetch_subscription_including_deleted(
+        self,
+        *,
+        project_id: UUID,
+        #
+        subscription_id: UUID,
+    ) -> Optional[TriggerSubscription]:
+        async with self.engine.session() as session:
+            stmt = select(TriggerSubscriptionDBE).where(
+                TriggerSubscriptionDBE.project_id == project_id,
+                TriggerSubscriptionDBE.id == subscription_id,
+            )
+            subscription_dbe = (await session.execute(stmt)).scalar_one_or_none()
+            if subscription_dbe is None:
+                return None
+            return map_subscription_dbe_to_dto(subscription_dbe=subscription_dbe)
+
     async def edit_subscription(
         self,
         *,
@@ -147,9 +165,14 @@ class TriggersDAO(TriggersDAOInterface):
         subscription: TriggerSubscriptionEdit,
     ) -> Optional[TriggerSubscription]:
         async with self.engine.session() as session:
-            stmt = select(TriggerSubscriptionDBE).where(
-                TriggerSubscriptionDBE.id == subscription.id,
-                TriggerSubscriptionDBE.project_id == project_id,
+            stmt = (
+                select(TriggerSubscriptionDBE)
+                .where(
+                    TriggerSubscriptionDBE.id == subscription.id,
+                    TriggerSubscriptionDBE.project_id == project_id,
+                    TriggerSubscriptionDBE.deleted_at.is_(None),
+                )
+                .with_for_update()
             )
 
             result = await session.execute(stmt)
@@ -179,27 +202,46 @@ class TriggersDAO(TriggersDAOInterface):
         self,
         *,
         project_id: UUID,
+        user_id: UUID,
         #
         subscription_id: UUID,
     ) -> bool:
         async with self.engine.session() as session:
-            stmt = select(TriggerSubscriptionDBE).where(
+            now = datetime.now(timezone.utc)
+            stmt = (
+                update(TriggerSubscriptionDBE)
+                .where(
+                    TriggerSubscriptionDBE.project_id == project_id,
+                    TriggerSubscriptionDBE.id == subscription_id,
+                    TriggerSubscriptionDBE.deleted_at.is_(None),
+                )
+                .values(
+                    deleted_at=now,
+                    deleted_by_id=user_id,
+                    updated_at=now,
+                    updated_by_id=user_id,
+                )
+                .returning(TriggerSubscriptionDBE.id)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            return result.scalar_one_or_none() is not None
+
+    async def purge_subscription(
+        self,
+        *,
+        project_id: UUID,
+        #
+        subscription_id: UUID,
+    ) -> bool:
+        async with self.engine.session() as session:
+            stmt = delete(TriggerSubscriptionDBE).where(
                 TriggerSubscriptionDBE.project_id == project_id,
                 TriggerSubscriptionDBE.id == subscription_id,
             )
-
             result = await session.execute(stmt)
-
-            subscription_dbe = result.scalar_one_or_none()
-
-            if not subscription_dbe:
-                return False
-
-            await session.delete(subscription_dbe)
-
             await session.commit()
-
-            return True
+            return bool(result.rowcount)
 
     async def query_subscriptions(
         self,
@@ -213,6 +255,7 @@ class TriggersDAO(TriggersDAOInterface):
         async with self.engine.session() as session:
             stmt = select(TriggerSubscriptionDBE).filter(
                 TriggerSubscriptionDBE.project_id == project_id,
+                TriggerSubscriptionDBE.deleted_at.is_(None),
             )
 
             if subscription:
@@ -282,7 +325,7 @@ class TriggersDAO(TriggersDAOInterface):
     ) -> Optional[Tuple[UUID, TriggerSubscription]]:
         # Deliberately unscoped: inbound Composio events carry only the provider
         # trigger_id (ti_*) and no tenant scope, so this recovers project_id from
-        # it. The one sanctioned cross-project read (trigger_id is partial-unique).
+        # it. Duplicate live ids across projects are ambiguous and fail closed.
         async with self.engine.session() as session:
             stmt = (
                 select(TriggerSubscriptionDBE)
@@ -290,15 +333,14 @@ class TriggersDAO(TriggersDAOInterface):
                     TriggerSubscriptionDBE.trigger_id == trigger_id,
                     TriggerSubscriptionDBE.deleted_at.is_(None),
                 )
-                .limit(1)
+                .limit(2)
             )
 
             result = await session.execute(stmt)
-
-            subscription_dbe = result.scalars().first()
-
-            if not subscription_dbe:
+            subscription_dbes = result.scalars().all()
+            if len(subscription_dbes) != 1:
                 return None
+            subscription_dbe = subscription_dbes[0]
 
             return (
                 subscription_dbe.project_id,
@@ -372,7 +414,7 @@ class TriggersDAO(TriggersDAOInterface):
             delivery_dbe=delivery_dbe,
         )
 
-    async def claim_delivery(
+    async def write_subscription_delivery_if_live(
         self,
         *,
         project_id: UUID,
@@ -380,58 +422,65 @@ class TriggersDAO(TriggersDAOInterface):
         #
         delivery: TriggerDeliveryCreate,
     ) -> Optional[TriggerDelivery]:
+        if delivery.subscription_id is None or delivery.schedule_id is not None:
+            return None
+
         delivery_dbe = map_delivery_dto_to_dbe_create(
             project_id=project_id,
             user_id=user_id,
-            #
             delivery=delivery,
         )
-
-        by_schedule = delivery.subscription_id is None
-
-        index_elements = (
-            ["project_id", "schedule_id", "event_id"]
-            if by_schedule
-            else ["project_id", "subscription_id", "event_id"]
+        values = {
+            column.name: getattr(delivery_dbe, column.name)
+            for column in TriggerDeliveryDBE.__table__.columns
+            if not (
+                column.name in ("id", "created_at", "updated_at", "deleted_at")
+                and getattr(delivery_dbe, column.name) is None
+            )
+        }
+        live_subscription = (
+            select(TriggerSubscriptionDBE.id)
+            .where(
+                TriggerSubscriptionDBE.project_id == project_id,
+                TriggerSubscriptionDBE.id == delivery.subscription_id,
+                TriggerSubscriptionDBE.deleted_at.is_(None),
+                TriggerSubscriptionDBE.flags.contains({"is_active": True}),
+            )
+            .with_for_update()
+            .cte("live_trigger_subscription")
         )
-        index_where = (
-            TriggerDeliveryDBE.schedule_id.isnot(None)
-            if by_schedule
-            else TriggerDeliveryDBE.subscription_id.isnot(None)
+        columns = list(values)
+        stmt = insert(TriggerDeliveryDBE).from_select(
+            columns,
+            select(
+                *(
+                    literal(
+                        values[column],
+                        type_=TriggerDeliveryDBE.__table__.c[column].type,
+                    )
+                    for column in columns
+                )
+            ).select_from(live_subscription),
         )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["project_id", "subscription_id", "event_id"],
+            index_where=TriggerDeliveryDBE.subscription_id.isnot(None),
+            set_={
+                "status": stmt.excluded.status,
+                "data": stmt.excluded.data,
+                "updated_at": datetime.now(timezone.utc),
+                "updated_by_id": stmt.excluded.created_by_id,
+            },
+        ).returning(TriggerDeliveryDBE)
 
         async with self.engine.session() as session:
-            values = {
-                c.name: getattr(delivery_dbe, c.name)
-                for c in TriggerDeliveryDBE.__table__.columns
-                if not (
-                    c.name in ("id", "created_at", "updated_at", "deleted_at")
-                    and getattr(delivery_dbe, c.name) is None
-                )
-            }
-
-            # The atomic claim: only the caller whose INSERT actually lands wins the row and may
-            # invoke the workflow. ON CONFLICT DO NOTHING (not DO UPDATE) means a second
-            # concurrent claim for the same event affects zero rows and RETURNING yields nothing.
-            stmt = (
-                insert(TriggerDeliveryDBE)
-                .values(**values)
-                .on_conflict_do_nothing(
-                    index_elements=index_elements,
-                    index_where=index_where,
-                )
-                .returning(TriggerDeliveryDBE)
-            )
             result = await session.execute(stmt)
             delivery_dbe = result.scalar_one_or_none()
             await session.commit()
 
-            if delivery_dbe is None:
-                return None
-
-        return map_delivery_dbe_to_dto(
-            delivery_dbe=delivery_dbe,
-        )
+        if delivery_dbe is None:
+            return None
+        return map_delivery_dbe_to_dto(delivery_dbe=delivery_dbe)
 
     async def update_delivery(
         self,
@@ -448,7 +497,15 @@ class TriggersDAO(TriggersDAOInterface):
                 "updated_at": datetime.now(timezone.utc),
             }
             if data is not None:
-                values["data"] = data.model_dump(mode="json", exclude_none=True)
+                update_data = cast(
+                    data.model_dump(mode="json", exclude_none=True), JSONB
+                )
+                values["data"] = cast(
+                    func.coalesce(
+                        cast(TriggerDeliveryDBE.data, JSONB), cast({}, JSONB)
+                    ).op("||")(update_data),
+                    JSON,
+                )
 
             stmt = (
                 update(TriggerDeliveryDBE)
@@ -662,6 +719,7 @@ class TriggersDAO(TriggersDAOInterface):
             stmt = select(TriggerScheduleDBE).where(
                 TriggerScheduleDBE.project_id == project_id,
                 TriggerScheduleDBE.id == schedule_id,
+                TriggerScheduleDBE.deleted_at.is_(None),
             )
 
             result = await session.execute(stmt)
@@ -675,6 +733,23 @@ class TriggersDAO(TriggersDAOInterface):
                 schedule_dbe=schedule_dbe,
             )
 
+    async def fetch_schedule_including_deleted(
+        self,
+        *,
+        project_id: UUID,
+        #
+        schedule_id: UUID,
+    ) -> Optional[TriggerSchedule]:
+        async with self.engine.session() as session:
+            stmt = select(TriggerScheduleDBE).where(
+                TriggerScheduleDBE.project_id == project_id,
+                TriggerScheduleDBE.id == schedule_id,
+            )
+            schedule_dbe = (await session.execute(stmt)).scalar_one_or_none()
+            if schedule_dbe is None:
+                return None
+            return map_schedule_dbe_to_dto(schedule_dbe=schedule_dbe)
+
     async def edit_schedule(
         self,
         *,
@@ -684,9 +759,14 @@ class TriggersDAO(TriggersDAOInterface):
         schedule: TriggerScheduleEdit,
     ) -> Optional[TriggerSchedule]:
         async with self.engine.session() as session:
-            stmt = select(TriggerScheduleDBE).where(
-                TriggerScheduleDBE.id == schedule.id,
-                TriggerScheduleDBE.project_id == project_id,
+            stmt = (
+                select(TriggerScheduleDBE)
+                .where(
+                    TriggerScheduleDBE.id == schedule.id,
+                    TriggerScheduleDBE.project_id == project_id,
+                    TriggerScheduleDBE.deleted_at.is_(None),
+                )
+                .with_for_update()
             )
 
             result = await session.execute(stmt)
@@ -716,27 +796,46 @@ class TriggersDAO(TriggersDAOInterface):
         self,
         *,
         project_id: UUID,
+        user_id: UUID,
         #
         schedule_id: UUID,
     ) -> bool:
         async with self.engine.session() as session:
-            stmt = select(TriggerScheduleDBE).where(
+            now = datetime.now(timezone.utc)
+            stmt = (
+                update(TriggerScheduleDBE)
+                .where(
+                    TriggerScheduleDBE.project_id == project_id,
+                    TriggerScheduleDBE.id == schedule_id,
+                    TriggerScheduleDBE.deleted_at.is_(None),
+                )
+                .values(
+                    deleted_at=now,
+                    deleted_by_id=user_id,
+                    updated_at=now,
+                    updated_by_id=user_id,
+                )
+                .returning(TriggerScheduleDBE.id)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            return result.scalar_one_or_none() is not None
+
+    async def purge_schedule(
+        self,
+        *,
+        project_id: UUID,
+        #
+        schedule_id: UUID,
+    ) -> bool:
+        async with self.engine.session() as session:
+            stmt = delete(TriggerScheduleDBE).where(
                 TriggerScheduleDBE.project_id == project_id,
                 TriggerScheduleDBE.id == schedule_id,
             )
-
             result = await session.execute(stmt)
-
-            schedule_dbe = result.scalar_one_or_none()
-
-            if not schedule_dbe:
-                return False
-
-            await session.delete(schedule_dbe)
-
             await session.commit()
-
-            return True
+            return bool(result.rowcount)
 
     async def query_schedules(
         self,
@@ -750,6 +849,7 @@ class TriggersDAO(TriggersDAOInterface):
         async with self.engine.session() as session:
             stmt = select(TriggerScheduleDBE).filter(
                 TriggerScheduleDBE.project_id == project_id,
+                TriggerScheduleDBE.deleted_at.is_(None),
             )
 
             if schedule:

--- a/api/oss/src/dbs/postgres/triggers/dao.py
+++ b/api/oss/src/dbs/postgres/triggers/dao.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from oss.src.core.shared.dtos import Status, Windowing
 from oss.src.core.shared.exceptions import EntityCreationConflict
 from oss.src.core.triggers.dtos import (
+    TRIGGER_DELIVERY_RETRYABLE_STATUS_CODE,
     TriggerDelivery,
     TriggerDeliveryCreate,
     TriggerDeliveryData,
@@ -690,7 +691,7 @@ class TriggersDAO(TriggersDAOInterface):
     ) -> bool:
         async with self.engine.session() as session:
             stmt = (
-                select(TriggerDeliveryDBE.id)
+                select(TriggerDeliveryDBE.status)
                 .where(
                     TriggerDeliveryDBE.project_id == project_id,
                     TriggerDeliveryDBE.subscription_id == subscription_id,
@@ -699,9 +700,13 @@ class TriggersDAO(TriggersDAOInterface):
                 .limit(1)
             )
 
-            result = await session.execute(stmt)
+            status = (await session.execute(stmt)).scalar_one_or_none()
 
-            return result.scalar_one_or_none() is not None
+        return self._dedup_seen_from_status(
+            status=status,
+            subscription_id=subscription_id,
+            event_id=event_id,
+        )
 
     async def dedup_seen_schedule(
         self,
@@ -712,7 +717,7 @@ class TriggersDAO(TriggersDAOInterface):
     ) -> bool:
         async with self.engine.session() as session:
             stmt = (
-                select(TriggerDeliveryDBE.id)
+                select(TriggerDeliveryDBE.status)
                 .where(
                     TriggerDeliveryDBE.project_id == project_id,
                     TriggerDeliveryDBE.schedule_id == schedule_id,
@@ -721,9 +726,37 @@ class TriggersDAO(TriggersDAOInterface):
                 .limit(1)
             )
 
-            result = await session.execute(stmt)
+            status = (await session.execute(stmt)).scalar_one_or_none()
 
-            return result.scalar_one_or_none() is not None
+        return self._dedup_seen_from_status(
+            status=status,
+            subscription_id=schedule_id,
+            event_id=event_id,
+        )
+
+    @staticmethod
+    def _dedup_seen_from_status(
+        *,
+        status: Optional[dict],
+        subscription_id: UUID,
+        event_id: str,
+    ) -> bool:
+        """No row at all is unambiguously unseen. A row stuck in the one
+        retryable terminal state (P1-8) is NOT a duplicate either — the retry
+        must reach the atomic claim, the actual authority on whether a
+        re-claim wins, instead of short-circuiting here. Every other status
+        (claimed, success, or a permanent failure) is a genuine duplicate."""
+        if status is None:
+            return False
+        if (status or {}).get("code") == TRIGGER_DELIVERY_RETRYABLE_STATUS_CODE:
+            log.info(
+                "[TRIGGERS] Retryable delivery found for (parent=%s, event=%s) "
+                "— treating as a retry, not a duplicate",
+                subscription_id,
+                event_id,
+            )
+            return False
+        return True
 
     # --- SCHEDULES ---------------------------------------------------------- #
 

--- a/api/oss/src/dbs/postgres/triggers/dao.py
+++ b/api/oss/src/dbs/postgres/triggers/dao.py
@@ -243,6 +243,30 @@ class TriggersDAO(TriggersDAOInterface):
             await session.commit()
             return bool(result.rowcount)
 
+    async def mark_subscription_needs_provider_cleanup(
+        self,
+        *,
+        project_id: UUID,
+        subscription_id: UUID,
+    ) -> None:
+        async with self.engine.session() as session:
+            merged_meta = cast(
+                func.coalesce(
+                    cast(TriggerSubscriptionDBE.meta, JSONB), cast({}, JSONB)
+                ).op("||")(cast({"needs_provider_cleanup": True}, JSONB)),
+                JSON,
+            )
+            stmt = (
+                update(TriggerSubscriptionDBE)
+                .where(
+                    TriggerSubscriptionDBE.project_id == project_id,
+                    TriggerSubscriptionDBE.id == subscription_id,
+                )
+                .values(meta=merged_meta)
+            )
+            await session.execute(stmt)
+            await session.commit()
+
     async def query_subscriptions(
         self,
         *,
@@ -339,6 +363,12 @@ class TriggersDAO(TriggersDAOInterface):
             result = await session.execute(stmt)
             subscription_dbes = result.scalars().all()
             if len(subscription_dbes) != 1:
+                if len(subscription_dbes) > 1:
+                    log.warning(
+                        "[TRIGGERS] Ambiguous trigger_id across projects — "
+                        "failing closed",
+                        trigger_id=trigger_id,
+                    )
                 return None
             subscription_dbe = subscription_dbes[0]
 
@@ -444,6 +474,12 @@ class TriggersDAO(TriggersDAOInterface):
                 TriggerSubscriptionDBE.project_id == project_id,
                 TriggerSubscriptionDBE.id == delivery.subscription_id,
                 TriggerSubscriptionDBE.deleted_at.is_(None),
+                # Deliberately `is_active` only, NOT `is_active AND is_valid` like
+                # `claim_trigger_delivery`'s real-invocation gate. The dispatcher
+                # calls this to record the "subscription is invalid" 409 delivery
+                # itself (dispatcher.py's `is_valid` branch), reached precisely
+                # when is_valid is False — requiring is_valid here would silently
+                # drop that failure explanation instead of recording it.
                 TriggerSubscriptionDBE.flags.contains({"is_active": True}),
             )
             .with_for_update()
@@ -467,7 +503,16 @@ class TriggersDAO(TriggersDAOInterface):
             index_where=TriggerDeliveryDBE.subscription_id.isnot(None),
             set_={
                 "status": stmt.excluded.status,
-                "data": stmt.excluded.data,
+                # Merge, not replace (P2-4): two redeliveries racing `dedup_seen` can
+                # both reach this upsert; a wholesale replace can drop fields the
+                # first write set (e.g. `data.session_id`) while the session still
+                # points at this delivery. Mirrors `update_delivery`'s merge.
+                "data": cast(
+                    func.coalesce(
+                        cast(TriggerDeliveryDBE.data, JSONB), cast({}, JSONB)
+                    ).op("||")(cast(stmt.excluded.data, JSONB)),
+                    JSON,
+                ),
                 "updated_at": datetime.now(timezone.utc),
                 "updated_by_id": stmt.excluded.created_by_id,
             },

--- a/api/oss/src/tasks/asyncio/triggers/dispatcher.py
+++ b/api/oss/src/tasks/asyncio/triggers/dispatcher.py
@@ -321,6 +321,9 @@ class TriggersDispatcher:
                 status=Status(code="400", message="failed"),
                 data=delivery_data.model_copy(update={"error": str(e)}),
             )
+            await self._abandon_claimed_session(
+                project_id=project_id, session_id=session_id
+            )
             return
 
         if self._dispatch_fn is not None:
@@ -339,6 +342,9 @@ class TriggersDispatcher:
                     delivery_id=delivery_id,
                     status=Status(code="500", message="failed"),
                     data=delivery_data.model_copy(update={"error": str(e)}),
+                )
+                await self._abandon_claimed_session(
+                    project_id=project_id, session_id=session_id
                 )
                 raise
             await self._complete_delivery(
@@ -427,7 +433,7 @@ class TriggersDispatcher:
         status: Status,
         data: TriggerDeliveryData,
     ) -> None:
-        await self.triggers_dao.write_subscription_delivery_if_live(
+        written = await self.triggers_dao.write_subscription_delivery_if_live(
             project_id=project_id,
             user_id=user_id,
             delivery=TriggerDeliveryCreate(
@@ -439,6 +445,37 @@ class TriggersDispatcher:
                 data=data,
             ),
         )
+        if written is None:
+            # The subscription went inactive/was deleted between the dispatcher's
+            # gate check and this write — not an error, but a silent no-op here
+            # otherwise looks identical to a normal write from the logs alone.
+            log.info(
+                "[TRIGGERS DISPATCHER] delivery write skipped — subscription %s "
+                "is no longer live/active (event=%s)",
+                subscription_id,
+                event_id,
+            )
+
+    async def _abandon_claimed_session(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+    ) -> None:
+        """Soft-delete the session_streams row `_run`'s claim inserted, when dispatch
+        fails before a turn ever starts. Its `flags` are NULL at claim time — the
+        orphan sweep only matches `is_alive: true` — so left alone it becomes a
+        permanent, un-sweepable phantom session (P0-3)."""
+        try:
+            await self.session_claims_dao.abandon_claimed_session(
+                project_id=project_id, session_id=session_id
+            )
+        except Exception:
+            log.error(
+                "[TRIGGERS DISPATCHER] failed to abandon claimed session=%s",
+                session_id,
+                exc_info=True,
+            )
 
     async def _complete_delivery(
         self,

--- a/api/oss/src/tasks/asyncio/triggers/dispatcher.py
+++ b/api/oss/src/tasks/asyncio/triggers/dispatcher.py
@@ -26,12 +26,10 @@ from oss.src.core.triggers.dtos import (
 )
 from oss.src.core.triggers.interfaces import TriggersDAOInterface
 from oss.src.core.sessions.dtos import (
-    SESSION_ORIGIN_TRIGGER,
-    SESSION_TRIGGER_KIND_SCHEDULE,
-    SESSION_TRIGGER_KIND_SUBSCRIPTION,
-    SessionTriggerRef,
+    SessionTriggerAttribution,
+    SessionTriggerKind,
 )
-from oss.src.core.sessions.streams.service import SessionStreamsService
+from oss.src.core.sessions.streams.interfaces import TriggerSessionClaimsDAOInterface
 from oss.src.core.workflows.service import WorkflowsService
 from oss.src.utils.logging import get_module_logger
 
@@ -49,16 +47,14 @@ class TriggersDispatcher:
         self,
         *,
         triggers_dao: TriggersDAOInterface,
+        session_claims_dao: TriggerSessionClaimsDAOInterface,
         workflows_service: WorkflowsService,
         dispatch_fn: Optional[Callable] = None,
-        streams_service: Optional[SessionStreamsService] = None,
     ):
         self.triggers_dao = triggers_dao
+        self.session_claims_dao = session_claims_dao
         self.workflows_service = workflows_service
         self._dispatch_fn = dispatch_fn
-        # Optional so existing wiring keeps working; without it a triggered session is
-        # indistinguishable from one a human started.
-        self._streams_service = streams_service
 
     def _build_context(
         self,
@@ -138,7 +134,7 @@ class TriggersDispatcher:
             inputs = resolve_target_fields(
                 template if template is not None else "$", context
             )
-            await self._write_delivery(
+            await self._write_subscription_delivery_if_live(
                 project_id=project_id,
                 user_id=subscription.created_by_id,
                 delivery_id=uuid_compat.uuid7(),
@@ -161,7 +157,7 @@ class TriggersDispatcher:
                 "[TRIGGERS DISPATCHER] Subscription %s is invalid — failed delivery",
                 subscription.id,
             )
-            await self._write_delivery(
+            await self._write_subscription_delivery_if_live(
                 project_id=project_id,
                 user_id=subscription.created_by_id,
                 delivery_id=uuid_compat.uuid7(),
@@ -242,30 +238,34 @@ class TriggersDispatcher:
         (project_id, subscription_id|schedule_id, event_id) the caller's earlier
         dedup pre-check reads. Two concurrent ticks/deliveries for the same event
         both reach `_run`, but only the one whose INSERT lands may invoke — the
-        other's claim returns None and it returns immediately. Every subsequent
+        other's claim returns false and it returns immediately. Every subsequent
         write in this method UPDATEs that same claimed row by id (never inserts),
         so a delivery-write failure after a successful invoke cannot look like "no
         row exists" to a retry and cause a re-invoke.
         """
         is_subscription = isinstance(entity, TriggerSubscription)
-        subscription_id = entity.id if is_subscription else None
-        schedule_id = None if is_subscription else entity.id
 
         delivery_id = uuid_compat.uuid7()
+        session_id = uuid4().hex
         user_id = entity.created_by_id
+        kind = (
+            SessionTriggerKind.subscription
+            if is_subscription
+            else SessionTriggerKind.schedule
+        )
 
-        claimed = await self.triggers_dao.claim_delivery(
+        claimed = await self.session_claims_dao.claim_trigger_delivery(
             project_id=project_id,
             user_id=user_id,
-            delivery=TriggerDeliveryCreate(
-                id=delivery_id,
-                subscription_id=subscription_id,
-                schedule_id=schedule_id,
-                event_id=event_id,
-                status=Status(code="102", message="claimed"),
+            event_id=event_id,
+            session_id=session_id,
+            attribution=SessionTriggerAttribution(
+                configuration_id=entity.id,
+                kind=kind,
+                delivery_id=delivery_id,
             ),
         )
-        if claimed is None:
+        if not claimed:
             log.info(
                 "[TRIGGERS DISPATCHER] claim lost for entity=%s event=%s — already "
                 "claimed/delivered, skipping invoke",
@@ -273,93 +273,74 @@ class TriggersDispatcher:
                 event_id,
             )
             return
-        delivery_id = claimed.id
 
-        context = self._build_context(
-            event=event,
-            entity=entity,
-            project_id=project_id,
-        )
-
-        template = entity.data.inputs_fields
-        inputs = resolve_target_fields(
-            template if template is not None else "$", context
-        )
-
-        references = (
-            {
-                k: ref.model_dump(mode="json", exclude_none=True)
-                for k, ref in entity.data.references.items()
-            }
-            if entity.data.references
-            else None
-        )
-        selector = (
-            entity.data.selector.model_dump(mode="json", exclude_none=True)
-            if entity.data.selector
-            else None
-        )
-
-        delivery_data = TriggerDeliveryData(
-            event_key=entity.data.event_key,
-            references=entity.data.references,
-            inputs=inputs if isinstance(inputs, dict) else {"value": inputs},
-        )
-
-        if not references:
+        delivery_data = TriggerDeliveryData(session_id=session_id)
+        try:
+            context = self._build_context(
+                event=event,
+                entity=entity,
+                project_id=project_id,
+            )
+            template = entity.data.inputs_fields
+            inputs = resolve_target_fields(
+                template if template is not None else "$", context
+            )
+            references = (
+                {
+                    k: ref.model_dump(mode="json", exclude_none=True)
+                    for k, ref in entity.data.references.items()
+                }
+                if entity.data.references
+                else None
+            )
+            if not references:
+                raise ValueError("Entity has no bound workflow reference")
+            selector = (
+                entity.data.selector.model_dump(mode="json", exclude_none=True)
+                if entity.data.selector
+                else None
+            )
+            delivery_data = TriggerDeliveryData(
+                session_id=session_id,
+                event_key=entity.data.event_key,
+                references=entity.data.references,
+                inputs=inputs if isinstance(inputs, dict) else {"value": inputs},
+            )
+            request = WorkflowServiceRequest(
+                references=references,
+                selector=selector,
+                session_id=session_id,
+                data=WorkflowRequestData(
+                    inputs=inputs if isinstance(inputs, dict) else {"value": inputs},
+                ),
+            )
+        except Exception as e:
             await self._complete_delivery(
                 project_id=project_id,
                 delivery_id=delivery_id,
                 status=Status(code="400", message="failed"),
-                data=delivery_data.model_copy(
-                    update={"error": "Entity has no bound workflow reference"}
-                ),
+                data=delivery_data.model_copy(update={"error": str(e)}),
             )
             return
 
-        # Mint the session here rather than letting the runner fall back to its own: owning the
-        # id is what lets this delivery name the session it produced, and lets the row be marked
-        # as automation-started before the run creates it.
-        session_id = uuid4().hex
-        delivery_data = delivery_data.model_copy(update={"session_id": session_id})
-        if self._streams_service is not None:
+        if self._dispatch_fn is not None:
+            # Detached completion means the runner accepted ownership. The API has no durable
+            # callback for the run's later terminal outcome, so this delivery remains 202.
             try:
-                await self._streams_service.set_origin(
+                run_id = await self._dispatch_fn(
                     project_id=project_id,
                     user_id=user_id,
-                    session_id=session_id,
-                    origin=SESSION_ORIGIN_TRIGGER,
-                    # Stamped here because this is the only place that knows WHICH automation
-                    # fired: nothing links a session back to a trigger afterwards.
-                    trigger=SessionTriggerRef(
-                        id=str(entity.id),
-                        name=entity.name,
-                        kind=(
-                            SESSION_TRIGGER_KIND_SUBSCRIPTION
-                            if is_subscription
-                            else SESSION_TRIGGER_KIND_SCHEDULE
-                        ),
-                    ),
+                    request=request,
                 )
-            except Exception as e:  # best-effort: a missing tag must not block the run
-                log.warning("[TRIGGERS DISPATCHER] origin stamp failed: %s", e)
-
-        request = WorkflowServiceRequest(
-            references=references,
-            selector=selector,
-            session_id=session_id,
-            data=WorkflowRequestData(
-                inputs=inputs if isinstance(inputs, dict) else {"value": inputs},
-            ),
-        )
-
-        if self._dispatch_fn is not None:
-            # Detached path: hand off to the runner, complete the claimed delivery.
-            run_id = await self._dispatch_fn(
-                project_id=project_id,
-                user_id=user_id,
-                request=request,
-            )
+            except Exception as e:
+                log.error("[TRIGGERS DISPATCHER] detached invoke failed: %s", e)
+                await self._complete_delivery(
+                    project_id=project_id,
+                    delivery_id=delivery_id,
+                    status=Status(code="500", message="failed"),
+                    data=delivery_data.model_copy(update={"error": str(e)}),
+                )
+                raise
             await self._complete_delivery(
                 project_id=project_id,
                 delivery_id=delivery_id,
@@ -434,7 +415,7 @@ class TriggersDispatcher:
             event_id,
         )
 
-    async def _write_delivery(
+    async def _write_subscription_delivery_if_live(
         self,
         *,
         project_id: UUID,
@@ -446,7 +427,7 @@ class TriggersDispatcher:
         status: Status,
         data: TriggerDeliveryData,
     ) -> None:
-        await self.triggers_dao.write_delivery(
+        await self.triggers_dao.write_subscription_delivery_if_live(
             project_id=project_id,
             user_id=user_id,
             delivery=TriggerDeliveryCreate(

--- a/api/oss/src/tasks/taskiq/triggers/worker.py
+++ b/api/oss/src/tasks/taskiq/triggers/worker.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from uuid import UUID
 
 from taskiq import AsyncBroker, Context, TaskiqDepends
 
-from oss.src.core.triggers.dtos import TRIGGER_MAX_RETRIES, TriggerSchedule
+from oss.src.core.triggers.dtos import TRIGGER_MAX_RETRIES
 from oss.src.core.triggers.interfaces import TriggersDAOInterface
 from oss.src.tasks.asyncio.triggers.dispatcher import TriggersDispatcher
 from oss.src.utils.env import env
@@ -93,11 +93,29 @@ class TriggersWorker:
             project_id: str,
             event_id: str,
             event: Dict[str, Any],
-            schedule: Dict[str, Any],
+            schedule_id: Optional[str] = None,
+            schedule: Optional[Dict[str, Any]] = None,
             #
             context: Context = TaskiqDepends(),
         ) -> None:
-            entity = TriggerSchedule.model_validate(schedule)
+            queued_schedule_id = schedule_id or (schedule or {}).get("id")
+            if queued_schedule_id is None:
+                log.warning(
+                    "[TASK] triggers.dispatch_schedule Missing schedule id — skipping"
+                )
+                return
+
+            resolved_project_id = UUID(project_id)
+            entity = await self.triggers_dao.fetch_schedule(
+                project_id=resolved_project_id,
+                schedule_id=UUID(str(queued_schedule_id)),
+            )
+            if entity is None or not entity.flags.is_active:
+                log.info(
+                    "[TASK] triggers.dispatch_schedule Schedule %s is deleted or inactive — skipping",
+                    queued_schedule_id,
+                )
+                return
 
             log.info(
                 f"[TASK] triggers.dispatch_schedule "
@@ -105,7 +123,7 @@ class TriggersWorker:
             )
 
             await self.dispatcher.dispatch_schedule(
-                project_id=UUID(project_id),
+                project_id=resolved_project_id,
                 schedule=entity,
                 event_id=event_id,
                 event=event,

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_schedules.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_schedules.py
@@ -205,4 +205,44 @@ class TestTriggerSchedulesLifecycle:
         assert delete.status_code == 204
 
         fetch = authed_api("GET", f"/triggers/schedules/{schedule_id}")
-        assert fetch.status_code == 404
+        assert fetch.status_code == 200, fetch.text
+        fetched = fetch.json()
+        assert fetched["count"] == 1
+        historical = fetched["schedule"]
+        assert historical["id"] == schedule_id
+        assert historical["name"] == edited["name"]
+        assert historical["description"] == edited["description"]
+        assert historical["data"] == edited["data"]
+        assert historical["flags"] == edited["flags"]
+        assert historical["deleted_at"] is not None
+        assert historical["deleted_by_id"] is not None
+
+        list_response = authed_api("GET", "/triggers/schedules/")
+        assert list_response.status_code == 200, list_response.text
+        listing = list_response.json()
+        assert all(item["id"] != schedule_id for item in listing["schedules"])
+        query_response = authed_api(
+            "POST",
+            "/triggers/schedules/query",
+            json={"schedule": {"name": edited["name"]}},
+        )
+        assert query_response.status_code == 200, query_response.text
+        query = query_response.json()
+        assert all(item["id"] != schedule_id for item in query["schedules"])
+
+        rejected_edit = authed_api(
+            "PUT",
+            f"/triggers/schedules/{schedule_id}",
+            json={
+                "schedule": {
+                    "id": schedule_id,
+                    "name": historical["name"],
+                    "description": historical["description"],
+                    "data": historical["data"],
+                    "flags": historical["flags"],
+                }
+            },
+        )
+        assert rejected_edit.status_code == 404, rejected_edit.text
+        rejected_start = authed_api("POST", f"/triggers/schedules/{schedule_id}/start")
+        assert rejected_start.status_code == 404, rejected_start.text

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
@@ -190,13 +190,57 @@ class TestTriggerSubscriptionsLifecycle:
         revoke = authed_api("POST", f"/triggers/subscriptions/{subscription_id}/revoke")
         assert revoke.status_code == 200, revoke.text
         assert revoke.json()["subscription"]["flags"]["is_active"] is False
+        revoked = revoke.json()["subscription"]
 
         # DELETE
         delete = authed_api("DELETE", f"/triggers/subscriptions/{subscription_id}")
         assert delete.status_code == 204
 
         fetch = authed_api("GET", f"/triggers/subscriptions/{subscription_id}")
-        assert fetch.status_code == 404
+        assert fetch.status_code == 200, fetch.text
+        fetched = fetch.json()
+        assert fetched["count"] == 1
+        historical = fetched["subscription"]
+        assert historical["id"] == subscription_id
+        assert historical["connection_id"] == revoked["connection_id"]
+        assert historical["name"] == revoked["name"]
+        assert historical["data"] == revoked["data"]
+        assert historical["flags"] == revoked["flags"]
+        assert historical["deleted_at"] is not None
+        assert historical["deleted_by_id"] is not None
+
+        list_response = authed_api("GET", "/triggers/subscriptions/")
+        assert list_response.status_code == 200, list_response.text
+        listing = list_response.json()
+        assert all(item["id"] != subscription_id for item in listing["subscriptions"])
+        query_response = authed_api(
+            "POST",
+            "/triggers/subscriptions/query",
+            json={"subscription": {"name": historical["name"]}},
+        )
+        assert query_response.status_code == 200, query_response.text
+        query = query_response.json()
+        assert all(item["id"] != subscription_id for item in query["subscriptions"])
+
+        rejected_edit = authed_api(
+            "PUT",
+            f"/triggers/subscriptions/{subscription_id}",
+            json={
+                "subscription": {
+                    "id": subscription_id,
+                    "connection_id": historical["connection_id"],
+                    "name": historical["name"],
+                    "description": historical.get("description"),
+                    "data": historical["data"],
+                    "flags": historical["flags"],
+                }
+            },
+        )
+        assert rejected_edit.status_code == 404, rejected_edit.text
+        rejected_start = authed_api(
+            "POST", f"/triggers/subscriptions/{subscription_id}/start"
+        )
+        assert rejected_start.status_code == 404, rejected_start.text
 
         # C7: deleting the subscription must NOT delete/revoke the connection.
         conn = authed_api("GET", f"/tools/connections/{connection_id}")

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
@@ -158,92 +158,97 @@ class TestTriggerSubscriptionsLifecycle:
         connection_id = self._create_connection(authed_api)
         workflow_slug = _create_workflow(authed_api)
 
-        # CREATE — binds the event to a workflow reference on the shared connection
-        create = authed_api(
-            "POST",
-            "/triggers/subscriptions/",
-            json={
-                "subscription": {
-                    "name": f"sub-{uuid4().hex[:8]}",
-                    "connection_id": connection_id,
-                    "data": {
-                        "event_key": "GITHUB_STAR_ADDED_EVENT",
-                        "trigger_config": {"owner": "acme", "repo": "widgets"},
-                        "inputs_fields": {"repo": "$.event.attributes.repository"},
-                        "references": {"workflow": {"slug": workflow_slug}},
-                    },
-                }
-            },
-        )
-        assert create.status_code == 200, create.text
-        sub = create.json()["subscription"]
-        subscription_id = sub["id"]
-        assert sub["connection_id"] == connection_id
-        assert sub["trigger_id"] is not None
-        assert sub["flags"]["is_active"] is True
+        try:
+            # CREATE — binds the event to a workflow reference on the shared connection
+            create = authed_api(
+                "POST",
+                "/triggers/subscriptions/",
+                json={
+                    "subscription": {
+                        "name": f"sub-{uuid4().hex[:8]}",
+                        "connection_id": connection_id,
+                        "data": {
+                            "event_key": "GITHUB_STAR_ADDED_EVENT",
+                            "trigger_config": {"owner": "acme", "repo": "widgets"},
+                            "inputs_fields": {"repo": "$.event.attributes.repository"},
+                            "references": {"workflow": {"slug": workflow_slug}},
+                        },
+                    }
+                },
+            )
+            assert create.status_code == 200, create.text
+            sub = create.json()["subscription"]
+            subscription_id = sub["id"]
+            assert sub["connection_id"] == connection_id
+            assert sub["trigger_id"] is not None
+            assert sub["flags"]["is_active"] is True
 
-        # LIST
-        listing = authed_api("GET", "/triggers/subscriptions/").json()
-        assert any(s["id"] == subscription_id for s in listing["subscriptions"])
+            # LIST
+            listing = authed_api("GET", "/triggers/subscriptions/").json()
+            assert any(s["id"] == subscription_id for s in listing["subscriptions"])
 
-        # DISABLE (revoke the subscription, not the connection)
-        revoke = authed_api("POST", f"/triggers/subscriptions/{subscription_id}/revoke")
-        assert revoke.status_code == 200, revoke.text
-        assert revoke.json()["subscription"]["flags"]["is_active"] is False
-        revoked = revoke.json()["subscription"]
+            # DISABLE (revoke the subscription, not the connection)
+            revoke = authed_api(
+                "POST", f"/triggers/subscriptions/{subscription_id}/revoke"
+            )
+            assert revoke.status_code == 200, revoke.text
+            assert revoke.json()["subscription"]["flags"]["is_active"] is False
+            revoked = revoke.json()["subscription"]
 
-        # DELETE
-        delete = authed_api("DELETE", f"/triggers/subscriptions/{subscription_id}")
-        assert delete.status_code == 204
+            # DELETE
+            delete = authed_api("DELETE", f"/triggers/subscriptions/{subscription_id}")
+            assert delete.status_code == 204
 
-        fetch = authed_api("GET", f"/triggers/subscriptions/{subscription_id}")
-        assert fetch.status_code == 200, fetch.text
-        fetched = fetch.json()
-        assert fetched["count"] == 1
-        historical = fetched["subscription"]
-        assert historical["id"] == subscription_id
-        assert historical["connection_id"] == revoked["connection_id"]
-        assert historical["name"] == revoked["name"]
-        assert historical["data"] == revoked["data"]
-        assert historical["flags"] == revoked["flags"]
-        assert historical["deleted_at"] is not None
-        assert historical["deleted_by_id"] is not None
+            fetch = authed_api("GET", f"/triggers/subscriptions/{subscription_id}")
+            assert fetch.status_code == 200, fetch.text
+            fetched = fetch.json()
+            assert fetched["count"] == 1
+            historical = fetched["subscription"]
+            assert historical["id"] == subscription_id
+            assert historical["connection_id"] == revoked["connection_id"]
+            assert historical["name"] == revoked["name"]
+            assert historical["data"] == revoked["data"]
+            assert historical["flags"] == revoked["flags"]
+            assert historical["deleted_at"] is not None
+            assert historical["deleted_by_id"] is not None
 
-        list_response = authed_api("GET", "/triggers/subscriptions/")
-        assert list_response.status_code == 200, list_response.text
-        listing = list_response.json()
-        assert all(item["id"] != subscription_id for item in listing["subscriptions"])
-        query_response = authed_api(
-            "POST",
-            "/triggers/subscriptions/query",
-            json={"subscription": {"name": historical["name"]}},
-        )
-        assert query_response.status_code == 200, query_response.text
-        query = query_response.json()
-        assert all(item["id"] != subscription_id for item in query["subscriptions"])
+            list_response = authed_api("GET", "/triggers/subscriptions/")
+            assert list_response.status_code == 200, list_response.text
+            listing = list_response.json()
+            assert all(
+                item["id"] != subscription_id for item in listing["subscriptions"]
+            )
+            query_response = authed_api(
+                "POST",
+                "/triggers/subscriptions/query",
+                json={"subscription": {"name": historical["name"]}},
+            )
+            assert query_response.status_code == 200, query_response.text
+            query = query_response.json()
+            assert all(item["id"] != subscription_id for item in query["subscriptions"])
 
-        rejected_edit = authed_api(
-            "PUT",
-            f"/triggers/subscriptions/{subscription_id}",
-            json={
-                "subscription": {
-                    "id": subscription_id,
-                    "connection_id": historical["connection_id"],
-                    "name": historical["name"],
-                    "description": historical.get("description"),
-                    "data": historical["data"],
-                    "flags": historical["flags"],
-                }
-            },
-        )
-        assert rejected_edit.status_code == 404, rejected_edit.text
-        rejected_start = authed_api(
-            "POST", f"/triggers/subscriptions/{subscription_id}/start"
-        )
-        assert rejected_start.status_code == 404, rejected_start.text
+            rejected_edit = authed_api(
+                "PUT",
+                f"/triggers/subscriptions/{subscription_id}",
+                json={
+                    "subscription": {
+                        "id": subscription_id,
+                        "connection_id": historical["connection_id"],
+                        "name": historical["name"],
+                        "description": historical.get("description"),
+                        "data": historical["data"],
+                        "flags": historical["flags"],
+                    }
+                },
+            )
+            assert rejected_edit.status_code == 404, rejected_edit.text
+            rejected_start = authed_api(
+                "POST", f"/triggers/subscriptions/{subscription_id}/start"
+            )
+            assert rejected_start.status_code == 404, rejected_start.text
 
-        # C7: deleting the subscription must NOT delete/revoke the connection.
-        conn = authed_api("GET", f"/tools/connections/{connection_id}")
-        assert conn.status_code == 200, conn.text
-
-        authed_api("DELETE", f"/tools/connections/{connection_id}")
+            # C7: deleting the subscription must NOT delete/revoke the connection.
+            conn = authed_api("GET", f"/tools/connections/{connection_id}")
+            assert conn.status_code == 200, conn.text
+        finally:
+            authed_api("DELETE", f"/tools/connections/{connection_id}")

--- a/api/oss/tests/pytest/integration/sessions/conftest.py
+++ b/api/oss/tests/pytest/integration/sessions/conftest.py
@@ -1,0 +1,32 @@
+import socket
+from functools import lru_cache
+from urllib.parse import urlparse
+
+import pytest
+
+from oss.src.utils.env import env
+
+
+@lru_cache(maxsize=1)
+def _postgres_reachable() -> bool:
+    """TCP-probe the configured core Postgres once per session.
+
+    The integration DAO tests here need a real Postgres. The default URI points
+    at the Docker-network host `postgres:5432`, which resolves in-compose/CI but
+    not on a bare host (`load-env` leaves it commented). Probe rather than error
+    so a native `py-run-tests --api` skips these instead of failing setup.
+    """
+    parsed = urlparse(env.postgres.uri_core)
+    host = parsed.hostname or "postgres"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _skip_when_postgres_unreachable(request):
+    if request.node.get_closest_marker("integration") and not _postgres_reachable():
+        pytest.skip("Postgres not reachable — skipping session DAO integration tests")

--- a/api/oss/tests/pytest/integration/sessions/test_sessions_query_postgres.py
+++ b/api/oss/tests/pytest/integration/sessions/test_sessions_query_postgres.py
@@ -1,0 +1,286 @@
+"""Database-backed coverage for `/sessions/query`'s windowing + origin contract.
+
+The existing query/contract unit tests (`test_sessions_query_contract.py` and
+friends) only compile SQL — they never execute it against Postgres. That is the
+root reason four production defects survived review: `limit=0` returning every
+row, `origins:["manual"]` matching zero rows against a real NULL-origin row,
+`next` without its companion bound compiling to no WHERE clause, and keyset
+paging never being exercised against real rows. This module seeds real
+`session_streams` rows and executes the real DAO query (and the request-model
+validation in front of it) so those four classes of bug show up as a failing
+assertion, not a passing compiled-SQL check.
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy import text
+
+import oss.src.dbs.postgres.shared.engine as engine_module
+import oss.src.models.db_models  # noqa: F401
+from oss.src.apis.fastapi.sessions.models import SessionQueryRequest
+from oss.src.apis.fastapi.sessions.utils import normalize_session_query_request
+from oss.src.core.sessions.dtos import SessionOrigin
+from oss.src.core.sessions.streams.dtos import SessionStreamQuery
+from oss.src.core.shared.dtos import Windowing
+from oss.src.dbs.postgres.sessions.streams.dao import (
+    MAX_SESSION_QUERY_LIMIT,
+    SessionStreamsDAO,
+)
+from oss.src.dbs.postgres.shared.engine import get_transactions_engine
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_engine_per_test():
+    engine_module._transactions_engine = None
+    yield
+    if engine_module._transactions_engine is not None:
+        await engine_module._transactions_engine.close()
+        engine_module._transactions_engine = None
+
+
+@pytest.fixture
+async def seeded_project():
+    """Provision the FK chain and seed 5 session_streams rows with staggered
+    `created_at` timestamps: 3 human (untagged, NULL origin) and 2 trigger-origin
+    (tagged `ag.origin=trigger`)."""
+    engine = get_transactions_engine()
+    user_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    base = datetime.now(timezone.utc) - timedelta(hours=1)
+    manual_ids = [f"sq-manual-{i}-{uuid.uuid4().hex[:8]}" for i in range(3)]
+    trigger_ids = [f"sq-trigger-{i}-{uuid.uuid4().hex[:8]}" for i in range(2)]
+
+    async with engine.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO users (id, uid, username, email) "
+                "VALUES (:id, :uid, :username, :email)"
+            ),
+            {
+                "id": user_id,
+                "uid": str(user_id),
+                "username": "sessions-query-postgres-test",
+                "email": f"sessions-query-{user_id.hex[:8]}@example.com",
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO organizations (id, name, owner_id) "
+                "VALUES (:id, :name, :owner_id)"
+            ),
+            {"id": organization_id, "name": "sq-org", "owner_id": user_id},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO workspaces (id, name, organization_id) "
+                "VALUES (:id, :name, :organization_id)"
+            ),
+            {
+                "id": workspace_id,
+                "name": "sq-ws",
+                "organization_id": organization_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO projects "
+                "(id, project_name, workspace_id, organization_id) "
+                "VALUES (:id, :name, :workspace_id, :organization_id)"
+            ),
+            {
+                "id": project_id,
+                "name": "sq-project",
+                "workspace_id": workspace_id,
+                "organization_id": organization_id,
+            },
+        )
+
+        # Oldest -> newest: manual[0], manual[1], manual[2], trigger[0], trigger[1].
+        for index, session_id in enumerate(manual_ids + trigger_ids):
+            is_trigger = session_id in trigger_ids
+            created_at = base + timedelta(minutes=index)
+            tags = (
+                {
+                    "ag.origin": "trigger",
+                    "ag.trigger.id": str(uuid.uuid4()),
+                    "ag.trigger.kind": "schedule",
+                    "ag.trigger.delivery_id": str(uuid.uuid4()),
+                }
+                if is_trigger
+                else None
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO session_streams "
+                    "(id, project_id, created_by_id, session_id, created_at, tags) "
+                    "VALUES (:id, :project_id, :user_id, :session_id, :created_at, "
+                    "CAST(:tags AS jsonb))"
+                ),
+                {
+                    "id": uuid.uuid4(),
+                    "project_id": project_id,
+                    "user_id": user_id,
+                    "session_id": session_id,
+                    "created_at": created_at,
+                    # `json.dumps(None) == "null"` — a JSON-null scalar, not a SQL
+                    # NULL bind — sidesteps asyncpg's ambiguous-type-for-NULL error
+                    # on a bound parameter feeding a `CAST(:x AS jsonb)` expression.
+                    # It round-trips to Python `None` on read either way.
+                    "tags": json.dumps(tags),
+                },
+            )
+        await session.commit()
+
+    yield {
+        "project_id": project_id,
+        "user_id": user_id,
+        "manual_ids": manual_ids,
+        "trigger_ids": trigger_ids,
+    }
+
+    async with engine.session() as session:
+        await session.execute(
+            text("DELETE FROM session_streams WHERE project_id = :project_id"),
+            {"project_id": project_id},
+        )
+        await session.execute(
+            text("DELETE FROM projects WHERE id = :id"), {"id": project_id}
+        )
+        await session.execute(
+            text("DELETE FROM workspaces WHERE id = :id"), {"id": workspace_id}
+        )
+        await session.execute(
+            text("DELETE FROM organizations WHERE id = :id"),
+            {"id": organization_id},
+        )
+        await session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_id})
+        await session.commit()
+
+
+async def test_sessions_query_limit_origin_cursor_and_paging_against_real_sql(
+    seeded_project,
+):
+    project_id = seeded_project["project_id"]
+    manual_ids = set(seeded_project["manual_ids"])
+    trigger_ids = set(seeded_project["trigger_ids"])
+    dao = SessionStreamsDAO(engine=get_transactions_engine())
+
+    # -- P0-1: limit bounds -------------------------------------------------- #
+    # The request model rejects the pathological values before they ever reach
+    # the DAO — this is the primary defense.
+    for bad_limit in (0, -1, MAX_SESSION_QUERY_LIMIT + 1):
+        with pytest.raises(ValidationError):
+            SessionQueryRequest(windowing=Windowing(limit=bad_limit))
+    SessionQueryRequest(windowing=Windowing(limit=MAX_SESSION_QUERY_LIMIT))  # no raise
+
+    # Defense-in-depth: an internal caller that builds a `Windowing` directly
+    # (bypassing the request model) must still get a bounded, non-empty result —
+    # never "no LIMIT clause at all" (the actual P0-1 bug) and never a 500 from a
+    # literal `LIMIT -1`.
+    zero_limit_rows = await dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(),
+        windowing=Windowing(limit=0),
+    )
+    assert len(zero_limit_rows) == 1
+    negative_limit_rows = await dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(),
+        windowing=Windowing(limit=-5),
+    )
+    assert len(negative_limit_rows) == 1
+
+    # -- P1-1: origins ["manual"] must match the NULL-origin rows ------------ #
+    manual_rows = await dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(origins=[SessionOrigin.manual]),
+        windowing=Windowing(limit=MAX_SESSION_QUERY_LIMIT),
+    )
+    assert {row.stream.session_id for row in manual_rows} == manual_ids
+    assert all(row.stream.origin == SessionOrigin.manual for row in manual_rows)
+
+    trigger_rows = await dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(origins=[SessionOrigin.trigger]),
+        windowing=Windowing(limit=MAX_SESSION_QUERY_LIMIT),
+    )
+    assert {row.stream.session_id for row in trigger_rows} == trigger_ids
+
+    both_rows = await dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(
+            origins=[SessionOrigin.manual, SessionOrigin.trigger]
+        ),
+        windowing=Windowing(limit=MAX_SESSION_QUERY_LIMIT),
+    )
+    assert {row.stream.session_id for row in both_rows} == manual_ids | trigger_ids
+
+    exclude_trigger_rows = await dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(exclude_origins=[SessionOrigin.trigger]),
+        windowing=Windowing(limit=MAX_SESSION_QUERY_LIMIT),
+    )
+    assert {row.stream.session_id for row in exclude_trigger_rows} == manual_ids
+
+    # -- P1-2: `next` without its companion bound must 422, not silently no-op #
+    with pytest.raises(HTTPException) as excinfo:
+        normalize_session_query_request(
+            SessionQueryRequest(windowing=Windowing(next=uuid.uuid4(), limit=5))
+        )
+    assert excinfo.value.status_code == 422
+
+    with pytest.raises(HTTPException) as excinfo:
+        normalize_session_query_request(
+            SessionQueryRequest(
+                windowing=Windowing(next=uuid.uuid4(), limit=5, order="ascending")
+            )
+        )
+    assert excinfo.value.status_code == 422
+
+    # Providing the companion bound is a normal, valid request.
+    normalize_session_query_request(
+        SessionQueryRequest(
+            windowing=Windowing(
+                next=uuid.uuid4(), newest=datetime.now(timezone.utc), limit=5
+            )
+        )
+    )
+
+    # -- P1-3 sanity / paging: three pages, both cursor fields, no gaps or dupes #
+    async def _next_page(cursor_stream):
+        if cursor_stream is None:
+            windowing = Windowing(limit=2, order="descending")
+        else:
+            windowing = Windowing(
+                limit=2,
+                order="descending",
+                newest=cursor_stream.updated_at or cursor_stream.created_at,
+                next=cursor_stream.id,
+            )
+        return await dao.query(
+            project_id=project_id,
+            filter=SessionStreamQuery(),
+            windowing=windowing,
+        )
+
+    page1 = await _next_page(None)
+    assert len(page1) == 2
+    page2 = await _next_page(page1[-1].stream)
+    assert len(page2) == 2
+    page3 = await _next_page(page2[-1].stream)
+    assert len(page3) == 1
+
+    seen = [row.stream.session_id for row in page1 + page2 + page3]
+    assert len(seen) == len(set(seen)), "keyset paging must never repeat a row"
+    assert set(seen) == manual_ids | trigger_ids

--- a/api/oss/tests/pytest/integration/sessions/test_trigger_session_claim_postgres.py
+++ b/api/oss/tests/pytest/integration/sessions/test_trigger_session_claim_postgres.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 import oss.src.dbs.postgres.shared.engine as engine_module
 import oss.src.models.db_models  # noqa: F401
 from oss.src.core.sessions.dtos import (
+    SessionOrigin,
     SessionTriggerAttribution,
     SessionTriggerKind,
 )
@@ -276,9 +277,8 @@ async def test_claim_atomically_merges_tags_flags_and_delivery_data(trigger_proj
 
     assert claimed is True
     assert heartbeat_result is not None
-    assert heartbeat_result.tags["ag.trigger.delivery_id"] == str(
-        attribution.delivery_id
-    )
+    assert heartbeat_result.delivery is not None
+    assert heartbeat_result.delivery.id == attribution.delivery_id
 
     stream = await streams_dao.get_by_session_id(
         project_id=project_id, session_id=session_id
@@ -289,7 +289,32 @@ async def test_claim_atomically_merges_tags_flags_and_delivery_data(trigger_proj
     assert stream.turn_id == turn_id
     assert stream.meta == {"source": "existing"}
     assert stream.flags.is_running is True
+    # Reserved attribution keys are stripped at the DTO mapping chokepoint (P1-6) —
+    # only caller-owned tags survive on `stream.tags`. The typed fields carry the
+    # attribution instead.
     assert stream.tags == {
+        "customer": "acme",
+        "ag.private": "keep",
+    }
+    assert stream.origin == SessionOrigin.trigger
+    assert stream.trigger is not None
+    assert stream.trigger.id == schedule_id
+    assert stream.trigger.kind == SessionTriggerKind.schedule
+    assert stream.delivery is not None
+    assert stream.delivery.id == attribution.delivery_id
+
+    # The raw row still carries the full merged tag set — the origin predicate
+    # (and the orphan-sweep/list filters) read the SQL column directly, never the
+    # sanitized DTO.
+    async with engine.session() as session:
+        raw_tags = await session.scalar(
+            text(
+                "SELECT tags FROM session_streams "
+                "WHERE project_id = :project_id AND session_id = :session_id"
+            ),
+            {"project_id": project_id, "session_id": session_id},
+        )
+    assert raw_tags == {
         "customer": "acme",
         "ag.private": "keep",
         "ag.origin": "trigger",
@@ -297,7 +322,6 @@ async def test_claim_atomically_merges_tags_flags_and_delivery_data(trigger_proj
         "ag.trigger.kind": "schedule",
         "ag.trigger.delivery_id": str(attribution.delivery_id),
     }
-    assert "ag.trigger.name" not in stream.tags
 
     delivery = await triggers_dao.fetch_delivery(
         project_id=project_id, delivery_id=attribution.delivery_id
@@ -441,7 +465,8 @@ async def test_different_events_create_distinct_delivery_session_pairs(trigger_p
         assert delivery.event_id == event_id
         assert delivery.data.session_id == session_id
         assert stream is not None
-        assert stream.tags["ag.trigger.delivery_id"] == str(attribution.delivery_id)
+        assert stream.delivery is not None
+        assert stream.delivery.id == attribution.delivery_id
 
 
 async def test_attribution_failure_rolls_back_claim_and_allows_retry(trigger_project):
@@ -481,3 +506,54 @@ async def test_attribution_failure_rolls_back_claim_and_allows_retry(trigger_pro
         attribution=attribution,
     )
     assert retried is True
+
+
+async def test_abandon_claimed_session_soft_deletes_the_phantom_row(trigger_project):
+    """P0-3: a claim followed by a pre-invoke dispatch failure must not leave a
+    permanent, un-sweepable phantom session. `abandon_claimed_session` is the
+    dispatcher's cleanup call for that path — verify it actually soft-deletes the
+    row the claim inserted (flags=NULL, so nothing else can end it)."""
+    engine = get_transactions_engine()
+    streams_dao = SessionStreamsDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    user_id = trigger_project["user_id"]
+    schedule_id = trigger_project["schedule_id"]
+    session_id = uuid.uuid4().hex
+
+    claimed = await streams_dao.claim_trigger_delivery(
+        project_id=project_id,
+        user_id=user_id,
+        event_id="phantom-event",
+        session_id=session_id,
+        attribution=SessionTriggerAttribution(
+            configuration_id=schedule_id,
+            kind=SessionTriggerKind.schedule,
+            delivery_id=uuid.uuid4(),
+        ),
+    )
+    assert claimed is True
+
+    claimed_stream = await streams_dao.get_by_session_id(
+        project_id=project_id, session_id=session_id
+    )
+    assert claimed_stream is not None
+    assert claimed_stream.flags.is_alive is False  # flags=NULL decodes to all-False
+
+    abandoned = await streams_dao.abandon_claimed_session(
+        project_id=project_id, session_id=session_id
+    )
+    assert abandoned is True
+
+    # Soft-deleted: gone from the default (non-deleted) read, matching a killed
+    # session's tombstone semantics — not a permanent, visible phantom.
+    assert (
+        await streams_dao.get_by_session_id(
+            project_id=project_id, session_id=session_id
+        )
+        is None
+    )
+    tombstoned = await streams_dao.get_by_session_id_including_archived(
+        project_id=project_id, session_id=session_id
+    )
+    assert tombstoned is not None
+    assert tombstoned.deleted_at is not None

--- a/api/oss/tests/pytest/integration/sessions/test_trigger_session_claim_postgres.py
+++ b/api/oss/tests/pytest/integration/sessions/test_trigger_session_claim_postgres.py
@@ -289,12 +289,12 @@ async def test_claim_atomically_merges_tags_flags_and_delivery_data(trigger_proj
     assert stream.turn_id == turn_id
     assert stream.meta == {"source": "existing"}
     assert stream.flags.is_running is True
-    # Reserved attribution keys are stripped at the DTO mapping chokepoint (P1-6) —
-    # only caller-owned tags survive on `stream.tags`. The typed fields carry the
-    # attribution instead.
+    # The whole "ag." namespace is stripped at the DTO mapping chokepoint
+    # (P1-6/P3-7) — only genuinely non-"ag." tags survive on `stream.tags`,
+    # including "ag.private" despite not being one of the five attribution
+    # keys. The typed fields carry the attribution instead.
     assert stream.tags == {
         "customer": "acme",
-        "ag.private": "keep",
     }
     assert stream.origin == SessionOrigin.trigger
     assert stream.trigger is not None
@@ -506,6 +506,228 @@ async def test_attribution_failure_rolls_back_claim_and_allows_retry(trigger_pro
         attribution=attribution,
     )
     assert retried is True
+
+
+async def _seed_delivery(
+    engine,
+    *,
+    delivery_id,
+    project_id,
+    user_id,
+    schedule_id,
+    event_id,
+    status_code,
+    data="{}",
+):
+    async with engine.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO trigger_deliveries "
+                "(id, project_id, created_by_id, schedule_id, event_id, status, data) "
+                "VALUES (:id, :project_id, :user_id, :schedule_id, :event_id, "
+                "CAST(:status AS jsonb), CAST(:data AS json))"
+            ),
+            {
+                "id": delivery_id,
+                "project_id": project_id,
+                "user_id": user_id,
+                "schedule_id": schedule_id,
+                "event_id": event_id,
+                "status": f'{{"code": "{status_code}", "message": "x"}}',
+                "data": data,
+            },
+        )
+        await session.commit()
+
+
+async def test_retryable_failed_delivery_can_be_reclaimed_exactly_once(trigger_project):
+    """P1-8: a delivery stuck in the one retryable terminal state (500 — the
+    runner was unreachable, not a permanent rejection) must be re-claimable by
+    a fresh attempt, and the re-claim itself is exactly-once — a second
+    concurrent re-claim against the now-"102 claimed" row must lose, the same
+    as any other claim."""
+    engine = get_transactions_engine()
+    streams_dao = SessionStreamsDAO(engine=engine)
+    triggers_dao = TriggersDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    user_id = trigger_project["user_id"]
+    schedule_id = trigger_project["schedule_id"]
+    event_id = "retry-500-event"
+    original_delivery_id = uuid.uuid4()
+
+    # Mirrors what `_complete_delivery` writes after an invoke failure.
+    await _seed_delivery(
+        engine,
+        delivery_id=original_delivery_id,
+        project_id=project_id,
+        user_id=user_id,
+        schedule_id=schedule_id,
+        event_id=event_id,
+        status_code="500",
+        data='{"session_id": "original-session", "error": "runner unavailable"}',
+    )
+
+    retry_attribution = SessionTriggerAttribution(
+        configuration_id=schedule_id,
+        kind=SessionTriggerKind.schedule,
+        delivery_id=uuid.uuid4(),
+    )
+    retry_session_id = uuid.uuid4().hex
+
+    reclaimed = await streams_dao.claim_trigger_delivery(
+        project_id=project_id,
+        user_id=user_id,
+        event_id=event_id,
+        session_id=retry_session_id,
+        attribution=retry_attribution,
+    )
+    assert reclaimed is True
+
+    # The row's identity now belongs to the retry: the SAME (project, schedule,
+    # event) row is reused, but with a fresh id/status/data/session — a retry
+    # is not a second delivery.
+    delivery = await triggers_dao.fetch_delivery(
+        project_id=project_id, delivery_id=retry_attribution.delivery_id
+    )
+    assert delivery is not None
+    assert delivery.status.code == "102"
+    assert delivery.status.message == "claimed"
+    assert delivery.data.session_id == retry_session_id
+    assert (
+        await triggers_dao.fetch_delivery(
+            project_id=project_id, delivery_id=original_delivery_id
+        )
+        is None
+    ), "the original failed row's id must not survive as a separate row"
+
+    stream = await streams_dao.get_by_session_id(
+        project_id=project_id, session_id=retry_session_id
+    )
+    assert stream is not None
+    assert stream.delivery is not None
+    assert stream.delivery.id == retry_attribution.delivery_id
+
+    # A second re-claim attempt against the SAME event must now lose: the row
+    # is "102 claimed", not "500", so the retryable WHERE no longer matches —
+    # exactly the DO-NOTHING outcome a fresh duplicate claim always got.
+    second_claim = await streams_dao.claim_trigger_delivery(
+        project_id=project_id,
+        user_id=user_id,
+        event_id=event_id,
+        session_id=uuid.uuid4().hex,
+        attribution=SessionTriggerAttribution(
+            configuration_id=schedule_id,
+            kind=SessionTriggerKind.schedule,
+            delivery_id=uuid.uuid4(),
+        ),
+    )
+    assert second_claim is False
+
+
+@pytest.mark.parametrize("status_code", ["102", "200", "409"])
+async def test_non_retryable_delivery_cannot_be_reclaimed(trigger_project, status_code):
+    """A delivery that is still in-flight (102), succeeded (200), or failed for a
+    permanent reason (409 — e.g. an invalid subscription) must never be
+    re-claimed — only the one retryable terminal state (500) may be."""
+    engine = get_transactions_engine()
+    streams_dao = SessionStreamsDAO(engine=engine)
+    triggers_dao = TriggersDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    user_id = trigger_project["user_id"]
+    schedule_id = trigger_project["schedule_id"]
+    event_id = f"non-retryable-{status_code}-event"
+    existing_delivery_id = uuid.uuid4()
+
+    await _seed_delivery(
+        engine,
+        delivery_id=existing_delivery_id,
+        project_id=project_id,
+        user_id=user_id,
+        schedule_id=schedule_id,
+        event_id=event_id,
+        status_code=status_code,
+        data='{"session_id": "original-session"}',
+    )
+
+    claimed = await streams_dao.claim_trigger_delivery(
+        project_id=project_id,
+        user_id=user_id,
+        event_id=event_id,
+        session_id=uuid.uuid4().hex,
+        attribution=SessionTriggerAttribution(
+            configuration_id=schedule_id,
+            kind=SessionTriggerKind.schedule,
+            delivery_id=uuid.uuid4(),
+        ),
+    )
+    assert claimed is False
+
+    # The original row is untouched — no partial/attempted overwrite.
+    delivery = await triggers_dao.fetch_delivery(
+        project_id=project_id, delivery_id=existing_delivery_id
+    )
+    assert delivery is not None
+    assert delivery.status.code == status_code
+    assert delivery.data.session_id == "original-session"
+
+
+async def test_dedup_seen_schedule_treats_retryable_failure_as_unseen(trigger_project):
+    """P1-8: the dedup pre-check must not short-circuit a retry before it ever
+    reaches the atomic claim — that claim is the actual authority on whether a
+    re-claim wins. Only a genuinely terminal (non-retryable) status counts as
+    "seen"."""
+    engine = get_transactions_engine()
+    triggers_dao = TriggersDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    user_id = trigger_project["user_id"]
+    schedule_id = trigger_project["schedule_id"]
+    event_id = "dedup-500-event"
+
+    assert (
+        await triggers_dao.dedup_seen_schedule(
+            project_id=project_id, schedule_id=schedule_id, event_id=event_id
+        )
+        is False
+    ), "no row at all is unambiguously unseen"
+
+    await _seed_delivery(
+        engine,
+        delivery_id=uuid.uuid4(),
+        project_id=project_id,
+        user_id=user_id,
+        schedule_id=schedule_id,
+        event_id=event_id,
+        status_code="500",
+    )
+    assert (
+        await triggers_dao.dedup_seen_schedule(
+            project_id=project_id, schedule_id=schedule_id, event_id=event_id
+        )
+        is False
+    ), "a retryable failure must not read as a duplicate"
+
+    async with engine.session() as session:
+        await session.execute(
+            text(
+                "UPDATE trigger_deliveries SET status = CAST(:status AS jsonb) "
+                "WHERE project_id = :project_id AND schedule_id = :schedule_id "
+                "AND event_id = :event_id"
+            ),
+            {
+                "status": '{"code": "200", "message": "success"}',
+                "project_id": project_id,
+                "schedule_id": schedule_id,
+                "event_id": event_id,
+            },
+        )
+        await session.commit()
+
+    assert (
+        await triggers_dao.dedup_seen_schedule(
+            project_id=project_id, schedule_id=schedule_id, event_id=event_id
+        )
+        is True
+    ), "a genuinely completed delivery is a duplicate"
 
 
 async def test_abandon_claimed_session_soft_deletes_the_phantom_row(trigger_project):

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.dialects import postgresql
 
-from oss.src.core.sessions.dtos import SessionQuery
+from oss.src.core.sessions.dtos import SessionQuery, SessionQueryLifecycle
 from oss.src.core.sessions.service import SessionsService
 from oss.src.core.sessions.streams.dtos import (
     SessionStream,
@@ -257,7 +257,9 @@ async def test_references_and_session_ids_intersect():
 
     await service.query_sessions(
         project_id=_PROJECT,
-        query=SessionQuery(references=[{"id": str(uuid4())}], session_ids=["s2", "s3"]),
+        query=SessionQuery(
+            turn_references=[{"id": str(uuid4())}], session_ids=["s2", "s3"]
+        ),
     )
 
     assert streams.captured["session_ids"] == ["s2"]
@@ -270,7 +272,7 @@ async def test_disjoint_reference_and_id_filters_short_circuit_to_empty():
 
     result = await service.query_sessions(
         project_id=_PROJECT,
-        query=SessionQuery(references=[{"id": str(uuid4())}], session_ids=["s9"]),
+        query=SessionQuery(turn_references=[{"id": str(uuid4())}], session_ids=["s9"]),
     )
 
     assert result == []
@@ -297,13 +299,15 @@ async def test_count_uses_the_same_predicate_as_the_list():
     service = _service(streams, _FakeTurnsService([]))
     query = SessionQuery(
         search="refund",
-        include_ended=True,
         flags=SessionStreamQueryFlags(is_alive=True),
         exclude_session_ids=["pinned-1"],
     )
 
-    await service.query_sessions(project_id=_PROJECT, query=query)
-    total = await service.count_sessions(project_id=_PROJECT, query=query)
+    lifecycle = SessionQueryLifecycle(include_ended=True)
+    await service.query_sessions(project_id=_PROJECT, query=query, lifecycle=lifecycle)
+    total = await service.count_sessions(
+        project_id=_PROJECT, query=query, lifecycle=lifecycle
+    )
 
     assert total == 42
     assert streams.count_captured["filter"] == streams.captured["filter"]
@@ -320,7 +324,7 @@ async def test_count_short_circuits_on_an_empty_intersection():
 
     total = await service.count_sessions(
         project_id=_PROJECT,
-        query=SessionQuery(references=[{"id": str(uuid4())}], session_ids=["s9"]),
+        query=SessionQuery(turn_references=[{"id": str(uuid4())}], session_ids=["s9"]),
     )
 
     assert total == 0

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
@@ -174,6 +174,7 @@ class _FakeStreamsService:
         windowing=None,
         session_ids=None,
         exclude_session_ids=None,
+        read_options=None,
     ):
         self.captured = {
             "filter": filter,
@@ -205,6 +206,9 @@ class _FakeTurnsService:
 
     async def query_turns(self, *, project_id, query):
         return [_FakeTurn(sid) for sid in self.session_ids]
+
+    async def query_session_ids_by_references(self, *, project_id, references, limit):
+        return list(self.session_ids)[:limit]
 
     async def latest_turn_per_session(self, *, project_id, session_ids):
         return {}

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_references.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_references.py
@@ -65,6 +65,7 @@ class _FakeStreamsService:
         windowing=None,
         session_ids=None,
         exclude_session_ids=None,
+        read_options=None,
     ):
         if session_ids is not None:
             return [s for s in self.rows if s.session_id in session_ids]

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_search.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_search.py
@@ -152,6 +152,7 @@ class _FakeStreamsService:
         windowing=None,
         session_ids=None,
         exclude_session_ids=None,
+        read_options=None,
     ):
         self.query_calls.append({"project_id": project_id, "filter": filter})
         return [self.row] if self.row else []

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_windowing.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_windowing.py
@@ -91,6 +91,29 @@ def test_updated_at_cursor_rides_coalesced_updated_at():
     _assert_created_at_only_inside_coalesce(where)
 
 
+def test_updated_at_ascending_cursor_uses_oldest_with_id_tiebreak():
+    oldest = datetime.now(timezone.utc)
+    next_id = uuid7()
+    stmt = apply_windowing(
+        stmt=select(SessionStreamDBE),
+        DBE=SessionStreamDBE,
+        attribute="updated_at",
+        order="descending",
+        windowing=Windowing(
+            oldest=oldest,
+            next=next_id,
+            limit=20,
+            order="ascending",
+        ),
+    )
+    where = str(stmt.whereclause.compile(compile_kwargs={"literal_binds": True}))
+
+    assert f"{COALESCE_EXPR} >=" in where
+    assert f"{COALESCE_EXPR} >" in where
+    assert "session_streams.id >" in where
+    _assert_created_at_only_inside_coalesce(where)
+
+
 def test_created_at_attribute_behavior_is_unchanged():
     """Regression pin: current behavior for `attribute="created_at"` (observed
     directly against `apply_windowing` before this change) must not shift."""

--- a/api/oss/tests/pytest/unit/sessions/test_session_last_message.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_last_message.py
@@ -10,13 +10,18 @@ the fan-out the sessions router's module docstring rules out.
     whole page and that a deployment without the records engine still lists sessions.
 """
 
+import asyncio
 from typing import Dict, List, Optional
 from uuid import uuid4
 
 import pytest
 from sqlalchemy.dialects import postgresql
 
-from oss.src.core.sessions.dtos import SessionQuery
+from oss.src.core.sessions.dtos import (
+    SessionExpansion,
+    SessionQuery,
+    SessionQueryOptions,
+)
 from oss.src.core.sessions.records.dtos import SessionMessagePreview
 from oss.src.core.sessions.service import SessionsService
 from oss.src.core.sessions.streams.dtos import SessionStream
@@ -121,6 +126,16 @@ async def test_newest_message_wins_on_producer_event_time():
 
 
 @pytest.mark.asyncio
+async def test_text_is_checked_after_newest_message_selection_without_fallback():
+    dao, session = _dao()
+
+    await dao.latest_message_per_session(project_id=uuid4(), session_ids=["a"])
+
+    compiled = session.captured_stmt.compile(dialect=postgresql.dialect())
+    assert "text" not in compiled.params.values()
+
+
+@pytest.mark.asyncio
 async def test_no_ids_asks_the_database_nothing():
     dao, session = _dao()
 
@@ -166,7 +181,11 @@ class _FakeStreamsService:
 
 
 class _FakeTurnsService:
+    def __init__(self):
+        self.calls = 0
+
     async def latest_turn_per_session(self, **kwargs):
+        self.calls += 1
         return {}
 
 
@@ -197,11 +216,13 @@ def _service(records_service=None) -> SessionsService:
 @pytest.mark.asyncio
 async def test_the_whole_page_is_previewed_in_one_call():
     records = _FakeRecordsService(
-        {"a": SessionMessagePreview(session_id="a", text="ship it", source="user")}
+        {"a": SessionMessagePreview(text="ship it", source="user")}
     )
 
     items = await _service(records).query_sessions(
-        project_id=uuid4(), query=SessionQuery()
+        project_id=uuid4(),
+        query=SessionQuery(),
+        options=SessionQueryOptions(expand=[SessionExpansion.last_message]),
     )
 
     assert records.calls == [["a", "b"]]
@@ -213,8 +234,145 @@ async def test_the_whole_page_is_previewed_in_one_call():
 @pytest.mark.asyncio
 async def test_sessions_still_list_without_the_records_engine():
     items = await _service(records_service=None).query_sessions(
-        project_id=uuid4(), query=SessionQuery()
+        project_id=uuid4(),
+        query=SessionQuery(),
+        options=SessionQueryOptions(expand=[SessionExpansion.last_message]),
     )
 
     assert [item.session_id for item in items] == ["a", "b"]
     assert all(item.last_message is None for item in items)
+
+
+@pytest.mark.asyncio
+async def test_no_expansion_skips_records_but_still_loads_latest_turns():
+    records = _FakeRecordsService({})
+    service = _service(records)
+
+    items = await service.query_sessions(project_id=uuid4(), query=SessionQuery())
+
+    assert [item.session_id for item in items] == ["a", "b"]
+    assert records.calls == []
+    assert service.turns_service.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_and_latest_turn_batches_start_concurrently():
+    turns_started = asyncio.Event()
+    records_started = asyncio.Event()
+
+    class _ConcurrentTurns:
+        async def latest_turn_per_session(self, **kwargs):
+            turns_started.set()
+            await records_started.wait()
+            return {}
+
+    class _ConcurrentRecords:
+        async def latest_message_per_session(self, **kwargs):
+            records_started.set()
+            await turns_started.wait()
+            return {"a": SessionMessagePreview(text="concurrent")}
+
+    service = SessionsService(
+        streams_service=_FakeStreamsService([_stream("a")]),
+        turns_service=_ConcurrentTurns(),
+        interactions_service=object(),
+        mounts_service=object(),
+        records_service=_ConcurrentRecords(),
+    )
+
+    items = await asyncio.wait_for(
+        service.query_sessions(
+            project_id=uuid4(),
+            options=SessionQueryOptions(expand=[SessionExpansion.last_message]),
+        ),
+        timeout=1,
+    )
+
+    assert items[0].last_message.text == "concurrent"
+
+
+@pytest.mark.asyncio
+async def test_records_failure_returns_base_rows_without_previews():
+    class _FailingRecords:
+        async def latest_message_per_session(self, **kwargs):
+            raise RuntimeError("analytics unavailable")
+
+    items = await _service(_FailingRecords()).query_sessions(
+        project_id=uuid4(),
+        options=SessionQueryOptions(expand=[SessionExpansion.last_message]),
+    )
+
+    assert [item.session_id for item in items] == ["a", "b"]
+    assert all(item.last_message is None for item in items)
+
+
+@pytest.mark.asyncio
+async def test_latest_turn_failure_still_propagates_with_preview_expansion():
+    class _FailingTurns:
+        async def latest_turn_per_session(self, **kwargs):
+            raise RuntimeError("turn lookup failed")
+
+    service = SessionsService(
+        streams_service=_FakeStreamsService([_stream("a")]),
+        turns_service=_FailingTurns(),
+        interactions_service=object(),
+        mounts_service=object(),
+        records_service=_FakeRecordsService({}),
+    )
+
+    with pytest.raises(RuntimeError, match="turn lookup failed"):
+        await service.query_sessions(
+            project_id=uuid4(),
+            options=SessionQueryOptions(expand=[SessionExpansion.last_message]),
+        )
+
+
+@pytest.mark.asyncio
+async def test_latest_turn_failure_cancels_and_awaits_records_lookup():
+    records_started = asyncio.Event()
+    records_cancelled = asyncio.Event()
+    records_cleanup_finished = asyncio.Event()
+
+    class _FailingTurns:
+        async def latest_turn_per_session(self, **kwargs):
+            await records_started.wait()
+            raise RuntimeError("turn lookup failed")
+
+    class _CancellableRecords:
+        async def latest_message_per_session(self, **kwargs):
+            records_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                records_cancelled.set()
+                await asyncio.sleep(0)
+                records_cleanup_finished.set()
+                raise
+
+    service = SessionsService(
+        streams_service=_FakeStreamsService([_stream("a")]),
+        turns_service=_FailingTurns(),
+        interactions_service=object(),
+        mounts_service=object(),
+        records_service=_CancellableRecords(),
+    )
+
+    with pytest.raises(RuntimeError, match="turn lookup failed"):
+        await service.query_sessions(
+            project_id=uuid4(),
+            options=SessionQueryOptions(expand=[SessionExpansion.last_message]),
+        )
+
+    assert records_cancelled.is_set()
+    assert records_cleanup_finished.is_set()
+
+
+def test_public_preview_has_no_session_id():
+    preview = SessionMessagePreview(text="ship it", source="user")
+
+    assert preview.model_dump() == {
+        "text": "ship it",
+        "source": "user",
+        "timestamp": None,
+    }
+    assert "session_id" not in SessionMessagePreview.model_json_schema()["properties"]

--- a/api/oss/tests/pytest/unit/sessions/test_session_last_message.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_last_message.py
@@ -63,10 +63,15 @@ class _DummySessionContext:
 
 
 class _Row:
-    def __init__(self, session_id, record_source, attributes, timestamp=None):
+    """Mirrors the columns the DAO's `select(...)` now projects: `text` is already
+    the truncated `left(attributes->>'text', ...)` expression, not the raw
+    `attributes` blob — the fake session below skips real SQL execution, so it
+    must hand back what the query would have computed, not the pre-image."""
+
+    def __init__(self, session_id, record_source, text, timestamp=None):
         self.session_id = session_id
         self.record_source = record_source
-        self.attributes = attributes
+        self.text = text
         self.timestamp = timestamp
         self.created_at = None
 
@@ -131,8 +136,16 @@ async def test_text_is_checked_after_newest_message_selection_without_fallback()
 
     await dao.latest_message_per_session(project_id=uuid4(), session_ids=["a"])
 
-    compiled = session.captured_stmt.compile(dialect=postgresql.dialect())
-    assert "text" not in compiled.params.values()
+    sql = str(session.captured_stmt.compile(dialect=postgresql.dialect())).replace(
+        "\n", " "
+    )
+    where_clause = sql.split(" WHERE ", 1)[1].split(" ORDER BY ", 1)[0]
+
+    # Row selection (WHERE + DISTINCT ON + ORDER BY) never filters on message
+    # content — `text` is only ever projected (truncated) in the SELECT list, so a
+    # message with no/blank text is still the newest row chosen, and gets skipped
+    # in Python afterward rather than falling back to an older row that has text.
+    assert "text" not in where_clause
 
 
 @pytest.mark.asyncio
@@ -150,9 +163,9 @@ async def test_a_message_without_text_has_nothing_to_preview():
     # An attachment-only message carries no `text`; a row must not preview an empty string.
     dao, _ = _dao(
         rows=[
-            _Row("with-text", "user", {"type": "message", "text": "  ship it  "}),
-            _Row("no-text", "agent", {"type": "message"}),
-            _Row("blank", "agent", {"type": "message", "text": "   "}),
+            _Row("with-text", "user", "  ship it  "),
+            _Row("no-text", "agent", None),
+            _Row("blank", "agent", "   "),
             _Row("no-attributes", "agent", None),
         ]
     )

--- a/api/oss/tests/pytest/unit/sessions/test_session_response_sanitization.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_response_sanitization.py
@@ -31,10 +31,13 @@ RESERVED_TAGS = {
     "ag.trigger.kind": "schedule",
     "ag.trigger.delivery_id": "delivery-id",
     "ag.trigger.name": "Legacy name",
-}
-USER_TAGS = {
+    # P3-7: the whole "ag." namespace is reserved, not just the five exact
+    # attribution keys above — these two used to be preserved as "caller-owned"
+    # and no longer are.
     "ag.trigger.custom": {"spacing": "  unchanged\n  ", "values": [1, None]},
     "ag.private": False,
+}
+USER_TAGS = {
     "team": "support",
 }
 ALL_TAGS = {**RESERVED_TAGS, **USER_TAGS}

--- a/api/oss/tests/pytest/unit/sessions/test_session_response_sanitization.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_response_sanitization.py
@@ -1,0 +1,230 @@
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from oss.src.apis.fastapi.sessions.router import (
+    SessionsRootRouter,
+    SessionStreamsRouter,
+)
+from oss.src.apis.fastapi.sessions.utils import sanitize_session_stream
+from oss.src.core.sessions.dtos import SessionListItem, SessionQueryPage
+from oss.src.core.sessions.streams.dtos import (
+    CommandMode,
+    SessionHeartbeatResult,
+    SessionStream,
+    SessionStreamCommandResponse,
+)
+from oss.src.core.sessions.types import (
+    SessionDelivery,
+    SessionOrigin,
+    SessionTrigger,
+    SessionTriggerKind,
+)
+
+
+RESERVED_TAGS = {
+    "ag.origin": "trigger",
+    "ag.trigger.id": "configuration-id",
+    "ag.trigger.kind": "schedule",
+    "ag.trigger.delivery_id": "delivery-id",
+    "ag.trigger.name": "Legacy name",
+}
+USER_TAGS = {
+    "ag.trigger.custom": {"spacing": "  unchanged\n  ", "values": [1, None]},
+    "ag.private": False,
+    "team": "support",
+}
+ALL_TAGS = {**RESERVED_TAGS, **USER_TAGS}
+
+
+def _app(*routers) -> FastAPI:
+    app = FastAPI()
+    project_id = uuid4()
+    user_id = uuid4()
+
+    @app.middleware("http")
+    async def set_request_scope(request: Request, call_next):
+        request.state.project_id = str(project_id)
+        request.state.user_id = str(user_id)
+        return await call_next(request)
+
+    for router in routers:
+        app.include_router(router.router)
+    return app
+
+
+def _stream(*, tags=ALL_TAGS, session_id: str = "session-a") -> SessionStream:
+    return SessionStream(
+        id=uuid4(),
+        project_id=uuid4(),
+        session_id=session_id,
+        tags=tags,
+    )
+
+
+def _assert_only_user_tags(stream: dict) -> None:
+    assert stream["tags"] == USER_TAGS
+    assert not RESERVED_TAGS.keys() & stream["tags"].keys()
+
+
+def test_stream_sanitizer_returns_copies_without_mutating_service_dto():
+    stream = _stream()
+
+    sanitized = sanitize_session_stream(stream)
+
+    assert sanitized is not stream
+    assert sanitized.tags is not stream.tags
+    assert sanitized.tags == USER_TAGS
+    assert stream.tags == ALL_TAGS
+
+
+def test_root_query_serialization_strips_reserved_tags_and_keeps_typed_attribution():
+    trigger_id = uuid4()
+    delivery_id = uuid4()
+    attributed_data = _stream().model_dump()
+    attributed_data.update(
+        origin=SessionOrigin.trigger,
+        trigger=SessionTrigger(
+            id=trigger_id,
+            kind=SessionTriggerKind.schedule,
+            name="Current name",
+        ),
+        delivery=SessionDelivery(id=delivery_id),
+    )
+    attributed = SessionListItem(**attributed_data)
+    untagged = SessionListItem(
+        **_stream(tags=None, session_id="session-b").model_dump()
+    )
+    service = AsyncMock()
+    service.query_sessions_page.return_value = SessionQueryPage(
+        sessions=[attributed, untagged]
+    )
+    app = _app(SessionsRootRouter(sessions_service=service))
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        response = TestClient(app).post("/sessions/query", json={})
+
+    assert response.status_code == 200
+    sessions = response.json()["sessions"]
+    _assert_only_user_tags(sessions[0])
+    assert sessions[0]["origin"] == "trigger"
+    assert sessions[0]["trigger"] == {
+        "id": str(trigger_id),
+        "kind": "schedule",
+        "name": "Current name",
+    }
+    assert sessions[0]["delivery"] == {"id": str(delivery_id)}
+    assert "tags" not in sessions[1]
+    assert attributed.tags == ALL_TAGS
+    assert untagged.tags is None
+
+
+@pytest.mark.parametrize(
+    ("path", "service_method"),
+    [
+        ("/sessions/archive?session_id=session-a", "archive_session"),
+        ("/sessions/unarchive?session_id=session-a", "unarchive_session"),
+    ],
+)
+def test_root_mutation_serialization_strips_only_reserved_tags(path, service_method):
+    stream = _stream()
+    service = AsyncMock()
+    getattr(service, service_method).return_value = stream
+    app = _app(SessionsRootRouter(sessions_service=service))
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        response = TestClient(app).post(path)
+
+    assert response.status_code == 200
+    _assert_only_user_tags(response.json()["session"])
+    assert stream.tags == ALL_TAGS
+
+
+def test_plain_stream_response_families_strip_only_reserved_tags():
+    stream = _stream()
+    untagged = _stream(tags=None, session_id="session-b")
+    service = AsyncMock()
+    service.fetch.return_value = stream
+    service.query_streams.return_value = [stream, untagged]
+    service.set_header.return_value = stream
+    service.heartbeat.return_value = SessionHeartbeatResult(
+        stream=stream,
+        replica_id="replica-a",
+    )
+    service.command.return_value = SessionStreamCommandResponse(
+        mode=CommandMode.cancel,
+        session_id="session-a",
+        detached=True,
+    )
+    app = _app(
+        SessionStreamsRouter(
+            service=service,
+            interactions_service=AsyncMock(),
+        )
+    )
+    client = TestClient(app)
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        fetch = client.get("/sessions/streams/?session_id=session-a")
+        query = client.post("/sessions/streams/query", json={})
+        header = client.put(
+            "/sessions/streams/header?session_id=session-a",
+            json={"name": "Renamed"},
+        )
+        heartbeat = client.post(
+            "/sessions/streams/heartbeat",
+            json={"session_id": "session-a", "replica_id": "replica-a"},
+        )
+        command = client.post(
+            "/sessions/streams/",
+            json={"session_id": "session-a"},
+        )
+
+    assert fetch.status_code == 200
+    _assert_only_user_tags(fetch.json()["stream"])
+    assert query.status_code == 200
+    _assert_only_user_tags(query.json()["streams"][0])
+    assert query.json()["streams"][1]["tags"] is None
+    assert header.status_code == 200
+    _assert_only_user_tags(header.json()["stream"])
+    assert heartbeat.status_code == 200
+    _assert_only_user_tags(heartbeat.json()["stream"])
+    assert command.status_code == 200
+    assert "tags" not in command.json()
+    assert stream.tags == ALL_TAGS
+    assert untagged.tags is None
+
+
+def test_session_openapi_keeps_typed_attribution_and_generic_tags():
+    app = _app(
+        SessionsRootRouter(sessions_service=AsyncMock()),
+        SessionStreamsRouter(
+            service=AsyncMock(),
+            interactions_service=AsyncMock(),
+        ),
+    )
+    schemas = app.openapi()["components"]["schemas"]
+
+    for schema_name in ("SessionStream", "SessionListItem"):
+        properties = schemas[schema_name]["properties"]
+        assert {"origin", "trigger", "delivery", "tags"} <= properties.keys()
+        tag_shapes = properties["tags"]["anyOf"]
+        assert any(
+            shape.get("type") == "object" and shape.get("additionalProperties") is True
+            for shape in tag_shapes
+        )

--- a/api/oss/tests/pytest/unit/sessions/test_session_trigger_expansion.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_trigger_expansion.py
@@ -1,0 +1,232 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from oss.src.core.sessions.dtos import (
+    SessionExpansion,
+    SessionQueryOptions,
+    SessionTriggerKind,
+)
+from oss.src.core.sessions.service import SessionsService
+from oss.src.core.sessions.streams.dtos import (
+    SessionStream,
+    SessionStreamQuery,
+    SessionStreamQueryResult,
+    SessionStreamReadOptions,
+)
+from oss.src.core.sessions.streams.service import SessionStreamsService
+from oss.src.core.sessions.types import SessionTrigger
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
+
+
+def _compiled_query(*, include_trigger_details: bool) -> str:
+    statement = SessionStreamsDAO._query_select(
+        read_options=SessionStreamReadOptions(
+            include_trigger_details=include_trigger_details
+        )
+    )
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    ).replace("\n", " ")
+
+
+def test_trigger_joins_are_absent_without_expansion():
+    sql = _compiled_query(include_trigger_details=False)
+
+    assert "trigger_schedules" not in sql
+    assert "trigger_subscriptions" not in sql
+
+
+def test_trigger_expansion_joins_both_configuration_tables_by_typed_identity():
+    sql = _compiled_query(include_trigger_details=True)
+
+    assert "LEFT OUTER JOIN trigger_schedules" in sql
+    assert "LEFT OUTER JOIN trigger_subscriptions" in sql
+    assert "trigger_schedules.project_id = session_streams.project_id" in sql
+    assert "trigger_subscriptions.project_id = session_streams.project_id" in sql
+    assert "trigger_schedules.id = CASE WHEN" in sql
+    assert "trigger_subscriptions.id = CASE WHEN" in sql
+    assert "ag.trigger.kind" in sql
+    assert "schedule" in sql
+    assert "subscription" in sql
+    assert "ag.trigger.id" in sql
+    assert " AS UUID" in sql
+    assert "trigger_schedules.deleted_at" not in sql
+    assert "trigger_subscriptions.deleted_at" not in sql
+    assert "trigger_subscriptions.trigger_id" not in sql
+    assert "CAST(trigger_schedules.id" not in sql
+    assert "CAST(trigger_subscriptions.id" not in sql
+
+
+class _SessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _EmptyResult:
+    def all(self):
+        return []
+
+
+class _CountingSession:
+    def __init__(self, error=None):
+        self.error = error
+        self.execute_calls = 0
+        self.statement = None
+
+    async def execute(self, statement):
+        self.execute_calls += 1
+        self.statement = statement
+        if self.error:
+            raise self.error
+        return _EmptyResult()
+
+
+def _dao_with_session(session):
+    engine = type("Engine", (), {"session": lambda self: _SessionContext(session)})()
+    return SessionStreamsDAO(engine=engine)
+
+
+@pytest.mark.asyncio
+async def test_trigger_expansion_executes_one_joined_stream_statement():
+    session = _CountingSession()
+
+    result = await _dao_with_session(session).query(
+        project_id=uuid4(),
+        filter=SessionStreamQuery(),
+        read_options=SessionStreamReadOptions(include_trigger_details=True),
+    )
+
+    assert result == []
+    assert session.execute_calls == 1
+    sql = str(session.statement.compile(dialect=postgresql.dialect()))
+    assert "LEFT OUTER JOIN trigger_schedules" in sql
+    assert "LEFT OUTER JOIN trigger_subscriptions" in sql
+
+
+@pytest.mark.asyncio
+async def test_joined_stream_failure_propagates_without_fallback_query():
+    session = _CountingSession(error=RuntimeError("stream database unavailable"))
+
+    with pytest.raises(RuntimeError, match="stream database unavailable"):
+        await _dao_with_session(session).query(
+            project_id=uuid4(),
+            filter=SessionStreamQuery(),
+            read_options=SessionStreamReadOptions(include_trigger_details=True),
+        )
+
+    assert session.execute_calls == 1
+
+
+class _ProjectionDAO:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    async def query(self, **kwargs):
+        self.calls.append(kwargs)
+        return [self.result]
+
+
+@pytest.mark.asyncio
+async def test_stream_service_hydrates_name_without_changing_stream_query_shape():
+    trigger_id = uuid4()
+    stream = SessionStream(
+        id=uuid4(),
+        project_id=uuid4(),
+        session_id="session-a",
+        trigger=SessionTrigger(
+            id=trigger_id,
+            kind=SessionTriggerKind.schedule,
+        ),
+    )
+    dao = _ProjectionDAO(
+        SessionStreamQueryResult(stream=stream, trigger_name="Current name")
+    )
+    service = SessionStreamsService(streams_dao=dao, lock_engine=object())
+
+    result = await service.query_streams(
+        project_id=stream.project_id,
+        filter=SessionStreamQuery(),
+        read_options=SessionStreamReadOptions(include_trigger_details=True),
+    )
+
+    assert result == [
+        stream.model_copy(
+            update={
+                "trigger": stream.trigger.model_copy(update={"name": "Current name"})
+            }
+        )
+    ]
+    assert dao.calls[0]["read_options"].include_trigger_details is True
+
+
+@pytest.mark.asyncio
+async def test_missing_trigger_name_preserves_typed_id_and_kind():
+    trigger_id = uuid4()
+    stream = SessionStream(
+        id=uuid4(),
+        project_id=uuid4(),
+        session_id="session-a",
+        trigger=SessionTrigger(
+            id=trigger_id,
+            kind=SessionTriggerKind.subscription,
+        ),
+    )
+    service = SessionStreamsService(
+        streams_dao=_ProjectionDAO(SessionStreamQueryResult(stream=stream)),
+        lock_engine=object(),
+    )
+
+    result = await service.query_streams(
+        project_id=stream.project_id,
+        filter=SessionStreamQuery(),
+        read_options=SessionStreamReadOptions(include_trigger_details=True),
+    )
+
+    assert result[0].trigger.id == trigger_id
+    assert result[0].trigger.kind == SessionTriggerKind.subscription
+    assert result[0].trigger.name is None
+
+
+class _RootStreams:
+    def __init__(self, stream):
+        self.stream = stream
+        self.calls = []
+
+    async def query_streams(self, **kwargs):
+        self.calls.append(kwargs)
+        return [self.stream]
+
+
+class _RootTurns:
+    async def latest_turn_per_session(self, **kwargs):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_root_trigger_expansion_requests_trigger_details_from_stream_read():
+    stream = SessionStream(id=uuid4(), project_id=uuid4(), session_id="session-trigger")
+    streams = _RootStreams(stream)
+    service = SessionsService(
+        streams_service=streams,
+        turns_service=_RootTurns(),
+        interactions_service=object(),
+        mounts_service=object(),
+    )
+
+    await service.query_sessions(
+        project_id=stream.project_id,
+        options=SessionQueryOptions(expand=[SessionExpansion.trigger]),
+    )
+
+    assert streams.calls[0]["read_options"].include_trigger_details is True

--- a/api/oss/tests/pytest/unit/sessions/test_session_trigger_expansion.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_trigger_expansion.py
@@ -50,8 +50,12 @@ def test_trigger_expansion_joins_both_configuration_tables_by_typed_identity():
     assert "trigger_schedules.id = CASE WHEN" in sql
     assert "trigger_subscriptions.id = CASE WHEN" in sql
     assert "ag.trigger.kind" in sql
-    assert "schedule" in sql
-    assert "subscription" in sql
+    # Not `"schedule" in sql` / `"subscription" in sql` — the table names
+    # `trigger_schedules`/`trigger_subscriptions` (already asserted above)
+    # contain both substrings, so those checks would pass even if the CASE
+    # predicate's literal comparison were deleted. Assert the literal itself.
+    assert "= 'schedule'" in sql
+    assert "= 'subscription'" in sql
     assert "ag.trigger.id" in sql
     assert " AS UUID" in sql
     assert "trigger_schedules.deleted_at" not in sql

--- a/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
@@ -125,6 +125,16 @@ async def test_claim_compiles_as_one_postgres_statement():
     assert "ON CONFLICT (project_id, session_id) DO UPDATE" in sql
     assert "coalesce(session_streams.tags" in sql
     assert " || excluded.tags" in sql
+    # The session_streams INSERT's SELECT must read FROM the delivery CTE, not run
+    # unconditionally — that's what makes a lost delivery claim (empty CTE) insert
+    # zero rows instead of stamping a session anyway. The fake session below always
+    # returns a UUID regardless of statement shape (`assert claimed is True` alone
+    # is tautological), so this checks the actual SQL dependency: removing
+    # `.select_from(claimed_delivery)` from the DAO would drop this substring.
+    session_streams_insert = sql.split("INSERT INTO session_streams", 1)[1].split(
+        "ON CONFLICT", 1
+    )[0]
+    assert "FROM claimed_trigger_delivery" in session_streams_insert
     object_parameters = [
         value for value in compiled.params.values() if isinstance(value, dict)
     ]

--- a/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
@@ -121,6 +121,15 @@ async def test_claim_compiles_as_one_postgres_statement():
     assert "FOR UPDATE" in sql
     assert "claimed_trigger_delivery AS" in sql
     assert "INSERT INTO trigger_deliveries" in sql
+    # P1-8: the delivery claim re-claims a retryable-failed row instead of
+    # leaving it permanently stuck — DO UPDATE, gated on the existing row's
+    # status, not a bare DO NOTHING.
+    assert "ON CONFLICT (project_id, subscription_id, event_id)" in sql
+    delivery_insert = sql.split("INSERT INTO trigger_deliveries", 1)[1].split(
+        "INSERT INTO session_streams", 1
+    )[0]
+    assert "DO UPDATE SET" in delivery_insert
+    assert "WHERE (trigger_deliveries.status" in delivery_insert
     assert "INSERT INTO session_streams" in sql
     assert "ON CONFLICT (project_id, session_id) DO UPDATE" in sql
     assert "coalesce(session_streams.tags" in sql

--- a/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_trigger_stamp.py
@@ -1,138 +1,144 @@
-"""Unit tests for the automation stamp on a session row.
-
-An automation run is a session nobody named, so its row could say what the run did but never
-what fired it: `ag.origin` recorded only THAT something automated started it. The trigger's
-identity is stamped by the same writer as the origin — `set_origin` replaces tags wholesale, so
-a second writer would need a merge it does not have.
-
-The name is a snapshot, not a live join; see `SessionTriggerRef`.
-"""
-
-from typing import Any, Dict, Optional
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
 
 from oss.src.core.sessions.dtos import (
-    SESSION_ORIGIN_MANUAL,
-    SESSION_ORIGIN_TAG,
-    SESSION_ORIGIN_TRIGGER,
-    SESSION_TRIGGER_ID_TAG,
-    SESSION_TRIGGER_KIND_SCHEDULE,
-    SESSION_TRIGGER_KIND_TAG,
-    SESSION_TRIGGER_NAME_TAG,
-    SessionTriggerRef,
+    SessionOrigin,
+    SessionTriggerAttribution,
+    SessionTriggerKind,
 )
-from oss.src.core.sessions.streams.dtos import SessionStream
-from oss.src.core.sessions.streams.service import SessionStreamsService
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 
 
-class _RecordingDAO:
-    """Captures what `set_origin` writes. `update` returning a row is the common path — the
-    stream usually does not exist yet, but either branch writes the same tags."""
+class _Result:
+    def scalar_one_or_none(self):
+        return uuid4()
 
-    def __init__(self, *, row_exists: bool = True) -> None:
-        self.row_exists = row_exists
-        self.updated_tags: Optional[Dict[str, Any]] = None
-        self.created_tags: Optional[Dict[str, Any]] = None
 
-    async def update(self, *, project_id, user_id, session_id, stream):
-        self.updated_tags = stream.tags
-        if not self.row_exists:
-            return None
-        return SessionStream(
-            id=uuid4(),
-            project_id=project_id,
-            session_id=session_id,
-            tags=stream.tags,
+class _Session:
+    def __init__(self):
+        self.statement = None
+        self.commits = 0
+        self.rollbacks = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def execute(self, statement):
+        self.statement = statement
+        statement.compile(dialect=postgresql.dialect())
+        return _Result()
+
+    async def commit(self):
+        self.commits += 1
+
+    async def rollback(self):
+        self.rollbacks += 1
+
+
+class _Engine:
+    def __init__(self):
+        self.db_session = _Session()
+
+    def session(self):
+        return self.db_session
+
+
+def test_trigger_attribution_contains_only_durable_identifiers():
+    configuration_id = uuid4()
+    delivery_id = uuid4()
+
+    attribution = SessionTriggerAttribution(
+        configuration_id=configuration_id,
+        kind=SessionTriggerKind.schedule,
+        delivery_id=delivery_id,
+    )
+
+    assert attribution.model_dump() == {
+        "configuration_id": configuration_id,
+        "kind": SessionTriggerKind.schedule,
+        "delivery_id": delivery_id,
+    }
+    assert "name" not in SessionTriggerAttribution.model_fields
+    assert "meta" not in SessionTriggerAttribution.model_fields
+
+
+@pytest.mark.parametrize("kind", ["schedule", "subscription"])
+def test_trigger_kind_is_typed(kind):
+    attribution = SessionTriggerAttribution(
+        configuration_id=uuid4(),
+        kind=kind,
+        delivery_id=uuid4(),
+    )
+    assert attribution.kind == SessionTriggerKind(kind)
+
+
+def test_unknown_trigger_kind_is_rejected():
+    with pytest.raises(ValidationError):
+        SessionTriggerAttribution(
+            configuration_id=uuid4(),
+            kind="webhook",
+            delivery_id=uuid4(),
         )
 
-    async def create(self, *, project_id, user_id, stream):
-        self.created_tags = stream.tags
-        return SessionStream(
-            id=uuid4(),
-            project_id=project_id,
-            session_id=stream.session_id,
-            tags=stream.tags,
-        )
+
+def test_session_origin_is_typed():
+    assert {origin.value for origin in SessionOrigin} == {"manual", "trigger"}
 
 
-def _service(dao) -> SessionStreamsService:
-    return SessionStreamsService(streams_dao=dao, lock_engine=None)
+async def test_claim_compiles_as_one_postgres_statement():
+    engine = _Engine()
+    dao = SessionStreamsDAO(engine=engine)
+    session_id = uuid4().hex
+    configuration_id = uuid4()
+    delivery_id = uuid4()
 
-
-SESSION_ID = "0" * 32
-PROJECT_ID = UUID(int=1)
-
-
-@pytest.mark.asyncio
-async def test_manual_origin_stamps_no_trigger():
-    dao = _RecordingDAO()
-    await _service(dao).set_origin(
-        project_id=PROJECT_ID,
-        user_id=None,
-        session_id=SESSION_ID,
-        origin=SESSION_ORIGIN_MANUAL,
-    )
-    assert dao.updated_tags == {SESSION_ORIGIN_TAG: SESSION_ORIGIN_MANUAL}
-
-
-@pytest.mark.asyncio
-async def test_trigger_identity_rides_the_origin_write():
-    # One write, not two: the tags column is replaced wholesale.
-    dao = _RecordingDAO()
-    trigger_id = str(uuid4())
-    await _service(dao).set_origin(
-        project_id=PROJECT_ID,
-        user_id=None,
-        session_id=SESSION_ID,
-        origin=SESSION_ORIGIN_TRIGGER,
-        trigger=SessionTriggerRef(
-            id=trigger_id,
-            name="Nightly digest",
-            kind=SESSION_TRIGGER_KIND_SCHEDULE,
+    claimed = await dao.claim_trigger_delivery(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        event_id="event-1",
+        session_id=session_id,
+        attribution=SessionTriggerAttribution(
+            configuration_id=configuration_id,
+            kind=SessionTriggerKind.subscription,
+            delivery_id=delivery_id,
         ),
     )
-    assert dao.updated_tags == {
-        SESSION_ORIGIN_TAG: SESSION_ORIGIN_TRIGGER,
-        SESSION_TRIGGER_ID_TAG: trigger_id,
-        SESSION_TRIGGER_NAME_TAG: "Nightly digest",
-        SESSION_TRIGGER_KIND_TAG: SESSION_TRIGGER_KIND_SCHEDULE,
-    }
-    assert dao.created_tags is None
 
-
-@pytest.mark.asyncio
-async def test_unnamed_trigger_omits_the_name_rather_than_stamping_empty():
-    # A blank name would render as a blank row title; absence lets the row fall back.
-    dao = _RecordingDAO()
-    trigger_id = str(uuid4())
-    await _service(dao).set_origin(
-        project_id=PROJECT_ID,
-        user_id=None,
-        session_id=SESSION_ID,
-        origin=SESSION_ORIGIN_TRIGGER,
-        trigger=SessionTriggerRef(id=trigger_id, name=None, kind=None),
+    compiled = engine.db_session.statement.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": False}
     )
-    assert dao.updated_tags == {
-        SESSION_ORIGIN_TAG: SESSION_ORIGIN_TRIGGER,
-        SESSION_TRIGGER_ID_TAG: trigger_id,
-    }
-
-
-@pytest.mark.asyncio
-async def test_create_branch_stamps_the_same_tags():
-    # The row usually does NOT exist yet — the stamp happens before the run creates it.
-    dao = _RecordingDAO(row_exists=False)
-    trigger_id = str(uuid4())
-    await _service(dao).set_origin(
-        project_id=PROJECT_ID,
-        user_id=None,
-        session_id=SESSION_ID,
-        origin=SESSION_ORIGIN_TRIGGER,
-        trigger=SessionTriggerRef(
-            id=trigger_id, name="On PR opened", kind="subscription"
-        ),
+    sql = str(compiled)
+    assert claimed is True
+    assert sql.startswith("WITH live_trigger_configuration AS")
+    assert "trigger_subscriptions.deleted_at IS NULL" in sql
+    assert "trigger_subscriptions.flags @>" in sql
+    assert "FOR UPDATE" in sql
+    assert "claimed_trigger_delivery AS" in sql
+    assert "INSERT INTO trigger_deliveries" in sql
+    assert "INSERT INTO session_streams" in sql
+    assert "ON CONFLICT (project_id, session_id) DO UPDATE" in sql
+    assert "coalesce(session_streams.tags" in sql
+    assert " || excluded.tags" in sql
+    object_parameters = [
+        value for value in compiled.params.values() if isinstance(value, dict)
+    ]
+    assert {"session_id": session_id} in object_parameters
+    claim_status = next(
+        value for value in object_parameters if value.get("message") == "claimed"
     )
-    assert dao.created_tags == dao.updated_tags
-    assert dao.created_tags[SESSION_TRIGGER_NAME_TAG] == "On PR opened"
+    assert claim_status["code"] == "102"
+    assert claim_status["timestamp"]
+    assert {
+        "ag.origin": "trigger",
+        "ag.trigger.id": str(configuration_id),
+        "ag.trigger.kind": "subscription",
+        "ag.trigger.delivery_id": str(delivery_id),
+    } in object_parameters
+    assert engine.db_session.commits == 1
+    assert engine.db_session.rollbacks == 0

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
@@ -1,0 +1,703 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+
+from oss.src.apis.fastapi.sessions.models import (
+    SessionExcludeRequest,
+    SessionPredicatesRequest,
+    SessionQueryRequest,
+)
+from oss.src.apis.fastapi.sessions.router import SessionsRootRouter
+from oss.src.apis.fastapi.sessions.utils import (
+    compute_session_response_windowing,
+    normalize_session_query_request,
+    sanitize_session_tags,
+)
+from oss.src.core.sessions.dtos import (
+    SessionExpansion,
+    SessionListItem,
+    SessionOrigin,
+    SessionQuery,
+    SessionQueryLifecycle,
+    SessionQueryOptions,
+    SessionQueryPage,
+    SessionTriggerKind,
+)
+from oss.src.core.sessions.service import SessionsService
+from oss.src.core.sessions.streams.dtos import (
+    SessionStream,
+    SessionStreamQuery,
+    SessionStreamQueryFlags,
+)
+from oss.src.core.shared.dtos import Reference, Windowing
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
+from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
+from oss.src.dbs.postgres.sessions.streams.mappings import (
+    decode_session_attribution,
+)
+from oss.src.dbs.postgres.shared.utils import apply_windowing
+
+
+def test_nested_only_request_normalizes_by_semantic_role():
+    reference = Reference(id=uuid4())
+    normalized = normalize_session_query_request(
+        SessionQueryRequest(
+            session=SessionPredicatesRequest(
+                search=" refund ",
+                liveness=SessionStreamQueryFlags(is_alive=True),
+                origins=[SessionOrigin.trigger],
+            ),
+            session_ids=["session-b", "session-a"],
+            exclude=SessionExcludeRequest(
+                origins=[SessionOrigin.manual], session_ids=["session-c"]
+            ),
+            turn_references=[reference],
+            include_ended=True,
+            include_total=True,
+            expand=[SessionExpansion.last_message, SessionExpansion.trigger],
+            windowing=Windowing(limit=30),
+        )
+    )
+
+    assert normalized.predicates.search == "refund"
+    assert normalized.predicates.flags.is_alive is True
+    assert normalized.predicates.origins == [SessionOrigin.trigger]
+    assert normalized.predicates.session_ids == ["session-a", "session-b"]
+    assert normalized.predicates.exclude_origins == [SessionOrigin.manual]
+    assert normalized.predicates.exclude_session_ids == ["session-c"]
+    assert normalized.predicates.turn_references == [reference]
+    assert normalized.lifecycle.include_ended is True
+    assert normalized.options.include_total is True
+    assert normalized.options.expand == [
+        SessionExpansion.last_message,
+        SessionExpansion.trigger,
+    ]
+    assert normalized.windowing.limit == 30
+
+
+def test_flat_only_request_remains_valid():
+    reference = Reference(id=uuid4())
+    normalized = normalize_session_query_request(
+        SessionQueryRequest(
+            search="refund",
+            flags=SessionStreamQueryFlags(is_running=True),
+            origin=SessionOrigin.trigger,
+            session_ids=["session-a"],
+            exclude_origin=SessionOrigin.manual,
+            exclude_session_ids=["session-b"],
+            references=[reference],
+        )
+    )
+
+    assert normalized.predicates == SessionQuery(
+        search="refund",
+        flags=SessionStreamQueryFlags(is_running=True),
+        origins=[SessionOrigin.trigger],
+        session_ids=["session-a"],
+        exclude_origins=[SessionOrigin.manual],
+        exclude_session_ids=["session-b"],
+        turn_references=[reference],
+    )
+
+
+def test_equivalent_mixed_request_is_accepted_order_insensitively():
+    first = Reference(id=uuid4())
+    second = Reference(id=uuid4())
+    normalized = normalize_session_query_request(
+        SessionQueryRequest(
+            session=SessionPredicatesRequest(
+                search="refund",
+                origins=[SessionOrigin.trigger],
+            ),
+            search=" refund ",
+            origin=SessionOrigin.trigger,
+            session_ids=["session-a", "session-b"],
+            turn_references=[first, second],
+            references=[second, first],
+        )
+    )
+
+    assert normalized.predicates.search == "refund"
+    assert normalized.predicates.session_ids == ["session-a", "session-b"]
+    assert normalized.predicates.origins == [SessionOrigin.trigger]
+
+
+def test_semantically_empty_search_and_liveness_duplicates_are_equivalent():
+    normalized = normalize_session_query_request(
+        SessionQueryRequest.model_validate(
+            {
+                "session": {"search": "  ", "liveness": {}},
+                "search": None,
+                "flags": None,
+            }
+        )
+    )
+
+    assert normalized.predicates.search is None
+    assert normalized.predicates.flags == SessionStreamQueryFlags()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "session": {"search": "refund"},
+            "search": "invoice",
+        },
+        {"session": {"liveness": {"is_alive": True}}, "flags": {"is_alive": False}},
+        {
+            "exclude": {"origins": ["trigger"]},
+            "exclude_origin": "manual",
+        },
+        {
+            "turn_references": [{"id": str(uuid4())}],
+            "references": [{"id": str(uuid4())}],
+        },
+    ],
+)
+def test_contradictory_mixed_request_returns_422(payload):
+    with pytest.raises(HTTPException) as error:
+        normalize_session_query_request(SessionQueryRequest.model_validate(payload))
+
+    assert error.value.status_code == 422
+
+
+def test_explicit_empty_inclusions_are_preserved_as_match_nothing():
+    normalized = normalize_session_query_request(
+        SessionQueryRequest(
+            session=SessionPredicatesRequest(origins=[]),
+            session_ids=[],
+            turn_references=[],
+        )
+    )
+
+    assert normalized.predicates.session_ids == []
+    assert normalized.predicates.origins == []
+    assert normalized.predicates.turn_references == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"session_ids": ["bad/id"]},
+        {"exclude_session_ids": ["bad id"]},
+        {"session_ids": ["../bad"]},
+        {"exclude": {"session_ids": [""]}},
+        {"session_ids": [f"session-{index}" for index in range(501)]},
+        {"exclude": {"session_ids": [f"session-{index}" for index in range(501)]}},
+    ],
+)
+def test_session_id_lists_validate_values_and_500_bound(payload):
+    with pytest.raises(ValidationError):
+        SessionQueryRequest.model_validate(payload)
+
+
+def test_session_id_lists_accept_exactly_500_valid_ids():
+    session_ids = [f"session-{index}" for index in range(500)]
+
+    request = SessionQueryRequest(
+        session_ids=session_ids,
+        exclude=SessionExcludeRequest(session_ids=session_ids),
+    )
+
+    assert len(request.session_ids) == 500
+    assert len(request.exclude.session_ids) == 500
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"session": {"origins": ["trigger"], "unexpected": True}},
+        {"session": {"session_ids": ["session-a"]}},
+        {"exclude": {"session_ids": ["session-a"], "unexpected": True}},
+        {"expand": ["unknown"]},
+    ],
+)
+def test_new_contract_fields_and_enum_values_are_not_silently_ignored(payload):
+    with pytest.raises(ValidationError):
+        SessionQueryRequest.model_validate(payload)
+
+
+def test_openapi_session_predicates_exclude_session_ids():
+    schema = SessionPredicatesRequest.model_json_schema()
+
+    assert "session_ids" not in schema["properties"]
+    assert "session_ids" in SessionQueryRequest.model_json_schema()["properties"]
+
+
+def test_empty_legacy_references_remain_neutral():
+    normalized = normalize_session_query_request(SessionQueryRequest(references=[]))
+
+    assert normalized.predicates.turn_references is None
+
+
+def test_empty_legacy_references_do_not_conflict_with_canonical_references():
+    reference = Reference(id=uuid4())
+    normalized = normalize_session_query_request(
+        SessionQueryRequest(turn_references=[reference], references=[])
+    )
+
+    assert normalized.predicates.turn_references == [reference]
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (SessionQuery, {"include_total": True}),
+        (SessionQuery, {"include_ended": True}),
+        (SessionQueryLifecycle, {"search": "refund"}),
+        (SessionQueryOptions, {"session_ids": ["session-a"]}),
+    ],
+)
+def test_normalized_core_roles_forbid_misplaced_fields(model, payload):
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def _compile_stream_query(
+    *,
+    filter: SessionStreamQuery,
+    session_ids=None,
+    exclude_session_ids=None,
+    windowing=None,
+) -> str:
+    statement = SessionStreamsDAO._apply_filters(
+        select(SessionStreamDBE),
+        project_id=uuid4(),
+        filter=filter,
+        session_ids=session_ids,
+        exclude_session_ids=exclude_session_ids,
+    )
+    if windowing is not None:
+        statement = apply_windowing(
+            stmt=statement,
+            DBE=SessionStreamDBE,
+            attribute="updated_at",
+            order="descending",
+            windowing=windowing,
+        )
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    ).replace("\n", " ")
+
+
+def test_origin_include_and_exclude_apply_before_pagination():
+    sql = _compile_stream_query(
+        filter=SessionStreamQuery(
+            origins=[SessionOrigin.trigger],
+            exclude_origins=[SessionOrigin.trigger],
+        ),
+        windowing=Windowing(limit=1),
+    )
+
+    assert "ag.origin" in sql
+    assert " IN ('trigger')" in sql
+    assert "NOT IN ('trigger')" in sql
+    assert sql.index("ag.origin") < sql.index("ORDER BY") < sql.index("LIMIT")
+
+
+def test_excluding_trigger_retains_null_and_unstamped_rows():
+    sql = _compile_stream_query(
+        filter=SessionStreamQuery(exclude_origins=[SessionOrigin.trigger])
+    )
+
+    assert "IS NULL OR" in sql
+    assert "NOT IN ('trigger')" in sql
+
+
+def test_missing_origin_filter_adds_no_origin_predicate():
+    sql = _compile_stream_query(filter=SessionStreamQuery())
+
+    assert "ag.origin" not in sql
+
+
+def test_empty_origin_inclusion_compiles_to_match_nothing():
+    sql = _compile_stream_query(filter=SessionStreamQuery(origins=[]))
+
+    assert "1 != 1" in sql
+
+
+def test_session_id_exclusion_wins_on_overlap():
+    sql = _compile_stream_query(
+        filter=SessionStreamQuery(),
+        session_ids=["session-a"],
+        exclude_session_ids=["session-a"],
+    )
+
+    assert " IN ('session-a')" in sql
+    assert "NOT IN ('session-a')" in sql
+
+
+class _Streams:
+    def __init__(self, rows):
+        self.rows = rows
+        self.query_calls = []
+        self.count_calls = []
+
+    async def query_streams(self, **kwargs):
+        self.query_calls.append(kwargs)
+        return self.rows
+
+    async def count_streams(self, **kwargs):
+        self.count_calls.append(kwargs)
+        return len(self.rows)
+
+
+class _Turns:
+    def __init__(self, reference_session_ids=()):
+        self.reference_session_ids = list(reference_session_ids)
+        self.query_calls = []
+
+    async def query_turns(self, **kwargs):
+        self.query_calls.append(kwargs)
+        return [
+            type("Turn", (), {"session_id": session_id})()
+            for session_id in self.reference_session_ids
+        ]
+
+    async def latest_turn_per_session(self, **kwargs):
+        return {}
+
+
+def _service(rows, turns):
+    streams = _Streams(rows)
+    return (
+        SessionsService(
+            streams_service=streams,
+            turns_service=turns,
+            interactions_service=object(),
+            mounts_service=object(),
+        ),
+        streams,
+    )
+
+
+async def test_page_and_total_share_one_turn_reference_resolution():
+    project_id = uuid4()
+    row = SessionStream(id=uuid4(), project_id=project_id, session_id="session-a")
+    turns = _Turns(["session-a", "session-b"])
+    service, streams = _service([row], turns)
+
+    page = await service.query_sessions_page(
+        project_id=project_id,
+        query=SessionQuery(
+            turn_references=[Reference(id=uuid4())],
+            session_ids=["session-a"],
+            exclude_session_ids=["session-b"],
+        ),
+        options=SessionQueryOptions(include_total=True),
+    )
+
+    assert page.total == 1
+    assert len(turns.query_calls) == 1
+    assert streams.query_calls[0]["session_ids"] == ["session-a"]
+    assert streams.count_calls[0]["session_ids"] == ["session-a"]
+    assert streams.query_calls[0]["exclude_session_ids"] == ["session-b"]
+    assert streams.count_calls[0]["exclude_session_ids"] == ["session-b"]
+
+
+async def test_empty_request_is_origin_neutral():
+    project_id = uuid4()
+    rows = [
+        SessionStream(
+            id=uuid4(),
+            project_id=project_id,
+            session_id="trigger-session",
+            origin=SessionOrigin.trigger,
+        ),
+        SessionStream(id=uuid4(), project_id=project_id, session_id="unknown-session"),
+    ]
+    service, streams = _service(rows, _Turns())
+
+    result = await service.query_sessions(project_id=project_id)
+
+    assert [row.session_id for row in result] == [
+        "trigger-session",
+        "unknown-session",
+    ]
+    assert streams.query_calls[0]["filter"].origins is None
+    assert result[1].origin is None
+
+
+def _item(*, created_at, updated_at=None, item_id=None):
+    return SessionListItem(
+        id=item_id or uuid4(),
+        project_id=uuid4(),
+        session_id="session-a",
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+def test_response_cursor_uses_coalesced_activity_and_uuid_tiebreak():
+    created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    updated_at = created_at + timedelta(hours=1)
+    last_id = uuid4()
+    sessions = [
+        _item(created_at=created_at),
+        _item(created_at=created_at, updated_at=updated_at, item_id=last_id),
+    ]
+
+    result = compute_session_response_windowing(
+        sessions=sessions, requested=Windowing(limit=2, order="descending")
+    )
+
+    assert result.next == last_id
+    assert result.newest == updated_at
+    assert result.oldest is None
+    assert result.limit == 2
+
+
+def test_response_cursor_falls_back_to_created_at():
+    created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    result = compute_session_response_windowing(
+        sessions=[_item(created_at=created_at)], requested=Windowing(limit=1)
+    )
+
+    assert result.newest == created_at
+
+
+def test_ascending_response_cursor_uses_oldest_and_uuid_tiebreak():
+    activity = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    last_id = UUID(int=2)
+
+    result = compute_session_response_windowing(
+        sessions=[
+            _item(created_at=activity, item_id=UUID(int=1)),
+            _item(created_at=activity, item_id=last_id),
+        ],
+        requested=Windowing(limit=2, order="ascending"),
+    )
+
+    assert result.next == last_id
+    assert result.oldest == activity
+    assert result.newest is None
+
+
+@pytest.mark.parametrize("order", ["ascending", "descending"])
+def test_tied_activity_two_page_cursors_have_no_duplicates(order):
+    activity = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    rows = [
+        _item(created_at=activity, item_id=UUID(int=index)) for index in range(1, 6)
+    ]
+    ordered = sorted(rows, key=lambda row: row.id, reverse=order == "descending")
+    first_page = ordered[:2]
+    cursor = compute_session_response_windowing(
+        sessions=first_page,
+        requested=Windowing(limit=2, order=order),
+    )
+
+    if order == "ascending":
+        second_page = [
+            row
+            for row in ordered
+            if (row.updated_at or row.created_at) > cursor.oldest
+            or (
+                (row.updated_at or row.created_at) == cursor.oldest
+                and row.id > cursor.next
+            )
+        ][:2]
+    else:
+        second_page = [
+            row
+            for row in ordered
+            if (row.updated_at or row.created_at) < cursor.newest
+            or (
+                (row.updated_at or row.created_at) == cursor.newest
+                and row.id < cursor.next
+            )
+        ][:2]
+
+    assert {row.id for row in first_page}.isdisjoint(row.id for row in second_page)
+    assert [row.id for row in first_page + second_page] == [
+        row.id for row in ordered[:4]
+    ]
+
+
+def test_unwindowed_response_omits_response_windowing():
+    created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    sessions = [_item(created_at=created_at)]
+
+    assert compute_session_response_windowing(sessions=sessions, requested=None) is None
+
+
+@pytest.mark.parametrize(
+    ("requested", "count"),
+    [
+        (Windowing(), 1),
+        (Windowing(limit=0), 1),
+        (Windowing(limit=2), 1),
+        (Windowing(limit=2), 0),
+    ],
+)
+def test_terminal_windowed_response_keeps_windowing_without_next(requested, count):
+    created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    sessions = [_item(created_at=created_at) for _ in range(count)]
+
+    result = compute_session_response_windowing(
+        sessions=sessions,
+        requested=requested,
+    )
+
+    assert result is not None
+    assert result.next is None
+    assert result.limit == requested.limit
+    assert result.order == requested.order
+
+
+def test_terminal_windowed_response_clears_the_request_cursor():
+    created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    requested = Windowing(
+        limit=2,
+        next=uuid4(),
+        newest=created_at + timedelta(hours=1),
+        order="descending",
+    )
+
+    result = compute_session_response_windowing(
+        sessions=[_item(created_at=created_at)],
+        requested=requested,
+    )
+
+    assert result is not None
+    assert result.next is None
+    assert result.newest == requested.newest
+
+
+def test_typed_attribution_and_legacy_raw_tags_coexist():
+    trigger_id = uuid4()
+    delivery_id = uuid4()
+    tags = {
+        "ag.origin": "trigger",
+        "ag.trigger.id": str(trigger_id),
+        "ag.trigger.kind": "schedule",
+        "ag.trigger.delivery_id": str(delivery_id),
+        "team": "support",
+    }
+    origin, trigger, delivery = decode_session_attribution(tags)
+    item = SessionListItem(
+        id=uuid4(),
+        project_id=uuid4(),
+        session_id="session-a",
+        tags=tags,
+        origin=origin,
+        trigger=trigger,
+        delivery=delivery,
+    )
+
+    assert item.origin == SessionOrigin.trigger
+    assert item.trigger.id == trigger_id
+    assert item.trigger.kind == SessionTriggerKind.schedule
+    assert item.trigger.name is None
+    assert item.delivery.id == delivery_id
+    assert item.tags == tags
+
+
+def test_malformed_trigger_and_delivery_ids_degrade_independently():
+    delivery_id = uuid4()
+    origin, trigger, delivery = decode_session_attribution(
+        {
+            "ag.origin": "trigger",
+            "ag.trigger.id": "not-a-uuid",
+            "ag.trigger.kind": "schedule",
+            "ag.trigger.delivery_id": str(delivery_id),
+        }
+    )
+
+    assert origin == SessionOrigin.trigger
+    assert trigger is None
+    assert delivery.id == delivery_id
+
+    trigger_id = uuid4()
+    _, trigger, delivery = decode_session_attribution(
+        {
+            "ag.origin": "trigger",
+            "ag.trigger.id": str(trigger_id),
+            "ag.trigger.kind": "subscription",
+            "ag.trigger.delivery_id": "not-a-uuid",
+        }
+    )
+    assert trigger.id == trigger_id
+    assert delivery is None
+
+
+def test_reserved_attribution_tag_sanitizer_is_enabled_and_narrow():
+    tags = {
+        "ag.origin": "trigger",
+        "ag.trigger.id": str(uuid4()),
+        "ag.trigger.kind": "schedule",
+        "ag.trigger.delivery_id": str(uuid4()),
+        "ag.trigger.name": "Legacy snapshot",
+        "ag.trigger.custom": "preserve",
+        "ag.private": "preserve",
+        "team": "support",
+    }
+
+    assert sanitize_session_tags(tags) == {
+        "ag.trigger.custom": "preserve",
+        "ag.private": "preserve",
+        "team": "support",
+    }
+    assert len(tags) == 8
+
+
+def _request(project_id, user_id):
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/sessions/query",
+            "headers": [],
+            "app": FastAPI(),
+        }
+    )
+    request.state.project_id = str(project_id)
+    request.state.user_id = str(user_id)
+    return request
+
+
+async def test_router_consumes_nested_fields_and_projection_options():
+    service = AsyncMock()
+    service.query_sessions_page.return_value = SessionQueryPage()
+    router = SessionsRootRouter(sessions_service=service)
+    body = SessionQueryRequest(
+        session=SessionPredicatesRequest(
+            search="refund",
+            liveness=SessionStreamQueryFlags(is_alive=True),
+            origins=[SessionOrigin.trigger],
+        ),
+        session_ids=["session-a"],
+        exclude=SessionExcludeRequest(
+            origins=[SessionOrigin.manual], session_ids=["session-b"]
+        ),
+        turn_references=[Reference(id=uuid4())],
+        expand=[SessionExpansion.trigger],
+    )
+
+    with patch(
+        "oss.src.apis.fastapi.sessions.router.check_action_access",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        await router.query_sessions(
+            request=_request(uuid4(), uuid4()),
+            body=body,
+        )
+
+    call = service.query_sessions_page.await_args.kwargs
+    assert call["query"].search == "refund"
+    assert call["query"].flags.is_alive is True
+    assert call["query"].origins == [SessionOrigin.trigger]
+    assert call["query"].session_ids == ["session-a"]
+    assert call["query"].exclude_origins == [SessionOrigin.manual]
+    assert call["query"].exclude_session_ids == ["session-b"]
+    assert call["query"].turn_references == body.turn_references
+    assert call["options"].expand == [SessionExpansion.trigger]

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
@@ -27,6 +27,7 @@ from oss.src.core.sessions.dtos import (
     SessionQueryLifecycle,
     SessionQueryOptions,
     SessionQueryPage,
+    SessionTriggerAttribution,
     SessionTriggerKind,
 )
 from oss.src.core.sessions.service import SessionsService
@@ -39,7 +40,9 @@ from oss.src.core.shared.dtos import Reference, Windowing
 from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.dbs.postgres.sessions.streams.mappings import (
+    SESSION_RESERVED_TAG_KEYS,
     decode_session_attribution,
+    trigger_attribution_tags,
 )
 from oss.src.dbs.postgres.shared.utils import apply_windowing
 
@@ -356,12 +359,9 @@ class _Turns:
         self.reference_session_ids = list(reference_session_ids)
         self.query_calls = []
 
-    async def query_turns(self, **kwargs):
+    async def query_session_ids_by_references(self, **kwargs):
         self.query_calls.append(kwargs)
-        return [
-            type("Turn", (), {"session_id": session_id})()
-            for session_id in self.reference_session_ids
-        ]
+        return list(self.reference_session_ids)
 
     async def latest_turn_per_session(self, **kwargs):
         return {}
@@ -480,6 +480,27 @@ def test_ascending_response_cursor_uses_oldest_and_uuid_tiebreak():
     assert result.next == last_id
     assert result.oldest == activity
     assert result.newest is None
+
+
+@pytest.mark.parametrize("order", ["ascending", "descending"])
+def test_response_cursor_carries_interval_and_rate_across_pages(order):
+    # `terminal` (the no-more-pages branch) already copied these; the cursor
+    # branches dropped them, so a client-supplied interval/rate silently
+    # vanished the moment paging actually produced a `next` cursor.
+    created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    sessions = [
+        _item(created_at=created_at, item_id=UUID(int=1)),
+        _item(created_at=created_at, item_id=UUID(int=2)),
+    ]
+
+    result = compute_session_response_windowing(
+        sessions=sessions,
+        requested=Windowing(limit=2, order=order, interval=60, rate=0.5),
+    )
+
+    assert result.next is not None
+    assert result.interval == 60
+    assert result.rate == 0.5
 
 
 @pytest.mark.parametrize("order", ["ascending", "descending"])
@@ -647,6 +668,19 @@ def test_reserved_attribution_tag_sanitizer_is_enabled_and_narrow():
         "team": "support",
     }
     assert len(tags) == 8
+
+    # P1-7: the reserved-key list had already drifted across three hand-copied
+    # spots. Pin the writer's output as a subset of the single exported set, so a
+    # future fifth attribution key added to `trigger_attribution_tags` fails here
+    # instead of silently leaking on every read path.
+    written = trigger_attribution_tags(
+        SessionTriggerAttribution(
+            configuration_id=uuid4(),
+            kind=SessionTriggerKind.schedule,
+            delivery_id=uuid4(),
+        )
+    )
+    assert set(written) <= SESSION_RESERVED_TAG_KEYS
 
 
 def _request(project_id, user_id):

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
@@ -292,7 +292,14 @@ def _compile_stream_query(
     ).replace("\n", " ")
 
 
-def test_origin_include_and_exclude_apply_before_pagination():
+def test_dao_still_ands_a_contradictory_filter_it_is_handed_directly():
+    # P2-11: the DAO itself has no opinion on whether include/exclude contradict —
+    # it just ANDs both predicates, which always compiles to zero rows for an
+    # origin present in both lists. `normalize_session_query_request` (see
+    # `test_contradictory_origin_filter_is_rejected_with_422` below) is what
+    # actually rejects this before a real request ever reaches the DAO; this
+    # test only pins the DAO's own mechanical behavior for any other caller
+    # that builds a `SessionStreamQuery` directly.
     sql = _compile_stream_query(
         filter=SessionStreamQuery(
             origins=[SessionOrigin.trigger],
@@ -305,6 +312,38 @@ def test_origin_include_and_exclude_apply_before_pagination():
     assert " IN ('trigger')" in sql
     assert "NOT IN ('trigger')" in sql
     assert sql.index("ag.origin") < sql.index("ORDER BY") < sql.index("LIMIT")
+
+
+def test_contradictory_origin_filter_is_rejected_with_422():
+    with pytest.raises(HTTPException) as excinfo:
+        normalize_session_query_request(
+            SessionQueryRequest(
+                session=SessionPredicatesRequest(origins=[SessionOrigin.trigger]),
+                exclude=SessionExcludeRequest(origins=[SessionOrigin.trigger]),
+            )
+        )
+    assert excinfo.value.status_code == 422
+
+    # Overlapping in a longer list is still contradictory even when the lists
+    # aren't identical.
+    with pytest.raises(HTTPException) as excinfo:
+        normalize_session_query_request(
+            SessionQueryRequest(
+                session=SessionPredicatesRequest(
+                    origins=[SessionOrigin.trigger, SessionOrigin.manual]
+                ),
+                exclude=SessionExcludeRequest(origins=[SessionOrigin.trigger]),
+            )
+        )
+    assert excinfo.value.status_code == 422
+
+    # Disjoint include/exclude is a normal, valid request.
+    normalize_session_query_request(
+        SessionQueryRequest(
+            session=SessionPredicatesRequest(origins=[SessionOrigin.manual]),
+            exclude=SessionExcludeRequest(origins=[SessionOrigin.trigger]),
+        )
+    )
 
 
 def test_excluding_trigger_retains_null_and_unstamped_rows():
@@ -650,23 +689,23 @@ def test_malformed_trigger_and_delivery_ids_degrade_independently():
     assert delivery is None
 
 
-def test_reserved_attribution_tag_sanitizer_is_enabled_and_narrow():
+def test_reserved_attribution_tag_sanitizer_strips_the_whole_ag_namespace():
+    # P3-7: the whole "ag." prefix is reserved, not five exact names — a caller
+    # tag like "ag.private" or a future "ag.trigger.custom" must be stripped
+    # too, not preserved just because it isn't one of the writer's five keys.
     tags = {
         "ag.origin": "trigger",
         "ag.trigger.id": str(uuid4()),
         "ag.trigger.kind": "schedule",
         "ag.trigger.delivery_id": str(uuid4()),
         "ag.trigger.name": "Legacy snapshot",
-        "ag.trigger.custom": "preserve",
-        "ag.private": "preserve",
+        "ag.trigger.custom": "not preserved anymore",
+        "ag.private": "not preserved anymore",
         "team": "support",
     }
 
-    assert sanitize_session_tags(tags) == {
-        "ag.trigger.custom": "preserve",
-        "ag.private": "preserve",
-        "team": "support",
-    }
+    # Only a genuinely non-"ag." tag survives.
+    assert sanitize_session_tags(tags) == {"team": "support"}
     assert len(tags) == 8
 
     # P1-7: the reserved-key list had already drifted across three hand-copied

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
@@ -348,7 +348,7 @@ async def test_query_sessions_filters_by_references_via_turns_join():
 
     result = await svc.query_sessions(
         project_id=_PROJECT,
-        query=SessionQuery(references=[target_ref]),
+        query=SessionQuery(turn_references=[target_ref]),
     )
 
     assert len(result) == 1
@@ -365,7 +365,7 @@ async def test_query_sessions_no_matching_reference_short_circuits_empty():
 
     result = await svc.query_sessions(
         project_id=_PROJECT,
-        query=SessionQuery(references=[unmatched_ref]),
+        query=SessionQuery(turn_references=[unmatched_ref]),
     )
 
     assert result == []

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
@@ -72,6 +72,7 @@ class _FakeStreamsService:
         windowing=None,
         session_ids=None,
         exclude_session_ids=None,
+        read_options=None,
     ):
         self.query_calls.append(
             {
@@ -127,6 +128,16 @@ class _FakeTurnsService:
                 if t.references and any(r.id in wanted for r in t.references)
             ]
         return self.turns
+
+    async def query_session_ids_by_references(self, *, project_id, references, limit):
+        self.query_calls.append({"project_id": project_id, "references": references})
+        wanted = {r.id for r in references}
+        matched = {
+            t.session_id
+            for t in self.turns
+            if t.references and any(r.id in wanted for r in t.references)
+        }
+        return list(matched)[:limit]
 
     async def latest_turn_per_session(self, *, project_id, session_ids):
         by_session: dict = {}

--- a/api/oss/tests/pytest/unit/sessions/test_trigger_session_claim_postgres.py
+++ b/api/oss/tests/pytest/unit/sessions/test_trigger_session_claim_postgres.py
@@ -1,0 +1,483 @@
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+import oss.src.dbs.postgres.shared.engine as engine_module
+import oss.src.models.db_models  # noqa: F401
+from oss.src.core.sessions.dtos import (
+    SessionTriggerAttribution,
+    SessionTriggerKind,
+)
+from oss.src.core.sessions.streams.dtos import SessionStreamEdit, SessionStreamFlags
+from oss.src.core.shared.dtos import Status
+from oss.src.core.triggers.dtos import TriggerDeliveryData
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
+from oss.src.dbs.postgres.shared.engine import get_transactions_engine
+from oss.src.dbs.postgres.triggers.dao import TriggersDAO
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+class _PausedSession:
+    def __init__(self, session, *, read_complete, resume):
+        self._session = session
+        self._read_complete = read_complete
+        self._resume = resume
+        self._paused = False
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
+
+    async def execute(self, statement, *args, **kwargs):
+        result = await self._session.execute(statement, *args, **kwargs)
+        if not self._paused:
+            self._paused = True
+            self._read_complete.set()
+            await self._resume.wait()
+        return result
+
+
+class _PauseAfterReadEngine:
+    def __init__(self, engine):
+        self._engine = engine
+        self.read_complete = asyncio.Event()
+        self.resume = asyncio.Event()
+
+    @asynccontextmanager
+    async def session(self):
+        async with self._engine.session() as session:
+            yield _PausedSession(
+                session,
+                read_complete=self.read_complete,
+                resume=self.resume,
+            )
+
+
+class _Barrier:
+    def __init__(self, parties):
+        self._parties = parties
+        self._arrived = 0
+        self._lock = asyncio.Lock()
+        self._ready = asyncio.Event()
+
+    async def wait(self):
+        async with self._lock:
+            self._arrived += 1
+            if self._arrived == self._parties:
+                self._ready.set()
+        await self._ready.wait()
+
+
+class _BarrierSession:
+    def __init__(self, session, *, barrier):
+        self._session = session
+        self._barrier = barrier
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
+
+    async def execute(self, statement, *args, **kwargs):
+        await self._barrier.wait()
+        return await self._session.execute(statement, *args, **kwargs)
+
+
+class _BarrierBeforeExecuteEngine:
+    def __init__(self, engine, *, parties):
+        self._engine = engine
+        self._barrier = _Barrier(parties)
+
+    @asynccontextmanager
+    async def session(self):
+        async with self._engine.session() as session:
+            yield _BarrierSession(session, barrier=self._barrier)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fresh_engine_per_test():
+    engine_module._transactions_engine = None
+    yield
+    if engine_module._transactions_engine is not None:
+        await engine_module._transactions_engine.close()
+        engine_module._transactions_engine = None
+
+
+@pytest_asyncio.fixture
+async def trigger_project():
+    engine = get_transactions_engine()
+    user_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    schedule_id = uuid.uuid4()
+
+    async with engine.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO users (id, uid, username, email) "
+                "VALUES (:id, :uid, :username, :email)"
+            ),
+            {
+                "id": user_id,
+                "uid": str(user_id),
+                "username": "trigger-session-claim-test",
+                "email": f"trigger-session-claim-{user_id.hex[:8]}@example.com",
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO organizations (id, name, owner_id) "
+                "VALUES (:id, :name, :owner_id)"
+            ),
+            {
+                "id": organization_id,
+                "name": "trigger-session-claim-org",
+                "owner_id": user_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO workspaces (id, name, organization_id) "
+                "VALUES (:id, :name, :organization_id)"
+            ),
+            {
+                "id": workspace_id,
+                "name": "trigger-session-claim-workspace",
+                "organization_id": organization_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO projects "
+                "(id, project_name, workspace_id, organization_id) "
+                "VALUES (:id, :name, :workspace_id, :organization_id)"
+            ),
+            {
+                "id": project_id,
+                "name": "trigger-session-claim-project",
+                "workspace_id": workspace_id,
+                "organization_id": organization_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO trigger_schedules (id, project_id, created_by_id, flags) "
+                "VALUES (:id, :project_id, :user_id, CAST(:flags AS jsonb))"
+            ),
+            {
+                "id": schedule_id,
+                "project_id": project_id,
+                "user_id": user_id,
+                "flags": '{"is_active": true}',
+            },
+        )
+        await session.commit()
+
+    yield {
+        "project_id": project_id,
+        "user_id": user_id,
+        "schedule_id": schedule_id,
+    }
+
+    async with engine.session() as session:
+        for table in ("trigger_deliveries", "session_streams", "trigger_schedules"):
+            await session.execute(
+                text(f"DELETE FROM {table} WHERE project_id = :project_id"),
+                {"project_id": project_id},
+            )
+        await session.execute(
+            text("DELETE FROM projects WHERE id = :id"), {"id": project_id}
+        )
+        await session.execute(
+            text("DELETE FROM workspaces WHERE id = :id"), {"id": workspace_id}
+        )
+        await session.execute(
+            text("DELETE FROM organizations WHERE id = :id"),
+            {"id": organization_id},
+        )
+        await session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_id})
+        await session.commit()
+
+
+async def test_claim_atomically_merges_tags_flags_and_delivery_data(trigger_project):
+    engine = get_transactions_engine()
+    streams_dao = SessionStreamsDAO(engine=engine)
+    triggers_dao = TriggersDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    user_id = trigger_project["user_id"]
+    schedule_id = trigger_project["schedule_id"]
+    session_id = uuid.uuid4().hex
+    turn_id = uuid.uuid4().hex
+
+    async with engine.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO session_streams "
+                "(id, project_id, created_by_id, session_id, name, description, "
+                "flags, tags, meta, turn_id) VALUES "
+                "(:id, :project_id, :user_id, :session_id, :name, :description, "
+                "CAST(:flags AS jsonb), CAST(:tags AS jsonb), CAST(:meta AS json), :turn_id)"
+            ),
+            {
+                "id": uuid.uuid4(),
+                "project_id": project_id,
+                "user_id": user_id,
+                "session_id": session_id,
+                "name": "Existing session",
+                "description": "Keep this header",
+                "flags": '{"is_alive": true, "is_running": false, "is_attached": false}',
+                "tags": '{"customer": "acme", "ag.private": "keep"}',
+                "meta": '{"source": "existing"}',
+                "turn_id": turn_id,
+            },
+        )
+        await session.commit()
+
+    attribution = SessionTriggerAttribution(
+        configuration_id=schedule_id,
+        kind=SessionTriggerKind.schedule,
+        delivery_id=uuid.uuid4(),
+    )
+    paused_engine = _PauseAfterReadEngine(engine)
+    heartbeat_dao = SessionStreamsDAO(engine=paused_engine)
+    heartbeat = asyncio.create_task(
+        heartbeat_dao.update(
+            project_id=project_id,
+            user_id=user_id,
+            session_id=session_id,
+            stream=SessionStreamEdit(
+                flags=SessionStreamFlags(
+                    is_alive=True,
+                    is_running=True,
+                    is_attached=False,
+                ),
+                turn_id=turn_id,
+            ),
+        )
+    )
+    await paused_engine.read_complete.wait()
+
+    try:
+        claimed = await streams_dao.claim_trigger_delivery(
+            project_id=project_id,
+            user_id=user_id,
+            event_id="event-1",
+            session_id=session_id,
+            attribution=attribution,
+        )
+    finally:
+        paused_engine.resume.set()
+        heartbeat_result = await heartbeat
+
+    assert claimed is True
+    assert heartbeat_result is not None
+    assert heartbeat_result.tags["ag.trigger.delivery_id"] == str(
+        attribution.delivery_id
+    )
+
+    stream = await streams_dao.get_by_session_id(
+        project_id=project_id, session_id=session_id
+    )
+    assert stream is not None
+    assert stream.name == "Existing session"
+    assert stream.description == "Keep this header"
+    assert stream.turn_id == turn_id
+    assert stream.meta == {"source": "existing"}
+    assert stream.flags.is_running is True
+    assert stream.tags == {
+        "customer": "acme",
+        "ag.private": "keep",
+        "ag.origin": "trigger",
+        "ag.trigger.id": str(schedule_id),
+        "ag.trigger.kind": "schedule",
+        "ag.trigger.delivery_id": str(attribution.delivery_id),
+    }
+    assert "ag.trigger.name" not in stream.tags
+
+    delivery = await triggers_dao.fetch_delivery(
+        project_id=project_id, delivery_id=attribution.delivery_id
+    )
+    assert delivery is not None
+    assert delivery.data.session_id == session_id
+    assert delivery.status.code == "102"
+    assert delivery.status.message == "claimed"
+    assert delivery.status.timestamp is not None
+
+    await triggers_dao.update_delivery(
+        project_id=project_id,
+        delivery_id=attribution.delivery_id,
+        status=Status(code="200", message="success"),
+        data=TriggerDeliveryData(result={"outputs": {"ok": True}}),
+    )
+    completed = await triggers_dao.fetch_delivery(
+        project_id=project_id, delivery_id=attribution.delivery_id
+    )
+    assert completed is not None
+    assert completed.data.session_id == session_id
+    assert completed.data.result == {"outputs": {"ok": True}}
+
+
+async def test_duplicate_claims_race_as_separate_operations(trigger_project):
+    engine = get_transactions_engine()
+    barrier_engine = _BarrierBeforeExecuteEngine(engine, parties=2)
+    claims_dao = SessionStreamsDAO(engine=barrier_engine)
+    streams_dao = SessionStreamsDAO(engine=engine)
+    triggers_dao = TriggersDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    user_id = trigger_project["user_id"]
+    schedule_id = trigger_project["schedule_id"]
+    pairs = [
+        (
+            uuid.uuid4().hex,
+            SessionTriggerAttribution(
+                configuration_id=schedule_id,
+                kind=SessionTriggerKind.schedule,
+                delivery_id=uuid.uuid4(),
+            ),
+        )
+        for _ in range(2)
+    ]
+
+    async def claim(session_id, attribution):
+        return await claims_dao.claim_trigger_delivery(
+            project_id=project_id,
+            user_id=user_id,
+            event_id="duplicate-event",
+            session_id=session_id,
+            attribution=attribution,
+        )
+
+    results = await asyncio.gather(
+        *(claim(session_id, attribution) for session_id, attribution in pairs)
+    )
+    assert sorted(results) == [False, True]
+
+    winner = results.index(True)
+    loser = 1 - winner
+    winning_session_id, winning_attribution = pairs[winner]
+    losing_session_id, losing_attribution = pairs[loser]
+    delivery = await triggers_dao.fetch_delivery(
+        project_id=project_id,
+        delivery_id=winning_attribution.delivery_id,
+    )
+    assert delivery is not None
+    assert delivery.data.session_id == winning_session_id
+    assert (
+        await triggers_dao.fetch_delivery(
+            project_id=project_id,
+            delivery_id=losing_attribution.delivery_id,
+        )
+        is None
+    )
+    assert (
+        await streams_dao.get_by_session_id(
+            project_id=project_id, session_id=winning_session_id
+        )
+        is not None
+    )
+    assert (
+        await streams_dao.get_by_session_id(
+            project_id=project_id, session_id=losing_session_id
+        )
+        is None
+    )
+
+
+async def test_different_events_create_distinct_delivery_session_pairs(trigger_project):
+    engine = get_transactions_engine()
+    barrier_engine = _BarrierBeforeExecuteEngine(engine, parties=2)
+    claims_dao = SessionStreamsDAO(engine=barrier_engine)
+    streams_dao = SessionStreamsDAO(engine=engine)
+    triggers_dao = TriggersDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    user_id = trigger_project["user_id"]
+    schedule_id = trigger_project["schedule_id"]
+    pairs = [
+        (
+            f"event-{index}",
+            uuid.uuid4().hex,
+            SessionTriggerAttribution(
+                configuration_id=schedule_id,
+                kind=SessionTriggerKind.schedule,
+                delivery_id=uuid.uuid4(),
+            ),
+        )
+        for index in range(2)
+    ]
+
+    async def claim(event_id, session_id, attribution):
+        return await claims_dao.claim_trigger_delivery(
+            project_id=project_id,
+            user_id=user_id,
+            event_id=event_id,
+            session_id=session_id,
+            attribution=attribution,
+        )
+
+    results = await asyncio.gather(
+        *(
+            claim(event_id, session_id, attribution)
+            for event_id, session_id, attribution in pairs
+        )
+    )
+    assert results == [True, True]
+    assert pairs[0][1] != pairs[1][1]
+    assert pairs[0][2].delivery_id != pairs[1][2].delivery_id
+
+    for event_id, session_id, attribution in pairs:
+        delivery = await triggers_dao.fetch_delivery(
+            project_id=project_id,
+            delivery_id=attribution.delivery_id,
+        )
+        stream = await streams_dao.get_by_session_id(
+            project_id=project_id, session_id=session_id
+        )
+        assert delivery is not None
+        assert delivery.event_id == event_id
+        assert delivery.data.session_id == session_id
+        assert stream is not None
+        assert stream.tags["ag.trigger.delivery_id"] == str(attribution.delivery_id)
+
+
+async def test_attribution_failure_rolls_back_claim_and_allows_retry(trigger_project):
+    engine = get_transactions_engine()
+    streams_dao = SessionStreamsDAO(engine=engine)
+    project_id = trigger_project["project_id"]
+    attribution = SessionTriggerAttribution(
+        configuration_id=trigger_project["schedule_id"],
+        kind=SessionTriggerKind.schedule,
+        delivery_id=uuid.uuid4(),
+    )
+
+    with pytest.raises(IntegrityError):
+        await streams_dao.claim_trigger_delivery(
+            project_id=project_id,
+            user_id=trigger_project["user_id"],
+            event_id="retryable-event",
+            session_id=None,
+            attribution=attribution,
+        )
+
+    async with engine.session() as session:
+        delivery_count = await session.scalar(
+            text(
+                "SELECT count(*) FROM trigger_deliveries "
+                "WHERE project_id = :project_id AND event_id = 'retryable-event'"
+            ),
+            {"project_id": project_id},
+        )
+    assert delivery_count == 0
+
+    retried = await streams_dao.claim_trigger_delivery(
+        project_id=project_id,
+        user_id=trigger_project["user_id"],
+        event_id="retryable-event",
+        session_id=uuid.uuid4().hex,
+        attribution=attribution,
+    )
+    assert retried is True

--- a/api/oss/tests/pytest/unit/sessions/test_turns_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_turns_dao.py
@@ -360,6 +360,54 @@ async def test_query_turns_filters_by_references_gin_contains(dao, project_and_s
     assert results[0].id == matching.id
 
 
+async def test_query_session_ids_by_references_dedups_and_caps(dao, project_and_stream):
+    """P2-12: the session list's turn_references filter only ever needs the id set,
+    not every matching turn row. Two turns in the SAME session referencing the target
+    must collapse to one id (DISTINCT), and `limit` bounds the result even though more
+    session ids match."""
+    project_id = project_and_stream["project_id"]
+    stream_id = project_and_stream["stream_id"]
+    session_id = project_and_stream["session_id"]
+    other_session_id = session_id + "-other"
+
+    target_ref = Reference(id=uuid.uuid4(), slug="target-workflow", version="v1")
+
+    for turn_index in (0, 1):
+        await dao.append(
+            project_id=project_id,
+            user_id=None,
+            turn=SessionTurnCreate(
+                session_id=session_id,
+                stream_id=stream_id,
+                turn_index=turn_index,
+                harness_kind=HarnessKind.PI,
+                references=[target_ref],
+            ),
+        )
+    await dao.append(
+        project_id=project_id,
+        user_id=None,
+        turn=SessionTurnCreate(
+            session_id=other_session_id,
+            stream_id=stream_id,
+            turn_index=0,
+            harness_kind=HarnessKind.PI,
+            references=[target_ref],
+        ),
+    )
+
+    ids = await dao.query_session_ids_by_references(
+        project_id=project_id, references=[target_ref], limit=500
+    )
+    assert set(ids) == {session_id, other_session_id}
+
+    capped = await dao.query_session_ids_by_references(
+        project_id=project_id, references=[target_ref], limit=1
+    )
+    assert len(capped) == 1
+    assert capped[0] in {session_id, other_session_id}
+
+
 async def test_query_turns_orders_by_turn_index_with_id_tiebreaker(
     dao, project_and_stream
 ):

--- a/api/oss/tests/pytest/unit/sessions/test_wp5_dao_fanout.py
+++ b/api/oss/tests/pytest/unit/sessions/test_wp5_dao_fanout.py
@@ -21,6 +21,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import text
 
+from oss.src.apis.fastapi.sessions.utils import compute_session_response_windowing
+from oss.src.core.sessions.dtos import SessionOrigin
 from oss.src.core.sessions.interactions.dtos import (
     SessionInteractionCreate,
     SessionInteractionData,
@@ -30,6 +32,12 @@ from oss.src.core.sessions.interactions.dtos import (
     SessionInteractionStatus,
     SessionInteractionTransition,
 )
+from oss.src.core.sessions.streams.dtos import (
+    SessionStreamQuery,
+    SessionStreamReadOptions,
+)
+from oss.src.core.sessions.streams.service import SessionStreamsService
+from oss.src.core.shared.dtos import Windowing
 from oss.src.core.mounts.dtos import MountCreate, MountQuery
 import oss.src.models.db_models  # noqa: F401
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE  # noqa: F401
@@ -546,3 +554,370 @@ async def test_query_mounts_without_windowing_orders_oldest_first(mounts_dao, pr
     )
 
     assert [m.id for m in queried] == [mounts[1].id, mounts[2].id, mounts[0].id]
+
+
+async def test_stream_origin_filters_preserve_null_and_unstamped_rows(
+    streams_dao, project
+):
+    project_id = project["project_id"]
+    rows = [
+        (uuid.uuid4(), "trigger", '{"ag.origin": "trigger"}'),
+        (uuid.uuid4(), "unstamped", '{"team": "support"}'),
+        (uuid.uuid4(), "null-tags", None),
+    ]
+    async with get_transactions_engine().session() as session:
+        for row_id, suffix, tags in rows:
+            await session.execute(
+                text(
+                    "INSERT INTO session_streams "
+                    "(id, project_id, session_id, flags, tags) VALUES "
+                    "(:id, :project_id, :session_id, CAST(:flags AS jsonb), "
+                    "CAST(:tags AS jsonb))"
+                ),
+                {
+                    "id": row_id,
+                    "project_id": project_id,
+                    "session_id": f"origin-{suffix}-{uuid.uuid4().hex[:8]}",
+                    "flags": "{}",
+                    "tags": tags,
+                },
+            )
+        await session.commit()
+
+    included = await streams_dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(origins=[SessionOrigin.trigger]),
+    )
+    excluded = await streams_dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(exclude_origins=[SessionOrigin.trigger]),
+    )
+
+    assert [result.stream.id for result in included] == [rows[0][0]]
+    assert {result.stream.id for result in excluded} == {rows[1][0], rows[2][0]}
+
+
+@pytest.mark.parametrize("order", ["ascending", "descending"])
+async def test_stream_tied_activity_cursor_pages_without_duplicates(
+    streams_dao, project, order
+):
+    project_id = project["project_id"]
+    activity = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    row_ids = sorted(uuid.uuid4() for _ in range(5))
+    async with get_transactions_engine().session() as session:
+        for index, row_id in enumerate(row_ids):
+            await session.execute(
+                text(
+                    "INSERT INTO session_streams "
+                    "(id, project_id, session_id, created_at, updated_at, flags) VALUES "
+                    "(:id, :project_id, :session_id, :activity, :activity, "
+                    "CAST(:flags AS jsonb))"
+                ),
+                {
+                    "id": row_id,
+                    "project_id": project_id,
+                    "session_id": f"cursor-{order}-{index}-{uuid.uuid4().hex[:8]}",
+                    "activity": activity,
+                    "flags": "{}",
+                },
+            )
+        await session.commit()
+
+    first_page = await streams_dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(),
+        windowing=Windowing(limit=2, order=order),
+    )
+    first_page_streams = [result.stream for result in first_page]
+    cursor = compute_session_response_windowing(
+        sessions=first_page_streams,
+        requested=Windowing(limit=2, order=order),
+    )
+    second_page = await streams_dao.query(
+        project_id=project_id,
+        filter=SessionStreamQuery(),
+        windowing=cursor,
+    )
+
+    expected = sorted(row_ids, reverse=order == "descending")
+    second_page_streams = [result.stream for result in second_page]
+    assert [
+        stream.id for stream in first_page_streams + second_page_streams
+    ] == expected[:4]
+    assert {stream.id for stream in first_page_streams}.isdisjoint(
+        stream.id for stream in second_page_streams
+    )
+
+
+async def test_trigger_expansion_isolates_project_and_kind_for_live_and_deleted_names(
+    streams_dao, project
+):
+    engine = get_transactions_engine()
+    project_id = project["project_id"]
+    user_id = project["user_id"]
+    configuration_id = uuid.uuid4()
+    schedule_stream_id = uuid.uuid4()
+    subscription_stream_id = uuid.uuid4()
+    other_project_id = uuid.uuid4()
+    schedule_tags = (
+        '{"ag.origin":"trigger","ag.trigger.id":"'
+        f'{configuration_id}","ag.trigger.kind":"schedule"}}'
+    )
+    subscription_tags = (
+        '{"ag.origin":"trigger","ag.trigger.id":"'
+        f'{configuration_id}","ag.trigger.kind":"subscription"}}'
+    )
+    async with engine.session() as session:
+        scope = (
+            (
+                await session.execute(
+                    text(
+                        "SELECT workspace_id, organization_id FROM projects WHERE id = :id"
+                    ),
+                    {"id": project_id},
+                )
+            )
+            .mappings()
+            .one()
+        )
+        await session.execute(
+            text(
+                "INSERT INTO projects "
+                "(id, project_name, workspace_id, organization_id) "
+                "VALUES (:id, :name, :workspace_id, :organization_id)"
+            ),
+            {
+                "id": other_project_id,
+                "name": "trigger-join-isolation-project",
+                "workspace_id": scope["workspace_id"],
+                "organization_id": scope["organization_id"],
+            },
+        )
+        for scoped_project_id, suffix in (
+            (project_id, "target"),
+            (other_project_id, "other"),
+        ):
+            await session.execute(
+                text(
+                    "INSERT INTO gateway_connections "
+                    "(id, project_id, created_by_id, slug, provider_key, integration_key) "
+                    "VALUES (:id, :project_id, :user_id, :slug, :provider, :integration)"
+                ),
+                {
+                    "id": uuid.uuid4(),
+                    "project_id": scoped_project_id,
+                    "user_id": user_id,
+                    "slug": f"trigger-join-{suffix}",
+                    "provider": "composio",
+                    "integration": "github",
+                },
+            )
+        connections = (
+            await session.execute(
+                text(
+                    "SELECT project_id, id FROM gateway_connections "
+                    "WHERE project_id IN (:project_id, :other_project_id) "
+                    "AND slug IN ('trigger-join-target', 'trigger-join-other')"
+                ),
+                {
+                    "project_id": project_id,
+                    "other_project_id": other_project_id,
+                },
+            )
+        ).all()
+        connection_by_project = {row.project_id: row.id for row in connections}
+
+        for scoped_project_id, schedule_name, subscription_name in (
+            (project_id, "Target schedule", "Target subscription"),
+            (other_project_id, "Other schedule", "Other subscription"),
+        ):
+            await session.execute(
+                text(
+                    "INSERT INTO trigger_schedules (id, project_id, name) "
+                    "VALUES (:id, :project_id, :name)"
+                ),
+                {
+                    "id": configuration_id,
+                    "project_id": scoped_project_id,
+                    "name": schedule_name,
+                },
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO trigger_subscriptions "
+                    "(id, project_id, connection_id, name) "
+                    "VALUES (:id, :project_id, :connection_id, :name)"
+                ),
+                {
+                    "id": configuration_id,
+                    "project_id": scoped_project_id,
+                    "connection_id": connection_by_project[scoped_project_id],
+                    "name": subscription_name,
+                },
+            )
+
+        await session.execute(
+            text(
+                "INSERT INTO session_streams (id, project_id, session_id, tags) VALUES "
+                "(:schedule_stream_id, :project_id, :schedule_session_id, "
+                "CAST(:schedule_tags AS jsonb)), "
+                "(:subscription_stream_id, :project_id, :subscription_session_id, "
+                "CAST(:subscription_tags AS jsonb))"
+            ),
+            {
+                "schedule_stream_id": schedule_stream_id,
+                "subscription_stream_id": subscription_stream_id,
+                "project_id": project_id,
+                "schedule_session_id": "trigger-join-schedule",
+                "subscription_session_id": "trigger-join-subscription",
+                "schedule_tags": schedule_tags,
+                "subscription_tags": subscription_tags,
+            },
+        )
+        await session.commit()
+
+    options = SessionStreamReadOptions(include_trigger_details=True)
+    service = SessionStreamsService(streams_dao=streams_dao, lock_engine=object())
+    try:
+        unexpanded = await service.query_streams(
+            project_id=project_id,
+            filter=SessionStreamQuery(),
+        )
+        assert len(unexpanded) == 2
+        assert all(row.trigger.name is None for row in unexpanded)
+
+        live = await service.query_streams(
+            project_id=project_id,
+            filter=SessionStreamQuery(),
+            read_options=options,
+        )
+        assert len(live) == 2
+        live_by_id = {row.id: row for row in live}
+        assert set(live_by_id) == {schedule_stream_id, subscription_stream_id}
+        assert live_by_id[schedule_stream_id].trigger.name == "Target schedule"
+        assert live_by_id[subscription_stream_id].trigger.name == "Target subscription"
+
+        async with engine.session() as session:
+            await session.execute(
+                text(
+                    "UPDATE trigger_schedules "
+                    "SET name = :name, deleted_at = now() "
+                    "WHERE project_id = :project_id AND id = :id"
+                ),
+                {
+                    "name": "Deleted schedule",
+                    "project_id": project_id,
+                    "id": configuration_id,
+                },
+            )
+            await session.execute(
+                text(
+                    "UPDATE trigger_subscriptions "
+                    "SET name = :name, deleted_at = now() "
+                    "WHERE project_id = :project_id AND id = :id"
+                ),
+                {
+                    "name": "Deleted subscription",
+                    "project_id": project_id,
+                    "id": configuration_id,
+                },
+            )
+            await session.commit()
+
+        historical = await service.query_streams(
+            project_id=project_id,
+            filter=SessionStreamQuery(),
+            read_options=options,
+        )
+        assert len(historical) == 2
+        historical_by_id = {row.id: row for row in historical}
+        assert set(historical_by_id) == {schedule_stream_id, subscription_stream_id}
+        assert historical_by_id[schedule_stream_id].trigger.name == "Deleted schedule"
+        assert (
+            historical_by_id[subscription_stream_id].trigger.name
+            == "Deleted subscription"
+        )
+        assert all(
+            row.trigger.id == configuration_id for row in historical_by_id.values()
+        )
+    finally:
+        async with engine.session() as session:
+            await session.execute(
+                text("DELETE FROM projects WHERE id = :id"),
+                {"id": other_project_id},
+            )
+            await session.commit()
+
+
+async def test_trigger_expansion_guards_malformed_uuid_and_keeps_delivery(
+    streams_dao, project
+):
+    project_id = project["project_id"]
+    stream_id = uuid.uuid4()
+    delivery_id = uuid.uuid4()
+    tags = (
+        '{"ag.origin":"trigger","ag.trigger.id":"not-a-uuid",'
+        '"ag.trigger.kind":"schedule","ag.trigger.delivery_id":"'
+        f'{delivery_id}"}}'
+    )
+    async with get_transactions_engine().session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO session_streams (id, project_id, session_id, tags) "
+                "VALUES (:id, :project_id, :session_id, CAST(:tags AS jsonb))"
+            ),
+            {
+                "id": stream_id,
+                "project_id": project_id,
+                "session_id": f"malformed-trigger-{uuid.uuid4().hex[:8]}",
+                "tags": tags,
+            },
+        )
+        await session.commit()
+
+    service = SessionStreamsService(streams_dao=streams_dao, lock_engine=object())
+    rows = await service.query_streams(
+        project_id=project_id,
+        filter=SessionStreamQuery(),
+        read_options=SessionStreamReadOptions(include_trigger_details=True),
+    )
+
+    result = next(row for row in rows if row.id == stream_id)
+    assert result.trigger is None
+    assert result.delivery.id == delivery_id
+
+
+async def test_missing_trigger_configuration_keeps_typed_identity(streams_dao, project):
+    project_id = project["project_id"]
+    stream_id = uuid.uuid4()
+    trigger_id = uuid.uuid4()
+    tags = (
+        '{"ag.origin":"trigger","ag.trigger.id":"'
+        f'{trigger_id}","ag.trigger.kind":"subscription"}}'
+    )
+    async with get_transactions_engine().session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO session_streams (id, project_id, session_id, tags) "
+                "VALUES (:id, :project_id, :session_id, CAST(:tags AS jsonb))"
+            ),
+            {
+                "id": stream_id,
+                "project_id": project_id,
+                "session_id": f"missing-trigger-{uuid.uuid4().hex[:8]}",
+                "tags": tags,
+            },
+        )
+        await session.commit()
+
+    service = SessionStreamsService(streams_dao=streams_dao, lock_engine=object())
+    rows = await service.query_streams(
+        project_id=project_id,
+        filter=SessionStreamQuery(),
+        read_options=SessionStreamReadOptions(include_trigger_details=True),
+    )
+
+    result = next(row for row in rows if row.id == stream_id)
+    assert result.trigger.name is None
+    assert result.trigger.id == trigger_id
+    assert result.trigger.kind.value == "subscription"

--- a/api/oss/tests/pytest/unit/sessions/test_wp5_root_router.py
+++ b/api/oss/tests/pytest/unit/sessions/test_wp5_root_router.py
@@ -22,6 +22,7 @@ from fastapi import FastAPI, HTTPException, Request
 
 from oss.src.apis.fastapi.sessions.router import SessionsRootRouter
 from oss.src.apis.fastapi.sessions.models import SessionQueryRequest
+from oss.src.core.sessions.dtos import SessionQueryPage
 from oss.src.core.shared.dtos import Reference, Windowing
 
 
@@ -54,7 +55,7 @@ def _patched_access(allowed: bool):
 
 async def test_query_sessions_delegates_to_service():
     sessions_service = AsyncMock()
-    sessions_service.query_sessions.return_value = []
+    sessions_service.query_sessions_page.return_value = SessionQueryPage()
     router = SessionsRootRouter(sessions_service=sessions_service)
 
     project_id = uuid4()
@@ -71,10 +72,10 @@ async def test_query_sessions_delegates_to_service():
         result = await router.query_sessions(request=request, body=body)
 
     assert result.count == 0
-    sessions_service.query_sessions.assert_awaited_once()
-    call_kwargs = sessions_service.query_sessions.await_args.kwargs
+    sessions_service.query_sessions_page.assert_awaited_once()
+    call_kwargs = sessions_service.query_sessions_page.await_args.kwargs
     assert call_kwargs["project_id"] == project_id
-    assert call_kwargs["query"].references == [target_ref]
+    assert call_kwargs["query"].turn_references == [target_ref]
     assert call_kwargs["windowing"].order == "descending"
 
 

--- a/api/oss/tests/pytest/unit/sessions/test_wp5_root_router.py
+++ b/api/oss/tests/pytest/unit/sessions/test_wp5_root_router.py
@@ -93,7 +93,10 @@ async def test_query_sessions_rejects_without_view_permission():
             await router.query_sessions(request=request, body=SessionQueryRequest())
 
     assert exc_info.value.status_code == 403
-    sessions_service.query_sessions.assert_not_awaited()
+    # The router calls `query_sessions_page`, not `query_sessions` — asserting on
+    # the latter is tautological (an AsyncMock auto-creates it and it's never
+    # awaited regardless of what the router actually does).
+    sessions_service.query_sessions_page.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/tests/pytest/unit/triggers/conftest.py
+++ b/api/oss/tests/pytest/unit/triggers/conftest.py
@@ -1,0 +1,25 @@
+import socket
+from functools import lru_cache
+from urllib.parse import urlparse
+
+import pytest
+
+from oss.src.utils.env import env
+
+
+@lru_cache(maxsize=1)
+def _postgres_reachable() -> bool:
+    parsed = urlparse(env.postgres.uri_core)
+    host = parsed.hostname or "postgres"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _skip_when_postgres_unreachable(request):
+    if request.node.get_closest_marker("integration") and not _postgres_reachable():
+        pytest.skip("Postgres not reachable — skipping trigger DAO integration tests")

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_composio_adapter.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_composio_adapter.py
@@ -1,0 +1,48 @@
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from oss.src.core.triggers.exceptions import AdapterError
+from oss.src.core.triggers.providers.composio.adapter import ComposioTriggersAdapter
+
+
+def _status_error(status_code):
+    request = httpx.Request("DELETE", "https://backend.composio.dev/trigger")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"provider returned {status_code}",
+        request=request,
+        response=response,
+    )
+
+
+def _adapter_with_delete_error(error):
+    adapter = object.__new__(ComposioTriggersAdapter)
+    adapter._delete = AsyncMock(side_effect=error)
+    return adapter
+
+
+async def test_delete_subscription_accepts_provider_404_as_already_absent():
+    adapter = _adapter_with_delete_error(_status_error(404))
+
+    await adapter.delete_subscription(trigger_id="ti_absent")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _status_error(500),
+        httpx.ReadTimeout(
+            "provider timed out",
+            request=httpx.Request("DELETE", "https://backend.composio.dev/trigger"),
+        ),
+    ],
+)
+async def test_delete_subscription_propagates_transient_provider_failure(error):
+    adapter = _adapter_with_delete_error(error)
+
+    with pytest.raises(AdapterError) as exc_info:
+        await adapter.delete_subscription(trigger_id="ti_live")
+
+    assert exc_info.value.operation == "delete_subscription"

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_dao_lifecycle.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_dao_lifecycle.py
@@ -1,0 +1,112 @@
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+from sqlalchemy.dialects import postgresql
+
+from oss.src.core.triggers.dtos import (
+    TriggerScheduleData,
+    TriggerScheduleEdit,
+    TriggerSubscriptionData,
+    TriggerSubscriptionEdit,
+)
+from oss.src.dbs.postgres.triggers.dao import TriggersDAO
+from oss.src.dbs.postgres.triggers.dbes import TriggerSubscriptionDBE
+
+
+class _Result:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.rows
+
+    def scalar_one_or_none(self):
+        return self.rows[0] if len(self.rows) == 1 else None
+
+
+class _Session:
+    def __init__(self, rows):
+        self.rows = rows
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _Result(self.rows)
+
+
+class _Engine:
+    def __init__(self, rows):
+        self.db_session = _Session(rows)
+
+    @asynccontextmanager
+    async def session(self):
+        yield self.db_session
+
+
+def _subscription_dbe(*, project_id, trigger_id):
+    return TriggerSubscriptionDBE(
+        id=uuid4(),
+        project_id=project_id,
+        connection_id=uuid4(),
+        trigger_id=trigger_id,
+        data={"event_key": "github.issue.opened"},
+        flags={"is_active": True, "is_valid": True},
+    )
+
+
+async def test_cross_project_trigger_lookup_fails_closed_when_ambiguous():
+    trigger_id = "ti_shared"
+    engine = _Engine(
+        [
+            _subscription_dbe(project_id=uuid4(), trigger_id=trigger_id),
+            _subscription_dbe(project_id=uuid4(), trigger_id=trigger_id),
+        ]
+    )
+
+    result = await TriggersDAO(
+        engine=engine
+    ).get_project_and_subscription_by_trigger_id(trigger_id=trigger_id)
+
+    assert result is None
+    sql = str(engine.db_session.statement.compile(dialect=postgresql.dialect()))
+    assert "LIMIT" in sql
+
+
+async def test_subscription_edit_locks_live_row_before_mapping():
+    engine = _Engine([])
+
+    result = await TriggersDAO(engine=engine).edit_subscription(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        subscription=TriggerSubscriptionEdit(
+            id=uuid4(),
+            connection_id=uuid4(),
+            data=TriggerSubscriptionData(event_key="github.issue.opened"),
+        ),
+    )
+
+    assert result is None
+    sql = str(engine.db_session.statement.compile(dialect=postgresql.dialect()))
+    assert "deleted_at IS NULL" in sql
+    assert "FOR UPDATE" in sql
+
+
+async def test_schedule_edit_locks_live_row_before_mapping():
+    engine = _Engine([])
+
+    result = await TriggersDAO(engine=engine).edit_schedule(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        schedule=TriggerScheduleEdit(
+            id=uuid4(),
+            data=TriggerScheduleData(event_key="cron.tick", schedule="* * * * *"),
+        ),
+    )
+
+    assert result is None
+    sql = str(engine.db_session.statement.compile(dialect=postgresql.dialect()))
+    assert "deleted_at IS NULL" in sql
+    assert "FOR UPDATE" in sql

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_dao_update_delivery.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_dao_update_delivery.py
@@ -1,0 +1,54 @@
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+from sqlalchemy.dialects import postgresql
+
+from oss.src.core.shared.dtos import Status
+from oss.src.core.triggers.dtos import TriggerDeliveryData
+from oss.src.dbs.postgres.triggers.dao import TriggersDAO
+
+
+class _Result:
+    def scalar_one_or_none(self):
+        return None
+
+
+class _Session:
+    def __init__(self):
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        statement.compile(dialect=postgresql.dialect())
+        return _Result()
+
+    async def commit(self):
+        return None
+
+
+class _Engine:
+    def __init__(self):
+        self.db_session = _Session()
+
+    @asynccontextmanager
+    async def session(self):
+        yield self.db_session
+
+
+async def test_update_delivery_merges_terminal_data_in_postgres():
+    engine = _Engine()
+    dao = TriggersDAO(engine=engine)
+
+    result = await dao.update_delivery(
+        project_id=uuid4(),
+        delivery_id=uuid4(),
+        status=Status(code="200", message="success"),
+        data=TriggerDeliveryData(result={"ok": True}),
+    )
+
+    sql = str(engine.db_session.statement.compile(dialect=postgresql.dialect()))
+    assert result is None
+    assert "coalesce(CAST(trigger_deliveries.data AS JSONB)" in sql
+    assert " || " in sql
+    assert "CAST(" in sql
+    assert " AS JSON)" in sql

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_dispatcher.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_dispatcher.py
@@ -14,8 +14,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from oss.src.core.shared.dtos import Reference
+from oss.src.core.sessions.dtos import SessionTriggerKind
 from oss.src.core.triggers.dtos import (
-    TriggerDelivery,
     TriggerSchedule,
     TriggerScheduleData,
     TriggerScheduleFlags,
@@ -66,26 +66,13 @@ def _make_schedule(*, is_active=True, references=None, inputs_fields=None):
 
 
 def _make_dao(*, seen=False, claim_lost=False):
-    """`claim_lost=True` simulates a concurrent caller having already won the
-    atomic claim on `_run`'s delivery row (claim_delivery returns None) — the
-    scenario the dedup pre-check alone cannot catch (P1-3)."""
     dao = MagicMock()
     dao.dedup_seen = AsyncMock(return_value=seen)
     dao.dedup_seen_schedule = AsyncMock(return_value=seen)
     dao.write_delivery = AsyncMock()
+    dao.write_subscription_delivery_if_live = AsyncMock()
 
-    def _claim(*, project_id, user_id, delivery):
-        if claim_lost:
-            return None
-        return TriggerDelivery(
-            id=delivery.id,
-            subscription_id=delivery.subscription_id,
-            schedule_id=delivery.schedule_id,
-            event_id=delivery.event_id,
-            status=delivery.status,
-        )
-
-    dao.claim_delivery = AsyncMock(side_effect=_claim)
+    dao.claim_trigger_delivery = AsyncMock(return_value=not claim_lost)
     dao.update_delivery = AsyncMock()
     return dao
 
@@ -108,7 +95,9 @@ def test_build_context_normalizes_provider_envelope():
     project_id = uuid4()
     subscription = _make_subscription()
     dispatcher = TriggersDispatcher(
-        triggers_dao=MagicMock(), workflows_service=MagicMock()
+        triggers_dao=MagicMock(),
+        session_claims_dao=MagicMock(),
+        workflows_service=MagicMock(),
     )
 
     context = dispatcher._build_context(
@@ -130,7 +119,9 @@ def test_build_context_normalizes_provider_envelope():
 
 def test_build_context_tolerates_missing_metadata_and_payload():
     dispatcher = TriggersDispatcher(
-        triggers_dao=MagicMock(), workflows_service=MagicMock()
+        triggers_dao=MagicMock(),
+        session_claims_dao=MagicMock(),
+        workflows_service=MagicMock(),
     )
 
     context = dispatcher._build_context(
@@ -149,7 +140,9 @@ async def test_inactive_entity_is_skipped():
     project_id = uuid4()
     subscription = _make_subscription(is_active=False)
     dao = _make_dao()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=MagicMock())
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=MagicMock()
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
@@ -174,7 +167,9 @@ async def test_invalid_subscription_is_not_silently_skipped():
             span_id="sp-1",
         )
     )
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
@@ -184,8 +179,8 @@ async def test_invalid_subscription_is_not_silently_skipped():
     # The workflow must NOT run for an invalid subscription, and a failed
     # delivery must be recorded so the user can see why.
     workflows.invoke_workflow.assert_not_awaited()
-    dao.write_delivery.assert_awaited_once()
-    delivery = dao.write_delivery.await_args.kwargs["delivery"]
+    dao.write_subscription_delivery_if_live.assert_awaited_once()
+    delivery = dao.write_subscription_delivery_if_live.await_args.kwargs["delivery"]
     assert delivery.status.code == "409"
     assert "invalid" in delivery.data.error.lower()
 
@@ -194,7 +189,9 @@ async def test_duplicate_event_is_skipped():
     project_id = uuid4()
     subscription = _make_subscription(references={"workflow": Reference(slug="wf-1")})
     dao = _make_dao(seen=True)
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=MagicMock())
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=MagicMock()
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
@@ -210,7 +207,9 @@ async def test_missing_reference_writes_failed_delivery():
     dao = _make_dao()
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
@@ -218,12 +217,49 @@ async def test_missing_reference_writes_failed_delivery():
 
     workflows.invoke_workflow.assert_not_awaited()
     # _run claims the row FIRST (even though it will fail before ever invoking).
-    dao.claim_delivery.assert_awaited_once()
+    dao.claim_trigger_delivery.assert_awaited_once()
     dao.update_delivery.assert_awaited_once()
+    claim = dao.claim_trigger_delivery.await_args.kwargs
     update_kwargs = dao.update_delivery.await_args.kwargs
     assert update_kwargs["status"].code == "400"
     assert "no bound workflow" in update_kwargs["data"].error.lower()
+    assert update_kwargs["delivery_id"] == claim["attribution"].delivery_id
+    assert update_kwargs["data"].session_id == claim["session_id"]
     dao.write_delivery.assert_not_awaited()
+
+
+async def test_mapping_failure_keeps_claimed_session_and_skips_invoke(monkeypatch):
+    project_id = uuid4()
+    subscription = _make_subscription(
+        references={"workflow": Reference(slug="wf-1")},
+        inputs_fields={"number": "$.missing"},
+    )
+    dao = _make_dao()
+    workflows = MagicMock()
+    workflows.invoke_workflow = AsyncMock()
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
+
+    def _fail_mapping(*args, **kwargs):
+        raise ValueError("invalid input mapping")
+
+    monkeypatch.setattr(
+        "oss.src.tasks.asyncio.triggers.dispatcher.resolve_target_fields",
+        _fail_mapping,
+    )
+
+    await dispatcher.dispatch_subscription(
+        project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
+    )
+
+    claim = dao.claim_trigger_delivery.await_args.kwargs
+    completion = dao.update_delivery.await_args.kwargs
+    assert completion["status"].code == "400"
+    assert completion["data"].error == "invalid input mapping"
+    assert completion["data"].session_id == claim["session_id"]
+    assert completion["delivery_id"] == claim["attribution"].delivery_id
+    workflows.invoke_workflow.assert_not_awaited()
 
 
 async def test_happy_path_invokes_workflow_and_writes_success():
@@ -243,7 +279,9 @@ async def test_happy_path_invokes_workflow_and_writes_success():
     )
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock(return_value=response)
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
@@ -256,17 +294,25 @@ async def test_happy_path_invokes_workflow_and_writes_success():
 
     # The claim happens BEFORE invoke, and the terminal write is an UPDATE of the
     # SAME claimed row (never a fresh write_delivery insert) — the P1-3 contract.
-    dao.claim_delivery.assert_awaited_once()
-    claimed = dao.claim_delivery.await_args.kwargs["delivery"]
-    assert claimed.status.code == "102"
-    assert claimed.subscription_id == subscription.id
-    assert claimed.schedule_id is None
-    assert claimed.event_id == "e1"
+    dao.claim_trigger_delivery.assert_awaited_once()
+    claim = dao.claim_trigger_delivery.await_args.kwargs
+    attribution = claim["attribution"]
+    assert claim["event_id"] == "e1"
+    assert attribution.configuration_id == subscription.id
+    assert attribution.kind == SessionTriggerKind.subscription
+    assert set(attribution.model_dump()) == {
+        "configuration_id",
+        "kind",
+        "delivery_id",
+    }
 
     dao.update_delivery.assert_awaited_once()
     update_kwargs = dao.update_delivery.await_args.kwargs
-    assert update_kwargs["delivery_id"] == claimed.id
+    request = invoke_kwargs["request"]
+    assert claim["session_id"] == request.session_id
+    assert update_kwargs["delivery_id"] == attribution.delivery_id
     assert update_kwargs["status"].code == "200"
+    assert update_kwargs["data"].session_id == request.session_id
     assert update_kwargs["data"].inputs == {"number": 7}
     dao.write_delivery.assert_not_awaited()
 
@@ -278,7 +324,9 @@ async def test_test_subscription_captures_event_and_skips_workflow():
     dao = _make_dao()
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
@@ -286,8 +334,8 @@ async def test_test_subscription_captures_event_and_skips_workflow():
 
     dao.dedup_seen.assert_awaited_once()
     workflows.invoke_workflow.assert_not_awaited()
-    dao.write_delivery.assert_awaited_once()
-    delivery = dao.write_delivery.await_args.kwargs["delivery"]
+    dao.write_subscription_delivery_if_live.assert_awaited_once()
+    delivery = dao.write_subscription_delivery_if_live.await_args.kwargs["delivery"]
     assert delivery.status.code == "200"
     assert delivery.data.is_test is True
     # Default inputs_fields ("$") captures the whole resolved event context.
@@ -301,7 +349,9 @@ async def test_test_subscription_dedups():
     dao = _make_dao(seen=True)
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
@@ -325,13 +375,15 @@ async def test_workflow_non_200_writes_failed_delivery():
     )
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock(return_value=response)
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
     )
 
-    dao.claim_delivery.assert_awaited_once()
+    dao.claim_trigger_delivery.assert_awaited_once()
     dao.update_delivery.assert_awaited_once()
     update_kwargs = dao.update_delivery.await_args.kwargs
     assert update_kwargs["status"].code == "500"
@@ -352,7 +404,10 @@ async def test_detached_dispatch_writes_dispatched_delivery():
     run_id = "run-abc-123"
     dispatch_fn = AsyncMock(return_value=run_id)
     dispatcher = TriggersDispatcher(
-        triggers_dao=dao, workflows_service=workflows, dispatch_fn=dispatch_fn
+        triggers_dao=dao,
+        session_claims_dao=dao,
+        workflows_service=workflows,
+        dispatch_fn=dispatch_fn,
     )
 
     await dispatcher.dispatch_subscription(
@@ -363,12 +418,51 @@ async def test_detached_dispatch_writes_dispatched_delivery():
     dispatch_fn.assert_awaited_once()
     workflows.invoke_workflow.assert_not_awaited()
 
-    dao.claim_delivery.assert_awaited_once()
+    dao.claim_trigger_delivery.assert_awaited_once()
     dao.update_delivery.assert_awaited_once()
+    claim = dao.claim_trigger_delivery.await_args.kwargs
+    request = dispatch_fn.await_args.kwargs["request"]
     update_kwargs = dao.update_delivery.await_args.kwargs
     assert update_kwargs["status"].code == "202"
+    assert update_kwargs["status"].message == "dispatched"
     assert update_kwargs["data"].result == {"run_id": run_id}
+    assert request.session_id == claim["session_id"]
+    assert update_kwargs["data"].session_id == claim["session_id"]
+    assert update_kwargs["delivery_id"] == claim["attribution"].delivery_id
     dao.write_delivery.assert_not_awaited()
+
+
+async def test_detached_dispatch_failure_before_acceptance_marks_delivery_failed():
+    project_id = uuid4()
+    subscription = _make_subscription(references={"workflow": Reference(slug="wf-1")})
+    dao = _make_dao()
+    workflows = MagicMock()
+    workflows.invoke_workflow = AsyncMock()
+    dispatch_fn = AsyncMock(side_effect=RuntimeError("runner unavailable"))
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao,
+        session_claims_dao=dao,
+        workflows_service=workflows,
+        dispatch_fn=dispatch_fn,
+    )
+
+    with pytest.raises(RuntimeError, match="runner unavailable"):
+        await dispatcher.dispatch_subscription(
+            project_id=project_id,
+            subscription=subscription,
+            event_id="e1",
+            event=_EVENT,
+        )
+
+    claim = dao.claim_trigger_delivery.await_args.kwargs
+    request = dispatch_fn.await_args.kwargs["request"]
+    completion = dao.update_delivery.await_args.kwargs
+    assert completion["status"].code == "500"
+    assert completion["data"].error == "runner unavailable"
+    assert request.session_id == claim["session_id"]
+    assert completion["data"].session_id == claim["session_id"]
+    assert completion["delivery_id"] == claim["attribution"].delivery_id
+    workflows.invoke_workflow.assert_not_awaited()
 
 
 # --- SCHEDULES ---------------------------------------------------------------- #
@@ -385,7 +479,9 @@ _SCHEDULE_EVENT = {
 async def test_inactive_schedule_is_skipped():
     schedule = _make_schedule(is_active=False)
     dao = _make_dao()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=MagicMock())
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=MagicMock()
+    )
 
     await dispatcher.dispatch_schedule(
         project_id=uuid4(),
@@ -405,7 +501,9 @@ async def test_duplicate_schedule_event_is_skipped():
     dao = _make_dao(seen=True)
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_schedule(
         project_id=project_id,
@@ -439,7 +537,9 @@ async def test_first_schedule_event_invokes_workflow():
             span_id="sp-1",
         )
     )
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_schedule(
         project_id=project_id,
@@ -451,15 +551,16 @@ async def test_first_schedule_event_invokes_workflow():
     dao.dedup_seen_schedule.assert_awaited_once()
     workflows.invoke_workflow.assert_awaited_once()
 
-    dao.claim_delivery.assert_awaited_once()
-    claimed = dao.claim_delivery.await_args.kwargs["delivery"]
-    assert claimed.schedule_id == schedule.id
-    assert claimed.subscription_id is None
-    assert claimed.event_id == "e1"
+    dao.claim_trigger_delivery.assert_awaited_once()
+    claim = dao.claim_trigger_delivery.await_args.kwargs
+    attribution = claim["attribution"]
+    assert claim["event_id"] == "e1"
+    assert attribution.configuration_id == schedule.id
+    assert attribution.kind == SessionTriggerKind.schedule
 
     dao.update_delivery.assert_awaited_once()
     update_kwargs = dao.update_delivery.await_args.kwargs
-    assert update_kwargs["delivery_id"] == claimed.id
+    assert update_kwargs["delivery_id"] == attribution.delivery_id
     assert update_kwargs["status"].code == "200"
     dao.write_delivery.assert_not_awaited()
 
@@ -474,7 +575,9 @@ async def test_failed_schedule_invoke_records_the_row_the_retry_dedups_on():
 
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock(side_effect=RuntimeError("boom"))
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     with pytest.raises(RuntimeError):
         await dispatcher.dispatch_schedule(
@@ -486,8 +589,8 @@ async def test_failed_schedule_invoke_records_the_row_the_retry_dedups_on():
 
     # The row was claimed BEFORE invoke and completed to "500" via an UPDATE — a
     # retry's dedup_seen_schedule check will see it, and even if that read raced,
-    # the retry's own claim_delivery would still lose against this claimed row.
-    dao.claim_delivery.assert_awaited_once()
+    # the retry's own atomic claim would still lose against this claimed row.
+    dao.claim_trigger_delivery.assert_awaited_once()
     dao.update_delivery.assert_awaited_once()
     update_kwargs = dao.update_delivery.await_args.kwargs
     assert update_kwargs["status"].code == "500"
@@ -496,7 +599,7 @@ async def test_failed_schedule_invoke_records_the_row_the_retry_dedups_on():
 
 async def test_claim_lost_skips_invoke_even_when_dedup_precheck_missed_it():
     """P1-3: the dedup pre-check is a fast path, not the authority. If a
-    concurrent caller already won the atomic claim (claim_delivery -> None),
+    concurrent caller already won the atomic claim,
     _run must not invoke the workflow — even though dedup_seen reported unseen
     (the exact TOCTOU window between the pre-check read and the claim)."""
     project_id = uuid4()
@@ -504,13 +607,15 @@ async def test_claim_lost_skips_invoke_even_when_dedup_precheck_missed_it():
     dao = _make_dao(seen=False, claim_lost=True)
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_subscription(
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
     )
 
-    dao.claim_delivery.assert_awaited_once()
+    dao.claim_trigger_delivery.assert_awaited_once()
     workflows.invoke_workflow.assert_not_awaited()
     dao.update_delivery.assert_not_awaited()
     dao.write_delivery.assert_not_awaited()
@@ -522,7 +627,9 @@ async def test_claim_lost_skips_invoke_for_schedule_too():
     dao = _make_dao(seen=False, claim_lost=True)
     workflows = MagicMock()
     workflows.invoke_workflow = AsyncMock()
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     await dispatcher.dispatch_schedule(
         project_id=project_id,
@@ -531,16 +638,61 @@ async def test_claim_lost_skips_invoke_for_schedule_too():
         event=_SCHEDULE_EVENT,
     )
 
-    dao.claim_delivery.assert_awaited_once()
+    dao.claim_trigger_delivery.assert_awaited_once()
     workflows.invoke_workflow.assert_not_awaited()
     dao.update_delivery.assert_not_awaited()
+
+
+async def test_claim_failure_allows_retry_with_fresh_ids():
+    project_id = uuid4()
+    subscription = _make_subscription(references={"workflow": Reference(slug="wf-1")})
+    dao = _make_dao(seen=False)
+    dao.claim_trigger_delivery = AsyncMock(
+        side_effect=[RuntimeError("attribution failed"), True]
+    )
+    workflows = MagicMock()
+    workflows.invoke_workflow = AsyncMock(
+        return_value=SimpleNamespace(
+            status=SimpleNamespace(code=200, message="success"),
+            outputs={"ok": True},
+            trace_id="tr-1",
+            span_id="sp-1",
+        )
+    )
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
+
+    with pytest.raises(RuntimeError, match="attribution failed"):
+        await dispatcher.dispatch_subscription(
+            project_id=project_id,
+            subscription=subscription,
+            event_id="e1",
+            event=_EVENT,
+        )
+
+    workflows.invoke_workflow.assert_not_awaited()
+    dao.update_delivery.assert_not_awaited()
+
+    await dispatcher.dispatch_subscription(
+        project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
+    )
+
+    first_claim, retry_claim = dao.claim_trigger_delivery.await_args_list
+    assert first_claim.kwargs["session_id"] != retry_claim.kwargs["session_id"]
+    assert (
+        first_claim.kwargs["attribution"].delivery_id
+        != retry_claim.kwargs["attribution"].delivery_id
+    )
+    request = workflows.invoke_workflow.await_args.kwargs["request"]
+    assert request.session_id == retry_claim.kwargs["session_id"]
 
 
 async def test_post_invoke_write_failure_does_not_permit_a_reinvoke_on_retry():
     """P1-3's core scenario: the workflow succeeds, but the terminal delivery
     UPDATE fails (e.g. a transient DB error). Because the row was already
-    claimed via an atomic INSERT before invoke, a retry's claim_delivery call
-    on the same event finds the row already there and returns None — the retry
+    claimed via an atomic INSERT before invoke, a retry's claim call
+    on the same event finds the row already there and loses, so the retry
     must NOT re-invoke, regardless of whether the terminal write ever landed."""
     project_id = uuid4()
     subscription = _make_subscription(references={"workflow": Reference(slug="wf-1")})
@@ -558,7 +710,9 @@ async def test_post_invoke_write_failure_does_not_permit_a_reinvoke_on_retry():
     # write fails (simulating a transient DB error after a successful invoke).
     dao = _make_dao(seen=False)
     dao.update_delivery = AsyncMock(side_effect=RuntimeError("db write failed"))
-    dispatcher = TriggersDispatcher(triggers_dao=dao, workflows_service=workflows)
+    dispatcher = TriggersDispatcher(
+        triggers_dao=dao, session_claims_dao=dao, workflows_service=workflows
+    )
 
     with pytest.raises(RuntimeError, match="db write failed"):
         await dispatcher.dispatch_subscription(
@@ -569,14 +723,16 @@ async def test_post_invoke_write_failure_does_not_permit_a_reinvoke_on_retry():
         )
 
     workflows.invoke_workflow.assert_awaited_once()
-    dao.claim_delivery.assert_awaited_once()
+    dao.claim_trigger_delivery.assert_awaited_once()
 
     # Retry: the row _run claimed on attempt 1 is now a permanent (committed)
-    # row in the DB regardless of the UPDATE failure — claim_delivery must lose
+    # row in the DB regardless of the UPDATE failure, so the next claim must lose
     # this time (simulated here via claim_lost), so the retry does NOT invoke.
     dao_retry = _make_dao(seen=False, claim_lost=True)
     dispatcher_retry = TriggersDispatcher(
-        triggers_dao=dao_retry, workflows_service=workflows
+        triggers_dao=dao_retry,
+        session_claims_dao=dao_retry,
+        workflows_service=workflows,
     )
     workflows.invoke_workflow.reset_mock()
 

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_dispatcher.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_dispatcher.py
@@ -69,11 +69,11 @@ def _make_dao(*, seen=False, claim_lost=False):
     dao = MagicMock()
     dao.dedup_seen = AsyncMock(return_value=seen)
     dao.dedup_seen_schedule = AsyncMock(return_value=seen)
-    dao.write_delivery = AsyncMock()
     dao.write_subscription_delivery_if_live = AsyncMock()
 
     dao.claim_trigger_delivery = AsyncMock(return_value=not claim_lost)
     dao.update_delivery = AsyncMock()
+    dao.abandon_claimed_session = AsyncMock()
     return dao
 
 
@@ -149,7 +149,6 @@ async def test_inactive_entity_is_skipped():
     )
 
     dao.dedup_seen.assert_not_awaited()
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_invalid_subscription_is_not_silently_skipped():
@@ -198,7 +197,6 @@ async def test_duplicate_event_is_skipped():
     )
 
     dao.dedup_seen.assert_awaited_once()
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_missing_reference_writes_failed_delivery():
@@ -225,10 +223,17 @@ async def test_missing_reference_writes_failed_delivery():
     assert "no bound workflow" in update_kwargs["data"].error.lower()
     assert update_kwargs["delivery_id"] == claim["attribution"].delivery_id
     assert update_kwargs["data"].session_id == claim["session_id"]
-    dao.write_delivery.assert_not_awaited()
+    # P0-3: the claim inserted a session_streams row before this failure — it must
+    # be abandoned (soft-deleted), or it lingers forever as an un-sweepable phantom
+    # session (flags=NULL at claim time, so the orphan sweep can never match it).
+    dao.abandon_claimed_session.assert_awaited_once_with(
+        project_id=project_id, session_id=claim["session_id"]
+    )
 
 
-async def test_mapping_failure_keeps_claimed_session_and_skips_invoke(monkeypatch):
+async def test_mapping_failure_abandons_the_claimed_session_and_skips_invoke(
+    monkeypatch,
+):
     project_id = uuid4()
     subscription = _make_subscription(
         references={"workflow": Reference(slug="wf-1")},
@@ -260,6 +265,9 @@ async def test_mapping_failure_keeps_claimed_session_and_skips_invoke(monkeypatc
     assert completion["data"].session_id == claim["session_id"]
     assert completion["delivery_id"] == claim["attribution"].delivery_id
     workflows.invoke_workflow.assert_not_awaited()
+    dao.abandon_claimed_session.assert_awaited_once_with(
+        project_id=project_id, session_id=claim["session_id"]
+    )
 
 
 async def test_happy_path_invokes_workflow_and_writes_success():
@@ -314,7 +322,9 @@ async def test_happy_path_invokes_workflow_and_writes_success():
     assert update_kwargs["status"].code == "200"
     assert update_kwargs["data"].session_id == request.session_id
     assert update_kwargs["data"].inputs == {"number": 7}
-    dao.write_delivery.assert_not_awaited()
+    # The invoke succeeded, so the claimed session is real — it must not be
+    # abandoned (P0-3 only fires on the pre-invoke failure paths).
+    dao.abandon_claimed_session.assert_not_awaited()
 
 
 async def test_test_subscription_captures_event_and_skips_workflow():
@@ -357,7 +367,6 @@ async def test_test_subscription_dedups():
         project_id=project_id, subscription=subscription, event_id="e1", event=_EVENT
     )
 
-    dao.write_delivery.assert_not_awaited()
     workflows.invoke_workflow.assert_not_awaited()
 
 
@@ -387,7 +396,6 @@ async def test_workflow_non_200_writes_failed_delivery():
     dao.update_delivery.assert_awaited_once()
     update_kwargs = dao.update_delivery.await_args.kwargs
     assert update_kwargs["status"].code == "500"
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_detached_dispatch_writes_dispatched_delivery():
@@ -429,7 +437,6 @@ async def test_detached_dispatch_writes_dispatched_delivery():
     assert request.session_id == claim["session_id"]
     assert update_kwargs["data"].session_id == claim["session_id"]
     assert update_kwargs["delivery_id"] == claim["attribution"].delivery_id
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_detached_dispatch_failure_before_acceptance_marks_delivery_failed():
@@ -463,6 +470,11 @@ async def test_detached_dispatch_failure_before_acceptance_marks_delivery_failed
     assert completion["data"].session_id == claim["session_id"]
     assert completion["delivery_id"] == claim["attribution"].delivery_id
     workflows.invoke_workflow.assert_not_awaited()
+    # P0-3: dispatch never accepted the run, so the claimed row must be abandoned
+    # here too, not just on the input/reference-resolution failure path.
+    dao.abandon_claimed_session.assert_awaited_once_with(
+        project_id=project_id, session_id=claim["session_id"]
+    )
 
 
 # --- SCHEDULES ---------------------------------------------------------------- #
@@ -491,7 +503,6 @@ async def test_inactive_schedule_is_skipped():
     )
 
     dao.dedup_seen_schedule.assert_not_awaited()
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_duplicate_schedule_event_is_skipped():
@@ -519,7 +530,6 @@ async def test_duplicate_schedule_event_is_skipped():
     assert kwargs["event_id"] == "e1"
 
     workflows.invoke_workflow.assert_not_awaited()
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_first_schedule_event_invokes_workflow():
@@ -562,7 +572,6 @@ async def test_first_schedule_event_invokes_workflow():
     update_kwargs = dao.update_delivery.await_args.kwargs
     assert update_kwargs["delivery_id"] == attribution.delivery_id
     assert update_kwargs["status"].code == "200"
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_failed_schedule_invoke_records_the_row_the_retry_dedups_on():
@@ -594,7 +603,6 @@ async def test_failed_schedule_invoke_records_the_row_the_retry_dedups_on():
     dao.update_delivery.assert_awaited_once()
     update_kwargs = dao.update_delivery.await_args.kwargs
     assert update_kwargs["status"].code == "500"
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_claim_lost_skips_invoke_even_when_dedup_precheck_missed_it():
@@ -618,7 +626,6 @@ async def test_claim_lost_skips_invoke_even_when_dedup_precheck_missed_it():
     dao.claim_trigger_delivery.assert_awaited_once()
     workflows.invoke_workflow.assert_not_awaited()
     dao.update_delivery.assert_not_awaited()
-    dao.write_delivery.assert_not_awaited()
 
 
 async def test_claim_lost_skips_invoke_for_schedule_too():

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_lifecycle.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_lifecycle.py
@@ -1,0 +1,416 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from oss.src.apis.fastapi.triggers.router import TriggersRouter
+from oss.src.core.access.permissions.types import Permission
+from oss.src.core.triggers.dtos import (
+    TriggerSchedule,
+    TriggerScheduleData,
+    TriggerSubscription,
+    TriggerSubscriptionData,
+)
+from oss.src.core.triggers.exceptions import (
+    AdapterError,
+    ScheduleNotFoundError,
+    SubscriptionNotFoundError,
+)
+from oss.src.core.triggers.service import TriggersService
+
+
+def _subscription():
+    return TriggerSubscription(
+        id=uuid4(),
+        created_by_id=uuid4(),
+        connection_id=uuid4(),
+        trigger_id="ti_lifecycle",
+        data=TriggerSubscriptionData(event_key="github.issue.opened"),
+    )
+
+
+def _schedule():
+    return TriggerSchedule(
+        id=uuid4(),
+        created_by_id=uuid4(),
+        data=TriggerScheduleData(event_key="cron.tick", schedule="* * * * *"),
+    )
+
+
+def _service(*, subscription=None):
+    adapter = MagicMock()
+    adapter.delete_subscription = AsyncMock()
+    adapter.set_subscription_status = AsyncMock()
+    registry = MagicMock()
+    registry.get.return_value = adapter
+
+    connection = MagicMock()
+    connection.provider_key.value = "composio"
+    connections = MagicMock()
+    connections.get_connection = AsyncMock(return_value=connection)
+
+    dao = MagicMock()
+    dao.fetch_subscription = AsyncMock(return_value=subscription)
+    dao.delete_subscription = AsyncMock(return_value=True)
+    dao.purge_subscription = AsyncMock(return_value=True)
+    dao.delete_schedule = AsyncMock(return_value=True)
+
+    service = TriggersService(
+        adapter_registry=registry,
+        catalog_service=MagicMock(),
+        triggers_dao=dao,
+        connections_service=connections,
+        workflows_service=MagicMock(),
+    )
+    return service, dao, adapter
+
+
+async def test_normal_subscription_delete_cleans_provider_before_soft_delete():
+    subscription = _subscription()
+    service, dao, adapter = _service(subscription=subscription)
+    calls = []
+    adapter.delete_subscription.side_effect = lambda **_: calls.append("provider")
+    dao.delete_subscription.side_effect = lambda **_: calls.append("local") or True
+    user_id = uuid4()
+
+    deleted = await service.delete_subscription(
+        project_id=uuid4(),
+        user_id=user_id,
+        subscription_id=subscription.id,
+    )
+
+    assert deleted is True
+    assert calls == ["provider", "local"]
+    assert dao.delete_subscription.await_args.kwargs["user_id"] == user_id
+    dao.purge_subscription.assert_not_awaited()
+
+
+async def test_normal_subscription_delete_stops_on_provider_failure():
+    subscription = _subscription()
+    service, dao, adapter = _service(subscription=subscription)
+    adapter.delete_subscription.side_effect = AdapterError(
+        provider_key="composio",
+        operation="delete_subscription",
+        detail="already gone",
+    )
+
+    with pytest.raises(AdapterError):
+        await service.delete_subscription(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            subscription_id=subscription.id,
+        )
+    dao.delete_subscription.assert_not_awaited()
+
+
+async def test_test_cleanup_does_not_purge_after_provider_failure():
+    subscription = _subscription()
+    service, dao, adapter = _service(subscription=subscription)
+    adapter.delete_subscription.side_effect = AdapterError(
+        provider_key="composio",
+        operation="delete_subscription",
+        detail="timeout",
+    )
+
+    with pytest.raises(AdapterError):
+        await service.cleanup_test_subscription(
+            project_id=uuid4(),
+            subscription_id=subscription.id,
+        )
+    dao.purge_subscription.assert_not_awaited()
+
+
+async def test_test_cleanup_deletes_provider_before_physical_purge():
+    subscription = _subscription()
+    service, dao, adapter = _service(subscription=subscription)
+    calls = []
+    adapter.delete_subscription.side_effect = lambda **_: calls.append("provider")
+    dao.purge_subscription.side_effect = lambda **_: calls.append("purge") or True
+
+    purged = await service.cleanup_test_subscription(
+        project_id=uuid4(),
+        subscription_id=subscription.id,
+    )
+
+    assert purged is True
+    assert calls == ["provider", "purge"]
+    dao.delete_subscription.assert_not_awaited()
+
+
+async def test_exact_retrieval_returns_deleted_configurations_with_lifecycle_fields():
+    deleted_at = datetime.now(timezone.utc)
+    deleted_by_id = uuid4()
+    subscription = _subscription().model_copy(
+        update={"deleted_at": deleted_at, "deleted_by_id": deleted_by_id}
+    )
+    schedule = _schedule().model_copy(
+        update={"deleted_at": deleted_at, "deleted_by_id": deleted_by_id}
+    )
+    service, dao, _ = _service()
+    dao.fetch_subscription_including_deleted = AsyncMock(return_value=subscription)
+    dao.fetch_schedule_including_deleted = AsyncMock(return_value=schedule)
+    project_id = uuid4()
+
+    fetched_subscription = await service.fetch_subscription_including_deleted(
+        project_id=project_id,
+        subscription_id=subscription.id,
+    )
+    fetched_schedule = await service.fetch_schedule_including_deleted(
+        project_id=project_id,
+        schedule_id=schedule.id,
+    )
+
+    assert fetched_subscription is subscription
+    assert fetched_subscription.deleted_at == deleted_at
+    assert fetched_subscription.deleted_by_id == deleted_by_id
+    assert fetched_schedule is schedule
+    assert fetched_schedule.deleted_at == deleted_at
+    assert fetched_schedule.deleted_by_id == deleted_by_id
+
+
+async def test_exact_fetch_routes_use_historical_service_and_view_permission(
+    monkeypatch,
+):
+    check_access = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "oss.src.apis.fastapi.triggers.router.check_action_access",
+        check_access,
+    )
+    deleted_at = datetime.now(timezone.utc)
+    deleted_by_id = uuid4()
+    subscription = _subscription().model_copy(
+        update={"deleted_at": deleted_at, "deleted_by_id": deleted_by_id}
+    )
+    schedule = _schedule().model_copy(
+        update={"deleted_at": deleted_at, "deleted_by_id": deleted_by_id}
+    )
+    service = MagicMock()
+    service.fetch_subscription = AsyncMock()
+    service.fetch_schedule = AsyncMock()
+    service.fetch_subscription_including_deleted = AsyncMock(return_value=subscription)
+    service.fetch_schedule_including_deleted = AsyncMock(return_value=schedule)
+    router = TriggersRouter(triggers_service=service)
+    project_id = uuid4()
+    user_id = uuid4()
+    request = SimpleNamespace(
+        state=SimpleNamespace(project_id=str(project_id), user_id=str(user_id))
+    )
+
+    subscription_response = await router.fetch_subscription(
+        request,
+        subscription_id=subscription.id,
+    )
+    schedule_response = await router.fetch_schedule(
+        request,
+        schedule_id=schedule.id,
+    )
+
+    assert subscription_response.subscription is subscription
+    assert schedule_response.schedule is schedule
+    serialized_deleted_at = subscription_response.model_dump(mode="json")[
+        "subscription"
+    ]["deleted_at"]
+    assert datetime.fromisoformat(serialized_deleted_at) == deleted_at
+    assert schedule_response.model_dump(mode="json")["schedule"][
+        "deleted_by_id"
+    ] == str(deleted_by_id)
+    service.fetch_subscription_including_deleted.assert_awaited_once_with(
+        project_id=project_id,
+        subscription_id=subscription.id,
+    )
+    service.fetch_schedule_including_deleted.assert_awaited_once_with(
+        project_id=project_id,
+        schedule_id=schedule.id,
+    )
+    service.fetch_subscription.assert_not_awaited()
+    service.fetch_schedule.assert_not_awaited()
+    check_access.assert_has_awaits(
+        [
+            call(
+                user_uid=str(user_id),
+                project_id=str(project_id),
+                permission=Permission.VIEW_TRIGGERS,
+            ),
+            call(
+                user_uid=str(user_id),
+                project_id=str(project_id),
+                permission=Permission.VIEW_TRIGGERS,
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ("route_name", "service_name", "identifier_name"),
+    [
+        (
+            "fetch_subscription",
+            "fetch_subscription_including_deleted",
+            "subscription_id",
+        ),
+        ("fetch_schedule", "fetch_schedule_including_deleted", "schedule_id"),
+    ],
+)
+async def test_exact_fetch_route_returns_not_found_for_wrong_project(
+    monkeypatch,
+    route_name,
+    service_name,
+    identifier_name,
+):
+    monkeypatch.setattr(
+        "oss.src.apis.fastapi.triggers.router.check_action_access",
+        AsyncMock(return_value=True),
+    )
+    wrong_project_id = uuid4()
+    configuration_id = uuid4()
+    service = MagicMock()
+    historical_fetch = AsyncMock(return_value=None)
+    setattr(service, service_name, historical_fetch)
+    router = TriggersRouter(triggers_service=service)
+    request = SimpleNamespace(
+        state=SimpleNamespace(project_id=str(wrong_project_id), user_id=str(uuid4()))
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await getattr(router, route_name)(
+            request,
+            **{identifier_name: configuration_id},
+        )
+
+    assert exc_info.value.status_code == 404
+    historical_fetch.assert_awaited_once_with(
+        project_id=wrong_project_id,
+        **{identifier_name: configuration_id},
+    )
+
+
+async def test_deleted_configurations_are_rejected_by_edit_and_activation_paths():
+    service, dao, _ = _service(subscription=None)
+    dao.fetch_schedule = AsyncMock(return_value=None)
+
+    assert (
+        await service.edit_subscription(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            subscription=MagicMock(id=uuid4()),
+        )
+        is None
+    )
+    with pytest.raises(SubscriptionNotFoundError):
+        await service.set_subscription_active(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            subscription_id=uuid4(),
+            is_active=True,
+        )
+    assert (
+        await service.edit_schedule(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            schedule=MagicMock(id=uuid4()),
+        )
+        is None
+    )
+    with pytest.raises(ScheduleNotFoundError):
+        await service.set_schedule_active(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            schedule_id=uuid4(),
+            is_active=True,
+        )
+
+
+async def test_schedule_delete_passes_lifecycle_owner_to_dao():
+    service, dao, _ = _service()
+    user_id = uuid4()
+
+    assert await service.delete_schedule(
+        project_id=uuid4(),
+        user_id=user_id,
+        schedule_id=uuid4(),
+    )
+    assert dao.delete_schedule.await_args.kwargs["user_id"] == user_id
+
+
+async def test_subscription_activation_losing_to_delete_raises_not_found():
+    subscription = _subscription()
+    service, dao, _ = _service(subscription=subscription)
+    dao.edit_subscription = AsyncMock(return_value=None)
+
+    with pytest.raises(SubscriptionNotFoundError):
+        await service.set_subscription_active(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            subscription_id=subscription.id,
+            is_active=False,
+        )
+
+
+async def test_subscription_validity_update_losing_to_delete_raises_not_found():
+    subscription = _subscription()
+    service, dao, _ = _service(subscription=subscription)
+    dao.edit_subscription = AsyncMock(return_value=None)
+
+    with pytest.raises(SubscriptionNotFoundError):
+        await service.refresh_subscription(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            subscription_id=subscription.id,
+        )
+
+
+async def test_schedule_activation_losing_to_delete_raises_not_found():
+    schedule = _schedule()
+    service, dao, _ = _service()
+    dao.fetch_schedule = AsyncMock(return_value=schedule)
+    dao.edit_schedule = AsyncMock(return_value=None)
+
+    with pytest.raises(ScheduleNotFoundError):
+        await service.set_schedule_active(
+            project_id=uuid4(),
+            user_id=uuid4(),
+            schedule_id=schedule.id,
+            is_active=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "identifier_name"),
+    [
+        ("delete_subscription", "subscription_id"),
+        ("delete_schedule", "schedule_id"),
+    ],
+)
+async def test_delete_router_passes_user_to_service(
+    monkeypatch,
+    method_name,
+    identifier_name,
+):
+    monkeypatch.setattr(
+        "oss.src.apis.fastapi.triggers.router.check_action_access",
+        AsyncMock(return_value=True),
+    )
+    project_id = uuid4()
+    user_id = uuid4()
+    configuration_id = uuid4()
+    service = MagicMock()
+    delete_method = AsyncMock(return_value=True)
+    setattr(service, method_name, delete_method)
+    router = TriggersRouter(triggers_service=service)
+    request = SimpleNamespace(
+        state=SimpleNamespace(project_id=str(project_id), user_id=str(user_id))
+    )
+
+    await getattr(router, method_name)(
+        request,
+        **{identifier_name: configuration_id},
+    )
+
+    delete_method.assert_awaited_once_with(
+        project_id=project_id,
+        user_id=user_id,
+        **{identifier_name: configuration_id},
+    )

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_lifecycle.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_lifecycle.py
@@ -13,6 +13,7 @@ from oss.src.core.triggers.dtos import (
     TriggerScheduleData,
     TriggerSubscription,
     TriggerSubscriptionData,
+    TriggerSubscriptionFlags,
 )
 from oss.src.core.triggers.exceptions import (
     AdapterError,
@@ -22,13 +23,14 @@ from oss.src.core.triggers.exceptions import (
 from oss.src.core.triggers.service import TriggersService
 
 
-def _subscription():
+def _subscription(*, is_test=False):
     return TriggerSubscription(
         id=uuid4(),
         created_by_id=uuid4(),
         connection_id=uuid4(),
         trigger_id="ti_lifecycle",
         data=TriggerSubscriptionData(event_key="github.issue.opened"),
+        flags=TriggerSubscriptionFlags(is_test=is_test),
     )
 
 
@@ -57,6 +59,7 @@ def _service(*, subscription=None):
     dao.delete_subscription = AsyncMock(return_value=True)
     dao.purge_subscription = AsyncMock(return_value=True)
     dao.delete_schedule = AsyncMock(return_value=True)
+    dao.mark_subscription_needs_provider_cleanup = AsyncMock()
 
     service = TriggersService(
         adapter_registry=registry,
@@ -68,7 +71,7 @@ def _service(*, subscription=None):
     return service, dao, adapter
 
 
-async def test_normal_subscription_delete_cleans_provider_before_soft_delete():
+async def test_normal_subscription_delete_writes_local_state_before_provider_cleanup():
     subscription = _subscription()
     service, dao, adapter = _service(subscription=subscription)
     calls = []
@@ -83,13 +86,16 @@ async def test_normal_subscription_delete_cleans_provider_before_soft_delete():
     )
 
     assert deleted is True
-    assert calls == ["provider", "local"]
+    # Local-first (P0-2): a degraded provider must never block the local delete.
+    assert calls == ["local", "provider"]
     assert dao.delete_subscription.await_args.kwargs["user_id"] == user_id
     dao.purge_subscription.assert_not_awaited()
+    dao.mark_subscription_needs_provider_cleanup.assert_not_awaited()
 
 
-async def test_normal_subscription_delete_stops_on_provider_failure():
+async def test_normal_subscription_delete_survives_provider_failure():
     subscription = _subscription()
+    project_id = uuid4()
     service, dao, adapter = _service(subscription=subscription)
     adapter.delete_subscription.side_effect = AdapterError(
         provider_key="composio",
@@ -97,17 +103,101 @@ async def test_normal_subscription_delete_stops_on_provider_failure():
         detail="already gone",
     )
 
+    # The local delete must succeed despite the provider being unreachable — the
+    # old contract raised here and left the subscription both undeletable and
+    # unstoppable (P0-2). The failure is recorded for reconciliation, not raised.
+    deleted = await service.delete_subscription(
+        project_id=project_id,
+        user_id=uuid4(),
+        subscription_id=subscription.id,
+    )
+
+    assert deleted is True
+    dao.delete_subscription.assert_awaited_once()
+    dao.mark_subscription_needs_provider_cleanup.assert_awaited_once_with(
+        project_id=project_id,
+        subscription_id=subscription.id,
+    )
+
+
+async def test_subscription_stop_writes_local_state_before_provider_sync():
+    subscription = _subscription()
+    service, dao, adapter = _service(subscription=subscription)
+    stopped = subscription.model_copy(
+        update={"flags": subscription.flags.model_copy(update={"is_active": False})}
+    )
+    calls = []
+    adapter.set_subscription_status.side_effect = lambda **_: calls.append("provider")
+    dao.edit_subscription = AsyncMock(
+        side_effect=lambda **_: calls.append("local") or stopped
+    )
+
+    updated = await service.set_subscription_active(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        subscription_id=subscription.id,
+        is_active=False,
+    )
+
+    assert updated.flags.is_active is False
+    assert calls == ["local", "provider"]
+    dao.mark_subscription_needs_provider_cleanup.assert_not_awaited()
+
+
+async def test_subscription_stop_survives_provider_failure():
+    subscription = _subscription()
+    project_id = uuid4()
+    service, dao, adapter = _service(subscription=subscription)
+    dao.edit_subscription = AsyncMock(
+        return_value=subscription.model_copy(
+            update={"flags": subscription.flags.model_copy(update={"is_active": False})}
+        )
+    )
+    adapter.set_subscription_status.side_effect = AdapterError(
+        provider_key="composio",
+        operation="set_subscription_status",
+        detail="unreachable",
+    )
+
+    # A provider outage must not prevent a user from stopping a firing automation
+    # (P0-2's other half — /stop must not raise the same way /delete used to).
+    updated = await service.set_subscription_active(
+        project_id=project_id,
+        user_id=uuid4(),
+        subscription_id=subscription.id,
+        is_active=False,
+    )
+
+    assert updated.flags.is_active is False
+    dao.mark_subscription_needs_provider_cleanup.assert_awaited_once_with(
+        project_id=project_id,
+        subscription_id=subscription.id,
+    )
+
+
+async def test_subscription_start_stays_provider_first():
+    subscription = _subscription()
+    service, dao, adapter = _service(subscription=subscription)
+    adapter.set_subscription_status.side_effect = AdapterError(
+        provider_key="composio",
+        operation="set_subscription_status",
+        detail="unreachable",
+    )
+
+    # Starting keeps the old provider-first contract: an enable that can't reach
+    # the provider must not silently mark the subscription active.
     with pytest.raises(AdapterError):
-        await service.delete_subscription(
+        await service.set_subscription_active(
             project_id=uuid4(),
             user_id=uuid4(),
             subscription_id=subscription.id,
+            is_active=True,
         )
-    dao.delete_subscription.assert_not_awaited()
+    dao.edit_subscription.assert_not_called()
 
 
 async def test_test_cleanup_does_not_purge_after_provider_failure():
-    subscription = _subscription()
+    subscription = _subscription(is_test=True)
     service, dao, adapter = _service(subscription=subscription)
     adapter.delete_subscription.side_effect = AdapterError(
         provider_key="composio",
@@ -124,7 +214,7 @@ async def test_test_cleanup_does_not_purge_after_provider_failure():
 
 
 async def test_test_cleanup_deletes_provider_before_physical_purge():
-    subscription = _subscription()
+    subscription = _subscription(is_test=True)
     service, dao, adapter = _service(subscription=subscription)
     calls = []
     adapter.delete_subscription.side_effect = lambda **_: calls.append("provider")
@@ -138,6 +228,21 @@ async def test_test_cleanup_deletes_provider_before_physical_purge():
     assert purged is True
     assert calls == ["provider", "purge"]
     dao.delete_subscription.assert_not_awaited()
+
+
+async def test_cleanup_test_subscription_refuses_a_non_test_subscription():
+    # A physical, unrecoverable purge must never run against real automation
+    # history — only the short-lived is_test row `test_subscription`'s own
+    # teardown created.
+    subscription = _subscription(is_test=False)
+    service, dao, _ = _service(subscription=subscription)
+
+    with pytest.raises(ValueError, match="only purges test subscriptions"):
+        await service.cleanup_test_subscription(
+            project_id=uuid4(),
+            subscription_id=subscription.id,
+        )
+    dao.purge_subscription.assert_not_awaited()
 
 
 async def test_exact_retrieval_returns_deleted_configurations_with_lifecycle_fields():

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_schedules_refresh.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_schedules_refresh.py
@@ -133,6 +133,9 @@ class TestRefreshSchedules:
         ok = await service.refresh_schedules(timestamp=_TICK, interval=1)
         assert ok is True
         service.schedule_dispatch_task.kiq.assert_awaited_once()
+        payload = service.schedule_dispatch_task.kiq.await_args.kwargs
+        assert payload["schedule_id"] == str(sched.id)
+        assert "schedule" not in payload
 
     async def test_non_matching_schedule_is_skipped(self):
         # Fires only at minute 30; the tick is at minute 0.

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_soft_delete_postgres.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_soft_delete_postgres.py
@@ -349,9 +349,9 @@ async def test_soft_delete_retains_subscription_and_delivery_until_explicit_purg
     )
 
 
-@pytest.mark.parametrize("is_active", [False, True])
+@pytest.mark.parametrize("soft_deleted", [False, True])
 async def test_atomic_claim_rejects_disabled_or_deleted_schedule(
-    trigger_scope, is_active
+    trigger_scope, soft_deleted
 ):
     engine = get_transactions_engine()
     triggers_dao = TriggersDAO(engine=engine)
@@ -365,7 +365,7 @@ async def test_atomic_claim_rejects_disabled_or_deleted_schedule(
             data=TriggerScheduleData(event_key="cron.tick", schedule="* * * * *"),
         ),
     )
-    if is_active:
+    if soft_deleted:
         await triggers_dao.delete_schedule(
             project_id=project_id,
             user_id=user_id,

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_soft_delete_postgres.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_soft_delete_postgres.py
@@ -1,0 +1,409 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+import oss.src.dbs.postgres.shared.engine as engine_module
+import oss.src.models.db_models  # noqa: F401
+from oss.src.core.sessions.dtos import (
+    SessionTriggerAttribution,
+    SessionTriggerKind,
+)
+from oss.src.core.shared.dtos import Status
+from oss.src.core.triggers.dtos import (
+    TriggerDeliveryCreate,
+    TriggerScheduleCreate,
+    TriggerScheduleData,
+    TriggerSubscriptionCreate,
+    TriggerSubscriptionData,
+)
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
+from oss.src.dbs.postgres.gateway.connections.dbes import ConnectionDBE  # noqa: F401
+from oss.src.dbs.postgres.shared.engine import get_transactions_engine
+from oss.src.dbs.postgres.triggers.dao import TriggersDAO
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fresh_engine_per_test():
+    engine_module._transactions_engine = None
+    yield
+    if engine_module._transactions_engine is not None:
+        await engine_module._transactions_engine.close()
+        engine_module._transactions_engine = None
+
+
+@pytest_asyncio.fixture
+async def trigger_scope():
+    engine = get_transactions_engine()
+    user_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    connection_id = uuid.uuid4()
+
+    async with engine.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO users (id, uid, username, email) "
+                "VALUES (:id, :uid, :username, :email)"
+            ),
+            {
+                "id": user_id,
+                "uid": str(user_id),
+                "username": "trigger-soft-delete-test",
+                "email": f"trigger-soft-delete-{user_id.hex[:8]}@example.com",
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO organizations (id, name, owner_id) "
+                "VALUES (:id, :name, :owner_id)"
+            ),
+            {
+                "id": organization_id,
+                "name": "trigger-soft-delete-org",
+                "owner_id": user_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO workspaces (id, name, organization_id) "
+                "VALUES (:id, :name, :organization_id)"
+            ),
+            {
+                "id": workspace_id,
+                "name": "trigger-soft-delete-workspace",
+                "organization_id": organization_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO projects "
+                "(id, project_name, workspace_id, organization_id) "
+                "VALUES (:id, :name, :workspace_id, :organization_id)"
+            ),
+            {
+                "id": project_id,
+                "name": "trigger-soft-delete-project",
+                "workspace_id": workspace_id,
+                "organization_id": organization_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO gateway_connections "
+                "(id, project_id, created_by_id, slug, provider_key, integration_key) "
+                "VALUES (:id, :project_id, :user_id, :slug, :provider_key, :integration_key)"
+            ),
+            {
+                "id": connection_id,
+                "project_id": project_id,
+                "user_id": user_id,
+                "slug": "trigger-soft-delete-connection",
+                "provider_key": "composio",
+                "integration_key": "github",
+            },
+        )
+        await session.commit()
+
+    yield {
+        "project_id": project_id,
+        "user_id": user_id,
+        "connection_id": connection_id,
+    }
+
+    async with engine.session() as session:
+        for table in (
+            "trigger_deliveries",
+            "session_streams",
+            "trigger_subscriptions",
+            "trigger_schedules",
+            "gateway_connections",
+        ):
+            await session.execute(
+                text(f"DELETE FROM {table} WHERE project_id = :project_id"),
+                {"project_id": project_id},
+            )
+        await session.execute(
+            text("DELETE FROM projects WHERE id = :id"), {"id": project_id}
+        )
+        await session.execute(
+            text("DELETE FROM workspaces WHERE id = :id"), {"id": workspace_id}
+        )
+        await session.execute(
+            text("DELETE FROM organizations WHERE id = :id"), {"id": organization_id}
+        )
+        await session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_id})
+        await session.commit()
+
+
+async def test_soft_delete_retains_schedule_and_delivery_until_explicit_purge(
+    trigger_scope,
+):
+    engine = get_transactions_engine()
+    dao = TriggersDAO(engine=engine)
+    project_id = trigger_scope["project_id"]
+    user_id = trigger_scope["user_id"]
+    schedule = await dao.create_schedule(
+        project_id=project_id,
+        user_id=user_id,
+        schedule=TriggerScheduleCreate(
+            name="Historical schedule",
+            data=TriggerScheduleData(event_key="cron.tick", schedule="* * * * *"),
+        ),
+    )
+    delivery = await dao.write_delivery(
+        project_id=project_id,
+        user_id=user_id,
+        delivery=TriggerDeliveryCreate(
+            status=Status(code="200", message="success"),
+            schedule_id=schedule.id,
+            event_id="historical-event",
+        ),
+    )
+
+    assert await dao.delete_schedule(
+        project_id=project_id,
+        user_id=user_id,
+        schedule_id=schedule.id,
+    )
+    assert (
+        await dao.fetch_schedule(project_id=project_id, schedule_id=schedule.id) is None
+    )
+    assert await dao.query_schedules(project_id=project_id) == []
+    historical = await dao.fetch_schedule_including_deleted(
+        project_id=project_id,
+        schedule_id=schedule.id,
+    )
+    assert historical is not None
+    assert historical.deleted_at is not None
+    assert historical.deleted_by_id == user_id
+    assert historical.updated_at is not None
+    assert historical.updated_by_id == user_id
+    assert (
+        await dao.fetch_schedule_including_deleted(
+            project_id=uuid.uuid4(),
+            schedule_id=schedule.id,
+        )
+        is None
+    )
+    assert (
+        await dao.fetch_delivery(project_id=project_id, delivery_id=delivery.id)
+        is not None
+    )
+
+    assert await dao.purge_schedule(project_id=project_id, schedule_id=schedule.id)
+    assert (
+        await dao.fetch_schedule_including_deleted(
+            project_id=project_id,
+            schedule_id=schedule.id,
+        )
+        is None
+    )
+    assert (
+        await dao.fetch_delivery(project_id=project_id, delivery_id=delivery.id) is None
+    )
+
+
+async def test_soft_delete_retains_subscription_and_delivery_until_explicit_purge(
+    trigger_scope,
+):
+    engine = get_transactions_engine()
+    dao = TriggersDAO(engine=engine)
+    project_id = trigger_scope["project_id"]
+    user_id = trigger_scope["user_id"]
+    subscription = await dao.create_subscription(
+        project_id=project_id,
+        user_id=user_id,
+        subscription=TriggerSubscriptionCreate(
+            connection_id=trigger_scope["connection_id"],
+            name="Historical subscription",
+            data=TriggerSubscriptionData(event_key="github.issue.opened"),
+        ),
+        trigger_id="ti_historical",
+    )
+    delivery = await dao.write_delivery(
+        project_id=project_id,
+        user_id=user_id,
+        delivery=TriggerDeliveryCreate(
+            status=Status(code="200", message="success"),
+            subscription_id=subscription.id,
+            event_id="historical-subscription-event",
+        ),
+    )
+    lifecycle_checked_delivery = await dao.write_subscription_delivery_if_live(
+        project_id=project_id,
+        user_id=user_id,
+        delivery=TriggerDeliveryCreate(
+            status=Status(code="409", message="failed"),
+            subscription_id=subscription.id,
+            event_id="live-lifecycle-checked-event",
+        ),
+    )
+    assert lifecycle_checked_delivery is not None
+
+    assert await dao.delete_subscription(
+        project_id=project_id,
+        user_id=user_id,
+        subscription_id=subscription.id,
+    )
+    assert (
+        await dao.fetch_subscription(
+            project_id=project_id,
+            subscription_id=subscription.id,
+        )
+        is None
+    )
+    assert await dao.query_subscriptions(project_id=project_id) == []
+    assert (
+        await dao.fetch_subscription_by_trigger_id(
+            project_id=project_id,
+            trigger_id="ti_historical",
+        )
+        is None
+    )
+    assert (
+        await dao.get_project_and_subscription_by_trigger_id(trigger_id="ti_historical")
+        is None
+    )
+    historical = await dao.fetch_subscription_including_deleted(
+        project_id=project_id,
+        subscription_id=subscription.id,
+    )
+    assert historical is not None
+    assert historical.deleted_at is not None
+    assert historical.deleted_by_id == user_id
+    assert (
+        await dao.fetch_subscription_including_deleted(
+            project_id=uuid.uuid4(),
+            subscription_id=subscription.id,
+        )
+        is None
+    )
+    assert (
+        await dao.fetch_delivery(
+            project_id=project_id,
+            delivery_id=delivery.id,
+        )
+        is not None
+    )
+    assert (
+        await dao.write_subscription_delivery_if_live(
+            project_id=project_id,
+            user_id=user_id,
+            delivery=TriggerDeliveryCreate(
+                status=Status(code="409", message="failed"),
+                subscription_id=subscription.id,
+                event_id="post-delete-lifecycle-checked-event",
+            ),
+        )
+        is None
+    )
+    blocked_delivery_id = uuid.uuid4()
+    assert (
+        await SessionStreamsDAO(engine=engine).claim_trigger_delivery(
+            project_id=project_id,
+            user_id=user_id,
+            event_id="blocked-subscription-event",
+            session_id=uuid.uuid4().hex,
+            attribution=SessionTriggerAttribution(
+                configuration_id=subscription.id,
+                kind=SessionTriggerKind.subscription,
+                delivery_id=blocked_delivery_id,
+            ),
+        )
+        is False
+    )
+    assert (
+        await dao.fetch_delivery(
+            project_id=project_id,
+            delivery_id=blocked_delivery_id,
+        )
+        is None
+    )
+
+    assert await dao.purge_subscription(
+        project_id=project_id,
+        subscription_id=subscription.id,
+    )
+    assert (
+        await dao.fetch_subscription_including_deleted(
+            project_id=project_id,
+            subscription_id=subscription.id,
+        )
+        is None
+    )
+    assert (
+        await dao.fetch_delivery(project_id=project_id, delivery_id=delivery.id) is None
+    )
+    assert (
+        await dao.fetch_delivery(
+            project_id=project_id,
+            delivery_id=lifecycle_checked_delivery.id,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("is_active", [False, True])
+async def test_atomic_claim_rejects_disabled_or_deleted_schedule(
+    trigger_scope, is_active
+):
+    engine = get_transactions_engine()
+    triggers_dao = TriggersDAO(engine=engine)
+    streams_dao = SessionStreamsDAO(engine=engine)
+    project_id = trigger_scope["project_id"]
+    user_id = trigger_scope["user_id"]
+    schedule = await triggers_dao.create_schedule(
+        project_id=project_id,
+        user_id=user_id,
+        schedule=TriggerScheduleCreate(
+            data=TriggerScheduleData(event_key="cron.tick", schedule="* * * * *"),
+        ),
+    )
+    if is_active:
+        await triggers_dao.delete_schedule(
+            project_id=project_id,
+            user_id=user_id,
+            schedule_id=schedule.id,
+        )
+    else:
+        async with engine.session() as session:
+            await session.execute(
+                text(
+                    "UPDATE trigger_schedules SET flags = CAST(:flags AS jsonb) "
+                    "WHERE project_id = :project_id AND id = :schedule_id"
+                ),
+                {
+                    "flags": '{"is_active": false}',
+                    "project_id": project_id,
+                    "schedule_id": schedule.id,
+                },
+            )
+            await session.commit()
+
+    delivery_id = uuid.uuid4()
+    claimed = await streams_dao.claim_trigger_delivery(
+        project_id=project_id,
+        user_id=user_id,
+        event_id="blocked-event",
+        session_id=uuid.uuid4().hex,
+        attribution=SessionTriggerAttribution(
+            configuration_id=schedule.id,
+            kind=SessionTriggerKind.schedule,
+            delivery_id=delivery_id,
+        ),
+    )
+
+    assert claimed is False
+    assert (
+        await triggers_dao.fetch_delivery(
+            project_id=project_id,
+            delivery_id=delivery_id,
+        )
+        is None
+    )

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_subscription_test_mode.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_subscription_test_mode.py
@@ -56,6 +56,7 @@ def _make_service():
     dao.create_subscription = AsyncMock(side_effect=_persist_create)
     dao.edit_subscription = AsyncMock(side_effect=lambda **kw: kw["subscription"])
     dao.delete_subscription = AsyncMock(return_value=True)
+    dao.purge_subscription = AsyncMock(return_value=True)
     dao.fetch_subscription = AsyncMock(
         return_value=TriggerSubscription(
             id=uuid4(),
@@ -218,7 +219,8 @@ async def test_test_subscription_returns_captured_delivery_and_tears_down():
     created = service.dao.create_subscription.await_args.kwargs["subscription"]
     assert created.flags.is_test is True
     # ...and always torn down.
-    service.dao.delete_subscription.assert_awaited_once()
+    service.dao.purge_subscription.assert_awaited_once()
+    service.dao.delete_subscription.assert_not_awaited()
 
 
 async def test_test_subscription_times_out_and_tears_down():
@@ -234,7 +236,8 @@ async def test_test_subscription_times_out_and_tears_down():
     )
 
     assert result is None
-    service.dao.delete_subscription.assert_awaited_once()
+    service.dao.purge_subscription.assert_awaited_once()
+    service.dao.delete_subscription.assert_not_awaited()
 
 
 async def test_test_subscription_tears_down_on_error():
@@ -248,7 +251,8 @@ async def test_test_subscription_tears_down_on_error():
             subscription=_create(is_test=True),
         )
 
-    service.dao.delete_subscription.assert_awaited_once()
+    service.dao.purge_subscription.assert_awaited_once()
+    service.dao.delete_subscription.assert_not_awaited()
 
 
 async def test_test_subscription_reuses_existing_live_subscription_on_conflict():
@@ -281,6 +285,7 @@ async def test_test_subscription_reuses_existing_live_subscription_on_conflict()
     assert result is new_delivery
     # The existing live subscription must NOT be torn down.
     service.dao.delete_subscription.assert_not_awaited()
+    service.dao.purge_subscription.assert_not_awaited()
     # Only the single failed mint attempt — no duplicate persisted.
     service.dao.create_subscription.assert_awaited_once()
     # Reuse resolved via the exact colliding trigger_id, not a connection+event query.

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_worker_lifecycle.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_worker_lifecycle.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from oss.src.core.triggers.dtos import (
+    TriggerSchedule,
+    TriggerScheduleData,
+    TriggerScheduleFlags,
+)
+from oss.src.tasks.taskiq.triggers.worker import TriggersWorker
+
+
+class _Broker:
+    def task(self, **_kwargs):
+        return lambda function: function
+
+
+def _schedule(*, is_active=True):
+    return TriggerSchedule(
+        id=uuid4(),
+        created_by_id=uuid4(),
+        data=TriggerScheduleData(event_key="cron.tick", schedule="* * * * *"),
+        flags=TriggerScheduleFlags(is_active=is_active),
+    )
+
+
+def _worker(*, resolved):
+    dispatcher = MagicMock()
+    dispatcher.dispatch_schedule = AsyncMock()
+    dispatcher.dispatch_subscription = AsyncMock()
+    dao = MagicMock()
+    dao.fetch_schedule = AsyncMock(return_value=resolved)
+    worker = TriggersWorker(
+        broker=_Broker(),
+        dispatcher=dispatcher,
+        triggers_dao=dao,
+    )
+    return worker, dao, dispatcher
+
+
+async def test_schedule_task_reresolves_new_id_payload_before_dispatch():
+    current = _schedule()
+    worker, dao, dispatcher = _worker(resolved=current)
+    project_id = uuid4()
+
+    await worker.dispatch_schedule(
+        project_id=str(project_id),
+        schedule_id=str(current.id),
+        event_id="event-1",
+        event={},
+    )
+
+    dao.fetch_schedule.assert_awaited_once_with(
+        project_id=project_id,
+        schedule_id=current.id,
+    )
+    assert dispatcher.dispatch_schedule.await_args.kwargs["schedule"] is current
+
+
+async def test_schedule_task_supports_v0112_serialized_payload_but_uses_live_row():
+    stale = _schedule()
+    current = stale.model_copy(
+        update={"data": TriggerScheduleData(event_key="current", schedule="0 * * * *")}
+    )
+    worker, _, dispatcher = _worker(resolved=current)
+
+    await worker.dispatch_schedule(
+        project_id=str(uuid4()),
+        schedule=stale.model_dump(mode="json"),
+        event_id="event-1",
+        event={},
+    )
+
+    assert dispatcher.dispatch_schedule.await_args.kwargs["schedule"] is current
+
+
+async def test_schedule_task_skips_deleted_or_missing_schedule():
+    stale = _schedule()
+    worker, _, dispatcher = _worker(resolved=None)
+
+    await worker.dispatch_schedule(
+        project_id=str(uuid4()),
+        schedule=stale.model_dump(mode="json"),
+        event_id="event-1",
+        event={},
+    )
+
+    dispatcher.dispatch_schedule.assert_not_awaited()
+
+
+async def test_schedule_task_skips_schedule_disabled_after_enqueue():
+    disabled = _schedule(is_active=False)
+    worker, _, dispatcher = _worker(resolved=disabled)
+
+    await worker.dispatch_schedule(
+        project_id=str(uuid4()),
+        schedule_id=str(disabled.id),
+        event_id="event-1",
+        event={},
+    )
+
+    dispatcher.dispatch_schedule.assert_not_awaited()
+
+
+async def test_subscription_task_skips_deleted_subscription_lookup():
+    worker, dao, dispatcher = _worker(resolved=None)
+    dao.get_project_and_subscription_by_trigger_id = AsyncMock(return_value=None)
+
+    await worker.dispatch_trigger(
+        trigger_id="ti_deleted",
+        event_id="event-1",
+        event={},
+        context=SimpleNamespace(message=SimpleNamespace(labels={})),
+    )
+
+    dispatcher.dispatch_subscription.assert_not_awaited()

--- a/api/oss/tests/pytest/unit/workflows/test_invoke_detached.py
+++ b/api/oss/tests/pytest/unit/workflows/test_invoke_detached.py
@@ -211,6 +211,7 @@ def test_dispatch_fn_injected_into_both_consumers():
     )
     dispatcher = TriggersDispatcher(
         triggers_dao=SimpleNamespace(),
+        session_claims_dao=SimpleNamespace(),
         workflows_service=SimpleNamespace(),
         dispatch_fn=_dispatch,
     )


### PR DESCRIPTION
## Context
Automation-created sessions needed a reliable link to the configuration and exact delivery that started them. The previous path wrote attribution separately and exposed private `ag.*` tag keys, so failures, concurrent updates, or deletion could leave incomplete history.

## Changes
The dispatcher now claims a delivery and creates or merges its attributed session in one Postgres transaction before invoking the workflow. The session query accepts nested typed predicates, returns typed trigger and delivery relationships plus terminal windowing, and runs message or trigger enrichment only when requested. Normal schedule and subscription deletion is now soft deletion, while public session responses strip reserved attribution tags.

Before, a caller had to interpret `tags["ag.trigger.id"]`. After, it receives `trigger: {id, kind, name}` and `delivery: {id}`.

## Tests / notes
- 565 non-integration session and trigger tests passed after the final release pull.
- Real-Postgres claim, rollback, merge, cursor, origin, trigger-join, soft-delete, and retained-history tests passed.
- Schedule acceptance and authenticated session-query and exact-delivery wire checks passed.
- No migration, backfill, or index is included.

Stack: 1 of 4. Base: `release/v0.112.0`.