### PR TITLE
[feat] Agents keep the project sidebar (flat agent navigation)

### DIFF
--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import {memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode} from "react"
 
+import {workflowLatestRevisionQueryAtomFamily} from "@agenta/entities/workflow"
 import {ConfigProvider, Layout, Modal, theme} from "antd"
 import clsx from "clsx"
 import {atom} from "jotai"
@@ -10,6 +11,7 @@ import {useRouter} from "next/router"
 import {ErrorBoundary} from "react-error-boundary"
 
 import useIsomorphicLayoutEffect from "@/oss/hooks/useIsomorphicLayoutEffect"
+import {routerAppIdAtom} from "@/oss/state/app/atoms/fetcher"
 import {appStateSnapshotAtom, requestNavigationAtom} from "@/oss/state/appState"
 import {layoutFullHeightRequestAtom} from "@/oss/state/layout/fullHeight"
 import {cacheWorkspaceOrgPair} from "@/oss/state/org/selectors/org"
@@ -175,6 +177,13 @@ const appRouteSliceAtom = selectAtom(
 // String-valued so org/app churn inside urlAtom doesn't re-render AppWithVariants
 const baseAppURLAtom = eagerAtom((get) => get(urlAtom).baseAppURL)
 
+// True once the type lookup has given its final answer, even when that answer is nothing.
+const agentTypeSettledAtom = atom((get) => {
+    const appId = get(routerAppIdAtom)
+    if (!appId) return true
+    return !get(workflowLatestRevisionQueryAtomFamily(appId)).isPending
+})
+
 type StyleClasses = ReturnType<typeof useStyles>
 
 const {Content} = Layout
@@ -208,18 +217,18 @@ const AppWithVariants = memo(
         const isAnnotations = appState.pathname.includes("/annotations")
         const lastBasePathRef = useRef<string | null>(null)
         const lastNonSettingsPathRef = useRef<string | null>(null)
-        // Agents keep the project rail; only classic apps swap to the app-context one. Same early,
-        // app-id-keyed signal the playground shell uses, so both commit at the same instant.
+        // Same signal the playground shell reads, so sidebar and content commit together.
         const agentState = useAtomValue(playgroundEarlyAgentStateAtom)
+        const agentTypeSettled = useAtomValue(agentTypeSettledAtom)
         const currentSidebarViewIdRef = useRef<string | undefined>(undefined)
         const activeSidebarView = resolveSidebarView({
             pathname: appState.pathname,
             routeLayer: appState.routeLayer,
             agentState,
+            agentTypeSettled,
             currentViewId: currentSidebarViewIdRef.current,
         })
-        // Commit phase, not render: an abandoned render must not leave its view id behind as the
-        // rail that is "on screen", which is the one thing this ref is asked for.
+        // Update only after commit so abandoned renders cannot change the visible view.
         useIsomorphicLayoutEffect(() => {
             currentSidebarViewIdRef.current = activeSidebarView.id
         }, [activeSidebarView.id])

--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -20,6 +20,7 @@ import {
     lastNonDemoProjectAtom,
 } from "@/oss/state/project/selectors/project"
 import {urlAtom} from "@/oss/state/url"
+import {playgroundEarlyAgentStateAtom} from "@/oss/state/workflow"
 
 import CustomWorkflowBanner from "../CustomWorkflow/CustomWorkflowBanner"
 import ProtectedRoute from "../ProtectedRoute/ProtectedRoute"
@@ -206,10 +207,17 @@ const AppWithVariants = memo(
         const isAnnotations = appState.pathname.includes("/annotations")
         const lastBasePathRef = useRef<string | null>(null)
         const lastNonSettingsPathRef = useRef<string | null>(null)
+        // Agents keep the project rail; only classic apps swap to the app-context one. Same early,
+        // app-id-keyed signal the playground shell uses, so both commit at the same instant.
+        const agentState = useAtomValue(playgroundEarlyAgentStateAtom)
+        const currentSidebarViewIdRef = useRef<string | undefined>(undefined)
         const activeSidebarView = resolveSidebarView({
             pathname: appState.pathname,
             routeLayer: appState.routeLayer,
+            agentState,
+            currentViewId: currentSidebarViewIdRef.current,
         })
+        currentSidebarViewIdRef.current = activeSidebarView.id
 
         useEffect(() => {
             if (activeSidebarView.isBase) {

--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -9,6 +9,7 @@ import {eagerAtom} from "jotai-eager"
 import {useRouter} from "next/router"
 import {ErrorBoundary} from "react-error-boundary"
 
+import useIsomorphicLayoutEffect from "@/oss/hooks/useIsomorphicLayoutEffect"
 import {appStateSnapshotAtom, requestNavigationAtom} from "@/oss/state/appState"
 import {layoutFullHeightRequestAtom} from "@/oss/state/layout/fullHeight"
 import {cacheWorkspaceOrgPair} from "@/oss/state/org/selectors/org"
@@ -217,7 +218,11 @@ const AppWithVariants = memo(
             agentState,
             currentViewId: currentSidebarViewIdRef.current,
         })
-        currentSidebarViewIdRef.current = activeSidebarView.id
+        // Commit phase, not render: an abandoned render must not leave its view id behind as the
+        // rail that is "on screen", which is the one thing this ref is asked for.
+        useIsomorphicLayoutEffect(() => {
+            currentSidebarViewIdRef.current = activeSidebarView.id
+        }, [activeSidebarView.id])
 
         useEffect(() => {
             if (activeSidebarView.isBase) {

--- a/web/oss/src/components/Sidebar/dynamic/registry.ts
+++ b/web/oss/src/components/Sidebar/dynamic/registry.ts
@@ -15,6 +15,7 @@ import {pendingSessionOpenAtom} from "@/oss/components/AgentChatSlice/state/pend
 
 import {MAIN_SIDEBAR_SCOPE_ID, SESSIONS_SIDEBAR_KEY} from "../scopes/constants"
 
+import {SIDEBAR_SESSION_VISIBLE_LIMIT} from "./sessionOptions"
 import {sidebarSessionsListAtom, type SessionSidebarRef} from "./sessionsSource"
 import {gatedSidebarSource} from "./source"
 import type {
@@ -51,12 +52,17 @@ export const defineSidebarEntity = <TRef extends SidebarEntityRef>(
     activeSourceAtom: gatedSidebarSource(scopeId, parentKey, config.listAtom),
     getLabel: (ref) => config.getLabel(ref as TRef),
     childLink: (ref, projectURL) => `${projectURL}${config.childPath(ref as TRef)}`,
+    childMatchLinks: config.childMatchPaths
+        ? (ref, projectURL) =>
+              config.childMatchPaths!(ref as TRef).map((path) => `${projectURL}${path}`)
+        : undefined,
     emptyLabel: config.emptyLabel,
     maxItems: config.maxItems ?? DEFAULT_SIDEBAR_ENTITY_LIMIT,
     showAllLink: config.showAllPath
         ? (projectURL) => `${projectURL}${config.showAllPath}`
         : undefined,
     getIcon: config.getIcon ? (ref) => config.getIcon!(ref as TRef) : undefined,
+    getTooltip: config.getTooltip ? (ref) => config.getTooltip!(ref as TRef) : undefined,
     getOnClick: config.getOnClick ? (ref) => config.getOnClick!(ref as TRef) : undefined,
 })
 
@@ -80,6 +86,9 @@ const ENTITIES: SidebarEntity[] = [
         // The link navigates to the owning agent; the click hands over WHICH session, since the
         // playground has no way to read that from the route.
         childPath: (session) => `/apps/${session.appId}/playground`,
+        // Every session of an agent shares that one URL, so the path can't say which one is open —
+        // matching would highlight an arbitrary row. The agent row owns the highlight instead.
+        childMatchPaths: () => [],
         getOnClick: (session) => () => {
             if (!session.appId) return
             getDefaultStore().set(pendingSessionOpenAtom, {
@@ -95,8 +104,11 @@ const ENTITIES: SidebarEntity[] = [
                       size: 10,
                       weight: session.alive ? "fill" : "regular",
                   }),
+        // Which agent this conversation belongs to — the row's title is the session's own, and
+        // several agents' sessions sit in one flat list. No agent resolved yet, no tooltip.
+        getTooltip: (session) => session.agentName ?? undefined,
         emptyLabel: "No sessions",
-        maxItems: 7,
+        maxItems: SIDEBAR_SESSION_VISIBLE_LIMIT,
         showAllPath: "/sessions",
     }),
     defineSidebarEntity(MAIN_SIDEBAR_SCOPE_ID, AGENTS_SIDEBAR_KEY, {
@@ -104,7 +116,10 @@ const ENTITIES: SidebarEntity[] = [
         icon: createElement(RobotIcon, {size: 14}),
         listAtom: agentWorkflowsListQueryStateAtom,
         getLabel: (workflow) => workflow.name || workflow.slug || "Untitled agent",
-        childPath: (workflow) => `/apps/${workflow.id}/playground`,
+        childPath: (workflow) => `/apps/${workflow.id}/overview`,
+        // Agents keep the project rail, so this row stays visible on every page of the agent —
+        // overview, playground, sessions — and stays highlighted across all of them.
+        childMatchPaths: (workflow) => [`/apps/${workflow.id}`],
         emptyLabel: "No agents",
         showAllPath: "/agents",
     }),

--- a/web/oss/src/components/Sidebar/dynamic/registry.ts
+++ b/web/oss/src/components/Sidebar/dynamic/registry.ts
@@ -86,8 +86,7 @@ const ENTITIES: SidebarEntity[] = [
         // The link navigates to the owning agent; the click hands over WHICH session, since the
         // playground has no way to read that from the route.
         childPath: (session) => `/apps/${session.appId}/playground`,
-        // Every session of an agent shares that one URL, so the path can't say which one is open —
-        // matching would highlight an arbitrary row. The agent row owns the highlight instead.
+        // Every session shares that one URL, so matching would highlight an arbitrary row.
         childMatchPaths: () => [],
         getOnClick: (session) => () => {
             if (!session.appId) return
@@ -104,8 +103,7 @@ const ENTITIES: SidebarEntity[] = [
                       size: 10,
                       weight: session.alive ? "fill" : "regular",
                   }),
-        // Which agent this conversation belongs to — the row's title is the session's own, and
-        // several agents' sessions sit in one flat list. No agent resolved yet, no tooltip.
+        // Show the owning agent because sessions from multiple agents share this list.
         getTooltip: (session) => session.agentName ?? undefined,
         emptyLabel: "No sessions",
         maxItems: SIDEBAR_SESSION_VISIBLE_LIMIT,
@@ -117,8 +115,7 @@ const ENTITIES: SidebarEntity[] = [
         listAtom: agentWorkflowsListQueryStateAtom,
         getLabel: (workflow) => workflow.name || workflow.slug || "Untitled agent",
         childPath: (workflow) => `/apps/${workflow.id}/overview`,
-        // Agents keep the project rail, so this row stays visible on every page of the agent —
-        // overview, playground, sessions — and stays highlighted across all of them.
+        // Stays highlighted across all of the agent's pages, not just the one it links to.
         childMatchPaths: (workflow) => [`/apps/${workflow.id}`],
         emptyLabel: "No agents",
         showAllPath: "/agents",

--- a/web/oss/src/components/Sidebar/dynamic/types.ts
+++ b/web/oss/src/components/Sidebar/dynamic/types.ts
@@ -43,9 +43,7 @@ export interface SidebarEntityConfig<TRef extends SidebarEntityRef = SidebarEnti
     getLabel: (ref: TRef) => string
     /** Project-relative detail path, e.g. `(ref) => `/testsets/${ref.id}``. */
     childPath: (ref: TRef) => string
-    /** Project-relative prefixes the row is highlighted on, when they differ from `childPath`. An
-     * empty array keeps the row out of route matching (rows that share one URL can't tell each
-     * other apart from the path alone). Defaults to `[childPath]`. */
+    /** Prefixes the row is highlighted on; empty opts it out. Defaults to `[childPath]`. */
     childMatchPaths?: (ref: TRef) => string[]
     /** Shown (muted, disabled) when the group is open but has no items. */
     emptyLabel?: string
@@ -56,8 +54,7 @@ export interface SidebarEntityConfig<TRef extends SidebarEntityRef = SidebarEnti
     /** Per-row icon, overriding the shared kind icon — for rows whose state differs from each
      * other (a session's liveness dot, say), where one icon for the whole group says nothing. */
     getIcon?: (ref: TRef) => ReactElement
-    /** Hover tooltip for the row, for context the label can't carry (which agent a session
-     * belongs to). Omit — or return undefined — and the row keeps the default hover. */
+    /** Optional row tooltip for context not shown by the label. */
     getTooltip?: (ref: TRef) => string | undefined
     /** Extra work on click, alongside following `childPath` — e.g. handing the target to the
      * surface being navigated to. Runs in the default jotai store, not a hook. */

--- a/web/oss/src/components/Sidebar/dynamic/types.ts
+++ b/web/oss/src/components/Sidebar/dynamic/types.ts
@@ -43,6 +43,10 @@ export interface SidebarEntityConfig<TRef extends SidebarEntityRef = SidebarEnti
     getLabel: (ref: TRef) => string
     /** Project-relative detail path, e.g. `(ref) => `/testsets/${ref.id}``. */
     childPath: (ref: TRef) => string
+    /** Project-relative prefixes the row is highlighted on, when they differ from `childPath`. An
+     * empty array keeps the row out of route matching (rows that share one URL can't tell each
+     * other apart from the path alone). Defaults to `[childPath]`. */
+    childMatchPaths?: (ref: TRef) => string[]
     /** Shown (muted, disabled) when the group is open but has no items. */
     emptyLabel?: string
     /** Cap on rendered rows; overflow adds a "Show all" row. Defaults to 3. */
@@ -52,6 +56,9 @@ export interface SidebarEntityConfig<TRef extends SidebarEntityRef = SidebarEnti
     /** Per-row icon, overriding the shared kind icon — for rows whose state differs from each
      * other (a session's liveness dot, say), where one icon for the whole group says nothing. */
     getIcon?: (ref: TRef) => ReactElement
+    /** Hover tooltip for the row, for context the label can't carry (which agent a session
+     * belongs to). Omit — or return undefined — and the row keeps the default hover. */
+    getTooltip?: (ref: TRef) => string | undefined
     /** Extra work on click, alongside following `childPath` — e.g. handing the target to the
      * surface being navigated to. Runs in the default jotai store, not a hook. */
     getOnClick?: (ref: TRef) => () => void
@@ -69,9 +76,11 @@ export interface SidebarEntity {
     activeSourceAtom: Atom<SidebarEntitySource>
     getLabel: (ref: SidebarEntityRef) => string
     childLink: (ref: SidebarEntityRef, projectURL: string) => string
+    childMatchLinks?: (ref: SidebarEntityRef, projectURL: string) => string[]
     emptyLabel?: string
     maxItems: number
     showAllLink?: (projectURL: string) => string
     getIcon?: (ref: SidebarEntityRef) => ReactElement
+    getTooltip?: (ref: SidebarEntityRef) => string | undefined
     getOnClick?: (ref: SidebarEntityRef) => () => void
 }

--- a/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.test.ts
@@ -1,0 +1,55 @@
+import {createElement} from "react"
+
+import {describe, expect, it} from "vitest"
+
+import type {SidebarEntity, SidebarEntityRef, SidebarEntitySource} from "./types"
+import {resolveChildren} from "./useSidebarDynamicChildren"
+
+const ref = (id: string, name: string): SidebarEntityRef => ({id, name})
+
+const entity = (overrides: Partial<SidebarEntity> = {}): SidebarEntity => ({
+    parentKey: "project-sessions-link",
+    kind: "app",
+    activeSourceAtom: null as unknown as SidebarEntity["activeSourceAtom"],
+    getLabel: (r) => r.name ?? r.id,
+    childLink: (r) => `/apps/${r.id}/playground`,
+    icon: createElement("span"),
+    maxItems: 14,
+    ...overrides,
+})
+
+const ready = (refs: SidebarEntityRef[]): SidebarEntitySource => ({status: "ready", refs})
+
+describe("resolveChildren", () => {
+    it("carries the entity's tooltip onto each row", () => {
+        const children = resolveChildren(
+            entity({getTooltip: (r) => (r.id === "s1" ? "Arabic Poetry Scheduler" : undefined)}),
+            ready([ref("s1", "Morning poem"), ref("s2", "Untitled session")]),
+            "/w/w1/p/p1",
+        )
+
+        expect(children.map((child) => child.tooltip)).toEqual([
+            "Arabic Poetry Scheduler",
+            undefined,
+        ])
+    })
+
+    // A row whose agent hasn't resolved must not fall back to repeating its own label.
+    it("leaves the tooltip unset when the entity declares none", () => {
+        const children = resolveChildren(entity(), ready([ref("s1", "Morning poem")]), "/w/w1/p/p1")
+
+        expect(children[0].tooltip).toBeUndefined()
+    })
+
+    it("renders up to maxItems rows and adds Show all beyond it", () => {
+        const refs = Array.from({length: 20}, (_, index) => ref(`s${index}`, `Session ${index}`))
+        const children = resolveChildren(
+            entity({showAllLink: (projectURL) => `${projectURL}/sessions`}),
+            ready(refs),
+            "/w/w1/p/p1",
+        )
+
+        expect(children).toHaveLength(15)
+        expect(children.at(-1)?.title).toBe("Show all")
+    })
+})

--- a/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
+++ b/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
@@ -89,7 +89,9 @@ export const resolveChildren = (
         children.push({
             key: `${entity.parentKey}-${ref.id}`,
             title: entity.getLabel(ref),
+            tooltip: entity.getTooltip?.(ref),
             link: entity.childLink(ref, projectURL),
+            matchLinks: entity.childMatchLinks?.(ref, projectURL),
             icon: entity.getIcon?.(ref) ?? icon(),
             isDynamic: true,
             onClick: entity.getOnClick?.(ref),

--- a/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
@@ -271,6 +271,13 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                                     {labelNode}
                                 </div>
                             </Tooltip>
+                        ) : item.tooltip ? (
+                            // Expanded: only rows that ASK for a tooltip get one — the collapsed
+                            // rail falls back to the title because the label is hidden there, but
+                            // here that fallback would just repeat the visible text on every row.
+                            <Tooltip title={item.tooltip} placement="right" mouseEnterDelay={0.8}>
+                                <span className="w-full">{labelNode}</span>
+                            </Tooltip>
                         ) : (
                             labelNode
                         ),

--- a/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
@@ -272,9 +272,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                                 </div>
                             </Tooltip>
                         ) : item.tooltip ? (
-                            // Expanded: only rows that ASK for a tooltip get one — the collapsed
-                            // rail falls back to the title because the label is hidden there, but
-                            // here that fallback would just repeat the visible text on every row.
+                            // Expanded rows only show explicitly configured tooltips.
                             <Tooltip title={item.tooltip} placement="right" mouseEnterDelay={0.8}>
                                 <span className="w-full">{labelNode}</span>
                             </Tooltip>

--- a/web/oss/src/components/Sidebar/engine/SidebarShell.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarShell.tsx
@@ -59,8 +59,7 @@ const findSelectedRoute = (items: SidebarConfig[], currentPath = "") => {
 
     const visit = (nodes: SidebarConfig[], ancestors: string[]) => {
         nodes.forEach((item) => {
-            // `matchLinks` lets a row own more routes than it navigates to (Agents owns every
-            // agent's pages); an empty list opts it out of matching entirely.
+            // A row can own more routes than it navigates to; an empty list opts it out.
             const matchLinks = item.matchLinks ?? (item.link ? [item.link] : [])
             for (const matchLink of matchLinks) {
                 if (!pathMatchesLink(currentPath, matchLink)) continue

--- a/web/oss/src/components/Sidebar/engine/SidebarShell.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarShell.tsx
@@ -41,6 +41,8 @@ class SidebarErrorBoundary extends React.Component<React.PropsWithChildren, {has
 // path equals it or continues with a path/query/hash boundary. Query string and hash on
 // `currentPath` (router.asPath) are tolerated by the boundary check.
 const pathMatchesLink = (currentPath: string, link: string) => {
+    // A trailing slash means descendants only: `/apps/` claims `/apps/<id>` but not `/apps`.
+    if (link.endsWith("/")) return currentPath.startsWith(link)
     if (currentPath === link) return true
     if (!currentPath.startsWith(link)) return false
     const nextChar = currentPath.charAt(link.length)
@@ -57,13 +59,18 @@ const findSelectedRoute = (items: SidebarConfig[], currentPath = "") => {
 
     const visit = (nodes: SidebarConfig[], ancestors: string[]) => {
         nodes.forEach((item) => {
-            if (item.link && pathMatchesLink(currentPath, item.link)) {
-                const isExact = currentPath === item.link
-                const isSameLength = item.link.length === matchedLength
+            // `matchLinks` lets a row own more routes than it navigates to (Agents owns every
+            // agent's pages); an empty list opts it out of matching entirely.
+            const matchLinks = item.matchLinks ?? (item.link ? [item.link] : [])
+            for (const matchLink of matchLinks) {
+                if (!pathMatchesLink(currentPath, matchLink)) continue
+
+                const isExact = currentPath === matchLink
+                const isSameLength = matchLink.length === matchedLength
                 const isBetterMatch =
                     !matched ||
                     (isExact && !matchedIsExact) ||
-                    (isExact === matchedIsExact && item.link.length > matchedLength) ||
+                    (isExact === matchedIsExact && matchLink.length > matchedLength) ||
                     (isExact === matchedIsExact &&
                         isSameLength &&
                         matched.isDynamic &&
@@ -71,7 +78,7 @@ const findSelectedRoute = (items: SidebarConfig[], currentPath = "") => {
 
                 if (isBetterMatch) {
                     matched = item
-                    matchedLength = item.link.length
+                    matchedLength = matchLink.length
                     matchedIsExact = isExact
                     openKeys = ancestors
                 }

--- a/web/oss/src/components/Sidebar/engine/types.ts
+++ b/web/oss/src/components/Sidebar/engine/types.ts
@@ -26,8 +26,7 @@ export interface SidebarConfig {
     isPlaceholder?: boolean
     /** Render the item normally but suppress its navigation — clicking it is a no-op (current location). */
     inert?: boolean
-    /** Route prefixes that select this row, when they differ from `link`. An empty array opts the
-     * row out of route matching. Defaults to `[link]`. */
+    /** Route prefixes that select this row; empty opts it out of matching. Defaults to `[link]`. */
     matchLinks?: string[]
     /** Workflow categories that support this item. Omit to support every category. */
     workflowCategories?: readonly SidebarWorkflowCategory[]

--- a/web/oss/src/components/Sidebar/engine/types.ts
+++ b/web/oss/src/components/Sidebar/engine/types.ts
@@ -26,6 +26,9 @@ export interface SidebarConfig {
     isPlaceholder?: boolean
     /** Render the item normally but suppress its navigation — clicking it is a no-op (current location). */
     inert?: boolean
+    /** Route prefixes that select this row, when they differ from `link`. An empty array opts the
+     * row out of route matching. Defaults to `[link]`. */
+    matchLinks?: string[]
     /** Workflow categories that support this item. Omit to support every category. */
     workflowCategories?: readonly SidebarWorkflowCategory[]
 }

--- a/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
+++ b/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
@@ -83,16 +83,13 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 isHidden: hideAdvancedNav,
                 disabled: !hasProjectURL,
             },
-            // Agents before Sessions: a session is something an agent has, so the agent it belongs
-            // to reads first.
+            // Agents before Sessions: a session is something an agent has.
             {
                 key: AGENTS_SIDEBAR_KEY,
                 title: "Agents",
                 link: `${projectURL}/agents`,
                 icon: <RobotIcon size={14} />,
-                // An agent's own pages keep this rail, so Agents stays the active area throughout
-                // them. Only agents reach `/apps/<id>` with the project rail up — classic apps and
-                // evaluators swap to the app-context rail — so the prefix can't over-claim.
+                // Only agents reach `/apps/<id>` with this rail up, so the prefix can't over-claim.
                 matchLinks: [`${projectURL}/agents`, `${baseAppURL}/`],
                 // Onboarding IS agent creation — the list page is an empty dead-end until it commits.
                 disabled: !hasProjectURL || deadEndNavDisabled,
@@ -206,9 +203,7 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 icon: <LightningIcon size={14} />,
                 disabled: !hasProjectURL,
                 dataTour: "registry-nav",
-                // Agents navigate flat: no Registry, Evaluations or per-app Observability. They
-                // keep the project rail, so these never render for one — the categories say so
-                // outright, and cover the instant before agent-ness resolves.
+                // Agents navigate flat: no Registry, Evaluations or per-app Observability.
                 workflowCategories: ["app"],
             },
             {

--- a/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
+++ b/web/oss/src/components/Sidebar/hooks/useSidebarConfig/index.tsx
@@ -83,6 +83,21 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 isHidden: hideAdvancedNav,
                 disabled: !hasProjectURL,
             },
+            // Agents before Sessions: a session is something an agent has, so the agent it belongs
+            // to reads first.
+            {
+                key: AGENTS_SIDEBAR_KEY,
+                title: "Agents",
+                link: `${projectURL}/agents`,
+                icon: <RobotIcon size={14} />,
+                // An agent's own pages keep this rail, so Agents stays the active area throughout
+                // them. Only agents reach `/apps/<id>` with the project rail up — classic apps and
+                // evaluators swap to the app-context rail — so the prefix can't over-claim.
+                matchLinks: [`${projectURL}/agents`, `${baseAppURL}/`],
+                // Onboarding IS agent creation — the list page is an empty dead-end until it commits.
+                disabled: !hasProjectURL || deadEndNavDisabled,
+                tooltip: deadEndNavDisabled ? "Your agents will appear here" : undefined,
+            },
             {
                 key: SESSIONS_SIDEBAR_KEY,
                 title: "Sessions",
@@ -91,15 +106,6 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 // Sessions only exist once an agent has run — a dead-end during onboarding.
                 disabled: !hasProjectURL || deadEndNavDisabled,
                 tooltip: deadEndNavDisabled ? "Your sessions will appear here" : undefined,
-            },
-            {
-                key: AGENTS_SIDEBAR_KEY,
-                title: "Agents",
-                link: `${projectURL}/agents`,
-                icon: <RobotIcon size={14} />,
-                // Onboarding IS agent creation — the list page is an empty dead-end until it commits.
-                disabled: !hasProjectURL || deadEndNavDisabled,
-                tooltip: deadEndNavDisabled ? "Your agents will appear here" : undefined,
             },
             {
                 key: "evaluation-group",
@@ -200,7 +206,10 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 icon: <LightningIcon size={14} />,
                 disabled: !hasProjectURL,
                 dataTour: "registry-nav",
-                workflowCategories: ["app", "agent"],
+                // Agents navigate flat: no Registry, Evaluations or per-app Observability. They
+                // keep the project rail, so these never render for one — the categories say so
+                // outright, and cover the instant before agent-ness resolves.
+                workflowCategories: ["app"],
             },
             {
                 key: "app-evaluations-link",
@@ -211,6 +220,7 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 // Enabled for evaluators too — shows the runs scoped by the evaluator's id.
                 disabled: !hasProjectURL,
                 dataTour: "evaluations-nav",
+                workflowCategories: ["app", "evaluator"],
             },
             {
                 key: "app-traces-link",
@@ -219,6 +229,7 @@ export const useSidebarConfig = (): MainSidebarItems => {
                 isHidden: isHidden || hideAdvancedNav,
                 link: `${appURL || recentlyVisitedAppURL}/traces`,
                 disabled: !hasProjectURL,
+                workflowCategories: ["app", "evaluator"],
             },
         ]
     }, [

--- a/web/oss/src/components/Sidebar/scopes/viewRegistry.test.ts
+++ b/web/oss/src/components/Sidebar/scopes/viewRegistry.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it, vi} from "vitest"
+
+// The registry's `create` functions pull in the scope components, and with them next/font —
+// which needs the Next build pipeline. Matching itself is pure.
+vi.mock("next/font/google", () => ({
+    Inter: () => ({className: "", variable: "", style: {fontFamily: "Inter"}}),
+}))
+
+import {
+    MAIN_SIDEBAR_SCOPE_ID,
+    SETTINGS_SIDEBAR_SCOPE_ID,
+    WORKFLOW_SIDEBAR_SCOPE_ID,
+} from "./constants"
+import {resolveSidebarView, type SidebarViewMatchContext} from "./viewRegistry"
+
+const ctx = (overrides: Partial<SidebarViewMatchContext> = {}): SidebarViewMatchContext => ({
+    pathname: "/w/[workspace_id]/p/[project_id]/apps/[app_id]/playground",
+    routeLayer: "app",
+    agentState: "unknown",
+    ...overrides,
+})
+
+describe("resolveSidebarView", () => {
+    it("keeps the project rail on an agent's own pages", () => {
+        expect(resolveSidebarView(ctx({agentState: "agent"})).id).toBe(MAIN_SIDEBAR_SCOPE_ID)
+    })
+
+    it("swaps to the app-context rail for a classic app or evaluator", () => {
+        expect(resolveSidebarView(ctx({agentState: "non-agent"})).id).toBe(
+            WORKFLOW_SIDEBAR_SCOPE_ID,
+        )
+    })
+
+    it("holds the app-context rail while agent-ness is unknown", () => {
+        expect(resolveSidebarView(ctx({currentViewId: WORKFLOW_SIDEBAR_SCOPE_ID})).id).toBe(
+            WORKFLOW_SIDEBAR_SCOPE_ID,
+        )
+    })
+
+    it("falls back to the project rail when unknown with no rail to hold", () => {
+        expect(resolveSidebarView(ctx()).id).toBe(MAIN_SIDEBAR_SCOPE_ID)
+        expect(resolveSidebarView(ctx({currentViewId: MAIN_SIDEBAR_SCOPE_ID})).id).toBe(
+            MAIN_SIDEBAR_SCOPE_ID,
+        )
+    })
+
+    it("lets settings win over the held rail", () => {
+        const view = resolveSidebarView(
+            ctx({
+                pathname: "/w/[workspace_id]/p/[project_id]/settings",
+                routeLayer: "project",
+                currentViewId: WORKFLOW_SIDEBAR_SCOPE_ID,
+            }),
+        )
+        expect(view.id).toBe(SETTINGS_SIDEBAR_SCOPE_ID)
+    })
+
+    it("ignores agent-ness outside an app route", () => {
+        expect(resolveSidebarView(ctx({routeLayer: "project", agentState: "non-agent"})).id).toBe(
+            MAIN_SIDEBAR_SCOPE_ID,
+        )
+    })
+})

--- a/web/oss/src/components/Sidebar/scopes/viewRegistry.test.ts
+++ b/web/oss/src/components/Sidebar/scopes/viewRegistry.test.ts
@@ -1,7 +1,6 @@
 import {describe, expect, it, vi} from "vitest"
 
-// The registry's `create` functions pull in the scope components, and with them next/font —
-// which needs the Next build pipeline. Matching itself is pure.
+// The registry's `create` functions reach next/font, which needs the Next build pipeline.
 vi.mock("next/font/google", () => ({
     Inter: () => ({className: "", variable: "", style: {fontFamily: "Inter"}}),
 }))
@@ -17,6 +16,7 @@ const ctx = (overrides: Partial<SidebarViewMatchContext> = {}): SidebarViewMatch
     pathname: "/w/[workspace_id]/p/[project_id]/apps/[app_id]/playground",
     routeLayer: "app",
     agentState: "unknown",
+    agentTypeSettled: false,
     ...overrides,
 })
 
@@ -57,6 +57,33 @@ describe("resolveSidebarView", () => {
 
     it("ignores agent-ness outside an app route", () => {
         expect(resolveSidebarView(ctx({routeLayer: "project", agentState: "non-agent"})).id).toBe(
+            MAIN_SIDEBAR_SCOPE_ID,
+        )
+    })
+
+    it("settles a failed lookup on the app-context rail instead of stranding it", () => {
+        expect(resolveSidebarView(ctx({agentTypeSettled: true})).id).toBe(WORKFLOW_SIDEBAR_SCOPE_ID)
+    })
+
+    it("settles the same way from the project rail, so the swap still happens", () => {
+        expect(
+            resolveSidebarView(ctx({agentTypeSettled: true, currentViewId: MAIN_SIDEBAR_SCOPE_ID}))
+                .id,
+        ).toBe(WORKFLOW_SIDEBAR_SCOPE_ID)
+    })
+
+    it("does not settle while the lookup can still answer", () => {
+        expect(resolveSidebarView(ctx({agentTypeSettled: false})).id).toBe(MAIN_SIDEBAR_SCOPE_ID)
+    })
+
+    it("keeps a known agent on the project rail once its lookup settles", () => {
+        expect(resolveSidebarView(ctx({agentState: "agent", agentTypeSettled: true})).id).toBe(
+            MAIN_SIDEBAR_SCOPE_ID,
+        )
+    })
+
+    it("never settles a non-app route onto the app-context rail", () => {
+        expect(resolveSidebarView(ctx({routeLayer: "project", agentTypeSettled: true})).id).toBe(
             MAIN_SIDEBAR_SCOPE_ID,
         )
     })

--- a/web/oss/src/components/Sidebar/scopes/viewRegistry.ts
+++ b/web/oss/src/components/Sidebar/scopes/viewRegistry.ts
@@ -17,6 +17,8 @@ export interface SidebarViewMatchContext {
     routeLayer: RouteLayer
     /** Agent-ness of the routed app — "unknown" until its workflow type resolves. */
     agentState: PlaygroundAgentState
+    /** Whether the type lookup has given its final answer, even if that answer is nothing. */
+    agentTypeSettled: boolean
     /** The view on screen right now; held while `agentState` is unknown so the rail can't flash. */
     currentViewId?: string
 }
@@ -45,8 +47,7 @@ export const SIDEBAR_VIEWS = [
     },
     {
         id: WORKFLOW_SIDEBAR_SCOPE_ID,
-        // Agents navigate flat: they keep the project rail and never swap to the app-context one.
-        // Only classic prompt apps and evaluators get this view.
+        // Agents navigate flat and keep the project rail; only classic apps and evaluators swap.
         matches: (ctx: SidebarViewMatchContext) =>
             ctx.routeLayer === "app" && ctx.agentState === "non-agent",
         create: ({lastPath}: SidebarViewContext) => createWorkflowSidebarScope({lastPath}),
@@ -65,18 +66,21 @@ const BASE_VIEW = SIDEBAR_VIEWS[SIDEBAR_VIEWS.length - 1]
 
 /** First view whose `matches` accepts the path; falls back to the base view. */
 export const resolveSidebarView = (ctx: SidebarViewMatchContext): SidebarViewDefinition => {
-    const matched: SidebarViewDefinition =
-        SIDEBAR_VIEWS.find((view) => view.matches(ctx)) ?? BASE_VIEW
+    // A settled lookup that still can't say never will — don't strand a classic app on this rail.
+    const resolved: SidebarViewMatchContext =
+        ctx.agentState === "unknown" && ctx.agentTypeSettled
+            ? {...ctx, agentState: "non-agent"}
+            : ctx
 
-    // App route whose agent-ness hasn't resolved yet. An agent ends on the base view and a classic
-    // app on the workflow view, so committing now would swap the rail a moment later: hold the
-    // workflow rail if it is already up. A cold load with no rail to hold lands on the base view,
-    // which is where agents — the common case — belong anyway.
+    const matched: SidebarViewDefinition =
+        SIDEBAR_VIEWS.find((view) => view.matches(resolved)) ?? BASE_VIEW
+
+    // Still loading: hold the app-context rail if it is up, rather than swap it away and back.
     if (
         matched.isBase &&
-        ctx.routeLayer === "app" &&
-        ctx.agentState === "unknown" &&
-        ctx.currentViewId === WORKFLOW_SIDEBAR_SCOPE_ID
+        resolved.routeLayer === "app" &&
+        resolved.agentState === "unknown" &&
+        resolved.currentViewId === WORKFLOW_SIDEBAR_SCOPE_ID
     ) {
         return getSidebarViewDefinition(WORKFLOW_SIDEBAR_SCOPE_ID)
     }

--- a/web/oss/src/components/Sidebar/scopes/viewRegistry.ts
+++ b/web/oss/src/components/Sidebar/scopes/viewRegistry.ts
@@ -1,4 +1,5 @@
 import type {RouteLayer} from "@/oss/state/appState"
+import type {PlaygroundAgentState} from "@/oss/state/workflow"
 
 import type {SidebarScope} from "../engine/types"
 
@@ -14,6 +15,10 @@ import {createWorkflowSidebarScope} from "./workflowScope"
 export interface SidebarViewMatchContext {
     pathname: string
     routeLayer: RouteLayer
+    /** Agent-ness of the routed app — "unknown" until its workflow type resolves. */
+    agentState: PlaygroundAgentState
+    /** The view on screen right now; held while `agentState` is unknown so the rail can't flash. */
+    currentViewId?: string
 }
 
 export interface SidebarViewContext {
@@ -40,7 +45,10 @@ export const SIDEBAR_VIEWS = [
     },
     {
         id: WORKFLOW_SIDEBAR_SCOPE_ID,
-        matches: (ctx: SidebarViewMatchContext) => ctx.routeLayer === "app",
+        // Agents navigate flat: they keep the project rail and never swap to the app-context one.
+        // Only classic prompt apps and evaluators get this view.
+        matches: (ctx: SidebarViewMatchContext) =>
+            ctx.routeLayer === "app" && ctx.agentState === "non-agent",
         create: ({lastPath}: SidebarViewContext) => createWorkflowSidebarScope({lastPath}),
     },
     {
@@ -56,8 +64,25 @@ export type SidebarViewId = (typeof SIDEBAR_VIEWS)[number]["id"]
 const BASE_VIEW = SIDEBAR_VIEWS[SIDEBAR_VIEWS.length - 1]
 
 /** First view whose `matches` accepts the path; falls back to the base view. */
-export const resolveSidebarView = (ctx: SidebarViewMatchContext): SidebarViewDefinition =>
-    SIDEBAR_VIEWS.find((view) => view.matches(ctx)) ?? BASE_VIEW
+export const resolveSidebarView = (ctx: SidebarViewMatchContext): SidebarViewDefinition => {
+    const matched: SidebarViewDefinition =
+        SIDEBAR_VIEWS.find((view) => view.matches(ctx)) ?? BASE_VIEW
+
+    // App route whose agent-ness hasn't resolved yet. An agent ends on the base view and a classic
+    // app on the workflow view, so committing now would swap the rail a moment later: hold the
+    // workflow rail if it is already up. A cold load with no rail to hold lands on the base view,
+    // which is where agents — the common case — belong anyway.
+    if (
+        matched.isBase &&
+        ctx.routeLayer === "app" &&
+        ctx.agentState === "unknown" &&
+        ctx.currentViewId === WORKFLOW_SIDEBAR_SCOPE_ID
+    ) {
+        return getSidebarViewDefinition(WORKFLOW_SIDEBAR_SCOPE_ID)
+    }
+
+    return matched
+}
 
 /** Look up a view definition by id; falls back to the base view. */
 export const getSidebarViewDefinition = (id: string): SidebarViewDefinition =>

--- a/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
@@ -170,14 +170,15 @@ export const AgentCard = ({
         <div
             role="button"
             tabIndex={0}
-            onClick={onOpenPlayground}
+            // Agents page opens the overview; the home rail keeps opening the playground.
+            onClick={isGrid ? onOpenOverview : onOpenPlayground}
             onKeyDown={(event) => {
-                // Only the card itself: the menu trigger is a child, and its Enter/Space must
-                // not also open the playground.
+                // Only the card itself: the menu trigger is a child with its own Enter/Space.
                 if (event.target !== event.currentTarget) return
                 if (event.key === "Enter" || event.key === " ") {
                     event.preventDefault()
-                    onOpenPlayground()
+                    if (isGrid) onOpenOverview()
+                    else onOpenPlayground()
                 }
             }}
             className={`group box-border flex cursor-pointer flex-col transition-colors ${


### PR DESCRIPTION
## Context

Opening an agent used to swap the whole sidebar into an agent-context rail (Back, Overview, Playground, Sessions, Registry, Evaluations, Observability). Mahmoud redesigned this: agents are first-class rows in the project sidebar, and entering one should not take over navigation. Classic prompt apps keep the contextual rail unchanged.

## Changes

For agents only: clicking an agent keeps the project sidebar and opens that agent's overview; clicking a session keeps the sidebar and opens the playground on that session; Registry, Evaluations, and per-app Observability entries are removed for agents in every mode (the pages stay URL-reachable; only navigation is removed). The project rail is reordered to Home → Prompts → Agents → Sessions, the Agents entry reads as selected across an agent's routes, and while an app's agent-ness is still loading, the sidebar holds its current rail instead of flashing the wrong one (unit-tested guard). The sidebar's session rows also gain quality-of-life changes that share these files: the visible cap rises from 7 to 14 (constant exported and test-pinned on the parent branch) and hovering a session shows the owning agent's name.

Classic prompt apps behave exactly as before: they still swap to the contextual rail with all entries.

## Tests / notes

- 6 new unit tests pin the view-resolution rule (agent → project rail, prompt → contextual rail, unknown → hold current); 3 more cover tooltip flow and the display cap; 15 sidebar tests green, tsc/eslint/prettier clean.
- Live-verified across the four combinations (agent/prompt × Classic on/off), including hard reloads deep into agent URLs.
- Stacked PR: base is fix/empty-sessions-and-drive-views; merge order is #5943 → #5944 → this.

## What to QA

- Click an agent in the sidebar: overview opens, sidebar does not change, Agents row highlighted.
- Click a session under Sessions: the agent playground opens on that session, sidebar unchanged; hover a session row first: tooltip names the agent.
- Hard-reload an agent playground URL: no flash of the old agent-context rail.
- Open a classic Prompt app: the contextual rail still appears with all its entries.
- Regression: no Registry/Evaluations/Observability entries appear anywhere for an agent, in either Classic mode state.
