### PR TITLE
[fix] Mobile image build: tolerate the workspace's unused nextstepjs patch

### DIFF
--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -31,5 +31,8 @@ allowBuilds:
   protobufjs: false
   sharp: true
   unrs-resolver: true
+# The mobile Docker image installs a pruned tree that excludes web/oss, the only
+# consumer of the patch below, and pnpm fails an install whose patch matches nothing.
+allowUnusedPatches: true
 patchedDependencies:
   '@agentaai/nextstepjs@2.1.3-agenta.2': patches/@agentaai__nextstepjs@2.1.3-agenta.2.patch


### PR DESCRIPTION
## Context

The `agenta-web-mobile` image fails to build on every deploy. The build reaches the final Next.js build step and dies there:

```
[ERR_PNPM_UNUSED_PATCH] The following patches were not used: @agentaai/nextstepjs@2.1.3-agenta.2

Either remove them from "patchedDependencies" or update them to match packages in your dependencies.
[ERROR] Command failed with exit code 1: pnpm install
```

`web/pnpm-workspace.yaml` declares a patch for `@agentaai/nextstepjs`, and `web/oss` is the only package that depends on it. The mobile image never copies `web/oss` into the image. `web/mobile/docker/Dockerfile.gh` copies `mobile/` plus the `@agenta/*` workspace closure it links, and nothing else. The last build step then runs `pnpm turbo run build --filter=@agenta/mobile`, and pnpm re-installs the workspace before it runs that command. The install resolves a dependency graph that has no `web/oss` in it, which the build log shows directly:

```
Scope: all 9 workspace projects
[WARN] Installing a dependency from a non-existent directory: /app/ee
[WARN] Installing a dependency from a non-existent directory: /app/oss
```

With no consumer in the graph, the declared patch matches nothing, and pnpm 11 treats a declared-but-unused patch as a hard install error.

This is not a regression from any recent PR. The patch has been declared since June, and the mobile image has never built from this pruned tree. The `check mobile` CI job installs the full workspace, where the patch does apply, so it stays green and never sees the failure. Deployments that do not run the `web-mobile` compose profile are unaffected. The image is simply unbuildable.

## Changes

One line in `web/pnpm-workspace.yaml`:

```yaml
allowUnusedPatches: true
```

That downgrades the unused-patch check from an error to a warning. A pruned install now prints `[WARN] The following patches were not used: ...` and finishes, instead of exiting 1.

It does not weaken anything for the installs that matter. The patch is unused only when its consumer is absent from the tree. Any install that includes `web/oss`, which is CI, local development, and the OSS and EE images, still has the patch in the graph and still applies it.

## Tests

Validated against pnpm 11.1.2, the version `web/package.json` pins, in a throwaway two-package workspace that mirrors the shape here. One package depends on a patched package, the other does not.

- Both packages present, no new key: install succeeds and the patch is applied to the installed package. This is the baseline.
- Consumer package's directory removed, which is the image's situation: `ERR_PNPM_UNUSED_PATCH`, exit 1, with the same `Scope: all N workspace projects` preamble the real build log shows.
- Same tree with `allowUnusedPatches: true`: `[WARN] The following patches were not used: ...`, exit 0.
- Consumer package restored with the key still set: install succeeds and the patch is still applied. This is the case that proves full-workspace installs are unaffected.

`allowUnusedPatches` is not written into `pnpm-lock.yaml`, so this needs no lockfile update and `--frozen-lockfile` installs do not hit a config mismatch. Confirmed by inspecting the lockfile after installing with the key set.

## What to QA

- Build with the `web-mobile` profile. The image builds instead of failing at the turbo build step, and the build log carries the `[WARN] The following patches were not used` line where the error used to be.
- Regression: nothing should change in the OSS or EE web apps. The patch only adds a `sideEffects: false` tree-shaking hint to the nextstepjs package, and it still applies in those builds. If you want a check anyway, the onboarding tour is the surface that uses the package.
