### PR TITLE
[fix] Hide empty sessions from lists; connect overview Files to the agent drive

### DIFF
--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -357,8 +357,6 @@ export function DriveExplorer({
                         isFolder={selectedIsFolder}
                         rootLabel={rootLabel}
                         itemCount={selectedItemCount}
-                        totalCount={drive.fileCount}
-                        totalCapped={drive.fileCountCapped}
                         fileSize={selectedFileSize}
                         showOrigin={showOrigin}
                         isRepo={headerRepo.isRepo}

--- a/web/oss/src/components/Drives/DriveHeader.tsx
+++ b/web/oss/src/components/Drives/DriveHeader.tsx
@@ -31,8 +31,6 @@ export const DriveHeader = ({
     isFolder,
     rootLabel,
     itemCount,
-    totalCount,
-    totalCapped,
     fileSize,
     showOrigin,
     isRepo,
@@ -66,9 +64,6 @@ export const DriveHeader = ({
     onUploadStaged?: () => void
     /** Immediate-child count for a non-root folder (null when unknown / at root). */
     itemCount: number | null
-    /** Whole-drive file count — the chip at the root, preserving the old "N files". */
-    totalCount: number
-    totalCapped?: boolean
     fileSize?: number
     showOrigin: boolean
     /** This folder is a git repo → the details toggle reveals repo facts (else file details). */
@@ -94,7 +89,6 @@ export const DriveHeader = ({
     onRetry?: () => void
     retrying?: boolean
 }) => {
-    const atRoot = !selectedPath
     // A file always has details (size/modified); a folder only when it's a repo. Nothing selected
     // (transient null before the root auto-selects) → no toggle.
     const hasDetails = isFolder ? isRepo : selectedPath != null
@@ -148,16 +142,16 @@ export const DriveHeader = ({
                     rootLabel={rootLabel}
                     onNavigate={onNavigate}
                 />
+                {/* A folder's child count / a file's size. The root gets no chip — a whole-drive
+                    file count says nothing about what you're looking at. */}
                 <span className="shrink-0 text-xs text-colorTextTertiary">
-                    {atRoot
-                        ? `${totalCount}${totalCapped ? "+" : ""} file${totalCount === 1 ? "" : "s"}`
-                        : isFolder
-                          ? itemCount != null
-                              ? `${itemCount} item${itemCount === 1 ? "" : "s"}`
-                              : null
-                          : fileSize != null
-                            ? humanSize(fileSize)
-                            : null}
+                    {isFolder
+                        ? itemCount != null
+                            ? `${itemCount} item${itemCount === 1 ? "" : "s"}`
+                            : null
+                        : fileSize != null
+                          ? humanSize(fileSize)
+                          : null}
                 </span>
                 {!isFolder && showOrigin && selectedPath ? (
                     <Tag className="m-0 shrink-0 text-[12px] font-normal">

--- a/web/oss/src/components/Drives/isListableDrivePath.test.ts
+++ b/web/oss/src/components/Drives/isListableDrivePath.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest"
+
+import {AGENT_FILES_DIR, isListableDrivePath} from "./useSessionDrive"
+
+describe("isListableDrivePath", () => {
+    it("keeps ordinary files and folders", () => {
+        expect(isListableDrivePath("README.md")).toBe(true)
+        expect(isListableDrivePath("reports/q3.csv")).toBe(true)
+    })
+
+    it("drops empty and runner-internal paths", () => {
+        expect(isListableDrivePath("")).toBe(false)
+        expect(isListableDrivePath("/")).toBe(false)
+    })
+
+    // In the SESSION mount the bare name is the fold-point symlink into the agent mount, so it is
+    // plumbing rather than a file; its contents are listed folded under `agent-files/`.
+    it("drops the fold marker from the session mount", () => {
+        expect(isListableDrivePath(AGENT_FILES_DIR)).toBe(false)
+        expect(isListableDrivePath(`/${AGENT_FILES_DIR}`)).toBe(false)
+    })
+
+    // Inside the agent mount there is no fold, so the same name is a real directory the user made.
+    // Dropping it there hid the folder from the root listing while the count still counted it.
+    it("keeps a real agent-files directory that lives IN the agent mount", () => {
+        expect(isListableDrivePath(AGENT_FILES_DIR, {fromAgentMount: true})).toBe(true)
+        expect(isListableDrivePath(`${AGENT_FILES_DIR}/notes.md`, {fromAgentMount: true})).toBe(
+            true,
+        )
+    })
+
+    it("still drops internal paths from the agent mount", () => {
+        expect(isListableDrivePath("", {fromAgentMount: true})).toBe(false)
+    })
+})

--- a/web/oss/src/components/Drives/useSessionDrive.ts
+++ b/web/oss/src/components/Drives/useSessionDrive.ts
@@ -33,6 +33,15 @@ const stripLeadingSlashes = (s: string): string => {
     return i === 0 ? s : s.slice(i)
 }
 
+/** Drop an `agent-files/` fold prefix when a path still carries one — an agent-only drive presents
+ * the agent mount at its root, but a record-log or chat path may still name the fold. */
+const unfoldAgentPath = (rel: string): string =>
+    rel === AGENT_FILES_DIR
+        ? ""
+        : rel.startsWith(`${AGENT_FILES_DIR}/`)
+          ? rel.slice(AGENT_FILES_DIR.length + 1)
+          : rel
+
 export const fileOrigin = (path: string): FileOrigin => {
     const rel = cleanPath(path)
     return rel === AGENT_FILES_DIR || rel.startsWith(`${AGENT_FILES_DIR}/`) ? "agent" : "session"
@@ -149,6 +158,11 @@ export function useSessionDrive(
         mountFilesQueryFamily({mountId: agentMount?.id ?? "", includeGitignored}),
     )
 
+    // Agent-only drive (an overview surface — no conversation): the agent mount IS the drive, at its
+    // own root. The `agent-files/` fold needs a session cwd to fold INTO; without one it leaves the
+    // root resolving to no mount, so the lazy explorer subscribes to nothing and browses an empty tree.
+    const agentOnly = !sessionId && Boolean(agentMount)
+
     const activity = useAtomValue(sessionFileActivityAtomFamily(sessionId))
     // Durable, cross-device recency from the record log — the base layer under the live browser
     // activity below (which only sees THIS tab's turns). Without it, files created before this tab
@@ -164,12 +178,14 @@ export function useSessionDrive(
         const cwdStats = driveFileStats(listing)
         const cwdFiles = cwdStats.files.filter((f) => isListableDrivePath(f.path))
 
-        // Agent-mount files, presented under `agent-files/` so they read as a subfolder of cwd.
+        // Agent-mount files, presented under `agent-files/` so they read as a subfolder of cwd — or at
+        // the root when the agent mount is the whole drive.
         const agentListing = agentFilesQuery.data ?? null
         const agentStats = driveFileStats(agentListing)
+        const agentPrefix = agentOnly ? "" : `${AGENT_FILES_DIR}/`
         const agentFiles = agentStats.files.map((f) => ({
             ...f,
-            path: `${AGENT_FILES_DIR}/${cleanPath(f.path)}`,
+            path: `${agentPrefix}${cleanPath(f.path)}`,
         }))
         const files: MountFile[] = [...cwdFiles, ...agentFiles]
 
@@ -187,6 +203,8 @@ export function useSessionDrive(
 
         const resolveMount = (path: string): ResolvedMountPath | null => {
             const rel = cleanPath(path)
+            if (agentOnly)
+                return agentMount ? {mount: agentMount, path: unfoldAgentPath(rel)} : null
             if (agentMount && (rel === AGENT_FILES_DIR || rel.startsWith(`${AGENT_FILES_DIR}/`))) {
                 return {mount: agentMount, path: rel.slice(AGENT_FILES_DIR.length + 1)}
             }
@@ -224,10 +242,19 @@ export function useSessionDrive(
 
         const totalSize = cwdStats.totalSize + agentStats.totalSize
 
-        return {mount, files, filesByPath, resolveMount, totalSize, isLoading, errored}
+        return {
+            mount: agentOnly ? agentMount : mount,
+            files,
+            filesByPath,
+            resolveMount,
+            totalSize,
+            isLoading,
+            errored,
+        }
     }, [
         sessionId,
         artifactId,
+        agentOnly,
         mount,
         agentMount,
         filesQuery.data,
@@ -339,6 +366,12 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
     const agentMountQuery = useAtomValue(agentMountQueryFamily(artifactId ?? ""))
     const agentMount = artifactId ? (agentMountQuery.data ?? null) : null
 
+    // The agent mount is the WHOLE drive: no session, or a session that resolved without a cwd mount
+    // (nothing has run in it yet). Folding under `agent-files/` needs a cwd to fold into — without one
+    // the root resolves to no mount and the explorer browses an empty tree. Gated on the mounts query
+    // having ANSWERED so the presentation doesn't flip once a cwd mount appears mid-load.
+    const agentOnly = Boolean(agentMount) && !mount && (!sessionId || !mountsQuery.isPending)
+
     // Recents: the agent's own write/edit events from the durable record log (0 object-store scan).
     const recordRecency = useAtomValue(sessionRecordFileRecencyAtomFamily(sessionId))
 
@@ -397,13 +430,14 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
             .slice(0, SUMMARY_LATEST_LIMIT)
         // No in-conversation changes → present the top-level entries (files carry the store mtime;
         // folders sort after, alphabetically) so the surface reflects the drive's real contents.
-        // The agent mount's entries are presented under `agent-files/`, exactly as the full drive
-        // folds them — `resolveMount` below already maps that prefix back, so the rows open.
+        // The agent mount's entries are presented exactly as the full drive presents them (folded
+        // under `agent-files/`, or at the root when it IS the drive); `resolveMount` maps them back.
+        const agentPrefix = agentOnly ? "" : `${AGENT_FILES_DIR}/`
         const rootEntries: MountFile[] = [
             ...(rootQuery.data ?? []),
             ...(agentRootQuery.data ?? []).map((f) => ({
                 ...f,
-                path: `${AGENT_FILES_DIR}/${cleanPath(f.path)}`,
+                path: `${agentPrefix}${cleanPath(f.path)}`,
             })),
         ]
         const rootRecents: DriveRecentFile[] = rootEntries
@@ -427,6 +461,8 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
 
         const resolveMount = (path: string): ResolvedMountPath | null => {
             const rel = cleanPath(path)
+            if (agentOnly)
+                return agentMount ? {mount: agentMount, path: unfoldAgentPath(rel)} : null
             if (agentMount && (rel === AGENT_FILES_DIR || rel.startsWith(`${AGENT_FILES_DIR}/`))) {
                 return {mount: agentMount, path: rel.slice(AGENT_FILES_DIR.length + 1)}
             }
@@ -515,7 +551,7 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
                   : `${countLabel} file${fileCount === 1 && !fileCountCapped ? "" : "s"}`
 
         return {
-            mount,
+            mount: agentOnly ? agentMount : mount,
             files: recents,
             fileCount,
             fileCountCapped,
@@ -533,6 +569,7 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
     }, [
         sessionId,
         artifactId,
+        agentOnly,
         mount,
         agentMount,
         recordRecency,

--- a/web/oss/src/components/Drives/useSessionDrive.ts
+++ b/web/oss/src/components/Drives/useSessionDrive.ts
@@ -34,13 +34,21 @@ const stripLeadingSlashes = (s: string): string => {
 }
 
 /** Drop an `agent-files/` fold prefix when a path still carries one — an agent-only drive presents
- * the agent mount at its root, but a record-log or chat path may still name the fold. */
-const unfoldAgentPath = (rel: string): string =>
-    rel === AGENT_FILES_DIR
-        ? ""
-        : rel.startsWith(`${AGENT_FILES_DIR}/`)
-          ? rel.slice(AGENT_FILES_DIR.length + 1)
-          : rel
+ * the agent mount at its root, but a record-log or chat path may still name the fold. Skipped when
+ * the mount owns a real top-level `agent-files` entry: there the prefix is the file's own name, and
+ * unfolding it would resolve the directory to the mount root and its children to the wrong paths. */
+const unfoldAgentPath = (rel: string, agentOwnsFold = false): string => {
+    if (agentOwnsFold) return rel
+    if (rel === AGENT_FILES_DIR) return ""
+    return rel.startsWith(`${AGENT_FILES_DIR}/`) ? rel.slice(AGENT_FILES_DIR.length + 1) : rel
+}
+
+/** Does this mount hold a real top-level `agent-files` entry (which the fold prefix would shadow)? */
+const ownsAgentFilesEntry = (paths: readonly string[]): boolean =>
+    paths.some((p) => {
+        const rel = cleanPath(p)
+        return rel === AGENT_FILES_DIR || rel.startsWith(`${AGENT_FILES_DIR}/`)
+    })
 
 export const fileOrigin = (path: string): FileOrigin => {
     const rel = cleanPath(path)
@@ -158,10 +166,13 @@ export function useSessionDrive(
         mountFilesQueryFamily({mountId: agentMount?.id ?? "", includeGitignored}),
     )
 
-    // Agent-only drive (an overview surface — no conversation): the agent mount IS the drive, at its
-    // own root. The `agent-files/` fold needs a session cwd to fold INTO; without one it leaves the
-    // root resolving to no mount, so the lazy explorer subscribes to nothing and browses an empty tree.
-    const agentOnly = !sessionId && Boolean(agentMount)
+    // Agent-only drive: the agent mount IS the drive, at its own root. That covers an overview
+    // surface (no conversation) AND a session that resolved without a cwd mount — nothing has run in
+    // it yet. The `agent-files/` fold needs a cwd to fold INTO; without one the root resolves to no
+    // mount, so the lazy explorer subscribes to nothing and browses an empty tree. Gated on the mounts
+    // query having ANSWERED so the presentation doesn't flip once a cwd mount appears mid-load.
+    // Kept identical to `useSessionDriveSummary`'s predicate — the two must agree.
+    const agentOnly = Boolean(agentMount) && !mount && (!sessionId || !mountsQuery.isPending)
 
     const activity = useAtomValue(sessionFileActivityAtomFamily(sessionId))
     // Durable, cross-device recency from the record log — the base layer under the live browser
@@ -183,6 +194,7 @@ export function useSessionDrive(
         const agentListing = agentFilesQuery.data ?? null
         const agentStats = driveFileStats(agentListing)
         const agentPrefix = agentOnly ? "" : `${AGENT_FILES_DIR}/`
+        const agentOwnsFold = agentOnly && ownsAgentFilesEntry(agentStats.files.map((f) => f.path))
         const agentFiles = agentStats.files.map((f) => ({
             ...f,
             path: `${agentPrefix}${cleanPath(f.path)}`,
@@ -204,7 +216,9 @@ export function useSessionDrive(
         const resolveMount = (path: string): ResolvedMountPath | null => {
             const rel = cleanPath(path)
             if (agentOnly)
-                return agentMount ? {mount: agentMount, path: unfoldAgentPath(rel)} : null
+                return agentMount
+                    ? {mount: agentMount, path: unfoldAgentPath(rel, agentOwnsFold)}
+                    : null
             if (agentMount && (rel === AGENT_FILES_DIR || rel.startsWith(`${AGENT_FILES_DIR}/`))) {
                 return {mount: agentMount, path: rel.slice(AGENT_FILES_DIR.length + 1)}
             }
@@ -433,6 +447,8 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
         // The agent mount's entries are presented exactly as the full drive presents them (folded
         // under `agent-files/`, or at the root when it IS the drive); `resolveMount` maps them back.
         const agentPrefix = agentOnly ? "" : `${AGENT_FILES_DIR}/`
+        const agentOwnsFold =
+            agentOnly && ownsAgentFilesEntry((agentRootQuery.data ?? []).map((f) => f.path))
         const rootEntries: MountFile[] = [
             ...(rootQuery.data ?? []),
             ...(agentRootQuery.data ?? []).map((f) => ({
@@ -462,7 +478,9 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
         const resolveMount = (path: string): ResolvedMountPath | null => {
             const rel = cleanPath(path)
             if (agentOnly)
-                return agentMount ? {mount: agentMount, path: unfoldAgentPath(rel)} : null
+                return agentMount
+                    ? {mount: agentMount, path: unfoldAgentPath(rel, agentOwnsFold)}
+                    : null
             if (agentMount && (rel === AGENT_FILES_DIR || rel.startsWith(`${AGENT_FILES_DIR}/`))) {
                 return {mount: agentMount, path: rel.slice(AGENT_FILES_DIR.length + 1)}
             }

--- a/web/oss/src/components/Drives/useSessionDrive.ts
+++ b/web/oss/src/components/Drives/useSessionDrive.ts
@@ -63,10 +63,16 @@ export const fileOrigin = (path: string): FileOrigin => {
  * Excluded: runner plumbing ({@link isInternalDrivePath}), and the bare `agent-files` entry — that
  * one is the fold-point SYMLINK into the agent mount, not a file. Its CONTENTS are listed, folded
  * under `agent-files/` from the agent mount itself; the marker never is.
+ *
+ * That exclusion is about PROVENANCE, not the name: the marker only exists in the SESSION mount.
+ * Inside the agent mount, `agent-files` is an ordinary directory a user is free to create, so a
+ * caller listing agent-mount entries passes `fromAgentMount` and keeps it — otherwise the folder
+ * vanishes from the root listing while the file count still counts what is inside it.
  */
-export const isListableDrivePath = (path: string): boolean => {
+export const isListableDrivePath = (path: string, opts?: {fromAgentMount?: boolean}): boolean => {
     const rel = cleanPath(path)
-    return Boolean(rel) && rel !== AGENT_FILES_DIR && !isInternalDrivePath(rel)
+    if (!rel || isInternalDrivePath(rel)) return false
+    return opts?.fromAgentMount === true || rel !== AGENT_FILES_DIR
 }
 
 /** True when a listing holds BOTH agent and session files — the only time the origin tags/filter
@@ -395,7 +401,8 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
     // fallback over a row the list then drops. Computed here (cheap — records are few) to GATE the
     // queries off when records already carry the list, so an active conversation pays nothing extra.
     const hasVisibleRecords = useMemo(
-        () => [...recordRecency.keys()].some(isListableDrivePath),
+        // Wrapped, not passed by reference: `some` would hand the index in as the options arg.
+        () => [...recordRecency.keys()].some((p) => isListableDrivePath(p)),
         [recordRecency],
     )
 
@@ -449,15 +456,19 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
         const agentPrefix = agentOnly ? "" : `${AGENT_FILES_DIR}/`
         const agentOwnsFold =
             agentOnly && ownsAgentFilesEntry((agentRootQuery.data ?? []).map((f) => f.path))
+        // Filtered per SOURCE, before the fold prefix, so provenance is still known: a bare
+        // `agent-files` from the session mount is the fold marker and goes, the same name from the
+        // agent mount is a real directory and stays.
         const rootEntries: MountFile[] = [
-            ...(rootQuery.data ?? []),
-            ...(agentRootQuery.data ?? []).map((f) => ({
-                ...f,
-                path: `${agentPrefix}${cleanPath(f.path)}`,
-            })),
+            ...(rootQuery.data ?? []).filter((f) => isListableDrivePath(f.path)),
+            ...(agentRootQuery.data ?? [])
+                .filter((f) => isListableDrivePath(f.path, {fromAgentMount: true}))
+                .map((f) => ({
+                    ...f,
+                    path: `${agentPrefix}${cleanPath(f.path)}`,
+                })),
         ]
         const rootRecents: DriveRecentFile[] = rootEntries
-            .filter((f) => isListableDrivePath(f.path))
             .map((f) => ({...f, touchedAt: typeof f.mtime === "number" ? f.mtime : undefined}))
             .sort((a, b) =>
                 (b.touchedAt ?? 0) !== (a.touchedAt ?? 0)

--- a/web/oss/src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it} from "vitest"
+
+import {dropArchivedAgentSessions} from "./sessionsSource"
+import type {SessionSidebarRef} from "./sessionsSource"
+
+const ref = (over: Partial<SessionSidebarRef> & {id: string}): SessionSidebarRef => ({
+    sessionId: over.id,
+    name: over.id,
+    appId: null,
+    pinned: false,
+    alive: false,
+    agentName: null,
+    ...over,
+})
+
+const ARCHIVED = new Set(["agent-archived"])
+
+describe("dropArchivedAgentSessions", () => {
+    it("drops sessions whose agent is archived", () => {
+        const kept = dropArchivedAgentSessions(
+            [ref({id: "a", appId: "agent-archived"}), ref({id: "b", appId: "agent-live"})],
+            ARCHIVED,
+        )
+
+        expect(kept.map((r) => r.id)).toEqual(["b"])
+    })
+
+    // A pin is an explicit user request, the same exemption it gets from every other list rule.
+    it("keeps a PINNED session even when its agent is archived", () => {
+        const kept = dropArchivedAgentSessions(
+            [ref({id: "pinned", appId: "agent-archived", pinned: true})],
+            ARCHIVED,
+        )
+
+        expect(kept.map((r) => r.id)).toEqual(["pinned"])
+    })
+
+    it("keeps sessions that have no agent at all", () => {
+        const kept = dropArchivedAgentSessions([ref({id: "orphan", appId: null})], ARCHIVED)
+
+        expect(kept.map((r) => r.id)).toEqual(["orphan"])
+    })
+
+    // Absence of evidence is not evidence of archival: until the archived-ids query answers there
+    // is no set at all, and a pending query must never blank the group.
+    it("keeps everything until the archived answer arrives (null)", () => {
+        const refs = [ref({id: "a", appId: "agent-archived"}), ref({id: "b", appId: "agent-live"})]
+
+        expect(dropArchivedAgentSessions(refs, null).map((r) => r.id)).toEqual(["a", "b"])
+    })
+
+    // The filter runs before the visible cap, so a live session behind archived ones still lands
+    // in the rendered slots rather than losing them to rows that will never be shown.
+    it("frees capped slots for live sessions", () => {
+        const refs = [
+            ...Array.from({length: 3}, (_, i) => ref({id: `arch-${i}`, appId: "agent-archived"})),
+            ref({id: "live", appId: "agent-live"}),
+        ]
+
+        expect(dropArchivedAgentSessions(refs, ARCHIVED).map((r) => r.id)).toEqual(["live"])
+    })
+})

--- a/web/oss/src/components/Sidebar/dynamic/sessionOptions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionOptions.test.ts
@@ -11,7 +11,12 @@ vi.mock("@agenta/sdk/resources", () => ({
 
 import {sessionListPolicies} from "@/oss/lib/sessionListPolicies"
 
-import {SIDEBAR_SESSION_LIMIT, sidebarSessionFilters, sidebarSessionOptions} from "./sessionOptions"
+import {
+    SIDEBAR_SESSION_LIMIT,
+    SIDEBAR_SESSION_VISIBLE_LIMIT,
+    sidebarSessionFilters,
+    sidebarSessionOptions,
+} from "./sessionOptions"
 
 beforeEach(() => {
     fernQuerySessions.mockReset()
@@ -69,6 +74,13 @@ describe("sidebarSessionFilters", () => {
             excludeOrigins: undefined,
             expand: ["trigger"],
         })
+    })
+
+    // The request window exists to survive the unstarted rows dropped before render, so it has to
+    // stay comfortably wider than what the group actually shows.
+    it("requests a window far wider than the rows the group renders", () => {
+        expect(SIDEBAR_SESSION_VISIBLE_LIMIT).toBe(14)
+        expect(SIDEBAR_SESSION_LIMIT).toBeGreaterThan(SIDEBAR_SESSION_VISIBLE_LIMIT * 2)
     })
 
     it("sends pinned exclusions in the canonical recent request", async () => {

--- a/web/oss/src/components/Sidebar/dynamic/sessionOptions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionOptions.test.ts
@@ -11,7 +11,7 @@ vi.mock("@agenta/sdk/resources", () => ({
 
 import {sessionListPolicies} from "@/oss/lib/sessionListPolicies"
 
-import {sidebarSessionFilters, sidebarSessionOptions} from "./sessionOptions"
+import {SIDEBAR_SESSION_LIMIT, sidebarSessionFilters, sidebarSessionOptions} from "./sessionOptions"
 
 beforeEach(() => {
     fernQuerySessions.mockReset()
@@ -29,7 +29,7 @@ describe("sidebarSessionFilters", () => {
             includeArchived: false,
             sessionIds: undefined,
             excludeSessionIds: pinnedIds,
-            limit: 20,
+            limit: SIDEBAR_SESSION_LIMIT,
             lowPriority: true,
             origins: undefined,
             excludeOrigins: ["trigger"],
@@ -37,10 +37,12 @@ describe("sidebarSessionFilters", () => {
         })
     })
 
-    it("requests all 100 pinned rows in the explicit id group", () => {
-        const pinnedIds = Array.from({length: 100}, (_, index) => `pin-${index}`)
+    // Count must exceed the sidebar window, else the default limit alone would satisfy this.
+    it("widens the explicit id group to cover every pinned row", () => {
+        const pinCount = SIDEBAR_SESSION_LIMIT + 50
+        const pinnedIds = Array.from({length: pinCount}, (_, index) => `pin-${index}`)
         expect(sidebarSessionFilters({projectId: "project-1", sessionIds: pinnedIds}).limit).toBe(
-            100,
+            pinCount,
         )
     })
 
@@ -61,7 +63,7 @@ describe("sidebarSessionFilters", () => {
             includeArchived: false,
             sessionIds: pinnedIds,
             excludeSessionIds: undefined,
-            limit: 20,
+            limit: SIDEBAR_SESSION_LIMIT,
             lowPriority: true,
             origins: undefined,
             excludeOrigins: undefined,
@@ -88,7 +90,7 @@ describe("sidebarSessionFilters", () => {
             include_total: false,
             expand: [],
             windowing: {
-                limit: 20,
+                limit: SIDEBAR_SESSION_LIMIT,
                 next: undefined,
                 newest: undefined,
                 oldest: undefined,

--- a/web/oss/src/components/Sidebar/dynamic/sessionOptions.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionOptions.ts
@@ -7,7 +7,13 @@ import {
 
 import {sessionListPolicies} from "@/oss/lib/sessionListPolicies"
 
-export const SIDEBAR_SESSION_LIMIT = 20
+/**
+ * One request, deliberately much wider than the ~7 rows the sidebar shows. Unstarted sessions
+ * (a beat-only stream row, see `isStartedSession`) are the NEWEST, are dropped before render, and
+ * a burst of them would otherwise eat the whole window and leave the group empty. Rows are small
+ * here — this policy requests no expansions — and the server caps a window at 200.
+ */
+export const SIDEBAR_SESSION_LIMIT = 100
 
 export const sidebarSessionFilters = ({
     projectId,

--- a/web/oss/src/components/Sidebar/dynamic/sessionOptions.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionOptions.ts
@@ -8,12 +8,16 @@ import {
 import {sessionListPolicies} from "@/oss/lib/sessionListPolicies"
 
 /**
- * One request, deliberately much wider than the ~7 rows the sidebar shows. Unstarted sessions
- * (a beat-only stream row, see `isStartedSession`) are the NEWEST, are dropped before render, and
- * a burst of them would otherwise eat the whole window and leave the group empty. Rows are small
- * here — this policy requests no expansions — and the server caps a window at 200.
+ * One request, deliberately much wider than the {@link SIDEBAR_SESSION_VISIBLE_LIMIT} rows the
+ * sidebar shows. Unstarted sessions (a beat-only stream row, see `isStartedSession`) are the
+ * NEWEST, are dropped before render, and a burst of them would otherwise eat the whole window and
+ * leave the group empty. Rows are small here — this policy requests no expansions — and the server
+ * caps a window at 200.
  */
 export const SIDEBAR_SESSION_LIMIT = 100
+
+/** Rows the Sessions group renders before it collapses the rest behind "Show all". */
+export const SIDEBAR_SESSION_VISIBLE_LIMIT = 14
 
 export const sidebarSessionFilters = ({
     projectId,

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -1,5 +1,5 @@
 import {type SessionStream} from "@agenta/entities/session"
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {queryWorkflows, workflowMolecule} from "@agenta/entities/workflow"
 import {isStartedSession, pinnedSessionIdsAtom} from "@agenta/sessions/state"
 import {atom} from "jotai"
 import {atomWithQuery} from "jotai-tanstack-query"
@@ -79,6 +79,60 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
 }
 
 /**
+ * Ids of agents the user archived — ONE list request for the whole group, never a lookup per row.
+ *
+ * It has to be its own request: the app's workflows list sends `include_archived: false`, so an
+ * archived agent is simply ABSENT there, and absence is not proof — a workflow missing from a
+ * windowed list would read as archived and its live sessions would vanish. Asking WITH archived
+ * included and keeping the `deleted_at` ones gives a positive answer instead. Archived-ness is the
+ * same `deleted_at` signal the agents page splits its "Archived agents" tab on.
+ *
+ * Null until the answer arrives, so the filter below stays inert rather than hiding rows on a
+ * pending query. Gated with the rest of the group: a collapsed Sessions group never asks.
+ */
+const archivedAgentIdsQueryAtom = atomWithQuery<ReadonlySet<string> | null>((get) => {
+    const projectId = get(projectIdAtom)
+    return {
+        queryKey: ["sidebar", "workflows", "archived", projectId],
+        queryFn: async () => {
+            const response = await queryWorkflows({
+                projectId: projectId ?? "",
+                flags: {is_evaluator: false},
+                includeArchived: true,
+                lowPriority: true,
+            })
+            const archived = new Set<string>()
+            for (const workflow of response.workflows ?? []) {
+                if (workflow.deleted_at) archived.add(workflow.id)
+            }
+            return archived as ReadonlySet<string>
+        },
+        enabled: Boolean(projectId),
+        staleTime: 60_000,
+        refetchOnWindowFocus: false,
+    }
+})
+
+/**
+ * Drops sessions whose agent has been archived — an archived agent's conversations are not what the
+ * sidebar's short list is for.
+ *
+ * Rows that survive regardless: a PINNED one (a pin is explicit, the same exemption every other
+ * list rule gives it), one with no agent at all, and — while `archivedAgentIds` is null, i.e. the
+ * answer hasn't arrived — every row. A row is dropped only on positive proof its agent is archived,
+ * never on absent evidence.
+ *
+ * Runs BEFORE the visible cap so archived rows can't eat slots the backfill should have used.
+ */
+export const dropArchivedAgentSessions = (
+    refs: readonly SessionSidebarRef[],
+    archivedAgentIds: ReadonlySet<string> | null,
+): SessionSidebarRef[] =>
+    archivedAgentIds === null
+        ? [...refs]
+        : refs.filter((ref) => ref.pinned || !ref.appId || !archivedAgentIds.has(ref.appId))
+
+/**
  * Pinned sessions first, then the rest by activity.
  *
  * Pins are pulled to the top rather than left in place because a pinned conversation is one you
@@ -100,10 +154,16 @@ const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     )
 
     const isRef = (ref: SessionSidebarRef | null): ref is SessionSidebarRef => ref !== null
-    const refs = [
-        ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
-        ...recentRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
-    ]
+    // Archived agents' sessions go before anything downstream counts rows: the name resolution
+    // below and the group's visible cap both work off this list, so filtering here keeps archived
+    // rows from eating slots the backfill should have given to live ones.
+    const refs = dropArchivedAgentSessions(
+        [
+            ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+            ...recentRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+        ],
+        get(archivedAgentIdsQueryAtom).data ?? null,
+    )
     // Names are resolved for the RENDERED rows only. Each one subscribes to that agent's artifact
     // query, and the request window behind this list is several times what the group ever shows —
     // resolving all of it would fetch artifacts for rows nobody sees. The full list still goes out

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -1,5 +1,5 @@
 import {type SessionStream} from "@agenta/entities/session"
-import {pinnedSessionIdsAtom} from "@agenta/sessions/state"
+import {isStartedSession, pinnedSessionIdsAtom} from "@agenta/sessions/state"
 import {atom} from "jotai"
 import {atomWithQuery} from "jotai-tanstack-query"
 
@@ -83,9 +83,11 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
 const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     const pinned = new Set(get(pinnedSessionIdsAtom))
     const pinnedRows = get(sidebarPinnedSessionsQueryAtom).data ?? []
-    // The server excludes pins before paging; this remains a defensive dedupe.
+    // The server excludes pins before paging; this remains a defensive dedupe. Chats that were
+    // opened but never used are dropped here (the shared list rule) so the group's few slots hold
+    // real sessions — the window above is sized to have real ones left after this.
     const recentRows = (get(sidebarSessionsQueryAtom).data ?? []).filter(
-        (row) => !pinned.has(row.session_id),
+        (row) => !pinned.has(row.session_id) && isStartedSession(row),
     )
 
     const isRef = (ref: SessionSidebarRef | null): ref is SessionSidebarRef => ref !== null

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -8,7 +8,7 @@ import {sessionOpenTarget} from "@/oss/components/AgentChatSlice/assets/sessionO
 import {sessionListPolicies} from "@/oss/lib/sessionListPolicies"
 import {projectIdAtom} from "@/oss/state/project"
 
-import {sidebarSessionOptions} from "./sessionOptions"
+import {sidebarSessionOptions, SIDEBAR_SESSION_VISIBLE_LIMIT} from "./sessionOptions"
 import type {SidebarEntityRef} from "./types"
 
 /** A session row as the sidebar needs it: enough to label it, dot it, and open it. */
@@ -64,11 +64,7 @@ const sidebarPinnedSessionsQueryAtom = atomWithQuery<SessionStream[] | null>((ge
 
 /** Null when the row has no open target yet (no turns) — the sidebar drops it rather than
  * rendering a link to `/apps/null`. */
-const toSidebarRef = (
-    row: SessionStream,
-    pinned: Set<string>,
-    agentName: string | null,
-): SessionSidebarRef | null => {
+const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRef | null => {
     const target = sessionOpenTarget(row)
     if (!target) return null
     return {
@@ -78,7 +74,7 @@ const toSidebarRef = (
         appId: target.appId,
         pinned: pinned.has(row.session_id),
         alive: Boolean(row.flags?.is_alive),
-        agentName,
+        agentName: null,
     }
 }
 
@@ -91,8 +87,8 @@ const toSidebarRef = (
 const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     const pinned = new Set(get(pinnedSessionIdsAtom))
     // The owning agent's name for the row tooltip, read off the workflow ARTIFACT (a revision's
-    // own `name` is the variant's, never the entity's). Only the handful of apps these rows point
-    // at are resolved, and the group is gated, so a closed Sessions group asks for nothing.
+    // own `name` is the variant's, never the entity's). The group is gated, so a closed Sessions
+    // group asks for nothing.
     const agentNameOf = (appId: string | null) =>
         appId ? get(workflowMolecule.selectors.artifactName(appId)) : null
     const pinnedRows = get(sidebarPinnedSessionsQueryAtom).data ?? []
@@ -104,9 +100,17 @@ const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     )
 
     const isRef = (ref: SessionSidebarRef | null): ref is SessionSidebarRef => ref !== null
-    const toRef = (row: SessionStream) =>
-        toSidebarRef(row, pinned, agentNameOf(sessionOpenTarget(row)?.appId ?? null))
-    return [...pinnedRows.map(toRef).filter(isRef), ...recentRows.map(toRef).filter(isRef)]
+    const refs = [
+        ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+        ...recentRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+    ]
+    // Names are resolved for the RENDERED rows only. Each one subscribes to that agent's artifact
+    // query, and the request window behind this list is several times what the group ever shows —
+    // resolving all of it would fetch artifacts for rows nobody sees. The full list still goes out
+    // so the "Show all" overflow count stays honest.
+    return refs.map((ref, index) =>
+        index < SIDEBAR_SESSION_VISIBLE_LIMIT ? {...ref, agentName: agentNameOf(ref.appId)} : ref,
+    )
 })
 
 export const sidebarSessionsListAtom = atom((get) => {

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -1,4 +1,5 @@
 import {type SessionStream} from "@agenta/entities/session"
+import {workflowMolecule} from "@agenta/entities/workflow"
 import {isStartedSession, pinnedSessionIdsAtom} from "@agenta/sessions/state"
 import {atom} from "jotai"
 import {atomWithQuery} from "jotai-tanstack-query"
@@ -16,6 +17,8 @@ export interface SessionSidebarRef extends SidebarEntityRef {
     appId: string | null
     pinned: boolean
     alive: boolean
+    /** Owning agent's display name, for the row's hover tooltip. Null until the artifact resolves. */
+    agentName: string | null
 }
 
 /** Deliberately small — the sidebar shows the top of the list, and the sessions page owns
@@ -61,7 +64,11 @@ const sidebarPinnedSessionsQueryAtom = atomWithQuery<SessionStream[] | null>((ge
 
 /** Null when the row has no open target yet (no turns) — the sidebar drops it rather than
  * rendering a link to `/apps/null`. */
-const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRef | null => {
+const toSidebarRef = (
+    row: SessionStream,
+    pinned: Set<string>,
+    agentName: string | null,
+): SessionSidebarRef | null => {
     const target = sessionOpenTarget(row)
     if (!target) return null
     return {
@@ -71,6 +78,7 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
         appId: target.appId,
         pinned: pinned.has(row.session_id),
         alive: Boolean(row.flags?.is_alive),
+        agentName,
     }
 }
 
@@ -82,6 +90,11 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
  */
 const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     const pinned = new Set(get(pinnedSessionIdsAtom))
+    // The owning agent's name for the row tooltip, read off the workflow ARTIFACT (a revision's
+    // own `name` is the variant's, never the entity's). Only the handful of apps these rows point
+    // at are resolved, and the group is gated, so a closed Sessions group asks for nothing.
+    const agentNameOf = (appId: string | null) =>
+        appId ? get(workflowMolecule.selectors.artifactName(appId)) : null
     const pinnedRows = get(sidebarPinnedSessionsQueryAtom).data ?? []
     // The server excludes pins before paging; this remains a defensive dedupe. Chats that were
     // opened but never used are dropped here (the shared list rule) so the group's few slots hold
@@ -91,10 +104,9 @@ const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     )
 
     const isRef = (ref: SessionSidebarRef | null): ref is SessionSidebarRef => ref !== null
-    return [
-        ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
-        ...recentRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
-    ]
+    const toRef = (row: SessionStream) =>
+        toSidebarRef(row, pinned, agentNameOf(sessionOpenTarget(row)?.appId ?? null))
+    return [...pinnedRows.map(toRef).filter(isRef), ...recentRows.map(toRef).filter(isRef)]
 })
 
 export const sidebarSessionsListAtom = atom((get) => {

--- a/web/oss/src/components/pages/overview/agent/AgentFilesCard.tsx
+++ b/web/oss/src/components/pages/overview/agent/AgentFilesCard.tsx
@@ -9,7 +9,7 @@ import dynamic from "next/dynamic"
 
 import {timeAgo} from "@/oss/components/AgentChatSlice/state/sessions"
 import {agentMountQueryFamily} from "@/oss/components/Drives/agentDrive"
-import {AGENT_FILES_DIR, useSessionDrive} from "@/oss/components/Drives/useSessionDrive"
+import {useSessionDrive} from "@/oss/components/Drives/useSessionDrive"
 
 // The whole drive explorer, pulled in only once the drawer is actually opened.
 const FilesDrawer = dynamic(
@@ -106,9 +106,9 @@ const AgentFilesCard = ({appId}: {appId: string}) => {
                             key={file.path}
                             type="button"
                             onClick={() => {
-                                // The drive folds the agent mount in under `agent-files/`, so a
-                                // raw mount path would select nothing.
-                                setOpenPath(`${AGENT_FILES_DIR}/${file.path}`)
+                                // No session here, so the agent mount IS the drive: its own paths
+                                // select directly (no `agent-files/` fold).
+                                setOpenPath(file.path)
                                 setOpen(true)
                             }}
                             className="group box-border flex w-full cursor-pointer items-center gap-2 rounded-lg border-0 bg-transparent px-2 py-2.5 text-left hover:bg-colorFillQuaternary"

--- a/web/packages/agenta-sessions/src/state/index.ts
+++ b/web/packages/agenta-sessions/src/state/index.ts
@@ -18,6 +18,7 @@ export {
     selectedSessionListPolicy,
     isStartedSession,
     startedSessions,
+    awaitingHiddenRows,
     shouldLoadMoreForHiddenRows,
     type SessionOriginPolicy,
     type SessionListRequestPolicy,

--- a/web/packages/agenta-sessions/src/state/index.ts
+++ b/web/packages/agenta-sessions/src/state/index.ts
@@ -16,6 +16,9 @@ export {
     sessionListRequestFilters,
     sessionListIdGroupLimit,
     selectedSessionListPolicy,
+    isStartedSession,
+    startedSessions,
+    shouldLoadMoreForHiddenRows,
     type SessionOriginPolicy,
     type SessionListRequestPolicy,
 } from "./sessionListPolicy"

--- a/web/packages/agenta-sessions/src/state/sessionListPolicy.ts
+++ b/web/packages/agenta-sessions/src/state/sessionListPolicy.ts
@@ -1,4 +1,4 @@
-import type {SessionExpansion, SessionListFilters} from "@agenta/entities/session"
+import type {SessionExpansion, SessionListFilters, SessionStream} from "@agenta/entities/session"
 
 export type SessionOriginPolicy = "all" | "exclude-trigger" | "trigger-only"
 
@@ -20,6 +20,44 @@ export const selectedSessionListPolicy = (
     defaultPolicy: SessionListRequestPolicy,
     automationPolicy: SessionListRequestPolicy,
 ): SessionListRequestPolicy => (automationMode ? automationPolicy : defaultPolicy)
+
+/**
+ * Has this session started? The stream row exists from the runtime's first beat — before anyone
+ * types — so a list of every row fills with "Untitled session / No agent yet" placeholders for
+ * chats that were only opened. Started means the row carries something a person can recognise it
+ * by: a turn (the server attaches the latest turn's `references`, absent until there is one), a
+ * title, a message preview, or an automation identity (a trigger row IS its schedule, and the
+ * automations list must never blank).
+ *
+ * Display-only. Callers filter what they RENDER; nothing here may narrow a cached set the sidebar
+ * reconciler reads, which drops locally-known sessions the server omits.
+ */
+export const isStartedSession = (row: SessionStream): boolean =>
+    Boolean(
+        (row.references?.length ?? 0) > 0 ||
+        row.name?.trim() ||
+        row.last_message ||
+        row.origin === "trigger" ||
+        row.trigger,
+    )
+
+export const startedSessions = <T extends SessionStream>(rows: readonly T[]): T[] =>
+    rows.filter(isStartedSession)
+
+/**
+ * Should the list pull its next page before rendering? A page is 30 rows and unstarted ones are
+ * the NEWEST, so a burst of opened-but-unused chats can fill the whole first page — hiding them
+ * would otherwise leave a "No sessions yet" over a list that has plenty, one click down.
+ */
+export const shouldLoadMoreForHiddenRows = ({
+    visibleRows,
+    hasNextPage,
+    isFetchingNextPage,
+}: {
+    visibleRows: number
+    hasNextPage: boolean
+    isFetchingNextPage: boolean
+}): boolean => visibleRows === 0 && hasNextPage && !isFetchingNextPage
 
 export const sessionListIdGroupLimit = (
     sessionIds: readonly string[] | undefined,

--- a/web/packages/agenta-sessions/src/state/sessionListPolicy.ts
+++ b/web/packages/agenta-sessions/src/state/sessionListPolicy.ts
@@ -45,19 +45,39 @@ export const startedSessions = <T extends SessionStream>(rows: readonly T[]): T[
     rows.filter(isStartedSession)
 
 /**
- * Should the list pull its next page before rendering? A page is 30 rows and unstarted ones are
- * the NEWEST, so a burst of opened-but-unused chats can fill the whole first page — hiding them
- * would otherwise leave a "No sessions yet" over a list that has plenty, one click down.
+ * Is the list still waiting on a top-up? A page is 30 rows and unstarted ones are the NEWEST, so a
+ * burst of opened-but-unused chats can fill the whole first page — hiding them would otherwise
+ * leave a "No sessions yet" over a list that has plenty, one click down.
+ *
+ * Stays true for the WHOLE top-up, including while the request is in flight, so the list holds its
+ * loading state instead of flashing the empty one. A failed page ends the wait: `hasNextPage` is
+ * still true after a failure, so without this the list would wait forever on a page that never lands.
+ */
+export const awaitingHiddenRows = ({
+    visibleRows,
+    hasNextPage,
+    isError = false,
+}: {
+    visibleRows: number
+    hasNextPage: boolean
+    isError?: boolean
+}): boolean => visibleRows === 0 && hasNextPage && !isError
+
+/**
+ * The narrower "fire the request now" edge: only when nothing is already in flight, and never after
+ * a failure — `fetchNextPage` failing leaves `hasNextPage` true, so retrying on it would spin.
  */
 export const shouldLoadMoreForHiddenRows = ({
     visibleRows,
     hasNextPage,
     isFetchingNextPage,
+    isError = false,
 }: {
     visibleRows: number
     hasNextPage: boolean
     isFetchingNextPage: boolean
-}): boolean => visibleRows === 0 && hasNextPage && !isFetchingNextPage
+    isError?: boolean
+}): boolean => awaitingHiddenRows({visibleRows, hasNextPage, isError}) && !isFetchingNextPage
 
 export const sessionListIdGroupLimit = (
     sessionIds: readonly string[] | undefined,

--- a/web/packages/agenta-sessions/src/state/useSessionCardList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionCardList.ts
@@ -8,6 +8,7 @@ import {sessionRowVm, type SessionRowVm} from "../row/viewModel"
 
 import {pinnedSessionIdsAtom} from "./pins"
 import {
+    awaitingHiddenRows,
     shouldLoadMoreForHiddenRows,
     startedSessions,
     type SessionListRequestPolicy,
@@ -201,19 +202,22 @@ export const useSessionCardList = ({
 
     // A whole page can be unstarted rows (they are the newest) — pull the next one rather than
     // showing the card's empty state over sessions that exist one page down.
-    const topUp = shouldLoadMoreForHiddenRows({
+    const topUpArgs = {
         visibleRows: shownCount,
         hasNextPage: Boolean(hasNextPage),
-        isFetchingNextPage,
-    })
+        isError: listQuery.isFetchNextPageError,
+    }
+    // Held across the in-flight request too, or the card would flash empty mid-top-up.
+    const awaitingTopUp = awaitingHiddenRows(topUpArgs)
+    const shouldTopUp = shouldLoadMoreForHiddenRows({...topUpArgs, isFetchingNextPage})
     useEffect(() => {
-        if (topUp) void fetchNextPage()
-    }, [topUp, fetchNextPage])
+        if (shouldTopUp) void fetchNextPage()
+    }, [shouldTopUp, fetchNextPage])
 
     return {
         groups,
-        isPending: listQuery.isPending || topUp,
-        isEmpty: isEmpty && !topUp,
+        isPending: listQuery.isPending || awaitingTopUp,
+        isEmpty: isEmpty && !awaitingTopUp,
         /** All gated rows in this card's scope — the header's "N waiting" badge. */
         waitingTotal: waitingRowsAll.length,
         canShowMore,

--- a/web/packages/agenta-sessions/src/state/useSessionCardList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionCardList.ts
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from "react"
+import {useCallback, useEffect, useMemo, useState} from "react"
 
 import {type SessionExpansion, type SessionStream} from "@agenta/entities/session"
 import {projectIdAtom} from "@agenta/shared/state"
@@ -7,7 +7,11 @@ import {useAtomValue} from "jotai"
 import {sessionRowVm, type SessionRowVm} from "../row/viewModel"
 
 import {pinnedSessionIdsAtom} from "./pins"
-import type {SessionListRequestPolicy} from "./sessionListPolicy"
+import {
+    shouldLoadMoreForHiddenRows,
+    startedSessions,
+    type SessionListRequestPolicy,
+} from "./sessionListPolicy"
 import {
     pendingBySessionId,
     rowsFromPages,
@@ -109,7 +113,13 @@ export const useSessionCardList = ({
     const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds])
     // Memoized: `rowsFromPages` mints a new array per call, and an unstable array here would
     // re-derive every row VM (and re-render every memoized row) on every render.
-    const listRows = useMemo(() => rowsFromPages(listQuery.data?.pages), [listQuery.data?.pages])
+    // A chat that was opened but never used is not a session anyone is looking for — see
+    // `isStartedSession`. Pins and waiting rows are exempt: both are explicit, and a gated row
+    // has a turn by definition.
+    const listRows = useMemo(
+        () => startedSessions(rowsFromPages(listQuery.data?.pages)),
+        [listQuery.data?.pages],
+    )
     const waitingRowsAll = useMemo(
         () => (useWaiting ? rowsFromPages(waitingQuery.data?.pages) : []),
         [useWaiting, waitingQuery.data?.pages],
@@ -189,10 +199,21 @@ export const useSessionCardList = ({
         if (hasNextPage && !isFetchingNextPage) void fetchNextPage()
     }, [limit, hasNextPage, isFetchingNextPage, fetchNextPage])
 
+    // A whole page can be unstarted rows (they are the newest) — pull the next one rather than
+    // showing the card's empty state over sessions that exist one page down.
+    const topUp = shouldLoadMoreForHiddenRows({
+        visibleRows: shownCount,
+        hasNextPage: Boolean(hasNextPage),
+        isFetchingNextPage,
+    })
+    useEffect(() => {
+        if (topUp) void fetchNextPage()
+    }, [topUp, fetchNextPage])
+
     return {
         groups,
-        isPending: listQuery.isPending,
-        isEmpty,
+        isPending: listQuery.isPending || topUp,
+        isEmpty: isEmpty && !topUp,
         /** All gated rows in this card's scope — the header's "N waiting" badge. */
         waitingTotal: waitingRowsAll.length,
         canShowMore,

--- a/web/packages/agenta-sessions/src/state/useSessionsList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionsList.ts
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from "react"
+import {useCallback, useEffect, useMemo} from "react"
 
 import {type SessionExpansion, type SessionStream} from "@agenta/entities/session"
 import {projectIdAtom} from "@agenta/shared/state"
@@ -17,7 +17,12 @@ import {
     sessionStatusFilterAtom,
 } from "./filters"
 import {isSessionPinnedAtom, pinnedSessionIdsAtom, toggleSessionPinAtom} from "./pins"
-import {selectedSessionListPolicy, type SessionListRequestPolicy} from "./sessionListPolicy"
+import {
+    selectedSessionListPolicy,
+    shouldLoadMoreForHiddenRows,
+    startedSessions,
+    type SessionListRequestPolicy,
+} from "./sessionListPolicy"
 import {
     pendingBySessionId,
     rowsFromPages,
@@ -127,7 +132,12 @@ export const useSessionsList = ({
     const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds])
     // Memoized: `rowsFromPages` mints a new array per call, and an unstable array here would
     // re-derive every row VM (and re-render every memoized row) on every render.
-    const listRows = useMemo(() => rowsFromPages(listQuery.data?.pages), [listQuery.data?.pages])
+    // A chat that was opened but never used is not a session anyone is looking for — see
+    // `isStartedSession`. Pins are exempt: pinning is an explicit request, like the origin filter.
+    const listRows = useMemo(
+        () => startedSessions(rowsFromPages(listQuery.data?.pages)),
+        [listQuery.data?.pages],
+    )
     const pinnedRowsAll = useMemo(
         () => rowsFromPages(pinnedQuery.data?.pages),
         [pinnedQuery.data?.pages],
@@ -165,6 +175,18 @@ export const useSessionsList = ({
         return result
     }, [pinnedIds, knownById, listRows, pinnedSet, pendingBySession, showTriggered])
 
+    // A whole page can be unstarted rows (they are the newest); pull the next one instead of
+    // showing "No sessions yet" over a list that has plenty one page down.
+    const {hasNextPage, isFetchingNextPage, fetchNextPage} = listQuery
+    const topUp = shouldLoadMoreForHiddenRows({
+        visibleRows: listRows.length,
+        hasNextPage: Boolean(hasNextPage),
+        isFetchingNextPage,
+    })
+    useEffect(() => {
+        if (topUp) void fetchNextPage()
+    }, [topUp, fetchNextPage])
+
     const refetchList = listQuery.refetch
     const refetchPinned = pinnedQuery.refetch
     const refetch = useCallback(() => {
@@ -174,11 +196,13 @@ export const useSessionsList = ({
 
     return {
         groups,
-        isEmpty: groups.every((group) => group.rows.length === 0),
+        // Not "empty" while a top-up is on its way — that would flash the empty state over a
+        // list whose first page happened to be all unstarted rows.
+        isEmpty: !topUp && groups.every((group) => group.rows.length === 0),
         paging: {
-            hasNext: Boolean(listQuery.hasNextPage),
-            isLoadingNext: listQuery.isFetchingNextPage,
-            loadNext: () => void listQuery.fetchNextPage(),
+            hasNext: Boolean(hasNextPage),
+            isLoadingNext: isFetchingNextPage,
+            loadNext: () => void fetchNextPage(),
         },
         isPending: listQuery.isPending || (pinnedIds.length > 0 && pinnedQuery.isPending),
         isError: listQuery.isError || pinnedQuery.isError,

--- a/web/packages/agenta-sessions/src/state/useSessionsList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionsList.ts
@@ -18,6 +18,7 @@ import {
 } from "./filters"
 import {isSessionPinnedAtom, pinnedSessionIdsAtom, toggleSessionPinAtom} from "./pins"
 import {
+    awaitingHiddenRows,
     selectedSessionListPolicy,
     shouldLoadMoreForHiddenRows,
     startedSessions,
@@ -177,15 +178,18 @@ export const useSessionsList = ({
 
     // A whole page can be unstarted rows (they are the newest); pull the next one instead of
     // showing "No sessions yet" over a list that has plenty one page down.
-    const {hasNextPage, isFetchingNextPage, fetchNextPage} = listQuery
-    const topUp = shouldLoadMoreForHiddenRows({
+    const {hasNextPage, isFetchingNextPage, isFetchNextPageError, fetchNextPage} = listQuery
+    const topUpArgs = {
         visibleRows: listRows.length,
         hasNextPage: Boolean(hasNextPage),
-        isFetchingNextPage,
-    })
+        isError: isFetchNextPageError,
+    }
+    // Held across the in-flight request too, or the list would flash empty mid-top-up.
+    const awaitingTopUp = awaitingHiddenRows(topUpArgs)
+    const shouldTopUp = shouldLoadMoreForHiddenRows({...topUpArgs, isFetchingNextPage})
     useEffect(() => {
-        if (topUp) void fetchNextPage()
-    }, [topUp, fetchNextPage])
+        if (shouldTopUp) void fetchNextPage()
+    }, [shouldTopUp, fetchNextPage])
 
     const refetchList = listQuery.refetch
     const refetchPinned = pinnedQuery.refetch
@@ -198,7 +202,7 @@ export const useSessionsList = ({
         groups,
         // Not "empty" while a top-up is on its way — that would flash the empty state over a
         // list whose first page happened to be all unstarted rows.
-        isEmpty: !topUp && groups.every((group) => group.rows.length === 0),
+        isEmpty: !awaitingTopUp && groups.every((group) => group.rows.length === 0),
         paging: {
             hasNext: Boolean(hasNextPage),
             isLoadingNext: isFetchingNextPage,

--- a/web/packages/agenta-sessions/tests/unit/sessionListPolicy.test.ts
+++ b/web/packages/agenta-sessions/tests/unit/sessionListPolicy.test.ts
@@ -2,6 +2,7 @@ import type {SessionStream} from "@agenta/entities/session"
 import {describe, expect, it} from "vitest"
 
 import {
+    awaitingHiddenRows,
     isStartedSession,
     selectedSessionListPolicy,
     sessionListIdGroupLimit,
@@ -149,5 +150,41 @@ describe("shouldLoadMoreForHiddenRows", () => {
                 isFetchingNextPage: false,
             }),
         ).toBe(false)
+    })
+
+    // A failed `fetchNextPage` leaves `hasNextPage` true, so retrying on it spins forever.
+    it("does not retry a page that just failed", () => {
+        expect(
+            shouldLoadMoreForHiddenRows({
+                visibleRows: 0,
+                hasNextPage: true,
+                isFetchingNextPage: false,
+                isError: true,
+            }),
+        ).toBe(false)
+    })
+})
+
+describe("awaitingHiddenRows", () => {
+    // The status the list renders from: it must outlast the fetch trigger, or the empty state
+    // appears the moment the request starts and disappears again when it lands.
+    it("stays true while the top-up request is in flight", () => {
+        expect(awaitingHiddenRows({visibleRows: 0, hasNextPage: true})).toBe(true)
+        expect(
+            shouldLoadMoreForHiddenRows({
+                visibleRows: 0,
+                hasNextPage: true,
+                isFetchingNextPage: true,
+            }),
+        ).toBe(false)
+    })
+
+    it("ends the wait when the page fails, so the list stops hiding the empty state", () => {
+        expect(awaitingHiddenRows({visibleRows: 0, hasNextPage: true, isError: true})).toBe(false)
+    })
+
+    it("is not waiting once a row shows, or at the last page", () => {
+        expect(awaitingHiddenRows({visibleRows: 1, hasNextPage: true})).toBe(false)
+        expect(awaitingHiddenRows({visibleRows: 0, hasNextPage: false})).toBe(false)
     })
 })

--- a/web/packages/agenta-sessions/tests/unit/sessionListPolicy.test.ts
+++ b/web/packages/agenta-sessions/tests/unit/sessionListPolicy.test.ts
@@ -1,10 +1,17 @@
+import type {SessionStream} from "@agenta/entities/session"
 import {describe, expect, it} from "vitest"
 
 import {
+    isStartedSession,
     selectedSessionListPolicy,
     sessionListIdGroupLimit,
     sessionListRequestFilters,
+    shouldLoadMoreForHiddenRows,
+    startedSessions,
 } from "../../src/state/sessionListPolicy"
+
+const streamRow = (row: Partial<SessionStream>): SessionStream =>
+    ({project_id: "project-1", session_id: "session-1", ...row}) as SessionStream
 
 describe("sessionListRequestFilters", () => {
     it("maps each explicit origin policy into canonical entity filters", () => {
@@ -67,5 +74,80 @@ describe("sessionListRequestFilters", () => {
     it("requests all 100 waiting session ids instead of the default page", () => {
         const ids = Array.from({length: 100}, (_, index) => `waiting-${index}`)
         expect(sessionListIdGroupLimit(ids, 30)).toBe(100)
+    })
+})
+
+describe("isStartedSession", () => {
+    // The runtime beats a stream row into existence as soon as a chat is opened, so the row a
+    // list must hide carries nothing but liveness flags.
+    it("hides a chat that was opened but never used", () => {
+        expect(isStartedSession(streamRow({flags: {is_alive: true, is_running: false}}))).toBe(
+            false,
+        )
+        expect(isStartedSession(streamRow({name: "   ", references: []}))).toBe(false)
+    })
+
+    it("shows a session the moment it has a turn, a title, or a message", () => {
+        expect(isStartedSession(streamRow({references: [{id: "019ff0c7-9842-7671"}]}))).toBe(true)
+        expect(isStartedSession(streamRow({name: "Refund policy"}))).toBe(true)
+        expect(isStartedSession(streamRow({last_message: {content: "hello"}}))).toBe(true)
+    })
+
+    // An automation row IS its schedule — it has an identity before its first turn, and the
+    // automations list must never blank.
+    it("keeps automation rows regardless of turns", () => {
+        expect(isStartedSession(streamRow({origin: "trigger"}))).toBe(true)
+        expect(isStartedSession(streamRow({trigger: {id: "trigger-1", kind: "schedule"}}))).toBe(
+            true,
+        )
+    })
+
+    it("filters a page down to the started rows, keeping order", () => {
+        const rows = [
+            streamRow({session_id: "a", name: "Named"}),
+            streamRow({session_id: "b"}),
+            streamRow({session_id: "c", references: [{id: "app-1"}]}),
+        ]
+        expect(startedSessions(rows).map((row) => row.session_id)).toEqual(["a", "c"])
+    })
+})
+
+describe("shouldLoadMoreForHiddenRows", () => {
+    // Unstarted rows are the NEWEST, so a burst of opened chats can fill a whole 30-row page.
+    it("pulls the next page when the loaded one is entirely hidden", () => {
+        expect(
+            shouldLoadMoreForHiddenRows({
+                visibleRows: 0,
+                hasNextPage: true,
+                isFetchingNextPage: false,
+            }),
+        ).toBe(true)
+    })
+
+    it("does not stack fetches, and stops at the last page", () => {
+        expect(
+            shouldLoadMoreForHiddenRows({
+                visibleRows: 0,
+                hasNextPage: true,
+                isFetchingNextPage: true,
+            }),
+        ).toBe(false)
+        expect(
+            shouldLoadMoreForHiddenRows({
+                visibleRows: 0,
+                hasNextPage: false,
+                isFetchingNextPage: false,
+            }),
+        ).toBe(false)
+    })
+
+    it("leaves a page that has something to show alone", () => {
+        expect(
+            shouldLoadMoreForHiddenRows({
+                visibleRows: 1,
+                hasNextPage: true,
+                isFetchingNextPage: false,
+            }),
+        ).toBe(false)
     })
 })


### PR DESCRIPTION
## Context

Two founder-reported bugs. First, the Sessions page, home cards, and the sidebar's session list were flooded with "Untitled session / No agent yet" rows: the backend's liveness heartbeat creates a session row on first touch even when no conversation ever lands, and bursts of SDK-shaped traffic produced dozens of them (28 of the first 30 rows in the founder's project). Second, on an agent's overview page, Files → "View All" always opened an empty folder even though the agent's files exist and show in the card.

## Changes

**Empty sessions.** A shared list rule (`isStartedSession` in `@agenta/sessions`) shows a session only when a person could recognize it: it has a turn, a title, a message preview, or it is an automation. Pins and gated (waiting) rows are always kept. Applied at render level in the Sessions-page and card-list hooks; the reconciler and session creation are untouched. Because whole pages can consist of hidden rows, the list fetches the next page when everything it loaded was filtered. The sidebar additionally widens its single request window (20 → 100 rows) so empties cannot starve its seven recent slots, and filters by the same rule. Untitled-but-real conversations still show, by design.

**Overview Files.** The drive resolver only knew how to resolve paths through a session's working-directory mount, and the overview has no session, so the file browser mounted nothing and rendered an empty tree. The drive now presents the agent's own mount at the root when it is the whole drive (`agentOnly` mode), which also fixes the same empty browser in the playground config panel for sessions that have no working directory yet. The "N files" count chip next to the breadcrumb at root is removed (folder item counts and file sizes stay).

Before: 28 placeholder rows above two real sessions; View All shows an empty folder.
After: only real sessions listed everywhere; View All lists and opens the agent's actual files.

## Tests

- 7 new unit tests in `sessionListPolicy.test.ts` (hide beat-only rows, keep turn/title/preview/automation rows, order-preserving filtering, the three top-up decisions); package suite 45/45.
- Live-verified on the dev stack: fresh unsent session appears nowhere and pops into every list on its first message; View All opens real files and byte content renders; the sessions-with-mount path keeps the folded Agent/Session layout.

## What to QA

- Sessions page: no "Untitled session / No agent yet" placeholder rows; Load more only surfaces real conversations.
- Sidebar sessions group: lists your recent real sessions even right after creating several blank ones in the playground.
- Agent overview → Files → View All: the agent's files list and open.
- Regression: automations/schedule rows still show in their lists; pinned sessions always show; a session with a session working directory still shows the folded agent-files/ layout in the playground Files panel.
