### PR TITLE
[fix] Mobile typecheck: import the AgentaApi type namespace

### DIFF
--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -8,6 +8,7 @@
  * const events = await querySessionRecords({sessionId, projectId})
  * ```
  */
+import type {AgentaApi} from "@agentaai/api-client"
 import {z} from "zod"
 
 import {safeParseWithLogging} from "../../shared/utils/zodSchema"


### PR DESCRIPTION
The release branch's "check mobile" workflow fails on `web/packages/agenta-entities/src/session/api/api.ts`: it references `AgentaApi.SessionInteractionResolution` without importing the namespace (TS2503). The line landed in #5919; the web typechecks resolve the namespace ambiently, the mobile project graph does not, and the branch-level mobile workflow first completed a run only after today's merge train (earlier runs were superseded by rapid merges).

Fix: one type-only import, `import type {AgentaApi} from "@agentaai/api-client"`, matching the existing precedent in `trace/api/request.ts`.

Verified: `pnpm run types:check` passes in `@agenta/entities` and `@agenta/mobile`.