### PR TITLE
[refactor] The table's peripheral chrome comes off antd

### DIFF
--- a/web/oss/src/components/EvalRunDetails/hooks/useRowHeightMenuItems.tsx
+++ b/web/oss/src/components/EvalRunDetails/hooks/useRowHeightMenuItems.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from "react"
 
+import type {TableMenuItem} from "@agenta/ui/table"
 import {Rows} from "@phosphor-icons/react"
-import type {MenuProps} from "antd"
 import {useAtom} from "jotai"
 
 import {ROW_HEIGHT_CONFIG, scenarioRowHeightAtom, type ScenarioRowHeight} from "../state/rowHeight"
@@ -11,25 +11,28 @@ const ROW_HEIGHT_OPTIONS: ScenarioRowHeight[] = ["small", "medium", "large"]
 /**
  * Hook that returns menu items for row height selection in the settings dropdown
  */
-const useRowHeightMenuItems = (): MenuProps["items"] => {
+const useRowHeightMenuItems = (): TableMenuItem[] => {
     const [rowHeight, setRowHeight] = useAtom(scenarioRowHeightAtom)
 
-    return useMemo(() => {
-        const items: MenuProps["items"] = [
+    return useMemo(
+        () => [
             {
                 key: "row-height",
                 label: "Row height",
                 icon: <Rows size={16} />,
                 children: ROW_HEIGHT_OPTIONS.map((height) => ({
                     key: `row-height-${height}`,
-                    label: ROW_HEIGHT_CONFIG[height].label,
+                    label: (
+                        <span className={rowHeight === height ? "font-semibold" : undefined}>
+                            {ROW_HEIGHT_CONFIG[height].label}
+                        </span>
+                    ),
                     onClick: () => setRowHeight(height),
-                    style: rowHeight === height ? {fontWeight: 600} : undefined,
                 })),
             },
-        ]
-        return items
-    }, [rowHeight, setRowHeight])
+        ],
+        [rowHeight, setRowHeight],
+    )
 }
 
 export default useRowHeightMenuItems

--- a/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
+++ b/web/oss/src/components/TestcasesTableNew/components/TestcasesTableShell.tsx
@@ -10,11 +10,10 @@ import {
     useTypeChipFeature,
     type ExtendedColumn,
 } from "@agenta/ui/table"
-import type {ColumnDef, ColumnDefs} from "@agenta/ui/table"
+import type {ColumnDef, ColumnDefs, TableMenuItem} from "@agenta/ui/table"
 import {TypeChip, type ChipVariant} from "@agenta/ui/type-chip"
 import {PlusOutlined} from "@ant-design/icons"
 import {Button, Input, Skeleton, Tooltip} from "antd"
-import type {MenuProps} from "antd"
 import clsx from "clsx"
 import {useAtomValue} from "jotai"
 import {getDefaultStore} from "jotai/vanilla"
@@ -101,7 +100,7 @@ export interface TestcasesTableShellProps {
         size: "small" | "medium" | "large"
         heightPx: number
         maxLines: number
-        menuItems: MenuProps["items"]
+        menuItems: TableMenuItem[]
     }
     selectedRowKeys: React.Key[]
     onSelectedRowKeysChange: (keys: React.Key[]) => void
@@ -303,7 +302,7 @@ export function TestcasesTableShell(props: TestcasesTableShellProps) {
         entityObjectSubKeys,
     ])
 
-    const settingsMenuItems = useMemo<MenuProps["items"]>(
+    const settingsMenuItems = useMemo<TableMenuItem[]>(
         () => rowHeight.menuItems,
         [rowHeight.menuItems],
     )

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/createStandardColumns.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/columns/createStandardColumns.tsx
@@ -2,23 +2,28 @@ import type {ComponentType, ReactNode} from "react"
 
 import {MoreOutlined} from "@ant-design/icons"
 import {Copy, DownloadSimple} from "@phosphor-icons/react"
-import {Dropdown, Tooltip, Typography} from "antd"
-import type {MenuProps} from "antd"
 
 import {InitialsAvatar} from "../../components/presentational/avatar"
 import {CopyButton} from "../../components/presentational/CopyButton"
 import {StatusIndicator, type StatusTone} from "../../components/presentational/status"
 import {Tag, type TagProps} from "../../components/presentational/tag"
 import {Button} from "../../components/ui/button"
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+} from "../../components/ui/dropdown-menu"
+import {SimpleTooltip} from "../../components/ui/tooltip-composed"
 import {copyToClipboard} from "../../utils/copyToClipboard"
 import type {ColumnDef, ColumnDefs} from "../columnDef"
 import ColumnVisibilityMenuTrigger from "../components/columnVisibility/ColumnVisibilityMenuTrigger"
 import SkeletonLine from "../components/common/SkeletonLine"
+import {renderTableMenuItems, type TableMenuItem} from "../tableMenu"
 import type {InfiniteTableRowBase} from "../types"
 
 // Default fallback for UserReference - just shows the userId
 const DefaultUserReference = ({userId}: {userId: string | null | undefined}) => {
-    if (!userId) return <Typography.Text type="secondary">—</Typography.Text>
+    if (!userId) return <span className="text-colorTextSecondary">—</span>
     return <span className="truncate">{userId}</span>
 }
 
