### PR TITLE
[fix] Subscription with unresolvable workflow reference returns 422, not 500

### DIFF
--- a/api/ee/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
+++ b/api/ee/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
@@ -229,9 +229,10 @@ class TestTriggerSubscriptionsLifecycle:
 
     def test_create_list_disable_delete_keeps_connection(self, triggers_api):
         connection_id = self._create_connection(triggers_api)
-        workflow_slug = _create_workflow(triggers_api)
 
         try:
+            workflow_slug = _create_workflow(triggers_api)
+
             create = triggers_api(
                 "POST",
                 "/triggers/subscriptions/",

--- a/api/ee/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
+++ b/api/ee/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
@@ -94,6 +94,46 @@ def _delete_account_by_email(admin_api, *, email):
     assert resp.status_code == 204, resp.text
 
 
+def _create_workflow(triggers_api):
+    """Build a workflow + variant + committed revision; return its slug."""
+    slug = f"sub-wf-{uuid4().hex[:8]}"
+
+    wf = triggers_api(
+        "POST", "/workflows/", json={"workflow": {"slug": slug, "name": slug}}
+    )
+    assert wf.status_code == 200, wf.text
+    workflow_id = wf.json()["workflow"]["id"]
+
+    variant = triggers_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"{slug}-v",
+                "name": "Default",
+                "workflow_id": workflow_id,
+            }
+        },
+    )
+    assert variant.status_code == 200, variant.text
+    variant_id = variant.json()["workflow_variant"]["id"]
+
+    commit = triggers_api(
+        "POST",
+        "/workflows/revisions/commit",
+        json={
+            "workflow_revision": {
+                "slug": f"{slug}-v1",
+                "workflow_id": workflow_id,
+                "workflow_variant_id": variant_id,
+                "message": "initial",
+            }
+        },
+    )
+    assert commit.status_code == 200, commit.text
+    return slug
+
+
 @pytest.fixture(scope="class")
 def triggers_api(admin_api, ag_env):
     account = _create_developer_business_account(admin_api)
@@ -189,6 +229,7 @@ class TestTriggerSubscriptionsLifecycle:
 
     def test_create_list_disable_delete_keeps_connection(self, triggers_api):
         connection_id = self._create_connection(triggers_api)
+        workflow_slug = _create_workflow(triggers_api)
 
         try:
             create = triggers_api(
@@ -202,7 +243,7 @@ class TestTriggerSubscriptionsLifecycle:
                             "event_key": "GITHUB_STAR_ADDED_EVENT",
                             "trigger_config": {"owner": "acme", "repo": "widgets"},
                             "inputs_fields": {"repo": "$.event.attributes.repository"},
-                            "references": {"workflow": {"slug": "triage"}},
+                            "references": {"workflow": {"slug": workflow_slug}},
                         },
                     }
                 },

--- a/api/oss/src/apis/fastapi/triggers/router.py
+++ b/api/oss/src/apis/fastapi/triggers/router.py
@@ -1011,6 +1011,8 @@ class TriggersRouter:
             )
         except ConnectionNotFoundError as e:
             raise HTTPException(status_code=404, detail=e.message) from e
+        except TriggerReferenceInvalid as e:
+            raise HTTPException(status_code=422, detail=e.message) from e
 
         return TriggerSubscriptionResponse(
             count=1 if subscription else 0,
@@ -1122,12 +1124,15 @@ class TriggersRouter:
                 detail="Path subscription_id does not match body id",
             )
 
-        subscription = await self.triggers_service.edit_subscription(
-            project_id=UUID(request.state.project_id),
-            user_id=UUID(str(request.state.user_id)),
-            #
-            subscription=body.subscription,
-        )
+        try:
+            subscription = await self.triggers_service.edit_subscription(
+                project_id=UUID(request.state.project_id),
+                user_id=UUID(str(request.state.user_id)),
+                #
+                subscription=body.subscription,
+            )
+        except TriggerReferenceInvalid as e:
+            raise HTTPException(status_code=422, detail=e.message) from e
         if not subscription:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py
