### PR TITLE
fix(frontend): Keep agent question textarea inside its card

### DIFF
--- a/web/packages/agenta-entity-ui/src/gatewayTool/components/SchemaForm.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTool/components/SchemaForm.tsx
@@ -16,10 +16,10 @@ import {
     AccordionContent,
     AccordionItem,
     AccordionTrigger,
+    AutosizeTextarea,
     Button,
     Input,
     InputNumber,
-    Textarea,
 } from "@agenta/ui/ui"
 import {CaretLeft, CaretRight, Check, MinusCircle, Plus} from "@phosphor-icons/react"
 // DELIBERATE RESIDUE — antd `Form` stays as the state engine (registration, rules,
@@ -1168,7 +1168,12 @@ function SchemaFormField({
                         rules={rules}
                         initialValue={field.default}
                     >
-                        <Textarea rows={3} placeholder={field.label} disabled={disabled} />
+                        {/* Autosize owns the height, so there is no grabber to drag off the card. */}
+                        <AutosizeTextarea
+                            autoSize={{minRows: 3, maxRows: 20}}
+                            placeholder={field.label}
+                            disabled={disabled}
+                        />
                     </Form.Item>
                 )
             }

--- a/web/packages/agenta-ui/src/components/ui/input.tsx
+++ b/web/packages/agenta-ui/src/components/ui/input.tsx
@@ -80,7 +80,12 @@ function Textarea({className, variant, size, rows = 3, ...props}: TextareaProps)
             data-slot="textarea"
             rows={rows}
             // align-bottom = antd's `vertical-align: bottom` — kills the inline descender gap under the box.
-            className={cn(inputVariants({variant, size}), "py-input-y align-bottom", className)}
+            // resize-y: preflight is off, so the UA default `resize: both` drags out of the container.
+            className={cn(
+                inputVariants({variant, size}),
+                "py-input-y align-bottom resize-y",
+                className,
+            )}
             {...props}
         />
     )


### PR DESCRIPTION
## Context

The agent asks questions in the playground through an inline card. When a question is an open text question, its input was a plain textarea locked at three rows, and two things went wrong. You could grab the corner and drag it sideways until it spilled out of the card. A long answer also stayed squeezed into three visible lines, so reading back what you had written meant dragging the box bigger by hand.

The sideways drag has a simple cause. Tailwind preflight is switched off across the app on purpose, so antd keeps its own styles. That leaves the browser default of `resize: both` in place on every textarea.

## Changes

The open text question now renders `AutosizeTextarea` instead of a fixed `Textarea`.

Before:

```tsx
<Textarea rows={3} placeholder={field.label} disabled={disabled} />
```

After:

```tsx
<AutosizeTextarea autoSize={{minRows: 3, maxRows: 20}} placeholder={field.label} disabled={disabled} />
```

It starts at three rows, grows with the answer up to twenty, then scrolls inside itself. The autosize owns the height, so the component sets `resize: none` and there is no corner grabber left to drag in any direction.

The second change is one line in the shared `@agenta/ui` `Textarea`, which now defaults to `resize-y`. That closes the same sideways drag in the four other places rendering this primitive: `ResultViewer`, `EntityCommitFooter`, `CustomProviderForm` and `ClaudePermissionsControl`. Where autosize is in play its `resize-none` still wins, because `cn` merges through tailwind-merge and the later class takes precedence.

## Tests / notes

- `pnpm lint-fix` is clean, and `pnpm turbo run build --filter=@agenta/ui --filter=@agenta/entity-ui` typechecks clean.
- The twenty row cap comes from the issue. It is only reached when the answer really is twenty lines or more, so the field is never tall on its own. If it reads as too tall in the transcript, the number is a single literal in `SchemaForm.tsx`.
- `SchemaForm` also renders inside `ToolExecutionDrawer`, so open text arguments there pick up the same control.

## What to QA

- In the agent playground, get the agent to ask an open text question (a schema field carrying `format: "multiline"`). Drag the input's bottom right corner sideways. Nothing moves horizontally and the input stays inside the card.
- Paste about thirty lines into that input. The box grows to roughly twenty visible lines, then scrolls inside itself instead of growing further.
- Reload the page with a half written answer in the box. The draft comes back and the box is sized to the restored text, not collapsed to three rows.
- Regression: open a tool from the tool execution drawer that takes a long text argument. The field still accepts input and submits normally.

Closes AGE-4108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
