### PR TITLE
[fix] Waiting cards refuse transcript adoption without proof they ended

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/loadSession.ts
@@ -1,4 +1,8 @@
-import {fetchSessionInteractionStatesAtom, fetchSessionRecordsAtom} from "@agenta/entities/session"
+import {
+    fetchSessionInteractionStatesAtom,
+    fetchSessionRecordsAtom,
+    type SessionInteractionRowStates,
+} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 import {getDefaultStore} from "jotai"
 
@@ -29,6 +33,13 @@ export interface SessionTranscript {
      * `transcriptToMessages` deliberately holds flat while a turn grows (issue #5530).
      */
     recordCount: number
+    /**
+     * The interaction lifecycle rows this transcript was replayed against. Records never carry a
+     * row's later lifecycle, so this is the only place the adoption guard can see whether a card is
+     * still awaiting the user (`pending`) or has ended. Empty when the fetch failed or the
+     * session has no rows; the two cases are indistinguishable here.
+     */
+    interactionRows?: SessionInteractionRowStates
 }
 
 export const loadSessionMessages = async (
@@ -52,13 +63,19 @@ export const loadSessionMessages = async (
                 if (!fresh || fresh.length === 0) return
                 const freshMsgs = transcriptToMessages(fresh, {interactionRowStates})
                 if (freshMsgs && freshMsgs.length > 0) {
-                    onRefreshed({messages: freshMsgs, recordCount: fresh.length})
+                    onRefreshed({
+                        messages: freshMsgs,
+                        recordCount: fresh.length,
+                        interactionRows: interactionRowStates,
+                    })
                 }
             })
         }
         if (!records || records.length === 0) return null
         const messages = transcriptToMessages(records, {interactionRowStates})
