### PR TITLE
[refactor] Break the antd ColumnsType coupling with a local ColumnDef

### DIFF
--- a/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/etl/useEtlColumns.tsx
@@ -19,8 +19,8 @@
 import {useMemo} from "react"
 
 import {groupRunColumns, type ColumnGroup, type RunSchema} from "@agenta/entities/evaluationRun/etl"
+import type {ColumnDefs} from "@agenta/ui/table"
 import {Tooltip} from "antd"
-import type {ColumnsType} from "antd/es/table"
 
 import type {PreviewTableRow} from "../atoms/tableRows"
 
@@ -57,8 +57,8 @@ export const useEtlColumns = ({
     runId,
     schema,
     comparisonSchemas,
-}: UseEtlColumnsArgs): ColumnsType<PreviewTableRow> => {
-    return useMemo<ColumnsType<PreviewTableRow>>(() => {
+}: UseEtlColumnsArgs): ColumnDefs<PreviewTableRow> => {
+    return useMemo<ColumnDefs<PreviewTableRow>>(() => {
         if (!schema || !projectId || !runId) return []
 
         // "metrics"-kind columns are intentionally skipped here. The

--- a/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
+++ b/web/oss/src/components/EvalRunDetails/utils/buildPreviewColumns.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 
 import {ColumnVisibilityHeader, type ExtendedColumn as ExtendedColumnType} from "@agenta/ui/table"
+import type {ColumnDef, ColumnDefs} from "@agenta/ui/table"
 import {Tooltip} from "antd"
-import type {ColumnsType, ColumnType} from "antd/es/table"
 import clsx from "clsx"
 
 import type {
@@ -109,13 +109,13 @@ export interface BuildPreviewColumnsArgs<RowType> {
         human: MetricColumnDefinition[]
     }
     evaluationType: "auto" | "human" | "online"
-    getRenderer?: (column: EvaluationTableColumn) => ColumnType<RowType>["render"] | undefined
+    getRenderer?: (column: EvaluationTableColumn) => ColumnDef<RowType>["render"] | undefined
     isSkeletonRow?: (record: RowType) => boolean
     renderSkeleton?: (context: SkeletonRenderContext<RowType>) => React.ReactNode
 }
 
 export interface BuildPreviewColumnsResult<RowType> {
-    columns: ColumnsType<RowType>
+    columns: ColumnDefs<RowType>
 }
 
 /** antd column extended with the visibility-menu label consumed by useColumnVisibility */
@@ -144,7 +144,7 @@ const createStaticMetricColumns = <RowType,>(
             metricType: metric.metricType,
         }
 
-        const baseRender: ColumnType<RowType>["render"] = (_value, record: any) => (
+        const baseRender: ColumnDef<RowType>["render"] = (_value, record: any) => (
             <PreviewEvaluationMetricCell
                 scenarioId={record.scenarioId ?? record.id}
                 runId={record.runId}
@@ -170,7 +170,7 @@ const createStaticMetricColumns = <RowType,>(
             }
         }
 
-        const render: ColumnType<RowType>["render"] = (value, record, index) => {
+        const render: ColumnDef<RowType>["render"] = (value, record, index) => {
             if (options.isSkeletonRow?.(record)) {
                 return options.getSkeletonContent({
                     type: "staticMetric",
@@ -226,8 +226,8 @@ export function buildPreviewColumns<RowType>({
 
     const wrapRender = (
         column: EvaluationTableColumn,
-        baseRender: ColumnType<RowType>["render"],
-    ): ColumnType<RowType>["render"] => {
+        baseRender: ColumnDef<RowType>["render"],
+    ): ColumnDef<RowType>["render"] => {
         if (!isSkeletonRow) {
             return baseRender
         }
@@ -286,7 +286,7 @@ export function buildPreviewColumns<RowType>({
             if (column.metaRole === "scenarioIndexStatus") {
                 const headerLabel = column.displayLabel ?? column.label
                 const titleNode = renderEllipsisTitle(headerLabel)
-                const baseRender: ColumnType<RowType>["render"] = (
+                const baseRender: ColumnDef<RowType>["render"] = (
                     value: number | string,
                     record: any,
                 ) => {
@@ -328,10 +328,7 @@ export function buildPreviewColumns<RowType>({
             if (column.metaRole === "timestamp") {
                 const headerLabel = column.displayLabel ?? column.label ?? "Timestamp"
                 const titleNode = renderEllipsisTitle(headerLabel)
-                const baseRender: ColumnType<RowType>["render"] = (
-                    _value: unknown,
-                    record: any,
-                ) => {
+                const baseRender: ColumnDef<RowType>["render"] = (_value: unknown, record: any) => {
                     const timestamp = record?.timestamp
                     if (!timestamp) {
                         return (
@@ -375,7 +372,7 @@ export function buildPreviewColumns<RowType>({
             if (column.metaRole === "action") {
                 const headerLabel = column.displayLabel ?? column.label
                 const titleNode = renderEllipsisTitle(headerLabel)
-                const baseRender: ColumnType<RowType>["render"] = (_: unknown, record: any) => (
+                const baseRender: ColumnDef<RowType>["render"] = (_: unknown, record: any) => (
                     <PreviewEvaluationActionCell
                         scenarioId={record.scenarioId ?? record.id}
                         runId={record.runId}
@@ -397,7 +394,7 @@ export function buildPreviewColumns<RowType>({
             }
         }
 
-        const fallbackRender: ColumnType<RowType>["render"] = () => (
+        const fallbackRender: ColumnDef<RowType>["render"] = () => (
             <span className="text-xs text-neutral-500">
                 {column.description || column.path || column.metricType || "—"}
             </span>
@@ -405,7 +402,7 @@ export function buildPreviewColumns<RowType>({
 
         const customRender = getRenderer?.(column)
 
-        const renderByStepType: ColumnType<RowType>["render"] | undefined = (() => {
+        const renderByStepType: ColumnDef<RowType>["render"] | undefined = (() => {
             if (column.stepType === "input") {
                 return (_: unknown, record: any) => (
                     <PreviewEvaluationInputCell
@@ -477,7 +474,7 @@ export function buildPreviewColumns<RowType>({
     })
 
     orderedGroups.forEach((group) => {
-        const children: ColumnType<RowType>[] = []
+        const children: ColumnDef<RowType>[] = []
 
         group.columnIds.forEach((columnId) => {
             const column = columnsMap.get(columnId)

--- a/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
+++ b/web/oss/src/components/EvaluationRunsTablePOC/hooks/useEvaluationRunsColumns/index.tsx
@@ -7,7 +7,7 @@ import {
     createTableColumns,
     type TableColumnConfig,
 } from "@agenta/ui/table"
-import type {ColumnsType} from "antd/es/table"
+import type {ColumnDefs} from "@agenta/ui/table"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {
@@ -691,7 +691,7 @@ const useEvaluationRunsColumns = ({
         isMetricHidden,
     ])
 
-    const columns = useMemo<ColumnsType<EvaluationRunTableRow>>(() => {
+    const columns = useMemo<ColumnDefs<EvaluationRunTableRow>>(() => {
         const columnConfigs: TableColumnConfig<EvaluationRunTableRow>[] = []
 
         columnConfigs.push(

--- a/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/LinkedSpansTabItem/index.tsx
+++ b/web/oss/src/components/SharedDrawers/TraceDrawer/components/TraceContent/components/LinkedSpansTabItem/index.tsx
@@ -3,8 +3,8 @@ import {useCallback, useMemo} from "react"
 import {CopyTooltip as EnhancedTooltip} from "@agenta/ui/copy-tooltip"
 import {InfiniteVirtualTable} from "@agenta/ui/table"
 import type {InfiniteTableRowBase} from "@agenta/ui/table"
+import type {ColumnDefs} from "@agenta/ui/table"
 import {Tag, Typography} from "antd"
-import type {ColumnsType} from "antd/es/table"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {getObservabilityColumns} from "@/oss/components/pages/observability/assets/getObservabilityColumns"
@@ -67,8 +67,8 @@ const LinkedSpansTabItem = ({isActive}: LinkedSpansTabItemProps) => {
         [linkedSpans],
     )
 
-    const baseColumns = useMemo<ColumnsType<LinkedSpanTableRow>>(
-        () => getObservabilityColumns({evaluatorSlugs}) as ColumnsType<LinkedSpanTableRow>,
+    const baseColumns = useMemo<ColumnDefs<LinkedSpanTableRow>>(
+        () => getObservabilityColumns({evaluatorSlugs}) as ColumnDefs<LinkedSpanTableRow>,
         [evaluatorSlugs],
     )
 
@@ -95,8 +95,8 @@ const LinkedSpansTabItem = ({isActive}: LinkedSpansTabItemProps) => {
         [linkedSpans],
     )
 
-    const filteredColumns = useMemo<ColumnsType<LinkedSpanTableRow>>(() => {
-        const idColumn: ColumnsType<LinkedSpanTableRow>[number] = {
+    const filteredColumns = useMemo<ColumnDefs<LinkedSpanTableRow>>(() => {
+        const idColumn: ColumnDefs<LinkedSpanTableRow>[number] = {
             title: "ID",
             key: "id",
             dataIndex: ["span_id"],

--- a/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
+++ b/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
@@ -10,11 +10,11 @@ import {
     useTypeChipFeature,
     type ExtendedColumn,
 } from "@agenta/ui/table"
+import type {ColumnDef, ColumnDefs} from "@agenta/ui/table"
 import {TypeChip, type ChipVariant} from "@agenta/ui/type-chip"
 import {PlusOutlined} from "@ant-design/icons"
 import {Button, Input, Skeleton, Tooltip} from "antd"
 import type {MenuProps} from "antd"
-import type {ColumnType, ColumnsType} from "antd/es/table"
 import clsx from "clsx"
 import {useAtomValue} from "jotai"
 import {getDefaultStore} from "jotai/vanilla"
@@ -445,7 +445,7 @@ export function TestcasesTableShell(props: TestcasesTableShellProps) {
     // Columns definition
     // Use TestcaseCell for entity-aware rendering (reads from entity atoms in global store)
     // Supports grouped columns (e.g., "group.column" renders under "group" header)
-    const columns = useMemo<ColumnsType<TestcaseTableRow>>(() => {
+    const columns = useMemo<ColumnDefs<TestcaseTableRow>>(() => {
         const isEditable = mode === "edit"
 
         const getRenamedColumnKey = (col: Column, newName: string) => {
@@ -485,7 +485,7 @@ export function TestcasesTableShell(props: TestcasesTableShellProps) {
         const createColumnDef = (
             col: Column,
             displayName: string,
-        ): ColumnType<TestcaseTableRow> => ({
+        ): ColumnDef<TestcaseTableRow> => ({
             key: col.key,
             dataIndex: col.key,
             title:
@@ -555,7 +555,7 @@ export function TestcasesTableShell(props: TestcasesTableShellProps) {
         const createCollapsedColumnDef = (
             groupPath: string,
             _childColumns: Column[],
-        ): ColumnType<TestcaseTableRow> => {
+        ): ColumnDef<TestcaseTableRow> => {
             const displayName = groupPath.includes(".")
                 ? groupPath.substring(groupPath.lastIndexOf(".") + 1)
                 : groupPath

--- a/web/oss/src/components/TestcasesTableNew/utils/groupColumns.ts
+++ b/web/oss/src/components/TestcasesTableNew/utils/groupColumns.ts
@@ -1,6 +1,6 @@
 import type {ReactNode} from "react"
 
-import type {ColumnType} from "antd/es/table"
+import type {ColumnDef} from "@agenta/ui/table"
 
 import type {Column} from "@/oss/state/entities/testcase/columnState"
 
@@ -10,13 +10,13 @@ import type {Column} from "@/oss/state/entities/testcase/columnState"
 export interface ColumnGroup<T> {
     key: string
     title: string
-    children: ColumnType<T>[]
+    children: ColumnDef<T>[]
 }
 
 /**
  * Result of grouping columns - either a regular column or a group
  */
-export type GroupedColumn<T> = ColumnType<T> | ColumnGroup<T>
+export type GroupedColumn<T> = ColumnDef<T> | ColumnGroup<T>
 
 /** Default max depth for group expansion (1 = only top-level groups expand by default) */
 const DEFAULT_MAX_DEPTH = 1
@@ -32,7 +32,7 @@ export interface GroupColumnsOptions<T> {
     /** Function to render the group header (receives groupName, isCollapsed, childCount) */
     renderGroupHeader?: (groupName: string, isCollapsed: boolean, childCount: number) => ReactNode
     /** Function to create a collapsed column (shows full JSON) */
-    createCollapsedColumnDef?: (groupName: string, childColumns: Column[]) => ColumnType<T>
+    createCollapsedColumnDef?: (groupName: string, childColumns: Column[]) => ColumnDef<T>
     /** Maximum depth for group expansion (default: 2). Beyond this depth, columns show as JSON */
     maxDepth?: number
 }
@@ -90,11 +90,11 @@ function isExpandedColumn(col: Column): boolean {
  */
 function groupColumnsRecursive<T>(
     columns: Column[],
-    createColumnDef: (col: Column, displayName: string) => ColumnType<T>,
+    createColumnDef: (col: Column, displayName: string) => ColumnDef<T>,
     options: GroupColumnsOptions<T> | undefined,
     parentPath: string,
     currentDepth: number,
-): ColumnType<T>[] {
+): ColumnDef<T>[] {
     const {
         collapsedGroups,
         onGroupHeaderClick,
@@ -103,7 +103,7 @@ function groupColumnsRecursive<T>(
         maxDepth = DEFAULT_MAX_DEPTH,
     } = options ?? {}
 
-    const result: ColumnType<T>[] = []
+    const result: ColumnDef<T>[] = []
     const groupMap = new Map<string, {columns: Column[]; order: number}>()
     let orderCounter = 0
 
@@ -116,7 +116,7 @@ function groupColumnsRecursive<T>(
             result.push({
                 ...createColumnDef(col, col.name),
                 __order: orderCounter++,
-            } as ColumnType<T> & {__order: number})
+            } as ColumnDef<T> & {__order: number})
             return
         }
 
@@ -142,7 +142,7 @@ function groupColumnsRecursive<T>(
             result.push({
                 ...createColumnDef(col, displayName),
                 __order: orderCounter++,
-            } as ColumnType<T> & {__order: number})
+            } as ColumnDef<T> & {__order: number})
         }
     })
 
@@ -165,7 +165,7 @@ function groupColumnsRecursive<T>(
             result.push({
                 ...collapsedCol,
                 __order: group.order,
-            } as ColumnType<T> & {__order: number})
+            } as ColumnDef<T> & {__order: number})
         } else {
             // Expanded state: recursively group children
             const children = groupColumnsRecursive(
@@ -187,20 +187,20 @@ function groupColumnsRecursive<T>(
                 title,
                 children,
                 __order: group.order,
-            } as ColumnType<T> & {__order: number})
+            } as ColumnDef<T> & {__order: number})
         }
     })
 
     // Sort by original order to maintain column sequence
     result.sort((a, b) => {
-        const orderA = (a as ColumnType<T> & {__order?: number}).__order ?? 0
-        const orderB = (b as ColumnType<T> & {__order?: number}).__order ?? 0
+        const orderA = (a as ColumnDef<T> & {__order?: number}).__order ?? 0
+        const orderB = (b as ColumnDef<T> & {__order?: number}).__order ?? 0
         return orderA - orderB
     })
 
     // Clean up __order property
     result.forEach((col) => {
-        delete (col as ColumnType<T> & {__order?: number}).__order
+        delete (col as ColumnDef<T> & {__order?: number}).__order
     })
 
     return result
@@ -209,10 +209,10 @@ function groupColumnsRecursive<T>(
 /**
  * Count leaf columns in a nested column structure
  */
-function countLeafColumns<T>(columns: ColumnType<T>[]): number {
+function countLeafColumns<T>(columns: ColumnDef<T>[]): number {
     let count = 0
     columns.forEach((col) => {
-        const children = (col as ColumnType<T> & {children?: ColumnType<T>[]}).children
+        const children = (col as ColumnDef<T> & {children?: ColumnDef<T>[]}).children
         if (children && children.length > 0) {
             count += countLeafColumns(children)
         } else {
@@ -238,8 +238,8 @@ function countLeafColumns<T>(columns: ColumnType<T>[]): number {
  */
 export function groupColumns<T>(
     columns: Column[],
-    createColumnDef: (col: Column, displayName: string) => ColumnType<T>,
+    createColumnDef: (col: Column, displayName: string) => ColumnDef<T>,
     options?: GroupColumnsOptions<T>,
-): ColumnType<T>[] {
+): ColumnDef<T>[] {
     return groupColumnsRecursive(columns, createColumnDef, options, "", 0)
 }

--- a/web/oss/src/components/TestsetsTable/assets/createTestsetsColumns.tsx
+++ b/web/oss/src/components/TestsetsTable/assets/createTestsetsColumns.tsx
@@ -1,5 +1,6 @@
 import {UserAuthorLabel} from "@agenta/entities/shared/user"
 import {createStandardColumns} from "@agenta/ui/table"
+import type {ColumnDefs} from "@agenta/ui/table"
 import {LoadingOutlined, MinusCircleOutlined, PlusCircleOutlined} from "@ant-design/icons"
 import {
     ArrowCounterClockwise,
@@ -11,7 +12,6 @@ import {
     PencilSimple,
 } from "@phosphor-icons/react"
 import {Tag} from "antd"
-import type {ColumnsType} from "antd/es/table"
 
 import CommitMessageCell from "@/oss/components/TestsetsTable/components/CommitMessageCell"
 import type {ExportFileType} from "@/oss/services/testsets/api"
@@ -50,7 +50,7 @@ export function createTestsetsColumns(
         exportingRowKey = null,
         expandState,
     }: CreateTestsetsColumnsOptions,
-): ColumnsType<TestsetTableRow> {
+): ColumnDefs<TestsetTableRow> {
     const isArchived = mode === "archived"
     const isSelectMode = interactionMode === "select"
     const isManageMode = !isSelectMode

--- a/web/oss/src/components/TestsetsTable/hooks/useTestsetsColumns.tsx
+++ b/web/oss/src/components/TestsetsTable/hooks/useTestsetsColumns.tsx
@@ -1,9 +1,9 @@
 import {useMemo} from "react"
 
 import {formatDate} from "@agenta/shared/utils/dateTime"
+import type {ColumnDefs} from "@agenta/ui/table"
 import {ArchiveIcon, GearSix, Note, Copy, PencilSimple} from "@phosphor-icons/react"
 import {Button, Dropdown} from "antd"
-import type {ColumnsType} from "antd/es/table"
 
 import {copyToClipboard} from "@/oss/lib/helpers/copyToClipboard"
 
@@ -22,7 +22,7 @@ export const useTestsetsColumns = ({
     onClone,
     onRename,
     onDelete,
-}: UseTestsetsColumnsParams): ColumnsType<TestsetTableRow> => {
+}: UseTestsetsColumnsParams): ColumnDefs<TestsetTableRow> => {
     return useMemo(
         () => [
             {

--- a/web/oss/src/components/pages/agents/AgentsTableSection.tsx
+++ b/web/oss/src/components/pages/agents/AgentsTableSection.tsx
@@ -6,15 +6,16 @@ import type {
     TableFeaturePagination,
     TableScopeConfig,
 } from "@agenta/ui/table"
+import type {ColumnDefs} from "@agenta/ui/table"
 import {PlusIcon, TrayIcon} from "@phosphor-icons/react"
 import {Button, Input, Space} from "antd"
-import type {ColumnsType, TableProps} from "antd/es/table"
+import type {TableProps} from "antd/es/table"
 
 import type {AppWorkflowRow} from "@/oss/components/pages/app-management/store"
 import {useDebounceInput} from "@/oss/hooks/useDebounceInput"
 
 interface AgentsTableSectionProps {
-    columns: ColumnsType<AppWorkflowRow>
+    columns: ColumnDefs<AppWorkflowRow>
     rows: AppWorkflowRow[]
     tableScope: TableScopeConfig
     pagination: TableFeaturePagination<AppWorkflowRow>

--- a/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
+++ b/web/oss/src/components/pages/observability/assets/getObservabilityColumns.tsx
@@ -10,15 +10,14 @@ import {
 import {CostCell} from "@agenta/observability-ui"
 import {DurationCell} from "@agenta/observability-ui"
 import {NodeNameCell} from "@agenta/observability-ui"
+import {SpanIdChip} from "@agenta/observability-ui"
 import {StatusRenderer} from "@agenta/observability-ui"
 import {TimestampCell} from "@agenta/observability-ui"
 import {UsageCell} from "@agenta/observability-ui"
 import {sanitizeDataWithBlobUrls} from "@agenta/shared/utils"
 import {LastInputMessageCell, SmartCellContent} from "@agenta/ui/cell-renderers"
 import {CopyTooltip as TooltipWithCopyAction} from "@agenta/ui/copy-tooltip"
-import {ColumnVisibilityMenuTrigger, type ExtendedColumn} from "@agenta/ui/table"
-import {Tag} from "antd"
-import {ColumnsType} from "antd/es/table"
+import {ColumnVisibilityMenuTrigger, type ColumnDefs, type ExtendedColumn} from "@agenta/ui/table"
 
 import {TraceSpanNode} from "@/oss/services/tracing/types"
 
@@ -31,13 +30,13 @@ interface ObservabilityColumnsProps {
 // Row alias: TraceSpanNode lacks the required key + index signature of InfiniteTableRowBase.
 export type TraceRow = TraceSpanNode & {key: Key; [key: string]: unknown}
 
-// antd column extended with props consumed by the InfiniteVirtualTable layer.
+// Table column extended with props consumed by the InfiniteVirtualTable layer.
 type ObservabilityColumn = ExtendedColumn<TraceRow>
 
-const collectDefaultHiddenColumnKeys = <T,>(columns: ColumnsType<T>): string[] => {
+const collectDefaultHiddenColumnKeys = <T,>(columns: ColumnDefs<T>): string[] => {
     const hiddenKeys = new Set<string>()
 
-    const visit = (cols: ColumnsType<T>) => {
+    const visit = (cols: ColumnDefs<T>) => {
         cols.forEach((column) => {
             const key = column.key != null ? String(column.key) : null
             if (key && (column as {defaultHidden?: boolean}).defaultHidden) {
@@ -71,9 +70,7 @@ export const getObservabilityColumns = ({evaluatorSlugs}: ObservabilityColumnsPr
                 const shortId = spanId ? spanId.split("-")[0] : "-"
                 return (
                     <TooltipWithCopyAction copyText={spanId || ""} title="Copy span id">
-                        <Tag className="font-mono bg-[var(--ag-c-0517290F)]" bordered={false}>
-                            # {shortId}
-                        </Tag>
+                        <SpanIdChip id={shortId} />
                     </TooltipWithCopyAction>
                 )
             },

--- a/web/oss/src/components/pages/observability/assets/types.d.ts
+++ b/web/oss/src/components/pages/observability/assets/types.d.ts
@@ -1,17 +1,10 @@
-import {Avatar} from "antd"
-import {ColumnsType} from "antd/es/table"
-
-import {TraceSpanNode} from "@/oss/services/tracing/types"
+import type {ColumnDefs} from "@agenta/ui/table"
 
 export interface ObservabilityHeaderProps {
     /** Only the CSV export pipeline reads this — it derives the header row from the column titles. */
-    columns: ColumnsType<any>
+    columns: ColumnDefs<any>
     componentType: "traces" | "sessions"
     isLoading?: boolean
     onRefresh?: () => void | Promise<void>
     refreshTrigger?: number
 }
-
-export type AvatarTreeContentProps = {
-    value: TraceSpanNode
-} & React.ComponentProps<typeof Avatar>

--- a/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
+++ b/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
@@ -7,10 +7,11 @@ import type {
     TableFeaturePagination,
     TableScopeConfig,
 } from "@agenta/ui/table"
+import type {ColumnDefs} from "@agenta/ui/table"
 import {FolderIcon, PlusIcon, SquaresFourIcon, TrashIcon} from "@phosphor-icons/react"
 import {Button, Dropdown, Input, Space} from "antd"
 import type {MenuProps} from "antd"
-import type {ColumnsType, TableProps} from "antd/es/table"
+import type {TableProps} from "antd/es/table"
 
 import {getAppTypeIcon} from "../assets/iconHelpers"
 import type {FolderTreeItem} from "../assets/utils"
@@ -19,7 +20,7 @@ import type {PromptsTableRow} from "../types"
 import SetupWorkflowIcon from "./SetupWorkflowIcon"
 
 interface PromptsTableSectionProps {
-    columns: ColumnsType<PromptsTableRow>
+    columns: ColumnDefs<PromptsTableRow>
     tableRows: PromptsTableRow[]
     tableScope: TableScopeConfig
     tablePagination: TableFeaturePagination<PromptsTableRow>

--- a/web/packages/agenta-entity-ui/src/shared/EntityTable.tsx
+++ b/web/packages/agenta-entity-ui/src/shared/EntityTable.tsx
@@ -57,9 +57,9 @@ import {
     type TableScopeConfig,
     type TypeChipConfig,
 } from "@agenta/ui/table"
+import type {ColumnDef, ColumnDefs} from "@agenta/ui/table"
 import {Checkbox, RadioGroup, RadioGroupItem} from "@agenta/ui/ui"
 import type {GroupColumnsOptions} from "@agenta/ui/utils"
-import type {ColumnType, ColumnsType} from "antd/es/table"
 import {useAtomValue, useSetAtom} from "jotai"
 import {getDefaultStore} from "jotai/vanilla"
 
@@ -130,9 +130,9 @@ export interface EntityTableProps<
      */
     grouping?: boolean | GroupColumnsOptions<TRow, TColumn>
     /** Extra columns prepended to the column list */
-    prependColumns?: ColumnsType<TRow>
+    prependColumns?: ColumnDefs<TRow>
     /** Extra columns appended to the column list */
-    appendColumns?: ColumnsType<TRow>
+    appendColumns?: ColumnDefs<TRow>
     /** Optional cell renderer override for entity-specific display rules. */
     renderCell?: (
         value: unknown,
@@ -410,7 +410,7 @@ export function EntityTable<
     }, [grouping, collapsedGroups, toggleGroupCollapse, getRowData])
 
     // Build table columns
-    const tableColumns: ColumnsType<TRow> = useMemo(() => {
+    const tableColumns: ColumnDefs<TRow> = useMemo(() => {
         // Selection column. Header is `Checkbox` (select-all) ONLY when the
         // table is multi-select — single-select has no select-all concept.
         // Row control mirrors that: `Checkbox` for multi-select, `Radio` for
@@ -419,7 +419,7 @@ export function EntityTable<
         // checkboxes whose behaviour silently replaces the previous
         // selection on every click — the "we do something else behind the
         // curtains" UX wart Arda flagged on 2026-06-01.
-        const selectionColumn: ColumnType<TRow> = {
+        const selectionColumn: ColumnDef<TRow> = {
             key: "__selection",
             title: multiSelect ? (
                 <Checkbox
@@ -481,7 +481,7 @@ export function EntityTable<
         } as BuildEntityColumnsOptions<TRow, TColumn>)
 
         // Assemble final columns
-        const result: ColumnsType<TRow> = []
+        const result: ColumnDefs<TRow> = []
         if (selectable) result.push(selectionColumn)
         if (prependColumns) result.push(...prependColumns)
         result.push(...entityColumns)

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/antdColumns.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/antdColumns.ts
@@ -1,0 +1,19 @@
+import type {ColumnsType as AntdColumnsType} from "antd/es/table"
+
+import type {ColumnDefs} from "./columnDef"
+
+/**
+ * The one place the table's own column model meets antd's.
+ *
+ * `ColumnDef` is deliberately narrower than antd's `ColumnType` in two spots — `dataIndex`
+ * excludes antd's `SpecialString<RecordType>` arm (which admits the whole record type), and the
+ * cell-props bags are keyed to `HTMLElement` rather than `any` — so the crossing is asserted
+ * rather than inferred. Keep the assertion here; do not import antd column types elsewhere in
+ * this directory.
+ */
+export const toAntdColumns = <RecordType>(columns: ColumnDefs<RecordType>) =>
+    columns as unknown as AntdColumnsType<RecordType>
+
+/** Columns arriving from an antd-typed call site, on their way into the table. */
+export const fromAntdColumns = <RecordType>(columns: AntdColumnsType<RecordType>) =>
+    columns as unknown as ColumnDefs<RecordType>

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/columnDef.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/columnDef.ts
@@ -1,0 +1,117 @@
+import type {CSSProperties, HTMLAttributes, Key, ReactNode, TdHTMLAttributes} from "react"
+
+/**
+ * The table's own column model. It is structurally the shape `<Table>` consumes but owns no
+ * antd types, so the rest of the table can be ported off antd one piece at a time. The antd
+ * bridge lives in `./antdColumns`.
+ *
+ * Function-valued props are declared with METHOD syntax on purpose: method params are checked
+ * bivariantly, so a column may annotate `render(value: string, …)` and still be assignable
+ * here. That is what antd buys with `any`, without the `any`.
+ */
+
+export type ColumnAlign = "start" | "end" | "left" | "right" | "center" | "justify" | "match-parent"
+
+export type ColumnFixed = "start" | "end" | "left" | "right" | boolean
+
+export type ColumnEllipsis = boolean | {showTitle?: boolean}
+
+export type ColumnRowScope = "row" | "rowgroup"
+
+export type ColumnDataIndex = string | number | readonly (string | number)[]
+
+export type ColumnSortOrder = "descend" | "ascend" | null
+
+/** Props a column hands to a header or body cell — the `<td>`/`<th>` attribute bag. */
+export type ColumnCellProps = HTMLAttributes<HTMLElement> & TdHTMLAttributes<HTMLElement>
+
+/** A cell renderer may return a node, or a node plus cell overrides (colSpan, style, …). */
+export interface RenderedColumnCell {
+    props?: {
+        key?: Key
+        className?: string
+        style?: CSSProperties
+        colSpan?: number
+        rowSpan?: number
+    }
+    children?: ReactNode
+}
+
+export type ColumnRenderResult = ReactNode | RenderedColumnCell
+
+export interface ColumnFilterItem {
+    text: ReactNode
+    value: Key | boolean
+    children?: ColumnFilterItem[]
+}
+
+/** Argument passed to the function form of `title`. Sort state is opaque — the virtual table
+ * never sorts, and typing the column here would make every title contravariantly fragile. */
+export interface ColumnTitleContext {
+    sortOrder?: ColumnSortOrder
+    sortColumns?: {column: unknown; order: ColumnSortOrder}[]
+    filters?: Record<string, (Key | boolean)[]>
+}
+
+export type ColumnTitle = ReactNode | ((context: ColumnTitleContext) => ReactNode)
+
+export type ColumnCompareFn<RecordType> = (
+    a: RecordType,
+    b: RecordType,
+    sortOrder?: ColumnSortOrder,
+) => number
+
+export interface ColumnSorterConfig<RecordType> {
+    compare?: ColumnCompareFn<RecordType>
+    multiple?: number
+}
+
+interface ColumnDefBase<RecordType> {
+    title?: ColumnTitle
+    key?: Key
+    className?: string
+    hidden?: boolean
+    fixed?: ColumnFixed
+    ellipsis?: ColumnEllipsis
+    align?: ColumnAlign
+    rowScope?: ColumnRowScope
+    width?: number | string
+    minWidth?: number
+    colSpan?: number
+    rowSpan?: number
+    onHeaderCell?(column: ColumnDefs<RecordType>[number], index?: number): ColumnCellProps
+    onCell?(record: RecordType, index?: number): ColumnCellProps
+    /** Sorting/filtering are declared for shape compatibility; the virtual table does not use them. */
+    sorter?: boolean | ColumnCompareFn<RecordType> | ColumnSorterConfig<RecordType>
+    sortOrder?: ColumnSortOrder
+    defaultSortOrder?: ColumnSortOrder
+    sortDirections?: ColumnSortOrder[]
+    filtered?: boolean
+    filters?: ColumnFilterItem[]
+    filterMultiple?: boolean
+    filteredValue?: (Key | boolean)[] | null
+    defaultFilteredValue?: (Key | boolean)[] | null
+    filterIcon?: ReactNode | ((filtered: boolean) => ReactNode)
+    filterMode?: "menu" | "tree"
+    onFilter?(value: Key | boolean, record: RecordType): boolean
+    render?(value: unknown, record: RecordType, index: number): ColumnRenderResult
+    shouldCellUpdate?(record: RecordType, prevRecord: RecordType): boolean
+}
+
+/** A leaf column: it maps a record to a cell. */
+export interface ColumnDef<RecordType> extends ColumnDefBase<RecordType> {
+    dataIndex?: ColumnDataIndex
+}
+
+/** A header group: it owns nested columns instead of a `dataIndex`. */
+export interface ColumnGroupDef<RecordType> extends ColumnDefBase<RecordType> {
+    children: ColumnDefs<RecordType>
+}
+
+/** The `columns` prop shape — leaves and groups, in render order. */
+export type ColumnDefs<RecordType> = (ColumnDef<RecordType> | ColumnGroupDef<RecordType>)[]
+
+export const isColumnGroupDef = <RecordType>(
+    column: ColumnDefs<RecordType>[number],
+): column is ColumnGroupDef<RecordType> =>
+    "children" in column && Array.isArray((column as ColumnGroupDef<RecordType>).children)

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/buildEntityColumns.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/buildEntityColumns.tsx
@@ -2,7 +2,7 @@
  * Entity Column Builder
  *
  * Converts entity column definitions (any type extending `GroupableColumn`) into
- * Ant Design `ColumnsType` using the `groupColumns` utility and `SmartCellContent`
+ * Ant Design `ColumnDefs` using the `groupColumns` utility and `SmartCellContent`
  * for default cell rendering.
  *
  * This helper standardizes column building for entity tables, reducing boilerplate
@@ -33,7 +33,6 @@
 import type {ReactNode} from "react"
 
 import {getValueAtStringPath} from "@agenta/shared/utils"
-import type {ColumnType, ColumnsType} from "antd/es/table"
 
 import {SmartCellContent} from "../../CellRenderers"
 import {
@@ -41,6 +40,7 @@ import {
     type GroupColumnsOptions,
     groupColumns,
 } from "../../utils/groupColumns"
+import type {ColumnDef, ColumnDefs} from "../columnDef"
 
 // ============================================================================
 // TYPES
@@ -125,7 +125,7 @@ const DEFAULT_COLUMN_WIDTH = 150
  * Build Ant Design table columns from entity column definitions.
  *
  * Converts `GroupableColumn[]` (or any subtype like `EntityColumnDef`) into
- * `ColumnsType` using the `groupColumns` utility. Uses `SmartCellContent` as
+ * `ColumnDefs` using the `groupColumns` utility. Uses `SmartCellContent` as
  * the default cell renderer with path-based value extraction.
  *
  * @template TRow - Row data type
@@ -133,7 +133,7 @@ const DEFAULT_COLUMN_WIDTH = 150
  *
  * @param columns - Array of column definitions
  * @param options - Configuration for rendering, grouping, and width
- * @returns Ant Design ColumnsType ready for table rendering
+ * @returns Ant Design ColumnDefs ready for table rendering
  *
  * @example
  * ```typescript
@@ -156,7 +156,7 @@ const DEFAULT_COLUMN_WIDTH = 150
 export function buildEntityColumns<
     TRow,
     TColumn extends GroupableColumn & {width?: number} = GroupableColumn & {width?: number},
->(columns: TColumn[], options: BuildEntityColumnsOptions<TRow, TColumn>): ColumnsType<TRow> {
+>(columns: TColumn[], options: BuildEntityColumnsOptions<TRow, TColumn>): ColumnDefs<TRow> {
     const {
         getRowData,
         getCellValue,
@@ -165,7 +165,7 @@ export function buildEntityColumns<
         renderCell,
     } = options
 
-    const createColumnDef = (col: TColumn, displayName: string): ColumnType<TRow> => ({
+    const createColumnDef = (col: TColumn, displayName: string): ColumnDef<TRow> => ({
         key: col.key,
         title: displayName,
         width: col.width ?? defaultWidth,

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/createStandardColumns.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/createStandardColumns.tsx
@@ -4,7 +4,6 @@ import {MoreOutlined} from "@ant-design/icons"
 import {Copy, DownloadSimple} from "@phosphor-icons/react"
 import {Dropdown, Tooltip, Typography} from "antd"
 import type {MenuProps} from "antd"
-import type {ColumnsType, ColumnType} from "antd/es/table"
 
 import {InitialsAvatar} from "../../components/presentational/avatar"
 import {CopyButton} from "../../components/presentational/CopyButton"
@@ -12,6 +11,7 @@ import {StatusIndicator, type StatusTone} from "../../components/presentational/
 import {Tag, type TagProps} from "../../components/presentational/tag"
 import {Button} from "../../components/ui/button"
 import {copyToClipboard} from "../../utils/copyToClipboard"
+import type {ColumnDef, ColumnDefs} from "../columnDef"
 import ColumnVisibilityMenuTrigger from "../components/columnVisibility/ColumnVisibilityMenuTrigger"
 import SkeletonLine from "../components/common/SkeletonLine"
 import type {InfiniteTableRowBase} from "../types"
@@ -60,7 +60,7 @@ export interface TextColumnDef<T = unknown> {
     /** Lock column from being hidden in visibility menu (defaults to true if fixed is set) */
     columnVisibilityLocked?: boolean
     /** Custom value extractor for CSV export (read by useTableExport) */
-    exportValue?: (row: T, column?: ColumnsType<T>[number], columnIndex?: number) => unknown
+    exportValue?: (row: T, column?: ColumnDefs<T>[number], columnIndex?: number) => unknown
 }
 
 export interface DateColumnDef {
@@ -225,7 +225,7 @@ export type StandardColumnDef<T = unknown> =
  */
 export function createStandardColumns<T extends InfiniteTableRowBase>(
     defs: StandardColumnDef<T>[],
-): ColumnsType<T> {
+): ColumnDefs<T> {
     return defs.map((def) => {
         switch (def.type) {
             case "text":
@@ -251,7 +251,7 @@ export function createStandardColumns<T extends InfiniteTableRowBase>(
     })
 }
 
-function createTextColumn<T>(def: TextColumnDef<T>): ColumnType<T> {
+function createTextColumn<T>(def: TextColumnDef<T>): ColumnDef<T> {
     return {
         title: def.title,
         dataIndex: def.key,
@@ -263,14 +263,14 @@ function createTextColumn<T>(def: TextColumnDef<T>): ColumnType<T> {
             if ((record as InfiniteTableRowBase).__isSkeleton) return <SkeletonLine width="55%" />
             if (def.render) return def.render(value, record)
             return value as ReactNode
-        }) as ColumnType<T>["render"],
+        }) as ColumnDef<T>["render"],
         // Lock column from being toggled in visibility menu (explicit or derived from fixed)
         columnVisibilityLocked: def.columnVisibilityLocked ?? Boolean(def.fixed),
         ...(def.exportValue ? {exportValue: def.exportValue} : {}),
         onHeaderCell: () => ({
             style: {minWidth: def.width},
         }),
-    } as ColumnType<T>
+    } as ColumnDef<T>
 }
 
 const formatDateCell = (value?: string | null) => {
@@ -288,7 +288,7 @@ const formatDateCell = (value?: string | null) => {
     }
 }
 
-function createDateColumn<T>(def: DateColumnDef): ColumnType<T> {
+function createDateColumn<T>(def: DateColumnDef): ColumnDef<T> {
     const width = def.width || 200
     return {
         title: def.title,
@@ -317,7 +317,7 @@ const readCell = <T,>(
     return typeof raw === "string" ? raw : ""
 }
 
-function createMonoColumn<T extends InfiniteTableRowBase>(def: MonoColumnDef<T>): ColumnType<T> {
+function createMonoColumn<T extends InfiniteTableRowBase>(def: MonoColumnDef<T>): ColumnDef<T> {
     const {key, title, width, fixed, getValue, emptyText = "—"} = def
 
     return {
@@ -340,10 +340,10 @@ function createMonoColumn<T extends InfiniteTableRowBase>(def: MonoColumnDef<T>)
             )
         },
         onHeaderCell: () => ({style: {minWidth: width}}),
-    } as ColumnType<T>
+    } as ColumnDef<T>
 }
 
-function createSlugColumn<T extends InfiniteTableRowBase>(def: SlugColumnDef<T>): ColumnType<T> {
+function createSlugColumn<T extends InfiniteTableRowBase>(def: SlugColumnDef<T>): ColumnDef<T> {
     const {key, title, width, fixed, getValue, emptyText = "—"} = def
 
     return {
@@ -378,12 +378,10 @@ function createSlugColumn<T extends InfiniteTableRowBase>(def: SlugColumnDef<T>)
             )
         },
         onHeaderCell: () => ({style: {minWidth: width}}),
-    } as ColumnType<T>
+    } as ColumnDef<T>
 }
 
-function createEntityColumn<T extends InfiniteTableRowBase>(
-    def: EntityColumnDef<T>,
-): ColumnType<T> {
+function createEntityColumn<T extends InfiniteTableRowBase>(def: EntityColumnDef<T>): ColumnDef<T> {
     const {key, title, width, fixed, getName, getChips, hideAvatar} = def
 
     return {
@@ -433,12 +431,12 @@ function createEntityColumn<T extends InfiniteTableRowBase>(
             )
         },
         onHeaderCell: () => ({style: {minWidth: width}}),
-    } as ColumnType<T>
+    } as ColumnDef<T>
 }
 
 function createActionsColumn<T extends InfiniteTableRowBase>(
     def: ActionsColumnDef<T>,
-): ColumnType<T> & {columnVisibilityLocked?: boolean; exportEnabled?: boolean} {
+): ColumnDef<T> & {columnVisibilityLocked?: boolean; exportEnabled?: boolean} {
     const {
         items,
         width = 56, // TODO: try 61px here
@@ -613,7 +611,7 @@ function createActionsColumn<T extends InfiniteTableRowBase>(
     }
 }
 
-function createUserColumn<T extends InfiniteTableRowBase>(def: UserColumnDef<T>): ColumnType<T> {
+function createUserColumn<T extends InfiniteTableRowBase>(def: UserColumnDef<T>): ColumnDef<T> {
     const {key, title, width = 180, getUserId} = def
 
     return {

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/createTableColumns.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/createTableColumns.ts
@@ -1,13 +1,12 @@
 import type {ReactNode} from "react"
 
-import type {ColumnsType} from "antd/es/table"
-
 import {cn} from "../../utils/styles"
+import type {ColumnDefs} from "../columnDef"
 
 import type {TableColumnConfig, TableColumnGroup, TableColumnCell} from "./types"
 
-type ColumnWithChildren<Row extends object> = ColumnsType<Row>[number] & {
-    children?: ColumnsType<Row>
+type ColumnWithChildren<Row extends object> = ColumnDefs<Row>[number] & {
+    children?: ColumnDefs<Row>
 }
 
 /**
@@ -23,11 +22,11 @@ interface ExtendedColumnProps<Row extends object> {
     exportLabel?: string
     exportEnabled?: boolean
     exportDataIndex?: unknown
-    exportValue?: (row: Row, column?: ColumnsType<Row>[number], columnIndex?: number) => unknown
+    exportValue?: (row: Row, column?: ColumnDefs<Row>[number], columnIndex?: number) => unknown
     exportFormatter?: (
         value: unknown,
         row: Row,
-        column?: ColumnsType<Row>[number],
+        column?: ColumnDefs<Row>[number],
         columnIndex?: number,
     ) => string | undefined
     exportMetadata?: unknown
@@ -35,7 +34,7 @@ interface ExtendedColumnProps<Row extends object> {
 
 type ExtendedColumn<Row extends object> = ColumnWithChildren<Row> & ExtendedColumnProps<Row>
 
-type OnHeaderCell<Row extends object> = ColumnsType<Row>[number]["onHeaderCell"]
+type OnHeaderCell<Row extends object> = ColumnDefs<Row>[number]["onHeaderCell"]
 type OnHeaderCellArgs<Row extends object> = Parameters<NonNullable<OnHeaderCell<Row>>>
 type OnHeaderCellResult<Row extends object> = ReturnType<NonNullable<OnHeaderCell<Row>>>
 
@@ -60,7 +59,7 @@ const resolveTitle = <Row extends object>(
 }
 
 const applyCellRenderer = <Row extends object>(
-    column: ColumnsType<Row>[number],
+    column: ColumnDefs<Row>[number],
     cell?: TableColumnCell<Row>,
 ) => {
     if (!cell) return
@@ -72,7 +71,7 @@ const applyCellRenderer = <Row extends object>(
 const buildColumn = <Row extends object>(
     config: TableColumnConfig<Row>,
     depth = 0,
-): ColumnsType<Row>[number] => {
+): ColumnDefs<Row>[number] => {
     const column: ExtendedColumn<Row> = {
         key: config.key,
         title: resolveTitle(config, depth),
@@ -163,4 +162,4 @@ const buildColumn = <Row extends object>(
 
 export const createTableColumns = <Row extends object>(
     groups: TableColumnGroup<Row>[],
-): ColumnsType<Row> => normalizeGroups(groups).map((config) => buildColumn(config))
+): ColumnDefs<Row> => normalizeGroups(groups).map((config) => buildColumn(config))

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/types.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/types.ts
@@ -1,6 +1,6 @@
 import type {Key, ReactNode} from "react"
 
-import type {ColumnsType, ColumnType} from "antd/es/table"
+import type {ColumnDef, ColumnDefs} from "../columnDef"
 
 export interface TableColumnCell<Row extends object> {
     render: (row: Row, rowIndex: number) => ReactNode
@@ -25,16 +25,16 @@ export interface TableColumnConfig<Row extends object> {
     visibilityTitle?: ReactNode
     cell?: TableColumnCell<Row>
     children?: TableColumnConfig<Row>[]
-    columnProps?: Partial<ColumnsType<Row>[number]>
-    shouldCellUpdate?: ColumnsType<Row>[number]["shouldCellUpdate"]
+    columnProps?: Partial<ColumnDefs<Row>[number]>
+    shouldCellUpdate?: ColumnDefs<Row>[number]["shouldCellUpdate"]
     exportLabel?: string
     exportEnabled?: boolean
-    exportDataIndex?: ColumnType<Row>["dataIndex"]
-    exportValue?: (row: Row, column?: ColumnsType<Row>[number], columnIndex?: number) => unknown
+    exportDataIndex?: ColumnDef<Row>["dataIndex"]
+    exportValue?: (row: Row, column?: ColumnDefs<Row>[number], columnIndex?: number) => unknown
     exportFormatter?: (
         value: unknown,
         row: Row,
-        column?: ColumnsType<Row>[number],
+        column?: ColumnDefs<Row>[number],
         columnIndex?: number,
     ) => string | undefined
     exportMetadata?: unknown
@@ -44,4 +44,4 @@ export type TableColumnGroup<Row extends object> = TableColumnConfig<Row> | Tabl
 
 export type TableColumnsBuilder<Row extends object> = (
     config: TableColumnGroup<Row>[],
-) => ColumnsType<Row>
+) => ColumnDefs<Row>

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
@@ -17,6 +17,7 @@ import type {TableProps, TableRef} from "antd/es/table"
 import {useSetAtom} from "jotai"
 
 import {cn} from "../../utils/styles"
+import {toAntdColumns} from "../antdColumns"
 import {
     deleteColumnViewportVisibilityAtom,
     setColumnUserVisibilityAtom,
@@ -737,7 +738,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
                         <Table<RecordType>
                             ref={tableComponentRef}
                             className={tableClassName}
-                            columns={finalColumns}
+                            columns={toAntdColumns(finalColumns)}
                             dataSource={dataSource}
                             rowKey={rowKey}
                             pagination={false}

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnDomRefs.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnDomRefs.ts
@@ -1,6 +1,6 @@
 import {useLayoutEffect, useRef} from "react"
 
-import type {ColumnsType} from "antd/es/table"
+import type {ColumnDefs} from "../columnDef"
 
 interface ColumnDomRefs {
     cols: HTMLTableColElement[]
@@ -12,7 +12,7 @@ interface ColumnDomRefs {
  */
 const useColumnDomRefs = <RecordType>(
     containerRef: React.RefObject<HTMLDivElement | null>,
-    columns: ColumnsType<RecordType>,
+    columns: ColumnDefs<RecordType>,
 ) => {
     const columnDomRefs = useRef<Map<string, ColumnDomRefs>>(new Map())
 

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnVisibility.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnVisibility.ts
@@ -1,11 +1,11 @@
 import type {ReactNode} from "react"
 import {useCallback, useMemo, useRef} from "react"
 
-import type {ColumnsType} from "antd/es/table"
 import {useAtomValue} from "jotai"
 import {LOW_PRIORITY, useSetAtomWithSchedule} from "jotai-scheduler"
 
 import {getColumnHiddenKeysAtom} from "../atoms/columnHiddenKeys"
+import type {ColumnDefs} from "../columnDef"
 import type {ExtendedColumn} from "../types"
 
 type Key = string
@@ -30,7 +30,7 @@ export interface ColumnTreeNode {
 const toKey = (key: React.Key | undefined): Key | null =>
     key === undefined || key === null ? null : String(key)
 
-const collectKeys = <RecordType>(columns: ColumnsType<RecordType>): Key[] => {
+const collectKeys = <RecordType>(columns: ColumnDefs<RecordType>): Key[] => {
     const result: Key[] = []
     const visit = (cols: ExtendedColumn<RecordType>[]) => {
         cols.forEach((col) => {
@@ -43,7 +43,7 @@ const collectKeys = <RecordType>(columns: ColumnsType<RecordType>): Key[] => {
     return Array.from(new Set(result))
 }
 
-const collectLeafKeys = <RecordType>(columns: ColumnsType<RecordType>): Key[] => {
+const collectLeafKeys = <RecordType>(columns: ColumnDefs<RecordType>): Key[] => {
     const result: Key[] = []
     const visit = (cols: ExtendedColumn<RecordType>[]) => {
         cols.forEach((col) => {
@@ -60,9 +60,9 @@ const collectLeafKeys = <RecordType>(columns: ColumnsType<RecordType>): Key[] =>
 }
 
 const filterColumnsRecursive = <RecordType>(
-    columns: ColumnsType<RecordType>,
+    columns: ColumnDefs<RecordType>,
     hidden: Set<Key>,
-): ColumnsType<RecordType> => {
+): ColumnDefs<RecordType> => {
     const map = (cols: ExtendedColumn<RecordType>[]): ExtendedColumn<RecordType>[] =>
         cols
             .map((col): ExtendedColumn<RecordType> | null => {
@@ -77,11 +77,11 @@ const filterColumnsRecursive = <RecordType>(
             })
             .filter((col): col is ExtendedColumn<RecordType> => col !== null)
 
-    return map(columns as ExtendedColumn<RecordType>[]) as ColumnsType<RecordType>
+    return map(columns as ExtendedColumn<RecordType>[]) as ColumnDefs<RecordType>
 }
 
 export const useColumnVisibility = <RecordType>(
-    columns: ColumnsType<RecordType>,
+    columns: ColumnDefs<RecordType>,
     {storageKey, defaultHiddenKeys = []}: Options = {},
 ) => {
     const allKeys = useMemo(() => collectKeys(columns), [columns])
@@ -138,7 +138,7 @@ export const useColumnVisibility = <RecordType>(
     )
 
     const collectDescendantKeys = useCallback(
-        (cols: ColumnsType<RecordType>, target: Key): Key[] => {
+        (cols: ColumnDefs<RecordType>, target: Key): Key[] => {
             const keys: Key[] = []
             const visit = (items: ExtendedColumn<RecordType>[]) => {
                 items.forEach((col) => {
@@ -195,7 +195,7 @@ export const useColumnVisibility = <RecordType>(
     }
 
     const buildTree = useCallback(
-        (cols: ColumnsType<RecordType>): ColumnTreeNode[] => {
+        (cols: ColumnDefs<RecordType>): ColumnTreeNode[] => {
             const map = (items: ExtendedColumn<RecordType>[]): ColumnTreeNode[] => {
                 const nodes: ColumnTreeNode[] = []
                 items.forEach((col) => {
@@ -207,7 +207,7 @@ export const useColumnVisibility = <RecordType>(
                     }
                     const subtreeKeys: Key[] = [
                         k,
-                        ...collectDescendantKeys([col] as ColumnsType<RecordType>, k).filter(
+                        ...collectDescendantKeys([col] as ColumnDefs<RecordType>, k).filter(
                             (x) => x !== k,
                         ),
                     ]

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnVisibilityControls.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnVisibilityControls.ts
@@ -1,8 +1,7 @@
 import {useCallback, useMemo} from "react"
 import type {Key} from "react"
 
-import type {ColumnsType} from "antd/es/table"
-
+import type {ColumnDefs} from "../columnDef"
 import type {ColumnTreeNode, ColumnVisibilityState} from "../types"
 
 /**
@@ -10,7 +9,7 @@ import type {ColumnTreeNode, ColumnVisibilityState} from "../types"
  * Note: The hook uses string internally for keys but the atom uses React.Key
  */
 interface ColumnVisibilityHookResult<RecordType> {
-    visibleColumns: ColumnsType<RecordType>
+    visibleColumns: ColumnDefs<RecordType>
     leafKeys: string[]
     allKeys: string[]
     hiddenKeys: Key[]

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useResizableColumns.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useResizableColumns.ts
@@ -1,28 +1,28 @@
 import {useCallback, useMemo, useRef, useState} from "react"
 
-import type {ColumnsType, ColumnType} from "antd/es/table"
 import {useAtom} from "jotai"
 
 import {getColumnWidthsAtom} from "../atoms/columnWidths"
+import type {ColumnDef, ColumnDefs} from "../columnDef"
 import {ResizableTitle, type ResizableTitleProps} from "../components/common/ResizableTitle"
 
 const DEFAULT_MIN_WIDTH = 48
 
-type ColumnEntry<RowType> = ColumnsType<RowType>[number]
-type ColumnWithChildren<RowType> = ColumnType<RowType> & {children?: ColumnsType<RowType>}
+type ColumnEntry<RowType> = ColumnDefs<RowType>[number]
+type ColumnWithChildren<RowType> = ColumnDef<RowType> & {children?: ColumnDefs<RowType>}
 
 const getColumnChildren = <RowType>(column: ColumnEntry<RowType>) =>
     (column as ColumnWithChildren<RowType>).children
 
-const collectLeafColumns = <RowType>(columns: ColumnsType<RowType>): ColumnType<RowType>[] => {
-    const result: ColumnType<RowType>[] = []
-    const visit = (cols: ColumnsType<RowType>) => {
+const collectLeafColumns = <RowType>(columns: ColumnDefs<RowType>): ColumnDef<RowType>[] => {
+    const result: ColumnDef<RowType>[] = []
+    const visit = (cols: ColumnDefs<RowType>) => {
         cols.forEach((col) => {
             const children = getColumnChildren(col)
             if (children && children.length) {
                 visit(children)
             } else {
-                result.push(col as ColumnType<RowType>)
+                result.push(col as ColumnDef<RowType>)
             }
         })
     }
@@ -31,7 +31,7 @@ const collectLeafColumns = <RowType>(columns: ColumnsType<RowType>): ColumnType<
 }
 
 const computeTotalWidth = <RowType>(
-    columns: ColumnsType<RowType>,
+    columns: ColumnDefs<RowType>,
     widthOverrides: Record<string, number>,
     minWidth: number,
 ): number => {
@@ -44,18 +44,18 @@ const computeTotalWidth = <RowType>(
 }
 
 export interface UseResizableColumnsArgs<RowType> {
-    columns: ColumnsType<RowType>
+    columns: ColumnDefs<RowType>
     enabled?: boolean
     minWidth?: number
     scopeId?: string | null
 }
 
 export interface UseResizableColumnsResult<RowType> {
-    columns: ColumnsType<RowType>
+    columns: ColumnDefs<RowType>
     headerComponents: {
         cell: typeof ResizableTitle
     } | null
-    getTotalWidth: (cols?: ColumnsType<RowType>) => number
+    getTotalWidth: (cols?: ColumnDefs<RowType>) => number
     isResizing: boolean
 }
 
@@ -121,10 +121,10 @@ export const useResizableColumns = <RowType>({
     )
 
     const makeColumnsResizable = useCallback(
-        (cols: ColumnsType<RowType>): ColumnsType<RowType> =>
+        (cols: ColumnDefs<RowType>): ColumnDefs<RowType> =>
             cols.map((colEntry) => {
-                const column = colEntry as ColumnType<RowType> & {
-                    children?: ColumnsType<RowType>
+                const column = colEntry as ColumnDef<RowType> & {
+                    children?: ColumnDefs<RowType>
                 }
 
                 const colKey = (column.key ??
@@ -139,7 +139,7 @@ export const useResizableColumns = <RowType>({
 
                 if (hasChildren) {
                     const nextChildren = makeColumnsResizable(
-                        column.children as ColumnsType<RowType>,
+                        column.children as ColumnDefs<RowType>,
                     )
                     if (isFixed) {
                         return {
@@ -205,7 +205,7 @@ export const useResizableColumns = <RowType>({
     }, [columns, enabled, makeColumnsResizable])
 
     const getTotalWidth = useCallback(
-        (cols: ColumnsType<RowType> = resizableColumns) =>
+        (cols: ColumnDefs<RowType> = resizableColumns) =>
             computeTotalWidth(cols, columnWidths, minWidth),
         [columnWidths, minWidth, resizableColumns],
     )

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useScopedColumnVisibility.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useScopedColumnVisibility.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from "react"
 
-import type {ColumnsType} from "antd/es/table"
-
+import type {ColumnDefs} from "../columnDef"
 import {useColumnVisibility} from "../hooks/useColumnVisibility"
 
 interface Options {
@@ -11,7 +10,7 @@ interface Options {
 }
 
 export const useScopedColumnVisibility = <Row extends object>(
-    columns: ColumnsType<Row>,
+    columns: ColumnDefs<Row>,
     {scopeId, storageKey, defaultHiddenKeys = []}: Options,
 ) => {
     const scopedStorageKey = useMemo(() => {

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useSmartResizableColumns.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useSmartResizableColumns.ts
@@ -1,29 +1,29 @@
 import {useCallback, useMemo, useRef, useState} from "react"
 
-import type {ColumnsType, ColumnType} from "antd/es/table"
 import {useAtom} from "jotai"
 
 import {getColumnWidthsAtom} from "../atoms/columnWidths"
+import type {ColumnDef, ColumnDefs} from "../columnDef"
 import {ResizableTitle, type ResizableTitleProps} from "../components/common/ResizableTitle"
 
 const DEFAULT_MIN_WIDTH = 150
 const DEFAULT_COLUMN_WIDTH = 200
 
-type ColumnEntry<RowType> = ColumnsType<RowType>[number]
-type ColumnWithChildren<RowType> = ColumnType<RowType> & {children?: ColumnsType<RowType>}
+type ColumnEntry<RowType> = ColumnDefs<RowType>[number]
+type ColumnWithChildren<RowType> = ColumnDef<RowType> & {children?: ColumnDefs<RowType>}
 
 const getColumnChildren = <RowType>(column: ColumnEntry<RowType>) =>
     (column as ColumnWithChildren<RowType>).children
 
-const collectLeafColumns = <RowType>(columns: ColumnsType<RowType>): ColumnType<RowType>[] => {
-    const result: ColumnType<RowType>[] = []
-    const visit = (cols: ColumnsType<RowType>) => {
+const collectLeafColumns = <RowType>(columns: ColumnDefs<RowType>): ColumnDef<RowType>[] => {
+    const result: ColumnDef<RowType>[] = []
+    const visit = (cols: ColumnDefs<RowType>) => {
         cols.forEach((col) => {
             const children = getColumnChildren(col)
             if (children && children.length) {
                 visit(children)
             } else {
-                result.push(col as ColumnType<RowType>)
+                result.push(col as ColumnDef<RowType>)
             }
         })
     }
@@ -41,7 +41,7 @@ interface ColumnMeta {
 }
 
 export interface UseSmartResizableColumnsArgs<RowType> {
-    columns: ColumnsType<RowType>
+    columns: ColumnDefs<RowType>
     enabled?: boolean
     minWidth?: number
     scopeId?: string | null
@@ -50,11 +50,11 @@ export interface UseSmartResizableColumnsArgs<RowType> {
 }
 
 export interface UseSmartResizableColumnsResult<RowType> {
-    columns: ColumnsType<RowType>
+    columns: ColumnDefs<RowType>
     headerComponents: {
         cell: typeof ResizableTitle
     } | null
-    getTotalWidth: (cols?: ColumnsType<RowType>) => number
+    getTotalWidth: (cols?: ColumnDefs<RowType>) => number
     isResizing: boolean
     /** Whether any column has been manually resized by the user */
     hasUserResizedAny: boolean
@@ -91,7 +91,7 @@ export const useSmartResizableColumns = <RowType>({
 
     // Extract column metadata
     const analyzeColumns = useCallback(
-        (cols: ColumnsType<RowType>): ColumnMeta[] => {
+        (cols: ColumnDefs<RowType>): ColumnMeta[] => {
             const leafColumns = collectLeafColumns(cols)
             return leafColumns.map((col) => {
                 const key = (col?.key ?? col?.dataIndex ?? "") as string
@@ -364,13 +364,10 @@ export const useSmartResizableColumns = <RowType>({
     )
 
     const makeColumnsResizable = useCallback(
-        (
-            cols: ColumnsType<RowType>,
-            computedWidths: Record<string, number>,
-        ): ColumnsType<RowType> =>
+        (cols: ColumnDefs<RowType>, computedWidths: Record<string, number>): ColumnDefs<RowType> =>
             cols.map((colEntry) => {
-                const column = colEntry as ColumnType<RowType> & {
-                    children?: ColumnsType<RowType>
+                const column = colEntry as ColumnDef<RowType> & {
+                    children?: ColumnDefs<RowType>
                 }
 
                 const colKey = (column.key ??
@@ -384,16 +381,14 @@ export const useSmartResizableColumns = <RowType>({
 
                 if (hasChildren) {
                     const nextChildren = makeColumnsResizable(
-                        column.children as ColumnsType<RowType>,
+                        column.children as ColumnDefs<RowType>,
                         computedWidths,
                     )
 
                     // Wire a resize handle on the group header. The drag delta
                     // is distributed proportionally across every leaf so the
                     // group expands uniformly.
-                    const leafDescendants = collectLeafColumns(
-                        nextChildren,
-                    ) as ColumnType<RowType>[]
+                    const leafDescendants = collectLeafColumns(nextChildren) as ColumnDef<RowType>[]
                     const childSnapshots = leafDescendants
                         .map((leaf) => {
                             const leafKey = (leaf?.key ?? "") as string
@@ -477,7 +472,7 @@ export const useSmartResizableColumns = <RowType>({
     }, [columns, enabled, analyzeColumns, computeSmartWidths, makeColumnsResizable])
 
     const getTotalWidth = useCallback(
-        (cols: ColumnsType<RowType> = resizableColumns) => {
+        (cols: ColumnDefs<RowType> = resizableColumns) => {
             const leafColumns = collectLeafColumns(cols)
             return leafColumns.reduce((sum, col) => {
                 const width = typeof col.width === "number" ? col.width : minWidth

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableExport.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableExport.ts
@@ -1,7 +1,6 @@
 import {useCallback} from "react"
 
-import type {ColumnsType} from "antd/es/table"
-
+import type {ColumnDefs} from "../columnDef"
 import type {InfiniteTableRowBase} from "../types"
 
 export const EXPORT_RESOLVE_SKIP = Symbol("EXPORT_RESOLVE_SKIP")
@@ -11,7 +10,7 @@ interface ExtendedColumnProps {
     visibilityHidden?: boolean
     visibilityLocked?: boolean
     columnProps?: {hidden?: boolean}
-    children?: ColumnsType<InfiniteTableRowBase>
+    children?: ColumnDefs<InfiniteTableRowBase>
     dataIndex?: string | number | readonly (string | number)[]
     key?: React.Key
     title?: React.ReactNode
@@ -23,10 +22,10 @@ interface ExtendedColumnProps {
     exportEnabled?: boolean
 }
 
-type ColumnWithExtensions<Row> = ColumnsType<Row>[number] & ExtendedColumnProps
+type ColumnWithExtensions<Row> = ColumnDefs<Row>[number] & ExtendedColumnProps
 
 const columnIsHidden = <Row extends InfiniteTableRowBase>(
-    column: ColumnsType<Row>[number],
+    column: ColumnDefs<Row>[number],
 ): boolean => {
     const extColumn = column as ColumnWithExtensions<Row>
     if (extColumn?.visibilityHidden) return true
@@ -35,14 +34,14 @@ const columnIsHidden = <Row extends InfiniteTableRowBase>(
 }
 
 const flattenColumns = <Row extends InfiniteTableRowBase>(
-    columns: ColumnsType<Row>,
-): ColumnsType<Row> => {
-    const flat: ColumnsType<Row> = []
+    columns: ColumnDefs<Row>,
+): ColumnDefs<Row> => {
+    const flat: ColumnDefs<Row> = []
     columns.forEach((column) => {
         if (!column) return
         const extColumn = column as ColumnWithExtensions<Row>
         if (extColumn.children && extColumn.children.length) {
-            flat.push(...flattenColumns(extColumn.children as ColumnsType<Row>))
+            flat.push(...flattenColumns(extColumn.children as ColumnDefs<Row>))
         } else {
             flat.push(column)
         }
@@ -51,7 +50,7 @@ const flattenColumns = <Row extends InfiniteTableRowBase>(
 }
 
 const getColumnIdentifier = <Row extends InfiniteTableRowBase>(
-    column: ColumnsType<Row>[number],
+    column: ColumnDefs<Row>[number],
     index: number,
 ) => {
     const extColumn = column as ColumnWithExtensions<Row>
@@ -69,7 +68,7 @@ const getColumnIdentifier = <Row extends InfiniteTableRowBase>(
 }
 
 const getColumnKey = <Row extends InfiniteTableRowBase>(
-    column: ColumnsType<Row>[number],
+    column: ColumnDefs<Row>[number],
     index: number,
 ) => {
     const extColumn = column as ColumnWithExtensions<Row>
@@ -80,7 +79,7 @@ const getColumnKey = <Row extends InfiniteTableRowBase>(
 }
 
 const getColumnLabel = <Row extends InfiniteTableRowBase>(
-    column: ColumnsType<Row>[number],
+    column: ColumnDefs<Row>[number],
     index: number,
 ) => {
     const extColumn = column as ColumnWithExtensions<Row>
@@ -188,7 +187,7 @@ const filterSkeletonRows = <Row extends InfiniteTableRowBase>(
 }
 
 export interface TableExportColumnContext<Row extends InfiniteTableRowBase> {
-    column: ColumnsType<Row>[number]
+    column: ColumnDefs<Row>[number]
     columnIndex: number
 }
 
@@ -212,7 +211,7 @@ export interface TableExportOptions<Row extends InfiniteTableRowBase> {
 export interface TableExportParams<
     Row extends InfiniteTableRowBase,
 > extends TableExportOptions<Row> {
-    columns: ColumnsType<Row>
+    columns: ColumnDefs<Row>
     rows: Row[]
 }
 

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableHeaderHeight.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableHeaderHeight.ts
@@ -1,10 +1,12 @@
 import {useLayoutEffect, useState, type RefObject} from "react"
 
-import type {ColumnsType, TableProps} from "antd/es/table"
+import type {TableProps} from "antd/es/table"
+
+import type {ColumnDefs} from "../columnDef"
 
 interface UseTableHeaderHeightOptions<RecordType> {
     containerRef: RefObject<HTMLDivElement | null>
-    columns: ColumnsType<RecordType>
+    columns: ColumnDefs<RecordType>
     dataSource: RecordType[]
     components?: TableProps<RecordType>["components"]
 }

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
@@ -2,13 +2,13 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import type {Key, MouseEvent, ReactNode, RefObject} from "react"
 
 import {Grid} from "antd"
-import type {ColumnsType} from "antd/es/table"
 import type {WritableAtom} from "jotai"
 import {useAtom} from "jotai"
 import {atom} from "jotai"
 
 import {SearchInput} from "../../components/ui/input-composed"
 import {cn} from "../../utils/styles"
+import type {ColumnDefs} from "../columnDef"
 import type {InfiniteDatasetStore} from "../createInfiniteDatasetStore"
 import type {
     TableScopeConfig,
@@ -158,7 +158,7 @@ export interface UseTableManagerReturn<T extends InfiniteTableRowBase> {
     rowExportingKey: string | null
 
     /** Ref to store current columns for export */
-    columnsRef: RefObject<ColumnsType<T> | null>
+    columnsRef: RefObject<ColumnDefs<T> | null>
 
     /** Search term value (only meaningful when search config is provided) */
     searchTerm: string
@@ -281,7 +281,7 @@ export function useTableManager<T extends InfiniteTableRowBase>({
     // Export state
     const [rowExportingKey, setRowExportingKey] = useState<string | null>(null)
     const tableExport = useTableExport<T>()
-    const columnsRef = useRef<ColumnsType<T> | null>(null)
+    const columnsRef = useRef<ColumnDefs<T> | null>(null)
 
     // Auto-reset pagination when search dependencies change (skip initial mount)
     const searchDepsInitialized = useRef(false)

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTypeChipColumns.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTypeChipColumns.tsx
@@ -1,10 +1,9 @@
 import {useMemo} from "react"
 import type {ReactNode} from "react"
 
-import type {ColumnGroupType, ColumnType, ColumnsType} from "antd/es/table"
-
 import {TypeChip} from "../../type-chip/TypeChip"
 import type {ChipVariant} from "../../type-chip/TypeChip"
+import type {ColumnDef, ColumnDefs, ColumnGroupDef} from "../columnDef"
 import type {TypeChipConfig} from "../types"
 import {
     defaultHeaderVariant,
@@ -12,17 +11,17 @@ import {
     type ColumnTypeInfo,
 } from "../utils/detectColumnTypes"
 
-function collectLeafKeys<R>(columns: ColumnsType<R>): string[] {
+function collectLeafKeys<R>(columns: ColumnDefs<R>): string[] {
     const keys: string[] = []
 
     for (const col of columns) {
-        const groupColumn = col as ColumnGroupType<R>
+        const groupColumn = col as ColumnGroupDef<R>
         if (Array.isArray(groupColumn.children) && groupColumn.children.length > 0) {
-            keys.push(...collectLeafKeys(groupColumn.children as ColumnsType<R>))
+            keys.push(...collectLeafKeys(groupColumn.children as ColumnDefs<R>))
             continue
         }
 
-        const key = (col as ColumnType<R>).key
+        const key = (col as ColumnDef<R>).key
         if (typeof key === "string" && key) keys.push(key)
     }
 
@@ -39,9 +38,9 @@ function wrapTitleWithChip(original: ReactNode, chip: ReactNode): ReactNode {
 }
 
 function resolveTitleWithChip<R>(
-    title: ColumnType<R>["title"],
+    title: ColumnDef<R>["title"],
     chip: ReactNode,
-): ColumnType<R>["title"] {
+): ColumnDef<R>["title"] {
     if (typeof title === "function") {
         return (props) => wrapTitleWithChip(title(props), chip)
     }
@@ -50,24 +49,24 @@ function resolveTitleWithChip<R>(
 }
 
 function enhanceLeafColumns<R>(
-    columns: ColumnsType<R>,
+    columns: ColumnDefs<R>,
     columnTypes: Map<string, ColumnTypeInfo>,
     resolveVariant: (key: string, info: ColumnTypeInfo | undefined) => ChipVariant | undefined,
-): ColumnsType<R> {
+): ColumnDefs<R> {
     return columns.map((col) => {
-        const groupColumn = col as ColumnGroupType<R>
+        const groupColumn = col as ColumnGroupDef<R>
         if (Array.isArray(groupColumn.children) && groupColumn.children.length > 0) {
             return {
                 ...col,
                 children: enhanceLeafColumns(
-                    groupColumn.children as ColumnsType<R>,
+                    groupColumn.children as ColumnDefs<R>,
                     columnTypes,
                     resolveVariant,
                 ),
             }
         }
 
-        const key = String((col as ColumnType<R>).key ?? "")
+        const key = String((col as ColumnDef<R>).key ?? "")
         const typeInfo = columnTypes.get(key)
 
         const variant = resolveVariant(key, typeInfo)
@@ -76,7 +75,7 @@ function enhanceLeafColumns<R>(
         return {
             ...col,
             title: resolveTitleWithChip(
-                (col as ColumnType<R>).title,
+                (col as ColumnDef<R>).title,
                 <TypeChip variant={variant} />,
             ),
         }
@@ -84,10 +83,10 @@ function enhanceLeafColumns<R>(
 }
 
 export function useTypeChipColumns<R extends object>(
-    columns: ColumnsType<R>,
+    columns: ColumnDefs<R>,
     dataSource: R[],
     typeChips: TypeChipConfig<R> | undefined,
-): ColumnsType<R> {
+): ColumnDefs<R> {
     const leafKeys = useMemo(() => collectLeafKeys(columns), [columns])
 
     const columnTypes = useMemo((): Map<string, ColumnTypeInfo> | null => {
@@ -105,7 +104,7 @@ export function useTypeChipColumns<R extends object>(
         return detectColumnTypes(rows, leafKeys)
     }, [typeChips?.enabled, typeChips?.getRowValue, dataSource, leafKeys])
 
-    return useMemo((): ColumnsType<R> => {
+    return useMemo((): ColumnDefs<R> => {
         if (!typeChips?.enabled || !columnTypes) return columns
 
         const resolveVariant = typeChips.resolveHeaderVariant ?? defaultHeaderVariant

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/index.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/index.ts
@@ -116,6 +116,27 @@ export type {UseTypeChipFeatureResult} from "./hooks/useTypeChipFeature"
 export {RowHeightContext, useRowHeightContext} from "./context/RowHeightContext"
 export type {RowHeightContextValue} from "./context/RowHeightContext"
 export * from "./types"
+export {isColumnGroupDef} from "./columnDef"
+export type {
+    ColumnDef,
+    ColumnDefs,
+    ColumnGroupDef,
+    ColumnAlign,
+    ColumnFixed,
+    ColumnEllipsis,
+    ColumnRowScope,
+    ColumnDataIndex,
+    ColumnSortOrder,
+    ColumnCellProps,
+    ColumnRenderResult,
+    RenderedColumnCell,
+    ColumnFilterItem,
+    ColumnTitle,
+    ColumnTitleContext,
+    ColumnCompareFn,
+    ColumnSorterConfig,
+} from "./columnDef"
+export {toAntdColumns, fromAntdColumns} from "./antdColumns"
 export type {VisibilityRegistrationHandler} from "./components/ColumnVisibilityHeader"
 
 // Shared hooks for cell renderers

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/types.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/types.ts
@@ -1,11 +1,12 @@
 import type {Key, ReactNode} from "react"
 
-import type {ColumnsType, ColumnType, ColumnGroupType, TableProps} from "antd/es/table"
+import type {TableProps} from "antd/es/table"
 import type {Getter} from "jotai"
 import type {Store} from "jotai/vanilla/store"
 
 import type {ChipVariant} from "../type-chip/TypeChip"
 
+import type {ColumnDef, ColumnDefs, ColumnGroupDef} from "./columnDef"
 import type {VisibilityRegistrationHandler} from "./components/ColumnVisibilityHeader"
 import type {ColumnTypeInfo} from "./utils/detectColumnTypes"
 
@@ -37,9 +38,9 @@ export interface ExtendedColumnProps<RecordType> {
 }
 
 /**
- * Extended column type combining Ant Design's ColumnType with custom props
+ * Extended column type combining Ant Design's ColumnDef with custom props
  */
-export type ExtendedColumn<RecordType> = (ColumnType<RecordType> | ColumnGroupType<RecordType>) &
+export type ExtendedColumn<RecordType> = (ColumnDef<RecordType> | ColumnGroupDef<RecordType>) &
     ExtendedColumnProps<RecordType>
 
 /**
@@ -47,15 +48,15 @@ export type ExtendedColumn<RecordType> = (ColumnType<RecordType> | ColumnGroupTy
  */
 export const isColumnGroup = <RecordType>(
     column: ExtendedColumn<RecordType>,
-): column is ColumnGroupType<RecordType> & ExtendedColumnProps<RecordType> => {
+): column is ColumnGroupDef<RecordType> & ExtendedColumnProps<RecordType> => {
     return "children" in column && Array.isArray(column.children) && column.children.length > 0
 }
 
 /**
- * Safely cast ColumnsType to ExtendedColumn array
+ * Safely cast ColumnDefs to ExtendedColumn array
  */
 export const asExtendedColumns = <RecordType>(
-    columns: ColumnsType<RecordType>,
+    columns: ColumnDefs<RecordType>,
 ): ExtendedColumn<RecordType>[] => {
     return columns as ExtendedColumn<RecordType>[]
 }
@@ -118,7 +119,7 @@ export interface ColumnVisibilityState<RecordType> {
     toggleColumn: (key: Key) => void
     toggleTree: (key: Key) => void
     reset: () => void
-    visibleColumns: ColumnsType<RecordType>
+    visibleColumns: ColumnDefs<RecordType>
     columnTree: ColumnTreeNode[]
     version: number
 }
@@ -351,7 +352,7 @@ export interface TypeChipConfig<RecordType> {
 }
 
 export interface InfiniteVirtualTableProps<RecordType, ExpandedChildType = unknown> {
-    columns: ColumnsType<RecordType>
+    columns: ColumnDefs<RecordType>
     dataSource: RecordType[]
     loadMore: () => void
     rowKey: TableProps<RecordType>["rowKey"]

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/utils/columnUtils.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/utils/columnUtils.ts
@@ -1,18 +1,18 @@
 import type {Key} from "react"
 
-import type {ColumnsType} from "antd/es/table"
+import type {ColumnDefs} from "../columnDef"
 
 /**
  * Collects all column keys that have `fixed` property set
  */
 export const collectFixedColumnKeys = <RecordType extends object>(
-    columns: ColumnsType<RecordType>,
+    columns: ColumnDefs<RecordType>,
 ): string[] => {
     const keys = new Set<string>()
-    const visit = (cols: ColumnsType<RecordType>) => {
+    const visit = (cols: ColumnDefs<RecordType>) => {
         cols.forEach((column) => {
-            const typedColumn = column as ColumnsType<RecordType>[number] & {
-                children?: ColumnsType<RecordType>
+            const typedColumn = column as ColumnDefs<RecordType>[number] & {
+                children?: ColumnDefs<RecordType>
             }
             if (!typedColumn) return
             const columnKey = typedColumn.key
@@ -39,12 +39,12 @@ export const toColumnKey = (key: Key | undefined): string | null =>
  * Builds a map of parent column keys to their descendant leaf keys
  */
 export const buildColumnDescendantMap = <RecordType extends object>(
-    columns: ColumnsType<RecordType>,
+    columns: ColumnDefs<RecordType>,
 ): Map<string, string[]> => {
     const map = new Map<string, string[]>()
-    const gatherDescendants = (column: ColumnsType<RecordType>[number]): string[] => {
-        const typedColumn = column as ColumnsType<RecordType>[number] & {
-            children?: ColumnsType<RecordType>
+    const gatherDescendants = (column: ColumnDefs<RecordType>[number]): string[] => {
+        const typedColumn = column as ColumnDefs<RecordType>[number] & {
+            children?: ColumnDefs<RecordType>
         }
         if (!typedColumn) return []
         const key = toColumnKey(typedColumn.key)

--- a/web/packages/agenta-ui/src/utils/groupColumns.ts
+++ b/web/packages/agenta-ui/src/utils/groupColumns.ts
@@ -8,7 +8,7 @@
 
 import type {ReactNode} from "react"
 
-import type {ColumnType} from "antd/es/table"
+import type {ColumnDef} from "../InfiniteVirtualTable/columnDef"
 
 // ============================================================================
 // TYPES
@@ -42,7 +42,7 @@ export interface GroupColumnsOptions<T, C extends GroupableColumn = GroupableCol
     /** Function to render the group header */
     renderGroupHeader?: (groupPath: string, isCollapsed: boolean, childCount: number) => ReactNode
     /** Function to create a collapsed column (shows full JSON) */
-    createCollapsedColumnDef?: (groupPath: string, childColumns: C[]) => ColumnType<T>
+    createCollapsedColumnDef?: (groupPath: string, childColumns: C[]) => ColumnDef<T>
     /** Maximum depth for group expansion (default: 1). Beyond this depth, columns show as JSON */
     maxDepth?: number
 }
@@ -55,7 +55,7 @@ export interface GroupColumnsOptions<T, C extends GroupableColumn = GroupableCol
 const DEFAULT_MAX_DEPTH = 1
 
 /** Internal column type with ordering metadata for sorting during grouping */
-type OrderedColumn<T> = ColumnType<T> & {__order?: number}
+type OrderedColumn<T> = ColumnDef<T> & {__order?: number}
 
 /**
  * Check if a column key indicates it belongs to a group
@@ -99,10 +99,10 @@ function isExpandedColumn(col: GroupableColumn): boolean {
 /**
  * Count leaf columns in a nested column structure
  */
-function countLeafColumns<T>(columns: ColumnType<T>[]): number {
+function countLeafColumns<T>(columns: ColumnDef<T>[]): number {
     let count = 0
     columns.forEach((col) => {
-        const children = (col as ColumnType<T> & {children?: ColumnType<T>[]}).children
+        const children = (col as ColumnDef<T> & {children?: ColumnDef<T>[]}).children
         if (children && children.length > 0) {
             count += countLeafColumns(children)
         } else {
@@ -120,11 +120,11 @@ function countLeafColumns<T>(columns: ColumnType<T>[]): number {
  */
 function groupColumnsRecursive<T, C extends GroupableColumn>(
     columns: C[],
-    createColumnDef: (col: C, displayName: string) => ColumnType<T>,
+    createColumnDef: (col: C, displayName: string) => ColumnDef<T>,
     options: GroupColumnsOptions<T, C> | undefined,
     parentPath: string,
     currentDepth: number,
-): ColumnType<T>[] {
+): ColumnDef<T>[] {
     const {
         collapsedGroups,
         onGroupHeaderClick,
@@ -133,7 +133,7 @@ function groupColumnsRecursive<T, C extends GroupableColumn>(
         maxDepth = DEFAULT_MAX_DEPTH,
     } = options ?? {}
 
-    const result: ColumnType<T>[] = []
+    const result: ColumnDef<T>[] = []
     const groupMap = new Map<string, {columns: C[]; order: number}>()
     let orderCounter = 0
 
@@ -251,8 +251,8 @@ function groupColumnsRecursive<T, C extends GroupableColumn>(
  */
 export function groupColumns<T, C extends GroupableColumn = GroupableColumn>(
     columns: C[],
-    createColumnDef: (col: C, displayName: string) => ColumnType<T>,
+    createColumnDef: (col: C, displayName: string) => ColumnDef<T>,
     options?: GroupColumnsOptions<T, C>,
-): ColumnType<T>[] {
+): ColumnDef<T>[] {
     return groupColumnsRecursive(columns, createColumnDef, options, "", 0)
 }


### PR DESCRIPTION
## Context

`InfiniteVirtualTable` is typed against antd's `ColumnsType`. That type reaches 22 files and 160 references across packages and both apps, and every new table column adds to it. The table itself has to come off antd eventually, since the target architecture is one antd-free app, and this type surface is what blocks every step of that port.

This is step 1 of the table port from `docs/design/observability-packages/plan.md` §8, pulled forward because it is mechanical, carries no visual risk, and lands independently.

## Changes

`ColumnDef<T>` now lives in `packages/agenta-ui/src/InfiniteVirtualTable/columnDef.ts`, alongside `ColumnGroupDef`, `ColumnDefs` and the supporting scalars. antd's `ColumnsType` becomes an adapter applied at exactly one place:

```
columns={toAntdColumns(finalColumns)}
```

The table's rendering does not move. `<Table virtual>` stays exactly as it is. Only the type surface changes, so the later steps stop being blocked on a 22-file refactor.

One decision worth a reviewer's eye. Every function-valued column prop (`render`, `onCell`, `onHeaderCell`, `shouldCellUpdate`, `onFilter`) is declared with method syntax, not property syntax:

```
render(value: unknown, record: T, index: number): RenderedColumnCell
```

Method parameters are checked bivariantly, so a column may still write `render: (date: string) => …` and stay assignable. That is what antd was buying with `any`, obtained here without one. Property syntax with `unknown` would have broken about fifty call sites.

`getObservabilityColumns.tsx` also drops its last antd import, swapping `Tag` for the `SpanIdChip` built in `obs/wp3`.

## Tests / notes

- OSS, EE, mobile and `@agenta/ui` typecheck. `@agenta/ui`, `@agenta/entity-ui` and `@agenta/observability-ui` build and lint. `@agenta/entity-ui`'s 325 tests pass.
- Two corrections to the plan's measurement. `packages/agenta-ui/src/utils/groupColumns.ts` sits outside the directory that was measured but is antd-typed and feeds `buildEntityColumns`, so it had to move here or the package would not compile. And the observability `types.d.ts` antd import did not fall out for free: it also imported `Avatar` for an exported `AvatarTreeContentProps`, which turned out to have no references anywhere in `oss`, `ee`, `packages` or `mobile`, so it is deleted.
- `fromAntdColumns` is exported but currently unused. It exists for the four raw `<Table>` call sites deliberately left on antd (`MetadataSummaryTable`, `getAnnotationTableColumns`, `ConfigurationTable`, `DeploymentHistoryModal`).

## What to QA

No visual change is expected anywhere. The risk is a column silently losing its renderer, so spot-check the tables that were retyped.

- Observability traces: all columns render, the span-id chip still shows, resizing a column still works.
- Testsets and test cases tables: columns render and group headers still nest.
- Evaluation runs and run details: columns render, including the ETL preview columns.
- Prompts and Agents table sections: columns render.