@@ -153,7 +158,7 @@ export interface ActionItem<T> {
     label: string
     icon?: ReactNode
     danger?: boolean
-    onClick: (record: T, event?: {domEvent: React.MouseEvent | React.KeyboardEvent}) => void
+    onClick: (record: T) => void
     /** Hide this action conditionally */
     hidden?: (record: T) => boolean
     /** Render the action but block it — e.g. while the same action is already running. */
@@ -330,7 +335,7 @@ function createMonoColumn<T extends InfiniteTableRowBase>(def: MonoColumnDef<T>)
         render: (_value: unknown, record: T) => {
             if (record.__isSkeleton) return <SkeletonLine width="70%" />
             const text = readCell(record, key, getValue)
-            if (!text) return <Typography.Text type="secondary">{emptyText}</Typography.Text>
+            if (!text) return <span className="text-colorTextSecondary">{emptyText}</span>
             return (
                 <div className="h-full flex items-center min-w-0">
                     <span className="font-mono text-xs truncate" title={text}>
@@ -356,7 +361,7 @@ function createSlugColumn<T extends InfiniteTableRowBase>(def: SlugColumnDef<T>)
         render: (_value: unknown, record: T) => {
             if (record.__isSkeleton) return <SkeletonLine width="70%" />
             const text = readCell(record, key, getValue)
-            if (!text) return <Typography.Text type="secondary">{emptyText}</Typography.Text>
+            if (!text) return <span className="text-colorTextSecondary">{emptyText}</span>
             return (
                 // `group` + the button's group-hover keeps the copy affordance quiet until
                 // the row is hovered, matching the `⋯` button's behaviour.
@@ -473,12 +478,7 @@ function createActionsColumn<T extends InfiniteTableRowBase>(
         render: (_, record) => {
             if (record.__isSkeleton) return null
 
-            // Build menu items from config
-            // MenuInfo interface from antd/rc-menu
-            interface MenuInfo {
-                domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
-            }
-            const menuItems: NonNullable<MenuProps["items"]> = []
+            const menuItems: TableMenuItem[] = []
 
             items.forEach((item) => {
                 if ("type" in item && item.type === "divider") {
@@ -506,10 +506,9 @@ function createActionsColumn<T extends InfiniteTableRowBase>(
                     icon: actionItem.icon,
                     danger: actionItem.danger,
                     disabled: isDisabled,
-                    onClick: (e: MenuInfo) => {
-                        e.domEvent.stopPropagation()
+                    onClick: () => {
                         if (isDisabled) return
-                        actionItem.onClick(record, e)
+                        actionItem.onClick(record)
                     },
                 })
             })
@@ -521,8 +520,7 @@ function createActionsColumn<T extends InfiniteTableRowBase>(
                     label: "Export row",
                     icon: <DownloadSimple size={16} />,
                     disabled: isExporting,
-                    onClick: (e: MenuInfo) => {
-                        e.domEvent.stopPropagation()
+                    onClick: () => {
                         if (!isExporting) {
                             onExportRow(record)
                         }
@@ -547,10 +545,7 @@ function createActionsColumn<T extends InfiniteTableRowBase>(
                         key: "copy-id",
                         label: "Copy ID",
                         icon: <Copy size={16} />,
-                        onClick: (e: MenuInfo) => {
-                            e.domEvent.stopPropagation()
-                            copyToClipboard(recordId)
-                        },
+                        onClick: () => copyToClipboard(recordId),
                     })
                 }
             }
@@ -563,10 +558,7 @@ function createActionsColumn<T extends InfiniteTableRowBase>(
                         key: "copy-slug",
                         label: "Copy Slug",
                         icon: <Copy size={16} />,
-                        onClick: (e: MenuInfo) => {
-                            e.domEvent.stopPropagation()
-                            copyToClipboard(slug)
-                        },
+                        onClick: () => copyToClipboard(slug),
                     })
                 }
             }
@@ -592,19 +584,25 @@ function createActionsColumn<T extends InfiniteTableRowBase>(
                     className="w-full h-full flex items-center justify-center"
                     onClick={(e) => e.stopPropagation()}
                 >
-                    <Dropdown
-                        trigger={["click"]}
-                        // minWidth (not a fixed width) so long labels like "Switch to this
-                        // organization" grow the menu instead of wrapping onto two lines.
-                        styles={{root: {minWidth: 200}}}
-                        menu={{items: cleanedItems}}
-                    >
-                        <Tooltip title="Actions">
-                            <Button onClick={(e) => e.stopPropagation()} variant="ghost" size="sm">
-                                {<MoreOutlined />}
-                            </Button>
-                        </Tooltip>
-                    </Dropdown>
+                    <DropdownMenu>
+                        <SimpleTooltip title="Actions">
+                            <DropdownMenuTrigger asChild>
+                                <Button
+                                    onClick={(e) => e.stopPropagation()}
+                                    variant="ghost"
+                                    size="sm"
+                                    aria-label="Actions"
+                                >
+                                    <MoreOutlined />
+                                </Button>
+                            </DropdownMenuTrigger>
+                        </SimpleTooltip>
+                        {/* minWidth (not a fixed width) so long labels like "Switch to this
+                            organization" grow the menu instead of wrapping onto two lines. */}
+                        <DropdownMenuContent align="end" className="min-w-[200px]">
+                            {renderTableMenuItems(cleanedItems)}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
                 </div>
             )
         },

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/components/ColumnVisibilityTrigger.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/components/ColumnVisibilityTrigger.tsx
@@ -2,9 +2,11 @@ import type {MouseEvent, ReactNode} from "react"
 import {useMemo, useState} from "react"
 
 import {GearSix} from "@phosphor-icons/react"
-import {Checkbox, Popover, Tooltip} from "antd"
 
 import {Button} from "../../components/ui/button"
+import {Checkbox} from "../../components/ui/checkbox"
+import {Popover, PopoverContent, PopoverTrigger} from "../../components/ui/popover"
+import {SimpleTooltip} from "../../components/ui/tooltip-composed"
 import type {ColumnVisibilityState} from "../types"
 
 type ColumnVisibilityControls<Row extends object> = ColumnVisibilityState<Row>
@@ -31,20 +33,25 @@ const DefaultVisibilityContent = <Row extends object>({
             const label = node.titleNode ?? node.label ?? String(node.key)
             const childNodes = node.children?.length ? renderNodes(node.children, depth + 1) : null
             const isGroup = Boolean(node.children?.length)
+            const id = `column-visibility-${String(node.key)}`
             return (
                 <div key={node.key} className="flex flex-col gap-1">
-                    <Checkbox
-                        indeterminate={node.indeterminate}
-                        checked={node.checked}
-                        onChange={() =>
-                            isGroup
-                                ? controls.toggleTree(node.key)
-                                : controls.toggleColumn(node.key)
-                        }
+                    <label
+                        htmlFor={id}
+                        className="flex items-center gap-2 cursor-pointer text-field-md text-colorText"
                         style={{marginLeft: depth ? depth * 12 : 0}}
                     >
+                        <Checkbox
+                            id={id}
+                            checked={node.indeterminate ? "indeterminate" : node.checked}
+                            onCheckedChange={() =>
+                                isGroup
+                                    ? controls.toggleTree(node.key)
+                                    : controls.toggleColumn(node.key)
+                            }
+                        />
                         {label}
-                    </Checkbox>
+                    </label>
                     {childNodes}
                 </div>
             )
@@ -52,9 +59,9 @@ const DefaultVisibilityContent = <Row extends object>({
 
     return (
         <div className="flex flex-col gap-3 min-w-[220px]">
-            <div className="text-xs text-zinc-6">Toggle columns</div>
+            <div className="text-xs text-colorTextSecondary">Toggle columns</div>
             <div className="max-h-64 overflow-auto pr-1">{renderNodes(nodes)}</div>
-            <div className="border-0 border-t border-solid border-zinc-2 my-1" />
+            <div className="h-px bg-colorBorderSecondary my-1" />
             <div className="flex justify-between gap-2">
                 <Button variant="outline" size="sm" onClick={() => controls.reset()}>
                     Reset
@@ -81,46 +88,43 @@ const ColumnVisibilityTrigger = <Row extends object>({
         [leafKeys, isHidden],
     )
 
-    const stopPropagation = (event: MouseEvent) => {
-        event.preventDefault()
-        event.stopPropagation()
-    }
+    // Stop the click reaching the header cell (which sorts) but do NOT preventDefault: the
+    // trigger's own open handler is composed onto this same element and is skipped once the
+    // event is default-prevented. That is what left this control dead under antd.
+    const stopPropagation = (event: MouseEvent) => event.stopPropagation()
 
     const triggerNode =
         variant === "icon" ? (
-            <Tooltip title={label}>
-                <Button
-                    className="rounded-control-round"
-                    size="icon"
-                    variant="ghost"
-                    onClick={stopPropagation}
-                >
-                    {<GearSix size={16} weight="bold" />}
-                </Button>
-            </Tooltip>
+            <Button
+                className="rounded-control-round"
+                size="icon"
+                variant="ghost"
+                aria-label={label}
+                onClick={stopPropagation}
+            >
+                <GearSix size={16} weight="bold" />
+            </Button>
         ) : (
             <Button variant="outline" onClick={stopPropagation}>
-                {<GearSix size={14} weight="bold" />}
+                <GearSix size={14} weight="bold" />
                 {label} ({visibleLeafCount})
             </Button>
         )
 
-    const content = renderContent ? (
-        renderContent(controls, () => setOpen(false))
-    ) : (
-        <DefaultVisibilityContent controls={controls} onClose={() => setOpen(false)} />
-    )
-
     return (
-        <Popover
-            trigger="click"
-            placement="bottomRight"
-            destroyOnHidden
-            open={open}
-            onOpenChange={(value) => setOpen(value)}
-            content={content}
-        >
-            {triggerNode}
+        <Popover open={open} onOpenChange={setOpen}>
+            {/* Tooltip outside, popover trigger inside: each `asChild` clones down to the same
+                button, so both sets of handlers compose onto it. */}
+            <SimpleTooltip title={variant === "icon" ? label : undefined}>
+                <PopoverTrigger asChild>{triggerNode}</PopoverTrigger>
+            </SimpleTooltip>
+            <PopoverContent align="end" className="w-auto p-3">
+                {renderContent ? (
+                    renderContent(controls, () => setOpen(false))
+                ) : (
+                    <DefaultVisibilityContent controls={controls} onClose={() => setOpen(false)} />
+                )}
+            </PopoverContent>
         </Popover>
     )
 }

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/components/TableDescription.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/components/TableDescription.tsx
@@ -1,7 +1,5 @@
 import type {ReactNode} from "react"
 
-import {Typography} from "antd"
-
 import {cn} from "../../utils/styles"
 
 export interface TableDescriptionProps {
@@ -37,13 +35,16 @@ const TableDescription = ({children, className, maxWidth = "prose"}: TableDescri
     }[maxWidth]
 
     return (
-        <Typography.Paragraph
-            type="secondary"
-            className={cn(maxWidthClass, "line-clamp-2 h-10", className)}
-            style={{marginBottom: 0}}
+        <p
+            className={cn(
+                "mb-0 text-colorTextSecondary",
+                maxWidthClass,
+                "line-clamp-2 h-10",
+                className,
+            )}
         >
             {children}
-        </Typography.Paragraph>
+        </p>
     )
 }
 

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/components/columnVisibility/TableSettingsDropdown.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/components/columnVisibility/TableSettingsDropdown.tsx
@@ -1,10 +1,16 @@
 import {type ReactNode, useState, useMemo, useCallback} from "react"
 
 import {DownloadSimple, Eye, GearSix, Trash} from "@phosphor-icons/react"
-import {Dropdown, Popover, Tooltip} from "antd"
-import type {MenuProps} from "antd"
 
 import {Button} from "../../../components/ui/button"
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+} from "../../../components/ui/dropdown-menu"
+import {Popover, PopoverAnchor, PopoverContent} from "../../../components/ui/popover"
+import {SimpleTooltip} from "../../../components/ui/tooltip-composed"
+import {renderTableMenuItems, type TableMenuItem} from "../../tableMenu"
 import type {ColumnVisibilityState} from "../../types"
 
 export interface TableSettingsDropdownProps<RowType extends object> {
@@ -19,7 +25,7 @@ export interface TableSettingsDropdownProps<RowType extends object> {
         close: () => void,
     ) => ReactNode
     /** Additional menu items to render after Column visibility */
-    additionalMenuItems?: MenuProps["items"]
+    additionalMenuItems?: TableMenuItem[]
 }
 
 /**
@@ -53,17 +59,14 @@ const TableSettingsDropdown = <RowType extends object>({
     }, [])
 
     const menuItems = useMemo(() => {
-        const items: MenuProps["items"] = []
+        const items: TableMenuItem[] = []
 
         // Column Visibility option
         items.push({
             key: "column-visibility",
             label: "Column visibility",
             icon: <Eye size={16} />,
-            onClick: (e) => {
-                e.domEvent.stopPropagation()
-                handleOpenColumnVisibility()
-            },
+            onClick: handleOpenColumnVisibility,
         })
 
         // Additional menu items (e.g., Row height)
@@ -80,8 +83,7 @@ const TableSettingsDropdown = <RowType extends object>({
                 label: isExporting ? "Exporting..." : "Export to CSV",
                 icon: <DownloadSimple size={16} />,
                 disabled: isExporting,
-                onClick: (e) => {
-                    e.domEvent.stopPropagation()
+                onClick: () => {
                     onExport()
                     setDropdownOpen(false)
                 },
@@ -97,8 +99,7 @@ const TableSettingsDropdown = <RowType extends object>({
                 icon: <Trash size={16} />,
                 disabled: deleteDisabled,
                 danger: true,
-                onClick: (e) => {
-                    e.domEvent.stopPropagation()
+                onClick: () => {
                     onDelete()
                     setDropdownOpen(false)
                 },
@@ -117,41 +118,39 @@ const TableSettingsDropdown = <RowType extends object>({
     ])
 
     return (
-        <Popover
-            trigger={[]}
-            placement="bottomRight"
-            open={columnVisibilityOpen}
-            onOpenChange={setColumnVisibilityOpen}
-            content={renderColumnVisibilityContent(controls, handleCloseColumnVisibility)}
-            destroyOnHidden
-        >
-            <Dropdown
-                trigger={["click"]}
-                placement="bottomRight"
-                open={dropdownOpen}
-                onOpenChange={(open) => {
-                    // Don't open dropdown if column visibility popover is open
-                    if (columnVisibilityOpen && open) return
-                    setDropdownOpen(open)
-                }}
-                menu={{items: menuItems}}
-                styles={{
-                    root: {
-                        minWidth: 180,
-                    },
-                }}
-            >
-                <Tooltip title="Table settings">
-                    <Button
-                        className="rounded-control-round"
-                        size="icon"
-                        variant="ghost"
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        {<GearSix size={16} weight="bold" />}
-                    </Button>
-                </Tooltip>
-            </Dropdown>
+        // The column-visibility popover is anchored to the same gear, so it wraps the menu and
+        // opens with no trigger of its own.
+        <Popover open={columnVisibilityOpen} onOpenChange={setColumnVisibilityOpen}>
+            <PopoverAnchor>
+                <DropdownMenu
+                    open={dropdownOpen}
+                    onOpenChange={(open) => {
+                        // Don't open dropdown if column visibility popover is open
+                        if (columnVisibilityOpen && open) return
+                        setDropdownOpen(open)
+                    }}
+                >
+                    <SimpleTooltip title="Table settings">
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                className="rounded-control-round"
+                                size="icon"
+                                variant="ghost"
+                                aria-label="Table settings"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                <GearSix size={16} weight="bold" />
+                            </Button>
+                        </DropdownMenuTrigger>
+                    </SimpleTooltip>
+                    <DropdownMenuContent align="end" className="min-w-[180px]">
+                        {renderTableMenuItems(menuItems)}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </PopoverAnchor>
+            <PopoverContent align="end" className="w-auto p-3">
+                {renderColumnVisibilityContent(controls, handleCloseColumnVisibility)}
+            </PopoverContent>
         </Popover>
     )
 }

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/components/common/ResizableTitle.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/components/common/ResizableTitle.tsx
@@ -1,9 +1,9 @@
 import {memo, useMemo, useState} from "react"
 import type {ThHTMLAttributes} from "react"
 
-import {Skeleton} from "antd"
 import {Resizable, type ResizeCallbackData} from "react-resizable"
 
+import {SkeletonBlock} from "../../../components/ui/skeleton"
 import {cn} from "../../../utils/styles"
 
 type ResizeHandler = (e: React.SyntheticEvent, data: ResizeCallbackData) => void
@@ -84,7 +84,9 @@ export const ResizableTitle = memo((props: ResizableTitleProps) => {
 })
 
 export const SkeletonCell = memo(() => (
-    <div className="min-h-[32px] flex justify-center [&_*]:!min-w-full [&_*]:!w-full [&_*]:!max-w-full">
-        <Skeleton.Input active style={{minHeight: 24, margin: 0, padding: 0}} />
+    <div className="min-h-[32px] flex justify-center">
+        {/* antd's Skeleton.Input, which the @agenta/ui port deliberately omits: a full-width
+            block at antd's controlHeight. */}
+        <SkeletonBlock active className="w-full h-6 rounded-control-sm" />
     </div>
 ))

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/features/InfiniteVirtualTableFeatureShell.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/features/InfiniteVirtualTableFeatureShell.tsx
@@ -2,11 +2,15 @@ import type {CSSProperties, Key, ReactNode} from "react"
 import {useCallback, useEffect, useMemo, useState} from "react"
 
 import {Export, Trash} from "@phosphor-icons/react"
-import type {MenuProps} from "antd"
-import {Grid, Pagination, Tabs, Tooltip} from "antd"
+// The last antd component in this package besides <Table>. @agenta/ui has no Pagination
+// primitive, and one page (application management) renders paginationMode="paginated".
+import {Pagination} from "antd"
 
 import {Button} from "../../components/ui/button"
 import {LoadingButton} from "../../components/ui/button-composed"
+import {Tabs, TabsList, TabsTrigger} from "../../components/ui/tabs"
+import {SimpleTooltip} from "../../components/ui/tooltip-composed"
+import {useIsNarrowScreen} from "../../hooks/useMediaQuery"
 import {cn} from "../../utils/styles"
 import ColumnVisibilityPopoverContent from "../components/columnVisibility/ColumnVisibilityPopoverContent"
 import TableSettingsDropdown from "../components/columnVisibility/TableSettingsDropdown"
@@ -17,6 +21,7 @@ import {useRowHeightFeature, type RowHeightFeatureConfig} from "../hooks/useRowH
 import useTableExport, {type TableExportOptions} from "../hooks/useTableExport"
 import {useTypeChipFeature} from "../hooks/useTypeChipFeature"
 import InfiniteVirtualTable from "../InfiniteVirtualTable"
+import type {TableMenuItem} from "../tableMenu"
 import type {
     ColumnVisibilityMenuRenderer,
     ColumnVisibilityState,
@@ -185,7 +190,7 @@ export interface InfiniteVirtualTableFeatureProps<Row extends InfiniteTableRowBa
      * Additional menu items for the settings dropdown.
      * Only used when useSettingsDropdown is true.
      */
-    settingsDropdownMenuItems?: MenuProps["items"]
+    settingsDropdownMenuItems?: TableMenuItem[]
     keyboardShortcuts?: InfiniteVirtualTableProps<Row>["keyboardShortcuts"]
     /**
      * Configuration for expandable rows.
@@ -345,12 +350,12 @@ function InfiniteVirtualTableFeatureShellBase<Row extends InfiniteTableRowBase>(
     const rowHeight = rowHeightFeature?.heightPx ?? rowHeightProp
 
     // Combine settings dropdown menu items with built-in table feature items
-    const combinedSettingsDropdownMenuItems = useMemo<MenuProps["items"]>(() => {
+    const combinedSettingsDropdownMenuItems = useMemo<TableMenuItem[] | undefined>(() => {
         const menuGroups = [
             typeChipFeature.menuItems,
             rowHeightFeature?.menuItems,
             settingsDropdownMenuItems,
-        ].filter((items): items is NonNullable<MenuProps["items"]> => Boolean(items?.length))
+        ].filter((items): items is TableMenuItem[] => Boolean(items?.length))
 
         if (!menuGroups.length) return undefined
 
@@ -360,8 +365,7 @@ function InfiniteVirtualTableFeatureShellBase<Row extends InfiniteTableRowBase>(
     }, [rowHeightFeature?.menuItems, settingsDropdownMenuItems, typeChipFeature.menuItems])
 
     // Responsive breakpoints for built-in action buttons
-    const screens = Grid.useBreakpoint()
-    const isNarrowScreen = !screens.lg
+    const isNarrowScreen = useIsNarrowScreen()
 
     // Hide built-in export/delete buttons when settings dropdown is active
     // (either forced via prop or responsive narrow screen)
@@ -540,7 +544,12 @@ function InfiniteVirtualTableFeatureShellBase<Row extends InfiniteTableRowBase>(
             </Button>
         )
         if (disabled && disabledTooltip) {
-            return <Tooltip title={disabledTooltip}>{button}</Tooltip>
+            // A disabled button swallows pointer events, so the tooltip needs a wrapper.
+            return (
+                <SimpleTooltip title={disabledTooltip}>
+                    <span>{button}</span>
+                </SimpleTooltip>
+            )
         }
         return button
     }, [deleteAction, hideBuiltInButtons])
@@ -562,9 +571,9 @@ function InfiniteVirtualTableFeatureShellBase<Row extends InfiniteTableRowBase>(
         )
         if (disabled && disabledTooltip) {
             return (
-                <Tooltip title={disabledTooltip}>
+                <SimpleTooltip title={disabledTooltip}>
                     <span>{button}</span>
-                </Tooltip>
+                </SimpleTooltip>
             )
         }
         return button
@@ -695,16 +704,20 @@ function InfiniteVirtualTableFeatureShellBase<Row extends InfiniteTableRowBase>(
                         : undefined
                 }
             >
+                {/* Tab bar only: the table below is the panel, so there is no TabsContent. */}
                 <Tabs
                     className="min-w-[320px]"
-                    activeKey={tabs.activeKey}
-                    items={tabs.items.map((item) => ({
-                        key: item.key,
-                        label: item.label,
-                    }))}
-                    onChange={tabs.onChange}
-                    destroyOnHidden
-                />
+                    value={tabs.activeKey}
+                    onValueChange={tabs.onChange}
+                >
+                    <TabsList>
+                        {tabs.items.map((item) => (
+                            <TabsTrigger key={item.key} value={item.key}>
+                                {item.label}
+                            </TabsTrigger>
+                        ))}
+                    </TabsList>
+                </Tabs>
             </div>
         )
     }, [tabs, headerExtra])

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useRowHeight.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useRowHeight.tsx
@@ -1,9 +1,10 @@
 import {useMemo} from "react"
 
 import {Rows} from "@phosphor-icons/react"
-import type {MenuProps} from "antd"
 import {atom, useAtom, useAtomValue} from "jotai"
 import {atomWithStorage} from "jotai/utils"
+
+import type {TableMenuItem} from "../tableMenu"
 
 /**
  * Row height size options
@@ -99,7 +100,7 @@ export interface UseRowHeightResult {
     /** Max lines to show in cells */
     maxLines: number
     /** Menu items for the settings dropdown */
-    menuItems: MenuProps["items"]
+    menuItems: TableMenuItem[]
 }
 
 /**
@@ -137,7 +138,7 @@ export function useRowHeight(
     const heightPx = useMemo(() => config.sizes[size].height, [config.sizes, size])
     const maxLines = useMemo(() => config.sizes[size].maxLines ?? 10, [config.sizes, size])
 
-    const menuItems = useMemo<MenuProps["items"]>(() => {
+    const menuItems = useMemo<TableMenuItem[]>(() => {
         const sizes: RowHeightSize[] = ["small", "medium", "large"]
         return [
             {
@@ -146,9 +147,13 @@ export function useRowHeight(
                 icon: <Rows size={16} />,
                 children: sizes.map((s) => ({
                     key: `row-height-${s}`,
-                    label: config.sizes[s].label,
+                    // The selected size reads as bold, the way antd's inline style did.
+                    label: (
+                        <span className={size === s ? "font-semibold" : undefined}>
+                            {config.sizes[s].label}
+                        </span>
+                    ),
                     onClick: () => setSize(s),
-                    style: size === s ? {fontWeight: 600} : undefined,
                 })),
             },
         ]

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useRowHeightFeature.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useRowHeightFeature.tsx
@@ -1,9 +1,9 @@
 import {useMemo} from "react"
 
-import type {MenuProps} from "antd"
 import {atomWithStorage} from "jotai/utils"
 
 import type {RowHeightContextValue} from "../context/RowHeightContext"
+import type {TableMenuItem} from "../tableMenu"
 
 import {
     DEFAULT_ROW_HEIGHT_CONFIG,
@@ -31,7 +31,7 @@ export interface UseRowHeightFeatureResult {
     /** Context value to provide to RowHeightContext.Provider */
     contextValue: RowHeightContextValue
     /** Menu items for the settings dropdown */
-    menuItems: MenuProps["items"]
+    menuItems: TableMenuItem[]
     /** Row height in pixels (for IVT rowHeight prop) */
     heightPx: number
 }

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTableManager.tsx
@@ -1,12 +1,12 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import type {Key, MouseEvent, ReactNode, RefObject} from "react"
 
