### PR TITLE
Rename model configuration section

### DIFF
--- a/web/oss/src/components/pages/overview/agent/AgentConfigurationCard.tsx
+++ b/web/oss/src/components/pages/overview/agent/AgentConfigurationCard.tsx
@@ -74,7 +74,7 @@ const AgentConfigurationCard = ({appId}: {appId: string}) => {
         {
             key: "model",
             icon: <CpuIcon size={16} />,
-            title: "Model & harness",
+            title: "Model",
             // A model is the one required setting, so its absence is a warning rather than a gap.
             ...(model ? stated(model) : {summary: "Choose a model", status: "warning" as const}),
         },

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -806,7 +806,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
         mh.hasModelOrHarness && {
             key: "model-harness",
             icon: <Cpu size={16} />,
-            title: "Model & harness",
+            title: "Model",
             titleBadge: modelHarnessBadge,
             summary: mh.modelSummary,
             indicator: sectionIndicator("model-harness"),
@@ -1051,7 +1051,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
 
             <SectionDrawer
                 open={openSection === "model-harness"}
-                title="Model & harness"
+                title="Model"
                 icon={<Cpu size={16} />}
                 onCancel={cancelSection}
                 onSave={saveSection}


### PR DESCRIPTION
## What changed

- Renamed the agent playground configuration section from “Model & harness” to “Model”.
- Applied the same label to the section drawer and agent overview card.

## Impact

This is a UI-only copy change. Harness selection and internal configuration keys are unchanged.

## Checks

- `git diff --check`
- Verified the pushed branch SHA matches the local commit
- Verified no `GitButler-Conflict` trailer is present
