### PR TITLE
fix(ui): stop long summaries from squeezing short titles in ConfigAccordionSection

### DIFF
--- a/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/section/ConfigAccordionSection.tsx
@@ -380,7 +380,7 @@ export function ConfigAccordionSection({
                     <span className="relative flex min-w-0">
                         <span
                             className={cn(
-                                "min-w-0 truncate font-medium",
+                                "shrink-0 truncate font-medium",
                                 size === "compact" ? "text-xs" : "text-sm",
                             )}
                         >
@@ -412,7 +412,7 @@ export function ConfigAccordionSection({
                     {titleBadge ? <span className="shrink-0">{titleBadge}</span> : null}
                 </div>
 
-                <div className="flex shrink-0 items-center gap-2">
+                <div className="flex min-w-0 items-center gap-2">
                     {summary && (!summaryCollapsedOnly || !isOpen) ? (
                         // antd `Text type="secondary"` is colorTextDescription, not colorTextSecondary.
                         <span className="max-w-[220px] truncate text-right text-xs text-colorTextDescription">


### PR DESCRIPTION
Fixes #5970

## Problem
The "Advanced" row's title in the agent Overview Configuration rail
renders as "Advan…" — clipped — while every other row's title shows in
full, even though "Advanced" is the shortest title of the group.

## Root cause
In ConfigAccordionSection, the title container has `min-w-0` (lets it
shrink to any size, even below its own content) while the summary
container has `shrink-0` (refuses to shrink at all, always claims its
full width up to its `max-w-[220px]` cap). The Advanced row's summary
("Sandbox: local · Permissions: allow-all") is the longest summary text
of any row in this rail — it claims its full space unconditionally, and
the title gets squeezed into whatever's left, even though the title
itself is short.

## Fix
Swapped which side is allowed to shrink: the title now keeps `shrink-0`
(renders at its natural size), and the summary container now has
`min-w-0` instead. The summary already has its own `truncate` +
`max-w-[220px]`, so it degrades gracefully with an ellipsis when space
is tight — it was designed to be the one that truncates, not the title.

## Scope note
ConfigAccordionSection is a shared primitive used elsewhere (e.g. the
agent playground config panel), not just this one card. This change only
affects layout when a summary was already claiming disproportionate
space at a short title's expense — every row where that squeeze wasn't
happening is visually unchanged. Flagging for a maintainer to
double-check other usages, since I wasn't able to get the local dev
server running to visually verify across all surfaces tonight.

## Testing
No existing test file covers this component's layout behavior. Happy to
add one if useful, or if a maintainer can verify visually — this is a
two-line class change with no logic changes.