-import {Grid} from "antd"
 import type {WritableAtom} from "jotai"
 import {useAtom} from "jotai"
 import {atom} from "jotai"
 
 import {SearchInput} from "../../components/ui/input-composed"
+import {useIsNarrowScreen} from "../../hooks/useMediaQuery"
 import {cn} from "../../utils/styles"
 import type {ColumnDefs} from "../columnDef"
 import type {InfiniteDatasetStore} from "../createInfiniteDatasetStore"
@@ -233,9 +233,7 @@ export function useTableManager<T extends InfiniteTableRowBase>({
     exportDisabledTooltip = "Select items to export",
     exportFilename = "table-export.csv",
 }: UseTableManagerConfig<T>): UseTableManagerReturn<T> {
-    // Responsive breakpoints
-    const screens = Grid.useBreakpoint()
-    const isNarrowScreen = !screens.lg
+    const isNarrowScreen = useIsNarrowScreen()
 
     // Normalize search config
     const searchConfig = search === true ? {} : search || undefined

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTypeChipFeature.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/hooks/useTypeChipFeature.tsx
@@ -1,10 +1,10 @@
 import {useCallback, useMemo} from "react"
 
 import {Tag} from "@phosphor-icons/react"
-import type {MenuProps} from "antd"
 import {atom, useAtom} from "jotai"
 import {atomWithStorage} from "jotai/utils"
 
+import type {TableMenuItem} from "../tableMenu"
 import type {TypeChipConfig} from "../types"
 
 type TypeChipEnabledAtom = ReturnType<typeof atomWithStorage<boolean>>
@@ -23,7 +23,7 @@ function getOrCreateAtom(storageKey: string, defaultEnabled: boolean): TypeChipE
 export interface UseTypeChipFeatureResult<RecordType> {
     enabled: boolean
     setEnabled: (enabled: boolean) => void
-    menuItems: MenuProps["items"]
+    menuItems: TableMenuItem[] | undefined
     typeChips: TypeChipConfig<RecordType> | undefined
 }
 
@@ -50,7 +50,7 @@ export function useTypeChipFeature<RecordType>(
         [config, setStoredEnabled],
     )
 
-    const menuItems = useMemo<MenuProps["items"]>(() => {
+    const menuItems = useMemo<TableMenuItem[] | undefined>(() => {
         if (!config?.storageKey && !config?.onEnabledChange) return undefined
 
         return [
@@ -58,10 +58,7 @@ export function useTypeChipFeature<RecordType>(
                 key: "type-chips-toggle",
                 label: enabled ? "Hide type chips" : "Show type chips",
                 icon: <Tag size={16} />,
-                onClick: (e) => {
-                    e.domEvent.stopPropagation()
-                    setEnabled(!enabled)
-                },
+                onClick: () => setEnabled(!enabled),
             },
         ]
     }, [config?.onEnabledChange, config?.storageKey, enabled, setEnabled])

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/index.ts
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/index.ts
@@ -138,6 +138,7 @@ export type {
 } from "./columnDef"
 export {toAntdColumns, fromAntdColumns} from "./antdColumns"
 export {AVT, ANTD_SELECTOR, stampTableDom, type AvtClass} from "./tableDom"
+export {renderTableMenuItems, type TableMenuItem} from "./tableMenu"
 export type {VisibilityRegistrationHandler} from "./components/ColumnVisibilityHeader"
 
 // Shared hooks for cell renderers

--- a/web/packages/agenta-ui/src/InfiniteVirtualTable/tableMenu.tsx
+++ b/web/packages/agenta-ui/src/InfiniteVirtualTable/tableMenu.tsx
@@ -1,0 +1,71 @@
+import type {ReactNode} from "react"
+
+import {
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
+} from "../components/ui/dropdown-menu"
+
+/**
+ * The table's menu model, replacing antd's `MenuProps["items"]`.
+ *
+ * A plain descriptor rather than JSX so the hooks that build menus stay renderer-agnostic, and
+ * so a caller cannot smuggle antd-shaped props (`onClick(e.domEvent)`, `danger`) through it.
+ * Stopping propagation is the renderer's job; an item's `onClick` takes no event.
+ */
+export type TableMenuItem =
+    | {type: "divider"; key?: string}
+    | {
+          key: string
+          label: ReactNode
+          icon?: ReactNode
+          disabled?: boolean
+          /** Destructive styling, antd's `danger`. */
+          danger?: boolean
+          onClick?: () => void
+          children?: TableMenuItem[]
+      }
+
+const isDivider = (item: TableMenuItem): item is {type: "divider"; key?: string} =>
+    "type" in item && item.type === "divider"
+
+export const renderTableMenuItems = (items: TableMenuItem[] | undefined): ReactNode =>
+    items?.map((item, index) => {
+        if (isDivider(item)) return <DropdownMenuSeparator key={item.key ?? `divider-${index}`} />
+
+        const content = (
+            <>
+                {item.icon}
+                {item.label}
+            </>
+        )
+
+        if (item.children?.length) {
+            return (
+                <DropdownMenuSub key={item.key}>
+                    <DropdownMenuSubTrigger disabled={item.disabled}>
+                        {content}
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent>
+                        {renderTableMenuItems(item.children)}
+                    </DropdownMenuSubContent>
+                </DropdownMenuSub>
+            )
+        }
+
+        return (
+            <DropdownMenuItem
+                key={item.key}
+                disabled={item.disabled}
+                variant={item.danger ? "destructive" : undefined}
+                onClick={(event) => {
+                    event.stopPropagation()
+                    item.onClick?.()
+                }}
+            >
+                {content}
+            </DropdownMenuItem>
+        )
+    })

--- a/web/packages/agenta-ui/src/hooks/index.ts
+++ b/web/packages/agenta-ui/src/hooks/index.ts
@@ -7,3 +7,4 @@
 export {useSelectionState, type UseSelectionStateResult} from "./useSelectionState"
 export {useRunAllShortcut, type UseRunAllShortcutParams} from "./useRunAllShortcut"
 export {useDefaultStoreAtomValue} from "./useDefaultStoreAtomValue"
+export {useMediaQuery, useIsNarrowScreen, NARROW_SCREEN_QUERY} from "./useMediaQuery"

--- a/web/packages/agenta-ui/src/hooks/useMediaQuery.ts
+++ b/web/packages/agenta-ui/src/hooks/useMediaQuery.ts
@@ -1,0 +1,29 @@
+import {useEffect, useState} from "react"
+
+/**
+ * Replaces antd's `Grid.useBreakpoint()` for the one thing the table asked it: is the viewport
+ * narrow. antd's `lg` is 992px, so `!screens.lg` is `max-width: 991.98px`.
+ *
+ * Starts false and reads after mount, the same way `useThemeMode` does. The value is
+ * client-only, so hydrating from it would mismatch the server render, and a wide-screen first
+ * paint is the same assumption antd made.
+ */
+export const useMediaQuery = (query: string): boolean => {
+    const [matches, setMatches] = useState(false)
+
+    useEffect(() => {
+        if (typeof window === "undefined" || !window.matchMedia) return
+        const list = window.matchMedia(query)
+        setMatches(list.matches)
+        const sync = (event: MediaQueryListEvent) => setMatches(event.matches)
+        list.addEventListener("change", sync)
+        return () => list.removeEventListener("change", sync)
+    }, [query])
+
+    return matches
+}
+
+/** antd's `lg` breakpoint, the only one the table used. */
+export const NARROW_SCREEN_QUERY = "(max-width: 991.98px)"
+
+export const useIsNarrowScreen = (): boolean => useMediaQuery(NARROW_SCREEN_QUERY)


### PR DESCRIPTION
## Context

`@agenta/ui`'s table package was antd well beyond the `<Table>` it renders. Nine files pulled in `Typography`, `Skeleton`, `Tooltip`, `Popover`, `Dropdown`, `Checkbox` and `Grid.useBreakpoint`, so "the table depends on antd" was much bigger than the one component that actually needs replacing.

Step 2 of `docs/design/observability-packages/plan.md` §8 shrinks that to the render leaf, which is what makes step 3 a single-file project.

## Changes

The swaps go onto the primitives WP3 established. Two are worth calling out.

**`Grid.useBreakpoint()` → `useIsNarrowScreen()`.** Both call sites only ever read `!screens.lg`, so the replacement is a small `matchMedia` hook on antd's own `lg` value (992px), living in `@agenta/ui/hooks` where mobile can use it too.

**`MenuProps["items"]` → `TableMenuItem[]`.** The hooks that build menus now return a plain descriptor and one renderer turns it into `dropdown-menu` parts:

```
{key, label, icon?, disabled?, danger?, onClick?, children?} | {type: "divider"}
```

That also drops the antd-shaped `onClick(e.domEvent)` from the package's public `ActionItem`. No consumer used the event argument. Stopping propagation is the renderer's job now, so an item's `onClick` takes nothing.

**A live bug goes with it.** The column-visibility gear did nothing when clicked. Its trigger called `preventDefault()`, and a default-prevented event makes antd and Radix both skip the open handler composed onto the same element. What that handler wanted was `stopPropagation()`, so the header cell does not sort out from under the click. It now does only that, and the gear opens.

## Tests / notes

- OSS, EE, mobile and `@agenta/ui` typecheck. `@agenta/ui` lints clean; `@agenta/entity-ui` is 330 tests green.
- Two OSS call sites were still building antd menu items for `settingsDropdownMenuItems` (`EvalRunDetails` and `TestcasesTableNew`); both now build `TableMenuItem[]`.
- **Two antd components stay in the package, deliberately.** `Table` is step 3 and the point of the sequence. `Pagination` has no `@agenta/ui` equivalent, and building one means page numbers, ellipsis and a total count, which is new UI that wants a design pass rather than an invented primitive. One page (`ApplicationManagementSection`) renders `paginationMode="paginated"`.
- **Also deferred:** the checkable `Tree` inside `ColumnVisibilityPopoverContent`, for the same reason — there is no checkable-tree primitive to swap onto. Its sibling `ColumnVisibilityTrigger` uses a recursive checkbox list and is ported here, so the pattern for a later port already exists.
- I could not run this against a browser (no dev server was up), so the QA below matters more than usual.

## What to QA

Every change is a visual swap, so the risk is a control that looks or behaves subtly differently.

- Any table's gear icon: it opens. This is the fix, and on `main` the icon does nothing on several tables.
- In that popover: checkboxes toggle, a group checkbox shows the mixed state when only some children are on, Reset and Close work.
- A table with the settings dropdown (test cases, evaluation run details): the gear opens a menu with Column visibility, Row height, Export to CSV and Delete. Row height opens a submenu and the current size reads bold.
- Choosing Column visibility from that menu opens the visibility popover anchored to the same gear.
- A row's `⋯` actions menu: items fire, destructive items are red, dividers sit between groups and never at an edge.
- Narrow the window below 992px: the delete and export buttons move into the settings dropdown, and widening moves them back.
- Table description text and the loading skeleton in a resizable header cell still look right in both themes.
