### PR TITLE
docs: plan runner subscription status path

### DIFF
--- a/docs/design/runner-subscription-status/README.md
+++ b/docs/design/runner-subscription-status/README.md
@@ -1,0 +1,34 @@
+# Runner subscription status
+
+> AGENT-GENERATED, low weight. This is a draft. Mahmoud must approve product and interface decisions.
+
+This folder plans how Agenta shows whether a runner can use a model subscription.
+
+The runner is the private Node service that starts Codex, Pi, or Claude Code. A harness is the
+program that communicates with the model and uses tools. The frontend is the Agenta web application.
+
+## Reading order
+
+1. [context.md](context.md) explains the user problem and the limits.
+2. [research.md](research.md) shows the current code path and the code evidence.
+3. [api-design.md](api-design.md) defines the proposed response and the new path.
+4. [plan.md](plan.md) lists the implementation work in dependency order.
+5. [qa.md](qa.md) defines the test cases.
+6. [status.md](status.md) records the current state and open decisions.
+
+## Proposed path
+
+```text
+Mounted login folder
+        ↓
+Node runner: inspect local login files
+        ↓  authenticated private HTTP
+Python agent service: remove private details and return status
+        ↓  authenticated public HTTP
+Frontend query: cache status for a short time
+        ↓
+Subscription card: show connected, not found, or unavailable
+```
+
+The browser must not contact the runner. The browser must not receive the runner token, file paths,
+login tokens, account names, or token contents.

