### PR TITLE
feat(frontend): Humanize the Build tool log and dock Files as a pane

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1,4 +1,13 @@
-import {lazy, Suspense, useCallback, useEffect, useRef, useState, type CSSProperties} from "react"
+import {
+    lazy,
+    Suspense,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    useSyncExternalStore,
+    type CSSProperties,
+} from "react"
 
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
@@ -20,7 +29,12 @@ import ShowConfigPanelButton from "./components/ShowConfigPanelButton"
 import {chatPanelMaximizedAtom, configPanelCollapsedAtom} from "./state/panelLayout"
 import {pendingSessionOpenAtom} from "./state/pendingSessionOpen"
 import {useReconcileServerSessions} from "./state/projectSessions"
-import {FILES_PANE_MAX, FILES_PANE_MIN, filesPaneWidthAtom} from "./state/rightPanel"
+import {
+    FILES_PANE_MAX,
+    FILES_PANE_MIN,
+    filesPaneWidthAtom,
+    PANES_COEXIST_MIN_WINDOW,
+} from "./state/rightPanel"
 import {useChatScopeKey} from "./state/scope"
 import {
     activeSessionIdAtomFamily,
@@ -48,6 +62,22 @@ const SessionRail = lazy(() => import("./components/SessionRail"))
 const RAIL_WIDTH = 300
 const RAIL_MIN_WIDTH = 240
 const RAIL_MAX_WIDTH = 480
+
+// Media-query subscription for the coexistence threshold (window width, not container width, on
+// purpose: the rule assumes the nav sidebar at its default width, per the threshold's derivation).
+const coexistMediaQuery = () => window.matchMedia(`(min-width: ${PANES_COEXIST_MIN_WINDOW}px)`)
+const subscribeCoexist = (onChange: () => void) => {
+    const mql = coexistMediaQuery()
+    mql.addEventListener("change", onChange)
+    return () => mql.removeEventListener("change", onChange)
+}
+/** True when the window fits config pane + transcript + Files pane together at fair widths. */
+const useCanPanesCoexist = () =>
+    useSyncExternalStore(
+        subscribeCoexist,
+        () => coexistMediaQuery().matches,
+        () => false,
+    )
 
 /**
  * AgentChatPanel — the agent-generation surface hosted INSIDE the playground (the third
@@ -152,21 +182,34 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     // DriveSessionProvider needs it here because it sits OUTSIDE the per-tab conversations.
     const artifactId = useAtomValue(workflowMolecule.selectors.workflowId(entityId))
 
-    // Config pane and Files pane are mutually exclusive: opening one collapses the other, so the
-    // transcript always keeps room. Transition-edge effects (prev refs), not state syncs — each
-    // watches only the flip that should evict the other, so they can't ping-pong.
+    // On windows too narrow to fit config pane + transcript + Files pane at fair widths, the two
+    // side panes are mutually exclusive: opening one collapses the other, so the transcript always
+    // keeps room. Wide windows skip the eviction and let both stay open. Transition-edge effects
+    // (prev refs), not state syncs — each watches only the flip that should evict the other, so
+    // they can't ping-pong.
+    const canPanesCoexist = useCanPanesCoexist()
     const setConfigPanelCollapsed = useSetAtom(configPanelCollapsedAtom)
     const prevFilesOpenRef = useRef(filesPane.open)
     useEffect(() => {
-        if (filesPane.open && !prevFilesOpenRef.current) setConfigPanelCollapsed(true)
+        if (filesPane.open && !prevFilesOpenRef.current && !canPanesCoexist)
+            setConfigPanelCollapsed(true)
         prevFilesOpenRef.current = filesPane.open
-    }, [filesPane.open, setConfigPanelCollapsed])
+    }, [filesPane.open, canPanesCoexist, setConfigPanelCollapsed])
     const closeFilesPane = filesPane.close
     const prevConfigCollapsedRef = useRef(configPanelCollapsed)
     useEffect(() => {
-        if (!configPanelCollapsed && prevConfigCollapsedRef.current) closeFilesPane()
+        if (!configPanelCollapsed && prevConfigCollapsedRef.current && !canPanesCoexist)
+            closeFilesPane()
         prevConfigCollapsedRef.current = configPanelCollapsed
-    }, [configPanelCollapsed, closeFilesPane])
+    }, [configPanelCollapsed, canPanesCoexist, closeFilesPane])
+    // Shrinking below the threshold with BOTH open: keep the Files pane (the content surface the
+    // user opened deliberately) and collapse the config pane — the same choice opening Files makes.
+    const prevCoexistRef = useRef(canPanesCoexist)
+    useEffect(() => {
+        if (!canPanesCoexist && prevCoexistRef.current && filesPane.open && !configPanelCollapsed)
+            setConfigPanelCollapsed(true)
+        prevCoexistRef.current = canPanesCoexist
+    }, [canPanesCoexist, filesPane.open, configPanelCollapsed, setConfigPanelCollapsed])
 
     // A trigger test asks for a fresh session: create + activate one, then clear the flag so the
     // new session's conversation consumes the turn (the per-session consumer skips flagged runs).

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -152,6 +152,22 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     // DriveSessionProvider needs it here because it sits OUTSIDE the per-tab conversations.
     const artifactId = useAtomValue(workflowMolecule.selectors.workflowId(entityId))
 
+    // Config pane and Files pane are mutually exclusive: opening one collapses the other, so the
+    // transcript always keeps room. Transition-edge effects (prev refs), not state syncs — each
+    // watches only the flip that should evict the other, so they can't ping-pong.
+    const setConfigPanelCollapsed = useSetAtom(configPanelCollapsedAtom)
+    const prevFilesOpenRef = useRef(filesPane.open)
+    useEffect(() => {
+        if (filesPane.open && !prevFilesOpenRef.current) setConfigPanelCollapsed(true)
+        prevFilesOpenRef.current = filesPane.open
+    }, [filesPane.open, setConfigPanelCollapsed])
+    const closeFilesPane = filesPane.close
+    const prevConfigCollapsedRef = useRef(configPanelCollapsed)
+    useEffect(() => {
+        if (!configPanelCollapsed && prevConfigCollapsedRef.current) closeFilesPane()
+        prevConfigCollapsedRef.current = configPanelCollapsed
+    }, [configPanelCollapsed, closeFilesPane])
+
     // A trigger test asks for a fresh session: create + activate one, then clear the flag so the
     // new session's conversation consumes the turn (the per-session consumer skips flagged runs).
     const pendingRun = useAtomValue(simulatedAgentRunAtomFamily(entityId))

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -1,20 +1,26 @@
 import {lazy, Suspense, useCallback, useEffect, useRef, useState, type CSSProperties} from "react"
 
+import {workflowMolecule} from "@agenta/entities/workflow"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {Splitter, Tabs} from "antd"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
 
+import {DriveSessionProvider} from "@/oss/components/Drives/driveSessionContext"
+import {SessionFilesPane, useSessionFilesPane} from "@/oss/components/Drives/SessionFilesPane"
 import {useOptionalOnboardingContext} from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingContext"
 
 // Direct file import — the barrel would statically pull the inspector drawer into this chunk.
 import {ConversationSkeleton, SessionBarSkeleton} from "./components/AgentChatSkeleton"
 import InspectSessionButton from "./components/Inspector/InspectSessionButton"
 import MountFade from "./components/MountFade"
+import OpenFilesPaneButton from "./components/OpenFilesPaneButton"
+import RightPanelSplit from "./components/RightPanel/RightPanelSplit"
 import ShowConfigPanelButton from "./components/ShowConfigPanelButton"
 import {chatPanelMaximizedAtom, configPanelCollapsedAtom} from "./state/panelLayout"
 import {pendingSessionOpenAtom} from "./state/pendingSessionOpen"
 import {useReconcileServerSessions} from "./state/projectSessions"
+import {FILES_PANE_MAX, FILES_PANE_MIN, filesPaneWidthAtom} from "./state/rightPanel"
 import {useChatScopeKey} from "./state/scope"
 import {
     activeSessionIdAtomFamily,
@@ -138,6 +144,14 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     // Tolerate a stale active id (its tab was closed) by falling back to the first tab.
     const activeId = sessions.some((s) => s.id === rawActiveId) ? rawActiveId : sessions[0]?.id
 
+    // Docked Files pane — a full-height sibling of the WHOLE chat column (session bar included),
+    // like the config pane on the other side: its divider runs to the top and the session bar
+    // stays confined to the chat. Follows the ACTIVE session (openers set per-session atoms).
+    const filesPane = useSessionFilesPane(activeId ?? "")
+    // Workflow artifact id — the key for the agent's durable `agent-files` mount; the pane's
+    // DriveSessionProvider needs it here because it sits OUTSIDE the per-tab conversations.
+    const artifactId = useAtomValue(workflowMolecule.selectors.workflowId(entityId))
+
     // A trigger test asks for a fresh session: create + activate one, then clear the flag so the
     // new session's conversation consumes the turn (the per-session consumer skips flagged runs).
     const pendingRun = useAtomValue(simulatedAgentRunAtomFamily(entityId))
@@ -215,86 +229,108 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
                 </div>
             </Splitter.Panel>
             <Splitter.Panel collapsible={false} className="!overflow-hidden !p-0">
-                <Tabs
-                    animated={false}
-                    // The session bar is an ABSOLUTE overlay (`.ant-tabs-nav` pinned top) so its
-                    // presence never reflows the content. The build↔chat motion is published as a
-                    // CSS var (`--agent-bar-inset`: 48 in build, 0 in chat) that the TRANSCRIPT column
-                    // consumes as its top padding — so only the transcript eases, not the context rail
-                    // beside it (which the shared content-holder padding used to drag up too).
-                    style={
-                        {
-                            "--agent-bar-inset": chromeHidden || chatMaximized ? "0px" : "48px",
-                        } as CSSProperties
+                {/* [chat column | Files pane] — the pane pushes the tabs (bar included) aside and
+                    collapses to 0; the bar's "«/»" toggle and the pane header's "»" both drive it. */}
+                <RightPanelSplit
+                    open={filesPane.open}
+                    widthAtom={filesPaneWidthAtom}
+                    min={FILES_PANE_MIN}
+                    max={FILES_PANE_MAX}
+                    panel={
+                        activeId ? (
+                            <DriveSessionProvider sessionId={activeId} artifactId={artifactId}>
+                                <SessionFilesPane sessionId={activeId} />
+                            </DriveSessionProvider>
+                        ) : null
                     }
-                    className="relative flex h-full min-h-0 min-w-0 w-full flex-col [&_.ant-tabs-content]:h-full [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-tabpane]:h-full [&_.ant-tabs-nav]:!mb-0"
-                    activeKey={activeId}
-                    onChange={setActiveSession}
-                    renderTabBar={() => (
-                        // renderTabBar's node stands in for the nav, so making IT absolute (pinned top,
-                        // bounded to the pane width) takes the bar out of flow — the transcript no longer
-                        // reflows when it appears, and the strip has a bounded width so tabs scroll. It just
-                        // fades (opacity) out in chat mode / onboarding while the content padding animates.
-                        <div
-                            className="absolute inset-x-0 top-0 z-10 min-w-0 overflow-hidden motion-safe:transition-opacity motion-safe:duration-[240ms] motion-safe:ease-[cubic-bezier(0.4,0,0.2,1)]"
-                            style={{
-                                opacity: chromeHidden || chatMaximized ? 0 : 1,
-                                pointerEvents: chromeHidden || chatMaximized ? "none" : undefined,
-                            }}
-                            // opacity/pointerEvents hide it visually + for the mouse; `inert` also drops
-                            // the hidden tabs from keyboard tab order + a11y (mirrors the rail above).
-                            inert={chromeHidden || chatMaximized}
-                        >
-                            {/* Region fallback = the same bar skeleton the pre-confirmation gate
+                >
+                    <Tabs
+                        animated={false}
+                        // The session bar is an ABSOLUTE overlay (`.ant-tabs-nav` pinned top) so its
+                        // presence never reflows the content. The build↔chat motion is published as a
+                        // CSS var (`--agent-bar-inset`: 48 in build, 0 in chat) that the TRANSCRIPT column
+                        // consumes as its top padding — so only the transcript eases, not the context rail
+                        // beside it (which the shared content-holder padding used to drag up too).
+                        style={
+                            {
+                                "--agent-bar-inset": chromeHidden || chatMaximized ? "0px" : "48px",
+                            } as CSSProperties
+                        }
+                        className="relative flex h-full min-h-0 min-w-0 w-full flex-col [&_.ant-tabs-content]:h-full [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-tabpane]:h-full [&_.ant-tabs-nav]:!mb-0"
+                        activeKey={activeId}
+                        onChange={setActiveSession}
+                        renderTabBar={() => (
+                            // renderTabBar's node stands in for the nav, so making IT absolute (pinned top,
+                            // bounded to the pane width) takes the bar out of flow — the transcript no longer
+                            // reflows when it appears, and the strip has a bounded width so tabs scroll. It just
+                            // fades (opacity) out in chat mode / onboarding while the content padding animates.
+                            <div
+                                className="absolute inset-x-0 top-0 z-10 min-w-0 overflow-hidden motion-safe:transition-opacity motion-safe:duration-[240ms] motion-safe:ease-[cubic-bezier(0.4,0,0.2,1)]"
+                                style={{
+                                    opacity: chromeHidden || chatMaximized ? 0 : 1,
+                                    pointerEvents:
+                                        chromeHidden || chatMaximized ? "none" : undefined,
+                                }}
+                                // opacity/pointerEvents hide it visually + for the mouse; `inert` also drops
+                                // the hidden tabs from keyboard tab order + a11y (mirrors the rail above).
+                                inert={chromeHidden || chatMaximized}
+                            >
+                                {/* Region fallback = the same bar skeleton the pre-confirmation gate
                             renders, so the strip's lane holds its shape while this chunk loads; the
                             real bar eases in over it (MountFade) instead of popping. */}
-                            <Suspense fallback={<SessionBarSkeleton />}>
-                                <MountFade>
-                                    <SessionTagBar
-                                        sessions={sessions}
-                                        activeId={activeId}
-                                        onSelect={setActiveSession}
-                                        onAdd={addSession}
-                                        addDisabled={addLocked}
-                                        onClose={closeSession}
-                                        onRename={handleRename}
-                                        showSessions={!chatMaximized}
-                                        leftExtra={
-                                            !chatMaximized && configPanelCollapsed ? (
-                                                <ShowConfigPanelButton />
-                                            ) : undefined
-                                        }
-                                        extra={
-                                            chatMaximized ? undefined : (
-                                                <InspectSessionButton
-                                                    sessionId={activeId ?? null}
-                                                />
-                                            )
-                                        }
-                                    />
-                                </MountFade>
-                            </Suspense>
-                        </div>
-                    )}
-                    items={sessions.map((session) => ({
-                        key: session.id,
-                        // Bar is rendered by `renderTabBar` (SessionTagBar); the per-item label is unused.
-                        label: null,
-                        children: (
-                            // The heavy conversation body hydrates behind its own transcript/composer
-                            // skeleton (same shape the frame reserves) and eases in over it.
-                            <Suspense fallback={<ConversationSkeleton />}>
-                                <MountFade className="h-full min-h-0 w-full">
-                                    <AgentConversation
-                                        entityId={entityId}
-                                        sessionId={session.id}
-                                        revealPlayedRef={composerRevealPlayedRef}
-                                    />
-                                </MountFade>
-                            </Suspense>
-                        ),
-                    }))}
-                />
+                                <Suspense fallback={<SessionBarSkeleton />}>
+                                    <MountFade>
+                                        <SessionTagBar
+                                            sessions={sessions}
+                                            activeId={activeId}
+                                            onSelect={setActiveSession}
+                                            onAdd={addSession}
+                                            addDisabled={addLocked}
+                                            onClose={closeSession}
+                                            onRename={handleRename}
+                                            showSessions={!chatMaximized}
+                                            leftExtra={
+                                                !chatMaximized && configPanelCollapsed ? (
+                                                    <ShowConfigPanelButton />
+                                                ) : undefined
+                                            }
+                                            extra={
+                                                chatMaximized ? undefined : (
+                                                    <>
+                                                        <InspectSessionButton
+                                                            sessionId={activeId ?? null}
+                                                        />
+                                                        <OpenFilesPaneButton
+                                                            sessionId={activeId ?? null}
+                                                        />
+                                                    </>
+                                                )
+                                            }
+                                        />
+                                    </MountFade>
+                                </Suspense>
+                            </div>
+                        )}
+                        items={sessions.map((session) => ({
+                            key: session.id,
+                            // Bar is rendered by `renderTabBar` (SessionTagBar); the per-item label is unused.
+                            label: null,
+                            children: (
+                                // The heavy conversation body hydrates behind its own transcript/composer
+                                // skeleton (same shape the frame reserves) and eases in over it.
+                                <Suspense fallback={<ConversationSkeleton />}>
+                                    <MountFade className="h-full min-h-0 w-full">
+                                        <AgentConversation
+                                            entityId={entityId}
+                                            sessionId={session.id}
+                                            revealPlayedRef={composerRevealPlayedRef}
+                                        />
+                                    </MountFade>
+                                </Suspense>
+                            ),
+                        }))}
+                    />
+                </RightPanelSplit>
             </Splitter.Panel>
         </Splitter>
     )

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -17,11 +17,8 @@ import {useAtomValue, useSetAtom, useStore} from "jotai"
 import {ContextRail} from "@/oss/components/Drives/ContextRail"
 import {DriveFileLinkProvider} from "@/oss/components/Drives/DriveFileLinkProvider"
 import {DriveSessionProvider} from "@/oss/components/Drives/driveSessionContext"
