### PR TITLE
[fix] Fill session titles server-side and persist complete workflow references

### DIFF
--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000021_add_session_streams_references.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000021_add_session_streams_references.py
@@ -1,0 +1,52 @@
+"""add references to session_streams
+
+References rode only on `session_turns`, appended fire-and-forget after a run starts. When
+that append never lands — or lands with the caller's partial reference set — the session
+row itself says nothing about what it runs, and the list has no id to open it with. Give
+the row its own copy, filled once at run time and never overwritten, so a dropped turn
+append can no longer strand a session.
+
+Nullable, and indexed the same way `session_turns.references` is: the reference-scoped
+session filter resolves ids through BOTH columns and unions them, so this one is on a
+`@>` containment path too and needs the same GIN `jsonb_path_ops` index to stay off a
+sequential scan.
+
+Revision ID: oss000000021
+Revises: oss000000020
+Create Date: 2026-08-12 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "oss000000021"
+down_revision: Union[str, None] = "oss000000020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "session_streams",
+        sa.Column(
+            "references",
+            postgresql.JSONB(none_as_null=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_session_streams_references",
+        "session_streams",
+        ["references"],
+        postgresql_using="gin",
+        postgresql_ops={"references": "jsonb_path_ops"},
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_session_streams_references", table_name="session_streams")
+    op.drop_column("session_streams", "references")

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -24,7 +24,8 @@ from oss.src.core.sessions.interactions.dtos import (
 )
 from oss.src.core.sessions.mounts.dtos import SessionMount, SessionMountQuery
 from oss.src.core.sessions.turns.dtos import HarnessKind, SessionTurn, SessionTurnQuery
-from oss.src.core.shared.dtos import OTelSpanId, Reference, Windowing
+from oss.src.core.sessions.types import SessionReference
+from oss.src.core.shared.dtos import OTelSpanId, Windowing
 from oss.src.dbs.postgres.sessions.streams.dao import MAX_SESSION_QUERY_LIMIT
 
 
@@ -61,7 +62,7 @@ class SessionQueryRequest(BaseModel):
     # Canonical explicit set selection. It intersects with turn_references.
     session_ids: Optional[List[SessionId]] = Field(default=None, max_length=500)
     exclude: Optional[SessionExcludeRequest] = None
-    turn_references: Optional[List[Reference]] = None
+    turn_references: Optional[List[SessionReference]] = None
     # Include ended (killed) sessions so the list keeps resumable history, not just live ones.
     include_ended: bool = False
     # Include archived sessions — off by default (archive hides); on for the archived view.
@@ -72,7 +73,7 @@ class SessionQueryRequest(BaseModel):
     windowing: Optional[Windowing] = None
 
     # Compatibility inputs for the currently released flat predicates.
-    references: Optional[List[Reference]] = None
+    references: Optional[List[SessionReference]] = None
     # Case-insensitive substring match over the session title (`session_streams.name`).
     search: Optional[str] = None
     # Liveness filter (alive ⊇ running ⊇ attached) against the row's mirrored flags.
@@ -295,7 +296,7 @@ class SessionTurnAppendRequest(BaseModel):
     harness_kind: HarnessKind
     agent_session_id: Optional[str] = None
     sandbox_id: Optional[str] = None
-    references: Optional[List[Reference]] = None
+    references: Optional[List[SessionReference]] = None
     trace_id: Optional[UUID] = None
     span_id: Optional[OTelSpanId] = None
     start_time: Optional[datetime] = None

--- a/api/oss/src/core/sessions/dtos.py
+++ b/api/oss/src/core/sessions/dtos.py
@@ -5,9 +5,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from oss.src.core.sessions.records.dtos import SessionMessagePreview
 from oss.src.core.sessions.streams.dtos import SessionStream, SessionStreamQueryFlags
-from oss.src.core.shared.dtos import Reference
+from oss.src.core.sessions.types import ReferenceKey as ReferenceKey
 from oss.src.core.sessions.types import SessionDelivery as SessionDelivery
 from oss.src.core.sessions.types import SessionOrigin as SessionOrigin
+from oss.src.core.sessions.types import SessionReference as SessionReference
 from oss.src.core.sessions.types import SessionTrigger as SessionTrigger
 from oss.src.core.sessions.types import (
     SessionTriggerAttribution as SessionTriggerAttribution,
@@ -16,16 +17,15 @@ from oss.src.core.sessions.types import SessionTriggerKind as SessionTriggerKind
 
 
 class SessionListItem(SessionStream):
-    """A `/sessions/query` row, enriched at READ time with the session's HIGHEST
-    `turn_index` turn's `references` — the agent/workflow that produced the latest turn.
+    """A `/sessions/query` row, enriched at READ time with the session's last message.
 
-    Also carries the session's last message, so a row can say what happened rather than only
-    when. Both enrichments are batch lookups keyed on the whole page; never one call per row.
+    `references` prefers the stream row's own (filled once at run time) and falls back to
+    the HIGHEST `turn_index` turn's — the agent/workflow that produced the latest turn.
+    The fallback is what keeps rows written before the stream column existed openable.
+    Both enrichments are batch lookups keyed on the whole page; never one call per row.
 
-    Hydrated by `SessionsService.query_sessions`; never denormalized onto `session_streams`
-    (see that method's docstring)."""
+    Hydrated by `SessionsService.query_sessions`."""
 
-    references: Optional[List[Reference]] = None
     # The session's newest `message` record, hydrated by the same batch pattern. Absent when the
     # session has no message yet, or when the deployment runs without the records (tracing) engine.
     last_message: Optional[SessionMessagePreview] = None
@@ -45,7 +45,7 @@ class SessionQuery(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    turn_references: Optional[List[Reference]] = None
+    turn_references: Optional[List[SessionReference]] = None
     # Case-insensitive substring match over the session title (`session_streams.name`).
     search: Optional[str] = None
     # Liveness (alive ⊇ running ⊇ attached), matched against the row's mirrored `flags`.

--- a/api/oss/src/core/sessions/service.py
+++ b/api/oss/src/core/sessions/service.py
@@ -91,15 +91,16 @@ class SessionsService:
     ) -> List[SessionListItem]:
         """List/filter sessions, newest -> oldest, windowed.
 
-        Reads the merged stream rows; when `turn_references` is set, first joins the
-        turns' references (WP1's GIN `.contains()`) to resolve the matching
-        `session_id`s, then filters the stream query to that set. No
-        denormalization onto the stream row (B3) — revisit only if the join
-        proves hot.
+        Reads the merged stream rows; when `turn_references` is set, resolves the
+        matching `session_id`s from BOTH reference columns (the turns' references
+        and the stream row's own fill-once `references`, each GIN `.contains()`),
+        unions them, then filters the stream query to that set. See
+        `_resolve_session_ids` for the per-side caps and ordering.
 
-        Each row is enriched (READ-time only, see `SessionListItem`) with its latest
-        turn's `references` and its last message, each via a single batch lookup keyed on
-        every listed `session_id` — never one call per row (WP0-R3).
+        Each row is enriched (READ-time only, see `SessionListItem`) with its last
+        message via a single batch lookup keyed on every listed `session_id` — never one
+        call per row (WP0-R3). `references` come from the stream row when it has them and
+        fall back to the same batch lookup's latest turn otherwise.
         """
         page = await self.query_sessions_page(
             project_id=project_id,
@@ -202,8 +203,11 @@ class SessionsService:
             turn = latest_turns.get(stream.session_id)
             items.append(
                 SessionListItem(
-                    **stream.model_dump(),
-                    references=turn.references if turn else None,
+                    **stream.model_dump(exclude={"references"}),
+                    # The row's own references first: they are written by the beat, which
+                    # every run makes, whereas the turn append is fire-and-forget. The turn
+                    # is the fallback that keeps pre-column rows openable.
+                    references=stream.references or (turn.references if turn else None),
                     last_message=previews.get(stream.session_id),
                 )
             )
@@ -288,13 +292,35 @@ class SessionsService:
         if query.turn_references is not None:
             if not query.turn_references:
                 return []
-            from_references = set(
-                await self.turns_service.query_session_ids_by_references(
+            # Both reference columns, unioned: a session whose turn append was dropped is
+            # findable only through the stream row, and one that predates that column only
+            # through its turns. Matching either is what makes an agent-scoped list agree
+            # with what the list can actually open.
+            by_turns, by_streams = await asyncio.gather(
+                self.turns_service.query_session_ids_by_references(
                     project_id=project_id,
                     references=query.turn_references,
                     limit=TURN_REFERENCES_SESSION_ID_CAP,
-                )
+                ),
+                self.streams_service.query_session_ids_by_references(
+                    project_id=project_id,
+                    references=query.turn_references,
+                    limit=TURN_REFERENCES_SESSION_ID_CAP,
+                ),
             )
+            from_references = set(by_turns) | set(by_streams)
+            # Re-cap the union: each side is capped on its own, so their union could carry
+            # twice the bound P2-12 put on this derived set. Each side already returns its
+            # most recently active matches, so the ids reaching here are the ones worth
+            # keeping; WHICH of them survives this final trim is arbitrary though, because
+            # the two lists carry no timestamp to merge on. It only bites a project with
+            # more than the cap of sessions matching one reference, where the list is
+            # windowed regardless. Carrying activity timestamps up through both DAOs to
+            # merge exactly is the fix if that ever stops being true.
+            if len(from_references) > TURN_REFERENCES_SESSION_ID_CAP:
+                from_references = set(
+                    sorted(from_references)[:TURN_REFERENCES_SESSION_ID_CAP]
+                )
 
         explicit: Optional[Set[str]] = (
             set(query.session_ids) if query.session_ids is not None else None

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
@@ -8,7 +8,12 @@ from pydantic import BaseModel, Field, field_validator
 from agenta.sdk.models.workflows import WorkflowServiceRequestData
 
 from oss.src.core.shared.dtos import Header, Identifier, Lifecycle
-from oss.src.core.sessions.types import SessionDelivery, SessionOrigin, SessionTrigger
+from oss.src.core.sessions.types import (
+    SessionDelivery,
+    SessionOrigin,
+    SessionReference,
+    SessionTrigger,
+)
 
 
 class SessionStreamFlags(BaseModel):
@@ -36,6 +41,10 @@ class SessionStream(Identifier, Header, Lifecycle):
     tags: Optional[Dict[str, Any]] = None
     meta: Optional[Dict[str, Any]] = None
     turn_id: Optional[str] = None
+    # What this session runs. Filled once, from the first beat that knows — turn appends
+    # are fire-and-forget, so a session whose only reference carrier was a dropped append
+    # is unopenable forever.
+    references: Optional[List[SessionReference]] = None
     # Set = archived (hidden but restorable); distinct from `deleted_at` (killed, still listed).
     archived_at: Optional[datetime] = None
     origin: Optional[SessionOrigin] = None
@@ -58,6 +67,7 @@ class SessionStreamCreate(Header):
     tags: Optional[Dict[str, Any]] = None
     meta: Optional[Dict[str, Any]] = None
     turn_id: Optional[str] = None
+    references: Optional[List[SessionReference]] = None
 
 
 class SessionStreamEdit(Header):
@@ -71,7 +81,9 @@ class SessionStreamHeaderEdit(Header):
     """The rename edit: a full-PUT of the header fields only.
 
     Distinct from SessionStreamEdit (used by the flag-mirror/heartbeat paths) so the
-    liveness-only writes can never carry name/description, and vice versa.
+    liveness-only writes can never carry name/description, and vice versa. The one
+    other header writer is the heartbeat's fill-once proposal, which goes through the
+    DAO's NULL-guarded `fill_missing` and so cannot overwrite this edit.
 
     ``name`` may be omitted/``None`` (no change) or an empty string (the explicit
     clear-title action the chat rail's rename path uses), but a NON-empty name must
@@ -139,10 +151,21 @@ class SessionStreamCommandResponse(BaseModel):
 
 
 class SessionHeartbeatRequest(BaseModel):
+    """A beat, plus what this run knows about the session that nothing else records.
+
+    ``name`` and ``references`` are PROPOSALS, not edits: the service writes each only
+    onto a NULL column (see `SessionStreamsService.heartbeat`). The runner is the only
+    component present on every execution path — browser, headless invoke, scheduled
+    trigger — so it is the only one that can title and attribute a session that no
+    browser will ever render.
+    """
+
     session_id: str
     replica_id: str = Field(min_length=1)  # the runner CONTAINER (affinity / owner key)
     turn_id: Optional[str] = None  # the current TURN (proves alive-lock ownership)
     is_running: bool = True
+    name: Optional[str] = None
+    references: Optional[List[SessionReference]] = None
 
 
 class SessionLiveness(BaseModel):

--- a/api/oss/src/core/sessions/streams/interfaces.py
+++ b/api/oss/src/core/sessions/streams/interfaces.py
@@ -11,7 +11,7 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamQueryResult,
     SessionStreamReadOptions,
 )
-from oss.src.core.sessions.types import SessionTriggerAttribution
+from oss.src.core.sessions.types import SessionReference, SessionTriggerAttribution
 from oss.src.core.shared.dtos import Windowing
 
 
@@ -90,6 +90,30 @@ class SessionStreamsDAOInterface(ABC):
         session_id: str,
         header: SessionStreamHeaderEdit,
     ) -> Optional[SessionStream]: ...
