### PR TITLE
fix(frontend/sdk): show every tool call the same way, live and after reload

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -52,6 +52,18 @@ regexes = [
   # Dummy SeaweedFS STS signing key shown (commented) as a format hint in the dev
   # env examples. Decodes to "this-is-a-signing-key-for-mounts" — not a real secret.
   '''dGhpcy1pcy1hLXNpZ25pbmcta2V5LWZvci1tb3VudHM=''',
+  # ------------------------------------------- INTERACTION-ROW JOIN KEYS (uuids)
+  # The replayed-transcript fixtures under AgentChatSlice carry a recorded session's
+  # interaction rows, whose `token` is the uuid joining a row to its tool call — a
+  # durable interaction id, not a credential. generic-api-key reads each one as a
+  # secret. Exempts the VALUE only, never a path: a `paths` entry makes gitleaks skip
+  # the whole file before scanning it, so a real key added to a fixture would go
+  # unseen. Anchored, so only an exact lowercase uuid is exempt.
+  # Scoping this further to a `"token": "<uuid>"` LINE needs a second `[[allowlists]]`
+  # block with regexTarget = "line"; gitleaks 8.24.3 (pinned by 17-secret-scan.yml)
+  # silently ignores the plural form and drops every allowlist above with it. Tighten
+  # this when that pin moves past 8.26.
+  '''^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$''',
   # ----------------------------------------------------------------------------
 ]
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -517,9 +517,10 @@ class SessionsRecordsConfig(BaseModel):
 
     # When a record body exceeds the cap, preserve its structure + partial content (trim only
     # the large field values) instead of replacing the whole body with {"_truncated": True}.