@@ -68,6 +68,46 @@ _requires_connected_account = pytest.mark.skipif(
 )
 
 
+def _create_workflow(authed_api):
+    """Build a workflow + variant + committed revision; return its slug."""
+    slug = f"ing-wf-{uuid4().hex[:8]}"
+
+    wf = authed_api(
+        "POST", "/workflows/", json={"workflow": {"slug": slug, "name": slug}}
+    )
+    assert wf.status_code == 200, wf.text
+    workflow_id = wf.json()["workflow"]["id"]
+
+    variant = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"{slug}-v",
+                "name": "Default",
+                "workflow_id": workflow_id,
+            }
+        },
+    )
+    assert variant.status_code == 200, variant.text
+    variant_id = variant.json()["workflow_variant"]["id"]
+
+    commit = authed_api(
+        "POST",
+        "/workflows/revisions/commit",
+        json={
+            "workflow_revision": {
+                "slug": f"{slug}-v1",
+                "workflow_id": workflow_id,
+                "workflow_variant_id": variant_id,
+                "message": "initial",
+            }
+        },
+    )
+    assert commit.status_code == 200, commit.text
+    return slug
+
+
 # ---------------------------------------------------------------------------
 # Signature verification is unconditional — unsigned/forged events are rejected.
 # Needs a resolvable webhook secret, which requires Composio enabled.
@@ -202,67 +242,73 @@ class TestTriggerIngressDedup:
         )
         assert conn.status_code == 200, conn.text
         connection_id = conn.json()["connection"]["id"]
+        workflow_slug = _create_workflow(authed_api)
 