--- a/docs/design/runner-subscription-status/api-design.md
+++ b/docs/design/runner-subscription-status/api-design.md
@@ -1,0 +1,185 @@
+# API design
+
+> AGENT-GENERATED, low weight. This is a draft. Mahmoud must approve product and interface decisions.
+
+## Design rule
+
+The runner owns the local file check. The Python agent service owns the public response. The
+frontend only receives status values.
+
+## Runner endpoint
+
+Add an authenticated endpoint:
+
+```http
+GET /subscription-status
+Authorization: Bearer <runner-token>
+```
+
+Proposed runner response:
+
+```json
+{
+  "version": 1,
+  "harnesses": {
+    "codex": {
+      "state": "ready",
+      "provider": "openai"
+    },
+    "pi_core": {
+      "state": "not_configured"
+    },
+    "claude": {
+      "state": "login_unusable",
+      "provider": "anthropic"
+    }
+  }
+}
+```
+
+Allowed `state` values:
+
+| State | Meaning |
+| --- | --- |
+| `ready` | The mount variable is set. The expected login file exists and passes a local shape check. |
+| `not_configured` | The runner has no mount variable for this harness. |
+| `login_missing` | The mount is configured, but the expected login file does not exist. |
+| `login_unusable` | The file is empty, unreadable, or does not have the minimum expected shape. |
+| `unsupported` | This runner version cannot check this harness. |
+
+The endpoint must not return:
+
+- Environment variable values.
+- File paths.
+- Tokens or token prefixes.
+- Account names or email addresses.
+- Subscription plan names.
+- Raw file or parse errors.
+
+The runner must require its shared token for this endpoint. Do not add this information to the
+public `/health` response.
+
+## Agent service endpoint
+
+Add a public endpoint on the Python agent service:
+
+```http
+POST /runtime/subscription-status
+```
+
+Proposed request for the current deployment-wide runner:
+
+```json
+{
+  "harness": "codex"
+}
+```
+
+When Agenta Cloud adds per-user runner connections, the request must use a server-owned reference:
+
+```json
+{
+  "harness": "codex",
+  "runner_connection_id": "019d952f-0000-0000-0000-000000000000"
+}
+```
+
+The endpoint must not accept a runner URL from the browser. The server resolves the connection ID
+to the private URL and runner token. The status request and model run must use the same resolver.
+
+The agent service calls the runner endpoint with `AGENTA_RUNNER_INTERNAL_URL` and
+`AGENTA_RUNNER_TOKEN`.
+
+Proposed public response:
+
+```json
+{
+  "runner": "connected",
+  "checked_at": "2026-08-12T12:00:00Z",
+  "harnesses": {
+    "codex": {
+      "state": "ready",
+      "provider": "openai"
+    }
+  }
+}
+```
+
+Allowed `runner` values:
+
+| State | Meaning |
+| --- | --- |
+| `connected` | The service received a valid response from the runner. |
+| `unavailable` | The service has no runner URL, cannot contact the runner, or receives an invalid response. |
+| `incompatible` | The runner is active but does not support this endpoint or response version. |
+
+The agent service must return HTTP 200 for these three operational states. This lets the frontend
+show a setup state without treating an inactive local runner as an application error. Authentication
+and permission failures still use normal HTTP error codes.
+
+The response is deployment state. It is not project data. The public route must still require an
+authenticated Agenta user. The implementation must apply the same access rule that protects agent
+configuration reads.
+
+## Frontend query
+
+Add a frontend API function for `POST /runtime/subscription-status`. Use a schema check at the API
+boundary.
+
+Add a TanStack Query atom with these initial rules:
+
+- Query only when the user selects `self_managed`.
+- Cache for 10 seconds.
+- Refresh every 15 seconds while the subscription card is visible.
+- Refresh when the browser window becomes active.
+- Do not persist the result in IndexedDB or local storage.
+- Provide a manual **Check again** action.
+
+The dynamic query must remain separate from `harnessCatalogQueryAtom`. The catalog answers what a
+harness supports. The new query answers what this runner can use now.
+
+## Frontend display
+
+`ProviderCredentialsSection` receives the status for the selected harness. The card shows one main
+message:
+
+| Runner and harness state | User message |
+| --- | --- |
+| Loading | `Checking the runner…` |
+| `connected` and `ready` | `Subscription login found` |
+| `connected` and `not_configured` | `Runner found. Subscription folder is not configured.` |
+| `connected` and `login_missing` | `Runner found. Login file is missing.` |
+| `connected` and `login_unusable` | `Runner found. Login file cannot be used.` |
+| `unavailable` | `Runner is not connected.` |
+| `incompatible` | `Update the runner to check subscription status.` |
+| Query error | `Agenta could not check the runner.` |
+
+The card keeps the setup documentation link. It adds **Check again**. It does not say that a
+subscription is verified. A file check cannot verify provider access.
+
+## Complete data path
+
+```text
+1. User selects Subscription.
+2. ProviderCredentialsSection requests the runtime status atom.
+3. The atom calls the frontend API function.
+4. The frontend sends POST /runtime/subscription-status to the Python agent service.
+5. The agent service sends GET /subscription-status to the runner.
+6. The agent service authenticates with the private runner token.
+7. The runner checks only the login location for each installed harness.
+8. The runner returns status values to the agent service.
+9. The agent service validates and sanitizes the response.
+10. The frontend validates the public response.
+11. ProviderCredentialsSection selects the current harness and shows its state.
+```
+
+## Open interface decisions
+
+1. Decide whether the public route belongs on the Python agent service or the main FastAPI API.
+   The Python agent service is the shorter path because it already calls the runner. The main API
+   is easier for the frontend to consume through the generated client.
+2. Decide the permission for the public route. It must match an existing read permission.
+3. Decide whether Pi can report one provider login or multiple provider logins. Pi can use more
+   than one provider, so a later response can use a provider map if the first version needs it.
+4. Decide whether the first release supports only the deployment runner. Per-user Agenta Cloud
+   runners require a runner connection resource and a shared server-side resolver first.

