### PR TITLE
[fix] Keep reference families and propose session names from the runner

### DIFF
--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -21,7 +21,7 @@ import {
 } from "../../responder.ts";
 import {
   buildInteractionData,
-  buildWorkflowReferences,
+  buildWorkflowReferenceList,
   createInteraction,
   resolveInteraction,
 } from "../../sessions/interactions.ts";
@@ -367,7 +367,7 @@ export async function runTurn(
           }
         : undefined;
     if (turnLedgerContext) {
-      const workflowRefs = buildWorkflowReferences(
+      const workflowRefs = buildWorkflowReferenceList(
         request.runContext?.workflow,
       );
       // Row existence proves only that a turn started. Native continuation is trustworthy only
@@ -381,7 +381,7 @@ export async function runTurn(
           turnId: request.turnId,
           agentSessionId: env.session?.agentSessionId,
           sandboxId: env.sandbox?.sandboxId,
-          references: workflowRefs ? Object.values(workflowRefs) : undefined,
+          references: workflowRefs,
           traceId: run.traceId() ?? request.runContext?.trace?.trace_id,
           spanId: request.runContext?.trace?.span_id,
           startTime: turnStartedAt,

--- a/services/runner/src/engines/sandbox_agent/session-continuity-durable.ts
+++ b/services/runner/src/engines/sandbox_agent/session-continuity-durable.ts
@@ -9,14 +9,23 @@
  * `session_states.data` blob.
  */
 import { apiBase } from "../../apiBase.ts";
+import type { ReferenceKey } from "../../sessions/interactions.ts";
 import type { SessionContinuityStore } from "./session-continuity.ts";
 
 function defaultLog(msg: string): void {
   process.stderr.write(`[session-continuity/durable] ${msg}\n`);
 }
 
-/** A platform entity reference (the API `Reference` shape). */
-export type TurnReference = { id?: string; slug?: string; version?: string };
+/**
+ * A platform entity reference (the API `Reference` shape), plus which workflow entity it names.
+ * `key` is optional on the type because rows written before it existed carry none.
+ */
+export type TurnReference = {
+  id?: string;
+  slug?: string;
+  version?: string;
+  key?: ReferenceKey;
+};
 
 export interface WireSessionTurn {
   turn_id?: string;

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -68,7 +68,11 @@ import { applyDaytonaSdkEnv } from "./engines/sandbox_agent/daytona-provider.ts"
 import { isEntrypoint } from "./entry.ts";
 import { insecureEgressAllowed } from "./tools/ssrf-guard.ts";
 import { startAliveWatchdog } from "./sessions/alive.ts";
-import { cancelStaleInteractions } from "./sessions/interactions.ts";
+import {
+  buildWorkflowReferenceList,
+  cancelStaleInteractions,
+} from "./sessions/interactions.ts";
+import { proposeSessionName } from "./sessions/name.ts";
 import {
   buildPersistingEmitter,
   noteRecordsIncomplete,
@@ -477,11 +481,20 @@ async function runAndStreamWithApiBaseResolved(
     // `controller.abort()` is what makes the control-plane signal actually reach this
     // in-flight run — before this, a session-owned run's controller was never aborted.
     // Awaited (WP3) so the first heartbeat's stream_id is ready before the turn starts.
+    //
+    // The beat also proposes the two things a headless session otherwise never gets: a name
+    // (no browser ever renders it, and the browser is the only other title writer) and the
+    // run's workflow references (they ride only a fire-and-forget turn append today, so a
+    // dropped append leaves a row the UI cannot open). Both are fill-once server-side.
     const watchdog = await startAliveWatchdog(
       sessionId,
       turnId,
       runCredential(request),
       () => controller.abort(),
+      {
+        name: proposeSessionName(request),
+        references: buildWorkflowReferenceList(request.runContext?.workflow),
+      },
     );
     aliveWatchdog = watchdog;
     // The heartbeat response already carries the session_streams row id — free, no extra

--- a/services/runner/src/sessions/alive.ts
+++ b/services/runner/src/sessions/alive.ts
@@ -32,7 +32,19 @@ export const REPLICA_ID =
   process.env.AGENTA_RUNNER_REPLICA_ID?.trim() || randomUUID();
 
 import { refreshCredential } from "./auth.ts";
+import type { TypedReference } from "./interactions.ts";
 
+/**
+ * Fill-once session facts this run proposes alongside the beat. The server writes each only
+ * while the stored value is NULL, so every beat may carry them: a beat can fill a NULL field
+ * once, never change an existing one, and the "heartbeats don't churn headers" invariant holds.
+ */
+export interface SessionProposal {
+  /** A name for an otherwise-untitled session (see `sessions/name.ts`). */
+  name?: string;
+  /** The run's workflow references, so the stream row is openable without a turn append. */
+  references?: TypedReference[];
+}
 
 /** Refresh the run credential every Nth heartbeat (well inside the ~15-min token TTL). */
 const REFRESH_EVERY_N_HEARTBEATS = Math.max(
@@ -62,6 +74,7 @@ async function sendHeartbeat(
   turnId: string,
   authorization: string,
   isRunning = true,
+  proposal?: SessionProposal,
 ): Promise<{ streamId: string | undefined; interrupted: boolean }> {
   try {
     const url = `${apiBase()}/sessions/streams/heartbeat`;
@@ -76,6 +89,10 @@ async function sendHeartbeat(
         replica_id: REPLICA_ID,
         turn_id: turnId,
         is_running: isRunning,
+        ...(proposal?.name ? { name: proposal.name } : {}),
+        ...(proposal?.references?.length
+          ? { references: proposal.references }
+          : {}),
       }),
     });
     if (!res.ok) {
@@ -161,12 +178,16 @@ export async function claimSessionOwnership(
  * starts the turn — every later heartbeat stays fire-and-forget. Returns a `release()` function
  * the caller MUST await in the run's `finally` so the heartbeat stops and the row is marked
  * `ended`.
+ *
+ * `proposal` rides EVERY beat rather than only the first. The server fills each field once, so
+ * repeating them is a no-op, and one payload for all beats beats a "was this the first?" flag.
  */
 export async function startAliveWatchdog(
   sessionId: string,
   turnId: string,
   authorization: string,
   onInterrupted?: () => void,
+  proposal?: SessionProposal,
 ): Promise<{
   release: () => Promise<void>;
   credential: () => string;
@@ -192,7 +213,13 @@ export async function startAliveWatchdog(
   };
 
   // Await the FIRST beat so streamId is ready before the caller starts the turn.
-  const first = await sendHeartbeat(sessionId, turnId, credential);
+  const first = await sendHeartbeat(
+    sessionId,
+    turnId,
+    credential,
+    true,
+    proposal,
+  );
   handleBeat(first);
 
   const interval = setInterval(() => {
@@ -202,7 +229,9 @@ export async function startAliveWatchdog(
         const fresh = await refreshCredential(apiBase(), credential);
         if (fresh) credential = fresh;
       }
-      handleBeat(await sendHeartbeat(sessionId, turnId, credential));
+      handleBeat(
+        await sendHeartbeat(sessionId, turnId, credential, true, proposal),
+      );
     })();
   }, REFRESH_INTERVAL_MS);
 
@@ -215,7 +244,7 @@ export async function startAliveWatchdog(
     async release() {
       clearInterval(interval);
       // Mark the stream row ended (best-effort; the orphan sweep catches a miss).
-      await sendHeartbeat(sessionId, turnId, credential, false);
+      await sendHeartbeat(sessionId, turnId, credential, false, proposal);
     },
     credential: () => credential,
     streamId: () => streamId,

--- a/services/runner/src/sessions/interactions.ts
+++ b/services/runner/src/sessions/interactions.ts
@@ -17,6 +17,28 @@ export type InteractionResolution = {
 type Reference = { id?: string; slug?: string; version?: string };
 
 /**
+ * Which of the three workflow entities a reference names. Spelled `key`, matching the
+ * reference lists evaluation runs already store.
+ */
+export type ReferenceKey =
+  | "workflow"
+  | "workflow_variant"
+  | "workflow_revision";
+
+/**
+ * A reference that still says which entity it names after it leaves the keyed map. Stored
+ * reference lists are flat, so without this a reader can only guess which id is the workflow.
+ */
+export type TypedReference = Reference & { key: ReferenceKey };
+
+/** The run's workflow identity: the artifact (the workflow), its variant, and its revision. */
+type WorkflowIdentity = {
+  artifact?: Reference;
+  variant?: Reference;
+  revision?: Reference;
+};
+
+/**
  * The gated call a durable interaction row describes.
  *
  * `tool_call_id` is the HARNESS's id for the call, which the interaction `token` is not — the
@@ -47,13 +69,7 @@ export type InteractionData = {
 
 /** Build the invoke `references` from the runner's run-context workflow identity. */
 export function buildWorkflowReferences(
-  workflow:
-    | {
-        artifact?: Reference;
-        variant?: Reference;
-        revision?: Reference;
-      }
-    | undefined,
+  workflow: WorkflowIdentity | undefined,
 ): Record<string, Reference> | undefined {
   if (!workflow) return undefined;
   const refs: Record<string, Reference> = {};
@@ -64,19 +80,30 @@ export function buildWorkflowReferences(
 }
 
 /**
+ * The same identity as the flat list every PERSISTED shape uses (the turn-ledger append, the
+ * session heartbeat), each element carrying the family key it was stored under. That key is the
+ * only place the family lives, so serializing the map's values alone strands the reader with
+ * bare uuids and no way to tell the workflow from its variant.
+ */
+export function buildWorkflowReferenceList(
+  workflow: WorkflowIdentity | undefined,
+): TypedReference[] | undefined {
+  const refs = buildWorkflowReferences(workflow);
+  if (!refs) return undefined;
+  return Object.entries(refs).map(([key, reference]) => ({
+    ...reference,
+    key: key as ReferenceKey,
+  }));
+}
+
+/**
  * The durable `data` for one gate: what was asked, who to attribute it to, and what config the
  * turn ran under. The two attribution fields are omitted (not null, not `{}`) when the request
  * carries neither, so a legacy row's shape is exactly what it was before this field existed.
  */
 export function buildInteractionData(
   request: {
-    runContext?: {
-      workflow?: {
-        artifact?: Reference;
-        variant?: Reference;
-        revision?: Reference;
-      };
-    };
+    runContext?: { workflow?: WorkflowIdentity };
     effectiveParameters?: Record<string, unknown>;
   },
   tool: string,

--- a/services/runner/src/sessions/name.ts
+++ b/services/runner/src/sessions/name.ts
@@ -1,0 +1,31 @@
+/**
+ * The session name this run proposes to the coordination plane.
+ *
+ * A session is named by the browser today, so any run no browser ever rendered (a headless
+ * invoke, a scheduled trigger) stays untitled forever. The runner is the one place every
+ * execution path passes through holding both the session id and the user's first message, so it
+ * proposes a name on the heartbeat; the server fills it only while the stored name is NULL, and
+ * a rename or the browser's own auto-title always wins by overwriting.
+ */
+import { type AgentRunRequest, messageText } from "../protocol.ts";
+
+/** Mirrors the browser auto-title's `AUTO_TITLE_MAX_CHARS` so both writers produce one string. */
+const NAME_MAX_CODE_POINTS = 60;
+
+/**
+ * The first user message's text, trimmed and capped. Undefined when the request carries no
+ * readable user text at all (an attachment- or image-only turn, or a resume whose tail is a
+ * tool envelope) — a session is better untitled than titled with an empty string.
+ */
+export function proposeSessionName(
+  request: AgentRunRequest,
+): string | undefined {
+  for (const message of request.messages ?? []) {
+    if (message?.role !== "user") continue;
+    const text = messageText(message.content).trim();
+    if (!text) continue;
+    // Cut on code points, not UTF-16 units, so an emoji straddling the cap isn't halved.
+    return Array.from(text).slice(0, NAME_MAX_CODE_POINTS).join("");
+  }
+  return undefined;
+}

--- a/services/runner/tests/unit/session-proposal.test.ts
+++ b/services/runner/tests/unit/session-proposal.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for the fill-once session facts the runner proposes on its heartbeat:
+ *
+ *  - `proposeSessionName` — the first user message's text, trimmed and capped on CODE POINTS,
+ *    the only thing that names a session no browser ever renders.
+ *  - `buildWorkflowReferenceList` — the flat, `key`-discriminated serialization every stored
+ *    reference list uses. A bare `Object.values` of the keyed map drops the family, which is
+ *    what left stored turns as three (or one) anonymous uuids.
+ *  - the heartbeat body carrying both.
+ */
+import { describe, it, beforeEach, afterEach, vi } from "vitest";
+import assert from "node:assert/strict";
+
+import type { AgentRunRequest } from "../../src/protocol.ts";
+
+const fetchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+  fetchCalls.push({
+    url,
+    body: init?.body ? JSON.parse(init.body as string) : {},
+  });
+  return new Response(
+    JSON.stringify({ ok: true, stream: { id: "stream-1" } }),
+    {
+      status: 200,
+    },
+  );
+});
+
+const { startAliveWatchdog } = await import("../../src/sessions/alive.ts");
+const { buildWorkflowReferenceList } =
+  await import("../../src/sessions/interactions.ts");
+const { proposeSessionName } = await import("../../src/sessions/name.ts");
+
+/** A minimal request carrying only what the proposal reads. */
+function requestWith(messages: AgentRunRequest["messages"]): AgentRunRequest {
+  return { messages } as AgentRunRequest;
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("proposeSessionName", () => {
+  it("takes the first user message's text, trimmed", () => {
+    const name = proposeSessionName(
+      requestWith([{ role: "user", content: "  ship the release  " }]),
+    );
+    assert.equal(name, "ship the release");
+  });
+
+  it("concatenates text parts and ignores non-text ones", () => {
+    const name = proposeSessionName(
+      requestWith([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "check " },
+            { type: "image", data: "AAAA", mimeType: "image/png" },
+            { type: "text", text: "this screenshot" },
+          ],
+        },
+      ]),
+    );
+    assert.equal(name, "check this screenshot");
+  });
+
+  it("names the session from the FIRST user message, not the latest turn", () => {
+    const name = proposeSessionName(
+      requestWith([
+        { role: "user", content: "first ask" },
+        { role: "assistant", content: "done" },
+        { role: "user", content: "second ask" },
+      ]),
+    );
+    assert.equal(name, "first ask");
+  });
+
+  it("caps at 60 code points without halving an emoji at the boundary", () => {
+    const text = `${"a".repeat(59)}😀b`;
+    const name = proposeSessionName(
+      requestWith([{ role: "user", content: text }]),
+    );
+    assert.ok(name);
+    assert.equal(Array.from(name).length, 60);
+    assert.ok(name.endsWith("😀"), "the emoji was split into a lone surrogate");
+  });
+
+  it("is undefined when the turn carries no readable text", () => {
+    assert.equal(proposeSessionName(requestWith([])), undefined);
+    assert.equal(
+      proposeSessionName(requestWith([{ role: "assistant", content: "hi" }])),
+      undefined,
+    );
+    assert.equal(
+      proposeSessionName(
+        requestWith([
+          {
+            role: "user",
+            content: [
+              { type: "image", data: "AAAA", mimeType: "image/png" },
+              { type: "text", text: "   " },
+            ],
+          },
+        ]),
+      ),
+      undefined,
+    );
+    assert.equal(proposeSessionName({} as AgentRunRequest), undefined);
+  });
+});
+
+describe("buildWorkflowReferenceList", () => {
+  it("discriminates each element by its workflow entity, keeping slug and version", () => {
+    const refs = buildWorkflowReferenceList({
+      artifact: { id: "wf-1", slug: "my-agent" },
+      variant: { id: "var-1", slug: "default" },
+      revision: { id: "rev-1", version: "3" },
+    });
+    assert.deepEqual(refs, [
+      { id: "wf-1", slug: "my-agent", key: "workflow" },
+      { id: "var-1", slug: "default", key: "workflow_variant" },
+      { id: "rev-1", version: "3", key: "workflow_revision" },
+    ]);
+  });
+
+  it("keeps the key on a partial family — the variant-only headless shape", () => {
+    assert.deepEqual(buildWorkflowReferenceList({ variant: { id: "var-1" } }), [
+      { id: "var-1", key: "workflow_variant" },
+    ]);
+  });
+
+  it("is undefined when the run has no workflow identity", () => {
+    assert.equal(buildWorkflowReferenceList(undefined), undefined);
+    assert.equal(buildWorkflowReferenceList({}), undefined);
+  });
+});
+
+describe("heartbeat session proposal", () => {
+  it("carries name and typed references on the first beat", async () => {
+    const watchdog = await startAliveWatchdog(
+      "sess-1",
+      "turn-1",
+      "cred",
+      undefined,
+      {
+        name: "ship the release",
+        references: buildWorkflowReferenceList({
+          artifact: { id: "wf-1" },
+          variant: { id: "var-1" },
+        }),
+      },
+    );
+
+    const beat = fetchCalls.find((c) => c.url.includes("heartbeat"));
+    assert.ok(beat);
+    assert.equal(beat.body["name"], "ship the release");
+    assert.deepEqual(beat.body["references"], [
+      { id: "wf-1", key: "workflow" },
+      { id: "var-1", key: "workflow_variant" },
+    ]);
+
+    await watchdog.release();
+  });
+
+  it("repeats the proposal on the turn-end beat — the server fills each field once", async () => {
+    const watchdog = await startAliveWatchdog(
+      "sess-2",
+      "turn-2",
+      "cred",
+      undefined,
+      { name: "ship the release" },
+    );
+    fetchCalls.length = 0;
+
+    await watchdog.release();
+
+    const beat = fetchCalls.find((c) => c.url.includes("heartbeat"));
+    assert.ok(beat);
+    assert.equal(beat.body["is_running"], false);
+    assert.equal(beat.body["name"], "ship the release");
+  });
+
+  it("omits both fields when the run proposes neither", async () => {
+    const watchdog = await startAliveWatchdog("sess-3", "turn-3", "cred");
+
+    const beat = fetchCalls.find((c) => c.url.includes("heartbeat"));
+    assert.ok(beat);
+    assert.ok(!("name" in beat.body), "an empty name must not be sent");
+    assert.ok(!("references" in beat.body), "an empty list must not be sent");
+
+    await watchdog.release();
+  });
+});


### PR DESCRIPTION
## Context

This is the second PR of the untitled-sessions stack. It sits on top of #5991.

**What the user sees.** Clicking a session row sometimes goes nowhere. The link points at a route that does not exist.

**Why it happens.** The runner creates the session row for every headless run. It stored references that carried no label.

A "reference" is a pointer to a stored entity, such as `{"id": "..."}`. A run has three of them: the workflow, its variant and its revision. `buildWorkflowReferences` builds them as a map with those three names as keys. The old code then serialized the map with `Object.values(...)`, which throws the keys away. The stored list held three bare ids and nothing that says which is which.

So the frontend had to guess. It treated the first UUID as the agent. Sometimes that UUID was a variant id, and a variant id is a dead route.

## Changes

### Each reference keeps its family name

Every serialized reference element now carries a `key`.

Look at the reference list the runner sends for one run.

Before:

```json
[{"id": "wf-1"}, {"id": "var-1"}, {"id": "rev-1"}]
```

After:

```json
[{"id": "wf-1", "key": "workflow"}, {"id": "var-1", "key": "workflow_variant"}, {"id": "rev-1", "key": "workflow_revision"}]
```

### The heartbeat proposes a session name

The heartbeat is the periodic call the runner makes to the API to say a run is still alive.

A new function, `proposeSessionName(request)`, builds a title. It takes the first user message that has text. It joins that message's text parts, trims the result, and cuts it to 60 Unicode code points. It counts code points rather than UTF-16 units, so it never splits an emoji in half. It proposes nothing when the input carries only attachments.

The proposal and the run's typed references ride every heartbeat, including the final beat that releases the session. The API from #5991 fills each field only while the stored value is NULL. So a repeat is a no-op, and a rename always wins.

One difference between the two writers is on purpose. The API's browser path reads the first user message only, which matches what the browser does. The runner instead skips ahead to the first message that has text. Fill-once makes the two work together: a session whose first message is an image still gets a title from its first readable message.

## Tests

- `pnpm run typecheck` is clean.
- 2,144 unit tests, 8 integration tests and 18 acceptance tests pass.
- 12 new unit tests cover `proposeSessionName` and the typed serialization. One of them checks the code-point cut on a string that ends in an emoji.
- The live QA run in #5991 exercised this end to end. The heartbeat created the row with the proposed name and the keyed references.