-    # Off = legacy whole-body drop. On makes reconstruction from records higher-fidelity.
+    # Off = legacy whole-body drop, which loses the record's type and id and leaves the
+    # replayed tool card unable to settle. Default ON since 2026-08-11.
     smart_truncation: bool = (
-        os.getenv("AGENTA_RECORDS_SMART_TRUNCATION") or "false"
+        os.getenv("AGENTA_RECORDS_SMART_TRUNCATION") or "true"
     ).lower() in _TRUTHY
 
     model_config = ConfigDict(extra="ignore")

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -69,6 +69,54 @@ _REQUIRES_TOOL_CALL_ID = {
 _REQUIRES_TOOL_NAME = {"tool-input-start", "tool-input-available"}
 
 
+# Envelope keys an MCP-style tool call wraps its real arguments in.
+_TOOL_ARGUMENT_ENVELOPE_KEYS = frozenset(
+    {"tool", "server", "name", "toolName", "serverName", "tool_name", "server_name"}
+)
+
+
+def _unwrap_tool_arguments(value: Any) -> Any:
+    """Unwrap a ``{tool, server, arguments}`` MCP transport envelope to the bare arguments.
+
+    A card body reads its fields at the top level (``input.workflow_revision``), so a call that
+    streams as the envelope drops to the raw-JSON fallback the same call renders a card for. Unwrap
+    only when every sibling of ``arguments`` is a string-valued envelope key, so a tool whose real
+    input carries its own ``arguments`` field passes through untouched. Deliberately the same
+    conservative rule as ``unwrapToolArguments`` in the replay builder (transcriptToMessages.ts) —
+    live and replay must agree on the shape.
+    """
+    if not isinstance(value, dict):
+        return value
+    args = value.get("arguments")
+    if not isinstance(args, dict):
+        return value
+    siblings = [key for key in value if key != "arguments"]
+    if not siblings:
+        return value
+    if all(
+        key in _TOOL_ARGUMENT_ENVELOPE_KEYS and isinstance(value[key], str)
+        for key in siblings
+    ):
+        return args
+    return value
+
+
+def _tool_call_input(source: Dict[str, Any]) -> Any:
+    """The real args to show for a tool call.
+
+    Prefer ``rawInput`` (the tool's real args, per ACP); the runner leaves the plain ``input`` empty
+    on some tool-call paths. ``is not None`` (not truthiness): a legit empty ``{}`` is real args, not
+    absent. Then strip the MCP envelope so every path — gated, ungated, and the ungated re-emit that
+    lands after a gate — shows the same bare arguments.
+    """
+    raw = (
+        source["rawInput"]
+        if source.get("rawInput") is not None
+        else source.get("input")
+    )
+    return _unwrap_tool_arguments(raw)
+
+
 def _conform(part: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Normalize a part at the yield boundary so it never violates the AI SDK's strict
     ``uiMessageChunkSchema``. Returns ``None`` when the part is unsalvageable and must be
@@ -215,15 +263,7 @@ async def _agent_run_to_vercel_parts_impl(
                     "type": "tool-input-available",
                     "toolCallId": tool_call_id,
                     "toolName": tool_name,
-                    # Prefer `rawInput` (the tool's real args, per ACP); the runner leaves the
-                    # plain `input` empty on some tool-call paths — mirrors the approval /
-                    # client-tool reads in `_interaction_parts` so every path shows real args.
-                    # `is not None` (not truthiness): a legit empty `{}` is real args, not absent.
-                    "input": (
-                        data["rawInput"]
-                        if data.get("rawInput") is not None
-                        else data.get("input")
-                    ),
+                    "input": _tool_call_input(data),
                 }
                 if _conform(input_part) is not None:
                     content_parts_emitted += 1
@@ -505,15 +545,7 @@ async def _agent_stream_to_vercel_stream_impl(
                     "type": "tool-input-available",
                     "toolCallId": tool_call_id,
                     "toolName": tool_name,
-                    # Prefer `rawInput` (the tool's real args, per ACP); the runner leaves the
-                    # plain `input` empty on some tool-call paths — mirrors the approval /
-                    # client-tool reads in `_interaction_parts` so every path shows real args.
-                    # `is not None` (not truthiness): a legit empty `{}` is real args, not absent.
-                    "input": (
-                        data["rawInput"]
-                        if data.get("rawInput") is not None
-                        else data.get("input")
-                    ),
+                    "input": _tool_call_input(data),
                 }
                 if _conform(input_part) is not None:
                     content_parts_emitted += 1
@@ -683,11 +715,7 @@ def _interaction_parts(
             # (which carries only the drift-prone ACP title) cannot downgrade it back and re-break
             # the resume key. See the tool_call handler's `tool_names_by_id.get(...)` preference.
             names[tool_call_id] = tool_name
-            real_input = (
-                tool_call["rawInput"]
-                if tool_call.get("rawInput") is not None
-                else tool_call.get("input")
-            )
+            real_input = _tool_call_input(tool_call)
             # EGRESS side of the HITL key: what name+args the FE persists on the approval part
             # (and folds back on resume). Compare to the runner's live `[HITL] gate` identity.
             log.info(
@@ -768,6 +796,7 @@ def _interaction_parts(
                 if tool_call.get("rawInput") is not None
                 else tool_call.get("input")
             )
+        real_input = _unwrap_tool_arguments(real_input)
         if tool_call_id is not None and tool_call_id not in seen_tool_calls:
             seen_tool_calls.add(tool_call_id)
             yield {

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_tool_arguments.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_tool_arguments.py
@@ -1,0 +1,256 @@
+"""The live stream shows the LETTER, not the envelope.
+
+An MCP-routed harness wraps a tool's arguments in a transport envelope —
+``{"tool": ..., "server": ..., "arguments": {...}}`` — and the durable records carry that
+wrapper verbatim. Card bodies read their fields at the top level (``input.workflow_revision``),
+so an enveloped input drops to the raw-JSON fallback the same call renders a card for. The replay
+builder already strips the envelope (``unwrapToolArguments``, transcriptToMessages.ts); these pin
+the live egress doing the same, under the same conservative rule, on every path — ordinary calls,
+gated calls, and the ungated re-emit that lands after a gate.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List
+
+import pytest
+
+from agenta.sdk.agents.adapters.vercel.stream import (
+    _unwrap_tool_arguments,
+    agent_run_to_vercel_parts,
+    agent_stream_to_vercel_stream,
+)
+from agenta.sdk.agents.streaming import AgentStream
+
+BARE_ARGS = {"workflow_revision": "rev-1", "message": "ship it"}
+ENVELOPE = {"tool": "commit_revision", "server": "agenta-tools", "arguments": BARE_ARGS}
+
+
+async def _records(items: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+def _run(events: List[Dict[str, Any]]) -> AgentStream:
+    records: List[Dict[str, Any]] = [{"kind": "event", "event": e} for e in events]
+    records.append(
+        {
+            "kind": "result",
+            "result": {
+                "ok": True,
+                "output": "",
+                "stopReason": "stop",
+                "sessionId": "conv-1",
+            },
+        }
+    )
+    return AgentStream(_records(records))
+
+
+async def _live_inputs(events: List[Dict[str, Any]]) -> List[Any]:
+    """The `input` of every `tool-input-available` the ROUTING-layer egress emits.
+
+    `agent_stream_to_vercel_stream` is the function the live request path runs, so the assertions
+    ride the real live shape rather than its dev-only twin.
+    """
+
+    async def gen() -> AsyncIterator[Dict[str, Any]]:
+        for event in events:
+            yield {"type": event.get("type"), "data": event}
+
+    return [
+        part["input"]
+        async for part in agent_stream_to_vercel_stream(gen())
+        if part.get("type") == "tool-input-available"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The unwrap rule itself.
+# ---------------------------------------------------------------------------
+
+
+def test_unwrap_strips_the_mcp_envelope() -> None:
+    assert _unwrap_tool_arguments(ENVELOPE) == BARE_ARGS
+
+
+def test_unwrap_accepts_every_envelope_key_alias() -> None:
+    """The harnesses spell the envelope's name fields differently; all of them are recognized,
+    matching the replay builder's key set exactly."""
+    for key in (
+        "tool",
+        "server",
+        "name",
+        "toolName",
+        "serverName",
+        "tool_name",
+        "server_name",
+    ):
+        assert _unwrap_tool_arguments({key: "x", "arguments": BARE_ARGS}) == BARE_ARGS
+
+
+def test_unwrap_leaves_a_tool_whose_real_args_include_arguments() -> None:
+    """A tool whose own input carries an `arguments` field alongside a NON-envelope sibling is not
+    an envelope — unwrapping it would silently discard the sibling."""
+    real = {"arguments": {"a": 1}, "command": "run"}
+    assert _unwrap_tool_arguments(real) == real
+
+
+def test_unwrap_requires_string_valued_siblings() -> None:
+    """A sibling that is not a string means this is the tool's own payload, not the transport
+    wrapper (whose name fields are always strings)."""
+    real = {"tool": {"nested": True}, "arguments": {"a": 1}}
+    assert _unwrap_tool_arguments(real) == real
+
+
+def test_unwrap_leaves_a_lone_arguments_field() -> None:
+    """No siblings at all: `{"arguments": ...}` is the tool's own shape, not a stripped envelope."""
+    real = {"arguments": {"a": 1}}
+    assert _unwrap_tool_arguments(real) == real
+
+
+@pytest.mark.parametrize("value", [None, "", "text", 7, [1, 2], {"a": 1}])
+def test_unwrap_passes_non_envelopes_through_unchanged(value: Any) -> None:
+    assert _unwrap_tool_arguments(value) == value
+
+
+# ---------------------------------------------------------------------------
+# The egress paths.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ordinary_tool_call_streams_bare_arguments() -> None:
+    """The ordinary (non-gated) MCP tool call — the case behind `rename_agent`, `discover_tools`
+    and friends streaming the envelope live while replaying bare."""
+    events = [
+        {
+            "type": "tool_call",
+            "id": "tool-1",
+            "name": "rename_agent",
+            "input": ENVELOPE,
+        },
+        {"type": "done", "stopReason": "stop"},
+    ]
+    assert await _live_inputs(events) == [BARE_ARGS]
+
+    parts = [part async for part in agent_run_to_vercel_parts(_run(events))]
+    inputs = [p["input"] for p in parts if p.get("type") == "tool-input-available"]
+    assert inputs == [BARE_ARGS]
+
+
+@pytest.mark.asyncio
+async def test_raw_input_envelope_is_unwrapped_too() -> None:
+    """`rawInput` still wins over `input`, and is unwrapped on the way out."""
+    events = [
+        {
+            "type": "tool_call",
+            "id": "tool-1",
+            "name": "read_config",
+            "input": {},
+            "rawInput": ENVELOPE,
+        },
+        {"type": "done", "stopReason": "stop"},
+    ]
+    assert await _live_inputs(events) == [BARE_ARGS]
+
+
+@pytest.mark.asyncio
+async def test_ungated_reemit_after_a_gate_keeps_the_bare_input() -> None:
+    """The gate re-stamps the call with the tool's bare args; a later ungated `tool_call` for the
+    same id used to overwrite them with the envelope, so one call showed two different shapes live
+    depending on when you looked. Both emissions now agree.
+    """
+    events = [
+        {"type": "tool_call", "id": "tool-1", "name": "execute", "input": {}},
+        {
+            "type": "interaction_request",
+            "id": "perm-1",
+            "kind": "user_approval",
+            "payload": {
+                "toolCallId": "tool-1",
+                "toolCall": {
+                    "id": "tool-1",
+                    "resolvedName": "commit_revision",
+                    "rawInput": BARE_ARGS,
+                },
+            },
+        },
+        # The runner re-emits the call ungated once it runs, carrying the raw envelope.
+        {
+            "type": "tool_call",
+            "id": "tool-1",
+            "name": "execute",
+            "input": ENVELOPE,
+        },
+        {"type": "done", "stopReason": "stop"},
+    ]
+    inputs = await _live_inputs(events)
+    # The initial empty emit, the gate's refresh, then the ungated re-emit — the last two agree.
+    assert inputs[-1] == BARE_ARGS
+    assert inputs[-1] == inputs[-2]
+
+
+@pytest.mark.asyncio
+async def test_gated_call_streams_bare_arguments_when_the_gate_carries_the_envelope() -> (
+    None
+):
+    """A gate whose `rawInput` is itself the envelope (no bare args anywhere upstream) still shows
+    the letter."""
+    events = [
+        {
+            "type": "interaction_request",
+            "id": "perm-1",
+            "kind": "user_approval",
+            "payload": {
+                "toolCallId": "tool-1",
+                "toolCall": {
+                    "id": "tool-1",
+                    "name": "commit_revision",
+                    "rawInput": ENVELOPE,
+                },
+            },
+        },
+        {"type": "done", "stopReason": "paused"},
+    ]
+    assert await _live_inputs(events) == [BARE_ARGS]
+
+
+@pytest.mark.asyncio
+async def test_client_tool_request_streams_bare_arguments() -> None:
+    """The client-tool path feeds the elicitation/connect widgets, which read `input` fields at the
+    top level — an envelope there breaks the widget, not just the payload block."""
+    events = [
+        {
+            "type": "interaction_request",
+            "id": "client-1",
+            "kind": "client_tool",
+            "payload": {
+                "toolCallId": "tool-client-1",
+                "toolName": "request_connection",
+                "input": {
+                    "tool": "request_connection",
+                    "server": "agenta-tools",
+                    "arguments": {"integration": "slack"},
+                },
+                "render": {"kind": "connect"},
+            },
+        },
+        {"type": "done", "stopReason": "paused"},
+    ]
+    assert await _live_inputs(events) == [{"integration": "slack"}]
+
+
+@pytest.mark.asyncio
+async def test_a_non_enveloped_call_is_untouched() -> None:
+    """The harnesses that send bare names/args are unaffected — no shape change for them."""
+    events = [
+        {
+            "type": "tool_call",
+            "id": "tool-1",
+            "name": "read_file",
+            "input": {"path": "a.md"},
+        },
+        {"type": "done", "stopReason": "stop"},
+    ]
+    assert await _live_inputs(events) == [{"path": "a.md"}]

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -923,6 +923,47 @@ function acpToolContentText(content: any): string {
   return "";
 }
 
+/** JSON of a value, treating "no information" serializations as absent. */
+function jsonText(value: unknown): string {
+  try {
+    const text = JSON.stringify(value);
+    if (!text || text === "{}" || text === "[]" || text === "null") return "";
+    return text;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Text of an OBJECT `rawOutput`. codex-acp never sends a `content` array on the update that
+ * completes a tool call — it sends a plain object whose shape depends on the tool: shell/exec
+ * `{formatted_output, exit_code}`, an MCP call `{result, error}` (result being an MCP
+ * CallToolResult carrying `content[]`), the unified exec path `{output}`. `acpToolContentText`
+ * reads none of those and returns "", which is why every codex tool result — successes and
+ * failures alike — stored and streamed empty.
+ *
+ * Candidates are tried in that order and an empty one falls through to the next, so a failed MCP
+ * call (`{result: null, error: "..."}`) carries its real error message; an object with no known
+ * key serializes whole, so a completed call is never silently empty.
+ */
+function acpRawOutputText(raw: any): string {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return "";
+  for (const key of ["formatted_output", "result", "output", "error"]) {
+    const value = raw[key];
+    if (typeof value === "string") {
+      if (value) return value;
+      continue;
+    }
+    if (value && typeof value === "object") {
+      const text = acpToolContentText(value.content) || acpToolContentText(value);
+      if (text) return text;
+      const json = jsonText(value);
+      if (json) return json;
+    }
+  }
+  return jsonText(raw);
+}
+
 /**
  * Is this line part of the pi-acp startup banner that some setups emit as the first agent
  * message chunk, ahead of the real answer? pi-acp's `buildStartupInfo` produces, in order:
@@ -1470,7 +1511,8 @@ export function createSandboxAgentOtel(
     if (status !== "completed" && status !== "failed") return;
     const out =
       acpToolContentText(update.content) ||
-      acpToolContentText(update.rawOutput);
+      acpToolContentText(update.rawOutput) ||
+      acpRawOutputText(update.rawOutput);
     if (entry.span) {
       setOutput(entry.span, out, capture);
       if (status === "failed")

--- a/services/runner/tests/unit/otel-tool-output-text.test.ts
+++ b/services/runner/tests/unit/otel-tool-output-text.test.ts
@@ -1,0 +1,152 @@
+/**
+ * What a completed tool call reports as its output, per harness wire shape.
+ *
+ * Claude and Pi close a tool call with an ACP `content` array. codex-acp does not: it closes with
+ * a plain OBJECT `rawOutput` whose shape depends on the tool. The reader only understood content
+ * arrays, so every codex tool result stored and streamed EMPTY — successes and errors alike — and
+ * nothing caught it because this path had no test.
+ *
+ * The rawOutput fixtures below are the shapes `@agentclientprotocol/codex-acp` 1.1.7 actually
+ * builds (`dist/index.js`: `createMcpRawOutput`, `completeCommandExecutionEvent`, and the unified
+ * exec function-call path). Keep them faithful to the bundle — a fixture invented here proves
+ * nothing about the bridge.
+ *
+ * Run: pnpm exec vitest run tests/unit/otel-tool-output-text.test.ts
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import type { AgentEvent } from "../../src/protocol.ts";
+
+/** Drive one tool call to completion and return the `tool_result` it records. */
+function resultOf(
+  update: Record<string, unknown>,
+  harness = "codex",
+): { output: string; isError: boolean } {
+  const run = createSandboxAgentOtel({
+    harness,
+    model: "openai-codex/gpt-5.5",
+  });
+  run.start({ prompt: "run it" });
+  run.handleUpdate({
+    sessionUpdate: "tool_call",
+    toolCallId: "call_1",
+    title: "shell",
+    rawInput: { command: ["bash", "-lc", "ls"] },
+  });
+  run.handleUpdate({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "call_1",
+    status: "completed",
+    ...update,
+  });
+  run.finish();
+  const result = run
+    .events()
+    .find((event) => event.type === "tool_result") as Extract<
+    AgentEvent,
+    { type: "tool_result" }
+  >;
+  assert.ok(result, "the completing update must record a tool_result");
+  return { output: result.output ?? "", isError: result.isError === true };
+}
+
+describe("codex tool results (object rawOutput)", () => {
+  it("reports a shell command's output, not an empty string", () => {
+    const result = resultOf({
+      rawOutput: {
+        formatted_output: "AGENTS.md\nREADME.md\n",
+        exit_code: 0,
+      },
+    });
+    assert.equal(result.output, "AGENTS.md\nREADME.md\n");
+    assert.equal(result.isError, false);
+  });
+
+  it("reports the text blocks of a successful MCP call", () => {
+    const result = resultOf({
+      rawOutput: {
+        result: {
+          content: [{ type: "text", text: "variant deployed" }],
+          isError: false,
+        },
+        error: null,
+      },
+    });
+    assert.equal(result.output, "variant deployed");
+  });
+
+  it("reports a failed MCP call's error message, so the failure is diagnosable", () => {
+    const result = resultOf({
+      status: "failed",
+      rawOutput: {
+        result: null,
+        error: "MCP server 'agenta' returned: unauthorized (401)",
+      },
+    });
+    assert.equal(result.isError, true);
+    assert.match(result.output, /unauthorized \(401\)/);
+  });
+
+  it("reports the output of the unified exec path, which sends `{output}`", () => {
+    const result = resultOf({
+      rawOutput: { output: "hello from the sandbox" },
+    });
+    assert.equal(result.output, "hello from the sandbox");
+  });
+
+  it("keeps the exit code when a command succeeded with no output", () => {
+    // Falling through an empty `formatted_output` to the whole object is what keeps a silent
+    // command from looking identical to the bug this test pins.
+    const result = resultOf({
+      rawOutput: { formatted_output: "", exit_code: 0 },
+    });
+    assert.notEqual(result.output, "");
+    assert.match(result.output, /exit_code/);
+  });
+
+  it("serializes an object with no known key rather than dropping it", () => {
+    const result = resultOf({
+      rawOutput: { status: "ok", saved_path: "/w/a.png" },
+    });
+    assert.notEqual(result.output, "");
+    assert.deepEqual(JSON.parse(result.output), {
+      status: "ok",
+      saved_path: "/w/a.png",
+    });
+  });
+});
+
+describe("the harnesses that already worked stay unchanged", () => {
+  it("reads a Claude/Pi content array", () => {
+    const result = resultOf(
+      { content: [{ content: { type: "text", text: "sunny" } }] },
+      "claude",
+    );
+    assert.equal(result.output, "sunny");
+  });
+
+  it("prefers the content array over rawOutput when both are present", () => {
+    const result = resultOf(
+      {
+        content: [{ content: { type: "text", text: "from content" } }],
+        rawOutput: { formatted_output: "from rawOutput" },
+      },
+      "claude",
+    );
+    assert.equal(result.output, "from content");
+  });
+
+  it("reads a plain string rawOutput", () => {
+    const result = resultOf({ rawOutput: "plain text output" }, "pi");
+    assert.equal(result.output, "plain text output");
+  });
+
+  it("records an empty output when the update carries no output at all", () => {
+    // Not every close carries a payload (codex-acp closes a fileChange with status only).
+    // The fallback must not invent text for an absent rawOutput.
+    const result = resultOf({});
+    assert.equal(result.output, "");
+  });
+});

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/abandonedFormSession.liveChunks.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/abandonedFormSession.liveChunks.json
@@ -1,0 +1,379 @@
+[
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_6Ev3NNVyPlFdRIoDRF4RKN3w|fc_0127887… <83 chars elided>",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_6Ev3NNVyPlFdRIoDRF4RKN3w|fc_0127887… <83 chars elided>",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <195 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_6Ev3NNVyPlFdRIoDRF4RKN3w|fc_0127887… <83 chars elided>",
+    "output": "---\nname: \"build-an-agent\"\ndescription: … <12820 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_9TZhCpuETAWXy0ruPgYnC8v7|fc_0127887… <83 chars elided>",
+    "toolName": "find"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_9TZhCpuETAWXy0ruPgYnC8v7|fc_0127887… <83 chars elided>",
+    "toolName": "find",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <171 chars elided>",
+      "pattern": "references/agent-templates/index.md"
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "call_9TZhCpuETAWXy0ruPgYnC8v7|fc_0127887… <83 chars elided>",
+    "errorText": "error: Found argument '--no-require-git'… <248 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_F4rCCLQOVRBsIyguLveYaXqs|fc_0127887… <83 chars elided>",
+    "toolName": "ls"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_F4rCCLQOVRBsIyguLveYaXqs|fc_0127887… <83 chars elided>",
+    "toolName": "ls",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <171 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_F4rCCLQOVRBsIyguLveYaXqs|fc_0127887… <83 chars elided>",
+    "output": ".agenta-skill-set.json\nbuild-an-agent/"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_CgCsnin4iSnw6I6orMZ0bBxV|fc_0127887… <83 chars elided>",
+    "toolName": "ls"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_CgCsnin4iSnw6I6orMZ0bBxV|fc_0127887… <83 chars elided>",
+    "toolName": "ls",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <186 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_CgCsnin4iSnw6I6orMZ0bBxV|fc_0127887… <83 chars elided>",
+    "output": "references/\nSKILL.md"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_07YbzYFCW64e3ZGooV6NQ2ze|fc_0127887… <83 chars elided>",
+    "toolName": "ls"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_07YbzYFCW64e3ZGooV6NQ2ze|fc_0127887… <83 chars elided>",
+    "toolName": "ls",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <197 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "call_07YbzYFCW64e3ZGooV6NQ2ze|fc_0127887… <83 chars elided>",
+    "errorText": "Path not found: /tmp/agenta/mounts/019fe… <213 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_QdfzWu4Fit44c3RZPp0mhpmx|fc_0127887… <83 chars elided>",
+    "toolName": "ls"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_QdfzWu4Fit44c3RZPp0mhpmx|fc_0127887… <83 chars elided>",
+    "toolName": "ls",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <197 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_QdfzWu4Fit44c3RZPp0mhpmx|fc_0127887… <83 chars elided>",
+    "output": "agent-templates/\nconfig-schema.md\ntrigger-inputs.md"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_cos65iPtQcwoSeCo274tHxpu|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_cos65iPtQcwoSeCo274tHxpu|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <222 chars elided>"
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_36OO60wY2e9UxrP0QmiATv3K|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_36OO60wY2e9UxrP0QmiATv3K|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c20-8d… <174 chars elided>"
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_OaTDsWsrPzndHArJ2NYK6zaZ|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_OaTDsWsrPzndHArJ2NYK6zaZ|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <212 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "call_36OO60wY2e9UxrP0QmiATv3K|fc_0b9b71f… <83 chars elided>",
+    "errorText": "ENOENT: no such file or directory, acces… <218 chars elided>"
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "call_OaTDsWsrPzndHArJ2NYK6zaZ|fc_0b9b71f… <83 chars elided>",
+    "errorText": "ENOENT: no such file or directory, acces… <256 chars elided>"
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_cos65iPtQcwoSeCo274tHxpu|fc_0b9b71f… <83 chars elided>",
+    "output": "# Agent template playbooks\n\nMatch the us… <4532 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_y3gX69Fmcfs71YOv3iBQQ0mS|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_y3gX69Fmcfs71YOv3iBQQ0mS|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <214 chars elided>"
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_5gXdoIef4ScubRAhB2KCD3Ig|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_5gXdoIef4ScubRAhB2KCD3Ig|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <212 chars elided>"
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_tIalLuExYiDMiSN8Otvoaz1a|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_tIalLuExYiDMiSN8Otvoaz1a|fc_0b9b71f… <83 chars elided>",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe7de-5e28-7c70-b3… <195 chars elided>",
+      "limit": 220,
+      "offset": 1
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "call_5gXdoIef4ScubRAhB2KCD3Ig|fc_0b9b71f… <83 chars elided>",
+    "errorText": "ENOENT: no such file or directory, acces… <256 chars elided>"
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_tIalLuExYiDMiSN8Otvoaz1a|fc_0b9b71f… <83 chars elided>",
+    "output": "---\nname: \"build-an-agent\"\ndescription: … <12820 chars elided>"
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_y3gX69Fmcfs71YOv3iBQQ0mS|fc_0b9b71f… <83 chars elided>",
+    "output": "# The agent config, field by field\n\nRead… <17820 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_oKZiZXfG0lf35KE3WNAOIDws|fc_0b9b71f… <83 chars elided>",
+    "toolName": "discover_tools"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_oKZiZXfG0lf35KE3WNAOIDws|fc_0b9b71f… <83 chars elided>",
+    "toolName": "discover_tools",
+    "input": {
+      "provider": "composio",
+      "use_cases": [
+        "send a Telegram message"
+      ],
+      "limit_alternatives": 5
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+    "toolName": "request_input"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+    "toolName": "request_input",
+    "input": {
+      "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "time_of_day",
+          "timezone",
+          "telegram_chat"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "default": "Asia/Riyadh",
+            "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+          },
+          "time_of_day": {
+            "type": "string",
+            "title": "Morning delivery time",
+            "format": "time",
+            "default": "08:00"
+          },
+          "poetry_style": {
+            "type": "string",
+            "title": "Poetry preference",
+            "format": "multiline",
+            "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+            "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+          },
+          "telegram_chat": {
+            "type": "string",
+            "title": "Telegram chat ID or @username"
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+    "toolName": "request_input",
+    "input": {
+      "message": "To schedule this correctly, tell me when and where to send the daily Arabic poem. The Telegram chat ID or username is not a secret; Telegram credentials will be connected separately.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "time_of_day",
+          "timezone",
+          "telegram_chat"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "default": "Asia/Riyadh",
+            "description": "IANA timezone, for example Asia/Riyadh or Europe/London"
+          },
+          "time_of_day": {
+            "type": "string",
+            "title": "Morning delivery time",
+            "format": "time",
+            "default": "08:00"
+          },
+          "poetry_style": {
+            "type": "string",
+            "title": "Poetry preference",
+            "format": "multiline",
+            "default": "A short Arabic poem or excerpt, with the poet’s name and a brief English explanation.",
+            "description": "Optional: classical or modern, poet preferences, translation/explanation, and desired length"
+          },
+          "telegram_chat": {
+            "type": "string",
+            "title": "Telegram chat ID or @username"
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "call_Dd5g7Xd92RxD0l0TV55ul07V|fc_0b9b71f5a8fc3f56016a79dcd4ea7081a09d6aedfee011e1a6",
+      "render": {
+        "kind": "elicitation"
+      }
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "call_oKZiZXfG0lf35KE3WNAOIDws|fc_0b9b71f… <83 chars elided>",
+    "errorText": "aborted"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_iLvfcJo0QEc2TmNlKZrFyeD6|fc_0a6f77e… <83 chars elided>",
+    "toolName": "rename_session"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_iLvfcJo0QEc2TmNlKZrFyeD6|fc_0a6f77e… <83 chars elided>",
+    "toolName": "rename_session",
+    "input": {
+      "name": "Daily Arabic Poetry",
+      "description": "Setting up a Telegram agent to send Arab… <128 chars elided>"
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_QKleioohKPLZ8UoK09ayHOIX|fc_0a6f77e… <83 chars elided>",
+    "toolName": "rename_agent"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_QKleioohKPLZ8UoK09ayHOIX|fc_0a6f77e… <83 chars elided>",
+    "toolName": "rename_agent",
+    "input": {
+      "name": "Arabic Poetry Scheduler",
+      "description": "Configures and schedules daily Arabic poetry messages to Telegram."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_iLvfcJo0QEc2TmNlKZrFyeD6|fc_0a6f77e… <83 chars elided>",
+    "output": "{\"stream\":{\"created_at\":\"2026-08-10T14:0… <725 chars elided>"
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_QKleioohKPLZ8UoK09ayHOIX|fc_0a6f77e… <83 chars elided>",
+    "output": "{\"count\":1,\"workflow\":{\"flags\":{\"is_appl… <482 chars elided>"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/arabicPoetrySession.interactions.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/arabicPoetrySession.interactions.json
@@ -1,0 +1,315 @@
+[
+  {
+    "id": "019fefed-f51e-77e0-9809-6922354745a4",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "turn_id": "15afd5eb-0b2e-4e9d-93c3-e05e38a9df91",
+    "token": "474a769d-6115-4cc0-8262-5258e75d4444",
+    "kind": "client_tool",
+    "status": "responded",
+    "created_at": "2026-08-11T08:26:17.246365+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "message": "حدّد وقت الإرسال اليومي ووجهة تيليغرام. لا تُدخل أي رمز سري هنا؛ سيتم طلب الربط الآمن بشكل منفصل عند الحاجة.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "time",
+              "timezone",
+              "telegram_destination"
+            ],
+            "properties": {
+              "time": {
+                "type": "string",
+                "title": "وقت الإرسال",
+                "default": "08:00"
+              },
+              "timezone": {
+                "type": "string",
+                "title": "المنطقة الزمنية",
+                "default": "Asia/Riyadh",
+                "description": "مثال: Asia/Riyadh أو Europe/Paris"
+              },
+              "telegram_destination": {
+                "type": "string",
+                "title": "وجهة تيليغرام",
+                "description": "@username أو Chat ID"
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "tool": "request_input",
+        "tool_call_id": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a"
+      },
+      "references": {
+        "workflow": {
+          "id": "019fefed-a7c9-7382-9db1-a0f141ac4533",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae"
+        },
+        "workflow_variant": {
+          "id": "019fefed-a80a-70d3-95cf-5245f42330c0",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae.default"
+        },
+        "workflow_revision": {
+          "id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace",
+          "slug": "b9cda5b228e2",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "output": {
+          "action": "accept",
+          "content": {
+            "time": "08:00",
+            "timezone": "Berlin",
+            "telegram_destination": "@mmabrouk1987"
+          },
+          "humanFriendlyMessage": "Provided the requested input."
+        },
+        "outcome": "completed",
+        "tool_name": "mcp.agenta-tools.request_input",
+        "tool_call_id": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a"
+      }
+    }
+  },
+  {
+    "id": "019fefee-797f-70f3-805f-b9b87fc5601b",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "turn_id": "eaf2691a-af15-4c19-a19c-4e93f4ebe02d",
+    "token": "e8324b9a-1c00-4d4d-908f-7a3d0870a40a",
+    "kind": "client_tool",
+    "status": "responded",
+    "created_at": "2026-08-11T08:26:51.13517+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "mode": "oauth",
+          "slug": "telegram-main",
+          "integration": "telegram"
+        },
+        "tool": "request_connection",
+        "tool_call_id": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647"
+      },
+      "references": {
+        "workflow": {
+          "id": "019fefed-a7c9-7382-9db1-a0f141ac4533",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae"
+        },
+        "workflow_variant": {
+          "id": "019fefed-a80a-70d3-95cf-5245f42330c0",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae.default"
+        },
+        "workflow_revision": {
+          "id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace",
+          "slug": "b9cda5b228e2",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "output": {
+          "slug": "telegram-main",
+          "connected": true,
+          "integration": "telegram"
+        },
+        "outcome": "completed",
+        "tool_name": "mcp.agenta-tools.request_connection",
+        "tool_call_id": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647"
+      }
+    }
+  },
+  {
+    "id": "019fefef-139e-7f12-8172-96bd77a915bc",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "turn_id": "1f66ce52-0695-4e39-a2ad-8a6f130d1888",
+    "token": "9b6b1049-602d-4b5b-b147-00c12946ae65",
+    "kind": "user_approval",
+    "status": "resolved",
+    "created_at": "2026-08-11T08:27:30.590922+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+          }
+        },
+        "tool": "commit_revision",
+        "tool_call_id": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e"
+      },
+      "references": {
+        "workflow": {
+          "id": "019fefed-a7c9-7382-9db1-a0f141ac4533",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae"
+        },
+        "workflow_variant": {
+          "id": "019fefed-a80a-70d3-95cf-5245f42330c0",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae.default"
+        },
+        "workflow_revision": {
+          "id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace",
+          "slug": "b9cda5b228e2",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "verdict": "approved",
+        "tool_call_id": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e"
+      }
+    }
+  },
+  {
+    "id": "019fefef-3f6e-7920-b7d1-534641b5bdce",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "turn_id": "b313f335-25cd-4050-b7ed-6f4a7da1bb03",
+    "token": "39463b6b-3962-4c36-a881-dcd8920f36c4",
+    "kind": "user_approval",
+    "status": "resolved",
+    "created_at": "2026-08-11T08:27:41.806913+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "name": "telegram_send_message",
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+          }
+        },
+        "tool": "commit_revision",
+        "tool_call_id": "exec-54209338-b2ec-4baf-8851-8bf777361c93"
+      },
+      "references": {
+        "workflow": {
+          "id": "019fefed-a7c9-7382-9db1-a0f141ac4533",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae"
+        },
+        "workflow_variant": {
+          "id": "019fefed-a80a-70d3-95cf-5245f42330c0",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae.default"
+        },
+        "workflow_revision": {
+          "id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace",
+          "slug": "b9cda5b228e2",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "verdict": "approved",
+        "tool_call_id": "exec-54209338-b2ec-4baf-8851-8bf777361c93"
+      }
+    }
+  },
+  {
+    "id": "019fefef-5fd6-7513-b992-fb174f587db7",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "turn_id": "221e3456-8500-4f08-be53-f0fcba4ec5fc",
+    "token": "f5f71920-93cc-4603-9cb3-91ef2e19b9c5",
+    "kind": "user_approval",
+    "status": "resolved",
+    "created_at": "2026-08-11T08:27:50.102869+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "data": {
+            "schedule": "0 7 * * *",
+            "event_key": "daily_arabic_poetry",
+            "inputs_fields": {
+              "payload": {
+                "timezone": "Europe/Berlin",
+                "local_time": "08:00",
+                "destination": "@mmabrouk1987"
+              },
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "أرسل قصيدة عربية صباحية قصيرة (4 إلى 8 أبيات) إلى تيليغرام باستخدام أداة الإرسال… <123 chars elided>"
+                }
+              ]
+            }
+          },
+          "name": "قصيدة عربية صباحية",
+          "description": "إرسال قصيدة عربية يومية إلى @mmabrouk1987 الساعة 08:00 بتوقيت برلين."
+        },
+        "tool": "create_schedule",
+        "tool_call_id": "exec-328ad873-f1f0-4307-b130-1bc33218bd67"
+      },
+      "references": {
+        "workflow": {
+          "id": "019fefed-a7c9-7382-9db1-a0f141ac4533",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae"
+        },
+        "workflow_variant": {
+          "id": "019fefed-a80a-70d3-95cf-5245f42330c0",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoebjxbae.default"
+        },
+        "workflow_revision": {
+          "id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace",
+          "slug": "b9cda5b228e2",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "verdict": "approved",
+        "tool_call_id": "exec-328ad873-f1f0-4307-b130-1bc33218bd67"
+      }
+    }
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/arabicPoetrySession.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/arabicPoetrySession.json
@@ -1,0 +1,1411 @@
+[
+  {
+    "id": "2d97d856-bbcb-4ace-a20a-f67a8c04e49c",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "I want to create an agent that send me a daily arabic poetry on telegram each morning",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-11T08:25:59.401708+00:00"
+  },
+  {
+    "id": "476717c7-ef0d-4375-a76a-c309ee251d76",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Preparing to build an agent**\n\nI need to focus on understanding the build-an… <366 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:26:04.619805+00:00"
+  },
+  {
+    "id": "f2304847-3ccf-46a7-87eb-0342b94d25b9",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "مرحبًا! سأساعدك في إعداد وكيل يرسل قصيدة عربية يوميًا عبر تيليغرام صباحًا. سأتحقق أولًا من الإعدادات المطلوبة ثم أضبط الجدولة والمحتوى بطريقة عملية.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:26:04.619805+00:00"
+  },
+  {
+    "id": "944be153-2e7d-5da7-ad9b-b38f169a01ea",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-9a4c928f-bec2-4c68-b3e3-6a2c4f9cd078",
+      "name": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18/.codex/skills/build-an-agent/SKILL.md'",
+      "type": "tool_call"
+    },
+    "created_at": "2026-08-11T08:26:04.619805+00:00"
+  },
+  {
+    "id": "80402e88-e1c3-581e-bdc7-ebee2da27e83",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-9a4c928f-bec2-4c68-b3e3-6a2c4f9cd078",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:26:04.619805+00:00"
+  },
+  {
+    "id": "e420f28c-5498-4b0b-9744-9b247e855e4f",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 10684,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:04.619805+00:00"
+  },
+  {
+    "id": "c9355104-70a8-51dc-ad9e-d4c2ae8313fd",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-ab0304b9-061e-41ab-93c0-52207465da66",
+      "name": "\"sed -n '1,220p' .codex/skills/build-an-agent/references/agent-templates/index.m… <155 chars elided>",
+      "type": "tool_call",
+      "input": {
+        "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18",
+        "command": "/bin/bash -lc \"sed -n '1,220p' .codex/skills/build-an-agent/references/agent-tem… <169 chars elided>"
+      }
+    },
+    "created_at": "2026-08-11T08:26:07.229302+00:00"
+  },
+  {
+    "id": "879bfdd3-c788-516e-be0c-6269492ded28",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-ab0304b9-061e-41ab-93c0-52207465da66",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:26:07.229302+00:00"
+  },
+  {
+    "id": "ac7e8a27-6874-4163-b64c-1e1cc35c5f00",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 13806,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:07.229302+00:00"
+  },
+  {
+    "id": "3bb1201f-b873-4100-8ffb-5b6203e38dd3",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 19345,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:10.446908+00:00"
+  },
+  {
+    "id": "ad562e2c-4833-4acf-8460-b69d83c42f63",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Clarifying connection details**\n\nI need to clarify the timezone, time, and t… <762 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:26:14.952695+00:00"
+  },
+  {
+    "id": "4572bc73-cce2-505c-a7d0-da6d7b4ed598",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-da715af9-296c-4bcd-95e4-aab1fbccee5a",
+      "name": "mcp.agenta-tools.rename_agent",
+      "type": "tool_call",
+      "input": {
+        "tool": "rename_agent",
+        "server": "agenta-tools",
+        "arguments": {
+          "name": "Arabic Poetry Telegram Agent",
+          "description": "Sends a daily Arabic poem to the user on Telegram each morning; setup is in progress."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:26:14.952695+00:00"
+  },
+  {
+    "id": "e28423cd-f525-5d99-8b78-0fe166dbbac9",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-da715af9-296c-4bcd-95e4-aab1fbccee5a",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:26:14.952695+00:00"
+  },
+  {
+    "id": "47a3af32-3a4b-5a6b-9b67-327842e11946",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-0916682c-3475-430e-a907-a4bad6d18016",
+      "name": "mcp.agenta-tools.rename_session",
+      "type": "tool_call",
+      "input": {
+        "tool": "rename_session",
+        "server": "agenta-tools",
+        "arguments": {
+          "name": "Daily Arabic Poetry",
+          "description": "Setting up a Telegram agent that sends one Arabic poem every morning; timezone and Telegram destination are still needed."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:26:14.952695+00:00"
+  },
+  {
+    "id": "00a6e386-3ac0-5932-9406-7977ea8b7326",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 14,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-0916682c-3475-430e-a907-a4bad6d18016",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:26:14.952695+00:00"
+  },
+  {
+    "id": "cc2f70f6-1d17-40ab-abb4-61a680943ceb",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 15,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 22590,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:14.952695+00:00"
+  },
+  {
+    "id": "5810e82a-a54d-4975-a221-77e6def052b5",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 16,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "لإكمال الإعداد، أحتاج وقت الإرسال والمنطقة الزمنية، ومعرّف وجهة تيليغرام (مثل `@username` أو Chat ID). كما سأحتاج منك ربط حساب تيليغرام إذا لم يكن متصلًا بعد.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:26:17.576328+00:00"
+  },
+  {
+    "id": "e1b2e2cf-a327-5da4-879f-617be610b4d2",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 17,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a",
+      "name": "mcp.agenta-tools.request_input",
+      "type": "tool_call",
+      "input": {
+        "tool": "request_input",
+        "server": "agenta-tools",
+        "arguments": {
+          "message": "حدّد وقت الإرسال اليومي ووجهة تيليغرام. لا تُدخل أي رمز سري هنا؛ سيتم طلب الربط الآمن بشكل منفصل عند الحاجة.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "time",
+              "timezone",
+              "telegram_destination"
+            ],
+            "properties": {
+              "time": {
+                "type": "string",
+                "title": "وقت الإرسال",
+                "default": "08:00"
+              },
+              "timezone": {
+                "type": "string",
+                "title": "المنطقة الزمنية",
+                "default": "Asia/Riyadh",
+                "description": "مثال: Asia/Riyadh أو Europe/Paris"
+              },
+              "telegram_destination": {
+                "type": "string",
+                "title": "وجهة تيليغرام",
+                "description": "@username أو Chat ID"
+              }
+            },
+            "x-ag-stepper": true
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:26:17.576328+00:00"
+  },
+  {
+    "id": "e5b56049-3867-5756-b5dc-4b2bb586e538",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 18,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "474a769d-6115-4cc0-8262-5258e75d4444",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "message": "حدّد وقت الإرسال اليومي ووجهة تيليغرام. لا تُدخل أي رمز سري هنا؛ سيتم طلب الربط الآمن بشكل منفصل عند الحاجة.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "time",
+              "timezone",
+              "telegram_destination"
+            ],
+            "properties": {
+              "time": {
+                "type": "string",
+                "title": "وقت الإرسال",
+                "default": "08:00"
+              },
+              "timezone": {
+                "type": "string",
+                "title": "المنطقة الزمنية",
+                "default": "Asia/Riyadh",
+                "description": "مثال: Asia/Riyadh أو Europe/Paris"
+              },
+              "telegram_destination": {
+                "type": "string",
+                "title": "وجهة تيليغرام",
+                "description": "@username أو Chat ID"
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "render": {
+          "kind": "elicitation"
+        },
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "message": "حدّد وقت الإرسال اليومي ووجهة تيليغرام. لا تُدخل أي رمز سري هنا؛ سيتم طلب الربط الآمن بشكل منفصل عند الحاجة.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "time",
+                "timezone",
+                "telegram_destination"
+              ],
+              "properties": {
+                "time": {
+                  "type": "string",
+                  "title": "وقت الإرسال",
+                  "default": "08:00"
+                },
+                "timezone": {
+                  "type": "string",
+                  "title": "المنطقة الزمنية",
+                  "default": "Asia/Riyadh",
+                  "description": "مثال: Asia/Riyadh أو Europe/Paris"
+                },
+                "telegram_destination": {
+                  "type": "string",
+                  "title": "وجهة تيليغرام",
+                  "description": "@username أو Chat ID"
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "toolCallId": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a",
+          "resolvedName": "request_input"
+        },
+        "toolName": "request_input",
+        "toolCallId": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a"
+      }
+    },
+    "created_at": "2026-08-11T08:26:17.576328+00:00"
+  },
+  {
+    "id": "24a70aaa-257f-46d7-9e03-d03c2c9390f4",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 19,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 22590,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:17.576328+00:00"
+  },
+  {
+    "id": "95af67d8-a927-48e4-9ea6-98d5e81c7b5a",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 20,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "811444b054af99078d2d9a2c0eaa7fda",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:26:17.576328+00:00"
+  },
+  {
+    "id": "dce64cd0-c2ac-476b-a990-d156b816052b",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 21,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 23349,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:17.576328+00:00"
+  },
+  {
+    "id": "0c1dc713-6b31-445d-91cd-1d2f29f0d0f6",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 11552,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:40.655288+00:00"
+  },
+  {
+    "id": "10af04c8-1205-427f-ad3d-f1ef65825e6e",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "سأكمل الإعداد بالوقت والوجهة اللذين حددتهما، وسأتحقق من صيغة المنطقة الزمنية قبل تفعيل الجدولة.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:26:42.558957+00:00"
+  },
+  {
+    "id": "c289ecbd-764b-539e-b07a-544bc5a302ed",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-4964e651-d4e6-4bd6-9ecd-45d6824f2787",
+      "name": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18/.codex/skills/build-an-agent/SKILL.md'",
+      "type": "tool_call"
+    },
+    "created_at": "2026-08-11T08:26:42.558957+00:00"
+  },
+  {
+    "id": "d413af6a-4274-5fed-8bd7-439208f5b4a7",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-4964e651-d4e6-4bd6-9ecd-45d6824f2787",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:26:42.558957+00:00"
+  },
+  {
+    "id": "d7224eb9-8004-4483-a22c-869b61fabe51",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 17581,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:42.558957+00:00"
+  },
+  {
+    "id": "71e1a5ed-17b6-5ef1-854c-72f368de6618",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-41caf722-e73c-49c1-9d9f-04502720681f",
+      "name": "mcp.agenta-tools.discover_tools",
+      "type": "tool_call",
+      "input": {
+        "tool": "discover_tools",
+        "server": "agenta-tools",
+        "arguments": {
+          "use_cases": [
+            "send a Telegram message"
+          ],
+          "limit_alternatives": 10
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:26:48.858466+00:00"
+  },
+  {
+    "id": "5fdfee11-6a2e-5580-ba4e-26a1894d1ef3",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-41caf722-e73c-49c1-9d9f-04502720681f",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:26:48.858466+00:00"
+  },
+  {
+    "id": "04401333-a2a1-45fa-9289-6179e1bdbf91",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 20587,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:48.858466+00:00"
+  },
+  {
+    "id": "103e7f64-372f-4256-8c06-97980cfdc45a",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "تيليغرام غير مربوط بعد، لذلك سأطلب الآن ربطًا آمنًا للبوت؛ بعد إتمام الربط سأثبت إعدادات الوكيل وأفعّل الرسالة اليومية.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:26:51.478863+00:00"
+  },
+  {
+    "id": "a2225d22-0e82-5ceb-8fb3-6a8a72f7f7e7",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647",
+      "name": "mcp.agenta-tools.request_connection",
+      "type": "tool_call",
+      "input": {
+        "tool": "request_connection",
+        "server": "agenta-tools",
+        "arguments": {
+          "mode": "oauth",
+          "slug": "telegram-main",
+          "integration": "telegram"
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:26:51.478863+00:00"
+  },
+  {
+    "id": "bfcc2796-c1f3-540f-ac8a-dd37c45f9a3e",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "e8324b9a-1c00-4d4d-908f-7a3d0870a40a",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "mode": "oauth",
+          "slug": "telegram-main",
+          "integration": "telegram"
+        },
+        "render": {
+          "kind": "connect"
+        },
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "mode": "oauth",
+            "slug": "telegram-main",
+            "integration": "telegram"
+          },
+          "toolCallId": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647",
+          "resolvedName": "request_connection"
+        },
+        "toolName": "request_connection",
+        "toolCallId": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647"
+      }
+    },
+    "created_at": "2026-08-11T08:26:51.478863+00:00"
+  },
+  {
+    "id": "0476e766-8e33-414f-bc23-001ce1326b9a",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 20587,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:26:51.478863+00:00"
+  },
+  {
+    "id": "a28998bf-cc1d-4d5c-8dfe-0089694ec9ad",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "361c0014999570d00db83e33ba42d9c9",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:26:51.478863+00:00"
+  },
+  {
+    "id": "09ce7c43-14c3-4bd3-bcf1-78da307483ee",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Continuing exploration of tools**\n\nI need to keep going and read the instruc… <310 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:27:17.653135+00:00"
+  },
+  {
+    "id": "9ac01767-2431-401c-a202-582386c5db1d",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 11876,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:27:17.653135+00:00"
+  },
+  {
+    "id": "a54b0d13-16fd-47c1-9e26-469be044ee65",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "تم ربط تيليغرام بنجاح. سأثبت الآن الجدولة اليومية الساعة 08:00 بتوقيت برلين وأجهّز نص الرسالة العربية.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:27:20.478765+00:00"
+  },
+  {
+    "id": "97f6eac6-4caf-4012-871e-c8504af2a03b",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Considering schedule creation**\n\nI need to create a schedule that requires a… <415 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:27:22.872343+00:00"
+  },
+  {
+    "id": "f184e019-f598-5b48-bec1-9ed99e4f5fe8",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-241ba39b-348a-4e81-b664-9582ab765c70",
+      "name": "mcp.agenta-tools.read_config",
+      "type": "tool_call",
+      "input": {
+        "tool": "read_config",
+        "server": "agenta-tools",
+        "arguments": {
+          "target": {
+            "path": [
+              "parameters",
+              "agent"
+            ]
+          },
+          "description": "قراءة إعدادات الوكيل الحالية قبل تفعيل الجدولة."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:27:22.872343+00:00"
+  },
+  {
+    "id": "492e6b83-a94d-53f2-b4e9-7ce564737453",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-241ba39b-348a-4e81-b664-9582ab765c70",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:27:22.872343+00:00"
+  },
+  {
+    "id": "494935bf-eeaa-4765-bda4-ec2dab53ad95",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 17540,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:27:22.872343+00:00"
+  },
+  {
+    "id": "0a6d8c22-4775-5fb2-baf8-680509507099",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-f8f66a00-901c-4908-adce-d1d72791820e",
+      "name": "mcp.agenta-tools.discover_tools",
+      "type": "tool_call",
+      "input": {
+        "tool": "discover_tools",
+        "server": "agenta-tools",
+        "arguments": {
+          "use_cases": [
+            "send a Telegram message"
+          ],
+          "limit_alternatives": 10
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:27:24.779333+00:00"
+  },
+  {
+    "id": "aa5d5208-6789-53d3-affb-f483b311bca2",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-f8f66a00-901c-4908-adce-d1d72791820e",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:27:24.779333+00:00"
+  },
+  {
+    "id": "64769e31-29c7-4bb2-8cd6-8758d03d9ebf",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 18064,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:27:24.779333+00:00"
+  },
+  {
+    "id": "e6367b89-c2b6-5c10-b1b3-d0abce7757e9",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e",
+      "name": "mcp.agenta-tools.commit_revision",
+      "type": "tool_call",
+      "input": {
+        "tool": "commit_revision",
+        "server": "agenta-tools",
+        "arguments": {
+          "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:27:30.88087+00:00"
+  },
+  {
+    "id": "726def05-4ee2-5e9b-8acb-8192f473b35a",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "9b6b1049-602d-4b5b-b147-00c12946ae65",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+            "workflow_revision": {
+              "delta": {
+                "operations": [
+                  {
+                    "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "instructions",
+                      "agents_md"
+                    ],
+                    "operation": "set"
+                  },
+                  {
+                    "value": {
+                      "type": "gateway",
+                      "action": "SEND_MESSAGE",
+                      "provider": "composio",
+                      "connection": "telegram-main",
+                      "integration": "telegram"
+                    },
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "tools"
+                    ],
+                    "operation": "add_item"
+                  }
+                ]
+              },
+              "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+            }
+          },
+          "toolCallId": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e",
+          "resolvedName": "commit_revision"
+        },
+        "toolCallId": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:27:30.88087+00:00"
+  },
+  {
+    "id": "3fd5de0c-e089-4b9b-8491-f1bde7228122",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 18064,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:27:30.88087+00:00"
+  },
+  {
+    "id": "644054ce-09b6-46b6-8f39-6882107dce55",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "5cbe6381e09036d60eab66fe90010044",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:27:30.88087+00:00"
+  },
+  {
+    "id": "974a8b27-6300-54a6-ac3a-b3870f3869e8",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-54209338-b2ec-4baf-8851-8bf777361c93",
+      "name": "mcp.agenta-tools.commit_revision",
+      "type": "tool_call",
+      "input": {
+        "tool": "commit_revision",
+        "server": "agenta-tools",
+        "arguments": {
+          "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "name": "telegram_send_message",
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:27:42.140719+00:00"
+  },
+  {
+    "id": "485e3274-54a0-5569-8d46-c3980636f60c",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "39463b6b-3962-4c36-a881-dcd8920f36c4",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+            "workflow_revision": {
+              "delta": {
+                "operations": [
+                  {
+                    "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "instructions",
+                      "agents_md"
+                    ],
+                    "operation": "set"
+                  },
+                  {
+                    "value": {
+                      "name": "telegram_send_message",
+                      "type": "gateway",
+                      "action": "SEND_MESSAGE",
+                      "provider": "composio",
+                      "connection": "telegram-main",
+                      "integration": "telegram"
+                    },
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "tools"
+                    ],
+                    "operation": "add_item"
+                  }
+                ]
+              },
+              "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+            }
+          },
+          "toolCallId": "exec-54209338-b2ec-4baf-8851-8bf777361c93",
+          "resolvedName": "commit_revision"
+        },
+        "toolCallId": "exec-54209338-b2ec-4baf-8851-8bf777361c93",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:27:42.140719+00:00"
+  },
+  {
+    "id": "6dc2d0c3-698e-4d7c-8e05-4dab12369d5a",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 20035,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:27:42.140719+00:00"
+  },
+  {
+    "id": "f7a51bdc-f781-4765-a709-4d95bbd7eb9d",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "17c0bc0046046c92c94c53e777ace6b7",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:27:42.140719+00:00"
+  },
+  {
+    "id": "90981da4-88e8-410a-b93d-74be3c52d548",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Scheduling details**\n\nI need to set up a schedule now, which involves specif… <325 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:27:50.469168+00:00"
+  },
+  {
+    "id": "dba455db-e277-5b67-81d1-03b1ebcefe87",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-328ad873-f1f0-4307-b130-1bc33218bd67",
+      "name": "mcp.agenta-tools.create_schedule",
+      "type": "tool_call",
+      "input": {
+        "tool": "create_schedule",
+        "server": "agenta-tools",
+        "arguments": {
+          "data": {
+            "schedule": "0 7 * * *",
+            "event_key": "daily_arabic_poetry",
+            "inputs_fields": {
+              "payload": {
+                "timezone": "Europe/Berlin",
+                "local_time": "08:00",
+                "destination": "@mmabrouk1987"
+              },
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "أرسل قصيدة عربية صباحية قصيرة (4 إلى 8 أبيات) إلى تيليغرام باستخدام أداة الإرسال… <123 chars elided>"
+                }
+              ]
+            }
+          },
+          "name": "قصيدة عربية صباحية",
+          "description": "إرسال قصيدة عربية يومية إلى @mmabrouk1987 الساعة 08:00 بتوقيت برلين."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:27:50.469168+00:00"
+  },
+  {
+    "id": "c14b02b3-fb77-5f73-860f-77e5e9c064a0",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "f5f71920-93cc-4603-9cb3-91ef2e19b9c5",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "data": {
+              "schedule": "0 7 * * *",
+              "event_key": "daily_arabic_poetry",
+              "inputs_fields": {
+                "payload": {
+                  "timezone": "Europe/Berlin",
+                  "local_time": "08:00",
+                  "destination": "@mmabrouk1987"
+                },
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": "أرسل قصيدة عربية صباحية قصيرة (4 إلى 8 أبيات) إلى تيليغرام باستخدام أداة الإرسال… <123 chars elided>"
+                  }
+                ]
+              }
+            },
+            "name": "قصيدة عربية صباحية",
+            "description": "إرسال قصيدة عربية يومية إلى @mmabrouk1987 الساعة 08:00 بتوقيت برلين."
+          },
+          "toolCallId": "exec-328ad873-f1f0-4307-b130-1bc33218bd67",
+          "resolvedName": "create_schedule"
+        },
+        "toolCallId": "exec-328ad873-f1f0-4307-b130-1bc33218bd67",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:27:50.469168+00:00"
+  },
+  {
+    "id": "e7a9bbf0-9e47-4f7b-aa4f-c2d6c0e28033",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 20482,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:27:50.469168+00:00"
+  },
+  {
+    "id": "bf45fb5a-7f2e-4059-9ba5-2fe9dcb486d8",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "d90bef7637284a25aebb41f9157bc38c",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:27:50.469168+00:00"
+  },
+  {
+    "id": "ffa80ad7-db7e-414a-9e61-c0ff8dd4421e",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Drafting scheduling details**\n\nI need to provide concise scheduling informat… <397 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:28:00.508217+00:00"
+  },
+  {
+    "id": "5de2d8a7-7ae6-46e9-9a70-32ca65dbdd4f",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 23734,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:28:00.802236+00:00"
+  },
+  {
+    "id": "80eb5097-98b1-4731-8347-ad1050fa3ebf",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 578,
+      "total": 815,
+      "output": 237
+    },
+    "created_at": "2026-08-11T08:28:00.802236+00:00"
+  },
+  {
+    "id": "2f8985c1-14ea-4aec-86fe-6697a08bf5f3",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "تم إعداد الوكيل وتفعيل الجدولة اليومية لإرسال قصيدة عربية إلى `@mmabrouk1987` عبر تيليغرام. ستعمل الساعة 08:00 بتوقيت برلين شتاءً، و09:00 صيفًا بسبب الجدولة بتوقيت UTC.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:28:00.802236+00:00"
+  },
+  {
+    "id": "1f4877c7-2dab-455b-ba7b-be2d7a99bb85",
+    "session_id": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "80827cd7306000361e343e21a54021d8"
+    },
+    "created_at": "2026-08-11T08:28:00.802236+00:00"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/arabicPoetrySession.liveChunks.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/arabicPoetrySession.liveChunks.json
@@ -1,0 +1,519 @@
+[
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-9a4c928f-bec2-4c68-b3e3-6a2c4f9cd078",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18/.codex/skills/build-an-agent/SKILL.md'"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-9a4c928f-bec2-4c68-b3e3-6a2c4f9cd078",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18/.codex/skills/build-an-agent/SKILL.md'",
+    "input": null
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-9a4c928f-bec2-4c68-b3e3-6a2c4f9cd078",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-ab0304b9-061e-41ab-93c0-52207465da66",
+    "toolName": "\"sed -n '1,220p' .codex/skills/build-an-agent/references/agent-templates/index.m… <155 chars elided>"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-ab0304b9-061e-41ab-93c0-52207465da66",
+    "toolName": "\"sed -n '1,220p' .codex/skills/build-an-agent/references/agent-templates/index.m… <155 chars elided>",
+    "input": {
+      "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18",
+      "command": "/bin/bash -lc \"sed -n '1,220p' .codex/skills/build-an-agent/references/agent-tem… <169 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-ab0304b9-061e-41ab-93c0-52207465da66",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-da715af9-296c-4bcd-95e4-aab1fbccee5a",
+    "toolName": "mcp.agenta-tools.rename_agent"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-da715af9-296c-4bcd-95e4-aab1fbccee5a",
+    "toolName": "mcp.agenta-tools.rename_agent",
+    "input": {
+      "name": "Arabic Poetry Telegram Agent",
+      "description": "Sends a daily Arabic poem to the user on Telegram each morning; setup is in progress."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-da715af9-296c-4bcd-95e4-aab1fbccee5a",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-0916682c-3475-430e-a907-a4bad6d18016",
+    "toolName": "mcp.agenta-tools.rename_session"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-0916682c-3475-430e-a907-a4bad6d18016",
+    "toolName": "mcp.agenta-tools.rename_session",
+    "input": {
+      "name": "Daily Arabic Poetry",
+      "description": "Setting up a Telegram agent that sends one Arabic poem every morning; timezone and Telegram destination are still needed."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-0916682c-3475-430e-a907-a4bad6d18016",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a",
+    "toolName": "mcp.agenta-tools.request_input"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a",
+    "toolName": "mcp.agenta-tools.request_input",
+    "input": {
+      "message": "حدّد وقت الإرسال اليومي ووجهة تيليغرام. لا تُدخل أي رمز سري هنا؛ سيتم طلب الربط الآمن بشكل منفصل عند الحاجة.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "time",
+          "timezone",
+          "telegram_destination"
+        ],
+        "properties": {
+          "time": {
+            "type": "string",
+            "title": "وقت الإرسال",
+            "default": "08:00"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "المنطقة الزمنية",
+            "default": "Asia/Riyadh",
+            "description": "مثال: Asia/Riyadh أو Europe/Paris"
+          },
+          "telegram_destination": {
+            "type": "string",
+            "title": "وجهة تيليغرام",
+            "description": "@username أو Chat ID"
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a",
+    "toolName": "request_input",
+    "input": {
+      "message": "حدّد وقت الإرسال اليومي ووجهة تيليغرام. لا تُدخل أي رمز سري هنا؛ سيتم طلب الربط الآمن بشكل منفصل عند الحاجة.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "time",
+          "timezone",
+          "telegram_destination"
+        ],
+        "properties": {
+          "time": {
+            "type": "string",
+            "title": "وقت الإرسال",
+            "default": "08:00"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "المنطقة الزمنية",
+            "default": "Asia/Riyadh",
+            "description": "مثال: Asia/Riyadh أو Europe/Paris"
+          },
+          "telegram_destination": {
+            "type": "string",
+            "title": "وجهة تيليغرام",
+            "description": "@username أو Chat ID"
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a",
+      "render": {
+        "kind": "elicitation"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-4964e651-d4e6-4bd6-9ecd-45d6824f2787",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18/.codex/skills/build-an-agent/SKILL.md'"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-4964e651-d4e6-4bd6-9ecd-45d6824f2787",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fefed-ae53-7513-aca4-1ae2e72c9d18/.codex/skills/build-an-agent/SKILL.md'",
+    "input": null
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-4964e651-d4e6-4bd6-9ecd-45d6824f2787",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-41caf722-e73c-49c1-9d9f-04502720681f",
+    "toolName": "mcp.agenta-tools.discover_tools"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-41caf722-e73c-49c1-9d9f-04502720681f",
+    "toolName": "mcp.agenta-tools.discover_tools",
+    "input": {
+      "use_cases": [
+        "send a Telegram message"
+      ],
+      "limit_alternatives": 10
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-41caf722-e73c-49c1-9d9f-04502720681f",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647",
+    "toolName": "mcp.agenta-tools.request_connection"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647",
+    "toolName": "mcp.agenta-tools.request_connection",
+    "input": {
+      "mode": "oauth",
+      "slug": "telegram-main",
+      "integration": "telegram"
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647",
+    "toolName": "request_connection",
+    "input": {
+      "mode": "oauth",
+      "slug": "telegram-main",
+      "integration": "telegram"
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "exec-da6e14d6-e6a6-4afc-b444-4c982fc5e647",
+      "render": {
+        "kind": "connect"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-241ba39b-348a-4e81-b664-9582ab765c70",
+    "toolName": "mcp.agenta-tools.read_config"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-241ba39b-348a-4e81-b664-9582ab765c70",
+    "toolName": "mcp.agenta-tools.read_config",
+    "input": {
+      "target": {
+        "path": [
+          "parameters",
+          "agent"
+        ]
+      },
+      "description": "قراءة إعدادات الوكيل الحالية قبل تفعيل الجدولة."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-241ba39b-348a-4e81-b664-9582ab765c70",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-f8f66a00-901c-4908-adce-d1d72791820e",
+    "toolName": "mcp.agenta-tools.discover_tools"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-f8f66a00-901c-4908-adce-d1d72791820e",
+    "toolName": "mcp.agenta-tools.discover_tools",
+    "input": {
+      "use_cases": [
+        "send a Telegram message"
+      ],
+      "limit_alternatives": 10
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-f8f66a00-901c-4908-adce-d1d72791820e",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e",
+    "toolName": "mcp.agenta-tools.commit_revision"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e",
+    "toolName": "mcp.agenta-tools.commit_revision",
+    "input": {
+      "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e",
+    "toolName": "commit_revision",
+    "input": {
+      "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+      }
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "9b6b1049-602d-4b5b-b147-00c12946ae65",
+    "toolCallId": "exec-57e938d0-7b53-4ee3-9008-bc994291ad5e"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-54209338-b2ec-4baf-8851-8bf777361c93",
+    "toolName": "mcp.agenta-tools.commit_revision"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-54209338-b2ec-4baf-8851-8bf777361c93",
+    "toolName": "mcp.agenta-tools.commit_revision",
+    "input": {
+      "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "name": "telegram_send_message",
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-54209338-b2ec-4baf-8851-8bf777361c93",
+    "toolName": "commit_revision",
+    "input": {
+      "description": "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "أنت وكيل ودود يرسل قصيدة عربية قصيرة وأصلية يوميًا عبر تيليغرام.\n\nعند تشغيلك بوا… <256 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "name": "telegram_send_message",
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019fefed-a8a0-7720-bbe6-85b60d5b2ace"
+      }
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "39463b6b-3962-4c36-a881-dcd8920f36c4",
+    "toolCallId": "exec-54209338-b2ec-4baf-8851-8bf777361c93"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-328ad873-f1f0-4307-b130-1bc33218bd67",
+    "toolName": "mcp.agenta-tools.create_schedule"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-328ad873-f1f0-4307-b130-1bc33218bd67",
+    "toolName": "mcp.agenta-tools.create_schedule",
+    "input": {
+      "data": {
+        "schedule": "0 7 * * *",
+        "event_key": "daily_arabic_poetry",
+        "inputs_fields": {
+          "payload": {
+            "timezone": "Europe/Berlin",
+            "local_time": "08:00",
+            "destination": "@mmabrouk1987"
+          },
+          "messages": [
+            {
+              "role": "user",
+              "content": "أرسل قصيدة عربية صباحية قصيرة (4 إلى 8 أبيات) إلى تيليغرام باستخدام أداة الإرسال… <123 chars elided>"
+            }
+          ]
+        }
+      },
+      "name": "قصيدة عربية صباحية",
+      "description": "إرسال قصيدة عربية يومية إلى @mmabrouk1987 الساعة 08:00 بتوقيت برلين."
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-328ad873-f1f0-4307-b130-1bc33218bd67",
+    "toolName": "create_schedule",
+    "input": {
+      "data": {
+        "schedule": "0 7 * * *",
+        "event_key": "daily_arabic_poetry",
+        "inputs_fields": {
+          "payload": {
+            "timezone": "Europe/Berlin",
+            "local_time": "08:00",
+            "destination": "@mmabrouk1987"
+          },
+          "messages": [
+            {
+              "role": "user",
+              "content": "أرسل قصيدة عربية صباحية قصيرة (4 إلى 8 أبيات) إلى تيليغرام باستخدام أداة الإرسال… <123 chars elided>"
+            }
+          ]
+        }
+      },
+      "name": "قصيدة عربية صباحية",
+      "description": "إرسال قصيدة عربية يومية إلى @mmabrouk1987 الساعة 08:00 بتوقيت برلين."
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "f5f71920-93cc-4603-9cb3-91ef2e19b9c5",
+    "toolCallId": "exec-328ad873-f1f0-4307-b130-1bc33218bd67"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/connectAndFormsSession.interactions.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/connectAndFormsSession.interactions.json
@@ -1,0 +1,272 @@
+[
+  {
+    "id": "019fec2e-3811-7753-b5c4-cd6a74dee185",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "turn_id": "6d5e0a55-2d1e-4c44-9703-8e17fca3cef0",
+    "token": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+    "kind": "client_tool",
+    "status": "cancelled",
+    "created_at": "2026-08-10T14:57:59.825957+00:00",
+    "data": {
+      "request": {
+        "tool": "request_connection",
+        "args": {
+          "integration": "telegram",
+          "slug": "telegram-main",
+          "mode": "api_key"
+        }
+      },
+      "references": {
+        "workflow": {
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck",
+          "id": "019febd8-d9b7-7351-a7d4-8b4fa4a5a4cb"
+        },
+        "workflow_variant": {
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck.default",
+          "id": "019febd8-d9e5-74a0-8ed1-71453438c78e"
+        },
+        "workflow_revision": {
+          "version": "1",
+          "slug": "189c3d56677b",
+          "id": "019febd8-da57-7d41-bfd0-c286c198f19d"
+        }
+      }
+    }
+  },
+  {
+    "id": "019fec31-2e9c-7e50-9e0b-d56a706e9f0f",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "turn_id": "7f530533-8394-446e-be2d-212b476cb2c1",
+    "token": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+    "kind": "client_tool",
+    "status": "cancelled",
+    "created_at": "2026-08-10T15:01:14.012506+00:00",
+    "data": {
+      "request": {
+        "tool": "request_input",
+        "args": {
+          "message": "The Telegram connection attempt timed out, but we can continue configuring the a… <182 chars elided>",
+          "requestedSchema": {
+            "type": "object",
+            "x-ag-stepper": true,
+            "properties": {
+              "morning_time": {
+                "type": "string",
+                "format": "cron",
+                "title": "Daily schedule",
+                "description": "Five-field UTC cron expression for the delivery time. Example: 0 7 * * * means 07:00 UTC every day.",
+                "default": "0 7 * * *"
+              },
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "description": "IANA time zone used to convert your preferred local morning time, such as Europe/Paris or Asia/Riyadh.",
+                "default": "Asia/Riyadh"
+              },
+              "chat_id": {
+                "type": "string",
+                "title": "Telegram chat ID",
+                "description": "Numeric chat ID or @channel username. For a private chat, message the bot first.",
+                "default": ""
+              }
+            },
+            "required": [
+              "morning_time",
+              "timezone",
+              "chat_id"
+            ]
+          }
+        }
+      },
+      "references": {
+        "workflow": {
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck",
+          "id": "019febd8-d9b7-7351-a7d4-8b4fa4a5a4cb"
+        },
+        "workflow_variant": {
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck.default",
+          "id": "019febd8-d9e5-74a0-8ed1-71453438c78e"
+        },
+        "workflow_revision": {
+          "version": "1",
+          "slug": "189c3d56677b",
+          "id": "019febd8-da57-7d41-bfd0-c286c198f19d"
+        }
+      }
+    }
+  },
+  {
+    "id": "019fed5d-3831-7693-9797-62af93351e9f",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "turn_id": "3d544f94-aab5-4341-b620-f82d22999371",
+    "token": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+    "kind": "client_tool",
+    "status": "responded",
+    "created_at": "2026-08-10T20:28:57.266128+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "message": "Choose the daily local delivery time and time zone for your Arabic poetry message.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "morning_time",
+              "timezone"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Asia/Riyadh",
+                "description": "IANA time zone, such as Asia/Riyadh, Europe/Paris, or America/New_York."
+              },
+              "morning_time": {
+                "type": "string",
+                "title": "Morning delivery time",
+                "format": "cron",
+                "default": "0 7 * * *",
+                "description": "Five-field cron expression in UTC; the schedule builder can help set the local time."
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "tool": "request_input",
+        "tool_call_id": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064"
+      },
+      "references": {
+        "workflow": {
+          "id": "019febd8-d9b7-7351-a7d4-8b4fa4a5a4cb",
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck"
+        },
+        "workflow_variant": {
+          "id": "019febd8-d9e5-74a0-8ed1-71453438c78e",
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck.default"
+        },
+        "workflow_revision": {
+          "id": "019febd8-da57-7d41-bfd0-c286c198f19d",
+          "slug": "189c3d56677b",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "output": {
+          "action": "accept",
+          "content": {
+            "timezone": "berlun",
+            "morning_time": "0 7 * * *"
+          },
+          "humanFriendlyMessage": "Provided the requested input."
+        },
+        "outcome": "completed",
+        "tool_name": "request_input",
+        "tool_call_id": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064"
+      }
+    }
+  },
+  {
+    "id": "019fed5d-8870-7d22-8b43-e0266399d9f0",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "turn_id": "f0571f12-65ce-4430-896e-1d76185b3d5a",
+    "token": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+    "kind": "client_tool",
+    "status": "responded",
+    "created_at": "2026-08-10T20:29:17.808742+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "message": "Please confirm the time zone for the daily Telegram delivery.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "timezone"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Europe/Berlin",
+                "description": "IANA time-zone name, for example Europe/Berlin or Asia/Riyadh."
+              }
+            }
+          }
+        },
+        "tool": "request_input",
+        "tool_call_id": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df"
+      },
+      "references": {
+        "workflow": {
+          "id": "019febd8-d9b7-7351-a7d4-8b4fa4a5a4cb",
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck"
+        },
+        "workflow_variant": {
+          "id": "019febd8-d9e5-74a0-8ed1-71453438c78e",
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck.default"
+        },
+        "workflow_revision": {
+          "id": "019febd8-da57-7d41-bfd0-c286c198f19d",
+          "slug": "189c3d56677b",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "output": {
+          "action": "accept",
+          "content": {
+            "timezone": "berlin"
+          },
+          "humanFriendlyMessage": "Provided the requested input."
+        },
+        "outcome": "completed",
+        "tool_name": "request_input",
+        "tool_call_id": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df"
+      }
+    }
+  },
+  {
+    "id": "019fed5d-cc63-7a13-8695-c3aff230dcc8",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "turn_id": "adea2a42-2cf2-4387-b467-a77168884a2a",
+    "token": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+    "kind": "client_tool",
+    "status": "responded",
+    "created_at": "2026-08-10T20:29:35.203559+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "mode": "api_key",
+          "slug": "telegram-main",
+          "integration": "telegram"
+        },
+        "tool": "request_connection",
+        "tool_call_id": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b"
+      },
+      "references": {
+        "workflow": {
+          "id": "019febd8-d9b7-7351-a7d4-8b4fa4a5a4cb",
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck"
+        },
+        "workflow_variant": {
+          "id": "019febd8-d9e5-74a0-8ed1-71453438c78e",
+          "slug": "create-an-agent-that-sends-me-a-telegram-message-msn9jybyck.default"
+        },
+        "workflow_revision": {
+          "id": "019febd8-da57-7d41-bfd0-c286c198f19d",
+          "slug": "189c3d56677b",
+          "version": "1"
+        }
+      },
+      "resolution": {
+        "output": {
+          "slug": "telegram-main",
+          "reason": "Connection failed. Please try again.",
+          "connected": false,
+          "integration": "telegram"
+        },
+        "outcome": "completed",
+        "tool_name": "request_connection",
+        "tool_call_id": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b"
+      }
+    }
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/connectAndFormsSession.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/connectAndFormsSession.json
@@ -1,0 +1,1212 @@
+[
+  {
+    "id": "7cec46da-1175-41e7-ab2a-558ff3dd917a",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "I want to create an agent that sends me a telegram message everymorning with arabic poetry",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-10T14:57:27.428142+00:00"
+  },
+  {
+    "id": "144497c1-ac2d-4d81-8c24-dc71ed742804",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Configuring the agent**\n\nI need to configure the agent and start by reading th… <295 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:57:38.556601+00:00"
+  },
+  {
+    "id": "5f0fd731-30b7-55a1-8372-2889ce706f92",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_lBRmuwVnEUCMwsfW3Z5T83M9|fc_06ee41bfe9bafc80016a79e6e1d02081a28d8a6af70d6bb829",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-5bc2c9060a67/agents/skills/7fbe65435054f77ee392d890f704c382d76f27d6e9f638893a19479487201174/build-an-agent/SKILL.md"
+      }
+    },
+    "created_at": "2026-08-10T14:57:38.944693+00:00"
+  },
+  {
+    "id": "894a6bbf-df00-5f54-a61f-727f9da4c0b6",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_lBRmuwVnEUCMwsfW3Z5T83M9|fc_06ee41bfe9bafc80016a79e6e1d02081a28d8a6af70d6bb829",
+      "type": "tool_result",
+      "output": "---\nname: \"build-an-agent\"\ndescription: \"Build or configure an Agenta agent end … <12740 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:57:38.944693+00:00"
+  },
+  {
+    "id": "5d951f8a-5457-59cd-86d5-977f811e4662",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_vBZWFzFej71NAy58wAwtjGDc|fc_06ee41bfe9bafc80016a79e6e457b481a28c5c35cf9c95d4f3",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-5bc2c9060a67/agents/skills/7fbe65435054f77ee392d890f704c382d76f27d6e9f638893a19479487201174/build-an-agent"
+      }
+    },
+    "created_at": "2026-08-10T14:57:41.459997+00:00"
+  },
+  {
+    "id": "143bed53-eed5-56fd-93f8-ce45328da508",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_vBZWFzFej71NAy58wAwtjGDc|fc_06ee41bfe9bafc80016a79e6e457b481a28c5c35cf9c95d4f3",
+      "type": "tool_result",
+      "output": "references/\nSKILL.md",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:57:41.459997+00:00"
+  },
+  {
+    "id": "22f4fce6-b612-5d90-bf3f-d84be5e7cb05",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_rDpew8MsXztp6br8VvIBIsaH|fc_06ee41bfe9bafc80016a79e6e6629c81a2a8e60d1aa92d943a",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <139 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:57:43.55635+00:00"
+  },
+  {
+    "id": "7ff26c46-88f5-513e-9eb9-a23cb554e4db",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_rDpew8MsXztp6br8VvIBIsaH|fc_06ee41bfe9bafc80016a79e6e6629c81a2a8e60d1aa92d943a",
+      "type": "tool_result",
+      "output": "ENOENT: no such file or directory, access '/tmp/agenta/mounts/019fe1f4-c599-7c82… <183 chars elided>",
+      "isError": true
+    },
+    "created_at": "2026-08-10T14:57:43.55635+00:00"
+  },
+  {
+    "id": "0296cbbe-35c6-5059-be1c-8c1643fd7a30",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_wgHuIh11ZTgze2uRoRudUadp|fc_06ee41bfe9bafc80016a79e6e8aefc81a292791c5e07b24a03",
+      "name": "ls",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-5bc2c9060a67/agents/skills/7fbe65435054f77ee392d890f704c382d76f27d6e9f638893a19479487201174/build-an-agent/references"
+      }
+    },
+    "created_at": "2026-08-10T14:57:45.666859+00:00"
+  },
+  {
+    "id": "8e7eec13-35b4-5ab6-a52d-b12db1f53396",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_wgHuIh11ZTgze2uRoRudUadp|fc_06ee41bfe9bafc80016a79e6e8aefc81a292791c5e07b24a03",
+      "type": "tool_result",
+      "output": "agent-templates/\nconfig-schema.md\ntrigger-inputs.md",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:57:45.666859+00:00"
+  },
+  {
+    "id": "da39f602-cefd-5d91-8e59-6d2b1319a898",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_xleFrGiGjCTaEYQAvWfSrwHp|fc_06ee41bfe9bafc80016a79e6ebb7b481a2b795d9514db67742",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <142 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T14:57:49.076566+00:00"
+  },
+  {
+    "id": "c73a515c-ce9a-5fea-adf5-200dce45a2b7",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_xleFrGiGjCTaEYQAvWfSrwHp|fc_06ee41bfe9bafc80016a79e6ebb7b481a2b795d9514db67742",
+      "type": "tool_result",
+      "output": "# Agent template playbooks\n\nMatch the user's ask to a row, then read the named p… <4452 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:57:49.076566+00:00"
+  },
+  {
+    "id": "89778a3a-ce6b-4868-bc3e-dc98b6e411bd",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Clarifying telegram details**\n\nI need to clarify the missing timezone and the … <385 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:57:53.185972+00:00"
+  },
+  {
+    "id": "37f72c17-16df-49a2-814d-32b896a0cbe1",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "Hello! I can set this up as a daily Telegram poetry agent. I’ll first check the available Telegram sending action, then I’ll need your preferred morning time/time zone and Telegram chat destination.",
+      "type": "message"
+    },
+    "created_at": "2026-08-10T14:57:53.485821+00:00"
+  },
+  {
+    "id": "6395c1c4-9192-5d3a-a22a-47834650bbb5",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 14,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_4Glz6VcncRObF0lMKi28Opja|fc_06ee41bfe9bafc80016a79e6f09a0081a2b6d78ac43c77d7e4",
+      "name": "discover_tools",
+      "type": "tool_call",
+      "input": {
+        "provider": "composio",
+        "use_cases": [
+          "send a Telegram message"
+        ],
+        "limit_alternatives": 5
+      }
+    },
+    "created_at": "2026-08-10T14:57:56.488094+00:00"
+  },
+  {
+    "id": "a2f11304-3a7c-5459-9670-0ec263c090d6",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 15,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_4Glz6VcncRObF0lMKi28Opja|fc_06ee41bfe9bafc80016a79e6f09a0081a2b6d78ac43c77d7e4",
+      "type": "tool_result",
+      "output": "{\"capabilities\":[{\"use_case\":\"send a Telegram message\",\"integration\":\"telegram\",… <6750 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T14:57:56.488094+00:00"
+  },
+  {
+    "id": "3c3c286a-9ae6-4a19-be4d-c1df046bda9e",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 16,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Requesting connection first**\n\nI need to request a connection right now, but I… <323 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T14:57:59.707136+00:00"
+  },
+  {
+    "id": "fc27d0dd-7540-5f9d-b677-ec40887cef08",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 17,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+      "name": "request_connection",
+      "type": "tool_call",
+      "input": {
+        "mode": "api_key",
+        "slug": "telegram-main",
+        "integration": "telegram"
+      }
+    },
+    "created_at": "2026-08-10T14:58:00.107869+00:00"
+  },
+  {
+    "id": "76ea9a55-c998-5a8e-a3f0-8fee3498984b",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 18,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "mode": "api_key",
+          "slug": "telegram-main",
+          "integration": "telegram"
+        },
+        "render": {
+          "kind": "connect"
+        },
+        "toolCall": {
+          "id": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+          "kind": "client",
+          "name": "request_connection",
+          "input": {
+            "mode": "api_key",
+            "slug": "telegram-main",
+            "integration": "telegram"
+          },
+          "rawInput": {
+            "mode": "api_key",
+            "slug": "telegram-main",
+            "integration": "telegram"
+          },
+          "toolCallId": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab"
+        },
+        "toolName": "request_connection",
+        "toolCallId": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab"
+      }
+    },
+    "created_at": "2026-08-10T14:58:00.107869+00:00"
+  },
+  {
+    "id": "7f606197-ebc5-4d5d-81a2-35d49c14832b",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 19,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "f03e7e8e2cc55d0e6e126b66d24559a3",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-10T14:58:00.107869+00:00"
+  },
+  {
+    "id": "3635fc95-8e12-5d97-8439-b30ba993c549",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+      "name": "request_input",
+      "type": "tool_call",
+      "input": {
+        "message": "The Telegram connection attempt timed out, but we can continue configuring the a… <182 chars elided>",
+        "requestedSchema": {
+          "type": "object",
+          "required": [
+            "morning_time",
+            "timezone",
+            "chat_id"
+          ],
+          "properties": {
+            "chat_id": {
+              "type": "string",
+              "title": "Telegram chat ID",
+              "default": "",
+              "description": "Numeric chat ID or @channel username. For a private chat, message the bot first."
+            },
+            "timezone": {
+              "type": "string",
+              "title": "Time zone",
+              "default": "Asia/Riyadh",
+              "description": "IANA time zone used to convert your preferred local morning time, such as Europe/Paris or Asia/Riyadh."
+            },
+            "morning_time": {
+              "type": "string",
+              "title": "Daily schedule",
+              "format": "cron",
+              "default": "0 7 * * *",
+              "description": "Five-field UTC cron expression for the delivery time. Example: 0 7 * * * means 07:00 UTC every day."
+            }
+          },
+          "x-ag-stepper": true
+        }
+      }
+    },
+    "created_at": "2026-08-10T15:01:14.295467+00:00"
+  },
+  {
+    "id": "801a1dd8-3675-5f12-a6fc-ed074650f791",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "message": "The Telegram connection attempt timed out, but we can continue configuring the a… <182 chars elided>",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "morning_time",
+              "timezone",
+              "chat_id"
+            ],
+            "properties": {
+              "chat_id": {
+                "type": "string",
+                "title": "Telegram chat ID",
+                "default": "",
+                "description": "Numeric chat ID or @channel username. For a private chat, message the bot first."
+              },
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Asia/Riyadh",
+                "description": "IANA time zone used to convert your preferred local morning time, such as Europe/Paris or Asia/Riyadh."
+              },
+              "morning_time": {
+                "type": "string",
+                "title": "Daily schedule",
+                "format": "cron",
+                "default": "0 7 * * *",
+                "description": "Five-field UTC cron expression for the delivery time. Example: 0 7 * * * means 07:00 UTC every day."
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "render": {
+          "kind": "elicitation"
+        },
+        "toolCall": {
+          "id": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+          "kind": "client",
+          "name": "request_input",
+          "input": {
+            "message": "The Telegram connection attempt timed out, but we can continue configuring the a… <182 chars elided>",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "morning_time",
+                "timezone",
+                "chat_id"
+              ],
+              "properties": {
+                "chat_id": {
+                  "type": "string",
+                  "title": "Telegram chat ID",
+                  "default": "",
+                  "description": "Numeric chat ID or @channel username. For a private chat, message the bot first."
+                },
+                "timezone": {
+                  "type": "string",
+                  "title": "Time zone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA time zone used to convert your preferred local morning time, such as Europe/Paris or Asia/Riyadh."
+                },
+                "morning_time": {
+                  "type": "string",
+                  "title": "Daily schedule",
+                  "format": "cron",
+                  "default": "0 7 * * *",
+                  "description": "Five-field UTC cron expression for the delivery time. Example: 0 7 * * * means 07:00 UTC every day."
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "rawInput": {
+            "message": "The Telegram connection attempt timed out, but we can continue configuring the a… <182 chars elided>",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "morning_time",
+                "timezone",
+                "chat_id"
+              ],
+              "properties": {
+                "chat_id": {
+                  "type": "string",
+                  "title": "Telegram chat ID",
+                  "default": "",
+                  "description": "Numeric chat ID or @channel username. For a private chat, message the bot first."
+                },
+                "timezone": {
+                  "type": "string",
+                  "title": "Time zone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA time zone used to convert your preferred local morning time, such as Europe/Paris or Asia/Riyadh."
+                },
+                "morning_time": {
+                  "type": "string",
+                  "title": "Daily schedule",
+                  "format": "cron",
+                  "default": "0 7 * * *",
+                  "description": "Five-field UTC cron expression for the delivery time. Example: 0 7 * * * means 07:00 UTC every day."
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "toolCallId": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb"
+        },
+        "toolName": "request_input",
+        "toolCallId": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb"
+      }
+    },
+    "created_at": "2026-08-10T15:01:14.295467+00:00"
+  },
+  {
+    "id": "a39296c2-204d-4065-a5c1-61356f22107f",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "296649b252a567806cc4c37147301e4a",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-10T15:01:14.295467+00:00"
+  },
+  {
+    "id": "f2882d4c-2e1d-57ae-995c-73dbbb1b4ce2",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_sZkmXv4b22ZLXSfLe00ljAyX|fc_0efd0b0daec5dc77016a7a3479eee4819ebe68006ecacc4851",
+      "name": "rename_session",
+      "type": "tool_call",
+      "input": {
+        "name": "Daily Arabic Poetry",
+        "description": "Setting up a Telegram agent to send Arabic poetry each morning; delivery time, time zone, chat destination, and Telegram connection are still needed."
+      }
+    },
+    "created_at": "2026-08-10T20:28:43.862838+00:00"
+  },
+  {
+    "id": "8723dfda-6aa0-5334-b74c-3a345f9effcf",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_sZkmXv4b22ZLXSfLe00ljAyX|fc_0efd0b0daec5dc77016a7a3479eee4819ebe68006ecacc4851",
+      "type": "tool_result",
+      "output": "{\"stream\":{\"created_at\":\"2026-08-10T14:57:26.954046Z\",\"updated_at\":\"2026-08-10T2… <666 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T20:28:43.862838+00:00"
+  },
+  {
+    "id": "b4caa975-2091-43b4-b015-ed0b83f0bc04",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0.027517150000000004,
+      "type": "usage",
+      "input": 6,
+      "total": 38774,
+      "output": 204
+    },
+    "created_at": "2026-08-10T20:28:45.87144+00:00"
+  },
+  {
+    "id": "57414f72-4e3e-485a-abf6-c1a74ea73224",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "No problem. The setup is paused; when you’re ready, provide your preferred morni… <130 chars elided>",
+      "type": "message"
+    },
+    "created_at": "2026-08-10T20:28:45.87144+00:00"
+  },
+  {
+    "id": "cd920e95-de56-4773-9f3d-1098f2a75ec1",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "2ad9766cba43e0f34a5fc4f92a34552a"
+    },
+    "created_at": "2026-08-10T20:28:45.87144+00:00"
+  },
+  {
+    "id": "ffe22e5e-128c-4887-a96c-b64f26176ba7",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "@mmabrouk1987",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-10T20:28:52.992748+00:00"
+  },
+  {
+    "id": "8897b14b-eb6b-43d7-8fd1-71cf115d596b",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "Thanks — I’ll use `@mmabrouk1987` as the Telegram destination. What morning time and time zone should I use?",
+      "type": "message"
+    },
+    "created_at": "2026-08-10T20:28:56.403303+00:00"
+  },
+  {
+    "id": "8e65b172-6f69-5ddc-92cb-af45eb2313b2",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+      "name": "request_input",
+      "type": "tool_call",
+      "input": {
+        "message": "Choose the daily local delivery time and time zone for your Arabic poetry message.",
+        "requestedSchema": {
+          "type": "object",
+          "required": [
+            "morning_time",
+            "timezone"
+          ],
+          "properties": {
+            "timezone": {
+              "type": "string",
+              "title": "Time zone",
+              "default": "Asia/Riyadh",
+              "description": "IANA time zone, such as Asia/Riyadh, Europe/Paris, or America/New_York."
+            },
+            "morning_time": {
+              "type": "string",
+              "title": "Morning delivery time",
+              "format": "cron",
+              "default": "0 7 * * *",
+              "description": "Five-field cron expression in UTC; the schedule builder can help set the local time."
+            }
+          },
+          "x-ag-stepper": true
+        }
+      }
+    },
+    "created_at": "2026-08-10T20:28:57.578517+00:00"
+  },
+  {
+    "id": "64e9683c-28c5-505e-ad55-ac27d49c6b07",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "message": "Choose the daily local delivery time and time zone for your Arabic poetry message.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "morning_time",
+              "timezone"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Asia/Riyadh",
+                "description": "IANA time zone, such as Asia/Riyadh, Europe/Paris, or America/New_York."
+              },
+              "morning_time": {
+                "type": "string",
+                "title": "Morning delivery time",
+                "format": "cron",
+                "default": "0 7 * * *",
+                "description": "Five-field cron expression in UTC; the schedule builder can help set the local time."
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "render": {
+          "kind": "elicitation"
+        },
+        "toolCall": {
+          "id": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+          "kind": "client",
+          "name": "request_input",
+          "input": {
+            "message": "Choose the daily local delivery time and time zone for your Arabic poetry message.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "morning_time",
+                "timezone"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Time zone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA time zone, such as Asia/Riyadh, Europe/Paris, or America/New_York."
+                },
+                "morning_time": {
+                  "type": "string",
+                  "title": "Morning delivery time",
+                  "format": "cron",
+                  "default": "0 7 * * *",
+                  "description": "Five-field cron expression in UTC; the schedule builder can help set the local time."
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "rawInput": {
+            "message": "Choose the daily local delivery time and time zone for your Arabic poetry message.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "morning_time",
+                "timezone"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Time zone",
+                  "default": "Asia/Riyadh",
+                  "description": "IANA time zone, such as Asia/Riyadh, Europe/Paris, or America/New_York."
+                },
+                "morning_time": {
+                  "type": "string",
+                  "title": "Morning delivery time",
+                  "format": "cron",
+                  "default": "0 7 * * *",
+                  "description": "Five-field cron expression in UTC; the schedule builder can help set the local time."
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "toolCallId": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064"
+        },
+        "toolName": "request_input",
+        "toolCallId": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064"
+      }
+    },
+    "created_at": "2026-08-10T20:28:57.578517+00:00"
+  },
+  {
+    "id": "52753f52-76ff-47f4-858c-9af0c3f15e4d",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0.027517150000000004,
+      "type": "usage",
+      "input": 6,
+      "total": 38774,
+      "output": 204
+    },
+    "created_at": "2026-08-10T20:28:57.578517+00:00"
+  },
+  {
+    "id": "b632fe9c-24e7-41a0-ac45-88eec0e6386a",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "af9d734b4b4cdc1215cb34bfc5d9d5ac",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-10T20:28:57.929468+00:00"
+  },
+  {
+    "id": "17c99bea-453d-421c-bc12-0cf5d1989d90",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "I received `berlun` as the time zone, which doesn’t match an IANA time-zone name… <124 chars elided>",
+      "type": "message"
+    },
+    "created_at": "2026-08-10T20:29:16.86967+00:00"
+  },
+  {
+    "id": "cfebf2ad-a197-5b43-8beb-40393c9bbadf",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+      "name": "request_input",
+      "type": "tool_call",
+      "input": {
+        "message": "Please confirm the time zone for the daily Telegram delivery.",
+        "requestedSchema": {
+          "type": "object",
+          "required": [
+            "timezone"
+          ],
+          "properties": {
+            "timezone": {
+              "type": "string",
+              "title": "Time zone",
+              "default": "Europe/Berlin",
+              "description": "IANA time-zone name, for example Europe/Berlin or Asia/Riyadh."
+            }
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-10T20:29:18.126652+00:00"
+  },
+  {
+    "id": "f2d95f66-affd-5f64-bd03-5ff92f1cd70d",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "message": "Please confirm the time zone for the daily Telegram delivery.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "timezone"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Europe/Berlin",
+                "description": "IANA time-zone name, for example Europe/Berlin or Asia/Riyadh."
+              }
+            }
+          }
+        },
+        "render": {
+          "kind": "elicitation"
+        },
+        "toolCall": {
+          "id": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+          "kind": "client",
+          "name": "request_input",
+          "input": {
+            "message": "Please confirm the time zone for the daily Telegram delivery.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "timezone"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Time zone",
+                  "default": "Europe/Berlin",
+                  "description": "IANA time-zone name, for example Europe/Berlin or Asia/Riyadh."
+                }
+              }
+            }
+          },
+          "rawInput": {
+            "message": "Please confirm the time zone for the daily Telegram delivery.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "timezone"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Time zone",
+                  "default": "Europe/Berlin",
+                  "description": "IANA time-zone name, for example Europe/Berlin or Asia/Riyadh."
+                }
+              }
+            }
+          },
+          "toolCallId": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df"
+        },
+        "toolName": "request_input",
+        "toolCallId": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df"
+      }
+    },
+    "created_at": "2026-08-10T20:29:18.126652+00:00"
+  },
+  {
+    "id": "d8bc5b3f-2fa3-4ddd-b903-6c0f787fc1d5",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "17ca7cad69f4e5511638692450765780",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-10T20:29:18.126652+00:00"
+  },
+  {
+    "id": "746a84be-88b8-4962-a686-2d758bfb2169",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Configuring time zones**\n\nOkay, I need to clarify that there’s an issue with t… <373 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T20:29:31.611053+00:00"
+  },
+  {
+    "id": "a5ec2243-c2b0-5b0a-ab6b-b41a29a21278",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_Kb9sHoiYpWYSLt9TlfgQgJOn|fc_003fa00ff68094b6016a7a34ab2d88819eb5114fe6b34bee42",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <134 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T20:29:31.611053+00:00"
+  },
+  {
+    "id": "9f22edc4-2a8a-5263-b698-35815289df0d",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_UNiPSa9Yve89KPw88Osv2uil|fc_003fa00ff68094b6016a7a34ab2d9c819eb0f16812dc03456b",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <135 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T20:29:31.611053+00:00"
+  },
+  {
+    "id": "523777d7-180f-5b84-a3fe-9491ab91f338",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_ALQN5hGLZnULtlcMELhNTwtV|fc_003fa00ff68094b6016a7a34ab2da4819ea0066314829b7c7b",
+      "name": "read",
+      "type": "tool_call",
+      "input": {
+        "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <142 chars elided>"
+      }
+    },
+    "created_at": "2026-08-10T20:29:31.611053+00:00"
+  },
+  {
+    "id": "e1dc10db-d5fc-5540-949b-17dc5c757cb0",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_ALQN5hGLZnULtlcMELhNTwtV|fc_003fa00ff68094b6016a7a34ab2da4819ea0066314829b7c7b",
+      "type": "tool_result",
+      "output": "# Agent template playbooks\n\nMatch the user's ask to a row, then read the named p… <4452 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T20:29:31.611053+00:00"
+  },
+  {
+    "id": "67be11e0-c4fb-5c21-bcc3-840e2b0e6103",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_Kb9sHoiYpWYSLt9TlfgQgJOn|fc_003fa00ff68094b6016a7a34ab2d88819eb5114fe6b34bee42",
+      "type": "tool_result",
+      "output": "# The agent config, field by field\n\nRead this before your first `commit_revision… <17740 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T20:29:31.611053+00:00"
+  },
+  {
+    "id": "885b0380-592e-5032-a329-9c4b43830b59",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_UNiPSa9Yve89KPw88Osv2uil|fc_003fa00ff68094b6016a7a34ab2d9c819eb0f16812dc03456b",
+      "type": "tool_result",
+      "output": "# What a schedule or subscription passes to the run\n\nRead this when you create a… <4692 chars elided>",
+      "isError": false
+    },
+    "created_at": "2026-08-10T20:29:31.611053+00:00"
+  },
+  {
+    "id": "c700296c-82f2-5dff-b3d3-cf78e976ff31",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+      "name": "request_connection",
+      "type": "tool_call",
+      "input": {
+        "mode": "api_key",
+        "slug": "telegram-main",
+        "integration": "telegram"
+      }
+    },
+    "created_at": "2026-08-10T20:29:35.521589+00:00"
+  },
+  {
+    "id": "9f315b21-6297-5191-a403-d52abb8290a9",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "mode": "api_key",
+          "slug": "telegram-main",
+          "integration": "telegram"
+        },
+        "render": {
+          "kind": "connect"
+        },
+        "toolCall": {
+          "id": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+          "kind": "client",
+          "name": "request_connection",
+          "input": {
+            "mode": "api_key",
+            "slug": "telegram-main",
+            "integration": "telegram"
+          },
+          "rawInput": {
+            "mode": "api_key",
+            "slug": "telegram-main",
+            "integration": "telegram"
+          },
+          "toolCallId": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b"
+        },
+        "toolName": "request_connection",
+        "toolCallId": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b"
+      }
+    },
+    "created_at": "2026-08-10T20:29:35.521589+00:00"
+  },
+  {
+    "id": "6ce86457-eaed-4735-95db-b921882d33f7",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "25c002d243fae0df7814995d18f63d9a",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-10T20:29:35.521589+00:00"
+  },
+  {
+    "id": "6456ee67-d61a-43b0-a888-e4a80650cdef",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "**Requesting connection again**\n\nI'm considering if I can commit to a tool with … <300 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-10T20:29:51.866077+00:00"
+  },
+  {
+    "id": "4f8d9088-9601-5063-9551-515d6fb68a98",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "call_pqSSnHadzjhDWjoxKBYrAbMe|fc_0363efaf4edf4457016a7a34bf6244819fa11049629969decf",
+      "name": "request_connection",
+      "type": "tool_call",
+      "input": {
+        "mode": "api_key",
+        "slug": "telegram-main",
+        "integration": "telegram"
+      }
+    },
+    "created_at": "2026-08-10T20:29:52.48712+00:00"
+  },
+  {
+    "id": "d03d9656-70e0-51f3-95b4-f902df05e29a",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "call_pqSSnHadzjhDWjoxKBYrAbMe|fc_0363efaf4edf4457016a7a34bf6244819fa11049629969decf",
+      "type": "tool_result",
+      "output": "{\"connected\":false,\"integration\":\"telegram\",\"slug\":\"telegram-main\",\"reason\":\"Connection failed. Please try again.\"}",
+      "isError": false
+    },
+    "created_at": "2026-08-10T20:29:52.48712+00:00"
+  },
+  {
+    "id": "0cbf6728-1ecb-497d-ae16-a927f33e1a87",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0.0347918,
+      "type": "usage",
+      "input": 6,
+      "total": 47077,
+      "output": 532
+    },
+    "created_at": "2026-08-10T20:29:56.796123+00:00"
+  },
+  {
+    "id": "e09b9157-8c98-4f64-bf24-45fae58bc9b4",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "The Telegram connection failed again, so I couldn’t finish creating the agent or… <208 chars elided>",
+      "type": "message"
+    },
+    "created_at": "2026-08-10T20:29:56.796123+00:00"
+  },
+  {
+    "id": "e852864a-10a5-4c1b-8319-68725719be84",
+    "session_id": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "2b23f11dcba8e2fbdc59aaee7a8f37c0"
+    },
+    "created_at": "2026-08-10T20:29:56.796123+00:00"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/connectAndFormsSession.liveChunks.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/connectAndFormsSession.liveChunks.json
@@ -1,0 +1,499 @@
+[
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_lBRmuwVnEUCMwsfW3Z5T83M9|fc_06ee41bfe9bafc80016a79e6e1d02081a28d8a6af70d6bb829",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_lBRmuwVnEUCMwsfW3Z5T83M9|fc_06ee41bfe9bafc80016a79e6e1d02081a28d8a6af70d6bb829",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-5bc2c9060a67/agents/skills/7fbe65435054f77ee392d890f704c382d76f27d6e9f638893a19479487201174/build-an-agent/SKILL.md"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_lBRmuwVnEUCMwsfW3Z5T83M9|fc_06ee41bfe9bafc80016a79e6e1d02081a28d8a6af70d6bb829",
+    "output": "---\nname: \"build-an-agent\"\ndescription: \"Build or configure an Agenta agent end … <12740 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_vBZWFzFej71NAy58wAwtjGDc|fc_06ee41bfe9bafc80016a79e6e457b481a28c5c35cf9c95d4f3",
+    "toolName": "ls"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_vBZWFzFej71NAy58wAwtjGDc|fc_06ee41bfe9bafc80016a79e6e457b481a28c5c35cf9c95d4f3",
+    "toolName": "ls",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-5bc2c9060a67/agents/skills/7fbe65435054f77ee392d890f704c382d76f27d6e9f638893a19479487201174/build-an-agent"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_vBZWFzFej71NAy58wAwtjGDc|fc_06ee41bfe9bafc80016a79e6e457b481a28c5c35cf9c95d4f3",
+    "output": "references/\nSKILL.md"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_rDpew8MsXztp6br8VvIBIsaH|fc_06ee41bfe9bafc80016a79e6e6629c81a2a8e60d1aa92d943a",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_rDpew8MsXztp6br8VvIBIsaH|fc_06ee41bfe9bafc80016a79e6e6629c81a2a8e60d1aa92d943a",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <139 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "call_rDpew8MsXztp6br8VvIBIsaH|fc_06ee41bfe9bafc80016a79e6e6629c81a2a8e60d1aa92d943a",
+    "errorText": "ENOENT: no such file or directory, access '/tmp/agenta/mounts/019fe1f4-c599-7c82… <183 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_wgHuIh11ZTgze2uRoRudUadp|fc_06ee41bfe9bafc80016a79e6e8aefc81a292791c5e07b24a03",
+    "toolName": "ls"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_wgHuIh11ZTgze2uRoRudUadp|fc_06ee41bfe9bafc80016a79e6e8aefc81a292791c5e07b24a03",
+    "toolName": "ls",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-5bc2c9060a67/agents/skills/7fbe65435054f77ee392d890f704c382d76f27d6e9f638893a19479487201174/build-an-agent/references"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_wgHuIh11ZTgze2uRoRudUadp|fc_06ee41bfe9bafc80016a79e6e8aefc81a292791c5e07b24a03",
+    "output": "agent-templates/\nconfig-schema.md\ntrigger-inputs.md"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_xleFrGiGjCTaEYQAvWfSrwHp|fc_06ee41bfe9bafc80016a79e6ebb7b481a2b795d9514db67742",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_xleFrGiGjCTaEYQAvWfSrwHp|fc_06ee41bfe9bafc80016a79e6ebb7b481a2b795d9514db67742",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <142 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_xleFrGiGjCTaEYQAvWfSrwHp|fc_06ee41bfe9bafc80016a79e6ebb7b481a2b795d9514db67742",
+    "output": "# Agent template playbooks\n\nMatch the user's ask to a row, then read the named p… <4452 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_4Glz6VcncRObF0lMKi28Opja|fc_06ee41bfe9bafc80016a79e6f09a0081a2b6d78ac43c77d7e4",
+    "toolName": "discover_tools"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_4Glz6VcncRObF0lMKi28Opja|fc_06ee41bfe9bafc80016a79e6f09a0081a2b6d78ac43c77d7e4",
+    "toolName": "discover_tools",
+    "input": {
+      "provider": "composio",
+      "use_cases": [
+        "send a Telegram message"
+      ],
+      "limit_alternatives": 5
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_4Glz6VcncRObF0lMKi28Opja|fc_06ee41bfe9bafc80016a79e6f09a0081a2b6d78ac43c77d7e4",
+    "output": "{\"capabilities\":[{\"use_case\":\"send a Telegram message\",\"integration\":\"telegram\",… <6750 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+    "toolName": "request_connection"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+    "toolName": "request_connection",
+    "input": {
+      "mode": "api_key",
+      "slug": "telegram-main",
+      "integration": "telegram"
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+    "toolName": "request_connection",
+    "input": {
+      "mode": "api_key",
+      "slug": "telegram-main",
+      "integration": "telegram"
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "call_UuNIUWzL6usJyTv4fonM1MVD|fc_06ee41bfe9bafc80016a79e6f72cd481a297c5892f04a2e3ab",
+      "render": {
+        "kind": "connect"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+    "toolName": "request_input"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+    "toolName": "request_input",
+    "input": {
+      "message": "The Telegram connection attempt timed out, but we can continue configuring the a… <182 chars elided>",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "morning_time",
+          "timezone",
+          "chat_id"
+        ],
+        "properties": {
+          "chat_id": {
+            "type": "string",
+            "title": "Telegram chat ID",
+            "default": "",
+            "description": "Numeric chat ID or @channel username. For a private chat, message the bot first."
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Asia/Riyadh",
+            "description": "IANA time zone used to convert your preferred local morning time, such as Europe/Paris or Asia/Riyadh."
+          },
+          "morning_time": {
+            "type": "string",
+            "title": "Daily schedule",
+            "format": "cron",
+            "default": "0 7 * * *",
+            "description": "Five-field UTC cron expression for the delivery time. Example: 0 7 * * * means 07:00 UTC every day."
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+    "toolName": "request_input",
+    "input": {
+      "message": "The Telegram connection attempt timed out, but we can continue configuring the a… <182 chars elided>",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "morning_time",
+          "timezone",
+          "chat_id"
+        ],
+        "properties": {
+          "chat_id": {
+            "type": "string",
+            "title": "Telegram chat ID",
+            "default": "",
+            "description": "Numeric chat ID or @channel username. For a private chat, message the bot first."
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Asia/Riyadh",
+            "description": "IANA time zone used to convert your preferred local morning time, such as Europe/Paris or Asia/Riyadh."
+          },
+          "morning_time": {
+            "type": "string",
+            "title": "Daily schedule",
+            "format": "cron",
+            "default": "0 7 * * *",
+            "description": "Five-field UTC cron expression for the delivery time. Example: 0 7 * * * means 07:00 UTC every day."
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "call_gSb5q9yeCF5kLzxDZSSyQj7b|fc_0675e2f2ddf77962016a79e7b82fcc8192adf4cb52bee72fdb",
+      "render": {
+        "kind": "elicitation"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_sZkmXv4b22ZLXSfLe00ljAyX|fc_0efd0b0daec5dc77016a7a3479eee4819ebe68006ecacc4851",
+    "toolName": "rename_session"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_sZkmXv4b22ZLXSfLe00ljAyX|fc_0efd0b0daec5dc77016a7a3479eee4819ebe68006ecacc4851",
+    "toolName": "rename_session",
+    "input": {
+      "name": "Daily Arabic Poetry",
+      "description": "Setting up a Telegram agent to send Arabic poetry each morning; delivery time, time zone, chat destination, and Telegram connection are still needed."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_sZkmXv4b22ZLXSfLe00ljAyX|fc_0efd0b0daec5dc77016a7a3479eee4819ebe68006ecacc4851",
+    "output": "{\"stream\":{\"created_at\":\"2026-08-10T14:57:26.954046Z\",\"updated_at\":\"2026-08-10T2… <666 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+    "toolName": "request_input"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+    "toolName": "request_input",
+    "input": {
+      "message": "Choose the daily local delivery time and time zone for your Arabic poetry message.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "morning_time",
+          "timezone"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Asia/Riyadh",
+            "description": "IANA time zone, such as Asia/Riyadh, Europe/Paris, or America/New_York."
+          },
+          "morning_time": {
+            "type": "string",
+            "title": "Morning delivery time",
+            "format": "cron",
+            "default": "0 7 * * *",
+            "description": "Five-field cron expression in UTC; the schedule builder can help set the local time."
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+    "toolName": "request_input",
+    "input": {
+      "message": "Choose the daily local delivery time and time zone for your Arabic poetry message.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "morning_time",
+          "timezone"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Asia/Riyadh",
+            "description": "IANA time zone, such as Asia/Riyadh, Europe/Paris, or America/New_York."
+          },
+          "morning_time": {
+            "type": "string",
+            "title": "Morning delivery time",
+            "format": "cron",
+            "default": "0 7 * * *",
+            "description": "Five-field cron expression in UTC; the schedule builder can help set the local time."
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "call_hrfjocnwl6NsJUwFv7qpf8ig|fc_0efd0b0daec5dc77016a7a348802cc819ebc221962d9853064",
+      "render": {
+        "kind": "elicitation"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+    "toolName": "request_input"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+    "toolName": "request_input",
+    "input": {
+      "message": "Please confirm the time zone for the daily Telegram delivery.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "timezone"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Europe/Berlin",
+            "description": "IANA time-zone name, for example Europe/Berlin or Asia/Riyadh."
+          }
+        }
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+    "toolName": "request_input",
+    "input": {
+      "message": "Please confirm the time zone for the daily Telegram delivery.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "timezone"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Europe/Berlin",
+            "description": "IANA time-zone name, for example Europe/Berlin or Asia/Riyadh."
+          }
+        }
+      }
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "call_XQIUlFOVdWHTXGrC3XtyIC6B|fc_04a6a06044dd409d016a7a349c7d7481a2bcbcf779ae5e27df",
+      "render": {
+        "kind": "elicitation"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_Kb9sHoiYpWYSLt9TlfgQgJOn|fc_003fa00ff68094b6016a7a34ab2d88819eb5114fe6b34bee42",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_Kb9sHoiYpWYSLt9TlfgQgJOn|fc_003fa00ff68094b6016a7a34ab2d88819eb5114fe6b34bee42",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <134 chars elided>"
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_UNiPSa9Yve89KPw88Osv2uil|fc_003fa00ff68094b6016a7a34ab2d9c819eb0f16812dc03456b",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_UNiPSa9Yve89KPw88Osv2uil|fc_003fa00ff68094b6016a7a34ab2d9c819eb0f16812dc03456b",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <135 chars elided>"
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_ALQN5hGLZnULtlcMELhNTwtV|fc_003fa00ff68094b6016a7a34ab2da4819ea0066314829b7c7b",
+    "toolName": "read"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_ALQN5hGLZnULtlcMELhNTwtV|fc_003fa00ff68094b6016a7a34ab2da4819ea0066314829b7c7b",
+    "toolName": "read",
+    "input": {
+      "path": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019fec2d-b859-70e1-827c-… <142 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_ALQN5hGLZnULtlcMELhNTwtV|fc_003fa00ff68094b6016a7a34ab2da4819ea0066314829b7c7b",
+    "output": "# Agent template playbooks\n\nMatch the user's ask to a row, then read the named p… <4452 chars elided>"
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_Kb9sHoiYpWYSLt9TlfgQgJOn|fc_003fa00ff68094b6016a7a34ab2d88819eb5114fe6b34bee42",
+    "output": "# The agent config, field by field\n\nRead this before your first `commit_revision… <17740 chars elided>"
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_UNiPSa9Yve89KPw88Osv2uil|fc_003fa00ff68094b6016a7a34ab2d9c819eb0f16812dc03456b",
+    "output": "# What a schedule or subscription passes to the run\n\nRead this when you create a… <4692 chars elided>"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+    "toolName": "request_connection"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+    "toolName": "request_connection",
+    "input": {
+      "mode": "api_key",
+      "slug": "telegram-main",
+      "integration": "telegram"
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+    "toolName": "request_connection",
+    "input": {
+      "mode": "api_key",
+      "slug": "telegram-main",
+      "integration": "telegram"
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "call_uB0CfsIvyzGrxnRwJnIFtuEx|fc_003fa00ff68094b6016a7a34ad9af8819e9bdd632bd58a737b",
+      "render": {
+        "kind": "connect"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "call_pqSSnHadzjhDWjoxKBYrAbMe|fc_0363efaf4edf4457016a7a34bf6244819fa11049629969decf",
+    "toolName": "request_connection"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "call_pqSSnHadzjhDWjoxKBYrAbMe|fc_0363efaf4edf4457016a7a34bf6244819fa11049629969decf",
+    "toolName": "request_connection",
+    "input": {
+      "mode": "api_key",
+      "slug": "telegram-main",
+      "integration": "telegram"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "call_pqSSnHadzjhDWjoxKBYrAbMe|fc_0363efaf4edf4457016a7a34bf6244819fa11049629969decf",
+    "output": "{\"connected\":false,\"integration\":\"telegram\",\"slug\":\"telegram-main\",\"reason\":\"Connection failed. Please try again.\"}"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/generate/build_live_chunks.py
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/generate/build_live_chunks.py
@@ -1,0 +1,83 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Run the REAL live egress over the golden record fixtures and save the tool-related chunks.
+
+The live path is `agent_stream_to_vercel_stream`
+(sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:378), which consumes the same neutral
+`{"type", "data"}` agenta events the records log persists. Feeding it the fixture records
+reproduces exactly the Vercel UI Message Stream the browser assembles on a live turn, so the
+replayed parts can be compared against it directly instead of against a guess.
+
+Records are split into turns on `done`, the way the runner emits one stream per turn, and only
+agent-sourced records are fed (a user message never rides the agent's egress).
+
+Must run from `sdks/python` so the SDK resolves, and NOT from a directory holding a module that
+shadows a stdlib name (the script's own directory goes on `sys.path`):
+
+    cd sdks/python
+    FIX=../../web/oss/src/components/AgentChatSlice/assets/__fixtures__
+    for n in arabicPoetrySession testRunApprovalsSession connectAndFormsSession abandonedFormSession; do
+        uv run --no-sync python $FIX/generate/build_live_chunks.py $FIX/$n.json $FIX/$n.liveChunks.json
+    done
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from agenta.sdk.agents.adapters.vercel.stream import agent_stream_to_vercel_stream
+
+KEEP = {
+    "tool-input-start",
+    "tool-input-available",
+    "tool-output-available",
+    "tool-output-error",
+    "tool-approval-request",
+    "tool-approval-response",
+    "data-render",
+    "data-approval-manifest",
+}
+
+
+async def run_turn(events):
+    async def gen():
+        for event in events:
+            yield event
+
+    return [
+        part
+        async for part in agent_stream_to_vercel_stream(gen())
+        if part.get("type") in KEEP
+    ]
+
+
+async def main():
+    records = json.loads(Path(sys.argv[1]).read_text())
+    turns, current = [], []
+    for record in records:
+        if record.get("sender") != "agent":
+            continue
+        payload = record.get("payload") or {}
+        current.append(
+            {
+                "type": payload.get("type") or record.get("session_update"),
+                "data": payload,
+            }
+        )
+        if (payload.get("type") or record.get("session_update")) == "done":
+            turns.append(current)
+            current = []
+    if current:
+        turns.append(current)
+
+    out = []
+    for turn in turns:
+        out.extend(await run_turn(turn))
+    Path(sys.argv[2]).write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n")
+    print(f"{sys.argv[2]}: {len(turns)} turns, {len(out)} tool chunks")
+
+
+asyncio.run(main())

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/generate/pull_session_fixtures.py
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/generate/pull_session_fixtures.py
@@ -1,0 +1,139 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Build golden replay fixtures from the rel112 deployment's real sessions.
+
+Records come from `agenta_ee_tracing.records` in the SAME order the API serves them
+(`api/oss/src/dbs/postgres/sessions/records/dao.py:119-123`: timestamp asc nullslast,
+created_at asc, record_index asc) and are mapped to the consumer-facing shape the zod
+transform produces (`web/packages/agenta-entities/src/session/core/schema.ts:39-49`).
+
+Interaction rows come from `agenta_ee_core.session_interactions` in the wire shape
+`sessionInteractionSchema` validates.
+
+Long strings are elided the way `abandonedFormSession.json` did: first 80 code points plus
+a `… <N chars elided>` marker. Structure is never touched.
+
+Read-only. Run against a deployment that still holds these sessions:
+
+    uv run web/oss/src/components/AgentChatSlice/assets/__fixtures__/generate/pull_session_fixtures.py \\
+        web/oss/src/components/AgentChatSlice/assets/__fixtures__
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PG = "agenta-ee-dev-rel112-postgres-1"
+OUT = Path(sys.argv[1])
+
+SESSIONS = {
+    "arabicPoetrySession": "3d99d178-b76b-4eb7-a9e9-ad43295ee2b8",
+    "testRunApprovalsSession": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "connectAndFormsSession": "cfee6813-a5ee-49b4-81ee-56dd1676afa6",
+}
+
+KEEP_FULL = 80
+ELIDE_OVER = 200
+
+
+def psql(db: str, sql: str):
+    out = subprocess.run(
+        [
+            "docker",
+            "exec",
+            PG,
+            "psql",
+            "-U",
+            "username",
+            "-d",
+            db,
+            "-t",
+            "-A",
+            "-c",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return json.loads(out) if out else []
+
+
+def elide(value):
+    if isinstance(value, str):
+        if len(value) <= ELIDE_OVER:
+            return value
+        return f"{value[:KEEP_FULL]}… <{len(value) - KEEP_FULL} chars elided>"
+    if isinstance(value, list):
+        return [elide(v) for v in value]
+    if isinstance(value, dict):
+        return {k: elide(v) for k, v in value.items()}
+    return value
+
+
+def records(session_id: str):
+    rows = psql(
+        "agenta_ee_tracing",
+        f"""
+        select coalesce(json_agg(x order by x.timestamp asc nulls last, x.created_at asc, x.record_index asc), '[]')
+        from (
+          select record_id, session_id, project_id, record_index, record_source, record_type,
+                 attributes, timestamp, created_at
+          from records where session_id = '{session_id}'
+        ) x;
+        """,
+    )
+    return [
+        {
+            "id": r["record_id"],
+            "session_id": r["session_id"],
+            "project_id": r["project_id"],
+            "event_index": r["record_index"],
+            "sender": r["record_source"],
+            "session_update": r["record_type"],
+            "payload": elide(r["attributes"]),
+            "created_at": r["created_at"] or r["timestamp"],
+        }
+        for r in rows
+    ]
+
+
+def interactions(session_id: str):
+    rows = psql(
+        "agenta_ee_core",
+        f"""
+        select coalesce(json_agg(x order by x.created_at asc), '[]')
+        from (
+          select id, session_id, turn_id, token, kind, status, data, created_at
+          from session_interactions where session_id = '{session_id}'
+        ) x;
+        """,
+    )
+    return [
+        {
+            "id": r["id"],
+            "session_id": r["session_id"],
+            "turn_id": r["turn_id"],
+            "token": r["token"],
+            "kind": r["kind"],
+            "status": r["status"],
+            "created_at": r["created_at"],
+            "data": elide(r["data"]),
+        }
+        for r in rows
+    ]
+
+
+for name, session_id in SESSIONS.items():
+    recs = records(session_id)
+    rows = interactions(session_id)
+    (OUT / f"{name}.json").write_text(
+        json.dumps(recs, indent=2, ensure_ascii=False) + "\n"
+    )
+    (OUT / f"{name}.interactions.json").write_text(
+        json.dumps(rows, indent=2, ensure_ascii=False) + "\n"
+    )
+    print(f"{name}: {len(recs)} records, {len(rows)} interaction rows")

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/goldenSessions.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/goldenSessions.ts
@@ -1,0 +1,95 @@
+/**
+ * The golden replay set: real sessions pulled read-only from the rel112 deployment.
+ *
+ *   `<name>.json`              — `agenta_ee_tracing.records`, ordered exactly as the API serves
+ *                                them (api/oss/src/dbs/postgres/sessions/records/dao.py:119-123)
+ *                                and mapped to the consumer shape of `sessionRecordSchema`
+ *                                (web/packages/agenta-entities/src/session/core/schema.ts:39-49).
+ *   `<name>.interactions.json` — `agenta_ee_core.session_interactions`, in the wire shape
+ *                                `sessionInteractionSchema` validates (schema.ts:52-70).
+ *   `<name>.liveChunks.json`   — the LIVE builder's output over the same records; see
+ *                                `transcriptLiveReplayParity.test.ts`.
+ *
+ * Long strings are elided (`… <N chars elided>`); structure is never touched. Regenerate the
+ * first two with `generate/pull_session_fixtures.py`, the third with `generate/build_live_chunks.py`.
+ *
+ * Between them these four sessions cover an approved commit, a discover/search call with a
+ * result, a form answered and a form abandoned, a connect completed and a connect declined, a
+ * schedule approval both resolved and still pending, and both the legacy and current interaction
+ * row contracts.
+ */
+import type {
+    SessionInteraction,
+    SessionInteractionRowState,
+    SessionInteractionRowStates,
+    SessionRecord,
+} from "@agenta/entities/session"
+
+import abandonedFormRecords from "./abandonedFormSession.json"
+import arabicPoetryInteractions from "./arabicPoetrySession.interactions.json"
+import arabicPoetryRecords from "./arabicPoetrySession.json"
+import connectAndFormsInteractions from "./connectAndFormsSession.interactions.json"
+import connectAndFormsRecords from "./connectAndFormsSession.json"
+import testRunApprovalsInteractions from "./testRunApprovalsSession.interactions.json"
+import testRunApprovalsRecords from "./testRunApprovalsSession.json"
+
+/**
+ * Mirrors `interactionStatesFromRows`
+ * (web/packages/agenta-entities/src/session/state/interactionStatus.ts:39-53), which is module
+ * private. The fixtures hold the raw API rows so they stay honest captures; this is the same join.
+ */
+export const rowStatesFromInteractions = (
+    rows: SessionInteraction[],
+): SessionInteractionRowStates => {
+    const states = new Map<string, SessionInteractionRowState>()
+    for (const row of rows) {
+        if (typeof row.token !== "string" || !row.token) continue
+        const toolCallId = row.data?.request?.tool_call_id
+        states.set(row.token, {
+            token: row.token,
+            status: row.status as SessionInteractionRowState["status"],
+            kind: row.kind as SessionInteractionRowState["kind"],
+            ...(row.data?.resolution ? {resolution: row.data.resolution} : {}),
+            ...(typeof toolCallId === "string" && toolCallId ? {toolCallId} : {}),
+        })
+    }
+    return states
+}
+
+export interface GoldenSession {
+    name: string
+    records: SessionRecord[]
+    /** The session's interaction rows, in the API wire shape. */
+    interactions: SessionInteraction[]
+    /** Those rows joined for replay — omitted for the record-only golden. */
+    rows?: SessionInteractionRowStates
+}
+
+const golden = (name: string, records: unknown, interactions: unknown[] = []): GoldenSession => ({
+    name,
+    records: records as SessionRecord[],
+    interactions: interactions as SessionInteraction[],
+    ...(interactions.length > 0
+        ? {rows: rowStatesFromInteractions(interactions as SessionInteraction[])}
+        : {}),
+})
+
+export const GOLDEN_SESSIONS: GoldenSession[] = [
+    // The record-only golden: a form left unanswered, with no interaction rows joined.
+    golden("abandonedFormSession", abandonedFormRecords),
+    // Commits (approved), discover_tools with a result, a schedule approval, an answered form,
+    // and a completed connect. MCP-routed harness.
+    golden("arabicPoetrySession", arabicPoetryRecords, arabicPoetryInteractions),
+    // Two commit approvals, two test_run approvals, an answered form, and a schedule approval
+    // still pending. MCP-routed harness.
+    golden("testRunApprovalsSession", testRunApprovalsRecords, testRunApprovalsInteractions),
+    // Forms answered and abandoned, a connect completed and one declined, and a mix of legacy
+    // rows (no `data.request.tool_call_id`) with new-contract rows that carry it.
+    golden("connectAndFormsSession", connectAndFormsRecords, connectAndFormsInteractions),
+]
+
+export const goldenSession = (name: string): GoldenSession => {
+    const found = GOLDEN_SESSIONS.find((g) => g.name === name)
+    if (!found) throw new Error(`unknown golden session ${name}`)
+    return found
+}

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/testRunApprovalsSession.interactions.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/testRunApprovalsSession.interactions.json
@@ -1,0 +1,335 @@
+[
+  {
+    "id": "019feff6-9efa-7c41-8b6f-58e4365fb830",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "turn_id": "13b32471-21e3-4904-baa9-c5d463b20293",
+    "token": "aa874b2c-2cd8-40d2-aba2-2ee0244db0a0",
+    "kind": "client_tool",
+    "status": "responded",
+    "created_at": "2026-08-11T08:35:45.018806+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "message": "Lovely idea—tell me when and where to send it, and I’ll configure the daily delivery.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "delivery_time",
+              "timezone",
+              "telegram_destination"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Etc/UTC",
+                "description": "Use an IANA name, such as Africa/Cairo or Asia/Riyadh."
+              },
+              "poetry_style": {
+                "type": "string",
+                "title": "Poetry preference",
+                "default": "Varied Arabic classics",
+                "description": "Optional: a style, era, poet, or leave as varied classics."
+              },
+              "delivery_time": {
+                "type": "string",
+                "title": "Morning delivery time",
+                "default": "08:00",
+                "description": "Your preferred local time."
+              },
+              "telegram_destination": {
+                "type": "string",
+                "title": "Telegram destination",
+                "description": "The chat ID or @channel username where the poem should be sent."
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "tool": "request_input",
+        "tool_call_id": "exec-2e49d279-c258-4f07-9165-9acb53c82a02"
+      },
+      "references": {
+        "workflow": {
+          "id": "019feff5-ffbd-75f3-8c26-a0418c1356cd",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m"
+        },
+        "workflow_variant": {
+          "id": "019feff5-fff2-7a71-9038-05d017b0e041",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m.default"
+        }
+      },
+      "resolution": {
+        "output": {
+          "action": "accept",
+          "content": {
+            "timezone": "Berlin",
+            "poetry_style": "Varied Arabic classics",
+            "delivery_time": "08:00",
+            "telegram_destination": "my username is @mmabrouk1987"
+          },
+          "humanFriendlyMessage": "Provided the requested input."
+        },
+        "outcome": "completed",
+        "tool_name": "mcp.agenta-tools.request_input",
+        "tool_call_id": "exec-2e49d279-c258-4f07-9165-9acb53c82a02"
+      }
+    }
+  },
+  {
+    "id": "019feff7-6bca-7923-987e-cae73d861b95",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "turn_id": "3388c3d7-6e0a-47ba-81dd-87cd5ceb09d5",
+    "token": "c6179e6c-c573-4ebc-b136-223301fca138",
+    "kind": "user_approval",
+    "status": "resolved",
+    "created_at": "2026-08-11T08:36:37.450739+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+          }
+        },
+        "tool": "commit_revision",
+        "tool_call_id": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5"
+      },
+      "references": {
+        "workflow": {
+          "id": "019feff5-ffbd-75f3-8c26-a0418c1356cd",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m"
+        },
+        "workflow_variant": {
+          "id": "019feff5-fff2-7a71-9038-05d017b0e041",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m.default"
+        }
+      },
+      "resolution": {
+        "verdict": "approved",
+        "tool_call_id": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5"
+      }
+    }
+  },
+  {
+    "id": "019feff7-ded4-7fe3-aa40-5e0e577b0c8e",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "turn_id": "17c48289-d8d3-49c0-b177-537505cca4b1",
+    "token": "f62bf104-f684-4616-8844-185e4def3ff4",
+    "kind": "user_approval",
+    "status": "resolved",
+    "created_at": "2026-08-11T08:37:06.900182+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "name": "telegram-send-message",
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+          }
+        },
+        "tool": "commit_revision",
+        "tool_call_id": "exec-c439557f-1178-42ea-92a9-083450faf74e"
+      },
+      "references": {
+        "workflow": {
+          "id": "019feff5-ffbd-75f3-8c26-a0418c1356cd",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m"
+        },
+        "workflow_variant": {
+          "id": "019feff5-fff2-7a71-9038-05d017b0e041",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m.default"
+        }
+      },
+      "resolution": {
+        "verdict": "approved",
+        "tool_call_id": "exec-c439557f-1178-42ea-92a9-083450faf74e"
+      }
+    }
+  },
+  {
+    "id": "019feff8-013c-7531-8a7a-7e9736bfcd8f",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "turn_id": "4f974add-a145-46d5-87f8-f2d8f5254838",
+    "token": "94b0ed74-0d2b-4c83-98ad-66ec0de6c5aa",
+    "kind": "user_approval",
+    "status": "resolved",
+    "created_at": "2026-08-11T08:37:15.708303+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "inputs": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Send today's daily Arabic poem now."
+              }
+            ]
+          },
+          "description": "Verifying that a poetry run reaches the configured Telegram destination.",
+          "expectations": {
+            "terminal_tool": "telegram-send-message"
+          }
+        },
+        "tool": "test_run",
+        "tool_call_id": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f"
+      },
+      "references": {
+        "workflow": {
+          "id": "019feff5-ffbd-75f3-8c26-a0418c1356cd",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m"
+        },
+        "workflow_variant": {
+          "id": "019feff5-fff2-7a71-9038-05d017b0e041",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m.default"
+        }
+      },
+      "resolution": {
+        "verdict": "approved",
+        "tool_call_id": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f"
+      }
+    }
+  },
+  {
+    "id": "019feff8-20a6-7740-abf0-fe9aa9b0d63c",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "turn_id": "1c497c41-6160-4c89-b2d6-df28d67e8fe0",
+    "token": "edcc155c-9ef5-4f93-9f7e-8de029105a1a",
+    "kind": "user_approval",
+    "status": "resolved",
+    "created_at": "2026-08-11T08:37:23.750666+00:00",
+    "data": {
+      "request": {
+        "args": {
+          "inputs": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Send today's daily Arabic poem now."
+              }
+            ]
+          },
+          "description": "Retrying the scheduled-message verification after the temporary runtime error.",
+          "expectations": {
+            "terminal_tool": "telegram-send-message"
+          }
+        },
+        "tool": "test_run",
+        "tool_call_id": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2"
+      },
+      "references": {
+        "workflow": {
+          "id": "019feff5-ffbd-75f3-8c26-a0418c1356cd",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m"
+        },
+        "workflow_variant": {
+          "id": "019feff5-fff2-7a71-9038-05d017b0e041",
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m.default"
+        }
+      },
+      "resolution": {
+        "verdict": "approved",
+        "tool_call_id": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2"
+      }
+    }
+  },
+  {
+    "id": "019feff9-6b39-7651-ab94-93191d5adb65",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "turn_id": "a27927d7-1430-4012-9b25-478f3276b4bc",
+    "token": "eca07d80-9b42-4f51-9009-2045ec8c9f92",
+    "kind": "user_approval",
+    "status": "pending",
+    "created_at": "2026-08-11T08:38:48.378065+00:00",
+    "data": {
+      "request": {
+        "tool": "create_schedule",
+        "args": {
+          "data": {
+            "event_key": "daily_arabic_poetry_tick",
+            "inputs_fields": {
+              "messages": [
+                {
+                  "content": "Send the daily Arabic poetry message now.",
+                  "role": "user"
+                }
+              ]
+            },
+            "schedule": "0 6 * * *"
+          },
+          "description": "Sends a varied Arabic classical poem to @mmabrouk1987 every day at 06:00 UTC.",
+          "name": "daily-arabic-poetry"
+        },
+        "tool_call_id": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb"
+      },
+      "references": {
+        "workflow": {
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m",
+          "id": "019feff5-ffbd-75f3-8c26-a0418c1356cd"
+        },
+        "workflow_variant": {
+          "slug": "create-an-agent-that-send-me-a-daily-arabic-msoen9ue4m.default",
+          "id": "019feff5-fff2-7a71-9038-05d017b0e041"
+        }
+      }
+    }
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/testRunApprovalsSession.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/testRunApprovalsSession.json
@@ -1,0 +1,1920 @@
+[
+  {
+    "id": "d846ec39-831f-484b-b7bc-d6c72faef64c",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "I want to create an agent that send me a daily arabic poetry on telegram each morning",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-11T08:35:24.00379+00:00"
+  },
+  {
+    "id": "64b3b4ca-faf0-4afb-85f4-333a4b93f4de",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Planning agent build**\n\nI need to build an agent to read before replying, wh… <369 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:35:28.822643+00:00"
+  },
+  {
+    "id": "b3de06d5-66dc-43cd-8a7d-235da78c699e",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "I’ll use the agent-setup guidance to shape this into a daily Telegram poetry assistant.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:35:28.822643+00:00"
+  },
+  {
+    "id": "a03649ae-d12c-5a45-9ab7-3cfb77348d1f",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-9cbc6832-93b9-46b3-881b-c736aab4cd52",
+      "name": "pwd && rg --files .codex/skills | sed -n '1,80p'",
+      "type": "tool_call",
+      "input": {
+        "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d",
+        "command": "pwd && rg --files .codex/skills | sed -n '1,80p'"
+      }
+    },
+    "created_at": "2026-08-11T08:35:28.822643+00:00"
+  },
+  {
+    "id": "849d73c0-69e1-5f91-814f-e62ff4f36372",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-9cbc6832-93b9-46b3-881b-c736aab4cd52",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:35:28.822643+00:00"
+  },
+  {
+    "id": "cac75121-2370-4d0a-89af-84d7b0c2a759",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 12089,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:35:28.822643+00:00"
+  },
+  {
+    "id": "3d37b8ec-b024-5aa8-9581-8043f9ba757d",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-364c4028-0ba0-4af0-95fd-857b958debcf",
+      "name": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d/.codex/skills/build-an-agent/SKILL.md'",
+      "type": "tool_call"
+    },
+    "created_at": "2026-08-11T08:35:32.643413+00:00"
+  },
+  {
+    "id": "45836406-0bc6-5dea-ad83-cd416ade96cb",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-364c4028-0ba0-4af0-95fd-857b958debcf",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:35:32.643413+00:00"
+  },
+  {
+    "id": "f95febd1-41f7-4d48-b2be-e9a252e37ca8",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 12883,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:35:32.643413+00:00"
+  },
+  {
+    "id": "3f0550c3-6ef1-4522-80e7-c83be4f369ea",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Considering tool integration**\n\nI’m thinking about needing an index and rele… <363 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:35:37.460694+00:00"
+  },
+  {
+    "id": "3719056e-8bb9-5d5d-8bbe-15094cd41cde",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-689e37ae-7861-4365-819b-6fc9078a91ec",
+      "name": "\"sed -n '1,200p' .codex/skills/build-an-agent/references/agent-templates/index.m… <155 chars elided>",
+      "type": "tool_call",
+      "input": {
+        "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d",
+        "command": "/bin/bash -lc \"sed -n '1,200p' .codex/skills/build-an-agent/references/agent-tem… <169 chars elided>"
+      }
+    },
+    "created_at": "2026-08-11T08:35:37.460694+00:00"
+  },
+  {
+    "id": "ced5de3f-918b-56a2-a77b-d79cc80be6ff",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-689e37ae-7861-4365-819b-6fc9078a91ec",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:35:37.460694+00:00"
+  },
+  {
+    "id": "c07fe587-a8af-4093-9d7e-ef7f13640acc",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 16066,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:35:37.460694+00:00"
+  },
+  {
+    "id": "15a371c9-436f-4228-8fb0-36523e416759",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 21922,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:35:39.357641+00:00"
+  },
+  {
+    "id": "da265820-db0c-5cf1-8d4a-63f2de9020c0",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 14,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-0395e8f9-bea2-4c09-812b-b0ebe398ffc9",
+      "name": "mcp.agenta-tools.rename_agent",
+      "type": "tool_call",
+      "input": {
+        "tool": "rename_agent",
+        "server": "agenta-tools",
+        "arguments": {
+          "name": "Daily Arabic Poetry",
+          "description": "Sends a selected Arabic poem to Telegram each morning; waiting for your delivery details."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:35:42.677583+00:00"
+  },
+  {
+    "id": "595004eb-1c4a-5b80-a49c-b7d296e8069c",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 15,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-0395e8f9-bea2-4c09-812b-b0ebe398ffc9",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:35:42.677583+00:00"
+  },
+  {
+    "id": "f8a6a842-2d60-58d8-b402-c04f6005fa27",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 16,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-9497eaea-9394-4ec6-bcaf-de65e4405fdc",
+      "name": "mcp.agenta-tools.rename_session",
+      "type": "tool_call",
+      "input": {
+        "tool": "rename_session",
+        "server": "agenta-tools",
+        "arguments": {
+          "name": "Daily Arabic poetry",
+          "description": "Setting up a scheduled Telegram message with Arabic poetry each morning."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:35:42.677583+00:00"
+  },
+  {
+    "id": "b2e6fed0-c5a9-57c0-9c27-64cf51b753f6",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 17,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-9497eaea-9394-4ec6-bcaf-de65e4405fdc",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:35:42.677583+00:00"
+  },
+  {
+    "id": "e226e65e-674a-439d-8090-7e22ad572c59",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 18,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 23354,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:35:42.677583+00:00"
+  },
+  {
+    "id": "ffe721fe-56b4-5091-858b-02e9ac31d384",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 19,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-2e49d279-c258-4f07-9165-9acb53c82a02",
+      "name": "mcp.agenta-tools.request_input",
+      "type": "tool_call",
+      "input": {
+        "tool": "request_input",
+        "server": "agenta-tools",
+        "arguments": {
+          "message": "Lovely idea—tell me when and where to send it, and I’ll configure the daily delivery.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "delivery_time",
+              "timezone",
+              "telegram_destination"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Etc/UTC",
+                "description": "Use an IANA name, such as Africa/Cairo or Asia/Riyadh."
+              },
+              "poetry_style": {
+                "type": "string",
+                "title": "Poetry preference",
+                "default": "Varied Arabic classics",
+                "description": "Optional: a style, era, poet, or leave as varied classics."
+              },
+              "delivery_time": {
+                "type": "string",
+                "title": "Morning delivery time",
+                "default": "08:00",
+                "description": "Your preferred local time."
+              },
+              "telegram_destination": {
+                "type": "string",
+                "title": "Telegram destination",
+                "description": "The chat ID or @channel username where the poem should be sent."
+              }
+            },
+            "x-ag-stepper": true
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:35:45.281116+00:00"
+  },
+  {
+    "id": "b7ab8bc7-01a7-5a52-8adf-04a7c8fa44ef",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 20,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "aa874b2c-2cd8-40d2-aba2-2ee0244db0a0",
+      "kind": "client_tool",
+      "type": "interaction_request",
+      "payload": {
+        "input": {
+          "message": "Lovely idea—tell me when and where to send it, and I’ll configure the daily delivery.",
+          "requestedSchema": {
+            "type": "object",
+            "required": [
+              "delivery_time",
+              "timezone",
+              "telegram_destination"
+            ],
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "title": "Time zone",
+                "default": "Etc/UTC",
+                "description": "Use an IANA name, such as Africa/Cairo or Asia/Riyadh."
+              },
+              "poetry_style": {
+                "type": "string",
+                "title": "Poetry preference",
+                "default": "Varied Arabic classics",
+                "description": "Optional: a style, era, poet, or leave as varied classics."
+              },
+              "delivery_time": {
+                "type": "string",
+                "title": "Morning delivery time",
+                "default": "08:00",
+                "description": "Your preferred local time."
+              },
+              "telegram_destination": {
+                "type": "string",
+                "title": "Telegram destination",
+                "description": "The chat ID or @channel username where the poem should be sent."
+              }
+            },
+            "x-ag-stepper": true
+          }
+        },
+        "render": {
+          "kind": "elicitation"
+        },
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "message": "Lovely idea—tell me when and where to send it, and I’ll configure the daily delivery.",
+            "requestedSchema": {
+              "type": "object",
+              "required": [
+                "delivery_time",
+                "timezone",
+                "telegram_destination"
+              ],
+              "properties": {
+                "timezone": {
+                  "type": "string",
+                  "title": "Time zone",
+                  "default": "Etc/UTC",
+                  "description": "Use an IANA name, such as Africa/Cairo or Asia/Riyadh."
+                },
+                "poetry_style": {
+                  "type": "string",
+                  "title": "Poetry preference",
+                  "default": "Varied Arabic classics",
+                  "description": "Optional: a style, era, poet, or leave as varied classics."
+                },
+                "delivery_time": {
+                  "type": "string",
+                  "title": "Morning delivery time",
+                  "default": "08:00",
+                  "description": "Your preferred local time."
+                },
+                "telegram_destination": {
+                  "type": "string",
+                  "title": "Telegram destination",
+                  "description": "The chat ID or @channel username where the poem should be sent."
+                }
+              },
+              "x-ag-stepper": true
+            }
+          },
+          "toolCallId": "exec-2e49d279-c258-4f07-9165-9acb53c82a02",
+          "resolvedName": "request_input"
+        },
+        "toolName": "request_input",
+        "toolCallId": "exec-2e49d279-c258-4f07-9165-9acb53c82a02"
+      }
+    },
+    "created_at": "2026-08-11T08:35:45.281116+00:00"
+  },
+  {
+    "id": "7dbb1421-8a86-496b-bb2d-89b640c239e4",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 21,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 23354,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:35:45.281116+00:00"
+  },
+  {
+    "id": "b3eb4bb1-f140-4112-ba9e-15e2cf4815c4",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 22,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "528f8e1adab5bbe01a1abaebf5ec89d3",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:35:45.281116+00:00"
+  },
+  {
+    "id": "867ec120-fb64-448d-9c94-fc7248585193",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 23,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 24077,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:35:45.281116+00:00"
+  },
+  {
+    "id": "e1be3ce0-6988-4713-9b77-0b8baa95e9d7",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "I have your preferences: 08:00 Berlin time, varied Arabic classics, delivered to **@mmabrouk1987**. I’ll finish the schedule and check the Telegram connection needed for delivery.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:36:17.083077+00:00"
+  },
+  {
+    "id": "5407eaed-8690-5a01-bb60-e554d439f3e6",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-fcdc6464-27e9-42c1-b367-6a7e57f4c3ef",
+      "name": "List files in 'skills'",
+      "type": "tool_call"
+    },
+    "created_at": "2026-08-11T08:36:17.592968+00:00"
+  },
+  {
+    "id": "c098414e-9dc6-4870-91d1-b03e1aa2ec6b",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 13136,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:17.592968+00:00"
+  },
+  {
+    "id": "38ed7b86-5954-5c47-adc9-a0fed888f10b",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-fcdc6464-27e9-42c1-b367-6a7e57f4c3ef",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:36:17.592968+00:00"
+  },
+  {
+    "id": "47515f82-585a-52d7-aecb-934d21a30801",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-cb593d92-5a71-43b4-a205-58fba4fa77b2",
+      "name": "\"sed -n '1,260p' .codex/skills/build-an-agent/SKILL.md && sed -n '1,260p' .codex… <128 chars elided>",
+      "type": "tool_call",
+      "input": {
+        "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d",
+        "command": "/bin/bash -lc \"sed -n '1,260p' .codex/skills/build-an-agent/SKILL.md && sed -n '… <142 chars elided>"
+      }
+    },
+    "created_at": "2026-08-11T08:36:19.490769+00:00"
+  },
+  {
+    "id": "de806ffa-c74c-58d3-9334-a6113c582ffb",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-cb593d92-5a71-43b4-a205-58fba4fa77b2",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:36:19.490769+00:00"
+  },
+  {
+    "id": "8a476143-e15b-4f86-9140-c493a12a2894",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 13924,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:19.490769+00:00"
+  },
+  {
+    "id": "b95ac26d-b8e6-5a40-8ee4-cf7663f94223",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-61548bbc-9caf-4bc8-a942-fa4c55a4a363",
+      "name": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d/.codex/skills/build-an-agent/references/agent-templates/index.md'",
+      "type": "tool_call"
+    },
+    "created_at": "2026-08-11T08:36:21.288292+00:00"
+  },
+  {
+    "id": "31437b9c-5e6b-5627-acab-6ab1bc68c312",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-61548bbc-9caf-4bc8-a942-fa4c55a4a363",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:36:21.288292+00:00"
+  },
+  {
+    "id": "0d61c3c8-b85f-4709-bb2d-9e94184d57e1",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 21972,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:21.288292+00:00"
+  },
+  {
+    "id": "5b9e6b92-cc67-48e6-99e2-2ff7bd029cbf",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 23049,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:23.100257+00:00"
+  },
+  {
+    "id": "0691432a-c57d-4ae4-a019-a93c7bd6c8de",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 23120,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:26.109943+00:00"
+  },
+  {
+    "id": "728e83fb-66d3-59fe-acf4-ecfffc9f79e8",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-0afda786-b668-4f51-b739-718b91bb682d",
+      "name": "mcp.agenta-tools.discover_tools",
+      "type": "tool_call",
+      "input": {
+        "tool": "discover_tools",
+        "server": "agenta-tools",
+        "arguments": {
+          "use_cases": [
+            "send a Telegram message"
+          ]
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:36:30.723999+00:00"
+  },
+  {
+    "id": "95364403-fa5a-5ae6-8473-60b9247baec9",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 13,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-0afda786-b668-4f51-b739-718b91bb682d",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:36:32.040472+00:00"
+  },
+  {
+    "id": "50f46c41-53f4-4325-85d5-4546a9f6b600",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 14,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 30438,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:32.040472+00:00"
+  },
+  {
+    "id": "a6fb9965-282b-5b9b-b2c7-42c55fce1af0",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 15,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-83ed40a6-3aba-4728-9845-ec8512bd7199",
+      "name": "mcp.agenta-tools.read_config",
+      "type": "tool_call",
+      "input": {
+        "tool": "read_config",
+        "server": "agenta-tools",
+        "arguments": {
+          "target": {
+            "path": [
+              "parameters",
+              "agent"
+            ]
+          },
+          "description": "Reading the current instructions and tools so I can add the Telegram delivery safely."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:36:33.623111+00:00"
+  },
+  {
+    "id": "f9ed9479-dfdb-573b-8d5a-80259fe635ce",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 16,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-83ed40a6-3aba-4728-9845-ec8512bd7199",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:36:33.623111+00:00"
+  },
+  {
+    "id": "21b53b94-fc8e-4c04-975c-7ddacc81cbef",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 17,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 31962,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:33.623111+00:00"
+  },
+  {
+    "id": "b5b1ac6e-da56-46a1-97e2-8cb987e6ea51",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 18,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Configuring commit instructions**\n\nI need to gather the commit instructions … <424 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:36:37.745395+00:00"
+  },
+  {
+    "id": "96457d06-a2fb-53c8-a9f8-d279a94f2a7a",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 19,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5",
+      "name": "mcp.agenta-tools.commit_revision",
+      "type": "tool_call",
+      "input": {
+        "tool": "commit_revision",
+        "server": "agenta-tools",
+        "arguments": {
+          "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:36:37.745395+00:00"
+  },
+  {
+    "id": "2500de02-4e13-545e-ab5f-0744d5f0efc8",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 20,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "c6179e6c-c573-4ebc-b136-223301fca138",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+            "workflow_revision": {
+              "delta": {
+                "operations": [
+                  {
+                    "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "instructions",
+                      "agents_md"
+                    ],
+                    "operation": "set"
+                  },
+                  {
+                    "value": {
+                      "type": "gateway",
+                      "action": "SEND_MESSAGE",
+                      "provider": "composio",
+                      "connection": "telegram-main",
+                      "integration": "telegram"
+                    },
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "tools"
+                    ],
+                    "operation": "add_item"
+                  }
+                ]
+              },
+              "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+            }
+          },
+          "toolCallId": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5",
+          "resolvedName": "commit_revision"
+        },
+        "toolCallId": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:36:37.745395+00:00"
+  },
+  {
+    "id": "f17c5511-808f-4db1-a109-dc58f8fe1f23",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 21,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 31962,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:36:37.745395+00:00"
+  },
+  {
+    "id": "7b1fbeb8-81e9-40ca-bdc2-ffacbc7bb8c0",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 22,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "2cbd6228c140e1de51e22badd26d1593",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:36:37.745395+00:00"
+  },
+  {
+    "id": "2da80f6a-7c84-4197-b0a2-2bc06fce4861",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 32845,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:37:02.626697+00:00"
+  },
+  {
+    "id": "5ed08453-bb07-538f-b194-125a64ffc030",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-3354148f-2eda-4df1-8642-7005a2cb9f7a",
+      "name": "mcp.agenta-tools.read_config",
+      "type": "tool_call",
+      "input": {
+        "tool": "read_config",
+        "server": "agenta-tools",
+        "arguments": {
+          "target": {
+            "path": [
+              "parameters",
+              "agent"
+            ]
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:37:04.342525+00:00"
+  },
+  {
+    "id": "9dd583be-d2cc-5d6f-b261-8f04cc860452",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-3354148f-2eda-4df1-8642-7005a2cb9f7a",
+      "type": "tool_result",
+      "output": "",
+      "isError": false
+    },
+    "created_at": "2026-08-11T08:37:04.342525+00:00"
+  },
+  {
+    "id": "7cba1800-d19e-4d57-95ef-ed8323147723",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 33067,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:37:04.342525+00:00"
+  },
+  {
+    "id": "0f56877d-7ec3-505c-ae21-2061c7e0f302",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-c439557f-1178-42ea-92a9-083450faf74e",
+      "name": "mcp.agenta-tools.commit_revision",
+      "type": "tool_call",
+      "input": {
+        "tool": "commit_revision",
+        "server": "agenta-tools",
+        "arguments": {
+          "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+          "workflow_revision": {
+            "delta": {
+              "operations": [
+                {
+                  "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "instructions",
+                    "agents_md"
+                  ],
+                  "operation": "set"
+                },
+                {
+                  "value": {
+                    "name": "telegram-send-message",
+                    "type": "gateway",
+                    "action": "SEND_MESSAGE",
+                    "provider": "composio",
+                    "connection": "telegram-main",
+                    "integration": "telegram"
+                  },
+                  "target": [
+                    "parameters",
+                    "agent",
+                    "tools"
+                  ],
+                  "operation": "add_item"
+                }
+              ]
+            },
+            "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:37:07.257984+00:00"
+  },
+  {
+    "id": "7765618c-d4cd-5cd6-84fa-daec41f85130",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "f62bf104-f684-4616-8844-185e4def3ff4",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+            "workflow_revision": {
+              "delta": {
+                "operations": [
+                  {
+                    "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "instructions",
+                      "agents_md"
+                    ],
+                    "operation": "set"
+                  },
+                  {
+                    "value": {
+                      "name": "telegram-send-message",
+                      "type": "gateway",
+                      "action": "SEND_MESSAGE",
+                      "provider": "composio",
+                      "connection": "telegram-main",
+                      "integration": "telegram"
+                    },
+                    "target": [
+                      "parameters",
+                      "agent",
+                      "tools"
+                    ],
+                    "operation": "add_item"
+                  }
+                ]
+              },
+              "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+            }
+          },
+          "toolCallId": "exec-c439557f-1178-42ea-92a9-083450faf74e",
+          "resolvedName": "commit_revision"
+        },
+        "toolCallId": "exec-c439557f-1178-42ea-92a9-083450faf74e",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:37:07.257984+00:00"
+  },
+  {
+    "id": "2b661db1-f505-421d-987f-9a0d4a66f8bd",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 33067,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:37:07.257984+00:00"
+  },
+  {
+    "id": "a0f65e88-23b0-4ec2-ab9c-56009252301a",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 12,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "ebe090272bc73a0475e3db95bb0a6303",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:37:07.257984+00:00"
+  },
+  {
+    "id": "982d7480-0aa4-43ed-bdbd-aef32452bf5e",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Planning user warnings**\n\nI need to warn the user before running a test. But… <312 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:37:15.73188+00:00"
+  },
+  {
+    "id": "926f5d0e-0a99-4908-ab25-ba1473fb4f4d",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "The Telegram sender is connected and the agent is configured. A verification run… <138 chars elided>",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:37:15.73188+00:00"
+  },
+  {
+    "id": "add1eb1e-aa69-5fd3-a2b1-b324601abec9",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+      "name": "mcp.agenta-tools.test_run",
+      "type": "tool_call",
+      "input": {
+        "tool": "test_run",
+        "server": "agenta-tools",
+        "arguments": {
+          "inputs": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Send today's daily Arabic poem now."
+              }
+            ]
+          },
+          "description": "Verifying that a poetry run reaches the configured Telegram destination.",
+          "expectations": {
+            "terminal_tool": "telegram-send-message"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:37:15.73188+00:00"
+  },
+  {
+    "id": "696c39ed-a426-5fb7-9215-67de7c5f76fc",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "94b0ed74-0d2b-4c83-98ad-66ec0de6c5aa",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "inputs": {
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "Send today's daily Arabic poem now."
+                }
+              ]
+            },
+            "description": "Verifying that a poetry run reaches the configured Telegram destination.",
+            "expectations": {
+              "terminal_tool": "telegram-send-message"
+            }
+          },
+          "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+          "resolvedName": "test_run"
+        },
+        "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:37:16.094183+00:00"
+  },
+  {
+    "id": "4007691f-5fc7-480f-b4d8-2aa1b34640ad",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 33876,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:37:16.094183+00:00"
+  },
+  {
+    "id": "e33b7a4c-8cf5-4b2e-8e9f-80cd370c07e7",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "3f13a3922d30cac665e7b772e430384f",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:37:16.094183+00:00"
+  },
+  {
+    "id": "a5d40130-90bd-5bd6-9a01-30e65796a421",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "interaction_response",
+    "payload": {
+      "id": "94b0ed74-0d2b-4c83-98ad-66ec0de6c5aa",
+      "kind": "user_approval",
+      "type": "interaction_response",
+      "payload": {
+        "approved": true,
+        "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f"
+      }
+    },
+    "created_at": "2026-08-11T08:37:20.981484+00:00"
+  },
+  {
+    "id": "fe5147f0-273a-5dbc-bd81-2fea9fcad88e",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+      "name": "test_run",
+      "type": "tool_call",
+      "input": {
+        "tool": "test_run",
+        "server": "agenta-tools",
+        "arguments": {
+          "inputs": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Send today's daily Arabic poem now."
+              }
+            ]
+          },
+          "description": "Verifying that a poetry run reaches the configured Telegram destination.",
+          "expectations": {
+            "terminal_tool": "telegram-send-message"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:37:20.981484+00:00"
+  },
+  {
+    "id": "d48af819-0199-5091-b7c8-2f5a1bda09ae",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+      "type": "tool_result",
+      "output": "",
+      "isError": true
+    },
+    "created_at": "2026-08-11T08:37:21.28353+00:00"
+  },
+  {
+    "id": "d27c6bdb-3deb-4745-9fce-da7d8ff312d2",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 35499,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:37:21.28353+00:00"
+  },
+  {
+    "id": "51021927-851d-4a88-b6f6-a299d327e862",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Considering a retry**\n\nI think I might need to retry that action since there… <317 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:37:24.130875+00:00"
+  },
+  {
+    "id": "8d969229-89d4-59ef-82ca-42487eac3fab",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+      "name": "mcp.agenta-tools.test_run",
+      "type": "tool_call",
+      "input": {
+        "tool": "test_run",
+        "server": "agenta-tools",
+        "arguments": {
+          "inputs": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Send today's daily Arabic poem now."
+              }
+            ]
+          },
+          "description": "Retrying the scheduled-message verification after the temporary runtime error.",
+          "expectations": {
+            "terminal_tool": "telegram-send-message"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:37:24.130875+00:00"
+  },
+  {
+    "id": "fa72f615-c649-5a37-b7b3-1080f2a652d4",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "edcc155c-9ef5-4f93-9f7e-8de029105a1a",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "inputs": {
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "Send today's daily Arabic poem now."
+                }
+              ]
+            },
+            "description": "Retrying the scheduled-message verification after the temporary runtime error.",
+            "expectations": {
+              "terminal_tool": "telegram-send-message"
+            }
+          },
+          "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+          "resolvedName": "test_run"
+        },
+        "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:37:24.130875+00:00"
+  },
+  {
+    "id": "f43d4858-545d-4594-ae44-ec075bf5d7c3",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 35499,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:37:24.130875+00:00"
+  },
+  {
+    "id": "c1523a50-676d-470d-ac9c-9eb62a3448ef",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "5a01f1ddb95579e69bb12ada7f31a107",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:37:24.130875+00:00"
+  },
+  {
+    "id": "0fdac1c0-b609-51c8-b4bd-6ca7dcb3b3f4",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "interaction_response",
+    "payload": {
+      "id": "edcc155c-9ef5-4f93-9f7e-8de029105a1a",
+      "kind": "user_approval",
+      "type": "interaction_response",
+      "payload": {
+        "approved": true,
+        "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2"
+      }
+    },
+    "created_at": "2026-08-11T08:38:19.56671+00:00"
+  },
+  {
+    "id": "54ec0d41-ac4e-4635-896a-9a18c9ed87b3",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 35811,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:38:19.56671+00:00"
+  },
+  {
+    "id": "4a5ef35d-954d-548e-814a-1ae6f74e6e7c",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+      "name": "test_run",
+      "type": "tool_call",
+      "input": {
+        "tool": "test_run",
+        "server": "agenta-tools",
+        "arguments": {
+          "inputs": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Send today's daily Arabic poem now."
+              }
+            ]
+          },
+          "description": "Retrying the scheduled-message verification after the temporary runtime error.",
+          "expectations": {
+            "terminal_tool": "telegram-send-message"
+          }
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:38:19.56671+00:00"
+  },
+  {
+    "id": "2c102751-42dc-5604-b493-b003c93d20c0",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "tool_result",
+    "payload": {
+      "id": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+      "type": "tool_result",
+      "output": "",
+      "isError": true
+    },
+    "created_at": "2026-08-11T08:38:20.168052+00:00"
+  },
+  {
+    "id": "51f8b931-1358-4358-a04e-7c772c55c687",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 5,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 35910,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:38:21.472325+00:00"
+  },
+  {
+    "id": "8c473738-2b0b-4d6e-a979-07db5d12253f",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 6,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "The first verification hit a temporary local-runtime setup error, so I’m retrying it once before proceeding to the schedule.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:38:25.206589+00:00"
+  },
+  {
+    "id": "4132ffa1-dd97-441b-b6e1-e6a42641d8ee",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 7,
+    "sender": "agent",
+    "session_update": "thought",
+    "payload": {
+      "text": "\n\n**Finalizing approval details**\n\nI need to get user approval on the scheduling… <368 chars elided>",
+      "type": "thought"
+    },
+    "created_at": "2026-08-11T08:38:26.904367+00:00"
+  },
+  {
+    "id": "50f89f0b-1b6a-43b9-94dd-90ba6fa818fe",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 8,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 0,
+      "total": 36345,
+      "output": 0
+    },
+    "created_at": "2026-08-11T08:38:26.904367+00:00"
+  },
+  {
+    "id": "10dc9b41-644e-4dd4-adef-c5802929ffec",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 9,
+    "sender": "agent",
+    "session_update": "usage",
+    "payload": {
+      "cost": 0,
+      "type": "usage",
+      "input": 277,
+      "total": 509,
+      "output": 232
+    },
+    "created_at": "2026-08-11T08:38:26.904367+00:00"
+  },
+  {
+    "id": "902f9fa3-3630-4044-bfb0-d342574832ca",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 10,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "The Telegram delivery is configured, though platform verification is unavailable… <140 chars elided>",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:38:26.904367+00:00"
+  },
+  {
+    "id": "c6f2e882-90ba-4701-acee-210ce662dfdd",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 11,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "2e0cb5e9c3366d0a2121ba760160c2f9"
+    },
+    "created_at": "2026-08-11T08:38:26.904367+00:00"
+  },
+  {
+    "id": "353e16a0-0b59-48ed-9b6b-19da01369baf",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 0,
+    "sender": "user",
+    "session_update": "message",
+    "payload": {
+      "text": "let's just choose one time, I dont care about winter time",
+      "type": "message",
+      "attachments": []
+    },
+    "created_at": "2026-08-11T08:38:44.547838+00:00"
+  },
+  {
+    "id": "5b0e84ca-ce42-4bd9-9f04-6004ab9f2590",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 1,
+    "sender": "agent",
+    "session_update": "message",
+    "payload": {
+      "text": "I’ll use 06:00 UTC, which is 08:00 in Berlin right now. Creating the daily schedule now.",
+      "type": "message"
+    },
+    "created_at": "2026-08-11T08:38:48.686447+00:00"
+  },
+  {
+    "id": "e2b7247d-ee92-5b85-b84a-ac0e050d840e",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 2,
+    "sender": "agent",
+    "session_update": "tool_call",
+    "payload": {
+      "id": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb",
+      "name": "mcp.agenta-tools.create_schedule",
+      "type": "tool_call",
+      "input": {
+        "tool": "create_schedule",
+        "server": "agenta-tools",
+        "arguments": {
+          "data": {
+            "schedule": "0 6 * * *",
+            "event_key": "daily_arabic_poetry_tick",
+            "inputs_fields": {
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "Send the daily Arabic poetry message now."
+                }
+              ]
+            }
+          },
+          "name": "daily-arabic-poetry",
+          "description": "Sends a varied Arabic classical poem to @mmabrouk1987 every day at 06:00 UTC."
+        }
+      }
+    },
+    "created_at": "2026-08-11T08:38:48.686447+00:00"
+  },
+  {
+    "id": "9d0309cc-6e75-5918-8d40-7c27747f97e2",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 3,
+    "sender": "agent",
+    "session_update": "interaction_request",
+    "payload": {
+      "id": "eca07d80-9b42-4f51-9009-2045ec8c9f92",
+      "kind": "user_approval",
+      "type": "interaction_request",
+      "payload": {
+        "options": [
+          {
+            "kind": "allow_once",
+            "name": "Allow",
+            "optionId": "allow_once"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow for This Session",
+            "optionId": "allow_session"
+          },
+          {
+            "kind": "allow_always",
+            "name": "Allow and Don't Ask Again",
+            "optionId": "allow_always"
+          },
+          {
+            "kind": "reject_once",
+            "name": "Decline",
+            "optionId": "decline"
+          }
+        ],
+        "toolCall": {
+          "kind": "execute",
+          "status": "pending",
+          "rawInput": {
+            "data": {
+              "schedule": "0 6 * * *",
+              "event_key": "daily_arabic_poetry_tick",
+              "inputs_fields": {
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": "Send the daily Arabic poetry message now."
+                  }
+                ]
+              }
+            },
+            "name": "daily-arabic-poetry",
+            "description": "Sends a varied Arabic classical poem to @mmabrouk1987 every day at 06:00 UTC."
+          },
+          "toolCallId": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb",
+          "resolvedName": "create_schedule"
+        },
+        "toolCallId": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb",
+        "availableReplies": [
+          "once",
+          "always",
+          "reject"
+        ]
+      }
+    },
+    "created_at": "2026-08-11T08:38:48.686447+00:00"
+  },
+  {
+    "id": "34072e4d-a19e-4904-a980-5df1c637c439",
+    "session_id": "f60bc4f8-cd39-495d-ada8-1ceb354ec16e",
+    "project_id": "019fe1f4-c599-7c82-9350-c1f0ed5d660c",
+    "event_index": 4,
+    "sender": "agent",
+    "session_update": "done",
+    "payload": {
+      "type": "done",
+      "traceId": "1ba78a82f31380e8e4e5fd97ecdd09d9",
+      "stopReason": "paused"
+    },
+    "created_at": "2026-08-11T08:38:48.686447+00:00"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/__fixtures__/testRunApprovalsSession.liveChunks.json
+++ b/web/oss/src/components/AgentChatSlice/assets/__fixtures__/testRunApprovalsSession.liveChunks.json
@@ -1,0 +1,698 @@
+[
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-9cbc6832-93b9-46b3-881b-c736aab4cd52",
+    "toolName": "pwd && rg --files .codex/skills | sed -n '1,80p'"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-9cbc6832-93b9-46b3-881b-c736aab4cd52",
+    "toolName": "pwd && rg --files .codex/skills | sed -n '1,80p'",
+    "input": {
+      "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d",
+      "command": "pwd && rg --files .codex/skills | sed -n '1,80p'"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-9cbc6832-93b9-46b3-881b-c736aab4cd52",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-364c4028-0ba0-4af0-95fd-857b958debcf",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d/.codex/skills/build-an-agent/SKILL.md'"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-364c4028-0ba0-4af0-95fd-857b958debcf",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d/.codex/skills/build-an-agent/SKILL.md'",
+    "input": null
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-364c4028-0ba0-4af0-95fd-857b958debcf",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-689e37ae-7861-4365-819b-6fc9078a91ec",
+    "toolName": "\"sed -n '1,200p' .codex/skills/build-an-agent/references/agent-templates/index.m… <155 chars elided>"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-689e37ae-7861-4365-819b-6fc9078a91ec",
+    "toolName": "\"sed -n '1,200p' .codex/skills/build-an-agent/references/agent-templates/index.m… <155 chars elided>",
+    "input": {
+      "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d",
+      "command": "/bin/bash -lc \"sed -n '1,200p' .codex/skills/build-an-agent/references/agent-tem… <169 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-689e37ae-7861-4365-819b-6fc9078a91ec",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-0395e8f9-bea2-4c09-812b-b0ebe398ffc9",
+    "toolName": "mcp.agenta-tools.rename_agent"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-0395e8f9-bea2-4c09-812b-b0ebe398ffc9",
+    "toolName": "mcp.agenta-tools.rename_agent",
+    "input": {
+      "name": "Daily Arabic Poetry",
+      "description": "Sends a selected Arabic poem to Telegram each morning; waiting for your delivery details."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-0395e8f9-bea2-4c09-812b-b0ebe398ffc9",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-9497eaea-9394-4ec6-bcaf-de65e4405fdc",
+    "toolName": "mcp.agenta-tools.rename_session"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-9497eaea-9394-4ec6-bcaf-de65e4405fdc",
+    "toolName": "mcp.agenta-tools.rename_session",
+    "input": {
+      "name": "Daily Arabic poetry",
+      "description": "Setting up a scheduled Telegram message with Arabic poetry each morning."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-9497eaea-9394-4ec6-bcaf-de65e4405fdc",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-2e49d279-c258-4f07-9165-9acb53c82a02",
+    "toolName": "mcp.agenta-tools.request_input"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-2e49d279-c258-4f07-9165-9acb53c82a02",
+    "toolName": "mcp.agenta-tools.request_input",
+    "input": {
+      "message": "Lovely idea—tell me when and where to send it, and I’ll configure the daily delivery.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "delivery_time",
+          "timezone",
+          "telegram_destination"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Etc/UTC",
+            "description": "Use an IANA name, such as Africa/Cairo or Asia/Riyadh."
+          },
+          "poetry_style": {
+            "type": "string",
+            "title": "Poetry preference",
+            "default": "Varied Arabic classics",
+            "description": "Optional: a style, era, poet, or leave as varied classics."
+          },
+          "delivery_time": {
+            "type": "string",
+            "title": "Morning delivery time",
+            "default": "08:00",
+            "description": "Your preferred local time."
+          },
+          "telegram_destination": {
+            "type": "string",
+            "title": "Telegram destination",
+            "description": "The chat ID or @channel username where the poem should be sent."
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-2e49d279-c258-4f07-9165-9acb53c82a02",
+    "toolName": "request_input",
+    "input": {
+      "message": "Lovely idea—tell me when and where to send it, and I’ll configure the daily delivery.",
+      "requestedSchema": {
+        "type": "object",
+        "required": [
+          "delivery_time",
+          "timezone",
+          "telegram_destination"
+        ],
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "title": "Time zone",
+            "default": "Etc/UTC",
+            "description": "Use an IANA name, such as Africa/Cairo or Asia/Riyadh."
+          },
+          "poetry_style": {
+            "type": "string",
+            "title": "Poetry preference",
+            "default": "Varied Arabic classics",
+            "description": "Optional: a style, era, poet, or leave as varied classics."
+          },
+          "delivery_time": {
+            "type": "string",
+            "title": "Morning delivery time",
+            "default": "08:00",
+            "description": "Your preferred local time."
+          },
+          "telegram_destination": {
+            "type": "string",
+            "title": "Telegram destination",
+            "description": "The chat ID or @channel username where the poem should be sent."
+          }
+        },
+        "x-ag-stepper": true
+      }
+    }
+  },
+  {
+    "type": "data-render",
+    "data": {
+      "toolCallId": "exec-2e49d279-c258-4f07-9165-9acb53c82a02",
+      "render": {
+        "kind": "elicitation"
+      }
+    }
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-fcdc6464-27e9-42c1-b367-6a7e57f4c3ef",
+    "toolName": "List files in 'skills'"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-fcdc6464-27e9-42c1-b367-6a7e57f4c3ef",
+    "toolName": "List files in 'skills'",
+    "input": null
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-fcdc6464-27e9-42c1-b367-6a7e57f4c3ef",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-cb593d92-5a71-43b4-a205-58fba4fa77b2",
+    "toolName": "\"sed -n '1,260p' .codex/skills/build-an-agent/SKILL.md && sed -n '1,260p' .codex… <128 chars elided>"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-cb593d92-5a71-43b4-a205-58fba4fa77b2",
+    "toolName": "\"sed -n '1,260p' .codex/skills/build-an-agent/SKILL.md && sed -n '1,260p' .codex… <128 chars elided>",
+    "input": {
+      "cwd": "/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d",
+      "command": "/bin/bash -lc \"sed -n '1,260p' .codex/skills/build-an-agent/SKILL.md && sed -n '… <142 chars elided>"
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-cb593d92-5a71-43b4-a205-58fba4fa77b2",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-61548bbc-9caf-4bc8-a942-fa4c55a4a363",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d/.codex/skills/build-an-agent/references/agent-templates/index.md'"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-61548bbc-9caf-4bc8-a942-fa4c55a4a363",
+    "toolName": "Read file '/tmp/agenta/mounts/019fe1f4-c599-7c82-9350-c1f0ed5d660c/019feff6-4b8f-7831-8798-afc654d5618d/.codex/skills/build-an-agent/references/agent-templates/index.md'",
+    "input": null
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-61548bbc-9caf-4bc8-a942-fa4c55a4a363",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-0afda786-b668-4f51-b739-718b91bb682d",
+    "toolName": "mcp.agenta-tools.discover_tools"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-0afda786-b668-4f51-b739-718b91bb682d",
+    "toolName": "mcp.agenta-tools.discover_tools",
+    "input": {
+      "use_cases": [
+        "send a Telegram message"
+      ]
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-0afda786-b668-4f51-b739-718b91bb682d",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-83ed40a6-3aba-4728-9845-ec8512bd7199",
+    "toolName": "mcp.agenta-tools.read_config"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-83ed40a6-3aba-4728-9845-ec8512bd7199",
+    "toolName": "mcp.agenta-tools.read_config",
+    "input": {
+      "target": {
+        "path": [
+          "parameters",
+          "agent"
+        ]
+      },
+      "description": "Reading the current instructions and tools so I can add the Telegram delivery safely."
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-83ed40a6-3aba-4728-9845-ec8512bd7199",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5",
+    "toolName": "mcp.agenta-tools.commit_revision"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5",
+    "toolName": "mcp.agenta-tools.commit_revision",
+    "input": {
+      "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5",
+    "toolName": "commit_revision",
+    "input": {
+      "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+      }
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "c6179e6c-c573-4ebc-b136-223301fca138",
+    "toolCallId": "exec-0cb27e20-8243-418e-9676-af60d15eb6d5"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-3354148f-2eda-4df1-8642-7005a2cb9f7a",
+    "toolName": "mcp.agenta-tools.read_config"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-3354148f-2eda-4df1-8642-7005a2cb9f7a",
+    "toolName": "mcp.agenta-tools.read_config",
+    "input": {
+      "target": {
+        "path": [
+          "parameters",
+          "agent"
+        ]
+      }
+    }
+  },
+  {
+    "type": "tool-output-available",
+    "toolCallId": "exec-3354148f-2eda-4df1-8642-7005a2cb9f7a",
+    "output": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-c439557f-1178-42ea-92a9-083450faf74e",
+    "toolName": "mcp.agenta-tools.commit_revision"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-c439557f-1178-42ea-92a9-083450faf74e",
+    "toolName": "mcp.agenta-tools.commit_revision",
+    "input": {
+      "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "name": "telegram-send-message",
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-c439557f-1178-42ea-92a9-083450faf74e",
+    "toolName": "commit_revision",
+    "input": {
+      "description": "Configuring the agent to send one varied Arabic classic poem to the confirmed Telegram username each morning.",
+      "workflow_revision": {
+        "delta": {
+          "operations": [
+            {
+              "value": "You send a daily Arabic poetry message to Telegram. Every scheduled run, do exac… <406 chars elided>",
+              "target": [
+                "parameters",
+                "agent",
+                "instructions",
+                "agents_md"
+              ],
+              "operation": "set"
+            },
+            {
+              "value": {
+                "name": "telegram-send-message",
+                "type": "gateway",
+                "action": "SEND_MESSAGE",
+                "provider": "composio",
+                "connection": "telegram-main",
+                "integration": "telegram"
+              },
+              "target": [
+                "parameters",
+                "agent",
+                "tools"
+              ],
+              "operation": "add_item"
+            }
+          ]
+        },
+        "base_revision_id": "019feff6-0072-7a00-899d-59a9cc1a414a"
+      }
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "f62bf104-f684-4616-8844-185e4def3ff4",
+    "toolCallId": "exec-c439557f-1178-42ea-92a9-083450faf74e"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+    "toolName": "mcp.agenta-tools.test_run"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+    "toolName": "mcp.agenta-tools.test_run",
+    "input": {
+      "inputs": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Send today's daily Arabic poem now."
+          }
+        ]
+      },
+      "description": "Verifying that a poetry run reaches the configured Telegram destination.",
+      "expectations": {
+        "terminal_tool": "telegram-send-message"
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+    "toolName": "test_run",
+    "input": {
+      "inputs": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Send today's daily Arabic poem now."
+          }
+        ]
+      },
+      "description": "Verifying that a poetry run reaches the configured Telegram destination.",
+      "expectations": {
+        "terminal_tool": "telegram-send-message"
+      }
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "94b0ed74-0d2b-4c83-98ad-66ec0de6c5aa",
+    "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+    "toolName": "test_run"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+    "toolName": "test_run",
+    "input": {
+      "inputs": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Send today's daily Arabic poem now."
+          }
+        ]
+      },
+      "description": "Verifying that a poetry run reaches the configured Telegram destination.",
+      "expectations": {
+        "terminal_tool": "telegram-send-message"
+      }
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "exec-626ba8eb-d7dd-4077-b222-bc8dcd09649f",
+    "errorText": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+    "toolName": "mcp.agenta-tools.test_run"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+    "toolName": "mcp.agenta-tools.test_run",
+    "input": {
+      "inputs": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Send today's daily Arabic poem now."
+          }
+        ]
+      },
+      "description": "Retrying the scheduled-message verification after the temporary runtime error.",
+      "expectations": {
+        "terminal_tool": "telegram-send-message"
+      }
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+    "toolName": "test_run",
+    "input": {
+      "inputs": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Send today's daily Arabic poem now."
+          }
+        ]
+      },
+      "description": "Retrying the scheduled-message verification after the temporary runtime error.",
+      "expectations": {
+        "terminal_tool": "telegram-send-message"
+      }
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "edcc155c-9ef5-4f93-9f7e-8de029105a1a",
+    "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2"
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+    "toolName": "test_run"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+    "toolName": "test_run",
+    "input": {
+      "inputs": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Send today's daily Arabic poem now."
+          }
+        ]
+      },
+      "description": "Retrying the scheduled-message verification after the temporary runtime error.",
+      "expectations": {
+        "terminal_tool": "telegram-send-message"
+      }
+    }
+  },
+  {
+    "type": "tool-output-error",
+    "toolCallId": "exec-9255970a-8bc6-4f7e-b072-3aa9dd3730b2",
+    "errorText": ""
+  },
+  {
+    "type": "tool-input-start",
+    "toolCallId": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb",
+    "toolName": "mcp.agenta-tools.create_schedule"
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb",
+    "toolName": "mcp.agenta-tools.create_schedule",
+    "input": {
+      "data": {
+        "schedule": "0 6 * * *",
+        "event_key": "daily_arabic_poetry_tick",
+        "inputs_fields": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Send the daily Arabic poetry message now."
+            }
+          ]
+        }
+      },
+      "name": "daily-arabic-poetry",
+      "description": "Sends a varied Arabic classical poem to @mmabrouk1987 every day at 06:00 UTC."
+    }
+  },
+  {
+    "type": "tool-input-available",
+    "toolCallId": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb",
+    "toolName": "create_schedule",
+    "input": {
+      "data": {
+        "schedule": "0 6 * * *",
+        "event_key": "daily_arabic_poetry_tick",
+        "inputs_fields": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Send the daily Arabic poetry message now."
+            }
+          ]
+        }
+      },
+      "name": "daily-arabic-poetry",
+      "description": "Sends a varied Arabic classical poem to @mmabrouk1987 every day at 06:00 UTC."
+    }
+  },
+  {
+    "type": "tool-approval-request",
+    "approvalId": "eca07d80-9b42-4f51-9009-2045ec8c9f92",
+    "toolCallId": "exec-b1dc2fc6-805d-4f5e-9eac-d782ed0086bb"
+  }
+]