-import {
-    SessionFilesDrawer,
-    filesDrawerOpenAtomFamily,
-    filesDrawerStagedAtomFamily,
-} from "@/oss/components/Drives/SessionFilesDrawer"
+import {filesDrawerStagedAtomFamily} from "@/oss/components/Drives/SessionFilesDrawer"
+import {useSessionFilesPane} from "@/oss/components/Drives/SessionFilesPane"
 import {openTraceDrawerAtom} from "@/oss/components/SharedDrawers/TraceDrawer/store/traceDrawerStore"
 
 import {describeAccepted} from "./assets/attachments"
@@ -147,12 +144,13 @@ const AgentConversation = ({
         turnNumbers,
     } = useTurnInspector({sessionId, messages})
 
-    // Quick Look + Files-window hosts: cards/tiles/rail request via atoms; these resolve against
+    // Quick Look + Files openers: cards/tiles/rail request via atoms; these resolve against
     // THIS conversation's drive: the link provider makes filename mentions clickable, and the
-    // Files drawer (below) hosts both the grid and the single-file preview in one surface.
+    // docked Files pane (hosted a level up in AgentChatPanel, beside the whole chat column)
+    // shows the grid and the single-file preview — every opener (cards, links, rail, the
+    // session bar "«") lands there.
     const quickLookHost = <DriveFileLinkProvider sessionId={sessionId} artifactId={artifactId} />
-    const filesWindowHost = <SessionFilesDrawer sessionId={sessionId} />
-    const setFilesWindowOpen = useSetAtom(filesDrawerOpenAtomFamily(sessionId))
+    const {openPane: openFilesPane} = useSessionFilesPane(sessionId)
     const setFilesStaged = useSetAtom(filesDrawerStagedAtomFamily(sessionId))
 
     // ── "Run in playground" seam (producer: a trigger drawer's Run-in-playground) ──
@@ -593,7 +591,6 @@ const AgentConversation = ({
                 {/* Themed confirm dialogs (rewind-past-a-tool) mount through this holder. */}
                 {modalContextHolder}
                 {quickLookHost}
-                {filesWindowHost}
                 {uploadsEnabled ? (
                     <AttachmentViewerDrawer
                         uploads={files}
@@ -602,7 +599,9 @@ const AgentConversation = ({
                     />
                 ) : null}
                 {/* Resizable [chat | right panel] split. The panel (turn inspector OR session content)
-                pushes the chat aside rather than overlaying it, and collapses to 0 when closed. */}
+                pushes the chat aside rather than overlaying it, and collapses to 0 when closed.
+                (The Files pane is NOT here: it docks a level up, beside the whole chat column —
+                session bar included — see AgentChatPanel.) */}
                 <RightPanelSplit
                     open={inspectorOpen}
                     // Same bar inset as the transcript column: the Inspector is a separate split pane,
@@ -719,7 +718,7 @@ const AgentConversation = ({
                             sessionId={sessionId}
                             busy={busy}
                             hidden={buildMode || inspectorOpen}
-                            onOpenFiles={() => setFilesWindowOpen(true)}
+                            onOpenFiles={openFilesPane}
                             onStageFiles={
                                 uploadsEnabled ? (files) => setFilesStaged(files) : undefined
                             }

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.test.tsx
@@ -228,8 +228,7 @@ describe("Build mode, commit with a committed base to diff against", () => {
     })
 
     it("humanizes the ask — the raw wire name stays out of the card body", () => {
-        // Build now reads like Chat: the friendly body carries the ask; the raw name lives in
-        // tooltips / the payload expander, never as a header row.
+        // Build reads like Chat: raw wire names live in tooltips, never as a header row.
         const rendered = render(TEXT_ONLY_APPROVAL)
 
         expect(rendered).not.toContain("commit_revision")

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.test.tsx
@@ -227,10 +227,12 @@ describe("Build mode, commit with a committed base to diff against", () => {
         expect(rendered).not.toContain("The agent wants to run this tool before it can keep going.")
     })
 
-    it("keeps the raw tool name that Build-mode debuggers steer by", () => {
+    it("humanizes the ask — the raw wire name stays out of the card body", () => {
+        // Build now reads like Chat: the friendly body carries the ask; the raw name lives in
+        // tooltips / the payload expander, never as a header row.
         const rendered = render(TEXT_ONLY_APPROVAL)
 
-        expect(rendered).toContain("commit_revision")
+        expect(rendered).not.toContain("commit_revision")
     })
 
     it("still shows the imported content when the commit imports files", () => {

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -331,9 +331,7 @@ const ApprovalDock = ({
                             ) : null}
                         </div>
 
-                        {/* The ask: one humanized sentence in BOTH modes — the raw tool name stays
-                            reachable via the tooltip and the payload expander. A friendly body
-                            (headline: null) says the rest. */}
+                        {/* One humanized sentence in both modes; the raw name lives in the tooltip. */}
                         {renderer?.headline !== null ? (
                             !renderer ? (
                                 <Text

--- a/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ApprovalDock.tsx
@@ -244,8 +244,6 @@ const ApprovalDock = ({
     // Chat-mode display name: raw "scary" names stay Build-only; the shared resolver humanizes
     // gateway/MCP/plain names. Raw name stays reachable via the tooltip and the payload expander.
     const friendly = current ? resolveToolDisplay(current.toolName) : null
-    // A source badge we can state factually from the tool name — not a guessed risk level.
-    const source = friendly?.kind === "mcp" ? "MCP tool" : null
 
     // "Always allow this tool": writes a config permission so the runner stops gating this tool
     // (per-tool `permission` for gateway/custom-function tools; `harness.permissions.allow` for
@@ -333,28 +331,11 @@ const ApprovalDock = ({
                             ) : null}
                         </div>
 
-                        {/* Identity + ask. Build always keeps the raw tool name, friendly body or
-                            not (debuggers steer by it); Chat folds a humanized name into one
-                            sentence — the raw name stays reachable via the tooltip and the payload
-                            expander. A friendly body (headline: null) says the rest. */}
-                        {!chatMode ? (
-                            <div className="flex min-w-0 items-center gap-2">
-                                <Text
-                                    className="!text-xs !font-medium min-w-0 truncate"
-                                    title={current.toolName}
-                                >
-                                    {current.toolName}
-                                </Text>
-                                {source ? (
-                                    <span className="shrink-0 rounded border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-1.5 py-px text-xs text-colorTextSecondary">
-                                        {source}
-                                    </span>
-                                ) : null}
-                            </div>
-                        ) : null}
-
+                        {/* The ask: one humanized sentence in BOTH modes — the raw tool name stays
+                            reachable via the tooltip and the payload expander. A friendly body
+                            (headline: null) says the rest. */}
                         {renderer?.headline !== null ? (
-                            !renderer && chatMode ? (
+                            !renderer ? (
                                 <Text
                                     type="secondary"
                                     className="!text-xs"
@@ -369,7 +350,7 @@ const ApprovalDock = ({
                                 </Text>
                             ) : (
                                 <Text type="secondary" className="!text-xs">
-                                    {renderer?.headline ??
+                                    {renderer.headline ??
                                         "The agent wants to run this tool before it can keep going."}
                                 </Text>
                             )

--- a/web/oss/src/components/AgentChatSlice/components/Inspector/InspectSessionButton.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/Inspector/InspectSessionButton.tsx
@@ -18,8 +18,10 @@ export default function InspectSessionButton({sessionId}: {sessionId: string | n
 
     if (!inspectorEnabled) return null
 
+    // placement="left": near the page's right edge a top-centered tooltip overflows the
+    // viewport for a frame (horizontal-scrollbar flicker).
     return (
-        <Tooltip title={open ? "Hide inspector" : "Inspect session"}>
+        <Tooltip title={open ? "Hide inspector" : "Inspect session"} placement="left">
             <Button
                 type={open ? "primary" : "text"}
                 size="small"

--- a/web/oss/src/components/AgentChatSlice/components/Inspector/lenses/RuntimeLens.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/Inspector/lenses/RuntimeLens.tsx
@@ -21,7 +21,7 @@ import {FILE_ITEM_VARIANTS, FILE_SPRING} from "@/oss/components/Drives/driveMoti
 import {useDriveArtifactId} from "@/oss/components/Drives/driveSessionContext"
 import {humanSize} from "@/oss/components/Drives/driveTree"
 import {driveQuickLookAtomFamily} from "@/oss/components/Drives/quickLook"
-import {filesDrawerOpenAtomFamily} from "@/oss/components/Drives/SessionFilesDrawer"
+import {useSessionFilesPane} from "@/oss/components/Drives/SessionFilesPane"
 import {driveHasMixedOrigins, useSessionDriveSummary} from "@/oss/components/Drives/useSessionDrive"
 import StatesTab from "@/oss/components/SessionInspector/tabs/StatesTab"
 import StreamsTab from "@/oss/components/SessionInspector/tabs/StreamsTab"
@@ -36,7 +36,7 @@ const DriveFilesCard = ({
     drive: ReturnType<typeof useSessionDriveSummary>
 }) => {
     const openQuickLook = useSetAtom(driveQuickLookAtomFamily(sessionId))
-    const openFiles = useSetAtom(filesDrawerOpenAtomFamily(sessionId))
+    const {openPane: openFiles} = useSessionFilesPane(sessionId)
 
     // The loading skeleton is the SAME list rendering placeholder rows, so skeleton → real is a
     // per-row content swap inside one AnimatePresence (no block→list jump, no layout shift). Terminal
@@ -75,7 +75,7 @@ const DriveFilesCard = ({
                     // from its record log) — say so instead of an empty list.
                     <button
                         type="button"
-                        onClick={() => openFiles(true)}
+                        onClick={() => openFiles()}
                         className="w-fit cursor-pointer rounded border-0 bg-transparent px-1.5 py-0.5 text-xs text-colorTextTertiary hover:text-colorText"
                     >
                         No changes yet — browse all {drive.fileCount}
@@ -127,7 +127,7 @@ const DriveFilesCard = ({
                                                   showOrigin={driveHasMixedOrigins(drive.recents)}
                                                   onOpen={() =>
                                                       f.is_folder
-                                                          ? openFiles(true)
+                                                          ? openFiles()
                                                           : openQuickLook({path: f.path})
                                                   }
                                               />
@@ -144,7 +144,7 @@ const DriveFilesCard = ({
                         {drive.fileCount > 5 ? (
                             <button
                                 type="button"
-                                onClick={() => openFiles(true)}
+                                onClick={() => openFiles()}
                                 className="mt-1 flex w-fit cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1.5 py-0.5 text-xs text-[var(--ag-colorInfo)] hover:underline"
                             >
                                 View all files

--- a/web/oss/src/components/AgentChatSlice/components/OpenFilesPaneButton.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/OpenFilesPaneButton.tsx
@@ -1,0 +1,27 @@
+/**
+ * The session bar's Files-pane toggle — mirrors the config panel's collapse pair: "«" while the
+ * pane is hidden (it expands leftward from the right edge), "»" while shown (clicking tucks it
+ * back). The pane's own header "»" is the same collapse, reachable from the other end.
+ */
+import {CaretDoubleLeft, CaretDoubleRight} from "@phosphor-icons/react"
+import {Button, Tooltip} from "antd"
+
+import {useSessionFilesPane} from "@/oss/components/Drives/SessionFilesPane"
+
+export default function OpenFilesPaneButton({sessionId}: {sessionId: string | null}) {
+    const {open, toggle} = useSessionFilesPane(sessionId ?? "")
+
+    return (
+        <Tooltip title={open ? "Hide files" : "Show files"}>
+            <Button
+                type="text"
+                size="small"
+                icon={open ? <CaretDoubleRight size={14} /> : <CaretDoubleLeft size={14} />}
+                disabled={!sessionId}
+                onClick={toggle}
+                aria-label={open ? "Hide files pane" : "Show files pane"}
+                aria-pressed={open}
+            />
+        </Tooltip>
+    )
+}

--- a/web/oss/src/components/AgentChatSlice/components/OpenFilesPaneButton.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/OpenFilesPaneButton.tsx
@@ -1,26 +1,29 @@
 /**
- * The session bar's Files-pane toggle — mirrors the config panel's collapse pair: "«" while the
- * pane is hidden (it expands leftward from the right edge), "»" while shown (clicking tucks it
- * back). The pane's own header "»" is the same collapse, reachable from the other end.
+ * The session bar's Files-pane opener — mirrors the config panel's collapse pair: "«" while the
+ * pane is hidden (it expands leftward from the right edge), gone while shown (the pane header's
+ * own "»" is the collapse, so a second chevron in the bar would be a duplicate).
  */
-import {CaretDoubleLeft, CaretDoubleRight} from "@phosphor-icons/react"
+import {CaretDoubleLeft} from "@phosphor-icons/react"
 import {Button, Tooltip} from "antd"
 
 import {useSessionFilesPane} from "@/oss/components/Drives/SessionFilesPane"
 
 export default function OpenFilesPaneButton({sessionId}: {sessionId: string | null}) {
-    const {open, toggle} = useSessionFilesPane(sessionId ?? "")
+    const {open, openPane} = useSessionFilesPane(sessionId ?? "")
+
+    if (open) return null
 
     return (
-        <Tooltip title={open ? "Hide files" : "Show files"}>
+        // placement="left": the button hugs the page's right edge, and a top-centered tooltip
+        // overflows the viewport for a frame (horizontal-scrollbar flicker).
+        <Tooltip title="Show files" placement="left">
             <Button
                 type="text"
                 size="small"
-                icon={open ? <CaretDoubleRight size={14} /> : <CaretDoubleLeft size={14} />}
+                icon={<CaretDoubleLeft size={14} />}
                 disabled={!sessionId}
-                onClick={toggle}
-                aria-label={open ? "Hide files pane" : "Show files pane"}
-                aria-pressed={open}
+                onClick={openPane}
+                aria-label="Show files pane"
             />
         </Tooltip>
     )

--- a/web/oss/src/components/AgentChatSlice/components/RightPanel/RightPanelSplit.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/RightPanel/RightPanelSplit.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useState, type ReactNode} from "react"
 
 import {Splitter} from "antd"
-import {useAtom} from "jotai"
+import {useAtom, type WritableAtom} from "jotai"
 
 import {
     CHAT_MIN,
@@ -11,11 +11,8 @@ import {
 } from "../../state/rightPanel"
 
 /** Clamp the panel width to [min, max] AND never let the chat fall below its floor. */
-const clampWidth = (w: number, total: number) =>
-    Math.max(
-        RIGHT_PANEL_MIN,
-        Math.min(w, RIGHT_PANEL_MAX, Math.max(RIGHT_PANEL_MIN, total - CHAT_MIN)),
-    )
+const clampWidth = (w: number, total: number, min: number, max: number) =>
+    Math.max(min, Math.min(w, max, Math.max(min, total - CHAT_MIN)))
 
 // Open/close slide duration. The class must be a static string (Tailwind JIT can't see
 // interpolated names), so the 240ms is duplicated there
@@ -61,12 +58,20 @@ const RightPanelSplit = ({
     open,
     panel,
     children,
+    widthAtom = rightPanelWidthAtom,
+    min = RIGHT_PANEL_MIN,
+    max = RIGHT_PANEL_MAX,
 }: {
     open: boolean
     panel: ReactNode
     children: ReactNode
+    /** Persisted width store + clamp bounds — defaults are the Inspector's; the Files pane passes
+     * its own so the two right-edge panes keep independent widths. */
+    widthAtom?: WritableAtom<number, [number], void>
+    min?: number
+    max?: number
 }) => {
-    const [persisted, setPersisted] = useAtom(rightPanelWidthAtom)
+    const [persisted, setPersisted] = useAtom(widthAtom)
     const [live, setLive] = useState(persisted)
     const [dragging, setDragging] = useState(false)
 
@@ -121,26 +126,26 @@ const RightPanelSplit = ({
     // settle to the target (open → live, closed → 0) so the slide runs off a painted prior value.
     const panelSize = preFrame ? (open ? 0 : live) : open ? live : 0
     // Suppress the min clamp on the collapsed frames so the 0-basis "from"/"to" isn't snapped up
-    // to RIGHT_PANEL_MIN by antd (which would erase the slide).
-    const panelMin = open && !preFrame ? `${RIGHT_PANEL_MIN}px` : 0
+    // to the pane min by antd (which would erase the slide).
+    const panelMin = open && !preFrame ? `${min}px` : 0
 
     return (
         <Splitter
             className={`h-full min-h-0 w-full flex-1 ${FILL_PANE_CLASS} ${BAR_INSET_CLASS} ${animate ? DRIVEN_SLIDE_CLASS : ""}`}
             onResizeStart={() => setDragging(true)}
             onResize={(sizes) => {
-                if (open) setLive(clampWidth(sizes[1], sizes[0] + sizes[1]))
+                if (open) setLive(clampWidth(sizes[1], sizes[0] + sizes[1], min, max))
             }}
             onResizeEnd={(sizes) => {
                 setDragging(false)
-                if (open) setPersisted(clampWidth(sizes[1], sizes[0] + sizes[1]))
+                if (open) setPersisted(clampWidth(sizes[1], sizes[0] + sizes[1], min, max))
             }}
         >
             <Splitter.Panel min={`${CHAT_MIN}px`}>{children}</Splitter.Panel>
             <Splitter.Panel
                 size={panelSize}
                 min={panelMin}
-                max={`${RIGHT_PANEL_MAX}px`}
+                max={`${max}px`}
                 resizable={open && !preFrame}
             >
                 {open || closing ? panel : null}

--- a/web/oss/src/components/AgentChatSlice/components/RightPanel/RightPanelSplit.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/RightPanel/RightPanelSplit.tsx
@@ -130,8 +130,10 @@ const RightPanelSplit = ({
     const panelMin = open && !preFrame ? `${min}px` : 0
 
     return (
+        // playground-splitter classes: this divider renders EXACTLY like the config pane's (2px
+        // hairline + centered grip) instead of antd's default bar, so all vertical seams match.
         <Splitter
-            className={`h-full min-h-0 w-full flex-1 ${FILL_PANE_CLASS} ${BAR_INSET_CLASS} ${animate ? DRIVEN_SLIDE_CLASS : ""}`}
+            className={`h-full min-h-0 w-full flex-1 playground-splitter playground-splitter-agent ${FILL_PANE_CLASS} ${BAR_INSET_CLASS} ${animate ? DRIVEN_SLIDE_CLASS : ""}`}
             onResizeStart={() => setDragging(true)}
             onResize={(sizes) => {
                 if (open) setLive(clampWidth(sizes[1], sizes[0] + sizes[1], min, max))

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -145,9 +145,9 @@ const IOBlock = ({label, value, danger}: {label: string; value: string; danger?:
     </div>
 )
 
-/** One tool's row: name + status, plus (in Build's `detailed` step log) the tool's input and its
- * output/error as monospace blocks. Chat mode keeps the quiet one-line summary. The Approve/Deny
- * action lives in the persistent ApprovalDock, so a gate here is just marked "Awaiting approval". */
+/** One tool's row: humanized name + status + one-line summary; in Build (`detailed`) the row also
+ * expands to the tool's input and output/error as monospace blocks. The Approve/Deny action lives
+ * in the persistent ApprovalDock, so a gate here is just marked "Awaiting approval". */
 const ToolRow = ({
     part,
     live,
@@ -158,22 +158,20 @@ const ToolRow = ({
     detailed?: boolean
 }) => {
     const name = partToolName(part)
-    // Build keeps the raw wire name (debuggers steer by it); Chat shows the humanized label with
-    // the raw name on the tooltip — same split the ApprovalDock made for HITL gates.
+    // Humanized label in both modes; the raw wire name stays reachable via the tooltip.
     const display = resolveToolDisplay(name)
-    const shownName = detailed ? name : display.label
+    const shownName = display.label
     const state = part.state as string
     const input = (part as {input?: unknown}).input
     const output = (part as {output?: unknown}).output
     const errorText = (part as {errorText?: string}).errorText
     const nonFinalError = state === "output-error" && isNonFinalRunnerError(errorText)
-    const notHandled = state === "output-available" && isNotHandledOutput(output)
     // `approval-responded` is resolved (the user answered) — not "running". Its execution shows on
     // a sibling part, so this must not spin forever (the cold-replay lingering-gate spinner).
     const running =
         !isSettled(state) && state !== "approval-requested" && state !== "approval-responded"
-    // The line after the name: an awaiting-approval marker, a live "running…", the settled one-line
-    // summary (Chat), or a short status word (Build shows the full output block below instead).
+    // The line after the name: an awaiting-approval marker, a live "running…", or the settled
+    // one-line summary (Build's full payload lives in the row expander below).
     const midText =
         state === "approval-requested"
             ? "Awaiting approval"
@@ -183,17 +181,7 @@ const ToolRow = ({
                   : "approved"
               : live && running
                 ? "running…"
-                : detailed
-                  ? nonFinalError
-                      ? rowSummary(part, display)
-                      : state === "output-error"
-                        ? "failed"
-                        : state === "output-denied"
-                          ? "denied"
-                          : notHandled
-                            ? "not handled by this client"
-                            : null
-                  : rowSummary(part, display)
+                : rowSummary(part, display)
 
     // Track presence explicitly: a legit `null` output is real (don't hide it), and
     // `output-available` with no `output` key must not open an empty expander.
@@ -217,7 +205,7 @@ const ToolRow = ({
             <Text className="!text-xs !font-medium min-w-0 truncate" title={name}>
                 {shownName}
             </Text>
-            {!detailed && display.source ? (
+            {display.source ? (
                 <Text type="secondary" className="!text-xs shrink-0 whitespace-nowrap">
                     {display.source}
                 </Text>
@@ -292,18 +280,17 @@ interface ToolActivityProps {
     parts: ToolUIPart[]
     /** This turn is the one being generated right now. */
     isStreaming?: boolean
-    /** Build mode: render the full step log (per-tool input + output/error inline), instead of the
-     * calm collapsed "Used N tools" summary Chat mode shows. */
+    /** Build mode: rows in the expanded list also expose the tool's input + output/error as
+     * expandable monospace blocks (the full payloads; Chat keeps one-line summaries only). */
     detailed?: boolean
 }
 
 /**
- * Renders a group of tool calls inside an agent turn. Three modes:
- *  - **Build step log** (`detailed`): a left-gutter timeline of every tool with its input and
- *    output/error as monospace blocks — the power-user view, scoped to Build mode.
- *  - **Live** (streaming + a tool still in flight, Chat mode): the same gutter but one-line rows,
- *    so you watch each tool fire.
- *  - **Chat settled**: a single quiet "Used N tools" line; click to expand a one-line-summary list.
+ * Renders a group of tool calls inside an agent turn. Two modes:
+ *  - **Live** (streaming + a tool still in flight): a left-gutter timeline of every tool, so you
+ *    watch each tool fire. In Build the rows also expand to full payloads.
+ *  - **Settled**: a single quiet "Used N tools" line; click to expand the row list. Build rows
+ *    keep their per-tool input/output/error expanders there, so no payload is ever out of reach.
  *
  * An `approval-requested` tool is marked "Awaiting approval" in every mode; the Approve/Deny action
  * lives in the persistent ApprovalDock. The FE only renders tool calls — it never executes them.
@@ -313,19 +300,16 @@ const ToolActivity = ({parts, isStreaming = false, detailed = false}: ToolActivi
     const live = isStreaming && anyUnsettled
     const approvalPending = parts.some((p) => (p.state as string) === "approval-requested")
 
-    // Chat-mode in-thread file cards: one artifact card per file this group wrote/updated
-    // (successful calls only), deduped by path with the LAST op winning. The card is anchored to
-    // the TOOL step that produced it; a bare filename the reply mentions renders as a compact
-    // inline reference instead (see the markdown file-link resolver), never a second block card.
-    // Not rendered in the Build step log — there the raw tool rows already show the writes.
-    const fileCards = detailed
-        ? []
-        : dedupeByPath(
-              parts
-                  .filter((p) => (p.state as string) === "output-available")
-                  .map((p) => detectFileActivity(partToolName(p), (p as {input?: unknown}).input))
-                  .filter((a): a is FileActivity => Boolean(a)),
-          )
+    // In-thread file cards: one artifact card per file this group wrote/updated (successful calls
+    // only), deduped by path with the LAST op winning. The card is anchored to the TOOL step that
+    // produced it; a bare filename the reply mentions renders as a compact inline reference
+    // instead (see the markdown file-link resolver), never a second block card.
+    const fileCards = dedupeByPath(
+        parts
+            .filter((p) => (p.state as string) === "output-available")
+            .map((p) => detectFileActivity(partToolName(p), (p as {input?: unknown}).input))
+            .filter((a): a is FileActivity => Boolean(a)),
+    )
 
     // Persisted by the group's first tool-call id so the expanded list survives a Virtuoso unmount.
     const groupKey = toolGroupKey(parts[0]?.toolCallId ?? "grp")
@@ -335,8 +319,8 @@ const ToolActivity = ({parts, isStreaming = false, detailed = false}: ToolActivi
     // Keep the gate visible in-context: force the list open whenever one is awaiting approval.
     const expanded = open || approvalPending
 
-    // ---- Build step log (detailed) OR live streaming: the gutter timeline, always visible ----
-    if (detailed || live) {
+    // ---- Live streaming: the gutter timeline, always visible while tools are in flight ----
+    if (live) {
         return (
             <div className="flex min-w-0 flex-col border-0 border-l-2 border-solid border-colorBorderSecondary pl-3">
                 {parts.map((part, i) => (
@@ -411,6 +395,7 @@ const ToolActivity = ({parts, isStreaming = false, detailed = false}: ToolActivi
                             key={`${part.toolCallId || part.type}-${i}`}
                             part={part}
                             live={false}
+                            detailed={detailed}
                         />
                     ))}
                 </div>

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -145,9 +145,7 @@ const IOBlock = ({label, value, danger}: {label: string; value: string; danger?:
     </div>
 )
 
-/** One tool's row: humanized name + status + one-line summary; in Build (`detailed`) the row also
- * expands to the tool's input and output/error as monospace blocks. The Approve/Deny action lives
- * in the persistent ApprovalDock, so a gate here is just marked "Awaiting approval". */
+/** One tool row: humanized name + status + summary; Build rows expand to input/output blocks. */
 const ToolRow = ({
     part,
     live,
@@ -170,8 +168,7 @@ const ToolRow = ({
     // a sibling part, so this must not spin forever (the cold-replay lingering-gate spinner).
     const running =
         !isSettled(state) && state !== "approval-requested" && state !== "approval-responded"
-    // The line after the name: an awaiting-approval marker, a live "running…", or the settled
-    // one-line summary (Build's full payload lives in the row expander below).
+    // Status line: an approval marker, a live "running…", or the settled one-line summary.
     const midText =
         state === "approval-requested"
             ? "Awaiting approval"
@@ -280,30 +277,20 @@ interface ToolActivityProps {
     parts: ToolUIPart[]
     /** This turn is the one being generated right now. */
     isStreaming?: boolean
-    /** Build mode: rows in the expanded list also expose the tool's input + output/error as
-     * expandable monospace blocks (the full payloads; Chat keeps one-line summaries only). */
+    /** Build mode: expanded rows expose full input/output/error payload expanders. */
     detailed?: boolean
 }
 
 /**
- * Renders a group of tool calls inside an agent turn. Two modes:
- *  - **Live** (streaming + a tool still in flight): a left-gutter timeline of every tool, so you
- *    watch each tool fire. In Build the rows also expand to full payloads.
- *  - **Settled**: a single quiet "Used N tools" line; click to expand the row list. Build rows
- *    keep their per-tool input/output/error expanders there, so no payload is ever out of reach.
- *
- * An `approval-requested` tool is marked "Awaiting approval" in every mode; the Approve/Deny action
- * lives in the persistent ApprovalDock. The FE only renders tool calls — it never executes them.
+ * A group of tool calls in one turn: a live gutter timeline while streaming, else a collapsed
+ * "Used N tools" summary. Approve/Deny lives in the ApprovalDock; the FE never executes tools.
  */
 const ToolActivity = ({parts, isStreaming = false, detailed = false}: ToolActivityProps) => {
     const anyUnsettled = parts.some((p) => !isSettled(p.state as string))
     const live = isStreaming && anyUnsettled
     const approvalPending = parts.some((p) => (p.state as string) === "approval-requested")
 
-    // In-thread file cards: one artifact card per file this group wrote/updated (successful calls
-    // only), deduped by path with the LAST op winning. The card is anchored to the TOOL step that
-    // produced it; a bare filename the reply mentions renders as a compact inline reference
-    // instead (see the markdown file-link resolver), never a second block card.
+    // One card per file this group wrote (successful calls only, last op per path wins).
     const fileCards = dedupeByPath(
         parts
             .filter((p) => (p.state as string) === "output-available")
@@ -319,7 +306,7 @@ const ToolActivity = ({parts, isStreaming = false, detailed = false}: ToolActivi
     // Keep the gate visible in-context: force the list open whenever one is awaiting approval.
     const expanded = open || approvalPending
 
-    // ---- Live streaming: the gutter timeline, always visible while tools are in flight ----
+    // ---- Live: the gutter timeline while tools are in flight ----
     if (live) {
         return (
             <div className="flex min-w-0 flex-col border-0 border-l-2 border-solid border-colorBorderSecondary pl-3">

--- a/web/oss/src/components/AgentChatSlice/state/rightPanel.ts
+++ b/web/oss/src/components/AgentChatSlice/state/rightPanel.ts
@@ -14,3 +14,10 @@ export const rightPanelWidthAtom = atomWithStorage<number>(
 export const RIGHT_PANEL_MIN = 360
 export const RIGHT_PANEL_MAX = 900
 export const CHAT_MIN = 460
+
+/** The Files pane (the drawer-turned-pane) shares RightPanelSplit but keeps its own persisted
+ * width + bounds — two-pane tree + preview needs more room than the Inspector, and the max stays
+ * generous so it can be dragged near-drawer-wide (the chat floor still caps it on small screens). */
+export const filesPaneWidthAtom = atomWithStorage<number>("agenta:agent-chat:files-pane-width", 620)
+export const FILES_PANE_MIN = 420
+export const FILES_PANE_MAX = 1600

--- a/web/oss/src/components/AgentChatSlice/state/rightPanel.ts
+++ b/web/oss/src/components/AgentChatSlice/state/rightPanel.ts
@@ -1,5 +1,7 @@
 import {atomWithStorage} from "jotai/utils"
 
+import {SIDEBAR_DEFAULT_WIDTH} from "@/oss/lib/atoms/sidebar"
+
 /**
  * Dock geometry for the chat's right split (RightPanelSplit) — now hosting the Inspector. The
  * Inspector's open/scope/lens live in `components/Inspector/state.ts`; this file only owns the
@@ -21,3 +23,13 @@ export const CHAT_MIN = 460
 export const filesPaneWidthAtom = atomWithStorage<number>("agenta:agent-chat:files-pane-width", 620)
 export const FILES_PANE_MIN = 420
 export const FILES_PANE_MAX = 1600
+
+/** The agent config pane's fixed width in MainLayout (`configDefaultSize`); kept in sync there. */
+const AGENT_CONFIG_WIDTH = 440
+/** Divider hairlines + panel edge paddings between the four regions. */
+const SEAM_SLACK = 25
+/** Window width at which config pane + transcript + Files pane all fit at fair widths (with the
+ * nav sidebar assumed open at its default). Below it the two side panes are mutually exclusive;
+ * at or above it they may stay open together. */
+export const PANES_COEXIST_MIN_WINDOW =
+    SIDEBAR_DEFAULT_WIDTH + AGENT_CONFIG_WIDTH + CHAT_MIN + FILES_PANE_MIN + SEAM_SLACK

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -68,6 +68,7 @@ export function DriveExplorer({
     stagedFiles,
     onStagedChange,
     mirrored = false,
+    initialShowTree = true,
     closeVariant = "close",
 }: {
     drive: SessionDriveData
@@ -91,6 +92,8 @@ export function DriveExplorer({
     onStagedChange?: (files: DroppedFile[]) => void
     /** Mirror the two-pane body: tree docked RIGHT, content LEFT (the in-chat Files pane). */
     mirrored?: boolean
+    /** Open with the tree collapsed — a single-file quick look; the toolbar toggle reveals it. */
+    initialShowTree?: boolean
     /** How `onClose` reads in the header: an "×" (overlay drawer) or a "»" collapse (docked pane). */
     closeVariant?: "close" | "collapse"
 }) {
@@ -124,6 +127,7 @@ export function DriveExplorer({
         searchActive,
         mirrored,
         initialWidth: mirrored ? TREE_WIDTH_COMPACT : undefined,
+        initialShow: initialShowTree,
     })
     const {showTree, toggleTree, treeVisible, treeShift} = pane
     const {archiveMounts, downloadingAll, handleDownloadAll} = useDriveDownloadAll({

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -32,7 +32,7 @@ import {useRepoInfo} from "./driveRepo"
 import {DriveToolbar} from "./DriveToolbar"
 import {DriveTreeList} from "./DriveTreeList"
 import {DriveTreePane} from "./DriveTreePane"
-import {looksLikeFilePath} from "./driveTreeView"
+import {TREE_WIDTH_COMPACT, looksLikeFilePath} from "./driveTreeView"
 import {type DriveId, type DriveScope} from "./driveTypes"
 import {type DroppedFile} from "./dropEntries"
 import {FolderView} from "./FolderView"
@@ -67,6 +67,8 @@ export function DriveExplorer({
     onToggleExpand,
     stagedFiles,
     onStagedChange,
+    mirrored = false,
+    closeVariant = "close",
 }: {
     drive: SessionDriveData
     /** Render this flat list instead of the mount's lazy-loaded tree — the local-file mode used to
@@ -87,6 +89,10 @@ export function DriveExplorer({
      * and clicks "Upload here" — shown as ghost tiles in the grid. The host owns the list. */
     stagedFiles?: DroppedFile[]
     onStagedChange?: (files: DroppedFile[]) => void
+    /** Mirror the two-pane body: tree docked RIGHT, content LEFT (the in-chat Files pane). */
+    mirrored?: boolean
+    /** How `onClose` reads in the header: an "×" (overlay drawer) or a "»" collapse (docked pane). */
+    closeVariant?: "close" | "collapse"
 }) {
     const rootLabel = driveRootLabel(drive.mount)
     const {
@@ -114,7 +120,11 @@ export function DriveExplorer({
     const chrome = onClose != null
     // Details toggle, lifted so the ONE header owns it (file meta OR repo facts, per selection).
     const [detailsOpen, setDetailsOpen] = useState(false)
-    const pane = useDriveTreePane({searchActive})
+    const pane = useDriveTreePane({
+        searchActive,
+        mirrored,
+        initialWidth: mirrored ? TREE_WIDTH_COMPACT : undefined,
+    })
     const {showTree, toggleTree, treeVisible, treeShift} = pane
     const {archiveMounts, downloadingAll, handleDownloadAll} = useDriveDownloadAll({
         drive,
@@ -312,6 +322,7 @@ export function DriveExplorer({
         body = (
             <DriveTreePane
                 pane={pane}
+                mirrored={mirrored}
                 treeScrollRef={treeScrollRef}
                 onTreeKeyDown={onTreeKeyDown}
                 treeDropProps={canUpload ? drop.containerDropProps(currentFolder) : undefined}
@@ -364,6 +375,7 @@ export function DriveExplorer({
                         onToggleDetails={() => setDetailsOpen((v) => !v)}
                         onNavigate={select}
                         onClose={onClose}
+                        closeVariant={closeVariant}
                         copyText={copyText}
                         ids={driveIds ?? []}
                         downloadMount={
@@ -407,6 +419,7 @@ export function DriveExplorer({
                         drawer-global), so no separate header banner here — a banner that mounts/unmounts
                         shoved the toolbar + panes on every upload state change. */}
                     <DriveToolbar
+                        mirrored={mirrored}
                         search={search}
                         setSearch={setSearch}
                         searchActive={searchActive}

--- a/web/oss/src/components/Drives/DriveFileContentViewer.tsx
+++ b/web/oss/src/components/Drives/DriveFileContentViewer.tsx
@@ -2,7 +2,7 @@ import {useState} from "react"
 
 import {type Mount} from "@agenta/entities/session"
 import {DownloadSimple} from "@phosphor-icons/react"
-import {Button} from "antd"
+import {Button, Tooltip} from "antd"
 import {AnimatePresence, motion} from "motion/react"
 
 import {resolveDriveFileKind} from "./driveKinds"
@@ -54,25 +54,27 @@ export const DriveFileContentViewer = ({
 }
 
 /** Download button for one file — raw bytes, so every type round-trips (not just text). Shared by
- * the drawer header and the file preview, so both report a failure the same way. */
+ * the drawer header and the file preview, so both report a failure the same way. Icon-only: the
+ * label crowded the pane header, and the tooltip carries the word. */
 export const DriveFileDownloadButton = ({mount, path}: {mount: Mount | null; path: string}) => {
     const download = useDriveFileDownload()
     const [downloading, setDownloading] = useState(false)
     return (
-        <Button
-            icon={<DownloadSimple size={13} />}
-            disabled={!mount}
-            loading={downloading}
-            onClick={async () => {
-                setDownloading(true)
-                try {
-                    await download(mount, path)
-                } finally {
-                    setDownloading(false)
-                }
-            }}
-        >
-            Download
-        </Button>
+        <Tooltip title="Download">
+            <Button
+                icon={<DownloadSimple size={13} />}
+                aria-label="Download"
+                disabled={!mount}
+                loading={downloading}
+                onClick={async () => {
+                    setDownloading(true)
+                    try {
+                        await download(mount, path)
+                    } finally {
+                        setDownloading(false)
+                    }
+                }}
+            />
+        </Tooltip>
     )
 }

--- a/web/oss/src/components/Drives/DriveHeader.tsx
+++ b/web/oss/src/components/Drives/DriveHeader.tsx
@@ -3,6 +3,7 @@ import {CopyButton} from "@agenta/ui/components/presentational"
 import {
     ArrowsIn,
     ArrowsOut,
+    CaretDoubleRight,
     DotsThree,
     DownloadSimple,
     GitBranch,
@@ -38,6 +39,7 @@ export const DriveHeader = ({
     onToggleDetails,
     onNavigate,
     onClose,
+    closeVariant = "close",
     copyText,
     ids,
     downloadMount,
@@ -72,6 +74,8 @@ export const DriveHeader = ({
     onToggleDetails: () => void
     onNavigate: (path: string) => void
     onClose: () => void
+    /** How `onClose` reads: an "×" (overlay drawer) or a "»" that collapses the docked pane. */
+    closeVariant?: "close" | "collapse"
     copyText: (text: string, successMessage?: string) => void
     ids: DriveId[]
     downloadMount: Mount | null
@@ -113,12 +117,27 @@ export const DriveHeader = ({
         },
     ]
     return (
-        <div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-colorBorderSecondary px-3 py-2">
-            <Tooltip title="Close">
+        // Docked-pane variant: pin the header to the session bar's exact height + border token so
+        // its bottom border CONTINUES the bar's line across the divider (offset heights read as
+        // two stacked lines at the junction).
+        <div
+            className={`flex shrink-0 items-center gap-2 border-0 border-b border-solid px-3 ${
+                closeVariant === "collapse"
+                    ? "h-[48px] border-[var(--ag-surface-card-border)]"
+                    : "border-colorBorderSecondary py-2"
+            }`}
+        >
+            <Tooltip title={closeVariant === "collapse" ? "Collapse files" : "Close"}>
                 <Button
                     type="text"
-                    aria-label="Close"
-                    icon={<X size={16} />}
+                    aria-label={closeVariant === "collapse" ? "Collapse files pane" : "Close"}
+                    icon={
+                        closeVariant === "collapse" ? (
+                            <CaretDoubleRight size={16} />
+                        ) : (
+                            <X size={16} />
+                        )
+                    }
                     onClick={onClose}
                     className="!h-7 !w-7 !p-0 !text-colorTextSecondary hover:!text-colorText"
                 />

--- a/web/oss/src/components/Drives/DriveToolbar.tsx
+++ b/web/oss/src/components/Drives/DriveToolbar.tsx
@@ -24,6 +24,7 @@ export function DriveToolbar({
     inGitScope,
     showGitignored,
     setShowGitignored,
+    mirrored = false,
 }: {
     search: string
     setSearch: (value: string) => void
@@ -40,12 +41,19 @@ export function DriveToolbar({
     inGitScope: boolean
     showGitignored: boolean
     setShowGitignored: (update: (v: boolean) => boolean) => void
+    /** Mirrored explorer (tree docked RIGHT): reverse the row so the tree toggle stays above the
+     * tree pane it controls and the filters take the left. */
+    mirrored?: boolean
 }) {
     return (
-        /* Shared toolbar — the show/hide tree toggle sits FIRST (left), directly above the
-            tree pane it controls; then search + filters. Search forces the tree of matches
-            (see body), so the toggle is disabled while searching. */
-        <div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-colorBorderSecondary px-3 py-2">
+        /* Shared toolbar — the show/hide tree toggle sits FIRST, directly above the tree pane it
+            controls (left normally, right when mirrored); then search + filters. Search forces the
+            tree of matches (see body), so the toggle is disabled while searching. */
+        <div
+            className={`flex shrink-0 items-center gap-2 border-0 border-b border-solid border-colorBorderSecondary px-3 py-2 ${
+                mirrored ? "flex-row-reverse" : ""
+            }`}
+        >
             <Tooltip
                 title={
                     searchActive

--- a/web/oss/src/components/Drives/DriveTreePane.tsx
+++ b/web/oss/src/components/Drives/DriveTreePane.tsx
@@ -17,6 +17,7 @@ export function DriveTreePane({
     treeDropProps,
     rows,
     children,
+    mirrored = false,
 }: {
     pane: DriveTreePaneState
     treeScrollRef: (el: HTMLDivElement | null) => void
@@ -27,6 +28,9 @@ export function DriveTreePane({
     rows: ReactNode
     /** The content pane: the folder grid or the file preview. */
     children: ReactNode
+    /** Dock the tree on the RIGHT and the content on the LEFT (row-reverse keeps DOM/focus order:
+     * tree first). Pair with `useDriveTreePane({mirrored})` so the resize drag direction matches. */
+    mirrored?: boolean
 }) {
     const {
         paneW,
@@ -42,12 +46,14 @@ export function DriveTreePane({
     // continuous pass. The tree's INNER content is a FIXED TREE_WIDTH box clipped by the outer
     // `overflow-hidden`, so it slides out cleanly (its rows never reflow as the pane narrows).
     return (
-        <div className="flex min-h-0 w-full flex-1">
+        <div className={`flex min-h-0 w-full flex-1 ${mirrored ? "flex-row-reverse" : ""}`}>
             {/* Width rides the `paneW` MotionValue: the toggle animates it (see the effect above),
                     a drag writes it per pointer move — either way motion updates the DOM directly,
                     no React render per frame. */}
             <motion.div
-                className="min-h-0 shrink-0 overflow-hidden border-0 border-r border-solid border-colorBorderSecondary"
+                className={`min-h-0 shrink-0 overflow-hidden border-0 border-solid border-colorBorderSecondary ${
+                    mirrored ? "border-l" : "border-r"
+                }`}
                 style={{width: paneW}}
             >
                 {/* Inner rides `innerW`, which a DRAG updates (content reflows to the new width)

--- a/web/oss/src/components/Drives/FilesDrawer.tsx
+++ b/web/oss/src/components/Drives/FilesDrawer.tsx
@@ -45,7 +45,7 @@ const DriveExplorer = dynamic(() => import("./DriveExplorer").then((m) => m.Driv
  * place by `useDriveSelection` (remounting there would wipe a search typed against the skeleton),
  * and drive→null is just a host tearing down on close.
  */
-const useDriveGeneration = (mountId: string | null | undefined): string => {
+export const useDriveGeneration = (mountId: string | null | undefined): string => {
     const seen = useRef<string | null>(null)
     const generation = useRef(0)
     if (mountId && seen.current !== mountId) {

--- a/web/oss/src/components/Drives/SessionFilesDrawer.tsx
+++ b/web/oss/src/components/Drives/SessionFilesDrawer.tsx
@@ -30,7 +30,8 @@ export const filesDrawerStagedAtomFamily = atomFamily((_sessionId: string) =>
 )
 
 // A requested path may be a tool-path tail; match it against a full drive path by suffix.
-const matchesTail = (filePath: string, requested: string): boolean =>
+// (Shared with SessionFilesPane, the docked variant of this host.)
+export const matchesTail = (filePath: string, requested: string): boolean =>
     filePath === requested || requested.endsWith(`/${filePath}`)
 
 export function SessionFilesDrawer({sessionId}: {sessionId: string}) {

--- a/web/oss/src/components/Drives/SessionFilesPane.tsx
+++ b/web/oss/src/components/Drives/SessionFilesPane.tsx
@@ -101,6 +101,8 @@ export function SessionFilesPane({sessionId}: {sessionId: string}) {
                 onClose={close}
                 closeVariant="collapse"
                 mirrored
+                // A quick look flagged hideTree (a config file row) opens on the file alone.
+                initialShowTree={!quickLook?.hideTree}
                 driveIds={driveIds}
                 stagedFiles={staged}
                 onStagedChange={setStaged}

--- a/web/oss/src/components/Drives/SessionFilesPane.tsx
+++ b/web/oss/src/components/Drives/SessionFilesPane.tsx
@@ -1,0 +1,110 @@
+/**
+ * SessionFilesPane — the chat host's DOCKED replacement for {@link SessionFilesDrawer}: the same
+ * per-session glue (this conversation's open + quick-look + staged atoms → the shared
+ * {@link DriveExplorer}), but rendered inline in a resizable right-side splitter pane instead of an
+ * overlay drawer. The pane mirrors the explorer (tree RIGHT, content LEFT) and swaps the drawer's
+ * "×" for a "»" collapse. The overlay drawer stays in use for the non-chat hosts (config panel,
+ * agent overview).
+ *
+ * Openers are unchanged: tiles, in-thread cards, rail rows, and chat links all set the same
+ * per-session atoms; `useSessionFilesPane` folds them into the split's open flag.
+ */
+import {useCallback, useEffect, useMemo} from "react"
+
+import {atom, useAtom} from "jotai"
+import {atomFamily} from "jotai/utils"
+import dynamic from "next/dynamic"
+
+import {useChatScopeKey} from "@/oss/components/AgentChatSlice/state/scope"
+
+import {type DriveId} from "./DriveExplorer"
+import {DriveExplorerSkeleton} from "./DriveExplorerSkeleton"
+import {useDriveArtifactId} from "./driveSessionContext"
+import {useDriveGeneration} from "./FilesDrawer"
+import {driveQuickLookAtomFamily} from "./quickLook"
+import {filesDrawerStagedAtomFamily, matchesTail} from "./SessionFilesDrawer"
+import {useSessionDriveSummary} from "./useSessionDrive"
+
+// Heavy body — loaded lazily on first open (the split unmounts the pane while collapsed).
+const DriveExplorer = dynamic(() => import("./DriveExplorer").then((m) => m.DriveExplorer), {
+    ssr: false,
+    loading: () => <DriveExplorerSkeleton />,
+})
+
+// The pane's open flag belongs to the chat PANEL (keyed by the app scope), not to one session:
+// adding or switching tabs must not snap an open pane shut. Quick-look + staged drops stay
+// per-session (they are selection state) and latch this flag open via the effect below.
+const filesPaneOpenAtomFamily = atomFamily((_scope: string) => atom(false))
+
+/** The pane's open/close/toggle — one hook so the splitter host, the session bar toggle, and
+ * every opener (config Files section, context rail, inspector) drive the SAME state. */
+export const useSessionFilesPane = (sessionId: string) => {
+    const scope = useChatScopeKey()
+    const [scopeOpen, setScopeOpen] = useAtom(filesPaneOpenAtomFamily(scope))
+    const [quickLook, setQuickLook] = useAtom(driveQuickLookAtomFamily(sessionId))
+    const [staged, setStaged] = useAtom(filesDrawerStagedAtomFamily(sessionId))
+    // A per-session opener (file card, chat link, staged drop) latches the panel-level flag, so
+    // the pane it opened survives a later session switch/add.
+    const sessionRequested = quickLook != null || staged.length > 0
+    useEffect(() => {
+        if (sessionRequested) setScopeOpen(true)
+    }, [sessionRequested, setScopeOpen])
+    const open = scopeOpen || sessionRequested
+    const close = useCallback(() => {
+        setScopeOpen(false)
+        setQuickLook(null)
+        setStaged([])
+    }, [setScopeOpen, setQuickLook, setStaged])
+    const openPane = useCallback(() => setScopeOpen(true), [setScopeOpen])
+    const toggle = useCallback(() => (open ? close() : openPane()), [open, close, openPane])
+    return {open, close, openPane, toggle}
+}
+
+export function SessionFilesPane({sessionId}: {sessionId: string}) {
+    const {open, close} = useSessionFilesPane(sessionId)
+    const [quickLook] = useAtom(driveQuickLookAtomFamily(sessionId))
+    const [staged, setStaged] = useAtom(filesDrawerStagedAtomFamily(sessionId))
+    const artifactId = useDriveArtifactId()
+
+    // Summary drive (cheap) — DriveExplorer lazy-loads the rest. Gated on open (the agent-mount query
+    // keys on artifactId, so a live id while collapsed would fetch the agent drive before it's shown).
+    const drive = useSessionDriveSummary(
+        open ? sessionId : "",
+        open ? (artifactId ?? undefined) : undefined,
+    )
+
+    // Resolve the quick-look path (possibly a tail) to the presented drive path the tree selects by.
+    const initialPath = useMemo(() => {
+        if (!quickLook) return null
+        const hit = drive.recents.find((f) => matchesTail(f.path, quickLook.path))
+        return hit?.path ?? quickLook.path
+    }, [quickLook, drive.recents])
+
+    const driveIds = useMemo(
+        () =>
+            [
+                drive.mount?.id ? {key: "mount", label: "Drive ID", value: drive.mount.id} : null,
+                sessionId ? {key: "owner", label: "Session ID", value: sessionId} : null,
+            ].filter(Boolean) as DriveId[],
+        [drive.mount?.id, sessionId],
+    )
+
+    const driveGeneration = useDriveGeneration(drive.mount?.id)
+
+    return (
+        <div className="flex h-full min-h-0 w-full flex-col">
+            <DriveExplorer
+                key={driveGeneration}
+                drive={drive}
+                scope="session"
+                initialPath={initialPath}
+                onClose={close}
+                closeVariant="collapse"
+                mirrored
+                driveIds={driveIds}
+                stagedFiles={staged}
+                onStagedChange={setStaged}
+            />
+        </div>
+    )
+}

--- a/web/oss/src/components/Drives/StorageFilesHeader.tsx
+++ b/web/oss/src/components/Drives/StorageFilesHeader.tsx
@@ -16,7 +16,7 @@ import {useSessionFilesPane} from "./SessionFilesPane"
 export default function StorageFilesHeader({revisionId}: {revisionId?: string | null}) {
     const {drive, sessionId} = useConfigDrive(revisionId)
     // A toggle, not just an opener: clicking "N files" tucks the pane away again if it is open.
-    const {toggle: togglePane} = useSessionFilesPane(sessionId)
+    const {open: paneOpen, toggle: togglePane} = useSessionFilesPane(sessionId)
 
     if (drive.isLoading) {
         return <Skeleton.Button active size="small" style={{width: 44, height: 14}} />
@@ -39,6 +39,7 @@ export default function StorageFilesHeader({revisionId}: {revisionId?: string | 
             return (
                 <button
                     type="button"
+                    aria-expanded={paneOpen}
                     onClick={(e) => {
                         e.currentTarget.blur()
                         togglePane()
@@ -58,6 +59,7 @@ export default function StorageFilesHeader({revisionId}: {revisionId?: string | 
     return (
         <button
             type="button"
+            aria-expanded={paneOpen}
             // Blur on open so the drawer's ESC-close doesn't restore a (keyboard-modality) focus ring
             // to this trigger. Genuine Tab focus still shows the ring via FOCUS_RING.
             onClick={(e) => {

--- a/web/oss/src/components/Drives/StorageFilesHeader.tsx
+++ b/web/oss/src/components/Drives/StorageFilesHeader.tsx
@@ -2,20 +2,21 @@
  * StorageFilesHeader — the right-side content of the config panel's "Files" header bar.
  *
  * Mirrors the sibling Triggers header's count, and doubles as the "browse all" entry: clicking it
- * opens the Files drawer at the tree root (the body's rows open the same drawer preselected on a
- * file). Slotted into the entity-ui `AgentOperationsSections` header by the app layer, which owns
- * the chat session state that package can't reach.
+ * opens the chat's docked Files pane at the tree root (the body's rows open the same pane
+ * preselected on a file). Slotted into the entity-ui `AgentOperationsSections` header by the app
+ * layer, which owns the chat session state that package can't reach.
  */
 import {CircleNotch, FolderOpen} from "@phosphor-icons/react"
 import {Skeleton} from "antd"
-import {useSetAtom} from "jotai"
 
-import {configFilesDrawerAtomFamily, useConfigDrive} from "./configDrive"
+import {useConfigDrive} from "./configDrive"
 import {DriveWarningBadge, FOCUS_RING} from "./DriveFileRow"
+import {useSessionFilesPane} from "./SessionFilesPane"
 
 export default function StorageFilesHeader({revisionId}: {revisionId?: string | null}) {
-    const {drive} = useConfigDrive(revisionId)
-    const setDrawer = useSetAtom(configFilesDrawerAtomFamily(revisionId ?? ""))
+    const {drive, sessionId} = useConfigDrive(revisionId)
+    // A toggle, not just an opener: clicking "N files" tucks the pane away again if it is open.
+    const {toggle: togglePane} = useSessionFilesPane(sessionId)
 
     if (drive.isLoading) {
         return <Skeleton.Button active size="small" style={{width: 44, height: 14}} />
@@ -40,7 +41,7 @@ export default function StorageFilesHeader({revisionId}: {revisionId?: string | 
                     type="button"
                     onClick={(e) => {
                         e.currentTarget.blur()
-                        setDrawer({open: true, initialPath: null, staged: []})
+                        togglePane()
                     }}
                     className={`flex cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-xs text-[var(--ag-colorTextTertiary)] transition-colors hover:text-[var(--ag-colorText)] ${FOCUS_RING}`}
                 >
@@ -61,7 +62,7 @@ export default function StorageFilesHeader({revisionId}: {revisionId?: string | 
             // to this trigger. Genuine Tab focus still shows the ring via FOCUS_RING.
             onClick={(e) => {
                 e.currentTarget.blur()
-                setDrawer({open: true, initialPath: null, staged: []})
+                togglePane()
             }}
             className={`flex cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-xs text-[var(--ag-colorTextTertiary)] transition-colors hover:text-[var(--ag-colorText)] ${FOCUS_RING}`}
         >

--- a/web/oss/src/components/Drives/StorageFilesHeader.tsx
+++ b/web/oss/src/components/Drives/StorageFilesHeader.tsx
@@ -2,21 +2,20 @@
  * StorageFilesHeader — the right-side content of the config panel's "Files" header bar.
  *
  * Mirrors the sibling Triggers header's count, and doubles as the "browse all" entry: clicking it
- * opens the chat's docked Files pane at the tree root (the body's rows open the same pane
- * preselected on a file). Slotted into the entity-ui `AgentOperationsSections` header by the app
- * layer, which owns the chat session state that package can't reach.
+ * opens the overlay Files DRAWER (the body's rows open the docked pane on one file instead).
+ * Slotted into the entity-ui `AgentOperationsSections` header by the app layer, which owns the
+ * chat session state that package can't reach.
  */
 import {CircleNotch, FolderOpen} from "@phosphor-icons/react"
 import {Skeleton} from "antd"
+import {useSetAtom} from "jotai"
 
-import {useConfigDrive} from "./configDrive"
+import {configFilesDrawerOpenAtomFamily, useConfigDrive} from "./configDrive"
 import {DriveWarningBadge, FOCUS_RING} from "./DriveFileRow"
-import {useSessionFilesPane} from "./SessionFilesPane"
 
 export default function StorageFilesHeader({revisionId}: {revisionId?: string | null}) {
-    const {drive, sessionId} = useConfigDrive(revisionId)
-    // A toggle, not just an opener: clicking "N files" tucks the pane away again if it is open.
-    const {open: paneOpen, toggle: togglePane} = useSessionFilesPane(sessionId)
+    const {drive} = useConfigDrive(revisionId)
+    const setDrawerOpen = useSetAtom(configFilesDrawerOpenAtomFamily(revisionId ?? ""))
 
     if (drive.isLoading) {
         return <Skeleton.Button active size="small" style={{width: 44, height: 14}} />
@@ -39,10 +38,9 @@ export default function StorageFilesHeader({revisionId}: {revisionId?: string | 
             return (
                 <button
                     type="button"
-                    aria-expanded={paneOpen}
                     onClick={(e) => {
                         e.currentTarget.blur()
-                        togglePane()
+                        setDrawerOpen(true)
                     }}
                     className={`flex cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-xs text-[var(--ag-colorTextTertiary)] transition-colors hover:text-[var(--ag-colorText)] ${FOCUS_RING}`}
                 >
@@ -59,12 +57,11 @@ export default function StorageFilesHeader({revisionId}: {revisionId?: string | 
     return (
         <button
             type="button"
-            aria-expanded={paneOpen}
             // Blur on open so the drawer's ESC-close doesn't restore a (keyboard-modality) focus ring
             // to this trigger. Genuine Tab focus still shows the ring via FOCUS_RING.
             onClick={(e) => {
                 e.currentTarget.blur()
-                togglePane()
+                setDrawerOpen(true)
             }}
             className={`flex cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-xs text-[var(--ag-colorTextTertiary)] transition-colors hover:text-[var(--ag-colorText)] ${FOCUS_RING}`}
         >

--- a/web/oss/src/components/Drives/StorageSection.tsx
+++ b/web/oss/src/components/Drives/StorageSection.tsx
@@ -8,19 +8,23 @@
  * agent's durable folder is a subfolder of this working folder, so it needs no separate drive
  * here. Lives in the app layer because it reads the chat slice's session state.
  */
+import {useMemo} from "react"
+
 import {CircleNotch} from "@phosphor-icons/react"
 import {Typography} from "antd"
-import {useSetAtom} from "jotai"
+import {useAtom, useSetAtom} from "jotai"
 import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 import {isAgentFileUploadsEnabled} from "@/oss/components/AgentChatSlice/assets/constants"
 
-import {useConfigDrive} from "./configDrive"
+import {configFilesDrawerOpenAtomFamily, useConfigDrive} from "./configDrive"
+import {type DriveId} from "./DriveExplorer"
 import {DriveFileRow, DriveRetryButton, SKELETON_ROW_COUNT} from "./DriveFileRow"
 import {DriveItemContextMenu, useCopyDrivePath, useDriveItemDownload} from "./DriveItemContextMenu"
 import {listArrowKeyDown} from "./driveKeyboard"
 import {FILE_ITEM_VARIANTS, FILE_SPRING} from "./driveMotion"
 import {humanSize, relativeTime} from "./driveTree"
+import {FilesDrawer} from "./FilesDrawer"
 import {driveQuickLookAtomFamily} from "./quickLook"
 import {isRecentlyChanged, useRecentChangeClock} from "./recentChange"
 import {filesDrawerStagedAtomFamily} from "./SessionFilesDrawer"
@@ -77,15 +81,16 @@ const RecentFileRow = ({
 
 export default function StorageSection({revisionId}: {revisionId?: string | null}) {
     const {drive, sessionId} = useConfigDrive(revisionId)
-    // Openers land in the chat's DOCKED Files pane (the same state every chat opener drives):
-    // rows preselect the clicked file, the header opens the root.
+    // A row opens the chat's DOCKED pane on that file with the tree collapsed; the header's icon
+    // opens the browse-all DRAWER instead (see StorageFilesHeader).
     const {openPane: openPaneRoot} = useSessionFilesPane(sessionId)
     const setQuickLook = useSetAtom(driveQuickLookAtomFamily(sessionId))
     const setPaneStaged = useSetAtom(filesDrawerStagedAtomFamily(sessionId))
+    const [drawerOpen, setDrawerOpen] = useAtom(configFilesDrawerOpenAtomFamily(revisionId ?? ""))
     const openPane = (initialPath: string | null) => {
         // No resolved session id → the per-session quick-look atom is not the one the docked
         // pane reads, so open at the root instead of writing into an orphaned bucket.
-        if (initialPath && sessionId) setQuickLook({path: initialPath})
+        if (initialPath && sessionId) setQuickLook({path: initialPath, hideTree: true})
         else openPaneRoot()
     }
     // Drop-to-stage: a file drag over the Files peek opens the pane with the files staged, so the
@@ -97,6 +102,15 @@ export default function StorageSection({revisionId}: {revisionId?: string | null
     )
     const copyPath = useCopyDrivePath()
     const download = useDriveItemDownload(drive)
+    // Raw ids for the drawer header's overflow menu (the drive id + the session it belongs to).
+    const driveIds = useMemo(
+        () =>
+            [
+                drive.mount?.id ? {key: "mount", label: "Drive ID", value: drive.mount.id} : null,
+                sessionId ? {key: "owner", label: "Session ID", value: sessionId} : null,
+            ].filter(Boolean) as DriveId[],
+        [drive.mount?.id, sessionId],
+    )
 
     const now = useRecentChangeClock(drive.lastTouchedAt)
     // Render the drive's canonical recents verbatim (no local filtering) so the config Files list and
@@ -233,6 +247,15 @@ export default function StorageSection({revisionId}: {revisionId?: string | null
                     )}
                 </motion.div>
             </AnimatePresence>
+
+            {/* Browse-all overlay drawer — the Files header's icon opens it (rows use the pane). */}
+            <FilesDrawer
+                open={drawerOpen}
+                onClose={() => setDrawerOpen(false)}
+                drive={drive}
+                driveIds={driveIds}
+                scope="session"
+            />
         </div>
     )
 }

--- a/web/oss/src/components/Drives/StorageSection.tsx
+++ b/web/oss/src/components/Drives/StorageSection.tsx
@@ -83,7 +83,9 @@ export default function StorageSection({revisionId}: {revisionId?: string | null
     const setQuickLook = useSetAtom(driveQuickLookAtomFamily(sessionId))
     const setPaneStaged = useSetAtom(filesDrawerStagedAtomFamily(sessionId))
     const openPane = (initialPath: string | null) => {
-        if (initialPath) setQuickLook({path: initialPath})
+        // No resolved session id → the per-session quick-look atom is not the one the docked
+        // pane reads, so open at the root instead of writing into an orphaned bucket.
+        if (initialPath && sessionId) setQuickLook({path: initialPath})
         else openPaneRoot()
     }
     // Drop-to-stage: a file drag over the Files peek opens the pane with the files staged, so the

--- a/web/oss/src/components/Drives/StorageSection.tsx
+++ b/web/oss/src/components/Drives/StorageSection.tsx
@@ -3,29 +3,28 @@
  *
  * One flat file view (no App/Session split — the config surface is "simply files"): the active
  * conversation's working files, newest first, with the full relative path (mono) so the raw
- * cwd/session UUIDs stay abstracted away. Rows open the DriveDrawer preselected on the clicked
- * file; the Files header count (StorageFilesHeader) opens it at the tree root. The agent's durable
- * folder is a subfolder of this working folder, so it needs no separate drive here. Lives in the
- * app layer because it reads the chat slice's session state.
+ * cwd/session UUIDs stay abstracted away. Rows open the chat's docked Files pane preselected on
+ * the clicked file; the Files header count (StorageFilesHeader) opens it at the tree root. The
+ * agent's durable folder is a subfolder of this working folder, so it needs no separate drive
+ * here. Lives in the app layer because it reads the chat slice's session state.
  */
-import {useMemo} from "react"
-
 import {CircleNotch} from "@phosphor-icons/react"
 import {Typography} from "antd"
-import {useAtom} from "jotai"
+import {useSetAtom} from "jotai"
 import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 import {isAgentFileUploadsEnabled} from "@/oss/components/AgentChatSlice/assets/constants"
 
-import {configFilesDrawerAtomFamily, useConfigDrive} from "./configDrive"
-import {type DriveId} from "./DriveExplorer"
+import {useConfigDrive} from "./configDrive"
 import {DriveFileRow, DriveRetryButton, SKELETON_ROW_COUNT} from "./DriveFileRow"
 import {DriveItemContextMenu, useCopyDrivePath, useDriveItemDownload} from "./DriveItemContextMenu"
 import {listArrowKeyDown} from "./driveKeyboard"
 import {FILE_ITEM_VARIANTS, FILE_SPRING} from "./driveMotion"
 import {humanSize, relativeTime} from "./driveTree"
-import {FilesDrawer} from "./FilesDrawer"
+import {driveQuickLookAtomFamily} from "./quickLook"
 import {isRecentlyChanged, useRecentChangeClock} from "./recentChange"
+import {filesDrawerStagedAtomFamily} from "./SessionFilesDrawer"
+import {useSessionFilesPane} from "./SessionFilesPane"
 import {useStageDrop} from "./useDriveDrop"
 import {driveHasMixedOrigins, type DriveRecentFile} from "./useSessionDrive"
 
@@ -78,29 +77,24 @@ const RecentFileRow = ({
 
 export default function StorageSection({revisionId}: {revisionId?: string | null}) {
     const {drive, sessionId} = useConfigDrive(revisionId)
-    // Drawer request is shared with the Files header (which opens it at the root); rows open it
-    // preselected on the clicked file.
-    const [drawer, setDrawer] = useAtom(configFilesDrawerAtomFamily(revisionId ?? ""))
-    const openDrawer = (initialPath: string | null) =>
-        setDrawer({open: true, initialPath, staged: []})
-    // Drop-to-stage: a file drag over the Files peek opens the drawer with the files staged, so the
+    // Openers land in the chat's DOCKED Files pane (the same state every chat opener drives):
+    // rows preselect the clicked file, the header opens the root.
+    const {openPane: openPaneRoot} = useSessionFilesPane(sessionId)
+    const setQuickLook = useSetAtom(driveQuickLookAtomFamily(sessionId))
+    const setPaneStaged = useSetAtom(filesDrawerStagedAtomFamily(sessionId))
+    const openPane = (initialPath: string | null) => {
+        if (initialPath) setQuickLook({path: initialPath})
+        else openPaneRoot()
+    }
+    // Drop-to-stage: a file drag over the Files peek opens the pane with the files staged, so the
     // destination folder is chosen there (this flat peek has no folder of its own).
     const {dropActive, dropProps: stageDropProps} = useStageDrop(
-        isAgentFileUploadsEnabled() && drive.mount
-            ? (files) => setDrawer({open: true, initialPath: null, staged: files})
+        isAgentFileUploadsEnabled() && drive.mount && sessionId
+            ? (files) => setPaneStaged(files)
             : undefined,
     )
     const copyPath = useCopyDrivePath()
     const download = useDriveItemDownload(drive)
-    // Raw ids for the drawer header's overflow menu (the drive id + the session it belongs to).
-    const driveIds = useMemo(
-        () =>
-            [
-                drive.mount?.id ? {key: "mount", label: "Drive ID", value: drive.mount.id} : null,
-                sessionId ? {key: "owner", label: "Session ID", value: sessionId} : null,
-            ].filter(Boolean) as DriveId[],
-        [drive.mount?.id, sessionId],
-    )
 
     const now = useRecentChangeClock(drive.lastTouchedAt)
     // Render the drive's canonical recents verbatim (no local filtering) so the config Files list and
@@ -181,7 +175,7 @@ export default function StorageSection({revisionId}: {revisionId?: string | null
                                                           now,
                                                       )}
                                                       showOrigin={showOrigin}
-                                                      onOpen={() => openDrawer(file.path)}
+                                                      onOpen={() => openPane(file.path)}
                                                       onCopyPath={copyPath}
                                                       onDownload={download}
                                                   />
@@ -237,19 +231,6 @@ export default function StorageSection({revisionId}: {revisionId?: string | null
                     )}
                 </motion.div>
             </AnimatePresence>
-
-            {/* The ONE Files drawer (DriveExplorer: lazy per-directory loading + the single header).
-                Same component the chat uses; only the open-atom + resolved drive differ. */}
-            <FilesDrawer
-                open={drawer.open}
-                onClose={() => setDrawer((prev) => ({...prev, open: false, staged: []}))}
-                drive={drive}
-                driveIds={driveIds}
-                scope="session"
-                initialPath={drawer.initialPath}
-                stagedFiles={drawer.staged}
-                onStagedChange={(files) => setDrawer((prev) => ({...prev, staged: files}))}
-            />
         </div>
     )
 }

--- a/web/oss/src/components/Drives/configDrive.ts
+++ b/web/oss/src/components/Drives/configDrive.ts
@@ -1,12 +1,13 @@
 /**
  * Shared state for the config panel's "Files" region, split across two DOM locations: the header
- * bar (rendered by the entity-ui `AgentOperationsSections`) shows the count; the body
- * (`StorageSection`) lists recents. Both resolve the same session/artifact drive via
- * {@link useConfigDrive}, and both open the chat's docked Files pane (the per-session atoms in
- * `SessionFilesDrawer`/`quickLook`) rather than a drawer of their own.
+ * bar (rendered by the entity-ui `AgentOperationsSections`) shows the count and opens the overlay
+ * browse DRAWER; the body (`StorageSection`) lists recents, and a row opens the chat's docked
+ * Files PANE on that file (tree collapsed). Both resolve the same session/artifact drive via
+ * {@link useConfigDrive}.
  */
 import {workflowMolecule} from "@agenta/entities/workflow"
-import {useAtomValue} from "jotai"
+import {atom, useAtomValue} from "jotai"
+import {atomFamily} from "jotai/utils"
 
 import {useChatScopeKey} from "@/oss/components/AgentChatSlice/state/scope"
 import {isSessionFresh} from "@/oss/components/AgentChatSlice/state/sessionEphemera"
@@ -16,6 +17,9 @@ import {
 } from "@/oss/components/AgentChatSlice/state/sessions"
 
 import {useSessionDriveSummary, type SessionDriveData} from "./useSessionDrive"
+
+/** The Files header's browse-all drawer, one open flag per config revision. */
+export const configFilesDrawerOpenAtomFamily = atomFamily((_revisionId: string) => atom(false))
 
 /**
  * The drive backing the config panel's Files region: the active conversation's cwd mount plus the

--- a/web/oss/src/components/Drives/configDrive.ts
+++ b/web/oss/src/components/Drives/configDrive.ts
@@ -1,13 +1,12 @@
 /**
  * Shared state for the config panel's "Files" region, split across two DOM locations: the header
- * bar (rendered by the entity-ui `AgentOperationsSections`) shows the count and opens the drawer;
- * the body (`StorageSection`) lists recents and opens the same drawer preselected on a row. Both
- * resolve the same session/artifact drive via {@link useConfigDrive} and share one drawer request
- * via {@link configFilesDrawerAtomFamily}, keyed by the edited revision.
+ * bar (rendered by the entity-ui `AgentOperationsSections`) shows the count; the body
+ * (`StorageSection`) lists recents. Both resolve the same session/artifact drive via
+ * {@link useConfigDrive}, and both open the chat's docked Files pane (the per-session atoms in
+ * `SessionFilesDrawer`/`quickLook`) rather than a drawer of their own.
  */
 import {workflowMolecule} from "@agenta/entities/workflow"
-import {atom, useAtomValue} from "jotai"
-import {atomFamily} from "jotai/utils"
+import {useAtomValue} from "jotai"
 
 import {useChatScopeKey} from "@/oss/components/AgentChatSlice/state/scope"
 import {isSessionFresh} from "@/oss/components/AgentChatSlice/state/sessionEphemera"
@@ -16,21 +15,7 @@ import {
     sessionsListAtomFamily,
 } from "@/oss/components/AgentChatSlice/state/sessions"
 
-import {type DroppedFile} from "./dropEntries"
 import {useSessionDriveSummary, type SessionDriveData} from "./useSessionDrive"
-
-export interface ConfigFilesDrawerRequest {
-    open: boolean
-    /** Preselect this path in the tree/preview when opening; null opens at the root. */
-    initialPath: string | null
-    /** Files dropped on the Files peek, staged (unwritten) until a destination is chosen in the drawer. */
-    staged: DroppedFile[]
-}
-
-/** One drawer-open request per config revision, shared by the Files header and body. */
-export const configFilesDrawerAtomFamily = atomFamily((_revisionId: string) =>
-    atom<ConfigFilesDrawerRequest>({open: false, initialPath: null, staged: []}),
-)
 
 /**
  * The drive backing the config panel's Files region: the active conversation's cwd mount plus the

--- a/web/oss/src/components/Drives/driveTreeView.ts
+++ b/web/oss/src/components/Drives/driveTreeView.ts
@@ -26,6 +26,8 @@ export const EMPTY_STR_SET: ReadonlySet<string> = new Set<string>()
 // content pane (flex-fill) tracks it exactly — no antd ResizeObserver re-deriving flex-basis after the
 // tween and snapping the width a second time. A custom pointer handle drags the width in [MIN, MAX].
 export const TREE_WIDTH = 260
+/** Narrower rest width for the docked (mirrored) Files pane, which has less room than the drawer. */
+export const TREE_WIDTH_COMPACT = 200
 export const TREE_MIN = 180
 export const TREE_MAX = 480
 export const TREE_TRANSITION = {

--- a/web/oss/src/components/Drives/quickLook.tsx
+++ b/web/oss/src/components/Drives/quickLook.tsx
@@ -13,5 +13,5 @@ import {atom} from "jotai"
 import {atomFamily} from "jotai/utils"
 
 export const driveQuickLookAtomFamily = atomFamily((_sessionId: string) =>
-    atom<{path: string} | null>(null),
+    atom<{path: string; hideTree?: boolean} | null>(null),
 )

--- a/web/oss/src/components/Drives/useDriveTreePane.ts
+++ b/web/oss/src/components/Drives/useDriveTreePane.ts
@@ -9,7 +9,17 @@ import {animate, useMotionValue} from "motion/react"
 
 import {TREE_MAX, TREE_MIN, TREE_TRANSITION, TREE_WIDTH} from "./driveTreeView"
 
-export function useDriveTreePane({searchActive}: {searchActive: boolean}) {
+export function useDriveTreePane({
+    searchActive,
+    mirrored = false,
+    initialWidth = TREE_WIDTH,
+}: {
+    searchActive: boolean
+    /** Tree pane docked on the RIGHT (content left) — inverts the resize-drag direction. */
+    mirrored?: boolean
+    /** Starting rest width — hosts with less room (the docked pane) open the tree narrower. */
+    initialWidth?: number
+}) {
     // The one presentation is the tree navigator + content pane; the file TREE pane can be hidden to
     // give the content pane the full width. Searching always forces the tree (its filtered rows ARE
     // the results), so the effective visibility is `showTree || searchActive` (see `treeVisible`).
@@ -22,10 +32,10 @@ export function useDriveTreePane({searchActive}: {searchActive: boolean}) {
     // which is exactly the jank a splitter drag can't afford). `paneW` is the clipping pane (0 when
     // hidden); `innerW` is the tree content, which follows a DRAG (content reflows to the new width)
     // but holds its rest width through a COLLAPSE (content clips, never reflows).
-    const [treeWidth, setTreeWidth] = useState(TREE_WIDTH)
+    const [treeWidth, setTreeWidth] = useState(initialWidth)
     const [treeDragging, setTreeDragging] = useState(false)
-    const paneW = useMotionValue(TREE_WIDTH)
-    const innerW = useMotionValue(TREE_WIDTH)
+    const paneW = useMotionValue(initialWidth)
+    const innerW = useMotionValue(initialWidth)
     const treeDrag = useRef<{startX: number; startW: number} | null>(null)
     const onTreeHandleDown = useCallback(
         (e: React.PointerEvent<HTMLDivElement>) => {
@@ -40,11 +50,13 @@ export function useDriveTreePane({searchActive}: {searchActive: boolean}) {
         (e: React.PointerEvent<HTMLDivElement>) => {
             const st = treeDrag.current
             if (!st) return
-            const w = Math.min(TREE_MAX, Math.max(TREE_MIN, st.startW + (e.clientX - st.startX)))
+            // Mirrored: the tree sits right of the handle, so dragging LEFT widens it.
+            const delta = mirrored ? st.startX - e.clientX : e.clientX - st.startX
+            const w = Math.min(TREE_MAX, Math.max(TREE_MIN, st.startW + delta))
             paneW.set(w)
             innerW.set(w)
         },
-        [paneW, innerW],
+        [paneW, innerW, mirrored],
     )
     const onTreeHandleUp = useCallback(
         (e: React.PointerEvent<HTMLDivElement>) => {

--- a/web/oss/src/components/Drives/useDriveTreePane.ts
+++ b/web/oss/src/components/Drives/useDriveTreePane.ts
@@ -13,17 +13,20 @@ export function useDriveTreePane({
     searchActive,
     mirrored = false,
     initialWidth = TREE_WIDTH,
+    initialShow = true,
 }: {
     searchActive: boolean
     /** Tree pane docked on the RIGHT (content left) — inverts the resize-drag direction. */
     mirrored?: boolean
     /** Starting rest width — hosts with less room (the docked pane) open the tree narrower. */
     initialWidth?: number
+    /** Open with the tree collapsed (a single-file quick look); the toolbar toggle reveals it. */
+    initialShow?: boolean
 }) {
     // The one presentation is the tree navigator + content pane; the file TREE pane can be hidden to
     // give the content pane the full width. Searching always forces the tree (its filtered rows ARE
     // the results), so the effective visibility is `showTree || searchActive` (see `treeVisible`).
-    const [showTree, setShowTree] = useState(true)
+    const [showTree, setShowTree] = useState(initialShow)
     const toggleTree = useCallback(() => setShowTree((v) => !v), [])
     // Draggable tree-pane width. The REST width is React state (persists across a hide/show and feeds
     // the toggle's anticipated-shift math), committed ONCE at drag end. The LIVE width is a
@@ -34,7 +37,8 @@ export function useDriveTreePane({
     // but holds its rest width through a COLLAPSE (content clips, never reflows).
     const [treeWidth, setTreeWidth] = useState(initialWidth)
     const [treeDragging, setTreeDragging] = useState(false)
-    const paneW = useMotionValue(initialWidth)
+    // Start the clip pane at 0 when the tree opens hidden, so mount doesn't flash-animate it shut.
+    const paneW = useMotionValue(initialShow ? initialWidth : 0)
     const innerW = useMotionValue(initialWidth)
     const treeDrag = useRef<{startX: number; startW: number} | null>(null)
     const onTreeHandleDown = useCallback(

--- a/web/oss/src/components/OverlayScrollbar/index.tsx
+++ b/web/oss/src/components/OverlayScrollbar/index.tsx
@@ -123,8 +123,11 @@ const OverlayScrollbar = ({target}: OverlayScrollbarProps) => {
     if (!metrics) return null
 
     return (
+        // right-[6px]: the panel's edge belongs to the splitter divider, whose dragger hit area
+        // extends 6px into the panel with a HIGHER z — a thumb at the edge sat on the resize grip
+        // and stole its pointer. Inset past the dragger so scrollbar and divider never overlap.
         <div
-            className="pointer-events-none absolute right-0 z-20 w-2"
+            className="pointer-events-none absolute right-[6px] z-20 w-2"
             style={{top: metrics.trackTop, height: metrics.trackHeight}}
         >
             <div

--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -491,7 +491,12 @@ const PlaygroundMainView = ({
                                 "playground-generation",
                                 {
                                     "ag-scroll-quiet grow w-full h-full overflow-y-auto overflow-x-hidden":
-                                        !isComparisonView,
+                                        !isComparisonView && !isAgentConfig,
+                                    // Agent chat scrolls itself: overflow-hidden here avoids the
+                                    // reserved scrollbar gutter (a dead strip right of the Files
+                                    // pane divider that the chat could never fill).
+                                    "grow w-full h-full overflow-hidden":
+                                        !isComparisonView && isAgentConfig,
                                     "grow w-full h-full overflow-auto [&::-webkit-scrollbar]:w-0":
                                         isComparisonView,
                                     // Chat = the recessed canvas the message/composer surfaces sit on.

--- a/web/oss/src/components/Playground/Components/MainLayout/index.tsx
+++ b/web/oss/src/components/Playground/Components/MainLayout/index.tsx
@@ -238,8 +238,12 @@ const PlaygroundMainView = ({
     // shrinks it. (A larger max just teased a few px of "expansion" — antd counts px sizes against
     // the full container INCLUDING the 12px gutter bar, whose overflow flex-shrink taxes both
     // panels, so the panel never even reached the old 450.)
+    // Agent bounds are PIXELS on both ends: with a percentage min, a wide (4K) window computes
+    // min (20% ≈ 700px+) ABOVE the fixed max — the panel mounts at the min, the first drag snaps
+    // it to the max, and the divider is then pinned between inverted constraints.
     const configDefaultSize = isAgentConfig ? 440 : "50%"
-    const configMaxSize = isAgentConfig ? 440 : "70%"
+    const configMinSize = isAgentConfig ? 340 : "20%"
+    const configMaxSize = isAgentConfig ? 640 : "70%"
     // Let the runs panel auto-fill in agent mode. A px config default + a "50%" runs default
     // don't sum to 100%, so antd scales BOTH up to fill the container — pushing config past its
     // px max on mount, which then snaps down on the first drag. An undefined runs default fills
@@ -375,7 +379,7 @@ const PlaygroundMainView = ({
                     <SplitterPanel
                         defaultSize={configDefaultSize}
                         size={configCollapsed ? 0 : undefined}
-                        min="20%"
+                        min={configMinSize}
                         max={configMaxSize}
                         // antd panels default to overflow:auto; the section inside owns scrolling, and
                         // a transient overflow leaves Chrome's thin panel scrollbar stuck full-height.

--- a/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundHeader/index.tsx
@@ -85,6 +85,9 @@ type PlaygroundHeaderProps = BaseContainerProps
 /** Entity types that represent evaluator downstream nodes */
 const EVALUATOR_ENTITY_TYPES = ["workflow"]
 
+// Build/Chat switch parked (not removed): Build is the only reachable mode until this flips back.
+const SHOW_MODE_SWITCH = false
+
 /** Resolves a user UUID to a display name via workspace members */
 const MemberAuthor: React.FC<{userId: string}> = ({userId}) => {
     const memberAtom = useMemo(() => workspaceMemberByIdFamily(userId), [userId])
@@ -263,7 +266,8 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
 
     // Build/Chat mode: "chat" maximizes the chat pane (config hidden, session rail shown); "build"
     // is the 2-panel edit view. The boolean maximize atom is the single source of truth (also read
-    // by MainLayout + the chat panel), surfaced here as a persistent, labeled mode switch.
+    // by MainLayout + the chat panel). The switch is hidden for now — Build is the only reachable
+    // mode — but the atom and the Chat rendering register stay wired for its return.
     const chatMaximized = useAtomValue(chatPanelMaximizedAtom)
     const setChatMaximized = useSetAtom(chatPanelMaximizedAtom)
 
@@ -806,15 +810,19 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({className, ...divPro
                     )}
                     {isAgentWorkflow && !chromeHidden && (
                         <>
-                            <Segmented
-                                aria-label="Playground mode"
-                                value={chatMaximized ? "chat" : "build"}
-                                onChange={(value) => setChatMaximized(value === "chat")}
-                                options={[
-                                    {label: "Build", value: "build"},
-                                    {label: "Chat", value: "chat"},
-                                ]}
-                            />
+                            {/* Build/Chat switch hidden for now (Chat mode stays in the codebase);
+                                the playground runs in Build until the switch returns. */}
+                            {SHOW_MODE_SWITCH && (
+                                <Segmented
+                                    aria-label="Playground mode"
+                                    value={chatMaximized ? "chat" : "build"}
+                                    onChange={(value) => setChatMaximized(value === "chat")}
+                                    options={[
+                                        {label: "Build", value: "build"},
+                                        {label: "Chat", value: "chat"},
+                                    ]}
+                                />
+                            )}
                             {(settingsMenuItems?.length ?? 0) > 0 && (
                                 <Dropdown
                                     trigger={["click"]}

--- a/web/oss/test-results/junit.xml
+++ b/web/oss/test-results/junit.xml
@@ -1,75 +1,71 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="30" failures="0" errors="0" time="0.032288188">
-    <testsuite name="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" timestamp="2026-08-01T11:09:33.230Z" hostname="hetznerdev" tests="11" failures="0" errors="0" skipped="0" time="0.010121087">
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; posts the multipart fields and returns a validated response" time="0.003471653">
+<testsuites name="vitest tests" tests="29" failures="0" errors="0" time="0.025659775">
+    <testsuite name="src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts" timestamp="2026-08-12T09:15:15.367Z" hostname="hetznerdev" tests="5" failures="0" errors="0" skipped="0" time="0.006595871">
+        <testcase classname="src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts" name="dropArchivedAgentSessions &gt; drops sessions whose agent is archived" time="0.00298518">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; reports upload progress" time="0.000814108">
+        <testcase classname="src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts" name="dropArchivedAgentSessions &gt; keeps a PINNED session even when its agent is archived" time="0.000411566">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; forwards the abort signal and preserves cancellation" time="0.000653035">
+        <testcase classname="src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts" name="dropArchivedAgentSessions &gt; keeps sessions that have no agent at all" time="0.000352505">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; turns a network failure into a retryable user-safe error" time="0.000686211">
+        <testcase classname="src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts" name="dropArchivedAgentSessions &gt; keeps everything until the archived answer arrives (null)" time="0.000385075">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 413 to a short non-retryable error" time="0.000424088">
-        </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 422 to a short non-retryable error" time="0.000196312">
-        </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 429 to a short non-retryable error" time="0.000154228">
-        </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; maps HTTP 404 to a short non-retryable error" time="0.000152516">
-        </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; honours Retry-After for an upload already in flight" time="0.000302608">
-        </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; logs schema drift and throws a controlled retryable error" time="0.001929139">
-        </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachmentTransport.test.ts" name="uploadAttachment &gt; rejects uppercase attachment ids emitted outside the canonical server contract" time="0.000383141">
+        <testcase classname="src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts" name="dropArchivedAgentSessions &gt; frees capped slots for live sessions" time="0.000417075">
         </testcase>
     </testsuite>
-    <testsuite name="src/components/AgentChatSlice/assets/attachments.test.ts" timestamp="2026-08-01T11:09:33.231Z" hostname="hetznerdev" tests="3" failures="0" errors="0" skipped="0" time="0.00468596">
-        <testcase classname="src/components/AgentChatSlice/assets/attachments.test.ts" name="attachment validation &gt; accepts an unrecognized media type through the other bucket" time="0.00267367">
+    <testsuite name="src/components/Sidebar/dynamic/sessionOptions.test.ts" timestamp="2026-08-12T09:15:15.368Z" hostname="hetznerdev" tests="5" failures="0" errors="0" skipped="0" time="0.006274991">
+        <testcase classname="src/components/Sidebar/dynamic/sessionOptions.test.ts" name="sidebarSessionFilters &gt; excludes pinned ids from the recent request before pagination" time="0.002145593">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachments.test.ts" name="attachment validation &gt; enforces the 10 MB cap for the other bucket" time="0.000485362">
+        <testcase classname="src/components/Sidebar/dynamic/sessionOptions.test.ts" name="sidebarSessionFilters &gt; widens the explicit id group to cover every pinned row" time="0.000358212">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/attachments.test.ts" name="attachment validation &gt; enforces the per-message count cap" time="0.000246304">
+        <testcase classname="src/components/Sidebar/dynamic/sessionOptions.test.ts" name="sidebarSessionFilters &gt; drops the exclude-trigger filter and requests the trigger expansion for the pinned request" time="0.000233281">
         </testcase>
-    </testsuite>
-    <testsuite name="src/components/AgentChatSlice/assets/files.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="2" failures="0" errors="0" skipped="0" time="0.002946947">
-        <testcase classname="src/components/AgentChatSlice/assets/files.test.ts" name="attachment file parts &gt; stores size under providerMetadata.agenta" time="0.001929868">
+        <testcase classname="src/components/Sidebar/dynamic/sessionOptions.test.ts" name="sidebarSessionFilters &gt; requests a window far wider than the rows the group renders" time="0.000233093">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/files.test.ts" name="attachment file parts &gt; uses attachment when a replayed part has no filename" time="0.000179434">
+        <testcase classname="src/components/Sidebar/dynamic/sessionOptions.test.ts" name="sidebarSessionFilters &gt; sends pinned exclusions in the canonical recent request" time="0.001710749">
         </testcase>
     </testsuite>
-    <testsuite name="src/components/AgentChatSlice/assets/inFlightSubmit.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="1" failures="0" errors="0" skipped="0" time="0.004511831">
-        <testcase classname="src/components/AgentChatSlice/assets/inFlightSubmit.test.ts" name="in-flight submit guard &gt; drops a second submit while the first await is unresolved" time="0.003093821">
+    <testsuite name="src/components/Sidebar/dynamic/useSidebarDynamicChildren.test.ts" timestamp="2026-08-12T09:15:15.369Z" hostname="hetznerdev" tests="3" failures="0" errors="0" skipped="0" time="0.004142973">
+        <testcase classname="src/components/Sidebar/dynamic/useSidebarDynamicChildren.test.ts" name="resolveChildren &gt; carries the entity&apos;s tooltip onto each row" time="0.001744459">
+        </testcase>
+        <testcase classname="src/components/Sidebar/dynamic/useSidebarDynamicChildren.test.ts" name="resolveChildren &gt; leaves the tooltip unset when the entity declares none" time="0.000210302">
+        </testcase>
+        <testcase classname="src/components/Sidebar/dynamic/useSidebarDynamicChildren.test.ts" name="resolveChildren &gt; renders up to maxItems rows and adds Show all beyond it" time="0.000943581">
         </testcase>
     </testsuite>
-    <testsuite name="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="11" failures="0" errors="0" skipped="0" time="0.005936531">
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; overlays a persisted approval response with the live response shape" time="0.001695614">
+    <testsuite name="src/components/Sidebar/scopes/viewRegistry.test.ts" timestamp="2026-08-12T09:15:15.370Z" hostname="hetznerdev" tests="11" failures="0" errors="0" skipped="0" time="0.005574563">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; keeps the project rail on an agent&apos;s own pages" time="0.001910912">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; keeps an unanswered request pending" time="0.000248943">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; swaps to the app-context rail for a classic app or evaluator" time="0.00024845">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; lets an executed tool result supersede a later approval response" time="0.00020205">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; holds the app-context rail while agent-ness is unknown" time="0.000304673">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; falls back to the interaction id when the response omits the tool-call id" time="0.00017115">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; falls back to the project rail when unknown with no rail to hold" time="0.000288891">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; reopens deferred call b when its turn-2 approval request arrives" time="0.00078471">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; lets settings win over the held rail" time="0.00022323">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; keeps a real tool error closed when a late approval request arrives" time="0.000160332">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; ignores agent-ness outside an app route" time="0.000221317">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages approval hydration &gt; merges a paused turn with its resume into one message and settles the re-emitted call once" time="0.000819154">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; settles a failed lookup on the app-context rail instead of stranding it" time="0.000220787">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages paused end-marker &gt; flags the message whose turn ended paused (done.stopReason)" time="0.000186444">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; settles the same way from the project rail, so the swap still happens" time="0.000201564">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages paused end-marker &gt; does not flag a normally completed turn" time="0.00014934">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; does not settle while the lookup can still answer" time="0.00022567">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages attachments &gt; rebuilds user attachment references as file parts with filenames" time="0.000353669">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; keeps a known agent on the project rail once its lookup settles" time="0.000251638">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/assets/transcriptToMessages.test.ts" name="transcriptToMessages attachments &gt; ignores an attachment delivery record instead of rendering a part" time="0.000128959">
+        <testcase classname="src/components/Sidebar/scopes/viewRegistry.test.ts" name="resolveSidebarView &gt; never settles a non-app route onto the app-context rail" time="0.000159585">
         </testcase>
     </testsuite>
-    <testsuite name="src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts" timestamp="2026-08-01T11:09:33.232Z" hostname="hetznerdev" tests="2" failures="0" errors="0" skipped="0" time="0.004085832">
-        <testcase classname="src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts" name="attachment upload controls &gt; aborts an in-flight upload before removing its chip" time="0.002586717">
+    <testsuite name="src/components/Sidebar/components/assets/workflowEntitySelection.test.ts" timestamp="2026-08-12T09:15:15.370Z" hostname="hetznerdev" tests="5" failures="0" errors="0" skipped="0" time="0.003071377">
+        <testcase classname="src/components/Sidebar/components/assets/workflowEntitySelection.test.ts" name="resolveWorkflowEntitySelection &gt; uses the workflow resolved from the current route first" time="0.001260199">
         </testcase>
-        <testcase classname="src/components/AgentChatSlice/hooks/useAttachmentUploads.test.ts" name="attachment upload controls &gt; holds retry until the Retry-After deadline" time="0.000224426">
+        <testcase classname="src/components/Sidebar/components/assets/workflowEntitySelection.test.ts" name="resolveWorkflowEntitySelection &gt; resolves the current route workflow id before falling back to recents" time="0.000173705">
+        </testcase>
+        <testcase classname="src/components/Sidebar/components/assets/workflowEntitySelection.test.ts" name="resolveWorkflowEntitySelection &gt; falls back to recents when the current route workflow id is stale" time="0.000126304">
+        </testcase>
+        <testcase classname="src/components/Sidebar/components/assets/workflowEntitySelection.test.ts" name="resolveWorkflowEntitySelection &gt; prefers the recent app on project-level routes" time="0.00010657">
+        </testcase>
+        <testcase classname="src/components/Sidebar/components/assets/workflowEntitySelection.test.ts" name="resolveWorkflowEntitySelection &gt; falls back to the recent evaluator when there is no recent app" time="0.000098764">
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
> Stacked PR: base is `feat/agent-flat-navigation`; this diff contains only the Files-pane / Build-log work.

## Context
The agent playground kept two rendering registers. Build mode showed raw wire tool names, a permanently expanded step log, and approval cards headed by the raw tool name, while the humanized rendering existed only in Chat mode. Files lived in an overlay drawer that covered the conversation instead of sitting beside it.

## Changes
Build mode now uses Chat's humanized register without losing debugging power, and the Files drawer becomes a docked pane.

**Transcript.** Tool rows show the humanized label and source in both modes; the raw wire name moved to the tooltip. Settled turns collapse to the "Used N tools" summary in Build too. Expanding it shows the rows, and in Build each row still expands to its full input/output/error blocks, so no payload is out of reach. File cards (one per file the turn wrote) now render in Build as well.

Before (Build): an always-visible gutter list of rows like `mcp__agenta-tools__commit_revision`.
After (Build): `Used 3 tools` when settled; expanded rows read `Commit revision`, and a click opens the payload.

**Approvals.** The raw-name header row is gone. Build shows the same sentence Chat had ("The agent wants to use X from Y before it can keep going") and keeps its extras: the compact body and the View trace link. One test pinned the old raw-name contract and was updated.

**Files pane.** The session Files drawer is now a full-height resizable pane docked right of the whole chat column (session bar included), 420 to 1600 px wide. Inside it the layout is mirrored: file tree on the right, content on the left, toolbar reversed to match, and its header is pinned to the session bar's 48 px so the border reads as one line. A `«` button in the session bar opens it and flips to `»`; the pane header's `»` collapses it. The open flag is panel-scoped, so adding or switching sessions no longer closes the pane; the previewed file stays per session. Every opener converges on the pane: in-thread file cards, chat file links, the context rail, the inspector's runtime lens, and the config panel's Files section (whose "N files" header now toggles it). The overlay drawer remains only for the agent overview host.

**Mode switch.** The Build/Chat segmented control is parked behind `SHOW_MODE_SWITCH = false` in the playground header. All Chat-mode code stays for its return.

## Tests
- `vitest` suites for AgentChatSlice and Drives pass (34 files, 362 tests), including the updated ApprovalDock contract tests.
- `tsc --noEmit` clean; changed files linted and formatted.
- Verified live on the dev stack through two rounds of screenshot review.

## What to QA
- Open an agent playground and run a turn that uses tools. The settled turn shows a "Used N tools" line; expanding it shows humanized rows; clicking a row reveals input/output blocks.
- Trigger a tool approval. The card reads as a sentence with the friendly tool name; View trace still shows in Build.
- Click `«` in the session bar. The Files pane opens with the tree on the right; the button now shows `»`. Add a session with `+`: the pane stays open.
- In the config panel, click the Files header ("N files"). The pane opens; click again and it closes. Clicking a file row opens the pane preselected on that file.
- Regression: the agent overview page's files card still opens the overlay drawer, and the Turn Inspector still opens and resizes independently of the Files pane.