-        create = authed_api(
-            "POST",
-            "/triggers/subscriptions/",
-            json={
-                "subscription": {
-                    "name": f"sub-{uuid4().hex[:8]}",
-                    "connection_id": connection_id,
-                    "data": {
-                        "event_key": "GITHUB_STAR_ADDED_EVENT",
-                        "trigger_config": {"owner": "acme", "repo": "widgets"},
-                        "inputs_fields": {"repo": "$.event.attributes.repository"},
-                        "references": {"workflow": {"slug": "triage"}},
-                    },
-                }
-            },
-        )
-        assert create.status_code == 200, create.text
-        sub = create.json()["subscription"]
-        subscription_id = sub["id"]
-        trigger_id = sub["trigger_id"]
-
-        event_id = uuid4().hex
-        envelope = {
-            "type": "github_star_added_event",
-            "metadata": {"trigger_id": trigger_id, "id": event_id},
-            "payload": {"repository": "acme/widgets"},
-        }
-        body = json.dumps(envelope).encode()
-        secret = _resolve_webhook_secret()
-        if not secret:
-            pytest.skip("no Composio webhook secret resolvable; signing would 401")
-
-        # Post the same logical event twice (provider redelivery) as two DISTINCT
-        # provider-level deliveries (own webhook-id/timestamp each) — the
-        # replay guard dedups webhook-id, not metadata.id, so this exercises the
-        # delivery-row dedup layer beneath it.
-        for _ in range(2):
-            webhook_id = f"msg_{uuid4().hex}"
-            timestamp = str(int(time.time()))
-            headers = {
-                "Content-Type": "application/json",
-                "webhook-id": webhook_id,
-                "webhook-timestamp": timestamp,
-                "webhook-signature": _sign(secret, webhook_id, timestamp, body),
-            }
-            ack = unauthed_api(
-                "POST", "/triggers/composio/events/", data=body, headers=headers
+        try:
+            create = authed_api(
+                "POST",
+                "/triggers/subscriptions/",
+                json={
+                    "subscription": {
+                        "name": f"sub-{uuid4().hex[:8]}",
+                        "connection_id": connection_id,
+                        "data": {
+                            "event_key": "GITHUB_STAR_ADDED_EVENT",
+                            "trigger_config": {"owner": "acme", "repo": "widgets"},
+                            "inputs_fields": {"repo": "$.event.attributes.repository"},
+                            "references": {"workflow": {"slug": workflow_slug}},
+                        },
+                    }
+                },
             )
-            assert ack.status_code == 202, ack.text
+            assert create.status_code == 200, create.text
+            sub = create.json()["subscription"]
+            subscription_id = sub["id"]
+            trigger_id = sub["trigger_id"]
 
-        # The dispatch is async; the dedup guard means at most one delivery row
-        # exists for this (subscription, event_id).
-        deliveries = authed_api(
-            "POST",
-            "/triggers/deliveries/query",
-            json={
-                "delivery": {"subscription_id": subscription_id, "event_id": event_id}
-            },
-        ).json()["deliveries"]
-        assert len(deliveries) <= 1
+            event_id = uuid4().hex
+            envelope = {
+                "type": "github_star_added_event",
+                "metadata": {"trigger_id": trigger_id, "id": event_id},
+                "payload": {"repository": "acme/widgets"},
+            }
+            body = json.dumps(envelope).encode()
+            secret = _resolve_webhook_secret()
+            if not secret:
+                pytest.skip("no Composio webhook secret resolvable; signing would 401")
 
-        authed_api("DELETE", f"/triggers/subscriptions/{subscription_id}")
-        authed_api("DELETE", f"/tools/connections/{connection_id}")
+            # Post the same logical event twice (provider redelivery) as two DISTINCT
+            # provider-level deliveries (own webhook-id/timestamp each) — the
+            # replay guard dedups webhook-id, not metadata.id, so this exercises the
+            # delivery-row dedup layer beneath it.
+            for _ in range(2):
+                webhook_id = f"msg_{uuid4().hex}"
+                timestamp = str(int(time.time()))
+                headers = {
+                    "Content-Type": "application/json",
+                    "webhook-id": webhook_id,
+                    "webhook-timestamp": timestamp,
+                    "webhook-signature": _sign(secret, webhook_id, timestamp, body),
+                }
+                ack = unauthed_api(
+                    "POST", "/triggers/composio/events/", data=body, headers=headers
+                )
+                assert ack.status_code == 202, ack.text
+
+            # The dispatch is async; the dedup guard means at most one delivery row
+            # exists for this (subscription, event_id).
+            deliveries = authed_api(
+                "POST",
+                "/triggers/deliveries/query",
+                json={
+                    "delivery": {
+                        "subscription_id": subscription_id,
+                        "event_id": event_id,
+                    }
+                },
+            ).json()["deliveries"]
+            assert len(deliveries) <= 1
+
+            authed_api("DELETE", f"/triggers/subscriptions/{subscription_id}")
+        finally:
+            authed_api("DELETE", f"/tools/connections/{connection_id}")

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py
@@ -226,6 +226,10 @@ class TestTriggerIngressReplayAndFreshness:
 @_requires_connected_account
 class TestTriggerIngressDedup:
     def test_duplicate_event_id_writes_single_delivery(self, authed_api, unauthed_api):
+        secret = _resolve_webhook_secret()
+        if not secret:
+            pytest.skip("no Composio webhook secret resolvable; signing would 401")
+
         # Create a connection + subscription so an inbound ti_* resolves locally.
         slug = f"acc-{uuid4().hex[:8]}"
         conn = authed_api(
@@ -242,9 +246,10 @@ class TestTriggerIngressDedup:
         )
         assert conn.status_code == 200, conn.text
         connection_id = conn.json()["connection"]["id"]
-        workflow_slug = _create_workflow(authed_api)
 
         try:
+            workflow_slug = _create_workflow(authed_api)
+
             create = authed_api(
                 "POST",
                 "/triggers/subscriptions/",
@@ -273,9 +278,6 @@ class TestTriggerIngressDedup:
                 "payload": {"repository": "acme/widgets"},
             }
             body = json.dumps(envelope).encode()
-            secret = _resolve_webhook_secret()
-            if not secret:
-                pytest.skip("no Composio webhook secret resolvable; signing would 401")
 
             # Post the same logical event twice (provider redelivery) as two DISTINCT
             # provider-level deliveries (own webhook-id/timestamp each) — the
@@ -295,19 +297,25 @@ class TestTriggerIngressDedup:
                 )
                 assert ack.status_code == 202, ack.text
 
