### PR TITLE
[fix] One malformed schedule row no longer halts schedule dispatch

### DIFF
--- a/api/oss/src/dbs/postgres/triggers/dao.py
+++ b/api/oss/src/dbs/postgres/triggers/dao.py
@@ -24,6 +24,7 @@ from oss.src.core.triggers.dtos import (
     TriggerSubscriptionQuery,
 )
 from oss.src.core.triggers.interfaces import TriggersDAOInterface
+from oss.src.utils.logging import get_module_logger
 
 from oss.src.dbs.postgres.shared.engine import (
     TransactionsEngine,
@@ -45,6 +46,8 @@ from oss.src.dbs.postgres.triggers.mappings import (
     map_subscription_dto_to_dbe_create,
     map_subscription_dto_to_dbe_edit,
 )
+
+log = get_module_logger(__name__)
 
 
 class TriggersDAO(TriggersDAOInterface):
@@ -818,7 +821,22 @@ class TriggersDAO(TriggersDAOInterface):
 
             result = await session.execute(stmt)
 
-            return [
-                (dbe.project_id, map_schedule_dbe_to_dto(schedule_dbe=dbe))
-                for dbe in result.scalars().all()
-            ]
+            schedules: List[Tuple[UUID, TriggerSchedule]] = []
+            for dbe in result.scalars().all():
+                try:
+                    schedules.append(
+                        (dbe.project_id, map_schedule_dbe_to_dto(schedule_dbe=dbe))
+                    )
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    # One malformed row must not drop every project's active
+                    # schedules for the tick; skip it and keep the rest.
+                    # Pydantic's ValidationError.__str__ embeds the offending
+                    # input_value, so log the exception type only, never {e}.
+                    log.error(
+                        "[SCHEDULE] Skipping malformed schedule row",
+                        schedule_id=str(dbe.id),
+                        project_id=str(dbe.project_id),
+                        error_type=type(e).__name__,
+                    )
+
+            return schedules

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_dao_fetch_active_schedules.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_dao_fetch_active_schedules.py
@@ -1,0 +1,104 @@
+"""Pins per-row error isolation in ``fetch_active_schedules_with_project``.
+
+Regression coverage for a real incident: a schedule row with malformed
+``data`` (missing the required ``event_key``/``schedule`` fields) raised a
+pydantic ``ValidationError`` inside the DAO's row-mapping list comprehension,
+which aborted the whole fetch and made the ``refresh_schedules`` cron skip
+every project's schedules for that tick, every minute, until the row was
+fixed. Stubs the engine/session; no DB.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from oss.src.dbs.postgres.triggers import dao as dao_module
+from oss.src.dbs.postgres.triggers.dao import TriggersDAO
+from oss.src.dbs.postgres.triggers.dbes import TriggerScheduleDBE
+
+
+class _Result:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.rows
+
+
+class _Session:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def execute(self, statement):
+        return _Result(self.rows)
+
+
+class _Engine:
+    def __init__(self, rows):
+        self.db_session = _Session(rows)
+
+    @asynccontextmanager
+    async def session(self):
+        yield self.db_session
+
+
+def _schedule_dbe(*, project_id, data):
+    return TriggerScheduleDBE(
+        id=uuid4(),
+        project_id=project_id,
+        data=data,
+        flags={"is_active": True},
+    )
+
+
+async def test_fetch_active_schedules_skips_malformed_row_instead_of_raising():
+    good_project = uuid4()
+    bad_project = uuid4()
+    good = _schedule_dbe(
+        project_id=good_project,
+        data={"event_key": "cron.tick", "schedule": "* * * * *"},
+    )
+    # Missing the required event_key/schedule fields, as seeded/legacy rows can be.
+    bad = _schedule_dbe(project_id=bad_project, data={"cron": "0 6 * * *"})
+    engine = _Engine([bad, good])
+
+    result = await TriggersDAO(engine=engine).fetch_active_schedules_with_project()
+
+    assert [project_id for project_id, _ in result] == [good_project]
+    assert result[0][1].id == good.id
+
+
+async def test_fetch_active_schedules_returns_all_rows_when_none_are_malformed():
+    project_id = uuid4()
+    good = _schedule_dbe(
+        project_id=project_id,
+        data={"event_key": "cron.tick", "schedule": "* * * * *"},
+    )
+    engine = _Engine([good])
+
+    result = await TriggersDAO(engine=engine).fetch_active_schedules_with_project()
+
+    assert [project_id for project_id, _ in result] == [project_id]
+
+
+async def test_malformed_row_log_never_includes_the_payload(monkeypatch):
+    # Pydantic's ValidationError.__str__ embeds the offending input_value, so
+    # the log call must never interpolate the exception itself into the
+    # message; only schedule_id/project_id/error_type are safe to log.
+    secret_marker = "USER_SECRET_ap9x2q"
+    bad = _schedule_dbe(project_id=uuid4(), data={"cron": secret_marker})
+    engine = _Engine([bad])
+
+    mock_error = MagicMock()
+    monkeypatch.setattr(dao_module.log, "error", mock_error)
+
+    await TriggersDAO(engine=engine).fetch_active_schedules_with_project()
+
+    mock_error.assert_called_once()
+    call_text = " ".join(str(a) for a in mock_error.call_args.args) + " ".join(
+        f"{k}={v}" for k, v in mock_error.call_args.kwargs.items()
+    )
+    assert secret_marker not in call_text


### PR DESCRIPTION
## Context

On a shared development deployment, one schedule row with malformed `data`
(missing the required `event_key`/`schedule` fields — an old shape with
`{"cron": "..."}` instead) made the `refresh_schedules` background cron
silently stop dispatching **every** active schedule in **every** project,
every minute, for as long as the row existed. This does not crash the API
process; it fails the fetch, logs an error, and returns quietly. That makes
it worse in one way, not better: nothing pages, nothing 500s, no container
restarts. Automations across the whole platform just stop firing, with no
user-visible signal, until someone happens to notice and finds the bad row.

I verified this directly on the dev deployment with the fix genuinely
inactive (temporarily reverted the file, restarted the API container, and
confirmed via a log-string check that the running process had the reverted
code before trusting any observation — a stale hot-reloader had fooled an
earlier run today). With one malformed row present and a second, healthy,
every-minute schedule running in an unrelated project:

**Before**, every tick for 2+ minutes:
```
2026-08-11T10:02:00.146Z [SCHEDULE] Refreshing schedules at 2026-08-11 10:01:00+00:00 every 1 minute(s)
2026-08-11T10:02:00.151Z [ERROR] [SCHEDULE] Error fetching active schedules: 2 validation errors for TriggerScheduleData
schedule
  File ".../core/triggers/service.py", line 1554, in refresh_schedules
    schedules = await self.dao.fetch_active_schedules_with_project()
  File ".../dbs/postgres/triggers/dao.py", line 925, in fetch_active_schedules_with_project
    (dbe.project_id, map_schedule_dbe_to_dto(schedule_dbe=dbe))
  File ".../dbs/postgres/triggers/mappings.py", line 156, in map_schedule_dbe_to_dto
    data=TriggerScheduleData.model_validate(schedule_dbe.data),
pydantic_core._pydantic_core.ValidationError: 2 validation errors for TriggerScheduleData
```
No `Dispatching...`/`Dispatched.` lines at all during this window, for the
healthy schedule or anything else. A direct API query for that schedule's
deliveries confirmed it: `count: 0`. Container uptime was unaffected
(`StartedAt` unchanged across both ticks) — the process stayed up the
whole time, just silently doing nothing.

This matches (and explains) an incident from earlier today, cited in the
original version of this PR, where the same traceback appeared in the logs
for five consecutive ticks. That incident did **not** crash the API either
— the container restart that coincided with it in the timeline turned out
to be an unrelated, deliberate restart from other work on the same shared
box, not caused by this bug. Correcting that here since it changes the
claim this PR makes.

## Changes

`fetch_active_schedules_with_project` in
`api/oss/src/dbs/postgres/triggers/dao.py` mapped every active schedule row
to a DTO in one list comprehension; one row failing `pydantic.model_validate`
raised out of the whole comprehension and aborted the entire fetch. It now
maps each row inside its own `try/except`: a row that fails to parse is
logged (schedule id + project id, no data dump, to avoid leaking user
content into logs) and skipped, while every other row still makes it into
the result.

**After**, same setup, with the fix loaded:
```
2026-08-11T10:05:00.079Z [ERROR] [SCHEDULE] Skipping malformed schedule row: 2 validation errors for TriggerScheduleData
2026-08-11T10:05:00.083Z [SCHEDULE] Dispatching...  project_id=... schedule_id=<healthy>
2026-08-11T10:05:00.085Z [SCHEDULE] Dispatched.     project_id=... schedule_id=<healthy>
```
The healthy schedule dispatched on both subsequent ticks; the API query for
its deliveries went from `count: 0` to `count: 2`. Container `StartedAt`
was unchanged throughout.

## Tests / notes

- Added `api/oss/tests/pytest/unit/triggers/test_triggers_dao_fetch_active_schedules.py`,
  a focused unit test (stubbed DB session, no real Postgres) pinning that a
  malformed row is skipped rather than raised, and that a clean batch is
  returned unaffected. `oss/tests/pytest/unit/triggers/` as a whole: 140
  passed, 4 skipped (pre-existing, need a real Postgres connection).
- `ruff format` + `ruff check` clean across `api/`.
- Reproduced both the before and after states live on a shared development
  deployment as described above, using two throwaway accounts/projects
  (one hosting the malformed row, one hosting a healthy control schedule).
  Deleted the malformed row, the healthy schedule, and both throwaway
  accounts afterward; verified zero residue.

Caught `Exception` rather than the narrower `pydantic.ValidationError`:
the per-row block's only job is turning one DB row into one DTO, and any
failure there (a bad JSON shape, a flags dict that doesn't match
`TriggerScheduleFlags`, a future migration leaving old rows un-backfilled)
is equally "this row didn't parse, skip it," not a bug elsewhere in the
function. This matches the existing broad-except convention already used a
few lines away in `refresh_schedules` for the same reason.