### PR TITLE
[feat] Hide the Deploy button in agent playgrounds

### DIFF
--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
@@ -296,8 +296,10 @@ const PlaygroundVariantConfigHeader = ({
                     </>
                 ) : (
                     <>
-                        {/* Agent playgrounds don't deploy — Commit is the only publish action there. */}
-                        {!embedded && !isEvaluatorEntity && !isAgentEffective && (
+                        {/* Agent playgrounds don't deploy — Commit is the only publish action
+                            there. showAgentHeader also covers the loading window, so Deploy
+                            can't flash before agent-ness resolves. */}
+                        {!embedded && !isEvaluatorEntity && !showAgentHeader && (
                             <DeployVariantButton revisionId={variantId} />
                         )}
 

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/assets/PlaygroundVariantConfigHeader.tsx
@@ -296,16 +296,9 @@ const PlaygroundVariantConfigHeader = ({
                     </>
                 ) : (
                     <>
-                        {!embedded && !isEvaluatorEntity && (
-                            // Agents get a labeled secondary "Deploy" so the action row reads as a
-                            // hierarchy (primary Commit, secondary Deploy, ghost kebab); other
-                            // surfaces keep the icon-only deploy.
-                            <DeployVariantButton
-                                revisionId={variantId}
-                                {...(isAgentEffective
-                                    ? ({label: "Deploy", type: "default", size: "small"} as const)
-                                    : {})}
-                            />
+                        {/* Agent playgrounds don't deploy — Commit is the only publish action there. */}
+                        {!embedded && !isEvaluatorEntity && !isAgentEffective && (
+                            <DeployVariantButton revisionId={variantId} />
                         )}
 
                         <CommitVariantChangesButton


### PR DESCRIPTION
## Context

The agent playground showed two publish actions side by side: Commit and a labeled Deploy button. For agents, Deploy is not part of the workflow; Commit is the only publish action that matters there. Mahmoud decided to remove Deploy from the agent playground while keeping it for classic apps.

## Changes

The Deploy button in the playground config header now renders only when the entity is not an agent. The check reuses `isAgentEffective`, the signal the same file already uses to switch the header into agent mode. Since Deploy no longer renders for agents, the agent-only label/type/size override on the button was dead code and is removed; classic apps keep the icon-only Deploy exactly as before. The Commit button is untouched in both modes.

Before: agent playground header shows Commit plus a labeled "Deploy" button.
After: agent playground header shows Commit only. Classic completion/chat playgrounds keep their Deploy button unchanged.

Other `DeployVariantButton` render sites were checked and left alone: the Registry variants table is not a playground surface, and the embedded drawer path already hides Deploy unconditionally.

## Tests / notes

- `tsc --noEmit` on web/oss: clean apart from one pre-existing unrelated error in `agenta-entities/src/session/api/api.ts`.
- `next lint --fix` on the touched file: clean.
- Live-checked on the dev stack: two agent playgrounds show Commit only; the classic Completion playground still opens the Deploy modal.

## What to QA

- Open any agent playground. The config header shows Commit but no Deploy button.
- Open a classic Completion or Chat app playground. The Deploy button is still there and opens the deploy modal.
- Regression to watch: the Commit button and the kebab menu in the agent header still work as before.