+
+    @abstractmethod
+    async def query_session_ids_by_references(
+        self,
+        *,
+        project_id: UUID,
+        references: List[SessionReference],
+        limit: int,
+    ) -> List[str]:
+        """Session ids whose stream-row references satisfy the same containment the
+        turns query applies."""
+        ...
+
+    @abstractmethod
+    async def fill_missing(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        name: Optional[str] = None,
+        references: Optional[List[SessionReference]] = None,
+    ) -> bool:
+        """Write each field onto the row only where it is still NULL; never overwrite."""
+        ...
 
     @abstractmethod
     async def delete_by_session_id(

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -13,7 +13,7 @@ Command matrix (inputs/data × force):
 """
 
 import uuid_utils.compat as uuid
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 from uuid import UUID
 
 from oss.src.utils.logging import get_module_logger
@@ -69,14 +69,71 @@ from oss.src.core.sessions.streams.types import (
 )
 from oss.src.core.sessions.streams.interfaces import SessionStreamsDAOInterface
 from oss.src.core.sessions.streams.runner_client import kill_runner_sandbox
+from oss.src.core.sessions.types import SessionReference
 from oss.src.core.shared.dtos import Windowing
 
 log = get_module_logger(__name__)
+
+# Longest server-filled session title. Matches the browser's `AUTO_TITLE_MAX_CHARS`
+# (web/oss/src/components/AgentChatSlice/state/sessions.ts) so the two writers cannot
+# disagree about how long a title from a first message is.
+SESSION_NAME_MAX_CHARS = 60
 
 
 def _validate_session_id(session_id: str) -> None:
     if not _validate_session_id_fn(session_id):
         raise SessionIdInvalid(session_id)
+
+
+def normalize_session_name(name: Optional[str]) -> Optional[str]:
+    """Trim and cap a proposed title. Whitespace-only means "no proposal", not "clear it"."""
+    if not name:
+        return None
+    trimmed = name.strip()
+    if not trimmed:
+        return None
+    return trimmed[:SESSION_NAME_MAX_CHARS]
+
+
+def _first_user_message_text(messages: List[Any]) -> Optional[str]:
+    """Text of the first user message, joining its text parts — the browser's rule."""
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if content is None:
+            content = message.get("parts")
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return None
+        texts = [
+            part["text"]
+            for part in content
+            if isinstance(part, dict)
+            and part.get("type") == "text"
+            and isinstance(part.get("text"), str)
+        ]
+        return " ".join(texts) if texts else None
+    return None
+
+
+def derive_session_name(inputs: Optional[Dict[str, Any]]) -> Optional[str]:
+    """A title proposal from a turn's inputs, matching the browser's auto-title exactly.
+
+    This backs the browser send path, so it copies the browser's rule rather than the
+    runner's: first user message only, text parts joined with a space. The runner's
+    `proposeSessionName` deliberately differs (skips ahead to the first message that HAS
+    text, joins with no separator). Do not "align" them — fill-once makes them
+    complementary. If a first message carries no text this returns None, the column stays
+    NULL, and the runner's proposal fills it on the next beat.
+    """
+    if not isinstance(inputs, dict):
+        return None
+    messages = inputs.get("messages")
+    if not isinstance(messages, list):
+        return None
+    return normalize_session_name(_first_user_message_text(messages))
 
 
 class SessionStreamsService:
@@ -190,6 +247,9 @@ class SessionStreamsService:
             mode = CommandMode.attach
 
         session_id = request.session_id
+        proposed_name = derive_session_name(
+            request.data.inputs if request.data else None
+        )
 
         if mode == CommandMode.send:
             liveness = await get_session_liveness(
@@ -201,6 +261,7 @@ class SessionStreamsService:
                 project_id=project_id,
                 user_id=user_id,
                 session_id=session_id,
+                name=proposed_name,
             )
             return SessionStreamCommandResponse(
                 mode=mode,
@@ -215,6 +276,7 @@ class SessionStreamsService:
                 project_id=project_id,
                 user_id=user_id,
                 session_id=session_id,
+                name=proposed_name,
             )
             return SessionStreamCommandResponse(
                 mode=mode,
@@ -347,6 +409,14 @@ class SessionStreamsService:
         project_id: UUID,
         request: SessionHeartbeatRequest,
     ) -> SessionHeartbeatResult:
+        """Refresh the nest, mirror it onto the row, and fill what the row still lacks.
+
+        The beat carries two FILL-ONCE proposals, `name` and `references`. Each is
+        written only where the stored column is NULL, so the "heartbeats don't churn
+        the header" invariant still holds in the form that matters: a beat can give a
+        session its first title, and can never change one. A rename, the browser
+        auto-title and `rename_session` all overwrite, so they always win.
+        """
         _validate_session_id(request.session_id)
 
         # A turn that was already displaced (handover, cancel, steer, kill, sweep) is dead
@@ -564,6 +634,12 @@ class SessionStreamsService:
         # never established, and re-arming them. `None` leaves the column as it is.
         durable_turn_id = request.turn_id if is_current_turn else None
 
+        # Proposals, not edits: written by `create` on a brand-new row and by
+        # `fill_missing` (NULL-guarded) on an existing one, so a beat can title and
+        # attribute a session nothing else will, and can never overwrite a rename.
+        proposed_name = normalize_session_name(request.name)
+        proposed_references = request.references or None
+
         if prior_stream is None:
             try:
                 stream = await self._dao.create(
@@ -573,11 +649,37 @@ class SessionStreamsService:
                         session_id=request.session_id,
                         flags=flags,
                         turn_id=durable_turn_id,
+                        name=proposed_name,
+                        references=proposed_references,
                     ),
                 )
             except SessionStreamAlreadyExists:
                 # `_start_turn` won the first-touch race; fall through and update its row.
                 stream = None
+
+        # The runner re-proposes on EVERY beat, so skip the round-trip once the row already
+        # holds a value. `fill_missing` is NULL-guarded in SQL regardless — this read only
+        # avoids a no-op UPDATE per beat per session, it is not what makes the fill safe.
+        if stream is None and prior_stream is not None:
+            fill_name = proposed_name if prior_stream.name is None else None
+            fill_references = (
+                proposed_references if not prior_stream.references else None
+            )
+            if fill_name or fill_references:
+                await self._dao.fill_missing(
+                    project_id=project_id,
+                    session_id=request.session_id,
+                    name=fill_name,
+                    references=fill_references,
+                )
+        elif stream is None and (proposed_name or proposed_references):
+            # Lost the create race: no row was read, so propose both and let SQL decide.
+            await self._dao.fill_missing(
+                project_id=project_id,
+                session_id=request.session_id,
+                name=proposed_name,
+                references=proposed_references,
+            )
 
         if stream is None:
             stream = await self._dao.update(
@@ -733,6 +835,19 @@ class SessionStreamsService:
             streams.append(stream)
         return streams
 
+    async def query_session_ids_by_references(
+        self,
+        *,
+        project_id: UUID,
+        references: List[SessionReference],
+        limit: int,
+    ) -> List[str]:
+        return await self._dao.query_session_ids_by_references(
+            project_id=project_id,
+            references=references,
+            limit=limit,
+        )
+
     async def count_streams(
         self,
         *,
@@ -807,6 +922,7 @@ class SessionStreamsService:
         project_id: UUID,
         user_id: UUID,
         session_id: str,
+        name: Optional[str] = None,
     ) -> str:
         turn_id = str(uuid.uuid7())
         acquired = await acquire_alive(
@@ -843,6 +959,7 @@ class SessionStreamsService:
                         session_id=session_id,
                         flags=flags,
                         turn_id=turn_id,
+                        name=name,
                     ),
                 )
                 created = True
@@ -879,6 +996,14 @@ class SessionStreamsService:
                     project_id=project_id,
                     user_id=user_id,
                     session_id=session_id,