-            # The dispatch is async; the dedup guard means at most one delivery row
-            # exists for this (subscription, event_id).
-            deliveries = authed_api(
-                "POST",
-                "/triggers/deliveries/query",
-                json={
-                    "delivery": {
-                        "subscription_id": subscription_id,
-                        "event_id": event_id,
-                    }
-                },
-            ).json()["deliveries"]
-            assert len(deliveries) <= 1
+            # The dispatch is async; poll until the delivery lands, then assert the
+            # dedup guard collapsed both provider-level deliveries into exactly one.
+            deliveries = []
+            deadline = time.time() + 10
+            while time.time() < deadline:
+                deliveries = authed_api(
+                    "POST",
+                    "/triggers/deliveries/query",
+                    json={
+                        "delivery": {
+                            "subscription_id": subscription_id,
+                            "event_id": event_id,
+                        }
+                    },
+                ).json()["deliveries"]
+                if deliveries:
+                    break
+                time.sleep(0.5)
+            assert len(deliveries) == 1
 
             authed_api("DELETE", f"/triggers/subscriptions/{subscription_id}")
         finally:

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
@@ -33,6 +33,46 @@ _requires_connected_account = pytest.mark.skipif(
 )
 
 
+def _create_workflow(authed_api):
+    """Build a workflow + variant + committed revision; return its slug."""
+    slug = f"sub-wf-{uuid4().hex[:8]}"
+
+    wf = authed_api(
+        "POST", "/workflows/", json={"workflow": {"slug": slug, "name": slug}}
+    )
+    assert wf.status_code == 200, wf.text
+    workflow_id = wf.json()["workflow"]["id"]
+
+    variant = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"{slug}-v",
+                "name": "Default",
+                "workflow_id": workflow_id,
+            }
+        },
+    )
+    assert variant.status_code == 200, variant.text
+    variant_id = variant.json()["workflow_variant"]["id"]
+
+    commit = authed_api(
+        "POST",
+        "/workflows/revisions/commit",
+        json={
+            "workflow_revision": {
+                "slug": f"{slug}-v1",
+                "workflow_id": workflow_id,
+                "workflow_variant_id": variant_id,
+                "message": "initial",
+            }
+        },
+    )
+    assert commit.status_code == 200, commit.text
+    return slug
+
+
 # ---------------------------------------------------------------------------
 # DB-only: reads, queries, 404s (no Composio needed)
 # ---------------------------------------------------------------------------

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py
@@ -156,6 +156,7 @@ class TestTriggerSubscriptionsLifecycle:
 
     def test_create_list_disable_delete_keeps_connection(self, authed_api):
         connection_id = self._create_connection(authed_api)
+        workflow_slug = _create_workflow(authed_api)
 
         # CREATE — binds the event to a workflow reference on the shared connection
         create = authed_api(
@@ -169,7 +170,7 @@ class TestTriggerSubscriptionsLifecycle:
                         "event_key": "GITHUB_STAR_ADDED_EVENT",
                         "trigger_config": {"owner": "acme", "repo": "widgets"},
                         "inputs_fields": {"repo": "$.event.attributes.repository"},
-                        "references": {"workflow": {"slug": "triage"}},
+                        "references": {"workflow": {"slug": workflow_slug}},
                     },
                 }
             },


### PR DESCRIPTION
## Context

Creating or editing a trigger subscription with a workflow reference that
can't resolve to a runnable revision returned a 500 "contact support"
instead of a usable error. The schedules routes already handled this: they
catch `TriggerReferenceInvalid` and return a 422 with an actionable
message. The subscription routes never caught it, so the same domain
exception raised in `core/triggers/service.py` escaped `@intercept_exceptions()`
as an opaque 500.

