### PR TITLE
fix(frontend): session UX follow-ups: sidebar liveness, composer handoff race, archive fixes

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -144,9 +144,9 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
         if (pendingOpenForScope.sessionId) {
             adoptSession({id: pendingOpenForScope.sessionId, title: pendingOpenForScope.title})
         } else {
-            // No id means "start a fresh conversation here" — Home's composer. A new empty session
-            // is also what lets a seeded first message find an empty conversation to send into.
-            addSession()
+            // No id means "start a fresh conversation here" — Home's composer. It may name the
+            // session up front, so the message it sent along lands in this one and no other.
+            addSession({id: pendingOpenForScope.newSessionId})
         }
         setPendingOpen(null)
     }, [pendingOpenForScope, adoptSession, addSession, setPendingOpen])

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -277,6 +277,7 @@ const AgentConversation = ({
         // Files picked on Home / the overview, where there was no session to upload against.
         onSeedFiles: attachments.addFiles,
         attachmentsSettled,
+        isHydrating,
     })
     const consumedRunNonceRef = useRef<number | null>(null)
 

--- a/web/oss/src/components/AgentChatSlice/components/SessionRunSpinner.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRunSpinner.tsx
@@ -1,0 +1,25 @@
+import {CircleNotchIcon} from "@phosphor-icons/react"
+import clsx from "clsx"
+
+/** Box the playground's status dot reserves for this, so starting a run swaps the glyph without
+ * nudging the label sideways. */
+export const SESSION_RUN_GLYPH_PX = 12
+
+/**
+ * The one "thinking" animation, shared by the playground's session chips/rail/history and the
+ * sidebar's session rows — one glyph and one motion, so a running session reads the same wherever
+ * you catch sight of it. Only the size adapts to the surface.
+ *
+ * `motion-safe` leaves a static notch when the user asks for less motion: still distinct from the
+ * idle dot, so the state survives without the spin.
+ */
+export const SessionRunSpinner = ({size, className}: {size?: number; className?: string}) => (
+    <CircleNotchIcon
+        size={size ?? SESSION_RUN_GLYPH_PX}
+        weight="bold"
+        aria-hidden
+        // `!` on the colour: antd's `.ant-menu-item .ant-menu-item-icon` rule outranks a plain
+        // utility class, which left the sidebar's copy inheriting row text instead of the accent.
+        className={clsx("shrink-0 !text-colorInfo motion-safe:animate-spin", className)}
+    />
+)

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -13,6 +13,7 @@ import {type SessionDotStatus, sessionDotStatusAtomFamily} from "../state/livene
 import {useChatScopeKey} from "../state/scope"
 import {type AgentChatSession, sessionFirstUserTextAtomFamily} from "../state/sessions"
 