--- a/docs/design/runner-subscription-status/context.md
+++ b/docs/design/runner-subscription-status/context.md
@@ -1,0 +1,36 @@
+# Context
+
+> AGENT-GENERATED, low weight. This is a draft. Mahmoud must approve product and interface decisions.
+
+## Current user experience
+
+The user can select **Subscription** in the model credentials section. The frontend then shows a
+self-managed information card and a link to the self-hosting guide.
+
+The user must start the runner with a mounted login folder. Agenta does not show whether the runner
+is active or whether the login file exists. The user learns about an incorrect setup only after a
+run fails.
+
+## Goal
+
+Show whether the selected harness can find its subscription login before the user starts a run.
+
+The first version reports local configuration. It does not prove that the provider accepts the
+login. A successful model run remains the final proof.
+
+## Non-goals
+
+- Do not send a login token to Agenta Cloud.
+- Do not send login file contents to the frontend.
+- Do not contact OpenAI, Anthropic, or another provider during a status request.
+- Do not start a paid model run during a status request.
+- Do not add the dynamic status to the static harness catalog.
+- Do not support subscription login in a Daytona sandbox. The current runner rejects this mode.
+
+## Success criteria
+
+- The frontend can distinguish a runner that is not reachable from a runner with no login.
+- The frontend can show whether the selected harness has a usable local login file.
+- The status request does not expose secrets or local file paths.
+- An old runner does not break the page. The frontend shows an unknown status.
+- The status can change without a page reload after the user starts the runner or signs in again.