--- a/web/oss/src/components/AgentChatSlice/assets/approvalGrantKey.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/approvalGrantKey.test.ts
@@ -1,0 +1,180 @@
+/**
+ * THE PERMISSION KEY CHAIN, end to end: an approval card's tool name → the config key
+ * "always allow" writes → the rule the runner matches a gate against.
+ *
+ * Four components have to agree on one string, and nothing in the type system makes them:
+ *  1. the card's name — `partToolName` off the tool part (ApprovalDock.tsx:61), built either live
+ *     by the SDK egress (`_approval_tool_name`, stream.py:817-833) or on reload by
+ *     `transcriptToMessages`;
+ *  2. the grant key — `gateRulePattern` (toolPermission.ts:138) applied to that name VERBATIM,
+ *     written into `harness.permissions.allow` by `withHarnessToolAllow`;
+ *  3. the wire filter — `wire_author_permission_rules` (permission_rules.py:39) drops `mcp__`
+ *     patterns on the way to the runner;
+ *  4. the runner — `ruleMatches` compares the surviving pattern against `gate.toolName`
+ *     (permission-plan.ts:245-268), which is `spec?.name ?? displayName` (acp-interactions.ts:878)
+ *     and is stamped back onto the emitted gate as `resolvedName` (acp-interactions.ts:243).
+ *
+ * (4) is what makes the goldens usable as a runner oracle: the `resolvedName` recorded in each
+ * fixture's `user_approval` payload IS the `gate.toolName` that run's permission gate matched on.
+ * So a replayed card whose name equals `resolvedName` keys exactly what the runner reads.
+ *
+ * The break this pins: replay used to name a gate from the durable `tool_call` row, which under an
+ * MCP-routing harness is `mcp.agenta-tools.commit_revision`. That is a different string at every
+ * link — a different label, a grant key the runner can never match, and (worse) a name that walks
+ * straight past the platform-op guard that exists to keep `commit_revision` always gated.
+ */
+import type {SessionRecord} from "@agenta/entities/session"
+import {
+    findGrantableHarnessTool,
+    gateRulePattern,
+    readHarnessAllowList,
+    withHarnessToolAllow,
+} from "@agenta/entity-ui/drill-in"
+import {describe, expect, it} from "vitest"
+
+import arabicPoetryRecords from "./__fixtures__/arabicPoetrySession.json"
+import testRunApprovalsRecords from "./__fixtures__/testRunApprovalsSession.json"
+import {partToolName} from "./toolDisplay"
+import {transcriptToMessages} from "./transcriptToMessages"
+
+type AnyPart = Record<string, unknown>
+
+const MCP_ROUTED_GOLDENS = [
+    {name: "arabicPoetrySession", records: arabicPoetryRecords},
+    {name: "testRunApprovalsSession", records: testRunApprovalsRecords},
+] as const
+
+/**
+ * The runner's own gate identity per toolCallId, read from the durable `user_approval` payload:
+ * `resolvedName` is the value `acp-interactions.ts:243` copies off `gate.toolName`.
+ */
+const runnerGateNames = (records: unknown[]): Map<string, string> => {
+    const names = new Map<string, string>()
+    for (const raw of records) {
+        const row = raw as {session_update?: string; payload?: Record<string, unknown>}
+        const payload = row.payload ?? {}
+        if (row.session_update !== "interaction_request" || payload.kind !== "user_approval") {
+            continue
+        }
+        const request = (payload.payload ?? {}) as Record<string, unknown>
+        const toolCall = (request.toolCall ?? {}) as Record<string, unknown>
+        const toolCallId = request.toolCallId ?? toolCall.toolCallId ?? toolCall.id
+        if (typeof toolCallId === "string" && typeof toolCall.resolvedName === "string") {
+            names.set(toolCallId, toolCall.resolvedName)
+        }
+    }
+    return names
+}
+
+/**
+ * Replayed tool parts that carry an approval marker, keyed by toolCallId — the parts the dock reads
+ * a `toolName` off (ApprovalDock.tsx:56-66). Matched by marker rather than by `approval-requested`
+ * state: an answered gate settles to its result but keeps the same name, and the name is what the
+ * grant is keyed on whether the card is open now or was open then.
+ */
+const replayedGates = (records: unknown[]): Map<string, AnyPart> => {
+    const gates = new Map<string, AnyPart>()
+    for (const message of transcriptToMessages(records as SessionRecord[]) ?? []) {
+        if (message.role !== "assistant") continue
+        for (const raw of message.parts as unknown as AnyPart[]) {
+            const approval = raw.approval as {id?: unknown} | undefined
+            if (approval?.id && raw.toolCallId) gates.set(String(raw.toolCallId), raw)
+        }
+    }
+    return gates
+}
+
+/**
+ * The runner's rule matcher, mirroring `ruleMatches`/`toolNamesMatch` (permission-plan.ts:245-268)
+ * for the plain-name rules the card writes: the seven Pi built-ins fold case, every other
+ * author-chosen name compares exactly. Prefix rules (`Bash(git:*)`) are not reachable from the
+ * card, which only ever writes a bare gate name.
+ */
+const PI_BUILTINS = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"])
+const runnerRuleMatches = (pattern: string, gateToolName: string): boolean => {
+    const rule = pattern.trim().toLowerCase()
+    const gate = gateToolName.trim().toLowerCase()
+    if (PI_BUILTINS.has(rule) && PI_BUILTINS.has(gate)) return rule === gate
+    return pattern === gateToolName
+}
+
+/** `wire_author_permission_rules` (permission_rules.py:49): `mcp__` patterns never reach the runner. */
+const survivesWireFilter = (pattern: string): boolean => !pattern.startsWith("mcp__")
+
+describe("the card's tool name is the runner's gate name", () => {
+    for (const golden of MCP_ROUTED_GOLDENS) {
+        it(`${golden.name}: every replayed gate is named exactly as the runner keyed it`, () => {
+            const expected = runnerGateNames(golden.records)
+            const gates = replayedGates(golden.records)
+            expect(expected.size).toBeGreaterThan(0)
+            expect([...expected.keys()].filter((id) => !gates.has(id))).toEqual([])
+            for (const [toolCallId, runnerName] of expected) {
+                expect(partToolName(gates.get(toolCallId) as never), toolCallId).toBe(runnerName)
+            }
+        })
+
+        it(`${golden.name}: no replayed gate can write a permission key at all`, () => {
+            // Every gate in these goldens is a platform op (commit_revision, test_run,
+            // create_schedule), and those must stay gated forever — `gateRulePattern` returns null,
+            // so the dock hides "always allow" and no key is written on either path.
+            for (const [toolCallId, part] of replayedGates(golden.records)) {
+                expect(gateRulePattern(partToolName(part as never)), toolCallId).toBeNull()
+            }
+        })
+    }
+
+    it("the pre-fix name would have escaped the platform-op guard", () => {
+        // Why the name above is load-bearing rather than cosmetic. The guard matches the bare
+        // platform-op name, and Codex's wrapper is `mcp.` — only Claude's `mcp__` form is rejected
+        // by shape — so the harness-wrapped name produced a rule for a tool that must never be
+        // auto-allowed, and one no gate can match (the runner keys `commit_revision`).
+        expect(gateRulePattern("commit_revision")).toBeNull()
+        const escaped = gateRulePattern("mcp.agenta-tools.commit_revision")
+        expect(escaped).toBe("mcp.agenta-tools.commit_revision")
+        expect(runnerRuleMatches(escaped!, "commit_revision")).toBe(false)
+    })
+})
+
+describe("a granted key survives the wire and matches the gate it was granted from", () => {
+    const config = {
+        agent: {
+            harness: {permissions: {allow: [], ask: [], deny: []}},
+            tools: [],
+        },
+    }
+
+    // Gate names as the card receives them, paired with the runner `gate.toolName` for the same
+    // call. A Pi built-in reaches the card lower-cased (`tool-bash`) while the ACP gate reports
+    // `Bash`; every other name is identical on both sides.
+    const grantable: {cardName: string; gateToolName: string}[] = [
+        {cardName: "bash", gateToolName: "Bash"},
+        {cardName: "Terminal", gateToolName: "Terminal"},
+        {cardName: "Write", gateToolName: "Write"},
+    ]
+
+    for (const {cardName, gateToolName} of grantable) {
+        it(`${cardName}: grant key reaches the runner and matches gate.toolName=${gateToolName}`, () => {
+            const info = findGrantableHarnessTool(config, cardName)
+            expect(info).not.toBeNull()
+            expect(info!.allowed).toBe(false)
+
+            const granted = withHarnessToolAllow(config, info!.pattern, true)
+            const stored = readHarnessAllowList(granted)
+            expect(stored).toEqual([info!.pattern])
+
+            const [key] = stored
+            expect(survivesWireFilter(key)).toBe(true)
+            expect(runnerRuleMatches(key, gateToolName)).toBe(true)
+        })
+    }
+
+    it("an MCP-wrapped gate never writes a key the wire would drop", () => {
+        // Claude's form is rejected at the card. Nothing else may reach the wire filter and be
+        // silently discarded there — a key that vanishes between the config and the runner reads
+        // as a granted permission that never takes effect.
+        expect(gateRulePattern("mcp__linear__create_issue")).toBeNull()
+        for (const {cardName} of grantable) {
+            expect(survivesWireFilter(gateRulePattern(cardName)!)).toBe(true)
+        }
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptBuilderParity.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptBuilderParity.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Drift alarm between the TWO replay builders.
+ *
+ * `web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts` and
+ * `web/packages/agenta-chat/src/assets/transcriptToMessages.ts` are near-copies of each other.
+ * They have silently diverged before, so this runs the SAME real-session fixtures through both
+ * and deep-compares the messages they produce. Three divergences are known and DELIBERATE
+ * (docs/design/client-tool-interaction-lifecycle/implementation.md, "6. Replay"); each is
+ * encoded below as a named, asserted expectation. Anything outside that allowlist fails.
+ *
+ * The golden set itself — provenance, coverage, and the row join — lives in
+ * `__fixtures__/goldenSessions.ts`.
+ */
+import {transcriptToMessages as pkgTranscriptToMessages} from "@agenta/chat/assets"
+import type {SessionRecord} from "@agenta/entities/session"
+import type {UIMessage} from "ai"
+import {describe, expect, it} from "vitest"
+
+import {GOLDEN_SESSIONS} from "./__fixtures__/goldenSessions"
+import {
+    APPROVED_EXECUTION_RESULT_UNKNOWN,
+    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
+    transcriptToMessages as ossTranscriptToMessages,
+} from "./transcriptToMessages"
+
+type AnyPart = Record<string, unknown>
+
+const partsOf = (messages: UIMessage[] | null): AnyPart[] =>
+    (messages ?? []).flatMap((m) => m.parts as unknown as AnyPart[])
+
+/**
+ * ALLOWLIST 1 — "approval manifest sibling part".
+ * The OSS copy emits a `data-approval-manifest` sibling beside an approval whose request carried
+ * a manifest (transcriptToMessages.ts:358-370); the package copy has no equivalent, so a replayed
+ * approval card there loses its manifest body. Deliberate; see implementation.md anchor 6, item 2.
+ * Dropping it from BOTH sides is what lets the rest of the comparison be exact.
+ */
+const stripApprovalManifests = (messages: UIMessage[] | null): UIMessage[] =>
+    (messages ?? []).map(
+        (m) =>
+            ({
+                ...m,
+                parts: (m.parts as unknown as AnyPart[]).filter(
+                    (p) => p.type !== "data-approval-manifest",
+                ),
+            }) as unknown as UIMessage,
+    )
+
+describe("replay builder copy-parity (oss vs @agenta/chat)", () => {
+    for (const golden of GOLDEN_SESSIONS) {
+        it(`${golden.name}: both copies build identical messages from records alone`, () => {
+            const oss = ossTranscriptToMessages(golden.records)
+            const pkg = pkgTranscriptToMessages(golden.records)
+            expect(partsOf(oss).length).toBeGreaterThan(0)
+            expect(stripApprovalManifests(pkg)).toEqual(stripApprovalManifests(oss))
+        })
+
+        if (!golden.rows) continue
+
+        it(`${golden.name}: both copies build identical messages once interaction rows settle them`, () => {
+            const options = {interactionRowStates: golden.rows}
+            const oss = ossTranscriptToMessages(golden.records, options)
+            const pkg = pkgTranscriptToMessages(golden.records, options)
+            expect(stripApprovalManifests(pkg)).toEqual(stripApprovalManifests(oss))
+        })
+    }
+})
+
+/**
+ * The allowlist entries themselves are asserted, so re-syncing the copies (which would be a
+ * legitimate change) shows up here as a failure asking for the allowlist to be updated, rather
+ * than passing silently while the entry rots.
+ */
+describe("replay builder copy-parity: the three DELIBERATE divergences", () => {
+    const approvalWithManifest = (): SessionRecord[] =>
+        [
+            {
+                id: "r1",
+                session_id: "s1",
+                project_id: "p1",
+                event_index: 0,
+                sender: "agent",
+                session_update: "interaction_request",
+                payload: {
+                    id: "approval-1",
+                    kind: "user_approval",
+                    type: "interaction_request",
+                    payload: {
+                        toolCall: {
+                            toolCallId: "call-1",
+                            resolvedName: "commit_revision",
+                            kind: "execute",
+                            rawInput: {workflow_revision: {}},
+                        },
+                        manifest: {files: [{path: "a.md"}]},
+                    },
+                },
+                created_at: "2026-08-11T00:00:00Z",
+            },
+        ] as unknown as SessionRecord[]
+
+    it("DIVERGENCE 1 — approval sentinel: OSS matches by equality, the package by prefix", () => {
+        // implementation.md anchor 6, item 1. A sentinel errorText reopens the approval gate.
+        // The package copy accepts the code plus trailing prose; OSS requires the exact string.
+        const withSentinel = (errorText: string): SessionRecord[] =>
+            [
+                {
+                    id: "r1",
+                    session_id: "s1",
+                    project_id: "p1",
+                    event_index: 0,
+                    sender: "agent",
+                    session_update: "tool_call",
+                    payload: {id: "call-1", name: "commit_revision", type: "tool_call", input: {}},
+                    created_at: "2026-08-11T00:00:00Z",
+                },
+                {
+                    id: "r2",
+                    session_id: "s1",
+                    project_id: "p1",
+                    event_index: 1,
+                    sender: "agent",
+                    session_update: "tool_result",
+                    payload: {id: "call-1", type: "tool_result", isError: true, output: errorText},
+                    created_at: "2026-08-11T00:00:01Z",
+                },
+                {
+                    id: "r3",
+                    session_id: "s1",
+                    project_id: "p1",
+                    event_index: 2,
+                    sender: "agent",
+                    session_update: "interaction_request",
+                    payload: {
+                        id: "approval-1",
+                        kind: "user_approval",
+                        type: "interaction_request",
+                        payload: {
+                            toolCall: {toolCallId: "call-1", resolvedName: "commit_revision"},
+                        },
+                    },
+                    created_at: "2026-08-11T00:00:02Z",
+                },
+            ] as unknown as SessionRecord[]
+
+        // The exact sentinel: both copies reopen the gate. No divergence here.
+        const exact = withSentinel(APPROVED_EXECUTION_RESULT_UNKNOWN)
+        expect(partsOf(ossTranscriptToMessages(exact))[0].state).toBe("approval-requested")
+        expect(partsOf(pkgTranscriptToMessages(exact))[0].state).toBe("approval-requested")
+
+        // The sentinel CODE with extra prose appended: only the package copy reopens the gate.
+        const withSuffix = withSentinel(`${APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX}: and more`)
+        expect(partsOf(ossTranscriptToMessages(withSuffix))[0].state).toBe("output-error")
+        expect(partsOf(pkgTranscriptToMessages(withSuffix))[0].state).toBe("approval-requested")
+    })
+
+    it("DIVERGENCE 2 — only OSS emits the `data-approval-manifest` sibling part", () => {
+        // implementation.md anchor 6, item 2. The package copy's replayed approval card loses
+        // its manifest body; `ApprovalDock.manifestsByToolCallId` (ApprovalDock.tsx:35-46) is the
+        // reader that goes empty there.
+        const records = approvalWithManifest()
+        const ossManifests = partsOf(ossTranscriptToMessages(records)).filter(
+            (p) => p.type === "data-approval-manifest",
+        )
+        const pkgManifests = partsOf(pkgTranscriptToMessages(records)).filter(
+            (p) => p.type === "data-approval-manifest",
+        )
+        expect(ossManifests).toHaveLength(1)
+        expect(ossManifests[0]).toMatchObject({
+            id: "call-1",
+            data: {toolCallId: "call-1", approvalId: "approval-1"},
+        })
+        expect(pkgManifests).toHaveLength(0)
+    })
+
+    it("DIVERGENCE 3 — `attachment_delivery` is a COMMENT-only difference today", () => {
+        // implementation.md anchor 6, item 3 recorded this as behavioral. It no longer is: both
+        // copies fall through the same `default:` arm and drop the event. Asserted so that if
+        // either copy grows a real `attachment_delivery` branch, this fails and the divergence
+        // list gets revisited instead of quietly becoming true again.
+        const records = [
+            {
+                id: "r1",
+                session_id: "s1",
+                project_id: "p1",
+                event_index: 0,
+                sender: "agent",
+                session_update: "attachment_delivery",
+                payload: {id: "a1", type: "attachment_delivery", attachmentId: "att-1"},
+                created_at: "2026-08-11T00:00:00Z",
+            },
+            {
+                id: "r2",
+                session_id: "s1",
+                project_id: "p1",
+                event_index: 1,
+                sender: "agent",
+                session_update: "message",
+                payload: {type: "message", text: "hi"},
+                created_at: "2026-08-11T00:00:01Z",
+            },
+        ] as unknown as SessionRecord[]
+        expect(pkgTranscriptToMessages(records)).toEqual(ossTranscriptToMessages(records))
+        expect(partsOf(ossTranscriptToMessages(records))).toEqual([{type: "text", text: "hi"}])
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptLiveReplayParity.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptLiveReplayParity.test.ts
@@ -1,0 +1,282 @@
+/**
+ * LIVE vs REPLAY parity, against the real live builder — not a stand-in for it.
+ *
+ * The `*.liveChunks.json` fixtures are the actual output of
+ * `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:378`
+ * (`agent_stream_to_vercel_stream`) run over the SAME golden record fixtures. That function
+ * consumes the neutral `{"type", "data"}` agenta events the records log persists, so replaying
+ * the records through it reproduces the exact Vercel UI Message Stream a live turn emits. Records
+ * were split into turns on `done` and only agent-sourced rows were fed, the way the runner emits
+ * one stream per turn. Regenerate with `__fixtures__/generate/build_live_chunks.py` (its docstring
+ * has the exact command; it must run from `sdks/python`).
+ *
+ * Only tool-related chunks are kept (`tool-input-*`, `tool-output-*`, `tool-approval-request`,
+ * `data-render`, `data-approval-manifest`) — text and reasoning are not where the cards break.
+ *
+ * `foldLiveChunks` below is the small part of `useChat` that matters here: chunks for one
+ * `toolCallId` collapse into one part, last write wins. Everything else is a direct comparison.
+ *
+ * Both once-known divergences are settled and asserted below. Nothing here is skipped: a failure
+ * is a real disagreement between what a session shows live and what it shows after a reload.
+ */
+import type {UIMessage} from "ai"
+import {describe, expect, it} from "vitest"
+
+import abandonedFormLive from "./__fixtures__/abandonedFormSession.liveChunks.json"
+import arabicPoetryLive from "./__fixtures__/arabicPoetrySession.liveChunks.json"
+import connectAndFormsLive from "./__fixtures__/connectAndFormsSession.liveChunks.json"
+import {GOLDEN_SESSIONS} from "./__fixtures__/goldenSessions"
+import testRunApprovalsLive from "./__fixtures__/testRunApprovalsSession.liveChunks.json"
+import {transcriptToMessages} from "./transcriptToMessages"
+
+type Chunk = Record<string, unknown>
+type AnyPart = Record<string, unknown>
+
+const LIVE_CHUNKS: Record<string, Chunk[]> = {
+    abandonedFormSession: abandonedFormLive as unknown as Chunk[],
+    arabicPoetrySession: arabicPoetryLive as unknown as Chunk[],
+    connectAndFormsSession: connectAndFormsLive as unknown as Chunk[],
+    testRunApprovalsSession: testRunApprovalsLive as unknown as Chunk[],
+}
+
+/**
+ * Sessions whose harness routes platform tools over MCP (Codex names them
+ * `mcp.agenta-tools.<tool>`). The known divergence only exists on this shape; the other two
+ * sessions ran a harness that sends bare names and are byte-identical live vs replay.
+ */
+const MCP_ROUTED = new Set(["arabicPoetrySession", "testRunApprovalsSession"])
+
+interface LivePart {
+    toolCallId: string
+    toolName?: unknown
+    input?: unknown
+    output?: unknown
+    errorText?: unknown
+    approvalId?: unknown
+    renderKind?: unknown
+}
+
+/** The slice of `useChat` assembly that matters: one part per toolCallId, last write wins. */
+const foldLiveChunks = (chunks: Chunk[]): Map<string, LivePart> => {
+    const parts = new Map<string, LivePart>()
+    const at = (id: string): LivePart => {
+        const existing = parts.get(id)
+        if (existing) return existing
+        const fresh: LivePart = {toolCallId: id}
+        parts.set(id, fresh)
+        return fresh
+    }
+    for (const chunk of chunks) {
+        if (chunk.type === "data-render") {
+            const data = (chunk.data ?? {}) as Record<string, unknown>
+            const id = data.toolCallId
+            if (typeof id !== "string") continue
+            at(id).renderKind = (data.render as Record<string, unknown> | undefined)?.kind
+            continue
+        }
+        const id = chunk.toolCallId
+        if (typeof id !== "string") continue
+        const part = at(id)
+        switch (chunk.type) {
+            case "tool-input-start":
+                part.toolName = chunk.toolName
+                break
+            case "tool-input-available":
+                part.toolName = chunk.toolName
+                part.input = chunk.input
+                break
+            case "tool-output-available":
+                part.output = chunk.output
+                break
+            case "tool-output-error":
+                part.errorText = chunk.errorText
+                break
+            case "tool-approval-request":
+                part.approvalId = chunk.approvalId
+                break
+            default:
+                break
+        }
+    }
+    return parts
+}
+
+const replayParts = (messages: UIMessage[] | null) => {
+    const parts = new Map<string, AnyPart>()
+    const renderKinds = new Map<string, unknown>()
+    for (const message of messages ?? []) {
+        for (const raw of message.parts as unknown as AnyPart[]) {
+            if (raw.type === "data-render") {
+                const data = (raw.data ?? {}) as Record<string, unknown>
+                if (typeof data.toolCallId === "string") {
+                    renderKinds.set(
+                        data.toolCallId,
+                        (data.render as Record<string, unknown> | undefined)?.kind,
+                    )
+                }
+                continue
+            }
+            if (typeof raw.toolCallId === "string") parts.set(raw.toolCallId, raw)
+        }
+    }
+    return {parts, renderKinds}
+}
+
+const replayToolName = (part: AnyPart): string =>
+    part.type === "dynamic-tool"
+        ? String(part.toolName ?? "")
+        : String(part.type).replace(/^tool-/, "")
+
+/** Absent input is `null` on the wire and `undefined` on a replayed part; both read as absent. */
+const normalize = (value: unknown): unknown => (value === undefined ? null : value)
+
+/** The `{tool, server, arguments}` shape an MCP-routed harness wraps a call's arguments in. */
+const isMcpEnvelope = (value: unknown): boolean =>
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).tool === "string" &&
+    typeof (value as Record<string, unknown>).server === "string" &&
+    typeof (value as Record<string, unknown>).arguments === "object"
+
+const sessions = GOLDEN_SESSIONS.map((golden) => ({
+    ...golden,
+    live: foldLiveChunks(LIVE_CHUNKS[golden.name]),
+    // Compared without interaction rows: the live stream has no row join either, so this is the
+    // like-for-like comparison. Row settlement is covered by transcriptReplayShapeContract.test.ts.
+    replay: replayParts(transcriptToMessages(golden.records)),
+}))
+
+describe("live vs replay: the same tool parts exist, keyed the same way", () => {
+    for (const session of sessions) {
+        it(`${session.name}: every live tool part is replayed under the same toolCallId`, () => {
+            expect(session.live.size).toBeGreaterThan(0)
+            const missing = [...session.live.keys()].filter((id) => !session.replay.parts.has(id))
+            expect(missing).toEqual([])
+        })
+
+        it(`${session.name}: replay invents no tool part the live stream never emitted`, () => {
+            const extra = [...session.replay.parts.keys()].filter((id) => !session.live.has(id))
+            expect(extra).toEqual([])
+        })
+
+        it(`${session.name}: approval markers match the live \`tool-approval-request\` chunks`, () => {
+            // ApprovalDock.tsx:57-58 keys the dock off `approval.id`; live carries it as the
+            // `approvalId` of a strict `tool-approval-request` chunk.
+            for (const [id, live] of session.live) {
+                const replay = session.replay.parts.get(id)!
+                const replayApprovalId = (replay.approval as {id?: unknown} | undefined)?.id
+                expect(normalize(replayApprovalId), `approval marker for ${id}`).toEqual(
+                    normalize(live.approvalId),
+                )
+            }
+        })
+
+        it(`${session.name}: \`data-render\` siblings match, so widget dispatch resolves the same`, () => {
+            // registry.tsx:20-27 — `render.kind` is the primary dispatch axis on both paths.
+            for (const [id, live] of session.live) {
+                expect(
+                    normalize(session.replay.renderKinds.get(id)),
+                    `render kind for ${id}`,
+                ).toEqual(normalize(live.renderKind))
+            }
+        })
+
+        it(`${session.name}: tool outputs replay exactly as they streamed`, () => {
+            for (const [id, live] of session.live) {
+                if (live.output === undefined) continue
+                expect(session.replay.parts.get(id)!.output, `output for ${id}`).toEqual(
+                    live.output,
+                )
+            }
+        })
+    }
+})
+
+describe("live vs replay: full part parity where no known divergence applies", () => {
+    for (const session of sessions.filter((s) => !MCP_ROUTED.has(s.name))) {
+        it(`${session.name}: every part's tool name and input are byte-identical to live`, () => {
+            for (const [id, live] of session.live) {
+                const replay = session.replay.parts.get(id)!
+                expect(replayToolName(replay), `tool name for ${id}`).toBe(live.toolName)
+                expect(normalize(replay.input), `input for ${id}`).toEqual(normalize(live.input))
+            }
+        })
+    }
+
+    for (const session of sessions.filter((s) => MCP_ROUTED.has(s.name))) {
+        it(`${session.name}: client-tool parts are identical to live (name AND input)`, () => {
+            // The client-tool replay path re-stamps name and input from the `interaction_request`
+            // payload (transcriptToMessages.ts:225-247), which is what the live egress does too
+            // (stream.py:750-780). These are the parts the elicitation/connect widgets read.
+            const clientToolIds = [...session.live.entries()].filter(
+                ([, live]) => live.renderKind !== undefined,
+            )
+            expect(clientToolIds.length).toBeGreaterThan(0)
+            for (const [id, live] of clientToolIds) {
+                const replay = session.replay.parts.get(id)!
+                expect(replayToolName(replay), `tool name for ${id}`).toBe(live.toolName)
+                expect(normalize(replay.input), `input for ${id}`).toEqual(normalize(live.input))
+            }
+        })
+
+        it(`${session.name}: gated (approval) parts replay under the live resolved tool name`, () => {
+            // Live pins an approval part to the STABLE resolved name — `_approval_tool_name`
+            // prefers `toolCall.resolvedName` (stream.py:817-833) and re-emits
+            // `tool-input-available` under it (stream.py:711-726). Replay reads the same field in
+            // the same order (`approvalToolName`), so the durable row's harness-wrapped name
+            // (`mcp.agenta-tools.commit_revision`) never reaches the card. That name is not just a
+            // label: `useAlwaysAllowTool` keys the "always allow" grant off it verbatim, so a
+            // replayed card that used the wrapped name wrote a permission key the runner's gate
+            // (`gate.toolName` = the same `resolvedName`) can never match. Pinned end to end in
+            // `approvalGrantKey.test.ts`.
+            const gated = [...session.live.entries()].filter(([, live]) => live.approvalId)
+            expect(gated.length).toBeGreaterThan(0)
+            for (const [id, live] of gated) {
+                expect(replayToolName(session.replay.parts.get(id)!), `tool name for ${id}`).toBe(
+                    live.toolName,
+                )
+            }
+        })
+
+        it(`${session.name}: gated (approval) parts carry the same input as live`, () => {
+            // The bug this whole suite exists for: a replayed approval card must show the tool's
+            // own arguments, the same ones the live card showed. Live re-stamps them from
+            // `toolCall.rawInput` (stream.py:686-690); replay unwraps the MCP envelope off the
+            // durable `tool_call` record. Same result — asserted so it stays that way.
+            const gated = [...session.live.entries()].filter(([, live]) => live.approvalId)
+            expect(gated.length).toBeGreaterThan(0)
+            for (const [id, live] of gated) {
+                expect(
+                    normalize(session.replay.parts.get(id)!.input),
+                    `approval input for ${id}`,
+                ).toEqual(normalize(live.input))
+            }
+        })
+
+        it(`${session.name}: every tool call streams the bare arguments, never the MCP envelope`, () => {
+            // An MCP-routed harness wraps a call's arguments in a `{tool, server, arguments}`
+            // transport envelope, and the durable records keep the wrapper. Cards read their fields
+            // at the top level (`input.workflow_revision`), so an enveloped input renders as raw
+            // JSON where the same call renders a card. Live used to strip it only on the gated path
+            // — an ordinary call streamed the envelope, and a late ungated `tool_call` for an
+            // already-gated id even overwrote the gate's bare args with it, so one call showed two
+            // shapes live depending on when you looked. `_unwrap_tool_arguments` (stream.py) now
+            // applies the same conservative rule as `unwrapToolArguments`
+            // (transcriptToMessages.ts:123-134) on every egress path.
+            const enveloped = session.records.filter((record) => {
+                const input = (record.payload as {input?: unknown} | undefined)?.input
+                return isMcpEnvelope(input)
+            })
+            // Guard: these sessions must actually exercise the unwrap, or the loop below proves
+            // nothing.
+            expect(enveloped.length).toBeGreaterThan(0)
+            for (const [id, live] of session.live) {
+                expect(isMcpEnvelope(live.input), `live envelope leaked on ${id}`).toBe(false)
+                expect(normalize(session.replay.parts.get(id)!.input), `input for ${id}`).toEqual(
+                    normalize(live.input),
+                )
+            }
+        })
+    }
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptReplayShapeContract.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptReplayShapeContract.test.ts
@@ -1,0 +1,372 @@
+/**
+ * SHAPE CONTRACT — a replayed part must satisfy what the CARDS read.
+ *
+ * The live path (runner AgentEvent → `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`
+ * → `useChat`) is the reference shape: the cards were written against it. Replay
+ * (`transcriptToMessages`) rebuilds the same parts from durable records plus interaction rows,
+ * and has silently produced a DIFFERENT shape before — a card that renders properly live and as
+ * raw JSON on reload. Every assertion here is derived from an actual read in a card component
+ * and cites it, so "live shape" is enforced as a contract rather than asserted by vibes.
+ *
+ * The fixtures and the deliberate oss-vs-package divergences live in
+ * `transcriptBuilderParity.test.ts`; this file reuses its golden set.
+ */
+import type {SessionInteraction, SessionRecord} from "@agenta/entities/session"
+import {
+    CLIENT_TOOL_DESCRIPTORS,
+    CLIENT_TOOL_INTERACTION_ENDED_OUTPUT,
+} from "@agenta/shared/clientTools"
+import {parseElicitationPayload} from "@agenta/shared/utils"
+import type {ToolUIPart, UIMessage} from "ai"
+import {describe, expect, it} from "vitest"
+
+import {getPendingApprovals} from "../components/ApprovalDock"
+import {clientToolMeta, isClientToolPart} from "../components/clientTools/meta"
+
+import {goldenSession, rowStatesFromInteractions} from "./__fixtures__/goldenSessions"
+import {canonicalToolName, partToolName} from "./toolDisplay"
+import {transcriptToMessages} from "./transcriptToMessages"
+
+type AnyPart = Record<string, unknown>
+
+const INTERACTION_ROWS = (name: string): SessionInteraction[] => goldenSession(name).interactions
+
+const build = (name: string): UIMessage[] => {
+    const golden = goldenSession(name)
+    return transcriptToMessages(golden.records, {interactionRowStates: golden.rows}) ?? []
+}
+
+const allParts = (messages: UIMessage[]): AnyPart[] =>
+    messages.flatMap((m) => m.parts as unknown as AnyPart[])
+
+const isToolLike = (p: AnyPart): boolean => typeof p.toolCallId === "string"
+
+const partById = (messages: UIMessage[], toolCallId: string): AnyPart | undefined =>
+    allParts(messages).find((p) => p.toolCallId === toolCallId)
+
+/** The message a part belongs to — `data-render` siblings are resolved per message. */
+const messageOf = (messages: UIMessage[], part: AnyPart): UIMessage | undefined =>
+    messages.find((m) => (m.parts as unknown as AnyPart[]).includes(part))
+
+/** Same key resolution the builder uses for a `client_tool` request. */
+const clientToolIdOf = (payload: Record<string, unknown>): string => {
+    const req = (payload.payload ?? {}) as Record<string, unknown>
+    const toolCall = (req.toolCall ?? {}) as Record<string, unknown>
+    return String(req.toolCallId ?? toolCall.id ?? toolCall.toolCallId ?? payload.id ?? "")
+}
+
+const interactionRequests = (records: SessionRecord[], kind: string) =>
+    records
+        .map((r) => (r.payload ?? {}) as Record<string, unknown>)
+        .filter((p) => p.type === "interaction_request" && p.kind === kind)
+
+const SESSIONS_WITH_ROWS = [
+    "arabicPoetrySession",
+    "testRunApprovalsSession",
+    "connectAndFormsSession",
+]
+
+describe("replayed approval parts satisfy what ApprovalDock and its bodies read", () => {
+    for (const name of SESSIONS_WITH_ROWS) {
+        const rows = INTERACTION_ROWS(name).filter((r) => r.kind === "user_approval")
+        if (rows.length === 0) continue
+
+        it(`${name}: every approval row's token lands on a part as \`approval.id\``, () => {
+            // ApprovalDock.tsx:57-58 — a gate with no `approval.id` is invisible to the dock, so
+            // the transcript would hold an unanswerable turn forever.
+            const parts = allParts(build(name))
+            const approvalIds = new Set(
+                parts
+                    .map((p) => (p.approval as {id?: unknown} | undefined)?.id)
+                    .filter((id): id is string => typeof id === "string"),
+            )
+            for (const row of rows) expect(approvalIds).toContain(row.token)
+        })
+
+        it(`${name}: approval parts carry a string toolCallId and a settled-or-gated state`, () => {
+            // `getPendingApprovals` (ApprovalDock.tsx:55-58) needs `isToolPart` + `toolCallId` to
+            // key the manifest lookup; `clientToolMeta` (meta.ts:29) reads the same field.
+            const parts = allParts(build(name)).filter((p) => p.approval !== undefined)
+            expect(parts.length).toBeGreaterThan(0)
+            for (const p of parts) {
+                expect(typeof p.toolCallId).toBe("string")
+                expect(String(p.toolCallId)).not.toBe("")
+                expect([
+                    "approval-requested",
+                    "approval-responded",
+                    "output-available",
+                    "output-error",
+                    "output-denied",
+                ]).toContain(p.state)
+            }
+        })
+
+        it(`${name}: the approval body's tool key resolves to the row's tool`, () => {
+            // ApprovalDock.tsx:235 — `resolveApprovalRenderer(canonicalToolName(toolName))`, and
+            // the registry (approvals/registry.tsx:34-39) is keyed by the bare `commit_revision`.
+            // If this drifts, the specialized card silently degrades to the raw-payload fallback.
+            const messages = build(name)
+            for (const row of rows) {
+                const toolCallId = (row.data?.request as Record<string, unknown> | undefined)
+                    ?.tool_call_id
+                if (typeof toolCallId !== "string") continue
+                const part = partById(messages, toolCallId)
+                expect(part, `no part for ${toolCallId}`).toBeDefined()
+                const expected = (row.data?.request as Record<string, unknown>).tool
+                expect(canonicalToolName(partToolName(part as unknown as ToolUIPart))).toBe(
+                    expected,
+                )
+            }
+        })
+
+        it(`${name}: approval inputs are the tool's own arguments, not the MCP envelope`, () => {
+            // CommitRevisionApproval.tsx:97 reads `input.workflow_revision` at the TOP level, and
+            // toolDisplay.ts:62-67 summarizes the same way. The durable `tool_call` record for an
+            // MCP-routed call stores `{tool, server, arguments}`; live re-stamps the bare args
+            // (stream.py:686-690, 717-726). A wrapped input renders the card as raw JSON.
+            const messages = build(name)
+            const expectedTopLevelKey: Record<string, string> = {
+                commit_revision: "workflow_revision",
+                create_schedule: "data",
+                test_run: "inputs",
+            }
+            for (const row of rows) {
+                const request = (row.data?.request ?? {}) as Record<string, unknown>
+                const toolCallId = request.tool_call_id
+                if (typeof toolCallId !== "string") continue
+                const part = partById(messages, toolCallId)
+                const input = part?.input as Record<string, unknown> | undefined
+                expect(input, `no input for ${String(request.tool)}`).toBeTypeOf("object")
+                expect(Object.keys(input ?? {})).not.toContain("arguments")
+                expect(Object.keys(input ?? {})).not.toContain("server")
+                const key = expectedTopLevelKey[String(request.tool)]
+                if (key) expect(input).toHaveProperty(key)
+            }
+        })
+
+        it(`${name}: pending rows stay gated and terminal rows do not`, () => {
+            // `getPendingApprovals` scans for `state === "approval-requested"` across the whole
+            // transcript (ApprovalDock.tsx:50-67). A terminal row left gated holds the composer.
+            const messages = build(name)
+            const pending = getPendingApprovals(messages).map((a) => a.approvalId)
+            for (const row of rows) {
+                if (row.status === "pending") expect(pending).toContain(row.token)
+                else expect(pending).not.toContain(row.token)
+            }
+        })
+    }
+})
+
+describe("replayed client-tool parts satisfy what the client-tool dispatcher reads", () => {
+    for (const name of SESSIONS_WITH_ROWS.concat("abandonedFormSession")) {
+        it(`${name}: every client_tool request produces a part under its own toolCallId`, () => {
+            // ClientToolPart.tsx:64 stamps `data-client-tool-call-id={meta.toolCallId}` and
+            // settles through it (ClientToolPart.tsx:44-58); a missing or renamed id means the
+            // widget's answer never reaches the parked call.
+            const golden = goldenSession(name)
+            const messages = build(name)
+            const requests = interactionRequests(golden.records, "client_tool")
+            expect(requests.length).toBeGreaterThan(0)
+            for (const payload of requests) {
+                const toolCallId = clientToolIdOf(payload)
+                expect(partById(messages, toolCallId), `no part for ${toolCallId}`).toBeDefined()
+            }
+        })
+
+        it(`${name}: each client_tool part has its sibling data-render part in the SAME message`, () => {
+            // registry.tsx:20-27 — `render.kind` is the primary dispatch axis and arrives only as
+            // a sibling `data-render` part, resolved per message by `buildRenderMap`. Lose it and
+            // dispatch falls back to `toolName`, and an unknown tool auto-settles as "not handled".
+            const golden = goldenSession(name)
+            const messages = build(name)
+            const kinds = new Set([
+                CLIENT_TOOL_DESCRIPTORS.connection.renderKind,
+                CLIENT_TOOL_DESCRIPTORS.elicitation.renderKind,
+            ])
+            for (const payload of interactionRequests(golden.records, "client_tool")) {
+                const req = (payload.payload ?? {}) as Record<string, unknown>
+                if (!req.render) continue
+                const toolCallId = clientToolIdOf(payload)
+                const part = partById(messages, toolCallId)!
+                const siblings = (messageOf(messages, part)?.parts ?? []) as unknown as AnyPart[]
+                const render = siblings.find(
+                    (p) =>
+                        p.type === "data-render" &&
+                        (p.data as Record<string, unknown>)?.toolCallId === toolCallId,
+                )
+                expect(render, `no data-render sibling for ${toolCallId}`).toBeDefined()
+                const kind = (
+                    (render!.data as Record<string, unknown>).render as
+                        | Record<string, unknown>
+                        | undefined
+                )?.kind
+                expect(kinds).toContain(kind)
+            }
+        })
+
+        it(`${name}: client-tool parts are never mistaken for approval gates`, () => {
+            // meta.ts:65-67 — `isClientToolPart` refuses a part in an approval state or carrying
+            // an `approval` marker, so a client tool that picked one up renders no widget at all.
+            const golden = goldenSession(name)
+            const messages = build(name)
+            for (const payload of interactionRequests(golden.records, "client_tool")) {
+                const part = partById(messages, clientToolIdOf(payload))!
+                expect(part.approval).toBeUndefined()
+                expect(["approval-requested", "approval-responded"]).not.toContain(part.state)
+                const meta = clientToolMeta(part as unknown as ToolUIPart)
+                expect(meta.toolCallId).toBe(part.toolCallId)
+                expect(meta.toolName).toBe(partToolName(part as unknown as ToolUIPart))
+            }
+        })
+    }
+
+    it("request_input inputs parse as elicitation payloads", () => {
+        // ElicitationWidget.tsx:131 — a payload that fails `parseElicitationPayload` renders the
+        // degradation card instead of the form. Covers a form answered, one still open, and one
+        // abandoned, across the legacy and current record contracts.
+        let checked = 0
+        for (const name of SESSIONS_WITH_ROWS.concat("abandonedFormSession")) {
+            const golden = goldenSession(name)
+            const messages = build(name)
+            for (const payload of interactionRequests(golden.records, "client_tool")) {
+                const req = (payload.payload ?? {}) as Record<string, unknown>
+                if (req.toolName !== CLIENT_TOOL_DESCRIPTORS.elicitation.toolName) continue
+                const part = partById(messages, clientToolIdOf(payload))!
+                const parsed = parseElicitationPayload(part.input)
+                expect(parsed.ok, `${name}: ${parsed.ok ? "" : parsed.reason}`).toBe(true)
+                checked += 1
+            }
+        }
+        expect(checked).toBeGreaterThanOrEqual(4)
+    })
+
+    it("request_connection inputs carry the fields the connect flow keys on", () => {
+        // useConnectFlow.ts:197-203 reads `integration`, `slug` and `mode` off `meta.input`; an
+        // empty integration makes the widget's Connect button a no-op.
+        let checked = 0
+        for (const name of SESSIONS_WITH_ROWS) {
+            const golden = goldenSession(name)
+            const messages = build(name)
+            for (const payload of interactionRequests(golden.records, "client_tool")) {
+                const req = (payload.payload ?? {}) as Record<string, unknown>
+                if (req.toolName !== CLIENT_TOOL_DESCRIPTORS.connection.toolName) continue
+                const input = partById(messages, clientToolIdOf(payload))!.input as Record<
+                    string,
+                    unknown
+                >
+                expect(typeof input.integration).toBe("string")
+                expect(input.integration).not.toBe("")
+                expect(["oauth", "api_key", undefined]).toContain(input.mode)
+                checked += 1
+            }
+        }
+        expect(checked).toBeGreaterThanOrEqual(3)
+    })
+})
+
+describe("interaction rows settle replayed cards the way the widgets expect", () => {
+    it("a responded row replays the answer the user actually gave", () => {
+        // settleClientToolPart (transcriptToMessages.ts:112-136) hands the saved output straight
+        // to the widget's settled branch — ElicitationWidget.tsx:227-244 renders
+        // `output.humanFriendlyMessage`, ConnectToolWidget.tsx:99-118 reads `output.connected`.
+        const messages = build("connectAndFormsSession")
+        const rows = INTERACTION_ROWS("connectAndFormsSession")
+        const responded = rows.filter(
+            (r) => r.status === "responded" && r.data?.resolution?.output !== undefined,
+        )
+        expect(responded.length).toBeGreaterThanOrEqual(3)
+        for (const row of responded) {
+            const toolCallId =
+                ((row.data?.request as Record<string, unknown>)?.tool_call_id as string) ??
+                row.token!
+            const part = partById(messages, toolCallId)
+            expect(part, `no part for ${toolCallId}`).toBeDefined()
+            expect(part!.state).toBe("output-available")
+            expect(part!.output).toEqual(row.data!.resolution!.output)
+        }
+    })
+
+    it("a cancelled row with no saved answer settles to the NEUTRAL terminal output", () => {
+        // transcriptToMessages.ts:132-135. The widgets must not invent "Dismissed" or
+        // "Connection not completed" for a gate that merely died — see implementation.md anchor 6.
+        const messages = build("connectAndFormsSession")
+        const cancelled = INTERACTION_ROWS("connectAndFormsSession").filter(
+            (r) => r.status === "cancelled" && !r.data?.resolution,
+        )
+        expect(cancelled.length).toBeGreaterThanOrEqual(2)
+        for (const row of cancelled) {
+            const part = partById(messages, row.token!)
+            expect(part, `no part for ${row.token}`).toBeDefined()
+            expect(part!.state).toBe("output-available")
+            expect(part!.output).toEqual(CLIENT_TOOL_INTERACTION_ENDED_OUTPUT)
+        }
+    })
+
+    it("a form with NO row stays open so the widget renders it again after reload", () => {
+        // The abandoned-form golden: no interaction rows are joined, so the parked part must
+        // survive as `input-available` and `isClientToolPart` must still route it to a widget
+        // (meta.ts:57-70) rather than the transcript showing a dead card.
+        const messages = transcriptToMessages(goldenSession("abandonedFormSession").records)!
+        const last = messages[messages.length - 1]
+        const parked = (last.parts as unknown as AnyPart[]).filter(
+            (p) => isToolLike(p) && p.state === "input-available",
+        )
+        expect(parked.length).toBe(1)
+        expect(
+            isClientToolPart(parked[0] as unknown as ToolUIPart, {
+                isStreaming: false,
+                isLastMessage: true,
+            }),
+        ).toBe(true)
+        expect(parseElicitationPayload(parked[0].input).ok).toBe(true)
+    })
+
+    it("legacy rows without `data.request.tool_call_id` still join by token equality", () => {
+        // interactionStatus.ts:14-17 documents the legacy join. `connectAndFormsSession` holds
+        // both contracts, so this proves the fallback still settles the older rows.
+        const rows = INTERACTION_ROWS("connectAndFormsSession")
+        const legacy = rows.filter(
+            (r) => (r.data?.request as Record<string, unknown>)?.tool_call_id === undefined,
+        )
+        expect(legacy.length).toBeGreaterThanOrEqual(2)
+        const states = rowStatesFromInteractions(rows)
+        for (const row of legacy) expect(states.get(row.token!)?.toolCallId).toBeUndefined()
+        const messages = build("connectAndFormsSession")
+        for (const row of legacy)
+            expect(partById(messages, row.token!)?.state).toBe("output-available")
+    })
+})
+
+describe("KNOWN LIVE-VS-REPLAY DRIFT — awaiting a decision, do not 'fix' by editing a test", () => {
+    /**
+     * The live egress re-stamps a gated tool part with the STABLE resolved name
+     * (`_approval_tool_name` prefers `toolCall.resolvedName`, stream.py:681 and 817-833) and
+     * re-emits `tool-input-available` under it (stream.py:711-726). Replay never reads
+     * `resolvedName`: an existing part keeps whatever name the durable `tool_call` carried
+     * (transcriptToMessages.ts:332-347 only synthesizes a part when none exists, and then reads
+     * `toolCall.name || title || kind`, which on these rows is the literal "execute").
+     *
+     * So for an MCP-routed harness (Codex, Claude) every approval part is named
+     * `mcp.agenta-tools.commit_revision` on replay and `commit_revision` live. Both copies of the
+     * builder agree, so `transcriptBuilderParity.test.ts` is green; the divergence is live-vs-replay.
+     *
+     * Consequences found: `resolveToolDisplay` (toolDisplay.ts:90-102) labels the replayed gate
+     * "Mcp.agenta tools.commit revision" where live says "Commit revision", and that label is what
+     * ApprovalDock renders (ApprovalDock.tsx:454, 581) and what `useAlwaysAllowTool.grant` puts on
+     * the draft-change signal (useAlwaysAllowTool.tsx:96-127) — which routes by the RAW name, the
+     * one toolDisplay.ts:49-51 warns must match the wire name verbatim.
+     *
+     * Unskip once Mahmoud picks the canonical name.
+     */
+    it.skip("DRIFT: a replayed approval part is named with the live resolved name", () => {
+        const messages = build("arabicPoetrySession")
+        const rows = INTERACTION_ROWS("arabicPoetrySession").filter(
+            (r) => r.kind === "user_approval",
+        )
+        for (const row of rows) {
+            const request = (row.data?.request ?? {}) as Record<string, unknown>
+            const part = partById(messages, request.tool_call_id as string)!
+            expect(partToolName(part as unknown as ToolUIPart)).toBe(request.tool)
+        }
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -1075,3 +1075,168 @@ describe("golden: an abandoned form card from a real pre-fix session", () => {
         expect(part?.output).not.toEqual({action: "cancel"})
     })
 })
+
+/**
+ * codex-acp reports an MCP call's rawInput as the `{tool, server, arguments}` wrapper, and the
+ * DURABLE record keeps it — while the live stream hands the FE the bare ACP `rawInput`. Replaying
+ * the wrapper verbatim made card bodies (which read `input.workflow_revision`) and
+ * `extractCallDescription` (which reads `input.description`) miss their fields, so a replayed call
+ * dropped to raw JSON where the live one rendered a card. Shape taken from session 3d99d178; the
+ * guard mirrors `unwrapCodexMcpArgs` in services/runner/src/permission-plan.ts.
+ */
+describe("transcriptToMessages MCP argument wrapper", () => {
+    const bareArgs = {
+        description: "تكوين الوكيل",
+        workflow_revision: {base_revision_id: "rev-1"},
+    }
+    const wrapped = {tool: "commit_revision", server: "agenta-tools", arguments: bareArgs}
+    const mcpCall = (input: unknown): SessionRecord =>
+        record("record-call", {
+            type: "tool_call",
+            id: "exec-1",
+            name: "mcp.agenta-tools.commit_revision",
+            input,
+        })
+
+    it("unwraps the wrapper so a replayed call carries the same input as the live part", () => {
+        expect(firstPart([mcpCall(wrapped)]).input).toEqual(bareArgs)
+    })
+
+    it("unwraps on the resume re-emit of an already-seen tool call", () => {
+        const part = firstPart([
+            mcpCall({tool: "commit_revision", server: "agenta-tools", arguments: {stale: true}}),
+            mcpCall(wrapped),
+        ])
+        expect(part.input).toEqual(bareArgs)
+    })
+
+    it("unwraps the part synthesized by an approval gate", () => {
+        const part = firstPart([
+            record("record-request", {
+                type: "interaction_request",
+                id: "approval-1",
+                kind: "user_approval",
+                payload: {
+                    toolCallId: "exec-1",
+                    toolCall: {name: "commit_revision", rawInput: wrapped},
+                },
+            }),
+        ])
+        expect(part.input).toEqual(bareArgs)
+    })
+
+    it("leaves a real input that merely HAS an arguments field untouched", () => {
+        const real = {arguments: {a: 1}, timeout: 30}
+        expect(firstPart([mcpCall(real)]).input).toEqual(real)
+    })
+
+    it("leaves a lookalike whose envelope key is not a string untouched", () => {
+        const real = {tool: "x", server: 42, arguments: {a: 1}}
+        expect(firstPart([mcpCall(real)]).input).toEqual(real)
+    })
+
+    it("leaves a bare input (no arguments field) untouched", () => {
+        expect(firstPart([mcpCall({command: "ls"})]).input).toEqual({command: "ls"})
+    })
+})
+
+/**
+ * The durable `tool_call` record wraps the model's arguments in an MCP envelope
+ * (`{tool, server, arguments}`), while the live stream emits the bare ACP `rawInput`. Replay has to
+ * hand the cards that same bare shape or a call that rendered a friendly card live comes back as
+ * raw JSON on reload. Payload trimmed from real session `3d99d178-b76b-4eb7-a9e9-ad43295ee2b8`.
+ */
+describe("transcriptToMessages tool input unwrapping", () => {
+    const bareArguments = {
+        description: "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+        workflow_revision: {
+            delta: {
+                operations: [
+                    {
+                        value: {
+                            name: "telegram_send_message",
+                            type: "gateway",
+                            action: "SEND_MESSAGE",
+                            provider: "composio",
+                            connection: "telegram-main",
+                            integration: "telegram",
+                        },
+                        target: ["parameters", "agent", "tools"],
+                        operation: "add_item",
+                    },
+                ],
+            },
+            base_revision_id: "019fefed-a8a0-7720-bbe6-85b60d5b2ace",
+        },
+    }
+    const wrappedInput = {tool: "commit_revision", server: "agenta-tools", arguments: bareArguments}
+
+    const toolPart = (records: SessionRecord[]): Record<string, unknown> => {
+        const messages = transcriptToMessages(records)
+        expect(messages).not.toBeNull()
+        return (messages?.[0].parts ?? [])[0] as unknown as Record<string, unknown>
+    }
+
+    const toolCall = (id: string, input: unknown): SessionRecord =>
+        record(id, {
+            type: "tool_call",
+            id: "tool-1",
+            name: "mcp.agenta-tools.commit_revision",
+            input,
+        })
+
+    it("unwraps the envelope so the card reads `workflow_revision` at the top level", () => {
+        const part = toolPart([toolCall("record-call", wrappedInput)])
+
+        expect(part.input).toEqual(bareArguments)
+        expect(part.input).toHaveProperty("workflow_revision")
+        expect(part.input).not.toHaveProperty("arguments")
+    })
+
+    it("unwraps a resume's re-emitted call, which updates the kept part in place", () => {
+        const part = toolPart([
+            toolCall("record-call", wrappedInput),
+            toolCall("record-resume-call", wrappedInput),
+        ])
+
+        expect(part.input).toEqual(bareArguments)
+    })
+
+    it("unwraps the envelope on a part built from an interaction_request", () => {
+        const part = toolPart([
+            record("record-request", {
+                type: "interaction_request",
+                id: "approval-1",
+                kind: "user_approval",
+                payload: {
+                    toolCallId: "tool-1",
+                    toolCall: {
+                        kind: "execute",
+                        toolCallId: "tool-1",
+                        resolvedName: "commit_revision",
+                        rawInput: wrappedInput,
+                    },
+                },
+            }),
+        ])
+
+        expect(part.state).toBe("approval-requested")
+        expect(part.input).toEqual(bareArguments)
+    })
+
+    it("passes an already-bare input through unchanged", () => {
+        expect(toolPart([toolCall("record-call", bareArguments)]).input).toEqual(bareArguments)
+    })
+
+    it("leaves a real `arguments` field alone when a sibling is not an envelope key", () => {
+        const realInput = {arguments: {"--json": true}, workflow_revision: {message: "keep me"}}
+
+        expect(toolPart([toolCall("record-call", realInput)]).input).toEqual(realInput)
+    })
+
+    it("leaves a lone `arguments` field alone — nothing proves it is an envelope", () => {
+        const realInput = {arguments: {"--json": true}}
+
+        expect(toolPart([toolCall("record-call", realInput)]).input).toEqual(realInput)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -101,6 +101,65 @@ const newDraft = (id: string, role: "user" | "assistant"): DraftMessage => ({
 
 const toolPartType = (name?: string | null): string => (name ? `tool-${name}` : "dynamic-tool")
 
+/** Envelope keys an MCP-style `tool_call` record wraps its real arguments in. */
+const TOOL_ARGUMENT_ENVELOPE_KEYS = new Set([
+    "tool",
+    "server",
+    "name",
+    "toolName",
+    "serverName",
+    "tool_name",
+    "server_name",
+])
+
+/**
+ * Unwrap a `{tool, server, arguments}` record wrapper to the bare arguments. Card bodies read their
+ * fields at the top level (`input.workflow_revision`), and the live stream hands them the ACP
+ * `rawInput`, which is already bare — only the durable record carries the wrapper, so without this
+ * a replayed call drops to the raw-JSON fallback the same call renders a card for live.
+ * Unwraps only when every sibling of `arguments` is a string-valued envelope key, so a tool whose
+ * real input carries its own `arguments` field passes through untouched.
+ */
+function unwrapToolArguments(input: unknown): unknown {
+    if (!input || typeof input !== "object" || Array.isArray(input)) return input
+    const wrapper = input as Record<string, unknown>
+    const args = wrapper.arguments
+    if (!args || typeof args !== "object" || Array.isArray(args)) return input
+    const siblings = Object.keys(wrapper).filter((key) => key !== "arguments")
+    if (siblings.length === 0) return input
+    const isEnvelope = siblings.every(
+        (key) => TOOL_ARGUMENT_ENVELOPE_KEYS.has(key) && typeof wrapper[key] === "string",
+    )
+    return isEnvelope ? args : input
+}
+
+/** Keys an ACP tool call can carry its resolved agenta tool spec under (`_tool_spec_of`). */
+const TOOL_SPEC_KEYS = ["spec", "toolSpec", "resolvedTool", "tool"] as const
+
+/**
+ * The gated tool's name, in the live egress's order (`_approval_tool_name`, stream.py:817-833):
+ * the STABLE `resolvedName` the runner stamps on the gate first — it is the runner's own
+ * `gate.toolName` (acp-interactions.ts:243), the name the permission gate matches on — then the
+ * resolved spec's canonical `name`, and only then the ACP display fields, which drift.
+ * The durable `tool_call` row carries the harness-wrapped name instead
+ * (`mcp.agenta-tools.commit_revision`), so reading it here labelled a replayed gate
+ * "Mcp.agenta tools.commit revision" and keyed its "always allow" grant off that string.
+ */
+function approvalToolName(toolCall: Record<string, unknown>): string | undefined {
+    const spec = TOOL_SPEC_KEYS.map((key) => toolCall[key]).find(
+        (value): value is Record<string, unknown> =>
+            Boolean(value) && typeof value === "object" && !Array.isArray(value),
+    )
+    const candidates = [
+        toolCall.resolvedName,
+        spec?.name,
+        toolCall.name,
+        toolCall.title,
+        toolCall.kind,
+    ]
+    return candidates.find((value): value is string => typeof value === "string" && value !== "")
+}
+
 const isRunnerSentinelError = (part: Part): boolean => {
     const errorText = typeof part.errorText === "string" ? part.errorText : ""
     return (
@@ -197,7 +256,7 @@ function replayClientTool(
     )
     if (!toolCallId) return
     const toolName = str(reqPayload.toolName ?? toolCall.name ?? toolCall.title)
-    const input = reqPayload.input ?? toolCall.rawInput ?? toolCall.input
+    const input = unwrapToolArguments(reqPayload.input ?? toolCall.rawInput ?? toolCall.input)
     let part = index.tools.get(toolCallId)
     if (!part) {
         // The runner parked without first surfacing the tool call — synthesize one.
@@ -289,14 +348,14 @@ function applyEvent(
                 // A resume re-emits the approved call with the same toolCallId. Update the existing
                 // part (kept across the pause boundary) in place instead of rendering a duplicate;
                 // its tool_result then settles that one part to a single ✓.
-                if (payload.input !== undefined) existing.input = payload.input
+                if (payload.input !== undefined) existing.input = unwrapToolArguments(payload.input)
                 return
             }
             const part: Part = {
                 type: toolPartType(payload.name as string),
                 toolCallId,
                 state: "input-available",
-                input: payload.input,
+                input: unwrapToolArguments(payload.input),
             }
             draft.parts.push(part)
             index.tools.set(toolCallId, part)
@@ -329,21 +388,25 @@ function applyEvent(
             const toolCallId = str(
                 reqPayload.toolCallId ?? toolCall.id ?? toolCall.toolCallId ?? payload.id,
             )
+            const toolName = approvalToolName(toolCall)
             let part = index.tools.get(toolCallId)
             if (!part) {
                 // The runner parked without first surfacing the tool call — synthesize one.
                 part = {
-                    type: toolPartType(
-                        (toolCall.name as string) ||
-                            (toolCall.title as string) ||
-                            (toolCall.kind as string),
-                    ),
+                    type: toolPartType(toolName),
                     toolCallId,
                     state: "input-available",
-                    input: toolCall.rawInput ?? toolCall.input,
+                    input: unwrapToolArguments(toolCall.rawInput ?? toolCall.input),
                 }
                 draft.parts.push(part)
                 index.tools.set(toolCallId, part)
+            } else if (toolName) {
+                // Live re-stamps an already-surfaced call with the gate's resolved name
+                // (stream.py:711-726), so the card never shows the durable row's harness-wrapped
+                // name. Rename here too, or the same gate replays under a different name than it
+                // streamed — and `useAlwaysAllowTool` keys the grant off that name verbatim.
+                if (part.type === "dynamic-tool") part.toolName = toolName
+                else part.type = toolPartType(toolName)
             }
             index.approvals.set(str(payload.id), part)
             const canRequestApproval =

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -118,6 +118,65 @@ const newDraft = (id: string, role: "user" | "assistant"): DraftMessage => ({
 
 const toolPartType = (name?: string | null): string => (name ? `tool-${name}` : "dynamic-tool")
 
+/** Envelope keys an MCP-style `tool_call` record wraps its real arguments in. */
+const TOOL_ARGUMENT_ENVELOPE_KEYS = new Set([
+    "tool",
+    "server",
+    "name",
+    "toolName",
+    "serverName",
+    "tool_name",
+    "server_name",
+])
+
+/**
+ * Unwrap a `{tool, server, arguments}` record wrapper to the bare arguments. Card bodies read their
+ * fields at the top level (`input.workflow_revision`), and the live stream hands them the ACP
+ * `rawInput`, which is already bare — only the durable record carries the wrapper, so without this
+ * a replayed call drops to the raw-JSON fallback the same call renders a card for live.
+ * Unwraps only when every sibling of `arguments` is a string-valued envelope key, so a tool whose
+ * real input carries its own `arguments` field passes through untouched.
+ */
+function unwrapToolArguments(input: unknown): unknown {
+    if (!input || typeof input !== "object" || Array.isArray(input)) return input
+    const wrapper = input as Record<string, unknown>
+    const args = wrapper.arguments
+    if (!args || typeof args !== "object" || Array.isArray(args)) return input
+    const siblings = Object.keys(wrapper).filter((key) => key !== "arguments")
+    if (siblings.length === 0) return input
+    const isEnvelope = siblings.every(
+        (key) => TOOL_ARGUMENT_ENVELOPE_KEYS.has(key) && typeof wrapper[key] === "string",
+    )
+    return isEnvelope ? args : input
+}
+
+/** Keys an ACP tool call can carry its resolved agenta tool spec under (`_tool_spec_of`). */
+const TOOL_SPEC_KEYS = ["spec", "toolSpec", "resolvedTool", "tool"] as const
+
+/**
+ * The gated tool's name, in the live egress's order (`_approval_tool_name`, stream.py:817-833):
+ * the STABLE `resolvedName` the runner stamps on the gate first — it is the runner's own
+ * `gate.toolName` (acp-interactions.ts:243), the name the permission gate matches on — then the
+ * resolved spec's canonical `name`, and only then the ACP display fields, which drift.
+ * The durable `tool_call` row carries the harness-wrapped name instead
+ * (`mcp.agenta-tools.commit_revision`), so reading it here labelled a replayed gate
+ * "Mcp.agenta tools.commit revision" and keyed its "always allow" grant off that string.
+ */
+function approvalToolName(toolCall: Record<string, unknown>): string | undefined {
+    const spec = TOOL_SPEC_KEYS.map((key) => toolCall[key]).find(
+        (value): value is Record<string, unknown> =>
+            Boolean(value) && typeof value === "object" && !Array.isArray(value),
+    )
+    const candidates = [
+        toolCall.resolvedName,
+        spec?.name,
+        toolCall.name,
+        toolCall.title,
+        toolCall.kind,
+    ]
+    return candidates.find((value): value is string => typeof value === "string" && value !== "")
+}
+
 const isRunnerSentinelError = (part: Part): boolean => {
     const errorText = typeof part.errorText === "string" ? part.errorText : ""
     return (
@@ -218,7 +277,7 @@ function replayClientTool(
     )
     if (!toolCallId) return
     const toolName = str(reqPayload.toolName ?? toolCall.name ?? toolCall.title)
-    const input = reqPayload.input ?? toolCall.rawInput ?? toolCall.input
+    const input = unwrapToolArguments(reqPayload.input ?? toolCall.rawInput ?? toolCall.input)
     let part = index.tools.get(toolCallId)
     if (!part) {
         // The runner parked without first surfacing the tool call — synthesize one.
@@ -310,14 +369,14 @@ function applyEvent(
                 // A resume re-emits the approved call with the same toolCallId. Update the existing
                 // part (kept across the pause boundary) in place instead of rendering a duplicate;
                 // its tool_result then settles that one part to a single ✓.
-                if (payload.input !== undefined) existing.input = payload.input
+                if (payload.input !== undefined) existing.input = unwrapToolArguments(payload.input)
                 return
             }
             const part: Part = {
                 type: toolPartType(payload.name as string),
                 toolCallId,
                 state: "input-available",
-                input: payload.input,
+                input: unwrapToolArguments(payload.input),
             }
             draft.parts.push(part)
             index.tools.set(toolCallId, part)
@@ -350,21 +409,25 @@ function applyEvent(
             const toolCallId = str(
                 reqPayload.toolCallId ?? toolCall.id ?? toolCall.toolCallId ?? payload.id,
             )
+            const toolName = approvalToolName(toolCall)
             let part = index.tools.get(toolCallId)
             if (!part) {
                 // The runner parked without first surfacing the tool call — synthesize one.
                 part = {
-                    type: toolPartType(
-                        (toolCall.name as string) ||
-                            (toolCall.title as string) ||
-                            (toolCall.kind as string),
-                    ),
+                    type: toolPartType(toolName),
                     toolCallId,
                     state: "input-available",
-                    input: toolCall.rawInput ?? toolCall.input,
+                    input: unwrapToolArguments(toolCall.rawInput ?? toolCall.input),
                 }
                 draft.parts.push(part)
                 index.tools.set(toolCallId, part)
+            } else if (toolName) {
+                // Live re-stamps an already-surfaced call with the gate's resolved name
+                // (stream.py:711-726), so the card never shows the durable row's harness-wrapped
+                // name. Rename here too, or the same gate replays under a different name than it
+                // streamed — and `useAlwaysAllowTool` keys the grant off that name verbatim.
+                if (part.type === "dynamic-tool") part.toolName = toolName
+                else part.type = toolPartType(toolName)
             }
             index.approvals.set(str(payload.id), part)
             const canRequestApproval =

--- a/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/transcriptToMessages.test.ts
@@ -807,3 +807,140 @@ describe("golden: an abandoned form card from a real pre-fix session", () => {
         expect(part?.output).not.toEqual({action: "cancel"})
     })
 })
+
+/**
+ * The durable `tool_call` record wraps the model's arguments in an MCP envelope
+ * (`{tool, server, arguments}`), while the live stream emits the bare ACP `rawInput`. Replay has to
+ * hand the cards that same bare shape or a call that rendered a friendly card live comes back as
+ * raw JSON on reload. Payload trimmed from real session `3d99d178-b76b-4eb7-a9e9-ad43295ee2b8`.
+ */
+describe("transcriptToMessages tool input unwrapping", () => {
+    const bareArguments = {
+        description: "تكوين الوكيل لإرسال قصيدة عربية يومية عبر تيليغرام.",
+        workflow_revision: {
+            delta: {
+                operations: [
+                    {
+                        value: {
+                            name: "telegram_send_message",
+                            type: "gateway",
+                            action: "SEND_MESSAGE",
+                            provider: "composio",
+                            connection: "telegram-main",
+                            integration: "telegram",
+                        },
+                        target: ["parameters", "agent", "tools"],
+                        operation: "add_item",
+                    },
+                ],
+            },
+            base_revision_id: "019fefed-a8a0-7720-bbe6-85b60d5b2ace",
+        },
+    }
+    const wrappedInput = {tool: "commit_revision", server: "agenta-tools", arguments: bareArguments}
+
+    const toolPart = (records: SessionRecord[]): Record<string, unknown> => {
+        const messages = transcriptToMessages(records)
+        expect(messages).not.toBeNull()
+        return (messages?.[0].parts ?? [])[0] as unknown as Record<string, unknown>
+    }
+
+    const toolCall = (id: string, input: unknown): SessionRecord =>
+        record(id, {
+            type: "tool_call",
+            id: "tool-1",
+            name: "mcp.agenta-tools.commit_revision",
+            input,
+        })
+
+    it("unwraps the envelope so the card reads `workflow_revision` at the top level", () => {
+        const part = toolPart([toolCall("record-call", wrappedInput)])
+
+        expect(part.input).toEqual(bareArguments)
+        expect(part.input).toHaveProperty("workflow_revision")
+        expect(part.input).not.toHaveProperty("arguments")
+    })
+
+    it("unwraps a resume's re-emitted call, which updates the kept part in place", () => {
+        const part = toolPart([
+            toolCall("record-call", wrappedInput),
+            toolCall("record-resume-call", wrappedInput),
+        ])
+
+        expect(part.input).toEqual(bareArguments)
+    })
+
+    it("unwraps the envelope on a part built from an interaction_request", () => {
+        const part = toolPart([
+            record("record-request", {
+                type: "interaction_request",
+                id: "approval-1",
+                kind: "user_approval",
+                payload: {
+                    toolCallId: "tool-1",
+                    toolCall: {
+                        kind: "execute",
+                        toolCallId: "tool-1",
+                        resolvedName: "commit_revision",
+                        rawInput: wrappedInput,
+                    },
+                },
+            }),
+        ])
+
+        expect(part.state).toBe("approval-requested")
+        expect(part.input).toEqual(bareArguments)
+    })
+
+    it("passes an already-bare input through unchanged", () => {
+        expect(toolPart([toolCall("record-call", bareArguments)]).input).toEqual(bareArguments)
+    })
+
+    it("leaves a real `arguments` field alone when a sibling is not an envelope key", () => {
+        const realInput = {arguments: {"--json": true}, workflow_revision: {message: "keep me"}}
+
+        expect(toolPart([toolCall("record-call", realInput)]).input).toEqual(realInput)
+    })
+
+    it("leaves a lone `arguments` field alone — nothing proves it is an envelope", () => {
+        const realInput = {arguments: {"--json": true}}
+
+        expect(toolPart([toolCall("record-call", realInput)]).input).toEqual(realInput)
+    })
+})
+
+/** Parity with the OSS original: the durable record keeps codex-acp's `{tool, server, arguments}`
+ * wrapper while the live stream hands the FE the bare ACP `rawInput`. Unwrap it, but only when
+ * every sibling of `arguments` is a string-valued envelope key. */
+describe("transcriptToMessages MCP argument wrapper", () => {
+    const bareArgs = {description: "commit it", workflow_revision: {base_revision_id: "rev-1"}}
+    const inputOf = (input: unknown): unknown => {
+        const parts = (transcriptToMessages([
+            record("r-call", {
+                type: "tool_call",
+                id: "exec-1",
+                name: "mcp.agenta-tools.commit_revision",
+                input,
+            }),
+        ])?.[0].parts ?? []) as unknown as Record<string, unknown>[]
+        return parts[0]?.input
+    }
+
+    it("unwraps the wrapper so a replayed call matches the live part", () => {
+        expect(
+            inputOf({tool: "commit_revision", server: "agenta-tools", arguments: bareArgs}),
+        ).toEqual(bareArgs)
+    })
+
+    it("leaves a real input that merely HAS an arguments field untouched", () => {
+        expect(inputOf({arguments: {a: 1}, timeout: 30})).toEqual({arguments: {a: 1}, timeout: 30})
+    })
+
+    it("leaves a lookalike whose envelope key is not a string untouched", () => {
+        expect(inputOf({tool: "x", server: 42, arguments: {a: 1}})).toEqual({
+            tool: "x",
+            server: 42,
+            arguments: {a: 1},
+        })
+    })
+})


### PR DESCRIPTION
## Context

The same tool call looked different depending on when you looked at it. A commit approval card rendered as a clean "what is changing" view while the turn streamed, then a background refresh rebuilt the chat from the saved records and the same card degraded to a raw JSON blob. The cause: the chat has two builders (one for the live stream, one for the saved records), and they drifted apart with no test forcing them to agree. Found and diagnosed on 2026-08-11, sessions 3d99d178 and f60bc4f8 on the dev stack. This PR stacks on [#5919](https://github.com/Agenta-AI/agenta/pull/5919); its base will move to the release branch when that PR merges.

## Changes

Four fixes, each making the two builders agree, plus the tests that keep them agreeing.

1. Replay unwraps the transport envelope. Saved records store a tool call's input as `{tool, server, arguments: {...}}`. The cards read the bare arguments. Both replay copies now unwrap conservatively (only when every sibling of `arguments` is a string envelope key), so a replayed commit card finds `workflow_revision` at the top level and renders the real diff view instead of JSON.

2. The live stream shows the bare arguments too (Python SDK). Ordinary tool calls streamed the envelope, and a gated call could show the bare form first and the envelope moments later. The SDK's stream adapter now unwraps with the same rule, so live and reload show the same input, always.

Before (live, ordinary MCP call):
```
{"tool": "discover_tools", "server": "agenta-tools", "arguments": {"query": "telegram"}}
```
After (live and reload):
```
{"query": "telegram"}
```

3. Replayed approval cards use the resolved tool name. Replay kept the raw wire name, so a reloaded card said "Mcp.agenta tools.commit revision" where live said "Commit revision". Worse, the raw name slipped past the guard that keeps platform operations ungrantable: a replayed card could offer "Always allow" for `commit_revision` and store a permission key the runner can never match. Both copies now resolve the name the same way the live stream does; live and replayed cards produce the same name, the same grant eligibility, and the same permission key end to end.

4. Golden parity tests from real sessions. Three real sessions (commits, schedules, forms, connects, both interaction-row generations) are captured as fixtures, together with the actual output of the live builder over the same events. New suites assert: the two replay copies stay identical outside three documented, individually-pinned divergences; every replayed part carries the exact shape each card component reads (each assertion cites the component line it protects); and replayed parts equal live parts for the same records. Any future drift between the builders is a red build, not a UI surprise.

Also: the secret scanner config allowlists exactly the uuid-shaped interaction tokens inside the new fixtures (they are join keys, not credentials), verified against the gitleaks version CI pins; planted real-key shapes in the same files are still caught.

## Tests

- Both replay suites extended (unwrapping, resolved names); the new parity suites: builder copy-parity, per-card shape contracts, live-versus-replay equality; the permission-key chain test (card name to stored grant to runner matcher).
- Python SDK: 17 new stream-adapter tests; full agents suite 878 passed. ruff clean under CI's pinned version.
- web/oss AgentChatSlice: 30 files, 334 passed. tsc, eslint, prettier clean.

## What to QA

- Open an old codex session (for example the Arabic-poetry agent). The commit approval card shows the description and the config diff, and it stays that way after a reload. No raw `{tool, server, arguments}` JSON anywhere.
- Run a new agent turn with a tool call and compare the tool row live versus after a reload: identical input both times.
- Regression: approve a tool call live; the approval card and its "Always allow" options look and behave as before.