+import {SESSION_RUN_GLYPH_PX, SessionRunSpinner} from "./SessionRunSpinner"
 import SessionTabLabel, {type SessionTabLabelHandle} from "./SessionTabLabel"
 
 /** Slight left/right edge fade so tabs dissolve into the strip edges instead of a hard cut when
@@ -40,9 +41,10 @@ const STATUS_META: Record<
     idle: {dot: "bg-colorTextQuaternary", pulse: false, attention: false, title: "Idle"},
 }
 
-/** A session's run-state dot. Subscribes to just that session's effective-status atom (local run
- * state, or backend liveness when idle here) so a streaming conversation repaints only its own dot,
- * never the whole bar. */
+/** A session's run-state indicator: the shared spinner while a turn is in flight (the same glyph
+ * the sidebar's session rows use), a semantic dot for every other state. Subscribes to just that
+ * session's effective-status atom (local run state, or backend liveness when idle here) so a
+ * streaming conversation repaints only its own indicator, never the whole bar. */
 export const SessionStatusDot = ({
     sessionId,
     active = false,
@@ -57,26 +59,42 @@ export const SessionStatusDot = ({
     // colour even on the active tab, so its signal survives on the session you're looking at.
     const dotClassName = clsx(meta.dot, active && status === "idle" && "dark:bg-white")
     return (
+        // The box is the spinner's size in EVERY state, so a run starting or ending swaps the glyph
+        // without shifting the label beside it.
         <span
-            className={clsx(
-                "relative flex h-1.5 w-1.5 shrink-0",
-                // A halo ring makes an attention dot read as a badge even at 6px, so it stands out
-                // across a row of running/idle tabs without enlarging the dot itself.
-                meta.attention && "rounded-full ring-2 ring-offset-0",
-                status === "awaiting" && "ring-colorWarningBorder",
-                status === "error" && "ring-colorErrorBorder",
-            )}
+            className="relative flex shrink-0 items-center justify-center"
+            style={{width: SESSION_RUN_GLYPH_PX, height: SESSION_RUN_GLYPH_PX}}
             title={meta.title}
         >
-            {meta.pulse && (
+            {status === "running" ? (
+                <SessionRunSpinner />
+            ) : (
                 <span
                     className={clsx(
-                        "absolute inline-flex h-full w-full rounded-full opacity-60 motion-safe:animate-ping",
-                        dotClassName,
+                        "relative flex h-1.5 w-1.5",
+                        // A halo ring makes an attention dot read as a badge even at 6px, so it
+                        // stands out across a row of tabs without enlarging the dot itself.
+                        meta.attention && "rounded-full ring-2 ring-offset-0",
+                        status === "awaiting" && "ring-colorWarningBorder",
+                        status === "error" && "ring-colorErrorBorder",
                     )}
-                />
+                >
+                    {meta.pulse && (
+                        <span
+                            className={clsx(
+                                "absolute inline-flex h-full w-full rounded-full opacity-60 motion-safe:animate-ping",
+                                dotClassName,
+                            )}
+                        />
+                    )}
+                    <span
+                        className={clsx(
+                            "relative inline-flex h-1.5 w-1.5 rounded-full",
+                            dotClassName,
+                        )}
+                    />
+                </span>
             )}
-            <span className={clsx("relative inline-flex h-1.5 w-1.5 rounded-full", dotClassName)} />
         </span>
     )
 }

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {
     commandSessionStream,
+    invalidateSessionListQueries,
     killSession,
     recordInteractionAnswerAtom,
     revalidateSessionMountsAtom,
@@ -176,6 +177,10 @@ export const useAgentChatSession = ({
             revalidateSessionMounts(sessionId)
             revalidateSessionRecords(sessionId)
             void queryClient.invalidateQueries({queryKey: ["session-liveness"]})
+            // The first turn is what creates the durable session row; every later one changes its
+            // title/preview/activity. Nothing else tells the session lists, so they discovered a
+            // brand-new session only on their next poll or window refocus.
+            invalidateSessionListQueries()
         },
         onError: (err) => {
             // A failed stream never dispatches the pending resume, so drop the marker: leaving it

--- a/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit test for `shouldConsumeSeed` — which session may claim the message a composer sent along
+ * with its navigation.
+ *
+ * Regression: sending from an agent's overview put the message in the PREVIOUS session and left the
+ * new one empty (reproduced live on the 8180 dev stack: "PROBE-A1 …" landed in session
+ * 7e156d7b-61ce-49c6-8553-ca45b6eb6356 while the freshly created a1c5e023-… became the active,
+ * empty tab). The panel creates the new session in a parent effect, but a warm lazy chunk mounts
+ * the previous session's conversation in the same commit — and child effects run first, so the old
+ * session was still active and, with an unhydrated transcript, still looked empty when it claimed
+ * the seed.
+ */
+import {describe, expect, it} from "vitest"
+
+import {type AgentFirstRunSeed} from "../state/firstRunSeed"
+
+import {shouldConsumeSeed} from "./useFirstRunSeed"
+
+const APP = "app-1"
+const NEW_SESSION = "session-new"
+const OLD_SESSION = "session-old"
+
+const addressed: AgentFirstRunSeed = {
+    appId: APP,
+    sessionId: NEW_SESSION,
+    seedMessage: "ship it",
+    autoSend: true,
+}
+
+/** The id-less seed the agent-creation flow still sends. */
+const legacy: AgentFirstRunSeed = {appId: APP, seedMessage: "ship it", autoSend: true}
+
+const ask = (over: Partial<Parameters<typeof shouldConsumeSeed>[0]>) =>
+    shouldConsumeSeed({
+        seed: addressed,
+        entityId: "revision-1",
+        scopeKey: APP,
+        sessionId: NEW_SESSION,
+        activeSessionId: NEW_SESSION,
+        messagesCount: 0,
+        isHydrating: false,
+        ...over,
+    })
+
+describe("shouldConsumeSeed", () => {
+    it("gives an addressed seed to the session it names", () => {
+        expect(ask({})).toBe(true)
+    })
+
+    it("refuses an addressed seed in any other session, even the active empty one", () => {
+        expect(ask({sessionId: OLD_SESSION, activeSessionId: OLD_SESSION})).toBe(false)
+    })
+
+    it("still gives an addressed seed to its session when that session is not yet active", () => {
+        expect(ask({activeSessionId: OLD_SESSION})).toBe(true)
+    })
+
+    it("ignores a seed aimed at a different agent", () => {
+        expect(ask({scopeKey: "app-2", entityId: "revision-of-app-2"})).toBe(false)
+    })
+
+    it("does nothing without a seed", () => {
+        expect(ask({seed: null})).toBe(false)
+    })
+
+    it("matches a legacy seed on the active empty conversation", () => {
+        expect(ask({seed: legacy})).toBe(true)
+    })
+
+    it("refuses a legacy seed while the transcript is still hydrating", () => {
+        expect(ask({seed: legacy, isHydrating: true})).toBe(false)
+    })
+
+    it("refuses a legacy seed in a conversation that already has messages", () => {
+        expect(ask({seed: legacy, messagesCount: 3})).toBe(false)
+    })
+
+    it("refuses a legacy seed in an inactive session", () => {
+        expect(ask({seed: legacy, sessionId: OLD_SESSION})).toBe(false)
+    })
+
+    it("matches a legacy seed by revision id when the scope has not resolved", () => {
+        expect(ask({seed: {...legacy, revisionId: "revision-1"}, scopeKey: "__global__"})).toBe(
+            true,
+        )
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useFirstRunSeed.ts
@@ -3,13 +3,47 @@ import {type MutableRefObject, useEffect, useRef, useState} from "react"
 import {workflowBuildKitOverlayReadyAtomFamily} from "@agenta/entities/workflow"
 import {useAtom, useAtomValue} from "jotai"
 
-import {agentFirstRunSeedAtom} from "../state/firstRunSeed"
+import {agentFirstRunSeedAtom, type AgentFirstRunSeed} from "../state/firstRunSeed"
+
+/**
+ * Does THIS session own the pending seed?
+ *
+ * A seed that names its session is claimed by that session alone. The id-less legacy seed (agent
+ * creation) falls back to "the active conversation, while it is empty" — and must wait out
+ * hydration, because a session whose transcript is still loading is indistinguishable from an empty
+ * one and would swallow the message.
+ */
+export const shouldConsumeSeed = ({
+    seed,
+    entityId,
+    scopeKey,
+    sessionId,
+    activeSessionId,
+    messagesCount,
+    isHydrating,
+}: {
+    seed: AgentFirstRunSeed | null
+    entityId: string
+    scopeKey: string
+    sessionId: string
+    activeSessionId: string | null | undefined
+    messagesCount: number
+    isHydrating: boolean
+}): boolean => {
+    if (!seed) return false
+    const addressesThisAgent =
+        entityId === seed.revisionId || entityId === seed.appId || scopeKey === seed.appId
+    if (!addressesThisAgent) return false
+    if (seed.sessionId) return seed.sessionId === sessionId
+    if (activeSessionId !== sessionId) return false
+    return !isHydrating && messagesCount === 0
+}
 
 /**
  * First-run seed: a freshly-created agent (from Home's composer/template) surfaces its starting
  * prompt in the empty state (see AgentChatEmptyState) rather than pre-filling the composer, so it
- * reads as "here's what we'll do" not stray user input. Consumed once by the active session on a
- * fresh conversation, matching either the revision or app id, then cleared.
+ * reads as "here's what we'll do" not stray user input. Consumed once — by the session the seed
+ * names, or (id-less agent-creation seed) by the active empty conversation — then cleared.
  *
  * Also owns the auto-start: the seeded agent's model is usually gated (no provider key yet), and
  * connecting the key IS the go-ahead — so once the gate clears the seed sends itself rather than
@@ -25,6 +59,7 @@ export const useFirstRunSeed = ({
     handleSubmitRef,
     onSeedFiles,
     attachmentsSettled = true,
+    isHydrating = false,
 }: {
     entityId: string
     /** The chat scope — an app id. Lets a seed aimed at an existing agent match without knowing
@@ -34,6 +69,9 @@ export const useFirstRunSeed = ({
     activeSessionId: string | null | undefined
     messagesCount: number
     modelBlocked: boolean
+    /** True while this session's transcript loads from the durable log — an empty `messagesCount`
+     * says nothing yet, so an id-less seed must not read it as an empty conversation. */
+    isHydrating?: boolean
     /** Read at fire time so the transition drives the send, not a stale closure. */
     handleSubmitRef: MutableRefObject<(text: string) => void | Promise<void>>
     /** The chat's own `addFiles` — seed files go through the same staging paste and drop use. */
@@ -49,12 +87,18 @@ export const useFirstRunSeed = ({
     const seedConsumedRef = useRef(false)
     useEffect(() => {
         if (seedConsumedRef.current || !firstRunSeed) return
-        const addressesThisAgent =
-            entityId === firstRunSeed.revisionId ||
-            entityId === firstRunSeed.appId ||
-            scopeKey === firstRunSeed.appId
-        if (!addressesThisAgent) return
-        if (activeSessionId !== sessionId || messagesCount > 0) return
+        if (
+            !shouldConsumeSeed({
+                seed: firstRunSeed,
+                entityId,
+                scopeKey,
+                sessionId,
+                activeSessionId,
+                messagesCount,
+                isHydrating,
+            })
+        )
+            return
         seedConsumedRef.current = true
         setFirstRunPrompt(firstRunSeed.seedMessage)
         setFirstRunAutoSend(!!firstRunSeed.autoSend)
@@ -67,6 +111,7 @@ export const useFirstRunSeed = ({
         activeSessionId,
         sessionId,
         messagesCount,
+        isHydrating,
         setFirstRunSeed,
         onSeedFiles,
     ])

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionActions.tsx
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionActions.tsx
@@ -3,6 +3,7 @@ import {useCallback, useMemo} from "react"
 import {
     archiveSessionRemote,
     deleteSessionRemote,
+    invalidateSessionListQueries,
     setSessionHeader,
     unarchiveSessionRemote,
 } from "@agenta/entities/session"
@@ -53,7 +54,9 @@ export const useSessionActions = () => {
 
     const revalidate = useCallback(() => {
         void queryClient.invalidateQueries({queryKey: ["sessions-page"]})
-        void queryClient.invalidateQueries({queryKey: ["session-list"]})
+        // Token match — the sidebar nests the same list options behind `["sidebar", ...]`, which a
+        // `["session-list"]` prefix never reaches, so its rows outlived an archive/delete.
+        invalidateSessionListQueries()
     }, [queryClient])
 
     /** Is this session in the owning agent's local tab cache? Decides who makes the server call. */
@@ -90,7 +93,7 @@ export const useSessionActions = () => {
                     const title = next.trim()
                     if (!title) return
                     if (isCached(target) && target.appId) {
-                        store.set(renameSessionAtomFamily(target.appId), {
+                        await store.set(renameSessionAtomFamily(target.appId), {
                             id: target.sessionId,
                             title,
                         })
@@ -118,7 +121,9 @@ export const useSessionActions = () => {
                 const local = target.archived
                     ? unarchiveSessionAtomFamily
                     : archiveSessionAtomFamily
-                store.set(local(target.appId), target.sessionId)
+                // Awaited: the atom's own server write is fire-and-forget, so revalidating straight
+                // after it refetched the row in its PRE-archive state and the lists kept showing it.
+                await store.set(local(target.appId), target.sessionId)
             } else {
                 const call = target.archived ? unarchiveSessionRemote : archiveSessionRemote
                 const ok = await call({sessionId: target.sessionId, projectId})
@@ -143,7 +148,8 @@ export const useSessionActions = () => {
                 okButtonProps: {danger: true},
                 onOk: async () => {
                     if (isCached(target) && target.appId) {
-                        store.set(deleteSessionAtomFamily(target.appId), target.sessionId)
+                        // Await for the same reason as archive above — the lists refetch next.
+                        await store.set(deleteSessionAtomFamily(target.appId), target.sessionId)
                     } else {
                         const ok = await deleteSessionRemote({
                             sessionId: target.sessionId,

--- a/web/oss/src/components/AgentChatSlice/hooks/useStartAgentSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useStartAgentSession.ts
@@ -1,5 +1,6 @@
 import {useCallback} from "react"
 
+import {generateId} from "@agenta/shared/utils"
 import {useAtomValue, useSetAtom} from "jotai"
 import {useRouter} from "next/router"
 
@@ -12,9 +13,9 @@ import {pendingSessionOpenAtom} from "../state/pendingSessionOpen"
  * Start a NEW conversation with an existing agent, seeded with what the user typed — the daily
  * action, as opposed to creating an agent, which happens once.
  *
- * Two carriers ride the navigation: the pending-open slot (no session id = "open a fresh session
- * here") and the first-run seed (the message, sent as soon as the model is ready). Together they
- * land the user in a new conversation with their request already in flight.
+ * Two carriers ride the navigation: the pending-open slot ("create a fresh session, under this id")
+ * and the first-run seed (the message for that same id, sent as soon as the model is ready).
+ * Together they land the user in a new conversation with their request already in flight.
  */
 export function useStartAgentSession(): (input: {
     appId: string
@@ -29,12 +30,15 @@ export function useStartAgentSession(): (input: {
     return useCallback(
         ({appId, message, files}) => {
             const seedMessage = message.trim()
-            setPendingOpen({appId})
+            // Minted here so both carriers name the same session: the playground creates THIS id,
+            // and the message is claimed by it alone — never by whichever session was open last.
+            const sessionId = generateId()
+            setPendingOpen({appId, newSessionId: sessionId})
             // `autoSend`: the user already pressed Start, so asking them to press it again on the
             // other side would be the same decision twice.
             // Files alone are a valid send: the chat holds the turn until they finish uploading.
             if (seedMessage || files?.length)
-                setSeed({appId, seedMessage, autoSend: true, seedFiles: files})
+                setSeed({appId, sessionId, seedMessage, autoSend: true, seedFiles: files})
 
             router.push(`${baseAppURL}/${appId}/playground`).catch(() => {
                 setPendingOpen(null)

--- a/web/oss/src/components/AgentChatSlice/state/firstRunSeed.ts
+++ b/web/oss/src/components/AgentChatSlice/state/firstRunSeed.ts
@@ -8,6 +8,10 @@ import {atom} from "jotai"
  */
 export interface AgentFirstRunSeed {
     appId: string
+    /** The session this message belongs to, minted by the composer alongside
+     * `pendingSessionOpenAtom.newSessionId`. Without it the seed goes to whichever session is active
+     * and looks empty on arrival — the PREVIOUS one, if it mounts before the new one is created. */
+    sessionId?: string
     /** Known only when the agent was just created. Starting a conversation with an EXISTING agent
      * (Home's composer) has no revision in hand, and matches on the chat scope instead. */
     revisionId?: string

--- a/web/oss/src/components/AgentChatSlice/state/pendingSessionOpen.ts
+++ b/web/oss/src/components/AgentChatSlice/state/pendingSessionOpen.ts
@@ -13,6 +13,10 @@ export interface PendingSessionOpen {
     /** Adopt this existing session. Omit to start a fresh one instead — which is what Home's
      * composer does when you pick an agent and describe a task. */
     sessionId?: string
+    /** Create the fresh session under THIS id (composers mint it up front so the message they send
+     * along can name its session — see `agentFirstRunSeedAtom.sessionId`). Ignored when
+     * `sessionId` adopts an existing session. */
+    newSessionId?: string
     title?: string
 }
 

--- a/web/oss/src/components/AgentChatSlice/state/sessions.delete.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.delete.test.ts
@@ -23,19 +23,23 @@ interface DeleteSessionRemoteArgs {
 }
 
 const deleteSessionRemote = vi.fn(async (_args: DeleteSessionRemoteArgs) => true)
+const archiveSessionRemote = vi.fn(async (_args: DeleteSessionRemoteArgs) => true)
+const unarchiveSessionRemote = vi.fn(async (_args: DeleteSessionRemoteArgs) => true)
 
 vi.mock("@agenta/entities/session", () => ({
     deleteSessionRemote: (args: DeleteSessionRemoteArgs) => deleteSessionRemote(args),
-    archiveSessionRemote: vi.fn(async () => true),
-    unarchiveSessionRemote: vi.fn(async () => true),
-    setSessionHeader: vi.fn(),
+    archiveSessionRemote: (args: DeleteSessionRemoteArgs) => archiveSessionRemote(args),
+    unarchiveSessionRemote: (args: DeleteSessionRemoteArgs) => unarchiveSessionRemote(args),
+    setSessionHeader: vi.fn(async () => true),
 }))
 
 const {
     adoptSessionAtomFamily,
+    archiveSessionAtomFamily,
     deleteSessionAtomFamily,
     reconcileServerSessionsAtomFamily,
     sessionHistoryAtomFamily,
+    unarchiveSessionAtomFamily,
 } = await import("./sessions")
 
 /** A young session as the rail holds it before any reconcile: no `serverKnown`. */
@@ -51,6 +55,8 @@ const historyIds = (store: ReturnType<typeof createStore>, scope: string) =>
 
 beforeEach(() => {
     deleteSessionRemote.mockClear()
+    archiveSessionRemote.mockClear()
+    unarchiveSessionRemote.mockClear()
 })
 
 describe("deleteSessionAtomFamily", () => {
@@ -125,5 +131,54 @@ describe("deleteSessionAtomFamily", () => {
         ])
 
         expect(historyIds(store, scope)).toEqual(["from-another-device"])
+    })
+})
+
+/**
+ * Archive had the same `serverKnown` hole delete closed: archiving a session inside the window
+ * between its first turn and the next reconcile skipped the server entirely, and the reconcile
+ * then flipped the local flag back — the session reappeared in every list.
+ */
+describe("archiveSessionAtomFamily", () => {
+    it("archives remotely even before the session is server-known", async () => {
+        const scope = "archive-young"
+        const store = newStoreWithSession(scope, "young-a")
+
+        await store.set(archiveSessionAtomFamily(scope), "young-a")
+
+        expect(archiveSessionRemote).toHaveBeenCalledWith({
+            sessionId: "young-a",
+            projectId: "project-1",
+        })
+    })
+
+    // The caller revalidates its lists as soon as this resolves, so the write must be awaitable.
+    it("resolves only once the server write settles", async () => {
+        const scope = "archive-await"
+        const store = newStoreWithSession(scope, "young-b")
+        let landed = false
+        archiveSessionRemote.mockImplementationOnce(async () => {
+            await new Promise((r) => setTimeout(r, 10))
+            landed = true
+            return true
+        })
+
+        await store.set(archiveSessionAtomFamily(scope), "young-b")
+
+        expect(landed).toBe(true)
+    })
+
+    it("unarchives remotely on the same terms", async () => {
+        const scope = "archive-undo"
+        const store = newStoreWithSession(scope, "young-c")
+
+        await store.set(archiveSessionAtomFamily(scope), "young-c")
+        await store.set(unarchiveSessionAtomFamily(scope), "young-c")
+
+        expect(unarchiveSessionRemote).toHaveBeenCalledWith({
+            sessionId: "young-c",
+            projectId: "project-1",
+        })
+        expect(historyIds(store, scope)).toEqual(["young-c"])
     })
 })

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -253,10 +253,13 @@ export const openSessionIdsAtomFamily = atomFamily((key: string) =>
     atom((get) => new Set(currentOpenIds(get, key))),
 )
 
-/** Create a session and make it the active open tab. Returns the new id. */
+/** Create a session and make it the active open tab. Returns the new id. An explicit `id` lets a
+ * caller that already addressed something to this session — a composer's seeded message — name it
+ * before the session exists. Callers wired straight to a click handler pass an event, not options,
+ * so the id is read defensively. */
 export const addSessionAtomFamily = atomFamily((key: string) =>
-    atom(null, (get, set) => {
-        const id = generateId()
+    atom(null, (get, set, options?: {id?: string}) => {
+        const id = options?.id || generateId()
         // Brand-new, never-run session: no backend records yet, so skip its empty-cache hydration.
         markSessionFresh(id)
         // Read open ids BEFORE mutating history, else the fallback would re-count the new id.
@@ -397,8 +400,12 @@ export const deleteSessionAtomFamily = atomFamily((key: string) =>
         // `.catch` rather than `void`: `callFern` RETHROWS aborts/timeouts, so a bare `void` on a
         // fire-and-forget call is an unhandled rejection. Nothing to do on failure — the tombstone
         // above carries the retry.
+        // Returned, not just fired: callers that must not revalidate a list before the server has
+        // the change (see `useSessionActions`) await it.
         const projectId = get(projectIdAtom)
-        if (projectId) deleteSessionRemote({sessionId: id, projectId}).catch(() => {})
+        return projectId
+            ? deleteSessionRemote({sessionId: id, projectId}).catch(() => {})
+            : undefined
     }),
 )
 
@@ -424,9 +431,11 @@ export const archiveSessionAtomFamily = atomFamily((key: string) =>
             set(activeByAppAtom, {...active, [key]: open.filter((x) => x !== id)[0] ?? ""})
         }
 
-        // Server-known sessions archive remotely; a purely-local session just carries the local flag.
+        // Ungated and returned for the same reasons as the delete path above (#5543).
         const projectId = get(projectIdAtom)
-        if (projectId && target.serverKnown) void archiveSessionRemote({sessionId: id, projectId})
+        return projectId
+            ? archiveSessionRemote({sessionId: id, projectId}).catch(() => {})
+            : undefined
     }),
 )
 
@@ -443,8 +452,11 @@ export const unarchiveSessionAtomFamily = atomFamily((key: string) =>
             [key]: (all[key] ?? []).map((s) => (s.id === id ? {...s, archived: false} : s)),
         })
 
+        // Ungated for the same reason as archive above.
         const projectId = get(projectIdAtom)
-        if (projectId && target.serverKnown) void unarchiveSessionRemote({sessionId: id, projectId})
+        return projectId
+            ? unarchiveSessionRemote({sessionId: id, projectId}).catch(() => {})
+            : undefined
     }),
 )
 
@@ -660,8 +672,11 @@ export const renameSessionAtomFamily = atomFamily((key: string) =>
         // Persist the title to the durable stream header so it syncs across devices and survives a
         // localStorage wipe. Best-effort/optimistic — the local update above already shows it. Send
         // the trimmed string (empty clears the server name too, since the header merge is partial).
+        // Returned so a caller that revalidates a list next can await the header write first.
         const projectId = get(projectIdAtom)
-        if (projectId) void setSessionHeader({sessionId: id, projectId, name: title.trim()})
+        return projectId
+            ? setSessionHeader({sessionId: id, projectId, name: title.trim()}).catch(() => {})
+            : undefined
     }),
 )
 

--- a/web/oss/src/components/Layout/ProjectWatch.test.tsx
+++ b/web/oss/src/components/Layout/ProjectWatch.test.tsx
@@ -6,10 +6,15 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
 const mocks = vi.hoisted(() => ({
     invalidateAgentsWorkflowQueries: vi.fn(() => Promise.resolve()),
     invalidateQueries: vi.fn(() => Promise.resolve()),
+    invalidateSessionListQueries: vi.fn(),
 }))
 
 vi.mock("@agenta/shared/api", () => ({
     queryClient: {invalidateQueries: mocks.invalidateQueries},
+}))
+
+vi.mock("@agenta/entities/session", () => ({
+    invalidateSessionListQueries: mocks.invalidateSessionListQueries,
 }))
 
 vi.mock("@/oss/components/pages/agents/store", () => ({
@@ -88,6 +93,7 @@ beforeEach(() => {
     sources.length = 0
     mocks.invalidateAgentsWorkflowQueries.mockClear()
     mocks.invalidateQueries.mockClear()
+    mocks.invalidateSessionListQueries.mockClear()
 })
 
 afterEach(async () => {
@@ -101,7 +107,9 @@ afterEach(async () => {
 })
 
 describe("ProjectWatch", () => {
-    it("maps session changes to the project session-list prefix", async () => {
+    // Through the shared helper, not a `["session-list", projectId]` prefix: the sidebar nests the
+    // same options behind `["sidebar", ...]`, which a positional prefix match never reaches.
+    it("maps session changes to every session-list query", async () => {
         const source = await mountProjectWatch()
 
         expect(source?.url).toBe("/api/sessions/watch?project_id=project-1")
@@ -114,10 +122,7 @@ describe("ProjectWatch", () => {
             )
         })
 
-        expect(mocks.invalidateQueries).toHaveBeenCalledWith({
-            queryKey: ["session-list", "project-1"],
-            exact: false,
-        })
+        expect(mocks.invalidateSessionListQueries).toHaveBeenCalledOnce()
         expect(mocks.invalidateAgentsWorkflowQueries).not.toHaveBeenCalled()
     })
 
@@ -150,10 +155,7 @@ describe("ProjectWatch", () => {
         })
 
         expect(mocks.invalidateAgentsWorkflowQueries).toHaveBeenCalledOnce()
-        expect(mocks.invalidateQueries).toHaveBeenCalledWith({
-            queryKey: ["session-list", "project-1"],
-            exact: false,
-        })
+        expect(mocks.invalidateSessionListQueries).toHaveBeenCalledOnce()
         expect(mocks.invalidateQueries).toHaveBeenCalledWith({
             queryKey: ["workflows", "artifact"],
             exact: false,

--- a/web/oss/src/components/Layout/ProjectWatch.tsx
+++ b/web/oss/src/components/Layout/ProjectWatch.tsx
@@ -1,11 +1,10 @@
 import {useCallback, useMemo} from "react"
 
+import {invalidateSessionListQueries} from "@agenta/entities/session"
 import {queryClient} from "@agenta/shared/api"
-import {useAtomValue} from "jotai"
 
 import {invalidateAgentsWorkflowQueries} from "@/oss/components/pages/agents/store"
 import {useProjectWatch, type ProjectWatchHandlers} from "@/oss/hooks/useProjectWatch"
-import {projectIdAtom} from "@/oss/state/project"
 
 const workflowIdFromEvent = (event: MessageEvent<string>): string | null => {
     try {
@@ -18,16 +17,6 @@ const workflowIdFromEvent = (event: MessageEvent<string>): string | null => {
 }
 
 const ProjectWatch = () => {
-    const projectId = useAtomValue(projectIdAtom)
-
-    const invalidateSessions = useCallback(() => {
-        if (!projectId) return
-        void queryClient.invalidateQueries({
-            queryKey: ["session-list", projectId],
-            exact: false,
-        })
-    }, [projectId])
-
     const invalidateWorkflow = useCallback((event: MessageEvent<string>) => {
         void invalidateAgentsWorkflowQueries()
         const workflowId = workflowIdFromEvent(event)
@@ -39,21 +28,21 @@ const ProjectWatch = () => {
     }, [])
 
     const revalidateProjectLists = useCallback(() => {
-        invalidateSessions()
+        invalidateSessionListQueries()
         void invalidateAgentsWorkflowQueries()
         void queryClient.invalidateQueries({
             queryKey: ["workflows", "artifact"],
             exact: false,
         })
-    }, [invalidateSessions])
+    }, [])
 
     const handlers = useMemo(
         (): ProjectWatchHandlers => ({
             ready: revalidateProjectLists,
-            "session-changed": invalidateSessions,
+            "session-changed": invalidateSessionListQueries,
             "workflow-changed": invalidateWorkflow,
         }),
-        [invalidateSessions, invalidateWorkflow, revalidateProjectLists],
+        [invalidateWorkflow, revalidateProjectLists],
     )
 
     useProjectWatch({on: handlers})

--- a/web/oss/src/components/Sidebar/dynamic/SessionRowActions.tsx
+++ b/web/oss/src/components/Sidebar/dynamic/SessionRowActions.tsx
@@ -1,0 +1,102 @@
+import {memo, useCallback, useMemo, useState, type ReactNode} from "react"
+
+import {DotsThreeVertical} from "@phosphor-icons/react"
+import {Button, Dropdown} from "antd"
+
+import {
+    useSessionActions,
+    type SessionActionTarget,
+} from "@/oss/components/AgentChatSlice/hooks/useSessionActions"
+
+import type {SessionSidebarRef} from "./sessionsSource"
+
+const CONTEXT_TRIGGER: ("contextMenu" | "hover" | "click")[] = ["contextMenu"]
+const CLICK_TRIGGER: ("contextMenu" | "hover" | "click")[] = ["click"]
+const KEBAB_ICON = <DotsThreeVertical size={14} />
+
+/**
+ * Per-row session actions for the sidebar — the same verbs the playground's session bar offers,
+ * from the same `useSessionActions` set, so the two surfaces cannot drift apart.
+ *
+ * Wraps the row's label: right-click anywhere on it, or use the kebab that appears on hover. The
+ * kebab's 20px slot is always reserved so revealing it never reflows the label, but the button
+ * itself mounts only while hot (each one carries a Dropdown + Button subtree, times every row).
+ */
+const SessionRowActions = ({
+    session,
+    children,
+}: {
+    session: SessionSidebarRef
+    children: ReactNode
+}) => {
+    const {menuItems, onMenuClick} = useSessionActions()
+    const [hot, setHot] = useState(false)
+    const [open, setOpen] = useState(false)
+
+    const target = useMemo(
+        (): SessionActionTarget => ({
+            sessionId: session.sessionId,
+            appId: session.appId,
+            name: session.name ?? null,
+            // The sidebar list requests `includeArchived: false`, so a row here is never archived.
+            archived: false,
+        }),
+        [session.sessionId, session.appId, session.name],
+    )
+    const menu = useMemo(
+        () => ({items: menuItems(target), onClick: onMenuClick(target)}),
+        [menuItems, onMenuClick, target],
+    )
+
+    const onEnter = useCallback(() => setHot(true), [])
+    const onLeave = useCallback((e: React.MouseEvent<HTMLElement>) => {
+        // Don't unmount the kebab out from under keyboard focus.
+        if (!e.currentTarget.contains(document.activeElement)) setHot(false)
+    }, [])
+    const onBlur = useCallback((e: React.FocusEvent<HTMLElement>) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setHot(false)
+    }, [])
+    // The row's link stretches a ::before over the whole item — swallow the kebab's click so
+    // opening the menu doesn't also navigate into the session.
+    const swallow = useCallback((e: React.MouseEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+    }, [])
+
+    return (
+        <Dropdown menu={menu} trigger={CONTEXT_TRIGGER}>
+            <span
+                className="flex w-full min-w-0 items-center"
+                onMouseEnter={onEnter}
+                onMouseLeave={onLeave}
+                onFocus={onEnter}
+                onBlur={onBlur}
+            >
+                <span className="min-w-0 flex-1 truncate">{children}</span>
+                <span
+                    className="relative z-[1] flex h-5 w-5 shrink-0 items-center justify-center"
+                    onClick={swallow}
+                >
+                    {(hot || open) && (
+                        <Dropdown
+                            menu={menu}
+                            trigger={CLICK_TRIGGER}
+                            open={open}
+                            onOpenChange={setOpen}
+                        >
+                            <Button
+                                type="text"
+                                size="small"
+                                aria-label={`Actions for ${session.name || "Untitled session"}`}
+                                icon={KEBAB_ICON}
+                                className="!h-5 !w-5 !min-w-0 !p-0"
+                            />
+                        </Dropdown>
+                    )}
+                </span>
+            </span>
+        </Dropdown>
+    )
+}
+
+export default memo(SessionRowActions)

--- a/web/oss/src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest"
 
-import {dropArchivedAgentSessions, withActiveLocalSession} from "./sessionsSource"
+import {dropArchivedAgentSessions, withLocalSessions} from "./sessionsSource"
 import type {SessionSidebarRef} from "./sessionsSource"
 
 const ref = (over: Partial<SessionSidebarRef> & {id: string}): SessionSidebarRef => ({
@@ -62,23 +62,23 @@ describe("dropArchivedAgentSessions", () => {
     })
 })
 
-describe("withActiveLocalSession", () => {
-    // The bug this exists for: a just-created session is client-side only until its first turn
-    // runs, so the server-backed list cannot contain it and the sidebar showed nothing.
-    it("adds the open session when the server list has never heard of it", () => {
-        const merged = withActiveLocalSession(
-            [ref({id: "served"})],
-            ref({id: "fresh", appId: "agent-1"}),
-        )
+/**
+ * A session's row can only come from the local tab store until its FIRST turn lands: the server row
+ * carries no `references` before then, so `sessionOpenTarget` rejects it and the server-backed list
+ * drops it. What goes in that local set decides which sessions the sidebar can show at all.
+ */
+describe("withLocalSessions", () => {
+    it("adds a session the server list has never heard of", () => {
+        const merged = withLocalSessions([ref({id: "served"})], [ref({id: "fresh"})])
 
         expect(merged.map((r) => r.id)).toEqual(["fresh", "served"])
     })
 
     // The server row carries the title, preview and liveness the local one cannot know.
     it("keeps the server row when both describe the same session", () => {
-        const merged = withActiveLocalSession(
+        const merged = withLocalSessions(
             [ref({id: "shared", name: "Real title", alive: true})],
-            ref({id: "shared", name: null}),
+            [ref({id: "shared", name: null})],
         )
 
         expect(merged).toHaveLength(1)
@@ -86,26 +86,36 @@ describe("withActiveLocalSession", () => {
         expect(merged[0].alive).toBe(true)
     })
 
+    // The regression: keying this on the ACTIVE session alone meant switching tabs mid-first-turn
+    // dropped the running session's row, taking its spinner with it.
+    it("keeps a running session alongside the one now active", () => {
+        const merged = withLocalSessions(
+            [ref({id: "served"})],
+            [ref({id: "now-active"}), ref({id: "still-running"})],
+        )
+
+        expect(merged.map((r) => r.id)).toEqual(["now-active", "still-running", "served"])
+    })
+
     it("leads the unpinned rows without displacing pins", () => {
-        const merged = withActiveLocalSession(
+        const merged = withLocalSessions(
             [ref({id: "pin-a", pinned: true}), ref({id: "pin-b", pinned: true}), ref({id: "old"})],
-            ref({id: "fresh"}),
+            [ref({id: "fresh"})],
         )
 
         expect(merged.map((r) => r.id)).toEqual(["pin-a", "pin-b", "fresh", "old"])
     })
 
     it("appends when every row is pinned", () => {
-        const merged = withActiveLocalSession([ref({id: "pin", pinned: true})], ref({id: "fresh"}))
+        const merged = withLocalSessions([ref({id: "pin", pinned: true})], [ref({id: "fresh"})])
 
         expect(merged.map((r) => r.id)).toEqual(["pin", "fresh"])
     })
 
-    // Off a playground there is no open session — the empty-session filter must keep its full
-    // reach, so nothing is exempted.
-    it("changes nothing when no session is open", () => {
+    // Off a playground nothing is exempted, so the empty-session filter keeps its full reach.
+    it("changes nothing when there are no local sessions", () => {
         const refs = [ref({id: "a"}), ref({id: "b"})]
 
-        expect(withActiveLocalSession(refs, null).map((r) => r.id)).toEqual(["a", "b"])
+        expect(withLocalSessions(refs, []).map((r) => r.id)).toEqual(["a", "b"])
     })
 })

--- a/web/oss/src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/dropArchivedAgentSessions.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest"
 
-import {dropArchivedAgentSessions} from "./sessionsSource"
+import {dropArchivedAgentSessions, withActiveLocalSession} from "./sessionsSource"
 import type {SessionSidebarRef} from "./sessionsSource"
 
 const ref = (over: Partial<SessionSidebarRef> & {id: string}): SessionSidebarRef => ({
@@ -9,6 +9,7 @@ const ref = (over: Partial<SessionSidebarRef> & {id: string}): SessionSidebarRef
     appId: null,
     pinned: false,
     alive: false,
+    running: false,
     agentName: null,
     ...over,
 })
@@ -58,5 +59,53 @@ describe("dropArchivedAgentSessions", () => {
         ]
 
         expect(dropArchivedAgentSessions(refs, ARCHIVED).map((r) => r.id)).toEqual(["live"])
+    })
+})
+
+describe("withActiveLocalSession", () => {
+    // The bug this exists for: a just-created session is client-side only until its first turn
+    // runs, so the server-backed list cannot contain it and the sidebar showed nothing.
+    it("adds the open session when the server list has never heard of it", () => {
+        const merged = withActiveLocalSession(
+            [ref({id: "served"})],
+            ref({id: "fresh", appId: "agent-1"}),
+        )
+
+        expect(merged.map((r) => r.id)).toEqual(["fresh", "served"])
+    })
+
+    // The server row carries the title, preview and liveness the local one cannot know.
+    it("keeps the server row when both describe the same session", () => {
+        const merged = withActiveLocalSession(
+            [ref({id: "shared", name: "Real title", alive: true})],
+            ref({id: "shared", name: null}),
+        )
+
+        expect(merged).toHaveLength(1)
+        expect(merged[0].name).toBe("Real title")
+        expect(merged[0].alive).toBe(true)
+    })
+
+    it("leads the unpinned rows without displacing pins", () => {
+        const merged = withActiveLocalSession(
+            [ref({id: "pin-a", pinned: true}), ref({id: "pin-b", pinned: true}), ref({id: "old"})],
+            ref({id: "fresh"}),
+        )
+
+        expect(merged.map((r) => r.id)).toEqual(["pin-a", "pin-b", "fresh", "old"])
+    })
+
+    it("appends when every row is pinned", () => {
+        const merged = withActiveLocalSession([ref({id: "pin", pinned: true})], ref({id: "fresh"}))
+
+        expect(merged.map((r) => r.id)).toEqual(["pin", "fresh"])
+    })
+
+    // Off a playground there is no open session — the empty-session filter must keep its full
+    // reach, so nothing is exempted.
+    it("changes nothing when no session is open", () => {
+        const refs = [ref({id: "a"}), ref({id: "b"})]
+
+        expect(withActiveLocalSession(refs, null).map((r) => r.id)).toEqual(["a", "b"])
     })
 })

--- a/web/oss/src/components/Sidebar/dynamic/registry.ts
+++ b/web/oss/src/components/Sidebar/dynamic/registry.ts
@@ -7,10 +7,11 @@ import {
     // nonArchivedEvaluatorsAtom,
     promptWorkflowsListQueryStateAtom,
 } from "@agenta/entities/workflow"
-import {ChatsCircleIcon, CircleIcon, CircleNotchIcon, PushPinIcon} from "@phosphor-icons/react"
+import {ChatsCircleIcon, CircleIcon, PushPinIcon} from "@phosphor-icons/react"
 import {RobotIcon} from "@phosphor-icons/react"
 import {atom, getDefaultStore} from "jotai"
 
+import {SessionRunSpinner} from "@/oss/components/AgentChatSlice/components/SessionRunSpinner"
 import {pendingSessionOpenAtom} from "@/oss/components/AgentChatSlice/state/pendingSessionOpen"
 
 import {MAIN_SIDEBAR_SCOPE_ID, SESSIONS_SIDEBAR_KEY} from "../scopes/constants"
@@ -99,10 +100,11 @@ const ENTITIES: SidebarEntity[] = [
             })
         },
         // A turn in flight outranks the pin: "this one is working right now" is the state you scan
-        // the list for, and the pin is still readable from the row's position at the top.
+        // the list for, and the pin is still readable from the row's position at the top. Same
+        // glyph and motion the playground's session chips use — one animation for one meaning.
         getIcon: (session) =>
             session.running
-                ? createElement(CircleNotchIcon, {size: 12, className: "animate-spin"})
+                ? createElement(SessionRunSpinner)
                 : session.pinned
                   ? createElement(PushPinIcon, {size: 14, weight: "fill"})
                   : createElement(CircleIcon, {

--- a/web/oss/src/components/Sidebar/dynamic/registry.ts
+++ b/web/oss/src/components/Sidebar/dynamic/registry.ts
@@ -7,7 +7,7 @@ import {
     // nonArchivedEvaluatorsAtom,
     promptWorkflowsListQueryStateAtom,
 } from "@agenta/entities/workflow"
-import {ChatsCircleIcon, CircleIcon, PushPinIcon} from "@phosphor-icons/react"
+import {ChatsCircleIcon, CircleIcon, CircleNotchIcon, PushPinIcon} from "@phosphor-icons/react"
 import {RobotIcon} from "@phosphor-icons/react"
 import {atom, getDefaultStore} from "jotai"
 
@@ -16,6 +16,7 @@ import {pendingSessionOpenAtom} from "@/oss/components/AgentChatSlice/state/pend
 import {MAIN_SIDEBAR_SCOPE_ID, SESSIONS_SIDEBAR_KEY} from "../scopes/constants"
 
 import {SIDEBAR_SESSION_VISIBLE_LIMIT} from "./sessionOptions"
+import SessionRowActions from "./SessionRowActions"
 import {sidebarSessionsListAtom, type SessionSidebarRef} from "./sessionsSource"
 import {gatedSidebarSource} from "./source"
 import type {
@@ -64,6 +65,7 @@ export const defineSidebarEntity = <TRef extends SidebarEntityRef>(
     getIcon: config.getIcon ? (ref) => config.getIcon!(ref as TRef) : undefined,
     getTooltip: config.getTooltip ? (ref) => config.getTooltip!(ref as TRef) : undefined,
     getOnClick: config.getOnClick ? (ref) => config.getOnClick!(ref as TRef) : undefined,
+    wrapRow: config.wrapRow ? (ref, node) => config.wrapRow!(ref as TRef, node) : undefined,
 })
 
 // ── Add a new dynamic entity by appending one entry here. Nothing else. ──────
@@ -96,13 +98,18 @@ const ENTITIES: SidebarEntity[] = [
                 title: session.name ?? undefined,
             })
         },
+        // A turn in flight outranks the pin: "this one is working right now" is the state you scan
+        // the list for, and the pin is still readable from the row's position at the top.
         getIcon: (session) =>
-            session.pinned
-                ? createElement(PushPinIcon, {size: 14, weight: "fill"})
-                : createElement(CircleIcon, {
-                      size: 10,
-                      weight: session.alive ? "fill" : "regular",
-                  }),
+            session.running
+                ? createElement(CircleNotchIcon, {size: 12, className: "animate-spin"})
+                : session.pinned
+                  ? createElement(PushPinIcon, {size: 14, weight: "fill"})
+                  : createElement(CircleIcon, {
+                        size: 10,
+                        weight: session.alive ? "fill" : "regular",
+                    }),
+        wrapRow: (session, node) => createElement(SessionRowActions, {session, children: node}),
         // Show the owning agent because sessions from multiple agents share this list.
         getTooltip: (session) => session.agentName ?? undefined,
         emptyLabel: "No sessions",

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -10,6 +10,7 @@ import {
     activeSessionIdAtomFamily,
     defaultScopeKeyAtom,
     sessionsListAtomFamily,
+    sessionStatusAtomFamily,
 } from "@/oss/components/AgentChatSlice/state/sessions"
 import {isValidUUID} from "@/oss/lib/helpers/validators"
 import {sessionListPolicies} from "@/oss/lib/sessionListPolicies"
@@ -90,55 +91,68 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
 }
 
 /**
- * The conversation open in the playground right now, as a sidebar row — or null off a playground.
+ * Playground sessions the server-backed list cannot show yet, as sidebar rows.
  *
- * A new session is created CLIENT-side (`addSessionAtomFamily` writes localStorage); the server
- * first hears about it when its first turn runs. So the server-backed list below cannot show a
- * just-created session at all, and even once the row exists the empty-session filter hides it until
- * it has a turn. Reading the local tab store closes both gaps for the one session that is
- * definitely not abandoned: the one you are looking at. Every other empty session stays hidden.
+ * A session is created CLIENT-side (`addSessionAtomFamily` writes localStorage); the server first
+ * hears about it when its first turn runs, and even then its row carries no `references` until that
+ * turn lands — so `sessionOpenTarget` rejects it and the list below drops it. Until the first turn
+ * completes, the local tab store is the ONLY place a session exists for the sidebar.
  *
- * Scope is the routed app id, so the row disappears when you navigate away from that playground —
- * an abandoned blank chat never lingers here. Surfaces that override the chat scope through React
- * context (the revision drawer, onboarding) are not reflected; the sidebar cannot read context.
+ * Two sessions qualify, and both are demonstrably not abandoned:
+ *  - the one you are looking at;
+ *  - any that is RUNNING or awaiting your input. Keying this on "active" alone was the bug behind
+ *    Mahmoud's repro: switching tabs mid-first-turn dropped the running session's row (and with it
+ *    the spinner) until its turn finished and the server list could carry it.
+ *
+ * Scope is the routed app id, so rows disappear when you leave that playground — an abandoned blank
+ * chat never lingers. Surfaces that override the chat scope through React context (the revision
+ * drawer, onboarding) are not reflected; the sidebar cannot read context.
  */
-const activePlaygroundSessionRefAtom = atom<SessionSidebarRef | null>((get) => {
+const localPlaygroundSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     const scope = get(defaultScopeKeyAtom)
     // The scope key doubles as the app id for the row's link, so it must be a real one.
-    if (!isValidUUID(scope)) return null
+    if (!isValidUUID(scope)) return []
     const sessions = get(sessionsListAtomFamily(scope))
     const rawActiveId = get(activeSessionIdAtomFamily(scope))
     // Same fallback the panel applies to a stale active id (its tab was closed).
     const active = sessions.find((session) => session.id === rawActiveId) ?? sessions[0] ?? null
-    if (!active) return null
-    return {
-        id: active.id,
-        sessionId: active.id,
-        name: active.title?.trim() || null,
-        appId: scope,
-        pinned: get(pinnedSessionIdsAtom).includes(active.id),
-        alive: false,
-        running: false,
-        agentName: null,
+    const pinned = get(pinnedSessionIdsAtom)
+    // `error` is settled, not live — an errored empty session is as abandoned as an untouched one.
+    const isLive = (id: string) => {
+        const status = get(sessionStatusAtomFamily(id))
+        return status === "running" || status === "awaiting"
     }
+    return sessions
+        .filter((session) => session.id === active?.id || isLive(session.id))
+        .map((session) => ({
+            id: session.id,
+            sessionId: session.id,
+            name: session.title?.trim() || null,
+            appId: scope,
+            pinned: pinned.includes(session.id),
+            alive: false,
+            running: false,
+            agentName: null,
+        }))
 })
 
 /**
- * Adds the actively-open session to the list, unless the server already returned it — the server
- * row wins there, it carries the title, preview and liveness this local one cannot know.
+ * Adds the local playground rows to the list, skipping any the server already returned — the server
+ * row wins there, it carries the title, preview and liveness the local one cannot know.
  *
- * Lands at the head of the unpinned rows: it is the most recently touched session by definition,
- * and pins keep the top the way they do everywhere else.
+ * They land at the head of the unpinned rows: they are the most recently touched sessions by
+ * definition, and pins keep the top the way they do everywhere else.
  */
-export const withActiveLocalSession = (
+export const withLocalSessions = (
     refs: readonly SessionSidebarRef[],
-    active: SessionSidebarRef | null,
+    locals: readonly SessionSidebarRef[],
 ): SessionSidebarRef[] => {
-    if (!active) return [...refs]
-    if (refs.some((ref) => ref.sessionId === active.sessionId)) return [...refs]
+    const known = new Set(refs.map((ref) => ref.sessionId))
+    const missing = locals.filter((local) => !known.has(local.sessionId))
+    if (!missing.length) return [...refs]
     const firstUnpinned = refs.findIndex((ref) => !ref.pinned)
     const at = firstUnpinned === -1 ? refs.length : firstUnpinned
-    return [...refs.slice(0, at), active, ...refs.slice(at)]
+    return [...refs.slice(0, at), ...missing, ...refs.slice(at)]
 }
 
 /**
@@ -220,7 +234,7 @@ const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     // Archived agents' sessions go before anything downstream counts rows: the name resolution
     // below and the group's visible cap both work off this list, so filtering here keeps archived
     // rows from eating slots the backfill should have given to live ones.
-    const refs = withActiveLocalSession(
+    const refs = withLocalSessions(
         dropArchivedAgentSessions(
             [
                 ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
@@ -228,7 +242,7 @@ const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
             ],
             get(archivedAgentIdsQueryAtom).data ?? null,
         ),
-        get(activePlaygroundSessionRefAtom),
+        get(localPlaygroundSessionRefsAtom),
     )
     // Names and run state are resolved for the RENDERED rows only. Each name subscribes to that
     // agent's artifact query, and the request window behind this list is several times what the

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -5,6 +5,13 @@ import {atom} from "jotai"
 import {atomWithQuery} from "jotai-tanstack-query"
 
 import {sessionOpenTarget} from "@/oss/components/AgentChatSlice/assets/sessionOpenTarget"
+import {sessionDotStatusAtomFamily} from "@/oss/components/AgentChatSlice/state/liveness"
+import {
+    activeSessionIdAtomFamily,
+    defaultScopeKeyAtom,
+    sessionsListAtomFamily,
+} from "@/oss/components/AgentChatSlice/state/sessions"
+import {isValidUUID} from "@/oss/lib/helpers/validators"
 import {sessionListPolicies} from "@/oss/lib/sessionListPolicies"
 import {projectIdAtom} from "@/oss/state/project"
 
@@ -17,6 +24,8 @@ export interface SessionSidebarRef extends SidebarEntityRef {
     appId: string | null
     pinned: boolean
     alive: boolean
+    /** A turn is in flight — the row spins. Resolved for rendered rows only (see below). */
+    running: boolean
     /** Owning agent's display name, for the row's hover tooltip. Null until the artifact resolves. */
     agentName: string | null
 }
@@ -70,12 +79,66 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
     return {
         id: row.session_id,
         sessionId: row.session_id,
-        name: row.name?.trim() || "Untitled session",
+        // Raw, so the row menu's rename prefills the real name instead of the label's fallback.
+        name: row.name?.trim() || null,
         appId: target.appId,
         pinned: pinned.has(row.session_id),
         alive: Boolean(row.flags?.is_alive),
+        running: false,
         agentName: null,
     }
+}
+
+/**
+ * The conversation open in the playground right now, as a sidebar row — or null off a playground.
+ *
+ * A new session is created CLIENT-side (`addSessionAtomFamily` writes localStorage); the server
+ * first hears about it when its first turn runs. So the server-backed list below cannot show a
+ * just-created session at all, and even once the row exists the empty-session filter hides it until
+ * it has a turn. Reading the local tab store closes both gaps for the one session that is
+ * definitely not abandoned: the one you are looking at. Every other empty session stays hidden.
+ *
+ * Scope is the routed app id, so the row disappears when you navigate away from that playground —
+ * an abandoned blank chat never lingers here. Surfaces that override the chat scope through React
+ * context (the revision drawer, onboarding) are not reflected; the sidebar cannot read context.
+ */
+const activePlaygroundSessionRefAtom = atom<SessionSidebarRef | null>((get) => {
+    const scope = get(defaultScopeKeyAtom)
+    // The scope key doubles as the app id for the row's link, so it must be a real one.
+    if (!isValidUUID(scope)) return null
+    const sessions = get(sessionsListAtomFamily(scope))
+    const rawActiveId = get(activeSessionIdAtomFamily(scope))
+    // Same fallback the panel applies to a stale active id (its tab was closed).
+    const active = sessions.find((session) => session.id === rawActiveId) ?? sessions[0] ?? null
+    if (!active) return null
+    return {
+        id: active.id,
+        sessionId: active.id,
+        name: active.title?.trim() || null,
+        appId: scope,
+        pinned: get(pinnedSessionIdsAtom).includes(active.id),
+        alive: false,
+        running: false,
+        agentName: null,
+    }
+})
+
+/**
+ * Adds the actively-open session to the list, unless the server already returned it — the server
+ * row wins there, it carries the title, preview and liveness this local one cannot know.
+ *
+ * Lands at the head of the unpinned rows: it is the most recently touched session by definition,
+ * and pins keep the top the way they do everywhere else.
+ */
+export const withActiveLocalSession = (
+    refs: readonly SessionSidebarRef[],
+    active: SessionSidebarRef | null,
+): SessionSidebarRef[] => {
+    if (!active) return [...refs]
+    if (refs.some((ref) => ref.sessionId === active.sessionId)) return [...refs]
+    const firstUnpinned = refs.findIndex((ref) => !ref.pinned)
+    const at = firstUnpinned === -1 ? refs.length : firstUnpinned
+    return [...refs.slice(0, at), active, ...refs.slice(at)]
 }
 
 /**
@@ -157,19 +220,28 @@ const sidebarSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     // Archived agents' sessions go before anything downstream counts rows: the name resolution
     // below and the group's visible cap both work off this list, so filtering here keeps archived
     // rows from eating slots the backfill should have given to live ones.
-    const refs = dropArchivedAgentSessions(
-        [
-            ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
-            ...recentRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
-        ],
-        get(archivedAgentIdsQueryAtom).data ?? null,
+    const refs = withActiveLocalSession(
+        dropArchivedAgentSessions(
+            [
+                ...pinnedRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+                ...recentRows.map((row) => toSidebarRef(row, pinned)).filter(isRef),
+            ],
+            get(archivedAgentIdsQueryAtom).data ?? null,
+        ),
+        get(activePlaygroundSessionRefAtom),
     )
-    // Names are resolved for the RENDERED rows only. Each one subscribes to that agent's artifact
-    // query, and the request window behind this list is several times what the group ever shows —
-    // resolving all of it would fetch artifacts for rows nobody sees. The full list still goes out
-    // so the "Show all" overflow count stays honest.
+    // Names and run state are resolved for the RENDERED rows only. Each name subscribes to that
+    // agent's artifact query, and the request window behind this list is several times what the
+    // group ever shows — resolving all of it would fetch artifacts for rows nobody sees. The full
+    // list still goes out so the "Show all" overflow count stays honest.
     return refs.map((ref, index) =>
-        index < SIDEBAR_SESSION_VISIBLE_LIMIT ? {...ref, agentName: agentNameOf(ref.appId)} : ref,
+        index < SIDEBAR_SESSION_VISIBLE_LIMIT
+            ? {
+                  ...ref,
+                  agentName: agentNameOf(ref.appId),
+                  running: get(sessionDotStatusAtomFamily(ref.sessionId)) === "running",
+              }
+            : ref,
     )
 })
 

--- a/web/oss/src/components/Sidebar/dynamic/types.ts
+++ b/web/oss/src/components/Sidebar/dynamic/types.ts
@@ -1,4 +1,4 @@
-import type {ReactElement} from "react"
+import type {ReactElement, ReactNode} from "react"
 
 import type {ListQueryState} from "@agenta/entities/shared"
 import type {Atom} from "jotai"
@@ -59,6 +59,9 @@ export interface SidebarEntityConfig<TRef extends SidebarEntityRef = SidebarEnti
     /** Extra work on click, alongside following `childPath` — e.g. handing the target to the
      * surface being navigated to. Runs in the default jotai store, not a hook. */
     getOnClick?: (ref: TRef) => () => void
+    /** Wraps the rendered row so an entity can add per-row chrome (a kebab menu, a right-click
+     * menu). Returns an ELEMENT, so the wrapper component — not this closure — owns the hooks. */
+    wrapRow?: (ref: TRef, node: ReactNode) => ReactElement
 }
 
 /**
@@ -80,4 +83,5 @@ export interface SidebarEntity {
     getIcon?: (ref: SidebarEntityRef) => ReactElement
     getTooltip?: (ref: SidebarEntityRef) => string | undefined
     getOnClick?: (ref: SidebarEntityRef) => () => void
+    wrapRow?: (ref: SidebarEntityRef, node: ReactNode) => ReactElement
 }

--- a/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
+++ b/web/oss/src/components/Sidebar/dynamic/useSidebarDynamicChildren.ts
@@ -95,6 +95,7 @@ export const resolveChildren = (
             icon: entity.getIcon?.(ref) ?? icon(),
             isDynamic: true,
             onClick: entity.getOnClick?.(ref),
+            wrapRow: entity.wrapRow ? (node) => entity.wrapRow!(ref, node) : undefined,
         })
     }
 

--- a/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
+++ b/web/oss/src/components/Sidebar/engine/SidebarMenu.tsx
@@ -249,13 +249,16 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
                         </span>
                     )
 
-                    const labelNode = item.dataTour ? (
+                    const tourNode = item.dataTour ? (
                         <span className="w-full" data-tour={item.dataTour}>
                             {node}
                         </span>
                     ) : (
                         node
                     )
+                    // Per-row chrome (kebab / right-click menu). A collapsed rail has no room for
+                    // it, and its own Tooltip wrapper below owns the row instead.
+                    const labelNode = item.wrapRow && !collapsed ? item.wrapRow(tourNode) : tourNode
 
                     const menuItem = {
                         icon: item.icon,

--- a/web/oss/src/components/Sidebar/engine/types.ts
+++ b/web/oss/src/components/Sidebar/engine/types.ts
@@ -1,4 +1,4 @@
-import type {ComponentType, JSX, MouseEvent} from "react"
+import type {ComponentType, JSX, MouseEvent, ReactElement, ReactNode} from "react"
 
 import type {MenuProps} from "antd"
 import type {PrimitiveAtom, WritableAtom} from "jotai"
@@ -28,6 +28,8 @@ export interface SidebarConfig {
     inert?: boolean
     /** Route prefixes that select this row; empty opts it out of matching. Defaults to `[link]`. */
     matchLinks?: string[]
+    /** Wraps the row's label with per-row chrome (kebab / right-click menu). Skipped when collapsed. */
+    wrapRow?: (node: ReactNode) => ReactElement
     /** Workflow categories that support this item. Omit to support every category. */
     workflowCategories?: readonly SidebarWorkflowCategory[]
 }

--- a/web/packages/agenta-entities/src/gatewayTrigger/state/invalidate.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/state/invalidate.ts
@@ -3,29 +3,16 @@
 
 import {queryClient} from "@agenta/shared/api"
 
-/**
- * Every session-list query (desktop's `useSessionList`, the sidebar, mobile's infinite list and
- * head) is built from the same `sessionListQueryOptions()` in `@agenta/entities/session`, whose
- * key starts `["session-list", projectId, ...]`. The sidebar and mobile nest that array behind
- * their own prefix (`["sidebar", ...]`, `["mobile", ...]`, `["mobile", "head", ...]`), so a plain
- * prefix match on `["session-list"]` only catches desktop. A `session-list` token match anywhere
- * in the key catches all of them without enumerating each nesting or over-invalidating unrelated
- * mobile/sidebar queries (session-stream, liveness, pins, ...) that don't carry that token.
- */
-function invalidateSessionLists(): void {
-    queryClient.invalidateQueries({
-        predicate: (query) => query.queryKey.includes("session-list"),
-    })
-}
+import {invalidateSessionListQueries} from "../../session/state/invalidate"
 
 export function invalidateTriggerSchedules(): void {
     queryClient.invalidateQueries({queryKey: ["triggers", "schedules"]})
     // A rename/delete changes what an automation-mode session row shows (name, or the
     // historical-name fallback) — the list must refetch, not just the trigger's own cache.
-    invalidateSessionLists()
+    invalidateSessionListQueries()
 }
 
 export function invalidateTriggerSubscriptions(): void {
     queryClient.invalidateQueries({queryKey: ["triggers", "subscriptions"]})
-    invalidateSessionLists()
+    invalidateSessionListQueries()
 }

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -91,6 +91,7 @@ export {
     type SessionListCursor,
     type SessionListFilters,
 } from "./state/listOptions"
+export {invalidateSessionListQueries} from "./state/invalidate"
 export {shouldAdoptServerTranscript, type TranscriptAdoptionInput} from "./core/transcriptAdoption"
 export {deriveMountRows, mountBreadcrumbs, type MountRow} from "./core/mountBrowser"
 export {pickCwdMount} from "./core/mountSelection"

--- a/web/packages/agenta-entities/src/session/state/invalidate.ts
+++ b/web/packages/agenta-entities/src/session/state/invalidate.ts
@@ -1,0 +1,17 @@
+import {queryClient} from "@agenta/shared/api"
+
+/**
+ * Refetch every session-list query, wherever it is nested.
+ *
+ * All of them are built from the same `sessionListQueryOptions()`, whose key starts
+ * `["session-list", projectId, ...]` — but the sidebar and mobile nest that array behind their own
+ * prefix (`["sidebar", ...]`, `["mobile", ...]`, `["mobile", "head", ...]`), and TanStack matches
+ * prefixes positionally from index 0, so `["session-list"]` reaches desktop ONLY. A token match
+ * catches all of them without enumerating each nesting, and without touching the sibling
+ * sidebar/mobile queries (session-stream, liveness, pins, …) that don't carry the token.
+ */
+export function invalidateSessionListQueries(): void {
+    void queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey.includes("session-list"),
+    })
+}


### PR DESCRIPTION
## What this does

Fixes four session-UX problems found in founder QA after the #5943–#5945 merge, in one connected package: sessions now appear in the sidebar the moment you create them, show a live running indicator that survives switching sessions, carry the same actions menu as the playground, and the overview/home composer can no longer lose your first message to a stale session.

## Fixes

**New sessions appear in the sidebar immediately.** Two real causes, neither the empty-session filter: (1) a new session exists only client-side until its first turn lands, so the server-backed sidebar had nothing to show; (2) the sidebar nests the session-list query under a `["sidebar", ...]` key, so every existing `["session-list"]` prefix invalidation silently missed it and rows refreshed only on the 30s stale timer. Now: one shared `invalidateSessionListQueries()` helper is the single invalidation path (ProjectWatch, session actions, gateway triggers, and the turn that first persists a session all use it), and `withLocalSessions` merges locally-known sessions (the active one, plus any running/awaiting in scope) into the list until the server catches up. Stale empty sessions stay hidden.

**Running spinner that tracks the run, not the viewport.** Sidebar rows show a spinner while that session's agent run is in flight, driven by the same status atom that layers backend liveness under local run state, so it also picks up runs started in other tabs or by other devices via the existing 15s poll. Founder-reported bug fixed along the way: a first-turn session's row (and spinner) vanished when you switched sessions, because the injected local row was keyed to the active session alone; running/awaiting sessions now stay injected regardless of which session is active.

**One thinking animation everywhere.** New shared `SessionRunSpinner` renders the running state in all four surfaces (sidebar, playground tab strip, session rail, history menu): same glyph, same motion, same `colorInfo` tone in both themes (an antd menu-icon CSS rule was silently recoloring the sidebar copy; fixed). The `awaiting` state keeps its pulsing "needs you" dot on purpose.

**Sidebar session actions menu.** Right-click or kebab on any sidebar session row: Rename, Pin, Archive, Delete, identical to the playground because it reuses `useSessionActions` outright (a generic `wrapRow` capability in the sidebar engine carries it). Two pre-existing archive bugs found and fixed while wiring it, both also affecting the playground bar: archiving a young session silently never reached the server (`serverKnown` gate, same hole #5543 closed for delete), and the list refetch raced the archive write (mutations now return promises and are awaited).

**Composer handoff race (flaky "message lands in an old session or disappears").** The overview/home composer stored the draft and "create a session" as two unaddressed atoms; whichever session pane mounted first claimed the message. With a warm route chunk that was the PREVIOUS session, which either ran the message in an old conversation or, if its history hydrated first, dropped the message entirely. The composer now mints the session id up front and addresses both atoms to it; claiming is exact (`shouldConsumeSeed`, extracted and unit-tested), and hydrating sessions refuse legacy unaddressed seeds. Reproduced both failure modes live before the fix; 4/4 correct runs after, including the home composer and the mid-hydration case.

## Verification

- Live on the dev stack: new session appears instantly; spinner survives session switches for the full run and clears on settle (measured, including the founder's exact repro); menu actions land server-side (`archived_at` confirmed on the wire, row gone in <700ms); composer scenario correct 4/4 with the failing preconditions deliberately recreated.
- Both themes verified with computed styles and screenshots (spinner color identical chip vs sidebar in light and dark; menu renders antd dark surfaces).
- Tests: ~410 passing across Sidebar/AgentChatSlice/Layout (new: 6 `withLocalSessions` cases including a direct regression pin, 10 `shouldConsumeSeed` cases, 3 archive cases), 974 in @agenta/entities, 49 in @agenta/sessions. `tsc --noEmit` clean for oss and ee.

## Known limits (deliberate)

- A session still on its FIRST turn stops being visible if you leave the playground page entirely before the turn completes: the server row has no open target yet, and rendering rows that link nowhere is the exact thing the null-drop guard exists to prevent. It reappears when the turn lands.
- The drawer and onboarding chat scopes do not show the injected local row (they override the chat scope via React context, which the sidebar cannot read); they showed nothing before either.
- On playground arrival the auto-created blank tab shows as "Untitled session" in the sidebar while you are in it; it disappears on navigate-away. Founder-flagged as acceptable.