Before:
```
POST /triggers/subscriptions/  (bad workflow reference)
500 {"detail":{"message":"An unexpected error occurred. Please try again
     later or contact support.","operation_id":"create_subscription"}}
```

After:
```
POST /triggers/subscriptions/  (bad workflow reference)
422 {"detail":"Bound workflow reference could not be resolved to a
     runnable revision."}
```

## Changes

- `create_subscription` and `edit_subscription` in
  `api/oss/src/apis/fastapi/triggers/router.py` now catch
  `TriggerReferenceInvalid` and map it to a 422, matching the pattern
  already used by `create_schedule`/`edit_schedule`.
- The acceptance tests for subscriptions (OSS and EE) posted
  `references: {workflow: {slug: "triage"}}` without ever creating a
  workflow named `triage`. That made every gated lifecycle test 500 (now
  422) before it reached the create/list/disable/delete flow it's
  supposed to exercise. Ported the `_create_workflow` helper from
  `test_triggers_schedules.py` into both files and bind the subscription
  to a real, committed workflow revision.
- Added `try/finally` connection cleanup to the OSS ingress dedup test
  (`test_triggers_ingress.py`), mirroring the EE subscriptions test, so a
  failed assertion doesn't orphan a Composio connection.

The equivalent cleanup for the OSS subscriptions lifecycle test could not
be added in this PR; see "Known gap" below.

## Tests / notes

- `ruff format` + `ruff check` clean across `api/`.
- Ran the ungated suite against the live dev deployment (`release/v0.112.0`
  lineage): `oss/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py`,
  `oss/tests/pytest/acceptance/triggers/test_triggers_ingress.py`,
  `ee/tests/pytest/acceptance/triggers/test_triggers_subscriptions.py`.
  21 passed, 3 skipped (the gated lifecycle tests, no
  `COMPOSIO_TEST_CONNECTED_ACCOUNT`).
- Probed the fix directly: posted a subscription with an unresolvable
  workflow reference against the live API and confirmed 422 with the
  message above (previously 500).
- With `COMPOSIO_TEST_CONNECTED_ACCOUNT=1`, the three gated lifecycle
  tests now fail at a 424 from Composio ("Connected account is not in an
  ACTIVE state") instead of the 500. That's expected and is the
  remaining blocker described below, not a regression from this change:
  the workflow-reference fix gets them past the point this PR is about
  and into the next, unrelated gap.

## Known gap: OSS subscriptions lifecycle test still lacks try/finally cleanup

The OSS lifecycle test (`test_triggers_subscriptions.py::TestTriggerSubscriptionsLifecycle::test_create_list_disable_delete_keeps_connection`)
still leaves its connection uncleaned on assertion failure, unlike the EE
version. Wrapping its body in `try/finally` re-indents nearly every line
in it, and those lines are currently owned by an unrelated, already
in-flight branch in the same GitButler workspace (`api/session-ux-contract`,
part of a separate session-automation-attribution stack) that added the
soft-delete assertions this test body now contains. Landing the
`try/finally` here would have forced this PR to stack on and depend on
that unrelated branch. I left the workflow-binding fix (the actual point
of the test) in and dropped only the cleanup wrapper, to keep this PR
independent and mergeable against `release/v0.112.0` on its own. Once the
session-ux-contract stack lands, re-adding the `try/finally` here should
apply cleanly.

## Remaining blocker (out of scope, do not fix here)

Even with both fixes, the gated lifecycle tests (OSS subscriptions, EE
subscriptions, OSS ingress dedup) fail at a 424: `POST /tools/connections/`
always mints a fresh `INITIALIZING` Composio connected account, and there
is no adoption path for a pre-authorized `ACTIVE` one. That's a design gap
in the connection-creation flow, not something this PR's scope covers.