+                )
+            # Same fill-once proposal the runner's beat makes, so a browser session is
+            # titled even when the client's auto-title effect never runs.
+            if name and updated is not None and updated.name is None:
+                await self._dao.fill_missing(
+                    project_id=project_id,
+                    session_id=session_id,
+                    name=name,
                 )
         await self._publish_lifecycle(
             project_id=project_id,

--- a/api/oss/src/core/sessions/turns/dtos.py
+++ b/api/oss/src/core/sessions/turns/dtos.py
@@ -6,7 +6,8 @@ from pydantic import BaseModel
 
 from agenta.sdk.agents.dtos import HarnessKind
 
-from oss.src.core.shared.dtos import Identifier, Lifecycle, OTelSpanId, Reference
+from oss.src.core.sessions.types import SessionReference
+from oss.src.core.shared.dtos import Identifier, Lifecycle, OTelSpanId
 
 
 class SessionTurn(Identifier, Lifecycle):
@@ -18,7 +19,7 @@ class SessionTurn(Identifier, Lifecycle):
     harness_kind: HarnessKind
     agent_session_id: Optional[str] = None
     sandbox_id: Optional[str] = None
-    references: Optional[List[Reference]] = None
+    references: Optional[List[SessionReference]] = None
     trace_id: Optional[UUID] = None
     span_id: Optional[OTelSpanId] = None
     start_time: Optional[datetime] = None
@@ -33,7 +34,7 @@ class SessionTurnCreate(BaseModel):
     harness_kind: HarnessKind
     agent_session_id: Optional[str] = None
     sandbox_id: Optional[str] = None
-    references: Optional[List[Reference]] = None
+    references: Optional[List[SessionReference]] = None
     trace_id: Optional[UUID] = None
     span_id: Optional[OTelSpanId] = None
     start_time: Optional[datetime] = None
@@ -51,4 +52,4 @@ class SessionTurnQuery(BaseModel):
     session_id: Optional[str] = None
     stream_id: Optional[UUID] = None
     harness_kind: Optional[HarnessKind] = None
-    references: Optional[List[Reference]] = None
+    references: Optional[List[SessionReference]] = None

--- a/api/oss/src/core/sessions/types.py
+++ b/api/oss/src/core/sessions/types.py
@@ -2,7 +2,48 @@ from enum import Enum
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+
+from oss.src.core.shared.dtos import Reference
+
+
+class ReferenceKey(str, Enum):
+    """The workflow-family member a stored reference element points at."""
+
+    workflow = "workflow"
+    workflow_variant = "workflow_variant"
+    workflow_revision = "workflow_revision"
+
+
+class SessionReference(Reference):
+    """A reference element that carries its own family.
+
+    Sessions persist references as a flat list (`session_turns.references`,
+    `session_streams.references`), so the map key that named the family upstream is
+    gone by the time a reader sees the row — leaving "first UUID in the list" as the
+    only way to guess which element is the workflow.
+
+    ``key`` is the name `evaluation_runs.references` already uses for the same flat-list
+    discriminator (`dbs/postgres/evaluations/utils.py`), and the same one tracing carries
+    in `OTelReference.attributes["key"]`.
+
+    It is a plain string rather than ``ReferenceKey`` on purpose: a turn append is
+    fire-and-forget, so rejecting an unrecognized family would drop the whole turn, which
+    is the failure this field exists to prevent. Producers inside the API use
+    ``ReferenceKey``; readers treat anything else as untyped.
+    """
+
+    key: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_plain_reference(cls, value):
+        # Most producers build the shared `Reference`; pydantic rejects a parent-class
+        # instance where a subclass is declared, so accept one as the untagged element it
+        # is rather than making every caller change type.
+        if isinstance(value, Reference):
+            return value.model_dump()
+        return value
 
 
 class SessionOrigin(str, Enum):

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -569,7 +569,15 @@ class WorkflowsService:
     def _validate_execution_reference_families(
         *,
         request: WorkflowServiceRequest,
-    ) -> tuple[Optional[Reference], Optional[Reference], Optional[Reference]]:
+    ) -> tuple[
+        Optional[str], Optional[Reference], Optional[Reference], Optional[Reference]
+    ]:
+        """Returns the caller's family name and its (artifact, variant, revision) refs.
+
+        The family name matters to the caller because the resolved references are written
+        back under it: re-keying an `application_variant` request's result as `workflow`
+        would make the request carry two families, which this very check rejects.
+        """
         refs = request.references or {}
 
         families = {
@@ -606,10 +614,10 @@ class WorkflowsService:
             raise error
 
         if not populated:
-            return None, None, None
+            return None, None, None, None
 
-        _, artifact_ref, variant_ref, revision_ref = populated[0]
-        return artifact_ref, variant_ref, revision_ref
+        family, artifact_ref, variant_ref, revision_ref = populated[0]
+        return family, artifact_ref, variant_ref, revision_ref
 
     @staticmethod
     def _get_revision_data(
@@ -816,11 +824,13 @@ class WorkflowsService:
 
         refs = request.references
         (
+            family,
             workflow_ref,
             workflow_variant_ref,
             workflow_revision_ref,
         ) = self._validate_execution_reference_families(request=request)
         workflow_revision = None
+        retrieval_info: Optional[RetrievalInfo] = None
         selector_key = (
             request.selector.get("key")
             if isinstance(request.selector, dict)
@@ -833,14 +843,22 @@ class WorkflowsService:
                 if workflow_ref and workflow_ref.slug
                 else None
             )
-            workflow_revision, _, _ = await self.retrieve_workflow_revision(
+            (
+                workflow_revision,
+                _,
+                retrieval_info,
+            ) = await self.retrieve_workflow_revision(
                 project_id=project_id,
                 environment_ref=refs["environment"],
                 key=key,
             )
 
         elif workflow_revision_ref or workflow_variant_ref or workflow_ref:
-            workflow_revision, _, _ = await self.retrieve_workflow_revision(
+            (
+                workflow_revision,
+                _,
+                retrieval_info,
+            ) = await self.retrieve_workflow_revision(
                 project_id=project_id,
                 workflow_ref=workflow_ref,
                 workflow_variant_ref=workflow_variant_ref,
@@ -853,6 +871,84 @@ class WorkflowsService:
             request.data.revision = {
                 "data": workflow_revision.data.model_dump(mode="json")
             }
+
+        self._write_back_resolved_references(
+            request=request,
+            family=family or "workflow",
+            retrieval_info=retrieval_info,
+        )
+
+    @staticmethod
+    def _write_back_resolved_references(
+        *,
+        request: WorkflowServiceRequest,
+        family: str,
+        retrieval_info: Optional[RetrievalInfo],
+    ) -> None:
+        """Put the references this resolution actually used back onto the request.
+
+        Embedding the revision in `request.data.revision` above is what suppresses the
+        SDK's reference hydration, and that hydration is the only step that adds the
+        sibling artifact and revision references. Without this write-back a caller who
+        sent one variant reference (`test_run` does exactly that) produces a turn stored
+        with that single reference, and a session the UI has no artifact id to open.
+
+        Only the caller's own family is written. A key the caller left empty is added
+        outright; a key they did supply is ENRICHED, never replaced — the caller's own
+        values always win, and the resolution only fills the fields they omitted. That
+        matters because a caller who sends a bare variant id (`test_run` again) would
+        otherwise store a variant element with no slug, while the SDK-hydration path
+        stores one with a slug: the same session described two ways depending on which
+        producer wrote it.
+        """
+        if not retrieval_info or not retrieval_info.references:
+            return
+
+        targets = {
+            "workflow": family,
+            "workflow_variant": f"{family}_variant",
+            "workflow_revision": f"{family}_revision",
+        }
+        references = dict(request.references or {})
+        for key, reference in retrieval_info.references.items():
+            target = targets.get(key)
+            if target is None:
+                continue
+            existing = references.get(target)
+            references[target] = (
+                reference
+                if existing is None
+                else WorkflowsService._enrich_reference(
+                    existing=existing,
+                    resolved=reference,
+                )
+            )
+
+        request.references = references
+
+    @staticmethod
+    def _enrich_reference(*, existing, resolved: Reference):
+        """Fill the fields the caller omitted; keep every field they set.
+
+        Refuses to merge when the two disagree on an identity the caller pinned — the id
+        or the slug — because either mismatch means they name different entities, and the
+        merge would produce one reference carrying the caller's id with another entity's
+        slug, or vice versa.
+        """
+        current = (
+            {key: value for key, value in existing.items() if value is not None}
+            if isinstance(existing, dict)
+            else existing.model_dump(exclude_none=True)
+        )
+
+        for field in ("id", "slug"):
+            mine, theirs = current.get(field), getattr(resolved, field)
+            if mine is not None and theirs is not None and str(mine) != str(theirs):
+                return existing
+
+        merged = resolved.model_dump(exclude_none=True)
+        merged.update(current)
+        return Reference(**merged)
 
     # workflows ----------------------------------------------------------------
 

--- a/api/oss/src/dbs/postgres/sessions/references.py
+++ b/api/oss/src/dbs/postgres/sessions/references.py
@@ -1,0 +1,59 @@
+"""JSONB (de)serialization for the reference lists sessions store.
+
+Shared by `session_turns.references` and `session_streams.references` so the two
+columns can never drift into different element shapes.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from oss.src.core.sessions.types import SessionReference
+
+
+def references_to_json(
+    references: Optional[List[SessionReference]],
+) -> Optional[List[dict]]:
+    if not references:
+        return None
+    return [
+        reference.model_dump(mode="json", exclude_none=True) for reference in references
+    ]
+
+
+def references_from_json(
+    references: Optional[List[dict]],
+) -> Optional[List[SessionReference]]:
+    if not references:
+        return None
+    return [
+        SessionReference.model_validate(reference)
+        for reference in references
+        if isinstance(reference, dict)
+    ]
+
+
+def references_containment_json(
+    references: Optional[List[SessionReference]],
+) -> Optional[List[Any]]:
+    """The `@>` operand for a reference filter, deduplicated by id/slug.
+
+    `key` is excluded, exactly as eval_runs excludes its own: containment is a subset
+    match, so an operand carrying the discriminator would stop matching every row written
+    before elements were tagged.
+
+    One definition for both reference columns — `session_turns` and `session_streams` are
+    unioned into a single filter result, so a semantic difference between them would make
+    the same query return different sessions depending on which column happened to be
+    populated.
+    """
+    if not references:
+        return None
+
+    deduplicated: Dict[Any, Any] = {}
+    for reference in references:
+        deduplicated[reference.id or reference.slug] = reference.model_dump(
+            mode="json",
+            exclude_none=True,
+            exclude={"key"},
+        )
+
+    return list(deduplicated.values()) or None

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -3,12 +3,22 @@ from typing import List, Optional
 from uuid import UUID
 
 import uuid_utils.compat as uuid
-from sqlalchemy import case, cast, delete as sa_delete, func, literal, or_, select
+from sqlalchemy import (
+    case,
+    cast,
+    delete as sa_delete,
+    func,
+    literal,
+    or_,
+    select,
+    update as sa_update,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID, insert
 from sqlalchemy.exc import IntegrityError
 
 from oss.src.core.sessions.dtos import (
     SessionOrigin,
+    SessionReference,
     SessionTriggerAttribution,
     SessionTriggerKind,
 )
@@ -34,6 +44,10 @@ from oss.src.dbs.postgres.shared.engine import (
     get_transactions_engine,
 )
 from oss.src.dbs.postgres.shared.utils import apply_windowing
+from oss.src.dbs.postgres.sessions.references import (
+    references_containment_json,
+    references_to_json,
+)
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.dbs.postgres.sessions.streams.mappings import (
     SESSION_ORIGIN_TAG_KEY,
@@ -500,6 +514,92 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
             await session.commit()
             await session.refresh(dbe)
         return map_stream_dbe_to_dto(stream_dbe=dbe)
+
+    async def query_session_ids_by_references(
+        self,
+        *,
+        project_id: UUID,
+        references: List[SessionReference],
+        limit: int,
+    ) -> List[str]:
+        """Sessions whose OWN references satisfy the filter — the turns query's twin.
+
+        Unioned with the turns result rather than replacing it: a session whose turn
+        append was dropped is findable only through this column, and one that predates
+        the column only through the turns.
+        """
+        containment = references_containment_json(references)
+        if containment is None:
+            return []
+        async with self.engine.session() as session:
+            # No DISTINCT needed — (project_id, session_id) is unique here — which is what
+            # lets the cap order by last activity, the same expression the list itself
+            # sorts by, so a capped filter keeps the rows a user would see first.
+            stmt = (
+                select(SessionStreamDBE.session_id)
+                .where(
+                    SessionStreamDBE.project_id == project_id,
+                    SessionStreamDBE.references.contains(containment),
+                )
+                .order_by(
+                    func.coalesce(
+                        SessionStreamDBE.updated_at, SessionStreamDBE.created_at
+                    ).desc()
+                )
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            return [row[0] for row in result.all()]
+
+    async def fill_missing(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        name: Optional[str] = None,
+        references: Optional[List[SessionReference]] = None,
+    ) -> bool:
+        """Write `name` / `references` onto the row ONLY where it still holds NULL.
+
+        One COALESCE'd UPDATE rather than a read-then-write: a rename landing between a
+        read and a write would otherwise be silently overwritten by a heartbeat's
+        proposal, which is exactly what fill-once must never do. Returns whether a row
+        was touched. `updated_at` is deliberately not bumped — the flag mirror owns it,
+        and a fill is not activity.
+
+        An empty proposal (``""`` / ``[]``) means nothing to say, not something to store.
+        A row gets exactly one fill per column, so writing a blank title or an empty list
+        would spend it and make the real value arriving on a later beat un-writable.
+        Callers normalize too; this is what makes the DAO safe on its own.
+        """
+        values = {}
+        guards = []
+        if name:
+            values["name"] = func.coalesce(SessionStreamDBE.name, name)
+            guards.append(SessionStreamDBE.name.is_(None))
+        if references:
+            values["references"] = func.coalesce(
+                SessionStreamDBE.references,
+                cast(references_to_json(references), JSONB),
+            )
+            guards.append(SessionStreamDBE.references.is_(None))
+        if not values:
+            return False
+
+        async with self.engine.session() as session:
+            stmt = (
+                sa_update(SessionStreamDBE)
+                .where(
+                    SessionStreamDBE.project_id == project_id,
+                    SessionStreamDBE.session_id == session_id,
+                    SessionStreamDBE.deleted_at.is_(None),
+                    or_(*guards),
+                )
+                .values(**values)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+        return bool(result.rowcount)
 
     async def update_header(
         self,

--- a/api/oss/src/dbs/postgres/sessions/streams/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dbes.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     TIMESTAMP,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 
 from oss.src.dbs.postgres.shared.base import Base
 from oss.src.dbs.postgres.shared.dbas import (
@@ -36,8 +37,11 @@ class SessionStreamDBE(
     1:1 with session_id per project. Redis is authoritative for the nest bools;
     this row mirrors them in ``flags`` for durability / orphan sweep / observability.
     ``updated_at`` (LifecycleDBA) is the heartbeat timestamp — no separate column.
-    ``name``/``description`` (HeaderDBA) are written only on the rename edit, never
-    on a flag-mirror write, so heartbeats don't churn them.
+    ``description`` (HeaderDBA) is written only on the rename edit, never on a
+    flag-mirror write, so heartbeats don't churn it. ``name`` and ``references`` are
+    additionally FILL-ONCE: a heartbeat may write either onto a NULL column and never
+    over an existing value, so a session nothing else names still gets a title while a
+    rename always wins.
     sandbox_id is NOT stored here (it lives on the latest session_turns row).
     """
 
@@ -45,6 +49,11 @@ class SessionStreamDBE(
 
     # Bare string correlator — NOT an FK (sessions may be external).
     session_id = Column(String, nullable=False)
+
+    # What this session runs, as the flat tagged list session_turns already stores.
+    # Duplicated off the turn on purpose: a turn append is fire-and-forget, so the row
+    # itself has to carry enough to open the session.
+    references = Column(JSONB(none_as_null=True), nullable=True)
 
     # Current turn (uuid7 minted by the service); the Postgres mirror of the Redis
     # alive/running lock value. Null when idle/ended. Not a pk — a token-like correlator.
@@ -80,5 +89,11 @@ class SessionStreamDBE(
             "ix_session_streams_flags",
             "flags",
             postgresql_using="gin",
+        ),
+        Index(
+            "ix_session_streams_references",
+            "references",
+            postgresql_using="gin",
+            postgresql_ops={"references": "jsonb_path_ops"},
         ),
     )

--- a/api/oss/src/dbs/postgres/sessions/streams/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/mappings.py
@@ -17,6 +17,10 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamHeaderEdit,
     SessionStreamQueryResult,
 )
+from oss.src.dbs.postgres.sessions.references import (
+    references_from_json,
+    references_to_json,
+)
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 
 
@@ -131,6 +135,7 @@ def map_stream_dto_to_dbe_create(
         tags=stream.tags,
         meta=stream.meta,
         turn_id=stream.turn_id,
+        references=references_to_json(stream.references),
     )
 
 
@@ -152,6 +157,7 @@ def map_stream_dbe_to_dto(
         name=stream_dbe.name,
         description=stream_dbe.description,
         turn_id=stream_dbe.turn_id,
+        references=references_from_json(stream_dbe.references),
         archived_at=stream_dbe.archived_at,
         flags=SessionStreamFlags.model_validate(stream_dbe.flags)
         if stream_dbe.flags

--- a/api/oss/src/dbs/postgres/sessions/turns/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/turns/dao.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from sqlalchemy import and_, delete as sa_delete, or_, select
+from sqlalchemy import and_, delete as sa_delete, func, or_, select
 from sqlalchemy import update as sa_update
 from sqlalchemy.exc import IntegrityError
 
@@ -140,13 +140,16 @@ class SessionTurnsDAO(SessionTurnsDAOInterface):
         if turn_references is None:
             return []
         async with self.engine.session() as session:
+            # GROUP BY, not DISTINCT, so the cap can keep the most recently active
+            # sessions instead of an arbitrary `limit` of the matches.
             stmt = (
                 select(SessionTurnDBE.session_id)
                 .where(
                     SessionTurnDBE.project_id == project_id,
                     SessionTurnDBE.references.contains(turn_references),
                 )
-                .distinct()
+                .group_by(SessionTurnDBE.session_id)
+                .order_by(func.max(SessionTurnDBE.start_time).desc().nullslast())
                 .limit(limit)
             )
             result = await session.execute(stmt)

--- a/api/oss/src/dbs/postgres/sessions/turns/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/turns/mappings.py
@@ -1,31 +1,16 @@
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID
 
-from oss.src.core.shared.dtos import Reference
 from oss.src.core.sessions.turns.dtos import (
     HarnessKind,
     SessionTurn,
     SessionTurnCreate,
 )
+from oss.src.dbs.postgres.sessions.references import (
+    references_from_json,
+    references_to_json,
+)
 from oss.src.dbs.postgres.sessions.turns.dbes import SessionTurnDBE
-
-
-def _references_to_json(
-    references: Optional[List[Reference]],
-) -> Optional[List[dict]]:
-    if not references:
-        return None
-    return [
-        reference.model_dump(mode="json", exclude_none=True) for reference in references
-    ]
-
-
-def _references_from_json(
-    references: Optional[List[dict]],
-) -> Optional[List[Reference]]:
-    if not references:
-        return None
-    return [Reference.model_validate(reference) for reference in references]
 
 
 def map_turn_dto_to_dbe_create(
@@ -46,7 +31,7 @@ def map_turn_dto_to_dbe_create(
         harness_kind=turn.harness_kind.value,
         agent_session_id=turn.agent_session_id,
         sandbox_id=turn.sandbox_id,
-        references=_references_to_json(turn.references),
+        references=references_to_json(turn.references),
         trace_id=turn.trace_id,
         span_id=turn.span_id,
         start_time=turn.start_time,
@@ -76,7 +61,7 @@ def map_turn_dbe_to_dto(
         harness_kind=HarnessKind(turn_dbe.harness_kind),
         agent_session_id=turn_dbe.agent_session_id,
         sandbox_id=turn_dbe.sandbox_id,
-        references=_references_from_json(turn_dbe.references),
+        references=references_from_json(turn_dbe.references),
         trace_id=turn_dbe.trace_id,
         span_id=turn_dbe.span_id,
         start_time=turn_dbe.start_time,

--- a/api/oss/src/dbs/postgres/sessions/turns/utils.py
+++ b/api/oss/src/dbs/postgres/sessions/turns/utils.py
@@ -1,22 +1,14 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from oss.src.core.sessions.turns.dtos import SessionTurnQuery
+from oss.src.dbs.postgres.sessions.references import references_containment_json
 
 
 def query_turn_references(
     turn: Optional[SessionTurnQuery] = None,
 ) -> Optional[List[Any]]:
     """eval_runs pattern: flatten to bare {id, slug, version} dicts for .contains()."""
-    if not turn or not turn.references:
+    if not turn:
         return None
 
-    _references: Dict[Any, Any] = dict()
-
-    for reference in turn.references:
-        _key = reference.id or reference.slug
-        _references[_key] = reference.model_dump(
-            mode="json",
-            exclude_none=True,
-        )
-
-    return list(_references.values()) or None
+    return references_containment_json(turn.references)

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_filters.py
@@ -161,10 +161,18 @@ def _stream(session_id: str) -> SessionStream:
 
 
 class _FakeStreamsService:
-    def __init__(self, streams: Optional[List[SessionStream]] = None):
+    def __init__(
+        self,
+        streams: Optional[List[SessionStream]] = None,
+        reference_session_ids: Optional[List[str]] = None,
+    ):
         self.streams = streams if streams is not None else []
         self.captured: Dict[str, object] = {}
         self.count_captured: Dict[str, object] = {}
+        self.reference_session_ids = reference_session_ids or []
+
+    async def query_session_ids_by_references(self, *, project_id, references, limit):
+        return self.reference_session_ids[:limit]
 
     async def query_streams(
         self,

--- a/api/oss/tests/pytest/unit/sessions/test_query_sessions_references.py
+++ b/api/oss/tests/pytest/unit/sessions/test_query_sessions_references.py
@@ -22,7 +22,7 @@ from oss.src.core.sessions.dtos import SessionListItem
 from oss.src.core.sessions.service import SessionsService
 from oss.src.core.sessions.streams.dtos import SessionStream
 from oss.src.core.sessions.turns.dtos import HarnessKind, SessionTurn
-from oss.src.core.shared.dtos import Reference
+from oss.src.core.sessions.types import SessionReference
 
 
 _PROJECT = uuid4()
@@ -35,7 +35,7 @@ def _stream(session_id: str) -> SessionStream:
 def _turn(
     session_id: str,
     turn_index: int,
-    references: Optional[List[Reference]] = None,
+    references: Optional[List[SessionReference]] = None,
 ) -> SessionTurn:
     return SessionTurn(
         id=uuid4(),
@@ -126,8 +126,8 @@ async def test_query_sessions_echoes_highest_turn_index_references():
     session_with_turns = "session-with-turns"
     session_without_turns = "session-without-turns"
 
-    early_ref = Reference(id=uuid4(), slug="early-workflow", version="v1")
-    latest_ref = Reference(id=uuid4(), slug="latest-workflow", version="v2")
+    early_ref = SessionReference(id=uuid4(), slug="early-workflow", version="v1")
+    latest_ref = SessionReference(id=uuid4(), slug="latest-workflow", version="v2")
 
     streams = [_stream(session_with_turns), _stream(session_without_turns)]
     turns_by_session = {

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_query_contract.py
@@ -36,7 +36,8 @@ from oss.src.core.sessions.streams.dtos import (
     SessionStreamQuery,
     SessionStreamQueryFlags,
 )
-from oss.src.core.shared.dtos import Reference, Windowing
+from oss.src.core.sessions.types import SessionReference
+from oss.src.core.shared.dtos import Windowing
 from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.dbs.postgres.sessions.streams.mappings import (
@@ -48,7 +49,7 @@ from oss.src.dbs.postgres.shared.utils import apply_windowing
 
 
 def test_nested_only_request_normalizes_by_semantic_role():
-    reference = Reference(id=uuid4())
+    reference = SessionReference(id=uuid4())
     normalized = normalize_session_query_request(
         SessionQueryRequest(
             session=SessionPredicatesRequest(
@@ -85,7 +86,7 @@ def test_nested_only_request_normalizes_by_semantic_role():
 
 
 def test_flat_only_request_remains_valid():
-    reference = Reference(id=uuid4())
+    reference = SessionReference(id=uuid4())
     normalized = normalize_session_query_request(
         SessionQueryRequest(
             search="refund",
@@ -110,8 +111,8 @@ def test_flat_only_request_remains_valid():
 
 
 def test_equivalent_mixed_request_is_accepted_order_insensitively():
-    first = Reference(id=uuid4())
-    second = Reference(id=uuid4())
+    first = SessionReference(id=uuid4())
+    second = SessionReference(id=uuid4())
     normalized = normalize_session_query_request(
         SessionQueryRequest(
             session=SessionPredicatesRequest(
@@ -241,7 +242,7 @@ def test_empty_legacy_references_remain_neutral():
 
 
 def test_empty_legacy_references_do_not_conflict_with_canonical_references():
-    reference = Reference(id=uuid4())
+    reference = SessionReference(id=uuid4())
     normalized = normalize_session_query_request(
         SessionQueryRequest(turn_references=[reference], references=[])
     )
@@ -379,10 +380,14 @@ def test_session_id_exclusion_wins_on_overlap():
 
 
 class _Streams:
-    def __init__(self, rows):
+    def __init__(self, rows, reference_session_ids=()):
         self.rows = rows
         self.query_calls = []
         self.count_calls = []
+        self.reference_session_ids = list(reference_session_ids)
+
+    async def query_session_ids_by_references(self, *, project_id, references, limit):
+        return self.reference_session_ids[:limit]
 
     async def query_streams(self, **kwargs):
         self.query_calls.append(kwargs)
@@ -428,7 +433,7 @@ async def test_page_and_total_share_one_turn_reference_resolution():
     page = await service.query_sessions_page(
         project_id=project_id,
         query=SessionQuery(
-            turn_references=[Reference(id=uuid4())],
+            turn_references=[SessionReference(id=uuid4())],
             session_ids=["session-a"],
             exclude_session_ids=["session-b"],
         ),
@@ -751,7 +756,7 @@ async def test_router_consumes_nested_fields_and_projection_options():
         exclude=SessionExcludeRequest(
             origins=[SessionOrigin.manual], session_ids=["session-b"]
         ),
-        turn_references=[Reference(id=uuid4())],
+        turn_references=[SessionReference(id=uuid4())],
         expand=[SessionExpansion.trigger],
     )
 

--- a/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
+++ b/api/oss/tests/pytest/unit/sessions/test_sessions_root_service.py
@@ -57,12 +57,20 @@ def _turn(session_id: str, references: Optional[List[Reference]] = None) -> Sess
 
 
 class _FakeStreamsService:
-    def __init__(self, row: Optional[SessionStream] = None):
+    def __init__(
+        self,
+        row: Optional[SessionStream] = None,
+        reference_session_ids: Optional[list] = None,
+    ):
         self.row = row
         self.hard_delete_calls: list[dict] = []
         self.archive_calls: list[dict] = []
         self.unarchive_calls: list[dict] = []
         self.query_calls: list[dict] = []
+        self.reference_session_ids = reference_session_ids or []
+
+    async def query_session_ids_by_references(self, *, project_id, references, limit):
+        return self.reference_session_ids[:limit]
 
     async def query_streams(
         self,
@@ -336,9 +344,8 @@ async def test_query_sessions_no_filter_returns_all_streams():
     # `SessionStream` -- equality is type-sensitive in pydantic, so compare the inherited
     # fields as a dict (full-field pinning) and assert the added fields separately.
     assert len(result) == 1
-    assert (
-        result[0].model_dump(exclude={"references", "last_message"})
-        == stream.model_dump()
+    assert result[0].model_dump(exclude={"references", "last_message"}) == (
+        stream.model_dump(exclude={"references"})
     )
     assert result[0].references is None
     # No records service wired here, so the row lists without a preview rather than failing.

--- a/api/oss/tests/pytest/unit/sessions/test_stream_fill_missing_postgres.py
+++ b/api/oss/tests/pytest/unit/sessions/test_stream_fill_missing_postgres.py
@@ -1,0 +1,306 @@
+"""`fill_missing` against a real Postgres — the statement, not a fake of it.
+
+Fill-once is enforced by SQL (COALESCE per column behind a NULL guard), so a fake that
+mirrors the rule proves the service calls it correctly and nothing about whether the rule
+holds. The cases that matter are the ones a mistake in the statement would break: a
+second fill must not overwrite, and a rename must survive every later beat.
+
+Requires the core_oss migration chain applied and POSTGRES_URI_CORE pointed at that
+database (same fixture shape as test_wp5_dao_fanout.py); skipped when Postgres is
+unreachable.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from oss.src.core.sessions.streams.dtos import (
+    SessionStreamCreate,
+    SessionStreamHeaderEdit,
+)
+from oss.src.core.sessions.types import ReferenceKey, SessionReference
+import oss.src.models.db_models  # noqa: F401
+from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE  # noqa: F401
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
+import oss.src.dbs.postgres.shared.engine as engine_module
+from oss.src.dbs.postgres.shared.engine import get_transactions_engine
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_engine_per_test():
+    engine_module._transactions_engine = None
+    yield
+    if engine_module._transactions_engine is not None:
+        await engine_module._transactions_engine.close()
+        engine_module._transactions_engine = None
+
+
+@pytest.fixture
+async def project():
+    """Provision the minimal FK chain: user -> org -> workspace -> project."""
+    engine = get_transactions_engine()
+
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    async with engine.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO users (id, uid, username, email) "
+                "VALUES (:id, :uid, :username, :email)"
+            ),
+            {
+                "id": user_id,
+                "uid": str(user_id),
+                "username": "fill-missing-test",
+                "email": f"fill-missing-test-{user_id.hex[:8]}@example.com",
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO organizations (id, name, owner_id) "
+                "VALUES (:id, :name, :owner_id)"
+            ),
+            {"id": org_id, "name": "fill-missing-test-org", "owner_id": user_id},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO workspaces (id, name, organization_id) "
+                "VALUES (:id, :name, :organization_id)"
+            ),
+            {
+                "id": workspace_id,
+                "name": "fill-missing-test-ws",
+                "organization_id": org_id,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO projects (id, project_name, workspace_id, organization_id) "
+                "VALUES (:id, :project_name, :workspace_id, :organization_id)"
+            ),
+            {
+                "id": project_id,
+                "project_name": "fill-missing-test-project",
+                "workspace_id": workspace_id,
+                "organization_id": org_id,
+            },
+        )
+        await session.commit()
+
+    yield {"project_id": project_id, "user_id": user_id}
+
+    async with engine.session() as session:
+        await session.execute(
+            text("DELETE FROM session_streams WHERE project_id = :project_id"),
+            {"project_id": project_id},
+        )
+        await session.execute(
+            text("DELETE FROM projects WHERE id = :id"), {"id": project_id}
+        )
+        await session.execute(
+            text("DELETE FROM workspaces WHERE id = :id"), {"id": workspace_id}
+        )
+        await session.execute(
+            text("DELETE FROM organizations WHERE id = :id"), {"id": org_id}
+        )
+        await session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_id})
+        await session.commit()
+
+
+def _references(slug: str) -> list[SessionReference]:
+    return [
+        SessionReference(id=uuid.uuid4(), slug=slug, key=ReferenceKey.workflow),
+        SessionReference(id=uuid.uuid4(), slug=slug, key=ReferenceKey.workflow_variant),
+    ]
+
+
+async def _stream(dao: SessionStreamsDAO, project_id, session_id: str):
+    return await dao.create(
+        project_id=project_id,
+        user_id=None,
+        stream=SessionStreamCreate(session_id=session_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fill_missing_writes_then_refuses_to_overwrite(project):
+    dao = SessionStreamsDAO()
+    project_id = project["project_id"]
+    session_id = f"fill_{uuid.uuid4().hex[:12]}"
+    await _stream(dao, project_id, session_id)
+
+    first_references = _references("first")
+    filled = await dao.fill_missing(
+        project_id=project_id,
+        session_id=session_id,
+        name="First title",
+        references=first_references,
+    )
+    assert filled is True
+    row = await dao.get_by_session_id(project_id=project_id, session_id=session_id)
+    assert row.name == "First title"
+    assert row.references == first_references
+
+    # The second beat proposes something else entirely; both columns must ignore it.
+    filled_again = await dao.fill_missing(
+        project_id=project_id,
+        session_id=session_id,
+        name="Second title",
+        references=_references("second"),
+    )
+    row = await dao.get_by_session_id(project_id=project_id, session_id=session_id)
+    assert filled_again is False
+    assert row.name == "First title"
+    assert row.references == first_references
+
+
+@pytest.mark.asyncio
+async def test_a_rename_survives_every_later_fill(project):
+    """The invariant the whole design rests on: the runner re-proposes forever, and a
+    human's title must outlive all of it."""
+    dao = SessionStreamsDAO()
+    project_id = project["project_id"]
+    session_id = f"fill_{uuid.uuid4().hex[:12]}"
+    await _stream(dao, project_id, session_id)
+
+    await dao.update_header(
+        project_id=project_id,
+        user_id=project["user_id"],
+        session_id=session_id,
+        header=SessionStreamHeaderEdit(name="Named by a human"),
+    )
+
+    for _ in range(3):
+        await dao.fill_missing(
+            project_id=project_id,
+            session_id=session_id,
+            name="Proposed by the runner",
+        )
+
+    row = await dao.get_by_session_id(project_id=project_id, session_id=session_id)
+    assert row.name == "Named by a human"
+
+
+@pytest.mark.asyncio
+async def test_each_column_fills_independently(project):
+    # A beat carrying only a name must still fill references later, and vice versa —
+    # the guard is per column, not per row.
+    dao = SessionStreamsDAO()
+    project_id = project["project_id"]
+    session_id = f"fill_{uuid.uuid4().hex[:12]}"
+    await _stream(dao, project_id, session_id)
+
+    await dao.fill_missing(
+        project_id=project_id, session_id=session_id, name="Only a name"
+    )
+    references = _references("later")
+    await dao.fill_missing(
+        project_id=project_id, session_id=session_id, references=references
+    )
+
+    row = await dao.get_by_session_id(project_id=project_id, session_id=session_id)
+    assert row.name == "Only a name"
+    assert row.references == references
+    assert row.references[0].key == "workflow"
+
+
+@pytest.mark.asyncio
+async def test_a_killed_row_is_not_filled(project):
+    """`deleted_at IS NULL` is in the WHERE for a reason: a late beat from the turn that
+    was killed must not write to the tombstone."""
+    dao = SessionStreamsDAO()
+    project_id = project["project_id"]
+    session_id = f"fill_{uuid.uuid4().hex[:12]}"
+    await _stream(dao, project_id, session_id)
+    await dao.delete_by_session_id(project_id=project_id, session_id=session_id)
+
+    filled = await dao.fill_missing(
+        project_id=project_id, session_id=session_id, name="Too late"
+    )
+
+    assert filled is False
+
+
+@pytest.mark.asyncio
+async def test_the_stream_reference_filter_matches_by_containment(project):
+    """The stream half of the reference-scoped list filter, against real `@>`.
+
+    Containment is a subset match on a JSONB array, which is easy to get wrong in a way
+    that still compiles: the operand must match an element that is a SUPERSET of it, and
+    it must not carry `key` or it would miss every untagged row.
+    """
+    dao = SessionStreamsDAO()
+    project_id = project["project_id"]
+    workflow_id = uuid.uuid4()
+
+    matching = f"fill_{uuid.uuid4().hex[:12]}"
+    await _stream(dao, project_id, matching)
+    await dao.fill_missing(
+        project_id=project_id,
+        session_id=matching,
+        references=[
+            SessionReference(id=workflow_id, slug="chat", key=ReferenceKey.workflow),
+            SessionReference(id=uuid.uuid4(), key=ReferenceKey.workflow_variant),
+        ],
+    )
+
+    other = f"fill_{uuid.uuid4().hex[:12]}"
+    await _stream(dao, project_id, other)
+    await dao.fill_missing(
+        project_id=project_id,
+        session_id=other,
+        references=[SessionReference(id=uuid.uuid4(), key=ReferenceKey.workflow)],
+    )
+
+    found = await dao.query_session_ids_by_references(
+        project_id=project_id,
+        references=[SessionReference(id=workflow_id)],
+        limit=500,
+    )
+    assert found == [matching]
+
+    # A filter that names the family must still match: `key` is excluded from the operand.
+    found_with_key = await dao.query_session_ids_by_references(
+        project_id=project_id,
+        references=[SessionReference(id=workflow_id, key=ReferenceKey.workflow)],
+        limit=500,
+    )
+    assert found_with_key == [matching]
+
+    # And an untagged row written before the discriminator existed is still findable.
+    legacy = f"fill_{uuid.uuid4().hex[:12]}"
+    legacy_id = uuid.uuid4()
+    await _stream(dao, project_id, legacy)
+    await dao.fill_missing(
+        project_id=project_id,
+        session_id=legacy,
+        references=[SessionReference(id=legacy_id)],
+    )
+    assert await dao.query_session_ids_by_references(
+        project_id=project_id,
+        references=[SessionReference(id=legacy_id, key=ReferenceKey.workflow)],
+        limit=500,
+    ) == [legacy]
+
+
+@pytest.mark.asyncio
+async def test_fill_missing_is_scoped_to_its_project(project):
+    dao = SessionStreamsDAO()
+    project_id = project["project_id"]
+    session_id = f"fill_{uuid.uuid4().hex[:12]}"
+    await _stream(dao, project_id, session_id)
+
+    filled = await dao.fill_missing(
+        project_id=uuid.uuid4(), session_id=session_id, name="Another tenant"
+    )
+
+    row = await dao.get_by_session_id(project_id=project_id, session_id=session_id)
+    assert filled is False
+    assert row.name is None

--- a/api/oss/tests/pytest/unit/sessions/test_stream_fill_once.py
+++ b/api/oss/tests/pytest/unit/sessions/test_stream_fill_once.py
@@ -1,0 +1,447 @@
+"""A session gets a title and its references from the run itself, exactly once.
+
+Before this, the browser was the only component that ever wrote a session name and the
+only reliable writer of a complete reference set: 98.6% of sessions were untitled and
+every untitled one was created headlessly (runner beat or trigger dispatch), so no
+browser ever rendered it. The fix lets the beat propose both, under one rule — write
+only where the column is still NULL.
+
+The rule cuts both ways, and both directions are pinned here: a beat must be able to
+title a session nothing else will, and a beat must never touch a name a human (rename,
+`rename_session`) or the browser auto-title already set.
+"""
+
+from typing import Optional
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+from oss.src.core.sessions.streams.dtos import (
+    SessionHeartbeatRequest,
+    SessionStream,
+    SessionStreamCommandRequest,
+    SessionStreamHeaderEdit,
+)
+from oss.src.core.sessions.streams.service import (
+    SESSION_NAME_MAX_CHARS,
+    SessionStreamsService,
+    derive_session_name,
+    normalize_session_name,
+)
+from oss.src.core.sessions.types import ReferenceKey, SessionReference
+
+from unit.sessions.test_project_scoped_locks import _FakeRedis
+
+
+_PROJECT = uuid4()
+_SESSION = "session_fill_once"
+
+
+class _FakeStreamsDAO:
+    """One in-memory row with the real DAO's fill-once contract.
+
+    `fill_missing` mirrors the real statement's semantics — COALESCE per column behind a
+    NULL guard — so a service-level test asserts the same rule the SQL enforces.
+    """
+
+    def __init__(self, existing: Optional[SessionStream] = None):
+        self.row = existing
+        self.fills: list[dict] = []
+
+    async def get_by_session_id(self, *, project_id: UUID, session_id: str):
+        return self.row
+
+    async def create(self, *, project_id, user_id, stream):
+        kwargs = dict(
+            id=uuid4(),
+            project_id=project_id,
+            session_id=stream.session_id,
+            name=stream.name,
+            description=stream.description,
+            turn_id=stream.turn_id,
+            references=stream.references,
+        )
+        if stream.flags is not None:
+            kwargs["flags"] = stream.flags
+        self.row = SessionStream(**kwargs)
+        return self.row
+
+    async def update(self, *, project_id, user_id, session_id, stream):
+        prior = self.row
+        self.row = SessionStream(
+            id=prior.id if prior else uuid4(),
+            project_id=project_id,
+            session_id=session_id,
+            name=stream.name
+            if stream.name is not None
+            else (prior.name if prior else None),
+            flags=stream.flags
+            if stream.flags is not None
+            else (prior.flags if prior else None),
+            turn_id=stream.turn_id
+            if stream.turn_id is not None
+            else (prior.turn_id if prior else None),
+            references=prior.references if prior else None,
+        )
+        return self.row
+
+    async def update_header(self, *, project_id, user_id, session_id, header):
+        if self.row is None:
+            return None
+        prior = self.row
+        self.row = prior.model_copy(
+            update={
+                "name": header.name if header.name is not None else prior.name,
+                "description": header.description
+                if header.description is not None
+                else prior.description,
+            }
+        )
+        return self.row
+
+    async def fill_missing(
+        self, *, project_id, session_id, name=None, references=None
+    ) -> bool:
+        self.fills.append({"name": name, "references": references})
+        if self.row is None:
+            return False
+        update = {}
+        # Truthiness, like the real statement: an empty proposal is not a proposal.
+        if name and self.row.name is None:
+            update["name"] = name
+        if references and self.row.references is None:
+            update["references"] = references
+        if not update:
+            return False
+        self.row = self.row.model_copy(update=update)
+        return True
+
+    async def delete_by_session_id(self, *, project_id, session_id):
+        return True
+
+
+@pytest_asyncio.fixture
+async def lock_engine():
+    from oss.src.dbs.redis.shared.engine import LockEngine
+
+    eng = LockEngine()
+    with patch.object(eng, "_client", return_value=_FakeRedis()):
+        yield eng
+
+
+def _service(lock_engine, dao):
+    return SessionStreamsService(streams_dao=dao, lock_engine=lock_engine)
+
+
+def _beat(turn: str, *, name=None, references=None) -> SessionHeartbeatRequest:
+    return SessionHeartbeatRequest(
+        session_id=_SESSION,
+        replica_id="replica-a",
+        turn_id=turn,
+        is_running=True,
+        name=name,
+        references=references,
+    )
+
+
+def _references() -> list[SessionReference]:
+    return [
+        SessionReference(id=uuid4(), slug="wf", key=ReferenceKey.workflow),
+        SessionReference(id=uuid4(), slug="wf-var", key=ReferenceKey.workflow_variant),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Normalization: what a proposal is worth before it reaches the row.
+# ---------------------------------------------------------------------------
+
+
+def test_a_proposal_is_trimmed_and_capped():
+    assert normalize_session_name("  Migrate billing  ") == "Migrate billing"
+    assert len(normalize_session_name("x" * 500)) == SESSION_NAME_MAX_CHARS
+
+
+def test_a_blank_proposal_is_no_proposal_not_a_clear():
+    # An empty name is the explicit clear-title action on the rename path; a beat must
+    # never be able to express it, or an idle runner would erase a title.
+    assert normalize_session_name("   ") is None
+    assert normalize_session_name("") is None
+    assert normalize_session_name(None) is None
+
+
+def test_the_title_is_the_first_user_message_like_the_browser():
+    inputs = {
+        "messages": [
+            {"role": "system", "content": "ignored"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Run the"},
+                    {"type": "image", "url": "http://x"},
+                    {"type": "text", "text": "migration"},
+                ],
+            },
+            {"role": "user", "content": "second message, never used"},
+        ]
+    }
+    assert derive_session_name(inputs) == "Run the migration"
+
+
+def test_an_image_only_first_message_yields_no_title():
+    # Matches the browser, which keeps only `type === "text"` parts and gives up on "".
+    inputs = {
+        "messages": [{"role": "user", "content": [{"type": "image", "url": "u"}]}]
+    }
+    assert derive_session_name(inputs) is None
+    assert derive_session_name({"messages": []}) is None
+    assert derive_session_name(None) is None
+
+
+# ---------------------------------------------------------------------------
+# The beat fills a NULL, on the row it creates and on one that already exists.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_beat_that_creates_the_row_titles_it(lock_engine):
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+
+    result = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("turn-1", name="Nightly changelog")
+    )
+
+    assert result.stream.name == "Nightly changelog"
+
+
+@pytest.mark.asyncio
+async def test_a_later_beat_fills_a_row_that_is_still_untitled(lock_engine):
+    # The row usually exists before the runner has anything to say about it: `_start_turn`
+    # or a trigger claim created it. That row is exactly the untitled population.
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1"))
+    assert dao.row.name is None
+
+    result = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("turn-1", name="Filled later")
+    )
+
+    assert result.stream.name == "Filled later"
+
+
+@pytest.mark.asyncio
+async def test_a_beat_never_overwrites_an_existing_title(lock_engine):
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    await svc.set_header(
+        project_id=_PROJECT,
+        user_id=None,
+        session_id=_SESSION,
+        header=SessionStreamHeaderEdit(name="Named by a human"),
+    )
+
+    result = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("turn-1", name="Proposed by the runner")
+    )
+
+    assert result.stream.name == "Named by a human"
+    assert dao.row.name == "Named by a human"
+
+
+@pytest.mark.asyncio
+async def test_a_rename_after_a_fill_still_wins(lock_engine):
+    # The fill is not a claim on the name: renaming overwrites, so the user is never
+    # fighting the runner for the title.
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1", name="Auto title"))
+
+    await svc.set_header(
+        project_id=_PROJECT,
+        user_id=None,
+        session_id=_SESSION,
+        header=SessionStreamHeaderEdit(name="My title"),
+    )
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1", name="Auto title"))
+
+    assert dao.row.name == "My title"
+
+
+@pytest.mark.asyncio
+async def test_the_proposal_repeats_on_every_beat_without_repeating_the_write(
+    lock_engine,
+):
+    """The runner re-proposes the same name on every beat, including the final
+    is_running=false release beat. Filling is idempotent, and once the row holds a value
+    the service stops issuing the write at all rather than paying a no-op UPDATE per beat
+    per session."""
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1", name="Same title"))
+    writes_after_first = len(dao.fills)
+    for _ in range(3):
+        await svc.heartbeat(
+            project_id=_PROJECT, request=_beat("turn-1", name="Same title")
+        )
+    await svc.heartbeat(
+        project_id=_PROJECT,
+        request=SessionHeartbeatRequest(
+            session_id=_SESSION,
+            replica_id="replica-a",
+            turn_id="turn-1",
+            is_running=False,
+            name="Same title",
+        ),
+    )
+
+    assert dao.row.name == "Same title"
+    assert len(dao.fills) == writes_after_first
+
+
+@pytest.mark.asyncio
+async def test_a_beat_without_a_proposal_does_not_touch_the_row(lock_engine):
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1"))
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1"))
+
+    assert dao.fills == [], "a beat with nothing to say must not issue a write"
+
+
+# ---------------------------------------------------------------------------
+# The same rule, applied to references.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_beat_records_what_the_session_runs(lock_engine):
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    references = _references()
+
+    result = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("turn-1", references=references)
+    )
+
+    assert result.stream.references == references
+    assert result.stream.references[0].key == "workflow"
+
+
+@pytest.mark.asyncio
+async def test_references_fill_a_row_that_has_none_and_are_then_frozen(lock_engine):
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1"))
+    first = _references()
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1", references=first))
+
+    later = [SessionReference(id=uuid4(), key=ReferenceKey.workflow)]
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-2", references=later))
+
+    assert dao.row.references == first
+
+
+@pytest.mark.asyncio
+async def test_an_empty_reference_list_does_not_burn_the_fill(lock_engine):
+    """A beat that has nothing to attribute must leave the slot open.
+
+    Each column is fillable exactly once, so storing `[]` would spend that one chance and
+    make the real references arriving on a later beat un-writable — the session would stay
+    unopenable for the reason the column exists to prevent.
+    """
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1", references=[]))
+    assert dao.row.references is None
+
+    references = _references()
+    await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("turn-2", references=references)
+    )
+
+    assert dao.row.references == references
+
+
+@pytest.mark.asyncio
+async def test_an_empty_name_does_not_burn_the_fill(lock_engine):
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1", name="   "))
+    assert dao.row.name is None
+
+    await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("turn-2", name="A real title")
+    )
+
+    assert dao.row.name == "A real title"
+
+
+@pytest.mark.asyncio
+async def test_a_title_fill_leaves_existing_references_alone(lock_engine):
+    # The two columns are filled independently: a beat carrying only a name must not
+    # reset references, and vice versa.
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    references = _references()
+    await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("turn-1", references=references)
+    )
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("turn-1", name="A title"))
+
+    assert dao.row.references == references
+    assert dao.row.name == "A title"
+
+
+# ---------------------------------------------------------------------------
+# The browser send path fills from its own inputs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_send_titles_the_session_from_its_inputs(lock_engine):
+    # The client's auto-title effect is fire-and-forget with no retry; deriving the same
+    # title server-side means a dropped PUT no longer leaves the session nameless.
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+
+    await svc.command(
+        project_id=_PROJECT,
+        user_id=uuid4(),
+        request=SessionStreamCommandRequest(
+            session_id=_SESSION,
+            data={"inputs": {"messages": [{"role": "user", "content": "Ship it"}]}},
+        ),
+    )
+
+    assert dao.row.name == "Ship it"
+
+
+@pytest.mark.asyncio
+async def test_a_send_on_a_named_session_keeps_the_name(lock_engine):
+    dao = _FakeStreamsDAO()
+    svc = _service(lock_engine, dao)
+    await svc.set_header(
+        project_id=_PROJECT,
+        user_id=None,
+        session_id=_SESSION,
+        header=SessionStreamHeaderEdit(name="Kept"),
+    )
+
+    await svc.command(
+        project_id=_PROJECT,
+        user_id=uuid4(),
+        request=SessionStreamCommandRequest(
+            session_id=_SESSION,
+            data={"inputs": {"messages": [{"role": "user", "content": "Ship it"}]}},
+        ),
+    )
+
+    assert dao.row.name == "Kept"

--- a/api/oss/tests/pytest/unit/sessions/test_stream_references_storage.py
+++ b/api/oss/tests/pytest/unit/sessions/test_stream_references_storage.py
@@ -1,0 +1,463 @@
+"""`session_streams.references`: the SQL that fills it, the mapping that stores it, and
+the list that prefers it.
+
+The column exists because references rode only on `session_turns`, appended
+fire-and-forget after a run started. A dropped append left the row with nothing to open
+the session with — 98.2% of untitled sessions had no references at all. The row now
+carries its own copy.
+
+Complements `test_stream_fill_once.py`, which pins the service-level rule; this file pins
+the three places the rule has to survive: the statement, the JSONB round trip, and the
+read.
+"""
+
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from oss.src.core.sessions.dtos import SessionQuery, SessionQueryLifecycle
+from oss.src.core.sessions.service import SessionsService
+from oss.src.core.sessions.streams.dtos import (
+    SessionStream,
+    SessionStreamCreate,
+    SessionStreamQuery,
+)
+from oss.src.core.sessions.turns.dtos import SessionTurn
+from oss.src.core.sessions.types import ReferenceKey, SessionReference
+from oss.src.dbs.postgres.sessions.streams import dao as dao_module
+from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
+from oss.src.dbs.postgres.sessions.streams.mappings import (
+    map_stream_dbe_to_dto,
+    map_stream_dto_to_dbe_create,
+)
+
+from agenta.sdk.agents.dtos import HarnessKind
+
+
+_PROJECT = uuid4()
+
+
+def _references() -> List[SessionReference]:
+    return [
+        SessionReference(id=uuid4(), slug="chat", key=ReferenceKey.workflow),
+        SessionReference(id=uuid4(), slug="chat", key=ReferenceKey.workflow_variant),
+        SessionReference(
+            id=uuid4(), slug="chat", version="3", key=ReferenceKey.workflow_revision
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------------- #
+# The statement: fill-once is enforced in SQL, not by a read-then-write.
+# ---------------------------------------------------------------------------------- #
+
+
+class _DummyResult:
+    rowcount = 1
+
+
+class _DummySession:
+    def __init__(self):
+        self.captured_stmt = None
+
+    async def execute(self, stmt):
+        self.captured_stmt = stmt
+        return _DummyResult()
+
+    async def commit(self):
+        return None
+
+
+class _DummySessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _dao(monkeypatch):
+    session = _DummySession()
+    mock_engine = type(
+        "MockEngine", (), {"session": lambda self: _DummySessionContext(session)}
+    )()
+    monkeypatch.setattr(dao_module, "get_transactions_engine", lambda: mock_engine)
+    return dao_module.SessionStreamsDAO(), session
+
+
+def _compiled(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+@pytest.mark.asyncio
+async def test_the_fill_statement_coalesces_behind_a_null_guard(monkeypatch):
+    """One UPDATE, not a read-then-write.
+
+    A read-then-write would let a rename land in the gap and be silently overwritten by
+    a heartbeat's proposal — the one thing fill-once must never do.
+    """
+    dao, session = _dao(monkeypatch)
+
+    await dao.fill_missing(
+        project_id=_PROJECT,
+        session_id="s-1",
+        name="A title",
+        references=_references(),
+    )
+
+    sql = _compiled(session.captured_stmt).lower()
+    assert "update session_streams" in sql
+    assert "coalesce(session_streams.name" in sql
+    assert 'coalesce(session_streams."references"' in sql
+    assert "session_streams.name is null" in sql
+    assert 'session_streams."references" is null' in sql
+    # A killed row must not be resurrected by a late beat from its own last turn.
+    assert "session_streams.deleted_at is null" in sql
+
+
+@pytest.mark.asyncio
+async def test_filling_only_one_column_guards_only_that_column(monkeypatch):
+    dao, session = _dao(monkeypatch)
+
+    await dao.fill_missing(project_id=_PROJECT, session_id="s-1", name="A title")
+
+    sql = _compiled(session.captured_stmt).lower()
+    assert "coalesce(session_streams.name" in sql
+    assert "references" not in sql, (
+        "guarding on a column this call does not write would skip rows that need the name"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_fill_with_nothing_to_fill_issues_no_statement(monkeypatch):
+    dao, session = _dao(monkeypatch)
+
+    filled = await dao.fill_missing(project_id=_PROJECT, session_id="s-1")
+
+    assert filled is False
+    assert session.captured_stmt is None
+
+
+@pytest.mark.asyncio
+async def test_an_empty_proposal_is_not_a_proposal(monkeypatch):
+    """`""` and `[]` are "nothing to say", not "store empty". Each column is fillable
+    once, so writing either would spend that chance and refuse the real value later."""
+    dao, session = _dao(monkeypatch)
+
+    filled = await dao.fill_missing(
+        project_id=_PROJECT, session_id="s-1", name="", references=[]
+    )
+
+    assert filled is False
+    assert session.captured_stmt is None
+
+
+# ---------------------------------------------------------------------------------- #
+# The round trip: `key` survives storage.
+# ---------------------------------------------------------------------------------- #
+
+
+def test_references_round_trip_through_the_row_with_their_keys():
+    references = _references()
+
+    dbe = map_stream_dto_to_dbe_create(
+        project_id=_PROJECT,
+        user_id=None,
+        stream=SessionStreamCreate(session_id="s-1", references=references),
+    )
+    restored = map_stream_dbe_to_dto(stream_dbe=dbe)
+
+    assert [element["key"] for element in dbe.references] == [
+        "workflow",
+        "workflow_variant",
+        "workflow_revision",
+    ]
+    assert restored.references == references
+
+
+def test_an_untagged_legacy_element_still_reads_back():
+    # Rows written before elements carried a family must keep loading, untagged.
+    dbe = SessionStreamDBE(
+        id=uuid4(),
+        project_id=_PROJECT,
+        session_id="s-1",
+        references=[{"id": str(uuid4()), "slug": "legacy"}],
+    )
+
+    restored = map_stream_dbe_to_dto(stream_dbe=dbe)
+
+    assert restored.references[0].key is None
+    assert restored.references[0].slug == "legacy"
+
+
+def test_the_turn_append_accepts_and_stores_the_family_key():
+    """The runner stamps `key` on BOTH serializations, so the turn ledger has to keep it
+    too — not just the heartbeat. A partial family is the normal case: a variant-only run
+    emits exactly one element."""
+    from oss.src.apis.fastapi.sessions.models import SessionTurnAppendRequest
+    from oss.src.core.sessions.turns.dtos import SessionTurnCreate
+    from oss.src.dbs.postgres.sessions.turns.mappings import (
+        map_turn_dbe_to_dto,
+        map_turn_dto_to_dbe_create,
+    )
+
+    variant_id = uuid4()
+    request = SessionTurnAppendRequest.model_validate(
+        {
+            "session_id": "s-1",
+            "stream_id": str(uuid4()),
+            "turn_index": 0,
+            "harness_kind": "claude",
+            "references": [
+                {"id": str(variant_id), "slug": "wf", "key": "workflow_variant"}
+            ],
+        }
+    )
+
+    dbe = map_turn_dto_to_dbe_create(
+        project_id=_PROJECT,
+        user_id=None,
+        turn=SessionTurnCreate(
+            session_id="s-1",
+            stream_id=request.stream_id,
+            turn_index=0,
+            harness_kind=request.harness_kind,
+            references=request.references,
+        ),
+    )
+
+    assert dbe.references == [
+        {"slug": "wf", "id": str(variant_id), "key": "workflow_variant"}
+    ]
+    assert map_turn_dbe_to_dto(turn_dbe=dbe).references[0].key == "workflow_variant"
+
+
+def test_an_unrecognized_key_is_stored_rather_than_rejected():
+    """A turn append is fire-and-forget: rejecting an unknown family would drop the whole
+    turn, which is the failure the field exists to prevent."""
+    reference = SessionReference.model_validate(
+        {"id": str(uuid4()), "key": "application_revision"}
+    )
+
+    assert reference.key == "application_revision"
+
+
+# ---------------------------------------------------------------------------------- #
+# The read: the row's references win; the turn's are the fallback.
+# ---------------------------------------------------------------------------------- #
+
+
+class _FakeStreamsService:
+    def __init__(
+        self,
+        streams: List[SessionStream],
+        reference_session_ids: Optional[List[str]] = None,
+    ):
+        self._streams = streams
+        self.captured_session_ids: Optional[List[str]] = None
+        self.reference_session_ids = reference_session_ids or []
+
+    async def query_streams(self, **kwargs):
+        self.captured_session_ids = kwargs.get("session_ids")
+        return self._streams
+
+    async def count_streams(self, **kwargs):
+        return len(self._streams)
+
+    async def query_session_ids_by_references(self, *, project_id, references, limit):
+        return self.reference_session_ids[:limit]
+
+
+class _FakeTurnsService:
+    def __init__(
+        self,
+        turns: Dict[str, SessionTurn],
+        reference_session_ids: Optional[List[str]] = None,
+    ):
+        self._turns = turns
+        self.reference_session_ids = reference_session_ids or []
+
+    async def latest_turn_per_session(self, *, project_id, session_ids):
+        return {k: v for k, v in self._turns.items() if k in session_ids}
+
+    async def query_session_ids_by_references(self, *, project_id, references, limit):
+        return self.reference_session_ids[:limit]
+
+
+def _stream(session_id: str, references: Optional[List[SessionReference]] = None):
+    return SessionStream(
+        id=uuid4(),
+        project_id=_PROJECT,
+        session_id=session_id,
+        references=references,
+    )
+
+
+def _turn(session_id: str, references: List[SessionReference]) -> SessionTurn:
+    return SessionTurn(
+        id=uuid4(),
+        project_id=_PROJECT,
+        session_id=session_id,
+        stream_id=uuid4(),
+        turn_index=0,
+        harness_kind=HarnessKind.CLAUDE,
+        references=references,
+    )
+
+
+def _sessions_service(
+    streams,
+    turns,
+    *,
+    ids_by_turn_references=None,
+    ids_by_stream_references=None,
+):
+    streams_service = _FakeStreamsService(streams, ids_by_stream_references)
+    return (
+        SessionsService(
+            streams_service=streams_service,
+            turns_service=_FakeTurnsService(turns, ids_by_turn_references),
+            interactions_service=None,
+            mounts_service=None,
+        ),
+        streams_service,
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_list_prefers_the_row_over_the_turn():
+    row_references = _references()
+    turn_references = [SessionReference(id=uuid4(), key=ReferenceKey.workflow)]
+    svc, _ = _sessions_service(
+        [_stream("s-1", row_references)],
+        {"s-1": _turn("s-1", turn_references)},
+    )
+
+    result = await svc.query_sessions(project_id=_PROJECT)
+
+    assert result[0].references == row_references
+
+
+@pytest.mark.asyncio
+async def test_the_list_falls_back_to_the_turn_for_a_row_without_references():
+    # Every session that predates the column, plus any run whose beat carried nothing.
+    turn_references = [SessionReference(id=uuid4(), key=ReferenceKey.workflow)]
+    svc, _ = _sessions_service([_stream("s-1")], {"s-1": _turn("s-1", turn_references)})
+
+    result = await svc.query_sessions(project_id=_PROJECT)
+
+    assert result[0].references == turn_references
+
+
+@pytest.mark.asyncio
+async def test_a_session_with_neither_lists_without_references():
+    svc, _ = _sessions_service([_stream("s-1")], {})
+
+    result = await svc.query_sessions(project_id=_PROJECT)
+
+    assert result[0].references is None
+
+
+@pytest.mark.asyncio
+async def test_the_reference_filter_unions_both_reference_columns():
+    """An agent-scoped list must resolve through BOTH columns, or it disagrees with what
+    the list can open: a session whose turn append was dropped is findable only through
+    the stream row, and one that predates that column only through its turns."""
+    svc, streams_service = _sessions_service(
+        [_stream("s-turn"), _stream("s-stream")],
+        {},
+        ids_by_turn_references=["s-turn", "s-both"],
+        ids_by_stream_references=["s-stream", "s-both"],
+    )
+
+    await svc.query_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(turn_references=[SessionReference(id=uuid4())]),
+    )
+
+    assert streams_service.captured_session_ids == ["s-both", "s-stream", "s-turn"]
+
+
+@pytest.mark.asyncio
+async def test_a_stream_only_match_reaches_the_list():
+    """The whole point of the union, asserted on the returned rows rather than on the id
+    set: a session no turn reference can find still comes back from `query_sessions`."""
+    row_references = _references()
+    svc, _ = _sessions_service(
+        [_stream("s-stream-only", row_references)],
+        {},
+        ids_by_turn_references=[],
+        ids_by_stream_references=["s-stream-only"],
+    )
+
+    result = await svc.query_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(turn_references=[SessionReference(id=uuid4())]),
+    )
+
+    assert [item.session_id for item in result] == ["s-stream-only"]
+    assert result[0].references == row_references
+
+
+@pytest.mark.asyncio
+async def test_a_reference_matching_neither_column_still_short_circuits():
+    svc, streams_service = _sessions_service([], {})
+
+    result = await svc.query_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(turn_references=[SessionReference(id=uuid4())]),
+    )
+
+    assert result == []
+    assert streams_service.captured_session_ids is None, (
+        "an empty id set means the filter can match nothing; the row query is never run"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_union_is_re_capped():
+    # Each side is capped on its own, so their union could otherwise carry twice the
+    # bound P2-12 put on this derived set.
+    from oss.src.core.sessions.service import TURN_REFERENCES_SESSION_ID_CAP
+
+    cap = TURN_REFERENCES_SESSION_ID_CAP
+    svc, streams_service = _sessions_service(
+        [],
+        {},
+        ids_by_turn_references=[f"t-{i:04d}" for i in range(cap)],
+        ids_by_stream_references=[f"s-{i:04d}" for i in range(cap)],
+    )
+
+    await svc.query_sessions(
+        project_id=_PROJECT,
+        query=SessionQuery(turn_references=[SessionReference(id=uuid4())]),
+    )
+
+    assert len(streams_service.captured_session_ids) == cap
+
+
+@pytest.mark.asyncio
+async def test_the_reference_filter_still_matches_untagged_rows():
+    """`@>` is a containment match, so a filter carrying `key` would stop matching every
+    row written before elements were tagged. The query flatten drops it."""
+    from oss.src.core.sessions.turns.dtos import SessionTurnQuery
+    from oss.src.dbs.postgres.sessions.turns.utils import query_turn_references
+
+    reference = SessionReference(id=uuid4(), key=ReferenceKey.workflow)
+
+    flattened = query_turn_references(SessionTurnQuery(references=[reference]))
+
+    assert flattened == [{"id": str(reference.id)}]
+
+
+def test_the_stream_filter_is_unchanged_by_the_new_column():
+    # The list's row predicate never learned about references; the column is read-only
+    # decoration on a row already selected.
+    assert "references" not in SessionStreamQuery.model_fields
+    assert SessionQueryLifecycle().include_ended is False
+    assert SessionQuery().turn_references is None

--- a/api/oss/tests/pytest/unit/sessions/test_turns_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_turns_dao.py
@@ -20,7 +20,8 @@ from oss.src.core.sessions.turns.dtos import (
 )
 from oss.src.core.sessions.turns.service import SessionTurnsService
 from oss.src.core.sessions.turns.types import SessionTurnNotFound
-from oss.src.core.shared.dtos import Reference, Windowing
+from oss.src.core.sessions.types import SessionReference
+from oss.src.core.shared.dtos import Windowing
 import oss.src.models.db_models  # noqa: F401
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE  # noqa: F401
 from oss.src.dbs.postgres.sessions.turns.dao import SessionTurnsDAO
@@ -148,7 +149,7 @@ async def test_append_turn_persists_and_query_returns_turn_id(dao, project_and_s
     session_id = project_and_stream["session_id"]
     user_id = project_and_stream["user_id"]
 
-    workflow_ref = Reference(id=uuid.uuid4(), slug="my-workflow", version="v1")
+    workflow_ref = SessionReference(id=uuid.uuid4(), slug="my-workflow", version="v1")
 
     # span_id is a 16-hex OTel span id (runner shape), NOT a UUID; trace_id is a 32-hex
     # OTel trace id that still fits UUID.
@@ -207,7 +208,7 @@ async def test_complete_turn_is_guarded_idempotent_and_refuses_unknown(
     stream_id = project_and_stream["stream_id"]
     session_id = project_and_stream["session_id"]
     started_at = datetime.now(timezone.utc)
-    workflow_ref = Reference(id=uuid.uuid4(), slug="workflow", version="v1")
+    workflow_ref = SessionReference(id=uuid.uuid4(), slug="workflow", version="v1")
 
     started = await dao.append(
         project_id=project_id,
@@ -325,8 +326,8 @@ async def test_query_turns_filters_by_references_gin_contains(dao, project_and_s
         )
         await session.commit()
 
-    target_ref = Reference(id=uuid.uuid4(), slug="target-workflow", version="v1")
-    other_ref = Reference(id=uuid.uuid4(), slug="other-workflow", version="v1")
+    target_ref = SessionReference(id=uuid.uuid4(), slug="target-workflow", version="v1")
+    other_ref = SessionReference(id=uuid.uuid4(), slug="other-workflow", version="v1")
 
     matching = await dao.append(
         project_id=project_id,
@@ -370,7 +371,7 @@ async def test_query_session_ids_by_references_dedups_and_caps(dao, project_and_
     session_id = project_and_stream["session_id"]
     other_session_id = session_id + "-other"
 
-    target_ref = Reference(id=uuid.uuid4(), slug="target-workflow", version="v1")
+    target_ref = SessionReference(id=uuid.uuid4(), slug="target-workflow", version="v1")
 
     for turn_index in (0, 1):
         await dao.append(
@@ -460,7 +461,7 @@ async def test_query_turns_orders_by_turn_index_with_id_tiebreaker(
     )
     assert [r.turn_index for r in next_page] == [0]
 
-    tie_reference = Reference(id=uuid.uuid4(), slug="ordering-tie")
+    tie_reference = SessionReference(id=uuid.uuid4(), slug="ordering-tie")
     tied_turns = []
     for tied_session_id in (f"{session_id}-tie-a", f"{session_id}-tie-b"):
         tied_turns.append(

--- a/api/oss/tests/pytest/unit/sessions/test_wp5_root_router.py
+++ b/api/oss/tests/pytest/unit/sessions/test_wp5_root_router.py
@@ -23,7 +23,8 @@ from fastapi import FastAPI, HTTPException, Request
 from oss.src.apis.fastapi.sessions.router import SessionsRootRouter
 from oss.src.apis.fastapi.sessions.models import SessionQueryRequest
 from oss.src.core.sessions.dtos import SessionQueryPage
-from oss.src.core.shared.dtos import Reference, Windowing
+from oss.src.core.sessions.types import SessionReference
+from oss.src.core.shared.dtos import Windowing
 
 
 def _make_authed_request(app: FastAPI, project_id, user_id, method="POST") -> Request:
@@ -63,7 +64,7 @@ async def test_query_sessions_delegates_to_service():
     app = FastAPI()
     request = _make_authed_request(app, project_id, user_id)
 
-    target_ref = Reference(id=uuid4(), slug="wf", version="v1")
+    target_ref = SessionReference(id=uuid4(), slug="wf", version="v1")
     body = SessionQueryRequest(
         references=[target_ref], windowing=Windowing(order="descending")
     )

--- a/api/oss/tests/pytest/unit/workflows/test_ensure_request_revision_references.py
+++ b/api/oss/tests/pytest/unit/workflows/test_ensure_request_revision_references.py
@@ -1,0 +1,281 @@
+"""`_ensure_request_revision` writes the references it resolved back onto the request.
+
+Pre-embedding the revision into `request.data.revision` is what makes a headless invoke
+fast, and it is also what strands the session it creates: the SDK skips reference
+hydration whenever the caller supplied configuration, and that hydration is the only step
+that adds the sibling artifact and revision references. `test_run` forwards exactly one
+`workflow_variant` reference, so every session it created stored exactly that one — no
+artifact id, and therefore no way for the list to open the session (117 sessions with a
+variant-only reference navigated to `/apps/<variant-id>/playground`, a dead route).
+
+The write-back closes that. What it must NOT do is invent a family: re-keying an
+application request's resolution under `workflow` would leave the request carrying two
+competing families, which both the API and the SDK reject outright.
+"""
+
+from types import SimpleNamespace
+from typing import Optional
+from uuid import uuid4
+
+import pytest
+
+from agenta.sdk.models.workflows import WorkflowRequestData, WorkflowServiceRequest
+
+from oss.src.core.git.dtos import RetrievalInfo
+from oss.src.core.shared.dtos import Reference
+from oss.src.core.workflows.service import WorkflowsService
+
+
+class _StubWorkflowsService(WorkflowsService):
+    """The real `_ensure_request_revision`, with only the resolution stubbed."""
+
+    def __init__(
+        self, *, revision=None, retrieval_info: Optional[RetrievalInfo] = None
+    ):
+        self._revision = revision
+        self._retrieval_info = retrieval_info
+        self.retrieve_calls: list[dict] = []
+
+    async def retrieve_workflow_revision(self, **kwargs):
+        self.retrieve_calls.append(kwargs)
+        return self._revision, None, self._retrieval_info
+
+
+def _revision():
+    return SimpleNamespace(
+        data=SimpleNamespace(model_dump=lambda mode="json": {"url": "u"})
+    )
+
+
+def _retrieval_info(artifact_id, variant_id, revision_id) -> RetrievalInfo:
+    return RetrievalInfo(
+        references={
+            "workflow": Reference(id=artifact_id, slug="chat"),
+            "workflow_variant": Reference(id=variant_id, slug="chat"),
+            "workflow_revision": Reference(id=revision_id, slug="chat", version="3"),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_variant_only_request_ends_with_the_whole_family():
+    """The `test_run` shape: one variant reference in, the full family out."""
+    artifact_id, variant_id, revision_id = uuid4(), uuid4(), uuid4()
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=_retrieval_info(artifact_id, variant_id, revision_id),
+    )
+    request = WorkflowServiceRequest(
+        references={"workflow_variant": Reference(id=variant_id)}
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert set(request.references) == {
+        "workflow",
+        "workflow_variant",
+        "workflow_revision",
+    }
+    assert request.references["workflow"].id == artifact_id
+    assert request.references["workflow_revision"].id == revision_id
+    # Every element carries its slug, including the variant the caller sent as a bare id.
+    # The SDK-hydration path emits the variant slug, so a variant without one here would
+    # describe the same session differently depending on which producer wrote it.
+    assert request.references["workflow_variant"].id == variant_id
+    assert request.references["workflow_variant"].slug == "chat"
+    assert request.references["workflow"].slug == "chat"
+    assert request.references["workflow_revision"].version == "3"
+    # The reason the hydration that would have added them is skipped, unchanged.
+    assert request.data.revision == {"data": {"url": "u"}}
+
+
+@pytest.mark.asyncio
+async def test_the_callers_own_values_are_never_replaced():
+    # A caller's reference is the request, not a guess to be improved on: overwriting a
+    # value they set would silently redirect a run at something they did not ask for.
+    variant_id = uuid4()
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=_retrieval_info(uuid4(), variant_id, uuid4()),
+    )
+    caller_ref = Reference(id=variant_id, slug="as-the-caller-sent-it")
+    request = WorkflowServiceRequest(references={"workflow_variant": caller_ref})
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert request.references["workflow_variant"].id == variant_id
+    assert request.references["workflow_variant"].slug == "as-the-caller-sent-it"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_id_gains_the_slug_the_resolution_found():
+    variant_id = uuid4()
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=RetrievalInfo(
+            references={
+                "workflow_variant": Reference(id=variant_id, slug="chat", version="7"),
+            }
+        ),
+    )
+    request = WorkflowServiceRequest(
+        references={"workflow_variant": Reference(id=variant_id)}
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert request.references["workflow_variant"].id == variant_id
+    assert request.references["workflow_variant"].slug == "chat"
+    assert request.references["workflow_variant"].version == "7"
+
+
+@pytest.mark.asyncio
+async def test_a_caller_reference_sent_as_a_raw_dict_is_enriched_too():
+    # `references` is typed Union[Reference, dict] on the wire, so both shapes arrive.
+    variant_id = uuid4()
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=RetrievalInfo(
+            references={"workflow_variant": Reference(id=variant_id, slug="chat")}
+        ),
+    )
+    request = WorkflowServiceRequest(
+        references={"workflow_variant": {"id": variant_id}}
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert request.references["workflow_variant"].slug == "chat"
+
+
+@pytest.mark.asyncio
+async def test_a_reference_naming_a_different_entity_is_left_alone():
+    """Enriching across ids would produce one reference naming two things: the caller's
+    id with another entity's slug. Leave it exactly as sent instead."""
+    caller_variant_id = uuid4()
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=RetrievalInfo(
+            references={
+                "workflow_variant": Reference(id=uuid4(), slug="some-other-variant")
+            }
+        ),
+    )
+    request = WorkflowServiceRequest(
+        references={"workflow_variant": Reference(id=caller_variant_id)}
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert request.references["workflow_variant"].id == caller_variant_id
+    assert request.references["workflow_variant"].slug is None
+
+
+@pytest.mark.asyncio
+async def test_a_reference_whose_slug_disagrees_is_left_alone():
+    """The slug half of the same guard. A caller who pins a workflow by slug alone would
+    otherwise have another entity's id merged onto it, producing one reference that names
+    two entities — the failure mode the id guard already refuses in the other direction."""
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=RetrievalInfo(
+            references={
+                "workflow": Reference(id=uuid4(), slug="resolved-to-something-else")
+            }
+        ),
+    )
+    request = WorkflowServiceRequest(
+        references={"workflow": Reference(slug="as-the-caller-pinned-it")}
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert request.references["workflow"].slug == "as-the-caller-pinned-it"
+    assert request.references["workflow"].id is None
+
+
+@pytest.mark.asyncio
+async def test_the_resolution_is_written_back_under_the_callers_family():
+    """An application request must not come back carrying workflow references too.
+
+    Applications resolve through the workflow tables, so the resolution always reports
+    `workflow*` keys. Copying those keys verbatim would make the request carry two
+    populated families — the exact state `_validate_execution_reference_families` and its
+    SDK twin reject with a 400.
+    """
+    artifact_id = uuid4()
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=_retrieval_info(artifact_id, uuid4(), uuid4()),
+    )
+    request = WorkflowServiceRequest(
+        references={"application_variant": Reference(id=uuid4())}
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert set(request.references) == {
+        "application",
+        "application_variant",
+        "application_revision",
+    }
+    assert request.references["application"].id == artifact_id
+    assert "workflow" not in request.references
+
+
+@pytest.mark.asyncio
+async def test_an_environment_backed_request_gains_the_workflow_family():
+    # An environment reference names no artifact family of its own, so the resolved
+    # workflow family is what the session needs to be openable.
+    artifact_id = uuid4()
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=RetrievalInfo(
+            references={
+                "environment": Reference(id=uuid4(), slug="production"),
+                "environment_revision": Reference(id=uuid4()),
+                "workflow": Reference(id=artifact_id),
+                "workflow_revision": Reference(id=uuid4()),
+            }
+        ),
+    )
+    environment_ref = Reference(id=uuid4(), slug="production")
+    request = WorkflowServiceRequest(references={"environment": environment_ref})
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert request.references["workflow"].id == artifact_id
+    assert "workflow_revision" in request.references
+    assert request.references["environment"].slug == "production"
+    # Only the artifact family is written back; the environment's own siblings are not
+    # the session's target and adding them would widen what is stored for no reader.
+    assert "environment_revision" not in request.references
+
+
+@pytest.mark.asyncio
+async def test_a_request_that_already_carries_a_revision_is_left_alone():
+    service = _StubWorkflowsService(
+        revision=_revision(),
+        retrieval_info=_retrieval_info(uuid4(), uuid4(), uuid4()),
+    )
+    request = WorkflowServiceRequest(
+        references={"workflow_variant": Reference(id=uuid4())},
+        data=WorkflowRequestData(revision={"data": {"url": "already-here"}}),
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert set(request.references) == {"workflow_variant"}
+    assert service.retrieve_calls == []
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_reference_leaves_the_request_untouched():
+    service = _StubWorkflowsService(revision=None, retrieval_info=None)
+    request = WorkflowServiceRequest(
+        references={"workflow_variant": Reference(id=uuid4())}
+    )
+
+    await service._ensure_request_revision(project_id=uuid4(), request=request)
+
+    assert set(request.references) == {"workflow_variant"}


### PR DESCRIPTION
## Context

**What the user sees.** The session list in the OSS deployment shows thousands of rows named "Untitled". Most of those rows do nothing when you click them.

**Why it happens.** There are two causes. We wrote them up in `docs/design/untitled-sessions-investigation/findings.md`, which lands with the top PR of this stack.

*Cause 1: only the browser writes session titles.* A run that no browser renders never gets a title. That covers test runs, evaluations, scheduled triggers and direct API calls. We audited one database. It held 7,948 sessions, and 7,836 of them had no title. Not one of those came from the UI.

*Cause 2: headless runs save an incomplete reference set.* A "reference" is a pointer to a stored entity, such as `{"id": "..."}`. A run has three of them: the workflow, its variant and its revision. This PR calls those three the "family". The API function `_ensure_request_revision` puts the resolved revision directly into the request body. The SDK sees the revision, so it skips its own reference lookup. That lookup is the only step that attaches the sibling `workflow` and `workflow_revision` references. Without them the frontend has no workflow id, so it cannot build a link for the row.

## Changes

### 1. The server fills the title, one time only

The heartbeat is the periodic call the runner makes to the API to say a run is still alive. The heartbeat request now takes an optional `name`. The browser send path (`_start_turn`) sends a name too.

Both writers set the name only while the stored name is NULL. This PR calls that "fill once". A rename overwrites the name, so a rename always wins. The browser auto-title also overwrites, so it wins too. The fill never overwrites anything.

### 2. The API writes the resolved references back onto the request

`_ensure_request_revision` now copies the references it resolved back onto the request. The turn then records the whole family instead of only what the caller sent.

Look at the references a `test_run` request ends up storing.

Before:

```json
[{"id": "<variant-id>"}]
```

After:

```json
[{"id": "<workflow-id>", "slug": "my-agent", "key": "workflow"},
 {"id": "<variant-id>", "slug": "my-agent.default", "key": "workflow_variant"},
 {"id": "<revision-id>", "version": "3", "key": "workflow_revision"}]
```

The caller's own values always win. The write-back only fills the fields the caller left out. It refuses to merge when the caller's id or slug names a different entity than the one the lookup found.

### 3. The session row keeps its own copy of the references

A turn append is fire and forget. The API does not wait for it, so it can be lost. Until now the references rode only on that append.

Migration `oss000000021` adds a `references` column to `session_streams`. The column is JSONB and nullable. The migration also adds a GIN index that uses `jsonb_path_ops`.

The heartbeat fills the column once. The session list reads the column first, and falls back to the latest turn's references when the column is empty. The reference filter searches both columns and joins the two result sets. Each of the two queries sorts by last activity, so the cap keeps the newest rows.

A session whose turn append was dropped is no longer stuck. It opens, and agent-scoped queries still find it.

### 4. Each reference says which family member it is

A reference element now accepts an optional `key`. The value is `workflow`, `workflow_variant` or `workflow_revision`. Evaluation-run references and tracing attributes already use this same convention.

We store `key` permissively. An unknown value is kept, never rejected. A strict check would drop the whole turn append, and a dropped append is the failure this field exists to prevent. Containment filters leave `key` out, so rows written before the tag still match.

## Deploy ordering (read this before you deploy)

**What breaks.** The new API code needs the new column. Against a database without the migration, three things fail: `/sessions/query`, the heartbeat and `_start_turn`. The playground cannot start a turn.

**When it breaks.** Compose deploys are safe, because the api service waits for the alembic job. Two other cases are real risks:

1. A dev box hot-reloads this code but never reruns alembic. Note that `run.sh --recreate api` does not rerun it.
2. A rolling deploy puts the API image live before the migration runs.

**What to do.** Run the migration first. Start the new API code after it finishes.

## Tests

- 2,683 unit tests pass (`oss` plus `ee`). ruff reports nothing.
- 41 integration tests ran against a throwaway postgres:16. The full migration chain ran from an empty database. We read the query plan and confirmed it uses the new GIN index for the containment check. The suite skips itself when Postgres is unreachable.
- Live QA on a standalone OSS dev stack:
  - A headless `test_run` created a session. Its title was 60 code points long. `created_by_id` was NULL. The complete keyed family was on both the stream row and the turn.
  - The list returned that session even though it had zero turns.
  - Running the invoke again did not change the title. Fill-once held.
  - A rename stuck.
  - A first message with only an image wrote NULL, not an empty string.

## Related issue

Related: #5110 (AGE-3915). The write-back records the resolved revision on the session references when the run fires. That covers most of the audit-trail ask in that issue. But the trigger delivery row's `result` field still has no resolved revision, because this PR does not touch the dispatcher. So this PR does not close #5110.

## Stack

This is the bottom PR of three.

1. This PR: the API.
2. Next: the runner lane. It adds typed references and the name proposal.
3. Top: the web lane. It makes each list show only rows it can open.
