### PR TITLE
fix(observability): stop clipping wide y-axis labels on usage charts

### DIFF
--- a/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx
+++ b/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx
@@ -46,7 +46,7 @@ const CustomAreaChart: React.FC<CustomAreaChartProps> = ({
     return (
         <div className={`w-full ${className}`}>
             <ResponsiveContainer width="100%" height="100%">
-                <ReAreaChart data={data} margin={{top: 5, right: 5, left: -20, bottom: 0}}>
+                <ReAreaChart data={data} margin={{top: 5, right: 5, left: 0, bottom: 0}}>
                     <defs>
                         {categories.map((category, idx) => {
                             const colorKey = colors[idx % colors.length]


### PR DESCRIPTION
Fixes #5968

## Problem
The Usage card's Latency and Cost charts clip the leading digit of any
y-axis label wider than ~4 characters (e.g. 20Kms renders as 0Kms, 15Kms
as 5Kms), making the scale look like it counts down and back up.

## Root cause
CustomAreaChart.tsx sets a negative left margin on the chart
(`margin={{..., left: -20, ...}}`). This shifts the entire plot area,
including the y-axis tick labels, 20px left of where it should render.
Short labels (0ms, 5Kms) still fit within the SVG bounds after the shift,
but wider labels get pushed past the left edge and their leading
characters are clipped.

## Fix
Changed the margin's `left` value from `-20` to `0`, removing the offset
that pushes labels off-canvas.

## Testing
I wasn't able to get the local dev server running in time to capture a
before/after screenshot (dependency install + first-time package builds
didn't finish in my session). The root cause is directly confirmed by the
issue's own measurements — the reported label x-coordinates (-5, -8) match
exactly what a -20px left margin would produce for labels of that width.
Happy to provide a recording once I can get the dev environment running,
or if a maintainer can verify visually in the meantime.