### PR TITLE
fix(runner): advertise codex in the /health harnesses list

### DIFF
--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -572,9 +572,10 @@ export interface ModelConnection {
 
 export interface AgentRunRequest {
   /**
-   * Harness id: "pi_core" | "pi_agenta" | "claude". `pi_core` and `pi_agenta` both drive the
-   * ACP agent "pi" (pi_agenta is Pi with Agenta's forced skills/prompt/policy); "claude" drives
-   * the ACP agent "claude". Selected by the request; there is no engine selector.
+   * Harness id: "pi_core" | "pi_agenta" | "claude" | "codex". `pi_core` and `pi_agenta` both
+   * drive the ACP agent "pi" (pi_agenta is Pi with Agenta's forced skills/prompt/policy);
+   * "claude" and "codex" each drive the ACP agent of the same name. Selected by the request;
+   * there is no engine selector.
    */
   harness?: string;
   /** Sandbox: "local" | "daytona". */

--- a/services/runner/src/version.ts
+++ b/services/runner/src/version.ts
@@ -12,7 +12,18 @@ import pkg from "../package.json";
 export const PROTOCOL_VERSION = 1;
 export const RUNNER_VERSION: string = pkg.version;
 export const ENGINES = ["sandbox-agent"] as const;
-export const HARNESS_KINDS = ["pi_core", "claude", "pi_agenta"] as const;
+/**
+ * Harness ids this runner drives, advertised on `/health`. Mirrors the SDK's `HarnessKind`
+ * enum (`sdks/python/agenta/sdk/agents/dtos.py`), which is the source of truth; extend both
+ * together when a harness is added. Nothing is gated on this list, so a stale entry does not
+ * block a run — it only under-reports what the runner supports.
+ */
+export const HARNESS_KINDS = [
+  "pi_core",
+  "claude",
+  "pi_agenta",
+  "codex",
+] as const;
 
 export interface RunnerInfo {
   status: "ok";

--- a/services/runner/tests/acceptance/server-contract.test.ts
+++ b/services/runner/tests/acceptance/server-contract.test.ts
@@ -81,6 +81,13 @@ describe("GET /health contract", () => {
         (body.engines as string[]).includes("sandbox-agent"),
         "engines must include 'sandbox-agent'",
       );
+      // Every harness the runner can drive must be advertised: a client reading this payload
+      // decides what is available. Mirrors the SDK's `HarnessKind` enum.
+      assert.deepEqual(
+        [...(body.harnesses as string[])].sort(),
+        ["claude", "codex", "pi_agenta", "pi_core"],
+        "harnesses must advertise every supported harness",
+      );
     } finally {
       await s.close();
     }

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -77,6 +77,17 @@ describe("createAgentServer", () => {
           (body.engines as unknown[]).includes("sandbox-agent"),
       );
       assert.ok(Array.isArray(body.harnesses));
+      // Pinned as a literal set, NOT derived from `HARNESS_KINDS`: asserting the payload
+      // against its own source would hold for any list, which is how `codex` stayed missing
+      // while Codex runs worked. The expected members mirror the SDK's `HarnessKind` enum,
+      // pinned on the Python side by `test_identity_value_is_the_bare_harness_string`.
+      // Sorted because the advertisement's order carries no meaning.
+      assert.deepEqual([...(body.harnesses as string[])].sort(), [
+        "claude",
+        "codex",
+        "pi_agenta",
+        "pi_core",
+      ]);
     } finally {
       await s.close();
     }


### PR DESCRIPTION
## Summary

`GET /health` did not list `codex` among the runner's harnesses, so a client asking the runner what it supports concluded Codex was unavailable on a deployment where Codex runs work.

Root cause: `HARNESS_KINDS` in `services/runner/src/version.ts` is a hardcoded list that was never extended when Codex became a harness of its own.

```js
export const HARNESS_KINDS = ["pi_core", "claude", "pi_agenta"] as const;
```

Codex is a first-class harness everywhere else in the stack:

- `HarnessKind` in `sdks/python/agenta/sdk/agents/dtos.py` carries all four values, and `test_harness_identity.py` pins the set as `{"pi_core", "pi_agenta", "claude", "codex"}`.
- The generated API client (`web/packages/agenta-api-client/.../HarnessKind.ts`) lists `Codex: "codex"`.
- The `/run` wire contract has a `run_request.codex.json` golden asserted from both the Python and TypeScript sides.
- The runner drives it: `run-plan.ts` maps `codex` straight through to its ACP agent, and `acp-interactions.ts` branches on `acpAgent === "codex"`.

Only the runner's advertisement was stale. Nothing is gated on `HARNESS_KINDS` — the health payload is its sole consumer — so no run was ever blocked. The impact is that anything deciding what is available from this payload under-reports Codex, and it actively misleads while setting up a Codex mount: the endpoint saying Codex is absent reads as "the image doesn't have Codex" and sends you looking in the wrong place.

### Why it went unnoticed

Both `/health` tests asserted only that `harnesses` was an array, never its contents, so the list could drift from the enum silently. Both now pin the member set, which is what makes this a fix rather than a one-character patch.

### Changes

- `services/runner/src/version.ts` — add `codex`; document the SDK enum as the source of truth so the two are extended together.
- `services/runner/src/protocol.ts` — refresh the `AgentRunRequest.harness` docstring, which listed the same stale three ids.
- Both `/health` tests — assert the exact member set instead of `Array.isArray`.

Closes #5693

## Testing

### Verified locally

- `npx tsc --noEmit` in `services/runner` — passes (the typecheck gate CI runs).
- `npx vitest run --project unit tests/unit/server.test.ts` — 34/34 pass.
- `npx vitest run --project acceptance tests/acceptance/server-contract.test.ts` — 18/18 pass.
- Confirmed the new assertion actually catches the bug: stashing `src/version.ts` back to the three-entry list fails the health test with the expected diff, and restoring it passes.
- Full unit suite (`--project unit`): 2059 passed / 53 failed, **identical before and after this change** (same 15 files, byte-identical sets). Those 53 are pre-existing failures on my Windows machine caused by path-separator assumptions (`'\tmp\run-agent\README.md'` vs the expected `'/tmp/run-agent/README.md'`) in suites like `workspace-import` and `attachment-path-safety`. They are unrelated to this change and do not occur on the `ubuntu-latest` runner CI uses.

### Added or updated tests

Updated the two existing `/health` tests rather than adding new ones, since the gap was in what they asserted:

- `tests/unit/server.test.ts` — `GET /health returns runner identity` now asserts the sorted `harnesses` set equals `["claude", "codex", "pi_agenta", "pi_core"]`.
- `tests/acceptance/server-contract.test.ts` — the `/health` contract test asserts the same set.

The expected list is pinned as a literal rather than derived from `HARNESS_KINDS`: asserting the payload against its own source would hold for any list, which is exactly how this drift survived. Sorted because the advertisement's order carries no meaning.

### QA follow-up

N/A — no runtime behaviour changes. `HARNESS_KINDS` has no consumer other than the health payload, and Codex run dispatch goes through a separate path in `run-plan.ts` that this does not touch.

## Demo

N/A — not a UI change.

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