-        return messages ? {messages, recordCount: records.length} : null
+        return messages
+            ? {messages, recordCount: records.length, interactionRows: interactionRowStates}
+            : null
     } catch (err) {
         console.warn("[loadSessionMessages] hydration fetch failed:", err)
         return null

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
@@ -11,8 +11,15 @@
  * local `addToolOutput` settle is still waiting for `sendAutomaticallyWhen` to fire — the adopted
  * transcript predates the settle and silently discards it.
  */
+import type {
+    SessionInteractionRowState,
+    SessionInteractionRowStates,
+} from "@agenta/entities/session"
 import type {UIMessage} from "ai"
 import {describe, expect, it} from "vitest"
+
+import {goldenSession} from "../assets/__fixtures__/goldenSessions"
+import {transcriptToMessages} from "../assets/transcriptToMessages"
 
 import {shouldAdoptTranscript, shouldSkipRecordsRefresh} from "./useSessionHydration"
 
@@ -285,5 +292,151 @@ describe("shouldAdoptTranscript: waiting cards", () => {
                 [settledCard("call-1"), textMessage("server-tail")],
             ),
         ).toBe(true)
+    })
+})
+
+/**
+ * The blind spot the "unrecognized ⇒ settled" shortcut left open, asserted against real records.
+ *
+ * A card's `interaction_request` record — the one that re-stamps the harness-wrapped tool name and
+ * emits the `data-render` sibling — lands in the log AFTER its `tool_call`, but the server publishes
+ * the `interaction` event the instant the ROW is created. So the transcript the relay fetches in
+ * that window replays the card as `tool-mcp.agenta-tools.request_input` with no render sibling: the
+ * client-tool predicate cannot see it, and the old guard read "not a waiting card" as "settled" and
+ * adopted straight over the user's half-typed form.
+ *
+ * The fixture is the real `arabicPoetrySession` log cut at exactly that boundary, so the shape under
+ * test is the one production produces, not one this file asserts into existence.
+ */
+describe("shouldAdoptTranscript: harness-wrapped waiting card", () => {
+    const PARKED_CALL_ID = "exec-bf533142-0e4b-4e97-a3a7-20622ace0d0a"
+    const golden = goldenSession("arabicPoetrySession")
+    /** Records up to (not including) the parked card's `interaction_request`. */
+    const CUT = golden.records.findIndex((r) => r.session_update === "interaction_request")
+
+    /** The server copy in the race window: the card replayed from its harness-wrapped `tool_call`. */
+    const parkedServerMessages = transcriptToMessages(golden.records.slice(0, CUT))!
+    /** The same records once the card's terminal row settles it (`output-available`). */
+    const settledServerMessages = transcriptToMessages(golden.records.slice(0, CUT), {
+        interactionRowStates: golden.rows,
+    })!
+
+    const row = (
+        status: SessionInteractionRowState["status"],
+        resolution?: Record<string, unknown>,
+    ): SessionInteractionRowStates =>
+        new Map([
+            [
+                "row-token",
+                {
+                    token: "row-token",
+                    kind: "client_tool" as const,
+                    status,
+                    toolCallId: PARKED_CALL_ID,
+                    ...(resolution ? {resolution} : {}),
+                },
+            ],
+        ])
+
+    /** What the browser renders while the user types: the live-shaped, recognized card. */
+    const localWaiting = [
+        toolMessage({
+            id: "local-card",
+            toolCallId: PARKED_CALL_ID,
+            state: "input-available",
+            type: "dynamic-tool",
+        }),
+    ]
+
+    const at = ({
+        serverMessages,
+        interactionRows,
+        serverRecordCount = CUT,
+        watermark = 10,
+    }: {
+        serverMessages: UIMessage[]
+        interactionRows?: SessionInteractionRowStates
+        serverRecordCount?: number
+        watermark?: number
+    }) =>
+        shouldAdoptTranscript({
+            serverRecordCount,
+            serverMessages,
+            localMessages: localWaiting,
+            interactionRows,
+            watermark,
+            busy: false,
+            pendingResume: false,
+        })
+
+    it("replays the parked card unrecognizably — the premise of the bug", () => {
+        const part = parkedServerMessages
+            .flatMap((m) => m.parts ?? [])
+            .find((p) => (p as {toolCallId?: string}).toolCallId === PARKED_CALL_ID)
+        expect(part).toMatchObject({
+            type: "tool-mcp.agenta-tools.request_input",
+            state: "input-available",
+        })
+        // No `data-render` sibling anywhere in the replayed transcript for this call.
+        expect(
+            parkedServerMessages
+                .flatMap((m) => m.parts ?? [])
+                .some(
+                    (p) =>
+                        p.type === "data-render" &&
+                        (p as {data?: {toolCallId?: string}}).data?.toolCallId === PARKED_CALL_ID,
+                ),
+        ).toBe(false)
+    })
+
+    it("REFUSES the unrecognized card while its interaction row is still pending", () => {
+        // The regression: the log has grown (the card's own `tool_call` is new), so the growth path
+        // fires — the waiting-card guard is the only thing standing between the relay and the form.
+        expect(at({serverMessages: parkedServerMessages, interactionRows: row("pending")})).toBe(
+            false,
+        )
+    })
+
+    it("REFUSES it with no interaction rows at all — unrecognized is not evidence", () => {
+        expect(at({serverMessages: parkedServerMessages})).toBe(false)
+    })
+
+    it("adopts once the row is terminal, even before replay restamps the part", () => {
+        expect(
+            at({
+                serverMessages: parkedServerMessages,
+                interactionRows: row("responded", {outcome: "success", output: {when: "08:00"}}),
+            }),
+        ).toBe(true)
+    })
+
+    it("adopts on the part's own terminal state, with no rows to consult", () => {
+        expect(at({serverMessages: settledServerMessages})).toBe(true)
+    })
+
+    it("adopts the zombie card: no record growth, row terminal, stale local copy still live", () => {
+        // The dead-session case the no-growth path exists for — the log will never grow again, and
+        // only the terminal row can retire the phantom form.
+        expect(
+            at({
+                serverMessages: settledServerMessages,
+                interactionRows: row("cancelled"),
+                serverRecordCount: CUT,
+                watermark: CUT,
+            }),
+        ).toBe(true)
+    })
+
+    it("refuses the no-growth path when the row says the card is still waiting", () => {
+        // Belt and braces: even a server part that reads terminal must not retire a card whose row
+        // is `pending` on an unchanged log.
+        expect(
+            at({
+                serverMessages: settledServerMessages,
+                interactionRows: row("pending"),
+                serverRecordCount: CUT,
+                watermark: CUT,
+            }),
+        ).toBe(false)
     })
 })

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -4,6 +4,8 @@ import {
     revalidateSessionInteractionsAtom,
     revalidateSessionRecordsAtom,
     shouldAdoptServerTranscript,
+    type SessionInteractionRowState,
+    type SessionInteractionRowStates,
 } from "@agenta/entities/session"
 import {buildRenderMap, isPendingClientToolInteraction} from "@agenta/playground"
 import {type UIMessage} from "ai"
@@ -69,26 +71,61 @@ const pendingClientToolCallIds = (messages: UIMessage[]): Set<string> => {
     return pending
 }
 
