### PR TITLE
fix(frontend): resolve pinned automation session names outside automation mode

### DIFF
--- a/web/oss/src/components/Sidebar/dynamic/sessionOptions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionOptions.test.ts
@@ -45,8 +45,10 @@ describe("sidebarSessionFilters", () => {
     })
 
     // A pin is an explicit user request and overrides the sidebar's origin filter — a pinned
-    // automation session must still show (P2-8).
-    it("drops the exclude-trigger filter for the pinned request", () => {
+    // automation session must still show (P2-8). It also carries the `trigger` expansion so a
+    // pinned automation row's name resolves even though the sidebar's own policy never requests
+    // it (without this, the row falls back to "Missing schedule").
+    it("drops the exclude-trigger filter and requests the trigger expansion for the pinned request", () => {
         const pinnedIds = ["pin-1", "pin-2"]
         expect(
             sidebarSessionFilters({
@@ -63,7 +65,7 @@ describe("sidebarSessionFilters", () => {
             lowPriority: true,
             origins: undefined,
             excludeOrigins: undefined,
-            expand: [],
+            expand: ["trigger"],
         })
     })
 

--- a/web/oss/src/lib/sessionListPolicies.test.ts
+++ b/web/oss/src/lib/sessionListPolicies.test.ts
@@ -18,7 +18,7 @@ describe("session list caller policies", () => {
             agentOverviewHuman: {origin: "exclude-trigger", expansions: []},
             agentOverviewAutomation: {origin: "trigger-only", expansions: ["trigger"]},
             sidebar: {origin: "exclude-trigger", expansions: []},
-            sidebarPinned: {origin: "all", expansions: []},
+            sidebarPinned: {origin: "all", expansions: ["trigger"]},
             internal: {origin: "all", expansions: []},
             agentActivity: {origin: "all", expansions: []},
         })

--- a/web/oss/src/lib/sessionListPolicies.ts
+++ b/web/oss/src/lib/sessionListPolicies.ts
@@ -12,8 +12,10 @@ export const sessionListPolicies = {
     agentOverviewAutomation: {origin: "trigger-only", expansions: ["trigger"]},
     sidebar: {origin: "exclude-trigger", expansions: []},
     // A pin is an explicit user request and overrides the sidebar's origin filter — a pinned
-    // automation session must still show (P2-8).
-    sidebarPinned: {origin: "all", expansions: []},
+    // automation session must still show (P2-8). It also needs the `trigger` expansion: the
+    // sidebar's own policy never requests it, so a pinned automation row's name would otherwise
+    // never resolve and fall back to "Missing schedule".
+    sidebarPinned: {origin: "all", expansions: ["trigger"]},
     internal: {origin: "all", expansions: []},
     agentActivity: {origin: "all", expansions: []},
 } as const satisfies Record<string, SessionListRequestPolicy>

--- a/web/packages/agenta-sessions/src/state/useSessionCardList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionCardList.ts
@@ -1,6 +1,6 @@
 import {useCallback, useMemo, useState} from "react"
 
-import {type SessionStream} from "@agenta/entities/session"
+import {type SessionExpansion, type SessionStream} from "@agenta/entities/session"
 import {projectIdAtom} from "@agenta/shared/state"
 import {useAtomValue} from "jotai"
 
@@ -18,7 +18,10 @@ import {
 
 /**
  * A pin is an explicit user request and overrides the surface's origin filter — a pinned
- * automation session must still show on a human-mode (exclude-trigger) card (P2-8).
+ * automation session must still show on a human-mode (exclude-trigger) card (P2-8). It also
+ * needs the `trigger` expansion regardless of the card's own policy: a human-mode card never
+ * requests it, so a pinned automation row's name would otherwise never resolve and fall back to
+ * "Missing schedule".
  */
 export function pinnedSessionListArgs(
     policy: SessionListRequestPolicy,
@@ -28,7 +31,7 @@ export function pinnedSessionListArgs(
 ): SessionListOptions {
     return {
         originPolicy: "all",
-        expansions: policy.expansions,
+        expansions: Array.from(new Set<SessionExpansion>([...policy.expansions, "trigger"])),
         agentId,
         sessionIds: pinnedIds,
         enabled,

--- a/web/packages/agenta-sessions/src/state/useSessionsList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionsList.ts
@@ -1,6 +1,6 @@
 import {useCallback, useMemo} from "react"
 
-import {type SessionStream} from "@agenta/entities/session"
+import {type SessionExpansion, type SessionStream} from "@agenta/entities/session"
 import {projectIdAtom} from "@agenta/shared/state"
 import {useAtomValue, useSetAtom} from "jotai"
 
@@ -28,7 +28,10 @@ import {
 
 /**
  * A pin is an explicit user request and overrides the surface's origin filter — a pinned
- * automation session must still show in human (exclude-trigger) mode (P2-8).
+ * automation session must still show in human (exclude-trigger) mode (P2-8). It also needs the
+ * `trigger` expansion regardless of the surface's own policy: a human-mode surface never
+ * requests it, so a pinned automation row's name would otherwise never resolve and fall back to
+ * "Missing schedule".
  */
 export function pinnedSessionListArgs(
     shared: SessionListOptions,
@@ -37,6 +40,7 @@ export function pinnedSessionListArgs(
     return {
         ...shared,
         originPolicy: "all",
+        expansions: Array.from(new Set<SessionExpansion>([...shared.expansions, "trigger"])),
         sessionIds: pinnedIds,
         enabled: pinnedIds.length > 0,
     }

--- a/web/packages/agenta-sessions/tests/unit/useSessionCardList.test.ts
+++ b/web/packages/agenta-sessions/tests/unit/useSessionCardList.test.ts
@@ -4,19 +4,22 @@ import {pinnedSessionListArgs} from "../../src/state/useSessionCardList"
 
 describe("pinnedSessionListArgs", () => {
     // A pin is an explicit user request and overrides the surface's origin filter — a pinned
-    // automation session must still show on a human-mode (exclude-trigger) card (P2-8).
-    it("overrides the surface's origin policy to 'all', keeping its expansions", () => {
+    // automation session must still show on a human-mode (exclude-trigger) card (P2-8). It also
+    // needs the `trigger` expansion added regardless of the card's own policy: a human-mode card
+    // never requests it, so a pinned automation row's name would otherwise never resolve and
+    // fall back to "Missing schedule".
+    it("overrides the surface's origin policy to 'all' and adds the trigger expansion", () => {
         const policy = {origin: "exclude-trigger", expansions: ["last_message"]} as const
         expect(pinnedSessionListArgs(policy, "agent-1", ["pin-1", "pin-2"], true)).toEqual({
             originPolicy: "all",
-            expansions: ["last_message"],
+            expansions: ["last_message", "trigger"],
             agentId: "agent-1",
             sessionIds: ["pin-1", "pin-2"],
             enabled: true,
         })
     })
 
-    it("does the same for a trigger-only (automation) surface", () => {
+    it("does not duplicate the trigger expansion for a trigger-only (automation) surface", () => {
         const policy = {
             origin: "trigger-only",
             expansions: ["last_message", "trigger"],

--- a/web/packages/agenta-sessions/tests/unit/useSessionsList.test.ts
+++ b/web/packages/agenta-sessions/tests/unit/useSessionsList.test.ts
@@ -4,8 +4,11 @@ import {pinnedSessionListArgs} from "../../src/state/useSessionsList"
 
 describe("pinnedSessionListArgs", () => {
     // A pin is an explicit user request and overrides the surface's origin filter — a pinned
-    // automation session must still show in human (exclude-trigger) mode (P2-8).
-    it("overrides the origin policy to 'all', keeping every other shared filter", () => {
+    // automation session must still show in human (exclude-trigger) mode (P2-8). It also needs
+    // the `trigger` expansion added regardless of the surface's own policy: a human-mode surface
+    // never requests it, so a pinned automation row's name would otherwise never resolve and
+    // fall back to "Missing schedule".
+    it("overrides the origin policy to 'all' and adds the trigger expansion, keeping every other shared filter", () => {
         const shared = {
             originPolicy: "exclude-trigger" as const,
             expansions: ["last_message"] as const,
@@ -18,7 +21,22 @@ describe("pinnedSessionListArgs", () => {
         expect(pinnedSessionListArgs(shared, ["pin-1", "pin-2"])).toEqual({
             ...shared,
             originPolicy: "all",
+            expansions: ["last_message", "trigger"],
             sessionIds: ["pin-1", "pin-2"],
+            enabled: true,
+        })
+    })
+
+    it("does not duplicate the trigger expansion when the surface already requests it", () => {
+        const shared = {
+            originPolicy: "trigger-only" as const,
+            expansions: ["last_message", "trigger"] as const,
+        }
+        expect(pinnedSessionListArgs(shared, ["pin-1"])).toEqual({
+            ...shared,
+            originPolicy: "all",
+            expansions: ["last_message", "trigger"],
+            sessionIds: ["pin-1"],
             enabled: true,
         })
     })
@@ -28,6 +46,7 @@ describe("pinnedSessionListArgs", () => {
         expect(pinnedSessionListArgs(shared, [])).toEqual({
             ...shared,
             originPolicy: "all",
+            expansions: ["trigger"],
             sessionIds: [],
             enabled: false,
         })


### PR DESCRIPTION
## Symptom

Pinning an automation session made it visible in human/default mode (the P2-8
fix from #5927 works), but its title read **"Missing schedule"** instead of
the real schedule or subscription name — on the Sessions page's default view,
the Agent Overview / Home card's human "Sessions" section, and (by the same
code path) the sidebar's pinned list.

Before (Sessions page, default mode):

![missing schedule regression](https://github.com/Agenta-AI/agenta/releases/download/qa-session-ux-5927/06-pinned-sessions-page-missing-name-regression.png)

Before (Home card, human sessions section):

![home card missing schedule](https://github.com/Agenta-AI/agenta/releases/download/qa-session-ux-5927/07-home-card-missing-schedule-regression.png)

*(From the post-merge smoke QA on #5927; full walkthrough video at
https://github.com/Agenta-AI/agenta/releases/tag/qa-session-ux-5927.)*

## Root cause

Confirmed via network inspection: the same pinned session, queried from
automation mode, sent `"expand":["last_message","trigger"]` and resolved the
name correctly. Queried from human/default mode, the pinned sub-query sent
`"expand":["last_message"]` — no `"trigger"` — so the name never resolved.

`pinnedSessionListArgs()` in `useSessionsList.ts` and `useSessionCardList.ts`
overrides the pin's `originPolicy` to `"all"` (so the row shows up outside
automation mode, per P2-8) but left `expansions` as whatever the surrounding
surface's own policy requested. Every human-mode surface's policy omits
`trigger` by design (it's only needed for automation-origin rows), so a
pinned automation row landing in a human-mode list never asked for the one
field it needs to display its name. The sidebar's `sidebarPinned` policy in
`sessionListPolicies.ts` has the identical shape (`expansions: []`) and the
same gap.

## Fix

Add `"trigger"` to the pinned query's expansions in both hooks (deduped
against whatever the surface already requests), and to the `sidebarPinned`
policy — alongside the existing origin override, not instead of it. A pinned
automation row now resolves its name regardless of which surface's default
policy it's rendered under.

## Tests

Updated the existing `pinnedSessionListArgs()` unit tests in both hooks to
assert the added `"trigger"` expansion (and added a case confirming it isn't
duplicated when the surface already requests it), plus the
`sessionListPolicies` and sidebar `sessionOptions` tests for the
`sidebarPinned` policy change.

## Verification

- `pnpm --filter @agenta/sessions test:unit` — 38/38 pass
- `pnpm --filter @agenta/oss test:unit` — 480/480 pass (1 pre-existing skip)
- `pnpm --filter @agenta/oss exec tsc --noEmit` — clean
- `pnpm --filter @agenta/sessions run types:check` — clean
- `pnpm lint-fix` — clean (only pre-existing, unrelated warnings elsewhere)
- Live verification on the dev deployment pending the current web container
  restart; will confirm the pinned name resolves on the Sessions default
  view, the Home card, and the sidebar once it's back up.

Found during post-merge smoke QA of #5927 (session UX interface). That stack
is already merged, so this regression fix lands as its own PR rather than an
amendment.

Do not merge — Mahmoud reviews and merges.