--- a/docs/design/runner-subscription-status/plan.md
+++ b/docs/design/runner-subscription-status/plan.md
@@ -1,0 +1,92 @@
+# Implementation plan
+
+> AGENT-GENERATED, low weight. This is a draft. Mahmoud must approve product and interface decisions.
+
+## Recommended order
+
+### Define the runner status check
+
+Create a small detector for each harness. Each detector returns an allowed state. It never returns
+file data.
+
+Files:
+
+- `services/runner/src/subscription-status.ts` for detector logic and response types.
+- `services/runner/src/server.ts` for `GET /subscription-status` and runner-token authentication.
+- `services/runner/tests/unit/subscription-status.test.ts` for filesystem and redaction tests.
+- `services/runner/tests/unit/server.test.ts` for route authentication and response tests.
+
+### Add the server-to-runner client
+
+Add a Python client that calls the private runner endpoint. Reuse the internal runner URL and token.
+Validate the runner response before it reaches the public route.
+
+Put runner selection in one resolver. Both the status request and the model run must call this
+resolver. The first version can resolve only the deployment runner. A cloud version can later
+resolve a server-owned runner connection ID. Never accept an arbitrary runner URL from the browser.
+
+Candidate files:
+
+- `services/oss/src/agent/config.py` only if a shared timeout setting is required.
+- `services/oss/src/agent/runtime_status.py` for the HTTP client and response mapping.
+- `services/oss/src/agent/app.py` for `POST /runtime/subscription-status`.
+- `services/oss/tests/` for connected, unavailable, incompatible, and invalid-response tests.
+
+If the team selects the main FastAPI API for the public route, place the client beside
+`api/oss/src/core/sessions/streams/runner_client.py` and add a small runtime router under
+`api/oss/src/apis/fastapi/`. Do not implement both public routes.
+
+### Add the frontend API boundary
+
+Add the public response type and its runtime schema check. Follow the frontend rule that new main
+API calls use the generated client. A direct agent-service route can use the existing service URL
+pattern until the endpoint moves into the main API.
+
+Candidate files:
+
+- `web/packages/agenta-entities/src/workflow/api/api.ts` for a direct agent-service function, or a
+  new runtime entity module if the main API owns the route.
+- `web/packages/agenta-entities/src/workflow/state/subscriptionStatus.ts` for the query atom.
+- `web/packages/agenta-entities/src/workflow/state/index.ts` and
+  `web/packages/agenta-entities/src/workflow/index.ts` for exports.
+- Unit tests beside the new API and state code.
+
+### Connect the query to the subscription card
+
+Resolve the selected harness in `useModelHarness.tsx`. Read the new status query only when the
+selected connection mode is `self_managed`. Pass one display-ready status to the credentials
+section.
+
+Files:
+
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx`
+- `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx`
+- Component tests for every visible state.
+
+### Add compatibility and telemetry
+
+Treat runner HTTP 404 as `incompatible`. Treat network failure as `unavailable`. Do not log response
+bodies from a failed detector.
+
+Record status counts without user or token data. Useful fields are runner state, harness, status,
+and runner version.
+
+### Update setup documentation
+
+Explain the new status messages in the existing subscription runner guide. Keep the mounted-folder
+instructions because the detection does not replace the mount.
+
+## Delivery split
+
+The work can use three dependent changes:
+
+1. Runner endpoint and tests.
+2. Public server endpoint and tests.
+3. Frontend query, card states, and documentation.
+
+Do not ship the frontend state before the public endpoint exists. An old runner remains safe because
+the server maps a missing runner endpoint to `incompatible`.
+
+## Approval required
+
+Mahmoud must approve the public route location and the visible words before implementation starts.

--- a/docs/design/runner-subscription-status/qa.md
+++ b/docs/design/runner-subscription-status/qa.md
@@ -1,0 +1,52 @@
+# Test plan
+
+> AGENT-GENERATED, low weight. This is a draft. Mahmoud must approve product and interface decisions.
+
+## Runner tests
+
+- Reject a request with no runner token.
+- Reject a request with an incorrect runner token.
+- Return `not_configured` when the harness environment variable is not set.
+- Return `login_missing` when the folder exists but the expected file does not exist.
+- Return `login_unusable` when the file is empty, unreadable, or invalid.
+- Return `ready` when the file has the minimum valid shape.
+- Confirm that the JSON response has no path, token, account, email, or raw error.
+- Confirm that one harness check cannot stop the checks for other harnesses.
+
+Use temporary folders and fake tokens. Do not read a developer's real login folder.
+
+## Server tests
+
+- Map a valid runner response to `runner: connected`.
+- Map connection refusal and timeout to `runner: unavailable`.
+- Map runner HTTP 404 to `runner: incompatible`.
+- Reject an invalid runner response.
+- Confirm that the public response has no runner token or local path.
+- Confirm that an unauthenticated Agenta user cannot call the public route.
+- Reject an arbitrary runner URL in the public request.
+- Confirm that the status request and a model run resolve the same runner connection.
+
+## Frontend tests
+
+- Do not fetch status while the user selects **API key**.
+- Fetch status when the user selects **Subscription**.
+- Select the state for the current harness.
+- Show all messages defined in `api-design.md`.
+- Refetch when the user selects **Check again**.
+- Show unknown or incompatible status for an old runner.
+- Do not store the response in browser persistent storage.
+- Keep the setup guide link visible for all failure states.
+
+## Manual test
+
+1. Start Agenta without a subscription mount. Select **Subscription**. Confirm that the card shows
+   `Subscription folder is not configured.`
+2. Start the runner with an empty mounted folder. Confirm that the card shows `Login file is missing.`
+3. Add a fake invalid login file. Confirm that the card shows `Login file cannot be used.`
+4. Sign in with the harness on the host. Select **Check again**. Confirm that the card shows
+   `Subscription login found.`
+5. Stop the runner. Confirm that the card changes to `Runner is not connected.`
+6. Start an older runner without the new endpoint. Confirm that the card asks the user to update the
+   runner.
+7. Start one real low-cost model run. Confirm that the run succeeds. This step verifies provider
+   access. The status endpoint does not verify provider access.

--- a/docs/design/runner-subscription-status/research.md
+++ b/docs/design/runner-subscription-status/research.md
@@ -1,0 +1,105 @@
+# Research
+
+> AGENT-GENERATED, low weight. This is a draft. Mahmoud must approve product and interface decisions.
+
+## Observations
+
+These statements describe the current code.
+
+### The frontend does not contact the runner
+
+The Python agent service reads `AGENTA_RUNNER_INTERNAL_URL` and uses it to contact the runner. The
+frontend contacts the agent service through the gateway. The runner port stays private.
+
+Evidence:
+
+- `services/oss/src/agent/config.py` defines `runner_url()`.
+- `sdks/python/agenta/sdk/agents/utils/ts_runner.py` sends authenticated HTTP requests to the runner.
+- `docs/design/agent-workflows/documentation/running-the-agent.md` states that the frontend talks to
+  the agent through the gateway.
+
+### The current runner route is deployment-wide
+
+The current backend selects the runner from `AGENTA_RUNNER_INTERNAL_URL`. The agent configuration
+can select `runner.kind: sidecar`, but it does not carry a per-user runner connection or URL.
+
+Evidence:
+
+- `sdks/python/agenta/sdk/agents/handler.py` selects the backend from
+  `AGENTA_RUNNER_INTERNAL_URL`.
+- `sdks/python/agenta/sdk/utils/types.py` defines the current runner configuration.
+
+This means the current code can report the status of the deployment runner. It cannot select one
+runner for each Agenta Cloud user. Per-user cloud runners need a separate server-owned connection
+reference and routing feature.
+
+### The runner already knows the required login location
+
+For a local subscription run, `run-plan.ts` selects one environment variable for each harness:
+
+| Harness | Runner environment variable |
+| --- | --- |
+| Codex | `CODEX_HOME` |
+| Claude Code | `CLAUDE_CONFIG_DIR` |
+| Pi | `PI_CODING_AGENT_DIR` |
+
+The runner stops the run if the required variable is not set. This check happens only after the user
+starts a run.
+
+Evidence: `services/runner/src/engines/sandbox_agent/run-plan.ts`.
+
+### The runner can check a login file without returning the file
+
+Codex subscription mode uses `CODEX_HOME/auth.json`. The runner already checks whether this file is
+empty or unreadable when it explains an authentication failure.
+
+Evidence: `services/runner/src/engines/sandbox_agent/codex-assets.ts`.
+
+### The runner health response has no login status
+
+`GET /health` returns the runner version, protocol version, engines, and harnesses. It does not
+return subscription login status. The route is also available without the runner token.
+
+Evidence: `services/runner/src/server.ts`.
+
+### The frontend has a static harness catalog
+
+The frontend reads `GET /workflows/catalog/harnesses/` to learn which models, providers, and
+connection modes each harness supports. The frontend stores this result for five minutes and also
+persists it in the browser.
+
+This catalog describes product capability. It does not describe the current runner process.
+
+Evidence:
+
+- `api/oss/src/apis/fastapi/workflows/router.py`
+- `web/packages/agenta-entities/src/workflow/state/inspectMeta.ts`
+- `web/packages/agenta-entities/src/workflow/api/api.ts`
+
+### The current subscription card has no live status
+
+`ProviderCredentialsSection.tsx` shows a static self-managed card. It receives the selected mode and
+cloud flag. It does not read runner state.
+
+Evidence:
+`web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ProviderCredentialsSection.tsx`.
+
+## Interpretation
+
+These are low-confidence design conclusions. They are not confirmed product decisions.
+
+The shortest safe path is to add a private runner endpoint and proxy its sanitized result through
+the Python agent service. This path uses the same private runner URL and runner token as model runs.
+It does not give the browser access to the runner.
+
+The status request must use the same runner resolver as the model run. Otherwise, the frontend can
+show the status of one runner and send the model run to another runner.
+
+The static harness catalog is not a suitable path. The catalog is global and durable. Runner status
+is local and can change at any time.
+
+## Important limit
+
+A file check proves only that the runner can read a file with the expected shape. It does not prove
+that the token is current or that the subscription can use the selected model. Only a successful
+run proves provider access.

--- a/docs/design/runner-subscription-status/status.md
+++ b/docs/design/runner-subscription-status/status.md
@@ -7,22 +7,35 @@
 - Research is complete for the runner, Python service, catalog API, frontend query pattern, and
   subscription card.
 - The proposed private and public response shapes are in `api-design.md`.
-- No product code changed.
-- No route or response shape has approval.
+- The founder reviewed this plan on pull request 5985 on 2026-08-12 without change requests.
+- Implementation starts from this plan. The decisions below were taken to unblock it and are
+  recorded for founder review; each is reversible before the pull request lands.
+- The sibling AI-providers plan (`../provider-connections-models/`) consumes this status in its
+  subscription rows and picker entries. Terminology stays aligned: the runner reports subscription
+  status; the frontend surfaces it under the AI providers experience.
 
 ## Recommended decision
 
 Use a private authenticated runner endpoint. Proxy its sanitized status through the Python agent
 service. Keep the dynamic status separate from the static harness catalog.
 
-## Open decisions
+## Decisions taken for implementation (agent, for founder review)
 
-1. Public route location: Python agent service or main FastAPI API.
-2. Access permission for the public status route.
-3. Pi response shape when more than one provider login is present.
-4. Final frontend text.
-5. Delivery scope. The current code supports one deployment runner. Per-user cloud runners require
-   a new server-owned runner connection and routing mechanism.
+1. **Public route location: the Python agent service.** It already owns the runner URL and token,
+   the frontend already calls services directly for runs, and this avoids teaching the main API a
+   runner client for one status route. If the route later moves into the main API for generated
+   client coverage, the response shape stays the same.
+2. **Access permission: the same authentication that protects agent invocation.** The route
+   requires an authenticated Agenta user with access to the project, and returns HTTP 200 for the
+   three operational runner states.
+3. **Pi response shape: one state per harness in the first version.** Pi reports a single state
+   even though it can hold more than one provider login. A later version can add a provider map
+   without breaking the contract, because the response is versioned.
+4. **Frontend text: as written in `api-design.md`.** The card never claims a subscription is
+   verified; only a run proves provider access.
+5. **Delivery scope: the deployment runner only.** Per-user cloud runners need a server-owned
+   runner connection resource first, which is out of scope here. The resolver seam is kept so the
+   status request and the model run resolve the same runner.
 
 ## Planning constraint
 

--- a/docs/design/runner-subscription-status/status.md
+++ b/docs/design/runner-subscription-status/status.md
@@ -1,0 +1,32 @@
+# Status
+
+> AGENT-GENERATED, low weight. This is a draft. Mahmoud must approve product and interface decisions.
+
+## Current state
+
+- Research is complete for the runner, Python service, catalog API, frontend query pattern, and
+  subscription card.
+- The proposed private and public response shapes are in `api-design.md`.
+- No product code changed.
+- No route or response shape has approval.
+
+## Recommended decision
+
+Use a private authenticated runner endpoint. Proxy its sanitized status through the Python agent
+service. Keep the dynamic status separate from the static harness catalog.
+
+## Open decisions
+
+1. Public route location: Python agent service or main FastAPI API.
+2. Access permission for the public status route.
+3. Pi response shape when more than one provider login is present.
+4. Final frontend text.
+5. Delivery scope. The current code supports one deployment runner. Per-user cloud runners require
+   a new server-owned runner connection and routing mechanism.
+
+## Planning constraint
+
+The `plan-feature` instructions request the `design-interfaces` skill for a new response contract.
+That skill was not available in this session. The draft applies a manual interface review based on
+data ownership, credentials, routing, and runtime status. A later review must use that skill if it
+becomes available.


### PR DESCRIPTION
Users can select a model subscription before Agenta knows whether the runner is active or can read the mounted login. They see setup errors only after a run fails.

This draft plan defines a safe status path:

```text
Mounted login folder
    -> Node runner
    -> Python agent service
    -> authenticated frontend query
    -> subscription status card
```

The runner returns status values only. It does not return tokens, file paths, account details, or file contents.

The plan also records a routing limit. The current code selects one deployment runner through `AGENTA_RUNNER_INTERNAL_URL`. A different runner for each Agenta Cloud user requires a server-owned runner connection and a shared resolver for status checks and model runs.

## Included documents

- Current user experience, goals, and limits.
- Code research with the present request path.
- Proposed private and public response contracts.
- Complete path from runner to frontend.
- Implementation order and candidate files.
- Test plan and open decisions.

## Checks

- `git diff --check`
- Confirmed that the change contains seven planning documents only.
- Confirmed that the documents contain no em dash or banned product vocabulary.
- No product code changed, so no runtime test or docs site build was required.

## How to review

1. Read `README.md` for the proposed path and document order.
2. Read `research.md` for the current code behavior and routing limit.
3. Review `api-design.md` for the response shapes and security boundary.
4. Review `plan.md` for the implementation order.
5. Confirm the open decisions in `status.md`.
