### PR TITLE
[refactor] The observability filter engine moves into @agenta/observability

### DIFF
--- a/web/oss/src/components/Filters/Filters.tsx
+++ b/web/oss/src/components/Filters/Filters.tsx
@@ -2,6 +2,11 @@ import {useMemo, useState} from "react"
 
 import {evaluatorsListDataAtom, evaluatorFeedbackSchemasAtom} from "@agenta/entities/workflow"
 import {useEnsureEvaluatorEnrichment} from "@agenta/entity-ui/selection"
+import {FieldConfig, fieldConfigByOptionKey} from "@agenta/observability"
+import {getOperator, valueShapeFor} from "@agenta/observability"
+import {planInputs} from "@agenta/observability"
+import {normalizeFilter, toUIValue} from "@agenta/observability"
+import {NUM_OPS, STRING_EQU_AND_CONTAINS_OPS, STRING_EQU_OPS} from "@agenta/observability"
 import {
     ArrowClockwiseIcon,
     CaretDownIcon,
@@ -26,28 +31,10 @@ import {
 import {useAtomValue} from "jotai"
 import isEqual from "lodash/isEqual"
 
-import {
-    FieldConfig,
-    fieldConfigByOptionKey,
-} from "@/oss/components/pages/observability/assets/filters/fieldAdapter"
-import {
-    getOperator,
-    valueShapeFor,
-} from "@/oss/components/pages/observability/assets/filters/operatorRegistry"
-import {planInputs} from "@/oss/components/pages/observability/assets/filters/rulesEngine"
-import {
-    normalizeFilter,
-    toUIValue,
-} from "@/oss/components/pages/observability/assets/filters/valueCodec"
 import useLazyEffect from "@/oss/hooks/useLazyEffect"
 import {Filter, FilterConditions} from "@/oss/lib/Types"
 
 import CustomAntdBadge from "../CustomUIs/CustomAntdBadge"
-import {
-    NUM_OPS,
-    STRING_EQU_AND_CONTAINS_OPS,
-    STRING_EQU_OPS,
-} from "../pages/observability/assets/utils"
 
 import {
     buildCustomTreeNode,
@@ -463,7 +450,7 @@ const Filters: React.FC<Props> = ({
                     fc.baseField === "events" &&
                     (operator === "exists" || operator === "not_exists")
 
-                let valueToSend = value
+                let valueToSend: Filter["value"] | undefined = value
                 if (fc.optionKey === "custom") {
                     const vt = customValueType ?? "string"
                     const effType = vt === "number" ? "number" : "string"
@@ -526,7 +513,7 @@ const Filters: React.FC<Props> = ({
                 const filterForNormalization: Filter = {
                     field: fc.baseField,
                     operator,
-                    value: valueToSend,
+                    value: valueToSend ?? "",
                 }
                 if (keyForFilter) filterForNormalization.key = keyForFilter
                 const normalized = normalizeFilter(filterForNormalization, {

--- a/web/oss/src/components/Filters/helpers/utils.ts
+++ b/web/oss/src/components/Filters/helpers/utils.ts
@@ -1,9 +1,8 @@
+import {getOperator, type FieldConfig} from "@agenta/observability"
 import {TreeSelectProps} from "antd"
 
-import {getOperator} from "@/oss/components/pages/observability/assets/filters/operatorRegistry"
 import {FilterConditions} from "@/oss/lib/Types"
 
-import {FieldConfig} from "../../pages/observability/assets/filters/fieldAdapter"
 import {FilterItem} from "../types"
 import {CustomValueType, FilterGroup, FilterLeaf, FilterMenuNode, SelectOption} from "../types"
 

--- a/web/oss/src/components/Filters/types.d.ts
+++ b/web/oss/src/components/Filters/types.d.ts
@@ -1,6 +1,33 @@
-import type {ComponentType} from "react"
+import type {
+    ColumnGroup,
+    ColumnOption,
+    CustomValueType,
+    FilterGroup,
+    FilterItem,
+    FilterLeaf,
+    FilterMenuNode,
+    IconSlot,
+    InputConfig,
+    RowValidation,
+    SelectOption,
+} from "@agenta/observability"
 
-import type {IconProps} from "@phosphor-icons/react"
+// The filter-menu model belongs to the observability filter engine; re-exported
+// here (type-only, so nothing lands in the bundle) for the app's existing callers.
+export type {
+    ColumnGroup,
+    ColumnOption,
+    CustomValueType,
+    FilterGroup,
+    FilterItem,
+    FilterLeaf,
+    FilterMenuNode,
+    InputConfig,
+    RowValidation,
+    SelectOption,
+}
+
+export type IconType = IconSlot
 
 export interface Props {
     filterData?: Filter[]
@@ -14,98 +41,8 @@ export interface Props {
      * renders from the returned array, but mutations still target the
      * underlying `filter` state by index, so the reconciler MUST preserve
      * array length and per-index order.
-     *
-     * Used by observability to keep the permanent references row's label
-     * ("Application ID" vs "Evaluator ID") in sync with the dialog's local
-     * `trace_type` selection *before* the user clicks Apply — without the
-     * reconciler, the label only refreshes after Apply when the atom
-     * re-derives the permanent row.
      */
     reconcileFilterRows?: (rows: FilterItem[]) => FilterItem[]
 }
 
-export type CustomValueType = "string" | "number" | "boolean"
-
-export type FilterItem = Filter & {
-    selectedField?: string
-    fieldType?: "string" | "number" | "exists"
-    isCustomField?: boolean
-    baseField?: string
-    selectedLabel?: string
-    customValueType?: CustomValueType
-}
-
-export interface RowValidation {
-    isValid: boolean
-    valueInvalid?: boolean
-}
-
 export type FieldMenuItem = Required<MenuProps>["items"][number]
-
-export interface ColumnOption {
-    value: string
-    label: string
-    type?: string
-    icon?: ComponentType<IconProps>
-    children?: ColumnOption[]
-}
-
-export interface ColumnGroup {
-    field: string
-    label: string
-    options: ColumnOption[]
-}
-
-export type IconType = ComponentType<{size?: number}>
-
-type InputKind = "text" | "select" | "none"
-
-export interface SelectOption {
-    label: string
-    value: string | number
-    selectable?: boolean
-    children?: SelectOption[]
-    pathLabel?: string
-}
-
-type InputConfig =
-    | {kind: "text"; placeholder?: string}
-    | {
-          kind: "select"
-          options?: SelectOption[]
-          placeholder?: string
-          usesAttributeKeyTree?: boolean
-          treePath?: string
-      }
-    | {kind: "none"; display?: string}
-
-export interface FilterLeaf {
-    kind: "leaf"
-    field: string
-    value: string
-    label: string
-    type: "string" | "number" | "exists"
-    icon?: IconType
-    operatorOptions?: {value: any; label: string}[]
-    defaultValue?: Filter["value"]
-    keyInput?: InputConfig
-    valueInput?: InputConfig
-    disableValueInput?: boolean
-    valueDisplayText?: string
-    displayLabel?: string
-    optionKey?: string
-    queryKey?: string
-    referenceCategory?: string
-    referenceProperty?: string
-}
-
-export interface FilterGroup {
-    kind: "group"
-    label: string
-    children: (FilterLeaf | FilterGroup)[]
-    icon?: IconType
-    defaultValue?: string
-    titleClickDisplayLabel?: string
-    leafDisplayLabel?: string
-}
-export type FilterMenuNode = FilterLeaf | FilterGroup

--- a/web/oss/src/components/pages/evaluations/onlineEvaluation/EmptyStateOnlineEvaluation/EmptyStateOnlineEvaluation.tsx
+++ b/web/oss/src/components/pages/evaluations/onlineEvaluation/EmptyStateOnlineEvaluation/EmptyStateOnlineEvaluation.tsx
@@ -1,6 +1,6 @@
+import {EmptyState} from "@agenta/ui/components/presentational"
 import {Lightning} from "@phosphor-icons/react"
 
-import EmptyState from "@/oss/components/EmptyState"
 import {EMPTY_STATE_VIDEOS} from "@/oss/components/EmptyState/videos"
 
 const EmptyStateOnlineEvaluation = ({onCreateEvaluation}: {onCreateEvaluation: () => void}) => {

--- a/web/oss/src/components/pages/evaluations/onlineEvaluation/OnlineEvaluationDrawer.tsx
+++ b/web/oss/src/components/pages/evaluations/onlineEvaluation/OnlineEvaluationDrawer.tsx
@@ -8,6 +8,7 @@ import {
     evaluatorTemplatesQueryAtom,
     isOnlineCapableEvaluator,
 } from "@agenta/entities/workflow"
+import {getFilterColumns} from "@agenta/observability"
 import {message} from "@agenta/ui/app-message"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import {Button, Collapse, DatePicker, Form, Input, Select, Switch, Tooltip, Typography} from "antd"
@@ -19,7 +20,6 @@ import dynamic from "next/dynamic"
 import {useRouter} from "next/router"
 import {v4 as uuidv4} from "uuid"
 
-import getFilterColumns from "@/oss/components/pages/observability/assets/getFilterColumns"
 import type {Filter} from "@/oss/lib/Types"
 
 import {

--- a/web/oss/src/components/pages/evaluations/onlineEvaluation/assets/helpers.ts
+++ b/web/oss/src/components/pages/evaluations/onlineEvaluation/assets/helpers.ts
@@ -1,4 +1,5 @@
-import {inferReferenceOptionKey} from "@/oss/components/pages/observability/assets/filters/referenceUtils"
+import {inferReferenceOptionKey} from "@agenta/observability"
+
 import type {Filter, FilterConditions, FilterValue} from "@/oss/lib/Types"
 
 import type {

--- a/web/oss/src/components/pages/evaluations/onlineEvaluation/components/FiltersPreview.tsx
+++ b/web/oss/src/components/pages/evaluations/onlineEvaluation/components/FiltersPreview.tsx
@@ -1,14 +1,11 @@
 import {useMemo} from "react"
 
+import {fieldConfigByOptionKey, type FieldConfig} from "@agenta/observability"
+import {getOperator} from "@agenta/observability"
+import {getFilterColumns} from "@agenta/observability"
 import {Typography} from "antd"
 import clsx from "clsx"
 
-import {
-    fieldConfigByOptionKey,
-    type FieldConfig,
-} from "@/oss/components/pages/observability/assets/filters/fieldAdapter"
-import {getOperator} from "@/oss/components/pages/observability/assets/filters/operatorRegistry"
-import getFilterColumns from "@/oss/components/pages/observability/assets/getFilterColumns"
 import type {Filter, FilterConditions, FilterValue} from "@/oss/lib/Types"
 
 import type {QueryFilteringPayload} from "../../../../../services/onlineEvaluations/api"

--- a/web/oss/src/components/pages/observability/assets/filterColumnIcons.ts
+++ b/web/oss/src/components/pages/observability/assets/filterColumnIcons.ts
@@ -1,0 +1,41 @@
+/**
+ * Desktop's icon set for the filter field menu.
+ *
+ * The column table itself lives in `@agenta/observability/filters` as pure
+ * metadata; each host overlays its own icons by node label so the table can be
+ * shared with surfaces that use a different icon library.
+ */
+import type {FilterColumnIcons} from "@agenta/observability"
+import {
+    ArrowBendRightDownIcon,
+    ArrowBendRightUpIcon,
+    Chats,
+    CoinsIcon,
+    GearFineIcon,
+    LightningIcon,
+    MagnifyingGlassIcon,
+    PencilIcon,
+    PlusCircleIcon,
+    SpinnerIcon,
+    TimerIcon,
+    TreeStructureIcon,
+    TreeViewIcon,
+    WarningOctagonIcon,
+} from "@phosphor-icons/react"
+
+export const FILTER_COLUMN_ICONS: FilterColumnIcons = {
+    "Text search": MagnifyingGlassIcon,
+    "Input Key": ArrowBendRightDownIcon,
+    "Output Key": ArrowBendRightUpIcon,
+    Trace: TreeStructureIcon,
+    Span: TreeViewIcon,
+    Session: Chats,
+    "Duration (ms)": TimerIcon,
+    "Cost ($)": CoinsIcon,
+    Tokens: PlusCircleIcon,
+    Annotation: PencilIcon,
+    Status: SpinnerIcon,
+    Exception: WarningOctagonIcon,
+    Reference: GearFineIcon,
+    Custom: LightningIcon,
+}

--- a/web/oss/src/components/pages/observability/assets/utils.ts
+++ b/web/oss/src/components/pages/observability/assets/utils.ts
@@ -1,4 +1,3 @@
-import {FilterConditions} from "@/oss/lib/Types"
 import {TraceSpanNode} from "@/oss/services/tracing/types"
 
 export const filterTree = (node: TraceSpanNode, search: string) => {
@@ -17,47 +16,3 @@ export const filterTree = (node: TraceSpanNode, search: string) => {
 
     return null
 }
-
-export const COLLECTION_MEMBERSHIP_OPS: {value: FilterConditions; label: string}[] = [
-    {value: "in", label: "contains"},
-    {value: "not_in", label: "does not contain"},
-]
-
-export const STRING_EQU_OPS: {value: FilterConditions; label: string}[] = [
-    {value: "is", label: "is"},
-    {value: "is_not", label: "is not"},
-]
-
-export const STRING_EQU_AND_CONTAINS_OPS: {value: FilterConditions; label: string}[] = [
-    ...STRING_EQU_OPS,
-    ...COLLECTION_MEMBERSHIP_OPS,
-]
-
-export const EXISTS_OPS: {value: FilterConditions; label: string}[] = [
-    {value: "exists", label: "exists"},
-    {value: "not_exists", label: "not exists"},
-]
-
-export const STRING_SEARCH_OPS: {value: FilterConditions; label: string}[] = [
-    {value: "contains", label: "contains"},
-    {value: "startswith", label: "starts with"},
-    {value: "endswith", label: "ends with"},
-    // {value: "matches", label: "matches"},
-    // {value: "like", label: "like"},
-]
-
-export const STRING_COMPARISON_OPS: {value: FilterConditions; label: string}[] = [
-    {value: "gt", label: ">"},
-    {value: "lt", label: "<"},
-    {value: "gte", label: ">="},
-    {value: "lte", label: "<="},
-]
-
-export const NUM_OPS: {value: FilterConditions; label: string}[] = [
-    {value: "eq", label: "="},
-    {value: "neq", label: "!="},
-    {value: "gt", label: ">"},
-    {value: "lt", label: "<"},
-    {value: "gte", label: ">="},
-    {value: "lte", label: "<="},
-]

--- a/web/packages/agenta-observability/src/etl/exportUtils.ts
+++ b/web/packages/agenta-observability/src/etl/exportUtils.ts
@@ -2,14 +2,8 @@ import type {TraceSpan} from "@agenta/entities/trace"
 import {formatCurrency, formatLatency, formatTokenUsage} from "@agenta/shared/utils"
 import {formatDay} from "@agenta/shared/utils/dateTime"
 
-import type {TraceSpanNode} from "@/oss/services/tracing/types"
-import {
-    getAgDataInputs,
-    getAgDataOutputs,
-    getCost,
-    getLatency,
-    getTokens,
-} from "@/oss/state/newObservability/selectors/tracing"
+import type {TraceSpanNode} from "../core/traceSpan"
+import {getAgDataInputs, getAgDataOutputs, getCost, getLatency, getTokens} from "../state/selectors"
 
 export const DEFAULT_TRACE_EXPORT_HEADERS = [
     "Trace ID",

--- a/web/packages/agenta-observability/src/filters/attributeKeyOptions.ts
+++ b/web/packages/agenta-observability/src/filters/attributeKeyOptions.ts
@@ -1,5 +1,6 @@
-import {SelectOption} from "@/oss/components/Filters/types"
-import {TraceSpanNode} from "@/oss/services/tracing/types"
+import type {TraceSpanNode} from "../core/traceSpan"
+
+import type {SelectOption} from "./types"
 
 export type AttributeKeyTreeOption = SelectOption & {
     children?: AttributeKeyTreeOption[]

--- a/web/packages/agenta-observability/src/filters/fieldAdapter.ts
+++ b/web/packages/agenta-observability/src/filters/fieldAdapter.ts
@@ -1,9 +1,8 @@
-import {FilterLeaf, FilterGroup, FilterMenuNode} from "@/oss/components/Filters/types"
-import {FilterConditions} from "@/oss/lib/Types"
+import type {Filter, FilterConditions} from "../core/types"
 
-import {FILTER_COLUMNS} from "../constants"
-
+import {FILTER_COLUMNS} from "./filterColumns"
 import {ScalarType, getOperatorsForType} from "./operatorRegistry"
+import type {FilterGroup, FilterLeaf, FilterMenuNode, SelectOption} from "./types"
 
 export interface FieldConfig {
     optionKey: string
@@ -14,13 +13,13 @@ export interface FieldConfig {
     operatorOptions?: {value: FilterConditions; label: string}[]
     keyInput?: {
         kind: "none" | "text" | "select"
-        options?: any[]
+        options?: SelectOption[]
         placeholder?: string
         usesAttributeKeyTree?: boolean
         treePath?: string
     }
-    valueInput?: {kind: "none" | "text" | "select"; options?: any[]; placeholder?: string}
-    defaultValue?: any
+    valueInput?: {kind: "none" | "text" | "select"; options?: SelectOption[]; placeholder?: string}
+    defaultValue?: Filter["value"]
     disableValueInput?: boolean
     valueDisplayText?: string
     queryKey?: string
@@ -33,8 +32,8 @@ export interface FieldConfig {
      */
     referenceCategory?: string
     // reference/application/evaluator transforms
-    toExternal?: (normalized: any) => any
-    toUI?: (external: any) => any
+    toExternal?: (normalized: unknown) => Filter["value"]
+    toUI?: (external: unknown) => Filter["value"]
 }
 
 const toScalar = (leaf: FilterLeaf): ScalarType => leaf.type as ScalarType
@@ -64,10 +63,10 @@ const walk = (nodes: FilterMenuNode[], acc: FieldConfig[]) => {
                 ? leaf.keyInput.kind === "select"
                     ? {
                           kind: "select",
-                          options: (leaf as any).keyInput?.options,
+                          options: leaf.keyInput.options,
                           placeholder: leaf.keyInput.placeholder,
-                          usesAttributeKeyTree: (leaf as any).keyInput?.usesAttributeKeyTree,
-                          treePath: (leaf as any).keyInput?.treePath,
+                          usesAttributeKeyTree: leaf.keyInput.usesAttributeKeyTree,
+                          treePath: leaf.keyInput.treePath,
                       }
                     : leaf.keyInput.kind === "text"
                       ? {
@@ -80,8 +79,9 @@ const walk = (nodes: FilterMenuNode[], acc: FieldConfig[]) => {
                 ? {kind: "none"}
                 : leaf.valueInput
                   ? {
-                        kind: leaf.valueInput.kind as any,
-                        options: (leaf as any).valueInput?.options,
+                        kind: leaf.valueInput.kind,
+                        options:
+                            leaf.valueInput.kind === "select" ? leaf.valueInput.options : undefined,
                         placeholder:
                             leaf.valueInput.kind === "text"
                                 ? leaf.valueInput.placeholder
@@ -98,7 +98,7 @@ const walk = (nodes: FilterMenuNode[], acc: FieldConfig[]) => {
 
         // references/application/evaluator → keep simple mapper
         if (leaf.referenceCategory && leaf.referenceProperty) {
-            cfg.toExternal = (normalized: any) => {
+            cfg.toExternal = (normalized: unknown) => {
                 const entries = Array.isArray(normalized)
                     ? normalized
                     : normalized
@@ -118,23 +118,25 @@ const walk = (nodes: FilterMenuNode[], acc: FieldConfig[]) => {
                         : {...withKey, [leaf.referenceProperty!]: String(v)},
                 )
             }
-            cfg.toUI = (external: any) => {
+            cfg.toUI = (external: unknown) => {
                 const arr = Array.isArray(external) ? external : external ? [external] : []
                 // De-dup by extracted value. References can OR-match across
                 // slots in a single condition (e.g.,
                 // `[{id:X, key:eval}, {id:X, key:app}]` for "match this entity
                 // in either slot"). Without de-dup the UI shows the same id
                 // twice. The backend keeps the rich shape via `toExternal`.
-                const mapped = arr.map((e: any) =>
-                    e && typeof e === "object" ? (e[leaf.referenceProperty!] ?? "") : e,
+                const mapped = arr.map((e: unknown) =>
+                    e && typeof e === "object"
+                        ? ((e as Record<string, unknown>)[leaf.referenceProperty!] ?? "")
+                        : e,
                 )
                 const seen = new Set<string>()
-                const out: any[] = []
+                const out: Filter["value"][] = []
                 for (const v of mapped) {
                     const key = typeof v === "string" ? v : JSON.stringify(v)
                     if (seen.has(key)) continue
                     seen.add(key)
-                    out.push(v)
+                    out.push(v as Filter["value"])
                 }
                 return out
             }

--- a/web/packages/agenta-observability/src/filters/getFilterColumns.ts
+++ b/web/packages/agenta-observability/src/filters/getFilterColumns.ts
@@ -1,7 +1,6 @@
-import {FilterGroup, FilterLeaf, FilterMenuNode} from "@/oss/components/Filters/types"
-
-import {FILTER_COLUMNS} from "./constants"
-import {AttributeKeyTreeOption} from "./filters/attributeKeyOptions"
+import {AttributeKeyTreeOption} from "./attributeKeyOptions"
+import {FILTER_COLUMNS} from "./filterColumns"
+import type {FilterGroup, FilterLeaf, FilterMenuNode, IconSlot} from "./types"
 
 const cloneTreeOption = (option: AttributeKeyTreeOption): AttributeKeyTreeOption => ({
     ...option,
@@ -81,8 +80,24 @@ const applyAttributeKeyOptions = (
     return nodes
 }
 
+/** Host icon set, keyed by a node's `label`. Nodes with no entry render iconless. */
+export type FilterColumnIcons = Record<string, IconSlot>
+
+const applyIcons = (nodes: FilterMenuNode[], icons?: FilterColumnIcons): FilterMenuNode[] => {
+    if (!icons) return nodes
+    nodes.forEach((node) => {
+        const icon = icons[node.label]
+        if (icon) node.icon = icon
+        if (node.kind === "group") applyIcons((node as FilterGroup).children, icons)
+    })
+    return nodes
+}
+
 /** Single entry-point used by the UI */
-const getFilterColumns = (attributeKeyOptions?: AttributeKeyTreeOption[]): FilterMenuNode[] =>
-    applyAttributeKeyOptions(cloneNodes(FILTER_COLUMNS), attributeKeyOptions)
+const getFilterColumns = (
+    attributeKeyOptions?: AttributeKeyTreeOption[],
+    icons?: FilterColumnIcons,
+): FilterMenuNode[] =>
+    applyIcons(applyAttributeKeyOptions(cloneNodes(FILTER_COLUMNS), attributeKeyOptions), icons)
 
 export default getFilterColumns

--- a/web/packages/agenta-observability/src/filters/index.ts
+++ b/web/packages/agenta-observability/src/filters/index.ts
@@ -1,0 +1,32 @@
+export type {
+    ColumnGroup,
+    ColumnOption,
+    CustomValueType,
+    FilterGroup,
+    FilterItem,
+    FilterLeaf,
+    FilterMenuNode,
+    IconSlot,
+    InputConfig,
+    RowValidation,
+    SelectOption,
+} from "./types"
+
+export {FILTER_COLUMNS} from "./filterColumns"
+export * from "./operatorSets"
+export {
+    OPERATORS,
+    getOperator,
+    getOperatorsForType,
+    valueShapeFor,
+    type OperatorDef,
+    type ScalarType,
+    type ValueShape,
+} from "./operatorRegistry"
+export {planInputs, type InputPlan} from "./rulesEngine"
+export {normalizeFilter, normalizeValue, toUIValue, type NormalizerCtx} from "./valueCodec"
+export {buildFieldConfigs, fieldConfigByOptionKey, type FieldConfig} from "./fieldAdapter"
+export {buildAttributeKeyTreeOptions, type AttributeKeyTreeOption} from "./attributeKeyOptions"
+export {inferReferenceOptionKey, normalizeReferenceValue, parseReferenceKey} from "./referenceUtils"
+export {default as getFilterColumns, type FilterColumnIcons} from "./getFilterColumns"
+export {reconcileFilterRows} from "./reconcileFilterRows"

--- a/web/packages/agenta-observability/src/filters/operatorRegistry.ts
+++ b/web/packages/agenta-observability/src/filters/operatorRegistry.ts
@@ -1,4 +1,4 @@
-import {FilterConditions} from "@/oss/lib/Types"
+import type {FilterConditions} from "../core/types"
 
 export type ScalarType = "string" | "number" | "exists"
 export type ValueShape = "none" | "single" | "list" | "range"

--- a/web/packages/agenta-observability/src/filters/operatorSets.ts
+++ b/web/packages/agenta-observability/src/filters/operatorSets.ts
@@ -1,0 +1,45 @@
+import type {FilterConditions} from "../core/types"
+
+export const COLLECTION_MEMBERSHIP_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "in", label: "contains"},
+    {value: "not_in", label: "does not contain"},
+]
+
+export const STRING_EQU_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "is", label: "is"},
+    {value: "is_not", label: "is not"},
+]
+
+export const STRING_EQU_AND_CONTAINS_OPS: {value: FilterConditions; label: string}[] = [
+    ...STRING_EQU_OPS,
+    ...COLLECTION_MEMBERSHIP_OPS,
+]
+
+export const EXISTS_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "exists", label: "exists"},
+    {value: "not_exists", label: "not exists"},
+]
+
+export const STRING_SEARCH_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "contains", label: "contains"},
+    {value: "startswith", label: "starts with"},
+    {value: "endswith", label: "ends with"},
+    // {value: "matches", label: "matches"},
+    // {value: "like", label: "like"},
+]
+
+export const STRING_COMPARISON_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "gt", label: ">"},
+    {value: "lt", label: "<"},
+    {value: "gte", label: ">="},
+    {value: "lte", label: "<="},
+]
+
+export const NUM_OPS: {value: FilterConditions; label: string}[] = [
+    {value: "eq", label: "="},
+    {value: "neq", label: "!="},
+    {value: "gt", label: ">"},
+    {value: "lt", label: "<"},
+    {value: "gte", label: ">="},
+    {value: "lte", label: "<="},
+]

--- a/web/packages/agenta-observability/src/filters/reconcileFilterRows.ts
+++ b/web/packages/agenta-observability/src/filters/reconcileFilterRows.ts
@@ -1,0 +1,75 @@
+import type {FieldConfig} from "./fieldAdapter"
+import type {FilterItem} from "./types"
+
+/**
+ * Display-only projection that keeps the permanent references row's label in
+ * sync with the dialog's local `trace_type` selection.
+ *
+ * After Apply the atom regenerates the references row's `attributes.key` from
+ * the effective trace_type (annotation → evaluator, invocation → application).
+ * While the user is still editing, the row sits in local state, so changing
+ * trace_type would otherwise have no visible effect on the references label.
+ *
+ * Only ever rewrites label/field metadata — never `value` — and preserves array
+ * length and per-index order, because the dialog mutates the underlying state
+ * by index.
+ *
+ * Skipped for non-evaluator workflows: the references row is always pinned to
+ * `application` there, so flipping the label would be misleading.
+ */
+export const reconcileFilterRows = (
+    rows: FilterItem[],
+    workflowKind: string | null | undefined,
+    filterFieldMap: Map<string, FieldConfig>,
+): FilterItem[] => {
+    if (workflowKind !== "evaluator") return rows
+
+    const tt = rows.find((r) => r.selectedField === "trace_type" || r.field === "trace_type")
+    // Mirror the atom's trace_type intent resolution (controls.ts):
+    // honour `is_not`/`not_in` against the 2-value enum by flipping.
+    const op = tt?.operator
+    const rawValue = Array.isArray(tt?.value) ? tt?.value[0] : tt?.value
+    const isAffirm = op === "is" || op === "in"
+    const isNeg = op === "is_not" || op === "not_in"
+    const normalize = (x: unknown): "annotation" | "invocation" | null =>
+        x === "annotation" ? "annotation" : x === "invocation" ? "invocation" : null
+    const flip = (x: unknown): "annotation" | "invocation" | null =>
+        x === "annotation" ? "invocation" : x === "invocation" ? "annotation" : null
+    let effective: "annotation" | "invocation" | null = null
+    if (tt && isAffirm) effective = normalize(rawValue)
+    else if (tt && isNeg) effective = flip(rawValue)
+
+    // When trace_type is absent, fall through to "no opinion" — keep whatever
+    // the row currently shows (which came from the atom's default).
+    if (!effective) return rows
+
+    const targetCategory = effective === "invocation" ? "application" : "evaluator"
+
+    return rows.map((row) => {
+        if (!row.isPermanent) return row
+        const optionKey = row.selectedField || row.field
+        if (!optionKey) return row
+        const fc = filterFieldMap.get(optionKey)
+        if (!fc?.referenceCategory) return row
+        if (fc.referenceCategory !== "application" && fc.referenceCategory !== "evaluator") {
+            return row
+        }
+        if (fc.referenceCategory === targetCategory) return row
+        // Corresponding FieldConfig for the target category, same referenceProperty.
+        let target: FieldConfig | undefined
+        for (const candidate of filterFieldMap.values()) {
+            if (candidate.referenceCategory !== targetCategory) continue
+            if (candidate.referenceProperty !== fc.referenceProperty) continue
+            target = candidate
+            break
+        }
+        if (!target) return row
+        return {
+            ...row,
+            field: target.optionKey,
+            selectedField: target.optionKey,
+            selectedLabel: target.label,
+            baseField: target.baseField,
+        }
+    })
+}

--- a/web/packages/agenta-observability/src/filters/referenceUtils.ts
+++ b/web/packages/agenta-observability/src/filters/referenceUtils.ts
@@ -1,4 +1,4 @@
-import type {FilterValue} from "@/oss/lib/Types"
+import type {FilterValue} from "../core/types"
 
 type ReferenceCategory =
     | "reference"
@@ -44,7 +44,7 @@ const detectPropertyFromValue = (entry: Record<string, unknown>): string => {
 
 export const parseReferenceKey = (
     rawKey?: string,
-    rawValue?: any,
+    rawValue?: unknown,
 ): {category: ReferenceCategory; property: string} => {
     if (typeof rawKey === "string" && rawKey.trim() !== "") {
         const [categoryPart, propertyPart] = rawKey.split(".")

--- a/web/packages/agenta-observability/src/filters/rulesEngine.ts
+++ b/web/packages/agenta-observability/src/filters/rulesEngine.ts
@@ -1,4 +1,4 @@
-import {FilterConditions} from "@/oss/lib/Types"
+import type {FilterConditions} from "../core/types"
 
 import {FieldConfig} from "./fieldAdapter"
 import {getOperator, valueShapeFor} from "./operatorRegistry"

--- a/web/packages/agenta-observability/src/filters/types.ts
+++ b/web/packages/agenta-observability/src/filters/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Filter-menu metadata.
+ *
+ * The shapes the filter engine reads. Deliberately free of any rendering
+ * dependency: `icon` is a slot the host fills with its own icon set (OSS uses
+ * Phosphor, mobile uses Lucide), so the column table stays shareable.
+ */
+import type {ComponentType} from "react"
+
+import type {Filter} from "../core/types"
+
+export type IconSlot = ComponentType<{size?: number}>
+
+export type CustomValueType = "string" | "number" | "boolean"
+
+export type FilterItem = Filter & {
+    selectedField?: string
+    fieldType?: "string" | "number" | "exists"
+    isCustomField?: boolean
+    baseField?: string
+    selectedLabel?: string
+    customValueType?: CustomValueType
+}
+
+export interface RowValidation {
+    isValid: boolean
+    valueInvalid?: boolean
+}
+
+export interface ColumnOption {
+    value: string
+    label: string
+    type?: string
+    icon?: IconSlot
+    children?: ColumnOption[]
+}
+
+export interface ColumnGroup {
+    field: string
+    label: string
+    options: ColumnOption[]
+}
+
+export interface SelectOption {
+    label: string
+    value: string | number
+    selectable?: boolean
+    children?: SelectOption[]
+    pathLabel?: string
+}
+
+export type InputConfig =
+    | {kind: "text"; placeholder?: string}
+    | {
+          kind: "select"
+          options?: SelectOption[]
+          placeholder?: string
+          usesAttributeKeyTree?: boolean
+          treePath?: string
+      }
+    | {kind: "none"; display?: string}
+
+export interface FilterLeaf {
+    kind: "leaf"
+    field: string
+    value: string
+    label: string
+    type: "string" | "number" | "exists"
+    icon?: IconSlot
+    operatorOptions?: {value: Filter["operator"]; label: string}[]
+    defaultValue?: Filter["value"]
+    keyInput?: InputConfig
+    valueInput?: InputConfig
+    disableValueInput?: boolean
+    valueDisplayText?: string
+    displayLabel?: string
+    optionKey?: string
+    queryKey?: string
+    referenceCategory?: string
+    referenceProperty?: string
+}
+
+export interface FilterGroup {
+    kind: "group"
+    label: string
+    children: (FilterLeaf | FilterGroup)[]
+    icon?: IconSlot
+    defaultValue?: string
+    titleClickDisplayLabel?: string
+    leafDisplayLabel?: string
+}
+
+export type FilterMenuNode = FilterLeaf | FilterGroup

--- a/web/packages/agenta-observability/src/filters/valueCodec.ts
+++ b/web/packages/agenta-observability/src/filters/valueCodec.ts
@@ -1,5 +1,5 @@
-import {Filter} from "@/oss/lib/Types"
-import {coerceNumericValue} from "@/oss/state/newObservability"
+import type {Filter} from "../core/types"
+import {coerceNumericValue} from "../utils/filterCoercion"
 
 import {ScalarType, ValueShape, valueShapeFor} from "./operatorRegistry"
 
@@ -22,8 +22,8 @@ const toStringList = (v: unknown): string[] => {
 
 const toNumberPair = (v: unknown): number[] => {
     const out: number[] = []
-    const push = (raw: any) => {
-        const n = coerceNumericValue(raw) as any
+    const push = (raw: unknown) => {
+        const n = coerceNumericValue(raw as Filter["value"])
         if (typeof n === "number" && Number.isFinite(n)) out.push(n)
     }
     if (Array.isArray(v)) v.slice(0, 2).forEach(push)
@@ -47,8 +47,8 @@ const toNumberPair = (v: unknown): number[] => {
 export interface NormalizerCtx {
     fieldType: ScalarType
     opId: Filter["operator"]
-    toExternal?: (normalized: any) => any
-    toUI?: (external: any) => any
+    toExternal?: (normalized: unknown) => unknown
+    toUI?: (external: unknown) => unknown
 }
 
 export const normalizeValue = (raw: unknown, shape: ValueShape, t: ScalarType) => {
@@ -67,10 +67,10 @@ export const normalizeValue = (raw: unknown, shape: ValueShape, t: ScalarType) =
         return t === "number" ? list.map(coerceNumericValue) : list
     }
     if (Array.isArray(raw)) return raw[0] ?? ""
-    return t === "number" ? coerceNumericValue(raw as any) : (raw ?? "")
+    return t === "number" ? coerceNumericValue(raw as Filter["value"]) : (raw ?? "")
 }
 
-export const toUIValue = (external: any, shape: ValueShape) => {
+export const toUIValue = (external: unknown, shape: ValueShape) => {
     if (shape === "none") return ""
     if (shape === "range") return Array.isArray(external) ? external : []
     if (shape === "list") return Array.isArray(external) ? external : toStringList(external)
@@ -81,5 +81,5 @@ export const normalizeFilter = (f: Filter, ctx: NormalizerCtx): Filter => {
     const shape = valueShapeFor(ctx.opId, ctx.fieldType)
     const normalized = normalizeValue(f.value, shape, ctx.fieldType)
     const value = ctx.toExternal ? ctx.toExternal(normalized) : normalized
-    return {...f, value}
+    return {...f, value: value as Filter["value"]}
 }

--- a/web/packages/agenta-observability/tests/unit/reconcileFilterRows.test.ts
+++ b/web/packages/agenta-observability/tests/unit/reconcileFilterRows.test.ts
@@ -1,0 +1,155 @@
+import {describe, expect, it} from "vitest"
+
+import type {FieldConfig} from "../../src/filters/fieldAdapter"
+import {reconcileFilterRows} from "../../src/filters/reconcileFilterRows"
+import type {FilterItem} from "../../src/filters/types"
+
+const fc = (over: Partial<FieldConfig>): FieldConfig =>
+    ({
+        optionKey: "x",
+        baseField: "references",
+        label: "X",
+        type: "string",
+        operatorIds: [],
+        ...over,
+    }) as FieldConfig
+
+const APP = fc({
+    optionKey: "application.id",
+    label: "Application ID",
+    referenceCategory: "application",
+    referenceProperty: "id",
+})
+const EVAL = fc({
+    optionKey: "evaluator.id",
+    label: "Evaluator ID",
+    referenceCategory: "evaluator",
+    referenceProperty: "id",
+})
+const EVAL_SLUG = fc({
+    optionKey: "evaluator.slug",
+    label: "Evaluator Slug",
+    referenceCategory: "evaluator",
+    referenceProperty: "slug",
+})
+const MAP = new Map([
+    [APP.optionKey, APP],
+    [EVAL.optionKey, EVAL],
+    [EVAL_SLUG.optionKey, EVAL_SLUG],
+])
+
+const permanentRow = (f: FieldConfig): FilterItem =>
+    ({
+        field: f.optionKey,
+        selectedField: f.optionKey,
+        selectedLabel: f.label,
+        baseField: f.baseField,
+        operator: "in",
+        value: ["abc"],
+        isPermanent: true,
+    }) as FilterItem
+
+const traceTypeRow = (operator: string, value: unknown): FilterItem =>
+    ({field: "trace_type", selectedField: "trace_type", operator, value}) as FilterItem
+
+describe("reconcileFilterRows", () => {
+    it("is a no-op for non-evaluator workflows", () => {
+        const rows = [permanentRow(EVAL), traceTypeRow("is", "invocation")]
+        expect(reconcileFilterRows(rows, "application", MAP)).toBe(rows)
+        expect(reconcileFilterRows(rows, null, MAP)).toBe(rows)
+    })
+
+    it("flips the permanent row to application when trace_type is invocation", () => {
+        const out = reconcileFilterRows(
+            [permanentRow(EVAL), traceTypeRow("is", "invocation")],
+            "evaluator",
+            MAP,
+        )
+        expect(out[0].selectedLabel).toBe("Application ID")
+        expect(out[0].selectedField).toBe("application.id")
+        expect(out[0].field).toBe("application.id")
+    })
+
+    it("flips to evaluator when trace_type is annotation", () => {
+        const out = reconcileFilterRows(
+            [permanentRow(APP), traceTypeRow("is", "annotation")],
+            "evaluator",
+            MAP,
+        )
+        expect(out[0].selectedLabel).toBe("Evaluator ID")
+    })
+
+    it("honours a negated operator by flipping the enum", () => {
+        const out = reconcileFilterRows(
+            [permanentRow(EVAL), traceTypeRow("is_not", "annotation")],
+            "evaluator",
+            MAP,
+        )
+        expect(out[0].selectedLabel).toBe("Application ID")
+
+        const back = reconcileFilterRows(
+            [permanentRow(APP), traceTypeRow("not_in", ["invocation"])],
+            "evaluator",
+            MAP,
+        )
+        expect(back[0].selectedLabel).toBe("Evaluator ID")
+    })
+
+    it("unwraps an array value for affirmative operators", () => {
+        const out = reconcileFilterRows(
+            [permanentRow(EVAL), traceTypeRow("in", ["invocation"])],
+            "evaluator",
+            MAP,
+        )
+        expect(out[0].selectedLabel).toBe("Application ID")
+    })
+
+    it("keeps the row untouched when trace_type is absent or unrecognised", () => {
+        const rows = [permanentRow(EVAL)]
+        expect(reconcileFilterRows(rows, "evaluator", MAP)).toBe(rows)
+
+        const odd = [permanentRow(EVAL), traceTypeRow("is", "something-else")]
+        expect(reconcileFilterRows(odd, "evaluator", MAP)).toBe(odd)
+    })
+
+    it("never touches non-permanent rows", () => {
+        const user = {field: "evaluator.id", operator: "in", value: ["z"]} as FilterItem
+        const out = reconcileFilterRows(
+            [user, traceTypeRow("is", "invocation")],
+            "evaluator",
+            MAP,
+        )
+        expect(out[0]).toBe(user)
+    })
+
+    it("matches the target on referenceProperty, not just category", () => {
+        const out = reconcileFilterRows(
+            [permanentRow(EVAL_SLUG), traceTypeRow("is", "invocation")],
+            "evaluator",
+            MAP,
+        )
+        // no application/slug config exists, so the row is left alone
+        expect(out[0].selectedLabel).toBe("Evaluator Slug")
+    })
+
+    it("preserves array length and order (the dialog mutates by index)", () => {
+        const rows = [
+            traceTypeRow("is", "invocation"),
+            permanentRow(EVAL),
+            {field: "span_type", operator: "is", value: "chat"} as FilterItem,
+        ]
+        const out = reconcileFilterRows(rows, "evaluator", MAP)
+        expect(out).toHaveLength(3)
+        expect(out[0].field).toBe("trace_type")
+        expect(out[2].field).toBe("span_type")
+    })
+
+    it("never rewrites a row's value", () => {
+        const out = reconcileFilterRows(
+            [permanentRow(EVAL), traceTypeRow("is", "invocation")],
+            "evaluator",
+            MAP,
+        )
+        expect(out[0].value).toEqual(["abc"])
+    })
+})


### PR DESCRIPTION
## Context

The filter logic behind the observability filter dialog decided which inputs to show, how to normalise a filter, and how to reconcile rows when `trace_type` changes. All of it sat inside a 1,983-line antd component in the app, so mobile could not filter traces without copying the rules.

Third of five stacked PRs. Base is `obs/wp1-observability-state`.

## Changes

The engine moves to `@agenta/observability/filters`: `planInputs`, `normalizeFilter`, `toUIValue`, `fieldConfigByOptionKey`, `getFilterColumns`, `reconcileFilterRows`, the attribute-key tree builder and the export utilities. Unit tests come with them.

Field-menu icons stay out of the package. `FILTER_COLUMNS` is icon-free and `getFilterColumns(attributeKeyOptions, icons)` takes an icon map keyed by node label, so desktop can inject Phosphor and mobile can inject Lucide. The app's map lives in the new `assets/filterColumnIcons.ts`.

Two contracts worth knowing before you read the diff:

- `FilterValue` is deliberately `object`, not `Record<string, unknown>`. Interfaces have no implicit index signature, so the stricter form rejects every named filter-value type.
- `reconcileFilterRows` preserves array length and per-index order, because the dialog mutates its rows by index.

## Tests / notes

- `@agenta/observability` builds, lints and passes its unit tests, including 10 new ones covering `reconcileFilterRows`.
- Verified in the browser that the field menu still renders all 14 top-level nodes with their icons after the icon map became host-injected.
- Intermediate lanes in this stack may not build standalone. Only the tip is verified green.