-/** Locally-waiting cards the server copy shows as settled. A card the server does not carry at all
- * is NOT settled — the server has not caught up. */
+/** A tool part that has demonstrably terminated — the states replay writes when it settles a card
+ * from a terminal row (`settleClientToolPart`/`settleApprovalPart`). */
+const TERMINAL_PART_STATES = new Set(["output-available", "output-error", "output-denied"])
+
+/** A row whose lifecycle has ended. `pending` — a card still awaiting the user — is the only other
+ * value the API returns. */
+const isTerminalRow = (row: SessionInteractionRowState): boolean =>
+    row.status === "responded" || row.status === "resolved" || row.status === "cancelled"
+
+/** Interaction rows keyed the way replay joins them: the runner-stamped tool-call id when present,
+ * else the row token (legacy rows, and approval gates whose token IS the id). */
+const interactionRowsByCallId = (
+    rows: SessionInteractionRowStates | undefined,
+): Map<string, SessionInteractionRowState> => {
+    const byCallId = new Map<string, SessionInteractionRowState>()
+    for (const row of rows?.values() ?? []) byCallId.set(row.toolCallId ?? row.token, row)
+    return byCallId
+}
+
+/**
+ * Locally-waiting cards the server copy shows as settled, plus the ones its interaction row still
+ * shows waiting.
+ *
+ * Settled requires POSITIVE evidence of termination — a terminal part state, or a terminal
+ * interaction row for the same call. "Not recognized as a waiting card" is not evidence: a card
+ * replayed from the durable log carries its harness-wrapped tool name
+ * (`mcp.agenta-tools.request_input`) with no `data-render` sibling, so the client-tool predicate
+ * cannot see it and every freshly-parked card read as settled — adopting over the user's half-typed
+ * form. A card the server does not carry at all is NOT settled either: the server has not caught up.
+ */
 const settledLocallyWaitingIds = (
     localMessages: UIMessage[],
     serverMessages: UIMessage[],
-): {pending: Set<string>; settled: Set<string>} => {
+    interactionRows: SessionInteractionRowStates | undefined,
+): {pending: Set<string>; settled: Set<string>; rowStillWaiting: Set<string>} => {
     const pending = pendingClientToolCallIds(localMessages)
     const settled = new Set<string>()
-    if (pending.size === 0) return {pending, settled}
+    const rowStillWaiting = new Set<string>()
+    if (pending.size === 0) return {pending, settled, rowStillWaiting}
+    const rows = interactionRowsByCallId(interactionRows)
+    for (const id of pending) {
+        const row = rows.get(id)
+        if (row && !isTerminalRow(row)) rowStillWaiting.add(id)
+    }
     for (const message of serverMessages) {
         if (message.role !== "assistant") continue
-        const parts = message.parts ?? []
-        const renderMap = buildRenderMap(parts)
-        for (const part of parts) {
-            const {toolCallId} = part as {toolCallId?: unknown}
+        for (const part of message.parts ?? []) {
+            const {toolCallId, state} = part as {toolCallId?: unknown; state?: unknown}
             if (typeof toolCallId !== "string" || !pending.has(toolCallId)) continue
-            if (!isPendingClientToolInteraction(part, renderMap)) settled.add(toolCallId)
+            const row = rows.get(toolCallId)
+            if (TERMINAL_PART_STATES.has(String(state)) || (row && isTerminalRow(row)))
+                settled.add(toolCallId)
         }
     }
-    return {pending, settled}
+    return {pending, settled, rowStillWaiting}
 }
 
 /**
@@ -103,11 +140,16 @@ const settledLocallyWaitingIds = (
  * card, same terminal row, minus the newest turn) replace the screen AND localStorage, regress the
  * watermark, and release the composer against a truncated history. The zombie case clears both
  * floors with equality, so requiring them costs nothing.
+ *
+ * That no-growth path also needs the interaction row itself to be terminal. A zombie's row is
+ * `cancelled`/`responded`, so it still fires; a card that just parked has a `pending` row, and
+ * without that check an equal record count would let the relay adopt over a live form.
  */
 export const shouldAdoptTranscript = ({
     serverRecordCount,
     serverMessages,
     localMessages,
+    interactionRows,
     watermark,
     busy,
     pendingResume,
@@ -115,12 +157,18 @@ export const shouldAdoptTranscript = ({
     serverRecordCount: number
     serverMessages: UIMessage[]
     localMessages: UIMessage[]
+    /** Rows joined into the server transcript; empty when the fetch failed or the session has none. */
+    interactionRows?: SessionInteractionRowStates
     watermark: number | undefined
     busy: boolean
     /** A client-tool answer is recorded but its resume has not dispatched — see `pendingResumeRef`. */
     pendingResume: boolean
 }): boolean => {
-    const {pending, settled} = settledLocallyWaitingIds(localMessages, serverMessages)
+    const {pending, settled, rowStillWaiting} = settledLocallyWaitingIds(
+        localMessages,
+        serverMessages,
+        interactionRows,
+    )
     // A waiting card the server copy does not settle must never be overwritten: the user may be
     // mid-answer, and adopting would discard it.
     if (pending.size > 0 && settled.size !== pending.size) return false
@@ -138,6 +186,9 @@ export const shouldAdoptTranscript = ({
 
     return (
         pending.size > 0 &&
+        // A row that exists and still reads `pending` blocks. No row at all (row-less sessions
+        // exist) just means this extra check has nothing to say; part evidence still decides.
+        rowStillWaiting.size === 0 &&
         !busy &&
         !pendingResume &&
         serverRecordCount >= (watermark ?? 0) &&
@@ -211,12 +262,13 @@ export const useSessionHydration = ({
     const adoptServerTranscript = useCallback(
         (transcript: SessionTranscript | null, {armJump = true} = {}): boolean => {
             if (!transcript) return false
-            const {messages: serverMsgs, recordCount} = transcript
+            const {messages: serverMsgs, recordCount, interactionRows} = transcript
             if (
                 !shouldAdoptTranscript({
                     serverRecordCount: recordCount,
                     serverMessages: serverMsgs,
                     localMessages: messagesRef.current,
+                    interactionRows,
                     watermark: recordWatermarkRef.current,
                     busy: busyRef.current,
                     pendingResume: !!pendingResumeRef.current,


### PR DESCRIPTION
## Context

After #5919, the user-request form card in the agent chat kept refreshing while the user typed, and the typed input was lost. The chain: the browser now re-reads the conversation from the server the instant a card parks (the new interaction-event listener). The guard that should protect a waiting card during that re-read counted any server part it could not recognize as "settled". But the server's replay of a freshly parked card is built from the durable record's harness-wrapped tool name (`mcp.agenta-tools.request_input`) with no render marker, so the guard failed to recognize it, wrongly concluded the card had ended, and let the server copy replace the live chat. The replacement carries different internal ids, so React remounted the form widget and destroyed the draft. A background poll repeated this.

## Changes

`settledLocallyWaitingIds` now demands positive proof that a waiting card ended before it counts as settled: the server part sits in a terminal state (`output-available`, `output-error`, `output-denied`), or the card's interaction row has moved past `pending` (`responded`, `resolved`, `cancelled`). A part that is present but merely unrecognized now refuses adoption, exactly as an absent part always did.

The no-growth adoption path (which retires zombie cards in dead sessions) additionally refuses while any waiting card's row still reads `pending`. In a dead session the row is terminal, so that path keeps working; for a freshly parked live card the row is `pending`, so the card can no longer be swept away.

To make row evidence available, `SessionTranscript` now carries the interaction rows the transcript was replayed against (`loadSession.ts` already fetched them; it stopped discarding them). Rows and messages always come from the same fetch, so the two kinds of evidence cannot disagree across generations.

Before: a parked form card was replaced seconds after appearing, and typing was lost.
After: the card is replaced only when the server positively shows it ended.

## Tests

- 7 new tests in `useSessionHydration.test.ts`, derived from the real `arabicPoetrySession` golden records cut at the exact record boundary that reproduces the unrecognizable replay. With the old guard logic, the three refusal tests fail; with the new logic all 26 pass.
- Zombie-card non-regression is covered twice: the pre-existing settled-card test and a new golden-backed test with a real `cancelled` row.
- Full AgentChatSlice suite: 346 passed. `@agenta/entities`: 974 passed. Mobile transcript adoption: 6 passed.
- Reviewed adversarially (row-join parity with replay, terminal-status vocabulary against the API, sweep timing for `cancelled`, fetch-failure degradation): no confirmed defects.

## What to QA

- Start an agent chat that raises a form card. Type into the form slowly for ~20 seconds. The card must not refresh or lose the text.
- Answer the form. The run resumes and the answered card stays answered after a reload.
- Regression: open an old session whose form card was already answered or abandoned. The card must show as ended, not live (this is the zombie-card behavior from #5919 that had to survive).
