### PR TITLE
[refactor] Give table consumers class hooks that outlive antd

### DIFF
--- a/web/oss/src/components/EvalRunDetails/hooks/useCellVisibility.ts
+++ b/web/oss/src/components/EvalRunDetails/hooks/useCellVisibility.ts
@@ -33,8 +33,11 @@ export const useCellVisibility = () => {
             return undefined
         }
 
+        // `.avt-body` is the table package's stable hook. The antd selectors stay as a fallback
+        // for the raw <Table> call sites this hook is also used from.
         const root =
             scrollContainer ??
+            element.closest<HTMLDivElement>(".avt-body") ??
             element.closest<HTMLDivElement>(".ant-table-body") ??
             element.closest<HTMLDivElement>(".ant-table-body-inner") ??
             null

--- a/web/oss/src/components/pages/agents/AgentsTableSection.tsx
+++ b/web/oss/src/components/pages/agents/AgentsTableSection.tsx
@@ -82,7 +82,7 @@ export default function AgentsTableSection({
 
     return (
         <InfiniteVirtualTableFeatureShell<AppWorkflowRow>
-            className="grow min-h-0 [&_.ant-table-cell]:!align-middle [&_.ant-table-container]:!border-b"
+            className="grow min-h-0 [&_.avt-cell]:!align-middle [&_.avt-container]:!border-b"
             tableScope={tableScope}
             columns={columns}
             rowKey={(record) => record.key}

--- a/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/ObservabilityTable/index.tsx
@@ -297,7 +297,7 @@ const ObservabilityTable = () => {
                     enableExport={false}
                     useSettingsDropdown={false}
                     store={store}
-                    className="flex-1 min-h-0 [&_.ant-table-thead_tr:nth-child(2)]:hidden"
+                    className="flex-1 min-h-0 [&_.avt-thead_tr:nth-child(2)]:hidden"
                     rowSelection={{
                         selectedRowKeys,
                         type: "checkbox",

--- a/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
+++ b/web/oss/src/components/pages/observability/components/SessionsTable/index.tsx
@@ -138,7 +138,7 @@ const SessionsTable: React.FC = () => {
                         resizableColumns
                         enableExport={false}
                         useSettingsDropdown={false}
-                        className="flex-1 min-h-0 [&_.ant-table-tbody_.ant-table-cell]:align-top"
+                        className="flex-1 min-h-0 [&_.avt-row_.avt-cell]:align-top"
                         tableProps={{
                             bordered: true,
                             loading: isLoading && sessionIds.length === 0,

--- a/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
+++ b/web/oss/src/components/pages/prompts/components/PromptsTableSection.tsx
@@ -190,7 +190,7 @@ export const PromptsTableSection = ({
 
     return (
         <InfiniteVirtualTableFeatureShell<PromptsTableRow>
-            className="grow min-h-0 [&_.ant-table-cell]:!align-middle [&_.ant-table-container]:!border-b"
+            className="grow min-h-0 [&_.avt-cell]:!align-middle [&_.avt-container]:!border-b"
             tableScope={tableScope}
             columns={columns}
             rowKey={(record) => record.key}

--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -74,7 +74,9 @@ body {
     transition: opacity 0.3s ease;
 }
 
-.ant-table-row:hover .hover-button-wrapper {
+/* .avt-row is the table package's stable hook; the antd selector stays for raw <Table> users. */
+.ant-table-row:hover .hover-button-wrapper,
+.avt-row:hover .hover-button-wrapper {
     opacity: 1;
 }
 

--- a/web/packages/agenta-entity-ui/tests/unit/tableClassHooks.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/tableClassHooks.test.ts
@@ -1,0 +1,80 @@
+import {AVT, stampTableDom, toAntdColumns} from "@agenta/ui/table"
+import {describe, expect, it} from "vitest"
+
+/**
+ * The table's stable class hooks. App code targets `avt-*` so a selector does not depend on
+ * antd's DOM, which the render-leaf swap will replace. If these break, consumer styling
+ * silently stops applying, so the contract is pinned here rather than left to a browser pass.
+ */
+
+interface FakeNode {
+    classes: Set<string>
+    classList: {add: (c: string) => void}
+}
+
+const node = (): FakeNode => {
+    const classes = new Set<string>()
+    return {classes, classList: {add: (c: string) => classes.add(c)}}
+}
+
+/** Minimal stand-in for the mounted table: querySelector over a fixed selector map. */
+const container = (found: Record<string, FakeNode>) =>
+    ({
+        querySelector: (selector: string) => found[selector] ?? null,
+    }) as unknown as HTMLElement
+
+describe("stampTableDom", () => {
+    it("stamps the structural hooks onto antd's nodes", () => {
+        const nodes = {
+            ".ant-table-container": node(),
+            ".ant-table-body": node(),
+            ".ant-table-thead": node(),
+        }
+        stampTableDom(container(nodes))
+
+        expect([...nodes[".ant-table-container"].classes]).toEqual([AVT.container])
+        expect([...nodes[".ant-table-body"].classes]).toEqual([AVT.body])
+        expect([...nodes[".ant-table-thead"].classes]).toEqual([AVT.header])
+    })
+
+    it("skips nodes that are not present rather than throwing", () => {
+        expect(() => stampTableDom(container({}))).not.toThrow()
+        expect(() => stampTableDom(null)).not.toThrow()
+    })
+})
+
+describe("toAntdColumns cell hooks", () => {
+    interface Row {
+        id: string
+    }
+
+    it("adds the cell hooks to a plain column", () => {
+        const [column] = toAntdColumns<Row>([{key: "id", title: "ID"}])
+
+        expect(column.onCell?.({id: "a"}, 0)).toEqual({className: AVT.cell})
+        expect(column.onHeaderCell?.(column, 0)).toEqual({className: AVT.headerCell})
+    })
+
+    it("keeps a column's own cell props and appends the hook", () => {
+        const [column] = toAntdColumns<Row>([
+            {
+                key: "id",
+                onCell: () => ({className: "mine", colSpan: 2}),
+            },
+        ])
+
+        expect(column.onCell?.({id: "a"}, 0)).toEqual({
+            className: `mine ${AVT.cell}`,
+            colSpan: 2,
+        })
+    })
+
+    it("reaches columns nested in a group", () => {
+        const [group] = toAntdColumns<Row>([
+            {key: "g", title: "Group", children: [{key: "id", title: "ID"}]},
+        ])
+        const child = (group as {children: (typeof group)[]}).children[0]
+
+        expect(child.onCell?.({id: "a"}, 0)).toEqual({className: AVT.cell})
+    })
+})

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/antdColumns.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/antdColumns.ts
@@ -1,6 +1,8 @@
 import type {ColumnsType as AntdColumnsType} from "antd/es/table"
 
-import type {ColumnDefs} from "./columnDef"
+import type {ColumnCellProps, ColumnDefs} from "./columnDef"
+import {isColumnGroupDef} from "./columnDef"
+import {AVT} from "./tableDom"
 
 /**
  * The one place the table's own column model meets antd's.
@@ -11,8 +13,30 @@ import type {ColumnDefs} from "./columnDef"
  * rather than inferred. Keep the assertion here; do not import antd column types elsewhere in
  * this directory.
  */
+
+const withClass = (props: ColumnCellProps | undefined, className: string): ColumnCellProps => ({
+    ...props,
+    className: props?.className ? `${props.className} ${className}` : className,
+})
+
+/**
+ * Stamps the stable cell hooks. Cells are recycled by virtualization, so they cannot be
+ * stamped from a mount effect the way the structural nodes are.
+ */
+const withCellHooks = <RecordType>(columns: ColumnDefs<RecordType>): ColumnDefs<RecordType> =>
+    columns.map((column) => {
+        const next = {
+            ...column,
+            onCell: (record: RecordType, index?: number) =>
+                withClass(column.onCell?.(record, index), AVT.cell),
+            onHeaderCell: (col: ColumnDefs<RecordType>[number], index?: number) =>
+                withClass(column.onHeaderCell?.(col, index), AVT.headerCell),
+        }
+        return isColumnGroupDef(column) ? {...next, children: withCellHooks(column.children)} : next
+    }) as ColumnDefs<RecordType>
+
 export const toAntdColumns = <RecordType>(columns: ColumnDefs<RecordType>) =>
-    columns as unknown as AntdColumnsType<RecordType>
+    withCellHooks(columns) as unknown as AntdColumnsType<RecordType>
 
 /** Columns arriving from an antd-typed call site, on their way into the table. */
 export const fromAntdColumns = <RecordType>(columns: AntdColumnsType<RecordType>) =>

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/components/InfiniteVirtualTableInner.tsx
@@ -40,6 +40,7 @@ import useTableRowSelection from "../hooks/useTableRowSelection"
 import {useTypeChipColumns} from "../hooks/useTypeChipColumns"
 import {useTypeChipFeature} from "../hooks/useTypeChipFeature"
 import ColumnVisibilityProvider from "../providers/ColumnVisibilityProvider"
+import {ANTD_SELECTOR, AVT, stampTableDom} from "../tableDom"
 import type {InfiniteVirtualTableProps} from "../types"
 import {
     buildColumnDescendantMap,
@@ -190,9 +191,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
             return
         }
         const headerCells = Array.from(
-            container.querySelectorAll<HTMLTableCellElement>(
-                ".ant-table-thead th[data-column-key]",
-            ),
+            container.querySelectorAll<HTMLTableCellElement>(ANTD_SELECTOR.headerCellWithKey),
         ).filter((cell) => Number(cell.getAttribute("colspan") ?? "1") === 1)
         if (!headerCells.length) {
             columnDomRefs.current = new Map()
@@ -329,7 +328,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
         const tables = container.querySelectorAll<HTMLTableElement>(".ant-table table")
         tables.forEach((table) => {
             const selectionCol = table.querySelector<HTMLTableColElement>(
-                "colgroup col.ant-table-selection-col",
+                ANTD_SELECTOR.selectionCol,
             )
             if (selectionCol) {
                 selectionCol.style.width = widthPx
@@ -339,7 +338,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
         })
 
         const headerCells = container.querySelectorAll<HTMLTableCellElement>(
-            ".ant-table-thead th.ant-table-selection-column",
+            ANTD_SELECTOR.headerSelectionCell,
         )
         headerCells.forEach((cell) => {
             cell.style.width = widthPx
@@ -366,7 +365,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
             return
         }
         const headerEl =
-            container.querySelector<HTMLElement>(".ant-table-thead") ??
+            container.querySelector<HTMLElement>(ANTD_SELECTOR.header) ??
             container.querySelector<HTMLElement>("table thead")
         if (!headerEl) {
             setTableHeaderHeight(null)
@@ -411,7 +410,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
         const headerHeight =
             (typeof tableHeaderHeight === "number" && Number.isFinite(tableHeaderHeight)
                 ? tableHeaderHeight
-                : (containerRef.current?.querySelector(".ant-table-thead") as HTMLElement | null)
+                : (containerRef.current?.querySelector(ANTD_SELECTOR.header) as HTMLElement | null)
                       ?.offsetHeight) ?? null
 
         const computedY = Math.max((scrollY ?? 0) - (headerHeight ?? 0), 0)
@@ -692,6 +691,20 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
     const columnVisibilityVersion = version
     const tableComponentRef = tableRef as unknown as Ref<TableRef>
 
+    // Stable class hooks for app code, so a consumer's selector does not depend on antd's DOM.
+    // The structural nodes exist for the table's lifetime; rows and cells get theirs from
+    // rowClassName and the column adapter, because virtualization recycles them.
+    useEffect(() => {
+        stampTableDom(containerRef.current)
+    }, [dataSource])
+
+    const rowClassName = useMemo<TableProps<RecordType>["rowClassName"]>(() => {
+        const inherited = tablePropsWithShortcuts.rowClassName
+        if (!inherited) return AVT.row
+        if (typeof inherited !== "function") return cn(inherited, AVT.row)
+        return (record, index, indent) => cn(inherited(record, index, indent), AVT.row)
+    }, [tablePropsWithShortcuts.rowClassName])
+
     useEffect(() => {
         const key = resolvedScopeId
         if (!key) return undefined
@@ -731,6 +744,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
                     <div
                         ref={containerRef}
                         className={cn(
+                            AVT.root,
                             "[&_.ant-table-empty_.ant-table-body]:!overflow-x-hidden",
                             containerClassName,
                         )}
@@ -746,6 +760,7 @@ const InfiniteVirtualTableInnerBase = <RecordType extends object>({
                             rowSelection={tableRowSelection}
                             expandable={tableExpandable}
                             {...tablePropsWithShortcuts}
+                            rowClassName={rowClassName}
                             scroll={{
                                 x: scrollConfig.x,
                                 y: scrollConfig.y,

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnDomRefs.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useColumnDomRefs.ts
@@ -1,6 +1,7 @@
 import {useLayoutEffect, useRef} from "react"
 
 import type {ColumnDefs} from "../columnDef"
+import {ANTD_SELECTOR} from "../tableDom"
 
 interface ColumnDomRefs {
     cols: HTMLTableColElement[]
@@ -24,9 +25,7 @@ const useColumnDomRefs = <RecordType>(
         }
 
         const headerCells = Array.from(
-            container.querySelectorAll<HTMLTableCellElement>(
-                ".ant-table-thead th[data-column-key]",
-            ),
+            container.querySelectorAll<HTMLTableCellElement>(ANTD_SELECTOR.headerCellWithKey),
         ).filter((cell) => Number(cell.getAttribute("colspan") ?? "1") === 1)
 
         if (!headerCells.length) {

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useScrollConfig.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useScrollConfig.ts
@@ -2,6 +2,7 @@ import {useMemo, useRef, type RefObject} from "react"
 
 import type {TableProps} from "antd/es/table"
 
+import {ANTD_SELECTOR} from "../tableDom"
 import {shallowEqual} from "../utils/columnUtils"
 
 interface UseScrollConfigOptions<RecordType> {
@@ -50,7 +51,7 @@ const useScrollConfig = <RecordType>({
         const headerHeight =
             (typeof tableHeaderHeight === "number" && Number.isFinite(tableHeaderHeight)
                 ? tableHeaderHeight
-                : (containerRef.current?.querySelector(".ant-table-thead") as HTMLElement | null)
+                : (containerRef.current?.querySelector(ANTD_SELECTOR.header) as HTMLElement | null)
                       ?.offsetHeight) ?? null
 
         const computedY = Math.max((containerHeight ?? 0) - (headerHeight ?? 0), 0)

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useScrollContainer.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useScrollContainer.ts
@@ -1,5 +1,7 @@
 import {useEffect, useRef, useState} from "react"
 
+import {ANTD_SELECTOR} from "../tableDom"
+
 interface ScrollContainerResult {
     scrollContainer: HTMLDivElement | null
     visibilityRoot: HTMLDivElement | null
@@ -33,7 +35,7 @@ const useScrollContainer = (
             return
         }
 
-        const tableBody = containerElement.querySelector<HTMLDivElement>(".ant-table-body") ?? null
+        const tableBody = containerElement.querySelector<HTMLDivElement>(ANTD_SELECTOR.body) ?? null
 
         const isScrollable = (element: HTMLDivElement | null) => {
             if (!element) return false
@@ -52,7 +54,7 @@ const useScrollContainer = (
         }
 
         const headerContainer =
-            containerElement.querySelector<HTMLDivElement>(".ant-table-container") ??
+            containerElement.querySelector<HTMLDivElement>(ANTD_SELECTOR.container) ??
             containerElement
 
         if (headerContainer !== lastVisibilityRootRef.current) {

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableHeaderHeight.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableHeaderHeight.ts
@@ -3,6 +3,7 @@ import {useLayoutEffect, useState, type RefObject} from "react"
 import type {TableProps} from "antd/es/table"
 
 import type {ColumnDefs} from "../columnDef"
+import {ANTD_SELECTOR} from "../tableDom"
 
 interface UseTableHeaderHeightOptions<RecordType> {
     containerRef: RefObject<HTMLDivElement | null>
@@ -29,7 +30,7 @@ const useTableHeaderHeight = <RecordType>({
             return
         }
         const headerEl =
-            container.querySelector<HTMLElement>(".ant-table-thead") ??
+            container.querySelector<HTMLElement>(ANTD_SELECTOR.header) ??
             container.querySelector<HTMLElement>("table thead")
         if (!headerEl) {
             setTableHeaderHeight(null)

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
@@ -17,6 +17,7 @@ import type {
     TableDeleteConfig,
     TableExportConfig,
 } from "../features/InfiniteVirtualTableFeatureShell"
+import {ANTD_SELECTOR} from "../tableDom"
 import type {
     InfiniteTableRowBase,
     InfiniteVirtualTableProps,
@@ -31,7 +32,7 @@ const dummySearchAtom = atom("")
 const INTERACTIVE_SELECTOR =
     "button, a, input, textarea, select, [role='button'], [role='menuitem'], [role='checkbox'], " +
     ".ant-btn, .ant-checkbox, .ant-checkbox-input, .ant-checkbox-inner, .ant-checkbox-wrapper, " +
-    ".ant-select, .ant-dropdown-trigger, .ant-table-selection-column, .ag-table-actions-cell"
+    ANTD_SELECTOR.interactiveCell
 
 /**
  * Returns true when the click originated from an interactive element (button, link,

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/index.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/index.ts
@@ -137,6 +137,7 @@ export type {
     ColumnSorterConfig,
 } from "./columnDef"
 export {toAntdColumns, fromAntdColumns} from "./antdColumns"
+export {AVT, ANTD_SELECTOR, stampTableDom, type AvtClass} from "./tableDom"
 export type {VisibilityRegistrationHandler} from "./components/ColumnVisibilityHeader"
 
 // Shared hooks for cell renderers

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/tableDom.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/tableDom.ts
@@ -1,0 +1,55 @@
+/**
+ * The table's DOM contract, in one file.
+ *
+ * `AVT` names are stamped onto the rendered table by the package and are the only hooks app
+ * code should target. They survive the render-leaf swap; `.ant-table-*` will not.
+ *
+ * `ANTD_SELECTOR` is where each hook lives in antd's DOM today. It is the implementation
+ * detail the swap replaces, so keep every `.ant-table-*` string in this file and nowhere else
+ * in the directory.
+ */
+
+export const AVT = {
+    root: "avt-table",
+    container: "avt-container",
+    body: "avt-body",
+    header: "avt-thead",
+    row: "avt-row",
+    cell: "avt-cell",
+    headerCell: "avt-head-cell",
+} as const
+
+export type AvtClass = (typeof AVT)[keyof typeof AVT]
+
+export const ANTD_SELECTOR = {
+    container: ".ant-table-container",
+    body: ".ant-table-body",
+    bodyInner: ".ant-table-body-inner",
+    header: ".ant-table-thead",
+    headerCellWithKey: ".ant-table-thead th[data-column-key]",
+    headerSelectionCell: ".ant-table-thead th.ant-table-selection-column",
+    selectionCol: "colgroup col.ant-table-selection-col",
+    /** Cells that own their click, so row-click shortcuts skip them. */
+    interactiveCell:
+        ".ant-select, .ant-dropdown-trigger, .ant-table-selection-column, .ag-table-actions-cell",
+} as const
+
+/** Structural nodes rendered once per table, so a mount-time stamp is enough. */
+const STAMPED: [selector: string, className: string][] = [
+    [ANTD_SELECTOR.container, AVT.container],
+    [ANTD_SELECTOR.body, AVT.body],
+    [ANTD_SELECTOR.header, AVT.header],
+]
+
+/**
+ * Adds the stable class hooks to a mounted table.
+ *
+ * Rows and cells are not stamped here — virtualization recycles them, so they get their class
+ * through `rowClassName` and the column adapter instead.
+ */
+export const stampTableDom = (container: HTMLElement | null): void => {
+    if (!container) return
+    for (const [selector, className] of STAMPED) {
+        container.querySelector(selector)?.classList.add(className)
+    }
+}


### PR DESCRIPTION
## Context

App code that styles a table reaches into antd's DOM. The observability traces table hides a header row with `[&_.ant-table-thead_tr:nth-child(2)]:hidden`, the sessions table aligns body cells with `[&_.ant-table-tbody_.ant-table-cell]:align-top`, and four more places do the same.

`<Table virtual>` is going to be replaced (`docs/design/observability-packages/plan.md` §8 step 3). When it is, every one of those selectors stops matching. Nothing catches that: no type error, no failing test, just styling that quietly stops applying.

Step 4 of that plan exists to remove the trap before the swap, and it is scheduled ahead of the swap for exactly this reason. This PR does it.

## Changes

The table stamps its own class hooks, and app code targets those:

```
avt-table  avt-container  avt-body  avt-thead  avt-row  avt-cell  avt-head-cell
```

Structural nodes are stamped once on mount, since they live as long as the table does. Rows and cells cannot be stamped that way, because virtualization recycles them. Rows get their class through `rowClassName` (merged with whatever the caller passed) and cells through the column adapter, which was already the one place columns cross into antd.

Before, in `ObservabilityTable`:

```
className="flex-1 min-h-0 [&_.ant-table-thead_tr:nth-child(2)]:hidden"
```

After:

```
className="flex-1 min-h-0 [&_.avt-thead_tr:nth-child(2)]:hidden"
```

`tableDom.ts` is now the only file in the directory that spells an antd table selector. The six hooks that read the table's DOM go through its map, so step 3 edits one file instead of hunting selectors across the package.

Consumers migrated: the observability traces and sessions tables, the agents and prompts table sections, and `useCellVisibility`. `globals.css` keeps its antd selector next to the new one, because raw `<Table>` call sites still rely on it.

## Tests / notes

- Five unit tests pin the contract in `@agenta/entity-ui`: the structural stamp, the missing-node and null cases, cell hooks on a plain column, merging with a column's own `onCell` props, and reaching columns nested in a group. A broken hook is invisible at runtime, so a test is worth more here than a browser pass.
- `@agenta/entity-ui` is now 330 tests, up from 325. `@agenta/ui` and OSS both typecheck; `@agenta/ui`, `@agenta/entity-ui` and the touched OSS files lint clean.
- `AVT` and `stampTableDom` are exported from `@agenta/ui/table`, so app code can reference the names rather than hardcode them.
- Deliberately not migrated: the wrapper-scoped blocks in `globals.css`, `evaluations.css` and `human-evals.css` (`.comparison-table`, `.agenta-testsets-table`, `.org-domains-table`, `.no-expand-col` and the rest). They are structural, they carry real visual risk, and most belong to raw antd tables that keep `.ant-table-*` regardless. They are step-3 work.

## What to QA

No visual change is expected. The risk is a rule that stops applying, so check the four migrated surfaces.

- Observability traces: the second header row stays hidden.
- Observability sessions: body cell content sits at the top of its cell, not centred.
- Agents and Prompts table sections: cells are vertically centred and the table has its bottom border.
- Evaluation run details: scrolling a wide table still lazily renders cells as they come into view.
- Regression: hover a row anywhere with a hover action button. The button still fades in.
